### PR TITLE
Fix unused value warning due to inkwell API change. NFC.

### DIFF
--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -935,7 +935,7 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                     let signal_mem = ctx.signal_mem();
                     let iv = builder
                         .build_store(signal_mem, context.i8_type().const_int(0 as u64, false));
-                    iv.set_volatile(true);
+                    iv.set_volatile(true).unwrap();
                     finalize_opcode_stack_map(
                         intrinsics,
                         builder,

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -935,6 +935,7 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                     let signal_mem = ctx.signal_mem();
                     let iv = builder
                         .build_store(signal_mem, context.i8_type().const_int(0 as u64, false));
+                    // Any 'store' can be made volatile.
                     iv.set_volatile(true).unwrap();
                     finalize_opcode_stack_map(
                         intrinsics,


### PR DESCRIPTION
# Description
Fix unused value warning due to inkwell API change. No functionality change.