### PR TITLE
Hook up error propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All PRs to the Wasmer repository must add to this file.
 Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
+- [#381](https://github.com/wasmerio/wasmer/pull/381) Allow retrieving propagated user errors.
 - [#379](https://github.com/wasmerio/wasmer/pull/379) Fix small return types from imported functions.
 - [#371](https://github.com/wasmerio/wasmer/pull/371) Add more Debug impl for WASI types
 - [#368](https://github.com/wasmerio/wasmer/pull/368) Fix issue with write buffering

--- a/lib/clif-backend/src/signal/mod.rs
+++ b/lib/clif-backend/src/signal/mod.rs
@@ -27,7 +27,7 @@ thread_local! {
     pub static TRAP_EARLY_DATA: Cell<Option<Box<dyn Any>>> = Cell::new(None);
 }
 
-pub enum RunErr {
+pub enum CallProtError {
     Trap(WasmTrapInfo),
     Error(Box<dyn Any>),
 }
@@ -83,8 +83,8 @@ impl RunnableModule for Caller {
             match res {
                 Err(err) => {
                     match err {
-                        RunErr::Trap(info) => *trap_info = info,
-                        RunErr::Error(data) => *user_error = Some(data),
+                        CallProtError::Trap(info) => *trap_info = info,
+                        CallProtError::Error(data) => *user_error = Some(data),
                     }
                     false
                 }

--- a/lib/clif-backend/src/signal/mod.rs
+++ b/lib/clif-backend/src/signal/mod.rs
@@ -27,6 +27,11 @@ thread_local! {
     pub static TRAP_EARLY_DATA: Cell<Option<Box<dyn Any>>> = Cell::new(None);
 }
 
+pub enum RunErr {
+    Trap(WasmTrapInfo),
+    Error(Box<dyn Any>),
+}
+
 pub struct Caller {
     handler_data: HandlerData,
     trampolines: Arc<Trampolines>,
@@ -59,7 +64,8 @@ impl RunnableModule for Caller {
             func: NonNull<vm::Func>,
             args: *const u64,
             rets: *mut u64,
-            _trap_info: *mut WasmTrapInfo,
+            trap_info: *mut WasmTrapInfo,
+            user_error: *mut Option<Box<dyn Any>>,
             invoke_env: Option<NonNull<c_void>>,
         ) -> bool {
             let handler_data = &*invoke_env.unwrap().cast().as_ptr();
@@ -68,14 +74,22 @@ impl RunnableModule for Caller {
             let res = call_protected(handler_data, || {
                 // Leap of faith.
                 trampoline(ctx, func, args, rets);
-            })
-            .is_ok();
+            });
 
             // the trampoline is called from C on windows
             #[cfg(target_os = "windows")]
-            let res = call_protected(handler_data, trampoline, ctx, func, args, rets).is_ok();
+            let res = call_protected(handler_data, trampoline, ctx, func, args, rets);
 
-            res
+            match res {
+                Err(err) => {
+                    match err {
+                        RunErr::Trap(info) => *trap_info = info,
+                        RunErr::Error(data) => *user_error = Some(data),
+                    }
+                    false
+                }
+                Ok(()) => true,
+            }
         }
 
         let trampoline = self

--- a/lib/clif-backend/src/signal/unix.rs
+++ b/lib/clif-backend/src/signal/unix.rs
@@ -10,7 +10,7 @@
 //! unless you have memory unsafety elsewhere in your code.
 //!
 use crate::relocation::{TrapCode, TrapData};
-use crate::signal::HandlerData;
+use crate::signal::{HandlerData, RunErr};
 use libc::{c_int, c_void, siginfo_t};
 use nix::sys::signal::{
     sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal, SIGBUS, SIGFPE, SIGILL, SIGSEGV,
@@ -18,7 +18,7 @@ use nix::sys::signal::{
 use std::cell::{Cell, UnsafeCell};
 use std::ptr;
 use std::sync::Once;
-use wasmer_runtime_core::error::{RuntimeError, RuntimeResult};
+use wasmer_runtime_core::typed_func::WasmTrapInfo;
 
 extern "C" fn signal_trap_handler(
     signum: ::nix::libc::c_int,
@@ -62,7 +62,7 @@ pub unsafe fn trigger_trap() -> ! {
     longjmp(jmp_buf as *mut c_void, 0)
 }
 
-pub fn call_protected<T>(handler_data: &HandlerData, f: impl FnOnce() -> T) -> RuntimeResult<T> {
+pub fn call_protected<T>(handler_data: &HandlerData, f: impl FnOnce() -> T) -> Result<T, RunErr> {
     unsafe {
         let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
         let prev_jmp_buf = *jmp_buf;
@@ -76,7 +76,7 @@ pub fn call_protected<T>(handler_data: &HandlerData, f: impl FnOnce() -> T) -> R
             *jmp_buf = prev_jmp_buf;
 
             if let Some(data) = super::TRAP_EARLY_DATA.with(|cell| cell.replace(None)) {
-                Err(RuntimeError::Error { data })
+                Err(RunErr::Error(data))
             } else {
                 let (faulting_addr, inst_ptr) = CAUGHT_ADDRESSES.with(|cell| cell.get());
 
@@ -85,33 +85,18 @@ pub fn call_protected<T>(handler_data: &HandlerData, f: impl FnOnce() -> T) -> R
                     srcloc: _,
                 }) = handler_data.lookup(inst_ptr)
                 {
-                    Err(match Signal::from_c_int(signum) {
+                    Err(RunErr::Trap(match Signal::from_c_int(signum) {
                         Ok(SIGILL) => match trapcode {
-                            TrapCode::BadSignature => RuntimeError::Trap {
-                                msg: "incorrect call_indirect signature".into(),
-                            },
-                            TrapCode::IndirectCallToNull => RuntimeError::Trap {
-                                msg: "indirect call to null".into(),
-                            },
-                            TrapCode::HeapOutOfBounds => RuntimeError::Trap {
-                                msg: "memory out-of-bounds access".into(),
-                            },
-                            TrapCode::TableOutOfBounds => RuntimeError::Trap {
-                                msg: "table out-of-bounds access".into(),
-                            },
-                            _ => RuntimeError::Trap {
-                                msg: "unknown trap".into(),
-                            },
+                            TrapCode::BadSignature => WasmTrapInfo::IncorrectCallIndirectSignature,
+                            TrapCode::IndirectCallToNull => WasmTrapInfo::CallIndirectOOB,
+                            TrapCode::HeapOutOfBounds => WasmTrapInfo::MemoryOutOfBounds,
+                            TrapCode::TableOutOfBounds => WasmTrapInfo::CallIndirectOOB,
+                            _ => WasmTrapInfo::Unknown,
                         },
-                        Ok(SIGSEGV) | Ok(SIGBUS) => RuntimeError::Trap {
-                            msg: "memory out-of-bounds access".into(),
-                        },
-                        Ok(SIGFPE) => RuntimeError::Trap {
-                            msg: "illegal arithmetic operation".into(),
-                        },
+                        Ok(SIGSEGV) | Ok(SIGBUS) => WasmTrapInfo::MemoryOutOfBounds,
+                        Ok(SIGFPE) => WasmTrapInfo::IllegalArithmetic,
                         _ => unimplemented!(),
-                    }
-                    .into())
+                    }))
                 } else {
                     let signal = match Signal::from_c_int(signum) {
                         Ok(SIGFPE) => "floating-point exception",
@@ -122,10 +107,8 @@ pub fn call_protected<T>(handler_data: &HandlerData, f: impl FnOnce() -> T) -> R
                         _ => "unkown trapped signal",
                     };
                     // When the trap-handler is fully implemented, this will return more information.
-                    Err(RuntimeError::Trap {
-                        msg: format!("unknown trap at {:p} - {}", faulting_addr, signal).into(),
-                    }
-                    .into())
+                    let s = format!("unknown trap at {:p} - {}", faulting_addr, signal);
+                    Err(RunErr::Error(Box::new(s)))
                 }
             }
         } else {

--- a/lib/clif-backend/src/signal/windows.rs
+++ b/lib/clif-backend/src/signal/windows.rs
@@ -1,10 +1,11 @@
 use crate::relocation::{TrapCode, TrapData};
-use crate::signal::HandlerData;
+use crate::signal::{HandlerData, RunErr};
 use crate::trampoline::Trampoline;
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::ptr::{self, NonNull};
 use wasmer_runtime_core::error::{RuntimeError, RuntimeResult};
+use wasmer_runtime_core::typed_func::WasmTrapInfo;
 use wasmer_runtime_core::vm::Ctx;
 use wasmer_runtime_core::vm::Func;
 use wasmer_win_exception_handler::CallProtectedData;
@@ -28,7 +29,7 @@ pub fn call_protected(
     func: NonNull<Func>,
     param_vec: *const u64,
     return_vec: *mut u64,
-) -> RuntimeResult<()> {
+) -> Result<(), RunErr> {
     // TODO: trap early
     // user code error
     //    if let Some(msg) = super::TRAP_EARLY_DATA.with(|cell| cell.replace(None)) {
@@ -52,38 +53,22 @@ pub fn call_protected(
         srcloc: _,
     }) = handler_data.lookup(instruction_pointer as _)
     {
-        Err(match signum as DWORD {
-            EXCEPTION_ACCESS_VIOLATION => RuntimeError::Trap {
-                msg: "memory out-of-bounds access".into(),
-            },
+        Err(RunErr::Trap(match signum as DWORD {
+            EXCEPTION_ACCESS_VIOLATION => WasmTrapInfo::MemoryOutOfBounds,
             EXCEPTION_ILLEGAL_INSTRUCTION => match trapcode {
-                TrapCode::BadSignature => RuntimeError::Trap {
-                    msg: "incorrect call_indirect signature".into(),
-                },
-                TrapCode::IndirectCallToNull => RuntimeError::Trap {
-                    msg: "indirect call to null".into(),
-                },
-                TrapCode::HeapOutOfBounds => RuntimeError::Trap {
-                    msg: "memory out-of-bounds access".into(),
-                },
-                TrapCode::TableOutOfBounds => RuntimeError::Trap {
-                    msg: "table out-of-bounds access".into(),
-                },
-                _ => RuntimeError::Trap {
-                    msg: "unknown trap".into(),
-                },
+                TrapCode::BadSignature => WasmTrapInfo::IncorrectCallIndirectSignature,
+                TrapCode::IndirectCallToNull => WasmTrapInfo::CallIndirectOOB,
+                TrapCode::HeapOutOfBounds => WasmTrapInfo::MemoryOutOfBounds,
+                TrapCode::TableOutOfBounds => WasmTrapInfo::CallIndirectOOB,
+                TrapCode::UnreachableCodeReached => WasmTrapInfo::Unreachable,
+                _ => WasmTrapInfo::Unknown,
             },
-            EXCEPTION_STACK_OVERFLOW => RuntimeError::Trap {
-                msg: "stack overflow trap".into(),
-            },
-            EXCEPTION_INT_DIVIDE_BY_ZERO | EXCEPTION_INT_OVERFLOW => RuntimeError::Trap {
-                msg: "illegal arithmetic operation".into(),
-            },
-            _ => RuntimeError::Trap {
-                msg: "unknown trap".into(),
-            },
-        }
-        .into())
+            EXCEPTION_STACK_OVERFLOW => WasmTrapInfo::Unknown,
+            EXCEPTION_INT_DIVIDE_BY_ZERO | EXCEPTION_INT_OVERFLOW => {
+                WasmTrapInfo::IllegalArithmetic
+            }
+            _ => WasmTrapInfo::Unknown,
+        }))
     } else {
         let signal = match signum as DWORD {
             EXCEPTION_FLT_DENORMAL_OPERAND
@@ -98,10 +83,9 @@ pub fn call_protected(
             _ => "unkown trapped signal",
         };
 
-        Err(RuntimeError::Trap {
-            msg: format!("unknown trap at {} - {}", exception_address, signal).into(),
-        }
-        .into())
+        let s = format!("unknown trap at {} - {}", exception_address, signal);
+
+        Err(RunErr::Error(Box::new(s)))
     }
 }
 

--- a/lib/llvm-backend/build.rs
+++ b/lib/llvm-backend/build.rs
@@ -213,6 +213,8 @@ fn main() {
 
     println!("cargo:rustc-link-lib=static=llvm-backend");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=cpp/object_loader.cpp");
+    println!("cargo:rerun-if-changed=cpp/object_loader.hh");
 
     // Enable "nightly" cfg if the current compiler is nightly.
     if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -93,6 +93,7 @@ extern "C" {
         params: *const u64,
         results: *mut u64,
         trap_out: *mut WasmTrapInfo,
+        user_error: *mut Option<Box<dyn Any>>,
         invoke_env: Option<NonNull<c_void>>,
     ) -> bool;
 }

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -137,15 +137,13 @@ impl std::fmt::Display for RuntimeError {
                 write!(f, "WebAssembly trap occured during runtime: {}", msg)
             }
             RuntimeError::Error { data } => {
-                let msg = if let Some(s) = data.downcast_ref::<String>() {
-                    s
+                if let Some(s) = data.downcast_ref::<String>() {
+                    write!(f, "\"{}\"", s)
                 } else if let Some(s) = data.downcast_ref::<&str>() {
-                    s
+                    write!(f, "\"{}\"", s)
                 } else {
-                    "user-defined, opaque"
-                };
-
-                write!(f, "{}", msg)
+                    write!(f, "unknown error")
+                }
             }
         }
     }

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -528,6 +528,7 @@ fn call_func_with_index(
 
     let run_wasm = |result_space: *mut u64| unsafe {
         let mut trap_info = WasmTrapInfo::Unknown;
+        let mut user_error = None;
 
         let success = invoke(
             trampoline,
@@ -536,15 +537,20 @@ fn call_func_with_index(
             raw_args.as_ptr(),
             result_space,
             &mut trap_info,
+            &mut user_error,
             invoke_env,
         );
 
         if success {
             Ok(())
         } else {
-            Err(RuntimeError::Trap {
-                msg: trap_info.to_string().into(),
-            })
+            if let Some(data) = user_error {
+                Err(RuntimeError::Error { data })
+            } else {
+                Err(RuntimeError::Trap {
+                    msg: trap_info.to_string().into(),
+                })
+            }
         }
     };
 

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -230,7 +230,7 @@ impl WasmTypeList for Infallible {
         unreachable!()
     }
     fn types() -> &'static [Type] {
-        unreachable!()
+        &[]
     }
     #[allow(non_snake_case)]
     unsafe fn call<Rets: WasmTypeList>(

--- a/lib/runtime/tests/error_propagation.rs
+++ b/lib/runtime/tests/error_propagation.rs
@@ -1,0 +1,49 @@
+#[test]
+fn error_propagation() {
+    use std::convert::Infallible;
+    use wabt::wat2wasm;
+    use wasmer_runtime::{compile, error::RuntimeError, imports, Ctx, Func};
+
+    static WAT: &'static str = r#"
+        (module
+        (type (;0;) (func))
+        (import "env" "ret_err" (func $ret_err (type 0)))
+        (func $call_panic
+            call $ret_err
+        )
+        (export "call_err" (func $call_panic))
+        )
+    "#;
+
+    #[derive(Debug)]
+    struct ExitCode {
+        code: i32,
+    }
+
+    fn ret_err(_ctx: &mut Ctx) -> Result<Infallible, ExitCode> {
+        Err(ExitCode { code: 42 })
+    }
+
+    let wasm = wat2wasm(WAT).unwrap();
+
+    let module = compile(&wasm).unwrap();
+
+    let instance = module
+        .instantiate(&imports! {
+          "env" => {
+              "ret_err" => Func::new(ret_err),
+          },
+        })
+        .unwrap();
+
+    let foo: Func<(), ()> = instance.func("call_err").unwrap();
+
+    let result = foo.call();
+
+    if let Err(RuntimeError::Error { data }) = result {
+        let exit_code = data.downcast::<ExitCode>().unwrap();
+        assert_eq!(exit_code.code, 42);
+    } else {
+        panic!("didn't return RuntimeError::Error")
+    }
+}

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -205,7 +205,8 @@ impl RunnableModule for X64ExecutionContext {
             func: NonNull<vm::Func>,
             args: *const u64,
             rets: *mut u64,
-            _trap_info: *mut WasmTrapInfo,
+            trap_info: *mut WasmTrapInfo,
+            user_error: *mut Option<Box<dyn Any>>,
             num_params_plus_one: Option<NonNull<c_void>>,
         ) -> bool {
             let args = ::std::slice::from_raw_parts(
@@ -227,7 +228,13 @@ impl RunnableModule for X64ExecutionContext {
                     }
                     true
                 }
-                Err(_) => false,
+                Err(err) => {
+                    match err {
+                        protect_unix::RunErr::Trap(info) => *trap_info = info,
+                        protect_unix::RunErr::Error(data) => *user_error = Some(data),
+                    }
+                    false
+                }
             }
         }
 

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -230,8 +230,8 @@ impl RunnableModule for X64ExecutionContext {
                 }
                 Err(err) => {
                     match err {
-                        protect_unix::RunErr::Trap(info) => *trap_info = info,
-                        protect_unix::RunErr::Error(data) => *user_error = Some(data),
+                        protect_unix::CallProtError::Trap(info) => *trap_info = info,
+                        protect_unix::CallProtError::Error(data) => *user_error = Some(data),
                     }
                     false
                 }

--- a/lib/singlepass-backend/src/protect_unix.rs
+++ b/lib/singlepass-backend/src/protect_unix.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use std::cell::{Cell, UnsafeCell};
 use std::ptr;
 use std::sync::Once;
-use wasmer_runtime_core::error::{RuntimeError, RuntimeResult};
+use wasmer_runtime_core::typed_func::WasmTrapInfo;
 
 extern "C" fn signal_trap_handler(
     signum: ::nix::libc::c_int,
@@ -62,7 +62,12 @@ pub unsafe fn trigger_trap() -> ! {
     longjmp(jmp_buf as *mut c_void, 0)
 }
 
-pub fn call_protected<T>(f: impl FnOnce() -> T) -> RuntimeResult<T> {
+pub enum RunErr {
+    Trap(WasmTrapInfo),
+    Error(Box<dyn Any>),
+}
+
+pub fn call_protected<T>(f: impl FnOnce() -> T) -> Result<T, RunErr> {
     unsafe {
         let jmp_buf = SETJMP_BUFFER.with(|buf| buf.get());
         let prev_jmp_buf = *jmp_buf;
@@ -76,23 +81,24 @@ pub fn call_protected<T>(f: impl FnOnce() -> T) -> RuntimeResult<T> {
             *jmp_buf = prev_jmp_buf;
 
             if let Some(data) = TRAP_EARLY_DATA.with(|cell| cell.replace(None)) {
-                Err(RuntimeError::Error { data })
+                Err(RunErr::Error(data))
             } else {
-                let (faulting_addr, _inst_ptr) = CAUGHT_ADDRESSES.with(|cell| cell.get());
+                // let (faulting_addr, _inst_ptr) = CAUGHT_ADDRESSES.with(|cell| cell.get());
 
-                let signal = match Signal::from_c_int(signum) {
-                    Ok(SIGFPE) => "floating-point exception",
-                    Ok(SIGILL) => "illegal instruction",
-                    Ok(SIGSEGV) => "segmentation violation",
-                    Ok(SIGBUS) => "bus error",
-                    Err(_) => "error while getting the Signal",
-                    _ => "unkown trapped signal",
-                };
-                // When the trap-handler is fully implemented, this will return more information.
-                Err(RuntimeError::Trap {
-                    msg: format!("unknown trap at {:p} - {}", faulting_addr, signal).into(),
-                }
-                .into())
+                // let signal = match Signal::from_c_int(signum) {
+                //     Ok(SIGFPE) => "floating-point exception",
+                //     Ok(SIGILL) => "illegal instruction",
+                //     Ok(SIGSEGV) => "segmentation violation",
+                //     Ok(SIGBUS) => "bus error",
+                //     Err(_) => "error while getting the Signal",
+                //     _ => "unkown trapped signal",
+                // };
+                // // When the trap-handler is fully implemented, this will return more information.
+                // Err(RuntimeError::Trap {
+                //     msg: format!("unknown trap at {:p} - {}", faulting_addr, signal).into(),
+                // }
+                // .into())
+                Err(RunErr::Trap(WasmTrapInfo::Unknown))
             }
         } else {
             let ret = f(); // TODO: Switch stack?

--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use rand::{thread_rng, Rng};
 use std::cell::Cell;
+use std::convert::Infallible;
 use std::io::{self, Read, Seek, Write};
 use wasmer_runtime_core::{debug, memory::Memory, vm::Ctx};
 
@@ -1431,7 +1432,7 @@ pub fn poll_oneoff(
     debug!("wasi::poll_oneoff");
     unimplemented!()
 }
-pub fn proc_exit(ctx: &mut Ctx, code: __wasi_exitcode_t) -> Result<(), ExitCode> {
+pub fn proc_exit(ctx: &mut Ctx, code: __wasi_exitcode_t) -> Result<Infallible, ExitCode> {
     debug!("wasi::proc_exit, {}", code);
     Err(ExitCode { code })
 }


### PR DESCRIPTION
You can now retrieve the error from a panicking or error-returning imported function.

Example:

```rust
#[derive(Debug)]
struct ExitCode {
    code: i32,
}

fn do_panic(_ctx: &mut Ctx) -> Result<i32, ExitCode> {
    Err(ExitCode { code: 42 })
}

// This wasm functions calls `do_panic`.
let foo: Func<(), i32> = instance.func(...)?;

let result = foo.call();

println!("result: {:?}", result);

if let Err(RuntimeError::Error { data }) = result {
    if let Ok(exit_code) = data.downcast::<ExitCode>() {
        println!("exit code: {:?}", exit_code);
    }
}
```

outputs:

```
result: Err(unknown error)
exit code: ExitCode { code: 42 }
```