### PR TITLE
Wasmer run can run text wat files, not webassembly spectest files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#784](https://github.com/wasmerio/wasmer/pull/784) Fix help string for wasmer run.
+
 ## 0.7.0 - 2019-09-12
 
 Special thanks to @YaronWittenstein @penberg for their contributions.

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -64,7 +64,7 @@ mod wasmer_wasi {
 #[structopt(name = "wasmer", about = "Wasm execution runtime.", author)]
 /// The options for the wasmer Command Line Interface
 enum CLIOptions {
-    /// Run a WebAssembly file. Formats accepted: wasm, wast
+    /// Run a WebAssembly file. Formats accepted: wasm, wat
     #[structopt(name = "run")]
     Run(Run),
 


### PR DESCRIPTION
# Description
Correct an incorrect description of the `wasmer run` subcommand. It can't run webassembly spectest files (`.wast`), it can run webassembly text files (`.wat`).

# Review

- [x] Create a short description of the the change in the CHANGELOG.md file

n/a
