### PR TITLE
Fix/quiet some rustc warnings.

### DIFF
--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -111,7 +111,7 @@ pub struct EmscriptenData<'a> {
     pub dyn_call_iii: Option<Func<'a, (i32, i32, i32), i32>>,
     pub dyn_call_iiii: Option<Func<'a, (i32, i32, i32, i32), i32>>,
     pub dyn_call_iifi: Option<Func<'a, (i32, i32, f64, i32), i32>>,
-    pub dyn_call_v: Option<Func<'a, (i32)>>,
+    pub dyn_call_v: Option<Func<'a, i32>>,
     pub dyn_call_vi: Option<Func<'a, (i32, i32)>>,
     pub dyn_call_vii: Option<Func<'a, (i32, i32, i32)>>,
     pub dyn_call_viii: Option<Func<'a, (i32, i32, i32, i32)>>,
@@ -168,7 +168,7 @@ pub struct EmscriptenData<'a> {
     pub temp_ret_0: i32,
 
     pub stack_save: Option<Func<'a, (), i32>>,
-    pub stack_restore: Option<Func<'a, (i32)>>,
+    pub stack_restore: Option<Func<'a, i32>>,
     pub set_threw: Option<Func<'a, (i32, i32)>>,
     pub mapped_dirs: HashMap<String, PathBuf>,
 }

--- a/lib/middleware-common-tests/benches/metering_benchmark.rs
+++ b/lib/middleware-common-tests/benches/metering_benchmark.rs
@@ -189,7 +189,7 @@ fn bench_metering(c: &mut Criterion) {
             let wasm_binary = wat2wasm(WAT).unwrap();
             let module = compile_with(&wasm_binary, &compiler).unwrap();
             let import_object = imports! {};
-            let mut instance = module.instantiate(&import_object).unwrap();
+            let instance = module.instantiate(&import_object).unwrap();
             let add_to: Func<(i32, i32), i32> = instance.func("add_to").unwrap();
             b.iter(|| black_box(add_to.call(100, 4)))
         })
@@ -202,7 +202,7 @@ fn bench_metering(c: &mut Criterion) {
                    "gas" => Func::new(gas),
                 },
             };
-            let mut gas_instance = gas_module.instantiate(&gas_import_object).unwrap();
+            let gas_instance = gas_module.instantiate(&gas_import_object).unwrap();
             let gas_add_to: Func<(i32, i32), i32> = gas_instance.func("add_to").unwrap();
             b.iter(|| black_box(gas_add_to.call(100, 4)))
         })

--- a/lib/runtime/benches/many_instances.rs
+++ b/lib/runtime/benches/many_instances.rs
@@ -4,7 +4,7 @@ use criterion::Criterion;
 use tempfile::tempdir;
 use wasmer_runtime::{
     cache::{Cache, FileSystemCache, WasmHash},
-    compile, func, imports, instantiate, validate, ImportObject,
+    compile, func, imports, instantiate, validate,
 };
 use wasmer_runtime_core::vm::Ctx;
 
@@ -71,7 +71,7 @@ fn calling_fn_benchmark(c: &mut Criterion) {
     );
     let instance = instantiate(SIMPLE_WASM, &imports).unwrap();
     c.bench_function("calling fn", move |b| {
-        let entry_point = instance.func::<(i32), i32>("plugin_entrypoint").unwrap();
+        let entry_point = instance.func::<i32, i32>("plugin_entrypoint").unwrap();
         b.iter(|| entry_point.call(2).unwrap())
     });
 }

--- a/lib/singlepass-backend/src/emitter_x64.rs
+++ b/lib/singlepass-backend/src/emitter_x64.rs
@@ -1274,9 +1274,9 @@ impl Emitter for Assembler {
     fn emit_inline_breakpoint(&mut self, ty: InlineBreakpointType) {
         dynasm!(self
             ; ud2
-            ; .byte 0x0f ; .byte (0xb9u8 as i8) // ud
+            ; .byte 0x0f ; .byte 0xb9u8 as i8 // ud
             ; int -1
-            ; .byte (ty as u8 as i8)
+            ; .byte ty as u8 as i8
         );
     }
 }


### PR DESCRIPTION
No functionality change.

Remaining warnings are either dead code in examples/parallel-guest, or due to macros in typed_func.rs for which removing the "extra" parentheses breaks the build.