### PR TITLE
pin wapm version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Install Rust
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
             export PATH="$HOME/.cargo/bin:$PATH"
             cargo --version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,8 @@ jobs:
       - run:
           name: "Pull dependencies"
           command: |
-            git clone git@github.com:wasmerio/wapm-cli.git
+            git submodule init
+            git submodule update --remote
       - restore_cache:
           keys:
             - v8-cargo-cache-linux-nightly-{{ arch }}-{{ checksum "Cargo.lock" }}
@@ -220,7 +221,8 @@ jobs:
       - run:
           name: "Pull dependencies"
           command: |
-            git clone git@github.com:wasmerio/wapm-cli.git
+            git submodule init
+            git submodule update --remote
       - restore_cache:
           keys:
             - v8-cargo-cache-darwin-nightly-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
       - run:
           name: Install Rust
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2019-04-11
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
             export PATH="$HOME/.cargo/bin:$PATH"
             cargo --version
       # Use rust nightly (for singlepass, for now)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: "Pull dependencies"
           command: |
-            git clone --branch v0.1.0 --depth 1 https://github.com/wasmerio/wapm-cli
+            git clone git@github.com:wasmerio/wapm-cli.git
       - restore_cache:
           keys:
             - v8-cargo-cache-linux-nightly-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Install Rust
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+            curl -sSf https://sh.rustup.rs | sh -s -- -y
             export PATH="$HOME/.cargo/bin:$PATH"
             cargo --version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: "Pull dependencies"
           command: |
-            git clone git@github.com:wasmerio/wapm-cli.git
+            git clone --branch v0.1.0 --depth 1 https://github.com/wasmerio/wapm-cli
       - restore_cache:
           keys:
             - v8-cargo-cache-linux-nightly-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wapm-cli"]
+	path = wapm-cli
+	url = git@github.com:wasmerio/wapm-cli.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All PRs to the Wasmer repository must add to this file.
 Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
+- [#390](https://github.com/wasmerio/wasmer/pull/390) Pin released wapm version and add it as a git submodule
 - [#383](https://github.com/wasmerio/wasmer/pull/383) Hook up wasi exit code to wasmer cli.
 - [#382](https://github.com/wasmerio/wasmer/pull/382) Improve error message on `--backend` flag to only suggest currently enabled backends
 - [#381](https://github.com/wasmerio/wasmer/pull/381) Allow retrieving propagated user errors.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.3.0",
- "zbox 0.6.1 (git+https://github.com/wasmerio/zbox?branch=bundle-libsodium)",
 ]
 
 [[package]]

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -16,8 +16,3 @@ hashbrown = "0.1.8"
 generational-arena = "0.2.2"
 log = "0.4.6"
 byteorder = "1.3.1"
-
-[dependencies.zbox]
-git = "https://github.com/wasmerio/zbox"
-branch = "bundle-libsodium"
-features = ["libsodium-bundled"]

--- a/lib/wasi/src/state.rs
+++ b/lib/wasi/src/state.rs
@@ -12,42 +12,35 @@ use std::{
     time::SystemTime,
 };
 use wasmer_runtime_core::debug;
-use zbox::init_env as zbox_init_env;
 
 pub const MAX_SYMLINKS: usize = 100;
 
 #[derive(Debug)]
 pub enum WasiFile {
-    #[allow(dead_code)]
-    ZboxFile(zbox::File),
     HostFile(fs::File),
 }
 
 impl Write for WasiFile {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.write(buf),
             WasiFile::HostFile(hf) => hf.write(buf),
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.flush(),
             WasiFile::HostFile(hf) => hf.flush(),
         }
     }
 
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.write_all(buf),
             WasiFile::HostFile(hf) => hf.write_all(buf),
         }
     }
 
     fn write_fmt(&mut self, fmt: ::std::fmt::Arguments) -> io::Result<()> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.write_fmt(fmt),
             WasiFile::HostFile(hf) => hf.write_fmt(fmt),
         }
     }
@@ -56,28 +49,24 @@ impl Write for WasiFile {
 impl Read for WasiFile {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.read(buf),
             WasiFile::HostFile(hf) => hf.read(buf),
         }
     }
 
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.read_to_end(buf),
             WasiFile::HostFile(hf) => hf.read_to_end(buf),
         }
     }
 
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.read_to_string(buf),
             WasiFile::HostFile(hf) => hf.read_to_string(buf),
         }
     }
 
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.read_exact(buf),
             WasiFile::HostFile(hf) => hf.read_exact(buf),
         }
     }
@@ -86,7 +75,6 @@ impl Read for WasiFile {
 impl Seek for WasiFile {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         match self {
-            WasiFile::ZboxFile(zbf) => zbf.seek(pos),
             WasiFile::HostFile(hf) => hf.seek(pos),
         }
     }
@@ -183,9 +171,6 @@ pub struct WasiFs {
 
 impl WasiFs {
     pub fn new(preopened_files: &[String]) -> Result<Self, String> {
-        debug!("wasi::fs::init");
-        zbox_init_env();
-        debug!("wasi::fs::repo");
         /*let repo = RepoOpener::new()
         .create(true)
         .open("mem://wasmer-test-fs", "")


### PR DESCRIPTION
This PR pins the version of wapm-cli that gets distributed during releases. We can re-create the release, and will always install the same version of wapm-cli (until we update on a new wapm-cli release). 