### PR TITLE
feat(runtime-c-api) Generate the C/C++ header files in `OUT_DIR` (+ copy in `CARGO_MANIFEST_DIR`).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,11 +115,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cbindgen"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1271,7 +1273,7 @@ dependencies = [
 name = "wasmer-runtime-c-api"
 version = "0.2.1"
 dependencies = [
- "cbindgen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbindgen 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.2.1",
  "wasmer-runtime-core 0.2.1",
@@ -1401,7 +1403,7 @@ dependencies = [
 "checksum blake2b_simd 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce2571a6cd634670daa2977cc894c1cc2ba57c563c498e5a82c35446f34d056e"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
-"checksum cbindgen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32e01024aaf5390d6a8145047371a4f5b0063a14c1e411bc731353bd2278ca44"
+"checksum cbindgen 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "93aabdea4371364a6b05c72a64d26417ad7eae2b06ddf3c7eaf62b3699701ebe"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cexpr 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "644d693ecfa91955ed32dcc7eda4914e1be97a641fb6f0645a37348e20b230da"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ emtests:
 	WASM_EMSCRIPTEN_GENERATE_EMTESTS=1 cargo build -p wasmer-emscripten
 
 capi:
-	WASM_EMSCRIPTEN_GENERATE_C_API_HEADERS=1 cargo build --manifest-path lib/runtime-c-api/Cargo.toml --features generate-c-api-headers
+	cargo build --manifest-path lib/runtime-c-api/Cargo.toml
 
 # clean:
 #     rm -rf artifacts

--- a/lib/runtime-c-api/Cargo.toml
+++ b/lib/runtime-c-api/Cargo.toml
@@ -14,7 +14,7 @@ wasmer-runtime-core = { path = "../runtime-core", version = "0.2.1" }
 libc = "0.2"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [build-dependencies]
 cbindgen = "0.8"

--- a/lib/runtime-c-api/Cargo.toml
+++ b/lib/runtime-c-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmer-runtime-c-api"
 version = "0.2.1"
-description = "Wasmer c-api library"
+description = "Wasmer C API library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -17,9 +17,4 @@ libc = "0.2"
 crate-type = ["cdylib"]
 
 [build-dependencies]
-cbindgen = { version = "0.8", optional = true }
-
-[features]
-generate-c-api-headers = ["cbindgen"]
-
-
+cbindgen = "0.8"

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -1,28 +1,21 @@
-#[cfg(feature = "generate-c-api-headers")]
 extern crate cbindgen;
 
+use cbindgen::{Builder, Language};
 use std::{env, path::Path};
 
-static CAPI_ENV_VAR: &str = "WASM_EMSCRIPTEN_GENERATE_C_API_HEADERS";
-
 fn main() {
-    if env::var(CAPI_ENV_VAR).unwrap_or("0".to_string()) == "1" {
-        build();
-    }
-}
-
-#[cfg(feature = "generate-c-api-headers")]
-fn build() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_path = Path::new(&out_dir);
+
     let mut wasmer_h = out_path.to_path_buf();
     wasmer_h.push("wasmer.h");
+
     let mut wasmer_hh = out_path.to_path_buf();
     wasmer_hh.push("wasmer.hh");
 
-    use cbindgen::Language;
-    cbindgen::Builder::new()
+    Builder::new()
         .with_crate(crate_dir.clone())
         .with_language(Language::C)
         .with_include_guard("WASMER_H")
@@ -30,16 +23,11 @@ fn build() {
         .expect("Unable to generate C bindings")
         .write_to_file(wasmer_h);
 
-    cbindgen::Builder::new()
+    Builder::new()
         .with_crate(crate_dir)
         .with_language(Language::Cxx)
         .with_include_guard("WASMER_H")
         .generate()
         .expect("Unable to generate C++ bindings")
         .write_to_file(wasmer_hh);
-}
-
-#[cfg(not(feature = "generate-c-api-headers"))]
-fn build() {
-    panic!("environment var set to generate wasmer c API headers but generate-c-api-headers feature not enabled")
 }

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "generate-c-api-headers")]
 extern crate cbindgen;
 
-use std::env;
+use std::{env, path::Path};
 
 static CAPI_ENV_VAR: &str = "WASM_EMSCRIPTEN_GENERATE_C_API_HEADERS";
 
