### PR TITLE
Add minor changes to runtime/vm doc comments + make fns const fns

### DIFF
--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -195,13 +195,13 @@ unsafe impl Send for Intrinsics {}
 unsafe impl Sync for Intrinsics {}
 
 impl Intrinsics {
-    /// Memory grow offset
+    /// Offset of the `memory_grow` field.
     #[allow(clippy::erasing_op)]
-    pub fn offset_memory_grow() -> u8 {
+    pub const fn offset_memory_grow() -> u8 {
         (0 * ::std::mem::size_of::<usize>()) as u8
     }
-    /// Memory size offset
-    pub fn offset_memory_size() -> u8 {
+    /// Offset of the `memory_size` field.
+    pub const fn offset_memory_size() -> u8 {
         (1 * ::std::mem::size_of::<usize>()) as u8
     }
 }
@@ -462,63 +462,63 @@ impl Ctx {
 #[doc(hidden)]
 impl Ctx {
     #[allow(clippy::erasing_op)] // TODO
-    pub fn offset_memories() -> u8 {
+    pub const fn offset_memories() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_tables() -> u8 {
+    pub const fn offset_tables() -> u8 {
         1 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_globals() -> u8 {
+    pub const fn offset_globals() -> u8 {
         2 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_imported_memories() -> u8 {
+    pub const fn offset_imported_memories() -> u8 {
         3 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_imported_tables() -> u8 {
+    pub const fn offset_imported_tables() -> u8 {
         4 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_imported_globals() -> u8 {
+    pub const fn offset_imported_globals() -> u8 {
         5 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_imported_funcs() -> u8 {
+    pub const fn offset_imported_funcs() -> u8 {
         6 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_signatures() -> u8 {
+    pub const fn offset_signatures() -> u8 {
         7 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_intrinsics() -> u8 {
+    pub const fn offset_intrinsics() -> u8 {
         8 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_stack_lower_bound() -> u8 {
+    pub const fn offset_stack_lower_bound() -> u8 {
         9 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_memory_base() -> u8 {
+    pub const fn offset_memory_base() -> u8 {
         10 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_memory_bound() -> u8 {
+    pub const fn offset_memory_bound() -> u8 {
         11 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_internals() -> u8 {
+    pub const fn offset_internals() -> u8 {
         12 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_interrupt_signal_mem() -> u8 {
+    pub const fn offset_interrupt_signal_mem() -> u8 {
         13 * (mem::size_of::<usize>() as u8)
     }
 
-    pub fn offset_local_functions() -> u8 {
+    pub const fn offset_local_functions() -> u8 {
         14 * (mem::size_of::<usize>() as u8)
     }
 }
@@ -551,18 +551,18 @@ pub struct FuncCtx {
 }
 
 impl FuncCtx {
-    /// Offset to `vmctx`.
-    pub fn offset_vmctx() -> u8 {
+    /// Offset to the `vmctx` field.
+    pub const fn offset_vmctx() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
-    /// Offset to `func_env`.
-    pub fn offset_func_env() -> u8 {
+    /// Offset to the `func_env` field.
+    pub const fn offset_func_env() -> u8 {
         1 * (mem::size_of::<usize>() as u8)
     }
 
     /// Size of a `FuncCtx`.
-    pub fn size() -> u8 {
+    pub const fn size() -> u8 {
         mem::size_of::<Self>() as u8
     }
 }
@@ -572,10 +572,10 @@ impl FuncCtx {
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct ImportedFunc {
-    /// Const pointer to `Func`.
+    /// Pointer to the function itself.
     pub(crate) func: *const Func,
 
-    /// Mutable non-null pointer to `FuncCtx`.
+    /// Mutable non-null pointer to [`FuncCtx`].
     pub(crate) func_ctx: NonNull<FuncCtx>,
 }
 
@@ -585,19 +585,19 @@ pub struct ImportedFunc {
 unsafe impl Send for ImportedFunc {}
 
 impl ImportedFunc {
-    /// Offset to func.
+    /// Offset to the `func` field.
     #[allow(clippy::erasing_op)] // TODO
-    pub fn offset_func() -> u8 {
+    pub const fn offset_func() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
-    /// Offset to func_ctx.
-    pub fn offset_func_ctx() -> u8 {
+    /// Offset to the `func_ctx` field.
+    pub const fn offset_func_ctx() -> u8 {
         1 * (mem::size_of::<usize>() as u8)
     }
 
     /// Size of an `ImportedFunc`.
-    pub fn size() -> u8 {
+    pub const fn size() -> u8 {
         mem::size_of::<Self>() as u8
     }
 }
@@ -618,19 +618,19 @@ pub struct LocalTable {
 unsafe impl Send for LocalTable {}
 
 impl LocalTable {
-    /// Offset to base.
+    /// Offset to the `base` field.
     #[allow(clippy::erasing_op)] // TODO
-    pub fn offset_base() -> u8 {
+    pub const fn offset_base() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
-    /// Offset count.
-    pub fn offset_count() -> u8 {
+    /// Offset to the `count` field.
+    pub const fn offset_count() -> u8 {
         1 * (mem::size_of::<usize>() as u8)
     }
 
     /// Size of a `LocalTable`.
-    pub fn size() -> u8 {
+    pub const fn size() -> u8 {
         mem::size_of::<Self>() as u8
     }
 }
@@ -653,19 +653,19 @@ pub struct LocalMemory {
 unsafe impl Send for LocalMemory {}
 
 impl LocalMemory {
-    /// Offset base.
+    /// Offset to the `base` field.
     #[allow(clippy::erasing_op)] // TODO
-    pub fn offset_base() -> u8 {
+    pub const fn offset_base() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
-    /// Offset bound.
-    pub fn offset_bound() -> u8 {
+    /// Offset to the `bound` field.
+    pub const fn offset_bound() -> u8 {
         1 * (mem::size_of::<usize>() as u8)
     }
 
     /// Size of a `LocalMemory`.
-    pub fn size() -> u8 {
+    pub const fn size() -> u8 {
         mem::size_of::<Self>() as u8
     }
 }
@@ -679,19 +679,19 @@ pub struct LocalGlobal {
 }
 
 impl LocalGlobal {
-    /// Offset data.
+    /// Offset to the `data` field.
     #[allow(clippy::erasing_op)] // TODO
-    pub fn offset_data() -> u8 {
+    pub const fn offset_data() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
     /// A null `LocalGlobal`.
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self { data: 0 }
     }
 
     /// Size of a `LocalGlobal`.
-    pub fn size() -> u8 {
+    pub const fn size() -> u8 {
         mem::size_of::<Self>() as u8
     }
 }
@@ -718,7 +718,7 @@ unsafe impl Send for Anyfunc {}
 
 impl Anyfunc {
     /// A null `Anyfunc` value.
-    pub fn null() -> Self {
+    pub const fn null() -> Self {
         Self {
             func: ptr::null(),
             ctx: ptr::null_mut(),
@@ -726,24 +726,24 @@ impl Anyfunc {
         }
     }
 
-    /// The offset for this func.
+    /// Offset to the `func` field.
     #[allow(clippy::erasing_op)] // TODO
-    pub fn offset_func() -> u8 {
+    pub const fn offset_func() -> u8 {
         0 * (mem::size_of::<usize>() as u8)
     }
 
-    /// The offset of the vmctx.
-    pub fn offset_vmctx() -> u8 {
+    /// Offset to the `vmctx` field..
+    pub const fn offset_vmctx() -> u8 {
         1 * (mem::size_of::<usize>() as u8)
     }
 
-    /// The offset of the sig id.
-    pub fn offset_sig_id() -> u8 {
+    /// Offset to the `sig_id` field.
+    pub const fn offset_sig_id() -> u8 {
         2 * (mem::size_of::<usize>() as u8)
     }
 
     /// The size of `Anyfunc`.
-    pub fn size() -> u8 {
+    pub const fn size() -> u8 {
         mem::size_of::<Self>() as u8
     }
 }


### PR DESCRIPTION
Slightly improves readability of docs and makes more functions `const fn`