### PR TITLE
feat(github) Attach C & C++ headers to releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1050](https://github.com/wasmerio/wasmer/pull/1050) Attach C & C++ headers to releases.
 - [#1033](https://github.com/wasmerio/wasmer/pull/1033) Set cranelift backend as default compiler backend again, require at least one backend to be enabled for Wasmer CLI
 - [#1030](https://github.com/wasmerio/wasmer/pull/1030) Ability to generate `ImportObject` for a specific version WASI version with the C API.
 - [#1028](https://github.com/wasmerio/wasmer/pull/1028) Introduce strict/non-strict modes for `get_wasi_version`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,6 +190,7 @@ jobs:
           make capi
           make test-capi
           cp target/release/libwasmer_runtime_c_api.so ./artifacts
+          find target/release/build -name 'wasmer.h*' -exec cp {} ./artifacts ';'
         displayName: Build c-api (Linux)
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
       - bash: |


### PR DESCRIPTION
This patch copies the generated C and C++ headers of `wasmer-runtime-c-api` in the `artifacts` directory, so that they are attached to releases as assets.