### PR TITLE
use libc clock constants and add macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
           keys:
             - v4-test-cargo-cache-linux-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run: sudo apt-get install -y cmake
+      - run:
+          name: Run nginx
+          command:  cargo run -- run examples/nginx/nginx.wasm -- -v
       - run: make test
       - run: rustup component add rustfmt
       - run: make lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,39 @@ jobs:
             - target/debug/deps
           key: v4-test-cargo-cache-linux-{{ arch }}-{{ checksum "Cargo.lock" }}
 
+  test-macos:
+    macos:
+      xcode: "9.0"
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-cargo-cache-darwin-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Install CMAKE
+          command: |
+            curl -O https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz
+            tar xf cmake-3.4.1-Darwin-x86_64.tar.gz
+            export PATH="`pwd`/cmake-3.4.1-Darwin-x86_64/CMake.app/Contents/bin:$PATH"
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            export PATH="$HOME/.cargo/bin:$PATH"
+            cargo --version
+            rustup component add rustfmt
+      - run:
+          name: Execute tests
+          command: |
+            export PATH="`pwd`/cmake-3.4.1-Darwin-x86_64/CMake.app/Contents/bin:$PATH"
+            export PATH="$HOME/.cargo/bin:$PATH"
+            # We increase the ulimit for fixing cargo unclosed files in mac
+            ulimit -n 8000
+            sudo sysctl -w kern.maxfiles=655360 kern.maxfilesperproc=327680
+            make test
+            make lint
+
   test-and-build:
     docker:
       - image: circleci/rust:latest
@@ -172,6 +205,10 @@ workflows:
   main:
     jobs:
       - test:
+          filters:
+            branches:
+              ignore: master
+      - test-macos:
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ jobs:
           keys:
             - v4-test-cargo-cache-linux-{{ arch }}-{{ checksum "Cargo.lock" }}
       - run: sudo apt-get install -y cmake
-      - run:
-          name: Run nginx
-          command:  cargo run -- run examples/nginx/nginx.wasm -- -v
       - run: make test
       - run: rustup component add rustfmt
       - run: make lint

--- a/src/apis/emscripten/time.rs
+++ b/src/apis/emscripten/time.rs
@@ -7,16 +7,21 @@ use time;
 
 use crate::webassembly::Instance;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 use libc::{CLOCK_MONOTONIC, CLOCK_MONOTONIC_COARSE, CLOCK_REALTIME};
+
+#[cfg(target_os = "macos")]
+use libc::{CLOCK_MONOTONIC, CLOCK_REALTIME};
+#[cfg(target_os = "macos")]
+const CLOCK_MONOTONIC_COARSE: libc::clockid_t = 6;
 
 // some assumptions about the constants when targeting windows
 #[cfg(target_os = "windows")]
-const CLOCK_REALTIME: libc::c_int = 0;
+const CLOCK_REALTIME: libc::clockid_t = 0;
 #[cfg(target_os = "windows")]
-const CLOCK_MONOTONIC: libc::c_int = 1;
+const CLOCK_MONOTONIC: libc::clockid_t = 1;
 #[cfg(target_os = "windows")]
-const CLOCK_MONOTONIC_COARSE: libc::c_int = 6;
+const CLOCK_MONOTONIC_COARSE: libc::clockid_t = 6;
 
 /// emscripten: _gettimeofday
 pub extern "C" fn _gettimeofday(tp: c_int, tz: c_int, instance: &mut Instance) -> c_int {
@@ -43,7 +48,11 @@ pub extern "C" fn _gettimeofday(tp: c_int, tz: c_int, instance: &mut Instance) -
 }
 
 /// emscripten: _clock_gettime
-pub extern "C" fn _clock_gettime(clk_id: c_int, tp: c_int, instance: &mut Instance) -> c_int {
+pub extern "C" fn _clock_gettime(
+    clk_id: libc::clockid_t,
+    tp: c_int,
+    instance: &mut Instance,
+) -> c_int {
     debug!("emscripten::_clock_gettime {} {}", clk_id, tp);
     #[repr(C)]
     struct GuestTimeSpec {
@@ -72,7 +81,11 @@ pub extern "C" fn _clock_gettime(clk_id: c_int, tp: c_int, instance: &mut Instan
 }
 
 /// emscripten: ___clock_gettime
-pub extern "C" fn ___clock_gettime(clk_id: c_int, tp: c_int, instance: &mut Instance) -> c_int {
+pub extern "C" fn ___clock_gettime(
+    clk_id: libc::clockid_t,
+    tp: c_int,
+    instance: &mut Instance,
+) -> c_int {
     debug!("emscripten::___clock_gettime {} {}", clk_id, tp);
     _clock_gettime(clk_id, tp, instance)
 }


### PR DESCRIPTION
This PR fixes a bug introduced that would cause nginx to fail at runtime. 

Support for the monotonic clock id is added because the compiled nginx binary that is checked in requires it. Nginx uses a [compile-time flag](https://github.com/nginx/nginx/blob/4bf4650f2f10f7bbacfe7a33da744f18951d416d/src/core/ngx_times.c#L196). Windows does not always have these clock id constants, so they are polyfilled. 

The constants in `libc` are used because the platforms do not all use the same conventions. We can't assume the constants values.

A super simple integration test is added that runs nginx. This has room for improvement.