### PR TITLE
fix windows linking and appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - cargo -vV
 
 artifacts:
-  - path: target\%TARGET%\debug\wasmer.exe
+  - path: target\debug\wasmer.exe
     name: wasmer.exe
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -81,9 +81,7 @@ artifacts:
     name: wasmer.exe
 
 build_script:
-  - set BUILD_CMD=cargo +%TOOLCHAIN% build --target=%TARGET%
-  - echo [ %BUILD_CMD% ] & %BUILD_CMD%
+  - cargo build --verbose
 
 test_script:
-  - set TEST_CMD=cargo +%TOOLCHAIN% test --target=%TARGET% --no-fail-fast
-  - echo [ %TEST_CMD% ] & %TEST_CMD%
+  - cargo test --verbose

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,73 +70,11 @@ environment:
 #      MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-posix/seh/x86_64-7.3.0-release-posix-seh-rt_v5-rev0.7z/download#mingw-w64-x86_64-7.3.0-posix-seh.7z
 
 install:
-  - echo %PATH%
-  # force branch checkout (if knowable), then reset to the specific commit ## (can be needed for accurate code coverage info)
-  # * this allows later apps to see the branch name using standard `git branch` operations, yet always builds the correct specific commit
-  # * ref: <https://github.com/appveyor/ci/issues/1606>[`@`](https://archive.is/RVpnF)
-  - if DEFINED APPVEYOR_REPO_BRANCH if /I "%APPVEYOR_REPO_SCM%"=="git" ( git checkout "%APPVEYOR_REPO_BRANCH%" & git reset --hard "%APPVEYOR_REPO_COMMIT%" )
-  # ensure CWD is project main directory
-  - cd "%APPVEYOR_BUILD_FOLDER%"
-  # create a working area
-  - ps: if ( ! $env:CI_TEMP_DIR ) { $env:CI_TEMP_DIR = "${env:TEMP}\${env:APPVEYOR_JOB_ID}" ; mkdir -force $env:CI_TEMP_DIR | out-null }
-
-  # rust installation
-  - set "TARGET=%ARCH%-pc-windows-%ABI%"
-  # * install `rust` via `rustup`
-  - appveyor DownloadFile "https://win.rustup.rs/" -FileName "%CI_TEMP_DIR%\rustup-init.exe"
-  - call "%CI_TEMP_DIR%\rustup-init.exe" -y --default-toolchain %CHANNEL% --default-host %TARGET% --no-modify-path >NUL
-  - set "PATH=%PATH%;%USERPROFILE%\.cargo\bin"
-  - ps: $env:TOOLCHAIN = $(rustup show active-toolchain)
-  - rename "C:\Program Files\Git\usr\bin\sh.exe" sh2.exe
-  # * set RUST_BACKTRACE for enhanced error messages
-  - set RUST_BACKTRACE=1
-  # * show versions
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -yv --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV
-
-  # finalize FEATURES
-  - if /i "%CHANNEL%"=="nightly" set "FEATURES=nightly"
-
-  # "gnu" ABI setup
-  # * use the system MinGW/MSYS if we can
-  - if /i "%ABI%"=="gnu" set MSYS_BINDIR=C:\msys64\usr\bin
-  - if /i "%ABI%"=="gnu" if /i "%ARCH%"=="i686"   set "MSYS_BITS=32"
-  - if /i "%ABI%"=="gnu" if /i "%ARCH%"=="x86_64" set "MSYS_BITS=64"
-  - if defined MSYS_BITS set "MSYS_MINGWDIR=C:\msys64\mingw%MSYS_BITS%"
-  - if defined MSYS_MINGWDIR set "MSYS_BINDIR=C:\msys64\usr\bin"
-  ## * workaround for rust-lang/rust#47048 / rust-lang/rust#53454  ## !maint: remove when resolved
-  - if /i "%ABI%"=="gnu" if /i "%ARCH%"=="i686" if not DEFINED MINGW_URL set "MINGW_URL=https://downloads.sourceforge.net/project/mingw-w64/Toolchains targetting Win32/Personal Builds/mingw-builds/8.1.0/threads-posix/dwarf/i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z"
-  - if /i "%ABI%"=="gnu" if /i "%ARCH%"=="x86_64" if not DEFINED MINGW_URL set "MINGW_URL=https://downloads.sourceforge.net/project/mingw-w64/Toolchains targetting Win64/Personal Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z"
-  ##
-  # * specific MinGW, if specified
-  - ps: if ( ! $env:MINGW_ARCHIVE -and $env:MINGW_URL ) { $env:MINGW_ARCHIVE = $($([URI]$env:MINGW_URL).fragment).TrimStart('#') }
-  - ps: if ( ! $env:MINGW_ARCHIVE -and $env:MINGW_URL ) { $env:MINGW_ARCHIVE = $([URI]$env:MINGW_URL).segments[-1] }
-  - if defined MINGW_ARCHIVE curl --insecure -fsSL "%MINGW_URL%" -o "%CI_TEMP_DIR%\%MINGW_ARCHIVE%"
-  - if defined MINGW_ARCHIVE mkdir "%CI_TEMP_DIR%\MinGW" >NUL
-  - if defined MINGW_ARCHIVE 7z x -y "%CI_TEMP_DIR%\%MINGW_ARCHIVE%" -o"%CI_TEMP_DIR%\MinGW" >NUL
-  - if defined MINGW_ARCHIVE set "MSYS_MINGWDIR=%CI_TEMP_DIR%\MinGW\mingw%MSYS_BITS%"
-  - if defined MINGW_ARCHIVE set "MSYS_BINDIR=%MSYS_MINGWDIR%\bin"
-  # * MinGW/MSYS PATH setup
-  - if defined MSYS_MINGWDIR set PATH=%MSYS_MINGWDIR%\%ARCH%-w64-mingw32\bin;%MSYS_BINDIR%;%PATH%
-  ## * workaround for rust-lang/rust#47048 / rust-lang/rust#53454  ## !maint: remove when resolved
-  # ** ref: <https://github.com/rust-lang/rust/issues/47048>, <https://github.com/rust-lang/rust/issues/53454>
-  # ** egs: <https://github.com/pkgw/tectonic/commit/29686db533d8732d7d97fc94270ed33b77f29295>, <https://github.com/rukai/PF_Sandbox/blob/e842613cf9ff102dfb3fbd87381319e6e6dfe3ae/appveyor.yml>
-  - if /i "%ABI%"=="gnu" rustup install %CHANNEL%-%ARCH%-pc-windows-msvc
-  - if /i "%ABI%"=="gnu" rustup default %CHANNEL%-%ARCH%-pc-windows-msvc
-  - if /i "%ABI%"=="gnu" rustup target add %TARGET%
-  - if /i "%ABI%"=="gnu" rustup show
-  - if /i "%ABI%"=="gnu" rustc -vV
-  - ps: $env:TOOLCHAIN = $(rustup show active-toolchain)
-  # ** copy libs from gcc toolchain to rust toolchain (more specifically, "crt2.o" and "dllcrt2.o" are needed)
-  - if defined MSYS_MINGWDIR copy /y "%MSYS_MINGWDIR%\%ARCH%-w64-mingw32\lib\*.o" "%USERPROFILE%\.rustup\toolchains\%TOOLCHAIN%\lib\rustlib\%TARGET%\lib" >NUL
-  ##
-  - if /i "%ABI%"=="gnu" where gcc
-  - if /i "%ABI%"=="gnu" gcc --version
-
-  # "msvc" ABI setup
-  - if /i "%ABI%" == "msvc" if /i "%ARCH%" == "i686" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat"
-  - if /i "%ABI%" == "msvc" if /i "%ARCH%" == "x86_64" call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-  - if /i "%ABI%" == "msvc" if /i "%ARCH%" == "x86_64" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
 
 artifacts:
   - path: target\%TARGET%\debug\wasmer.exe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,3 @@
