### PR TITLE
Fix typo in comment.

### DIFF
--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -42,7 +42,7 @@ pub struct Ctx {
     pub import_backing: *mut ImportBacking,
     pub module: *const ModuleInner,
 
-    //// This is intended to be user-supplied, per-instance
+    /// This is intended to be user-supplied, per-instance
     /// contextual data. There are currently some issue with it,
     /// notably that it cannot be set before running the `start`
     /// function in a WebAssembly module.


### PR DESCRIPTION
"Then thou must count to three. Three shall be the number of the counting and the number of the counting shall be three. Four shalt thou not count, neither shalt thou count two, excepting that thou then proceedeth to three."