### PR TITLE
Run cargo fmt --all to make the ci linter happy

### DIFF
--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -148,5 +148,4 @@ mod tests {
         // verify it used the correct number of points
         assert_eq!(get_points_used(&instance), 109); // Used points will be slightly more than `limit` because of the way we do gas checking.
     }
-
 }

--- a/lib/runtime-core/build.rs
+++ b/lib/runtime-core/build.rs
@@ -38,6 +38,5 @@ fn main() {
             .file("image-loading-macos-x86-64.s")
             .compile("image-loading");
     } else {
-
     }
 }

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -363,5 +363,4 @@ mod memory_tests {
             "Max number of pages is required for shared memory"
         )
     }
-
 }

--- a/lib/runtime-core/src/table/mod.rs
+++ b/lib/runtime-core/src/table/mod.rs
@@ -165,5 +165,4 @@ mod table_tests {
         .unwrap();
         assert_eq!(table.size(), 10);
     }
-
 }

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -590,5 +590,4 @@ mod tests {
             f64::from_native(f64::from_binary((yf64).to_native().to_binary()))
         );
     }
-
 }

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -173,5 +173,4 @@ mod tests {
         // verify it works
         assert_eq!(value, 43);
     }
-
 }

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -1262,7 +1262,8 @@ impl X64FunctionCode {
                             }
                             m.state
                                 .stack_values
-                                .push(MachineValue::CopyStackBPRelative(offset)); // TODO: Read value at this offset
+                                .push(MachineValue::CopyStackBPRelative(offset));
+                            // TODO: Read value at this offset
                         }
                         _ => {
                             m.state.stack_values.push(MachineValue::Undefined);

--- a/lib/singlepass-backend/src/emitter_x64.rs
+++ b/lib/singlepass-backend/src/emitter_x64.rs
@@ -635,18 +635,14 @@ impl Emitter for Assembler {
         match (sz, src) {
             (Size::S64, Location::Imm32(src)) => dynasm!(self ; push src as i32),
             (Size::S64, Location::GPR(src)) => dynasm!(self ; push Rq(src as u8)),
-            (Size::S64, Location::Memory(src, disp)) => {
-                dynasm!(self ; push QWORD [Rq(src as u8) + disp])
-            }
+            (Size::S64, Location::Memory(src, disp)) => dynasm!(self ; push QWORD [Rq(src as u8) + disp]),
             _ => panic!("push {:?} {:?}", sz, src),
         }
     }
     fn emit_pop(&mut self, sz: Size, dst: Location) {
         match (sz, dst) {
             (Size::S64, Location::GPR(dst)) => dynasm!(self ; pop Rq(dst as u8)),
-            (Size::S64, Location::Memory(dst, disp)) => {
-                dynasm!(self ; pop QWORD [Rq(dst as u8) + disp])
-            }
+            (Size::S64, Location::Memory(dst, disp)) => dynasm!(self ; pop QWORD [Rq(dst as u8) + disp]),
             _ => panic!("pop {:?} {:?}", sz, dst),
         }
     }
@@ -851,54 +847,42 @@ impl Emitter for Assembler {
     fn emit_ucomiss(&mut self, src: XMMOrMemory, dst: XMM) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; ucomiss Rx(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; ucomiss Rx(dst as u8), [Rq(base as u8) + disp])
-            }
+            XMMOrMemory::Memory(base, disp) => dynasm!(self ; ucomiss Rx(dst as u8), [Rq(base as u8) + disp]),
         }
     }
 
     fn emit_ucomisd(&mut self, src: XMMOrMemory, dst: XMM) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; ucomisd Rx(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; ucomisd Rx(dst as u8), [Rq(base as u8) + disp])
-            }
+            XMMOrMemory::Memory(base, disp) => dynasm!(self ; ucomisd Rx(dst as u8), [Rq(base as u8) + disp]),
         }
     }
 
     fn emit_cvttss2si_32(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rd(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttss2si Rd(dst as u8), [Rq(base as u8) + disp])
-            }
+            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttss2si Rd(dst as u8), [Rq(base as u8) + disp]),
         }
     }
 
     fn emit_cvttss2si_64(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rq(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttss2si Rq(dst as u8), [Rq(base as u8) + disp])
-            }
+            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttss2si Rq(dst as u8), [Rq(base as u8) + disp]),
         }
     }
 
     fn emit_cvttsd2si_32(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rd(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttsd2si Rd(dst as u8), [Rq(base as u8) + disp])
-            }
+            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttsd2si Rd(dst as u8), [Rq(base as u8) + disp]),
         }
     }
 
     fn emit_cvttsd2si_64(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rq(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttsd2si Rq(dst as u8), [Rq(base as u8) + disp])
-            }
+            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttsd2si Rq(dst as u8), [Rq(base as u8) + disp]),
         }
     }
 

--- a/lib/singlepass-backend/src/machine.rs
+++ b/lib/singlepass-backend/src/machine.rs
@@ -500,5 +500,4 @@ mod test {
 
         machine.release_locations_keep_state(&mut assembler, &locs);
     }
-
 }

--- a/lib/spectests/tests/spectest.rs
+++ b/lib/spectests/tests/spectest.rs
@@ -1265,5 +1265,4 @@ mod tests {
             self.to_bits() == 0x7FF8_0000_0000_0000 || self.to_bits() == 0xFFF8_0000_0000_0000
         }
     }
-
 }


### PR DESCRIPTION
I noticed a CI failure in #736 due to linter. Some errors were my file, but many of these linter errors exist on master.

I just let `cargo fmt --all` fix them up, so the linter is happy on the CI and it is easier to check if a new PR broke something.