### PR TITLE
Improve wasmer invoke function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1054](https://github.com/wasmerio/wasmer/pull/1054) Improve `--invoke` output in Wasmer CLI
 - [#1053](https://github.com/wasmerio/wasmer/pull/1053) For RuntimeError and breakpoints, use Box<Any + Send> instead of Box<Any>.
 - [#1052](https://github.com/wasmerio/wasmer/pull/1052) Fix minor panic and improve Error handling in singlepass backend.
 - [#1050](https://github.com/wasmerio/wasmer/pull/1050) Attach C & C++ headers to releases.

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -499,7 +499,7 @@ fn execute_wasi(
                 .map_err(|e| format!("Invoke failed: {:?}", e))?
                 .call(&args)
                 .map_err(|e| format!("Calling invoke fn failed: {:?}", e))?;
-            println!("{} returned {:?}", invoke_fn, invoke_result);
+            println!("{}({:?}) returned {:?}", invoke_fn, args, invoke_result);
             return Ok(());
         } else {
             result = start.call();
@@ -836,7 +836,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                 .map_err(|e| format!("{:?}", e))?
                 .call(&args)
                 .map_err(|e| format!("{:?}", e))?;
-            println!("main() returned: {:?}", result);
+            println!("{}({:?}) returned: {:?}", invoke_fn, args, result);
         }
     }
 

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -836,7 +836,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                 .map_err(|e| format!("{:?}", e))?
                 .call(&args)
                 .map_err(|e| format!("{:?}", e))?;
-            println!("{}({:?}) returned: {:?}", invoke_fn, args, result);
+            println!("{}({:?}) returned {:?}", invoke_fn, args, result);
         }
     }
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
Prior to this PR, when executing wasmer, we will have this in the stdout:
 
```bash
➜  wasmer fib32.wasm --invoke fib 30
main() returned: [I32(832040)]
```

Note that it says `main()` returned even if the function called is `fib`.
This PR fixes this and improves the messaging also for WASI invoked functions

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
