### PR TITLE
Fix issue 1057 + improve llvm/state.rs code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1058](https://github.com/wasmerio/wasmer/pull/1058) Fix minor panic issue when `wasmer::compile_with` called with llvm backend.
 - [#1056](https://github.com/wasmerio/wasmer/pull/1056) Improved `--invoke` args parsing (supporting `i32`, `i64`, `f32` and `f32`) in Wasmer CLI
 - [#1054](https://github.com/wasmerio/wasmer/pull/1054) Improve `--invoke` output in Wasmer CLI
 - [#1053](https://github.com/wasmerio/wasmer/pull/1053) For RuntimeError and breakpoints, use Box<Any + Send> instead of Box<Any>.


### PR DESCRIPTION
# Description

This pull request is doing:
- Fix issue https://github.com/wasmerio/wasmer/issues/1057 (subtraction overflow panic in State::peek1_extra) by using `checked_sub`
- replace other part of `state.rs` subject to potential substration overflow with `checked_sub`
- add more detail on the Errors messages in `state.rs`
- rename some variable for better understanding of the code.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
