### PR TITLE
Add func method to Instance

### DIFF
--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -101,7 +101,7 @@ impl PartialEq for RuntimeError {
 #[derive(Debug, Clone)]
 pub enum ResolveError {
     Signature { expected: FuncSig, found: Vec<Type> },
-    NoSuchExport { name: String },
+    ExportNotFound { name: String },
     ExportWrongType { name: String },
 }
 

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -5,6 +5,7 @@ pub type CompileResult<T> = std::result::Result<T, Box<CompileError>>;
 pub type LinkResult<T> = std::result::Result<T, Vec<LinkError>>;
 pub type RuntimeResult<T> = std::result::Result<T, Box<RuntimeError>>;
 pub type CallResult<T> = std::result::Result<T, Box<CallError>>;
+pub type ResolveResult<T> = std::result::Result<T, Box<ResolveError>>;
 
 /// This is returned when the chosen compiler is unable to
 /// successfully compile the provided webassembly module into
@@ -93,6 +94,23 @@ impl PartialEq for RuntimeError {
     }
 }
 
+/// This error type is produced by resolving a wasm function
+/// given its name.
+///
+/// Comparing two `ResolveError`s always evaluates to false.
+#[derive(Debug, Clone)]
+pub enum ResolveError {
+    Signature { expected: FuncSig, found: Vec<Type> },
+    NoSuchExport { name: String },
+    ExportWrongType { name: String },
+}
+
+impl PartialEq for ResolveError {
+    fn eq(&self, _other: &ResolveError) -> bool {
+        false
+    }
+}
+
 /// This error type is produced by calling a wasm function
 /// exported from a module.
 ///
