### PR TITLE
Fix plugin example, add examples to test recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ test-rest:
 circleci-clean:
 	@if [ ! -z "${CIRCLE_JOB}" ]; then rm -f /home/circleci/project/target/debug/deps/libcranelift_wasm* && rm -f /Users/distiller/project/target/debug/deps/libcranelift_wasm*; fi;
 
-test: spectests emtests middleware wasitests circleci-clean test-rest
+test: spectests emtests middleware wasitests circleci-clean test-rest examples
 
 
 # Integration tests

--- a/examples/plugin.rs
+++ b/examples/plugin.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use wasmer_runtime::{func, imports, instantiate};
+use wasmer_runtime::{compile, func, imports};
 use wasmer_runtime_core::vm::Ctx;
 use wasmer_wasi::{
-    generate_import_object,
+    generate_import_object_for_version,
     state::{self, WasiFile, WasiFsError},
     types,
 };
@@ -133,9 +133,16 @@ fn main() {
         "Could not read in WASM plugin at {}",
         PLUGIN_LOCATION
     ));
+    let module = compile(&wasm_bytes).expect("wasm compilation");
+
+    // get the version of the WASI module in a non-strict way, meaning we're
+    // allowed to have extra imports
+    let wasi_version = wasmer_wasi::get_wasi_version(&module, false)
+        .expect("WASI version detected from Wasm module");
 
     // WASI imports
-    let mut base_imports = generate_import_object(vec![], vec![], vec![], vec![]);
+    let mut base_imports =
+        generate_import_object_for_version(wasi_version, vec![], vec![], vec![], vec![]);
     // env is the default namespace for extern functions
     let custom_imports = imports! {
         "env" => {
@@ -145,8 +152,9 @@ fn main() {
     // The WASI imports object contains all required import functions for a WASI module to run.
     // Extend this imports with our custom imports containing "it_works" function so that our custom wasm code may run.
     base_imports.extend(custom_imports);
-    let mut instance =
-        instantiate(&wasm_bytes[..], &base_imports).expect("failed to instantiate wasm module");
+    let mut instance = module
+        .instantiate(&base_imports)
+        .expect("failed to instantiate wasm module");
     // set up logging by replacing stdout
     initialize(instance.context_mut());
 


### PR DESCRIPTION
This was reported [on spectrum](https://spectrum.chat/wasmer/general/failure-running-plugin-sample-on-mac~58c72ff0-47cd-4158-8069-fb726d7bb5dd).  This PR fixes the issue and adds it to `test` so we test it in CI.