### PR TITLE
allow appveyor failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ os: Visual Studio 2017
 
 matrix:
   allow_failures:
-    - CHANNEL: nightly
+    - CHANNEL: stable
 #   - ABI: gnu
 
 environment:


### PR DESCRIPTION
Appveyor should always show a green check ✔️ when building until windows target is supported. 