### PR TITLE
fix(clif-backend) `Module::new` does not use its argument

### DIFF
--- a/lib/clif-backend/src/lib.rs
+++ b/lib/clif-backend/src/lib.rs
@@ -44,7 +44,7 @@ impl Compiler for CraneliftCompiler {
 
         let isa = get_isa();
 
-        let mut module = module::Module::new(wasm);
+        let mut module = module::Module::new();
         let module_env = module_env::ModuleEnv::new(&mut module, &*isa);
 
         let func_bodies = module_env.translate(wasm)?;

--- a/lib/clif-backend/src/module.rs
+++ b/lib/clif-backend/src/module.rs
@@ -25,7 +25,7 @@ pub struct Module {
 }
 
 impl Module {
-    pub fn new(wasm: &[u8]) -> Self {
+    pub fn new() -> Self {
         Self {
             info: ModuleInfo {
                 memories: Map::new(),


### PR DESCRIPTION
The `Module::new` method requires an argument (`wasm: &[u8]`) that is
never used.

This patch removes the argument, and updates the code accordingly.