### PR TITLE
feat(runtime-c-api) Ask `rustc` to generate a static library.

### DIFF
--- a/lib/runtime-c-api/Cargo.toml
+++ b/lib/runtime-c-api/Cargo.toml
@@ -14,7 +14,7 @@ wasmer-runtime-core = { path = "../runtime-core", version = "0.2.1" }
 libc = "0.2"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [build-dependencies]
 cbindgen = "0.8"


### PR DESCRIPTION
This is required to correctly link to the embedded runtime.