@@ -14,6 +14,12 @@ fn main() {
 #[cfg(feature = "generate-c-api-headers")]
 fn build() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_path = Path::new(&out_dir);
+    let mut wasmer_h = out_path.to_path_buf();
+    wasmer_h.push("wasmer.h");
+    let mut wasmer_hh = out_path.to_path_buf();
+    wasmer_hh.push("wasmer.hh");
 
     use cbindgen::Language;
     cbindgen::Builder::new()
@@ -22,7 +28,7 @@ fn build() {
         .with_include_guard("WASMER_H")
         .generate()
         .expect("Unable to generate C bindings")
-        .write_to_file("wasmer.h");
+        .write_to_file(wasmer_h);
 
     cbindgen::Builder::new()
         .with_crate(crate_dir)
@@ -30,7 +36,7 @@ fn build() {
         .with_include_guard("WASMER_H")
         .generate()
         .expect("Unable to generate C++ bindings")
-        .write_to_file("wasmer.hh");
+        .write_to_file(wasmer_hh);
 }
 
 #[cfg(not(feature = "generate-c-api-headers"))]

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -1,33 +1,52 @@
 extern crate cbindgen;
 
 use cbindgen::{Builder, Language};
-use std::{env, path::Path};
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut crate_wasmer_header_file = PathBuf::from(&crate_dir);
+    crate_wasmer_header_file.push("wasmer");
 
     let out_dir = env::var("OUT_DIR").unwrap();
-    let out_path = Path::new(&out_dir);
+    let mut out_wasmer_header_file = PathBuf::from(&out_dir);
+    out_wasmer_header_file.push("wasmer");
 
-    let mut wasmer_h = out_path.to_path_buf();
-    wasmer_h.push("wasmer.h");
-
-    let mut wasmer_hh = out_path.to_path_buf();
-    wasmer_hh.push("wasmer.hh");
-
+    // Generate the C bindings in the `OUT_DIR`.
+    out_wasmer_header_file.set_extension("h");
     Builder::new()
         .with_crate(crate_dir.clone())
         .with_language(Language::C)
         .with_include_guard("WASMER_H")
         .generate()
         .expect("Unable to generate C bindings")
-        .write_to_file(wasmer_h);
+        .write_to_file(out_wasmer_header_file.as_path());
 
+    // Generate the C++ bindings in the `OUT_DIR`.
+    out_wasmer_header_file.set_extension("hh");
     Builder::new()
         .with_crate(crate_dir)
         .with_language(Language::Cxx)
         .with_include_guard("WASMER_H")
         .generate()
         .expect("Unable to generate C++ bindings")
-        .write_to_file(wasmer_hh);
+        .write_to_file(out_wasmer_header_file.as_path());
+
+    // Copy the generated C bindings from `OUT_DIR` to
+    // `CARGO_MANIFEST_DIR`.
+    crate_wasmer_header_file.set_extension("h");
+    out_wasmer_header_file.set_extension("h");
+    fs::copy(
+        out_wasmer_header_file.as_path(),
+        crate_wasmer_header_file.as_path(),
+    )
+    .expect("Unable to copy the generated C bindings");
+
+    // Copy the generated C++ bindings from `OUT_DIR` to
+    // `CARGO_MANIFEST_DIR`.
+    crate_wasmer_header_file.set_extension("h");
+    crate_wasmer_header_file.set_extension("hh");
+    out_wasmer_header_file.set_extension("hh");
+    fs::copy(out_wasmer_header_file, crate_wasmer_header_file)
+        .expect("Unable to copy the generated C++ bindings");
 }

--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -1498,7 +1498,8 @@ fn take_last_error() -> Option<Box<Error>> {
 /// bytes needed to store a message.
 ///
 /// # Example
-/// ```
+///
+/// ```c
 /// int error_len = wasmer_last_error_length();
 /// char *error_str = malloc(error_len);
 /// ```
@@ -1517,7 +1518,8 @@ pub extern "C" fn wasmer_last_error_length() -> c_int {
 /// Returns `-1` if an error occurs.
 ///
 /// # Example
-/// ```
+///
+/// ```c
 /// int error_len = wasmer_last_error_length();
 /// char *error_str = malloc(error_len);
 /// wasmer_last_error_message(error_str, error_len);

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -417,7 +417,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
  * This can be used to dynamically allocate a buffer with the correct number of
  * bytes needed to store a message.
  * # Example
- * ```
+ * ```c
  * int error_len = wasmer_last_error_length();
  * char *error_str = malloc(error_len);
  * ```
@@ -430,7 +430,7 @@ int wasmer_last_error_length(void);
  * Returns the length of the string in bytes.
  * Returns `-1` if an error occurs.
  * # Example
- * ```
+ * ```c
  * int error_len = wasmer_last_error_length();
  * char *error_str = malloc(error_len);
  * wasmer_last_error_message(error_str, error_len);

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -333,7 +333,7 @@ wasmer_result_t wasmer_instantiate(wasmer_instance_t **instance,
 /// This can be used to dynamically allocate a buffer with the correct number of
 /// bytes needed to store a message.
 /// # Example
-/// ```
+/// ```c
 /// int error_len = wasmer_last_error_length();
 /// char *error_str = malloc(error_len);
 /// ```
@@ -344,7 +344,7 @@ int wasmer_last_error_length();
 /// Returns the length of the string in bytes.
 /// Returns `-1` if an error occurs.
 /// # Example
-/// ```
+/// ```c
 /// int error_len = wasmer_last_error_length();
 /// char *error_str = malloc(error_len);
 /// wasmer_last_error_message(error_str, error_len);


### PR DESCRIPTION
This patch changes the directory where the C/C++ header files are
generated, from `CARGO_MANIFEST_DIR` to `OUT_DIR`. The goal is: When
`wasm-runtime-c-api` is used as a dependency of another Rust project,
then the C header files are accessible in the `target/` directory
(i.e. the `OUT_DIR`).

A copy is kept in the `CARGO_MANIFEST_DIR` file, so that they can be
versionnized.

Also, since `rustc` has a `--out-dir` directory, it increases the
flexibility of this approach: The user can generate the C header files
where she wants.

The `WASM_EMSCRIPTEN_GENERATE_C_API_HEADERS` environement variable has
been removed.