### PR TITLE
create wasmer dir on install for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,20 +2234,20 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.3.0",
- "wasmer-emscripten 0.3.0",
- "wasmer-llvm-backend 0.3.0",
- "wasmer-middleware-common 0.3.0",
- "wasmer-runtime 0.3.0",
- "wasmer-runtime-abi 0.3.0",
- "wasmer-runtime-core 0.3.0",
- "wasmer-singlepass-backend 0.3.0",
- "wasmer-wasi 0.3.0",
+ "wasmer-clif-backend 0.4.0",
+ "wasmer-emscripten 0.4.0",
+ "wasmer-llvm-backend 0.4.0",
+ "wasmer-middleware-common 0.4.0",
+ "wasmer-runtime 0.4.0",
+ "wasmer-runtime-abi 0.4.0",
+ "wasmer-runtime-core 0.4.0",
+ "wasmer-singlepass-backend 0.4.0",
+ "wasmer-wasi 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-clif-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-codegen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2263,15 +2263,15 @@ dependencies = [
  "serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.3.0",
- "wasmer-win-exception-handler 0.3.0",
+ "wasmer-runtime-core 0.4.0",
+ "wasmer-win-exception-handler 0.4.0",
  "wasmparser 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-emscripten"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2280,15 +2280,15 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.3.0",
- "wasmer-llvm-backend 0.3.0",
- "wasmer-runtime-core 0.3.0",
- "wasmer-singlepass-backend 0.3.0",
+ "wasmer-clif-backend 0.4.0",
+ "wasmer-llvm-backend 0.4.0",
+ "wasmer-runtime-core 0.4.0",
+ "wasmer-singlepass-backend 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-llvm-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "capstone 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2303,42 +2303,42 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime-core 0.4.0",
  "wasmparser 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-middleware-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime-core 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.3.0",
- "wasmer-llvm-backend 0.3.0",
- "wasmer-runtime-core 0.3.0",
- "wasmer-singlepass-backend 0.3.0",
+ "wasmer-clif-backend 0.4.0",
+ "wasmer-llvm-backend 0.4.0",
+ "wasmer-runtime-core 0.4.0",
+ "wasmer-singlepass-backend 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-runtime-abi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime-core 0.4.0",
  "wasmparser 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zbox 0.6.1 (git+https://github.com/wasmerio/zbox?branch=bundle-libsodium)",
  "zstd 0.4.22+zstd.1.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2346,17 +2346,17 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-c-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cbindgen 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime 0.3.0",
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime 0.4.0",
+ "wasmer-runtime-core 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake2b_simd 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dynasm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2392,24 +2392,24 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime-core 0.4.0",
  "wasmparser 0.29.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-spectests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.3.0",
- "wasmer-llvm-backend 0.3.0",
- "wasmer-runtime-core 0.3.0",
- "wasmer-singlepass-backend 0.3.0",
+ "wasmer-clif-backend 0.4.0",
+ "wasmer-llvm-backend 0.4.0",
+ "wasmer-runtime-core 0.4.0",
+ "wasmer-singlepass-backend 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-wasi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2417,18 +2417,18 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime-core 0.4.0",
 ]
 
 [[package]]
 name = "wasmer-win-exception-handler"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.3.0",
+ "wasmer-runtime-core 0.4.0",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/installer/wasmer.iss
+++ b/src/installer/wasmer.iss
@@ -18,6 +18,9 @@ DisableWelcomePage=no
 Source: "..\..\target\release\wasmer.exe"; DestDir: "{app}\bin"
 Source: "..\..\wapm-cli\target\release\wapm.exe"; DestDir: "{app}\bin"
 
+[Dirs]
+Name: "{%USERPROFILE}\.wasmer"
+
 [Code]
 const EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
 
@@ -68,7 +71,7 @@ begin
     if CurStep = ssPostInstall 
      then begin 
      EnvAddPath(ExpandConstant('{app}') +'\bin');
-     EnvAddPath(ExpandConstant('{app}') +'\globals\wapm_packages\.bin');
+     EnvAddPath(ExpandConstant('{%USERPROFILE}') +'\globals\wapm_packages\.bin');
      end
 end;
 
@@ -77,6 +80,6 @@ begin
     if CurUninstallStep = usPostUninstall
     then begin 
     EnvRemovePath(ExpandConstant('{app}') +'\bin');
-    EnvAddPath(ExpandConstant('{app}') +'\globals\wapm_packages\.bin');
+    EnvAddPath(ExpandConstant('{%USERPROFILE}') +'\globals\wapm_packages\.bin');
     end
 end;


### PR DESCRIPTION
This PR creates the .wasmer dir in the home directory on windows with the inno setup installer. 

Additionally,  the new global wapm packages path is updated to use the correct path in the wasmer dir.

Also checking in the cargo.lock cause it hadn't been updated for 0.4.0.