### PR TITLE
Remove debug option from run command.

### DIFF
--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -33,9 +33,6 @@ enum CLIOptions {
 
 #[derive(Debug, StructOpt)]
 struct Run {
-    #[structopt(short = "d", long = "debug")]
-    debug: bool,
-
     // Disable the cache
     #[structopt(long = "disable-cache")]
     disable_cache: bool,


### PR DESCRIPTION
I was looking into the code and I noticed that this option is not used.
The `debug!` macro is used across the codebase, which looks more ideal.