### PR TITLE
Use union merge on the changelog file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 lib/emscripten/emtests/* linguist-vendored
 lib/spectests/spectests/* linguist-vendored
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#788](https://github.com/wasmerio/wasmer/pull/788) Use union merge on the changelog file.
 - [#785](https://github.com/wasmerio/wasmer/pull/785) Include Apache license file for spectests.
 - [#786](https://github.com/wasmerio/wasmer/pull/786) In the LLVM backend, lower atomic wasm operations to atomic machine instructions.
 - [#784](https://github.com/wasmerio/wasmer/pull/784) Fix help string for wasmer run.


### PR DESCRIPTION
# Description
This keeps both sides of a conflict. It's essentially the same as removing the
conflict markers.

# Review

- [x] Create a short description of the the change in the CHANGELOG.md file
