### PR TITLE
Turn a few more assert!s that should never fire into debug_assert!s.

### DIFF
--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -1764,11 +1764,11 @@ impl FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator {
                 let info = {
                     let mut info = i1.strip_pending() & i2.strip_pending();
                     if i1.has_pending_f32_nan() {
-                        assert!(i2.has_pending_f32_nan());
+                        debug_assert!(i2.has_pending_f32_nan());
                         info |= ExtraInfo::pending_f32_nan();
                     }
                     if i1.has_pending_f64_nan() {
-                        assert!(i2.has_pending_f64_nan());
+                        debug_assert!(i2.has_pending_f64_nan());
                         info |= ExtraInfo::pending_f64_nan();
                     }
                     info

--- a/lib/llvm-backend/src/state.rs
+++ b/lib/llvm-backend/src/state.rs
@@ -163,12 +163,12 @@ impl BitAnd for ExtraInfo {
     type Output = Self;
     fn bitand(self, other: Self) -> Self {
         // Pending canonicalizations are not safe to discard, or even reorder.
-        assert!(
+        debug_assert!(
             self.has_pending_f32_nan() == other.has_pending_f32_nan()
                 || self.is_arithmetic_f32()
                 || other.is_arithmetic_f32()
         );
-        assert!(
+        debug_assert!(
             self.has_pending_f64_nan() == other.has_pending_f64_nan()
                 || self.is_arithmetic_f64()
                 || other.is_arithmetic_f64()


### PR DESCRIPTION
These are here to protect against errors when refactoring more than anything else.
