### PR TITLE
In LLVM backend, track which floats are guaranteed to be arithmetic, which makes the canonicalization a no-op.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Special thanks to [@newpavlov](https://github.com/newpavlov) and [@Maxgy](https:
 - [#939](https://github.com/wasmerio/wasmer/pull/939) Fix bug causing attempts to append to files with WASI to delete the contents of the file
 - [#940](https://github.com/wasmerio/wasmer/pull/940) Update supported Rust version to 1.38+
 - [#923](https://github.com/wasmerio/wasmer/pull/923) Fix memory leak in the C API caused by an incorrect cast in `wasmer_trampoline_buffer_destroy`
+- [#934](https://github.com/wasmerio/wasmer/pull/934) Simplify float expressions in the LLVM backend.
 - [#921](https://github.com/wasmerio/wasmer/pull/921) In LLVM backend, annotate all memory accesses with TBAA metadata.
 - [#883](https://github.com/wasmerio/wasmer/pull/883) Allow floating point operations to have arbitrary inputs, even including SNaNs.
 - [#856](https://github.com/wasmerio/wasmer/pull/856) Expose methods in the runtime C API to get a WASI import object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#990](https://github.com/wasmerio/wasmer/pull/990) Default wasmer CLI to `run`.  Wasmer will now attempt to parse unrecognized command line options as if they were applied to the run command: `wasmer mywasm.wasm --dir=.` now works!
 - [#987](https://github.com/wasmerio/wasmer/pull/987) Fix `runtime-c-api` header files when compiled by gnuc.
 - [#957](https://github.com/wasmerio/wasmer/pull/957) Change the meaning of `wasmer_wasi::is_wasi_module` to detect any type of WASI module, add support for new wasi snapshot_preview1
+- [#934](https://github.com/wasmerio/wasmer/pull/934) Simplify float expressions in the LLVM backend.
 
 ## 0.10.2 - 2019-11-18
 
@@ -36,7 +37,6 @@ Special thanks to [@newpavlov](https://github.com/newpavlov) and [@Maxgy](https:
 - [#939](https://github.com/wasmerio/wasmer/pull/939) Fix bug causing attempts to append to files with WASI to delete the contents of the file
 - [#940](https://github.com/wasmerio/wasmer/pull/940) Update supported Rust version to 1.38+
 - [#923](https://github.com/wasmerio/wasmer/pull/923) Fix memory leak in the C API caused by an incorrect cast in `wasmer_trampoline_buffer_destroy`
-- [#934](https://github.com/wasmerio/wasmer/pull/934) Simplify float expressions in the LLVM backend.
 - [#921](https://github.com/wasmerio/wasmer/pull/921) In LLVM backend, annotate all memory accesses with TBAA metadata.
 - [#883](https://github.com/wasmerio/wasmer/pull/883) Allow floating point operations to have arbitrary inputs, even including SNaNs.
 - [#856](https://github.com/wasmerio/wasmer/pull/856) Expose methods in the runtime C API to get a WASI import object

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -2907,92 +2907,110 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
             Operator::F32Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let (i1, i2) = (i1.strip_pending(), i2.strip_pending());
+                let i1 = i1 | ExtraInfo::pending_f32_nan();
+                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f32_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F64Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let (i1, i2) = (i1.strip_pending(), i2.strip_pending());
+                let i1 = i1 | ExtraInfo::pending_f64_nan();
+                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f64_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F32x4Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f32x4(builder, intrinsics, v2, i2);
+                let i1 = i1 | ExtraInfo::pending_f32_nan();
+                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f32_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F64x2Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f64x2(builder, intrinsics, v2, i2);
+                let i1 = i1 | ExtraInfo::pending_f64_nan();
+                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f64_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F32Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let (i1, i2) = (i1.strip_pending(), i2.strip_pending());
+                let i1 = i1 | ExtraInfo::pending_f32_nan();
+                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f32_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F64Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let (i1, i2) = (i1.strip_pending(), i2.strip_pending());
+                let i1 = i1 | ExtraInfo::pending_f64_nan();
+                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f64_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F32x4Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f32x4(builder, intrinsics, v2, i2);
+                let i1 = i1 | ExtraInfo::pending_f32_nan();
+                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f32_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F64x2Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f64x2(builder, intrinsics, v2, i2);
+                let i1 = i1 | ExtraInfo::pending_f64_nan();
+                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f64_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F32Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let (i1, i2) = (i1.strip_pending(), i2.strip_pending());
+                let i1 = i1 | ExtraInfo::pending_f32_nan();
+                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f32_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F64Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let (i1, i2) = (i1.strip_pending(), i2.strip_pending());
+                let i1 = i1 | ExtraInfo::pending_f64_nan();
+                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f64_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F32x4Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f32x4(builder, intrinsics, v2, i2);
+                let i1 = i1 | ExtraInfo::pending_f32_nan();
+                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f32_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F64x2Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f64x2(builder, intrinsics, v2, i2);
+                let i1 = i1 | ExtraInfo::pending_f64_nan();
+                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, (i1 & i2) | ExtraInfo::pending_f64_nan());
+                state.push1_extra(res, i1 & i2);
             }
             Operator::F32Div => {
                 let (v1, v2) = state.pop2()?;
@@ -5527,24 +5545,72 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
             Operator::F32x4ReplaceLane { lane } => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
-                let v2 =
-                    apply_pending_canonicalization(builder, intrinsics, v2, i2).into_float_value();
-                let i2 = i2.strip_pending();
+                let push_pending_f32_nan_to_result =
+                    i1.has_pending_f32_nan() && i2.has_pending_f32_nan();
+                let (v1, v2) = if !push_pending_f32_nan_to_result {
+                    (
+                        apply_pending_canonicalization(
+                            builder,
+                            intrinsics,
+                            v1.as_basic_value_enum(),
+                            i1,
+                        )
+                        .into_vector_value(),
+                        apply_pending_canonicalization(
+                            builder,
+                            intrinsics,
+                            v2.as_basic_value_enum(),
+                            i2,
+                        )
+                        .into_float_value(),
+                    )
+                } else {
+                    (v1, v2.into_float_value())
+                };
                 let idx = intrinsics.i32_ty.const_int(lane.into(), false);
                 let res = builder.build_insert_element(v1, v2, idx, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2 & ExtraInfo::arithmetic_f32());
+                let info = if push_pending_f32_nan_to_result {
+                    ExtraInfo::pending_f32_nan()
+                } else {
+                    i1.strip_pending() & i2.strip_pending()
+                };
+                state.push1_extra(res, info);
             }
             Operator::F64x2ReplaceLane { lane } => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
-                let v2 =
-                    apply_pending_canonicalization(builder, intrinsics, v2, i2).into_float_value();
-                let i2 = i2.strip_pending();
+                let push_pending_f64_nan_to_result =
+                    i1.has_pending_f64_nan() && i2.has_pending_f64_nan();
+                let (v1, v2) = if !push_pending_f64_nan_to_result {
+                    (
+                        apply_pending_canonicalization(
+                            builder,
+                            intrinsics,
+                            v1.as_basic_value_enum(),
+                            i1,
+                        )
+                        .into_vector_value(),
+                        apply_pending_canonicalization(
+                            builder,
+                            intrinsics,
+                            v2.as_basic_value_enum(),
+                            i2,
+                        )
+                        .into_float_value(),
+                    )
+                } else {
+                    (v1, v2.into_float_value())
+                };
                 let idx = intrinsics.i32_ty.const_int(lane.into(), false);
                 let res = builder.build_insert_element(v1, v2, idx, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2 & ExtraInfo::arithmetic_f64());
+                let info = if push_pending_f64_nan_to_result {
+                    ExtraInfo::pending_f64_nan()
+                } else {
+                    i1.strip_pending() & i2.strip_pending()
+                };
+                state.push1_extra(res, info);
             }
             Operator::V8x16Swizzle => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -2907,110 +2907,122 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
             Operator::F32Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let i1 = i1 | ExtraInfo::pending_f32_nan();
-                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f32_nan(),
+                );
             }
             Operator::F64Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let i1 = i1 | ExtraInfo::pending_f64_nan();
-                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f64_nan(),
+                );
             }
             Operator::F32x4Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f32x4(builder, intrinsics, v2, i2);
-                let i1 = i1 | ExtraInfo::pending_f32_nan();
-                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f32_nan(),
+                );
             }
             Operator::F64x2Add => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f64x2(builder, intrinsics, v2, i2);
-                let i1 = i1 | ExtraInfo::pending_f64_nan();
-                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_add(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f64_nan(),
+                );
             }
             Operator::F32Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let i1 = i1 | ExtraInfo::pending_f32_nan();
-                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f32_nan(),
+                );
             }
             Operator::F64Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let i1 = i1 | ExtraInfo::pending_f64_nan();
-                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f64_nan(),
+                );
             }
             Operator::F32x4Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f32x4(builder, intrinsics, v2, i2);
-                let i1 = i1 | ExtraInfo::pending_f32_nan();
-                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f32_nan(),
+                );
             }
             Operator::F64x2Sub => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f64x2(builder, intrinsics, v2, i2);
-                let i1 = i1 | ExtraInfo::pending_f64_nan();
-                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_sub(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f64_nan(),
+                );
             }
             Operator::F32Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let i1 = i1 | ExtraInfo::pending_f32_nan();
-                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f32_nan(),
+                );
             }
             Operator::F64Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, v2) = (v1.into_float_value(), v2.into_float_value());
