### PR TITLE
Exception logging (win32): Handle error codes correctly, add some more strings

### DIFF
--- a/lib/clif-backend/src/signal/unix.rs
+++ b/lib/clif-backend/src/signal/unix.rs
@@ -107,7 +107,7 @@ pub fn call_protected<T>(
                         Ok(SIGSEGV) => "segmentation violation",
                         Ok(SIGBUS) => "bus error",
                         Err(_) => "error while getting the Signal",
-                        _ => "unkown trapped signal",
+                        _ => "unknown trapped signal",
                     };
                     // When the trap-handler is fully implemented, this will return more information.
                     let s = format!("unknown trap at {:p} - {}", faulting_addr, signal);

--- a/lib/clif-backend/src/signal/windows.rs
+++ b/lib/clif-backend/src/signal/windows.rs
@@ -4,7 +4,6 @@ use crate::trampoline::Trampoline;
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::ptr::{self, NonNull};
-use wasmer_runtime_core::error::{RuntimeError, RuntimeResult};
 use wasmer_runtime_core::typed_func::WasmTrapInfo;
 use wasmer_runtime_core::vm::Ctx;
 use wasmer_runtime_core::vm::Func;
@@ -12,10 +11,14 @@ use wasmer_win_exception_handler::CallProtectedData;
 pub use wasmer_win_exception_handler::_call_protected;
 use winapi::shared::minwindef::DWORD;
 use winapi::um::minwinbase::{
-    EXCEPTION_ACCESS_VIOLATION, EXCEPTION_FLT_DENORMAL_OPERAND, EXCEPTION_FLT_DIVIDE_BY_ZERO,
+    EXCEPTION_ACCESS_VIOLATION, EXCEPTION_ARRAY_BOUNDS_EXCEEDED, EXCEPTION_BREAKPOINT,
+    EXCEPTION_DATATYPE_MISALIGNMENT, EXCEPTION_FLT_DENORMAL_OPERAND, EXCEPTION_FLT_DIVIDE_BY_ZERO,
     EXCEPTION_FLT_INEXACT_RESULT, EXCEPTION_FLT_INVALID_OPERATION, EXCEPTION_FLT_OVERFLOW,
-    EXCEPTION_FLT_STACK_CHECK, EXCEPTION_FLT_UNDERFLOW, EXCEPTION_ILLEGAL_INSTRUCTION,
-    EXCEPTION_INT_DIVIDE_BY_ZERO, EXCEPTION_INT_OVERFLOW, EXCEPTION_STACK_OVERFLOW,
+    EXCEPTION_FLT_STACK_CHECK, EXCEPTION_FLT_UNDERFLOW, EXCEPTION_GUARD_PAGE,
+    EXCEPTION_ILLEGAL_INSTRUCTION, EXCEPTION_INT_DIVIDE_BY_ZERO, EXCEPTION_INT_OVERFLOW,
+    EXCEPTION_INVALID_HANDLE, EXCEPTION_IN_PAGE_ERROR, EXCEPTION_NONCONTINUABLE_EXCEPTION,
+    EXCEPTION_POSSIBLE_DEADLOCK, EXCEPTION_PRIV_INSTRUCTION, EXCEPTION_SINGLE_STEP,
+    EXCEPTION_STACK_OVERFLOW,
 };
 
 thread_local! {
@@ -43,7 +46,7 @@ pub fn call_protected(
     }
 
     let CallProtectedData {
-        code: signum,
+        code,
         exception_address,
         instruction_pointer,
     } = result.unwrap_err();
@@ -53,7 +56,7 @@ pub fn call_protected(
         srcloc: _,
     }) = handler_data.lookup(instruction_pointer as _)
     {
-        Err(CallProtError::Trap(match signum as DWORD {
+        Err(CallProtError::Trap(match code as DWORD {
             EXCEPTION_ACCESS_VIOLATION => WasmTrapInfo::MemoryOutOfBounds,
             EXCEPTION_ILLEGAL_INSTRUCTION => match trapcode {
                 TrapCode::BadSignature => WasmTrapInfo::IncorrectCallIndirectSignature,
@@ -70,7 +73,7 @@ pub fn call_protected(
             _ => WasmTrapInfo::Unknown,
         }))
     } else {
-        let signal = match signum as DWORD {
+        let signal = match code as DWORD {
             EXCEPTION_FLT_DENORMAL_OPERAND
             | EXCEPTION_FLT_DIVIDE_BY_ZERO
             | EXCEPTION_FLT_INEXACT_RESULT
@@ -80,10 +83,26 @@ pub fn call_protected(
             | EXCEPTION_FLT_UNDERFLOW => "floating-point exception",
             EXCEPTION_ILLEGAL_INSTRUCTION => "illegal instruction",
             EXCEPTION_ACCESS_VIOLATION => "segmentation violation",
-            _ => "unkown trapped signal",
+            EXCEPTION_DATATYPE_MISALIGNMENT => "datatype misalignment",
+            EXCEPTION_BREAKPOINT => "breakpoint",
+            EXCEPTION_SINGLE_STEP => "single step",
+            EXCEPTION_ARRAY_BOUNDS_EXCEEDED => "array bounds exceeded",
+            EXCEPTION_INT_DIVIDE_BY_ZERO => "int div by zero",
+            EXCEPTION_INT_OVERFLOW => "int overflow",
+            EXCEPTION_PRIV_INSTRUCTION => "priv instruction",
+            EXCEPTION_IN_PAGE_ERROR => "in page error",
+            EXCEPTION_NONCONTINUABLE_EXCEPTION => "non continuable exception",
+            EXCEPTION_STACK_OVERFLOW => "stack overflow",
+            EXCEPTION_GUARD_PAGE => "guard page",
+            EXCEPTION_INVALID_HANDLE => "invalid handle",
+            EXCEPTION_POSSIBLE_DEADLOCK => "possible deadlock",
+            _ => "unknown exception code",
         };
 
-        let s = format!("unknown trap at {} - {}", exception_address, signal);
+        let s = format!(
+            "unhandled trap at {:x} - code #{:x}: {}",
+            exception_address, code, signal,
+        );
 
         Err(CallProtError::Error(Box::new(s)))
     }

--- a/lib/singlepass-backend/src/protect_unix.rs
+++ b/lib/singlepass-backend/src/protect_unix.rs
@@ -111,7 +111,7 @@ pub fn call_protected<T>(f: impl FnOnce() -> T) -> Result<T, CallProtError> {
                 //     Ok(SIGSEGV) => "segmentation violation",
                 //     Ok(SIGBUS) => "bus error",
                 //     Err(_) => "error while getting the Signal",
-                //     _ => "unkown trapped signal",
+                //     _ => "unknown trapped signal",
                 // };
                 // // When the trap-handler is fully implemented, this will return more information.
                 // Err(RuntimeError::Trap {


### PR DESCRIPTION
Ran into a situation with an unknown exception from Cranelift (will probably report that one separately). Turns out the signum was "1" though which does not seem to correspond to any of the Windows error codes, except possibly STATUS_GUARD_PAGE which is 0x80000001, but only if we lost the top bit somewhere.

On Windows, exceptions seemed to be trapped by callProtected, which is implemented here: https://github.com/wasmerio/wasmer/blob/cade9a666f5dfedfc9352718988aa26f21b028f4/lib/win-exception-handler/exception_handling/exception_handling.c . It did not seem to correctly store and retrieve the exception code, instead always returning 1: ```longjmp(jmpBuf, 1);```

So I fixed it. And now the log output looks like this:

```
unhandled trap at 1560d5e7bab - code #c0000005: segmentation violation
```
