### PR TITLE
codegen: Remove unused LoadError import

### DIFF
--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -4,7 +4,6 @@ use crate::{
     cache::{Artifact, Error as CacheError},
     error::{CompileError, CompileResult},
     module::{ModuleInfo, ModuleInner},
-    parse::LoadError,
     structures::Map,
     types::{FuncIndex, FuncSig, SigIndex},
 };


### PR DESCRIPTION
Rustc complains that:

  warning: unused import: `parse::LoadError`
   --> lib/runtime-core/src/codegen.rs:7:5
    |
  7 |     parse::LoadError,
    |     ^^^^^^^^^^^^^^^^
    |