### PR TITLE
feat(runtime-c-api) Add support for clang in `WASMER_H_MACROS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#960](https://github.com/wasmerio/wasmer/pull/960) Fix `runtime-c-api` header files when compiled by clang.
 - [#925](https://github.com/wasmerio/wasmer/pull/925) Host functions can be closures with a captured environment.
 - [#917](https://github.com/wasmerio/wasmer/pull/917) Host functions (aka imported functions) may not have `&mut vm::Ctx` as first argument, i.e. the presence of the `&mut vm::Ctx` argument is optional.
 - [#915](https://github.com/wasmerio/wasmer/pull/915) All backends share the same definition of `Trampoline` (defined in `wasmer-runtime-core`).

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -21,7 +21,7 @@ fn main() {
     #endif
   #endif
 
-  #if defined(GCC)
+  #if defined(GCC) || defined(__clang__)
     #if defined(__x86_64__)
       #define ARCH_X86_64
     #endif

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -14,19 +14,21 @@ fn main() {
 
     const WASMER_PRE_HEADER: &str = r#"
 #if !defined(WASMER_H_MACROS)
-  #define WASMER_H_MACROS
-  #if defined(MSVC)
-    #if defined(_M_AMD64)
-      #define ARCH_X86_64
-    #endif
-  #endif
+#define WASMER_H_MACROS
 
-  #if defined(GCC) || defined(__clang__)
-    #if defined(__x86_64__)
-      #define ARCH_X86_64
-    #endif
-  #endif
+#if defined(MSVC)
+#if defined(_M_AMD64)
+#define ARCH_X86_64
 #endif
+#endif
+
+#if defined(GCC) || defined(__clang__)
+#if defined(__x86_64__)
+#define ARCH_X86_64
+#endif
+#endif
+
+#endif // WASMER_H_MACROS
 "#;
     // Generate the C bindings in the `OUT_DIR`.
     out_wasmer_header_file.set_extension("h");

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -13,20 +13,20 @@ fn main() {
     out_wasmer_header_file.push("wasmer");
 
     const WASMER_PRE_HEADER: &str = r#"
-#ifndef WASMER_H_MACROS
-#define WASMER_H_MACROS
-#if MSVC
-#ifdef _M_AMD64
-#define ARCH_X86_64
-#endif
-#endif
+#if !defined(WASMER_H_MACROS)
+  #define WASMER_H_MACROS
+  #if defined(MSVC)
+    #if defined(_M_AMD64)
+      #define ARCH_X86_64
+    #endif
+  #endif
 
-#if GCC
-#ifdef __x86_64__
-#define ARCH_X86_64
+  #if defined(GCC)
+    #if defined(__x86_64__)
+      #define ARCH_X86_64
+    #endif
+  #endif
 #endif
-#endif
-#endif // WASMER_H_MACROS
 "#;
     // Generate the C bindings in the `OUT_DIR`.
     out_wasmer_header_file.set_extension("h");

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1,18 +1,20 @@
 
 #if !defined(WASMER_H_MACROS)
-  #define WASMER_H_MACROS
-  #if defined(MSVC)
-    #if defined(_M_AMD64)
-      #define ARCH_X86_64
-    #endif
-  #endif
+#define WASMER_H_MACROS
 
-  #if defined(GCC) || defined(__clang__)
-    #if defined(__x86_64__)
-      #define ARCH_X86_64
-    #endif
-  #endif
+#if defined(MSVC)
+#if defined(_M_AMD64)
+#define ARCH_X86_64
 #endif
+#endif
+
+#if defined(GCC) || defined(__clang__)
+#if defined(__x86_64__)
+#define ARCH_X86_64
+#endif
+#endif
+
+#endif // WASMER_H_MACROS
 
 
 #ifndef WASMER_H

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1,18 +1,18 @@
 
-#ifndef WASMER_H_MACROS
-#define WASMER_H_MACROS
-#if MSVC
-#ifdef _M_AMD64
-#define ARCH_X86_64
-#endif
-#endif
+#if !defined(WASMER_H_MACROS)
+  #define WASMER_H_MACROS
+  #if defined(MSVC)
+    #if defined(_M_AMD64)
+      #define ARCH_X86_64
+    #endif
+  #endif
 
-#if GCC
-#ifdef __x86_64__
-#define ARCH_X86_64
+  #if defined(GCC) || defined(__clang__)
+    #if defined(__x86_64__)
+      #define ARCH_X86_64
+    #endif
+  #endif
 #endif
-#endif
-#endif // WASMER_H_MACROS
 
 
 #ifndef WASMER_H

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -1,18 +1,20 @@
 
 #if !defined(WASMER_H_MACROS)
-  #define WASMER_H_MACROS
-  #if defined(MSVC)
-    #if defined(_M_AMD64)
-      #define ARCH_X86_64
-    #endif
-  #endif
+#define WASMER_H_MACROS
 
-  #if defined(GCC) || defined(__clang__)
-    #if defined(__x86_64__)
-      #define ARCH_X86_64
-    #endif
-  #endif
+#if defined(MSVC)
+#if defined(_M_AMD64)
+#define ARCH_X86_64
 #endif
+#endif
+
+#if defined(GCC) || defined(__clang__)
+#if defined(__x86_64__)
+#define ARCH_X86_64
+#endif
+#endif
+
+#endif // WASMER_H_MACROS
 
 
 #ifndef WASMER_H

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -1,18 +1,18 @@
 
-#ifndef WASMER_H_MACROS
-#define WASMER_H_MACROS
-#if MSVC
-#ifdef _M_AMD64
-#define ARCH_X86_64
-#endif
-#endif
+#if !defined(WASMER_H_MACROS)
+  #define WASMER_H_MACROS
+  #if defined(MSVC)
+    #if defined(_M_AMD64)
+      #define ARCH_X86_64
+    #endif
+  #endif
 
-#if GCC
-#ifdef __x86_64__
-#define ARCH_X86_64
+  #if defined(GCC) || defined(__clang__)
+    #if defined(__x86_64__)
+      #define ARCH_X86_64
+    #endif
+  #endif
 #endif
-#endif
-#endif // WASMER_H_MACROS
 
 
 #ifndef WASMER_H


### PR DESCRIPTION
In #952, the `WASMER_H_MACROS` constant has been defined. The `ARCH_X86_64` constant is defined under 2 conditions: If the compiler is MSVC + `_M_AMD64` is defined, or if the compiler is GCC + `__x86_64__` is defined.

Clang is missing. And it breaks some projects (like https://github.com/wasmerio/php-ext-wasm or https://github.com/wasmerio/go-ext-wasm for instance).

This patch supports Clang.