### PR TITLE
fix(runtime-core) Remove unused imports

### DIFF
--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -1,9 +1,6 @@
-use crate::types::{
-    FuncSig, GlobalDescriptor, MemoryDescriptor, MemoryIndex, TableDescriptor, TableIndex, Type,
-    Value,
-};
+use crate::types::{FuncSig, GlobalDescriptor, MemoryDescriptor, TableDescriptor, Type, Value};
 use core::borrow::Borrow;
-use std::{any::Any, sync::Arc};
+use std::any::Any;
 
 pub type Result<T> = std::result::Result<T, Error>;
 pub type CompileResult<T> = std::result::Result<T, CompileError>;

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -6,7 +6,7 @@ use crate::{
     types::{FuncSig, Type, WasmExternType},
     vm::Ctx,
 };
-use std::{any::Any, cell::UnsafeCell, fmt, marker::PhantomData, mem, panic, ptr, sync::Arc};
+use std::{any::Any, cell::UnsafeCell, marker::PhantomData, mem, panic, ptr, sync::Arc};
 
 thread_local! {
     pub static EARLY_TRAPPER: UnsafeCell<Option<Box<dyn UserTrapper>>> = UnsafeCell::new(None);


### PR DESCRIPTION
This patch removes unused imports as reported by `rustc` as warnings.