### PR TITLE
Remove backend::Backend from runtime-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1128](https://github.com/wasmerio/wasmer/pull/1128) Fix a crash when a host function is missing and the `allow_missing_functions` flag is enabled
 - [#1099](https://github.com/wasmerio/wasmer/pull/1099) Remove `backend::Backend` from `wasmer_runtime_core`
+- [#1098](https://github.com/wasmerio/wasmer/pull/1098) Remove `backend::Backend` from `wasmer_runtime_core`
 - [#1097](https://github.com/wasmerio/wasmer/pull/1097) Move inline breakpoint outside of runtime backend
 - [#1095](https://github.com/wasmerio/wasmer/pull/1095) Update to cranelift 0.52.
 - [#1092](https://github.com/wasmerio/wasmer/pull/1092) Add `get_utf8_string_with_nul` to `WasmPtr` to read nul-terminated strings from memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## **[Unreleased]**
 
-- [#1098](https://github.com/wasmerio/wasmer/pull/1098) Remove `backend::Backend` from `wasmer_runtime_core`
+- [#1099](https://github.com/wasmerio/wasmer/pull/1099) Remove `backend::Backend` from `wasmer_runtime_core`
 - [#1097](https://github.com/wasmerio/wasmer/pull/1097) Move inline breakpoint outside of runtime backend
 - [#1095](https://github.com/wasmerio/wasmer/pull/1095) Update to cranelift 0.52.
 - [#1092](https://github.com/wasmerio/wasmer/pull/1092) Add `get_utf8_string_with_nul` to `WasmPtr` to read nul-terminated strings from memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1098](https://github.com/wasmerio/wasmer/pull/1098) Remove `backend::Backend` from `wasmer_runtime_core`
 - [#1097](https://github.com/wasmerio/wasmer/pull/1097) Move inline breakpoint outside of runtime backend
 - [#1095](https://github.com/wasmerio/wasmer/pull/1095) Update to cranelift 0.52.
 - [#1092](https://github.com/wasmerio/wasmer/pull/1092) Add `get_utf8_string_with_nul` to `WasmPtr` to read nul-terminated strings from memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1128](https://github.com/wasmerio/wasmer/pull/1128) Fix a crash when a host function is missing and the `allow_missing_functions` flag is enabled
 - [#1099](https://github.com/wasmerio/wasmer/pull/1099) Remove `backend::Backend` from `wasmer_runtime_core`
 - [#1098](https://github.com/wasmerio/wasmer/pull/1098) Remove `backend::Backend` from `wasmer_runtime_core`
+- [#1099](https://github.com/wasmerio/wasmer/pull/1099) Remove `backend::Backend` from `wasmer_runtime_core`
 - [#1097](https://github.com/wasmerio/wasmer/pull/1097) Move inline breakpoint outside of runtime backend
 - [#1095](https://github.com/wasmerio/wasmer/pull/1095) Update to cranelift 0.52.
 - [#1092](https://github.com/wasmerio/wasmer/pull/1092) Add `get_utf8_string_with_nul` to `WasmPtr` to read nul-terminated strings from memory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,8 @@ dependencies = [
  "criterion",
  "lazy_static",
  "memmap",
+ "serde",
+ "serde_derive",
  "tempfile",
  "wabt",
  "wasmer-clif-backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,9 @@ checksum = "d813022b2e00774a48eaf43caaa3c20b45f040ba8cbf398e2e8911a06668dbe6"
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+checksum = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
  "libc",
  "llvm-sys",
  "once_cell",
- "parking_lot 0.10.0",
+ "parking_lot",
  "regex",
 ]
 
@@ -829,38 +829,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.6.2",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1826,7 +1800,7 @@ dependencies = [
  "libc",
  "nix",
  "page_size",
- "parking_lot 0.9.0",
+ "parking_lot",
  "rustc_version",
  "serde",
  "serde-bench",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
+checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.7.0"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer"
@@ -1745,7 +1745,7 @@ dependencies = [
  "regex",
  "rustc_version",
  "semver",
- "smallvec 1.1.0",
+ "smallvec 0.6.13",
  "wabt",
  "wasmer-runtime-core",
  "wasmparser",
@@ -1832,7 +1832,7 @@ dependencies = [
  "serde-bench",
  "serde_bytes",
  "serde_derive",
- "smallvec 1.1.0",
+ "smallvec 0.6.13",
  "wasmparser",
  "winapi",
 ]
@@ -1861,7 +1861,7 @@ dependencies = [
  "nix",
  "serde",
  "serde_derive",
- "smallvec 1.1.0",
+ "smallvec 0.6.13",
  "wasmer-runtime-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,19 +86,16 @@ extra-debug = ["wasmer-clif-backend/debug", "wasmer-runtime-core/debug"]
 fast-tests = []
 backend-cranelift = [
     "wasmer-clif-backend",
-    "wasmer-runtime-core/backend-cranelift",
     "wasmer-runtime/cranelift",
     "wasmer-middleware-common-tests/clif",
 ]
 backend-llvm = [
     "wasmer-llvm-backend",
-    "wasmer-runtime-core/backend-llvm",
     "wasmer-runtime/llvm",
     "wasmer-middleware-common-tests/llvm",
 ]
 backend-singlepass = [
     "wasmer-singlepass-backend",
-    "wasmer-runtime-core/backend-singlepass",
     "wasmer-runtime/singlepass",
     "wasmer-middleware-common-tests/singlepass",
 ]

--- a/Makefile
+++ b/Makefile
@@ -222,38 +222,9 @@ check: check-bench
 	# as default, and test a minimal set of features with only one backend
 	# at a time.
 	cargo check --manifest-path lib/runtime/Cargo.toml
-	# Check some of the cases where deterministic execution could matter
-	cargo check --manifest-path lib/runtime/Cargo.toml --features "deterministic-execution"
-	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features \
-		--features=default-backend-singlepass,deterministic-execution
-	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features \
-		--features=default-backend-llvm,deterministic-execution
-	cargo check --release --manifest-path lib/runtime/Cargo.toml
 
 	$(RUNTIME_CHECK) \
-		--features=cranelift,cache,debug,llvm,singlepass,default-backend-singlepass
-	$(RUNTIME_CHECK) --release \
-		--features=cranelift,cache,llvm,singlepass,default-backend-singlepass
-	$(RUNTIME_CHECK) \
-		--features=cranelift,cache,debug,llvm,singlepass,default-backend-cranelift
-	$(RUNTIME_CHECK) --release \
-		--features=cranelift,cache,llvm,singlepass,default-backend-cranelift
-	$(RUNTIME_CHECK) \
-		--features=cranelift,cache,debug,llvm,singlepass,default-backend-llvm
-	$(RUNTIME_CHECK) --release \
-		--features=cranelift,cache,llvm,singlepass,default-backend-llvm
-	$(RUNTIME_CHECK) \
-		--features=singlepass,default-backend-singlepass,debug
-	$(RUNTIME_CHECK) --release \
-		--features=singlepass,default-backend-singlepass
-	$(RUNTIME_CHECK) \
-		--features=cranelift,default-backend-cranelift,debug
-	$(RUNTIME_CHECK) --release \
-		--features=cranelift,default-backend-cranelift
-	$(RUNTIME_CHECK) \
-		--features=llvm,default-backend-llvm,debug
-	$(RUNTIME_CHECK) --release \
-		--features=llvm,default-backend-llvm
+		--features=singlepass,cranelift,llvm,cache,debug,deterministic-execution
 
 # Release
 release:

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ check: check-bench
 	cargo check --manifest-path lib/runtime/Cargo.toml
 
 	$(RUNTIME_CHECK) \
-		--features=singlepass,cranelift,llvm,cache,debug,deterministic-execution
+		--features=default-backend-singlepass,singlepass,cranelift,llvm,cache,debug,deterministic-execution
 
 # Release
 release:

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,38 @@ check: check-bench
 	# as default, and test a minimal set of features with only one backend
 	# at a time.
 	cargo check --manifest-path lib/runtime/Cargo.toml
+	# Check some of the cases where deterministic execution could matter
+	cargo check --manifest-path lib/runtime/Cargo.toml --features "deterministic-execution"
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features \
+		--features=default-backend-singlepass,deterministic-execution
+	cargo check --manifest-path lib/runtime/Cargo.toml --no-default-features \
+		--features=default-backend-llvm,deterministic-execution
+	cargo check --release --manifest-path lib/runtime/Cargo.toml
 
 	$(RUNTIME_CHECK) \
+		--features=cranelift,cache,debug,llvm,singlepass,default-backend-singlepass
+	$(RUNTIME_CHECK) --release \
+		--features=cranelift,cache,llvm,singlepass,default-backend-singlepass
+	$(RUNTIME_CHECK) \
+		--features=cranelift,cache,debug,llvm,singlepass,default-backend-cranelift
+	$(RUNTIME_CHECK) --release \
+		--features=cranelift,cache,llvm,singlepass,default-backend-cranelift
+	$(RUNTIME_CHECK) \
+		--features=cranelift,cache,debug,llvm,singlepass,default-backend-llvm
+	$(RUNTIME_CHECK) --release \
+		--features=cranelift,cache,llvm,singlepass,default-backend-llvm
+	$(RUNTIME_CHECK) \
+		--features=singlepass,default-backend-singlepass,debug
+	$(RUNTIME_CHECK) --release \
+		--features=singlepass,default-backend-singlepass
+	$(RUNTIME_CHECK) \
+		--features=cranelift,default-backend-cranelift,debug
+	$(RUNTIME_CHECK) --release \
+		--features=cranelift,default-backend-cranelift
+	$(RUNTIME_CHECK) \
+		--features=llvm,default-backend-llvm,debug
+	$(RUNTIME_CHECK) --release \
+		--features=llvm,default-backend-llvm
 		--features=default-backend-singlepass,singlepass,cranelift,llvm,cache,debug,deterministic-execution
 
 # Release

--- a/lib/clif-backend/src/code.rs
+++ b/lib/clif-backend/src/code.rs
@@ -18,7 +18,7 @@ use std::mem;
 use std::sync::{Arc, RwLock};
 use wasmer_runtime_core::error::CompileError;
 use wasmer_runtime_core::{
-    backend::{Backend, CacheGen, Token},
+    backend::{CacheGen, Token},
     cache::{Artifact, Error as CacheError},
     codegen::*,
     memory::MemoryType,
@@ -58,8 +58,8 @@ impl ModuleCodeGenerator<CraneliftFunctionCodeGenerator, Caller, CodegenError>
         unimplemented!("cross compilation is not available for clif backend")
     }
 
-    fn backend_id() -> Backend {
-        Backend::Cranelift
+    fn backend_id() -> String {
+        "cranelift".to_string()
     }
 
     fn check_precondition(&mut self, _module_info: &ModuleInfo) -> Result<(), CodegenError> {

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -8721,8 +8721,8 @@ impl<'ctx> ModuleCodeGenerator<LLVMFunctionCodeGenerator<'ctx>, LLVMBackend, Cod
         }
     }
 
-    fn backend_id() -> Backend {
-        Backend::LLVM
+    fn backend_id() -> String {
+        "llvm".to_string()
     }
 
     fn check_precondition(&mut self, _module_info: &ModuleInfo) -> Result<(), CodegenError> {

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use wasmer_runtime_core::{
-    backend::{Backend, CacheGen, CompilerConfig, Token},
+    backend::{CacheGen, CompilerConfig, Token},
     cache::{Artifact, Error as CacheError},
     codegen::*,
     memory::MemoryType,

--- a/lib/middleware-common-tests/Cargo.toml
+++ b/lib/middleware-common-tests/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 [dependencies]
 wasmer-runtime-core = { path = "../runtime-core", version = "0.12.0" }
 wasmer-middleware-common = { path = "../middleware-common", version = "0.12.0" }
-wasmer-clif-backend = { path = "../clif-backend", version = "0.12.0" }
+wasmer-clif-backend = { path = "../clif-backend", version = "0.12.0", optional = true }
 wasmer-llvm-backend = { path = "../llvm-backend", version = "0.12.0", features = ["test"], optional = true }
 wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.12.0", optional = true }
 
 [features]
-clif = []
+clif = ["wasmer-clif-backend"]
 llvm = ["wasmer-llvm-backend"]
 singlepass = ["wasmer-singlepass-backend"]
 

--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -7,10 +7,7 @@ mod tests {
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
     use wasmer_runtime_core::state::CodeVersion;
-    use wasmer_runtime_core::{
-        backend::Compiler,
-        compile_with, imports, Func,
-    };
+    use wasmer_runtime_core::{backend::Compiler, compile_with, imports, Func};
 
     #[cfg(feature = "llvm")]
     fn get_compiler(limit: u64) -> impl Compiler {

--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -3,27 +3,23 @@ mod tests {
     use wabt::wat2wasm;
 
     use wasmer_middleware_common::metering::*;
-    use wasmer_runtime_core::backend::RunnableModule;
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
+    use wasmer_runtime_core::codegen::ModuleCodeGenerator;
     use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
     use wasmer_runtime_core::state::CodeVersion;
     use wasmer_runtime_core::{backend::Compiler, compile_with, imports, Func};
 
     #[cfg(feature = "llvm")]
-    fn get_compiler(limit: u64) -> impl Compiler {
-        use wasmer_llvm_backend::ModuleCodeGenerator as LLVMMCG;
-        let c: StreamingCompiler<LLVMMCG, _, _, _, _> = StreamingCompiler::new(move || {
-            let mut chain = MiddlewareChain::new();
-            chain.push(Metering::new(limit));
-            chain
-        });
-        c
-    }
+    use wasmer_llvm_backend::ModuleCodeGenerator as MCG;
 
     #[cfg(feature = "singlepass")]
+    use wasmer_singlepass_backend::ModuleCodeGenerator as MCG;
+
+    #[cfg(feature = "clif")]
+    compile_error!("cranelift does not implement metering yet");
+
     fn get_compiler(limit: u64) -> impl Compiler {
-        use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
-        let c: StreamingCompiler<SinglePassMCG, _, _, _, _> = StreamingCompiler::new(move || {
+        let c: StreamingCompiler<MCG, _, _, _, _> = StreamingCompiler::new(move || {
             let mut chain = MiddlewareChain::new();
             chain.push(Metering::new(limit));
             chain
@@ -33,13 +29,6 @@ mod tests {
 
     #[cfg(not(any(feature = "llvm", feature = "clif", feature = "singlepass")))]
     compile_error!("compiler not specified, activate a compiler via features");
-
-    #[cfg(feature = "clif")]
-    fn get_compiler(_limit: u64) -> impl Compiler {
-        compile_error!("cranelift does not implement metering");
-        use wasmer_clif_backend::CraneliftCompiler;
-        CraneliftCompiler::new()
-    }
 
     // Assemblyscript
     // export function add_to(x: i32, y: i32): i32 {
@@ -106,7 +95,7 @@ mod tests {
 
         let limit = 100u64;
 
-        let (compiler, backend_id) = get_compiler(limit);
+        let compiler = get_compiler(limit);
         let module = compile_with(&wasm_binary, &compiler).unwrap();
 
         let import_object = imports! {};
@@ -121,8 +110,8 @@ mod tests {
                 baseline: true,
                 msm: msm,
                 base: instance.module.runnable_module.get_code().unwrap().as_ptr() as usize,
+                backend: MCG::backend_id(),
                 runnable_module: instance.module.runnable_module.clone(),
-                backend: backend_id,
             });
             true
         } else {
@@ -148,7 +137,7 @@ mod tests {
 
         let limit = 100u64;
 
-        let (compiler, backend_id) = get_compiler(limit);
+        let compiler = get_compiler(limit);
         let module = compile_with(&wasm_binary, &compiler).unwrap();
 
         let import_object = imports! {};
@@ -168,7 +157,7 @@ mod tests {
                 baseline: true,
                 msm: msm,
                 base: instance.module.runnable_module.get_code().unwrap().as_ptr() as usize,
-                backend: backend_id,
+                backend: MCG::backend_id(),
                 runnable_module: instance.module.runnable_module.clone(),
             });
             true

--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -3,8 +3,8 @@ mod tests {
     use wabt::wat2wasm;
 
     use wasmer_middleware_common::metering::*;
-    use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_runtime_core::codegen::ModuleCodeGenerator;
+    use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
     use wasmer_runtime_core::state::CodeVersion;
     use wasmer_runtime_core::{backend::Compiler, compile_with, imports, Func};

--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -147,11 +147,7 @@ mod tests {
 
         let add_to: Func<(i32, i32), i32> = instance.func("add_to").unwrap();
 
-        let cv_pushed = if let Some(msm) = instance
-            .module
-            .runnable_module
-            .get_module_state_map()
-        {
+        let cv_pushed = if let Some(msm) = instance.module.runnable_module.get_module_state_map() {
             push_code_version(CodeVersion {
                 baseline: true,
                 msm: msm,

--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -150,7 +150,6 @@ mod tests {
         let cv_pushed = if let Some(msm) = instance
             .module
             .runnable_module
-            .borrow()
             .get_module_state_map()
         {
             push_code_version(CodeVersion {

--- a/lib/middleware-common-tests/src/lib.rs
+++ b/lib/middleware-common-tests/src/lib.rs
@@ -8,40 +8,40 @@ mod tests {
     use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
     use wasmer_runtime_core::state::CodeVersion;
     use wasmer_runtime_core::{
-        backend::{Backend, Compiler},
+        backend::Compiler,
         compile_with, imports, Func,
     };
 
     #[cfg(feature = "llvm")]
-    fn get_compiler(limit: u64) -> (impl Compiler, Backend) {
+    fn get_compiler(limit: u64) -> impl Compiler {
         use wasmer_llvm_backend::ModuleCodeGenerator as LLVMMCG;
         let c: StreamingCompiler<LLVMMCG, _, _, _, _> = StreamingCompiler::new(move || {
             let mut chain = MiddlewareChain::new();
             chain.push(Metering::new(limit));
             chain
         });
-        (c, Backend::LLVM)
+        c
     }
 
     #[cfg(feature = "singlepass")]
-    fn get_compiler(limit: u64) -> (impl Compiler, Backend) {
+    fn get_compiler(limit: u64) -> impl Compiler {
         use wasmer_singlepass_backend::ModuleCodeGenerator as SinglePassMCG;
         let c: StreamingCompiler<SinglePassMCG, _, _, _, _> = StreamingCompiler::new(move || {
             let mut chain = MiddlewareChain::new();
             chain.push(Metering::new(limit));
             chain
         });
-        (c, Backend::Singlepass)
+        c
     }
 
     #[cfg(not(any(feature = "llvm", feature = "clif", feature = "singlepass")))]
     compile_error!("compiler not specified, activate a compiler via features");
 
     #[cfg(feature = "clif")]
-    fn get_compiler(_limit: u64) -> (impl Compiler, Backend) {
+    fn get_compiler(_limit: u64) -> impl Compiler {
         compile_error!("cranelift does not implement metering");
         use wasmer_clif_backend::CraneliftCompiler;
-        (CraneliftCompiler::new(), Backend::Cranelift)
+        CraneliftCompiler::new()
     }
 
     // Assemblyscript
@@ -161,7 +161,12 @@ mod tests {
 
         let add_to: Func<(i32, i32), i32> = instance.func("add_to").unwrap();
 
-        let cv_pushed = if let Some(msm) = instance.module.runnable_module.get_module_state_map() {
+        let cv_pushed = if let Some(msm) = instance
+            .module
+            .runnable_module
+            .borrow()
+            .get_module_state_map()
+        {
             push_code_version(CodeVersion {
                 baseline: true,
                 msm: msm,

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -52,9 +52,5 @@ cc = "1.0"
 [features]
 debug = []
 trace = ["debug"]
-# backend flags no longer used
-"backend-cranelift" = []
-"backend-singlepass" = []
-"backend-llvm" = []
 managed = []
 deterministic-execution = ["wasmparser/deterministic"]

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -52,7 +52,7 @@ cc = "1.0"
 [features]
 debug = []
 trace = ["debug"]
-# backend flags used in conditional compilation of Backend::variants
+# backend flags no longer used
 "backend-cranelift" = []
 "backend-singlepass" = []
 "backend-llvm" = []

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -22,60 +22,6 @@ pub mod sys {
 }
 pub use crate::sig_registry::SigRegistry;
 
-/// Enum used to select which compiler should be used to generate code.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Backend {
-    Cranelift,
-    Singlepass,
-    LLVM,
-    Auto,
-}
-
-impl Backend {
-    /// Get a list of the currently enabled (via feature flag) backends.
-    pub fn variants() -> &'static [&'static str] {
-        &[
-            #[cfg(feature = "backend-cranelift")]
-            "cranelift",
-            #[cfg(feature = "backend-singlepass")]
-            "singlepass",
-            #[cfg(feature = "backend-llvm")]
-            "llvm",
-            "auto",
-        ]
-    }
-
-    /// Stable string representation of the backend.
-    /// It can be used as part of a cache key, for example.
-    pub fn to_string(&self) -> &'static str {
-        match self {
-            Backend::Cranelift => "cranelift",
-            Backend::Singlepass => "singlepass",
-            Backend::LLVM => "llvm",
-            Backend::Auto => "auto",
-        }
-    }
-}
-
-impl Default for Backend {
-    fn default() -> Self {
-        Backend::Cranelift
-    }
-}
-
-impl std::str::FromStr for Backend {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Backend, String> {
-        match s.to_lowercase().as_str() {
-            "singlepass" => Ok(Backend::Singlepass),
-            "cranelift" => Ok(Backend::Cranelift),
-            "llvm" => Ok(Backend::LLVM),
-            "auto" => Ok(Backend::Auto),
-            _ => Err(format!("The backend {} doesn't exist", s)),
-        }
-    }
-}
-
 /// The target architecture for code generation.
 #[derive(Copy, Clone, Debug)]
 pub enum Architecture {
@@ -102,22 +48,6 @@ pub struct InlineBreakpoint {
 
     /// Type of the inline breakpoint.
     pub ty: InlineBreakpointType,
-}
-
-#[cfg(test)]
-mod backend_test {
-    use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn str_repr_matches() {
-        // if this test breaks, think hard about why it's breaking
-        // can we avoid having these be different?
-
-        for &backend in &[Backend::Cranelift, Backend::LLVM, Backend::Singlepass] {
-            assert_eq!(backend, Backend::from_str(backend.to_string()).unwrap());
-        }
-    }
 }
 
 /// This type cannot be constructed from

--- a/lib/runtime-core/src/cache.rs
+++ b/lib/runtime-core/src/cache.rs
@@ -3,12 +3,11 @@
 //! and loaded to allow skipping compilation and fast startup.
 
 use crate::{
-    backend::Backend,
-    module::{Module, ModuleInfo},
+    module::ModuleInfo,
     sys::Memory,
 };
 use blake2b_simd::blake2bp;
-use std::{fmt, io, mem, slice};
+use std::{io, mem, slice};
 
 /// Indicates the invalid type of invalid cache file
 #[derive(Debug)]
@@ -35,7 +34,7 @@ pub enum Error {
     /// The cached binary has been invalidated.
     InvalidatedCache,
     /// The current backend does not support caching.
-    UnsupportedBackend(Backend),
+    UnsupportedBackend(String),
 }
 
 impl From<io::Error> for Error {
@@ -244,24 +243,6 @@ impl Artifact {
 
         Ok(buffer)
     }
-}
-
-/// A generic cache for storing and loading compiled wasm modules.
-///
-/// The `wasmer-runtime` supplies a naive `FileSystemCache` api.
-pub trait Cache {
-    /// Error type to return when load error occurs
-    type LoadError: fmt::Debug;
-    /// Error type to return when store error occurs
-    type StoreError: fmt::Debug;
-
-    /// loads a module using the default `Backend`
-    fn load(&self, key: WasmHash) -> Result<Module, Self::LoadError>;
-    /// loads a cached module using a specific `Backend`
-    fn load_with_backend(&self, key: WasmHash, backend: Backend)
-        -> Result<Module, Self::LoadError>;
-    /// Store a module into the cache with the given key
-    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), Self::StoreError>;
 }
 
 /// A unique ID generated from the version of Wasmer for use with cache versioning

--- a/lib/runtime-core/src/cache.rs
+++ b/lib/runtime-core/src/cache.rs
@@ -2,10 +2,7 @@
 //! serializing compiled wasm code to a binary format.  The binary format can be persisted,
 //! and loaded to allow skipping compilation and fast startup.
 
-use crate::{
-    module::ModuleInfo,
-    sys::Memory,
-};
+use crate::{module::ModuleInfo, sys::Memory};
 use blake2b_simd::blake2bp;
 use std::{io, mem, slice};
 

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -92,10 +92,10 @@ pub trait ModuleCodeGenerator<FCG: FunctionCodeGenerator<E>, RM: RunnableModule,
     ) -> Self;
 
     /// Returns the backend id associated with this MCG.
-    fn backend_id() -> Backend;
+    fn backend_id() -> String;
 
     /// It sets if the current compiler requires validation before compilation
-    fn requires_pre_validation(&self) -> bool {
+    fn requires_pre_validation() -> bool {
         true
     }
 
@@ -231,8 +231,8 @@ impl<
             validate_with_features(wasm, &compiler_config.features)?;
         }
 
-        let mut mcg = match MCG::backend_id() {
-            Backend::LLVM => MCG::new_with_target(
+        let mut mcg = match MCG::backend_id().as_ref() {
+            "llvm" => MCG::new_with_target(
                 compiler_config.triple.clone(),
                 compiler_config.cpu_name.clone(),
                 compiler_config.cpu_features.clone(),
@@ -242,7 +242,6 @@ impl<
         let mut chain = (self.middleware_chain_generator)();
         let info = crate::parse::read_module(
             wasm,
-            MCG::backend_id(),
             &mut mcg,
             &mut chain,
             &compiler_config,

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -240,12 +240,7 @@ impl<
             _ => MCG::new(),
         };
         let mut chain = (self.middleware_chain_generator)();
-        let info = crate::parse::read_module(
-            wasm,
-            &mut mcg,
-            &mut chain,
-            &compiler_config,
-        )?;
+        let info = crate::parse::read_module(wasm, &mut mcg, &mut chain, &compiler_config)?;
         let (exec_context, cache_gen) =
             mcg.finalize(&info.read().unwrap())
                 .map_err(|x| CompileError::InternalError {

--- a/lib/runtime-core/src/codegen.rs
+++ b/lib/runtime-core/src/codegen.rs
@@ -4,7 +4,7 @@
 use crate::fault::FaultInfo;
 use crate::{
     backend::RunnableModule,
-    backend::{Backend, CacheGen, Compiler, CompilerConfig, Features, Token},
+    backend::{CacheGen, Compiler, CompilerConfig, Features, Token},
     cache::{Artifact, Error as CacheError},
     error::{CompileError, CompileResult},
     module::{ModuleInfo, ModuleInner},
@@ -93,6 +93,11 @@ pub trait ModuleCodeGenerator<FCG: FunctionCodeGenerator<E>, RM: RunnableModule,
 
     /// Returns the backend id associated with this MCG.
     fn backend_id() -> Backend;
+
+    /// It sets if the current compiler requires validation before compilation
+    fn requires_pre_validation(&self) -> bool {
+        true
+    }
 
     /// Feeds the compiler config.
     fn feed_compiler_config(&mut self, _config: &CompilerConfig) -> Result<(), E> {
@@ -222,7 +227,7 @@ impl<
         compiler_config: CompilerConfig,
         _: Token,
     ) -> CompileResult<ModuleInner> {
-        if requires_pre_validation(MCG::backend_id()) {
+        if MCG::requires_pre_validation() {
             validate_with_features(wasm, &compiler_config.features)?;
         }
 
@@ -260,15 +265,6 @@ impl<
         token: Token,
     ) -> Result<ModuleInner, CacheError> {
         MCG::from_cache(artifact, token)
-    }
-}
-
-fn requires_pre_validation(backend: Backend) -> bool {
-    match backend {
-        Backend::Cranelift => true,
-        Backend::LLVM => true,
-        Backend::Singlepass => false,
-        Backend::Auto => false,
     }
 }
 

--- a/lib/runtime-core/src/module.rs
+++ b/lib/runtime-core/src/module.rs
@@ -1,7 +1,7 @@
 //! The module module contains the implementation data structures and helper functions used to
 //! manipulate and access wasm modules.
 use crate::{
-    backend::{Backend, RunnableModule},
+    backend::RunnableModule,
     cache::{Artifact, Error as CacheError},
     error,
     import::ImportObject,
@@ -65,7 +65,7 @@ pub struct ModuleInfo {
     /// Map signature index to function signature.
     pub signatures: Map<SigIndex, FuncSig>,
     /// Backend.
-    pub backend: Backend,
+    pub backend: String,
 
     /// Table of namespace indexes.
     pub namespace_table: StringTable<NamespaceIndex>,

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -3,7 +3,7 @@
 
 use crate::codegen::*;
 use crate::{
-    backend::{Backend, CompilerConfig, RunnableModule},
+    backend::{CompilerConfig, RunnableModule},
     error::CompileError,
     module::{
         DataInitializer, ExportIndex, ImportName, ModuleInfo, StringTable, StringTableBuilder,
@@ -57,7 +57,6 @@ pub fn read_module<
     E: Debug,
 >(
     wasm: &[u8],
-    backend: Backend,
     mcg: &mut MCG,
     middlewares: &mut MiddlewareChain,
     compiler_config: &CompilerConfig,
@@ -83,7 +82,7 @@ pub fn read_module<
 
         func_assoc: Map::new(),
         signatures: Map::new(),
-        backend: backend,
+        backend: MCG::backend_id(),
 
         namespace_table: StringTable::new(),
         name_table: StringTable::new(),

--- a/lib/runtime-core/src/state.rs
+++ b/lib/runtime-core/src/state.rs
@@ -2,7 +2,7 @@
 //! state could read or updated at runtime. Use cases include generating stack traces, switching
 //! generated code from one tier to another, or serializing state of a running instace.
 
-use crate::backend::{Backend, RunnableModule};
+use crate::backend::RunnableModule;
 use std::collections::BTreeMap;
 use std::ops::Bound::{Included, Unbounded};
 use std::sync::Arc;
@@ -186,7 +186,7 @@ pub struct CodeVersion {
     pub base: usize,
 
     /// The backend used to compile this module.
-    pub backend: Backend,
+    pub backend: String,
 
     /// `RunnableModule` for this code version.
     pub runnable_module: Arc<Box<dyn RunnableModule>>,

--- a/lib/runtime-core/src/tiering.rs
+++ b/lib/runtime-core/src/tiering.rs
@@ -1,6 +1,6 @@
 //! The tiering module supports switching between code compiled with different optimization levels
 //! as runtime.
-use crate::backend::{Backend, Compiler, CompilerConfig};
+use crate::backend::{Compiler, CompilerConfig};
 use crate::compile_with_config;
 use crate::fault::{
     catch_unsafe_unwind, ensure_sighandler, pop_code_version, push_code_version, with_ctx,
@@ -43,7 +43,7 @@ struct OptimizationState {
 }
 
 struct OptimizationOutcome {
-    backend_id: Backend,
+    backend_id: String,
     module: Module,
 }
 
@@ -54,7 +54,7 @@ unsafe impl Sync for CtxWrapper {}
 
 unsafe fn do_optimize(
     binary: &[u8],
-    backend_id: Backend,
+    backend_id: String,
     compiler: Box<dyn Compiler>,
     ctx: &Mutex<CtxWrapper>,
     state: &OptimizationState,
@@ -87,8 +87,8 @@ pub unsafe fn run_tiering<F: Fn(InteractiveShellContext) -> ShellExitOperation>(
     import_object: &ImportObject,
     start_raw: extern "C" fn(&mut Ctx),
     baseline: &mut Instance,
-    baseline_backend: Backend,
-    optimized_backends: Vec<(Backend, Box<dyn Fn() -> Box<dyn Compiler> + Send>)>,
+    baseline_backend: String,
+    optimized_backends: Vec<(String, Box<dyn Fn() -> Box<dyn Compiler> + Send>)>,
     interactive_shell: F,
 ) -> Result<(), String> {
     ensure_sighandler();
@@ -140,7 +140,7 @@ pub unsafe fn run_tiering<F: Fn(InteractiveShellContext) -> ShellExitOperation>(
     }));
 
     loop {
-        let new_optimized: Option<(Backend, &mut Instance)> = {
+        let new_optimized: Option<(String, &mut Instance)> = {
             let mut outcome = opt_state.outcome.lock().unwrap();
             if let Some(x) = outcome.take() {
                 let instance = x

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -1118,7 +1118,7 @@ mod vm_ctx_tests {
 
                 func_assoc: Map::new(),
                 signatures: Map::new(),
-                backend: "".to_string(),
+                backend: Default::default(),
 
                 namespace_table: StringTable::new(),
                 name_table: StringTable::new(),

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -1064,7 +1064,7 @@ mod vm_ctx_tests {
 
     fn generate_module() -> ModuleInner {
         use super::Func;
-        use crate::backend::{sys::Memory, Backend, CacheGen, RunnableModule};
+        use crate::backend::{sys::Memory, CacheGen, RunnableModule};
         use crate::cache::Error as CacheError;
         use crate::typed_func::Wasm;
         use crate::types::{LocalFuncIndex, SigIndex};
@@ -1118,7 +1118,7 @@ mod vm_ctx_tests {
 
                 func_assoc: Map::new(),
                 signatures: Map::new(),
-                backend: Backend::Cranelift,
+                backend: "".to_string(),
 
                 namespace_table: StringTable::new(),
                 name_table: StringTable::new(),

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -24,6 +24,14 @@ path = "../clif-backend"
 version = "0.12.0"
 optional = true
 
+# Dependencies for caching.
+[dependencies.serde]
+version = "1.0"
+# This feature is required for serde to support serializing/deserializing reference counted pointers (e.g. Rc and Arc).
+features = ["rc"]
+[dependencies.serde_derive]
+version = "1.0"
+
 [dev-dependencies]
 tempfile = "3.1"
 criterion = "0.2"

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -5,6 +5,7 @@
 use crate::Module;
 use memmap::Mmap;
 use std::{
+    fmt,
     fs::{create_dir_all, File},
     io::{self, Write},
     path::PathBuf,
@@ -12,9 +13,27 @@ use std::{
 
 use wasmer_runtime_core::cache::Error as CacheError;
 pub use wasmer_runtime_core::{
-    backend::Backend,
-    cache::{Artifact, Cache, WasmHash},
+    cache::{Artifact, WasmHash},
 };
+pub use super::Backend;
+
+/// A generic cache for storing and loading compiled wasm modules.
+///
+/// The `wasmer-runtime` supplies a naive `FileSystemCache` api.
+pub trait Cache {
+    /// Error type to return when load error occurs
+    type LoadError: fmt::Debug;
+    /// Error type to return when store error occurs
+    type StoreError: fmt::Debug;
+
+    /// loads a module using the default `Backend`
+    fn load(&self, key: WasmHash) -> Result<Module, Self::LoadError>;
+    /// loads a cached module using a specific `Backend`
+    fn load_with_backend(&self, key: WasmHash, backend: Backend)
+        -> Result<Module, Self::LoadError>;
+    /// Store a module into the cache with the given key
+    fn store(&mut self, key: WasmHash, module: Module) -> Result<(), Self::StoreError>;
+}
 
 /// Representation of a directory that contains compiled wasm artifacts.
 ///
@@ -105,7 +124,7 @@ impl Cache for FileSystemCache {
             wasmer_runtime_core::load_cache_with(
                 serialized_cache,
                 crate::compiler_for_backend(backend)
-                    .ok_or_else(|| CacheError::UnsupportedBackend(backend))?
+                    .ok_or_else(|| CacheError::UnsupportedBackend(backend.to_string().to_owned()))?
                     .as_ref(),
             )
         }

--- a/lib/runtime/src/cache.rs
+++ b/lib/runtime/src/cache.rs
@@ -11,11 +11,9 @@ use std::{
     path::PathBuf,
 };
 
-use wasmer_runtime_core::cache::Error as CacheError;
-pub use wasmer_runtime_core::{
-    cache::{Artifact, WasmHash},
-};
 pub use super::Backend;
+use wasmer_runtime_core::cache::Error as CacheError;
+pub use wasmer_runtime_core::cache::{Artifact, WasmHash};
 
 /// A generic cache for storing and loading compiled wasm modules.
 ///

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -350,3 +350,26 @@ pub fn compiler_for_backend(backend: Backend) -> Option<Box<dyn Compiler>> {
 
 /// The current version of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn str_repr_matches() {
+        // if this test breaks, think hard about why it's breaking
+        // can we avoid having these be different?
+
+        for &backend in &[
+            #[cfg(feature = "cranelift")]
+            Backend::Cranelift,
+            #[cfg(feature = "llvm")]
+            Backend::LLVM,
+            #[cfg(feature = "singlepass")]
+            Backend::Singlepass
+        ] {
+            assert_eq!(backend, Backend::from_str(backend.to_string()).unwrap());
+        }
+    }
+}

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -183,7 +183,7 @@ impl Default for Backend {
     fn default() -> Self {
         #[cfg(all(feature = "default-backend-singlepass", not(feature = "docs")))]
         return Backend::Singlepass;
-    
+
         #[cfg(any(feature = "default-backend-cranelift", feature = "docs"))]
         return Backend::Cranelift;
 
@@ -191,7 +191,6 @@ impl Default for Backend {
         return Backend::LLVM;
     }
 }
-
 
 /// Compile WebAssembly binary code into a [`Module`].
 /// This function is useful if it is necessary to

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -367,7 +367,7 @@ mod test {
             #[cfg(feature = "llvm")]
             Backend::LLVM,
             #[cfg(feature = "singlepass")]
-            Backend::Singlepass
+            Backend::Singlepass,
         ] {
             assert_eq!(backend, Backend::from_str(backend.to_string()).unwrap());
         }

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -164,14 +164,27 @@ pub enum Backend {
 }
 
 impl Backend {
+    /// Get a list of the currently enabled (via feature flag) backends.
+    pub fn variants() -> &'static [&'static str] {
+        &[
+            #[cfg(feature = "singlepass")]
+            "singlepass",
+            #[cfg(feature = "cranelift")]
+            "cranelift",
+            #[cfg(feature = "llvm")]
+            "llvm",
+            "auto",
+        ]
+    }
+
     /// Stable string representation of the backend.
     /// It can be used as part of a cache key, for example.
     pub fn to_string(&self) -> &'static str {
         match self {
-            #[cfg(feature = "cranelift")]
-            Backend::Cranelift => "cranelift",
             #[cfg(feature = "singlepass")]
             Backend::Singlepass => "singlepass",
+            #[cfg(feature = "cranelift")]
+            Backend::Cranelift => "cranelift",
             #[cfg(feature = "llvm")]
             Backend::LLVM => "llvm",
             Backend::Auto => "auto",
@@ -189,6 +202,22 @@ impl Default for Backend {
 
         #[cfg(all(feature = "default-backend-llvm", not(feature = "docs")))]
         return Backend::LLVM;
+    }
+}
+
+impl std::str::FromStr for Backend {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Backend, String> {
+        match s.to_lowercase().as_str() {
+            #[cfg(feature = "singlepass")]
+            "singlepass" => Ok(Backend::Singlepass),
+            #[cfg(feature = "cranelift")]
+            "cranelift" => Ok(Backend::Cranelift),
+            #[cfg(feature = "llvm")]
+            "llvm" => Ok(Backend::LLVM),
+            "auto" => Ok(Backend::Auto),
+            _ => Err(format!("The backend {} doesn't exist", s)),
+        }
     }
 }
 

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -646,12 +646,13 @@ impl ModuleCodeGenerator<X64FunctionCode, X64ExecutionContext, CodegenError>
         }
     }
 
-    fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {
-        unimplemented!("cross compilation is not available for singlepass backend")
+    /// Singlepass does validation as it compiles
+    fn requires_pre_validation(&self) -> bool {
+        false
     }
 
-    fn backend_id() -> Backend {
-        Backend::Singlepass
+    fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {
+        unimplemented!("cross compilation is not available for singlepass backend")
     }
 
     fn check_precondition(&mut self, _module_info: &ModuleInfo) -> Result<(), CodegenError> {

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -23,7 +23,7 @@ use std::{
 use wasmer_runtime_core::{
     backend::{
         sys::{Memory, Protect},
-        Architecture, Backend, CacheGen, CompilerConfig, InlineBreakpoint, InlineBreakpointType,
+        Architecture, CacheGen, CompilerConfig, InlineBreakpoint, InlineBreakpointType,
         MemoryBoundCheckMode, RunnableModule, Token,
     },
     cache::{Artifact, Error as CacheError},
@@ -647,8 +647,12 @@ impl ModuleCodeGenerator<X64FunctionCode, X64ExecutionContext, CodegenError>
     }
 
     /// Singlepass does validation as it compiles
-    fn requires_pre_validation(&self) -> bool {
+    fn requires_pre_validation() -> bool {
         false
+    }
+
+    fn backend_id() -> String {
+        "singlepass".to_string()
     }
 
     fn new_with_target(_: Option<String>, _: Option<String>, _: Option<String>) -> Self {

--- a/lib/wasi-experimental-io-devices/src/lib.rs
+++ b/lib/wasi-experimental-io-devices/src/lib.rs
@@ -454,7 +454,7 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
     let base_dir_fd = unsafe {
         fs.open_dir_all(
             VIRTUAL_ROOT_FD,
-            "_wasmer/fb0".to_string(),
+            "_wasmer/dev/fb0".to_string(),
             ALL_RIGHTS,
             ALL_RIGHTS,
             0,

--- a/lib/wasi-experimental-io-devices/src/lib.rs
+++ b/lib/wasi-experimental-io-devices/src/lib.rs
@@ -451,21 +451,10 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
         cursor: 0,
     });
 
-    let dev_fd = unsafe {
+    let base_dir_fd = unsafe {
         fs.open_dir_all(
             VIRTUAL_ROOT_FD,
-            "dev".to_string(),
-            ALL_RIGHTS,
-            ALL_RIGHTS,
-            0,
-        )
-        .map_err(|e| format!("fb: Failed to create dev folder {:?}", e))?
-    };
-
-    let fb_fd = unsafe {
-        fs.open_dir_all(
-            VIRTUAL_ROOT_FD,
-            "sys/class/graphics/wasmerfb0".to_string(),
+            "_wasmer/fb0".to_string(),
             ALL_RIGHTS,
             ALL_RIGHTS,
             0,
@@ -475,7 +464,7 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
 
     let _fd = fs
         .open_file_at(
-            dev_fd,
+            base_dir_fd,
             input_file,
             Fd::READ,
             "input".to_string(),
@@ -489,10 +478,10 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
 
     let _fd = fs
         .open_file_at(
-            dev_fd,
+            base_dir_fd,
             frame_buffer_file,
             Fd::READ | Fd::WRITE,
-            "wasmerfb0".to_string(),
+            "fb".to_string(),
             ALL_RIGHTS,
             ALL_RIGHTS,
             0,
@@ -503,7 +492,7 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
 
     let _fd = fs
         .open_file_at(
-            fb_fd,
+            base_dir_fd,
             resolution_file,
             Fd::READ | Fd::WRITE,
             "virtual_size".to_string(),
@@ -517,7 +506,7 @@ pub fn initialize(fs: &mut WasiFs) -> Result<(), String> {
 
     let _fd = fs
         .open_file_at(
-            fb_fd,
+            base_dir_fd,
             index_file,
             Fd::READ | Fd::WRITE,
             "buffer_index_display".to_string(),

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -941,7 +941,8 @@ fn interactive_shell(mut ctx: InteractiveShellContext) -> ShellExitOperation {
     }
 }
 
-fn get_backend(backend: Backend, _path: &PathBuf) -> Backend {
+#[allow(unused_variables)]
+fn get_backend(backend: Backend, path: &PathBuf) -> Backend {
     // Update backend when a backend flag is `auto`.
     // Use the Singlepass backend if it's enabled and the file provided is larger
     // than 10MiB (10485760 bytes), or it's enabled and the target architecture
@@ -950,7 +951,7 @@ fn get_backend(backend: Backend, _path: &PathBuf) -> Backend {
         Backend::Auto => {
             #[cfg(feature = "backend-singlepass")]
             {
-                let binary_size = match &_path.metadata() {
+                let binary_size = match &path.metadata() {
                     Ok(wasm_binary) => wasm_binary.len(),
                     Err(_e) => 0,
                 };

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -954,23 +954,24 @@ fn get_backend(backend: Backend, _path: &PathBuf) -> Backend {
                     Ok(wasm_binary) => wasm_binary.len(),
                     Err(_e) => 0,
                 };
-                if binary_size > 10485760 || cfg!(target_arch = "aarch64")
-                {
+                if binary_size > 10485760 || cfg!(target_arch = "aarch64") {
                     return Backend::Singlepass;
                 }
             }
-            
-            #[cfg(feature = "backend-cranelift")] {
+
+            #[cfg(feature = "backend-cranelift")]
+            {
                 return Backend::Cranelift;
             }
 
-            #[cfg(feature = "backend-llvm")] {
+            #[cfg(feature = "backend-llvm")]
+            {
                 return Backend::LLVM;
             }
 
             panic!("Can't find any backend");
         }
-        backend => backend
+        backend => backend,
     }
 }
 

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -30,13 +30,13 @@ use wasmer_llvm_backend::{
 };
 use wasmer_runtime::{
     cache::{Cache as BaseCache, FileSystemCache, WasmHash},
-    Value, VERSION,
+    Backend, Value, VERSION,
 };
 #[cfg(feature = "managed")]
 use wasmer_runtime_core::tiering::{run_tiering, InteractiveShellContext, ShellExitOperation};
 use wasmer_runtime_core::{
     self,
-    backend::{Backend, Compiler, CompilerConfig, Features, MemoryBoundCheckMode},
+    backend::{Compiler, CompilerConfig, Features, MemoryBoundCheckMode},
     debug,
     loader::{Instance as LoadedInstance, LocalLoader},
     Module,
@@ -143,7 +143,7 @@ struct Run {
     #[structopt(parse(from_os_str))]
     path: PathBuf,
 
-    /// Name of the backend to use. (x86_64)
+    /// Name of the backend to use (x86_64)
     #[cfg(target_arch = "x86_64")]
     #[structopt(
         long = "backend",
@@ -153,7 +153,7 @@ struct Run {
     )]
     backend: Backend,
 
-    /// Name of the backend to use. (aarch64)
+    /// Name of the backend to use (aarch64)
     #[cfg(target_arch = "aarch64")]
     #[structopt(
         long = "backend",
@@ -486,7 +486,7 @@ fn execute_wasi(
                 baseline: true,
                 msm: msm,
                 base: instance.module.runnable_module.get_code().unwrap().as_ptr() as usize,
-                backend: options.backend,
+                backend: options.backend.to_string().to_owned(),
                 runnable_module: instance.module.runnable_module.clone(),
             });
             true
@@ -618,8 +618,15 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
     };
 
     // Don't error on --enable-all for other backends.
-    if options.features.simd && options.backend != Backend::LLVM {
-        return Err("SIMD is only supported in the LLVM backend for now".to_string());
+    if options.features.simd {
+        #[cfg(feature = "backend-llvm")]
+        {
+            if options.backend != Backend::LLVM {
+                return Err("SIMD is only supported in the LLVM backend for now".to_string());
+            }
+        }
+        #[cfg(not(feature = "backend-llvm"))]
+        return Err("SIMD is not supported in this backend".to_string());
     }
 
     if !utils::is_wasm_binary(&wasm_binary) {
@@ -1031,16 +1038,10 @@ fn get_compiler_by_backend(backend: Backend, _opts: &Run) -> Option<Box<dyn Comp
                 StreamingCompiler::new(middlewares_gen);
             Box::new(c)
         }
-        #[cfg(not(feature = "backend-singlepass"))]
-        Backend::Singlepass => return None,
         #[cfg(feature = "backend-cranelift")]
         Backend::Cranelift => Box::new(CraneliftCompiler::new()),
-        #[cfg(not(feature = "backend-cranelift"))]
-        Backend::Cranelift => return None,
         #[cfg(feature = "backend-llvm")]
         Backend::LLVM => Box::new(LLVMCompiler::new()),
-        #[cfg(not(feature = "backend-llvm"))]
-        Backend::LLVM => return None,
         Backend::Auto => return None,
     })
 }

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -12,7 +12,7 @@ extern crate structopt;
 use std::collections::HashMap;
 use std::env;
 use std::error::Error;
-use std::fs::{metadata, read_to_string, File};
+use std::fs::{read_to_string, File};
 use std::io;
 use std::io::Read;
 use std::path::PathBuf;
@@ -941,29 +941,41 @@ fn interactive_shell(mut ctx: InteractiveShellContext) -> ShellExitOperation {
     }
 }
 
-fn update_backend(options: &mut Run) {
-    let binary_size = match metadata(&options.path) {
-        Ok(wasm_binary) => wasm_binary.len(),
-        Err(_e) => 0,
-    };
-
+fn get_backend(backend: Backend, _path: &PathBuf) -> Backend {
     // Update backend when a backend flag is `auto`.
     // Use the Singlepass backend if it's enabled and the file provided is larger
     // than 10MiB (10485760 bytes), or it's enabled and the target architecture
     // is AArch64. Otherwise, use the Cranelift backend.
-    if options.backend == Backend::Auto {
-        if Backend::variants().contains(&Backend::Singlepass.to_string())
-            && (binary_size > 10485760 || cfg!(target_arch = "aarch64"))
-        {
-            options.backend = Backend::Singlepass;
-        } else {
-            options.backend = Backend::Cranelift;
+    match backend {
+        Backend::Auto => {
+            #[cfg(feature = "backend-singlepass")]
+            {
+                let binary_size = match &_path.metadata() {
+                    Ok(wasm_binary) => wasm_binary.len(),
+                    Err(_e) => 0,
+                };
+                if binary_size > 10485760 || cfg!(target_arch = "aarch64")
+                {
+                    return Backend::Singlepass;
+                }
+            }
+            
+            #[cfg(feature = "backend-cranelift")] {
+                return Backend::Cranelift;
+            }
+
+            #[cfg(feature = "backend-llvm")] {
+                return Backend::LLVM;
+            }
+
+            panic!("Can't find any backend");
         }
+        backend => backend
     }
 }
 
 fn run(options: &mut Run) {
-    update_backend(options);
+    options.backend = get_backend(options.backend, &options.path);
     match execute_wasm(options) {
         Ok(()) => {}
         Err(message) => {
@@ -1042,7 +1054,7 @@ fn get_compiler_by_backend(backend: Backend, _opts: &Run) -> Option<Box<dyn Comp
         Backend::Cranelift => Box::new(CraneliftCompiler::new()),
         #[cfg(feature = "backend-llvm")]
         Backend::LLVM => Box::new(LLVMCompiler::new()),
-        Backend::Auto => return None,
+        _ => return None,
     })
 }
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR removes the dependency of a Backend in runtime-core. So it's agnostic and more backends can be plugged in easily.

Why this is important?
* By removing backends from wasmer-runtime-core we can make the runtime agnostic, so anyone can plug their own backend into Wasmer without needing to touch the main source code (V8, JavascriptCore, wasm3, ...).
* It simplifies the codebase and avoids code leaks from the backend to the runtime API.

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
