### PR TITLE
For RuntimeError and breakpoints, use Box<Any + Send> instead of Box<Any>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1053](https://github.com/wasmerio/wasmer/pull/1053) For RuntimeError and breakpoints, use Box<Any + Send> instead of Box<Any>.
 - [#1050](https://github.com/wasmerio/wasmer/pull/1050) Attach C & C++ headers to releases.
 - [#1033](https://github.com/wasmerio/wasmer/pull/1033) Set cranelift backend as default compiler backend again, require at least one backend to be enabled for Wasmer CLI
 - [#1030](https://github.com/wasmerio/wasmer/pull/1030) Ability to generate `ImportObject` for a specific version WASI version with the C API.

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -66,7 +66,7 @@ extern "C" {
         params: *const u64,
         results: *mut u64,
         trap_out: *mut WasmTrapInfo,
-        user_error: *mut Option<Box<dyn Any>>,
+        user_error: *mut Option<Box<dyn Any + Send>>,
         invoke_env: Option<NonNull<c_void>>,
     ) -> bool;
 }
@@ -427,7 +427,7 @@ impl RunnableModule for LLVMBackend {
         self.msm.clone()
     }
 
-    unsafe fn do_early_trap(&self, data: Box<dyn Any>) -> ! {
+    unsafe fn do_early_trap(&self, data: Box<dyn Any + Send>) -> ! {
         throw_any(Box::leak(data))
     }
 }

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -856,7 +856,8 @@ pub unsafe extern "C" fn callback_trampoline(
     callback: *mut BreakpointHandler,
 ) {
     let callback = Box::from_raw(callback);
-    let result: Result<(), Box<dyn std::any::Any>> = callback(BreakpointInfo { fault: None });
+    let result: Result<(), Box<dyn std::any::Any + Send>> =
+        callback(BreakpointInfo { fault: None });
     match result {
         Ok(()) => *b = None,
         Err(e) => *b = Some(e),

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -271,7 +271,7 @@ pub trait RunnableModule: Send + Sync {
     /// signature and an invoke function that can call the trampoline.
     fn get_trampoline(&self, info: &ModuleInfo, sig_index: SigIndex) -> Option<Wasm>;
 
-    unsafe fn do_early_trap(&self, data: Box<dyn Any>) -> !;
+    unsafe fn do_early_trap(&self, data: Box<dyn Any + Send>) -> !;
 
     /// Returns the machine code associated with this module.
     fn get_code(&self) -> Option<&[u8]> {

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -23,7 +23,7 @@ use wasmparser::{Operator, Type as WpType};
 
 /// A type that defines a function pointer, which is called when breakpoints occur.
 pub type BreakpointHandler =
-    Box<dyn Fn(BreakpointInfo) -> Result<(), Box<dyn Any>> + Send + Sync + 'static>;
+    Box<dyn Fn(BreakpointInfo) -> Result<(), Box<dyn Any + Send>> + Send + Sync + 'static>;
 
 /// Maps instruction pointers to their breakpoint handlers.
 pub type BreakpointMap = Arc<HashMap<usize, BreakpointHandler>>;

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -187,7 +187,7 @@ pub enum RuntimeError {
     /// Error.
     Error {
         /// Error data.
-        data: Box<dyn Any>,
+        data: Box<dyn Any + Send>,
     },
 }
 

--- a/lib/runtime-core/src/state.rs
+++ b/lib/runtime-core/src/state.rs
@@ -652,7 +652,7 @@ pub mod x64 {
         image: InstanceImage,
         vmctx: &mut Ctx,
         breakpoints: Option<BreakpointMap>,
-    ) -> Result<u64, Box<dyn Any>> {
+    ) -> Result<u64, Box<dyn Any + Send>> {
         let mut stack: Vec<u64> = vec![0; 1048576 * 8 / 8]; // 8MB stack
         let mut stack_offset: usize = stack.len();
 

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -78,7 +78,7 @@ pub type Invoke = unsafe extern "C" fn(
     args: *const u64,
     rets: *mut u64,
     trap_info: *mut WasmTrapInfo,
-    user_error: *mut Option<Box<dyn Any>>,
+    user_error: *mut Option<Box<dyn Any + Send>>,
     extra: Option<NonNull<c_void>>,
 ) -> bool;
 
@@ -201,7 +201,7 @@ where
     Rets: WasmTypeList,
 {
     /// The error type for this trait.
-    type Error: 'static;
+    type Error: Send + 'static;
     /// Get returns or error result.
     fn report(self) -> Result<Rets, Self::Error>;
 }
@@ -219,7 +219,7 @@ where
 impl<Rets, E> TrapEarly<Rets> for Result<Rets, E>
 where
     Rets: WasmTypeList,
-    E: 'static,
+    E: Send + 'static,
 {
     type Error = E;
     fn report(self) -> Result<Rets, E> {
@@ -507,7 +507,7 @@ macro_rules! impl_traits {
                         Ok(Ok(returns)) => return returns.into_c_struct(),
                         Ok(Err(err)) => {
                             let b: Box<_> = err.into();
-                            b as Box<dyn Any>
+                            b as Box<dyn Any + Send>
                         },
                         Err(err) => err,
                     };
@@ -619,7 +619,7 @@ macro_rules! impl_traits {
                         Ok(Ok(returns)) => return returns.into_c_struct(),
                         Ok(Err(err)) => {
                             let b: Box<_> = err.into();
-                            b as Box<dyn Any>
+                            b as Box<dyn Any + Send>
                         },
                         Err(err) => err,
                     };

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -1069,7 +1069,7 @@ mod vm_ctx_tests {
             fn get_trampoline(&self, _module: &ModuleInfo, _sig_index: SigIndex) -> Option<Wasm> {
                 unimplemented!("generate_module::get_trampoline")
             }
-            unsafe fn do_early_trap(&self, _: Box<dyn Any>) -> ! {
+            unsafe fn do_early_trap(&self, _: Box<dyn Any + Send>) -> ! {
                 unimplemented!("generate_module::do_early_trap")
             }
         }

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -206,7 +206,7 @@ pub struct X64FunctionCode {
     breakpoints: Option<
         HashMap<
             AssemblyOffset,
-            Box<dyn Fn(BreakpointInfo) -> Result<(), Box<dyn Any>> + Send + Sync + 'static>,
+            Box<dyn Fn(BreakpointInfo) -> Result<(), Box<dyn Any + Send>> + Send + Sync + 'static>,
         >,
     >,
     returns: SmallVec<[WpType; 1]>,
@@ -359,7 +359,7 @@ impl RunnableModule for X64ExecutionContext {
             args: *const u64,
             rets: *mut u64,
             trap_info: *mut WasmTrapInfo,
-            user_error: *mut Option<Box<dyn Any>>,
+            user_error: *mut Option<Box<dyn Any + Send>>,
             num_params_plus_one: Option<NonNull<c_void>>,
         ) -> bool {
             let rm: &Box<dyn RunnableModule> = &(&*(*ctx).module).runnable_module;
@@ -533,7 +533,7 @@ impl RunnableModule for X64ExecutionContext {
         })
     }
 
-    unsafe fn do_early_trap(&self, data: Box<dyn Any>) -> ! {
+    unsafe fn do_early_trap(&self, data: Box<dyn Any + Send>) -> ! {
         protect_unix::TRAP_EARLY_DATA.with(|x| x.set(Some(data)));
         protect_unix::trigger_trap();
     }

--- a/lib/singlepass-backend/src/protect_unix.rs
+++ b/lib/singlepass-backend/src/protect_unix.rs
@@ -16,7 +16,7 @@ use wasmer_runtime_core::fault::{begin_unsafe_unwind, catch_unsafe_unwind, ensur
 use wasmer_runtime_core::typed_func::WasmTrapInfo;
 
 thread_local! {
-    pub static TRAP_EARLY_DATA: Cell<Option<Box<dyn Any>>> = Cell::new(None);
+    pub static TRAP_EARLY_DATA: Cell<Option<Box<dyn Any + Send>>> = Cell::new(None);
 }
 
 pub unsafe fn trigger_trap() -> ! {
@@ -25,7 +25,7 @@ pub unsafe fn trigger_trap() -> ! {
 
 pub enum CallProtError {
     Trap(WasmTrapInfo),
-    Error(Box<dyn Any>),
+    Error(Box<dyn Any + Send>),
 }
 
 pub fn call_protected<T>(
@@ -48,6 +48,6 @@ pub fn call_protected<T>(
     }
 }
 
-pub unsafe fn throw(payload: Box<dyn Any>) -> ! {
+pub unsafe fn throw(payload: Box<dyn Any + Send>) -> ! {
     begin_unsafe_unwind(payload);
 }


### PR DESCRIPTION
# Description
For RuntimeError and breakpoints, use Box<Any + Send> instead of Box\<Any\>.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file

Fixes #1049 