### PR TITLE
fix(runtime-core) Remove an unused import

### DIFF
--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -1,4 +1,3 @@
-use crate::sys::Memory;
 use crate::types::{
     FuncSig, GlobalDescriptor, MemoryDescriptor, MemoryIndex, TableDescriptor, TableIndex, Type,
 };


### PR DESCRIPTION
This patch removes an unused import, namely `crate::sys::Memory`.