### PR TITLE
add more stubs for pthreading, exceptions, and some invokes

### DIFF
--- a/lib/emscripten/src/emscripten_target.rs
+++ b/lib/emscripten/src/emscripten_target.rs
@@ -118,6 +118,22 @@ pub fn _pthread_cond_destroy(_ctx: &mut Ctx, _a: i32) -> i32 {
     debug!("emscripten::_pthread_cond_destroy");
     0
 }
+pub fn _pthread_getspecific(_ctx: &mut Ctx, _a: i32) -> i32 {
+    debug!("emscripten::_pthread_getspecific");
+    0
+}
+pub fn _pthread_setspecific(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
+    debug!("emscripten::_pthread_setspecific");
+    0
+}
+pub fn _pthread_once(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
+    debug!("emscripten::_pthread_once");
+    0
+}
+pub fn _pthread_key_create(_ctx: &mut Ctx, _a: i32, _b: i32) -> i32 {
+    debug!("emscripten::_pthread_key_create");
+    0
+}
 pub fn _pthread_create(_ctx: &mut Ctx, _a: i32, _b: i32, _c: i32, _d: i32) -> i32 {
     debug!("emscripten::_pthread_create");
     0
@@ -424,6 +440,30 @@ pub fn invoke_viiiiiiiii(
         panic!("dyn_call_viiiiiiiii is set to None");
     }
 }
