### PR TITLE
Get aggressive about running cargo check over all packages with all features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,22 +116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "capstone"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "capstone-sys 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "capstone-sys"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cargo_toml"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,7 +1563,6 @@ name = "wasmer-llvm-backend"
 version = "0.8.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "capstone 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "inkwell 0.1.0 (git+https://github.com/wasmerio/inkwell?branch=llvm8-0)",
@@ -1811,8 +1794,6 @@ dependencies = [
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
-"checksum capstone 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "031ba51c39151a1d6336ec859646153187204b0147c7b3f6fe2de636f1b8dbb3"
-"checksum capstone-sys 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fae25eddcb80e24f98c35952c37a91ff7f8d0f60dbbdafb9763e8d5cc566b8d7"
 "checksum cargo_toml 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "097f5ce64ba566a83d9d914fd005de1e5937fdd57d8c5d99a7593040955d75a9"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cbindgen 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9daec6140ab4dcd38c3dd57e580b59a621172a526ac79f1527af760a55afeafd"

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,37 @@ check-bench-llvm:
 check-bench: check-bench-singlepass check-bench-llvm
 
 check: check-bench
-	cargo check --release --features backend-singlepass,backend-llvm,loader-kernel,debug
+	# TODO: We wanted `--workspace --exclude wasmer-runtime`, but for
+	# https://github.com/rust-lang/cargo/issues/6745 .
+	cargo check -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests
+	cargo check --release -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests
+	cargo check -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests --all-features
+	cargo check --release -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests --all-features
+	# wasmer-runtime doesn't work with all backends enabled at once.
+	#
+	# We test using manifest-path directly so as to disable the default.
+	# `--no-default-features` only disables the default features in the
+	# current package, not the package specified by `-p`. This is
+	# intentional.
+	#
+	# Test default features, test 'debug' feature only in non-release
+	# builds, test as many combined features as possible with each backend
+	# as default, and test a minimal set of features with only one backend
+	# at a time.
+	cargo check --manifest-path lib/runtime/Cargo.toml
+	cargo check --release --manifest-path lib/runtime/Cargo.toml
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,cache,debug,llvm,singlepass,default-backend-singlepass
+	cargo check --release --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,cache,llvm,singlepass,default-backend-singlepass
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,cache,debug,llvm,singlepass,default-backend-cranelift
+	cargo check --release --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,cache,llvm,singlepass,default-backend-cranelift
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,cache,debug,llvm,singlepass,default-backend-llvm
+	cargo check --release --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,cache,llvm,singlepass,default-backend-llvm
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features --features=singlepass,default-backend-singlepass,debug
+	cargo check --release --manifest-path lib/runtime/Cargo.toml --no-default-features --features=singlepass,default-backend-singlepass
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,default-backend-cranelift,debug
+	cargo check --release --manifest-path lib/runtime/Cargo.toml --no-default-features --features=cranelift,default-backend-cranelift
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features --features=llvm,default-backend-llvm,debug
+	cargo check --release --manifest-path lib/runtime/Cargo.toml --no-default-features --features=llvm,default-backend-llvm
 
 # Release
 release:

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,8 @@ check-bench-llvm:
 check-bench: check-bench-singlepass check-bench-llvm
 
 check: check-bench
-	# TODO: We wanted `--workspace --exclude wasmer-runtime`, but for
-	# https://github.com/rust-lang/cargo/issues/6745 .
+	# TODO: We wanted `--workspace --exclude wasmer-runtime`, but can't due
+	# to https://github.com/rust-lang/cargo/issues/6745 .
 	cargo check -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests
 	cargo check --release -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests
 	cargo check -p wasmer-clif-backend -p wasmer-singlepass-backend -p wasmer-middleware-common -p wasmer-runtime-core -p wasmer-emscripten -p wasmer-llvm-backend -p wasmer-wasi -p wasmer-kernel-loader -p wasmer-dev-utils -p wasmer-wasi-tests -p wasmer-middleware-common-tests -p wasmer-emscripten-tests --all-features

--- a/lib/llvm-backend/Cargo.toml
+++ b/lib/llvm-backend/Cargo.toml
@@ -11,7 +11,6 @@ wasmparser = "0.39.1"
 smallvec = "0.6"
 goblin = "0.0.24"
 libc = "0.2.60"
-capstone = { version = "0.6", optional = true }
 byteorder = "1"
 
 [dependencies.inkwell]
@@ -38,4 +37,3 @@ wabt = "0.9.1"
 
 [features]
 debug = ["wasmer-runtime-core/debug"]
-disasm = ["capstone"]

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -477,33 +477,3 @@ impl CacheGen for LLVMCache {
         Ok(([].as_ref().into(), memory))
     }
 }
-
-#[cfg(feature = "disasm")]
-unsafe fn disass_ptr(ptr: *const u8, size: usize, inst_count: usize) {
-    use capstone::arch::BuildsCapstone;
-    let mut cs = capstone::Capstone::new() // Call builder-pattern
-        .x86() // X86 architecture
-        .mode(capstone::arch::x86::ArchMode::Mode64) // 64-bit mode
-        .detail(true) // Generate extra instruction details
-        .build()
-        .expect("Failed to create Capstone object");
-
-    // Get disassembled instructions
-    let insns = cs
-        .disasm_count(
-            std::slice::from_raw_parts(ptr, size),
-            ptr as u64,
-            inst_count,
-        )
-        .expect("Failed to disassemble");
-
-    println!("count = {}", insns.len());
-    for insn in insns.iter() {
-        println!(
-            "0x{:x}: {:6} {}",
-            insn.address(),
-            insn.mnemonic().unwrap_or(""),
-            insn.op_str().unwrap_or("")
-        );
-    }
-}


### PR DESCRIPTION
Fixes the one issue uncovered. The capstone disassembling support in the LLVM backend was broken. Fixed by removing it. Instead, use the `--llvm-object-file` flag to get a finished object file to disassemble with any disassembler.
