### PR TITLE
[fix 962] Activate pre_validation when llvm backend selected

### DIFF
--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -263,7 +263,7 @@ impl<
 fn requires_pre_validation(backend: Backend) -> bool {
     match backend {
         Backend::Cranelift => true,
-        Backend::LLVM => false,
+        Backend::LLVM => true,
         Backend::Singlepass => false,
     }
 }


### PR DESCRIPTION
# Description

After analysis of issue https://github.com/wasmerio/wasmer/issues/962 by me and @nlewycky, it seems to be better to validate the wasm module before calling the llvm compiler.

This change will imply potential overhead in term of execution speed using llvm backend.

I will also suggest to set pre_validation to true for Singlepass by default:
https://github.com/wasmerio/wasmer/blob/5c1c786e355b7dc83f4fcb31c3739b0f1d9981c4/lib/runtime-core/src/codegen.rs#L263-L269

Additional improvement proposal for wasmer API & cli command options:
* add an API `compile_without_validation`.
* add a flag option in wasmer binary to deactivate `pre_validation` for all backend.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
