### PR TITLE
feat(runtime-core) Host function without a `vm::Ctx` argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-tests"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-backend 0.9.0",

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -131,10 +131,32 @@ pub trait WasmTypeList {
 }
 
 /// Empty trait to specify the kind of `ExternalFunction`: With or
-/// without a `vm::Ctx` argument.
+/// without a `vm::Ctx` argument. See the `ExplicitVmCtx` and the
+/// `ImplicitVmCtx` structures.
+///
+/// This type is never aimed to be used by a user. It is used by the
+/// trait system to automatically generate an appropriate `wrap`
+/// function.
 pub trait ExternalFunctionKind {}
 
+/// This empty structure indicates that an external function must
+/// contain an explicit `vm::Ctx` argument (at first position).
+///
+/// ```rs,ignore
+/// fn add_one(_: mut &vm::Ctx, x: i32) -> i32 {
+///     x + 1
+/// }
+/// ```
 pub struct ExplicitVmCtx {}
+
+/// This empty structure indicates that an external function has no
+/// `vm::Ctx` argument (at first position). Its signature is:
+///
+/// ```rs,ignore
+/// fn add_one(x: i32) -> i32 {
+///     x + 1
+/// }
+/// ```
 pub struct ImplicitVmCtx {}
 
 impl ExternalFunctionKind for ExplicitVmCtx {}

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -643,7 +643,12 @@ mod tests {
                     vec![$($x),*].iter().sum()
                 }
 
+                fn without_vmctx($($x: i32),*) -> i32 {
+                    vec![$($x),*].iter().sum()
+                }
+
                 let _func = Func::new(with_vmctx);
+                let _func = Func::new(without_vmctx);
             }
         }
     }
@@ -654,7 +659,12 @@ mod tests {
             0
         }
 
+        fn bar() -> i32 {
+            0
+        }
+
         let _ = Func::new(foo);
+        let _ = Func::new(bar);
     }
 
     test_func_arity_n!(test_func_arity_1, a);

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -562,6 +562,44 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    macro_rules! test_func_arity_n {
+        ($test_name:ident, $($x:ident),*) => {
+            #[test]
+            fn $test_name() {
+                use crate::vm;
+
+                fn with_vmctx(_: &mut vm::Ctx, $($x: i32),*) -> i32 {
+                    vec![$($x),*].iter().sum()
+                }
+
+                let _func = Func::new(with_vmctx);
+            }
+        }
+    }
+
+    #[test]
+    fn test_func_arity_0() {
+        fn foo(_: &mut vm::Ctx) -> i32 {
+            0
+        }
+
+        let _ = Func::new(foo);
+    }
+
+    test_func_arity_n!(test_func_arity_1, a);
+    test_func_arity_n!(test_func_arity_2, a, b);
+    test_func_arity_n!(test_func_arity_3, a, b, c);
+    test_func_arity_n!(test_func_arity_4, a, b, c, d);
+    test_func_arity_n!(test_func_arity_5, a, b, c, d, e);
+    test_func_arity_n!(test_func_arity_6, a, b, c, d, e, f);
+    test_func_arity_n!(test_func_arity_7, a, b, c, d, e, f, g);
+    test_func_arity_n!(test_func_arity_8, a, b, c, d, e, f, g, h);
+    test_func_arity_n!(test_func_arity_9, a, b, c, d, e, f, g, h, i);
+    test_func_arity_n!(test_func_arity_10, a, b, c, d, e, f, g, h, i, j);
+    test_func_arity_n!(test_func_arity_11, a, b, c, d, e, f, g, h, i, j, k);
+    test_func_arity_n!(test_func_arity_12, a, b, c, d, e, f, g, h, i, j, k, l);
+
     #[test]
     fn test_call() {
         fn foo(_ctx: &mut vm::Ctx, a: i32, b: i32) -> (i32, i32) {


### PR DESCRIPTION
Extracted from https://github.com/wasmerio/wasmer/pull/882.
~Includes https://github.com/wasmerio/wasmer/pull/916. Must not be merged until #916 lands in `master`.~
~If you want to compare only the different commits, see https://github.com/Hywan/wasmer/compare/feat-runtime-core-tests...Hywan:feat-runtime-core-host-function-without-vmctx?expand=1.~

This patch updates the `ExternalFunction` implementation to support host functions (aka imported functions) without having an explicit `vm::Ctx` argument.

It is thus possible to write:

```rust
fn add_one(x: i32) -> i32 {
    x + 1
}

let import_object = imports! {
    "env" => {
        "add_one" => func!(add_one);
    },
};
```

The previous form is still working though:

```rust
fn add_one(_: &mut vm::Ctx, x: i32) -> i32 {
    x + 1
}
```

The backends aren't modified. It means that the pointer to `vm::Ctx` is still inserted in the stack, but it is not used when the function doesn't need it.

We thought this is an acceptable trade-off.

About the C API. It has not check to ensure the type signature. Since the pointer to `vm::Ctx` is always inserted, the C API can digest host functions with or without a `vm::Ctx` argument. The C API uses [the `Export` + `FuncPointer` API](https://github.com/wasmerio/wasmer/blob/cf5b3cc09eff149ce415bd81846d84b2d2cdf3a3/lib/runtime-c-api/src/import/mod.rs#L630-L653) instead of going through the `Func` API (which is modified by this API), which is only possible since the C API only receives an opaque function pointer. Conclusion is: We can't ensure anything on the C side, but it will work with or without the `vm::Ctx` argument in theory.