### PR TITLE
Grow as a trait

### DIFF
--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -1,3 +1,4 @@
+use crate::grow::Grow;
 use crate::{
     error::{LinkError, LinkResult},
     export::{Context, Export},
@@ -15,7 +16,6 @@ use crate::{
     vm,
 };
 use std::{slice, sync::Arc};
-use crate::grow::Grow;
 
 #[derive(Debug)]
 pub struct LocalBacking {

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -15,6 +15,7 @@ use crate::{
     vm,
 };
 use std::{slice, sync::Arc};
+use crate::grow::Grow;
 
 #[derive(Debug)]
 pub struct LocalBacking {

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -311,3 +311,20 @@ impl From<ResolveError> for CallError {
         CallError::Resolve(resolve_err)
     }
 }
+
+#[derive(Debug)]
+pub enum GrowError {
+    MemoryGrowError,
+    TableGrowError,
+}
+
+impl std::fmt::Display for GrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            GrowError::MemoryGrowError => write!(f, "Unable to grow memory"),
+            GrowError::TableGrowError => write!(f, "Unable to grow table"),
+        }
+    }
+}
+
+impl std::error::Error for GrowError {}

--- a/lib/runtime-core/src/grow.rs
+++ b/lib/runtime-core/src/grow.rs
@@ -1,0 +1,5 @@
+use crate::error::GrowError;
+
+pub trait Grow<T> {
+    fn grow(&self, delta: T) -> Result<T, GrowError>;
+}

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cache;
 pub mod error;
 pub mod export;
 pub mod global;
+pub mod grow;
 pub mod import;
 pub mod instance;
 pub mod memory;

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -1,13 +1,13 @@
 use crate::{
-    error::{ CreationError, GrowError },
+    error::{CreationError, GrowError},
     export::Export,
+    grow::Grow,
     import::IsExport,
     memory::dynamic::DYNAMIC_GUARD_SIZE,
     memory::static_::{SAFE_STATIC_GUARD_SIZE, SAFE_STATIC_HEAP_SIZE},
     types::{MemoryDescriptor, ValueType},
     units::Pages,
     vm,
-    grow::Grow,
 };
 use std::{
     cell::{Cell, RefCell},

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -18,11 +18,16 @@ pub use self::atomic::Atomic;
 pub use self::dynamic::DynamicMemory;
 pub use self::static_::{SharedStaticMemory, StaticMemory};
 pub use self::view::{Atomically, MemoryView};
+use crate::error::GrowError;
 
 mod atomic;
 mod dynamic;
 mod static_;
 mod view;
+
+trait Grow {
+    fn grow(&self, delta: Pages) -> Result<Pages, GrowError>;
+}
 
 #[derive(Clone)]
 enum MemoryVariant {

--- a/lib/runtime-core/src/table/mod.rs
+++ b/lib/runtime-core/src/table/mod.rs
@@ -11,8 +11,8 @@ mod anyfunc;
 
 pub use self::anyfunc::Anyfunc;
 use self::anyfunc::AnyfuncTable;
-use crate::grow::Grow;
 use crate::error::GrowError;
+use crate::grow::Grow;
 
 pub enum Element<'a> {
     Anyfunc(Anyfunc<'a>),
@@ -114,9 +114,9 @@ impl Grow<u32> for Table {
         }
 
         match &mut *self.storage.borrow_mut() {
-            (TableStorage::Anyfunc(ref mut anyfunc_table), ref mut local) => {
-                anyfunc_table.grow(delta, local).ok_or(GrowError::TableGrowError)
-            }
+            (TableStorage::Anyfunc(ref mut anyfunc_table), ref mut local) => anyfunc_table
+                .grow(delta, local)
+                .ok_or(GrowError::TableGrowError),
         }
     }
 }


### PR DESCRIPTION
This PR refactors how `Memory` and `Table` grow their memory. Instead of concrete `impl`, we have a `Grow` trait. This trait is generic to the type that the memory grows. The `grow` method returns a  `Result<T, GrowError>`. 