+pub fn invoke_viiiiiiiiii(
+    ctx: &mut Ctx,
+    index: i32,
+    a1: i32,
+    a2: i32,
+    a3: i32,
+    a4: i32,
+    a5: i32,
+    a6: i32,
+    a7: i32,
+    a8: i32,
+    a9: i32,
+    a10: i32,
+) {
+    debug!("emscripten::invoke_viiiiiiiiii");
+    if let Some(dyn_call_viiiiiiiiii) = &get_emscripten_data(ctx).dyn_call_viiiiiiiiii {
+        dyn_call_viiiiiiiiii
+            .call(index, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+            .unwrap();
+    } else {
+        panic!("dyn_call_viiiiiiiiii is set to None");
+    }
+}
+
 pub fn invoke_iiji(ctx: &mut Ctx, index: i32, a1: i32, a2: i32, a3: i32, a4: i32) -> i32 {
     debug!("emscripten::invoke_iiji");
     if let Some(dyn_call_iiji) = &get_emscripten_data(ctx).dyn_call_iiji {
@@ -448,6 +488,15 @@ pub fn invoke_ji(ctx: &mut Ctx, index: i32, a1: i32) -> i32 {
         panic!("dyn_call_ji is set to None");
     }
 }
+pub fn invoke_jii(ctx: &mut Ctx, index: i32, a1: i32, a2: i32) -> i32 {
+    debug!("emscripten::invoke_jii");
+    if let Some(dyn_call_jii) = &get_emscripten_data(ctx).dyn_call_jii {
+        dyn_call_jii.call(index, a1, a2).unwrap()
+    } else {
+        panic!("dyn_call_jii is set to None");
+    }
+}
+
 pub fn invoke_jij(ctx: &mut Ctx, index: i32, a1: i32, a2: i32, a3: i32) -> i32 {
     debug!("emscripten::invoke_jij");
     if let Some(dyn_call_jij) = &get_emscripten_data(ctx).dyn_call_jij {

--- a/lib/emscripten/src/exception.rs
+++ b/lib/emscripten/src/exception.rs
@@ -14,3 +14,12 @@ pub fn ___cxa_throw(ctx: &mut Ctx, _ptr: u32, _ty: u32, _destructor: u32) {
     debug!("emscripten::___cxa_throw");
     _abort(ctx);
 }
+
+pub fn ___cxa_begin_catch(_ctx: &mut Ctx, _exception_object_ptr: u32) -> i32 {
+    debug!("emscripten::___cxa_begin_catch");
+    -1
+}
+
+pub fn ___cxa_end_catch(_ctx: &mut Ctx) {
+    debug!("emscripten::___cxa_end_catch");
+}

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -104,9 +104,12 @@ pub struct EmscriptenData<'a> {
     pub dyn_call_viiiiiii: Option<Func<'a, (i32, i32, i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_viiiiiiii: Option<Func<'a, (i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_viiiiiiiii: Option<Func<'a, (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
+    pub dyn_call_viiiiiiiiii:
+        Option<Func<'a, (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_iiji: Option<Func<'a, (i32, i32, i32, i32, i32), i32>>,
     pub dyn_call_j: Option<Func<'a, i32, i32>>,
     pub dyn_call_ji: Option<Func<'a, (i32, i32), i32>>,
+    pub dyn_call_jii: Option<Func<'a, (i32, i32, i32), i32>>,
     pub dyn_call_jij: Option<Func<'a, (i32, i32, i32, i32), i32>>,
     pub dyn_call_jjj: Option<Func<'a, (i32, i32, i32, i32, i32), i32>>,
     pub dyn_call_viiij: Option<Func<'a, (i32, i32, i32, i32, i32, i32)>>,
@@ -160,9 +163,11 @@ impl<'a> EmscriptenData<'a> {
         let dyn_call_viiiiiii = instance.func("dynCall_viiiiiii").ok();
         let dyn_call_viiiiiiii = instance.func("dynCall_viiiiiiii").ok();
         let dyn_call_viiiiiiiii = instance.func("dynCall_viiiiiiiii").ok();
+        let dyn_call_viiiiiiiiii = instance.func("dynCall_viiiiiiiiii").ok();
         let dyn_call_iiji = instance.func("dynCall_iiji").ok();
         let dyn_call_j = instance.func("dynCall_j").ok();
         let dyn_call_ji = instance.func("dynCall_ji").ok();
+        let dyn_call_jii = instance.func("dynCall_jii").ok();
         let dyn_call_jij = instance.func("dynCall_jij").ok();
         let dyn_call_jjj = instance.func("dynCall_jjj").ok();
         let dyn_call_viiij = instance.func("dynCall_viiij").ok();
@@ -209,9 +214,11 @@ impl<'a> EmscriptenData<'a> {
             dyn_call_viiiiiii,
             dyn_call_viiiiiiii,
             dyn_call_viiiiiiiii,
+            dyn_call_viiiiiiiiii,
             dyn_call_iiji,
             dyn_call_j,
             dyn_call_ji,
+            dyn_call_jii,
             dyn_call_jij,
             dyn_call_jjj,
             dyn_call_viiij,
@@ -562,6 +569,7 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
         "_kill" => func!(crate::process::_kill),
         "_llvm_stackrestore" => func!(crate::process::_llvm_stackrestore),
         "_llvm_stacksave" => func!(crate::process::_llvm_stacksave),
+        "_llvm_eh_typeid_for" => func!(crate::process::_llvm_eh_typeid_for),
         "_raise" => func!(crate::process::_raise),
         "_sem_init" => func!(crate::process::_sem_init),
         "_sem_post" => func!(crate::process::_sem_post),
@@ -597,6 +605,8 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
         // Exception
         "___cxa_allocate_exception" => func!(crate::exception::___cxa_allocate_exception),
         "___cxa_throw" => func!(crate::exception::___cxa_throw),
+        "___cxa_begin_catch" => func!(crate::exception::___cxa_begin_catch),
+        "___cxa_end_catch" => func!(crate::exception::___cxa_end_catch),
 
         // Time
         "_gettimeofday" => func!(crate::time::_gettimeofday),
@@ -675,6 +685,10 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
         "_pthread_rwlock_rdlock" => func!(crate::emscripten_target::_pthread_rwlock_rdlock),
         "_pthread_rwlock_unlock" => func!(crate::emscripten_target::_pthread_rwlock_unlock),
         "_pthread_setcancelstate" => func!(crate::emscripten_target::_pthread_setcancelstate),
+        "_pthread_getspecific" => func!(crate::emscripten_target::_pthread_getspecific),
+        "_pthread_setspecific" => func!(crate::emscripten_target::_pthread_setspecific),
+        "_pthread_once" => func!(crate::emscripten_target::_pthread_once),
+        "_pthread_key_create" => func!(crate::emscripten_target::_pthread_key_create),
         "___gxx_personality_v0" => func!(crate::emscripten_target::___gxx_personality_v0),
         "_getdtablesize" => func!(crate::emscripten_target::_getdtablesize),
         "_gethostbyaddr" => func!(crate::emscripten_target::_gethostbyaddr),
@@ -693,9 +707,12 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
         "invoke_viiiiiii" => func!(crate::emscripten_target::invoke_viiiiiii),
         "invoke_viiiiiiii" => func!(crate::emscripten_target::invoke_viiiiiiii),
         "invoke_viiiiiiiii" => func!(crate::emscripten_target::invoke_viiiiiiiii),
+        "invoke_viiiiiiiii" => func!(crate::emscripten_target::invoke_viiiiiiiii),
+        "invoke_viiiiiiiiii" => func!(crate::emscripten_target::invoke_viiiiiiiiii),
         "invoke_iiji" => func!(crate::emscripten_target::invoke_iiji),
         "invoke_j" => func!(crate::emscripten_target::invoke_j),
         "invoke_ji" => func!(crate::emscripten_target::invoke_ji),
+        "invoke_jii" => func!(crate::emscripten_target::invoke_jii),
         "invoke_jij" => func!(crate::emscripten_target::invoke_jij),
         "invoke_jjj" => func!(crate::emscripten_target::invoke_jjj),
         "invoke_viiij" => func!(crate::emscripten_target::invoke_viiij),

--- a/lib/emscripten/src/process.rs
+++ b/lib/emscripten/src/process.rs
@@ -150,6 +150,11 @@ pub fn _llvm_trap(ctx: &mut Ctx) {
     abort_with_message(ctx, "abort!");
 }
 
+pub fn _llvm_eh_typeid_for(_ctx: &mut Ctx, _type_info_addr: u32) -> i32 {
+    debug!("emscripten::_llvm_eh_typeid_for");
+    -1
+}
+
 pub fn _system(_ctx: &mut Ctx, _one: i32) -> c_int {
     debug!("emscripten::_system");
     // TODO: May need to change this Em impl to a working version


### PR DESCRIPTION
resolves #308 

Adds stubs for the WASM file submitted in the issue; `_llvm_eh_typeid_for` may be able to be properly implemented now, the pthread and cxa ones will require much larger changes