### PR TITLE
Improve build instructions in README, test on Rust 1.36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
   test-stable:
     docker:
-      - image: circleci/rust:latest
+      - image: circleci/rust:1.36
     <<: *run_with_build_env_vars
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -169,13 +169,18 @@ nginx and Lua do not work on Windows - you can track the progress on [this issue
 </details>
 
 ## Building
+[![Rustc Version 1.36+](https://img.shields.io/badge/rustc-1.36+-red.svg)](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html)
 
 Wasmer is built with [Cargo](https://crates.io/), the Rust package manager.
+
+The Singlepass backend requires nightly, so if you want to use it,
 
 Set Rust Nightly:
 ```
 rustup default nightly
 ```
+
+Otherwise an up to date (see badge above) verison of stable Rust will work.
 
 And install Wasmer
 ```sh


### PR DESCRIPTION
Copied from syn (which is copied from num) (https://github.com/dtolnay/syn/issues/372)

[rendered](https://github.com/wasmerio/wasmer/blob/8fa4ef34c13e0e339d9a1416dfd2229ded8f8b19/README.md#building)