### PR TITLE
allow resize_heap to grow heap in emscripten

### DIFF
--- a/lib/runtime-core/src/units.rs
+++ b/lib/runtime-core/src/units.rs
@@ -4,8 +4,8 @@ use std::{
     ops::{Add, Sub},
 };
 
-const WASM_PAGE_SIZE: usize = 65_536;
-const WASM_MAX_PAGES: usize = 65_536;
+pub const WASM_PAGE_SIZE: usize = 65_536;
+pub const WASM_MAX_PAGES: usize = 65_536;
 
 /// Units of WebAssembly pages (as specified to be 65,536 bytes).
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/lib/runtime-core/src/units.rs
+++ b/lib/runtime-core/src/units.rs
@@ -6,6 +6,8 @@ use std::{
 
 pub const WASM_PAGE_SIZE: usize = 65_536;
 pub const WASM_MAX_PAGES: usize = 65_536;
+// From emscripten resize_heap implementation
+pub const WASM_MIN_PAGES: usize = 256;
 
 /// Units of WebAssembly pages (as specified to be 65,536 bytes).
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Emscripten programs compiled with `-s ALLOW_MEMORY_GROWTH=1` will now work