### PR TITLE
Switch llvm-backend from PIC+Default (small) to Static+Large.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Blocks of changes will separated by version increments.
 
 ## **[Unreleased]**
 
+- [#790](https://github.com/wasmerio/wasmer/pull/790) Fix flaky test failure with LLVM, switch to large code model.
 - [#788](https://github.com/wasmerio/wasmer/pull/788) Use union merge on the changelog file.
 - [#785](https://github.com/wasmerio/wasmer/pull/785) Include Apache license file for spectests.
 - [#786](https://github.com/wasmerio/wasmer/pull/786) In the LLVM backend, lower atomic wasm operations to atomic machine instructions.

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -189,8 +189,8 @@ impl LLVMBackend {
                 &TargetMachine::get_host_cpu_name().to_string(),
                 &TargetMachine::get_host_cpu_features().to_string(),
                 OptimizationLevel::Aggressive,
-                RelocMode::PIC,
-                CodeModel::Default,
+                RelocMode::Static,
+                CodeModel::Large,
             )
             .unwrap();
 


### PR DESCRIPTION
# Description

Should fix flaky test failure:
```
spectest-a277b7d051ac0dde: /home/nick/llvm-8.0.1.src/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp:304: void llvm::RuntimeDyldELF::resolveX86_64Relocation(const llvm::SectionEntry&, uint64_t, uint64_t, uint32_t, int64_t, uint64_t): Assertion `isInt<32>(RealOffset)' failed.
```
(with assertions-enabled LLVM). The relocation in question is a `R_X86_64_PC32` with small offset against `.rodata`.

The switch from Default (small, JITDefault is a different default that we weren't using which is medium) to Large should fix the bug. Once we're using large code model, I think we can switch from PIC to static as either an optimization or a no-op.

# Review

- [x] Create a short description of the the change in the CHANGELOG.md file
