### PR TITLE
fix(runtime-core) `SharedMemory.desc` is never used, remove it

### DIFF
--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -284,6 +284,7 @@ impl Clone for UnsharedMemory {
 }
 
 pub struct SharedMemory {
+    #[allow(dead_code)]
     desc: MemoryDescriptor,
 }
 


### PR DESCRIPTION
This patch removes the `desc` field of `SharedMemory`. This field is
never used. Maybe it will be used in the future when the
implementations will be written, but so far, it only generates
warnings.