### PR TITLE
fix(runtime-c-api) Replace deprecated type aliases from libc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#494](https://github.com/wasmerio/wasmer/pull/494) Remove deprecated type aliases from libc in the runtime C API
 - [#474](https://github.com/wasmerio/wasmer/pull/474) Set the install name of the dylib to `@rpath`
 - [#490](https://github.com/wasmerio/wasmer/pull/490) Add MiddlewareChain and StreamingCompiler to runtime
 - [#487](https://github.com/wasmerio/wasmer/pull/487) Fix stack offset check in singlepass backend 

--- a/lib/runtime-c-api/src/export.rs
+++ b/lib/runtime-c-api/src/export.rs
@@ -11,7 +11,7 @@ use crate::{
     value::{wasmer_value, wasmer_value_t, wasmer_value_tag},
     wasmer_byte_array, wasmer_result_t,
 };
-use libc::{c_int, uint32_t};
+use libc::c_int;
 use std::{ptr, slice};
 use wasmer_runtime::{Instance, Memory, Module, Value};
 use wasmer_runtime_core::{export::Export, module::ExportIndex};
@@ -196,12 +196,12 @@ pub unsafe extern "C" fn wasmer_export_kind(
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe extern "C" fn wasmer_export_func_params_arity(
     func: *const wasmer_export_func_t,
-    result: *mut uint32_t,
+    result: *mut u32,
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
     if let Export::Function { ref signature, .. } = *export {
-        *result = signature.params().len() as uint32_t;
+        *result = signature.params().len() as u32;
         wasmer_result_t::WASMER_OK
     } else {
         update_last_error(CApiError {
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn wasmer_export_func_params_arity(
 pub unsafe extern "C" fn wasmer_export_func_params(
     func: *const wasmer_export_func_t,
     params: *mut wasmer_value_tag,
-    params_len: uint32_t,
+    params_len: u32,
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn wasmer_export_func_params(
 pub unsafe extern "C" fn wasmer_export_func_returns(
     func: *const wasmer_export_func_t,
     returns: *mut wasmer_value_tag,
-    returns_len: uint32_t,
+    returns_len: u32,
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
@@ -281,12 +281,12 @@ pub unsafe extern "C" fn wasmer_export_func_returns(
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe extern "C" fn wasmer_export_func_returns_arity(
     func: *const wasmer_export_func_t,
-    result: *mut uint32_t,
+    result: *mut u32,
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.export;
     if let Export::Function { ref signature, .. } = *export {
-        *result = signature.returns().len() as uint32_t;
+        *result = signature.returns().len() as u32;
         wasmer_result_t::WASMER_OK
     } else {
         update_last_error(CApiError {

--- a/lib/runtime-c-api/src/import.rs
+++ b/lib/runtime-c-api/src/import.rs
@@ -8,7 +8,7 @@ use crate::{
     value::wasmer_value_tag,
     wasmer_byte_array, wasmer_result_t,
 };
-use libc::{c_uint, uint32_t};
+use libc::c_uint;
 use std::{ffi::c_void, ptr, slice, sync::Arc};
 use wasmer_runtime::Module;
 use wasmer_runtime_core::{
@@ -222,11 +222,11 @@ pub unsafe extern "C" fn wasmer_import_descriptor_kind(
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe extern "C" fn wasmer_import_func_params_arity(
     func: *const wasmer_import_func_t,
-    result: *mut uint32_t,
+    result: *mut u32,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
     if let Export::Function { ref signature, .. } = *export {
-        *result = signature.params().len() as uint32_t;
+        *result = signature.params().len() as u32;
         wasmer_result_t::WASMER_OK
     } else {
         update_last_error(CApiError {
@@ -329,11 +329,11 @@ pub unsafe extern "C" fn wasmer_import_func_returns(
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe extern "C" fn wasmer_import_func_returns_arity(
     func: *const wasmer_import_func_t,
-    result: *mut uint32_t,
+    result: *mut u32,
 ) -> wasmer_result_t {
     let export = &*(func as *const Export);
     if let Export::Function { ref signature, .. } = *export {
-        *result = signature.returns().len() as uint32_t;
+        *result = signature.returns().len() as u32;
         wasmer_result_t::WASMER_OK
     } else {
         update_last_error(CApiError {

--- a/lib/runtime-c-api/src/instance.rs
+++ b/lib/runtime-c-api/src/instance.rs
@@ -8,7 +8,7 @@ use crate::{
     value::{wasmer_value, wasmer_value_t, wasmer_value_tag},
     wasmer_result_t,
 };
-use libc::{c_char, c_int, c_void, uint32_t, uint8_t};
+use libc::{c_char, c_int, c_void};
 use std::{collections::HashMap, ffi::CStr, slice};
 use wasmer_runtime::{Ctx, Global, ImportObject, Instance, Memory, Table, Value};
 use wasmer_runtime_core::{export::Export, import::Namespace};
@@ -29,8 +29,8 @@ pub struct wasmer_instance_context_t;
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_instantiate(
     instance: *mut *mut wasmer_instance_t,
-    wasm_bytes: *mut uint8_t,
-    wasm_bytes_len: uint32_t,
+    wasm_bytes: *mut u8,
+    wasm_bytes_len: u32,
     imports: *mut wasmer_import_t,
     imports_len: c_int,
 ) -> wasmer_result_t {
@@ -121,9 +121,9 @@ pub unsafe extern "C" fn wasmer_instance_call(
     instance: *mut wasmer_instance_t,
     name: *const c_char,
     params: *const wasmer_value_t,
-    params_len: uint32_t,
+    params_len: u32,
     results: *mut wasmer_value_t,
-    results_len: uint32_t,
+    results_len: u32,
 ) -> wasmer_result_t {
     if instance.is_null() {
         update_last_error(CApiError {
@@ -225,7 +225,7 @@ pub extern "C" fn wasmer_instance_context_data_set(
 #[no_mangle]
 pub extern "C" fn wasmer_instance_context_memory(
     ctx: *const wasmer_instance_context_t,
-    _memory_idx: uint32_t,
+    _memory_idx: u32,
 ) -> *const wasmer_memory_t {
     let ctx = unsafe { &*(ctx as *const Ctx) };
     let memory = ctx.memory(0);

--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -85,8 +85,6 @@
 extern crate wasmer_runtime;
 extern crate wasmer_runtime_core;
 
-use libc::{uint32_t, uint8_t};
-
 pub mod error;
 pub mod export;
 pub mod global;
@@ -108,18 +106,18 @@ pub enum wasmer_result_t {
 
 #[repr(C)]
 pub struct wasmer_limits_t {
-    pub min: uint32_t,
+    pub min: u32,
     pub max: wasmer_limit_option_t,
 }
 
 #[repr(C)]
 pub struct wasmer_limit_option_t {
     pub has_some: bool,
-    pub some: uint32_t,
+    pub some: u32,
 }
 
 #[repr(C)]
 pub struct wasmer_byte_array {
-    bytes: *const uint8_t,
-    bytes_len: uint32_t,
+    bytes: *const u8,
+    bytes_len: u32,
 }

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -1,7 +1,6 @@
 //! Create, read, write, grow, destroy memory of an instance.
 
 use crate::{error::update_last_error, wasmer_limits_t, wasmer_result_t};
-use libc::{uint32_t, uint8_t};
 use std::cell::Cell;
 use wasmer_runtime::Memory;
 use wasmer_runtime_core::{
@@ -57,10 +56,7 @@ pub unsafe extern "C" fn wasmer_memory_new(
 /// and `wasmer_last_error_message` to get an error message.
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_memory_grow(
-    memory: *mut wasmer_memory_t,
-    delta: uint32_t,
-) -> wasmer_result_t {
+pub extern "C" fn wasmer_memory_grow(memory: *mut wasmer_memory_t, delta: u32) -> wasmer_result_t {
     let memory = unsafe { &*(memory as *mut Memory) };
     let delta_result = memory.grow(Pages(delta));
     match delta_result {
@@ -75,7 +71,7 @@ pub extern "C" fn wasmer_memory_grow(
 /// Returns the current length in pages of the given memory
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> uint32_t {
+pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {
     let memory = unsafe { &*(memory as *const Memory) };
     let Pages(len) = memory.size();
     len
@@ -84,7 +80,7 @@ pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> uint32
 /// Gets the start pointer to the bytes within a Memory
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_memory_data(mem: *const wasmer_memory_t) -> *mut uint8_t {
+pub extern "C" fn wasmer_memory_data(mem: *const wasmer_memory_t) -> *mut u8 {
     let memory = unsafe { &*(mem as *const Memory) };
     memory.view::<u8>()[..].as_ptr() as *mut Cell<u8> as *mut u8
 }
@@ -92,10 +88,10 @@ pub extern "C" fn wasmer_memory_data(mem: *const wasmer_memory_t) -> *mut uint8_
 /// Gets the size in bytes of a Memory
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_memory_data_length(mem: *mut wasmer_memory_t) -> uint32_t {
+pub extern "C" fn wasmer_memory_data_length(mem: *mut wasmer_memory_t) -> u32 {
     let memory = mem as *mut Memory;
     let Bytes(len) = unsafe { (*memory).size().bytes() };
-    len as uint32_t
+    len as u32
 }
 
 /// Frees memory for the given Memory

--- a/lib/runtime-c-api/src/module.rs
+++ b/lib/runtime-c-api/src/module.rs
@@ -7,7 +7,7 @@ use crate::{
     instance::wasmer_instance_t,
     wasmer_byte_array, wasmer_result_t,
 };
-use libc::{c_int, uint32_t, uint8_t};
+use libc::c_int;
 use std::{collections::HashMap, slice};
 use wasmer_runtime::{compile, default_compiler, Global, ImportObject, Memory, Module, Table};
 use wasmer_runtime_core::{cache::Artifact, export::Export, import::Namespace, load_cache_with};
@@ -28,8 +28,8 @@ pub struct wasmer_serialized_module_t;
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_compile(
     module: *mut *mut wasmer_module_t,
-    wasm_bytes: *mut uint8_t,
-    wasm_bytes_len: uint32_t,
+    wasm_bytes: *mut u8,
+    wasm_bytes_len: u32,
 ) -> wasmer_result_t {
     let bytes: &[u8] = slice::from_raw_parts_mut(wasm_bytes, wasm_bytes_len as usize);
     let result = compile(bytes);
@@ -47,10 +47,7 @@ pub unsafe extern "C" fn wasmer_compile(
 /// Returns true for valid wasm bytes and false for invalid bytes
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_validate(
-    wasm_bytes: *const uint8_t,
-    wasm_bytes_len: uint32_t,
-) -> bool {
+pub unsafe extern "C" fn wasmer_validate(wasm_bytes: *const u8, wasm_bytes_len: u32) -> bool {
     if wasm_bytes.is_null() {
         return false;
     }
@@ -206,8 +203,8 @@ pub unsafe extern "C" fn wasmer_serialized_module_bytes(
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_serialized_module_from_bytes(
     serialized_module: *mut *mut wasmer_serialized_module_t,
-    serialized_module_bytes: *const uint8_t,
-    serialized_module_bytes_length: uint32_t,
+    serialized_module_bytes: *const u8,
+    serialized_module_bytes_length: u32,
 ) -> wasmer_result_t {
     if serialized_module.is_null() {
         update_last_error(CApiError {

--- a/lib/runtime-c-api/src/table.rs
+++ b/lib/runtime-c-api/src/table.rs
@@ -1,7 +1,6 @@
 //! Create, grow, destroy tables of an instance.
 
 use crate::{error::update_last_error, wasmer_limits_t, wasmer_result_t};
-use libc::uint32_t;
 use wasmer_runtime::Table;
 use wasmer_runtime_core::types::{ElementType, TableDescriptor};
 
@@ -53,10 +52,7 @@ pub unsafe extern "C" fn wasmer_table_new(
 /// and `wasmer_last_error_message` to get an error message.
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_table_grow(
-    table: *mut wasmer_table_t,
-    delta: uint32_t,
-) -> wasmer_result_t {
+pub extern "C" fn wasmer_table_grow(table: *mut wasmer_table_t, delta: u32) -> wasmer_result_t {
     let table = unsafe { &*(table as *mut Table) };
     let delta_result = table.grow(delta);
     match delta_result {
@@ -71,7 +67,7 @@ pub extern "C" fn wasmer_table_grow(
 /// Returns the current length of the given Table
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_table_length(table: *mut wasmer_table_t) -> uint32_t {
+pub extern "C" fn wasmer_table_length(table: *mut wasmer_table_t) -> u32 {
     let table = unsafe { &*(table as *mut Table) };
     table.size()
 }

--- a/lib/runtime-c-api/src/value.rs
+++ b/lib/runtime-c-api/src/value.rs
@@ -1,6 +1,5 @@
 //! Create and map Rust to WebAssembly values.
 
-use libc::{int32_t, int64_t};
 use wasmer_runtime::Value;
 use wasmer_runtime_core::types::Type;
 
@@ -18,8 +17,8 @@ pub enum wasmer_value_tag {
 #[derive(Clone, Copy)]
 #[allow(non_snake_case)]
 pub union wasmer_value {
-    pub I32: int32_t,
-    pub I64: int64_t,
+    pub I32: i32,
+    pub I64: i64,
     pub F32: f32,
     pub F64: f64,
 }


### PR DESCRIPTION
Since https://github.com/rust-lang/libc/pull/1379, fixed width integer
type aliases are deprecated. Thus, this patch uses Rust types instead
of libc aliases.