### PR TITLE
Add a StackLimit middleware for deterministically limiting runtime stack sizes.

### DIFF
--- a/lib/middleware-common/src/lib.rs
+++ b/lib/middleware-common/src/lib.rs
@@ -14,3 +14,4 @@
 pub mod block_trace;
 pub mod call_trace;
 pub mod metering;
+pub mod stack_limit;

--- a/lib/middleware-common/src/stack_limit.rs
+++ b/lib/middleware-common/src/stack_limit.rs
@@ -1,0 +1,154 @@
+use wasmer_runtime_core::{
+    codegen::{Event, EventSink, FunctionMiddleware, InternalEvent},
+    module::ModuleInfo,
+    vm::InternalField,
+    wasmparser::{Operator, Type as WpType, TypeOrFuncType as WpTypeOrFuncType},
+};
+
+static FIELD_STATIC_SLOTS: InternalField = InternalField::allocate();
+static FIELD_STACK_DEPTH: InternalField = InternalField::allocate();
+
+#[derive(Copy, Clone, Debug)]
+pub struct StaticSlotLimitExceededError;
+
+#[derive(Copy, Clone, Debug)]
+pub struct StackDepthExceededError;
+
+/// StackLimit is a compiler middleware that deterministically limit the size
+/// of virtual stack each module is allowed to use.
+pub struct StackLimit {
+    config: StackLimitConfig,
+    current_static_slots: Option<usize>,
+    prev_stack_depth: usize,
+}
+
+pub struct StackLimitConfig {
+    pub max_value_stack_depth: Option<usize>,
+    pub max_static_slot_count: Option<usize>,
+}
+
+impl StackLimit {
+    pub fn new(config: StackLimitConfig) -> StackLimit {
+        StackLimit {
+            config,
+            current_static_slots: None,
+            prev_stack_depth: 0,
+        }
+    }
+}
+
+impl FunctionMiddleware for StackLimit {
+    type Error = String;
+    fn feed_event<'a, 'b: 'a>(
+        &mut self,
+        op: Event<'a, 'b>,
+        _module_info: &ModuleInfo,
+        sink: &mut EventSink<'a, 'b>,
+    ) -> Result<(), Self::Error> {
+        match op {
+            Event::Internal(InternalEvent::FunctionBegin(_)) => {
+                self.current_static_slots = None;
+            }
+            Event::Internal(InternalEvent::FunctionStaticSlotCount(count)) => {
+                self.current_static_slots = Some(count);
+                if let Some(limit) = self.config.max_static_slot_count {
+                    sink.push(Event::Internal(InternalEvent::GetInternal(
+                        FIELD_STATIC_SLOTS.index() as _,
+                    )));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: count as i64,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64Add));
+                    sink.push(Event::Internal(InternalEvent::SetInternal(
+                        FIELD_STATIC_SLOTS.index() as _,
+                    )));
+
+                    sink.push(Event::Internal(InternalEvent::GetInternal(
+                        FIELD_STATIC_SLOTS.index() as _,
+                    )));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: limit as i64,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64GtU));
+                    sink.push(Event::WasmOwned(Operator::If {
+                        ty: WpTypeOrFuncType::Type(WpType::EmptyBlockType),
+                    }));
+                    sink.push(Event::Internal(InternalEvent::Breakpoint(Box::new(|_| {
+                        Err(Box::new(StaticSlotLimitExceededError))
+                    }))));
+                    sink.push(Event::WasmOwned(Operator::End));
+                }
+            }
+            Event::Internal(InternalEvent::ValueStackGrow(new_depth)) => {
+                if let Some(limit) = self.config.max_value_stack_depth {
+                    // Update.
+                    sink.push(Event::Internal(InternalEvent::GetInternal(
+                        FIELD_STACK_DEPTH.index() as _,
+                    )));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: self.prev_stack_depth as _,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64Sub));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: new_depth as i64,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64Add));
+                    sink.push(Event::Internal(InternalEvent::SetInternal(
+                        FIELD_STACK_DEPTH.index() as _,
+                    )));
+
+                    sink.push(Event::Internal(InternalEvent::GetInternal(
+                        FIELD_STACK_DEPTH.index() as _,
+                    )));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: limit as i64,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64GtU));
+                    sink.push(Event::WasmOwned(Operator::If {
+                        ty: WpTypeOrFuncType::Type(WpType::EmptyBlockType),
+                    }));
+                    sink.push(Event::Internal(InternalEvent::Breakpoint(Box::new(|_| {
+                        Err(Box::new(StackDepthExceededError))
+                    }))));
+                    sink.push(Event::WasmOwned(Operator::End));
+
+                    self.prev_stack_depth = new_depth;
+                }
+            }
+            Event::Internal(InternalEvent::FunctionEnd) => {
+                if let Some(_) = self.config.max_static_slot_count {
+                    // Resume the previous static slot count.
+                    sink.push(Event::Internal(InternalEvent::GetInternal(
+                        FIELD_STATIC_SLOTS.index() as _,
+                    )));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: self.current_static_slots.unwrap() as i64,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64Sub));
+                    sink.push(Event::Internal(InternalEvent::SetInternal(
+                        FIELD_STATIC_SLOTS.index() as _,
+                    )));
+
+                    self.current_static_slots = None;
+                }
+                if let Some(_) = self.config.max_value_stack_depth {
+                    // Resume the previous stack depth.
+                    sink.push(Event::Internal(InternalEvent::GetInternal(
+                        FIELD_STACK_DEPTH.index() as _,
+                    )));
+                    sink.push(Event::WasmOwned(Operator::I64Const {
+                        value: self.prev_stack_depth as i64,
+                    }));
+                    sink.push(Event::WasmOwned(Operator::I64Sub));
+                    sink.push(Event::Internal(InternalEvent::SetInternal(
+                        FIELD_STACK_DEPTH.index() as _,
+                    )));
+                    self.prev_stack_depth = 0;
+                }
+            }
+            _ => {}
+        }
+        sink.push(op);
+        Ok(())
+    }
+}

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -43,6 +43,12 @@ pub enum Event<'a, 'b> {
 pub enum InternalEvent {
     /// A function parse is about to begin.
     FunctionBegin(u32),
+    /// Total number of static slots (arguments and locals) of the current function.
+    /// Always emitted after `FunctionBegin` and before the first opcode.
+    FunctionStaticSlotCount(usize),
+    /// Indicates that the value stack growed.
+    /// The argument is the new total number of elements on the value stack.
+    ValueStackGrow(usize),
     /// A function parsing has just completed.
     FunctionEnd,
     /// A breakpoint emitted during parsing.
@@ -57,6 +63,8 @@ impl fmt::Debug for InternalEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             InternalEvent::FunctionBegin(_) => write!(f, "FunctionBegin"),
+            InternalEvent::FunctionStaticSlotCount(_) => write!(f, "FunctionStaticSlotCount"),
+            InternalEvent::ValueStackGrow(_) => write!(f, "ValueStackGrow"),
             InternalEvent::FunctionEnd => write!(f, "FunctionEnd"),
             InternalEvent::Breakpoint(_) => write!(f, "Breakpoint"),
             InternalEvent::SetInternal(_) => write!(f, "SetInternal"),

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -249,6 +249,7 @@ pub fn read_module<
                         .map_err(|x| LoadError::Codegen(format!("{:?}", x)))?;
                 }
 
+                let mut num_static_slots: usize = sig.params().len();
                 let mut body_begun = false;
 
                 loop {
@@ -260,6 +261,7 @@ pub fn read_module<
                                 fcg.feed_local(ty, count as usize)
                                     .map_err(|x| LoadError::Codegen(format!("{:?}", x)))?;
                             }
+                            num_static_slots += locals.len();
                         }
                         ParserState::CodeOperator(op) => {
                             if !body_begun {
@@ -270,6 +272,15 @@ pub fn read_module<
                                     .run(
                                         Some(fcg),
                                         Event::Internal(InternalEvent::FunctionBegin(id as u32)),
+                                        &info.read().unwrap(),
+                                    )
+                                    .map_err(|x| LoadError::Codegen(x))?;
+                                middlewares
+                                    .run(
+                                        Some(fcg),
+                                        Event::Internal(InternalEvent::FunctionStaticSlotCount(
+                                            num_static_slots,
+                                        )),
                                         &info.read().unwrap(),
                                     )
                                     .map_err(|x| LoadError::Codegen(x))?;

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -2226,7 +2226,6 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                         );
                         a.emit_inline_breakpoint(InlineBreakpointType::Middleware);
                     }
-                    InternalEvent::FunctionBegin(_) | InternalEvent::FunctionEnd => {}
                     InternalEvent::GetInternal(idx) => {
                         let idx = idx as usize;
                         assert!(idx < INTERNALS_SIZE);
@@ -2293,7 +2292,8 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                             Location::Memory(tmp, (idx * 8) as i32),
                         );
                         self.machine.release_temp_gpr(tmp);
-                    } //_ => unimplemented!(),
+                    }
+                    _ => {}
                 }
                 return Ok(());
             }


### PR DESCRIPTION
TODO:

- [x] InternalEvent: `FunctionStaticSlotCount`
- [ ] InternalEvent: `ValueStackGrow`
- [ ] Add tests.