### PR TITLE
avoid opening files when not needed in WASI, check for write permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#449](https://github.com/wasmerio/wasmer/pull/449) Fix bugs: opening host files in filestat and opening with write permissions unconditionally in path_open
 - [#442](https://github.com/wasmerio/wasmer/pull/442) Misc. WASI FS fixes and implement readdir
 - [#440](https://github.com/wasmerio/wasmer/pull/440) Fix type mismatch between `wasmer_instance_call` and `wasmer_export_func_*_arity` functions in the runtime C API.
 - [#269](https://github.com/wasmerio/wasmer/pull/269) Add better runtime docs

--- a/lib/wasi/src/state.rs
+++ b/lib/wasi/src/state.rs
@@ -451,3 +451,16 @@ pub struct WasiState<'a> {
     pub args: &'a [Vec<u8>],
     pub envs: &'a [Vec<u8>],
 }
+
+pub fn host_file_type_to_wasi_file_type(file_type: fs::FileType) -> __wasi_filetype_t {
+    // TODO: handle other file types
+    if file_type.is_dir() {
+        __WASI_FILETYPE_DIRECTORY
+    } else if file_type.is_file() {
+        __WASI_FILETYPE_REGULAR_FILE
+    } else if file_type.is_symlink() {
+        __WASI_FILETYPE_SYMBOLIC_LINK
+    } else {
+        __WASI_FILETYPE_UNKNOWN
+    }
+}

--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -1500,7 +1500,7 @@ pub fn path_open(
                 let real_opened_file = {
                     let mut open_options = std::fs::OpenOptions::new();
                     let open_options = open_options.read(true);
-                    let open_options = if dbg!(fs_rights_base & __WASI_RIGHT_FD_WRITE) != 0 {
+                    let open_options = if fs_rights_base & __WASI_RIGHT_FD_WRITE != 0 {
                         open_options.write(true)
                     } else {
                         open_options


### PR DESCRIPTION
resolves #438 

Follow up to  #448.  Turns out we don't have to complect things in that way, we can just be more conservative about opening files and granting write permissions