### PR TITLE
fix make debug-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,9 +168,9 @@ jobs:
             echo "${CIRCLE_TAG}" >> artifacts/git_version
             cp ./target/release/wasmer ./artifacts/$(./binary-name.sh)
       - run:
-          name: Debug release build
+          name: Debug flag checked
           command: |
-            make debug-release
+            cargo check --features "debug"
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,10 @@ jobs:
             echo "${VERSION}" >> artifacts/version
             echo "${CIRCLE_TAG}" >> artifacts/git_version
             cp ./target/release/wasmer ./artifacts/$(./binary-name.sh)
+      - run:
+          name: Debug release build
+          command: |
+            make debug-release
       - persist_to_workspace:
           root: .
           paths:

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,6 @@ release:
 	cargo build --release
 
 debug-release:
-	cargo build --release --features debug
-
-debug-release:
 	cargo build --release --features "debug"
 
 publish-release:

--- a/lib/emscripten/src/syscalls/unix.rs
+++ b/lib/emscripten/src/syscalls/unix.rs
@@ -282,7 +282,7 @@ pub fn ___syscall102(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_in
             let _proper_address = address as *const GuestSockaddrIn;
             debug!(
                     "=> address.sin_family: {:?}, address.sin_port: {:?}, address.sin_addr.s_addr: {:?}",
-                    (*_proper_address).sin_family, (*_proper_address).sin_port, (*_proper_address).sin_addr.s_addr
+                unsafe { (*_proper_address).sin_family }, unsafe { (*_proper_address).sin_port }, unsafe { (*_proper_address).sin_addr.s_addr }
                 );
 
             let status = unsafe { bind(socket, address, address_len) };


### PR DESCRIPTION
My guess without looking in to the history is that:
- the unsafe block was around the `debug!` call
- when debug was off, it was giving a warning because the unsafe block was empty
- the unsafe was removed to stop the warning
- it wasn't tested with the debug flag

This PR also
- cleans up the Makefile
- adds debug-release to CI