### PR TITLE
Improved Metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,7 @@ dependencies = [
  "wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.11.0",
  "wasmer-win-exception-handler 0.11.0",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.3 (git+https://github.com/AdamSLevy/wasmparser?branch=OperatorClonev0.39.3)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2170,7 +2170,7 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.3 (git+https://github.com/AdamSLevy/wasmparser?branch=OperatorClonev0.39.3)",
 ]
 
 [[package]]
@@ -2231,7 +2231,7 @@ dependencies = [
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime-core 0.11.0",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.3 (git+https://github.com/AdamSLevy/wasmparser?branch=OperatorClonev0.39.3)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2313,7 +2313,7 @@ dependencies = [
  "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.39.3 (git+https://github.com/AdamSLevy/wasmparser?branch=OperatorClonev0.39.3)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2400,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.39.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/AdamSLevy/wasmparser?branch=OperatorClonev0.39.3#dcff25a7822c35a9430761ce98e1d8f3a62d5de8"
 
 [[package]]
 name = "winapi"
@@ -2692,7 +2692,7 @@ dependencies = [
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasmer-clif-fork-frontend 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0cf2f552a9c1fda0555087170424bd8fedc63a079a97bb5638a4ef9b0d9656aa"
 "checksum wasmer-clif-fork-wasm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0073b512e1af5948d34be7944b74c747bbe735ccff2e2f28c26ed4c90725de8e"
-"checksum wasmparser 0.39.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c702914acda5feeeffbc29e4d953e5b9ce79d8b98da4dbf18a77086e116c5470"
+"checksum wasmparser 0.39.3 (git+https://github.com/AdamSLevy/wasmparser?branch=OperatorClonev0.39.3)" = "<none>"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,6 @@ crate-type = ["bin"]
 [[example]]
 name = "callback"
 crate-type = ["bin"]
+
+[patch.crates-io]
+wasmparser =  { git = "https://github.com/AdamSLevy/wasmparser", branch = "OperatorClonev0.39.3" }

--- a/lib/middleware-common-tests/benches/metering_benchmark.rs
+++ b/lib/middleware-common-tests/benches/metering_benchmark.rs
@@ -134,13 +134,13 @@ static WAT_GAS: &'static str = r#"
         "#;
 
 #[cfg(feature = "llvm")]
-fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
+fn get_compiler(metering: bool) -> impl Compiler {
     use wasmer_llvm_backend::ModuleCodeGenerator;
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     let c: StreamingCompiler<ModuleCodeGenerator, _, _, _, _> = StreamingCompiler::new(move || {
         let mut chain = MiddlewareChain::new();
         if metering {
-            chain.push(Metering::new(limit));
+            chain.push(Metering::new());
         }
         chain
     });
@@ -149,13 +149,13 @@ fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
 }
 
 #[cfg(feature = "singlepass")]
-fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
+fn get_compiler(metering: bool) -> impl Compiler {
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
     let c: StreamingCompiler<SinglePassMCG, _, _, _, _> = StreamingCompiler::new(move || {
         let mut chain = MiddlewareChain::new();
         if metering {
-            chain.push(Metering::new(limit));
+            chain.push(Metering::new());
         }
         chain
     });
@@ -166,7 +166,7 @@ fn get_compiler(limit: u64, metering: bool) -> impl Compiler {
 compile_error!("compiler not specified, activate a compiler via features");
 
 #[cfg(feature = "clif")]
-fn get_compiler(_limit: u64, metering: bool) -> impl Compiler {
+fn get_compiler(metering: bool) -> impl Compiler {
     compile_error!("cranelift does not implement metering");
     use wasmer_clif_backend::CraneliftCompiler;
     CraneliftCompiler::new()
@@ -185,7 +185,7 @@ fn bench_metering(c: &mut Criterion) {
     c.bench(
         "Meter",
         Benchmark::new("No Metering", |b| {
-            let compiler = get_compiler(0, false);
+            let compiler = get_compiler(false);
             let wasm_binary = wat2wasm(WAT).unwrap();
             let module = compile_with(&wasm_binary, &compiler).unwrap();
             let import_object = imports! {};
@@ -194,7 +194,7 @@ fn bench_metering(c: &mut Criterion) {
             b.iter(|| black_box(add_to.call(100, 4)))
         })
         .with_function("Gas Metering", |b| {
-            let compiler = get_compiler(0, false);
+            let compiler = get_compiler(false);
             let gas_wasm_binary = wat2wasm(WAT_GAS).unwrap();
             let gas_module = compile_with(&gas_wasm_binary, &compiler).unwrap();
             let gas_import_object = imports! {
@@ -207,13 +207,14 @@ fn bench_metering(c: &mut Criterion) {
             b.iter(|| black_box(gas_add_to.call(100, 4)))
         })
         .with_function("Built-in Metering", |b| {
-            let metering_compiler = get_compiler(std::u64::MAX, true);
+            let metering_compiler = get_compiler(true);
             let wasm_binary = wat2wasm(WAT).unwrap();
             let metering_module = compile_with(&wasm_binary, &metering_compiler).unwrap();
             let metering_import_object = imports! {};
             let mut metering_instance = metering_module
                 .instantiate(&metering_import_object)
                 .unwrap();
+            metering::set_limit(&mut metering_instance, std::u64::MAX);
             metering::set_points_used(&mut metering_instance, 0u64);
             let metering_add_to: Func<(i32, i32), i32> = metering_instance.func("add_to").unwrap();
             b.iter(|| black_box(metering_add_to.call(100, 4)))

--- a/lib/middleware-common/src/metering.rs
+++ b/lib/middleware-common/src/metering.rs
@@ -1,5 +1,5 @@
 use wasmer_runtime_core::{
-    codegen::{Event, EventSink, FunctionMiddleware, InternalEvent},
+    codegen::{Event, EventSink, FunctionMiddleware, InternalEvent::*},
     module::ModuleInfo,
     vm::{Ctx, InternalField},
     wasmparser::{Operator, Type as WpType, TypeOrFuncType as WpTypeOrFuncType},
@@ -9,25 +9,109 @@ use wasmer_runtime_core::{
 static INTERNAL_FIELD_USED: InternalField = InternalField::allocate();
 static INTERNAL_FIELD_LIMIT: InternalField = InternalField::allocate();
 
-/// Metering is a compiler middleware that calculates the cost of WebAssembly instructions at compile
-/// time and will count the cost of executed instructions at runtime. Within the Metering functionality,
-/// this instruction cost is called `points`.
+/// Metering is a compiler middleware that calculates the cost of WebAssembly instructions at
+/// compile time and will count the cost of executed instructions at runtime. Within the Metering
+/// functionality, this instruction cost is called `points`.
 ///
-/// The Metering struct takes a `limit` parameter which is the maximum number of points which can be
-/// used by an instance during a function call. If this limit is exceeded, the function call will
-/// trap. Each instance has a `points_used` field which can be used to track points used during
-/// a function call and should be set back to zero after a function call.
+/// Each instance has an `exec_limit` which is the maximum number of points which can be used by
+/// the instance during a function call. If this limit is exceeded, the function call will trap.
+/// Each instance has a `points_used` field which can be used to track points used during a
+/// function call and should be set back to zero after a function call.
 ///
 /// Each compiler backend with Metering enabled should produce the same cost used at runtime for
 /// the same function calls so we can say that the metering is deterministic.
-///
 pub struct Metering {
-    current_block: u64,
+    injections: Vec<Injection>,
+    current_block_injections: Vec<Injection>,
+    current_block_cost: u64,
 }
 
 impl Metering {
     pub fn new() -> Metering {
-        Metering { current_block: 0 }
+        Metering {
+            injections: Vec::new(),
+            current_block_injections: Vec::new(),
+            current_block_cost: 0,
+        }
+    }
+
+    fn set_costs<'a, 'b: 'a>(&mut self) {
+        for inj in &mut self.current_block_injections {
+            inj.check += self.current_block_cost;
+        }
+        // Set add of the last injection
+        if self.current_block_injections.len() > 0 {
+            let last_idx = self.current_block_injections.len() - 1;
+            self.current_block_injections[last_idx] = Injection {
+                add: self.current_block_cost,
+                check: 0,
+            };
+        }
+        self.current_block_cost = 0;
+    }
+
+    fn begin<'a, 'b: 'a>(&mut self) {
+        self.set_costs();
+        self.current_block_injections
+            .push(Injection { add: 0, check: 0 });
+    }
+    fn end<'a, 'b: 'a>(&mut self) {
+        self.set_costs();
+        self.injections.append(&mut self.current_block_injections);
+    }
+
+    fn inject_metering<'a, 'b: 'a>(&self, sink: &mut EventSink<'a, 'b>) {
+        let prev: Vec<Event> = sink.buffer.drain(..).collect();
+        let mut inj_idx: usize = 1;
+        for ev in prev {
+            match ev {
+                Event::Internal(FunctionBegin(_)) => {
+                    sink.push(ev);
+                    self.injections[0].inject(sink);
+                }
+                Event::Wasm(&ref op) | Event::WasmOwned(ref op) => match *op {
+                    Operator::End
+                    | Operator::If { .. }
+                    | Operator::Else
+                    | Operator::BrIf { .. }
+                    | Operator::Loop { .. }
+                    | Operator::Call { .. }
+                    | Operator::CallIndirect { .. } => {
+                        sink.push(ev);
+                        self.injections[inj_idx].inject(sink);
+                        inj_idx += 1;
+                    }
+                    _ => {
+                        sink.push(ev);
+                    }
+                },
+                _ => {
+                    sink.push(ev);
+                }
+            }
+        }
+    }
+
+    /// increment_cost adds 1 to the current_block_cost.
+    ///
+    /// Later this may be replaced with a cost map for assigning custom unique cost values to
+    /// specific Operators.
+    fn increment_cost<'a, 'b: 'a>(&mut self, ev: &Event<'a, 'b>) {
+        match ev {
+            Event::Internal(ref iev) => match iev {
+                FunctionBegin(_) | FunctionEnd | Breakpoint(_) => {
+                    return;
+                }
+                _ => {}
+            },
+            Event::Wasm(&ref op) | Event::WasmOwned(ref op) => match *op {
+                Operator::Unreachable | Operator::End | Operator::Else => {
+                    return;
+                }
+                _ => {}
+            },
+        }
+        self.current_block_cost += 1;
     }
 }
 
@@ -38,70 +122,66 @@ impl FunctionMiddleware for Metering {
     type Error = String;
     fn feed_event<'a, 'b: 'a>(
         &mut self,
-        op: Event<'a, 'b>,
+        ev: Event<'a, 'b>,
         _module_info: &ModuleInfo,
         sink: &mut EventSink<'a, 'b>,
     ) -> Result<(), Self::Error> {
-        match op {
-            Event::Internal(InternalEvent::FunctionBegin(_)) => {
-                self.current_block = 0;
-            }
+        // This involves making two passes over an entire function. The first pass counts the costs
+        // of each code segment. The final pass occurs when Event is FunctionEnd and we actually
+        // drain the EventSink and repopulate it with metering code injected.
+        match ev {
+            Event::Internal(ref iev) => match iev {
+                FunctionBegin(_) => {
+                    self.injections.clear();
+                    self.current_block_injections.clear();
+                    self.current_block_cost = 0;
+                    sink.push(ev);
+                    self.begin();
+                    return Ok(());
+                }
+                FunctionEnd => {
+                    self.end();
+                    self.inject_metering(sink);
+                    sink.push(ev);
+                    return Ok(());
+                }
+                _ => {
+                    self.increment_cost(&ev);
+                    sink.push(ev);
+                    return Ok(());
+                }
+            },
             Event::Wasm(&ref op) | Event::WasmOwned(ref op) => {
-                self.current_block += 1;
+                self.increment_cost(&ev);
+                match *op {
+                    Operator::End
+                    | Operator::If { .. }
+                    | Operator::Else
+                    | Operator::Br { .. }
+                    | Operator::BrIf { .. }
+                    | Operator::BrTable { .. }
+                    | Operator::Unreachable
+                    | Operator::Return => {
+                        self.end();
+                    }
+                    _ => {}
+                }
                 match *op {
                     Operator::Loop { .. }
-                    | Operator::Block { .. }
                     | Operator::End
                     | Operator::If { .. }
                     | Operator::Else
-                    | Operator::Unreachable
-                    | Operator::Br { .. }
-                    | Operator::BrTable { .. }
-                    | Operator::BrIf { .. }
-                    | Operator::Call { .. }
-                    | Operator::CallIndirect { .. }
-                    | Operator::Return => {
-                        sink.push(Event::Internal(InternalEvent::GetInternal(
-                            INTERNAL_FIELD_USED.index() as _,
-                        )));
-                        sink.push(Event::WasmOwned(Operator::I64Const {
-                            value: self.current_block as i64,
-                        }));
-                        sink.push(Event::WasmOwned(Operator::I64Add));
-                        sink.push(Event::Internal(InternalEvent::SetInternal(
-                            INTERNAL_FIELD_USED.index() as _,
-                        )));
-                        self.current_block = 0;
-                    }
-                    _ => {}
-                }
-                match *op {
-                    Operator::Br { .. }
-                    | Operator::BrTable { .. }
                     | Operator::BrIf { .. }
                     | Operator::Call { .. }
                     | Operator::CallIndirect { .. } => {
-                        sink.push(Event::Internal(InternalEvent::GetInternal(
-                            INTERNAL_FIELD_USED.index() as _,
-                        )));
-                        sink.push(Event::Internal(InternalEvent::GetInternal(
-                            INTERNAL_FIELD_LIMIT.index() as _,
-                        )));
-                        sink.push(Event::WasmOwned(Operator::I64GeU));
-                        sink.push(Event::WasmOwned(Operator::If {
-                            ty: WpTypeOrFuncType::Type(WpType::EmptyBlockType),
-                        }));
-                        sink.push(Event::Internal(InternalEvent::Breakpoint(Box::new(|_| {
-                            Err(Box::new(ExecutionLimitExceededError))
-                        }))));
-                        sink.push(Event::WasmOwned(Operator::End));
+                        self.begin();
                     }
                     _ => {}
                 }
             }
-            _ => {}
         }
-        sink.push(op);
+        sink.push(ev);
+
         Ok(())
     }
 }
@@ -140,4 +220,91 @@ pub fn get_execution_limit(instance: &Instance) -> u64 {
 
 pub fn get_execution_limit_ctx(ctx: &Ctx) -> u64 {
     ctx.get_internal(&INTERNAL_FIELD_LIMIT)
+}
+
+/// Injection is a struct that stores the cost of the subsequent code segment. It injects metering
+/// code into the EventSink.
+///
+/// Code segments may be nested such that multiple segments may begin at different places but all
+/// end at the same branching instruction. Thus entering into one code segment guarantees that you
+/// will proceed to the nested ones, until the first branching operator is reached. In these cases,
+/// the limit check can be done such that we ensure enough gas to complete the entire code segment,
+/// including nested parts. However it is important that we only add the cost up to the next
+/// metering injection.
+///
+/// For example, consider the following
+///
+/// - INJECT METERING CODE (check to if, add cost to next INJECT)
+/// | block
+/// |    ... (non-branching ops)
+/// |    loop
+/// |    - INJECT METERING CODE (check to if, add to next INJECT)
+/// |    |   ... (non-branching ops)
+/// |    |   loop
+/// |    |   - INJECT METERING CODE
+/// |    |   |    ... (non-branching ops)
+/// |____|___|___ if (first branching op)
+#[derive(Debug)]
+struct Injection {
+    check: u64,
+    add: u64,
+}
+
+impl Injection {
+    fn inject<'a, 'b: 'a>(&self, sink: &mut EventSink<'a, 'b>) {
+        if self.add == 0 {
+            return;
+        }
+        // PUSH USED
+        sink.push(Event::Internal(GetInternal(
+            INTERNAL_FIELD_USED.index() as _
+        )));
+
+        // PUSH COST (to next Injection)
+        sink.push(Event::WasmOwned(Operator::I64Const {
+            value: self.add as i64,
+        }));
+
+        // USED + COST
+        sink.push(Event::WasmOwned(Operator::I64Add));
+
+        // SAVE USED
+        sink.push(Event::Internal(SetInternal(
+            INTERNAL_FIELD_USED.index() as _
+        )));
+
+        // PUSH USED
+        sink.push(Event::Internal(GetInternal(
+            INTERNAL_FIELD_USED.index() as _
+        )));
+
+        if self.check > 0 {
+            // PUSH COST (to next branching op)
+            sink.push(Event::WasmOwned(Operator::I64Const {
+                value: self.check as i64,
+            }));
+
+            // USED + COST
+            sink.push(Event::WasmOwned(Operator::I64Add));
+        }
+
+        // PUSH LIMIT
+        sink.push(Event::Internal(GetInternal(
+            INTERNAL_FIELD_LIMIT.index() as _
+        )));
+
+        // IF USED > LIMIT
+        sink.push(Event::WasmOwned(Operator::I64GtU));
+        sink.push(Event::WasmOwned(Operator::If {
+            ty: WpTypeOrFuncType::Type(WpType::EmptyBlockType),
+        }));
+
+        //          TRAP! EXECUTION LIMIT EXCEEDED
+        sink.push(Event::Internal(Breakpoint(Box::new(|_| {
+            Err(Box::new(ExecutionLimitExceededError))
+        }))));
+
+        // ENDIF
+        sink.push(Event::WasmOwned(Operator::End));
+    }
 }

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 nix = "0.15"
 page_size = "0.4"
-wasmparser = "0.39.1"
+wasmparser = "0.39.3"
 parking_lot = "0.9"
 lazy_static = "1.4"
 errno = "0.2"

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -11,7 +11,6 @@ use crate::{
     structures::Map,
     types::{FuncIndex, FuncSig, SigIndex},
 };
-use smallvec::SmallVec;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt;
@@ -274,7 +273,8 @@ fn requires_pre_validation(backend: Backend) -> bool {
 
 /// A sink for parse events.
 pub struct EventSink<'a, 'b> {
-    buffer: SmallVec<[Event<'a, 'b>; 2]>,
+    /// document this
+    pub buffer: Vec<Event<'a, 'b>>,
 }
 
 impl<'a, 'b> EventSink<'a, 'b> {
@@ -301,18 +301,14 @@ impl MiddlewareChain {
     }
 
     /// Run this chain with the provided function code generator, event and module info.
-    pub(crate) fn run<E: Debug, FCG: FunctionCodeGenerator<E>>(
+    pub(crate) fn run<'a, 'b: 'a, E: Debug, FCG: FunctionCodeGenerator<E>>(
         &mut self,
         fcg: Option<&mut FCG>,
-        ev: Event,
+        mut sink: EventSink<'a, 'b>,
         module_info: &ModuleInfo,
     ) -> Result<(), String> {
-        let mut sink = EventSink {
-            buffer: SmallVec::new(),
-        };
-        sink.push(ev);
         for m in &mut self.chain {
-            let prev: SmallVec<[Event; 2]> = sink.buffer.drain().collect();
+            let prev: Vec<Event> = sink.buffer.drain(..).collect();
             for ev in prev {
                 m.feed_event(ev, module_info, &mut sink)?;
             }


### PR DESCRIPTION
# Description

This PR refactors the Metering middleware to address the issues described in #999. In short, the current metering does not prevent execution of code segments that exceed the limit, but instead only checks if limits are exceeded after execution of the code segment. Additionally the current metering does not catch some situations where the limit exceeded in the last few instructions of a function.

This metering injects limit checks prior to each code segment, ensure that execution does not proceed if there is not enough gas to reach the next branching instruction. Although after an ExecutionLimitExceededError the reported gas used will be greater than the limit, the execution will not have actually proceeded through that code segment. 

Additionally, this metering will check further ahead than eWasm metering in certain circumstances.

For example if we have multiple nested loops in a block without any branching instructions,
```
METER
Block
    ... // no branching ops
    Loop
        METER
        ... // no branching ops
        Loop
            METER
            ...
            IF // first branching op since first METER
                ...
            END
        End
    End
End
```

Each METER represents injected metering code that adds the cost of the next segment to the used points and checks it against the limit, trapping if exceeded.

Each METER that I listed will actually ensure that there is enough gas to reach the first branching op, which in my above example is IF. 

I'm happy to answer more questions about the Metering design. I believe it would benefit from additional tests that use more complex wasm code.

## Implementation details

In order to implement this metering as such, a refactor of `parse::read_module()` and `codegen::MiddlewareChain.run()` and `codegen::EventSink` was required. 

This metering algorithm requires the ability to modify previously seen Events that have already been pushed onto the EventSink inside of feed_event. This means that this middleware chain needs to see all of the Events within a function prior to any subsequent chains seeing any of the Events. Additionally this means that all ParserState(Operator) events for a given function need to all be loaded into memory at the same time. 

In parse::read_module, I clone each Operator and store them in an events Vec<Event>. I load a complete function and then I pass the whole events Ven to MiddlewareChain.run(), which passes all events through each middleware chain. 

Unfortunately wasmparser::Operator does not implement clone, so I had to fork it and add the trait. I have opened an [issue on the latest wasmparser](https://github.com/bytecodealliance/wasmparser/issues/149) but for compatability I applied my patch to the [version that is currently](https://github.com/AdamSLevy/wasmparser/tree/OperatorClonev0.39.3) being used. 


## Issues

Currently my refactor of `parse::read_module` and `codegen::MiddlewareChain.run` breaks the singlepass backend. This is not due to the metering code but due to my refactor of the runtime-core, as I have isolated that patch in testing. Alternatively you can just comment out the line that adds the metering middleware entirely from the middleware-common-tests to show that the issue lies deeper. 

When running the middleware-common-tests compilation fails with singlepass I get the following failure:
```
Errors were encountered when committing before finalization: UnknownLabel(Dynamic(DynamicLabel(3)))
```
https://gist.github.com/AdamSLevy/455d2a50ec1211d20efaebcd9c06eb1c#file-gistfile1-txt-L42-L102

I have compared my code very closely with the master branch and I am 99% certain that all mcg and fcg functions are being called in the proper order in my refactor. The only difference I can see is that the Events are now all WasmOwned. 

However my metering code works perfectly with the LLVM backend. I have been working with @MarkMcCaskey to come up with this refactor and I have run into this issue and can't work past it as I believe it would require me to learn the singlepass backend and the dynasmrt Assembler. 

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
