### PR TITLE
Improved fault debugging with emscripten

### DIFF
--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -646,6 +646,9 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
         "_emscripten_get_heap_size" => func!(crate::memory::_emscripten_get_heap_size),
         "_emscripten_resize_heap" => func!(crate::memory::_emscripten_resize_heap),
         "enlargeMemory" => func!(crate::memory::enlarge_memory),
+        "segfault" => func!(crate::memory::segfault),
+        "alignfault" => func!(crate::memory::alignfault),
+        "ftfault" => func!(crate::memory::ftfault),
         "getTotalMemory" => func!(crate::memory::get_total_memory),
         "___map_file" => func!(crate::memory::___map_file),
 

--- a/lib/emscripten/src/memory.rs
+++ b/lib/emscripten/src/memory.rs
@@ -95,6 +95,24 @@ pub fn abort_on_cannot_grow_memory_old(ctx: &mut Ctx) -> u32 {
     0
 }
 
+/// emscripten: segfault
+pub fn segfault(ctx: &mut Ctx) {
+    debug!("emscripten::segfault");
+    abort_with_message(ctx, "segmentation fault");
+}
+
+/// emscripten: alignfault
+pub fn alignfault(ctx: &mut Ctx) {
+    debug!("emscripten::alignfault");
+    abort_with_message(ctx, "alignment fault");
+}
+
+/// emscripten: ftfault
+pub fn ftfault(ctx: &mut Ctx) {
+    debug!("emscripten::ftfault");
+    abort_with_message(ctx, "Function table mask error");
+}
+
 /// emscripten: ___map_file
 pub fn ___map_file(_ctx: &mut Ctx, _one: u32, _two: u32) -> c_int {
     debug!("emscripten::___map_file");


### PR DESCRIPTION
Improved fault debugging with emscripten.

This is useful when compiling with emcc and the flag `-s SAFE_HEAP=1`.

@MarkMcCaskey @xmclark 