### PR TITLE
Recover properly when a stack overflow occurs in user code.

### DIFF
--- a/src/sighandler.rs
+++ b/src/sighandler.rs
@@ -12,7 +12,7 @@ use nix::sys::signal::{
 pub unsafe fn install_sighandler() {
     let sa = SigAction::new(
         SigHandler::Handler(signal_trap_handler),
-        SaFlags::empty(),
+        SaFlags::SA_ONSTACK,
         SigSet::empty(),
     );
     sigaction(SIGFPE, &sa).unwrap();


### PR DESCRIPTION
We should make the signal handler run on an alternative signal stack so that a stack overflow in user (WebAssembly) code doesn't prevent unwinding to the last `call_protected!` point.