### PR TITLE
fix(runtime-c-api) Fix several warnings

### DIFF
--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -302,8 +302,7 @@ pub extern "C" fn wasmer_table_grow(
 #[no_mangle]
 pub extern "C" fn wasmer_table_length(table: *mut wasmer_table_t) -> uint32_t {
     let table = unsafe { &*(table as *mut Table) };
-    let len = table.size();
-    len
+    table.size()
 }
 
 /// Frees memory for the given Table
@@ -355,11 +354,10 @@ pub extern "C" fn wasmer_global_get_descriptor(
 ) -> wasmer_global_descriptor_t {
     let global = unsafe { &*(global as *mut Global) };
     let descriptor = global.descriptor();
-    let desc = wasmer_global_descriptor_t {
+    wasmer_global_descriptor_t {
         mutable: descriptor.mutable,
         kind: descriptor.ty.into(),
-    };
-    desc
+    }
 }
 
 /// Frees memory for the given Global
@@ -451,7 +449,7 @@ pub unsafe extern "C" fn wasmer_module_instantiate(
 
         let namespace = namespaces
             .entry(module_name)
-            .or_insert_with(|| Namespace::new());
+            .or_insert_with(Namespace::new);
 
         let export = match import.tag {
             wasmer_import_export_kind::WASM_MEMORY => {
@@ -544,9 +542,9 @@ pub unsafe extern "C" fn wasmer_export_descriptors_get(
     }
     let named_export_descriptors =
         &mut *(export_descriptors as *mut NamedExportDescriptors);
-    let ptr = &mut (*named_export_descriptors).0[idx as usize] as *mut NamedExportDescriptor
-        as *mut wasmer_export_descriptor_t;
-    ptr
+    &mut (*named_export_descriptors).0[idx as usize]
+        as *mut NamedExportDescriptor
+        as *mut wasmer_export_descriptor_t
 }
 
 /// Gets name for the export descriptor
@@ -717,9 +715,9 @@ pub unsafe extern "C" fn wasmer_import_descriptors_get(
     }
     let named_import_descriptors =
         &mut *(import_descriptors as *mut NamedImportDescriptors);
-    let ptr = &mut (*named_import_descriptors).0[idx as usize] as *mut NamedImportDescriptor
-        as *mut wasmer_import_descriptor_t;
-    ptr
+    &mut (*named_import_descriptors).0[idx as usize]
+        as *mut NamedImportDescriptor
+        as *mut wasmer_import_descriptor_t
 }
 
 /// Gets name for the import descriptor
@@ -810,7 +808,7 @@ pub unsafe extern "C" fn wasmer_instantiate(
 
         let namespace = namespaces
             .entry(module_name)
-            .or_insert_with(|| Namespace::new());
+            .or_insert_with(Namespace::new);
 
         let export = match import.tag {
             wasmer_import_export_kind::WASM_MEMORY => {
@@ -900,7 +898,7 @@ pub unsafe extern "C" fn wasmer_instance_call(
 
     match result {
         Ok(results_vec) => {
-            if results_vec.len() > 0 {
+            if !results_vec.is_empty() {
                 let ret = match results_vec[0] {
                     Value::I32(x) => wasmer_value_t {
                         tag: wasmer_value_tag::WASM_I32,
@@ -984,8 +982,9 @@ pub unsafe extern "C" fn wasmer_exports_get(
         return ptr::null_mut();
     }
     let named_exports = &mut *(exports as *mut NamedExports);
-    let ptr = &mut (*named_exports).0[idx as usize] as *mut NamedExport as *mut wasmer_export_t;
-    ptr
+    &mut (*named_exports).0[idx as usize]
+        as *mut NamedExport
+        as *mut wasmer_export_t
 }
 
 /// Gets wasmer_export kind
@@ -1017,7 +1016,7 @@ pub unsafe extern "C" fn wasmer_export_func_params_arity(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         *result = signature.params().len() as uint32_t;
         wasmer_result_t::WASMER_OK
     } else {
@@ -1025,8 +1024,7 @@ pub unsafe extern "C" fn wasmer_export_func_params_arity(
             msg: "func ptr error in wasmer_export_func_params_arity".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Sets the params buffer to the parameter types of the given wasmer_export_func_t
@@ -1044,7 +1042,7 @@ pub unsafe extern "C" fn wasmer_export_func_params(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         let params: &mut [wasmer_value_tag] =
             slice::from_raw_parts_mut(params, params_len as usize);
         for (i, item) in signature.params().iter().enumerate() {
@@ -1056,8 +1054,7 @@ pub unsafe extern "C" fn wasmer_export_func_params(
             msg: "func ptr error in wasmer_export_func_params".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Sets the returns buffer to the parameter types of the given wasmer_export_func_t
@@ -1075,7 +1072,7 @@ pub unsafe extern "C" fn wasmer_export_func_returns(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         let returns: &mut [wasmer_value_tag] =
             slice::from_raw_parts_mut(returns, returns_len as usize);
         for (i, item) in signature.returns().iter().enumerate() {
@@ -1087,8 +1084,7 @@ pub unsafe extern "C" fn wasmer_export_func_returns(
             msg: "func ptr error in wasmer_export_func_returns".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Sets the result parameter to the arity of the returns of the wasmer_export_func_t
@@ -1105,7 +1101,7 @@ pub unsafe extern "C" fn wasmer_export_func_returns_arity(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         *result = signature.returns().len() as uint32_t;
         wasmer_result_t::WASMER_OK
     } else {
@@ -1113,8 +1109,7 @@ pub unsafe extern "C" fn wasmer_export_func_returns_arity(
             msg: "func ptr error in wasmer_export_func_results_arity".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Sets the result parameter to the arity of the params of the wasmer_import_func_t
@@ -1130,7 +1125,7 @@ pub unsafe extern "C" fn wasmer_import_func_params_arity(
     result: *mut uint32_t,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         *result = signature.params().len() as uint32_t;
         wasmer_result_t::WASMER_OK
     } else {
@@ -1138,8 +1133,7 @@ pub unsafe extern "C" fn wasmer_import_func_params_arity(
             msg: "func ptr error in wasmer_import_func_params_arity".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Creates new func
@@ -1181,7 +1175,7 @@ pub unsafe extern "C" fn wasmer_import_func_params(
     params_len: c_int,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         let params: &mut [wasmer_value_tag] =
             slice::from_raw_parts_mut(params, params_len as usize);
         for (i, item) in signature.params().iter().enumerate() {
@@ -1193,8 +1187,7 @@ pub unsafe extern "C" fn wasmer_import_func_params(
             msg: "func ptr error in wasmer_import_func_params".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Sets the returns buffer to the parameter types of the given wasmer_import_func_t
@@ -1211,7 +1204,7 @@ pub unsafe extern "C" fn wasmer_import_func_returns(
     returns_len: c_int,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         let returns: &mut [wasmer_value_tag] =
             slice::from_raw_parts_mut(returns, returns_len as usize);
         for (i, item) in signature.returns().iter().enumerate() {
@@ -1223,8 +1216,7 @@ pub unsafe extern "C" fn wasmer_import_func_returns(
             msg: "func ptr error in wasmer_import_func_returns".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Sets the result parameter to the arity of the returns of the wasmer_import_func_t
@@ -1240,7 +1232,7 @@ pub unsafe extern "C" fn wasmer_import_func_returns_arity(
     result: *mut uint32_t,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
-    let result = if let Export::Function { ref signature, .. } = *export {
+    if let Export::Function { ref signature, .. } = *export {
         *result = signature.returns().len() as uint32_t;
         wasmer_result_t::WASMER_OK
     } else {
@@ -1248,8 +1240,7 @@ pub unsafe extern "C" fn wasmer_import_func_returns_arity(
             msg: "func ptr error in wasmer_import_func_results_arity".to_string(),
         });
         wasmer_result_t::WASMER_ERROR
-    };
-    result
+    }
 }
 
 /// Frees memory for the given Func
@@ -1321,7 +1312,7 @@ pub unsafe extern "C" fn wasmer_export_func_call(
     let result = instance.call(&named_export.name, &params[..]);
     match result {
         Ok(results_vec) => {
-            if results_vec.len() > 0 {
+            if !results_vec.is_empty() {
                 let ret = match results_vec[0] {
                     Value::I32(x) => wasmer_value_t {
                         tag: wasmer_value_tag::WASM_I32,

--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -447,9 +447,7 @@ pub unsafe extern "C" fn wasmer_module_instantiate(
             return wasmer_result_t::WASMER_ERROR;
         };
 
-        let namespace = namespaces
-            .entry(module_name)
-            .or_insert_with(Namespace::new);
+        let namespace = namespaces.entry(module_name).or_insert_with(Namespace::new);
 
         let export = match import.tag {
             wasmer_import_export_kind::WASM_MEMORY => {
@@ -502,7 +500,8 @@ pub unsafe extern "C" fn wasmer_export_descriptors(
     let named_export_descriptors: Box<NamedExportDescriptors> = Box::new(NamedExportDescriptors(
         module.info().exports.iter().map(|e| e.into()).collect(),
     ));
-    *export_descriptors = Box::into_raw(named_export_descriptors) as *mut wasmer_export_descriptors_t;
+    *export_descriptors =
+        Box::into_raw(named_export_descriptors) as *mut wasmer_export_descriptors_t;
 }
 
 pub struct NamedExportDescriptors(Vec<NamedExportDescriptor>);
@@ -514,7 +513,9 @@ pub unsafe extern "C" fn wasmer_export_descriptors_destroy(
     export_descriptors: *mut wasmer_export_descriptors_t,
 ) {
     if !export_descriptors.is_null() {
-        drop(Box::from_raw(export_descriptors as *mut NamedExportDescriptors));
+        drop(Box::from_raw(
+            export_descriptors as *mut NamedExportDescriptors,
+        ));
     }
 }
 
@@ -540,10 +541,8 @@ pub unsafe extern "C" fn wasmer_export_descriptors_get(
     if export_descriptors.is_null() {
         return ptr::null_mut();
     }
-    let named_export_descriptors =
-        &mut *(export_descriptors as *mut NamedExportDescriptors);
-    &mut (*named_export_descriptors).0[idx as usize]
-        as *mut NamedExportDescriptor
+    let named_export_descriptors = &mut *(export_descriptors as *mut NamedExportDescriptors);
+    &mut (*named_export_descriptors).0[idx as usize] as *mut NamedExportDescriptor
         as *mut wasmer_export_descriptor_t
 }
 
@@ -687,7 +686,9 @@ pub unsafe extern "C" fn wasmer_import_descriptors_destroy(
     import_descriptors: *mut wasmer_import_descriptors_t,
 ) {
     if !import_descriptors.is_null() {
-        drop(Box::from_raw(import_descriptors as *mut NamedImportDescriptors));
+        drop(Box::from_raw(
+            import_descriptors as *mut NamedImportDescriptors,
+        ));
     }
 }
 
@@ -713,10 +714,8 @@ pub unsafe extern "C" fn wasmer_import_descriptors_get(
     if import_descriptors.is_null() {
         return ptr::null_mut();
     }
-    let named_import_descriptors =
-        &mut *(import_descriptors as *mut NamedImportDescriptors);
-    &mut (*named_import_descriptors).0[idx as usize]
-        as *mut NamedImportDescriptor
+    let named_import_descriptors = &mut *(import_descriptors as *mut NamedImportDescriptors);
+    &mut (*named_import_descriptors).0[idx as usize] as *mut NamedImportDescriptor
         as *mut wasmer_import_descriptor_t
 }
 
@@ -806,9 +805,7 @@ pub unsafe extern "C" fn wasmer_instantiate(
             return wasmer_result_t::WASMER_ERROR;
         };
 
-        let namespace = namespaces
-            .entry(module_name)
-            .or_insert_with(Namespace::new);
+        let namespace = namespaces.entry(module_name).or_insert_with(Namespace::new);
 
         let export = match import.tag {
             wasmer_import_export_kind::WASM_MEMORY => {
@@ -982,9 +979,7 @@ pub unsafe extern "C" fn wasmer_exports_get(
         return ptr::null_mut();
     }
     let named_exports = &mut *(exports as *mut NamedExports);
-    &mut (*named_exports).0[idx as usize]
-        as *mut NamedExport
-        as *mut wasmer_export_t
+    &mut (*named_exports).0[idx as usize] as *mut NamedExport as *mut wasmer_export_t
 }
 
 /// Gets wasmer_export kind

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -27,11 +27,9 @@ enum wasmer_value_tag {
 };
 typedef uint32_t wasmer_value_tag;
 
-typedef struct wasmer_instance_context_t wasmer_instance_context_t;
+typedef struct {
 
-typedef struct wasmer_instance_t wasmer_instance_t;
-
-typedef struct wasmer_module_t wasmer_module_t;
+} wasmer_module_t;
 
 typedef struct {
 
@@ -93,7 +91,15 @@ typedef struct {
 
 typedef struct {
 
+} wasmer_instance_t;
+
+typedef struct {
+
 } wasmer_memory_t;
+
+typedef struct {
+
+} wasmer_instance_context_t;
 
 typedef struct {
 
@@ -147,7 +153,7 @@ wasmer_byte_array wasmer_export_descriptor_name(wasmer_export_descriptor_t *expo
  * Gets export descriptors for the given module
  * The caller owns the object and should call `wasmer_export_descriptors_destroy` to free it.
  */
-void wasmer_export_descriptors(wasmer_module_t *module,
+void wasmer_export_descriptors(const wasmer_module_t *module,
                                wasmer_export_descriptors_t **export_descriptors);
 
 /**
@@ -173,7 +179,7 @@ int wasmer_export_descriptors_len(wasmer_export_descriptors_t *exports);
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_export_func_call(wasmer_export_func_t *func,
+wasmer_result_t wasmer_export_func_call(const wasmer_export_func_t *func,
                                         const wasmer_value_t *params,
                                         int params_len,
                                         wasmer_value_t *results,
@@ -185,7 +191,7 @@ wasmer_result_t wasmer_export_func_call(wasmer_export_func_t *func,
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_export_func_params(wasmer_export_func_t *func,
+wasmer_result_t wasmer_export_func_params(const wasmer_export_func_t *func,
                                           wasmer_value_tag *params,
                                           int params_len);
 
@@ -195,7 +201,7 @@ wasmer_result_t wasmer_export_func_params(wasmer_export_func_t *func,
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_export_func_params_arity(wasmer_export_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_export_func_params_arity(const wasmer_export_func_t *func, uint32_t *result);
 
 /**
  * Sets the returns buffer to the parameter types of the given wasmer_export_func_t
@@ -203,7 +209,7 @@ wasmer_result_t wasmer_export_func_params_arity(wasmer_export_func_t *func, uint
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_export_func_returns(wasmer_export_func_t *func,
+wasmer_result_t wasmer_export_func_returns(const wasmer_export_func_t *func,
                                            wasmer_value_tag *returns,
                                            int returns_len);
 
@@ -213,7 +219,8 @@ wasmer_result_t wasmer_export_func_returns(wasmer_export_func_t *func,
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_export_func_returns_arity(wasmer_export_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_export_func_returns_arity(const wasmer_export_func_t *func,
+                                                 uint32_t *result);
 
 /**
  * Gets wasmer_export kind
@@ -228,7 +235,7 @@ wasmer_byte_array wasmer_export_name(wasmer_export_t *export_);
 /**
  * Gets export func from export
  */
-const wasmer_export_func_t *wasmer_export_to_func(wasmer_export_t *export_);
+const wasmer_export_func_t *wasmer_export_to_func(const wasmer_export_t *export_);
 
 /**
  * Frees the memory for the given exports
@@ -290,7 +297,7 @@ wasmer_byte_array wasmer_import_descriptor_name(wasmer_import_descriptor_t *impo
  * Gets import descriptors for the given module
  * The caller owns the object and should call `wasmer_import_descriptors_destroy` to free it.
  */
-void wasmer_import_descriptors(wasmer_module_t *module,
+void wasmer_import_descriptors(const wasmer_module_t *module,
                                wasmer_import_descriptors_t **import_descriptors);
 
 /**
@@ -330,7 +337,7 @@ const wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_import_func_params(wasmer_import_func_t *func,
+wasmer_result_t wasmer_import_func_params(const wasmer_import_func_t *func,
                                           wasmer_value_tag *params,
                                           int params_len);
 
@@ -340,7 +347,7 @@ wasmer_result_t wasmer_import_func_params(wasmer_import_func_t *func,
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_import_func_params_arity(wasmer_import_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_import_func_params_arity(const wasmer_import_func_t *func, uint32_t *result);
 
 /**
  * Sets the returns buffer to the parameter types of the given wasmer_import_func_t
@@ -348,7 +355,7 @@ wasmer_result_t wasmer_import_func_params_arity(wasmer_import_func_t *func, uint
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_import_func_returns(wasmer_import_func_t *func,
+wasmer_result_t wasmer_import_func_returns(const wasmer_import_func_t *func,
                                            wasmer_value_tag *returns,
                                            int returns_len);
 
@@ -358,7 +365,8 @@ wasmer_result_t wasmer_import_func_returns(wasmer_import_func_t *func,
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_import_func_returns_arity(wasmer_import_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_import_func_returns_arity(const wasmer_import_func_t *func,
+                                                 uint32_t *result);
 
 /**
  * Calls an instances exported function by `name` with the provided parameters.
@@ -379,7 +387,7 @@ wasmer_result_t wasmer_instance_call(wasmer_instance_t *instance,
  * The index is always 0 until multiple memories are supported.
  */
 const wasmer_memory_t *wasmer_instance_context_memory(wasmer_instance_context_t *ctx,
-                                                      uint32_t memory_idx);
+                                                      uint32_t _memory_idx);
 
 /**
  * Frees memory for the given Instance
@@ -480,7 +488,7 @@ void wasmer_module_destroy(wasmer_module_t *module);
  * Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
  * and `wasmer_last_error_message` to get an error message.
  */
-wasmer_result_t wasmer_module_instantiate(wasmer_module_t *module,
+wasmer_result_t wasmer_module_instantiate(const wasmer_module_t *module,
                                           wasmer_instance_t **instance,
                                           wasmer_import_t *imports,
                                           int imports_len);

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -24,11 +24,9 @@ enum class wasmer_value_tag : uint32_t {
   WASM_F64,
 };
 
-struct wasmer_instance_context_t;
+struct wasmer_module_t {
 
-struct wasmer_instance_t;
-
-struct wasmer_module_t;
+};
 
 struct wasmer_export_descriptor_t {
 
@@ -88,7 +86,15 @@ struct wasmer_import_func_t {
 
 };
 
+struct wasmer_instance_t {
+
+};
+
 struct wasmer_memory_t {
+
+};
+
+struct wasmer_instance_context_t {
 
 };
 
@@ -138,7 +144,7 @@ wasmer_byte_array wasmer_export_descriptor_name(wasmer_export_descriptor_t *expo
 
 /// Gets export descriptors for the given module
 /// The caller owns the object and should call `wasmer_export_descriptors_destroy` to free it.
-void wasmer_export_descriptors(wasmer_module_t *module,
+void wasmer_export_descriptors(const wasmer_module_t *module,
                                wasmer_export_descriptors_t **export_descriptors);
 
 /// Frees the memory for the given export descriptors
@@ -156,7 +162,7 @@ int wasmer_export_descriptors_len(wasmer_export_descriptors_t *exports);
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_export_func_call(wasmer_export_func_t *func,
+wasmer_result_t wasmer_export_func_call(const wasmer_export_func_t *func,
                                         const wasmer_value_t *params,
                                         int params_len,
                                         wasmer_value_t *results,
@@ -166,7 +172,7 @@ wasmer_result_t wasmer_export_func_call(wasmer_export_func_t *func,
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_export_func_params(wasmer_export_func_t *func,
+wasmer_result_t wasmer_export_func_params(const wasmer_export_func_t *func,
                                           wasmer_value_tag *params,
                                           int params_len);
 
@@ -174,13 +180,13 @@ wasmer_result_t wasmer_export_func_params(wasmer_export_func_t *func,
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_export_func_params_arity(wasmer_export_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_export_func_params_arity(const wasmer_export_func_t *func, uint32_t *result);
 
 /// Sets the returns buffer to the parameter types of the given wasmer_export_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_export_func_returns(wasmer_export_func_t *func,
+wasmer_result_t wasmer_export_func_returns(const wasmer_export_func_t *func,
                                            wasmer_value_tag *returns,
                                            int returns_len);
 
@@ -188,7 +194,8 @@ wasmer_result_t wasmer_export_func_returns(wasmer_export_func_t *func,
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_export_func_returns_arity(wasmer_export_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_export_func_returns_arity(const wasmer_export_func_t *func,
+                                                 uint32_t *result);
 
 /// Gets wasmer_export kind
 wasmer_import_export_kind wasmer_export_kind(wasmer_export_t *export_);
@@ -197,7 +204,7 @@ wasmer_import_export_kind wasmer_export_kind(wasmer_export_t *export_);
 wasmer_byte_array wasmer_export_name(wasmer_export_t *export_);
 
 /// Gets export func from export
-const wasmer_export_func_t *wasmer_export_to_func(wasmer_export_t *export_);
+const wasmer_export_func_t *wasmer_export_to_func(const wasmer_export_t *export_);
 
 /// Frees the memory for the given exports
 void wasmer_exports_destroy(wasmer_exports_t *exports);
@@ -235,7 +242,7 @@ wasmer_byte_array wasmer_import_descriptor_name(wasmer_import_descriptor_t *impo
 
 /// Gets import descriptors for the given module
 /// The caller owns the object and should call `wasmer_import_descriptors_destroy` to free it.
-void wasmer_import_descriptors(wasmer_module_t *module,
+void wasmer_import_descriptors(const wasmer_module_t *module,
                                wasmer_import_descriptors_t **import_descriptors);
 
 /// Frees the memory for the given import descriptors
@@ -263,7 +270,7 @@ const wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_import_func_params(wasmer_import_func_t *func,
+wasmer_result_t wasmer_import_func_params(const wasmer_import_func_t *func,
                                           wasmer_value_tag *params,
                                           int params_len);
 
@@ -271,13 +278,13 @@ wasmer_result_t wasmer_import_func_params(wasmer_import_func_t *func,
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_import_func_params_arity(wasmer_import_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_import_func_params_arity(const wasmer_import_func_t *func, uint32_t *result);
 
 /// Sets the returns buffer to the parameter types of the given wasmer_import_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_import_func_returns(wasmer_import_func_t *func,
+wasmer_result_t wasmer_import_func_returns(const wasmer_import_func_t *func,
                                            wasmer_value_tag *returns,
                                            int returns_len);
 
@@ -285,7 +292,8 @@ wasmer_result_t wasmer_import_func_returns(wasmer_import_func_t *func,
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_import_func_returns_arity(wasmer_import_func_t *func, uint32_t *result);
+wasmer_result_t wasmer_import_func_returns_arity(const wasmer_import_func_t *func,
+                                                 uint32_t *result);
 
 /// Calls an instances exported function by `name` with the provided parameters.
 /// Results are set using the provided `results` pointer.
@@ -302,7 +310,7 @@ wasmer_result_t wasmer_instance_call(wasmer_instance_t *instance,
 /// Gets the memory within the context at the index `memory_idx`.
 /// The index is always 0 until multiple memories are supported.
 const wasmer_memory_t *wasmer_instance_context_memory(wasmer_instance_context_t *ctx,
-                                                      uint32_t memory_idx);
+                                                      uint32_t _memory_idx);
 
 /// Frees memory for the given Instance
 void wasmer_instance_destroy(wasmer_instance_t *instance);
@@ -377,7 +385,7 @@ void wasmer_module_destroy(wasmer_module_t *module);
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
 /// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
 /// and `wasmer_last_error_message` to get an error message.
-wasmer_result_t wasmer_module_instantiate(wasmer_module_t *module,
+wasmer_result_t wasmer_module_instantiate(const wasmer_module_t *module,
                                           wasmer_instance_t **instance,
                                           wasmer_import_t *imports,
                                           int imports_len);


### PR DESCRIPTION
This patch fixes several warnings: Some generated by `rustc`, some other generated by Clippy.

I tried to generate 3 “clean” commits:

  1. To remove unsafe blocks inside unsafe functions,
  2. To remove unmutated mutable bindings,
  3. To resolve Clippy warnings.

I hope those changes are OK for you. I will comment the patch a little bit to provide further help.