### PR TITLE
Added function to merge ImportObjects

### DIFF
--- a/lib/runtime-core/src/import.rs
+++ b/lib/runtime-core/src/import.rs
@@ -342,4 +342,25 @@ mod tests {
         }
         assert!(iter_counter == 2);
     }
+
+    #[test]
+    fn test_like_namespace_iteration() {
+        // Create some imports for testing
+        let imports = imports! {
+            "env" => {
+                "x" => Global::new(Value::I32(77)),
+                "y" => Global::new(Value::I32(77)),
+                "z" => Global::new(Value::I32(77)),
+            },
+        };
+        // Get the namespace and iterate over it
+        let namespace = imports.get_namespace("env").unwrap();
+        for (export_name, export) in namespace {
+            assert!(match export {
+                Export::Global(_) => true,
+                _ => false,
+            });
+        }
+        assert!(namespace.into_iter().count() == 3);
+    }
 }

--- a/lib/runtime-core/src/import.rs
+++ b/lib/runtime-core/src/import.rs
@@ -99,6 +99,24 @@ impl ImportObject {
         }
     }
 
+    /// Merge two `ImportObject`'s into one, also merging namespaces.
+    ///
+    /// When a namespace is unique to the first or second import object, that namespace is moved
+    /// directly into the merged import object. When a namespace with the same name occurs in both
+    /// import objects, a merge namespace is created. When an export is unique to the first or
+    /// second namespace, that export is moved directly into the merged namespace. When an export
+    /// with the same name occurs in both namespaces, then the export from the first namespace is
+    /// used, and the export from the second namespace is dropped.
+    ///
+    /// # Usage #
+    ///
+    /// ```
+    /// # use wasmer_runtime_core::import::ImportObject;
+    /// fn merge(imports_a: ImportObject, imports_b: ImportObject) {
+    ///     let merged_imports = ImportObject::merge(imports_a, imports_b);
+    ///     // ...
+    /// }
+    /// ```
     pub fn merge(mut imports_a: ImportObject, mut imports_b: ImportObject) -> Self {
         let names_a = imports_a.map.keys();
         let names_b = imports_b.map.keys();

--- a/lib/runtime-core/src/import.rs
+++ b/lib/runtime-core/src/import.rs
@@ -309,4 +309,37 @@ mod tests {
             _ => false,
         });
     }
+
+    #[test]
+    fn test_import_object_iteration() {
+        // Create some imports for testing
+        let imports = imports! {
+            "env" => {
+                "x" => Global::new(Value::I32(77)),
+            },
+            "env2" => {
+                "x" => Global::new(Value::I32(77)),
+            },
+        };
+        // Iterate over the namespaces by reference
+        for (namespace_name, namespace) in &imports {
+            let export = namespace.get_export("x").unwrap();
+            assert!(match export {
+                Export::Global(_) => true,
+                _ => false,
+            });
+        }
+        assert!((&imports).into_iter().count() == 2);
+        // Iterate over the namespaces by value
+        let mut iter_counter = 0;
+        for (namespace_name, namespace) in imports {
+            let export = namespace.get_export("x").unwrap();
+            assert!(match export {
+                Export::Global(_) => true,
+                _ => false,
+            });
+            iter_counter += 1;
+        }
+        assert!(iter_counter == 2);
+    }
 }

--- a/lib/runtime-core/src/import.rs
+++ b/lib/runtime-core/src/import.rs
@@ -155,6 +155,24 @@ impl ImportObject {
     }
 }
 
+impl IntoIterator for ImportObject {
+    type Item = (String, Box<dyn LikeNamespace>);
+    type IntoIter = hashbrown::hash_map::IntoIter<String, Box<dyn LikeNamespace>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ImportObject {
+    type Item = (&'a String, &'a Box<dyn LikeNamespace>);
+    type IntoIter = hashbrown::hash_map::Iter<'a, String, Box<dyn LikeNamespace>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.iter()
+    }
+}
+
 pub struct Namespace {
     map: HashMap<String, Box<dyn IsExport>>,
 }

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -429,10 +429,8 @@ impl LikeNamespace for Instance {
             .exports
             .iter()
             .map(|(name, export_index)| {
-                (
-                    name.to_string(),
-                    self.inner.get_export_from_index(&self.module, export_index),
-                )
+                let export = self.inner.get_export_from_index(&self.module, export_index);
+                (name.to_string(), export)
             })
             .collect()
     }

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -423,18 +423,6 @@ impl InstanceInner {
 }
 
 impl LikeNamespace for Instance {
-    fn get_all_exports(&self) -> HashMap<String, Export> {
-        self.module
-            .info
-            .exports
-            .iter()
-            .map(|(name, export_index)| {
-                let export = self.inner.get_export_from_index(&self.module, export_index);
-                (name.to_string(), export)
-            })
-            .collect()
-    }
-
     fn get_export(&self, name: &str) -> Option<Export> {
         let export_index = self.module.info.exports.get(name)?;
 

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -13,6 +13,7 @@ use crate::{
     types::{FuncIndex, FuncSig, GlobalIndex, LocalOrImport, MemoryIndex, TableIndex, Value},
     vm,
 };
+use hashbrown::HashMap;
 use std::{mem, sync::Arc};
 
 pub(crate) struct InstanceInner {
@@ -422,6 +423,20 @@ impl InstanceInner {
 }
 
 impl LikeNamespace for Instance {
+    fn get_all_exports(&self) -> HashMap<String, Export> {
+        self.module
+            .info
+            .exports
+            .iter()
+            .map(|(name, export_index)| {
+                (
+                    name.to_string(),
+                    self.inner.get_export_from_index(&self.module, export_index),
+                )
+            })
+            .collect()
+    }
+
     fn get_export(&self, name: &str) -> Option<Export> {
         let export_index = self.module.info.exports.get(name)?;
 

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -440,6 +440,10 @@ impl LikeNamespace for Instance {
 
         Some(self.inner.get_export_from_index(&self.module, export_index))
     }
+
+    fn export_names<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a> {
+        Box::new(self.module.info.exports.keys().map(|s| s.as_str()))
+    }
 }
 
 /// A representation of an exported WebAssembly function.


### PR DESCRIPTION
I thought I would try implementing the `ImportObject` merging I needed. The main use case is merging the Emscripten imports from `generate_emscripten_env` with the usual ones, i.e., `print_str` from the `wasmer-rust-example`.

Here's where I'm using it, in my attempt to update the `wasmer-rust-example` to run Emscripten stuff:

https://github.com/tprk77/wasmer-rust-example/blob/emscripten-wip/src/main.rs

Apologies in advance if my code is wacky, I'm still kind of learning Rust. I'd appreciate any feedback you might have.