### PR TITLE
memory fixes for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -14,6 +14,8 @@ page_size = "0.4.1"
 wasmparser = "0.23.0"
 parking_lot = "0.7.1"
 lazy_static = "1.2.0"
+libc = "0.2.48"
+errno = "0.2.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["memoryapi"] }

--- a/lib/runtime-core/src/sys/windows/memory.rs
+++ b/lib/runtime-core/src/sys/windows/memory.rs
@@ -30,7 +30,7 @@ impl Memory {
         let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE, PAGE_NOACCESS) };
 
         if ptr.is_null() {
-            Err(String::from("unable to allocate memory"))
+            Err("unable to allocate memory".to_string())
         } else {
             Ok(Self {
                 ptr: ptr as *mut u8,
@@ -69,7 +69,7 @@ impl Memory {
         let ptr = VirtualAlloc(start as _, size, MEM_COMMIT, protect);
 
         if ptr.is_null() {
-            Err(String::from("unable to protect memory"))
+            Err("unable to protect memory".to_string())
         } else {
             Ok(())
         }

--- a/lib/runtime-core/src/sys/windows/mod.rs
+++ b/lib/runtime-core/src/sys/windows/mod.rs
@@ -1,1 +1,3 @@
+mod memory;
+
 pub use self::memory::{Memory, Protect};


### PR DESCRIPTION
This PR fixes a few small issues with building memory code for windows. We use the winapi `VirtualFree` instead of `munmap`. A few crates were added that had been missing from the wasmer runtime crate. 