### PR TITLE
changes to make PHP run better

### DIFF
--- a/lib/emscripten/src/emscripten_target.rs
+++ b/lib/emscripten/src/emscripten_target.rs
@@ -5,13 +5,16 @@ use crate::env::get_emscripten_data;
 use libc::getdtablesize;
 use wasmer_runtime_core::vm::Ctx;
 
-pub fn setTempRet0(_ctx: &mut Ctx, _val: i32) {
-    debug!("emscripten::setTempRet0: {}", _val);
+pub fn setTempRet0(ctx: &mut Ctx, val: i32) {
+    debug!("emscripten::setTempRet0: {}", val);
+    get_emscripten_data(ctx).temp_ret_0 = val;
 }
-pub fn getTempRet0(_ctx: &mut Ctx) -> i32 {
+
+pub fn getTempRet0(ctx: &mut Ctx) -> i32 {
     debug!("emscripten::getTempRet0");
-    0
+    get_emscripten_data(ctx).temp_ret_0
 }
+
 pub fn invoke_i(ctx: &mut Ctx, index: i32) -> i32 {
     debug!("emscripten::invoke_i");
     if let Some(dyn_call_i) = &get_emscripten_data(ctx).dyn_call_i {

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -125,6 +125,8 @@ pub struct EmscriptenData<'a> {
     pub dyn_call_vijiii: Option<Func<'a, (i32, i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_vijj: Option<Func<'a, (i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_viidii: Option<Func<'a, (i32, i32, i32, f64, i32, i32)>>,
+    // REVIEW: is this okay?
+    pub temp_ret_0: i32,
 }
 
 impl<'a> EmscriptenData<'a> {
@@ -233,6 +235,7 @@ impl<'a> EmscriptenData<'a> {
             dyn_call_vijiii,
             dyn_call_vijj,
             dyn_call_viidii,
+            temp_ret_0: 0,
         }
     }
 }

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -125,7 +125,6 @@ pub struct EmscriptenData<'a> {
     pub dyn_call_vijiii: Option<Func<'a, (i32, i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_vijj: Option<Func<'a, (i32, i32, i32, i32, i32, i32)>>,
     pub dyn_call_viidii: Option<Func<'a, (i32, i32, i32, f64, i32, i32)>>,
-    // REVIEW: is this okay?
     pub temp_ret_0: i32,
 }
 

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -194,8 +194,8 @@ pub fn ___syscall85(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
 }
 
 pub fn ___syscall91(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
-    debug!("emscripten::___syscall91");
-    -1
+    debug!("emscripten::___syscall91 - stub");
+    0
 }
 
 pub fn ___syscall97(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {


### PR DESCRIPTION
Fixes:
- memory access when ending programs (by implementing `TempRet0`
- `munmap` errors from PHP by lying and just returning 0