### PR TITLE
Fix _localtime_r

### DIFF
--- a/src/apis/emscripten/time.rs
+++ b/src/apis/emscripten/time.rs
@@ -226,8 +226,8 @@ pub extern "C" fn _localtime_r(time_p: u32, result: u32, instance: &mut Instance
     //      https://stackoverflow.com/questions/19170721/real-time-awareness-of-timezone-change-in-localtime-vs-localtime-r
 
     unsafe {
-        let seconds = instance.memory_offset_addr(0, time_p as _) as *const i64;
-        let timespec = time::Timespec::new(*seconds, 0);
+        let seconds = instance.memory_offset_addr(0, time_p as _) as *const i32;
+        let timespec = time::Timespec::new(*seconds as _, 0);
         let result_tm = time::at(timespec);
 
         // debug!(


### PR DESCRIPTION
@xmclark 
This fixes an issue I was seeing an issue when running and nginx and doing an http request on macOS:
```
Timespec:Timespec { sec: 3274225150936145191, nsec: 0 }
```
```
thread 'main' panicked at 'localtime_r failed: No such file or directory (os error 2)', /Users/bfish/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.1.41/src/sys.rs:434:17
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:227
   4: <std::panicking::begin_panic::PanicPayload<A> as core::panic::BoxMeUp>::get
             at libstd/panicking.rs:476
   5: std::panicking::continue_panic_fmt
             at libstd/panicking.rs:390
   6: std::panicking::try::do_call
             at libstd/panicking.rs:345
   7: time::sys::inner::time_to_local_tm
             at /Users/bfish/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.1.41/src/sys.rs:434
   8: wasmer::recovery::do_unwind::{{closure}}
             at /Users/bfish/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.1.41/src/lib.rs:419
   9: wasmer::apis::emscripten::time::_localtime_r
             at src/apis/emscripten/time.rs:231
fatal runtime error: failed to initiate panic, error 5
```