### PR TITLE
Refactor to use internal memory descriptor to avoid panic

### DIFF
--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -115,7 +115,7 @@ impl LocalBacking {
     fn generate_memories(module: &ModuleInner) -> BoxedMap<LocalMemoryIndex, Memory> {
         let mut memories = Map::with_capacity(module.info.memories.len());
         for (_, &desc) in &module.info.memories {
-            memories.push(Memory::new(desc).expect("unable to create memory"));
+            memories.push(Memory::new(desc.into()).expect("unable to create memory"));
         }
 
         memories.into_boxed_map()
@@ -538,14 +538,14 @@ fn import_memories(
             .and_then(|namespace| namespace.get_export(&name));
         match memory_import {
             Some(Export::Memory(memory)) => {
-                if expected_memory_desc.fits_in_imported(memory.descriptor()) {
+                if expected_memory_desc.fits_in_imported(memory.desc) {
                     memories.push(memory.clone());
                     vm_memories.push(memory.vm_local_memory());
                 } else {
                     link_errors.push(LinkError::IncorrectMemoryDescriptor {
                         namespace: namespace.to_string(),
                         name: name.to_string(),
-                        expected: *expected_memory_desc,
+                        expected: (*expected_memory_desc).into(),
                         found: memory.descriptor(),
                     });
                 }

--- a/lib/runtime-core/src/memory/dynamic.rs
+++ b/lib/runtime-core/src/memory/dynamic.rs
@@ -2,7 +2,7 @@ use crate::error::GrowError;
 use crate::{
     error::CreationError,
     sys,
-    types::MemoryDescriptor,
+    types::MemoryDescriptorInternal,
     units::{Bytes, Pages},
     vm,
 };
@@ -30,7 +30,7 @@ pub struct DynamicMemory {
 
 impl DynamicMemory {
     pub(super) fn new(
-        desc: MemoryDescriptor,
+        desc: MemoryDescriptorInternal,
         local: &mut vm::LocalMemory,
     ) -> Result<Box<Self>, CreationError> {
         let min_bytes: Bytes = desc.minimum.into();

--- a/lib/runtime-core/src/memory/static_/unshared.rs
+++ b/lib/runtime-core/src/memory/static_/unshared.rs
@@ -3,7 +3,7 @@ use crate::{
     error::CreationError,
     memory::static_::{SAFE_STATIC_GUARD_SIZE, SAFE_STATIC_HEAP_SIZE},
     sys,
-    types::MemoryDescriptor,
+    types::MemoryDescriptorInternal,
     units::Pages,
     vm,
 };
@@ -27,7 +27,7 @@ pub struct StaticMemory {
 
 impl StaticMemory {
     pub(in crate::memory) fn new(
-        desc: MemoryDescriptor,
+        desc: MemoryDescriptorInternal,
         local: &mut vm::LocalMemory,
     ) -> Result<Box<Self>, CreationError> {
         let memory = {

--- a/lib/runtime-core/src/module.rs
+++ b/lib/runtime-core/src/module.rs
@@ -7,7 +7,7 @@ use crate::{
     types::{
         FuncIndex, FuncSig, GlobalDescriptor, GlobalIndex, GlobalInit, ImportedFuncIndex,
         ImportedGlobalIndex, ImportedMemoryIndex, ImportedTableIndex, Initializer,
-        LocalGlobalIndex, LocalMemoryIndex, LocalTableIndex, MemoryDescriptor, MemoryIndex,
+        LocalGlobalIndex, LocalMemoryIndex, LocalTableIndex, MemoryDescriptorInternal, MemoryIndex,
         SigIndex, TableDescriptor, TableIndex,
     },
     Instance,
@@ -30,13 +30,13 @@ pub struct ModuleInner {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModuleInfo {
     // This are strictly local and the typsystem ensures that.
-    pub memories: Map<LocalMemoryIndex, MemoryDescriptor>,
+    pub memories: Map<LocalMemoryIndex, MemoryDescriptorInternal>,
     pub globals: Map<LocalGlobalIndex, GlobalInit>,
     pub tables: Map<LocalTableIndex, TableDescriptor>,
 
     // These are strictly imported and the typesystem ensures that.
     pub imported_functions: Map<ImportedFuncIndex, ImportName>,
-    pub imported_memories: Map<ImportedMemoryIndex, (ImportName, MemoryDescriptor)>,
+    pub imported_memories: Map<ImportedMemoryIndex, (ImportName, MemoryDescriptorInternal)>,
     pub imported_tables: Map<ImportedTableIndex, (ImportName, TableDescriptor)>,
     pub imported_globals: Map<ImportedGlobalIndex, (ImportName, GlobalDescriptor)>,
 

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -9,8 +9,8 @@ use crate::{
     structures::{Map, TypedIndex},
     types::{
         ElementType, FuncIndex, FuncSig, GlobalDescriptor, GlobalIndex, GlobalInit,
-        ImportedGlobalIndex, Initializer, MemoryDescriptor, MemoryIndex, SigIndex, TableDescriptor,
-        TableIndex, Type, Value,
+        ImportedGlobalIndex, Initializer, MemoryDescriptorInternal, MemoryIndex, SigIndex,
+        TableDescriptor, TableIndex, Type, Value,
     },
     units::Pages,
 };
@@ -135,11 +135,12 @@ pub fn read_module<
                             .push((import_name, table_desc));
                     }
                     ImportSectionEntryType::Memory(memory_ty) => {
-                        let mem_desc = MemoryDescriptor {
-                            minimum: Pages(memory_ty.limits.initial),
-                            maximum: memory_ty.limits.maximum.map(|max| Pages(max)),
-                            shared: memory_ty.shared,
-                        };
+                        let mem_desc = MemoryDescriptorInternal::new(
+                            Pages(memory_ty.limits.initial),
+                            memory_ty.limits.maximum.map(|max| Pages(max)),
+                            memory_ty.shared,
+                        )
+                        .map_err(|x| LoadError::Codegen(format!("{:?}", x)))?;
                         info.write()
                             .unwrap()
                             .imported_memories
@@ -171,11 +172,12 @@ pub fn read_module<
                 info.write().unwrap().tables.push(table_desc);
             }
             ParserState::MemorySectionEntry(memory_ty) => {
-                let mem_desc = MemoryDescriptor {
-                    minimum: Pages(memory_ty.limits.initial),
-                    maximum: memory_ty.limits.maximum.map(|max| Pages(max)),
-                    shared: memory_ty.shared,
-                };
+                let mem_desc = MemoryDescriptorInternal::new(
+                    Pages(memory_ty.limits.initial),
+                    memory_ty.limits.maximum.map(|max| Pages(max)),
+                    memory_ty.shared,
+                )
+                .map_err(|x| LoadError::Codegen(format!("{:?}", x)))?;
 
                 info.write().unwrap().memories.push(mem_desc);
             }


### PR DESCRIPTION
See the issue this fixes for background:
Fixes #653 

There's probably more than one way to approach fixing this. Maybe there is a better way?

I chose this approach of creating an `MemoryDescriptorInternal` for internal usage to:

- maintain the current `MemoryDescriptor` public API
- remove the overloaded usage of `MemoryDescriptor` as both external configuration and internal metadata
- minimize changes where `MemoryDescriptor` is currently used internally.