### PR TITLE
Set target triple and datalayout when creating the LLVM module.

### DIFF
--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -4,8 +4,7 @@ use crate::structs::{Callbacks, LLVMModule, LLVMResult, MemProtect};
 use inkwell::{
     memory_buffer::MemoryBuffer,
     module::Module,
-    targets::{CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine},
-    OptimizationLevel,
+    targets::{FileType, TargetMachine},
 };
 use libc::c_char;
 use std::{
@@ -172,28 +171,8 @@ impl LLVMBackend {
         _intrinsics: Intrinsics,
         _stackmaps: &StackmapRegistry,
         _module_info: &ModuleInfo,
+        target_machine: &TargetMachine,
     ) -> (Self, LLVMCache) {
-        Target::initialize_x86(&InitializationConfig {
-            asm_parser: true,
-            asm_printer: true,
-            base: true,
-            disassembler: true,
-            info: true,
-            machine_code: true,
-        });
-        let triple = TargetMachine::get_default_triple().to_string();
-        let target = Target::from_triple(&triple).unwrap();
-        let target_machine = target
-            .create_target_machine(
-                &triple,
-                &TargetMachine::get_host_cpu_name().to_string(),
-                &TargetMachine::get_host_cpu_features().to_string(),
-                OptimizationLevel::Aggressive,
-                RelocMode::Static,
-                CodeModel::Large,
-            )
-            .unwrap();
-
         let memory_buffer = target_machine
             .write_to_memory_buffer(&module, FileType::Object)
             .unwrap();

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -3,12 +3,13 @@ use inkwell::{
     context::Context,
     module::{Linkage, Module},
     passes::PassManager,
+    targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetMachine},
     types::{BasicType, BasicTypeEnum, FunctionType, PointerType, VectorType},
     values::{
         BasicValue, BasicValueEnum, FloatValue, FunctionValue, IntValue, PhiValue, PointerValue,
         VectorValue,
     },
-    AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate,
+    AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate, OptimizationLevel,
 };
 use smallvec::SmallVec;
 use std::cell::RefCell;
@@ -677,6 +678,7 @@ pub struct LLVMModuleCodeGenerator {
     module: Module,
     stackmaps: Rc<RefCell<StackmapRegistry>>,
     track_state: bool,
+    target_machine: TargetMachine,
 }
 
 pub struct LLVMFunctionCodeGenerator {
@@ -7234,6 +7236,31 @@ impl ModuleCodeGenerator<LLVMFunctionCodeGenerator, LLVMBackend, CodegenError>
     fn new() -> LLVMModuleCodeGenerator {
         let context = Context::create();
         let module = context.create_module("module");
+
+        Target::initialize_x86(&InitializationConfig {
+            asm_parser: true,
+            asm_printer: true,
+            base: true,
+            disassembler: true,
+            info: true,
+            machine_code: true,
+        });
+        let triple = TargetMachine::get_default_triple().to_string();
+        let target = Target::from_triple(&triple).unwrap();
+        let target_machine = target
+            .create_target_machine(
+                &triple,
+                &TargetMachine::get_host_cpu_name().to_string(),
+                &TargetMachine::get_host_cpu_features().to_string(),
+                OptimizationLevel::Aggressive,
+                RelocMode::Static,
+                CodeModel::Large,
+            )
+            .unwrap();
+
+        module.set_target(&target);
+        module.set_data_layout(&target_machine.get_target_data().get_data_layout());
+
         let builder = context.create_builder();
 
         let intrinsics = Intrinsics::declare(&module, &context);
@@ -7259,6 +7286,7 @@ impl ModuleCodeGenerator<LLVMFunctionCodeGenerator, LLVMBackend, CodegenError>
             personality_func,
             stackmaps: Rc::new(RefCell::new(StackmapRegistry::default())),
             track_state: false,
+            target_machine: target_machine,
         }
     }
 
@@ -7430,6 +7458,7 @@ impl ModuleCodeGenerator<LLVMFunctionCodeGenerator, LLVMBackend, CodegenError>
             self.intrinsics.take().unwrap(),
             &*stackmaps,
             module_info,
+            &self.target_machine,
         );
         Ok((backend, Box::new(cache_gen)))
     }


### PR DESCRIPTION
We were giving LLVM a triple and datalayout only when producing native code from the LLVM IR. With this change, we tell LLVM as early as possible so that the entire optimization stack knows that it's safe to use target-specific constructs (including target intrinsics `@llvm.x86.sse2.ucomieq.sd`) as well as cost models (for autovectorization) and knowing the bitwidth of the registers so that we can know it's profitable to eliminate redundant extend/truncate casts.