### PR TITLE
feat(runtime-core-tests) Introduce the new `wasmer-runtime-core-tests` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-runtime-core-tests"
+version = "0.8.0"
+dependencies = [
+ "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmer-clif-backend 0.9.0",
+ "wasmer-llvm-backend 0.9.0",
+ "wasmer-runtime-core 0.9.0",
+ "wasmer-singlepass-backend 0.9.0",
+]
+
+[[package]]
 name = "wasmer-singlepass-backend"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "lib/singlepass-backend",
     "lib/runtime",
     "lib/runtime-core",
+    "lib/runtime-core-tests",
     "lib/emscripten",
     "lib/spectests",
     "lib/win-exception-handler",

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ generate: generate-spectests generate-emtests generate-wasitests
 
 # Spectests
 spectests-singlepass:
-	cargo +nightly test --manifest-path lib/spectests/Cargo.toml --release --features singlepass -- --nocapture
+	cargo test --manifest-path lib/spectests/Cargo.toml --release --features singlepass -- --nocapture
 
 spectests-cranelift:
 	cargo test --manifest-path lib/spectests/Cargo.toml --release --features clif -- --nocapture
@@ -88,8 +88,8 @@ wasitests: wasitests-unit wasitests-singlepass wasitests-cranelift wasitests-llv
 
 # Backends
 singlepass: spectests-singlepass emtests-singlepass middleware-singlepass wasitests-singlepass
-	cargo +nightly test -p wasmer-singlepass-backend --release
-	cargo +nightly test -p wasmer-runtime-core-tests --release --no-default-features --features backend-singlepass
+	cargo test -p wasmer-singlepass-backend --release
+	cargo test -p wasmer-runtime-core-tests --release --no-default-features --features backend-singlepass
 
 cranelift: spectests-cranelift emtests-cranelift middleware-cranelift wasitests-cranelift
 	cargo test -p wasmer-clif-backend --release

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ generate: generate-spectests generate-emtests generate-wasitests
 
 # Spectests
 spectests-singlepass:
-	cargo test --manifest-path lib/spectests/Cargo.toml --release --features singlepass -- --nocapture
+	cargo +nightly test --manifest-path lib/spectests/Cargo.toml --release --features singlepass -- --nocapture
 
 spectests-cranelift:
 	cargo test --manifest-path lib/spectests/Cargo.toml --release --features clif -- --nocapture
@@ -88,13 +88,16 @@ wasitests: wasitests-unit wasitests-singlepass wasitests-cranelift wasitests-llv
 
 # Backends
 singlepass: spectests-singlepass emtests-singlepass middleware-singlepass wasitests-singlepass
-	cargo test -p wasmer-singlepass-backend --release
+	cargo +nightly test -p wasmer-singlepass-backend --release
+	cargo +nightly test -p wasmer-runtime-core-tests --release --no-default-features --features backend-singlepass
 
 cranelift: spectests-cranelift emtests-cranelift middleware-cranelift wasitests-cranelift
 	cargo test -p wasmer-clif-backend --release
+	cargo test -p wasmer-runtime-core-tests --release
 
 llvm: spectests-llvm emtests-llvm wasitests-llvm
 	cargo test -p wasmer-llvm-backend --release
+	cargo test -p wasmer-runtime-core-tests --release --no-default-features --features backend-llvm
 
 
 # All tests
@@ -108,7 +111,20 @@ test-capi: capi
 capi-test: test-capi
 
 test-rest:
-	cargo test --release --all --exclude wasmer-runtime-c-api --exclude wasmer-emscripten --exclude wasmer-spectests --exclude wasmer-wasi --exclude wasmer-middleware-common --exclude wasmer-middleware-common-tests --exclude wasmer-singlepass-backend --exclude wasmer-clif-backend --exclude wasmer-llvm-backend --exclude wasmer-wasi-tests --exclude wasmer-emscripten-tests
+	cargo test --release \
+		--all \
+		--exclude wasmer-runtime-c-api \
+		--exclude wasmer-emscripten \
+		--exclude wasmer-spectests \
+		--exclude wasmer-wasi \
+		--exclude wasmer-middleware-common \
+		--exclude wasmer-middleware-common-tests \
+		--exclude wasmer-singlepass-backend \
+		--exclude wasmer-clif-backend \
+		--exclude wasmer-llvm-backend \
+		--exclude wasmer-wasi-tests \
+		--exclude wasmer-emscripten-tests \
+		--exclude wasmer-runtime-core-tests
 
 circleci-clean:
 	@if [ ! -z "${CIRCLE_JOB}" ]; then rm -f /home/circleci/project/target/debug/deps/libcranelift_wasm* && rm -f /Users/distiller/project/target/debug/deps/libcranelift_wasm*; fi;

--- a/lib/runtime-core-tests/Cargo.toml
+++ b/lib/runtime-core-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime-core-tests"
-version = "0.8.0"
+version = "0.9.0"
 description = "Tests for the Wasmer runtime core crate"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/lib/runtime-core-tests/Cargo.toml
+++ b/lib/runtime-core-tests/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "wasmer-runtime-core-tests"
+version = "0.8.0"
+description = "Tests for the Wasmer runtime core crate"
+license = "MIT"
+authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+wabt = "0.9.1"
+wasmer-runtime-core = { path = "../runtime-core", version = "0.9" }
+wasmer-clif-backend = { path = "../clif-backend", version = "0.9", optional = true }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.9", optional = true }
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.9", optional = true }
+
+[features]
+default = ["backend-cranelift"]
+backend-cranelift = ["wasmer-clif-backend"]
+backend-singlepass = ["wasmer-singlepass-backend"]
+backend-llvm = ["wasmer-llvm-backend"]

