### PR TITLE
feat(middleware_common::metering): Dynamic limit

### DIFF
--- a/lib/middleware-common-tests/benches/metering_benchmark.rs
+++ b/lib/middleware-common-tests/benches/metering_benchmark.rs
@@ -134,13 +134,13 @@ static WAT_GAS: &'static str = r#"
         "#;
 
 #[cfg(feature = "llvm")]
-fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
+fn get_compiler(metering: bool) -> impl Compiler {
     use wasmer_llvm_backend::ModuleCodeGenerator;
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     let c: StreamingCompiler<ModuleCodeGenerator, _, _, _, _> = StreamingCompiler::new(move || {
         let mut chain = MiddlewareChain::new();
         if metering {
-            chain.push(Metering::new(limit));
+            chain.push(Metering::new());
         }
         chain
     });
@@ -149,13 +149,13 @@ fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
 }
 
 #[cfg(feature = "singlepass")]
-fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
+fn get_compiler(metering: bool) -> impl Compiler {
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
     let c: StreamingCompiler<SinglePassMCG, _, _, _, _> = StreamingCompiler::new(move || {
         let mut chain = MiddlewareChain::new();
         if metering {
-            chain.push(Metering::new(limit));
+            chain.push(Metering::new());
         }
         chain
     });
@@ -166,7 +166,7 @@ fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
 compile_error!("compiler not specified, activate a compiler via features");
 
 #[cfg(feature = "clif")]
-fn get_compiler(_limit: u64, metering: bool) -> impl Compiler {
+fn get_compiler(metering: bool) -> impl Compiler {
     compile_error!("cranelift does not implement metering");
     use wasmer_clif_backend::CraneliftCompiler;
     CraneliftCompiler::new()
@@ -185,7 +185,7 @@ fn bench_metering(c: &mut Criterion) {
     c.bench(
         "Meter",
         Benchmark::new("No Metering", |b| {
-            let compiler = get_compiler(0, false);
+            let compiler = get_compiler(false);
             let wasm_binary = wat2wasm(WAT).unwrap();
             let module = compile_with(&wasm_binary, &compiler).unwrap();
             let import_object = imports! {};
@@ -194,7 +194,7 @@ fn bench_metering(c: &mut Criterion) {
             b.iter(|| black_box(add_to.call(100, 4)))
         })
         .with_function("Gas Metering", |b| {
-            let compiler = get_compiler(0, false);
+            let compiler = get_compiler(false);
             let gas_wasm_binary = wat2wasm(WAT_GAS).unwrap();
             let gas_module = compile_with(&gas_wasm_binary, &compiler).unwrap();
             let gas_import_object = imports! {
@@ -207,13 +207,14 @@ fn bench_metering(c: &mut Criterion) {
             b.iter(|| black_box(gas_add_to.call(100, 4)))
         })
         .with_function("Built-in Metering", |b| {
-            let metering_compiler = get_compiler(std::u64::MAX, true);
+            let metering_compiler = get_compiler(true);
             let wasm_binary = wat2wasm(WAT).unwrap();
             let metering_module = compile_with(&wasm_binary, &metering_compiler).unwrap();
             let metering_import_object = imports! {};
             let mut metering_instance = metering_module
                 .instantiate(&metering_import_object)
                 .unwrap();
+            metering::set_limit(&mut metering_instance, std::u64::MAX);
             metering::set_points_used(&mut metering_instance, 0u64);
             let metering_add_to: Func<(i32, i32), i32> = metering_instance.func("add_to").unwrap();
             b.iter(|| black_box(metering_add_to.call(100, 4)))


### PR DESCRIPTION
Add a dynamic limit to the metering::Metering middleware.

# Description

Previously a limit was hardcoded at compile time. This commit adds an
additional InternalField to track a dynamic limit unique to each
instance. This commit adds fn metering::set_limit(&mut Instance,  u64)
to allow limits to be changed.

This allows a module compiled with metering to be cached and re-used to
instantiate Instances with different limits.

implements #993

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
