### PR TITLE
Properly unwind to the calling point at WebAssembly-generated traps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use structopt::StructOpt;
 mod macros;
 pub mod apis;
 pub mod common;
+mod recovery;
 pub mod sighandler;
 #[cfg(test)]
 mod spectests;
@@ -94,9 +95,7 @@ fn execute_wasm(wasm_path: PathBuf) -> Result<(), String> {
                     Some(&webassembly::Export::Function(index)) => index,
                     _ => panic!("Main function not found"),
                 });
-        let main: extern "C" fn(&webassembly::Instance) =
-            get_instance_function!(instance, func_index);
-        main(&instance);
+        instance.start_func(func_index).unwrap();
     }
 
     Ok(())

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1,0 +1,41 @@
+//! When a WebAssembly module triggers any traps, we perform recovery here.
+
+use std::cell::UnsafeCell;
+
+extern "C" {
+    fn setjmp(env: *mut ::nix::libc::c_void) -> ::nix::libc::c_int;
+    fn longjmp(env: *mut ::nix::libc::c_void, val: ::nix::libc::c_int) -> !;
+}
+
+const SETJMP_BUFFER_LEN: usize = 27;
+
+thread_local! {
+    static SETJMP_BUFFER: UnsafeCell<[::nix::libc::c_int; SETJMP_BUFFER_LEN]> = UnsafeCell::new([0; SETJMP_BUFFER_LEN]);
+}
+
+/// Calls a function with longjmp receiver installed. The function must be compiled from WebAssembly;
+/// Otherwise, the behavior is undefined.
+pub unsafe fn protected_call<T, R>(f: fn(T) -> R, p: T) -> Result<R, i32> {
+    let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
+    let prev_jmp_buf = *jmp_buf;
+
+    let signum = setjmp(jmp_buf as *mut ::nix::libc::c_void);
+    if signum != 0 {
+        *jmp_buf = prev_jmp_buf;
+        Err(signum)
+    } else {
+        let ret = f(p);
+        *jmp_buf = prev_jmp_buf;
+        Ok(ret)
+    }
+}
+
+/// Unwinds to last protected_call.
+pub unsafe fn do_unwind(signum: i32) -> ! {
+    let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
+    if *jmp_buf == [0; SETJMP_BUFFER_LEN] {
+        ::std::process::abort();
+    }
+
+    longjmp(jmp_buf as *mut ::nix::libc::c_void, signum)
+}

--- a/src/sighandler.rs
+++ b/src/sighandler.rs
@@ -4,11 +4,10 @@
 //!
 //! Please read more about this here: https://github.com/CraneStation/wasmtime/issues/15
 //! This code is inspired by: https://github.com/pepyakin/wasmtime/commit/625a2b6c0815b21996e111da51b9664feb174622
+use super::recovery;
 use nix::sys::signal::{
-    sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal, SIGBUS, SIGFPE, SIGILL, SIGSEGV,
+    sigaction, SaFlags, SigAction, SigHandler, SigSet, SIGBUS, SIGFPE, SIGILL, SIGSEGV,
 };
-
-static mut SETJMP_BUFFER: [::nix::libc::c_int; 27] = [0; 27];
 
 pub unsafe fn install_sighandler() {
     let sa = SigAction::new(
@@ -20,29 +19,10 @@ pub unsafe fn install_sighandler() {
     sigaction(SIGILL, &sa).unwrap();
     sigaction(SIGSEGV, &sa).unwrap();
     sigaction(SIGBUS, &sa).unwrap();
-    let signum = setjmp((&mut SETJMP_BUFFER[..]).as_mut_ptr() as *mut ::nix::libc::c_void);
-    if signum != 0 {
-        let signal = Signal::from_c_int(signum).unwrap();
-        match signal {
-            SIGFPE => panic!("floating-point exception"),
-            SIGILL => panic!("illegal instruction"),
-            SIGSEGV => panic!("segmentation violation"),
-            SIGBUS => panic!("bus error"),
-            _ => panic!("signal error: {:?}", signal),
-        };
-    }
-}
-
-extern "C" {
-    fn setjmp(env: *mut ::nix::libc::c_void) -> ::nix::libc::c_int;
-    fn longjmp(env: *mut ::nix::libc::c_void, val: ::nix::libc::c_int);
 }
 
 extern "C" fn signal_trap_handler(signum: ::nix::libc::c_int) {
     unsafe {
-        longjmp(
-            (&mut SETJMP_BUFFER).as_mut_ptr() as *mut ::nix::libc::c_void,
-            signum,
-        );
+        recovery::do_unwind(signum);
     }
 }


### PR DESCRIPTION
This pull request implements catching and recovering from WebAssembly-generated traps, using signal handlers and `setjmp`/`longjmp`.

The async signal unsafety of Rust's TLS implementation (as discussed in https://github.com/CraneStation/wasmtime/issues/15 and https://github.com/rust-lang/rust/issues/43146) doesn't prevent us from accessing TLS inside our specific signal handler since we only handle `SIGFPE`, `SIGILL`, `SIGSEGV` and `SIGBUS` which are very special.