### PR TITLE
Remove structopt dependency from LLVM

### DIFF
--- a/lib/llvm-backend/Cargo.toml
+++ b/lib/llvm-backend/Cargo.toml
@@ -11,15 +11,16 @@ wasmparser = "0.35.1"
 smallvec = "0.6.10"
 goblin = "0.0.24"
 libc = "0.2.60"
-nix = "0.14.1"
 capstone = { version = "0.6.0", optional = true }
-structopt = "0.2.18"
 
 [dependencies.inkwell]
 git = "https://github.com/wasmerio/inkwell"
 branch = "llvm8-0"
 default-features = false
 features = ["llvm8-0", "target-x86"]
+
+[target.'cfg(unix)'.dependencies]
+nix = "0.14.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.7", features = ["memoryapi"] }

--- a/lib/llvm-backend/src/lib.rs
+++ b/lib/llvm-backend/src/lib.rs
@@ -17,7 +17,6 @@ mod structs;
 mod trampolines;
 
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 pub use code::LLVMFunctionCodeGenerator as FunctionCodeGenerator;
 pub use code::LLVMModuleCodeGenerator as ModuleCodeGenerator;
@@ -31,23 +30,20 @@ pub type LLVMCompiler = SimpleStreamingCompilerGen<
     code::CodegenError,
 >;
 
-#[derive(Debug, StructOpt, Clone)]
+#[derive(Debug, Clone)]
 /// LLVM backend flags.
-pub struct CLIOptions {
+pub struct LLVMOptions {
     /// Emit LLVM IR before optimization pipeline.
-    #[structopt(long = "backend-llvm-pre-opt-ir", parse(from_os_str))]
-    pre_opt_ir: Option<PathBuf>,
+    pub pre_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM IR after optimization pipeline.
-    #[structopt(long = "backend-llvm-post-opt-ir", parse(from_os_str))]
-    post_opt_ir: Option<PathBuf>,
+    pub post_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM generated native code object file.
-    #[structopt(long = "backend-llvm-object-file", parse(from_os_str))]
-    obj_file: Option<PathBuf>,
+    pub obj_file: Option<PathBuf>,
 }
 
-pub static mut GLOBAL_OPTIONS: CLIOptions = CLIOptions {
+pub static mut GLOBAL_OPTIONS: LLVMOptions = LLVMOptions {
     pre_opt_ir: None,
     post_opt_ir: None,
     obj_file: None,


### PR DESCRIPTION
* [x] Remove structopt dependency from LLVM
* [x] Fixed `dyn` warning in the wasmer cli
* [x] Make `nix` an optional dependency for LLVM backend