### PR TITLE
docs: fix markup runtime-core docs

### DIFF
--- a/lib/runtime-core/src/macros.rs
+++ b/lib/runtime-core/src/macros.rs
@@ -49,7 +49,7 @@ macro_rules! trace {
 /// # Usage
 ///
 /// Function pointers or closures are supported. Closures can capture
-/// their environment (with `move). The first parameter is likely to
+/// their environment (with `move`). The first parameter is likely to
 /// be of kind `vm::Ctx`, though it can be optional.
 ///
 /// ```


### PR DESCRIPTION
# Description

Trivial fix for this:
![image](https://user-images.githubusercontent.com/870638/71092799-3a074a00-21a8-11ea-8b01-2ef518fc2b52.png)

I don't believe this needs to go into the changelog, does it? 😉 