-# This appveyor build file is heavily inspired by uutils/coreutils
-# https://raw.githubusercontent.com/uutils/coreutils/d0db7bbaa46dabf65b71e3e33b1ed7595aaacc56/.appveyor.yml
-
 branches:
   except:
     - master
@@ -9,66 +6,12 @@ version: "{build} ~ {branch}"
 
 os: Visual Studio 2017
 
-matrix:
-  allow_failures:
-    - CHANNEL: stable
-#   - ABI: gnu
-
 environment:
   matrix:
-    # minimum version
-#    - CHANNEL: 1.31.0
-#      ARCH: i686
-#      ABI: msvc
-#    # "msvc" ABI
-#    - CHANNEL: stable
-#      ARCH: i686
-#      ABI: msvc
     - CHANNEL: stable
       ARCH: x86_64
       ABI: msvc
       TARGET: x86_64-pc-windows-msvc
-    #   - CHANNEL: beta
-    #     ARCH: i686
-    #     ABI: msvc
-    #   - CHANNEL: beta
-    #     ARCH: x86_64
-    #     ABI: msvc
-#    - CHANNEL: nightly
-#      ARCH: i686
-#      ABI: msvc
-#    - CHANNEL: nightly
-#      ARCH: x86_64
-#      ABI: msvc
-#    # "gnu" ABI
-#    - CHANNEL: stable
-#      ARCH: i686
-#      ABI: gnu
-#    - CHANNEL: stable
-#      ARCH: x86_64
-#      ABI: gnu
-    #   - CHANNEL: beta
-    #     ARCH: i686
-    #     ABI: gnu
-    #   - CHANNEL: beta
-    #     ARCH: x86_64
-    #     ABI: gnu
-    #   - CHANNEL: nightly
-    #     ARCH: i686
-    #     ABI: gnu
-    #   - CHANNEL: nightly
-    #     ARCH: x86_64
-    #     ABI: gnu
-    # * specific gnu compilers
-#    - CHANNEL: stable
-#      ARCH: i686
-#      ABI: gnu
-#      MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-win32/dwarf/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z/download
-#      MINGW_ARCHIVE: i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
-#    - CHANNEL: stable
-#      ARCH: x86_64
-#      ABI: gnu
-#      MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-posix/seh/x86_64-7.3.0-release-posix-seh-rt_v5-rev0.7z/download#mingw-w64-x86_64-7.3.0-posix-seh.7z
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
@@ -85,5 +28,5 @@ build_script:
   - cargo build --verbose
 
 test_script:
