### PR TITLE
Integrate with Fuzzit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Blocks of changes will separated by version increments.
 ## **[Unreleased]**
 
 - [#852](https://github.com/wasmerio/wasmer/pull/852) Make minor grammar/capitalization fixes to README.md
+- [#843](https://github.com/wasmerio/wasmer/pull/843) Integrate with Fuzzit
 - [#841](https://github.com/wasmerio/wasmer/pull/841) Slightly improve rustdoc documentation and small updates to outdated info in readme files
 - [#835](https://github.com/wasmerio/wasmer/pull/836) Update Cranelift fork version to `0.44.0`
 - [#836](https://github.com/wasmerio/wasmer/pull/836) Update Cranelift fork version to `0.44.0`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
   <a href="https://dev.azure.com/wasmerio/wasmer/_build/latest?definitionId=3&branchName=master">
     <img src="https://img.shields.io/azure-devops/build/wasmerio/wasmer/3.svg?style=flat-square" alt="Build Status">
   </a>
+  <a href="https://app.fuzzit.dev/orgs/wasmerio/dashboard">
+    <img src="https://app.fuzzit.dev/badge?org_id=wasmerio">
+  </a>
   <a href="https://github.com/wasmerio/wasmer/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/wasmerio/wasmer.svg?style=flat-square" alt="License">
   </a>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,30 @@ jobs:
         displayName: Tests (Windows)
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
+  - job: Fuzz_regression
+    displayName: Fuzz regression
+    pool:
+      vmImage: "ubuntu-16.04"
+    variables:
+      rust_toolchain: nightly-2019-08-15
+    steps:
+      - template: .azure/install-rust.yml
+      - bash: cargo install cargo-fuzz
+      - bash: ./fuzzit.sh local-regression
+
+  - job: Fuzz
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    pool:
+      vmImage: "ubuntu-16.04"
+    variables:
+      rust_toolchain: nightly-2019-08-15
+    steps:
+      - template: .azure/install-rust.yml
+      - bash: cargo install cargo-fuzz
+      - bash: ./fuzzit.sh fuzzing
+        env:
+          FUZZIT_API_KEY: $(FUZZIT_API_KEY)
+
   - job: Check
     pool:
       vmImage: "ubuntu-16.04"

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -xe
+
+# Validate arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
+
+# Configure
+NAME=wasmer
+TYPE=$1
+ROOT=`pwd`
+
+# Setup
+if [[ ! -f fuzzit || ! `./fuzzit --version` =~ $FUZZIT_VERSION$ ]]; then
+    wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
+    chmod a+x fuzzit
+fi
+./fuzzit --version
+
+# Fuzz
+function fuzz {
+    FUZZER=$1
+    TARGET=$2
+    DIR=${3:-.}
+    BUILD_DIR=./fuzz/target/x86_64-unknown-linux-gnu/debug
+    (
+        cd $DIR
+        cargo fuzz run $FUZZER -- -runs=0
+        $ROOT/fuzzit create job --type $TYPE $NAME/$TARGET $BUILD_DIR/$FUZZER
+    )
+}
+fuzz simple_instantiate simple-instantiate
+fuzz validate_wasm validate-wasm
+fuzz compile_wasm compile-wasm


### PR DESCRIPTION
# Description

Enables automated fuzzing on Fuzzit. Fuzz regression tests run every push and PR. Full fuzzing runs every push.

Uses the existing fuzz targets:
* simple-instantiate - Instantiate a WebAssembly program.
* validate-wasm - Validate WebAssembly code.
* compile-wasm - Compile WebAssembly code.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
