### PR TITLE
Call process::exit in WASI proc_exit syscall.

### DIFF
--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 use rand::{thread_rng, Rng};
 use std::cell::Cell;
 use std::io::{self, Read, Seek, Write};
+use std::process;
 use wasmer_runtime_core::{debug, memory::Memory, vm::Ctx};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1432,7 +1433,7 @@ pub fn poll_oneoff(
 }
 pub fn proc_exit(ctx: &mut Ctx, rval: __wasi_exitcode_t) -> Result<(), &'static str> {
     debug!("wasi::proc_exit, {}", rval);
-    Err("Instance exited")
+    process::exit(rval as i32);
 }
 pub fn proc_raise(ctx: &mut Ctx, sig: __wasi_signal_t) -> __wasi_errno_t {
     debug!("wasi::proc_raise");


### PR DESCRIPTION
Currently calling `proc_exit` causes an exception and does not set the exit code. This updates the syscall to use `std::process::exit` instead of calling `Err`.

Fixes: https://github.com/wasmerio/wasmer/issues/361