### PR TITLE
Add include guards for WASI APIs in runtime-c-api

### DIFF
--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -31,6 +31,11 @@ fn main() {
 "#
     .to_string();
 
+    #[cfg(feature = "wasi")]
+    {
+        pre_header += "#define WASMER_WASI_ENABLED\n";
+    }
+
     #[cfg(feature = "emscripten")]
     {
         pre_header += "#define WASMER_EMSCRIPTEN_ENABLED\n";
@@ -48,6 +53,7 @@ fn main() {
         .with_header(&pre_header)
         .with_define("target_family", "windows", "_WIN32")
         .with_define("target_arch", "x86_64", "ARCH_X86_64")
+        .with_define("feature", "wasi", "WASMER_WASI_ENABLED")
         .with_define("feature", "emscripten", "WASMER_EMSCRIPTEN_ENABLED")
         .generate()
         .expect("Unable to generate C bindings")
@@ -62,6 +68,7 @@ fn main() {
         .with_header(&pre_header)
         .with_define("target_family", "windows", "_WIN32")
         .with_define("target_arch", "x86_64", "ARCH_X86_64")
+        .with_define("feature", "wasi", "WASMER_WASI_ENABLED")
         .with_define("feature", "emscripten", "WASMER_EMSCRIPTEN_ENABLED")
         .generate()
         .expect("Unable to generate C++ bindings")

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -14,7 +14,7 @@
 #endif
 #endif
 
-#define WASMER_EMSCRIPTEN_ENABLED
+#define WASMER_WASI_ENABLED
 #endif // WASMER_H_MACROS
 
 
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#if defined(WASMER_WASI_ENABLED)
 enum Version {
   /**
    * Version cannot be detected or is unknown.
@@ -46,6 +47,7 @@ enum Version {
   Snapshot1 = 3,
 };
 typedef uint8_t Version;
+#endif
 
 /**
  * List of export/import kinds.
@@ -230,6 +232,7 @@ typedef struct {
 } wasmer_trampoline_buffer_t;
 #endif
 
+#if defined(WASMER_WASI_ENABLED)
 /**
  * Opens a directory that's visible to the WASI module as `alias` but
  * is backed by the host file at `host_file_path`
@@ -244,6 +247,7 @@ typedef struct {
    */
   wasmer_byte_array host_file_path;
 } wasmer_wasi_map_dir_entry_t;
+#endif
 
 /**
  * Creates a new Module from the given wasm bytes.
@@ -954,6 +958,7 @@ void *wasmer_trampoline_get_context(void);
  */
 bool wasmer_validate(const uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
 
+#if defined(WASMER_WASI_ENABLED)
 /**
  * Convenience function that creates a WASI import object with no arguments,
  * environment variables, preopened files, or mapped directories.
@@ -962,7 +967,9 @@ bool wasmer_validate(const uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
  * empty values.
  */
 wasmer_import_object_t *wasmer_wasi_generate_default_import_object(void);
+#endif
 
+#if defined(WASMER_WASI_ENABLED)
 /**
  * Creates a WASI import object.
  *
@@ -978,7 +985,9 @@ wasmer_import_object_t *wasmer_wasi_generate_import_object(const wasmer_byte_arr
                                                            unsigned int preopened_files_len,
                                                            const wasmer_wasi_map_dir_entry_t *mapped_dirs,
                                                            unsigned int mapped_dirs_len);
+#endif
 
+#if defined(WASMER_WASI_ENABLED)
 /**
  * Creates a WASI import object for a specific version.
  *
@@ -996,12 +1005,15 @@ wasmer_import_object_t *wasmer_wasi_generate_import_object_for_version(unsigned 
                                                                        unsigned int preopened_files_len,
                                                                        const wasmer_wasi_map_dir_entry_t *mapped_dirs,
                                                                        unsigned int mapped_dirs_len);
+#endif
 
+#if defined(WASMER_WASI_ENABLED)
 /**
  * Find the version of WASI used by the module.
  *
  * In case of error, the returned version is `Version::Unknown`.
  */
 Version wasmer_wasi_get_version(const wasmer_module_t *module);
+#endif
 
 #endif /* WASMER_H */

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -14,7 +14,7 @@
 #endif
 #endif
 
-#define WASMER_EMSCRIPTEN_ENABLED
+#define WASMER_WASI_ENABLED
 #endif // WASMER_H_MACROS
 
 
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <new>
 
+#if defined(WASMER_WASI_ENABLED)
 enum class Version : uint8_t {
   /// Version cannot be detected or is unknown.
   Unknown = 0,
@@ -37,6 +38,7 @@ enum class Version : uint8_t {
   /// `wasi_snapshot_preview1`.
   Snapshot1 = 3,
 };
+#endif
 
 /// List of export/import kinds.
 enum class wasmer_import_export_kind : uint32_t {
@@ -203,6 +205,7 @@ struct wasmer_trampoline_buffer_t {
 };
 #endif
 
+#if defined(WASMER_WASI_ENABLED)
 /// Opens a directory that's visible to the WASI module as `alias` but
 /// is backed by the host file at `host_file_path`
 struct wasmer_wasi_map_dir_entry_t {
@@ -211,6 +214,7 @@ struct wasmer_wasi_map_dir_entry_t {
   /// The backing file that the WASI module will interact with via the alias
   wasmer_byte_array host_file_path;
 };
+#endif
 
 extern "C" {
 
@@ -749,13 +753,16 @@ void *wasmer_trampoline_get_context();
 /// Returns true for valid wasm bytes and false for invalid bytes
 bool wasmer_validate(const uint8_t *wasm_bytes, uint32_t wasm_bytes_len);
 
+#if defined(WASMER_WASI_ENABLED)
 /// Convenience function that creates a WASI import object with no arguments,
 /// environment variables, preopened files, or mapped directories.
 ///
 /// This function is the same as calling [`wasmer_wasi_generate_import_object`] with all
 /// empty values.
 wasmer_import_object_t *wasmer_wasi_generate_default_import_object();
+#endif
 
+#if defined(WASMER_WASI_ENABLED)
 /// Creates a WASI import object.
 ///
 /// This function treats null pointers as empty collections.
@@ -769,7 +776,9 @@ wasmer_import_object_t *wasmer_wasi_generate_import_object(const wasmer_byte_arr
                                                            unsigned int preopened_files_len,
                                                            const wasmer_wasi_map_dir_entry_t *mapped_dirs,
                                                            unsigned int mapped_dirs_len);
+#endif
 
+#if defined(WASMER_WASI_ENABLED)
 /// Creates a WASI import object for a specific version.
 ///
 /// This function is similar to `wasmer_wasi_generate_import_object`
@@ -785,11 +794,14 @@ wasmer_import_object_t *wasmer_wasi_generate_import_object_for_version(unsigned 
                                                                        unsigned int preopened_files_len,
                                                                        const wasmer_wasi_map_dir_entry_t *mapped_dirs,
                                                                        unsigned int mapped_dirs_len);
+#endif
 
+#if defined(WASMER_WASI_ENABLED)
 /// Find the version of WASI used by the module.
 ///
 /// In case of error, the returned version is `Version::Unknown`.
 Version wasmer_wasi_get_version(const wasmer_module_t *module);
+#endif
 
 } // extern "C"
 


### PR DESCRIPTION
Improves correctness, but the readability does suffer.

In the future we should probably have separate header files or find a way to merge the conditional includes