-  - RUST_BACKTRACE=1
+  - set RUST_BACKTRACE=1
   - cargo test --verbose

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,6 +27,7 @@ environment:
     - CHANNEL: stable
       ARCH: x86_64
       ABI: msvc
+      TARGET: x86_64-pc-windows-msvc
     #   - CHANNEL: beta
     #     ARCH: i686
     #     ABI: msvc
@@ -84,4 +85,5 @@ build_script:
   - cargo build --verbose
 
 test_script:
+  - RUST_BACKTRACE=1
   - cargo test --verbose

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,9 +24,9 @@ environment:
 #    - CHANNEL: stable
 #      ARCH: i686
 #      ABI: msvc
-#    - CHANNEL: stable
-#      ARCH: x86_64
-#      ABI: msvc
+    - CHANNEL: stable
+      ARCH: x86_64
+      ABI: msvc
     #   - CHANNEL: beta
     #     ARCH: i686
     #     ABI: msvc
@@ -64,10 +64,10 @@ environment:
 #      ABI: gnu
 #      MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-win32/dwarf/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z/download
 #      MINGW_ARCHIVE: i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
-    - CHANNEL: stable
-      ARCH: x86_64
-      ABI: gnu
-      MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-posix/seh/x86_64-7.3.0-release-posix-seh-rt_v5-rev0.7z/download#mingw-w64-x86_64-7.3.0-posix-seh.7z
+#    - CHANNEL: stable
+#      ARCH: x86_64
+#      ABI: gnu
+#      MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-posix/seh/x86_64-7.3.0-release-posix-seh-rt_v5-rev0.7z/download#mingw-w64-x86_64-7.3.0-posix-seh.7z
 
 install:
   - echo %PATH%

