### PR TITLE
Trap unwind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install:
 	cargo install --path .
 
 test:
-	cargo test -- --test-threads=1 $(runargs)
+	cargo test -- $(runargs)
 
 release:
 	# If you are in OS-X, you will need mingw-w64 for cross compiling to windows

--- a/src/build_spectests.rs
+++ b/src/build_spectests.rs
@@ -163,7 +163,6 @@ impl WastTestGenerator {
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{{instantiate, compile, ImportObject, ResultObject, Instance, Export}};
@@ -511,9 +510,7 @@ fn {}_assert_malformed() {{
 #[test]
 fn {}() {{
     let result_object = create_module_{}();
-    let result = panic::catch_unwind(|| {{
-        {}(&result_object);
-    }});
+    let result = call_protected!({}(&result_object));
     assert!(result.is_err());
 }}\n",
                 trap_func_name,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,12 +4,7 @@
 #[macro_export]
 macro_rules! get_instance_function {
     ($instance:expr, $func_index:expr) => {{
-        use crate::sighandler::install_sighandler;
         use std::mem;
-
-        unsafe {
-            install_sighandler();
-        };
         let func_addr = $instance.get_function_pointer($func_index);
         unsafe { mem::transmute(func_addr) }
     }};

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,10 @@ use structopt::StructOpt;
 
 #[macro_use]
 mod macros;
+#[macro_use]
+mod recovery;
 pub mod apis;
 pub mod common;
-mod recovery;
 pub mod sighandler;
 #[cfg(test)]
 mod spectests;
@@ -86,7 +87,7 @@ fn execute_wasm(wasm_path: PathBuf) -> Result<(), String> {
         };
         let main: extern "C" fn(u32, u32, &webassembly::Instance) =
             get_instance_function!(instance, func_index);
-        main(0, 0, &instance);
+        return call_protected!(main(0, 0, &instance)).map_err(|err| format!("{}", err));
     } else {
         let func_index =
             instance
@@ -95,10 +96,10 @@ fn execute_wasm(wasm_path: PathBuf) -> Result<(), String> {
                     Some(&webassembly::Export::Function(index)) => index,
                     _ => panic!("Main function not found"),
                 });
-        instance.start_func(func_index).unwrap();
+        let main: extern "C" fn(&webassembly::Instance) =
+            get_instance_function!(instance, func_index);
+        return call_protected!(main(&instance)).map_err(|err| format!("{}", err));
     }
-
-    Ok(())
 }
 
 fn run(options: Run) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use structopt::StructOpt;
 mod macros;
 pub mod apis;
 pub mod common;
+mod recovery;
 pub mod sighandler;
 #[cfg(test)]
 mod spectests;
@@ -94,9 +95,7 @@ fn execute_wasm(wasm_path: PathBuf) -> Result<(), String> {
                     Some(&webassembly::Export::Function(index)) => index,
                     _ => panic!("Main function not found"),
                 });
-        let main: extern "C" fn(&webassembly::Instance) =
-            get_instance_function!(instance, func_index);
-        main(&instance);
+        instance.start_func(func_index).unwrap();
     }
 
     Ok(())

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -1,0 +1,41 @@
+//! When a WebAssembly module triggers any traps, we perform recovery here.
+
+use std::cell::UnsafeCell;
+
+extern "C" {
+    fn setjmp(env: *mut ::nix::libc::c_void) -> ::nix::libc::c_int;
+    fn longjmp(env: *mut ::nix::libc::c_void, val: ::nix::libc::c_int) -> !;
+}
+
+const SETJMP_BUFFER_LEN: usize = 27;
+
+thread_local! {
+    static SETJMP_BUFFER: UnsafeCell<[::nix::libc::c_int; SETJMP_BUFFER_LEN]> = UnsafeCell::new([0; SETJMP_BUFFER_LEN]);
+}
+
+/// Calls a function with longjmp receiver installed. The function must be compiled from WebAssembly;
+/// Otherwise, the behavior is undefined.
+pub unsafe fn protected_call<T, R>(f: fn(T) -> R, p: T) -> Result<R, i32> {
+    let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
+    let prev_jmp_buf = *jmp_buf;
+
+    let signum = setjmp(jmp_buf as *mut ::nix::libc::c_void);
+    if signum != 0 {
+        *jmp_buf = prev_jmp_buf;
+        Err(signum)
+    } else {
+        let ret = f(p);
+        *jmp_buf = prev_jmp_buf;
+        Ok(ret)
+    }
+}
+
+/// Unwinds to last protected_call.
+pub unsafe fn do_unwind(signum: i32) -> ! {
+    let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
+    if *jmp_buf == [0; SETJMP_BUFFER_LEN] {
+        ::std::process::abort();
+    }
+
+    longjmp(jmp_buf as *mut ::nix::libc::c_void, signum)
+}

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -5,34 +5,62 @@
 //! unless you have memory unsafety elsewhere in your code.
 
 use std::cell::UnsafeCell;
+use nix::sys::signal::{Signal, SIGFPE, SIGILL, SIGSEGV, SIGBUS};
+use super::webassembly::ErrorKind;
+use super::sighandler::install_sighandler;
 
 extern "C" {
-    fn setjmp(env: *mut ::nix::libc::c_void) -> ::nix::libc::c_int;
+    pub fn setjmp(env: *mut ::nix::libc::c_void) -> ::nix::libc::c_int;
     fn longjmp(env: *mut ::nix::libc::c_void, val: ::nix::libc::c_int) -> !;
 }
 
 const SETJMP_BUFFER_LEN: usize = 27;
 
 thread_local! {
-    static SETJMP_BUFFER: UnsafeCell<[::nix::libc::c_int; SETJMP_BUFFER_LEN]> = UnsafeCell::new([0; SETJMP_BUFFER_LEN]);
+    pub static SETJMP_BUFFER: UnsafeCell<[::nix::libc::c_int; SETJMP_BUFFER_LEN]> = UnsafeCell::new([0; SETJMP_BUFFER_LEN]);
 }
+
+// We need a macro since the arguments we will provide to the funciton
+// (and the return value) are not fixed to just one case: f(x) -> y
+// but multiple: f(x) -> y, f(a,b) -> c, ...
+// And right now it's impossible to handle with Rust function type system
 
 /// Calls a WebAssembly function with longjmp receiver installed. If a non-WebAssembly function is passed in,
