### PR TITLE
Pass llvm debug flags to the llvm backend.

### DIFF
--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -23,7 +23,7 @@ use structopt::StructOpt;
 use wasmer::*;
 use wasmer_clif_backend::CraneliftCompiler;
 #[cfg(feature = "backend-llvm")]
-use wasmer_llvm_backend::LLVMCompiler;
+use wasmer_llvm_backend::{LLVMCompiler, LLVMOptions};
 use wasmer_runtime::{
     cache::{Cache as BaseCache, FileSystemCache, WasmHash},
     Func, Value, VERSION,
@@ -109,7 +109,7 @@ pub struct LLVMCLIOptions {
     post_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM generated native code object file.
-    #[structopt(long = "backend-llvm-object-file", parse(from_os_str))]
+    #[structopt(long = "llvm-object-file", parse(from_os_str))]
     obj_file: Option<PathBuf>,
 }
 
@@ -405,6 +405,20 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
         None => return Err("the requested backend is not enabled".into()),
     };
 
+    #[cfg(feature = "backend-llvm")]
+    {
+       if options.backend == Backend::LLVM {
+            let options = options.backend_llvm_options.clone();
+            unsafe {
+                wasmer_llvm_backend::GLOBAL_OPTIONS = LLVMOptions {
+                    pre_opt_ir: options.pre_opt_ir,
+                    post_opt_ir: options.post_opt_ir,
+                    obj_file: options.obj_file,
+                }
+            }
+        }
+    }
+    
     let track_state = !options.no_track_state;
 
     #[cfg(feature = "loader-kernel")]

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -407,7 +407,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
 
     #[cfg(feature = "backend-llvm")]
     {
-       if options.backend == Backend::LLVM {
+        if options.backend == Backend::LLVM {
             let options = options.backend_llvm_options.clone();
             unsafe {
                 wasmer_llvm_backend::GLOBAL_OPTIONS = LLVMOptions {
@@ -418,7 +418,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
             }
         }
     }
-    
+
     let track_state = !options.no_track_state;
 
     #[cfg(feature = "loader-kernel")]


### PR DESCRIPTION
This was accidentally removed in 124ad73e8ae2c6864bad3ebe5572d79736cfd688 .