### PR TITLE
Add a Docker sandbox for building Wasmer

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,13 @@
+FROM ubuntu:19.04
+
+ARG RUST_TOOLCHAIN="nightly"
+
+ENV CARGO_HOME=/usr/local/rust
+ENV RUSTUP_HOME=/usr/local/rust
+ENV PATH="$PATH:$CARGO_HOME/bin"
+
+RUN apt-get update \
+    && apt-get -y install sudo strace curl cmake pkg-config python libssl-dev llvm-dev libz-dev gnuplot-nox \
+    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"

--- a/build
+++ b/build
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Wasmer build tool
+#
+# This is a script to build Wasmer in a Docker sandbox.
+#
+# To use the script, first make sure Docker is installed. Then build the
+# sandbox image with:
+#
+#   docker build --file Dockerfile.build --tag wasmer-build .
+#
+# After the sandbox image is built successfully, you can run commands in it
+# with this script.
+#
+# For example, to build Wasmer, run:
+#
+#   ./build make
+#
+# To test Wasmer, run:
+#
+#   ./build make test
+#
+# and so on.
+
+docker_hostname="wasmer-build"
+
+docker_img="wasmer-build"
+
+docker_workdir="/wasmer"
+
+docker_args=(
+  #
+  # General config.
+  #
+  --hostname=${docker_hostname}
+  --interactive
+  --network=host
+  --rm
+  --tty
+
+  #
+  # User and group config.
+  #
+  # Use the same user and group permissions as host to make integration
+  # between host and container simple.
+  #
+  --user "$(id --user):$(id --group)"
+  --volume "/etc/group:/etc/group:ro"
+  --volume "/etc/passwd:/etc/passwd:ro"
+  --volume "/etc/shadow:/etc/shadow:ro"
+
+  #
+  # Time zone config.
+  #
+  # Use the same time zone as the host.
+  #
+  --volume "/etc/localtime:/etc/localtime:ro"
+
+  #
+  # Linux capabilities.
+  #
+  # Add SYS_PTRACE capability to the container so that people can run
+  # `strace'.
+  #
+  --cap-add SYS_PTRACE
+
+  #
+  # Source directory.
+  #
+  --workdir=${docker_workdir}
+  --volume "$(pwd):${docker_workdir}:z"
+
+  #
+  # Environment variables.
+  #
+  --env "CARGO_HOME=${docker_workdir}/.cargo"
+)
+
+docker run ${docker_args[@]} ${docker_img} $*


### PR DESCRIPTION
Building Wasmer is bit of a pain, because it requires Rust nightly, and
bunch of OS specific packages.

To make building easier, this adds a "build" script at the top-level
directory, which can be used to build Wasmer within a Docker sandbox
that has all the necessary dependencies installed. The build environment
is based on latest Ubuntu 19.04.

You first need to build a Docker image of the sandbox:

    docker build --file Dockerfile.build --tag wasmer-build .

Then, to build Wasmer, run:

    ./build make

To test Wasmer, run:

    ./build make test

and so on.

You can also drop into a shell within the Docker with:

    ./build

The "build" script bind mounts current directory as "/wasmer" in the
Docker container, which allows inspecting the build contents like you
had built them on your local machine.

For future improvements, we should consider:

  - Consolidation with existing Dockerfile (that is used for Circle CI)

  - Publishing the build sandbox image on Docker Hub so that people
    don't have to build it themselves

  - Moving dependency installation to separate script, which can be
    reused outside of the Docker sandbox.

The work has been inspired by "devtool" in the Firecracker project:

  https://github.com/firecracker-microvm/firecracker/blob/master/tools/devtool

and "dbuild" in the Scylla project:

  https://github.com/scylladb/scylla/blob/master/tools/toolchain/dbuild