### PR TITLE
feat(runtime-c-api) Improve error message when instantiating a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#493](https://github.com/wasmerio/wasmer/pull/493) `wasmer_module_instantiate` has better error messages in the runtime C API
 - [#474](https://github.com/wasmerio/wasmer/pull/474) Set the install name of the dylib to `@rpath`
 - [#490](https://github.com/wasmerio/wasmer/pull/490) Add MiddlewareChain and StreamingCompiler to runtime
 - [#487](https://github.com/wasmerio/wasmer/pull/487) Fix stack offset check in singlepass backend 

--- a/lib/runtime-c-api/src/module.rs
+++ b/lib/runtime-c-api/src/module.rs
@@ -129,14 +129,14 @@ pub unsafe extern "C" fn wasmer_module_instantiate(
     }
 
     let module = &*(module as *const Module);
-    let new_instance = if let Ok(res) = module.instantiate(&import_object) {
-        res
-    } else {
-        update_last_error(CApiError {
-            msg: "error instantiating from module".to_string(),
-        });
-        return wasmer_result_t::WASMER_ERROR;
+    let new_instance = match module.instantiate(&import_object) {
+        Ok(instance) => instance,
+        Err(error) => {
+            update_last_error(error);
+            return wasmer_result_t::WASMER_ERROR;
+        }
     };
+
     *instance = Box::into_raw(Box::new(new_instance)) as *mut wasmer_instance_t;
     wasmer_result_t::WASMER_OK
 }


### PR DESCRIPTION
This patch improves the error message returned by `wasmer_module_instantiate`.