### PR TITLE
[fix issue #724] replace panic! with return Err()

### DIFF
--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -634,7 +634,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
 
                 if let Err(ref err) = result {
                     match err {
-                        RuntimeError::Trap { msg } => panic!("wasm trap occured: {}", msg),
+                        RuntimeError::Trap { msg } => return Err(format!("wasm trap occured: {}", msg)),
                         #[cfg(feature = "wasi")]
                         RuntimeError::Error { data } => {
                             if let Some(error_code) = data.downcast_ref::<wasmer_wasi::ExitCode>() {
@@ -644,7 +644,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                         #[cfg(not(feature = "wasi"))]
                         RuntimeError::Error { .. } => (),
                     }
-                    panic!("error: {:?}", err)
+                    return Err(format!("error: {:?}", err))
                 }
             }
         } else {

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -644,7 +644,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                         #[cfg(not(feature = "wasi"))]
                         RuntimeError::Error { .. } => (),
                     }
-                    return Err(format!("error: {:?}", err))
+                    return Err(format!("error: {:?}", err));
                 }
             }
         } else {

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -634,7 +634,9 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
 
                 if let Err(ref err) = result {
                     match err {
-                        RuntimeError::Trap { msg } => return Err(format!("wasm trap occured: {}", msg)),
+                        RuntimeError::Trap { msg } => {
+                            return Err(format!("wasm trap occured: {}", msg))
+                        }
                         #[cfg(feature = "wasi")]
                         RuntimeError::Error { data } => {
                             if let Some(error_code) = data.downcast_ref::<wasmer_wasi::ExitCode>() {


### PR DESCRIPTION
related to issue: https://github.com/wasmerio/wasmer/issues/724

after the patch:
```
./target/release/wasmer run reported_issues/panic_wasm_trap_occured_call_indirect.wasm 
sizeof(UAFME) = 4
execute_wasm: "wasm trap occured: `call_indirect` out-of-bounds"
```