### PR TITLE
Remove memory_base and memory_bound from InternalCtx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#783](https://github.com/wasmerio/wasmer/pull/783) Remove memory_base and memory_bound from InternalCtx.
 - [#809](https://github.com/wasmerio/wasmer/pull/809) Fix bugs leading to panics in `LocalBacking`.
 - [#822](https://github.com/wasmerio/wasmer/pull/822) Update Cranelift fork version to `0.43.1`
 - [#829](https://github.com/wasmerio/wasmer/pull/829) Fix deps on `make bench-*` commands; benchmarks don't compile other backends now
@@ -15,6 +16,12 @@ Blocks of changes will separated by version increments.
 - [#821](https://github.com/wasmerio/wasmer/issues/821) Remove patch version on most deps Cargo manifests.  This gives Wasmer library users more control over which versions of the deps they use.
 - [#820](https://github.com/wasmerio/wasmer/issues/820) Remove null-pointer checks in `WasmPtr` from runtime-core, re-add them in Emscripten
 - [#803](https://github.com/wasmerio/wasmer/issues/803) Add method to `Ctx` to invoke functions by their `TableIndex`
+- [#790](https://github.com/wasmerio/wasmer/pull/790) Fix flaky test failure with LLVM, switch to large code model.
+- [#788](https://github.com/wasmerio/wasmer/pull/788) Use union merge on the changelog file.
+- [#785](https://github.com/wasmerio/wasmer/pull/785) Include Apache license file for spectests.
+- [#786](https://github.com/wasmerio/wasmer/pull/786) In the LLVM backend, lower atomic wasm operations to atomic machine instructions.
+- [#784](https://github.com/wasmerio/wasmer/pull/784) Fix help string for wasmer run.
+- [#783](https://github.com/wasmerio/wasmer/pull/783) Remove memory_base and memory_bound from InternalCtx.
 - [#790](https://github.com/wasmerio/wasmer/pull/790) Fix flaky test failure with LLVM, switch to large code model.
 - [#788](https://github.com/wasmerio/wasmer/pull/788) Use union merge on the changelog file.
 - [#785](https://github.com/wasmerio/wasmer/pull/785) Include Apache license file for spectests.

--- a/lib/llvm-backend/src/intrinsics.rs
+++ b/lib/llvm-backend/src/intrinsics.rs
@@ -215,8 +215,6 @@ impl Intrinsics {
         let sigindex_ty = i32_ty;
         let rt_intrinsics_ty = i8_ty;
         let stack_lower_bound_ty = i8_ty;
-        let memory_base_ty = i8_ty;
-        let memory_bound_ty = i8_ty;
         let internals_ty = i64_ty;
         let interrupt_signal_mem_ty = i8_ty;
         let local_function_ty = i8_ptr_ty;
@@ -266,12 +264,6 @@ impl Intrinsics {
                     .ptr_type(AddressSpace::Generic)
                     .as_basic_type_enum(),
                 stack_lower_bound_ty
-                    .ptr_type(AddressSpace::Generic)
-                    .as_basic_type_enum(),
-                memory_base_ty
-                    .ptr_type(AddressSpace::Generic)
-                    .as_basic_type_enum(),
-                memory_bound_ty
                     .ptr_type(AddressSpace::Generic)
                     .as_basic_type_enum(),
                 internals_ty

--- a/lib/llvm-backend/src/stackmap.rs
+++ b/lib/llvm-backend/src/stackmap.rs
@@ -31,10 +31,6 @@ pub enum ValueSemantic {
     WasmStack(usize),
     Ctx,
     SignalMem,
-    PointerToMemoryBase,
-    PointerToMemoryBound, // 64-bit
-    MemoryBase,
-    MemoryBound, // 64-bit
     PointerToGlobal(usize),
     Global(usize),
     PointerToTableBase,
@@ -127,18 +123,6 @@ impl StackmapEntry {
                 ValueSemantic::Ctx => MachineValue::Vmctx,
                 ValueSemantic::SignalMem => {
                     MachineValue::VmctxDeref(vec![Ctx::offset_interrupt_signal_mem() as usize, 0])
-                }
-                ValueSemantic::PointerToMemoryBase => {
-                    MachineValue::VmctxDeref(vec![Ctx::offset_memory_base() as usize])
-                }
-                ValueSemantic::PointerToMemoryBound => {
-                    MachineValue::VmctxDeref(vec![Ctx::offset_memory_bound() as usize])
-                }
-                ValueSemantic::MemoryBase => {
-                    MachineValue::VmctxDeref(vec![Ctx::offset_memory_base() as usize, 0])
-                }
-                ValueSemantic::MemoryBound => {
-                    MachineValue::VmctxDeref(vec![Ctx::offset_memory_bound() as usize, 0])
                 }
                 ValueSemantic::PointerToGlobal(idx) => {
                     MachineValue::VmctxDeref(deref_global(module_info, idx, false))

--- a/lib/runtime-core/src/vmcalls.rs
+++ b/lib/runtime-core/src/vmcalls.rs
@@ -25,9 +25,6 @@ pub unsafe extern "C" fn local_static_memory_grow(
         Err(_) => -1,
     };
 
-    ctx.internal.memory_base = (*local_memory).base;
-    ctx.internal.memory_bound = (*local_memory).bound;
-
     ret
 }
 
@@ -53,9 +50,6 @@ pub unsafe extern "C" fn local_dynamic_memory_grow(
         Ok(old) => old.0 as i32,
         Err(_) => -1,
     };
-
-    ctx.internal.memory_base = (*local_memory).base;
-    ctx.internal.memory_bound = (*local_memory).bound;
 
     ret
 }
@@ -90,9 +84,6 @@ pub unsafe extern "C" fn imported_static_memory_grow(
         Err(_) => -1,
     };
 
-    ctx.internal.memory_base = (*local_memory).base;
-    ctx.internal.memory_bound = (*local_memory).bound;
-
     ret
 }
 
@@ -121,9 +112,6 @@ pub unsafe extern "C" fn imported_dynamic_memory_grow(
         Ok(old) => old.0 as i32,
         Err(_) => -1,
     };
-
-    ctx.internal.memory_base = (*local_memory).base;
-    ctx.internal.memory_bound = (*local_memory).bound;
 
     ret
 }


### PR DESCRIPTION
# Description
Remove the `memory_base` and `memory_bound` members on `InternalCtx`. These are redundant with the context's list of memories which also include a base and a bound. Use those instead.

# Review

- [x] Create a short description of the the change in the CHANGELOG.md file
