### PR TITLE
Fix warnings on windows build

### DIFF
--- a/lib/clif-backend/src/signal/windows.rs
+++ b/lib/clif-backend/src/signal/windows.rs
@@ -4,13 +4,9 @@ use crate::trampoline::Trampoline;
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::ptr;
+use wasmer_runtime_core::error::{RuntimeError, RuntimeResult};
 use wasmer_runtime_core::vm::Ctx;
 use wasmer_runtime_core::vm::Func;
-use wasmer_runtime_core::{
-    error::{RuntimeError, RuntimeResult},
-    structures::TypedIndex,
-    types::{MemoryIndex, TableIndex},
-};
 use wasmer_win_exception_handler::CallProtectedData;
 pub use wasmer_win_exception_handler::_call_protected;
 use winapi::shared::minwindef::DWORD;
@@ -47,8 +43,8 @@ pub fn call_protected(
 
     let CallProtectedData {
         code: signum,
-        exceptionAddress: exception_address,
-        instructionPointer: instruction_pointer,
+        exception_address,
+        instruction_pointer,
     } = result.unwrap_err();
 
     if let Some(TrapData {

--- a/lib/emscripten/src/env/unix/mod.rs
+++ b/lib/emscripten/src/env/unix/mod.rs
@@ -66,6 +66,8 @@ pub fn _unsetenv(ctx: &mut Ctx, name: c_int) -> c_int {
 #[allow(clippy::cast_ptr_alignment)]
 pub fn _getpwnam(ctx: &mut Ctx, name_ptr: c_int) -> c_int {
     debug!("emscripten::_getpwnam {}", name_ptr);
+    #[cfg(feature = "debug")]
+    let _ = name_ptr;
 
     #[repr(C)]
     struct GuestPasswd {

--- a/lib/emscripten/src/io/windows.rs
+++ b/lib/emscripten/src/io/windows.rs
@@ -1,4 +1,3 @@
-use libc::{c_char, c_int};
 use wasmer_runtime_core::vm::Ctx;
 
 // This may be problematic for msvc which uses inline functions for the printf family
@@ -15,13 +14,18 @@ use wasmer_runtime_core::vm::Ctx;
 //}
 
 /// putchar
-pub fn putchar(ctx: &mut Ctx, chr: i32) {
+pub fn putchar(_ctx: &mut Ctx, chr: i32) {
     unsafe { libc::putchar(chr) };
 }
 
 /// printf
-pub fn printf(ctx: &mut Ctx, memory_offset: i32, extra: i32) -> i32 {
+pub fn printf(_ctx: &mut Ctx, memory_offset: i32, extra: i32) -> i32 {
     debug!("emscripten::printf {}, {}", memory_offset, extra);
+    #[cfg(not(feature = "debug"))]
+    {
+        let _ = memory_offset;
+        let _ = extra;
+    }
     //    unsafe {
     //        let addr = emscripten_memory_pointer!(ctx.memory(0), memory_offset) as _;
     //        _printf(addr, extra)

--- a/lib/emscripten/src/process.rs
+++ b/lib/emscripten/src/process.rs
@@ -1,10 +1,9 @@
 use libc::{abort, c_char, c_int, exit, EAGAIN};
 
 #[cfg(not(target_os = "windows"))]
-use libc::pid_t;
-
+type PidT = libc::pid_t;
 #[cfg(target_os = "windows")]
-type pid_t = c_int;
+type PidT = c_int;
 
 use std::ffi::CStr;
 use wasmer_runtime_core::vm::Ctx;
@@ -22,7 +21,7 @@ pub fn _abort(_ctx: &mut Ctx) {
     }
 }
 
-pub fn _fork(_ctx: &mut Ctx) -> pid_t {
+pub fn _fork(_ctx: &mut Ctx) -> PidT {
     debug!("emscripten::_fork");
     // unsafe {
     //     fork()

--- a/lib/emscripten/src/stdio.rs
+++ b/lib/emscripten/src/stdio.rs
@@ -15,7 +15,7 @@ pub struct StdioCapturer {
 use libc::{STDERR_FILENO, STDOUT_FILENO};
 
 #[cfg(target_os = "windows")]
-const STDIN_FILENO: libc::c_int = 0;
+const _STDIN_FILENO: libc::c_int = 0;
 #[cfg(target_os = "windows")]
 const STDOUT_FILENO: libc::c_int = 1;
 #[cfg(target_os = "windows")]

--- a/lib/emscripten/src/syscalls/windows.rs
+++ b/lib/emscripten/src/syscalls/windows.rs
@@ -4,18 +4,20 @@ use libc::mkdir;
 use libc::open;
 use rand::Rng;
 use std::env;
-use std::ffi::CStr;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::Write;
 use std::os::raw::c_int;
 use wasmer_runtime_core::vm::Ctx;
 
+#[allow(non_camel_case_types)]
 type pid_t = c_int;
 
 /// open
 pub fn ___syscall5(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall5 (open) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     let pathname: u32 = varargs.get(ctx);
     let flags: i32 = varargs.get(ctx);
     let mode: u32 = varargs.get(ctx);
@@ -33,7 +35,7 @@ pub fn ___syscall5(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
             let mut urandom_file = File::create(tmp_dir).unwrap();
             // create some random bytes and put them into the file
             let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
-            urandom_file.write_all(&random_bytes);
+            let _ = urandom_file.write_all(&random_bytes).unwrap();
             // put the file path string into wasm memory
             let urandom_file_offset = unsafe { copy_cstr_into_wasm(ctx, ptr) };
             let raw_pointer_to_urandom_file =
@@ -57,16 +59,19 @@ pub fn ___syscall5(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
 }
 
 // chown
-pub fn ___syscall212(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall212(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall212 (chown) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 // mkdir
 pub fn ___syscall39(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall39 (mkdir) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     let pathname: u32 = varargs.get(ctx);
-    let mode: u32 = varargs.get(ctx);
     let pathname_addr = emscripten_memory_pointer!(ctx.memory(0), pathname) as *const i8;
     unsafe { mkdir(pathname_addr) }
 }
@@ -85,59 +90,73 @@ pub fn ___syscall202(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
 }
 
 /// dup3
-pub fn ___syscall330(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> pid_t {
+pub fn ___syscall330(_ctx: &mut Ctx, _which: c_int, mut _varargs: VarArgs) -> pid_t {
     debug!("emscripten::___syscall330 (dup3)");
     -1
 }
 
 /// ioctl
-pub fn ___syscall54(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall54(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall54 (ioctl) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 // socketcall
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall102(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall102(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall102 (socketcall) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 // pread
-pub fn ___syscall180(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall180(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall180 (pread) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 // pwrite
-pub fn ___syscall181(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall181(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall181 (pwrite) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 /// wait4
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall114(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> pid_t {
+pub fn ___syscall114(_ctx: &mut Ctx, _which: c_int, mut _varargs: VarArgs) -> pid_t {
     debug!("emscripten::___syscall114 (wait4)");
     -1
 }
 
 // select
 #[allow(clippy::cast_ptr_alignment)]
-pub fn ___syscall142(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall142(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall142 (newselect) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 // setpgid
-pub fn ___syscall57(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall57(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall57 (setpgid) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }
 
 /// uname
 // NOTE: Wondering if we should return custom utsname, like Emscripten.
-pub fn ___syscall122(ctx: &mut Ctx, which: c_int, mut varargs: VarArgs) -> c_int {
+pub fn ___syscall122(_ctx: &mut Ctx, which: c_int, mut _varargs: VarArgs) -> c_int {
     debug!("emscripten::___syscall122 (uname) {}", which);
+    #[cfg(not(feature = "debug"))]
+    let _ = which;
     -1
 }

--- a/lib/emscripten/src/time.rs
+++ b/lib/emscripten/src/time.rs
@@ -10,6 +10,7 @@ use libc::{clockid_t, time as libc_time};
 use libc::time_t;
 
 #[cfg(target_os = "windows")]
+#[allow(non_camel_case_types)]
 type clockid_t = c_int;
 
 #[cfg(target_os = "windows")]

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -90,6 +90,7 @@ pub unsafe fn allocate_cstr_on_stack<'a>(ctx: &'a mut Ctx, s: &str) -> (u32, &'a
     (offset, slice)
 }
 
+#[cfg(not(target_os = "windows"))]
 pub unsafe fn copy_terminated_array_of_cstrs(_ctx: &mut Ctx, cstrs: *mut *mut c_char) -> u32 {
     let _total_num = {
         let mut ptr = cstrs;

--- a/lib/win-exception-handler/exception_handling/exception_handling.c
+++ b/lib/win-exception-handler/exception_handling/exception_handling.c
@@ -67,16 +67,16 @@ uint8_t callProtected(trampoline_t trampoline,
         savedStackPointer = get_callee_frame_address();
         trampoline(ctx, func, param_vec, return_vec);
         out_result->code = 0;
-        out_result->exceptionAddress = 0;
-        out_result->instructionPointer = 0;
+        out_result->exception_address = 0;
+        out_result->instruction_pointer = 0;
 
         removeExceptionHandler();
         return TRUE;
     }
 
     out_result->code = (uint64_t)signum;
-    out_result->exceptionAddress = (uint64_t)caughtExceptionAddress;
-    out_result->instructionPointer = caughtInstructionPointer;
+    out_result->exception_address = (uint64_t)caughtExceptionAddress;
+    out_result->instruction_pointer = caughtInstructionPointer;
 
     caughtExceptionAddress = 0;
     caughtInstructionPointer = 0;

--- a/lib/win-exception-handler/exception_handling/exception_handling.h
+++ b/lib/win-exception-handler/exception_handling/exception_handling.h
@@ -10,8 +10,8 @@ typedef void(*trampoline_t)(struct wasmer_instance_context_t*,  const struct fun
 
 struct call_protected_result_t {
     uint64_t code;
-    uint64_t exceptionAddress;
-    uint64_t instructionPointer;
+    uint64_t exception_address;
+    uint64_t instruction_pointer;
 };
 
 uint8_t callProtected(

--- a/lib/win-exception-handler/src/exception_handling.rs
+++ b/lib/win-exception-handler/src/exception_handling.rs
@@ -7,8 +7,8 @@ type CallProtectedResult = Result<(), CallProtectedData>;
 #[repr(C)]
 pub struct CallProtectedData {
     pub code: u64,
-    pub exceptionAddress: u64,
-    pub instructionPointer: u64,
+    pub exception_address: u64,
+    pub instruction_pointer: u64,
 }
 
 extern "C" {
@@ -32,8 +32,8 @@ pub fn _call_protected(
 ) -> CallProtectedResult {
     let mut out_result = CallProtectedData {
         code: 0,
-        exceptionAddress: 0,
-        instructionPointer: 0,
+        exception_address: 0,
+        instruction_pointer: 0,
     };
     let result = unsafe {
         __call_protected(


### PR DESCRIPTION
Another developer recently went through and fixed many warnings that were polluting the build:

https://github.com/wasmerio/wasmer/pull/265
https://github.com/wasmerio/wasmer/pull/264
https://github.com/wasmerio/wasmer/pull/263
https://github.com/wasmerio/wasmer/pull/266

This was super great 💟 and it encouraged me to do the same. 

This PR addresses warnings emitted on the windows build. Many warnings from the emscripten and clif-backend module are fixed. 