### PR TITLE
Improvement cache in Windows

### DIFF
--- a/lib/runtime-core/src/cache.rs
+++ b/lib/runtime-core/src/cache.rs
@@ -241,5 +241,3 @@ pub trait Cache {
 /// A unique ID generated from the version of Wasmer for use with cache versioning
 pub const WASMER_VERSION_HASH: &'static str =
     include_str!(concat!(env!("OUT_DIR"), "/wasmer_version_hash.txt"));
-
-pub const WASMER_VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/lib/runtime-core/src/cache.rs
+++ b/lib/runtime-core/src/cache.rs
@@ -241,3 +241,5 @@ pub trait Cache {
 /// A unique ID generated from the version of Wasmer for use with cache versioning
 pub const WASMER_VERSION_HASH: &'static str =
     include_str!(concat!(env!("OUT_DIR"), "/wasmer_version_hash.txt"));
+
+pub const WASMER_VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -9,7 +9,7 @@ use std::{
 use wasmer_runtime_core::cache::Error as CacheError;
 pub use wasmer_runtime_core::{
     backend::Backend,
-    cache::{Artifact, Cache, WasmHash, WASMER_VERSION},
+    cache::{Artifact, Cache, WasmHash},
 };
 
 /// Representation of a directory that contains compiled wasm artifacts.

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -9,7 +9,7 @@ use std::{
 use wasmer_runtime_core::cache::Error as CacheError;
 pub use wasmer_runtime_core::{
     backend::Backend,
-    cache::{Artifact, Cache, WasmHash, WASMER_VERSION_HASH},
+    cache::{Artifact, Cache, WasmHash, WASMER_VERSION},
 };
 
 /// Representation of a directory that contains compiled wasm artifacts.
@@ -49,12 +49,7 @@ impl FileSystemCache {
     /// This method is unsafe because there's no way to ensure the artifacts
     /// stored in this cache haven't been corrupted or tampered with.
     pub unsafe fn new<P: Into<PathBuf>>(path: P) -> io::Result<Self> {
-        let path: PathBuf = {
-            let mut path = path.into();
-            path.push(WASMER_VERSION_HASH);
-            path
-        };
-
+        let path: PathBuf = path.into();
         if path.exists() {
             let metadata = path.metadata()?;
             if metadata.is_dir() {

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -813,7 +813,6 @@ fn main() {
     }
 }
 
-
 #[test]
 fn filesystem_cache_should_work() -> Result<(), String> {
     let wasmer_cache_dir = get_cache_dir();

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -18,7 +18,7 @@ use wasmer_clif_backend::CraneliftCompiler;
 #[cfg(feature = "backend-llvm")]
 use wasmer_llvm_backend::LLVMCompiler;
 use wasmer_runtime::{
-    cache::{Cache as BaseCache, FileSystemCache, WasmHash, WASMER_VERSION},
+    cache::{Cache as BaseCache, FileSystemCache, WasmHash, VERSION},
     Func, Value,
 };
 use wasmer_runtime_core::{
@@ -218,14 +218,14 @@ fn get_cache_dir() -> PathBuf {
     match env::var("WASMER_CACHE_DIR") {
         Ok(dir) => {
             let mut path = PathBuf::from(dir);
-            path.push(WASMER_VERSION);
+            path.push(VERSION);
             path
         }
         Err(_) => {
             // We use a temporal directory for saving cache files
             let mut temp_dir = env::temp_dir();
             temp_dir.push("wasmer");
-            temp_dir.push(WASMER_VERSION);
+            temp_dir.push(VERSION);
             temp_dir
         }
     }

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -812,3 +812,14 @@ fn main() {
         }
     }
 }
+
+
+#[test]
+fn filesystem_cache_should_work() -> Result<(), String> {
+    let wasmer_cache_dir = get_cache_dir();
+
+    unsafe {
+        FileSystemCache::new(wasmer_cache_dir).map_err(|e| format!("Cache error: {:?}", e))?
+    };
+    Ok(())
+}

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -818,8 +818,7 @@ fn main() {
 fn filesystem_cache_should_work() -> Result<(), String> {
     let wasmer_cache_dir = get_cache_dir();
 
-    unsafe {
-        FileSystemCache::new(wasmer_cache_dir).map_err(|e| format!("Cache error: {:?}", e))?
-    };
+    unsafe { FileSystemCache::new(wasmer_cache_dir).map_err(|e| format!("Cache error: {:?}", e))? };
+
     Ok(())
 }

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -220,7 +220,7 @@ fn get_cache_dir() -> PathBuf {
             let mut path = PathBuf::from(dir);
             path.push(WASMER_VERSION);
             path
-        },
+        }
         Err(_) => {
             // We use a temporal directory for saving cache files
             let mut temp_dir = env::temp_dir();

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -18,8 +18,8 @@ use wasmer_clif_backend::CraneliftCompiler;
 #[cfg(feature = "backend-llvm")]
 use wasmer_llvm_backend::LLVMCompiler;
 use wasmer_runtime::{
-    cache::{Cache as BaseCache, FileSystemCache, WasmHash, VERSION},
-    Func, Value,
+    cache::{Cache as BaseCache, FileSystemCache, WasmHash},
+    Func, Value, VERSION,
 };
 use wasmer_runtime_core::{
     self,


### PR DESCRIPTION
Caching was disabled on Windows, but can be re-enabled easily by improving the folder cache naming.

Reason why caching was disabled on Windows: We use a very long string (64 chars) for the wasmer version (hash). But we can use the version directly (no need to hashing)