### PR TITLE
llvm-backend: export FunctionCodeGenerator and ModuleCodeGenerator

### DIFF
--- a/lib/llvm-backend/src/lib.rs
+++ b/lib/llvm-backend/src/lib.rs
@@ -9,6 +9,9 @@ mod read_info;
 mod state;
 mod trampolines;
 
+pub use code::LLVMFunctionCodeGenerator as FunctionCodeGenerator;
+pub use code::LLVMModuleCodeGenerator as ModuleCodeGenerator;
+
 use wasmer_runtime_core::codegen::SimpleStreamingCompilerGen;
 
 pub type LLVMCompiler = SimpleStreamingCompilerGen<


### PR DESCRIPTION
This is in line with the singlepass-backend to be able to use LLVM MCG with
a StreamingCompiler (as in https://github.com/wasmerio/wasmer/pull/490).