### PR TITLE
remove unnecessary conditional compilation in cargo file for windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ wasmer-emscripten = { path = "lib/emscripten" }
 wasmer-llvm-backend = { path = "lib/llvm-backend" }
 
 [workspace]
-members = ["lib/clif-backend", "lib/runtime", "lib/runtime-core", "lib/emscripten", "lib/spectests", "lib/win-exception-handler", "lib/runtime-c-api"]
-
-[target.'cfg(not(windows))'.workspace]
 members = ["lib/clif-backend", "lib/runtime", "lib/runtime-core", "lib/emscripten", "lib/spectests", "lib/win-exception-handler", "lib/runtime-c-api", "lib/llvm-backend"]
 
 [build-dependencies]


### PR DESCRIPTION
It's not completely obvious, but this conditional workspace member is not valid for Cargo.toml. We also are already conditionally compiling the llvm backend for non windows targets.