### PR TITLE
Replace panic! & unimplemented! in runtime-code and llvm-backend

### DIFF
--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -1176,7 +1176,11 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                             BasicTypeEnum::FloatType(float_ty) => {
                                 float_ty.const_float(0.0).as_basic_value_enum()
                             }
-                            _ => unimplemented!(),
+                            _ => {
+                                return Err(CodegenError {
+                                    message: "Operator::End phi type unimplemented".to_string(),
+                                });
+                            }
                         };
                         state.push1(placeholder_value);
                         phi.as_instruction().erase_from_basic_block();
@@ -1741,7 +1745,12 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                             _ => value,
                         });
                     }
-                    _ => unimplemented!("multi-value returns"),
+                    _ => {
+                        return Err(CodegenError {
+                            message: "Operator::CallIndirect multi-value returns unimplemented"
+                                .to_string(),
+                        });
+                    }
                 }
             }
 
@@ -6853,7 +6862,9 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                 state.push1(result.try_as_basic_value().left().unwrap());
             }
             _ => {
-                unimplemented!("{:?}", op);
+                return Err(CodegenError {
+                    message: format!("Operator {:?} unimplemented", op),
+                });
             }
         }
 
@@ -6876,7 +6887,11 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                     "return",
                 )));
             }
-            _ => unimplemented!("multi-value returns not yet implemented"),
+            _ => {
+                return Err(CodegenError {
+                    message: "multi-value returns not yet implemented".to_string(),
+                });
+            }
         }
         Ok(())
     }
@@ -7051,7 +7066,10 @@ impl ModuleCodeGenerator<LLVMFunctionCodeGenerator, LLVMBackend, CodegenError>
             self.context.as_ref().unwrap(),
             self.builder.as_ref().unwrap(),
             self.intrinsics.as_ref().unwrap(),
-        );
+        )
+        .map_err(|e| CodegenError {
+            message: format!("trampolines generation error: {:?}", e),
+        })?;
 
         if let Some(path) = unsafe { &crate::GLOBAL_OPTIONS.pre_opt_ir } {
             self.module.print_to_file(path).unwrap();

--- a/lib/llvm-backend/src/trampolines.rs
+++ b/lib/llvm-backend/src/trampolines.rs
@@ -110,7 +110,7 @@ fn generate_trampoline(
             );
         }
         _ => {
-            return Err("trampoline function multi-value returns".to_string());
+            return Err("trampoline function multi-value returns unimplemented".to_string());
         }
     }
 

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -392,14 +392,19 @@ pub fn read_module<
 }
 
 pub fn wp_type_to_type(ty: WpType) -> Result<Type, BinaryReaderError> {
-    Ok(match ty {
-        WpType::I32 => Type::I32,
-        WpType::I64 => Type::I64,
-        WpType::F32 => Type::F32,
-        WpType::F64 => Type::F64,
-        WpType::V128 => Type::V128,
-        _ => panic!("broken invariant, invalid type"),
-    })
+    match ty {
+        WpType::I32 => Ok(Type::I32),
+        WpType::I64 => Ok(Type::I64),
+        WpType::F32 => Ok(Type::F32),
+        WpType::F64 => Ok(Type::F64),
+        WpType::V128 => Ok(Type::V128),
+        _ => {
+            return Err(BinaryReaderError {
+                message: "broken invariant, invalid type",
+                offset: -1isize as usize,
+            });
+        }
+    }
 }
 
 pub fn type_to_wp_type(ty: Type) -> WpType {


### PR DESCRIPTION
# Description

Replace `unimplemented!` by already used `CodegenError` in `lib/llvm-backend/src/code.rs`
Replace `unimplemented!` by `Err` in `lib/llvm-backend/src/trampolines.rs`
Replace `panic!` by already used `BinaryReaderError` in `lib/runtime-core/src/parse.rs`

# Review

- [ ] Create a short description of the the change in the CHANGELOG.md file
