### PR TITLE
chore(makefile) Remove the `capi` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ spectests:
 emtests:
 	WASM_EMSCRIPTEN_GENERATE_EMTESTS=1 cargo build -p wasmer-emscripten
 
-capi:
-	cargo build --manifest-path lib/runtime-c-api/Cargo.toml
-
 # clean:
 #     rm -rf artifacts
 


### PR DESCRIPTION
This target is no longer useful since the C and C++ header files are
generated each time for each build.