### PR TITLE
refactor getenv for windows

### DIFF
--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -1,16 +1,14 @@
 /// NOTE: These syscalls only support wasm_32 for now because they take u32 offset
 use libc::{c_int, c_long, getenv};
 
-use core::slice;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::c_char;
 
 use crate::utils::{
-    allocate_on_stack, copy_cstr_into_wasm, copy_terminated_array_of_cstrs, read_string_from_wasm,
+    allocate_on_stack, copy_cstr_into_wasm, read_string_from_wasm,
 };
 use crate::EmscriptenData;
-use wasmer_runtime_core::memory::Memory;
 use wasmer_runtime_core::vm::Ctx;
 
 #[link(name = "c")]
@@ -26,21 +24,15 @@ pub fn _getaddrinfo(_one: i32, _two: i32, _three: i32, _four: i32, _ctx: &mut Ct
 
 // #[no_mangle]
 /// emscripten: _getenv // (name: *const char) -> *const c_char;
-pub fn _getenv(name: i32, ctx: &mut Ctx) -> u32 {
+pub fn _getenv(name: u32, ctx: &mut Ctx) -> u32 {
     debug!("emscripten::_getenv");
-
-    let memory = ctx.memory(0);
-
-    let name_addr = emscripten_memory_pointer!(ctx.memory(0), name) as _;
-
-    debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
-
-    let c_str: *mut c_char = unsafe { getenv(name_addr as _) } as _;
+    let name_string = read_string_from_wasm(ctx.memory(0), name);
+    debug!("=> name({:?})", name_string);
+    let c_str = unsafe { getenv(name_string.as_ptr() as *const libc::c_char ) };
     if c_str.is_null() {
         return 0;
     }
-
-    unsafe { copy_cstr_into_wasm(ctx, c_str) }
+    copy_cstr_into_wasm(ctx, c_str as *const c_char)
 }
 
 /// emscripten: _setenv // (name: *const char, name: *const value, overwrite: int);


### PR DESCRIPTION
This PR upgrades the windows implementation for `getenv` to use a few safer wasm-string helper functions. 