### PR TITLE
Add Compile command.

### DIFF
--- a/lib/runtime-core/src/cache.rs
+++ b/lib/runtime-core/src/cache.rs
@@ -204,6 +204,6 @@ pub trait Cache {
     type LoadError: fmt::Debug;
     type StoreError: fmt::Debug;
 
-    fn load(&self, key: WasmHash) -> Result<Module, Self::LoadError>;
-    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), Self::StoreError>;
+    fn load(&self, key: String) -> Result<Module, Self::LoadError>;
+    fn store(&mut self, key: String, module: Module) -> Result<(), Self::StoreError>;
 }

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -81,10 +81,9 @@ impl Cache for FileSystemCache {
     type LoadError = CacheError;
     type StoreError = CacheError;
 
-    fn load(&self, key: WasmHash) -> Result<Module, CacheError> {
-        let filename = key.encode();
+    fn load(&self, key: String) -> Result<Module, CacheError> {
         let mut new_path_buf = self.path.clone();
-        new_path_buf.push(filename);
+        new_path_buf.push(key);
         let file = File::open(new_path_buf)?;
         let mmap = unsafe { Mmap::map(&file)? };
 
@@ -92,10 +91,9 @@ impl Cache for FileSystemCache {
         unsafe { wasmer_runtime_core::load_cache_with(serialized_cache, super::default_compiler()) }
     }
 
-    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), CacheError> {
-        let filename = key.encode();
+    fn store(&mut self, key: String, module: Module) -> Result<(), CacheError> {
         let mut new_path_buf = self.path.clone();
-        new_path_buf.push(filename);
+        new_path_buf.push(key);
 
         let serialized_cache = module.cache()?;
         let buffer = serialized_cache.serialize()?;

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -30,7 +30,7 @@ pub use wasmer_runtime_core::cache::{Artifact, Cache, WasmHash};
 ///     // Compute a key for a given WebAssembly binary
 ///     let key = WasmHash::generate(&[]);
 ///     // Store a module into the cache given a key
-///     fs_cache.store(key, module.clone())?;
+///     fs_cache.store(key.encode(), module.clone())?;
 ///     Ok(module)
 /// }
 /// ```

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -57,10 +57,6 @@ struct CacheGenerate {
 
 #[derive(Debug, StructOpt)]
 struct CacheRun {
-    /// Module name to run
-    #[structopt(parse(from_os_str))]
-    module_name: OsString,
-
     /// Module key in the cache
     #[structopt(parse(from_os_str))]
     module_key: OsString,
@@ -258,13 +254,12 @@ fn run_wasm_module_from_cache(options: &CacheRun) -> Result<(), String> {
         FileSystemCache::new(wasmer_cache_dir).map_err(|e| format!("Cache error: {:?}", e))?
     };
 
-    let key = String::from(options.module_key.to_str().unwrap());
+    let key = options.module_key.to_str().unwrap();
     let module = cache
-        .load(key)
+        .load(String::from(key))
         .map_err(|e| format!("Can't execute module from cache: {:?}", e))?;
 
-    let name = String::from(options.module_name.to_str().unwrap());
-    run_wasm_module(&module, name, &options.args)
+    run_wasm_module(&module, String::from(key), &options.args)
 }
 
 fn cache_run(options: CacheRun) {

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -105,8 +105,7 @@ fn load_wasm_binary(wasm_path: &PathBuf) -> Result<Vec<u8>, String> {
         return Ok(wasm_binary);
     }
 
-    wabt::wat2wasm(wasm_binary)
-            .map_err(|e| format!("Can't convert from wast to wasm: {:?}", e))
+    wabt::wat2wasm(wasm_binary).map_err(|e| format!("Can't convert from wast to wasm: {:?}", e))
 }
 
 /// Execute a wasm/wat file
@@ -118,9 +117,9 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
     let disable_cache = options.disable_cache;
 
     let module = if disable_cache {
-            let wasm_binary = load_wasm_binary(&options.path)?;
-            webassembly::compile(&wasm_binary[..])
-                .map_err(|e| format!("Can't compile module: {:?}", e))?
+        let wasm_binary = load_wasm_binary(&options.path)?;
+        webassembly::compile(&wasm_binary[..])
+            .map_err(|e| format!("Can't compile module: {:?}", e))?
     } else {
         // If we have cache enabled
         let wasmer_cache_dir = get_cache_dir();
@@ -133,9 +132,9 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
         };
 
         let module = match &options.from_cache {
-            Some(key) => {
-                cache.load(String::from(key.to_str().unwrap())).map_err(|e| format!("Can't load module from cache: {:?}", e))?
-            }
+            Some(key) => cache
+                .load(String::from(key.to_str().unwrap()))
+                .map_err(|e| format!("Can't load module from cache: {:?}", e))?,
             None => {
                 let wasm_binary = load_wasm_binary(&options.path)?;
 
@@ -225,7 +224,8 @@ fn compile_wasm(options: &Compile) -> Result<(), String> {
     };
 
     // We save the module into a cache file
-    cache.store(hash.encode(), module.clone())
+    cache
+        .store(hash.encode(), module.clone())
         .map_err(|e| format!("Can't store module in cache: {:?}", e))
 }
 
@@ -248,7 +248,7 @@ fn main() {
         #[cfg(target_os = "windows")]
         CLIOptions::Compile(_) => {
             println!("Compiling is disabled for Windows.");
-        },
+        }
         #[cfg(not(target_os = "windows"))]
         CLIOptions::SelfUpdate => update::self_update(),
         #[cfg(target_os = "windows")]


### PR DESCRIPTION
This command allows people to compile a wasm module to machine code ahead
of time. It dumps the data in the cache, so future runs can use it.

It also changes the Cache trait to use Strings as keys, so it's more flexible than using the WasmHash object directly.

I've added a --from-cache flag to the Run command to allow loading modules directly from the cache without having access to the wasm or wat files. I'm not super sold on this flag.

I'm super open to suggestions and other options.

Enjoy this doggo taking a bath:

![](https://i.pinimg.com/originals/3f/d2/07/3fd207d03c9211bb5fac00eaeaebebdf.jpg)