### PR TITLE
Add probable fix of memory leak in trampoline code

### DIFF
--- a/lib/runtime-c-api/src/trampoline.rs
+++ b/lib/runtime-c-api/src/trampoline.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn wasmer_trampoline_buffer_builder_build(
 #[allow(clippy::cast_ptr_alignment)]
 pub unsafe extern "C" fn wasmer_trampoline_buffer_destroy(buffer: *mut wasmer_trampoline_buffer_t) {
     if !buffer.is_null() {
-        Box::from_raw(buffer);
+        Box::from_raw(buffer as *mut TrampolineBuffer);
     }
 }
 


### PR DESCRIPTION
might be what's needed for #810 ; but despite my best efforts I could not get asan working on osx, so I did not test it.

By my count this accounts for 40 bytes, so there may be another issue

edit: unless Rust is optimizing out turning a zero-sized type into a Box, in which case, this should account for 48 bytes