### PR TITLE
Return impl Compiler from default_compiler to fix compilation features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,13 @@ test:
 	# cargo test --all --exclude wasmer-emscripten -- --test-threads=1 $(runargs)
 	cargo test --manifest-path lib/spectests/Cargo.toml --features clif
 	cargo test --manifest-path lib/spectests/Cargo.toml --features llvm
+	cargo test --manifest-path lib/runtime/Cargo.toml --features llvm
 	cargo build -p wasmer-runtime-c-api
 	cargo test -p wasmer-runtime-c-api -- --nocapture
 
 test-singlepass:
 	cargo test --manifest-path lib/spectests/Cargo.toml --features singlepass
+	cargo test --manifest-path lib/runtime/Cargo.toml --features singlepass
 
 test-emscripten-llvm:
 	cargo test --manifest-path lib/emscripten/Cargo.toml --features llvm -- --test-threads=1 $(runargs)

--- a/lib/runtime-c-api/src/module.rs
+++ b/lib/runtime-c-api/src/module.rs
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn wasmer_module_deserialize(
     let serialized_module: &[u8] = &*(serialized_module as *const &[u8]);
 
     match Artifact::deserialize(serialized_module) {
-        Ok(artifact) => match load_cache_with(artifact, default_compiler()) {
+        Ok(artifact) => match load_cache_with(artifact, &default_compiler()) {
             Ok(deserialized_module) => {
                 *module = Box::into_raw(Box::new(deserialized_module)) as _;
                 wasmer_result_t::WASMER_OK

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -94,7 +94,9 @@ impl Cache for FileSystemCache {
         let mmap = unsafe { Mmap::map(&file)? };
 
         let serialized_cache = Artifact::deserialize(&mmap[..])?;
-        unsafe { wasmer_runtime_core::load_cache_with(serialized_cache, super::default_compiler()) }
+        unsafe {
+            wasmer_runtime_core::load_cache_with(serialized_cache, &super::default_compiler())
+        }
     }
 
     fn store(&mut self, key: WasmHash, module: Module) -> Result<(), CacheError> {

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -131,7 +131,7 @@ use wasmer_runtime_core::backend::{Compiler, CompilerConfig};
 /// # Errors:
 /// If the operation fails, the function returns `Err(error::CompileError::...)`.
 pub fn compile(wasm: &[u8]) -> error::CompileResult<Module> {
-    wasmer_runtime_core::compile_with(&wasm[..], default_compiler())
+    wasmer_runtime_core::compile_with(&wasm[..], &default_compiler())
 }
 
 /// The same as `compile` but takes a `CompilerConfig` for the purpose of
@@ -140,7 +140,7 @@ pub fn compile_with_config(
     wasm: &[u8],
     compiler_config: CompilerConfig,
 ) -> error::CompileResult<Module> {
-    wasmer_runtime_core::compile_with_config(&wasm[..], default_compiler(), compiler_config)
+    wasmer_runtime_core::compile_with_config(&wasm[..], &default_compiler(), compiler_config)
 }
 
 /// The same as `compile_with_config` but takes a `Compiler` for the purpose of
@@ -177,9 +177,7 @@ pub fn instantiate(wasm: &[u8], import_object: &ImportObject) -> error::Result<I
 }
 
 /// Get a single instance of the default compiler to use.
-pub fn default_compiler() -> &'static dyn Compiler {
-    use lazy_static::lazy_static;
-
+pub fn default_compiler() -> impl Compiler {
     #[cfg(feature = "llvm")]
     use wasmer_llvm_backend::LLVMCompiler as DefaultCompiler;
 
@@ -189,11 +187,7 @@ pub fn default_compiler() -> &'static dyn Compiler {
     #[cfg(not(any(feature = "llvm", feature = "singlepass")))]
     use wasmer_clif_backend::CraneliftCompiler as DefaultCompiler;
 
-    lazy_static! {
-        static ref DEFAULT_COMPILER: DefaultCompiler = { DefaultCompiler::new() };
-    }
-
-    &*DEFAULT_COMPILER as &dyn Compiler
+    DefaultCompiler::new()
 }
 
 /// The current version of this crate


### PR DESCRIPTION
runtime compilation was failing (llvm/singlepass features) for the new compiler implementations for the `default_compiler` function due to changing types and state being added to the compilers.

This PR:
- adds runtime library tests for these features to catch the regression earlier
- refactors `default_compiler` to return `impl Compiler` and no longer a singleton to fix the compilation issue