### PR TITLE
Pass arguments to wasm application

### DIFF
--- a/src/apis/emscripten/mod.rs
+++ b/src/apis/emscripten/mod.rs
@@ -19,7 +19,7 @@ mod utils;
 mod varargs;
 
 pub use self::storage::{align_memory, static_alloc};
-pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm_stack};
+pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm, allocate_on_stack, allocate_cstr_on_stack};
 
 // TODO: Magic number - how is this calculated?
 const TOTAL_STACK: u32 = 5242880;

--- a/src/apis/emscripten/mod.rs
+++ b/src/apis/emscripten/mod.rs
@@ -19,7 +19,7 @@ mod utils;
 mod varargs;
 
 pub use self::storage::{align_memory, static_alloc};
-pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm};
+pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm_stack};
 
 // TODO: Magic number - how is this calculated?
 const TOTAL_STACK: u32 = 5242880;

--- a/src/apis/emscripten/mod.rs
+++ b/src/apis/emscripten/mod.rs
@@ -19,7 +19,7 @@ mod utils;
 mod varargs;
 
 pub use self::storage::{align_memory, static_alloc};
-pub use self::utils::is_emscripten_module;
+pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm};
 
 // TODO: Magic number - how is this calculated?
 const TOTAL_STACK: u32 = 5242880;

--- a/src/apis/emscripten/mod.rs
+++ b/src/apis/emscripten/mod.rs
@@ -23,10 +23,10 @@ pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm};
 
 // TODO: Magic number - how is this calculated?
 const TOTAL_STACK: u32 = 5242880;
-// TODO: Magic number stolen from the generated JS - how is this calculated?
+// TODO: Magic number - how is this calculated?
 const DYNAMICTOP_PTR_DIFF: u32 = 1088;
