### PR TITLE
no caching on windows

### DIFF
--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -86,7 +86,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let disable_cache = true;
     #[cfg(not(target_os = "windows"))]
-    let disable_windows = options.disable_cache;
+    let disable_cache = options.disable_cache;
 
     let wasm_path = &options.path;
 

--- a/src/installer/wasmer.iss
+++ b/src/installer/wasmer.iss
@@ -11,7 +11,7 @@ ChangesEnvironment=yes
 OutputBaseFilename=WasmerInstaller
 
 [Files]
-Source: "..\target\release\wasmer.exe"; DestDir: "{app}\bin"
+Source: "..\..\target\release\wasmer.exe"; DestDir: "{app}\bin"
 
 [Code]
 const EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';


### PR DESCRIPTION
Due to issues with reading virtual memory on windows, we will disable caching on windows for 0.2.0 release.