### PR TITLE
Update to Rust 1.39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/rust:1.38.0-stretch as wasmer-build-env
+FROM circleci/rust:1.39.0-stretch as wasmer-build-env
 RUN sudo apt-get update && \
   sudo apt-get install -y --no-install-recommends \
   cmake \

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ nginx and Lua do not work on Windows - you can track the progress on [this issue
 
 ## Building
 
-[![Rustc Version 1.38+](https://img.shields.io/badge/rustc-1.37+-red.svg?style=flat-square)](https://blog.rust-lang.org/2019/09/26/Rust-1.38.0.html)
+[![Rustc Version 1.39+](https://img.shields.io/badge/rustc-1.39+-red.svg?style=flat-square)](https://blog.rust-lang.org/2019/09/26/Rust-1.39.0.html)
 
 Wasmer is built with [Cargo](https://crates.io/), the Rust package manager.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       - script: cargo fmt --all -- --check
         displayName: Lint
     variables:
-      rust_toolchain: '1.38.0'
+      rust_toolchain: '1.39.0'
 
   - job: Test
     strategy:
@@ -39,7 +39,7 @@ jobs:
           CARGO_HTTP_CHECK_REVOKE: false
         windows:
           imageName: "vs2017-win2016"
-          rust_toolchain: '1.38.0'
+          rust_toolchain: '1.39.0'
     pool:
       vmImage: $(imageName)
     condition: in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/staging', 'refs/heads/trying')
@@ -100,7 +100,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.10
         windows:
           imageName: "vs2017-win2016"
-          rust_toolchain: '1.38.0'
+          rust_toolchain: '1.39.0'
           # RUSTFLAGS: -Ctarget-feature=+crt-static
     pool:
       vmImage: $(imageName)
@@ -163,7 +163,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.10
         windows:
           imageName: "vs2017-win2016"
-          rust_toolchain: '1.38.0'
+          rust_toolchain: '1.39.0'
           # RUSTFLAGS: -Ctarget-feature=+crt-static
     pool:
       vmImage: $(imageName)

--- a/lib/singlepass-backend/src/emitter_x64.rs
+++ b/lib/singlepass-backend/src/emitter_x64.rs
@@ -709,14 +709,18 @@ impl Emitter for Assembler {
         match (sz, src) {
             (Size::S64, Location::Imm32(src)) => dynasm!(self ; push src as i32),
             (Size::S64, Location::GPR(src)) => dynasm!(self ; push Rq(src as u8)),
-            (Size::S64, Location::Memory(src, disp)) => dynasm!(self ; push QWORD [Rq(src as u8) + disp]),
+            (Size::S64, Location::Memory(src, disp)) => {
+                dynasm!(self ; push QWORD [Rq(src as u8) + disp])
+            }
             _ => panic!("singlepass can't emit PUSH {:?} {:?}", sz, src),
         }
     }
     fn emit_pop(&mut self, sz: Size, dst: Location) {
         match (sz, dst) {
             (Size::S64, Location::GPR(dst)) => dynasm!(self ; pop Rq(dst as u8)),
-            (Size::S64, Location::Memory(dst, disp)) => dynasm!(self ; pop QWORD [Rq(dst as u8) + disp]),
+            (Size::S64, Location::Memory(dst, disp)) => {
+                dynasm!(self ; pop QWORD [Rq(dst as u8) + disp])
+            }
             _ => panic!("singlepass can't emit POP {:?} {:?}", sz, dst),
         }
     }
@@ -738,13 +742,21 @@ impl Emitter for Assembler {
     fn emit_neg(&mut self, sz: Size, value: Location) {
         match (sz, value) {
             (Size::S8, Location::GPR(value)) => dynasm!(self ; neg Rb(value as u8)),
-            (Size::S8, Location::Memory(value, disp)) => dynasm!(self ; neg [Rq(value as u8) + disp]),
+            (Size::S8, Location::Memory(value, disp)) => {
+                dynasm!(self ; neg [Rq(value as u8) + disp])
+            }
             (Size::S16, Location::GPR(value)) => dynasm!(self ; neg Rw(value as u8)),
-            (Size::S16, Location::Memory(value, disp)) => dynasm!(self ; neg [Rq(value as u8) + disp]),
+            (Size::S16, Location::Memory(value, disp)) => {
+                dynasm!(self ; neg [Rq(value as u8) + disp])
+            }
             (Size::S32, Location::GPR(value)) => dynasm!(self ; neg Rd(value as u8)),
-            (Size::S32, Location::Memory(value, disp)) => dynasm!(self ; neg [Rq(value as u8) + disp]),
+            (Size::S32, Location::Memory(value, disp)) => {
+                dynasm!(self ; neg [Rq(value as u8) + disp])
+            }
             (Size::S64, Location::GPR(value)) => dynasm!(self ; neg Rq(value as u8)),
-            (Size::S64, Location::Memory(value, disp)) => dynasm!(self ; neg [Rq(value as u8) + disp]),
+            (Size::S64, Location::Memory(value, disp)) => {
+                dynasm!(self ; neg [Rq(value as u8) + disp])
+            }
             _ => panic!("singlepass can't emit NEG {:?} {:?}", sz, value),
         }
     }
@@ -997,18 +1009,30 @@ impl Emitter for Assembler {
 
     fn emit_vmovaps(&mut self, src: XMMOrMemory, dst: XMMOrMemory) {
         match (src, dst) {
-            (XMMOrMemory::XMM(src), XMMOrMemory::XMM(dst)) => dynasm!(self ; movaps Rx(dst as u8), Rx(src as u8)),
-            (XMMOrMemory::Memory(base, disp), XMMOrMemory::XMM(dst)) => dynasm!(self ; movaps Rx(dst as u8), [Rq(base as u8) + disp]),
-            (XMMOrMemory::XMM(src), XMMOrMemory::Memory(base, disp)) => dynasm!(self ; movaps [Rq(base as u8) + disp], Rx(src as u8)),
+            (XMMOrMemory::XMM(src), XMMOrMemory::XMM(dst)) => {
+                dynasm!(self ; movaps Rx(dst as u8), Rx(src as u8))
+            }
+            (XMMOrMemory::Memory(base, disp), XMMOrMemory::XMM(dst)) => {
+                dynasm!(self ; movaps Rx(dst as u8), [Rq(base as u8) + disp])
+            }
+            (XMMOrMemory::XMM(src), XMMOrMemory::Memory(base, disp)) => {
+                dynasm!(self ; movaps [Rq(base as u8) + disp], Rx(src as u8))
+            }
             _ => panic!("singlepass can't emit VMOVAPS {:?} {:?}", src, dst),
         };
     }
 
     fn emit_vmovapd(&mut self, src: XMMOrMemory, dst: XMMOrMemory) {
         match (src, dst) {
-            (XMMOrMemory::XMM(src), XMMOrMemory::XMM(dst)) => dynasm!(self ; movapd Rx(dst as u8), Rx(src as u8)),
-            (XMMOrMemory::Memory(base, disp), XMMOrMemory::XMM(dst)) => dynasm!(self ; movapd Rx(dst as u8), [Rq(base as u8) + disp]),
-            (XMMOrMemory::XMM(src), XMMOrMemory::Memory(base, disp)) => dynasm!(self ; movapd [Rq(base as u8) + disp], Rx(src as u8)),
+            (XMMOrMemory::XMM(src), XMMOrMemory::XMM(dst)) => {
+                dynasm!(self ; movapd Rx(dst as u8), Rx(src as u8))
+            }
+            (XMMOrMemory::Memory(base, disp), XMMOrMemory::XMM(dst)) => {
+                dynasm!(self ; movapd Rx(dst as u8), [Rq(base as u8) + disp])
+            }
+            (XMMOrMemory::XMM(src), XMMOrMemory::Memory(base, disp)) => {
+                dynasm!(self ; movapd [Rq(base as u8) + disp], Rx(src as u8))
+            }
             _ => panic!("singlepass can't emit VMOVAPD {:?} {:?}", src, dst),
         };
     }
@@ -1080,57 +1104,77 @@ impl Emitter for Assembler {
 
     fn emit_vblendvps(&mut self, src1: XMM, src2: XMMOrMemory, mask: XMM, dst: XMM) {
         match src2 {
-            XMMOrMemory::XMM(src2) => dynasm!(self ; vblendvps Rx(dst as u8), Rx(mask as u8), Rx(src2 as u8), Rx(src1 as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; vblendvps Rx(dst as u8), Rx(mask as u8), [Rq(base as u8) + disp], Rx(src1 as u8)),
+            XMMOrMemory::XMM(src2) => {
+                dynasm!(self ; vblendvps Rx(dst as u8), Rx(mask as u8), Rx(src2 as u8), Rx(src1 as u8))
+            }
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; vblendvps Rx(dst as u8), Rx(mask as u8), [Rq(base as u8) + disp], Rx(src1 as u8))
+            }
         }
     }
 
     fn emit_vblendvpd(&mut self, src1: XMM, src2: XMMOrMemory, mask: XMM, dst: XMM) {
         match src2 {
-            XMMOrMemory::XMM(src2) => dynasm!(self ; vblendvpd Rx(dst as u8), Rx(mask as u8), Rx(src2 as u8), Rx(src1 as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; vblendvpd Rx(dst as u8), Rx(mask as u8), [Rq(base as u8) + disp], Rx(src1 as u8)),
+            XMMOrMemory::XMM(src2) => {
+                dynasm!(self ; vblendvpd Rx(dst as u8), Rx(mask as u8), Rx(src2 as u8), Rx(src1 as u8))
+            }
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; vblendvpd Rx(dst as u8), Rx(mask as u8), [Rq(base as u8) + disp], Rx(src1 as u8))
+            }
         }
     }
 
     fn emit_ucomiss(&mut self, src: XMMOrMemory, dst: XMM) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; ucomiss Rx(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; ucomiss Rx(dst as u8), [Rq(base as u8) + disp]),
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; ucomiss Rx(dst as u8), [Rq(base as u8) + disp])
+            }
         }
     }
 
     fn emit_ucomisd(&mut self, src: XMMOrMemory, dst: XMM) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; ucomisd Rx(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; ucomisd Rx(dst as u8), [Rq(base as u8) + disp]),
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; ucomisd Rx(dst as u8), [Rq(base as u8) + disp])
+            }
         }
     }
 
     fn emit_cvttss2si_32(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rd(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttss2si Rd(dst as u8), [Rq(base as u8) + disp]),
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; cvttss2si Rd(dst as u8), [Rq(base as u8) + disp])
+            }
         }
     }
 
     fn emit_cvttss2si_64(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rq(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttss2si Rq(dst as u8), [Rq(base as u8) + disp]),
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; cvttss2si Rq(dst as u8), [Rq(base as u8) + disp])
+            }
         }
     }
 
     fn emit_cvttsd2si_32(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rd(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttsd2si Rd(dst as u8), [Rq(base as u8) + disp]),
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; cvttsd2si Rd(dst as u8), [Rq(base as u8) + disp])
+            }
         }
     }
 
     fn emit_cvttsd2si_64(&mut self, src: XMMOrMemory, dst: GPR) {
         match src {
             XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rq(dst as u8), Rx(x as u8)),
-            XMMOrMemory::Memory(base, disp) => dynasm!(self ; cvttsd2si Rq(dst as u8), [Rq(base as u8) + disp]),
+            XMMOrMemory::Memory(base, disp) => {
+                dynasm!(self ; cvttsd2si Rq(dst as u8), [Rq(base as u8) + disp])
+            }
         }
     }
 


### PR DESCRIPTION
This PR updates the default Rust version to 1.39.

Necessary for code formatted with newer versions of `rustfmt` to pass the CI lint check.