### PR TITLE
Add pkg-config & libssl-dev to Linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sudo port install cmake
 #### Debian-based Linuxes
 
 ```sh
-sudo apt install cmake pkg-config
+sudo apt install cmake pkg-config libssl-dev
 ```
 
 #### FreeBSD

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ sudo port install cmake
 #### Debian-based Linuxes
 
 ```sh
-sudo apt install cmake
+sudo apt install cmake pkg-config
 ```
 
 #### FreeBSD


### PR DESCRIPTION
Got this message when compiling on Ubuntu 19.04:

```
It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.
```

&

```
Make sure you also have the development packages of openssl installed.
For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
```