### PR TITLE
Fixed false positives in Emscripten detection.

### DIFF
--- a/src/apis/emscripten/tests/is_emscripten_true.wast
+++ b/src/apis/emscripten/tests/is_emscripten_true.wast
@@ -1,6 +1,7 @@
 (module
  (type $FUNCSIG$ii (func (param i32) (result i32)))
  (import "env" "puts" (func $puts (param i32) (result i32)))
+ (import "env" "_emscripten_memcpy_big" (func $_emscripten_memcpy_big (param i32 i32 i32) (result i32)))
  (table 0 anyfunc)
  (memory $0 1)
  (data (i32.const 16) "hello, world!\00")

--- a/src/apis/emscripten/utils.rs
+++ b/src/apis/emscripten/utils.rs
@@ -8,8 +8,8 @@ use std::slice;
 
 /// We check if a provided module is an Emscripten generated one
 pub fn is_emscripten_module(module: &Module) -> bool {
-    for (module, _field) in &module.info.imported_funcs {
-        if module == "env" {
+    for (module, field) in &module.info.imported_funcs {
+        if field == "_emscripten_memcpy_big" && module == "env" {
             return true;
         }
     }


### PR DESCRIPTION
Almost all languages targeting WebAssembly create imports from
"env" module by default, which means that Emscripten was being
detected even when it wasn't used.

Use "_emscripten_memcpy_big" as a signal, since it's imported
in all WASM modules produced by Emscripten, even as simple as:

    EMSCRIPTEN_KEEPALIVE
    int
    main(int argc, const char** argv) {
        return 0;
    }

Signed-off-by: Piotr Sikora <piotrsikora@google.com>