### PR TITLE
fix(runtime-c-api) Prevent negative lengths in various places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#461](https://github.com/wasmerio/wasmer/pull/461) Prevent passing negative lengths in various places in the runtime C API
 - [#459](https://github.com/wasmerio/wasmer/pull/459) Add monotonic and real time clocks for wasi on windows
 - [#447](https://github.com/wasmerio/wasmer/pull/447) Add trace macro (`--features trace`) for more verbose debug statements
 - [#451](https://github.com/wasmerio/wasmer/pull/451) Add `--mapdir=src:dest` flag to rename host directories in the guest context

--- a/lib/runtime-c-api/src/import.rs
+++ b/lib/runtime-c-api/src/import.rs
@@ -8,7 +8,7 @@ use crate::{
     value::wasmer_value_tag,
     wasmer_byte_array, wasmer_result_t,
 };
-use libc::{c_int, uint32_t};
+use libc::{c_uint, uint32_t};
 use std::{ffi::c_void, ptr, slice, sync::Arc};
 use wasmer_runtime::Module;
 use wasmer_runtime_core::{
@@ -154,11 +154,11 @@ pub extern "C" fn wasmer_import_descriptors_destroy(
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_import_descriptors_len(
     exports: *mut wasmer_import_descriptors_t,
-) -> c_int {
+) -> c_uint {
     if exports.is_null() {
         return 0;
     }
-    (*(exports as *mut NamedImportDescriptors)).0.len() as c_int
+    (*(exports as *mut NamedImportDescriptors)).0.len() as c_uint
 }
 
 /// Gets import descriptor by index
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn wasmer_import_descriptors_len(
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_import_descriptors_get(
     import_descriptors: *mut wasmer_import_descriptors_t,
-    idx: c_int,
+    idx: c_uint,
 ) -> *mut wasmer_import_descriptor_t {
     if import_descriptors.is_null() {
         return ptr::null_mut();
@@ -244,9 +244,9 @@ pub unsafe extern "C" fn wasmer_import_func_params_arity(
 pub unsafe extern "C" fn wasmer_import_func_new(
     func: extern "C" fn(data: *mut c_void),
     params: *const wasmer_value_tag,
-    params_len: c_int,
+    params_len: c_uint,
     returns: *const wasmer_value_tag,
-    returns_len: c_int,
+    returns_len: c_uint,
 ) -> *mut wasmer_import_func_t {
     let params: &[wasmer_value_tag] = slice::from_raw_parts(params, params_len as usize);
     let params: Vec<Type> = params.iter().cloned().map(|x| x.into()).collect();
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn wasmer_import_func_new(
 pub unsafe extern "C" fn wasmer_import_func_params(
     func: *const wasmer_import_func_t,
     params: *mut wasmer_value_tag,
-    params_len: c_int,
+    params_len: c_uint,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
     if let Export::Function { ref signature, .. } = *export {
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn wasmer_import_func_params(
 pub unsafe extern "C" fn wasmer_import_func_returns(
     func: *const wasmer_import_func_t,
     returns: *mut wasmer_value_tag,
-    returns_len: c_int,
+    returns_len: c_uint,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
     if let Export::Function { ref signature, .. } = *export {

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -321,12 +321,12 @@ void wasmer_import_descriptors_destroy(wasmer_import_descriptors_t *import_descr
  * Gets import descriptor by index
  */
 wasmer_import_descriptor_t *wasmer_import_descriptors_get(wasmer_import_descriptors_t *import_descriptors,
-                                                          int idx);
+                                                          unsigned int idx);
 
 /**
  * Gets the length of the import descriptors
  */
-int wasmer_import_descriptors_len(wasmer_import_descriptors_t *exports);
+unsigned int wasmer_import_descriptors_len(wasmer_import_descriptors_t *exports);
 
 /**
  * Frees memory for the given Func
@@ -339,9 +339,9 @@ void wasmer_import_func_destroy(wasmer_import_func_t *func);
  */
 wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
                                              const wasmer_value_tag *params,
-                                             int params_len,
+                                             unsigned int params_len,
                                              const wasmer_value_tag *returns,
-                                             int returns_len);
+                                             unsigned int returns_len);
 
 /**
  * Sets the params buffer to the parameter types of the given wasmer_import_func_t
@@ -351,7 +351,7 @@ wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
  */
 wasmer_result_t wasmer_import_func_params(const wasmer_import_func_t *func,
                                           wasmer_value_tag *params,
-                                          int params_len);
+                                          unsigned int params_len);
 
 /**
  * Sets the result parameter to the arity of the params of the wasmer_import_func_t
@@ -369,7 +369,7 @@ wasmer_result_t wasmer_import_func_params_arity(const wasmer_import_func_t *func
  */
 wasmer_result_t wasmer_import_func_returns(const wasmer_import_func_t *func,
                                            wasmer_value_tag *returns,
-                                           int returns_len);
+                                           unsigned int returns_len);
 
 /**
  * Sets the result parameter to the arity of the returns of the wasmer_import_func_t

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -4,6 +4,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 
 enum class wasmer_import_export_kind : uint32_t {
   WASM_FUNCTION,
@@ -260,10 +261,10 @@ void wasmer_import_descriptors_destroy(wasmer_import_descriptors_t *import_descr
 
 /// Gets import descriptor by index
 wasmer_import_descriptor_t *wasmer_import_descriptors_get(wasmer_import_descriptors_t *import_descriptors,
-                                                          int idx);
+                                                          unsigned int idx);
 
 /// Gets the length of the import descriptors
-int wasmer_import_descriptors_len(wasmer_import_descriptors_t *exports);
+unsigned int wasmer_import_descriptors_len(wasmer_import_descriptors_t *exports);
 
 /// Frees memory for the given Func
 void wasmer_import_func_destroy(wasmer_import_func_t *func);
@@ -272,9 +273,9 @@ void wasmer_import_func_destroy(wasmer_import_func_t *func);
 /// The caller owns the object and should call `wasmer_import_func_destroy` to free it.
 wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
                                              const wasmer_value_tag *params,
-                                             int params_len,
+                                             unsigned int params_len,
                                              const wasmer_value_tag *returns,
-                                             int returns_len);
+                                             unsigned int returns_len);
 
 /// Sets the params buffer to the parameter types of the given wasmer_import_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
@@ -282,7 +283,7 @@ wasmer_import_func_t *wasmer_import_func_new(void (*func)(void *data),
 /// and `wasmer_last_error_message` to get an error message.
 wasmer_result_t wasmer_import_func_params(const wasmer_import_func_t *func,
                                           wasmer_value_tag *params,
-                                          int params_len);
+                                          unsigned int params_len);
 
 /// Sets the result parameter to the arity of the params of the wasmer_import_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.
@@ -296,7 +297,7 @@ wasmer_result_t wasmer_import_func_params_arity(const wasmer_import_func_t *func
 /// and `wasmer_last_error_message` to get an error message.
 wasmer_result_t wasmer_import_func_returns(const wasmer_import_func_t *func,
                                            wasmer_value_tag *returns,
-                                           int returns_len);
+                                           unsigned int returns_len);
 
 /// Sets the result parameter to the arity of the returns of the wasmer_import_func_t
 /// Returns `wasmer_result_t::WASMER_OK` upon success.


### PR DESCRIPTION
This PR prevents receiving negative lengths in various places in the code.