### PR TITLE
Fix runtime c api header preprocessor gcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## **[Unreleased]**
 
+- [#987](https://github.com/wasmerio/wasmer/pull/987) Fix `runtime-c-api` header files when compiled by gnuc.
+
 ## 0.10.2 - 2019-11-18
 
 - [#968](https://github.com/wasmerio/wasmer/pull/968) Added `--invoke` option to the command

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -22,7 +22,7 @@ fn main() {
 #endif
 #endif
 
-#if defined(GCC) || defined(__clang__)
+#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
 #if defined(__x86_64__)
 #define ARCH_X86_64
 #endif

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -8,7 +8,7 @@
 #endif
 #endif
 
-#if defined(GCC) || defined(__clang__)
+#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
 #if defined(__x86_64__)
 #define ARCH_X86_64
 #endif

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -8,7 +8,7 @@
 #endif
 #endif
 
-#if defined(GCC) || defined(__clang__)
+#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
 #if defined(__x86_64__)
 #define ARCH_X86_64
 #endif


### PR DESCRIPTION
`ARCH_X86_64` is correctly defined for GCC or clang, but gnuc was
missing. This patch fixes that.

Address https://github.com/wasmerio/php-ext-wasm/issues/93
Fix https://github.com/wasmerio/wasmer/issues/984