### PR TITLE
fix(clif-backend) Remove an unused variable declaration

### DIFF
--- a/lib/clif-backend/src/resolver.rs
+++ b/lib/clif-backend/src/resolver.rs
@@ -94,7 +94,6 @@ impl FuncResolverBuilder {
         info: &ModuleInfo,
     ) -> CompileResult<(Self, HandlerData)> {
         let num_func_bodies = function_bodies.len();
-        let mut compiled_functions: Vec<(Vec<u8>, RelocSink)> = Vec::with_capacity(num_func_bodies);
         let mut local_relocs = Map::with_capacity(num_func_bodies);
         let mut external_relocs = Map::with_capacity(num_func_bodies);
 


### PR DESCRIPTION
The `compiled_functions` variable is declared twice. The first
declaration is never used. This patch removes it.