### PR TITLE
Fix bug in getting a Memory from export in C API

### DIFF
--- a/lib/runtime-c-api/src/export.rs
+++ b/lib/runtime-c-api/src/export.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use libc::{c_int, c_uint};
 use std::{ptr, slice};
-use wasmer_runtime::{Instance, Memory, Module, Value};
+use wasmer_runtime::{Instance, Module, Value};
 use wasmer_runtime_core::{export::Export, module::ExportIndex};
 
 /// Intermediate representation of an `Export` instance that is
@@ -355,7 +355,8 @@ pub unsafe extern "C" fn wasmer_export_to_memory(
     let export = &named_export.export;
 
     if let Export::Memory(exported_memory) = export {
-        *memory = exported_memory as *const Memory as *mut wasmer_memory_t;
+        let mem = Box::new(exported_memory.clone());
+        *memory = Box::into_raw(mem) as *mut wasmer_memory_t;
         wasmer_result_t::WASMER_OK
     } else {
         update_last_error(CApiError {


### PR DESCRIPTION
I believe this fixes the non-deterministic crashing on OSX in `go-ext-wasm`