### PR TITLE
feat(runtime-c-api) Check buffer size before creating the slice, and fix `wasmer_last_error_message` returned value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#432](https://github.com/wasmerio/wasmer/pull/432) Fix returned value of `wasmer_last_error_message` in the runtime C API
 - [#413](https://github.com/wasmerio/wasmer/pull/413) Update LLVM backend to use new parser codegen traits
 
 ## 0.4.1 - 2018-05-06

--- a/lib/runtime-c-api/src/error.rs
+++ b/lib/runtime-c-api/src/error.rs
@@ -61,19 +61,19 @@ pub unsafe extern "C" fn wasmer_last_error_message(buffer: *mut c_char, length: 
         return -1;
     }
 
-    let last_error = match take_last_error() {
-        Some(err) => err,
+    let error_message = match take_last_error() {
+        Some(err) => err.to_string(),
         None => return 0,
     };
 
-    let error_message = last_error.to_string();
+    let length = length as usize;
 
-    let buffer = slice::from_raw_parts_mut(buffer as *mut u8, length as usize);
-
-    if error_message.len() >= buffer.len() {
-        // buffer to small for err  message
+    if error_message.len() >= length {
+        // buffer to small to hold the error message
         return -1;
     }
+
+    let buffer = slice::from_raw_parts_mut(buffer as *mut u8, length);
 
     ptr::copy_nonoverlapping(
         error_message.as_ptr(),

--- a/lib/runtime-c-api/src/error.rs
+++ b/lib/runtime-c-api/src/error.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn wasmer_last_error_message(buffer: *mut c_char, length: 
     // accidentally read into garbage.
     buffer[error_message.len()] = 0;
 
-    error_message.len() as c_int
+    error_message.len() as c_int + 1
 }
 
 #[derive(Debug)]

--- a/lib/runtime-c-api/src/error.rs
+++ b/lib/runtime-c-api/src/error.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn wasmer_last_error_message(buffer: *mut c_char, length: 
     let length = length as usize;
 
     if error_message.len() >= length {
-        // buffer to small to hold the error message
+        // buffer is too small to hold the error message
         return -1;
     }
 

--- a/lib/runtime-c-api/tests/test-instantiate.c
+++ b/lib/runtime-c-api/tests/test-instantiate.c
@@ -46,7 +46,8 @@ int main()
     int error_len = wasmer_last_error_length();
     printf("Error len: `%d`\n", error_len);
     char *error_str = malloc(error_len);
-    wasmer_last_error_message(error_str, error_len);
+    int error_result = wasmer_last_error_message(error_str, error_len);
+    assert(error_len == error_result);
     printf("Error str: `%s`\n", error_str);
     assert(0 == strcmp(error_str, "Call error: Parameters of type [I32] did not match signature [I32, I32] -> [I32]"));
     free(error_str);


### PR DESCRIPTION
It's safer to check the buffer size is large enough to hold the error
message before creating the slice from raw parts.

Also, this patch remove the need for `last_error`, simplifying the
code a little bit. The `length` variable is casted to `usize` once.

This patch also updates the returned value of `wasmer_last_error_message` by adding 1, so that it mimics the `wasmer_last_error_length` function that counts the trailing null byte.