### PR TITLE
Introduce the MemoryViewMut type

### DIFF
--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -17,7 +17,7 @@ use std::{
 pub use self::atomic::Atomic;
 pub use self::dynamic::DynamicMemory;
 pub use self::static_::{SharedStaticMemory, StaticMemory};
-pub use self::view::{Atomically, MemoryView};
+pub use self::view::{Atomically, MemoryView, MemoryViewMut};
 
 mod atomic;
 mod dynamic;
@@ -144,6 +144,14 @@ impl Memory {
         let length = self.size().bytes().0 / mem::size_of::<T>();
 
         unsafe { MemoryView::new(base as _, length as u32) }
+    }
+
+    pub fn view_mut<T: ValueType>(&mut self) -> MemoryViewMut<T> {
+        let vm::LocalMemory { base, .. } = unsafe { *self.vm_local_memory() };
+
+        let length = self.size().bytes().0 / mem::size_of::<T>();
+
+        unsafe { MemoryViewMut::new(base as _, length as u32) }
     }
 
     /// Convert this memory to a shared memory if the shared flag

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -159,6 +159,21 @@ impl Ctx {
         }
     }
 
+    pub fn memory_mut(&mut self, mem_index: u32) -> &mut Memory {
+        let module = unsafe { &*self.module };
+        let mem_index = MemoryIndex::new(mem_index as usize);
+        match mem_index.local_or_import(&module.info) {
+            LocalOrImport::Local(local_mem_index) => unsafe {
+                let local_backing = &mut *self.local_backing;
+                &mut local_backing.memories[local_mem_index]
+            },
+            LocalOrImport::Import(import_mem_index) => unsafe {
+                let import_backing = &mut *self.import_backing;
+                &mut import_backing.memories[import_mem_index]
+            },
+        }
+    }
+
     /// Gives access to the emscripten symbol map, used for debugging
     pub unsafe fn borrow_symbol_map(&self) -> &Option<HashMap<u32, String>> {
         &(*self.module).info.em_symbol_map


### PR DESCRIPTION
Introduce the `MemoryViewMut` type which will allow us to manage the instance's memory safely and with ease because `DerefMut<Target=[T]>` is implemented on it and allow us to use [`copy_from_slice`](https://doc.rust-lang.org/std/primitive.slice.html#method.copy_from_slice) to modify it.

I did not worked on the documentation yet, I am waiting for your approval about the correctness of this pull request first.