### PR TITLE
fill unsetenv for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +238,11 @@ dependencies = [
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -810,6 +834,7 @@ dependencies = [
 name = "wasmer-runtime-core"
 version = "0.1.2"
 dependencies = [
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -900,12 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cranelift-native 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "474bee81d620a473bf43411a3d6f10ffbf7965141dc5e5b76d8d2151dde3285d"
 "checksum cranelift-wasm 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49723365dab9a48b354bdc24cb6d9d5719bc1d3b858ffd2ea179d0d7d885804a"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
+"checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum field-offset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64e9bc339e426139e02601fa69d101e96a92aee71b58bc01697ec2a63a5c9e68"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"

--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -3,7 +3,7 @@ use libc::{
     c_int,
     c_long,
     getenv,
-    //sysconf, unsetenv,
+    //sysconf,
 };
 
 use core::slice;
@@ -82,7 +82,14 @@ pub fn _unsetenv(name: c_int, ctx: &mut Ctx) -> c_int {
 
     debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
 
-    unsafe { unsetenv(name_addr) }
+    unsafe {
+        let name = read_string_from_wasm(name, ctx.memory(0));
+        // no unsetenv on windows, so use putenv with an empty value
+        let unsetenv_string = format!("{}=", name);
+        let unsetenv_cstring = CString::from::<String>(unsetenv_string);
+        let unsetenv_raw_ptr = unsetenv_cstring.as_ptr();
+        putenv(unsetenv_raw_ptr)
+    }
 }
 
 #[allow(clippy::cast_ptr_alignment)]

--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -6,7 +6,6 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::c_char;
 
-use crate::utils::read_cstring_from_wasm;
 use crate::utils::{
     allocate_on_stack, copy_cstr_into_wasm, copy_terminated_array_of_cstrs, read_string_from_wasm,
 };
@@ -50,8 +49,8 @@ pub fn _setenv(name: u32, value: u32, overwrite: u32, ctx: &mut Ctx) -> c_int {
     let name_addr = emscripten_memory_pointer!(ctx.memory(0), name);
     let value_addr = emscripten_memory_pointer!(ctx.memory(0), value);
     // setenv does not exist on windows, so we hack it with _putenv
-    let name = read_cstring_from_wasm(ctx.memory(0), name);
-    let value = read_cstring_from_wasm(ctx.memory(0), value);
+    let name = read_string_from_wasm(ctx.memory(0), name);
+    let value = read_string_from_wasm(ctx.memory(0), value);
     let putenv_string = format!("{}={}", name, value);
     let putenv_cstring = CString::new(putenv_string).unwrap();
     let putenv_raw_ptr = putenv_cstring.as_ptr();
@@ -74,10 +73,10 @@ pub fn _putenv(name: c_int, ctx: &mut Ctx) -> c_int {
 pub fn _unsetenv(name: u32, ctx: &mut Ctx) -> c_int {
     debug!("emscripten::_unsetenv");
     let name_addr = emscripten_memory_pointer!(ctx.memory(0), name);
-    let name = read_cstring_from_wasm(ctx.memory(0), name);
+    let name = read_string_from_wasm(ctx.memory(0), name);
     // no unsetenv on windows, so use putenv with an empty value
     let unsetenv_string = format!("{}=", name);
-    let unsetenv_cstring = CString::from::<String>(unsetenv_string);
+    let unsetenv_cstring = CString::new(unsetenv_string).unwrap();
     let unsetenv_raw_ptr = unsetenv_cstring.as_ptr();
     debug!("=> name({:?})", name);
     unsafe { putenv(unsetenv_raw_ptr) }

--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -6,6 +6,7 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::c_char;
 
+use crate::utils::read_cstring_from_wasm;
 use crate::utils::{
     allocate_on_stack, copy_cstr_into_wasm, copy_terminated_array_of_cstrs, read_string_from_wasm,
 };
@@ -49,8 +50,8 @@ pub fn _setenv(name: u32, value: u32, overwrite: u32, ctx: &mut Ctx) -> c_int {
     let name_addr = emscripten_memory_pointer!(ctx.memory(0), name);
     let value_addr = emscripten_memory_pointer!(ctx.memory(0), value);
     // setenv does not exist on windows, so we hack it with _putenv
-    let name = read_string_from_wasm(ctx.memory(0), name);
-    let value = read_string_from_wasm(ctx.memory(0), value);
+    let name = read_cstring_from_wasm(ctx.memory(0), name);
+    let value = read_cstring_from_wasm(ctx.memory(0), value);
     let putenv_string = format!("{}={}", name, value);
     let putenv_cstring = CString::new(putenv_string).unwrap();
     let putenv_raw_ptr = putenv_cstring.as_ptr();
@@ -73,7 +74,7 @@ pub fn _putenv(name: c_int, ctx: &mut Ctx) -> c_int {
 pub fn _unsetenv(name: u32, ctx: &mut Ctx) -> c_int {
     debug!("emscripten::_unsetenv");
     let name_addr = emscripten_memory_pointer!(ctx.memory(0), name);
-    let name = read_string_from_wasm(ctx.memory(0), name);
+    let name = read_cstring_from_wasm(ctx.memory(0), name);
     // no unsetenv on windows, so use putenv with an empty value
     let unsetenv_string = format!("{}=", name);
     let unsetenv_cstring = CString::from::<String>(unsetenv_string);

--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -75,21 +75,16 @@ pub fn _putenv(name: c_int, ctx: &mut Ctx) -> c_int {
 }
 
 /// emscripten: _unsetenv // (name: *const char);
-pub fn _unsetenv(name: c_int, ctx: &mut Ctx) -> c_int {
+pub fn _unsetenv(name: u32, ctx: &mut Ctx) -> c_int {
     debug!("emscripten::_unsetenv");
-
     let name_addr = emscripten_memory_pointer!(ctx.memory(0), name);
-
-    debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
-
-    unsafe {
-        let name = read_string_from_wasm(name, ctx.memory(0));
-        // no unsetenv on windows, so use putenv with an empty value
-        let unsetenv_string = format!("{}=", name);
-        let unsetenv_cstring = CString::from::<String>(unsetenv_string);
-        let unsetenv_raw_ptr = unsetenv_cstring.as_ptr();
-        putenv(unsetenv_raw_ptr)
-    }
+    let name = read_string_from_wasm(ctx.memory(0), name);
+    // no unsetenv on windows, so use putenv with an empty value
+    let unsetenv_string = format!("{}=", name);
+    let unsetenv_cstring = CString::from::<String>(unsetenv_string);
+    let unsetenv_raw_ptr = unsetenv_cstring.as_ptr();
+    debug!("=> name({:?})", name);
+    unsafe { putenv(unsetenv_raw_ptr) }
 }
 
 #[allow(clippy::cast_ptr_alignment)]

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -14,6 +14,7 @@ use wasmer_runtime_core::{
     units::Pages,
     vm::Ctx,
 };
+use std::ffi::CString;
 
 /// We check if a provided module is an Emscripten generated one
 pub fn is_emscripten_module(module: &Module) -> bool {
@@ -157,12 +158,13 @@ pub unsafe fn copy_stat_into_wasm(ctx: &mut Ctx, buf: u32, stat: &stat) {
     (*stat_ptr).st_ino = stat.st_ino as _;
 }
 
-pub fn read_string_from_wasm(memory: &Memory, offset: u32) -> String {
-    memory.view::<u8>()[(offset as usize)..]
+pub fn read_cstring_from_wasm(memory: &Memory, offset: u32) -> CString {
+    let v: Vec<u8> = memory.view()[(offset as usize)..]
         .iter()
         .take_while(|cell| cell.get() != 0)
-        .map(|cell| cell.get() as char)
-        .collect()
+        .map(|cell| cell.get())
+        .collect();
+    CString::new(v).unwrap()
 }
 
 #[cfg(test)]

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -158,13 +158,13 @@ pub unsafe fn copy_stat_into_wasm(ctx: &mut Ctx, buf: u32, stat: &stat) {
     (*stat_ptr).st_ino = stat.st_ino as _;
 }
 
-pub fn read_cstring_from_wasm(memory: &Memory, offset: u32) -> CString {
+pub fn read_string_from_wasm(memory: &Memory, offset: u32) -> String {
     let v: Vec<u8> = memory.view()[(offset as usize)..]
         .iter()
-        .take_while(|cell| cell.get() != 0)
         .map(|cell| cell.get())
+        .take_while(|&byte| byte != 0)
         .collect();
-    CString::new(v).unwrap()
+    String::from_utf8_lossy(&v).to_owned().to_string()
 }
 
 #[cfg(test)]

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -2,6 +2,7 @@ use super::env;
 use super::env::get_emscripten_data;
 use libc::stat;
 use std::ffi::CStr;
+use std::ffi::CString;
 use std::mem::size_of;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
@@ -14,7 +15,6 @@ use wasmer_runtime_core::{
     units::Pages,
     vm::Ctx,
 };
-use std::ffi::CString;
 
 /// We check if a provided module is an Emscripten generated one
 pub fn is_emscripten_module(module: &Module) -> bool {


### PR DESCRIPTION
This PR fills `_unsetenv` for windows and re-uses the helper function `read_string_from_wasm` and the `setenv` function. This is required because `unsetenv` does not exist on windows. 