### PR TITLE
fix(emscripten) Various warning fixes and cleanups

### DIFF
--- a/lib/emscripten/src/emscripten_target.rs
+++ b/lib/emscripten/src/emscripten_target.rs
@@ -1,14 +1,14 @@
 use crate::env::get_emscripten_data;
 use wasmer_runtime_core::vm::Ctx;
 
-pub fn setTempRet0(ctx: &mut Ctx, a: i32) {
+pub fn setTempRet0(_ctx: &mut Ctx, _a: i32) {
     debug!("emscripten::setTempRet0");
 }
-pub fn getTempRet0(ctx: &mut Ctx) -> i32 {
+pub fn getTempRet0(_ctx: &mut Ctx) -> i32 {
     debug!("emscripten::getTempRet0");
     0
 }
-pub fn nullFunc_ji(ctx: &mut Ctx, a: i32) {
+pub fn nullFunc_ji(_ctx: &mut Ctx, _a: i32) {
     debug!("emscripten::nullFunc_ji");
 }
 pub fn invoke_i(ctx: &mut Ctx, index: i32) -> i32 {
@@ -83,158 +83,166 @@ pub fn invoke_viiii(ctx: &mut Ctx, index: i32, a1: i32, a2: i32, a3: i32, a4: i3
         panic!("dyn_call_viiii is set to None");
     }
 }
-pub fn __Unwind_Backtrace(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn __Unwind_Backtrace(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::__Unwind_Backtrace");
     0
 }
-pub fn __Unwind_FindEnclosingFunction(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn __Unwind_FindEnclosingFunction(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::__Unwind_FindEnclosingFunction");
     0
 }
-pub fn __Unwind_GetIPInfo(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn __Unwind_GetIPInfo(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::__Unwind_GetIPInfo");
     0
 }
-pub fn ___cxa_find_matching_catch_2(ctx: &mut Ctx) -> i32 {
+pub fn ___cxa_find_matching_catch_2(_ctx: &mut Ctx) -> i32 {
     debug!("emscripten::___cxa_find_matching_catch_2");
     0
 }
-pub fn ___cxa_find_matching_catch_3(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn ___cxa_find_matching_catch_3(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::___cxa_find_matching_catch_3");
     0
 }
-pub fn ___cxa_free_exception(ctx: &mut Ctx, a: i32) {
+pub fn ___cxa_free_exception(_ctx: &mut Ctx, _a: i32) {
     debug!("emscripten::___cxa_free_exception");
 }
-pub fn ___resumeException(ctx: &mut Ctx, a: i32) {
+pub fn ___resumeException(_ctx: &mut Ctx, _a: i32) {
     debug!("emscripten::___resumeException");
 }
-pub fn _dladdr(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn _dladdr(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::_dladdr");
     0
 }
-pub fn _pthread_cond_destroy(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_cond_destroy(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_cond_destroy");
     0
 }
-pub fn _pthread_cond_init(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn _pthread_cond_init(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::_pthread_cond_init");
     0
 }
-pub fn _pthread_cond_signal(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_cond_signal(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_cond_signal");
     0
 }
-pub fn _pthread_cond_wait(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn _pthread_cond_wait(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::_pthread_cond_wait");
     0
 }
-pub fn _pthread_condattr_destroy(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_condattr_destroy(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_condattr_destroy");
     0
 }
-pub fn _pthread_condattr_init(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_condattr_init(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_condattr_init");
     0
 }
-pub fn _pthread_condattr_setclock(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn _pthread_condattr_setclock(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::_pthread_condattr_setclock");
     0
 }
-pub fn _pthread_mutex_destroy(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_mutex_destroy(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_mutex_destroy");
     0
 }
-pub fn _pthread_mutex_init(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn _pthread_mutex_init(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::_pthread_mutex_init");
     0
 }
-pub fn _pthread_mutexattr_destroy(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_mutexattr_destroy(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_mutexattr_destroy");
     0
 }
-pub fn _pthread_mutexattr_init(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_mutexattr_init(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_mutexattr_init");
     0
 }
-pub fn _pthread_mutexattr_settype(ctx: &mut Ctx, a: i32, b: i32) -> i32 {
+pub fn _pthread_mutexattr_settype(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
     debug!("emscripten::_pthread_mutexattr_settype");
     0
 }
-pub fn _pthread_rwlock_rdlock(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_rwlock_rdlock(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_rwlock_rdlock");
     0
 }
-pub fn _pthread_rwlock_unlock(ctx: &mut Ctx, a: i32) -> i32 {
+pub fn _pthread_rwlock_unlock(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_rwlock_unlock");
     0
 }
-pub fn ___gxx_personality_v0(ctx: &mut Ctx, a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) -> i32 {
+pub fn ___gxx_personality_v0(
+    _ctx: &mut Ctx,
+    _a: i32,
+    _b: i32,
+    _c: i32,
+    _d: i32,
+    _e: i32,
+    _f: i32,
+) -> i32 {
     debug!("emscripten::___gxx_personality_v0");
     0
 }
 // round 2
-pub fn nullFunc_dii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_dii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_dii");
 }
-pub fn nullFunc_diiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_diiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_diiii");
 }
-pub fn nullFunc_iiji(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_iiji(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_iiji");
 }
-pub fn nullFunc_j(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_j(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_j");
 }
-pub fn nullFunc_jij(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_jij(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_jij");
 }
-pub fn nullFunc_jjj(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_jjj(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_jjj");
 }
-pub fn nullFunc_vd(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_vd(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_vd");
 }
-pub fn nullFunc_viiiiiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiiiiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiiiiii");
 }
-pub fn nullFunc_viiiiiiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiiiiiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiiiiiii");
 }
-pub fn nullFunc_viiiiiiiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiiiiiiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiiiiiiii");
 }
-pub fn nullFunc_viiij(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiij(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiij");
 }
-pub fn nullFunc_viiijiiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiijiiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiijiiii");
 }
-pub fn nullFunc_viiijiiiiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiijiiiiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiijiiiiii");
 }
-pub fn nullFunc_viij(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viij(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viij");
 }
-pub fn nullFunc_viiji(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viiji(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viiji");
 }
-pub fn nullFunc_viijiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viijiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viijiii");
 }
-pub fn nullFunc_viijj(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viijj(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viijj");
 }
-pub fn nullFunc_vij(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_vij(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_vij");
 }
-pub fn nullFunc_viji(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_viji(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_viji");
 }
-pub fn nullFunc_vijiii(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_vijiii(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_vijiii");
 }
-pub fn nullFunc_vijj(ctx: &mut Ctx, index: i32) {
+pub fn nullFunc_vijj(_ctx: &mut Ctx, _index: i32) {
     debug!("emscripten::nullFunc_vijj");
 }
 pub fn invoke_dii(ctx: &mut Ctx, index: i32, a1: i32, a2: i32) -> f64 {

--- a/lib/emscripten/src/emscripten_target.rs
+++ b/lib/emscripten/src/emscripten_target.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::env::get_emscripten_data;
 use wasmer_runtime_core::vm::Ctx;
 

--- a/lib/emscripten/src/env/mod.rs
+++ b/lib/emscripten/src/env/mod.rs
@@ -70,8 +70,8 @@ pub fn ___build_environment(ctx: &mut Ctx, environ: c_int) {
     // };
 }
 
-pub fn ___assert_fail(_ctx: &mut Ctx, a: c_int, b: c_int, c: c_int, d: c_int) {
-    debug!("emscripten::___assert_fail {} {} {} {}", a, b, c, d);
+pub fn ___assert_fail(_ctx: &mut Ctx, _a: c_int, _b: c_int, _c: c_int, _d: c_int) {
+    debug!("emscripten::___assert_fail {} {} {} {}", _a, _b, _c, _d);
     // TODO: Implement like emscripten expects regarding memory/page size
     // TODO raise an error
 }

--- a/lib/emscripten/src/errno.rs
+++ b/lib/emscripten/src/errno.rs
@@ -1,8 +1,8 @@
 // use std::collections::HashMap;
 use wasmer_runtime_core::vm::Ctx;
 
-pub fn ___seterrno(_ctx: &mut Ctx, value: i32) {
-    debug!("emscripten::___seterrno {}", value);
+pub fn ___seterrno(_ctx: &mut Ctx, _value: i32) {
+    debug!("emscripten::___seterrno {}", _value);
     // TODO: Incomplete impl
     eprintln!("failed to set errno!");
     // value

--- a/lib/emscripten/src/io/unix.rs
+++ b/lib/emscripten/src/io/unix.rs
@@ -3,7 +3,7 @@ use libc::printf as _printf;
 use wasmer_runtime_core::vm::Ctx;
 
 /// putchar
-pub fn putchar(ctx: &mut Ctx, chr: i32) {
+pub fn putchar(_ctx: &mut Ctx, chr: i32) {
     unsafe { libc::putchar(chr) };
 }
 

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -349,17 +349,17 @@ impl EmscriptenGlobals {
         let data = {
             let static_bump = STATIC_BUMP;
 
-            let mut STATIC_TOP = STATIC_BASE + static_bump;
+            let mut static_top = STATIC_BASE + static_bump;
 
             let memory_base = STATIC_BASE;
             let table_base = 0;
 
-            let temp_double_ptr = STATIC_TOP;
-            STATIC_TOP += 16;
+            let temp_double_ptr = static_top;
+            static_top += 16;
 
-            let dynamictop_ptr = static_alloc(&mut STATIC_TOP, 4);
+            let dynamictop_ptr = static_alloc(&mut static_top, 4);
 
-            let stacktop = align_memory(STATIC_TOP);
+            let stacktop = align_memory(static_top);
             let stack_max = stacktop + TOTAL_STACK;
 
             EmscriptenGlobalsData {

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -56,8 +56,6 @@ pub use self::utils::{
 
 // TODO: Magic number - how is this calculated?
 const TOTAL_STACK: u32 = 5_242_880;
-// TODO: Magic number - how is this calculated?
-const DYNAMICTOP_PTR_DIFF: u32 = 1088;
 // TODO: make this variable
 const STATIC_BUMP: u32 = 215_536;
 
@@ -72,22 +70,6 @@ lazy_static! {
 // Then 'dynamic' memory for sbrk.
 const GLOBAL_BASE: u32 = 1024;
 const STATIC_BASE: u32 = GLOBAL_BASE;
-
-fn stacktop(static_bump: u32) -> u32 {
-    align_memory(dynamictop_ptr(static_bump) + 4)
-}
-
-fn stack_max(static_bump: u32) -> u32 {
-    stacktop(static_bump) + TOTAL_STACK
-}
-
-fn dynamic_base(static_bump: u32) -> u32 {
-    align_memory(stack_max(static_bump))
-}
-
-fn dynamictop_ptr(static_bump: u32) -> u32 {
-    static_bump + DYNAMICTOP_PTR_DIFF
-}
 
 pub struct EmscriptenData<'a> {
     pub malloc: Func<'a, u32, u32>,

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -293,10 +293,6 @@ pub struct EmscriptenGlobalsData {
     table_base: u32,
     temp_double_ptr: u32,
     use_old_abort_on_cannot_grow_memory: bool,
-
-    // Global namespace
-    infinity: f64,
-    nan: f64,
 }
 
 pub struct EmscriptenGlobals {
@@ -375,9 +371,6 @@ impl EmscriptenGlobals {
                 table_base,
                 temp_double_ptr,
                 use_old_abort_on_cannot_grow_memory,
-
-                infinity: std::f64::INFINITY,
-                nan: std::f64::NAN,
             }
         };
 

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -366,7 +366,7 @@ impl EmscriptenGlobals {
             minimum: table_min,
             maximum: table_max,
         };
-        let mut table = Table::new(table_type).unwrap();
+        let table = Table::new(table_type).unwrap();
 
         let data = {
             let static_bump = STATIC_BUMP;

--- a/lib/emscripten/src/lock.rs
+++ b/lib/emscripten/src/lock.rs
@@ -2,13 +2,13 @@ use libc::c_int;
 use wasmer_runtime_core::vm::Ctx;
 
 // NOTE: Not implemented by Emscripten
-pub fn ___lock(_ctx: &mut Ctx, what: c_int) {
-    debug!("emscripten::___lock {}", what);
+pub fn ___lock(_ctx: &mut Ctx, _what: c_int) {
+    debug!("emscripten::___lock {}", _what);
 }
 
 // NOTE: Not implemented by Emscripten
-pub fn ___unlock(_ctx: &mut Ctx, what: c_int) {
-    debug!("emscripten::___unlock {}", what);
+pub fn ___unlock(_ctx: &mut Ctx, _what: c_int) {
+    debug!("emscripten::___unlock {}", _what);
 }
 
 // NOTE: Not implemented by Emscripten

--- a/lib/emscripten/src/memory.rs
+++ b/lib/emscripten/src/memory.rs
@@ -17,15 +17,15 @@ pub fn _emscripten_memcpy_big(ctx: &mut Ctx, dest: u32, src: u32, len: u32) -> u
 }
 
 /// emscripten: _emscripten_get_heap_size
-pub fn _emscripten_get_heap_size(ctx: &mut Ctx) -> u32 {
+pub fn _emscripten_get_heap_size(_ctx: &mut Ctx) -> u32 {
     debug!("emscripten::_emscripten_get_heap_size",);
     // TODO: Fix implementation
     16_777_216
 }
 
 /// emscripten: _emscripten_resize_heap
-pub fn _emscripten_resize_heap(ctx: &mut Ctx, requested_size: u32) -> u32 {
-    debug!("emscripten::_emscripten_resize_heap {}", requested_size);
+pub fn _emscripten_resize_heap(_ctx: &mut Ctx, _requested_size: u32) -> u32 {
+    debug!("emscripten::_emscripten_resize_heap {}", _requested_size);
     // TODO: Fix implementation
     0
 }
@@ -47,8 +47,11 @@ pub fn enlarge_memory(_ctx: &mut Ctx) -> u32 {
 }
 
 /// emscripten: abortOnCannotGrowMemory
-pub fn abort_on_cannot_grow_memory(ctx: &mut Ctx, requested_size: u32) -> u32 {
-    debug!("emscripten::abort_on_cannot_grow_memory {}", requested_size);
+pub fn abort_on_cannot_grow_memory(ctx: &mut Ctx, _requested_size: u32) -> u32 {
+    debug!(
+        "emscripten::abort_on_cannot_grow_memory {}",
+        _requested_size
+    );
     abort_with_message(ctx, "Cannot enlarge memory arrays!");
     0
 }

--- a/lib/emscripten/src/nullfunc.rs
+++ b/lib/emscripten/src/nullfunc.rs
@@ -1,58 +1,58 @@
 use super::process::abort_with_message;
 use wasmer_runtime_core::vm::Ctx;
 
-pub fn nullfunc_i(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_i {}", x);
+pub fn nullfunc_i(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_i {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'i'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_ii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_ii {}", x);
+pub fn nullfunc_ii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_ii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'ii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_iii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_iii {}", x);
+pub fn nullfunc_iii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_iii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'iii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_iiii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_iiii {}", x);
+pub fn nullfunc_iiii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_iiii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'iiii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_iiiii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_iiiii {}", x);
+pub fn nullfunc_iiiii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_iiiii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'iiiii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_iiiiii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_iiiiii {}", x);
+pub fn nullfunc_iiiiii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_iiiiii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'iiiiii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_v(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_v {}", x);
+pub fn nullfunc_v(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_v {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'v'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_vi(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_vi {}", x);
+pub fn nullfunc_vi(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_vi {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'vi'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_vii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_vii {}", x);
+pub fn nullfunc_vii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_vii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'vii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_viii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_viii {}", x);
+pub fn nullfunc_viii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_viii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'viii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 
-pub fn nullfunc_viiii(ctx: &mut Ctx, x: u32) {
-    debug!("emscripten::nullfunc_viiii {}", x);
+pub fn nullfunc_viiii(ctx: &mut Ctx, _x: u32) {
+    debug!("emscripten::nullfunc_viiii {}", _x);
     abort_with_message(ctx, "Invalid function pointer called with signature 'viiii'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this)");
 }
 

--- a/lib/emscripten/src/process.rs
+++ b/lib/emscripten/src/process.rs
@@ -98,7 +98,7 @@ pub fn _sem_wait(_ctx: &mut Ctx, _one: i32) -> i32 {
 }
 
 #[allow(clippy::cast_ptr_alignment)]
-pub fn _getgrent(ctx: &mut Ctx) -> c_int {
+pub fn _getgrent(_ctx: &mut Ctx) -> c_int {
     debug!("emscripten::_getgrent");
     -1
 }

--- a/lib/emscripten/src/signal.rs
+++ b/lib/emscripten/src/signal.rs
@@ -11,8 +11,8 @@ pub fn _sigemptyset(ctx: &mut Ctx, set: u32) -> i32 {
     0
 }
 
-pub fn _sigaction(_ctx: &mut Ctx, signum: u32, act: u32, oldact: u32) -> i32 {
-    debug!("emscripten::_sigaction {}, {}, {}", signum, act, oldact);
+pub fn _sigaction(_ctx: &mut Ctx, _signum: u32, _act: u32, _oldact: u32) -> i32 {
+    debug!("emscripten::_sigaction {}, {}, {}", _signum, _act, _oldact);
     0
 }
 
@@ -36,7 +36,7 @@ pub fn _sigprocmask(_ctx: &mut Ctx, _one: i32, _two: i32, _three: i32) -> i32 {
     0
 }
 
-pub fn _signal(_ctx: &mut Ctx, sig: u32, _two: i32) -> i32 {
-    debug!("emscripten::_signal ({})", sig);
+pub fn _signal(_ctx: &mut Ctx, _sig: u32, _two: i32) -> i32 {
+    debug!("emscripten::_signal ({})", _sig);
     0
 }

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -53,8 +53,8 @@ use libc::SO_NOSIGPIPE;
 const SO_NOSIGPIPE: c_int = 0;
 
 /// exit
-pub fn ___syscall1(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) {
-    debug!("emscripten::___syscall1 (exit) {}", which);
+pub fn ___syscall1(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) {
+    debug!("emscripten::___syscall1 (exit) {}", _which);
     let status: i32 = varargs.get(ctx);
     unsafe {
         exit(status);
@@ -62,9 +62,9 @@ pub fn ___syscall1(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) {
 }
 
 /// read
-pub fn ___syscall3(ctx: &mut Ctx, which: i32, mut varargs: VarArgs) -> i32 {
+pub fn ___syscall3(ctx: &mut Ctx, _which: i32, mut varargs: VarArgs) -> i32 {
     // -> ssize_t
-    debug!("emscripten::___syscall3 (read) {}", which);
+    debug!("emscripten::___syscall3 (read) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let buf: u32 = varargs.get(ctx);
     let count: i32 = varargs.get(ctx);
@@ -76,8 +76,8 @@ pub fn ___syscall3(ctx: &mut Ctx, which: i32, mut varargs: VarArgs) -> i32 {
 }
 
 /// write
-pub fn ___syscall4(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall4 (write) {}", which);
+pub fn ___syscall4(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall4 (write) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let buf: u32 = varargs.get(ctx);
     let count: i32 = varargs.get(ctx);
@@ -87,22 +87,22 @@ pub fn ___syscall4(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
 }
 
 /// close
-pub fn ___syscall6(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall6 (close) {}", which);
+pub fn ___syscall6(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall6 (close) {}", _which);
     let fd: i32 = varargs.get(ctx);
     debug!("fd: {}", fd);
     unsafe { close(fd) }
 }
 
 // chdir
-pub fn ___syscall12(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall12 (chdir) {}", which);
+pub fn ___syscall12(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall12 (chdir) {}", _which);
     let path_addr: i32 = varargs.get(ctx);
     unsafe {
         let path_ptr = emscripten_memory_pointer!(ctx.memory(0), path_addr) as *const i8;
-        let path = std::ffi::CStr::from_ptr(path_ptr);
+        let _path = std::ffi::CStr::from_ptr(path_ptr);
         let ret = chdir(path_ptr);
-        debug!("=> path: {:?}, ret: {}", path, ret);
+        debug!("=> path: {:?}, ret: {}", _path, ret);
         ret
     }
 }
@@ -168,8 +168,8 @@ pub fn ___syscall60(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
 }
 
 // dup2
-pub fn ___syscall63(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall63 (dup2) {}", which);
+pub fn ___syscall63(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall63 (dup2) {}", _which);
 
     let src: i32 = varargs.get(ctx);
     let dst: i32 = varargs.get(ctx);
@@ -233,17 +233,17 @@ pub fn ___syscall183(ctx: &mut Ctx, buf_offset: u32, _size: u32) -> u32 {
 }
 
 // mmap2
-pub fn ___syscall192(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall192 (mmap2) {}", which);
-    let addr: i32 = varargs.get(ctx);
+pub fn ___syscall192(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall192 (mmap2) {}", _which);
+    let _addr: i32 = varargs.get(ctx);
     let len: u32 = varargs.get(ctx);
-    let prot: i32 = varargs.get(ctx);
-    let flags: i32 = varargs.get(ctx);
+    let _prot: i32 = varargs.get(ctx);
+    let _flags: i32 = varargs.get(ctx);
     let fd: i32 = varargs.get(ctx);
-    let off: i32 = varargs.get(ctx);
+    let _off: i32 = varargs.get(ctx);
     debug!(
         "=> addr: {}, len: {}, prot: {}, flags: {}, fd: {}, off: {}",
-        addr, len, prot, flags, fd, off
+        _addr, len, _prot, _flags, fd, _off
     );
 
     if fd == -1 {
@@ -259,9 +259,9 @@ pub fn ___syscall192(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 }
 
 /// lseek
-pub fn ___syscall140(ctx: &mut Ctx, which: i32, mut varargs: VarArgs) -> i32 {
+pub fn ___syscall140(ctx: &mut Ctx, _which: i32, mut varargs: VarArgs) -> i32 {
     // -> c_int
-    debug!("emscripten::___syscall140 (lseek) {}", which);
+    debug!("emscripten::___syscall140 (lseek) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let offset: i32 = varargs.get(ctx);
     let whence: i32 = varargs.get(ctx);
@@ -271,15 +271,9 @@ pub fn ___syscall140(ctx: &mut Ctx, which: i32, mut varargs: VarArgs) -> i32 {
 
 /// readv
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall145(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> i32 {
+pub fn ___syscall145(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> i32 {
     // -> ssize_t
-    debug!("emscripten::___syscall145 (readv) {}", which);
-    // let fd: i32 = varargs.get(ctx);
-    // let iov: u32 = varargs.get(ctx);
-    // let iovcnt: i32 = varargs.get(ctx);
-    // debug!("=> fd: {}, iov: {}, iovcnt = {}", fd, iov, iovcnt);
-    // let iov_addr = emscripten_memory_pointer!(ctx.memory(0), iov) as *mut iovec;
-    // unsafe { readv(fd, iov_addr, iovcnt) }
+    debug!("emscripten::___syscall145 (readv) {}", _which);
 
     let fd: i32 = varargs.get(ctx);
     let iov: i32 = varargs.get(ctx);
@@ -314,9 +308,9 @@ pub fn ___syscall145(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> i32 {
 
 // writev
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall146(ctx: &mut Ctx, which: i32, mut varargs: VarArgs) -> i32 {
+pub fn ___syscall146(ctx: &mut Ctx, _which: i32, mut varargs: VarArgs) -> i32 {
     // -> ssize_t
-    debug!("emscripten::___syscall146 (writev) {}", which);
+    debug!("emscripten::___syscall146 (writev) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let iov: i32 = varargs.get(ctx);
     let iovcnt: i32 = varargs.get(ctx);
@@ -374,8 +368,8 @@ pub fn ___syscall199(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
 }
 
 // stat64
-pub fn ___syscall195(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall195 (stat64) {}", which);
+pub fn ___syscall195(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall195 (stat64) {}", _which);
     let pathname: u32 = varargs.get(ctx);
     let buf: u32 = varargs.get(ctx);
 
@@ -394,8 +388,8 @@ pub fn ___syscall195(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 }
 
 // fstat64
-pub fn ___syscall197(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall197 (fstat64) {}", which);
+pub fn ___syscall197(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall197 (fstat64) {}", _which);
     let fd: c_int = varargs.get(ctx);
     let buf: u32 = varargs.get(ctx);
 
@@ -418,8 +412,8 @@ pub fn ___syscall220(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
 }
 
 // fcntl64
-pub fn ___syscall221(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall221 (fcntl64) {}", which);
+pub fn ___syscall221(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall221 (fcntl64) {}", _which);
     // fcntl64
     let _fd: i32 = varargs.get(ctx);
     let cmd: u32 = varargs.get(ctx);
@@ -455,8 +449,8 @@ pub fn ___syscall334(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
 }
 
 // prlimit64
-pub fn ___syscall340(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall340 (prlimit64), {}", which);
+pub fn ___syscall340(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall340 (prlimit64), {}", _which);
     // NOTE: Doesn't really matter. Wasm modules cannot exceed WASM_PAGE_SIZE anyway.
     let _pid: i32 = varargs.get(ctx);
     let _resource: i32 = varargs.get(ctx);

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -42,17 +42,12 @@ use wasmer_runtime_core::vm::Ctx;
 use super::env;
 use std::cell::Cell;
 use std::slice;
-// use std::sys::fd::FileDesc;
 
 // Another conditional constant for name resolution: Macos et iOS use
 // SO_NOSIGPIPE as a setsockopt flag to disable SIGPIPE emission on socket.
 // Other platforms do otherwise.
-use crate::env::get_emscripten_data;
-use crate::utils::copy_cstr_into_wasm;
-use crate::utils::read_string_from_wasm;
 #[cfg(target_os = "darwin")]
 use libc::SO_NOSIGPIPE;
-use std::ffi::CString;
 
 #[cfg(not(target_os = "darwin"))]
 const SO_NOSIGPIPE: c_int = 0;
@@ -147,7 +142,6 @@ pub fn ___syscall42(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int
     // offset to a file descriptor, which contains a read end and write end, 2 integers
     let fd_offset: u32 = varargs.get(ctx);
 
-    use std::cell::Cell;
     let emscripten_memory = ctx.memory(0);
 
     // convert the file descriptor into a vec with two slots

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -43,15 +43,6 @@ use super::env;
 use std::cell::Cell;
 use std::slice;
 
-// Another conditional constant for name resolution: Macos et iOS use
-// SO_NOSIGPIPE as a setsockopt flag to disable SIGPIPE emission on socket.
-// Other platforms do otherwise.
-#[cfg(target_os = "darwin")]
-use libc::SO_NOSIGPIPE;
-
-#[cfg(not(target_os = "darwin"))]
-const SO_NOSIGPIPE: c_int = 0;
-
 /// exit
 pub fn ___syscall1(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) {
     debug!("emscripten::___syscall1 (exit) {}", _which);

--- a/lib/emscripten/src/syscalls/unix.rs
+++ b/lib/emscripten/src/syscalls/unix.rs
@@ -78,24 +78,24 @@ use libc::SO_NOSIGPIPE;
 const SO_NOSIGPIPE: c_int = 0;
 
 /// open
-pub fn ___syscall5(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall5 (open) {}", which);
+pub fn ___syscall5(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall5 (open) {}", _which);
     let pathname: u32 = varargs.get(ctx);
     let flags: i32 = varargs.get(ctx);
     let mode: u32 = varargs.get(ctx);
     let pathname_addr = emscripten_memory_pointer!(ctx.memory(0), pathname) as *const i8;
-    let path_str = unsafe { std::ffi::CStr::from_ptr(pathname_addr).to_str().unwrap() };
+    let _path_str = unsafe { std::ffi::CStr::from_ptr(pathname_addr).to_str().unwrap() };
     let fd = unsafe { open(pathname_addr, flags, mode) };
     debug!(
         "=> pathname: {}, flags: {}, mode: {} = fd: {}\npath: {}",
-        pathname, flags, mode, fd, path_str
+        pathname, flags, mode, fd, _path_str
     );
     fd
 }
 
 // chown
-pub fn ___syscall212(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall212 (chown) {}", which);
+pub fn ___syscall212(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall212 (chown) {}", _which);
 
     let pathname: u32 = varargs.get(ctx);
     let owner: u32 = varargs.get(ctx);
@@ -107,8 +107,8 @@ pub fn ___syscall212(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 }
 
 // mkdir
-pub fn ___syscall39(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall39 (mkdir) {}", which);
+pub fn ___syscall39(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall39 (mkdir) {}", _which);
     let pathname: u32 = varargs.get(ctx);
     let mode: u32 = varargs.get(ctx);
     let pathname_addr = emscripten_memory_pointer!(ctx.memory(0), pathname) as *const i8;
@@ -169,8 +169,8 @@ pub fn ___syscall330(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> pid_
 }
 
 /// ioctl
-pub fn ___syscall54(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall54 (ioctl) {}", which);
+pub fn ___syscall54(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall54 (ioctl) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let request: u32 = varargs.get(ctx);
     debug!("fd: {}, op: {}", fd, request);
@@ -212,8 +212,8 @@ pub fn ___syscall54(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int 
 
 // socketcall
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall102(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall102 (socketcall) {}", which);
+pub fn ___syscall102(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall102 (socketcall) {}", _which);
     let call: u32 = varargs.get(ctx);
     let mut socket_varargs: VarArgs = varargs.get(ctx);
 
@@ -280,10 +280,10 @@ pub fn ___syscall102(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 
             // Debug received address
             unsafe {
-                let proper_address = address as *const GuestSockaddrIn;
+                let _proper_address = address as *const GuestSockaddrIn;
                 debug!(
                     "=> address.sin_family: {:?}, address.sin_port: {:?}, address.sin_addr.s_addr: {:?}",
-                    (*proper_address).sin_family, (*proper_address).sin_port, (*proper_address).sin_addr.s_addr
+                    (*_proper_address).sin_family, (*_proper_address).sin_port, (*_proper_address).sin_addr.s_addr
                 );
             }
 
@@ -464,8 +464,8 @@ pub fn ___syscall102(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 }
 
 // pread
-pub fn ___syscall180(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall180 (pread) {}", which);
+pub fn ___syscall180(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall180 (pread) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let buf: u32 = varargs.get(ctx);
     let count: u32 = varargs.get(ctx);
@@ -481,8 +481,8 @@ pub fn ___syscall180(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 }
 
 // pwrite
-pub fn ___syscall181(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall181 (pwrite) {}", which);
+pub fn ___syscall181(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall181 (pwrite) {}", _which);
     let fd: i32 = varargs.get(ctx);
     let buf: u32 = varargs.get(ctx);
     let count: u32 = varargs.get(ctx);
@@ -521,8 +521,8 @@ pub fn ___syscall114(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> pid_
 
 // select
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall142(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall142 (newselect) {}", which);
+pub fn ___syscall142(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall142 (newselect) {}", _which);
 
     let nfds: i32 = varargs.get(ctx);
     let readfds: u32 = varargs.get(ctx);
@@ -540,8 +540,8 @@ pub fn ___syscall142(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int
 }
 
 // setpgid
-pub fn ___syscall57(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall57 (setpgid) {}", which);
+pub fn ___syscall57(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall57 (setpgid) {}", _which);
     let pid: i32 = varargs.get(ctx);
     let pgid: i32 = varargs.get(ctx);
     unsafe { setpgid(pid, pgid) }
@@ -549,8 +549,8 @@ pub fn ___syscall57(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int 
 
 /// uname
 // NOTE: Wondering if we should return custom utsname, like Emscripten.
-pub fn ___syscall122(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
-    debug!("emscripten::___syscall122 (uname) {}", which);
+pub fn ___syscall122(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_int {
+    debug!("emscripten::___syscall122 (uname) {}", _which);
     let buf: u32 = varargs.get(ctx);
     debug!("=> buf: {}", buf);
     let buf_addr = emscripten_memory_pointer!(ctx.memory(0), buf) as *mut utsname;

--- a/lib/emscripten/src/syscalls/unix.rs
+++ b/lib/emscripten/src/syscalls/unix.rs
@@ -279,13 +279,11 @@ pub fn ___syscall102(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_in
             let address = emscripten_memory_pointer!(ctx.memory(0), address) as *mut sockaddr;
 
             // Debug received address
-            unsafe {
-                let _proper_address = address as *const GuestSockaddrIn;
-                debug!(
+            let _proper_address = address as *const GuestSockaddrIn;
+            debug!(
                     "=> address.sin_family: {:?}, address.sin_port: {:?}, address.sin_addr.s_addr: {:?}",
                     (*_proper_address).sin_family, (*_proper_address).sin_port, (*_proper_address).sin_addr.s_addr
                 );
-            }
 
             let status = unsafe { bind(socket, address, address_len) };
             // debug!("=> status: {}", status);

--- a/lib/emscripten/src/syscalls/windows.rs
+++ b/lib/emscripten/src/syscalls/windows.rs
@@ -1,5 +1,4 @@
 use crate::utils::copy_cstr_into_wasm;
-use crate::utils::read_string_from_wasm;
 use crate::varargs::VarArgs;
 use libc::mkdir;
 use libc::open;

--- a/lib/emscripten/src/time.rs
+++ b/lib/emscripten/src/time.rs
@@ -75,8 +75,10 @@ pub fn _clock_gettime(ctx: &mut Ctx, clk_id: clockid_t, tp: c_int) -> c_int {
         tv_nsec: i32,
     }
 
+    #[allow(unreachable_patterns)]
     let timespec = match clk_id {
         CLOCK_REALTIME => time::get_time(),
+
         CLOCK_MONOTONIC | CLOCK_MONOTONIC_COARSE => {
             let precise_ns = time::precise_time_ns();
             time::Timespec::new(

--- a/lib/emscripten/src/time.rs
+++ b/lib/emscripten/src/time.rs
@@ -298,14 +298,14 @@ pub fn _time(ctx: &mut Ctx, time_p: u32) -> i32 {
 /// emscripten: _strftime
 pub fn _strftime(
     _ctx: &mut Ctx,
-    s_ptr: c_int,
-    maxsize: u32,
-    format_ptr: c_int,
-    tm_ptr: c_int,
+    _s_ptr: c_int,
+    _maxsize: u32,
+    _format_ptr: c_int,
+    _tm_ptr: c_int,
 ) -> i32 {
     debug!(
         "emscripten::_strftime {} {} {} {}",
-        s_ptr, maxsize, format_ptr, tm_ptr
+        _s_ptr, _maxsize, _format_ptr, _tm_ptr
     );
     0
 }

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -155,6 +155,7 @@ pub unsafe fn copy_stat_into_wasm(ctx: &mut Ctx, buf: u32, stat: &stat) {
     (*stat_ptr).st_ino = stat.st_ino as _;
 }
 
+#[allow(dead_code)] // it's used in `env/windows/mod.rs`.
 pub fn read_string_from_wasm(memory: &Memory, offset: u32) -> String {
     let v: Vec<u8> = memory.view()[(offset as usize)..]
         .iter()

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -91,7 +91,7 @@ pub unsafe fn allocate_cstr_on_stack<'a>(ctx: &'a mut Ctx, s: &str) -> (u32, &'a
 }
 
 pub unsafe fn copy_terminated_array_of_cstrs(_ctx: &mut Ctx, cstrs: *mut *mut c_char) -> u32 {
-    let total_num = {
+    let _total_num = {
         let mut ptr = cstrs;
         let mut counter = 0;
         while !(*ptr).is_null() {
@@ -102,7 +102,7 @@ pub unsafe fn copy_terminated_array_of_cstrs(_ctx: &mut Ctx, cstrs: *mut *mut c_
     };
     debug!(
         "emscripten::copy_terminated_array_of_cstrs::total_num: {}",
-        total_num
+        _total_num
     );
     0
 }


### PR DESCRIPTION
These patches fix all warnings reported by `rustc`. Each patch addresses a specific class of warnings.

Please, have a specific attention about the following patches:

  * https://github.com/wasmerio/wasmer/commit/ad099db0415185ce2411588390bbed2674d7405d,
  * https://github.com/wasmerio/wasmer/commit/7a88927aaf84bdd6d266197daa9e7da1bcf2dbd1,
  * https://github.com/wasmerio/wasmer/commit/14c837378eb43cda1d0aac46cceacaa5e2ad836d.

Hint for the review: I reckon it's easier to review one patch after another instead of the entire diff at all.