### PR TITLE
Cleanup some clippy warnings

### DIFF
--- a/lib/emscripten/src/process.rs
+++ b/lib/emscripten/src/process.rs
@@ -159,7 +159,7 @@ pub fn _system(_ctx: &mut Ctx, _one: i32) -> c_int {
     debug!("emscripten::_system");
     // TODO: May need to change this Em impl to a working version
     eprintln!("Can't call external programs");
-    return EAGAIN;
+    EAGAIN
 }
 
 pub fn _popen(_ctx: &mut Ctx, _one: i32, _two: i32) -> c_int {

--- a/lib/emscripten/src/time.rs
+++ b/lib/emscripten/src/time.rs
@@ -345,7 +345,7 @@ pub fn _strftime(
     // pad for null?
     let bytes = result_str.chars().count();
     if bytes as u32 > maxsize {
-        return 0;
+        0
     } else {
         // write output string
         for (i, c) in result_str.chars().enumerate() {

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -1468,7 +1468,7 @@ fn parse_function(
                     context,
                     &function,
                     -2147483904.0,
-                    2147483648.0,
+                    2_147_483_648.0,
                     v1,
                 );
                 let res =
@@ -1482,8 +1482,8 @@ fn parse_function(
                     intrinsics,
                     context,
                     &function,
-                    -2147483649.0,
-                    2147483648.0,
+                    -2_147_483_649.0,
+                    2_147_483_648.0,
                     v1,
                 );
                 let res =
@@ -1503,8 +1503,8 @@ fn parse_function(
                     intrinsics,
                     context,
                     &function,
-                    -9223373136366403584.0,
-                    9223372036854775808.0,
+                    -9_223_373_136_366_403_584.0,
+                    9_223_372_036_854_775_808.0,
                     v1,
                 );
                 let res =


### PR DESCRIPTION
Cleaned up some
- long literal lacking separators
- unneeded return