### PR TITLE
feat(runtime-c-api) `wasmer_validate` expects a `*const uint8_t`

### DIFF
--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -159,13 +159,13 @@ pub struct wasmer_byte_array {
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_validate(
-    wasm_bytes: *mut uint8_t,
+    wasm_bytes: *const uint8_t,
     wasm_bytes_len: uint32_t,
 ) -> bool {
     if wasm_bytes.is_null() {
         return false;
     }
-    let bytes: &[u8] = ::std::slice::from_raw_parts_mut(wasm_bytes, wasm_bytes_len as usize);
+    let bytes: &[u8] = ::std::slice::from_raw_parts(wasm_bytes, wasm_bytes_len as usize);
 
     wasmer_runtime_core::validate(bytes)
 }

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -535,6 +535,6 @@ wasmer_result_t wasmer_table_new(wasmer_table_t **table, wasmer_limits_t limits)
 /**
  * Returns true for valid wasm bytes and false for invalid bytes
  */
-bool wasmer_validate(uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
+bool wasmer_validate(const uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
 
 #endif /* WASMER_H */

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -418,7 +418,7 @@ uint32_t wasmer_table_length(wasmer_table_t *table);
 wasmer_result_t wasmer_table_new(wasmer_table_t **table, wasmer_limits_t limits);
 
 /// Returns true for valid wasm bytes and false for invalid bytes
-bool wasmer_validate(uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
+bool wasmer_validate(const uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
 
 } // extern "C"
 


### PR DESCRIPTION
This patch updates the first argument of `wasmer_validate` from `*mut
uint8_t` to `*const uint8_t`. Indeed, the
`wasmer-runtime-core::validate` function doesn't expect a mutable
slice, so it's not required to expect a mutable array from C.

Also, it's likely for the Wasm bytes to be stored in the
`wasmer_byte_array` structure. The first field `bytes` is defined as
`*const uint8_t`. So this patch avoids a cast when writing a C++
program.