### PR TITLE
bugfix: Replace echo with printf so "\n" renders.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,7 @@ wasmer_link() {
   SOURCE_STR="# Wasmer config\nexport WASMER_DIR=\"\$HOME/.wasmer\"\nexport WASMER_CACHE_DIR=\"\$WASMER_DIR/cache\"\nexport PATH=\"\$HOME/.wasmer/bin:\$PATH\"\n"
 
   # We create the wasmer.sh file
-  echo "$SOURCE_STR" > "$HOME/.wasmer/wasmer.sh"
+  printf "$SOURCE_STR" > "$HOME/.wasmer/wasmer.sh"
 
   if [ -z "${WASMER_PROFILE-}" ] ; then
     printf "${red}Profile not found. Tried:\n* ${WASMER_PROFILE} (as defined in \$PROFILE)\n* ~/.bashrc\n* ~/.bash_profile\n* ~/.zshrc\n* ~/.profile.\n"


### PR DESCRIPTION
### issue:
I just ran `curl https://get.wasmer.io -sSfL | sh` to install wasmer on my machine &mdash; very excited, this tool looks great! However, when my `.bashrc` calls `$HOME/.wasmer/wasmer.sh` nothing happens.

After a quick investigation, I saw that the newlines weren't being rendered properly.

Here are the contents of `wasmer.sh` after the current install:
```shell
# Wasmer config\nexport WASMER_DIR="$HOME/.wasmer"\nexport WASMER_CACHE_DIR="$WASMER_DIR/cache"\nexport PATH="$HOME/.wasmer/bin:$PATH"\n
```

### fix:
Switch from `echo` to `printf`.

### notes:
  I could have used the -e flag in echo, however other lines nearby use printf so I figured it would be smart to stay consistent.

  Also, I see the usage of `command printf`. Not 100% if this is necessary. I don't see why printf would be redefined in the shell. If we're doing this, then we might as well prefix every call to a builtin or binary with `command` _just to be safe_.