### PR TITLE
fix(runtime-c-api) Update `cbindgen`

### DIFF
--- a/lib/runtime-c-api/Cargo.toml
+++ b/lib/runtime-c-api/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-cbindgen = { version = "0.7.1", optional = true }
+cbindgen = { version = "0.8", optional = true }
 
 [features]
 generate-c-api-headers = ["cbindgen"]


### PR DESCRIPTION
When requiring `wasmer-runtime-c-api`, I get the following conflicts:

```
error: failed to select a version for `serde_derive`.
    ... required by package `cbindgen v0.7.1`
    ... which is depended on by `wasmer-runtime-c-api v0.2.1`
    ... which is depended on by `foo v0.1.0 (/private/tmp/foo)`
versions that meet the requirements `= 1.0.58` are: 1.0.58

all possible versions conflict with previously selected packages.

  previously selected package `serde_derive v1.0.89`
    ... which is depended on by `wasmer-runtime-core v0.2.1`
    ... which is depended on by `wasmer-runtime-c-api v0.2.1`
    ... which is depended on by `foo v0.1.0 (/private/tmp/foo)`

failed to select a version for `serde_derive` which could resolve this conflict
```

This issue resolves by updating `cbindgen` to 0.8.