### PR TITLE
Added support for indexed framebuffers in framebuffer files

### DIFF
--- a/lib/wasi-framebuffer/src/lib.rs
+++ b/lib/wasi-framebuffer/src/lib.rs
@@ -452,7 +452,7 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
     let fb_fd = unsafe {
         fs.open_dir_all(
             VIRTUAL_ROOT_FD,
-            "sys/class/graphics/wasmerfb".to_string(),
+            "sys/class/graphics/wasmerfb0".to_string(),
             ALL_RIGHTS,
             ALL_RIGHTS,
             0,


### PR DESCRIPTION
As the title states!

We spoke offline about this over slack, this simply renames the file from `wasmerfb` -> `wasmerfb0` 😄 