### PR TITLE
Fix issues with testing/linking singlepass in runtime-c-api

### DIFF
--- a/lib/runtime-core/image-loading-linux-x86-64.s
+++ b/lib/runtime-core/image-loading-linux-x86-64.s
@@ -81,7 +81,7 @@ pushq %r8
 pushq %r9
 pushq %r10
 
-callq get_boundary_register_preservation
+callq get_boundary_register_preservation@PLT
 
 # Keep this consistent with BoundaryRegisterPreservation
 movq %r15, 0(%rax)


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

This resolves the regression from #811 (singlepass tests in runtime-c-api no longer even linking under linux). (The failing serialize test is still problematic)

Thanks to @nlewycky for debugging this with me and finding the solution.

# Review

- [ ] Create a short description of the the change in the CHANGELOG.md file