-/// the behavior of protected_call is undefined.
-pub unsafe fn protected_call<T, R>(f: fn(T) -> R, p: T) -> Result<R, i32> {
-    let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
-    let prev_jmp_buf = *jmp_buf;
+/// the behavior of call_protected is undefined.
+#[macro_export]
+macro_rules! call_protected {
+    ($x:expr) => {unsafe {
+        use crate::webassembly::ErrorKind;
+        use crate::recovery::{SETJMP_BUFFER, setjmp};
+        use crate::sighandler::install_sighandler;
 
-    let signum = setjmp(jmp_buf as *mut ::nix::libc::c_void);
-    if signum != 0 {
-        *jmp_buf = prev_jmp_buf;
-        Err(signum)
-    } else {
-        let ret = f(p); // TODO: Switch stack?
-        *jmp_buf = prev_jmp_buf;
-        Ok(ret)
-    }
+        use nix::sys::signal::{Signal, SIGFPE, SIGILL, SIGSEGV, SIGBUS};
+
+        let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
+        let prev_jmp_buf = *jmp_buf;
+
+        install_sighandler();
+
+        let signum = setjmp(jmp_buf as *mut ::nix::libc::c_void);
+        if signum != 0 {
+            *jmp_buf = prev_jmp_buf;
+            let signal = match Signal::from_c_int(signum) {
+                Ok(SIGFPE) => "floating-point exception",
+                Ok(SIGILL) => "illegal instruction",
+                Ok(SIGSEGV) => "segmentation violation",
+                Ok(SIGBUS) => "bus error",
+                Err(_) => "error while getting the Signal",
+                _ => "unkown trapped signal",
+            };
+            Err(ErrorKind::RuntimeError(format!("trap - {}", signal)))
+        } else {
+            let ret = $x; // TODO: Switch stack?
+            *jmp_buf = prev_jmp_buf;
+            Ok(ret)
+        }
+    }}
 }
+
 
 /// Unwinds to last protected_call.
 pub unsafe fn do_unwind(signum: i32) -> ! {

--- a/src/sighandler.rs
+++ b/src/sighandler.rs
@@ -4,11 +4,10 @@
 //!
 //! Please read more about this here: https://github.com/CraneStation/wasmtime/issues/15
 //! This code is inspired by: https://github.com/pepyakin/wasmtime/commit/625a2b6c0815b21996e111da51b9664feb174622
+use super::recovery;
 use nix::sys::signal::{
-    sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal, SIGBUS, SIGFPE, SIGILL, SIGSEGV,
+    sigaction, SaFlags, SigAction, SigHandler, SigSet, SIGBUS, SIGFPE, SIGILL, SIGSEGV,
 };
-
-static mut SETJMP_BUFFER: [::nix::libc::c_int; 27] = [0; 27];
 
 pub unsafe fn install_sighandler() {
     let sa = SigAction::new(
@@ -20,29 +19,10 @@ pub unsafe fn install_sighandler() {
     sigaction(SIGILL, &sa).unwrap();
     sigaction(SIGSEGV, &sa).unwrap();
     sigaction(SIGBUS, &sa).unwrap();
-    let signum = setjmp((&mut SETJMP_BUFFER[..]).as_mut_ptr() as *mut ::nix::libc::c_void);
-    if signum != 0 {
-        let signal = Signal::from_c_int(signum).unwrap();
-        match signal {
-            SIGFPE => panic!("floating-point exception"),
-            SIGILL => panic!("illegal instruction"),
-            SIGSEGV => panic!("segmentation violation"),
-            SIGBUS => panic!("bus error"),
-            _ => panic!("signal error: {:?}", signal),
-        };
-    }
-}
-
-extern "C" {
-    fn setjmp(env: *mut ::nix::libc::c_void) -> ::nix::libc::c_int;
-    fn longjmp(env: *mut ::nix::libc::c_void, val: ::nix::libc::c_int);
 }
 
 extern "C" fn signal_trap_handler(signum: ::nix::libc::c_int) {
     unsafe {
-        longjmp(
-            (&mut SETJMP_BUFFER).as_mut_ptr() as *mut ::nix::libc::c_void,
-            signum,
-        );
+        recovery::do_unwind(signum);
     }
 }

--- a/src/spectests/address.rs
+++ b/src/spectests/address.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -1059,9 +1058,7 @@ fn c75_l192_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c75_l192_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c75_l192_action_invoke(&result_object);
-    });
+    let result = call_protected!(c75_l192_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1080,9 +1077,7 @@ fn c76_l194_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c76_l194_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c76_l194_action_invoke(&result_object);
-    });
+    let result = call_protected!(c76_l194_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1101,9 +1096,7 @@ fn c77_l195_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c77_l195_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c77_l195_action_invoke(&result_object);
-    });
+    let result = call_protected!(c77_l195_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1122,9 +1115,7 @@ fn c78_l196_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c78_l196_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c78_l196_action_invoke(&result_object);
-    });
+    let result = call_protected!(c78_l196_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1143,9 +1134,7 @@ fn c79_l197_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c79_l197_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c79_l197_action_invoke(&result_object);
-    });
+    let result = call_protected!(c79_l197_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1164,9 +1153,7 @@ fn c80_l198_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c80_l198_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c80_l198_action_invoke(&result_object);
-    });
+    let result = call_protected!(c80_l198_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1185,9 +1172,7 @@ fn c81_l200_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c81_l200_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c81_l200_action_invoke(&result_object);
-    });
+    let result = call_protected!(c81_l200_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1206,9 +1191,7 @@ fn c82_l201_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c82_l201_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c82_l201_action_invoke(&result_object);
-    });
+    let result = call_protected!(c82_l201_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1227,9 +1210,7 @@ fn c83_l202_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c83_l202_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c83_l202_action_invoke(&result_object);
-    });
+    let result = call_protected!(c83_l202_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1248,9 +1229,7 @@ fn c84_l203_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c84_l203_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c84_l203_action_invoke(&result_object);
-    });
+    let result = call_protected!(c84_l203_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1269,9 +1248,7 @@ fn c85_l204_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c85_l204_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c85_l204_action_invoke(&result_object);
-    });
+    let result = call_protected!(c85_l204_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2818,9 +2795,7 @@ fn c192_l479_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c192_l479_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c192_l479_action_invoke(&result_object);
-    });
+    let result = call_protected!(c192_l479_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2839,9 +2814,7 @@ fn c193_l481_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c193_l481_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c193_l481_action_invoke(&result_object);
-    });
+    let result = call_protected!(c193_l481_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2860,9 +2833,7 @@ fn c194_l482_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c194_l482_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c194_l482_action_invoke(&result_object);
-    });
+    let result = call_protected!(c194_l482_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2881,9 +2852,7 @@ fn c195_l483_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c195_l483_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c195_l483_action_invoke(&result_object);
-    });
+    let result = call_protected!(c195_l483_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2902,9 +2871,7 @@ fn c196_l484_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c196_l484_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c196_l484_action_invoke(&result_object);
-    });
+    let result = call_protected!(c196_l484_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2923,9 +2890,7 @@ fn c197_l485_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c197_l485_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c197_l485_action_invoke(&result_object);
-    });
+    let result = call_protected!(c197_l485_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2944,9 +2909,7 @@ fn c198_l486_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c198_l486_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c198_l486_action_invoke(&result_object);
-    });
+    let result = call_protected!(c198_l486_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2965,9 +2928,7 @@ fn c199_l487_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c199_l487_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c199_l487_action_invoke(&result_object);
-    });
+    let result = call_protected!(c199_l487_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2986,9 +2947,7 @@ fn c200_l489_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c200_l489_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c200_l489_action_invoke(&result_object);
-    });
+    let result = call_protected!(c200_l489_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3007,9 +2966,7 @@ fn c201_l490_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c201_l490_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c201_l490_action_invoke(&result_object);
-    });
+    let result = call_protected!(c201_l490_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3028,9 +2985,7 @@ fn c202_l491_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c202_l491_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c202_l491_action_invoke(&result_object);
-    });
+    let result = call_protected!(c202_l491_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3049,9 +3004,7 @@ fn c203_l492_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c203_l492_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c203_l492_action_invoke(&result_object);
-    });
+    let result = call_protected!(c203_l492_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3070,9 +3023,7 @@ fn c204_l493_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c204_l493_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c204_l493_action_invoke(&result_object);
-    });
+    let result = call_protected!(c204_l493_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3091,9 +3042,7 @@ fn c205_l494_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c205_l494_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c205_l494_action_invoke(&result_object);
-    });
+    let result = call_protected!(c205_l494_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3112,9 +3061,7 @@ fn c206_l495_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c206_l495_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c206_l495_action_invoke(&result_object);
-    });
+    let result = call_protected!(c206_l495_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3454,9 +3401,7 @@ fn c222_l539_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c222_l539_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c222_l539_action_invoke(&result_object);
-    });
+    let result = call_protected!(c222_l539_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3475,9 +3420,7 @@ fn c223_l541_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c223_l541_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c223_l541_action_invoke(&result_object);
-    });
+    let result = call_protected!(c223_l541_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3496,9 +3439,7 @@ fn c224_l542_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c224_l542_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c224_l542_action_invoke(&result_object);
-    });
+    let result = call_protected!(c224_l542_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3748,9 +3689,7 @@ fn c240_l586_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c240_l586_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c240_l586_action_invoke(&result_object);
-    });
+    let result = call_protected!(c240_l586_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3769,9 +3708,7 @@ fn c241_l588_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c241_l588_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c241_l588_action_invoke(&result_object);
-    });
+    let result = call_protected!(c241_l588_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3790,9 +3727,7 @@ fn c242_l589_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c242_l589_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c242_l589_action_invoke(&result_object);
-    });
+    let result = call_protected!(c242_l589_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/align.rs
+++ b/src/spectests/align.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/binary.rs
+++ b/src/spectests/binary.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/block.rs
+++ b/src/spectests/block.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/br.rs
+++ b/src/spectests/br.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/br_if.rs
+++ b/src/spectests/br_if.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/br_table.rs
+++ b/src/spectests/br_table.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/break_drop.rs
+++ b/src/spectests/break_drop.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/call.rs
+++ b/src/spectests/call.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -861,9 +860,7 @@ fn c46_l261_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c46_l261_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c46_l261_action_invoke(&result_object);
-    });
+    let result = call_protected!(c46_l261_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/call_indirect.rs
+++ b/src/spectests/call_indirect.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/comments.rs
+++ b/src/spectests/comments.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/const_.rs
+++ b/src/spectests/const_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/conversions.rs
+++ b/src/spectests/conversions.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -610,9 +609,7 @@ fn c39_l70_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c39_l70_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c39_l70_action_invoke(&result_object);
-    });
+    let result = call_protected!(c39_l70_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -631,9 +628,7 @@ fn c40_l71_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c40_l71_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c40_l71_action_invoke(&result_object);
-    });
+    let result = call_protected!(c40_l71_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -652,9 +647,7 @@ fn c41_l72_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c41_l72_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c41_l72_action_invoke(&result_object);
-    });
+    let result = call_protected!(c41_l72_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -673,9 +666,7 @@ fn c42_l73_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c42_l73_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c42_l73_action_invoke(&result_object);
-    });
+    let result = call_protected!(c42_l73_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -694,9 +685,7 @@ fn c43_l74_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c43_l74_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c43_l74_action_invoke(&result_object);
-    });
+    let result = call_protected!(c43_l74_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -715,9 +704,7 @@ fn c44_l75_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c44_l75_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c44_l75_action_invoke(&result_object);
-    });
+    let result = call_protected!(c44_l75_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -736,9 +723,7 @@ fn c45_l76_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c45_l76_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c45_l76_action_invoke(&result_object);
-    });
+    let result = call_protected!(c45_l76_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -757,9 +742,7 @@ fn c46_l77_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c46_l77_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c46_l77_action_invoke(&result_object);
-    });
+    let result = call_protected!(c46_l77_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -934,9 +917,7 @@ fn c60_l92_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c60_l92_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c60_l92_action_invoke(&result_object);
-    });
+    let result = call_protected!(c60_l92_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -955,9 +936,7 @@ fn c61_l93_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c61_l93_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c61_l93_action_invoke(&result_object);
-    });
+    let result = call_protected!(c61_l93_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -976,9 +955,7 @@ fn c62_l94_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c62_l94_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c62_l94_action_invoke(&result_object);
-    });
+    let result = call_protected!(c62_l94_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -997,9 +974,7 @@ fn c63_l95_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c63_l95_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c63_l95_action_invoke(&result_object);
-    });
+    let result = call_protected!(c63_l95_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1018,9 +993,7 @@ fn c64_l96_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c64_l96_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c64_l96_action_invoke(&result_object);
-    });
+    let result = call_protected!(c64_l96_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1039,9 +1012,7 @@ fn c65_l97_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c65_l97_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c65_l97_action_invoke(&result_object);
-    });
+    let result = call_protected!(c65_l97_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1060,9 +1031,7 @@ fn c66_l98_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c66_l98_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c66_l98_action_invoke(&result_object);
-    });
+    let result = call_protected!(c66_l98_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1081,9 +1050,7 @@ fn c67_l99_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c67_l99_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c67_l99_action_invoke(&result_object);
-    });
+    let result = call_protected!(c67_l99_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1270,9 +1237,7 @@ fn c82_l115_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c82_l115_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c82_l115_action_invoke(&result_object);
-    });
+    let result = call_protected!(c82_l115_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1291,9 +1256,7 @@ fn c83_l116_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c83_l116_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c83_l116_action_invoke(&result_object);
-    });
+    let result = call_protected!(c83_l116_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1312,9 +1275,7 @@ fn c84_l117_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c84_l117_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c84_l117_action_invoke(&result_object);
-    });
+    let result = call_protected!(c84_l117_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1333,9 +1294,7 @@ fn c85_l118_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c85_l118_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c85_l118_action_invoke(&result_object);
-    });
+    let result = call_protected!(c85_l118_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1354,9 +1313,7 @@ fn c86_l119_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c86_l119_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c86_l119_action_invoke(&result_object);
-    });
+    let result = call_protected!(c86_l119_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1375,9 +1332,7 @@ fn c87_l120_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c87_l120_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c87_l120_action_invoke(&result_object);
-    });
+    let result = call_protected!(c87_l120_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1396,9 +1351,7 @@ fn c88_l121_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c88_l121_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c88_l121_action_invoke(&result_object);
-    });
+    let result = call_protected!(c88_l121_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1417,9 +1370,7 @@ fn c89_l122_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c89_l122_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c89_l122_action_invoke(&result_object);
-    });
+    let result = call_protected!(c89_l122_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1606,9 +1557,7 @@ fn c104_l138_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c104_l138_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c104_l138_action_invoke(&result_object);
-    });
+    let result = call_protected!(c104_l138_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1627,9 +1576,7 @@ fn c105_l139_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c105_l139_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c105_l139_action_invoke(&result_object);
-    });
+    let result = call_protected!(c105_l139_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1648,9 +1595,7 @@ fn c106_l140_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c106_l140_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c106_l140_action_invoke(&result_object);
-    });
+    let result = call_protected!(c106_l140_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1669,9 +1614,7 @@ fn c107_l141_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c107_l141_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c107_l141_action_invoke(&result_object);
-    });
+    let result = call_protected!(c107_l141_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1690,9 +1633,7 @@ fn c108_l142_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c108_l142_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c108_l142_action_invoke(&result_object);
-    });
+    let result = call_protected!(c108_l142_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1711,9 +1652,7 @@ fn c109_l143_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c109_l143_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c109_l143_action_invoke(&result_object);
-    });
+    let result = call_protected!(c109_l143_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1732,9 +1671,7 @@ fn c110_l144_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c110_l144_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c110_l144_action_invoke(&result_object);
-    });
+    let result = call_protected!(c110_l144_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1753,9 +1690,7 @@ fn c111_l145_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c111_l145_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c111_l145_action_invoke(&result_object);
-    });
+    let result = call_protected!(c111_l145_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1774,9 +1709,7 @@ fn c112_l146_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c112_l146_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c112_l146_action_invoke(&result_object);
-    });
+    let result = call_protected!(c112_l146_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1795,9 +1728,7 @@ fn c113_l147_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c113_l147_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c113_l147_action_invoke(&result_object);
-    });
+    let result = call_protected!(c113_l147_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1816,9 +1747,7 @@ fn c114_l148_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c114_l148_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c114_l148_action_invoke(&result_object);
-    });
+    let result = call_protected!(c114_l148_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2029,9 +1958,7 @@ fn c131_l166_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c131_l166_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c131_l166_action_invoke(&result_object);
-    });
+    let result = call_protected!(c131_l166_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2050,9 +1977,7 @@ fn c132_l167_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c132_l167_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c132_l167_action_invoke(&result_object);
-    });
+    let result = call_protected!(c132_l167_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2071,9 +1996,7 @@ fn c133_l168_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c133_l168_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c133_l168_action_invoke(&result_object);
-    });
+    let result = call_protected!(c133_l168_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2092,9 +2015,7 @@ fn c134_l169_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c134_l169_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c134_l169_action_invoke(&result_object);
-    });
+    let result = call_protected!(c134_l169_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2113,9 +2034,7 @@ fn c135_l170_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c135_l170_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c135_l170_action_invoke(&result_object);
-    });
+    let result = call_protected!(c135_l170_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2134,9 +2053,7 @@ fn c136_l171_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c136_l171_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c136_l171_action_invoke(&result_object);
-    });
+    let result = call_protected!(c136_l171_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2155,9 +2072,7 @@ fn c137_l172_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c137_l172_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c137_l172_action_invoke(&result_object);
-    });
+    let result = call_protected!(c137_l172_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2176,9 +2091,7 @@ fn c138_l173_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c138_l173_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c138_l173_action_invoke(&result_object);
-    });
+    let result = call_protected!(c138_l173_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2329,9 +2242,7 @@ fn c150_l186_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c150_l186_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c150_l186_action_invoke(&result_object);
-    });
+    let result = call_protected!(c150_l186_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2350,9 +2261,7 @@ fn c151_l187_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c151_l187_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c151_l187_action_invoke(&result_object);
-    });
+    let result = call_protected!(c151_l187_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2371,9 +2280,7 @@ fn c152_l188_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c152_l188_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c152_l188_action_invoke(&result_object);
-    });
+    let result = call_protected!(c152_l188_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2392,9 +2299,7 @@ fn c153_l189_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c153_l189_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c153_l189_action_invoke(&result_object);
-    });
+    let result = call_protected!(c153_l189_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2413,9 +2318,7 @@ fn c154_l190_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c154_l190_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c154_l190_action_invoke(&result_object);
-    });
+    let result = call_protected!(c154_l190_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2434,9 +2337,7 @@ fn c155_l191_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c155_l191_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c155_l191_action_invoke(&result_object);
-    });
+    let result = call_protected!(c155_l191_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2455,9 +2356,7 @@ fn c156_l192_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c156_l192_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c156_l192_action_invoke(&result_object);
-    });
+    let result = call_protected!(c156_l192_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2476,9 +2375,7 @@ fn c157_l193_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c157_l193_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c157_l193_action_invoke(&result_object);
-    });
+    let result = call_protected!(c157_l193_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2689,9 +2586,7 @@ fn c174_l211_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c174_l211_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c174_l211_action_invoke(&result_object);
-    });
+    let result = call_protected!(c174_l211_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2710,9 +2605,7 @@ fn c175_l212_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c175_l212_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c175_l212_action_invoke(&result_object);
-    });
+    let result = call_protected!(c175_l212_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2731,9 +2624,7 @@ fn c176_l213_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c176_l213_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c176_l213_action_invoke(&result_object);
-    });
+    let result = call_protected!(c176_l213_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2752,9 +2643,7 @@ fn c177_l214_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c177_l214_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c177_l214_action_invoke(&result_object);
-    });
+    let result = call_protected!(c177_l214_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2773,9 +2662,7 @@ fn c178_l215_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c178_l215_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c178_l215_action_invoke(&result_object);
-    });
+    let result = call_protected!(c178_l215_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2794,9 +2681,7 @@ fn c179_l216_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c179_l216_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c179_l216_action_invoke(&result_object);
-    });
+    let result = call_protected!(c179_l216_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2815,9 +2700,7 @@ fn c180_l217_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c180_l217_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c180_l217_action_invoke(&result_object);
-    });
+    let result = call_protected!(c180_l217_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2836,9 +2719,7 @@ fn c181_l218_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c181_l218_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c181_l218_action_invoke(&result_object);
-    });
+    let result = call_protected!(c181_l218_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3037,9 +2918,7 @@ fn c197_l235_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c197_l235_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c197_l235_action_invoke(&result_object);
-    });
+    let result = call_protected!(c197_l235_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3058,9 +2937,7 @@ fn c198_l236_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c198_l236_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c198_l236_action_invoke(&result_object);
-    });
+    let result = call_protected!(c198_l236_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3079,9 +2956,7 @@ fn c199_l237_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c199_l237_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c199_l237_action_invoke(&result_object);
-    });
+    let result = call_protected!(c199_l237_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3100,9 +2975,7 @@ fn c200_l238_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c200_l238_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c200_l238_action_invoke(&result_object);
-    });
+    let result = call_protected!(c200_l238_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3121,9 +2994,7 @@ fn c201_l239_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c201_l239_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c201_l239_action_invoke(&result_object);
-    });
+    let result = call_protected!(c201_l239_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3142,9 +3013,7 @@ fn c202_l240_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c202_l240_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c202_l240_action_invoke(&result_object);
-    });
+    let result = call_protected!(c202_l240_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3163,9 +3032,7 @@ fn c203_l241_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c203_l241_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c203_l241_action_invoke(&result_object);
-    });
+    let result = call_protected!(c203_l241_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -3184,9 +3051,7 @@ fn c204_l242_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c204_l242_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c204_l242_action_invoke(&result_object);
-    });
+    let result = call_protected!(c204_l242_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/custom.rs
+++ b/src/spectests/custom.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/data.rs
+++ b/src/spectests/data.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/elem.rs
+++ b/src/spectests/elem.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -690,9 +689,7 @@ fn c44_l353_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c44_l353_assert_trap() {
     let result_object = create_module_21();
-    let result = panic::catch_unwind(|| {
-        c44_l353_action_invoke(&result_object);
-    });
+    let result = call_protected!(c44_l353_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/endianness.rs
+++ b/src/spectests/endianness.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/exports.rs
+++ b/src/spectests/exports.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/f32_.rs
+++ b/src/spectests/f32_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/f32_bitwise.rs
+++ b/src/spectests/f32_bitwise.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/f32_cmp.rs
+++ b/src/spectests/f32_cmp.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/f64_.rs
+++ b/src/spectests/f64_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/f64_bitwise.rs
+++ b/src/spectests/f64_bitwise.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/f64_cmp.rs
+++ b/src/spectests/f64_cmp.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/fac.rs
+++ b/src/spectests/fac.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/float_exprs.rs
+++ b/src/spectests/float_exprs.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/float_literals.rs
+++ b/src/spectests/float_literals.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/float_memory.rs
+++ b/src/spectests/float_memory.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/float_misc.rs
+++ b/src/spectests/float_misc.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/forward.rs
+++ b/src/spectests/forward.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/func.rs
+++ b/src/spectests/func.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/func_ptrs.rs
+++ b/src/spectests/func_ptrs.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -303,9 +302,7 @@ fn c20_l78_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c20_l78_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c20_l78_action_invoke(&result_object);
-    });
+    let result = call_protected!(c20_l78_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -324,9 +321,7 @@ fn c21_l79_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c21_l79_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c21_l79_action_invoke(&result_object);
-    });
+    let result = call_protected!(c21_l79_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -345,9 +340,7 @@ fn c22_l80_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c22_l80_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c22_l80_action_invoke(&result_object);
-    });
+    let result = call_protected!(c22_l80_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -450,9 +443,7 @@ fn c30_l89_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c30_l89_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c30_l89_action_invoke(&result_object);
-    });
+    let result = call_protected!(c30_l89_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -471,9 +462,7 @@ fn c31_l90_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c31_l90_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c31_l90_action_invoke(&result_object);
-    });
+    let result = call_protected!(c31_l90_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -492,9 +481,7 @@ fn c32_l91_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c32_l91_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c32_l91_action_invoke(&result_object);
-    });
+    let result = call_protected!(c32_l91_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/get_local.rs
+++ b/src/spectests/get_local.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/globals.rs
+++ b/src/spectests/globals.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -666,9 +665,7 @@ fn c32_l222_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c32_l222_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c32_l222_action_invoke(&result_object);
-    });
+    let result = call_protected!(c32_l222_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/i32_.rs
+++ b/src/spectests/i32_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -473,9 +472,7 @@ fn c25_l62_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c25_l62_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c25_l62_action_invoke(&result_object);
-    });
+    let result = call_protected!(c25_l62_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -494,9 +491,7 @@ fn c26_l63_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c26_l63_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c26_l63_action_invoke(&result_object);
-    });
+    let result = call_protected!(c26_l63_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -515,9 +510,7 @@ fn c27_l64_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c27_l64_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c27_l64_action_invoke(&result_object);
-    });
+    let result = call_protected!(c27_l64_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -728,9 +721,7 @@ fn c44_l82_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c44_l82_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c44_l82_action_invoke(&result_object);
-    });
+    let result = call_protected!(c44_l82_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -749,9 +740,7 @@ fn c45_l83_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c45_l83_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c45_l83_action_invoke(&result_object);
-    });
+    let result = call_protected!(c45_l83_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -938,9 +927,7 @@ fn c60_l99_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c60_l99_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c60_l99_action_invoke(&result_object);
-    });
+    let result = call_protected!(c60_l99_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -959,9 +946,7 @@ fn c61_l100_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c61_l100_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c61_l100_action_invoke(&result_object);
-    });
+    let result = call_protected!(c61_l100_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1196,9 +1181,7 @@ fn c80_l120_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c80_l120_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c80_l120_action_invoke(&result_object);
-    });
+    let result = call_protected!(c80_l120_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1217,9 +1200,7 @@ fn c81_l121_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c81_l121_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c81_l121_action_invoke(&result_object);
-    });
+    let result = call_protected!(c81_l121_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/i64_.rs
+++ b/src/spectests/i64_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -475,9 +474,7 @@ fn c25_l62_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c25_l62_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c25_l62_action_invoke(&result_object);
-    });
+    let result = call_protected!(c25_l62_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -496,9 +493,7 @@ fn c26_l63_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c26_l63_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c26_l63_action_invoke(&result_object);
-    });
+    let result = call_protected!(c26_l63_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -517,9 +512,7 @@ fn c27_l64_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c27_l64_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c27_l64_action_invoke(&result_object);
-    });
+    let result = call_protected!(c27_l64_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -730,9 +723,7 @@ fn c44_l82_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c44_l82_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c44_l82_action_invoke(&result_object);
-    });
+    let result = call_protected!(c44_l82_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -751,9 +742,7 @@ fn c45_l83_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c45_l83_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c45_l83_action_invoke(&result_object);
-    });
+    let result = call_protected!(c45_l83_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -940,9 +929,7 @@ fn c60_l99_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c60_l99_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c60_l99_action_invoke(&result_object);
-    });
+    let result = call_protected!(c60_l99_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -961,9 +948,7 @@ fn c61_l100_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c61_l100_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c61_l100_action_invoke(&result_object);
-    });
+    let result = call_protected!(c61_l100_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1198,9 +1183,7 @@ fn c80_l120_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c80_l120_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c80_l120_action_invoke(&result_object);
-    });
+    let result = call_protected!(c80_l120_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1219,9 +1202,7 @@ fn c81_l121_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c81_l121_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c81_l121_action_invoke(&result_object);
-    });
+    let result = call_protected!(c81_l121_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/if_.rs
+++ b/src/spectests/if_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -1224,9 +1223,7 @@ fn c48_l440_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c48_l440_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c48_l440_action_invoke(&result_object);
-    });
+    let result = call_protected!(c48_l440_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/int_exprs.rs
+++ b/src/spectests/int_exprs.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -565,9 +564,7 @@ fn c26_l113_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c26_l113_assert_trap() {
     let result_object = create_module_7();
-    let result = panic::catch_unwind(|| {
-        c26_l113_action_invoke(&result_object);
-    });
+    let result = call_protected!(c26_l113_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -586,9 +583,7 @@ fn c27_l114_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c27_l114_assert_trap() {
     let result_object = create_module_7();
-    let result = panic::catch_unwind(|| {
-        c27_l114_action_invoke(&result_object);
-    });
+    let result = call_protected!(c27_l114_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -607,9 +602,7 @@ fn c28_l115_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c28_l115_assert_trap() {
     let result_object = create_module_7();
-    let result = panic::catch_unwind(|| {
-        c28_l115_action_invoke(&result_object);
-    });
+    let result = call_protected!(c28_l115_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -628,9 +621,7 @@ fn c29_l116_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c29_l116_assert_trap() {
     let result_object = create_module_7();
-    let result = panic::catch_unwind(|| {
-        c29_l116_action_invoke(&result_object);
-    });
+    let result = call_protected!(c29_l116_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -690,9 +681,7 @@ fn c31_l132_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c31_l132_assert_trap() {
     let result_object = create_module_8();
-    let result = panic::catch_unwind(|| {
-        c31_l132_action_invoke(&result_object);
-    });
+    let result = call_protected!(c31_l132_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -711,9 +700,7 @@ fn c32_l133_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c32_l133_assert_trap() {
     let result_object = create_module_8();
-    let result = panic::catch_unwind(|| {
-        c32_l133_action_invoke(&result_object);
-    });
+    let result = call_protected!(c32_l133_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -732,9 +719,7 @@ fn c33_l134_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c33_l134_assert_trap() {
     let result_object = create_module_8();
-    let result = panic::catch_unwind(|| {
-        c33_l134_action_invoke(&result_object);
-    });
+    let result = call_protected!(c33_l134_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -753,9 +738,7 @@ fn c34_l135_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c34_l135_assert_trap() {
     let result_object = create_module_8();
-    let result = panic::catch_unwind(|| {
-        c34_l135_action_invoke(&result_object);
-    });
+    let result = call_protected!(c34_l135_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1030,9 +1013,7 @@ fn c47_l196_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c47_l196_assert_trap() {
     let result_object = create_module_12();
-    let result = panic::catch_unwind(|| {
-        c47_l196_action_invoke(&result_object);
-    });
+    let result = call_protected!(c47_l196_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1051,9 +1032,7 @@ fn c48_l197_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c48_l197_assert_trap() {
     let result_object = create_module_12();
-    let result = panic::catch_unwind(|| {
-        c48_l197_action_invoke(&result_object);
-    });
+    let result = call_protected!(c48_l197_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1072,9 +1051,7 @@ fn c49_l198_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c49_l198_assert_trap() {
     let result_object = create_module_12();
-    let result = panic::catch_unwind(|| {
-        c49_l198_action_invoke(&result_object);
-    });
+    let result = call_protected!(c49_l198_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1093,9 +1070,7 @@ fn c50_l199_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c50_l199_assert_trap() {
     let result_object = create_module_12();
-    let result = panic::catch_unwind(|| {
-        c50_l199_action_invoke(&result_object);
-    });
+    let result = call_protected!(c50_l199_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2015,9 +1990,7 @@ fn c106_l349_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c106_l349_assert_trap() {
     let result_object = create_module_19();
-    let result = panic::catch_unwind(|| {
-        c106_l349_action_invoke(&result_object);
-    });
+    let result = call_protected!(c106_l349_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -2036,9 +2009,7 @@ fn c107_l350_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c107_l350_assert_trap() {
     let result_object = create_module_19();
-    let result = panic::catch_unwind(|| {
-        c107_l350_action_invoke(&result_object);
-    });
+    let result = call_protected!(c107_l350_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/int_literals.rs
+++ b/src/spectests/int_literals.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/labels.rs
+++ b/src/spectests/labels.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/left_to_right.rs
+++ b/src/spectests/left_to_right.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/loop_.rs
+++ b/src/spectests/loop_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/memory.rs
+++ b/src/spectests/memory.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/memory_grow.rs
+++ b/src/spectests/memory_grow.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -83,9 +82,7 @@ fn c2_l15_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c2_l15_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c2_l15_action_invoke(&result_object);
-    });
+    let result = call_protected!(c2_l15_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -104,9 +101,7 @@ fn c3_l16_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c3_l16_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c3_l16_action_invoke(&result_object);
-    });
+    let result = call_protected!(c3_l16_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -125,9 +120,7 @@ fn c4_l17_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c4_l17_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c4_l17_action_invoke(&result_object);
-    });
+    let result = call_protected!(c4_l17_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -146,9 +139,7 @@ fn c5_l18_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c5_l18_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c5_l18_action_invoke(&result_object);
-    });
+    let result = call_protected!(c5_l18_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -227,9 +218,7 @@ fn c11_l24_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c11_l24_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c11_l24_action_invoke(&result_object);
-    });
+    let result = call_protected!(c11_l24_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -248,9 +237,7 @@ fn c12_l25_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c12_l25_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c12_l25_action_invoke(&result_object);
-    });
+    let result = call_protected!(c12_l25_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -1360,9 +1347,7 @@ fn c72_l286_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c72_l286_assert_trap() {
     let result_object = create_module_5();
-    let result = panic::catch_unwind(|| {
-        c72_l286_action_invoke(&result_object);
-    });
+    let result = call_protected!(c72_l286_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/memory_redundancy.rs
+++ b/src/spectests/memory_redundancy.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/nop.rs
+++ b/src/spectests/nop.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/return_.rs
+++ b/src/spectests/return_.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/select.rs
+++ b/src/spectests/select.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -396,9 +395,7 @@ fn c25_l59_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c25_l59_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c25_l59_action_invoke(&result_object);
-    });
+    let result = call_protected!(c25_l59_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -417,9 +414,7 @@ fn c26_l60_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c26_l60_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c26_l60_action_invoke(&result_object);
-    });
+    let result = call_protected!(c26_l60_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -438,9 +433,7 @@ fn c27_l61_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c27_l61_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c27_l61_action_invoke(&result_object);
-    });
+    let result = call_protected!(c27_l61_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -459,9 +452,7 @@ fn c28_l62_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c28_l62_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c28_l62_action_invoke(&result_object);
-    });
+    let result = call_protected!(c28_l62_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/set_local.rs
+++ b/src/spectests/set_local.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/stack.rs
+++ b/src/spectests/stack.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/start.rs
+++ b/src/spectests/start.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/store_retval.rs
+++ b/src/spectests/store_retval.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/switch.rs
+++ b/src/spectests/switch.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/tee_local.rs
+++ b/src/spectests/tee_local.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/token.rs
+++ b/src/spectests/token.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/traps.rs
+++ b/src/spectests/traps.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};
@@ -68,9 +67,7 @@ fn c1_l16_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c1_l16_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c1_l16_action_invoke(&result_object);
-    });
+    let result = call_protected!(c1_l16_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -89,9 +86,7 @@ fn c2_l17_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c2_l17_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c2_l17_action_invoke(&result_object);
-    });
+    let result = call_protected!(c2_l17_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -110,9 +105,7 @@ fn c3_l18_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c3_l18_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c3_l18_action_invoke(&result_object);
-    });
+    let result = call_protected!(c3_l18_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -131,9 +124,7 @@ fn c4_l19_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c4_l19_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c4_l19_action_invoke(&result_object);
-    });
+    let result = call_protected!(c4_l19_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -152,9 +143,7 @@ fn c5_l20_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c5_l20_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c5_l20_action_invoke(&result_object);
-    });
+    let result = call_protected!(c5_l20_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -173,9 +162,7 @@ fn c6_l21_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c6_l21_assert_trap() {
     let result_object = create_module_1();
-    let result = panic::catch_unwind(|| {
-        c6_l21_action_invoke(&result_object);
-    });
+    let result = call_protected!(c6_l21_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -239,9 +226,7 @@ fn c8_l34_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c8_l34_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c8_l34_action_invoke(&result_object);
-    });
+    let result = call_protected!(c8_l34_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -260,9 +245,7 @@ fn c9_l35_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c9_l35_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c9_l35_action_invoke(&result_object);
-    });
+    let result = call_protected!(c9_l35_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -281,9 +264,7 @@ fn c10_l36_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c10_l36_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c10_l36_action_invoke(&result_object);
-    });
+    let result = call_protected!(c10_l36_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -302,9 +283,7 @@ fn c11_l37_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c11_l37_assert_trap() {
     let result_object = create_module_2();
-    let result = panic::catch_unwind(|| {
-        c11_l37_action_invoke(&result_object);
-    });
+    let result = call_protected!(c11_l37_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -384,9 +363,7 @@ fn c13_l50_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c13_l50_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c13_l50_action_invoke(&result_object);
-    });
+    let result = call_protected!(c13_l50_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -405,9 +382,7 @@ fn c14_l51_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c14_l51_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c14_l51_action_invoke(&result_object);
-    });
+    let result = call_protected!(c14_l51_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -426,9 +401,7 @@ fn c15_l52_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c15_l52_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c15_l52_action_invoke(&result_object);
-    });
+    let result = call_protected!(c15_l52_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -447,9 +420,7 @@ fn c16_l53_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c16_l53_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c16_l53_action_invoke(&result_object);
-    });
+    let result = call_protected!(c16_l53_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -468,9 +439,7 @@ fn c17_l54_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c17_l54_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c17_l54_action_invoke(&result_object);
-    });
+    let result = call_protected!(c17_l54_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -489,9 +458,7 @@ fn c18_l55_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c18_l55_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c18_l55_action_invoke(&result_object);
-    });
+    let result = call_protected!(c18_l55_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -510,9 +477,7 @@ fn c19_l56_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c19_l56_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c19_l56_action_invoke(&result_object);
-    });
+    let result = call_protected!(c19_l56_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -531,9 +496,7 @@ fn c20_l57_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c20_l57_assert_trap() {
     let result_object = create_module_3();
-    let result = panic::catch_unwind(|| {
-        c20_l57_action_invoke(&result_object);
-    });
+    let result = call_protected!(c20_l57_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -643,9 +606,7 @@ fn c22_l78_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c22_l78_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c22_l78_action_invoke(&result_object);
-    });
+    let result = call_protected!(c22_l78_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -664,9 +625,7 @@ fn c23_l79_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c23_l79_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c23_l79_action_invoke(&result_object);
-    });
+    let result = call_protected!(c23_l79_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -685,9 +644,7 @@ fn c24_l80_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c24_l80_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c24_l80_action_invoke(&result_object);
-    });
+    let result = call_protected!(c24_l80_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -706,9 +663,7 @@ fn c25_l81_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c25_l81_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c25_l81_action_invoke(&result_object);
-    });
+    let result = call_protected!(c25_l81_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -727,9 +682,7 @@ fn c26_l82_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c26_l82_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c26_l82_action_invoke(&result_object);
-    });
+    let result = call_protected!(c26_l82_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -748,9 +701,7 @@ fn c27_l83_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c27_l83_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c27_l83_action_invoke(&result_object);
-    });
+    let result = call_protected!(c27_l83_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -769,9 +720,7 @@ fn c28_l84_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c28_l84_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c28_l84_action_invoke(&result_object);
-    });
+    let result = call_protected!(c28_l84_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -790,9 +739,7 @@ fn c29_l85_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c29_l85_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c29_l85_action_invoke(&result_object);
-    });
+    let result = call_protected!(c29_l85_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -811,9 +758,7 @@ fn c30_l86_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c30_l86_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c30_l86_action_invoke(&result_object);
-    });
+    let result = call_protected!(c30_l86_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -832,9 +777,7 @@ fn c31_l87_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c31_l87_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c31_l87_action_invoke(&result_object);
-    });
+    let result = call_protected!(c31_l87_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -853,9 +796,7 @@ fn c32_l88_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c32_l88_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c32_l88_action_invoke(&result_object);
-    });
+    let result = call_protected!(c32_l88_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -874,9 +815,7 @@ fn c33_l89_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c33_l89_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c33_l89_action_invoke(&result_object);
-    });
+    let result = call_protected!(c33_l89_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -895,9 +834,7 @@ fn c34_l90_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c34_l90_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c34_l90_action_invoke(&result_object);
-    });
+    let result = call_protected!(c34_l90_action_invoke(&result_object));
     assert!(result.is_err());
 }
 