-
-const STATIC_BUMP: u32 = 215536; // TODO: make this variable
+// TODO: make this variable
+const STATIC_BUMP: u32 = 215536;
 
 fn stacktop(static_bump: u32) -> u32 {
     align_memory(dynamictop_ptr(static_bump) + 4)
@@ -54,10 +54,18 @@ pub fn emscripten_set_up_memory(memory: &mut LinearMemory) {
     let dynamictop_ptr = dynamictop_ptr(STATIC_BUMP) as usize;
     let dynamictop_ptr_offset = dynamictop_ptr + mem::size_of::<u32>();
 
+    // println!("value = {:?}");
+
     // We avoid failures of setting the u32 in our memory if it's out of bounds
     if dynamictop_ptr_offset > memory.len() {
-        return;
+        return; // TODO: We should panic instead?
     }
+
+    // debug!("###### dynamic_base = {:?}", dynamic_base(STATIC_BUMP));
+    // debug!("###### dynamictop_ptr = {:?}", dynamictop_ptr);
+    // debug!("###### dynamictop_ptr_offset = {:?}", dynamictop_ptr_offset);
+
+
     let mem = &mut memory[dynamictop_ptr..dynamictop_ptr_offset];
     LittleEndian::write_u32(mem, dynamic_base(STATIC_BUMP));
 }
@@ -74,23 +82,7 @@ macro_rules! mock_external {
 
 pub fn generate_emscripten_env<'a, 'b>() -> ImportObject<&'a str, &'b str> {
     let mut import_object = ImportObject::new();
-    // Global
-    import_object.set(
-        "env",
-        "global1",
-        ImportValue::Global(24), // TODO
-    );
-    import_object.set(
-        "env",
-        "global2",
-        ImportValue::Global(50), // TODO
-    );
-    import_object.set(
-        "env",
-        "global3",
-        ImportValue::Global(67), // TODO
-    );
-
+    // Globals
     import_object.set(
         "env",
         "STACKTOP",
@@ -107,7 +99,6 @@ pub fn generate_emscripten_env<'a, 'b>() -> ImportObject<&'a str, &'b str> {
         ImportValue::Global(dynamictop_ptr(STATIC_BUMP) as _),
     );
     import_object.set("env", "tableBase", ImportValue::Global(0));
-
     // Print functions
     import_object.set("env", "printf", ImportValue::Func(io::printf as _));
     import_object.set("env", "putchar", ImportValue::Func(io::putchar as _));

--- a/src/apis/emscripten/mod.rs
+++ b/src/apis/emscripten/mod.rs
@@ -19,7 +19,7 @@ mod utils;
 mod varargs;
 
 pub use self::storage::{align_memory, static_alloc};
-pub use self::utils::{is_emscripten_module, copy_cstr_array_into_wasm, allocate_on_stack, allocate_cstr_on_stack};
+pub use self::utils::{is_emscripten_module, allocate_on_stack, allocate_cstr_on_stack};
 
 // TODO: Magic number - how is this calculated?
 const TOTAL_STACK: u32 = 5242880;

--- a/src/apis/emscripten/syscalls.rs
+++ b/src/apis/emscripten/syscalls.rs
@@ -524,7 +524,7 @@ pub extern "C" fn ___syscall192(
         "=> addr: {}, len: {}, prot: {}, flags: {}, fd: {}, off: {}",
         addr, len, prot, flags, fd, off
     );
-    
+
     let (memalign, memset) = {
         let emscripten_data = &instance.emscripten_data.as_ref().unwrap();
         (emscripten_data.memalign, emscripten_data.memset)
@@ -829,7 +829,7 @@ pub extern "C" fn ___syscall63(
     unsafe { dup2(src, dst) }
 }
 
-// newselect
+// select
 pub extern "C" fn ___syscall142(
     _which: c_int,
     mut varargs: VarArgs,
@@ -848,7 +848,7 @@ pub extern "C" fn ___syscall142(
 
     let readfds_ptr = instance.memory_offset_addr(0, readfds as _) as _;
     let writefds_ptr = instance.memory_offset_addr(0, writefds as _) as _;
-    
+
     unsafe { select(nfds, readfds_ptr, writefds_ptr, 0 as _, 0 as _) }
 }
 

--- a/src/apis/emscripten/utils.rs
+++ b/src/apis/emscripten/utils.rs
@@ -33,32 +33,6 @@ pub unsafe fn copy_cstr_into_wasm(instance: &mut Instance, cstr: *const c_char) 
     space_offset
 }
 
-pub unsafe fn copy_cstr_array_into_wasm(array_count: u32, array: *mut *mut c_char, instance: &mut Instance) -> u32 {
-    let array_offset = (instance.emscripten_data.as_ref().unwrap().malloc)((array_count as usize * size_of::<u32>()) as _, instance);
-
-    space_offset
-}
-
-pub unsafe fn copy_cstr_array_into_wasm_stack(array_count: u32, array: *mut *mut c_char, instance: &mut Instance) -> u32 {
-    let array_offset = (instance.emscripten_data.as_ref().unwrap().stack_alloc)(((array_count as usize + 1) * size_of::<u32>()) as _, instance);
-    let array_addr = instance.memory_offset_addr(0, array_offset as _) as *mut u32;
-    let array_slice = slice::from_raw_parts_mut(array_addr, array_count as usize);
-
-    for (i, ptr) in array_slice.iter_mut().enumerate() {
-        let offset = copy_cstr_into_wasm(instance, *array.add(i));
-        *ptr = offset;
-    }
-
-    // println!("###### x = {:?}", *array_addr.add(array_count as usize));
-
-    *array_addr.add(array_count as usize) = 0;
-
-    // let arg_addr = instance.memory_offset_addr(0, *array_addr.offset(0) as _) as *const i8;
-    // debug!("###### argv[0] = {:?}", CStr::from_ptr(arg_addr));
-
-    array_offset
-}
-
 pub unsafe fn allocate_on_stack<'a, T: Copy>(count: u32, instance: &'a Instance) -> (u32, &'a mut [T]) {
     let offset = (instance.emscripten_data.as_ref().unwrap().stack_alloc)(count * (size_of::<T>() as u32), instance);
     let addr = instance.memory_offset_addr(0, offset as _) as *mut T;

--- a/src/apis/emscripten/utils.rs
+++ b/src/apis/emscripten/utils.rs
@@ -2,7 +2,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use crate::webassembly::module::Module;
 use crate::webassembly::Instance;
 use libc::stat;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::slice;
 
@@ -16,7 +16,7 @@ pub fn is_emscripten_module(module: &Module) -> bool {
     return false;
 }
 
-pub unsafe fn copy_cstr_into_wasm(instance: &mut Instance, cstr: *const c_char) -> u32 {
+pub unsafe fn copy_cstr_into_wasm(instance: &Instance, cstr: *const c_char) -> u32 {
     let s = CStr::from_ptr(cstr).to_str().unwrap();
     let space_offset = (instance.emscripten_data.as_ref().unwrap().malloc)(s.len() as _, instance);
     let raw_memory = instance.memory_offset_addr(0, space_offset as _) as *mut u8;
@@ -26,6 +26,24 @@ pub unsafe fn copy_cstr_into_wasm(instance: &mut Instance, cstr: *const c_char) 
         *loc = byte;
     }
     space_offset
+}
+
+pub unsafe fn copy_cstr_array_into_wasm(array_count: u32, array: *mut *mut c_char, instance: &Instance) -> u32 {
+    let array_offset = (instance.emscripten_data.as_ref().unwrap().malloc)(array_count as _, instance);
+
+    let array_addr = instance.memory_offset_addr(0, array_offset as _) as *mut u32;
+    for i in 0..array_count {
+        let offset = copy_cstr_into_wasm(
+            instance,
+            *array.offset(i as isize)
+        );
+        *array_addr.offset(i as isize) = offset;
+    }
+
+    // let first_arg_addr = instance.memory_offset_addr(0, *array_addr.offset(0) as _) as *const i8;
+    // debug!("###### argv[0] = {:?}", CStr::from_ptr(first_arg_addr));
+
+    array_offset
 }
 
 pub unsafe fn copy_terminated_array_of_cstrs(

--- a/src/apis/emscripten/utils.rs
+++ b/src/apis/emscripten/utils.rs
@@ -27,15 +27,14 @@ pub unsafe fn copy_cstr_into_wasm(instance: &mut Instance, cstr: *const c_char) 
     for (byte, loc) in s.bytes().zip(slice.iter_mut()) {
         *loc = byte;
     }
-    
+
     *raw_memory.add(cstr_len) = 0;
-    
+
     space_offset
 }
 
 pub unsafe fn copy_cstr_array_into_wasm(array_count: u32, array: *mut *mut c_char, instance: &mut Instance) -> u32 {
     let array_offset = (instance.emscripten_data.as_ref().unwrap().stack_alloc)((array_count as usize * size_of::<u32>()) as _, instance);
-
     let array_addr = instance.memory_offset_addr(0, array_offset as _) as *mut u32;
     let array_slice = slice::from_raw_parts_mut(array_addr, array_count as usize);
 
@@ -44,16 +43,12 @@ pub unsafe fn copy_cstr_array_into_wasm(array_count: u32, array: *mut *mut c_cha
         *ptr = offset;
     }
 
-    // for i in 0..array_count {
-    //     let offset = copy_cstr_into_wasm(
-    //         instance,
-    //         *array.offset(i as isize)
-    //     );
-    //     *array_addr.offset(i as isize) = offset;
-    // }
+    // println!("###### x = {:?}", *array_addr.add(array_count as usize));
 
-    // let first_arg_addr = instance.memory_offset_addr(0, *array_addr.offset(0) as _) as *const i8;
-    // debug!("###### argv[0] = {:?}", CStr::from_ptr(first_arg_addr));
+    // *array_addr.add(array_count as usize) = 0;
+
+    // let arg_addr = instance.memory_offset_addr(0, *array_addr.offset(0) as _) as *const i8;
+    // debug!("###### argv[0] = {:?}", CStr::from_ptr(arg_addr));
 
     array_offset
 }

--- a/src/apis/emscripten/utils.rs
+++ b/src/apis/emscripten/utils.rs
@@ -5,6 +5,7 @@ use libc::stat;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::slice;
+use std::mem::size_of;
 
 /// We check if a provided module is an Emscripten generated one
 pub fn is_emscripten_module(module: &Module) -> bool {
@@ -29,7 +30,7 @@ pub unsafe fn copy_cstr_into_wasm(instance: &Instance, cstr: *const c_char) -> u
 }
 
 pub unsafe fn copy_cstr_array_into_wasm(array_count: u32, array: *mut *mut c_char, instance: &Instance) -> u32 {
-    let array_offset = (instance.emscripten_data.as_ref().unwrap().malloc)(array_count as _, instance);
+    let array_offset = (instance.emscripten_data.as_ref().unwrap().malloc)((array_count as usize * size_of::<u32>()) as _, instance);
 
     let array_addr = instance.memory_offset_addr(0, array_offset as _) as *mut u32;
     for i in 0..array_count {

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,4 +1,4 @@
 pub mod emscripten;
 pub mod host;
 
-pub use self::emscripten::{align_memory, generate_emscripten_env, is_emscripten_module, copy_cstr_array_into_wasm_stack};
+pub use self::emscripten::{align_memory, generate_emscripten_env, is_emscripten_module};

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,4 +1,4 @@
 pub mod emscripten;
 pub mod host;
 
-pub use self::emscripten::{align_memory, generate_emscripten_env, is_emscripten_module, copy_cstr_array_into_wasm};
+pub use self::emscripten::{align_memory, generate_emscripten_env, is_emscripten_module, copy_cstr_array_into_wasm_stack};

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,4 +1,4 @@
 pub mod emscripten;
 pub mod host;
 
-pub use self::emscripten::{align_memory, generate_emscripten_env, is_emscripten_module};
+pub use self::emscripten::{align_memory, generate_emscripten_env, is_emscripten_module, copy_cstr_array_into_wasm};

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -88,12 +88,12 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
             _ => panic!("_main emscripten function not found"),
         };
 
-        let main: extern "C" fn(u32, u32, &webassembly::Instance) =
+        let main: extern "C" fn(u32, u32, u32, &webassembly::Instance) =
             get_instance_function!(instance, func_index);
 
         let (argc, argv) = get_module_arguments(options, &mut instance);
 
-        return call_protected!(main(argc, argv, &instance)).map_err(|err| format!("{}", err));
+        return call_protected!(main(argc, argv, 0, &instance)).map_err(|err| format!("{}", err));
         // TODO: We should implement emscripten __ATEXIT__
     } else {
         let func_index =

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -155,9 +155,3 @@ fn main() {
         CLIOptions::SelfUpdate => update::self_update(),
     }
 }
-
-
-
-fn get_args() {
-
-}

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::process::exit;
 
-use apis::emscripten::copy_cstr_array_into_wasm;
+use apis::emscripten::copy_cstr_array_into_wasm_stack;
 use structopt::StructOpt;
 
 use wasmer::*;
@@ -88,12 +88,12 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
             _ => panic!("_main emscripten function not found"),
         };
 
-        let main: extern "C" fn(u32, u32, u32, &webassembly::Instance) =
+        let main: extern "C" fn(u32, u32, &webassembly::Instance) =
             get_instance_function!(instance, func_index);
 
         let (argc, argv) = get_module_arguments(options, &mut instance);
 
-        return call_protected!(main(argc, argv, 0, &instance)).map_err(|err| format!("{}", err));
+        return call_protected!(main(argc, argv, &instance)).map_err(|err| format!("{}", err));
         // TODO: We should implement emscripten __ATEXIT__
     } else {
         let func_index =
@@ -153,7 +153,7 @@ fn get_module_arguments(options: &Run, instance: &mut webassembly::Instance) -> 
 
     // Copy the the arguments into the wasm memory and get offset
     let argv_offset =  unsafe {
-        copy_cstr_array_into_wasm(argc, argv, instance)
+        copy_cstr_array_into_wasm_stack(argc, argv, instance)
     };
 
     debug!("argc = {:?}", argc);

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::process::exit;
 
-use apis::emscripten::copy_cstr_array_into_wasm_stack;
+use apis::emscripten::{allocate_on_stack, allocate_cstr_on_stack};
 use structopt::StructOpt;
 
 use wasmer::*;
@@ -91,7 +91,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
         let main: extern "C" fn(u32, u32, &webassembly::Instance) =
             get_instance_function!(instance, func_index);
 
-        let (argc, argv) = get_module_arguments(options, &mut instance);
+        let (argc, argv) = store_module_arguments(options, &mut instance);
 
         return call_protected!(main(argc, argv, &instance)).map_err(|err| format!("{}", err));
         // TODO: We should implement emscripten __ATEXIT__
@@ -128,36 +128,53 @@ fn main() {
     }
 }
 
-fn get_module_arguments(options: &Run, instance: &mut webassembly::Instance) -> (u32, u32) {
-    // Application Arguments
-    let mut arg_values: Vec<String> = Vec::new();
-    let mut arg_addrs: Vec<*const u8> = Vec::new();
-    let arg_length = options.args.len() + 1;
+fn store_module_arguments(options: &Run, instance: &mut webassembly::Instance) -> (u32, u32) {
+    let argc = options.args.len() + 1;
 
-    arg_values.reserve_exact(arg_length);
-    arg_addrs.reserve_exact(arg_length);
+    let (argv_offset, argv_slice): (_, &mut [u32]) = unsafe { allocate_on_stack(((argc + 1) * 4) as u32, instance) };
+    assert!(argv_slice.len() >= 1);
 
-    // Push name of wasm file
-    arg_values.push(format!("{}\0", options.path.to_str().unwrap()));
-    arg_addrs.push(arg_values[0].as_ptr());
+    argv_slice[0] = unsafe { allocate_cstr_on_stack(options.path.to_str().unwrap(), instance).0 };
 
-    // Push additional arguments
-    for (i, arg) in options.args.iter().enumerate() {
-        arg_values.push(format!("{}\0", arg));
-        arg_addrs.push(arg_values[i + 1].as_ptr());
+    for (slot, arg) in argv_slice[1..argc].iter_mut().zip(options.args.iter()) {
+        *slot = unsafe { allocate_cstr_on_stack(&arg, instance).0 };
     }
 
-    // Get argument count and pointer to addresses
-    let argv = arg_addrs.as_ptr() as *mut *mut i8;
-    let argc = arg_length as u32;
+    argv_slice[argc] = 0;
 
-    // Copy the the arguments into the wasm memory and get offset
-    let argv_offset =  unsafe {
-        copy_cstr_array_into_wasm_stack(argc, argv, instance)
-    };
-
-    debug!("argc = {:?}", argc);
-    debug!("argv = {:?}", arg_addrs);
-
-    (argc, argv_offset)
+    (argc as u32, argv_offset)
 }
+
+// fn get_module_arguments(options: &Run, instance: &mut webassembly::Instance) -> (u32, u32) {
+//     // Application Arguments
+//     let mut arg_values: Vec<String> = Vec::new();
+//     let mut arg_addrs: Vec<*const u8> = Vec::new();
+//     let arg_length = options.args.len() + 1;
+
+//     arg_values.reserve_exact(arg_length);
+//     arg_addrs.reserve_exact(arg_length);
+
+//     // Push name of wasm file
+//     arg_values.push(format!("{}\0", options.path.to_str().unwrap()));
+//     arg_addrs.push(arg_values[0].as_ptr());
+
+//     // Push additional arguments
+//     for (i, arg) in options.args.iter().enumerate() {
+//         arg_values.push(format!("{}\0", arg));
+//         arg_addrs.push(arg_values[i + 1].as_ptr());
+//     }
+
+//     // Get argument count and pointer to addresses
+//     let argv = arg_addrs.as_ptr() as *mut *mut i8;
+//     let argc = arg_length as u32;
+
+//     // Copy the the arguments into the wasm memory and get offset
+//     let argv_offset =  unsafe {
+//         copy_cstr_array_into_wasm(argc, argv, instance)
+//     };
+
+//     debug!("argc = {:?}", argc);
+//     debug!("argv = {:?}", arg_addrs);
+
+//     (argc, argv_offset)
+// }

--- a/src/webassembly/instance.rs
+++ b/src/webassembly/instance.rs
@@ -74,7 +74,7 @@ pub struct EmscriptenData {
     pub free: extern "C" fn(i32, &mut Instance),
     pub memalign: extern "C" fn (u32, u32, &mut Instance) -> u32,
     pub memset: extern "C" fn(u32, i32, u32, &mut Instance) -> u32,
-    pub stack_alloc: extern "C" fn (u32, &mut Instance) -> u32,
+    pub stack_alloc: extern "C" fn (u32, &Instance) -> u32,
 }
 
 impl fmt::Debug for EmscriptenData {

--- a/src/webassembly/instance.rs
+++ b/src/webassembly/instance.rs
@@ -265,7 +265,7 @@ impl Instance {
                     func
                     // unimplemented!()
                 }).collect();
-            
+
             if let Some(ref progress_bar) = progress_bar_option {
                 progress_bar.set_style(ProgressStyle::default_bar()
                     .template(&format!("{} {{msg}}", style("[{elapsed_precise}]").bold().dim())));

--- a/src/webassembly/module.rs
+++ b/src/webassembly/module.rs
@@ -9,7 +9,7 @@ use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::immediates::{Imm64, Offset32};
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{
-    self, AbiParam, ArgumentPurpose, ExtFuncData, ExternalName, FuncRef, InstBuilder, Signature,
+    self, AbiParam, ArgumentPurpose, ExtFuncData, ExternalName, FuncRef, InstBuilder, Signature, TrapCode,
 };
 use cranelift_codegen::isa::{CallConv, TargetFrontendConfig};
 use cranelift_entity::{EntityRef, PrimaryMap};
@@ -531,6 +531,8 @@ impl<'environment> FuncEnvironmentTrait for FuncEnvironment<'environment> {
         mflags.set_notrap();
         mflags.set_aligned();
         let func_ptr = pos.ins().load(ptr, mflags, entry_addr, 0);
+
+        pos.ins().trapz(func_ptr, TrapCode::IndirectCallToNull);
 
         // Build a value list for the indirect call instruction containing the callee, call_args,
         // and the vmctx parameter.


### PR DESCRIPTION
### What does this PR do?
- Adds support for passing extra arguments from `wasmer` to a wasm module.
  ```bash
  $ wasmer run example.wasm -- extra arguments
  ```

### How should this be manually tested?
- Compile a simple C file (that prints `argv` and `argc` to the console) using Emscripten.
  ```bash
  $ emcc simple.c -o simple.js
  ```
- Run wasmer on the generated wasm file
  ```bash
  $ wasmer run simple.wasm -- extra arguments
  ```

### Background context
- N/A

### Issues
- It currently ignores `--` and takes any extra argument after the wasm filepath. The example below still works.
  ```bash
  $ wasmer run example.wasm extra arguments
  ```
- Emscripten seems not allow `argc == 2`, so we cannot pass single arguments for now
  ```bash
  $ wasmer run example.wasm -- extra # Segfaults!
  ```