### PR TITLE
Add 🦀 to the Rust language

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl https://get.wasmer.io -sSfL | sh
 
 Wasmer runtime can also be embedded in different languages, so you can use WebAssembly anywhere ✨:
 
-* [**Rust**](https://github.com/wasmerio/wasmer-rust-example)
+* [🦀 **Rust**](https://github.com/wasmerio/wasmer-rust-example)
 * [**C/C++**](https://github.com/wasmerio/wasmer-c-api)
 * [**🐘 PHP**](https://github.com/wasmerio/php-ext-wasm)
 * [**🐍 Python**](https://github.com/wasmerio/python-ext-wasm)


### PR DESCRIPTION
The other languages have an emoji for the mascot so I thought I would make note of the Ferris the Crab mascot for Rust in the README.

https://rustacean.net