@@ -102,9 +120,7 @@ impl PartialEq for RuntimeError {
 /// Comparing two `CallError`s always evaluates to false.
 #[derive(Debug, Clone)]
 pub enum CallError {
-    Signature { expected: FuncSig, found: Vec<Type> },
-    NoSuchExport { name: String },
-    ExportNotFunc { name: String },
+    Resolve(ResolveError),
     Runtime(RuntimeError),
 }
 
@@ -160,5 +176,35 @@ impl From<Box<CallError>> for Box<Error> {
 impl From<Box<RuntimeError>> for Box<CallError> {
     fn from(runtime_err: Box<RuntimeError>) -> Self {
         Box::new(CallError::Runtime(*runtime_err))
+    }
+}
+
+impl From<CompileError> for Box<Error> {
+    fn from(compile_err: CompileError) -> Self {
+        Box::new(Error::CompileError(compile_err))
+    }
+}
+
+impl From<RuntimeError> for Box<Error> {
+    fn from(runtime_err: RuntimeError) -> Self {
+        Box::new(Error::RuntimeError(runtime_err))
+    }
+}
+
+impl From<CallError> for Box<Error> {
+    fn from(call_err: CallError) -> Self {
+        Box::new(Error::CallError(call_err))
+    }
+}
+
+impl From<RuntimeError> for Box<CallError> {
+    fn from(runtime_err: RuntimeError) -> Self {
+        Box::new(CallError::Runtime(runtime_err))
+    }
+}
+
+impl From<ResolveError> for Box<CallError> {
+    fn from(resolve_err: ResolveError) -> Self {
+        Box::new(CallError::Resolve(resolve_err))
     }
 }

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -179,6 +179,12 @@ impl From<Box<RuntimeError>> for Box<CallError> {
     }
 }
 
+impl From<Box<ResolveError>> for Box<CallError> {
+    fn from(resolve_err: Box<ResolveError>) -> Self {
+        Box::new(CallError::Resolve(*resolve_err))
+    }
+}
+
 impl From<CompileError> for Box<Error> {
     fn from(compile_err: CompileError) -> Self {
         Box::new(Error::CompileError(compile_err))

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -159,10 +159,29 @@ impl Instance {
         self.call_with_index(func_index, args)
     }
 
+    /// Returns a immutable reference to the
+    /// [`Ctx`] used by this Instance.
+    ///
+    /// [`Ctx`]: struct.Ctx.html
+    pub fn context(&self) -> &vm::Ctx {
+        &self.inner.vmctx
+    }
+
+    /// Returns a mutable reference to the
+    /// [`Ctx`] used by this Instance.
+    ///
+    /// [`Ctx`]: struct.Ctx.html
+    pub fn context_mut(&mut self) -> &mut vm::Ctx {
+        &mut self.inner.vmctx
+    }
+
+    /// Returns a iterator over all of the items
+    /// exported from this instance.
     pub fn exports(&mut self) -> ExportIter {
         ExportIter::new(&self.module, &mut self.inner)
     }
 
+    /// The module used to instantiate this Instance.
     pub fn module(&self) -> Module {
         Module::new(Rc::clone(&self.module))
     }

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -90,7 +90,7 @@ impl Instance {
             self.module
                 .exports
                 .get(name)
-                .ok_or_else(|| ResolveError::NoSuchExport {
+                .ok_or_else(|| ResolveError::ExportNotFound {
                     name: name.to_string(),
                 })?;
 
@@ -143,7 +143,7 @@ impl Instance {
             self.module
                 .exports
                 .get(name)
-                .ok_or_else(|| ResolveError::NoSuchExport {
+                .ok_or_else(|| ResolveError::ExportNotFound {
                     name: name.to_string(),
                 })?;
 

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::Token,
     backing::{ImportBacking, LocalBacking},
-    error::{CallError, CallResult, Result},
+    error::{CallError, CallResult, ResolveError, ResolveResult, Result},
     export::{
         Context, Export, ExportIter, FuncPointer, GlobalPointer, MemoryPointer, TablePointer,
     },
@@ -13,8 +13,7 @@ use crate::{
     },
     vm,
 };
-use std::mem;
-use std::rc::Rc;
+use std::{mem, rc::Rc};
 
 pub(crate) struct InstanceInner {
     #[allow(dead_code)]
@@ -72,6 +71,50 @@ impl Instance {
         Ok(instance)
     }
 
+    /// This returns the representation of a function that can be called
+    /// safely.
+    ///
+    /// # Usage:
+    /// ```
+    /// # use wasmer_runtime_core::Instance;
+    /// # fn call_foo(instance: &mut Instance) -> Option<()> {
+    /// instance
+    ///     .func("foo")?
+    ///     .call(&[])?;
+    /// # Some(())
+    /// # }
+    /// ```
+    pub fn func(&mut self, name: &str) -> ResolveResult<Function> {
+        let export_index =
+            self.module
+                .exports
+                .get(name)
+                .ok_or_else(|| ResolveError::NoSuchExport {
+                    name: name.to_string(),
+                })?;
+
+        if let ExportIndex::Func(func_index) = export_index {
+            let sig_index = *self
+                .module
+                .func_assoc
+                .get(*func_index)
+                .expect("broken invariant, incorrect func index");
+            let signature = self.module.sig_registry.lookup_func_sig(sig_index);
+
+            Ok(Function {
+                signature,
+                module: &self.module,
+                instance_inner: &mut self.inner,
+                func_index: *func_index,
+            })
+        } else {
+            Err(ResolveError::ExportWrongType {
+                name: name.to_string(),
+            }
+            .into())
+        }
+    }
+
     /// Call an exported webassembly function given the export name.
     /// Pass arguments by wrapping each one in the [`Value`] enum.
     /// The returned values are also each wrapped in a [`Value`].
@@ -99,16 +142,16 @@ impl Instance {
             self.module
                 .exports
                 .get(name)
-                .ok_or_else(|| CallError::NoSuchExport {
+                .ok_or_else(|| ResolveError::NoSuchExport {
                     name: name.to_string(),
                 })?;
 
         let func_index = if let ExportIndex::Func(func_index) = export_index {
             *func_index
         } else {
-            return Err(CallError::ExportNotFunc {
+            return Err(CallError::Resolve(ResolveError::ExportWrongType {
                 name: name.to_string(),
-            }
+            })
             .into());
         };
 
@@ -134,7 +177,7 @@ impl Instance {
         let signature = self.module.sig_registry.lookup_func_sig(sig_index);
 
         if !signature.check_sig(args) {
-            Err(CallError::Signature {
+            Err(ResolveError::Signature {
                 expected: signature.clone(),
                 found: args.iter().map(|val| val.ty()).collect(),
             })?
@@ -348,6 +391,84 @@ impl LikeNamespace for Instance {
         let export_index = self.module.exports.get(name)?;
 
         Some(self.inner.get_export_from_index(&self.module, export_index))
+    }
+}
+
+/// A representation of an exported WebAssembly function.
+pub struct Function<'a> {
+    signature: &'a FuncSig,
+    module: &'a ModuleInner,
+    instance_inner: &'a mut InstanceInner,
+    func_index: FuncIndex,
+}
+
+impl<'a> Function<'a> {
+    /// Call an exported webassembly function safely.
+    ///
+    /// Pass arguments by wrapping each one in the [`Value`] enum.
+    /// The returned values are also each wrapped in a [`Value`].
+    ///
+    /// [`Value`]: enum.Value.html
+    ///
+    /// # Note:
+    /// This returns `CallResult<Vec<Value>>` in order to support
+    /// the future multi-value returns webassembly feature.
+    ///
+    /// # Usage:
+    /// ```
+    /// # use wasmer_runtime_core::Instance;
+    /// # fn call_foo(instance: &mut Instance) -> Option<()> {
+    /// instance
+    ///     .func("foo")?
+    ///     .call(&[])?;
+    /// # Some(())
+    /// # }
+    /// ```
+    pub fn call(&mut self, params: &[Value]) -> CallResult<Vec<Value>> {
+        if !self.signature.check_sig(params) {
+            Err(ResolveError::Signature {
+                expected: self.signature.clone(),
+                found: params.iter().map(|val| val.ty()).collect(),
+            })?
+        }
+
+        let vmctx = match self.func_index.local_or_import(self.module) {
+            LocalOrImport::Local(_) => &mut *self.instance_inner.vmctx,
+            LocalOrImport::Import(imported_func_index) => {
+                self.instance_inner.import_backing.functions[imported_func_index].vmctx
+            }
+        };
+
+        let token = Token::generate();
+
+        let returns = self.module.protected_caller.call(
+            &self.module,
+            self.func_index,
+            params,
+            &self.instance_inner.import_backing,
+            vmctx,
+            token,
+        )?;
+
+        Ok(returns)
+    }
+
+    pub fn signature(&self) -> &FuncSig {
+        self.signature
+    }
+
+    pub fn raw(&self) -> *const vm::Func {
+        match self.func_index.local_or_import(self.module) {
+            LocalOrImport::Local(local_func_index) => self
+                .module
+                .func_resolver
+                .get(self.module, local_func_index)
+                .unwrap()
+                .as_ptr(),
+            LocalOrImport::Import(import_func_index) => {
+                self.instance_inner.import_backing.functions[import_func_index].func
+            }
+        }
     }
 }
 

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -77,11 +77,12 @@ impl Instance {
     /// # Usage:
     /// ```
     /// # use wasmer_runtime_core::Instance;
-    /// # fn call_foo(instance: &mut Instance) -> Option<()> {
+    /// # use wasmer_runtime_core::error::CallResult;
+    /// # fn call_foo(instance: &mut Instance) -> CallResult<()> {
     /// instance
     ///     .func("foo")?
     ///     .call(&[])?;
-    /// # Some(())
+    /// # Ok(())
     /// # }
     /// ```
     pub fn func(&mut self, name: &str) -> ResolveResult<Function> {
@@ -417,11 +418,12 @@ impl<'a> Function<'a> {
     /// # Usage:
     /// ```
     /// # use wasmer_runtime_core::Instance;
-    /// # fn call_foo(instance: &mut Instance) -> Option<()> {
+    /// # use wasmer_runtime_core::error::CallResult;
+    /// # fn call_foo(instance: &mut Instance) -> CallResult<()> {
     /// instance
     ///     .func("foo")?
     ///     .call(&[])?;
-    /// # Some(())
+    /// # Ok(())
     /// # }
     /// ```
     pub fn call(&mut self, params: &[Value]) -> CallResult<Vec<Value>> {

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -95,6 +95,44 @@ impl Ctx {
     }
 
     /// This exposes the specified memory of the WebAssembly instance
+    /// as a immutable slice.
+    ///
+    /// WebAssembly will soon support multiple linear memories, so this
+    /// forces the user to specify.
+    ///
+    /// # Usage:
+    ///
+    /// ```
+    /// # use wasmer_runtime_core::{
+    /// #     vm::Ctx,
+    /// # };
+    /// fn read_memory(ctx: &Ctx) -> u8 {
+    ///     let first_memory = ctx.memory(0);
+    ///     // Read the first byte of that linear memory.
+    ///     first_memory[0]
+    /// }
+    /// ```
+    pub fn memory<'a>(&'a self, mem_index: u32) -> &'a [u8] {
+        let module = unsafe { &*self.module };
+        let mem_index = MemoryIndex::new(mem_index as usize);
+        match mem_index.local_or_import(module) {
+            LocalOrImport::Local(local_mem_index) => {
+                let local_backing = unsafe { &*self.local_backing };
+                &local_backing.memories[local_mem_index][..]
+            }
+            LocalOrImport::Import(import_mem_index) => {
+                let import_backing = unsafe { &mut *self.import_backing };
+                let vm_memory_import = import_backing.memories[import_mem_index].clone();
+                unsafe {
+                    let memory = &*vm_memory_import.memory;
+
+                    slice::from_raw_parts(memory.base, memory.size)
+                }
+            }
+        }
+    }
+
+    /// This exposes the specified memory of the WebAssembly instance
     /// as a mutable slice.
     ///
     /// WebAssembly will soon support multiple linear memories, so this
@@ -108,12 +146,12 @@ impl Ctx {
     /// #     error::Result,
     /// # };
     /// extern fn host_func(ctx: &mut Ctx) {
-    ///     let first_memory = ctx.memory(0);
+    ///     let first_memory = ctx.memory_mut(0);
     ///     // Set the first byte of that linear memory.
     ///     first_memory[0] = 42;
     /// }
     /// ```
-    pub fn memory<'a>(&'a mut self, mem_index: u32) -> &'a mut [u8] {
+    pub fn memory_mut<'a>(&'a mut self, mem_index: u32) -> &'a mut [u8] {
         let module = unsafe { &*self.module };
         let mem_index = MemoryIndex::new(mem_index as usize);
         match mem_index.local_or_import(module) {

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -170,10 +170,11 @@ impl Ctx {
     }
 }
 
+enum InnerFunc {}
 /// Used to provide type safety (ish) for passing around function pointers.
 /// The typesystem ensures this cannot be dereferenced since an
 /// empty enum cannot actually exist.
-pub enum Func {}
+pub struct Func(InnerFunc);
 
 /// An imported function, which contains the vmctx that owns this function.
 #[derive(Debug, Clone)]

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -1,5 +1,5 @@
 pub use wasmer_runtime_core::import::ImportObject;
-pub use wasmer_runtime_core::instance::Instance;
+pub use wasmer_runtime_core::instance::{Function, Instance};
 pub use wasmer_runtime_core::module::Module;
 pub use wasmer_runtime_core::types::Value;
 pub use wasmer_runtime_core::vm::Ctx;
@@ -9,8 +9,9 @@ pub use wasmer_runtime_core::{compile_with, validate};
 pub use wasmer_runtime_core::error;
 pub use wasmer_runtime_core::imports;
 
-pub mod value {
-    pub use wasmer_runtime_core::types::{Type, Value};
+pub mod wasm {
+    pub use wasmer_runtime_core::instance::Function;
+    pub use wasmer_runtime_core::types::{FuncSig, Type, Value};
 }
 
 /// Compile WebAssembly binary code into a [`Module`].


### PR DESCRIPTION
This adds a `Function` type that is returned by the `func("...")` method on `Instance`. The `Function` type has methods to call, get the signature, and get the raw function pointer.