### PR TITLE
Make memalign optional if the wasm doesn't export it

### DIFF
--- a/lib/emscripten/src/env.rs
+++ b/lib/emscripten/src/env.rs
@@ -143,10 +143,11 @@ pub fn call_malloc(size: u32, ctx: &mut Ctx) -> u32 {
 }
 
 pub fn call_memalign(alignment: u32, size: u32, ctx: &mut Ctx) -> u32 {
-    get_emscripten_data(ctx)
-        .memalign
-        .call(alignment, size)
-        .unwrap()
+    if let Some(memalign) = &get_emscripten_data(ctx).memalign {
+        memalign.call(alignment, size).unwrap()
+    } else {
+        panic!("Memalign is set to None");
+    }
 }
 
 pub fn call_memset(pointer: u32, value: u32, size: u32, ctx: &mut Ctx) -> u32 {

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -507,6 +507,7 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
 
             // Linking
             "_dlclose" => func!(crate::linking::_dlclose),
+            "_dlerror" => func!(crate::linking::_dlerror),
             "_dlopen" => func!(crate::linking::_dlopen),
             "_dlsym" => func!(crate::linking::_dlsym),
 
@@ -517,6 +518,9 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
         },
         "global.Math" => {
             "pow" => func!(crate::math::pow),
+        },
+        "asm2wasm" => {
+            "f64-rem" => func!(crate::math::f64_rem),
         },
     };
     // mock_external!(env_namespace, _sched_yield);

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -140,6 +140,10 @@ pub fn run_emscripten_instance(
     let data_ptr = &mut data as *mut _ as *mut c_void;
     instance.context_mut().data = data_ptr;
 
+    if let Ok(_func) = instance.dyn_func("___emscripten_environ_constructor") {
+        instance.call("___emscripten_environ_constructor", &[])?;
+    }
+
     let main_func = instance.dyn_func("_main")?;
     let num_params = main_func.signature().params().len();
     let _result = match num_params {

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -91,7 +91,7 @@ fn dynamictop_ptr(static_bump: u32) -> u32 {
 pub struct EmscriptenData<'a> {
     pub malloc: Func<'a, u32, u32>,
     pub free: Func<'a, u32>,
-    pub memalign: Func<'a, (u32, u32), u32>,
+    pub memalign: Option<Func<'a, (u32, u32), u32>>,
     pub memset: Func<'a, (u32, u32, u32), u32>,
     pub stack_alloc: Func<'a, u32, u32>,
 
@@ -102,7 +102,11 @@ impl<'a> EmscriptenData<'a> {
     pub fn new(instance: &'a mut Instance) -> EmscriptenData<'a> {
         let malloc = instance.func("_malloc").unwrap();
         let free = instance.func("_free").unwrap();
-        let memalign = instance.func("_memalign").unwrap();
+        let memalign = if let Ok(func) = instance.func("_memalign") {
+            Some(func)
+        } else {
+            None
+        };
         let memset = instance.func("_memset").unwrap();
         let stack_alloc = instance.func("stackAlloc").unwrap();
 
@@ -511,7 +515,7 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
           "NaN" => Global::new(Value::F64(f64::NAN)),
           "Infinity" => Global::new(Value::F64(f64::INFINITY)),
         },
-        "math" => {
+        "global.Math" => {
             "pow" => func!(crate::math::pow),
         },
     };

--- a/lib/emscripten/src/process.rs
+++ b/lib/emscripten/src/process.rs
@@ -93,7 +93,7 @@ pub fn _sem_wait(_one: i32, _ctx: &mut Ctx) -> i32 {
 
 #[allow(clippy::cast_ptr_alignment)]
 pub fn _getgrent(ctx: &mut Ctx) -> c_int {
-    debug!("emscripten::_getgrent {}", name_ptr);
+    debug!("emscripten::_getgrent");
     -1
 }
 


### PR DESCRIPTION
Fixes all but 1 emtest: `test_env`.