### PR TITLE
Initial commit for support of AArch64 in the llvm backend.

### DIFF
--- a/.azure/install-llvm.yml
+++ b/.azure/install-llvm.yml
@@ -31,11 +31,14 @@ steps:
 
   - bash: |
       set -ex
+      mkdir Win64_Release
+      cd Win64_Release
       curl -OL https://github.com/wasmerio/llvm-build/releases/download/8.x/Win64_Release.zip
       7z x Win64_Release.zip
-      llvm=`pwd`/Win64_Release
+      llvm=`pwd`
       echo "##vso[task.prependpath]$llvm/bin"
       echo "##vso[task.setvariable variable=LLVM_SYS_80_PREFIX;]$llvm"
+      cd ..
     displayName: "Install LLVM (Windows)"
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/.azure/install-llvm.yml
+++ b/.azure/install-llvm.yml
@@ -31,9 +31,9 @@ steps:
 
   - bash: |
       set -ex
-      curl -OL https://github.com/wasmerio/windows-llvm-build/releases/download/v8.0.0/llvm-8.0.0-install.zip
-      7z x llvm-8.0.0-install.zip
-      llvm=`pwd`/llvm-8.0.0-install
+      curl -OL https://github.com/wasmerio/llvm-build/releases/download/8.x/Win64_Release.zip
+      7z x Win64_Release.zip
+      llvm=`pwd`/Win64_Release
       echo "##vso[task.prependpath]$llvm/bin"
       echo "##vso[task.setvariable variable=LLVM_SYS_80_PREFIX;]$llvm"
     displayName: "Install LLVM (Windows)"

--- a/.azure/install-llvm.yml
+++ b/.azure/install-llvm.yml
@@ -41,8 +41,8 @@ steps:
 
   # Just to make sure the paths and vars are set properly
   - powershell: |
