### PR TITLE
Turn this unreachable into a panic with an error message.

### DIFF
--- a/lib/singlepass-backend/src/emitter_x64.rs
+++ b/lib/singlepass-backend/src/emitter_x64.rs
@@ -926,7 +926,7 @@ impl Emitter for Assembler {
         match loc {
             Location::GPR(x) => dynasm!(self ; call Rq(x as u8)),
             Location::Memory(base, disp) => dynasm!(self ; call QWORD [Rq(base as u8) + disp]),
-            _ => unreachable!(),
+            _ => panic!("CALL {:?}", loc),
         }
     }
 


### PR DESCRIPTION
# Description
All errors with messages in this file are `panic!`s. Give this `unreachable!` a message (so I can debug when I hit it, only possible due to local changes) and turn it into a `panic!`.

# Review

- [ ] Create a short description of the the change in the CHANGELOG.md file

Too minor for changelog.
