### PR TITLE
Remove backend::Backend from runtime-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1098](https://github.com/wasmerio/wasmer/pull/1098) Remove `backend::Backend` from `wasmer_runtime_core`
 - [#1097](https://github.com/wasmerio/wasmer/pull/1097) Move inline breakpoint outside of runtime backend
 - [#1095](https://github.com/wasmerio/wasmer/pull/1095) Update to cranelift 0.52.
 - [#1092](https://github.com/wasmerio/wasmer/pull/1092) Add `get_utf8_string_with_nul` to `WasmPtr` to read nul-terminated strings from memory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,8 @@ dependencies = [
  "criterion",
  "lazy_static",
  "memmap",
+ "serde",
+ "serde_derive",
  "tempfile",
  "wabt",
  "wasmer-clif-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,19 +86,16 @@ extra-debug = ["wasmer-clif-backend/debug", "wasmer-runtime-core/debug"]
 fast-tests = []
 backend-cranelift = [
     "wasmer-clif-backend",
-    "wasmer-runtime-core/backend-cranelift",
     "wasmer-runtime/cranelift",
     "wasmer-middleware-common-tests/clif",
 ]
 backend-llvm = [
     "wasmer-llvm-backend",
-    "wasmer-runtime-core/backend-llvm",
     "wasmer-runtime/llvm",
     "wasmer-middleware-common-tests/llvm",
 ]
 backend-singlepass = [
     "wasmer-singlepass-backend",
-    "wasmer-runtime-core/backend-singlepass",
     "wasmer-runtime/singlepass",
     "wasmer-middleware-common-tests/singlepass",
 ]

--- a/lib/clif-backend/src/code.rs
+++ b/lib/clif-backend/src/code.rs
@@ -18,7 +18,7 @@ use std::mem;
 use std::sync::{Arc, RwLock};
 use wasmer_runtime_core::error::CompileError;
 use wasmer_runtime_core::{
-    backend::{Backend, CacheGen, Token},
+    backend::{CacheGen, Token},
     cache::{Artifact, Error as CacheError},
     codegen::*,
     memory::MemoryType,
@@ -58,8 +58,8 @@ impl ModuleCodeGenerator<CraneliftFunctionCodeGenerator, Caller, CodegenError>
         unimplemented!("cross compilation is not available for clif backend")
     }
 
-    fn backend_id() -> Backend {
-        Backend::Cranelift
+    fn backend_id() -> String {
+        "cranelift".to_string()
     }
 
     fn check_precondition(&mut self, _module_info: &ModuleInfo) -> Result<(), CodegenError> {

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -8721,8 +8721,8 @@ impl<'ctx> ModuleCodeGenerator<LLVMFunctionCodeGenerator<'ctx>, LLVMBackend, Cod
         }
     }
 
-    fn backend_id() -> Backend {
-        Backend::LLVM
+    fn backend_id() -> String {
+        "llvm".to_string()
     }
 
     fn check_precondition(&mut self, _module_info: &ModuleInfo) -> Result<(), CodegenError> {

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use wasmer_runtime_core::{
-    backend::{Backend, CacheGen, CompilerConfig, Token},
+    backend::{CacheGen, CompilerConfig, Token},
     cache::{Artifact, Error as CacheError},
     codegen::*,
     memory::MemoryType,

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -52,7 +52,7 @@ cc = "1.0"
 [features]
 debug = []
 trace = ["debug"]
-# backend flags used in conditional compilation of Backend::variants
+# backend flags no longer used
 "backend-cranelift" = []
 "backend-singlepass" = []
 "backend-llvm" = []

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -22,60 +22,6 @@ pub mod sys {
 }
 pub use crate::sig_registry::SigRegistry;
 
-/// Enum used to select which compiler should be used to generate code.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Backend {
-    Cranelift,
-    Singlepass,
-    LLVM,
-    Auto,
-}
-
-impl Backend {
-    /// Get a list of the currently enabled (via feature flag) backends.
-    pub fn variants() -> &'static [&'static str] {
-        &[
-            #[cfg(feature = "backend-cranelift")]
-            "cranelift",
-            #[cfg(feature = "backend-singlepass")]
-            "singlepass",
-            #[cfg(feature = "backend-llvm")]
-            "llvm",
-            "auto",
-        ]
-    }
-
-    /// Stable string representation of the backend.
-    /// It can be used as part of a cache key, for example.
-    pub fn to_string(&self) -> &'static str {
-        match self {
-            Backend::Cranelift => "cranelift",
-            Backend::Singlepass => "singlepass",
-            Backend::LLVM => "llvm",
-            Backend::Auto => "auto",
-        }
-    }
-}
-
-impl Default for Backend {
-    fn default() -> Self {
-        Backend::Cranelift
-    }
-}
-
-impl std::str::FromStr for Backend {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Backend, String> {
-        match s.to_lowercase().as_str() {
-            "singlepass" => Ok(Backend::Singlepass),
-            "cranelift" => Ok(Backend::Cranelift),
-            "llvm" => Ok(Backend::LLVM),
-            "auto" => Ok(Backend::Auto),
-            _ => Err(format!("The backend {} doesn't exist", s)),
-        }
-    }
-}
-
 /// The target architecture for code generation.
 #[derive(Copy, Clone, Debug)]
 pub enum Architecture {
@@ -102,22 +48,6 @@ pub struct InlineBreakpoint {
 
     /// Type of the inline breakpoint.
     pub ty: InlineBreakpointType,
-}
-
-#[cfg(test)]
-mod backend_test {
-    use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn str_repr_matches() {
-        // if this test breaks, think hard about why it's breaking
-        // can we avoid having these be different?
-
-        for &backend in &[Backend::Cranelift, Backend::LLVM, Backend::Singlepass] {
-            assert_eq!(backend, Backend::from_str(backend.to_string()).unwrap());
-        }
-    }
 }
 
 /// This type cannot be constructed from

--- a/lib/runtime-core/src/cache.rs
+++ b/lib/runtime-core/src/cache.rs
@@ -3,12 +3,11 @@
 //! and loaded to allow skipping compilation and fast startup.
 
 use crate::{
-    backend::Backend,
-    module::{Module, ModuleInfo},
+    module::ModuleInfo,
     sys::Memory,
 };
 use blake2b_simd::blake2bp;
-use std::{fmt, io, mem, slice};
+use std::{io, mem, slice};
 
 /// Indicates the invalid type of invalid cache file
 #[derive(Debug)]
@@ -35,7 +34,7 @@ pub enum Error {
     /// The cached binary has been invalidated.
     InvalidatedCache,
     /// The current backend does not support caching.
-    UnsupportedBackend(Backend),
+    UnsupportedBackend(String),
 }
 
 impl From<io::Error> for Error {
@@ -244,24 +243,6 @@ impl Artifact {
 
         Ok(buffer)
     }
-}
-
-/// A generic cache for storing and loading compiled wasm modules.
-///
-/// The `wasmer-runtime` supplies a naive `FileSystemCache` api.
-pub trait Cache {
-    /// Error type to return when load error occurs
-    type LoadError: fmt::Debug;
-    /// Error type to return when store error occurs
-    type StoreError: fmt::Debug;
-
-    /// loads a module using the default `Backend`
-    fn load(&self, key: WasmHash) -> Result<Module, Self::LoadError>;
-    /// loads a cached module using a specific `Backend`
-    fn load_with_backend(&self, key: WasmHash, backend: Backend)
-        -> Result<Module, Self::LoadError>;
-    /// Store a module into the cache with the given key
-    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), Self::StoreError>;
 }
 
 /// A unique ID generated from the version of Wasmer for use with cache versioning

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -93,10 +93,10 @@ pub trait ModuleCodeGenerator<FCG: FunctionCodeGenerator<E>, RM: RunnableModule,
     ) -> Self;
 
     /// Returns the backend id associated with this MCG.
-    fn backend_id() -> Backend;
+    fn backend_id() -> String;
 
     /// It sets if the current compiler requires validation before compilation
-    fn requires_pre_validation(&self) -> bool {
+    fn requires_pre_validation() -> bool {
         true
     }
 
@@ -232,8 +232,8 @@ impl<
             validate_with_features(wasm, &compiler_config.features)?;
         }
 
-        let mut mcg = match MCG::backend_id() {
-            Backend::LLVM => MCG::new_with_target(
+        let mut mcg = match MCG::backend_id().as_ref() {
+            "llvm" => MCG::new_with_target(
                 compiler_config.triple.clone(),
                 compiler_config.cpu_name.clone(),
                 compiler_config.cpu_features.clone(),
@@ -243,7 +243,6 @@ impl<
         let mut chain = (self.middleware_chain_generator)();
         let info = crate::parse::read_module(
             wasm,
-            MCG::backend_id(),
             &mut mcg,
             &mut chain,
             &compiler_config,

--- a/lib/runtime-core/src/module.rs
+++ b/lib/runtime-core/src/module.rs
@@ -1,7 +1,7 @@
 //! The module module contains the implementation data structures and helper functions used to
 //! manipulate and access wasm modules.
 use crate::{
-    backend::{Backend, RunnableModule},
+    backend::RunnableModule,
     cache::{Artifact, Error as CacheError},
     error,
     import::ImportObject,
@@ -67,7 +67,7 @@ pub struct ModuleInfo {
     /// Map signature index to function signature.
     pub signatures: Map<SigIndex, FuncSig>,
     /// Backend.
-    pub backend: Backend,
+    pub backend: String,
 
     /// Table of namespace indexes.
     pub namespace_table: StringTable<NamespaceIndex>,

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -3,7 +3,7 @@
 
 use crate::codegen::*;
 use crate::{
-    backend::{Backend, CompilerConfig, RunnableModule},
+    backend::{CompilerConfig, RunnableModule},
     error::CompileError,
     module::{
         DataInitializer, ExportIndex, ImportName, ModuleInfo, StringTable, StringTableBuilder,
@@ -57,7 +57,6 @@ pub fn read_module<
     E: Debug,
 >(
     wasm: &[u8],
-    backend: Backend,
     mcg: &mut MCG,
     middlewares: &mut MiddlewareChain,
     compiler_config: &CompilerConfig,
@@ -83,7 +82,7 @@ pub fn read_module<
 
         func_assoc: Map::new(),
         signatures: Map::new(),
-        backend: backend,
+        backend: MCG::backend_id(),
 
         namespace_table: StringTable::new(),
         name_table: StringTable::new(),

--- a/lib/runtime-core/src/state.rs
+++ b/lib/runtime-core/src/state.rs
@@ -2,7 +2,7 @@
 //! state could read or updated at runtime. Use cases include generating stack traces, switching
 //! generated code from one tier to another, or serializing state of a running instace.
 
-use crate::backend::{Backend, RunnableModule};
+use crate::backend::RunnableModule;
 use std::collections::BTreeMap;
 use std::ops::Bound::{Included, Unbounded};
 use std::{cell::RefCell, rc::Rc};
@@ -186,7 +186,7 @@ pub struct CodeVersion {
     pub base: usize,
 
     /// The backend used to compile this module.
-    pub backend: Backend,
+    pub backend: String,
 
     /// `RunnableModule` for this code version.
     pub runnable_module: Rc<RefCell<Box<dyn RunnableModule>>>,

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -1065,7 +1065,7 @@ mod vm_ctx_tests {
 
     fn generate_module() -> ModuleInner {
         use super::Func;
-        use crate::backend::{sys::Memory, Backend, CacheGen, RunnableModule};
+        use crate::backend::{sys::Memory, CacheGen, RunnableModule};
         use crate::cache::Error as CacheError;
         use crate::typed_func::Wasm;
         use crate::types::{LocalFuncIndex, SigIndex};
@@ -1119,7 +1119,7 @@ mod vm_ctx_tests {
 
                 func_assoc: Map::new(),
                 signatures: Map::new(),
-                backend: Backend::Cranelift,
+                backend: "".to_string(),
 
                 namespace_table: StringTable::new(),
                 name_table: StringTable::new(),

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -24,6 +24,14 @@ path = "../clif-backend"
 version = "0.12.0"
 optional = true
 
+# Dependencies for caching.
+[dependencies.serde]
+version = "1.0"
+# This feature is required for serde to support serializing/deserializing reference counted pointers (e.g. Rc and Arc).
+features = ["rc"]
+[dependencies.serde_derive]
+version = "1.0"
+
 [dev-dependencies]
 tempfile = "3.1"
 criterion = "0.2"

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -5,6 +5,7 @@
 use crate::Module;
 use memmap::Mmap;
 use std::{
+    fmt,
     fs::{create_dir_all, File},
     io::{self, Write},
     path::PathBuf,
@@ -12,9 +13,27 @@ use std::{
 
 use wasmer_runtime_core::cache::Error as CacheError;
 pub use wasmer_runtime_core::{
-    backend::Backend,
-    cache::{Artifact, Cache, WasmHash},
+    cache::{Artifact, WasmHash},
 };
+pub use super::Backend;
+
+/// A generic cache for storing and loading compiled wasm modules.
+///
+/// The `wasmer-runtime` supplies a naive `FileSystemCache` api.
+pub trait Cache {
+    /// Error type to return when load error occurs
+    type LoadError: fmt::Debug;
+    /// Error type to return when store error occurs
+    type StoreError: fmt::Debug;
+
+    /// loads a module using the default `Backend`
+    fn load(&self, key: WasmHash) -> Result<Module, Self::LoadError>;
+    /// loads a cached module using a specific `Backend`
+    fn load_with_backend(&self, key: WasmHash, backend: Backend)
+        -> Result<Module, Self::LoadError>;
+    /// Store a module into the cache with the given key
+    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), Self::StoreError>;
+}
 
 /// Representation of a directory that contains compiled wasm artifacts.
 ///
@@ -105,7 +124,7 @@ impl Cache for FileSystemCache {
             wasmer_runtime_core::load_cache_with(
                 serialized_cache,
                 crate::compiler_for_backend(backend)
-                    .ok_or_else(|| CacheError::UnsupportedBackend(backend))?
+                    .ok_or_else(|| CacheError::UnsupportedBackend(backend.to_string().to_owned()))?
                     .as_ref(),
             )
         }

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -24,7 +24,7 @@ use std::{cell::RefCell, rc::Rc};
 use wasmer_runtime_core::{
     backend::{
         sys::{Memory, Protect},
-        Architecture, Backend, CacheGen, CompilerConfig, InlineBreakpoint, InlineBreakpointType,
+        Architecture, CacheGen, CompilerConfig, InlineBreakpoint, InlineBreakpointType,
         MemoryBoundCheckMode, RunnableModule, Token,
     },
     cache::{Artifact, Error as CacheError},
@@ -648,8 +648,12 @@ impl ModuleCodeGenerator<X64FunctionCode, X64ExecutionContext, CodegenError>
     }
 
     /// Singlepass does validation as it compiles
-    fn requires_pre_validation(&self) -> bool {
+    fn requires_pre_validation() -> bool {
         false
+    }
+
+    fn backend_id() -> String {
+        "singlepass".to_string()
     }
 
     fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -647,12 +647,13 @@ impl ModuleCodeGenerator<X64FunctionCode, X64ExecutionContext, CodegenError>
         }
     }
 
-    fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {
-        unimplemented!("cross compilation is not available for singlepass backend")
+    /// Singlepass does validation as it compiles
+    fn requires_pre_validation(&self) -> bool {
+        false
     }
 
-    fn backend_id() -> Backend {
-        Backend::Singlepass
+    fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {
+        unimplemented!("cross compilation is not available for singlepass backend")
     }
 
     fn check_precondition(&mut self, _module_info: &ModuleInfo) -> Result<(), CodegenError> {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR removes the dependency of a Backend in runtime-core. So it's agnostic and more backends can be plugged in easily.

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
