### PR TITLE
fix bugs in emscripten socket syscalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#484](https://github.com/wasmerio/wasmer/pull/484) Fix bugs in emscripten socket syscalls
 - [#476](https://github.com/wasmerio/wasmer/pull/476) Fix bug with wasi::environ_get, fix off by one error in wasi::environ_sizes_get
 - [#470](https://github.com/wasmerio/wasmer/pull/470) Add mapdir support to Emscripten, implement getdents for Unix
 - [#467](https://github.com/wasmerio/wasmer/pull/467) `wasmer_instantiate` returns better error messages in the runtime C API

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -436,13 +436,13 @@ pub fn ___syscall191(ctx: &mut Ctx, _which: i32, mut varargs: VarArgs) -> i32 {
         _resource
     );
     let rlim_emptr: i32 = varargs.get(ctx);
-    let rlim = emscripten_memory_pointer!(ctx.memory(0), rlim_emptr) as *mut i64;
+    let rlim_ptr = emscripten_memory_pointer!(ctx.memory(0), rlim_emptr) as *mut u8;
+    let rlim = unsafe { slice::from_raw_parts_mut(rlim_ptr, 16) };
 
-    // set all to infinity
-    unsafe {
-        *(rlim.add(0)) = -1;
-        *(rlim.add(1)) = -1;
-    }
+    // set all to RLIM_INIFINTY
+    LittleEndian::write_i64(&mut rlim[..], -1);
+    LittleEndian::write_i64(&mut rlim[8..], -1);
+
     0
 }
 

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -425,13 +425,25 @@ pub fn ___syscall146(ctx: &mut Ctx, _which: i32, mut varargs: VarArgs) -> i32 {
 }
 
 pub fn ___syscall168(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
-    debug!("emscripten::___syscall168");
+    debug!("emscripten::___syscall168 - stub");
     -1
 }
 
-pub fn ___syscall191(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
-    debug!("emscripten::___syscall191 - stub");
-    -1
+pub fn ___syscall191(ctx: &mut Ctx, _which: i32, mut varargs: VarArgs) -> i32 {
+    let _resource: i32 = varargs.get(ctx);
+    debug!(
+        "emscripten::___syscall191 - mostly stub, resource: {}",
+        _resource
+    );
+    let rlim_emptr: i32 = varargs.get(ctx);
+    let rlim = emscripten_memory_pointer!(ctx.memory(0), rlim_emptr) as *mut i64;
+
+    // set all to infinity
+    unsafe {
+        *(rlim.add(0)) = -1;
+        *(rlim.add(1)) = -1;
+    }
+    0
 }
 
 pub fn ___syscall199(_ctx: &mut Ctx, _one: i32, _two: i32) -> i32 {
@@ -543,19 +555,23 @@ pub fn ___syscall340(ctx: &mut Ctx, _which: c_int, mut varargs: VarArgs) -> c_in
     debug!("emscripten::___syscall340 (prlimit64), {}", _which);
     // NOTE: Doesn't really matter. Wasm modules cannot exceed WASM_PAGE_SIZE anyway.
     let _pid: i32 = varargs.get(ctx);
-    let _resource: i32 = varargs.get(ctx);
+    let resource: i32 = varargs.get(ctx);
     let _new_limit: u32 = varargs.get(ctx);
     let old_limit: u32 = varargs.get(ctx);
+
+    let val = match resource {
+        // RLIMIT_NOFILE
+        7 => 1024,
+        _ => -1, // RLIM_INFINITY
+    };
 
     if old_limit != 0 {
         // just report no limits
         let buf_ptr = emscripten_memory_pointer!(ctx.memory(0), old_limit) as *mut u8;
         let buf = unsafe { slice::from_raw_parts_mut(buf_ptr, 16) };
 
-        LittleEndian::write_i32(&mut buf[..], -1); // RLIM_INFINITY
-        LittleEndian::write_i32(&mut buf[4..], -1); // RLIM_INFINITY
-        LittleEndian::write_i32(&mut buf[8..], -1); // RLIM_INFINITY
-        LittleEndian::write_i32(&mut buf[12..], -1); // RLIM_INFINITY
+        LittleEndian::write_i64(&mut buf[..], val);
+        LittleEndian::write_i64(&mut buf[8..], val);
     }
 
     0


### PR DESCRIPTION
resolves #482 
This PR fixes:
- incorrect argument order
  - which cascaded in to a casting issue 
  - which cascaded in to misaligning the arguments of a function
  - which cascaded in to attempting to access an OOB pointer
- sets fd limit to 1024, rather than emscripten's 64
- updates `prlimit64` to return the correct result for `RLIMIT_NOFILE`
- fixes bug in `prlimit64` due to a mistransaltion of the emscripten javascript