### PR TITLE
Minor cleanup in LLVM backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All PRs to the Wasmer repository must add to this file.
 Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
+- [#510](https://github.com/wasmerio/wasmer/pull/510) Simplify construction of floating point constants in LLVM backend. Fix LLVM assertion failure due to definition of %ctx.
 
 ## 0.5.1 - 2019-06-24
 - [#508](https://github.com/wasmerio/wasmer/pull/508) Update wapm version, includes bug fixes

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -849,22 +849,12 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
             }
             Operator::F32Const { value } => {
                 let bits = intrinsics.i32_ty.const_int(value.bits() as u64, false);
-                let space =
-                    builder.build_alloca(intrinsics.f32_ty.as_basic_type_enum(), "const_space");
-                let i32_space =
-                    builder.build_pointer_cast(space, intrinsics.i32_ptr_ty, "i32_space");
-                builder.build_store(i32_space, bits);
-                let f = builder.build_load(space, "f");
+                let f = builder.build_bitcast(bits, intrinsics.f32_ty, "f");
                 state.push1(f);
             }
             Operator::F64Const { value } => {
                 let bits = intrinsics.i64_ty.const_int(value.bits(), false);
-                let space =
-                    builder.build_alloca(intrinsics.f64_ty.as_basic_type_enum(), "const_space");
-                let i64_space =
-                    builder.build_pointer_cast(space, intrinsics.i64_ptr_ty, "i32_space");
-                builder.build_store(i64_space, bits);
-                let f = builder.build_load(space, "f");
+                let f = builder.build_bitcast(bits, intrinsics.f64_ty, "f");
                 state.push1(f);
             }
 

--- a/lib/llvm-backend/src/intrinsics.rs
+++ b/lib/llvm-backend/src/intrinsics.rs
@@ -159,10 +159,10 @@ impl Intrinsics {
         let imported_func_ty =
             context.struct_type(&[i8_ptr_ty_basic, ctx_ptr_ty.as_basic_type_enum()], false);
         let sigindex_ty = i32_ty;
-        let rt_intrinsics_ty = void_ty;
+        let rt_intrinsics_ty = i8_ty;
         let stack_lower_bound_ty = i8_ty;
         let memory_base_ty = i8_ty;
-        let memory_bound_ty = void_ty;
+        let memory_bound_ty = i8_ty;
         let internals_ty = i64_ty;
         let local_function_ty = i8_ptr_ty;
 


### PR DESCRIPTION
 - Simplify construction of floating point constants
 - Fix assertion failure due to definition of %ctx