### PR TITLE
Use --enable-simd to control whether SIMD is enabled in the wasmparser.

### DIFF
--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -1,6 +1,6 @@
 use crate::{
     backend::RunnableModule,
-    backend::{Backend, CacheGen, Compiler, CompilerConfig, Token},
+    backend::{Backend, CacheGen, Compiler, CompilerConfig, Features, Token},
     cache::{Artifact, Error as CacheError},
     error::{CompileError, CompileResult},
     module::{ModuleInfo, ModuleInner},
@@ -137,12 +137,12 @@ impl<
     }
 }
 
-pub fn default_validating_parser_config() -> wasmparser::ValidatingParserConfig {
+pub fn validating_parser_config(features: &Features) -> wasmparser::ValidatingParserConfig {
     wasmparser::ValidatingParserConfig {
         operator_config: wasmparser::OperatorValidatorConfig {
             enable_threads: false,
             enable_reference_types: false,
-            enable_simd: true,
+            enable_simd: features.simd,
             enable_bulk_memory: false,
             enable_multi_value: false,
         },
@@ -150,9 +150,9 @@ pub fn default_validating_parser_config() -> wasmparser::ValidatingParserConfig 
     }
 }
 
-fn validate(bytes: &[u8]) -> CompileResult<()> {
+fn validate(bytes: &[u8], features: &Features) -> CompileResult<()> {
     let mut parser =
-        wasmparser::ValidatingParser::new(bytes, Some(default_validating_parser_config()));
+        wasmparser::ValidatingParser::new(bytes, Some(validating_parser_config(features)));
     loop {
         let state = parser.read();
         match *state {
@@ -180,7 +180,7 @@ impl<
         _: Token,
     ) -> CompileResult<ModuleInner> {
         if requires_pre_validation(MCG::backend_id()) {
-            validate(wasm)?;
+            validate(wasm, &compiler_config.features)?;
         }
 
         let mut mcg = MCG::new();

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -150,7 +150,7 @@ pub fn validating_parser_config(features: &Features) -> wasmparser::ValidatingPa
     }
 }
 
-fn validate(bytes: &[u8], features: &Features) -> CompileResult<()> {
+fn validate_with_features(bytes: &[u8], features: &Features) -> CompileResult<()> {
     let mut parser =
         wasmparser::ValidatingParser::new(bytes, Some(validating_parser_config(features)));
     loop {
@@ -180,7 +180,7 @@ impl<
         _: Token,
     ) -> CompileResult<ModuleInner> {
         if requires_pre_validation(MCG::backend_id()) {
-            validate(wasm, &compiler_config.features)?;
+            validate_with_features(wasm, &compiler_config.features)?;
         }
 
         let mut mcg = MCG::new();

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -85,8 +85,10 @@ pub fn read_module<
         custom_sections: HashMap::new(),
     }));
 
-    let mut parser =
-        wasmparser::ValidatingParser::new(wasm, Some(default_validating_parser_config()));
+    let mut parser = wasmparser::ValidatingParser::new(
+        wasm,
+        Some(validating_parser_config(&compiler_config.features)),
+    );
 
     let mut namespace_builder = Some(StringTableBuilder::new());
     let mut name_builder = Some(StringTableBuilder::new());

--- a/lib/spectests/build/spectests.rs
+++ b/lib/spectests/build/spectests.rs
@@ -86,7 +86,7 @@ use wasmer_runtime_core::types::Value;
 use wasmer_runtime_core::{{Instance, module::Module}};
 use wasmer_runtime_core::error::Result;
 use wasmer_runtime_core::vm::Ctx;
-use wasmer_runtime_core::backend::Compiler;
+use wasmer_runtime_core::backend::{Compiler, CompilerConfig, Features};
 
 static IMPORT_MODULE: &str = r#"
 (module
@@ -136,7 +136,7 @@ pub fn generate_imports() -> ImportObject {
     let mut features = wabt::Features::new();
     features.enable_simd();
     let wasm_binary = wat2wasm_with_features(IMPORT_MODULE.as_bytes(), features).expect("WAST not valid or malformed");
-    let module = wasmer_runtime_core::compile_with(&wasm_binary[..], &get_compiler())
+    let module = wasmer_runtime_core::compile_with_config(&wasm_binary[..], &get_compiler(), CompilerConfig { features: Features { simd: true }, ..Default::default() })
         .expect("WASM can't be compiled");
     let instance = module
         .instantiate(&ImportObject::new())
@@ -408,7 +408,7 @@ fn test_module_{}() {{
     let module_str = \"{}\";
     println!(\"{{}}\", module_str);
     let wasm_binary = wat2wasm(module_str.as_bytes()).expect(\"WAST not valid or malformed\");
-    let module = wasmer_runtime_core::compile_with(&wasm_binary[..], &get_compiler()).expect(\"WASM can't be compiled\");
+    let module = wasmer_runtime_core::compile_with_config(&wasm_binary[..], &get_compiler(), CompilerConfig {{ features: Features {{ simd: true }}, ..Default::default() }}).expect(\"WASM can't be compiled\");
     module.instantiate(&generate_imports()).expect(\"WASM can't be instantiated\")
 }}\n",
                 self.last_module,
@@ -431,7 +431,7 @@ fn test_module_{}() {{
                 "#[test]
 fn {}_assert_invalid() {{
     let wasm_binary = {:?};
-    let module = wasmer_runtime_core::compile_with(&wasm_binary, &get_compiler());
+    let module = wasmer_runtime_core::compile_with_config(&wasm_binary, &get_compiler(), CompilerConfig {{ features: Features {{ simd: true }}, ..Default::default() }});
     assert!(module.is_err(), \"WASM should not compile as is invalid\");
 }}\n",
                 command_name,
@@ -562,7 +562,7 @@ fn {}_assert_invalid() {{
                 "#[test]
 fn {}_assert_malformed() {{
     let wasm_binary = {:?};
-    let compilation = wasmer_runtime_core::compile_with(&wasm_binary, &get_compiler());
+    let compilation = wasmer_runtime_core::compile_with_config(&wasm_binary, &get_compiler(), CompilerConfig {{ features: Features {{ simd: true }}, ..Default::default() }});
     assert!(compilation.is_err(), \"WASM should not compile as is malformed\");
 }}\n",
                 command_name,

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -440,6 +440,9 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                         CompilerConfig {
                             symbol_map: em_symbol_map,
                             track_state,
+                            features: Features {
+                                simd: options.features.simd || options.features.all,
+                            },
                             ..Default::default()
                         },
                         &*compiler,


### PR DESCRIPTION
Before this change, 'wasmer run --backend=llvm some-simd.wasm' would run without complaint.

Also, note that the flag is not part of the cache key, so after any successful run, we can run it again without passing the flag.