### PR TITLE
Add support for (register) command in spec tests and enable importing mutable globals.

### DIFF
--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -146,7 +146,7 @@ pub fn validating_parser_config(features: &Features) -> wasmparser::ValidatingPa
             enable_bulk_memory: false,
             enable_multi_value: false,
         },
-        mutable_global_imports: false,
+        mutable_global_imports: true,
     }
 }
 

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -140,7 +140,7 @@ pub fn validate_and_report_errors_with_features(
             enable_reference_types: false,
             enable_threads: false,
         },
-        mutable_global_imports: false,
+        mutable_global_imports: true,
     };
     let mut parser = wasmparser::ValidatingParser::new(wasm, Some(config));
     loop {

--- a/lib/spectests/build/spectests.rs
+++ b/lib/spectests/build/spectests.rs
@@ -132,7 +132,7 @@ fn get_compiler() -> impl Compiler {
   CraneliftCompiler::new()
 }
 
-pub fn generate_imports() -> ImportObject {
+pub fn generate_imports(extra_imports: Vec<(String, Instance)>) -> ImportObject {
     let mut features = wabt::Features::new();
     features.enable_simd();
     let wasm_binary = wat2wasm_with_features(IMPORT_MODULE.as_bytes(), features).expect("WAST not valid or malformed");
@@ -143,6 +143,9 @@ pub fn generate_imports() -> ImportObject {
         .expect("WASM can't be instantiated");
     let mut imports = ImportObject::new();
     imports.register("spectest", instance);
+    for (name, instance) in extra_imports {
+        imports.register(name, instance);
+    }
     imports
 }
 
@@ -303,6 +306,8 @@ struct WastTestGenerator {
     script_parser: ScriptParser,
     module_calls: HashMap<i32, Vec<String>>,
     buffer: String,
+    modules_by_name: HashMap<String, i32>,
+    registered_modules: Vec<(i32, String)>,
 }
 
 impl WastTestGenerator {
@@ -322,6 +327,8 @@ impl WastTestGenerator {
             script_parser: script,
             buffer: buffer,
             module_calls: HashMap::new(),
+            modules_by_name: HashMap::new(),
+            registered_modules: Vec::new(),
         }
     }
 
@@ -392,7 +399,7 @@ fn test_module_{}() {{
         self.module_calls.remove(&module);
     }
 
-    fn visit_module(&mut self, module: &ModuleBinary, _name: &Option<String>) {
+    fn visit_module(&mut self, module: &ModuleBinary, name: &Option<String>) {
         let wasm_binary: Vec<u8> = module.clone().into_vec();
         let mut features = Features::new();
         features.enable_simd();
@@ -409,7 +416,9 @@ fn test_module_{}() {{
     println!(\"{{}}\", module_str);
     let wasm_binary = wat2wasm(module_str.as_bytes()).expect(\"WAST not valid or malformed\");
     let module = wasmer_runtime_core::compile_with_config(&wasm_binary[..], &get_compiler(), CompilerConfig {{ features: Features {{ simd: true }}, ..Default::default() }}).expect(\"WASM can't be compiled\");
-    module.instantiate(&generate_imports()).expect(\"WASM can't be instantiated\")
+    let mut extra_imports = Vec::new();
+    {}
+    module.instantiate(&generate_imports(extra_imports)).expect(\"WASM can't be instantiated\")
 }}\n",
                 self.last_module,
                 // We do this to ident four spaces, so it looks aligned to the function body
@@ -417,9 +426,22 @@ fn test_module_{}() {{
                     .replace("\n", "\n    ")
                     .replace("\\", "\\\\")
                     .replace("\"", "\\\""),
+                self.registered_modules.iter().map(|(number, name)| format!("extra_imports.push((String::from(\"{}\"), create_module_{}()));", name, number)).fold(String::from(""), |acc, x| format!("{}{}\n", acc, x)),
             )
             .as_str(),
         );
+        if let Some(name) = name {
+            self.record_named_module(name);
+        }
+    }
+
+    fn record_named_module(&mut self, name: &String) {
+        self.modules_by_name.insert(name.clone(), self.last_module);
+    }
+
+    fn visit_register_module(&mut self, name: &String, as_name: &String) {
+        self.registered_modules
+            .push((*self.modules_by_name.get(name).unwrap(), as_name.clone()));
     }
 
     fn visit_assert_invalid(&mut self, module: &ModuleBinary) {
@@ -763,11 +785,8 @@ fn {}() {{
             } => {
                 // Do nothing for now
             }
-            CommandKind::Register {
-                name: _,
-                as_name: _,
-            } => {
-                // Do nothing for now
+            CommandKind::Register { name, as_name } => {
+                self.visit_register_module(name.as_ref().unwrap(), as_name);
             }
             CommandKind::PerformAction(action) => {
                 self.visit_perform_action(action);

--- a/lib/spectests/spectests/README.md
+++ b/lib/spectests/spectests/README.md
@@ -109,7 +109,6 @@ The following spec tests are currently covered:
 
 There are some cases that we decided to skip for now to accelerate the release schedule:
 
-  - `globals.wast`
 - `SKIP_CALL_INDIRECT_TYPE_MISMATCH`: we implemented traps in a fast way. We haven't yet covered the type mismatch on `call_indirect`. Specs affected:
 
   - `call_indirect.wast`

--- a/lib/spectests/spectests/README.md
+++ b/lib/spectests/spectests/README.md
@@ -25,7 +25,7 @@ Currently supported command assertions:
 - [x] `assert_malformed` _fully implemented_
 - [ ] `assert_uninstantiable` _not implemented yet_
 - [ ] `assert_exhaustion` _not implemented yet_
-- [ ] `register` _not implemented yet_
+- [x] `register` _fully implemented_
 - [x] `perform_action` _partially implemented, only function invocations for now_
 
 ### Covered spec tests
@@ -86,6 +86,7 @@ The following spec tests are currently covered:
 - [x] return.wast
 - [x] select.wast
 - [x] set_local.wast
+- [x] simd.wast
 - [ ] skip-stack-guard-page.wast
 - [x] stack.wast
 - [x] start.wast
@@ -108,7 +109,6 @@ The following spec tests are currently covered:
 
 There are some cases that we decided to skip for now to accelerate the release schedule:
 
-- `SKIP_MUTABLE_GLOBALS`: Right now the Wasm parser can't validate a module with imported/exported `mut` globals. We decided to skip the tests until Cranelift and wasmparser can handle this (see [original spec proposal](https://github.com/WebAssembly/mutable-global)). Spec tests affected:
   - `globals.wast`
 - `SKIP_CALL_INDIRECT_TYPE_MISMATCH`: we implemented traps in a fast way. We haven't yet covered the type mismatch on `call_indirect`. Specs affected:
 

--- a/lib/spectests/spectests/data.wast
+++ b/lib/spectests/spectests/data.wast
@@ -47,31 +47,27 @@
   (data (i32.const 1) "h")
 )
 
-;; SKIP_MUTABLE_GLOBALS
-;; (module
-;;   (global (import "spectest" "global_i32") i32)
-;;   (memory 1)
-;;   (data (get_global 0) "a")
-;; )
-;; SKIP_MUTABLE_GLOBALS
-;; (module
-;;   (global (import "spectest" "global_i32") i32)
-;;   (import "spectest" "memory" (memory 1))
-;;   (data (get_global 0) "a")
-;; )
+(module
+  (global (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (get_global 0) "a")
+)
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (get_global 0) "a")
+)
 
-;; SKIP_MUTABLE_GLOBALS
-;; (module
-;;   (global $g (import "spectest" "global_i32") i32)
-;;   (memory 1)
-;;   (data (get_global $g) "a")
-;; )
-;; SKIP_MUTABLE_GLOBALS
-;; (module
-;;   (global $g (import "spectest" "global_i32") i32)
-;;   (import "spectest" "memory" (memory 1))
-;;   (data (get_global $g) "a")
-;; )
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (memory 1)
+  (data (get_global $g) "a")
+)
+(module
+  (global $g (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 1))
+  (data (get_global $g) "a")
+)
 
 ;; Use of internal globals in constant expressions is not allowed in MVP.
 ;; (module (memory 1) (data (get_global 0) "a") (global i32 (i32.const 0)))
@@ -138,19 +134,17 @@
   (data (i32.const 0) "a")
 )
 
-;; SKIP_MUTABLE_GLOBALS
-;; (module
-;;   (global (import "spectest" "global_i32") i32)
-;;   (import "spectest" "memory" (memory 0))
-;;   (data (get_global 0) "a")
-;; )
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0))
+  (data (get_global 0) "a")
+)
 
-;; SKIP_MUTABLE_GLOBALS
-;; (module
-;;   (global (import "spectest" "global_i32") i32)
-;;   (import "spectest" "memory" (memory 0 3))
-;;   (data (get_global 0) "a")
-;; )
+(module
+  (global (import "spectest" "global_i32") i32)
+  (import "spectest" "memory" (memory 0 3))
+  (data (get_global 0) "a")
+)
 
 (module
   (import "spectest" "memory" (memory 0))

--- a/lib/spectests/spectests/globals.wast
+++ b/lib/spectests/spectests/globals.wast
@@ -246,11 +246,9 @@
 )
 
 ;; mutable globals can be exported
-;; SKIP_MUTABLE_GLOBALS
-;; (module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
+(module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
 
-;; SKIP_MUTABLE_GLOBALS
-;; (module (global (export "a") (mut f32) (f32.const 0)))
+(module (global (export "a") (mut f32) (f32.const 0)))
 
 (assert_invalid
   (module (global f32 (f32.neg (f32.const 0))))

--- a/lib/spectests/spectests/simd.wast
+++ b/lib/spectests/spectests/simd.wast
@@ -9,49 +9,48 @@
 
 ;; v128 globals
 
-;; wasmer silently doesn't implement (register) yet
-;;(module $M
-;;  (global (export "a") v128       (v128.const f32x4 0.0 1.0 2.0 3.0))
-;;  (global (export "b") (mut v128) (v128.const f32x4 4.0 5.0 6.0 7.0))
-;;)
-;;(register "M" $M)
+(module $M
+  (global (export "a") v128       (v128.const f32x4 0.0 1.0 2.0 3.0))
+  (global (export "b") (mut v128) (v128.const f32x4 4.0 5.0 6.0 7.0))
+)
+(register "M" $M)
 
 (module
-;;  (global $a (import "M" "a") v128)
-;;  (global $b (import "M" "b") (mut v128))
-  
-;;  (global $c v128       (global.get $a))
+  (global $a (import "M" "a") v128)
+  (global $b (import "M" "b") (mut v128))
+
+  (global $c v128       (global.get $a))
   (global $d v128       (v128.const i32x4 8 9 10 11))
-;;  (global $e (mut v128) (global.get $a))
-;;  (global $f (mut v128) (v128.const i32x4 12 13 14 15))
+  (global $e (mut v128) (global.get $a))
+  (global $f (mut v128) (v128.const i32x4 12 13 14 15))
 
-;;  (func (export "get-a") (result v128) (global.get $a))
-;;  (func (export "get-b") (result v128) (global.get $b))
-;;  (func (export "get-c") (result v128) (global.get $c))
+  (func (export "get-a") (result v128) (global.get $a))
+  (func (export "get-b") (result v128) (global.get $b))
+  (func (export "get-c") (result v128) (global.get $c))
   (func (export "get-d") (result v128) (global.get $d))
-;;  (func (export "get-e") (result v128) (global.get $e))
-;;  (func (export "get-f") (result v128) (global.get $f))
+  (func (export "get-e") (result v128) (global.get $e))
+  (func (export "get-f") (result v128) (global.get $f))
 
-;;  (func (export "set-b") (param $value v128) (global.set $b (local.get $value)))
-;;  (func (export "set-e") (param $value v128) (global.set $e (local.get $value)))
-;;  (func (export "set-f") (param $value v128) (global.set $f (local.get $value)))
+  (func (export "set-b") (param $value v128) (global.set $b (local.get $value)))
+  (func (export "set-e") (param $value v128) (global.set $e (local.get $value)))
+  (func (export "set-f") (param $value v128) (global.set $f (local.get $value)))
 )
 
-;;(assert_return (invoke "get-a") (v128.const f32x4 0.0 1.0 2.0 3.0))
-;;(assert_return (invoke "get-b") (v128.const f32x4 4.0 5.0 6.0 7.0))
-;;(assert_return (invoke "get-c") (v128.const f32x4 0.0 1.0 2.0 3.0))
+(assert_return (invoke "get-a") (v128.const f32x4 0.0 1.0 2.0 3.0))
+(assert_return (invoke "get-b") (v128.const f32x4 4.0 5.0 6.0 7.0))
+(assert_return (invoke "get-c") (v128.const f32x4 0.0 1.0 2.0 3.0))
 (assert_return (invoke "get-d") (v128.const i32x4 8 9 10 11))
-;;(assert_return (invoke "get-e") (v128.const f32x4 0.0 1.0 2.0 3.0))
-;;(assert_return (invoke "get-f") (v128.const i32x4 12 13 14 15))
+(assert_return (invoke "get-e") (v128.const f32x4 0.0 1.0 2.0 3.0))
+(assert_return (invoke "get-f") (v128.const i32x4 12 13 14 15))
 
-;;(invoke "set-b" (v128.const f64x2 nan:0x1 nan:0x2))
-;;(assert_return (invoke "get-b") (v128.const f64x2 nan:0x1 nan:0x2))
-;;
-;;(invoke "set-e" (v128.const f64x2 -nan:0x3 +inf))
-;;(assert_return (invoke "get-e") (v128.const f64x2 -nan:0x3 +inf))
-;;
-;;(invoke "set-f" (v128.const f32x4 -inf +3.14 10.0e30 +nan:0x42))
-;;(assert_return (invoke "get-f") (v128.const f32x4 -inf +3.14 10.0e30 +nan:0x42))
+(invoke "set-b" (v128.const f64x2 nan:0x1 nan:0x2))
+(assert_return (invoke "get-b") (v128.const f64x2 nan:0x1 nan:0x2))
+
+(invoke "set-e" (v128.const f64x2 -nan:0x3 +inf))
+(assert_return (invoke "get-e") (v128.const f64x2 -nan:0x3 +inf))
+
+(invoke "set-f" (v128.const f32x4 -inf +3.14 10.0e30 +nan:0x42))
+(assert_return (invoke "get-f") (v128.const f32x4 -inf +3.14 10.0e30 +nan:0x42))
 
 (assert_invalid (module (global v128 (i32.const 0))) "invalid initializer expression")
 (assert_invalid (module (global v128 (i64.const 0))) "invalid initializer expression")


### PR DESCRIPTION
Enable the part of the simd spec tests that now pass.