### PR TITLE
Use printf portably.

### DIFF
--- a/lib/runtime-c-api/tests/test-exports.c
+++ b/lib/runtime-c-api/tests/test-exports.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include "../wasmer.h"
 #include <assert.h>
@@ -242,7 +243,7 @@ int main()
 
         wasmer_result_t call_result = wasmer_export_func_call(exported_function, inputs, inputs_arity, outputs, outputs_arity);
 
-        printf("Result: %lld\n", outputs[0].value.I64);
+        printf("Result: %" PRId64 "\n", outputs[0].value.I64);
 
         assert(outputs[0].value.I64 == 7);
         assert(call_result == WASMER_OK);


### PR DESCRIPTION
PRId64 is defined to the right printf format string to print a int64_t on the current system.
