### PR TITLE
fix(singlepass-backend) Use wasmparser from `runtime-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,6 @@ dependencies = [
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.8.0",
- "wasmparser 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/lib/singlepass-backend/Cargo.toml
+++ b/lib/singlepass-backend/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 
 [dependencies]
 wasmer-runtime-core = { path = "../runtime-core", version = "0.8.0" }
-wasmparser = "0.39.1"
 dynasm = "0.3.2"
 dynasmrt = "0.3.1"
 lazy_static = "1.4"

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -1,15 +1,13 @@
 #![allow(clippy::forget_copy)] // Used by dynasm.
 #![warn(unused_imports)]
 
-use crate::emitter_x64::*;
-use crate::machine::*;
-use crate::protect_unix;
+use crate::{emitter_x64::*, machine::*, protect_unix};
 use dynasmrt::{x64::Assembler, AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi};
 use smallvec::SmallVec;
-use std::ptr::NonNull;
 use std::{
     any::Any,
     collections::{BTreeMap, HashMap},
+    ptr::NonNull,
     sync::{Arc, RwLock},
 };
 use wasmer_runtime_core::{
@@ -33,8 +31,8 @@ use wasmer_runtime_core::{
         TableIndex, Type,
     },
     vm::{self, LocalGlobal, LocalTable, INTERNALS_SIZE},
+    wasmparser::{MemoryImmediate, Operator, Type as WpType, TypeOrFuncType as WpTypeOrFuncType},
 };
-use wasmparser::{MemoryImmediate, Operator, Type as WpType, TypeOrFuncType as WpTypeOrFuncType};
 
 lazy_static! {
     /// Performs a System V call to `target` with [stack_top..stack_base] as the argument list, from right to left.

--- a/lib/singlepass-backend/src/machine.rs
+++ b/lib/singlepass-backend/src/machine.rs
@@ -1,9 +1,10 @@
 use crate::emitter_x64::*;
 use smallvec::SmallVec;
 use std::collections::HashSet;
-use wasmer_runtime_core::state::x64::X64Register;
-use wasmer_runtime_core::state::*;
-use wasmparser::Type as WpType;
+use wasmer_runtime_core::{
+    state::{x64::X64Register, *},
+    wasmparser::Type as WpType,
+};
 
 struct MachineStackOffset(usize);
 


### PR DESCRIPTION
The `wasmer-runtime-core` crate re-exports the `wasmparser`
crate. This patch updates the `singlepass-backend` crate to use
`wasmparser` through the `wasmer-runtime-core` crate, which removes a
direct dependency for this crate.