### PR TITLE
Adapt backend usage depending on wasm file executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1006](https://github.com/wasmerio/wasmer/pull/1006) Fix minor panic issue when `wasmer::compile_with` called with llvm backend
 - [#1009](https://github.com/wasmerio/wasmer/pull/1009) Enable LLVM verifier for all tests, add new llvm-backend-tests crate.
+- [#1004](https://github.com/wasmerio/wasmer/pull/1004) Add the Auto backend to enable to adapt backend usage depending on wasm file executed.
 
 ## 0.11.0 - 2019-11-22
 

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -28,6 +28,7 @@ pub enum Backend {
     Cranelift,
     Singlepass,
     LLVM,
+    Auto,
 }
 
 impl Backend {
@@ -40,6 +41,7 @@ impl Backend {
             "singlepass",
             #[cfg(feature = "backend-llvm")]
             "llvm",
+            "auto",
         ]
     }
 
@@ -50,6 +52,7 @@ impl Backend {
             Backend::Cranelift => "cranelift",
             Backend::Singlepass => "singlepass",
             Backend::LLVM => "llvm",
+            Backend::Auto => "auto",
         }
     }
 }
@@ -67,6 +70,7 @@ impl std::str::FromStr for Backend {
             "singlepass" => Ok(Backend::Singlepass),
             "cranelift" => Ok(Backend::Cranelift),
             "llvm" => Ok(Backend::LLVM),
+            "auto" => Ok(Backend::Auto),
             _ => Err(format!("The backend {} doesn't exist", s)),
         }
     }

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -265,6 +265,7 @@ fn requires_pre_validation(backend: Backend) -> bool {
         Backend::Cranelift => true,
         Backend::LLVM => true,
         Backend::Singlepass => false,
+        Backend::Auto => false,
     }
 }
 

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -254,11 +254,6 @@ pub fn compiler_for_backend(backend: Backend) -> Option<Box<dyn Compiler>> {
         #[cfg(feature = "llvm")]
         Backend::LLVM => Some(Box::new(wasmer_llvm_backend::LLVMCompiler::new())),
 
-        #[cfg(any(
-            not(feature = "llvm"),
-            not(feature = "singlepass"),
-            not(feature = "cranelift")
-        ))]
         _ => None,
     }
 }


### PR DESCRIPTION
Adapt backend usage depending on wasm file executed in issue #998.
Close #998 

# Description
Add `auto` backend into a runtime-core and use it as a default backend.
The `auto` backend is equivalent to: 
* singlepass if singlepass is enabled and the wasm file size is larger than 10MiB, or singlepass is enable and the target architecture is aarch64.
* cranelift otherwise.
