### PR TITLE
Update loader-kernel feature name, fix compilation track state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rustc_version = "0.2.3"
 
 [features]
 default = ["fast-tests", "wasi"]
-"loader:kernel" = ["wasmer-kernel-loader"]
+"loader-kernel" = ["wasmer-kernel-loader"]
 debug = ["wasmer-runtime-core/debug"]
 trace = ["wasmer-runtime-core/trace"]
 extra-debug = ["wasmer-clif-backend/debug", "wasmer-runtime-core/debug"]

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ install:
 	cargo install --path .
 
 check:
-	cargo check --release --features backend-singlepass,backend-llvm,loader:kernel
+	cargo check --release --features backend-singlepass,backend-llvm,loader-kernel
 
 release:
-	cargo build --release --features backend-singlepass,backend-llvm,loader:kernel
+	cargo build --release --features backend-singlepass,backend-llvm,loader-kernel
 
 # Only one backend (cranelift)
 release-fast:

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -1775,7 +1775,7 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                             .unwrap()
                             .insert(a.get_offset(), callback);
                     }
-                    InternalEvent::FunctionBegin(_) | InternalEvent::FunctionEnd => {},
+                    InternalEvent::FunctionBegin(_) | InternalEvent::FunctionEnd => {}
                     InternalEvent::GetInternal(idx) => {
                         let idx = idx as usize;
                         assert!(idx < INTERNALS_SIZE);
@@ -1826,7 +1826,11 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                             ),
                             Location::GPR(tmp),
                         );
-                        let loc = get_location_released(a, &mut self.machine, self.value_stack.pop().unwrap());
+                        let loc = get_location_released(
+                            a,
+                            &mut self.machine,
+                            self.value_stack.pop().unwrap(),
+                        );
 
                         // Move internal into storage.
                         Self::emit_relaxed_binop(
@@ -1838,8 +1842,7 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                             Location::Memory(tmp, (idx * 8) as i32),
                         );
                         self.machine.release_temp_gpr(tmp);
-                    }
-                    //_ => unimplemented!(),
+                    } //_ => unimplemented!(),
                 }
                 return Ok(());
             }

--- a/src/bin/kwasmd.rs
+++ b/src/bin/kwasmd.rs
@@ -5,10 +5,10 @@ extern crate structopt;
 
 use structopt::StructOpt;
 
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 use wasmer_singlepass_backend::SinglePassCompiler;
 
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 use std::os::unix::net::{UnixListener, UnixStream};
 
 #[derive(Debug, StructOpt)]
@@ -24,14 +24,14 @@ struct Listen {
     socket: String,
 }
 
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 const CMD_RUN_CODE: u32 = 0x901;
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 const CMD_READ_MEMORY: u32 = 0x902;
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 const CMD_WRITE_MEMORY: u32 = 0x903;
 
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 fn handle_client(mut stream: UnixStream) {
     use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
     use std::io::{Read, Write};
@@ -54,6 +54,7 @@ fn handle_client(mut stream: UnixStream) {
             symbol_map: None,
             memory_bound_check_mode: MemoryBoundCheckMode::Disable,
             enforce_stack_check: true,
+            track_state: false,
         },
         &SinglePassCompiler::new(),
     )
@@ -131,7 +132,7 @@ fn handle_client(mut stream: UnixStream) {
     }
 }
 
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 fn run_listen(opts: Listen) {
     let listener = UnixListener::bind(&opts.socket).unwrap();
     use std::thread;
@@ -154,7 +155,7 @@ fn run_listen(opts: Listen) {
     }
 }
 
-#[cfg(feature = "loader:kernel")]
+#[cfg(feature = "loader-kernel")]
 fn main() {
     let options = CLIOptions::from_args();
     match options {
@@ -164,7 +165,7 @@ fn main() {
     }
 }
 
-#[cfg(not(feature = "loader:kernel"))]
+#[cfg(not(feature = "loader-kernel"))]
 fn main() {
     panic!("Kwasm loader is not enabled during compilation.");
 }

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -143,7 +143,7 @@ struct Run {
 #[derive(Debug, Copy, Clone)]
 enum LoaderName {
     Local,
-    #[cfg(feature = "loader:kernel")]
+    #[cfg(feature = "loader-kernel")]
     Kernel,
 }
 
@@ -151,7 +151,7 @@ impl LoaderName {
     pub fn variants() -> &'static [&'static str] {
         &[
             "local",
-            #[cfg(feature = "loader:kernel")]
+            #[cfg(feature = "loader-kernel")]
             "kernel",
         ]
     }
@@ -162,7 +162,7 @@ impl FromStr for LoaderName {
     fn from_str(s: &str) -> Result<LoaderName, String> {
         match s.to_lowercase().as_str() {
             "local" => Ok(LoaderName::Local),
-            #[cfg(feature = "loader:kernel")]
+            #[cfg(feature = "loader-kernel")]
             "kernel" => Ok(LoaderName::Kernel),
             _ => Err(format!("The loader {} doesn't exist", s)),
         }
@@ -334,14 +334,14 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
 
     let track_state = !options.no_track_state;
 
-    #[cfg(feature = "loader:kernel")]
+    #[cfg(feature = "loader-kernel")]
     let is_kernel_loader = if let Some(LoaderName::Kernel) = options.loader {
         true
     } else {
         false
     };
 
-    #[cfg(not(feature = "loader:kernel"))]
+    #[cfg(not(feature = "loader-kernel"))]
     let is_kernel_loader = false;
 
     let module = if is_kernel_loader {
@@ -451,7 +451,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                     .load(LocalLoader)
                     .expect("Can't use the local loader"),
             ),
-            #[cfg(feature = "loader:kernel")]
+            #[cfg(feature = "loader-kernel")]
             LoaderName::Kernel => Box::new(
                 instance
                     .load(::wasmer_kernel_loader::KernelLoader)


### PR DESCRIPTION
- feature name `loader:kernel` -> `loader-kernel` (no colons)
- add track state `false` to loader kernel default, @losfair let me know if this default is incorrect
- cargo fmt