### PR TITLE
feat(runtime-core) `func!` supports closures

### DIFF
--- a/lib/runtime-core/src/macros.rs
+++ b/lib/runtime-core/src/macros.rs
@@ -45,6 +45,44 @@ macro_rules! trace {
 }
 
 /// Helper macro to create a new `Func` object using the provided function pointer.
+///
+/// # Usage
+///
+/// Function pointers or closures are supported. Closures can capture
+/// their environment (with `move). The first parameter is likely to
+/// be of kind `vm::Ctx`, though it can be optional.
+///
+/// ```
+/// # use wasmer_runtime_core::{imports, func};
+/// # use wasmer_runtime_core::vm;
+///
+/// // A function that has access to `vm::Ctx`.
+/// fn func_with_vmctx(_: &mut vm::Ctx, n: i32) -> i32 {
+///     n
+/// }
+///
+/// // A function that cannot access `vm::Ctx`.
+/// fn func(n: i32) -> i32 {
+///     n
+/// }
+///
+/// let i = 7;
+///
+/// let import_object = imports! {
+///     "env" => {
+///         "foo" => func!(func_with_vmctx),
+///         "bar" => func!(func),
+///         // A closure with a captured environment, and an access to `vm::Ctx`.
+///         "baz" => func!(move |_: &mut vm::Ctx, n: i32| -> i32 {
+///             n + i
+///         }),
+///         // A closure without a captured environment, and no access to `vm::Ctx`.
+///         "qux" => func!(|n: i32| -> i32 {
+///             n
+///         }),
+///     },
+/// };
+/// ```
 #[macro_export]
 macro_rules! func {
     ($func:expr) => {{

--- a/lib/runtime-core/src/macros.rs
+++ b/lib/runtime-core/src/macros.rs
@@ -94,12 +94,12 @@ macro_rules! func {
 ///
 /// [`ImportObject`]: struct.ImportObject.html
 ///
-/// # Note:
+/// # Note
 /// The `import` macro currently only supports
 /// importing functions.
 ///
 ///
-/// # Usage:
+/// # Usage
 /// ```
 /// # use wasmer_runtime_core::{imports, func};
 /// # use wasmer_runtime_core::vm::Ctx;

--- a/lib/runtime-core/src/macros.rs
+++ b/lib/runtime-core/src/macros.rs
@@ -47,7 +47,7 @@ macro_rules! trace {
 /// Helper macro to create a new `Func` object using the provided function pointer.
 #[macro_export]
 macro_rules! func {
-    ($func:path) => {{
+    ($func:expr) => {{
         $crate::Func::new($func)
     }};
 }


### PR DESCRIPTION
This patch updates the `func!` macro so that it can consume closures.

This patch also improves the documentation of the `func!` by explaining how to use it with examples (with function pointers or closures).