### PR TITLE
Enable compilation for specific target

### DIFF
--- a/lib/clif-backend/src/code.rs
+++ b/lib/clif-backend/src/code.rs
@@ -54,6 +54,10 @@ impl ModuleCodeGenerator<CraneliftFunctionCodeGenerator, Caller, CodegenError>
         }
     }
 
+    fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {
+        unimplemented!("cross compilation is not available for clif backend")
+    }
+
     fn backend_id() -> Backend {
         Backend::Cranelift
     }

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -129,6 +129,11 @@ pub struct CompilerConfig {
     pub enforce_stack_check: bool,
     pub track_state: bool,
     pub features: Features,
+
+    // target info used by LLVM
+    pub triple: Option<String>,
+    pub cpu_name: Option<String>,
+    pub cpu_features: Option<String>,
 }
 
 pub trait Compiler {

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -74,6 +74,13 @@ pub trait ModuleCodeGenerator<FCG: FunctionCodeGenerator<E>, RM: RunnableModule,
     /// Creates a new module code generator.
     fn new() -> Self;
 
+    /// Creates a new module code generator for specified target.
+    fn new_with_target(
+        triple: Option<String>,
+        cpu_name: Option<String>,
+        cpu_features: Option<String>,
+    ) -> Self;
+
     /// Returns the backend id associated with this MCG.
     fn backend_id() -> Backend;
 
@@ -206,7 +213,14 @@ impl<
             validate_with_features(wasm, &compiler_config.features)?;
         }
 
-        let mut mcg = MCG::new();
+        let mut mcg = match MCG::backend_id() {
+            Backend::LLVM => MCG::new_with_target(
+                compiler_config.triple.clone(),
+                compiler_config.cpu_name.clone(),
+                compiler_config.cpu_features.clone(),
+            ),
+            _ => MCG::new(),
+        };
         let mut chain = (self.middleware_chain_generator)();
         let info = crate::parse::read_module(
             wasm,

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -370,6 +370,10 @@ impl ModuleCodeGenerator<X64FunctionCode, X64ExecutionContext, CodegenError>
         }
     }
 
+    fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {
+        unimplemented!("cross compilation is not available for singlepass backend")
+    }
+
     fn backend_id() -> Backend {
         Backend::Singlepass
     }

--- a/src/bin/kwasmd.rs
+++ b/src/bin/kwasmd.rs
@@ -63,6 +63,7 @@ fn handle_client(mut stream: UnixStream) {
             enforce_stack_check: true,
             track_state: false,
             features: Default::default(),
+            ..Default::default()
         },
         &SinglePassCompiler::new(),
     )

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -447,6 +447,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                     simd: options.features.simd || options.features.all,
                     threads: options.features.threads || options.features.all,
                 },
+                ..Default::default()
             },
             &*compiler,
         )


### PR DESCRIPTION

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
By exposing the target information through `CompilerConfig`,
compiler(only LLVM at the moment) could create a machine with
different CPU feature flags other than current host, which makes it
capable to "cross compile" to some degree.

Update #959

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
