### PR TITLE
Fix no rule to make target 'wasi'

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Each integration can be tested separately:
 
 * Spec tests: `make spectests`
 * Emscripten: `make emtests`
-* WASI: `make wasi`
+* WASI: `make wasitests`
 * Middleware: `make middleware`
 * C API: `make capi`
 


### PR DESCRIPTION
# Description
No rule to make tarket 'wasi', so I updated the target name from 'wasi' to 'wasitests'

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
