### PR TITLE
Continuous fuzzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
   <a href="https://dev.azure.com/wasmerio/wasmer/_build/latest?definitionId=3&branchName=master">
     <img src="https://img.shields.io/azure-devops/build/wasmerio/wasmer/3.svg?style=flat-square" alt="Build Status">
   </a>
+  <a href="https://app.fuzzit.dev/orgs/wasmerio/dashboard">
+    <img src="https://app.fuzzit.dev/badge?org_id=wasmerio">
+  </a>
   <a href="https://github.com/wasmerio/wasmer/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/wasmerio/wasmer.svg?style=flat-square" alt="License">
   </a>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,30 @@ jobs:
         displayName: Tests (Windows)
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
+  - job: Fuzz_regression
+    displayName: Fuzz regression
+    pool:
+      vmImage: "ubuntu-16.04"
+    variables:
+      rust_toolchain: nightly-2019-08-15
+    steps:
+      - template: .azure/install-rust.yml
+      - bash: cargo install cargo-fuzz
+      - bash: ./fuzzit.sh local-regression
+
+  - job: Fuzz
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    pool:
+      vmImage: "ubuntu-16.04"
+    variables:
+      rust_toolchain: nightly-2019-08-15
+    steps:
+      - template: .azure/install-rust.yml
+      - bash: cargo install cargo-fuzz
+      - bash: ./fuzzit.sh fuzzing
+        env:
+          FUZZIT_API_KEY: $(FUZZIT_API_KEY)
+
   - job: Check
     pool:
       vmImage: "ubuntu-16.04"

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -xe
+
+# Validate arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
+
+# Configure
+NAME=wasmer
+TYPE=$1
+ROOT=`pwd`
+
+# Setup
+if [[ ! -f fuzzit || ! `./fuzzit --version` =~ $FUZZIT_VERSION$ ]]; then
+    wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
+    chmod a+x fuzzit
+fi
+./fuzzit --version
+
+# Fuzz
+function fuzz {
+    FUZZER=$1
+    TARGET=$2
+    DIR=${3:-.}
+    BUILD_DIR=./fuzz/target/x86_64-unknown-linux-gnu/debug
+    (
+        cd $DIR
+        cargo fuzz run $FUZZER -- -runs=0
+        $ROOT/fuzzit create job --type $TYPE $NAME/$TARGET $BUILD_DIR/$FUZZER
+    )
+}
+fuzz simple_instantiate simple-instantiate
+fuzz validate_wasm validate-wasm
+fuzz compile_wasm compile-wasm


### PR DESCRIPTION
Proposing to get continuous fuzzing running on Fuzzit, to provide some automated bug discovery. Integrates the nice existing fuzz target.

This integrates through Travis as shown in the Fuzzit docs. I see your main build system is Circle. If you'd rather do it through Circle I can look into it.

There's a [successful run](https://travis-ci.org/bookmoons/wasmer/builds/577214712) under my Travis account. If you'd like to try it you can set it up like this:
* Enable repo on [Travis](https://travis-ci.org/).
* In [Fuzzit](https://fuzzit.dev/) create the target `wasmer`.
* In Fuzzit settings grab an API key. In repo settings in Travis paste it to envvar `FUZZIT_API_KEY`.