### PR TITLE
fix(runtime-core) Share the definition of `Trampoline` across all the backends

### DIFF
--- a/lib/clif-backend/src/signal/mod.rs
+++ b/lib/clif-backend/src/signal/mod.rs
@@ -1,12 +1,14 @@
-use crate::relocation::{TrapData, TrapSink};
-use crate::resolver::FuncResolver;
-use crate::trampoline::Trampolines;
+use crate::{
+    relocation::{TrapData, TrapSink},
+    resolver::FuncResolver,
+    trampoline::Trampolines,
+};
 use libc::c_void;
 use std::{any::Any, cell::Cell, ptr::NonNull, sync::Arc};
 use wasmer_runtime_core::{
     backend::RunnableModule,
     module::ModuleInfo,
-    typed_func::{Wasm, WasmTrapInfo},
+    typed_func::{Trampoline, Wasm, WasmTrapInfo},
     types::{LocalFuncIndex, SigIndex},
     vm,
 };
@@ -59,7 +61,7 @@ impl RunnableModule for Caller {
 
     fn get_trampoline(&self, _: &ModuleInfo, sig_index: SigIndex) -> Option<Wasm> {
         unsafe extern "C" fn invoke(
-            trampoline: unsafe extern "C" fn(*mut vm::Ctx, NonNull<vm::Func>, *const u64, *mut u64),
+            trampoline: Trampoline,
             ctx: *mut vm::Ctx,
             func: NonNull<vm::Func>,
             args: *const u64,

--- a/lib/clif-backend/src/signal/windows.rs
+++ b/lib/clif-backend/src/signal/windows.rs
@@ -1,24 +1,30 @@
-use crate::relocation::{TrapCode, TrapData};
-use crate::signal::{CallProtError, HandlerData};
-use crate::trampoline::Trampoline;
-use std::cell::Cell;
-use std::ffi::c_void;
-use std::ptr::{self, NonNull};
-use wasmer_runtime_core::typed_func::WasmTrapInfo;
-use wasmer_runtime_core::vm::Ctx;
-use wasmer_runtime_core::vm::Func;
+use crate::{
+    relocation::{TrapCode, TrapData},
+    signal::{CallProtError, HandlerData},
+};
+use std::{
+    cell::Cell,
+    ffi::c_void,
+    ptr::{self, NonNull},
+};
+use wasmer_runtime_core::{
+    typed_func::{Trampoline, WasmTrapInfo},
+    vm::{Ctx, Func},
+};
 use wasmer_win_exception_handler::CallProtectedData;
 pub use wasmer_win_exception_handler::_call_protected;
-use winapi::shared::minwindef::DWORD;
-use winapi::um::minwinbase::{
-    EXCEPTION_ACCESS_VIOLATION, EXCEPTION_ARRAY_BOUNDS_EXCEEDED, EXCEPTION_BREAKPOINT,
-    EXCEPTION_DATATYPE_MISALIGNMENT, EXCEPTION_FLT_DENORMAL_OPERAND, EXCEPTION_FLT_DIVIDE_BY_ZERO,
-    EXCEPTION_FLT_INEXACT_RESULT, EXCEPTION_FLT_INVALID_OPERATION, EXCEPTION_FLT_OVERFLOW,
-    EXCEPTION_FLT_STACK_CHECK, EXCEPTION_FLT_UNDERFLOW, EXCEPTION_GUARD_PAGE,
-    EXCEPTION_ILLEGAL_INSTRUCTION, EXCEPTION_INT_DIVIDE_BY_ZERO, EXCEPTION_INT_OVERFLOW,
-    EXCEPTION_INVALID_HANDLE, EXCEPTION_IN_PAGE_ERROR, EXCEPTION_NONCONTINUABLE_EXCEPTION,
-    EXCEPTION_POSSIBLE_DEADLOCK, EXCEPTION_PRIV_INSTRUCTION, EXCEPTION_SINGLE_STEP,
-    EXCEPTION_STACK_OVERFLOW,
+use winapi::{
+    shared::minwindef::DWORD,
+    um::minwinbase::{
+        EXCEPTION_ACCESS_VIOLATION, EXCEPTION_ARRAY_BOUNDS_EXCEEDED, EXCEPTION_BREAKPOINT,
+        EXCEPTION_DATATYPE_MISALIGNMENT, EXCEPTION_FLT_DENORMAL_OPERAND,
+        EXCEPTION_FLT_DIVIDE_BY_ZERO, EXCEPTION_FLT_INEXACT_RESULT,
+        EXCEPTION_FLT_INVALID_OPERATION, EXCEPTION_FLT_OVERFLOW, EXCEPTION_FLT_STACK_CHECK,
+        EXCEPTION_FLT_UNDERFLOW, EXCEPTION_GUARD_PAGE, EXCEPTION_ILLEGAL_INSTRUCTION,
+        EXCEPTION_INT_DIVIDE_BY_ZERO, EXCEPTION_INT_OVERFLOW, EXCEPTION_INVALID_HANDLE,
+        EXCEPTION_IN_PAGE_ERROR, EXCEPTION_NONCONTINUABLE_EXCEPTION, EXCEPTION_POSSIBLE_DEADLOCK,
+        EXCEPTION_PRIV_INSTRUCTION, EXCEPTION_SINGLE_STEP, EXCEPTION_STACK_OVERFLOW,
+    },
 };
 
 thread_local! {

--- a/lib/clif-backend/src/trampoline.rs
+++ b/lib/clif-backend/src/trampoline.rs
@@ -1,18 +1,16 @@
-use crate::cache::TrampolineCache;
-use crate::resolver::NoopStackmapSink;
+use crate::{cache::TrampolineCache, resolver::NoopStackmapSink};
 use cranelift_codegen::{
     binemit::{NullTrapSink, Reloc, RelocSink},
     cursor::{Cursor, FuncCursor},
     ir::{self, InstBuilder},
     isa, Context,
 };
-use std::collections::HashMap;
-use std::{iter, mem, ptr::NonNull};
+use std::{collections::HashMap, iter, mem};
 use wasmer_runtime_core::{
     backend::sys::{Memory, Protect},
     module::{ExportIndex, ModuleInfo},
+    typed_func::Trampoline,
     types::{FuncSig, SigIndex, Type},
-    vm,
 };
 
 struct NullRelocSink {}
@@ -27,8 +25,6 @@ impl RelocSink for NullRelocSink {
 
     fn reloc_jt(&mut self, _: u32, _: Reloc, _: ir::JumpTable) {}
 }
-
-pub type Trampoline = unsafe extern "C" fn(*mut vm::Ctx, NonNull<vm::Func>, *const u64, *mut u64);
 
 pub struct Trampolines {
     memory: Memory,

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -52,16 +52,21 @@ impl fmt::Display for WasmTrapInfo {
 /// of the `Func` struct.
 pub trait Kind {}
 
-pub type Trampoline = unsafe extern "C" fn(*mut Ctx, NonNull<vm::Func>, *const u64, *mut u64);
+pub type Trampoline = unsafe extern "C" fn(
+    vmctx: *mut Ctx,
+    func: NonNull<vm::Func>,
+    args: *const u64,
+    rets: *mut u64,
+);
 pub type Invoke = unsafe extern "C" fn(
-    Trampoline,
-    *mut Ctx,
-    NonNull<vm::Func>,
-    *const u64,
-    *mut u64,
-    *mut WasmTrapInfo,
-    *mut Option<Box<dyn Any>>,
-    Option<NonNull<c_void>>,
+    trampoline: Trampoline,
+    vmctx: *mut Ctx,
+    func: NonNull<vm::Func>,
+    args: *const u64,
+    rets: *mut u64,
+    trap_info: *mut WasmTrapInfo,
+    user_error: *mut Option<Box<dyn Any>>,
+    extra: Option<NonNull<c_void>>,
 ) -> bool;
 
 /// TODO(lachlan): Naming TBD.

--- a/lib/win-exception-handler/src/exception_handling.rs
+++ b/lib/win-exception-handler/src/exception_handling.rs
@@ -1,7 +1,9 @@
 use std::ptr::NonNull;
-use wasmer_runtime_core::vm::{Ctx, Func};
+use wasmer_runtime_core::{
+    typed_func::Trampoline,
+    vm::{Ctx, Func},
+};
 
-type Trampoline = unsafe extern "C" fn(*mut Ctx, NonNull<Func>, *const u64, *mut u64);
 type CallProtectedResult = Result<(), CallProtectedData>;
 
 #[repr(C)]


### PR DESCRIPTION
Extracted from https://github.com/wasmerio/wasmer/pull/882.

This patch updates all the backends to use the definition of
`Trampoline` as defined in the `wasmer_runtime_core::typed_func`
module. That way, there is no copy of that type, and as such, it is
easier to avoid regression (a simple `cargo check` does the job).

This patch also formats the `use` statements in the updated files.
