### PR TITLE
fix(runtime-c-api) `wasmer_instance_call` types must matche `wasmer_export_func_*_arity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#440](https://github.com/wasmerio/wasmer/pull/440) Fix type mismatch between `wasmer_instance_call` and `wasmer_export_func_*_arity` functions in the runtime C API.
 - [#269](https://github.com/wasmerio/wasmer/pull/269) Add better runtime docs
 - [#432](https://github.com/wasmerio/wasmer/pull/432) Fix returned value of `wasmer_last_error_message` in the runtime C API
 - [#429](https://github.com/wasmerio/wasmer/pull/429) Get wasi::path_filestat_get working for some programs; misc. minor WASI FS improvements

--- a/lib/runtime-c-api/src/export.rs
+++ b/lib/runtime-c-api/src/export.rs
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn wasmer_export_func_params_arity(
 pub unsafe extern "C" fn wasmer_export_func_params(
     func: *const wasmer_export_func_t,
     params: *mut wasmer_value_tag,
-    params_len: c_int,
+    params_len: uint32_t,
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;

--- a/lib/runtime-c-api/src/export.rs
+++ b/lib/runtime-c-api/src/export.rs
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn wasmer_export_func_params(
 pub unsafe extern "C" fn wasmer_export_func_returns(
     func: *const wasmer_export_func_t,
     returns: *mut wasmer_value_tag,
-    returns_len: c_int,
+    returns_len: uint32_t,
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -125,9 +125,9 @@ pub unsafe extern "C" fn wasmer_instance_call(
     instance: *mut wasmer_instance_t,
     name: *const c_char,
     params: *const wasmer_value_t,
-    params_len: c_int,
+    params_len: uint32_t,
     results: *mut wasmer_value_t,
-    results_len: c_int,
+    results_len: uint32_t,
 ) -> wasmer_result_t {
     if instance.is_null() {
         update_last_error(CApiError {

--- a/lib/runtime-c-api/tests/test-exports.c
+++ b/lib/runtime-c-api/tests/test-exports.c
@@ -60,7 +60,6 @@ int main()
     assert(returns_sig[0] == WASM_I32);
     free(returns_sig);
 
-
     wasmer_value_t param_one;
     param_one.tag = WASM_I32;
     param_one.value.I32 = 7;
@@ -71,7 +70,7 @@ int main()
     wasmer_value_t result_one;
     wasmer_value_t results[] = {result_one};
 
-    wasmer_result_t call_result = wasmer_export_func_call(func, params, 2, results, 1);
+    wasmer_result_t call_result = wasmer_export_func_call(func, params, params_arity, results, returns_arity);
     printf("Call result:  %d\n", call_result);
     printf("Result: %d\n", results[0].value.I32);
     assert(results[0].value.I32 == 15);

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -215,7 +215,7 @@ wasmer_result_t wasmer_export_func_params_arity(const wasmer_export_func_t *func
  */
 wasmer_result_t wasmer_export_func_returns(const wasmer_export_func_t *func,
                                            wasmer_value_tag *returns,
-                                           int returns_len);
+                                           uint32_t returns_len);
 
 /**
  * Sets the result parameter to the arity of the returns of the wasmer_export_func_t

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -197,7 +197,7 @@ wasmer_result_t wasmer_export_func_call(const wasmer_export_func_t *func,
  */
 wasmer_result_t wasmer_export_func_params(const wasmer_export_func_t *func,
                                           wasmer_value_tag *params,
-                                          int params_len);
+                                          uint32_t params_len);
 
 /**
  * Sets the result parameter to the arity of the params of the wasmer_export_func_t

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -390,9 +390,9 @@ wasmer_result_t wasmer_import_func_returns_arity(const wasmer_import_func_t *fun
 wasmer_result_t wasmer_instance_call(wasmer_instance_t *instance,
                                      const char *name,
                                      const wasmer_value_t *params,
-                                     int params_len,
+                                     uint32_t params_len,
                                      wasmer_value_t *results,
-                                     int results_len);
+                                     uint32_t results_len);
 
 /**
  * Gets the `data` field within the context.

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -192,7 +192,7 @@ wasmer_result_t wasmer_export_func_params_arity(const wasmer_export_func_t *func
 /// and `wasmer_last_error_message` to get an error message.
 wasmer_result_t wasmer_export_func_returns(const wasmer_export_func_t *func,
                                            wasmer_value_tag *returns,
-                                           int returns_len);
+                                           uint32_t returns_len);
 
 /// Sets the result parameter to the arity of the returns of the wasmer_export_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -178,7 +178,7 @@ wasmer_result_t wasmer_export_func_call(const wasmer_export_func_t *func,
 /// and `wasmer_last_error_message` to get an error message.
 wasmer_result_t wasmer_export_func_params(const wasmer_export_func_t *func,
                                           wasmer_value_tag *params,
-                                          int params_len);
+                                          uint32_t params_len);
 
 /// Sets the result parameter to the arity of the params of the wasmer_export_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -313,9 +313,9 @@ wasmer_result_t wasmer_import_func_returns_arity(const wasmer_import_func_t *fun
 wasmer_result_t wasmer_instance_call(wasmer_instance_t *instance,
                                      const char *name,
                                      const wasmer_value_t *params,
-                                     int params_len,
+                                     uint32_t params_len,
                                      wasmer_value_t *results,
-                                     int results_len);
+                                     uint32_t results_len);
 
 /// Gets the `data` field within the context.
 void *wasmer_instance_context_data_get(const wasmer_instance_context_t *ctx);


### PR DESCRIPTION
The `wasmer_export_func_params_arity` and
`wasmer_export_func_returns_arity` functions store the arity in a
`uint32_t`. The `wasmer_instance_call` expects `c_int`. There is a
type mismatch here. It's not annoying in C or C++, but in some other
languages that have bindings to C/C++, it can imply useless casting.

This patch changes `wasmer_instance_call` to expect `uint32_t` for
`params_len` and `results_len` to match the
`wasmer_export_func_*_arity` functions.

Other patches do the same for `wasmer_export_func_params` and
`wasmer_export_func_returns`.