### PR TITLE
doc: add link to SO in C api example

### DIFF
--- a/lib/runtime-c-api/README.md
+++ b/lib/runtime-c-api/README.md
@@ -36,6 +36,7 @@ The C and C++ header files can be found in the source tree of this
 crate, respectively [`wasmer.h`][wasmer_h] and
 [`wasmer.hh`][wasmer_hh]. They are automatically generated, and always
 up-to-date in this repository.
+The runtime library needed to compile (so, dll, dylib) can be donwloaded in wasmer [release page](https://github.com/wasmerio/wasmer/releases).
 
 Here is a simple example to use the C API:
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
When I try to compile C API example, I didn't found easily the library needed to compile. I had to recompile wasmer before I found the library can be downlaoded in github release page. 

I make this PR just to update the doc so as other deveoppers don't take time to find SO file.

I have created an issue here : https://github.com/wasmerio/wasmer-c-api/issues/8 but I think the link as a better place in this README page.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
