### PR TITLE
Update memory mod.rs to include missing mod statement on Windows

### DIFF
--- a/lib/runtime-core/src/sys/windows/mod.rs
+++ b/lib/runtime-core/src/sys/windows/mod.rs
@@ -1,1 +1,3 @@
+mod memory;
+
 pub use self::memory::{Memory, Protect};


### PR DESCRIPTION
Closes https://github.com/wasmerio/wasmer-rust-example/issues/3

Fixes the missing mod statement that exists in the Unix variant of this file. Currently it's blocking any building on Windows.
