### PR TITLE
commit virtual memory before copying

### DIFF
--- a/lib/runtime-core/src/sys/windows/memory.rs
+++ b/lib/runtime-core/src/sys/windows/memory.rs
@@ -33,7 +33,7 @@ impl Memory {
 
         let protect = protection.to_protect_const();
 
-        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE, protect) };
+        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE | MEM_COMMIT, protect) };
 
         if ptr.is_null() {
             Err("unable to allocate memory".to_string())
@@ -57,7 +57,7 @@ impl Memory {
 
         let size = round_up_to_page_size(size, page_size::get());
 
-        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE, PAGE_NOACCESS) };
+        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE | MEM_COMMIT, PAGE_NOACCESS) };
 
         if ptr.is_null() {
             Err(MemoryCreationError::VirtualMemoryAllocationFailed(

--- a/lib/runtime-core/src/sys/windows/memory.rs
+++ b/lib/runtime-core/src/sys/windows/memory.rs
@@ -57,7 +57,14 @@ impl Memory {
 
         let size = round_up_to_page_size(size, page_size::get());
 
-        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE | MEM_COMMIT, PAGE_NOACCESS) };
+        let ptr = unsafe {
+            VirtualAlloc(
+                ptr::null_mut(),
+                size,
+                MEM_RESERVE | MEM_COMMIT,
+                PAGE_NOACCESS,
+            )
+        };
 
         if ptr.is_null() {
             Err(MemoryCreationError::VirtualMemoryAllocationFailed(


### PR DESCRIPTION
This fixes an issue on Windows when we clone `Memory`.