### PR TITLE
Use target from env in build.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#990](https://github.com/wasmerio/wasmer/pull/990) Default wasmer CLI to `run`.  Wasmer will now attempt to parse unrecognized command line options as if they were applied to the run command: `wasmer mywasm.wasm --dir=.` now works!
 - [#987](https://github.com/wasmerio/wasmer/pull/987) Fix `runtime-c-api` header files when compiled by gnuc.
 - [#957](https://github.com/wasmerio/wasmer/pull/957) Change the meaning of `wasmer_wasi::is_wasi_module` to detect any type of WASI module, add support for new wasi snapshot_preview1
+- [#1003](https://github.com/wasmerio/wasmer/pull/1003) Fix `build.rs` in `runtime-core` to allow cross compilation
 
 ## 0.10.2 - 2019-11-18
 

--- a/lib/runtime-core/build.rs
+++ b/lib/runtime-core/build.rs
@@ -29,11 +29,15 @@ fn main() {
         println!("cargo:rustc-cfg=nightly");
     }
 
-    if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    println!("cargo:warning=detected target {}-{}", target_os, target_arch);
+
+    if target_os == "linux" && target_arch == "x86_64" {
         cc::Build::new()
             .file("image-loading-linux-x86-64.s")
             .compile("image-loading");
-    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+    } else if target_os == "macos" && target_arch == "x86_64" {
         cc::Build::new()
             .file("image-loading-macos-x86-64.s")
             .compile("image-loading");

--- a/lib/runtime-core/build.rs
+++ b/lib/runtime-core/build.rs
@@ -31,7 +31,6 @@ fn main() {
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    println!("cargo:warning=detected target {}-{}", target_os, target_arch);
 
     if target_os == "linux" && target_arch == "x86_64" {
         cc::Build::new()


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

Cross compile is broken for wasmer-runtime-core. I tried compiling from linux -> macos (with lots of setup of dependencies first) and it compiled, but errored on the `build.rs`, which was using linux assembly instead of macos assembly.

Long explanation here to capture (and share) my learnings on this:

Digging into this, it turns out the reason was the use of `if cfg!(all(target_os = "linux", target_arch = "x86_64")) {` to check for the target in `build.rs`. This consistently detected the os as linux, even when I did `cargo build --target x86_64-apple-darwin`. However, the `TARGET` env variable was showing macos.

I thought this was a cargo bug, but as @nlewycky explained, build.rs is compiled for the host system (the one doing compilation), and correctly sets the target_os to linux. While the rest of the source code will have `cfg(target_os)` set to `macos`. The solution here is to rely on the `CARGO_CFG_TARGET_{OS,ARCH}` environmental variables in `build.rs` if you want to detect the system for which the library is being compiled for. (Normally they are the same, this bug only shows up during cross-compilation).

# Review

I didn't add unit tests, here but am testing it when imported in another project where I have a cross-compile build system set up. I can link the example code here if you want to run.

- [x] Add a short description of the the change to the CHANGELOG.md file
