### PR TITLE
feat(runtime-core) `Instance.exports` takes `&self` instead of `&mut self`

### DIFF
--- a/lib/runtime-core/src/export.rs
+++ b/lib/runtime-core/src/export.rs
@@ -40,13 +40,13 @@ impl FuncPointer {
 }
 
 pub struct ExportIter<'a> {
-    inner: &'a mut InstanceInner,
+    inner: &'a InstanceInner,
     iter: hash_map::Iter<'a, String, ExportIndex>,
     module: &'a ModuleInner,
 }
 
 impl<'a> ExportIter<'a> {
-    pub(crate) fn new(module: &'a ModuleInner, inner: &'a mut InstanceInner) -> Self {
+    pub(crate) fn new(module: &'a ModuleInner, inner: &'a InstanceInner) -> Self {
         Self {
             inner,
             iter: module.info.exports.iter(),

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -279,8 +279,8 @@ impl Instance {
 
     /// Returns an iterator over all of the items
     /// exported from this instance.
-    pub fn exports(&mut self) -> ExportIter {
-        ExportIter::new(&self.module, &mut self.inner)
+    pub fn exports(&self) -> ExportIter {
+        ExportIter::new(&self.module, &self.inner)
     }
 
     /// The module used to instantiate this Instance.


### PR DESCRIPTION
There is no reason for `exports` to take a mutable reference. This patch rewrites the `Instance.export` signature a little bit.