-      Write-Host "##vso[task.prependpath]$pwd/llvm-8.0.0-install/bin"
-      Write-Host "##vso[task.setvariable variable=LLVM_SYS_80_PREFIX;]$pwd/llvm-8.0.0-install/"
+      Write-Host "##vso[task.prependpath]$pwd/Win64_Release/bin"
+      Write-Host "##vso[task.setvariable variable=LLVM_SYS_80_PREFIX;]$pwd/Win64_Release/"
     displayName: Install LLVM (Windows)
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## **[Unreleased]**
 
 - [#1033](https://github.com/wasmerio/wasmer/pull/1033) Set cranelift backend as default compiler backend again, require at least one backend to be enabled for Wasmer CLI
+- [#1044](https://github.com/wasmerio/wasmer/pull/1044) Enable AArch64 support in the LLVM backend.
 - [#1030](https://github.com/wasmerio/wasmer/pull/1030) Ability to generate `ImportObject` for a specific version WASI version with the C API.
 - [#1028](https://github.com/wasmerio/wasmer/pull/1028) Introduce strict/non-strict modes for `get_wasi_version`
 - [#1029](https://github.com/wasmerio/wasmer/pull/1029) Add the “floating” `WasiVersion::Latest` version.

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ wasitests: wasitests-unit wasitests-singlepass wasitests-cranelift wasitests-llv
 # Backends
 singlepass: spectests-singlepass emtests-singlepass middleware-singlepass wasitests-singlepass
 	cargo test -p wasmer-singlepass-backend --release
-	cargo test -p wasmer-runtime-core-tests --release --no-default-features --features backend-singlepass
+	cargo test --manifest-path lib/runtime-core-tests/Cargo.toml --release --no-default-features --features backend-singlepass
 
 cranelift: spectests-cranelift emtests-cranelift middleware-cranelift wasitests-cranelift
 	cargo test -p wasmer-clif-backend --release
@@ -98,7 +98,7 @@ cranelift: spectests-cranelift emtests-cranelift middleware-cranelift wasitests-
 llvm: spectests-llvm emtests-llvm wasitests-llvm
 	cargo test -p wasmer-llvm-backend --release
 	cargo test -p wasmer-llvm-backend-tests --release
-	cargo test -p wasmer-runtime-core-tests --release --no-default-features --features backend-llvm
+	cargo test --manifest-path lib/runtime-core-tests/Cargo.toml --release --no-default-features --features backend-llvm
 
 
 # All tests

--- a/lib/llvm-backend/Cargo.toml
+++ b/lib/llvm-backend/Cargo.toml
@@ -17,11 +17,17 @@ goblin = "0.0.24"
 libc = "0.2.60"
 byteorder = "1"
 
-[dependencies.inkwell]
+[target.'cfg(target_arch = "x86_64")'.dependencies.inkwell]
 git = "https://github.com/TheDan64/inkwell"
 rev = "781620e9fa30e51a6e03bd0d49b5f5bb7a782520"
 default-features = false
 features = ["llvm8-0", "target-x86"]
+
+[target.'cfg(target_arch = "aarch64")'.dependencies.inkwell]
+git = "https://github.com/TheDan64/inkwell"
+rev = "781620e9fa30e51a6e03bd0d49b5f5bb7a782520"
+default-features = false
+features = ["llvm8-0", "target-aarch64"]
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.15"

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -8464,6 +8464,7 @@ impl<'ctx> ModuleCodeGenerator<LLVMFunctionCodeGenerator<'ctx>, LLVMBackend, Cod
         let triple = triple.unwrap_or(TargetMachine::get_default_triple().to_string());
 
         match triple {
+            #[cfg(target_arch = "x86_64")]
             _ if triple.starts_with("x86") => Target::initialize_x86(&InitializationConfig {
                 asm_parser: true,
                 asm_printer: true,
@@ -8472,6 +8473,7 @@ impl<'ctx> ModuleCodeGenerator<LLVMFunctionCodeGenerator<'ctx>, LLVMBackend, Cod
                 info: true,
                 machine_code: true,
             }),
+            #[cfg(target_arch = "aarch64")]
             _ if triple.starts_with("aarch64") => {
                 Target::initialize_aarch64(&InitializationConfig {
                     asm_parser: true,

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -8472,7 +8472,17 @@ impl<'ctx> ModuleCodeGenerator<LLVMFunctionCodeGenerator<'ctx>, LLVMBackend, Cod
                 info: true,
                 machine_code: true,
             }),
-            _ => unimplemented!("compile to target other than x86-64 is not supported"),
+            _ if triple.starts_with("aarch64") => {
+                Target::initialize_aarch64(&InitializationConfig {
+                    asm_parser: true,
+                    asm_printer: true,
+                    base: true,
+                    disassembler: true,
+                    info: true,
+                    machine_code: true,
+                })
+            }
+            _ => unimplemented!("target {} not supported", triple),
         }
 
         let target = Target::from_triple(&triple).unwrap();

--- a/lib/llvm-backend/src/lib.rs
+++ b/lib/llvm-backend/src/lib.rs
@@ -6,7 +6,10 @@
     unused_unsafe,
     unreachable_patterns
 )]
-#![cfg_attr(not(target_os = "windows"), deny(dead_code))]
+#![cfg_attr(
+    all(not(target_os = "windows"), not(target_arch = "aarch64")),
+    deny(dead_code)
+)]
 #![cfg_attr(nightly, feature(unwind_attributes))]
 #![doc(html_favicon_url = "https://wasmer.io/static/icons/favicon.ico")]
 #![doc(html_logo_url = "https://avatars3.githubusercontent.com/u/44205449?s=200&v=4")]

--- a/lib/spectests/tests/excludes.txt
+++ b/lib/spectests/tests/excludes.txt
@@ -273,6 +273,11 @@ llvm:fail:f64.wast:1621 # AssertReturn - result F64(0) ("0x0") does not match ex
 llvm:fail:f64.wast:2020 # AssertReturn - result F64(9223372036854775808) ("0x8000000000000000") does not match expected F64(0) ("0x0")
 llvm:fail:linking.wast:388 # AssertReturn - Call failed RuntimeError: WebAssembly trap occurred during runtime: incorrect `call_indirect` signature
 
+# LLVM AArch64
+llvm:skip:atomic.wast:*:*:aarch64 # Out of range relocations.
+llvm:skip:skip-stack-guard-page.wast:2275:*:aarch64 # Uncaught SIGSEGV only in release builds
+llvm:skip:skip-stack-guard-page.wast:2282:*:aarch64 # Uncaught SIGSEGV only in release builds
+
 # LLVM Windows
 llvm:skip:address.wast:*:windows
 llvm:skip:align.wast:*:windows


### PR DESCRIPTION
# Description
Enables AArch64 in the llvm backend, and inkwell when the target_arch is aarch64. Adds relevant failing spectests to the excludes.txt.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