--- a/lib/clif-backend/src/signal/windows.rs
+++ b/lib/clif-backend/src/signal/windows.rs
@@ -4,3 +4,7 @@ use wasmer_runtime_core::error::RuntimeResult;
 pub fn call_protected<T>(handler_data: &HandlerData, f: impl FnOnce() -> T) -> RuntimeResult<T> {
     unimplemented!("TODO");
 }
+
+pub unsafe fn trigger_trap() -> ! {
+    unimplemented!("TODO");
+}

--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -9,7 +9,6 @@ use crate::env::call_malloc;
 use crate::utils::{copy_cstr_into_wasm, read_string_from_wasm};
 use wasmer_runtime_core::vm::Ctx;
 
-#[link(name = "c")]
 extern "C" {
     #[link_name = "_putenv"]
     pub fn putenv(s: *const c_char) -> c_int;

--- a/lib/emscripten/src/io/windows.rs
+++ b/lib/emscripten/src/io/windows.rs
@@ -22,9 +22,9 @@ pub fn putchar(chr: i32, ctx: &mut Ctx) {
 /// printf
 pub fn printf(memory_offset: i32, extra: i32, ctx: &mut Ctx) -> i32 {
     debug!("emscripten::printf {}, {}", memory_offset, extra);
-//    unsafe {
-//        let addr = emscripten_memory_pointer!(ctx.memory(0), memory_offset) as _;
-//        _printf(addr, extra)
-//    }
+    //    unsafe {
+    //        let addr = emscripten_memory_pointer!(ctx.memory(0), memory_offset) as _;
+    //        _printf(addr, extra)
+    //    }
     -1
 }

--- a/lib/emscripten/src/io/windows.rs
+++ b/lib/emscripten/src/io/windows.rs
@@ -5,14 +5,14 @@ use wasmer_runtime_core::vm::Ctx;
 // this cfg_attr will try to link with the legacy lib that does not inline printf
 // this will allow for compiliation, but will produce a linker error if there is a problem
 // finding printf.
-#[cfg_attr(
-    all(windows, target_env = "msvc"),
-    link(name = "legacy_stdio_definitions", kind = "static-nobundle")
-)]
-extern "C" {
-    #[link_name = "printf"]
-    pub fn _printf(s: *const c_char, ...) -> c_int;
-}
+//#[cfg_attr(
+//    all(windows, target_env = "msvc"),
+//    link(name = "legacy_stdio_definitions", kind = "static-nobundle")
+//)]
+//extern "C" {
+//    #[link_name = "printf"]
+//    pub fn _printf(s: *const c_char, ...) -> c_int;
+//}
 
 /// putchar
 pub fn putchar(chr: i32, ctx: &mut Ctx) {
@@ -22,8 +22,9 @@ pub fn putchar(chr: i32, ctx: &mut Ctx) {
 /// printf
 pub fn printf(memory_offset: i32, extra: i32, ctx: &mut Ctx) -> i32 {
     debug!("emscripten::printf {}, {}", memory_offset, extra);
-    unsafe {
-        let addr = emscripten_memory_pointer!(ctx.memory(0), memory_offset) as _;
-        _printf(addr, extra)
-    }
+//    unsafe {
+//        let addr = emscripten_memory_pointer!(ctx.memory(0), memory_offset) as _;
+//        _printf(addr, extra)
+//    }
+    -1
 }

--- a/lib/emscripten/src/stdio.rs
+++ b/lib/emscripten/src/stdio.rs
@@ -12,7 +12,7 @@ pub struct StdioCapturer {
 }
 
 #[cfg(not(target_os = "windows"))]
-use libc::{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
+use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 
 #[cfg(target_os = "windows")]
 const STDIN_FILENO: libc::c_int = 0;
@@ -20,7 +20,6 @@ const STDIN_FILENO: libc::c_int = 0;
 const STDOUT_FILENO: libc::c_int = 1;
 #[cfg(target_os = "windows")]
 const STDERR_FILENO: libc::c_int = 2;
-
 
 // Implementation inspired in
 // https://github.com/rust-lang/rust/blob/7d52cbce6db83e4fc2d8706b4e4b9c7da76cbcf8/src/test/run-pass/issues/issue-30490.rs

--- a/lib/emscripten/src/stdio.rs
+++ b/lib/emscripten/src/stdio.rs
@@ -11,6 +11,17 @@ pub struct StdioCapturer {
     stderr_reader: libc::c_int,
 }
 
+#[cfg(not(target_os = "windows"))]
+use libc::{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
+
+#[cfg(target_os = "windows")]
+const STDIN_FILENO: libc::c_int = 0;
+#[cfg(target_os = "windows")]
+const STDOUT_FILENO: libc::c_int = 1;
+#[cfg(target_os = "windows")]
+const STDERR_FILENO: libc::c_int = 2;
+
+
 // Implementation inspired in
 // https://github.com/rust-lang/rust/blob/7d52cbce6db83e4fc2d8706b4e4b9c7da76cbcf8/src/test/run-pass/issues/issue-30490.rs
 // Currently only works in Unix systems (Mac, Linux)
@@ -30,14 +41,14 @@ impl StdioCapturer {
     }
 
     pub fn new() -> Self {
-        let stdout_backup = unsafe { libc::dup(libc::STDOUT_FILENO) };
-        let stderr_backup = unsafe { libc::dup(libc::STDERR_FILENO) };
+        let stdout_backup = unsafe { libc::dup(STDOUT_FILENO) };
+        let stderr_backup = unsafe { libc::dup(STDERR_FILENO) };
 
         let (stdout_reader, stdout_writer) = Self::pipe();
         let (stderr_reader, stderr_writer) = Self::pipe();
 
-        assert!(unsafe { libc::dup2(stdout_writer, libc::STDOUT_FILENO) } > -1);
-        assert!(unsafe { libc::dup2(stderr_writer, libc::STDERR_FILENO) } > -1);
+        assert!(unsafe { libc::dup2(stdout_writer, STDOUT_FILENO) } > -1);
+        assert!(unsafe { libc::dup2(stderr_writer, STDERR_FILENO) } > -1);
 
         // Make sure we close any duplicates of the writer end of the pipe,
         // otherwise we can get stuck reading from the pipe which has open
@@ -57,8 +68,8 @@ impl StdioCapturer {
         // The Stdio passed into the Command took over (and closed) std{out, err}
         // so we should restore them as they were.
 
-        assert!(unsafe { libc::dup2(self.stdout_backup, libc::STDOUT_FILENO) } > -1);
-        assert!(unsafe { libc::dup2(self.stderr_backup, libc::STDERR_FILENO) } > -1);
+        assert!(unsafe { libc::dup2(self.stdout_backup, STDOUT_FILENO) } > -1);
+        assert!(unsafe { libc::dup2(self.stderr_backup, STDERR_FILENO) } > -1);
 
         let fd = FileDescriptor::new(self.stdout_reader);
         let mut reader = BufReader::new(fd);

--- a/lib/emscripten/src/time.rs
+++ b/lib/emscripten/src/time.rs
@@ -10,7 +10,6 @@ use libc::{clockid_t, time as libc_time};
 type clockid_t = c_int;
 
 #[cfg(target_os = "windows")]
-#[link(name = "c")]
 extern "C" {
     #[link_name = "time"]
     pub fn libc_time(s: *const time_t) -> time_t;


### PR DESCRIPTION
This PR implements a stop-gap fix for compilation and linker errors in windows build. The appveyor file is updated to use the msvc toolchain. 