--- a/lib/runtime-core-tests/src/lib.rs
+++ b/lib/runtime-core-tests/src/lib.rs
@@ -1,0 +1,21 @@
+pub use wabt::wat2wasm;
+use wasmer_runtime_core::backend::Compiler;
+
+#[cfg(feature = "backend-cranelift")]
+pub fn get_compiler() -> impl Compiler {
+    use wasmer_clif_backend::CraneliftCompiler;
+
+    CraneliftCompiler::new()
+}
+
+#[cfg(feature = "backend-singlepass")]
+pub fn get_compiler() -> impl Compiler {
+    use wasmer_singlepass_backend::SinglePassCompiler;
+    SinglePassCompiler::new()
+}
+
+#[cfg(feature = "backend-llvm")]
+pub fn get_compiler() -> impl Compiler {
+    use wasmer_llvm_backend::LLVMCompiler;
+    LLVMCompiler::new()
+}

--- a/lib/runtime-core-tests/tests/imports.rs
+++ b/lib/runtime-core-tests/tests/imports.rs
@@ -1,0 +1,112 @@
+use wasmer_runtime_core::{
+    compile_with, error::RuntimeError, imports, memory::Memory, typed_func::Func,
+    types::MemoryDescriptor, units::Pages, vm,
+};
+use wasmer_runtime_core_tests::{get_compiler, wat2wasm};
+
+#[test]
+fn imported_functions_forms() {
+    const MODULE: &str = r#"
+(module
+  (type $type (func (param i32) (result i32)))
+  (import "env" "memory" (memory 1 1))
+  (import "env" "callback_fn_with_vmctx" (func $callback_fn_with_vmctx (type $type)))
+  (import "env" "callback_fn_trap_with_vmctx" (func $callback_fn_trap_with_vmctx (type $type)))
+  (func (export "function_fn_with_vmctx") (type $type)
+    get_local 0
+    call $callback_fn_with_vmctx)
+  (func (export "function_fn_trap_with_vmctx") (type $type)
+    get_local 0
+    call $callback_fn_trap_with_vmctx))
+"#;
+
+    let wasm_binary = wat2wasm(MODULE.as_bytes()).expect("WAST not valid or malformed");
+    let module = compile_with(&wasm_binary, &get_compiler()).unwrap();
+    let memory_descriptor = MemoryDescriptor::new(Pages(1), Some(Pages(1)), false).unwrap();
+    let memory = Memory::new(memory_descriptor).unwrap();
+
+    const SHIFT: i32 = 10;
+    memory.view()[0].set(SHIFT);
+
+    let import_object = imports! {
+        "env" => {
+            "memory" => memory.clone(),
+            "callback_fn_with_vmctx" => Func::new(callback_fn_with_vmctx),
+            "callback_fn_trap_with_vmctx" => Func::new(callback_fn_trap_with_vmctx),
+        },
+    };
+    let instance = module.instantiate(&import_object).unwrap();
+
+    macro_rules! call_and_assert {
+        ($function:ident, $expected_value:expr) => {
+            let $function: Func<i32, i32> = instance.func(stringify!($function)).unwrap();
+
+            let result = $function.call(1);
+
+            match (result, $expected_value) {
+                (Ok(value), expected_value) => assert_eq!(
+                    Ok(value),
+                    expected_value,
+                    concat!("Expected right when calling `", stringify!($function), "`.")
+                ),
+                (
+                    Err(RuntimeError::Error { data }),
+                    Err(RuntimeError::Error {
+                        data: expected_data,
+                    }),
+                ) => {
+                    if let (Some(data), Some(expected_data)) = (
+                        data.downcast_ref::<&str>(),
+                        expected_data.downcast_ref::<&str>(),
+                    ) {
+                        assert_eq!(
+                            data, expected_data,
+                            concat!("Expected right when calling `", stringify!($function), "`.")
+                        )
+                    } else if let (Some(data), Some(expected_data)) = (
+                        data.downcast_ref::<String>(),
+                        expected_data.downcast_ref::<String>(),
+                    ) {
+                        assert_eq!(
+                            data, expected_data,
+                            concat!("Expected right when calling `", stringify!($function), "`.")
+                        )
+                    } else {
+                        assert!(false, "Unexpected error, cannot compare it.")
+                    }
+                }
+                (result, expected_value) => assert!(
+                    false,
+                    format!(
+                        "Unexpected assertion for `{}`: left = `{:?}`, right = `{:?}`.",
+                        stringify!($function),
+                        result,
+                        expected_value
+                    )
+                ),
+            }
+        };
+    }
+
+    call_and_assert!(function_fn_with_vmctx, Ok(2 + SHIFT));
+    call_and_assert!(
+        function_fn_trap_with_vmctx,
+        Err(RuntimeError::Error {
+            data: Box::new(format!("baz {}", 2 + SHIFT))
+        })
+    );
+}
+
+fn callback_fn_with_vmctx(vmctx: &mut vm::Ctx, n: i32) -> Result<i32, ()> {
+    let memory = vmctx.memory(0);
+    let shift: i32 = memory.view()[0].get();
+
+    Ok(shift + n + 1)
+}
+
+fn callback_fn_trap_with_vmctx(vmctx: &mut vm::Ctx, n: i32) -> Result<i32, String> {
+    let memory = vmctx.memory(0);
+    let shift: i32 = memory.view()[0].get();
+
+    Err(format!("baz {}", shift + n + 1))
+}


### PR DESCRIPTION
Extracted from https://github.com/wasmerio/wasmer/pull/882.

This non-publishable new crate contains a test suite for the
`wasmer-runtime-core` crate. So far, the test suite is rather small,
but it aims to be extended in a close future.