### PR TITLE
Apply TBAA metadata in the LLVM backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#921](https://github.com/wasmerio/wasmer/pull/921) In LLVM backend, annotate all memory accesses with TBAA metadata.
 - [#883](https://github.com/wasmerio/wasmer/pull/883) Allow floating point operations to have arbitrary inputs, even including SNaNs.
 - [#856](https://github.com/wasmerio/wasmer/pull/856) Expose methods in the runtime C API to get a WASI import object
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.1.0"
-source = "git+https://github.com/wasmerio/inkwell?branch=llvm8-0#57e192cdccd6cde6ee5ee0a7e0b280490126d5c6"
+source = "git+https://github.com/wasmerio/inkwell?branch=llvm8-0#10d180807ce6e621ae13d74001bf5677b0e1f179"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-methods 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internal_macros"
 version = "0.1.0"
-source = "git+https://github.com/wasmerio/inkwell?branch=llvm8-0#57e192cdccd6cde6ee5ee0a7e0b280490126d5c6"
+source = "git+https://github.com/wasmerio/inkwell?branch=llvm8-0#10d180807ce6e621ae13d74001bf5677b0e1f179"
 dependencies = [
  "cargo_toml 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -9,12 +9,14 @@ use inkwell::{
 use libc::c_char;
 use std::{
     any::Any,
+    cell::RefCell,
     ffi::{c_void, CString},
     fs::File,
     io::Write,
     mem,
     ops::Deref,
     ptr::{self, NonNull},
+    rc::Rc,
     slice, str,
     sync::{Arc, Once},
 };
@@ -167,14 +169,14 @@ pub struct LLVMBackend {
 
 impl LLVMBackend {
     pub fn new(
-        module: Module,
+        module: Rc<RefCell<Module>>,
         _intrinsics: Intrinsics,
         _stackmaps: &StackmapRegistry,
         _module_info: &ModuleInfo,
         target_machine: &TargetMachine,
     ) -> (Self, LLVMCache) {
         let memory_buffer = target_machine
-            .write_to_memory_buffer(&module, FileType::Object)
+            .write_to_memory_buffer(&module.borrow_mut(), FileType::Object)
             .unwrap();
         let mem_buf_slice = memory_buffer.as_slice();
 

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -7316,15 +7316,13 @@ impl ModuleCodeGenerator<LLVMFunctionCodeGenerator, LLVMBackend, CodegenError>
             Some(Linkage::External),
         );
 
-        let signatures = Map::new();
-
         LLVMModuleCodeGenerator {
             context: Some(context),
             builder: Some(builder),
             intrinsics: Some(intrinsics),
             module,
             functions: vec![],
-            signatures,
+            signatures: Map::new(),
             signatures_raw: Map::new(),
             function_signatures: None,
             func_import_count: 0,

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -577,16 +577,16 @@ fn resolve_memory_ptr(
             tbaa_label(
                 module.clone(),
                 intrinsics,
-                "context_field_ptr_to_base",
+                "dynamic_memory_base",
                 base.as_instruction_value().unwrap(),
-                None,
+                Some(0),
             );
             tbaa_label(
                 module.clone(),
                 intrinsics,
-                "context_field_ptr_to_bounds",
+                "dynamic_memory_bounds",
                 bounds.as_instruction_value().unwrap(),
-                None,
+                Some(0),
             );
             (base, bounds)
         }

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -5787,6 +5787,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -5822,6 +5829,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -5855,6 +5869,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I64AtomicRmw8UAdd { ref memarg } => {
@@ -5889,6 +5910,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -5924,6 +5952,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -5959,6 +5994,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -5992,6 +6034,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I32AtomicRmw8USub { ref memarg } => {
@@ -6026,6 +6075,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6061,6 +6117,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6094,6 +6157,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I64AtomicRmw8USub { ref memarg } => {
@@ -6128,6 +6198,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6163,6 +6240,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6198,6 +6282,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6231,6 +6322,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I32AtomicRmw8UAnd { ref memarg } => {
@@ -6265,6 +6363,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6300,6 +6405,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6333,6 +6445,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I64AtomicRmw8UAnd { ref memarg } => {
@@ -6367,6 +6486,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6402,6 +6528,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6437,6 +6570,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6470,6 +6610,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I32AtomicRmw8UOr { ref memarg } => {
@@ -6504,6 +6651,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6539,6 +6693,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6572,6 +6733,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6607,6 +6775,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6642,6 +6817,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6677,6 +6859,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6710,6 +6899,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I32AtomicRmw8UXor { ref memarg } => {
@@ -6744,6 +6940,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6779,6 +6982,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6812,6 +7022,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I64AtomicRmw8UXor { ref memarg } => {
@@ -6846,6 +7063,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6881,6 +7105,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6916,6 +7147,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -6949,6 +7187,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I32AtomicRmw8UXchg { ref memarg } => {
@@ -6983,6 +7228,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -7018,6 +7270,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i32_ty, &state.var_name());
                 state.push1(old);
             }
@@ -7051,6 +7310,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I64AtomicRmw8UXchg { ref memarg } => {
@@ -7085,6 +7351,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -7120,6 +7393,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -7155,6 +7435,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_int_z_extend(old, intrinsics.i64_ty, &state.var_name());
                 state.push1(old);
             }
@@ -7188,6 +7475,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 state.push1(old);
             }
             Operator::I32AtomicRmw8UCmpxchg { ref memarg } => {
@@ -7226,6 +7520,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder
                     .build_extract_value(old, 0, "")
                     .unwrap()
@@ -7269,6 +7570,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder
                     .build_extract_value(old, 0, "")
                     .unwrap()
@@ -7308,6 +7616,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_extract_value(old, 0, "").unwrap();
                 state.push1(old);
             }
@@ -7347,6 +7662,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder
                     .build_extract_value(old, 0, "")
                     .unwrap()
@@ -7390,6 +7712,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder
                     .build_extract_value(old, 0, "")
                     .unwrap()
@@ -7433,6 +7762,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder
                     .build_extract_value(old, 0, "")
                     .unwrap()
@@ -7472,6 +7808,13 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                         AtomicOrdering::SequentiallyConsistent,
                     )
                     .unwrap();
+                tbaa_label(
+                    self.module.clone(),
+                    intrinsics,
+                    "memory",
+                    old.as_instruction_value().unwrap(),
+                    Some(0),
+                );
                 let old = builder.build_extract_value(old, 0, "").unwrap();
                 state.push1(old);
             }

--- a/lib/llvm-backend/src/intrinsics.rs
+++ b/lib/llvm-backend/src/intrinsics.rs
@@ -1183,7 +1183,8 @@ pub fn tbaa_label(
     //
     // LLVM TBAA supports many features, but we use it in a simple way, with
     // only scalar types that are children of the root node. Every TBAA type we
-    // declare is `noalias` with the others:
+    // declare is NoAlias with the others. See NoAlias, PartialAlias,
+    // MayAlias and MustAlias in the LLVM documentation:
     //   https://llvm.org/docs/AliasAnalysis.html#must-may-and-no-alias-responses
 
     let module = module.borrow_mut();


### PR DESCRIPTION
# Description
Inform LLVM that the pointers to memory, globals, locals, etc., are distinct.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
