### PR TITLE
Implement InternalEvent::Breakpoint in the llvm backend.

### DIFF
--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -39,7 +39,8 @@ extern "C" {
     fn module_delete(module: *mut LLVMModule);
     fn get_func_symbol(module: *mut LLVMModule, name: *const c_char) -> *const vm::Func;
 
-    fn throw_trap(ty: i32);
+    fn throw_trap(ty: i32) -> !;
+    fn throw_breakpoint(ty: i64) -> !;
 
     /// This should be the same as spliting up the fat pointer into two arguments,
     /// but this is cleaner, I think?
@@ -103,6 +104,7 @@ fn get_callbacks() -> Callbacks {
             fn_name!("vm.memory.size.static.local") => vmcalls::local_static_memory_size as _,
 
             fn_name!("vm.exception.trap") => throw_trap as _,
+            fn_name!("vm.breakpoint") => throw_breakpoint as _,
 
             _ => ptr::null(),
         }

--- a/lib/llvm-backend/src/intrinsics.rs
+++ b/lib/llvm-backend/src/intrinsics.rs
@@ -147,6 +147,7 @@ pub struct Intrinsics {
     pub memory_size_shared_import: FunctionValue,
 
     pub throw_trap: FunctionValue,
+    pub throw_breakpoint: FunctionValue,
 
     pub ctx_ptr_ty: PointerType,
 }
@@ -309,7 +310,6 @@ impl Intrinsics {
             i32_ty.fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false);
 
         let ret_i1_take_i1_i1 = i1_ty.fn_type(&[i1_ty_basic, i1_ty_basic], false);
-
         Self {
             ctlz_i32: module.add_function("llvm.ctlz.i32", ret_i32_take_i32_i1, None),
             ctlz_i64: module.add_function("llvm.ctlz.i64", ret_i64_take_i64_i1, None),
@@ -523,6 +523,11 @@ impl Intrinsics {
             throw_trap: module.add_function(
                 "vm.exception.trap",
                 void_ty.fn_type(&[i32_ty_basic], false),
+                None,
+            ),
+            throw_breakpoint: module.add_function(
+                "vm.breakpoint",
+                void_ty.fn_type(&[i64_ty_basic], false),
                 None,
             ),
             ctx_ptr_ty,

--- a/lib/middleware-common/src/metering.rs
+++ b/lib/middleware-common/src/metering.rs
@@ -129,7 +129,7 @@ pub fn set_points_used_ctx(ctx: &mut Ctx, value: u64) {
     ctx.set_internal(&INTERNAL_FIELD, value);
 }
 
-#[cfg(all(test, feature = "singlepass"))]
+#[cfg(all(test, any(feature = "singlepass", feature = "llvm")))]
 mod tests {
     use super::*;
     use wabt::wat2wasm;


### PR DESCRIPTION
Enable now-working metering unit tests when run with the llvm backend.