### PR TITLE
Add Export and GlobalDescriptor to Runtime API

### DIFF
--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -207,6 +207,7 @@ pub enum Initializer {
     GetGlobal(ImportedGlobalIndex),
 }
 
+/// Describes the mutability and type of a Global
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobalDescriptor {
     pub mutable: bool,

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -74,6 +74,7 @@
 //! [`wasmer-clif-backend`]: https://crates.io/crates/wasmer-clif-backend
 //! [`compile_with`]: fn.compile_with.html
 
+pub use wasmer_runtime_core::export::Export;
 pub use wasmer_runtime_core::global::Global;
 pub use wasmer_runtime_core::import::ImportObject;
 pub use wasmer_runtime_core::instance::{DynFunc, Instance};
@@ -95,7 +96,9 @@ pub mod wasm {
     //! Various types exposed by the Wasmer Runtime.
     pub use wasmer_runtime_core::global::Global;
     pub use wasmer_runtime_core::table::Table;
-    pub use wasmer_runtime_core::types::{FuncSig, MemoryDescriptor, TableDescriptor, Type, Value};
+    pub use wasmer_runtime_core::types::{
+        FuncSig, GlobalDescriptor, MemoryDescriptor, TableDescriptor, Type, Value,
+    };
 }
 
 pub mod error {


### PR DESCRIPTION
This was mentioned in the issue: https://github.com/wasmerio/wasmer/issues/319

It would be nice to be able to iterate exports without requiring `runtime-core`.