@@ -916,9 +853,7 @@ fn c35_l91_action_invoke(result_object: &ResultObject) {
 #[test]
 fn c35_l91_assert_trap() {
     let result_object = create_module_4();
-    let result = panic::catch_unwind(|| {
-        c35_l91_action_invoke(&result_object);
-    });
+    let result = call_protected!(c35_l91_action_invoke(&result_object));
     assert!(result.is_err());
 }
 

--- a/src/spectests/typecheck.rs
+++ b/src/spectests/typecheck.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/spectests/types.rs
+++ b/src/spectests/types.rs
@@ -5,7 +5,6 @@
     warnings,
     dead_code
 )]
-use std::panic;
 use wabt::wat2wasm;
 
 use crate::webassembly::{instantiate, compile, ImportObject, ResultObject, Instance, Export};

--- a/src/webassembly/instance.rs
+++ b/src/webassembly/instance.rs
@@ -519,16 +519,13 @@ impl Instance {
         get_function_addr(&func_index, &self.import_functions, &self.functions)
     }
 
-    pub fn start_func(&self, func_index: FuncIndex) -> Result<(), i32> {
-        let func: fn(&Instance) = get_instance_function!(&self, func_index);
-        unsafe { recovery::protected_call(func, self) }
-    }
-
-    pub fn start(&self) -> Result<(), i32> {
+    pub fn start(&self) -> Result<(), ErrorKind> {
         if let Some(func_index) = self.start_func {
-            self.start_func(func_index)
-        } else {
-            panic!("start func not found")
+            let func: fn(&Instance) = get_instance_function!(&self, func_index);
+            call_protected!(func(self))
+        }
+        else {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
Apart from the trap changes in the original PR #26, this PR is:
* Transforming the `protected_call` function into a `call_protected!` macro, since we need variadic function arguments (and they can't yet be handled with Rust's type system).
* Run tests is no longer limited to only one thread
