### PR TITLE
fix(runtime-c-api) Set the install name of the dylib to `@rpath`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,10 +284,11 @@ jobs:
             # VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
             # echo "${VERSION}" >> artifacts/version
       - run:
-          name: Dynamic library
+          name: Generate dynamic library for the runtime C API
           command: |
             export PATH="$HOME/.cargo/bin:$PATH"
             cargo build --release --manifest-path lib/runtime-c-api/Cargo.toml
+            install_name_tool -id "@rpath/libwasmer_runtime_c_api.dylib" target/release/libwasmer_runtime_c_api.dylib
             cp target/release/libwasmer_runtime_c_api.dylib ./artifacts
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
```sh
$ objdump -macho -dylib-id libwasmer_runtime_c_api.dylib
libwasmer_runtime_c_api.dylib:
/Users/distiller/project/target/release/deps/libwasmer_runtime_c_api.dylib
```

we observe that the dylib ID (aka install name) is set to
`/Users/distiller/project/target/release/deps/libwasmer_runtime_c_api.dylib`,
which is valid only in the context of CircleCI.

This patch changes the dylib ID to
`@rpath/libwasmer_runtime_c_api.dylib`, which can be then changed by
the linker option `-rpath` (use `-Wl,-rpath,$value` with the compiler
to send the `-rpath` value to the linker).

This is super useful when dynamically linking libraries against
another language. Having the dylib ID already set to `@rpath` avoid any
build system to call `install_name_tool` manually, which isn't always
possible (e.g. in Go with cgo where we can only pass options to the
compiler with `LDFLAGS`, it's impossible to run any arbitrary command).