### PR TITLE
fix appveyor installer and build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,34 +14,36 @@ environment:
 
 cache:
   - 'C:\Users\appveyor\.cargo'
+  - target
 
 install:
-  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -yv --default-host %target%
+  # uncomment these lines if the cache is cleared, or if we must re-install rust for some reason
+  # - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  # - rustup-init.exe -yv --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustup default stable-%target%
+  - rustup update
   - rustc -vV
   - cargo -vV
   # Install InnoSetup
   - appveyor-retry appveyor DownloadFile https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/2017-08-22-is.exe
   - 2017-08-22-is.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
   - set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+# uncomment to RDP to appveyor
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 build_script:
-  - cargo build --verbose
+   - cargo build --release --verbose
 
 test_script:
-  - set RUST_BACKTRACE=1
-  - cd ./lib/spectests && cargo test -- --test-threads 1 && cd ../..
+  - cargo test --package wasmer-spectests
 
-before_deploy:
+after_build:
   - cd ./src/installer
   - iscc wasmer.iss
   - copy /y .\WasmerInstaller.exe ..\..\WasmerInstaller-%APPVEYOR_REPO_TAG_NAME%.exe
-  - appveyor PushArtifact WasmerInstaller-%APPVEYOR_REPO_TAG_NAME%.exe
-
-artifacts:
-  - path: WasmerInstaller-%APPVEYOR_REPO_TAG_NAME%.exe
-    name: WasmerInstaller.exe
+  - appveyor PushArtifact ..\..\WasmerInstaller-%APPVEYOR_REPO_TAG_NAME%.exe
+  - cd ..\..\
 
 deploy:
   description: 'WasmerInstaller'

--- a/lib/runtime-core/src/sys/windows/memory.rs
+++ b/lib/runtime-core/src/sys/windows/memory.rs
@@ -33,7 +33,7 @@ impl Memory {
 
         let protect = protection.to_protect_const();
 
-        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE | MEM_COMMIT, protect) };
+        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE, protect) };
 
         if ptr.is_null() {
             Err("unable to allocate memory".to_string())
@@ -57,14 +57,7 @@ impl Memory {
 
         let size = round_up_to_page_size(size, page_size::get());
 
-        let ptr = unsafe {
-            VirtualAlloc(
-                ptr::null_mut(),
-                size,
-                MEM_RESERVE | MEM_COMMIT,
-                PAGE_NOACCESS,
-            )
-        };
+        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE, PAGE_NOACCESS) };
 
         if ptr.is_null() {
             Err(MemoryCreationError::VirtualMemoryAllocationFailed(


### PR DESCRIPTION
This PR introduces a few changes. I reset and squashed some commits to make the intentions more clear. Here are some of the high level changes:

- Reverted changes to how we allocate virtual memory, this may have been related to the issues we were seeing in appveyor builds.
- We now unregister exception handlers have functions have been executed. This is naive, but it fixes issues with assertions and panics triggering the windows exception handlers when they shouldn't.
- There were a few changes made to the appveyor file including some comments and changes to how artifacts are published, and tests executed

I have run these tests several times now, and feel confident that we should not have many more fluke failures. There is still more investigation needed...for example, spectests will fail if run singled threaded, but will pass if running multithreaded.