### PR TITLE
When modifying the value, also update its ExtraInfo.

### DIFF
--- a/lib/llvm-backend-tests/tests/compile.rs
+++ b/lib/llvm-backend-tests/tests/compile.rs
@@ -18,5 +18,23 @@ fn crash_return_with_float_on_stack() {
 "#;
     let wasm_binary = wat2wasm(MODULE.as_bytes()).expect("WAST not valid or malformed");
     let module = compile_with(&wasm_binary, &get_compiler()).unwrap();
-    let instance = module.instantiate(&imports! {}).unwrap();
+    module.instantiate(&imports! {}).unwrap();
+}
+
+#[test]
+fn crash_select_with_mismatched_pending() {
+    const MODULE: &str = r#"
+ (module
+  (func (param f64)
+    f64.const 0x0p+0 (;=0;)
+    local.get 0
+    f64.add
+    f64.const 0x0p+0 (;=0;)
+    i32.const 0
+    select
+    drop))
+"#;
+    let wasm_binary = wat2wasm(MODULE.as_bytes()).expect("WAST not valid or malformed");
+    let module = compile_with(&wasm_binary, &get_compiler()).unwrap();
+    module.instantiate(&imports! {}).unwrap();
 }

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -1730,15 +1730,17 @@ impl<'ctx> FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator<'ct
                 // If the pending bits of v1 and v2 are the same, we can pass
                 // them along to the result. Otherwise, apply pending
                 // canonicalizations now.
-                let (v1, v2) = if i1.has_pending_f32_nan() != i2.has_pending_f32_nan()
+                let (v1, i1, v2, i2) = if i1.has_pending_f32_nan() != i2.has_pending_f32_nan()
                     || i1.has_pending_f64_nan() != i2.has_pending_f64_nan()
                 {
                     (
                         apply_pending_canonicalization(builder, intrinsics, v1, i1),
+                        i1.strip_pending(),
                         apply_pending_canonicalization(builder, intrinsics, v2, i2),
+                        i2.strip_pending(),
                     )
                 } else {
-                    (v1, v2)
+                    (v1, i1, v2, i2)
                 };
                 let cond_value = builder.build_int_compare(
                     IntPredicate::NE,


### PR DESCRIPTION
Fixes a debug_assert! on python3.7 and rustpython in wapm.
