### PR TITLE
feat(runtime-core) Nicer panic output

### DIFF
--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
 edition = "2018"
 
+[lib]
+crate-type = ["dylib"]
+
 [dependencies]
 nix = "0.12.0"
 page_size = "0.4.1"
@@ -17,6 +20,8 @@ indexmap = "1.0.2"
 errno = "0.2.4"
 libc = "0.2.49"
 hex = "0.3.2"
+human-panic = "1.0"
+ctor = "0.1.7"
 
 # Dependencies for caching.
 [dependencies.serde]

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -100,3 +100,13 @@ pub unsafe fn load_cache_with(
 
 /// The current version of this crate
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[ctor::ctor]
+fn init() {
+    human_panic::setup_panic!(human_panic::Metadata {
+        name: "The Wasmer Runtime".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        authors: "Wasmer Engineering <engineering@wasmer.io".into(),
+        homepage: "https://github.com/wasmerio/wasmer".into(),
+    });
+}

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -106,7 +106,7 @@ fn init() {
     human_panic::setup_panic!(human_panic::Metadata {
         name: "The Wasmer Runtime".into(),
         version: env!("CARGO_PKG_VERSION").into(),
-        authors: "Wasmer Engineering <engineering@wasmer.io".into(),
+        authors: "Wasmer Engineering <engineering@wasmer.io>".into(),
         homepage: "https://github.com/wasmerio/wasmer".into(),
     });
 }


### PR DESCRIPTION
This adds the human-panic crate to print out a nicer panic message (as well as log the backtrace and whatnot).

Example output:

```
Well, this is embarrassing.

The Wasmer Runtime had a problem and crashed. To help us diagnose the problem you can send us a crash report.

We have generated a report file at "/var/folders/24/mfj_dsx13ln7jxrnrbb2vq0h0000gn/T/report-5012e1cd-3834-4ff2-8e3f-5b42c5735ca3.toml". Submit an issue or email with the subject of "The Wasmer Runtime Crash Report" and include the report as an attachment.

- Homepage: https://github.com/wasmerio/wasmer
- Authors: Wasmer Engineering <engineering@wasmer.io>

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thank you kindly!
```