-                let i1 = i1 | ExtraInfo::pending_f64_nan();
-                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f64_nan(),
+                );
             }
             Operator::F32x4Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f32x4(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f32x4(builder, intrinsics, v2, i2);
-                let i1 = i1 | ExtraInfo::pending_f32_nan();
-                let i2 = i2 | ExtraInfo::pending_f32_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f32_nan(),
+                );
             }
             Operator::F64x2Mul => {
                 let ((v1, i1), (v2, i2)) = state.pop2_extra()?;
                 let (v1, i1) = v128_into_f64x2(builder, intrinsics, v1, i1);
                 let (v2, i2) = v128_into_f64x2(builder, intrinsics, v2, i2);
-                let i1 = i1 | ExtraInfo::pending_f64_nan();
-                let i2 = i2 | ExtraInfo::pending_f64_nan();
                 let res = builder.build_float_mul(v1, v2, &state.var_name());
                 let res = builder.build_bitcast(res, intrinsics.i128_ty, "");
-                state.push1_extra(res, i1 & i2);
+                state.push1_extra(
+                    res,
+                    (i1.strip_pending() & i2.strip_pending()) | ExtraInfo::pending_f64_nan(),
+                );
             }
             Operator::F32Div => {
                 let (v1, v2) = state.pop2()?;

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -1740,7 +1740,11 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                 // We don't bother canonicalizing 'cond' here because we only
                 // compare it to zero, and that's invariant under
                 // canonicalization.
-                let (v1, v2) = if i1.has_pending_f32_nan() != i1.has_pending_f32_nan()
+
+                // If the pending bits of v1 and v2 are the same, we can pass
+                // them along to the result. Otherwise, apply pending
+                // canonicalizations now.
+                let (v1, v2) = if i1.has_pending_f32_nan() != i2.has_pending_f32_nan()
                     || i1.has_pending_f64_nan() != i2.has_pending_f64_nan()
                 {
                     (

--- a/lib/llvm-backend/src/state.rs
+++ b/lib/llvm-backend/src/state.rs
@@ -182,7 +182,7 @@ impl BitAnd for ExtraInfo {
             (false, false) => info,
             (true, false) => info | ExtraInfo::pending_f32_nan(),
             (false, true) => info | ExtraInfo::pending_f64_nan(),
-            (true, true) => panic!(""),
+            (true, true) => unreachable!("Can't form ExtraInfo with two pending canonicalizations"),
         };
         info
     }

--- a/lib/llvm-backend/src/state.rs
+++ b/lib/llvm-backend/src/state.rs
@@ -159,8 +159,16 @@ impl BitAnd for ExtraInfo {
     type Output = Self;
     fn bitand(self, other: Self) -> Self {
         // Pending canonicalizations are not safe to discard, or even reorder.
-        assert!(self.has_pending_f32_nan() == other.has_pending_f32_nan());
-        assert!(self.has_pending_f64_nan() == other.has_pending_f64_nan());
+        assert!(
+            self.has_pending_f32_nan() == other.has_pending_f32_nan()
+                || self.is_arithmetic_f32()
+                || other.is_arithmetic_f32()
+        );
+        assert!(
+            self.has_pending_f64_nan() == other.has_pending_f64_nan()
+                || self.is_arithmetic_f64()
+                || other.is_arithmetic_f64()
+        );
         let info = match (
             self.is_arithmetic_f32() && other.is_arithmetic_f32(),
             self.is_arithmetic_f64() && other.is_arithmetic_f64(),


### PR DESCRIPTION
# Description
This is a reimplementation of the patch in PR #651.

Extend state.rs ExtraInfo to track more information about floats. In addition to tracking whether the value has a pending canonicalization of NaNs, also track whether the value is known to be arithmetic (which includes infinities, regular values, and non-signalling NaNs (aka. "arithmetic NaNs" in the webassembly spec)). When the value is arithmetic, the correct sequence of operations to canonicalize the value is a no-op. Therefore, we create a lattice where pending+arithmetic=arithmetic.

Also, this extends the tracking to track all values, including non-SIMD integers. That's why there are more places where pending canonicalizations are applied.

Looking at c-wasm-simd128-example, this provides no performance change to the non-SIMD case (takes 58s on my noisy dev machine). The SIMD case drops from 46s to 29s.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
