### PR TITLE
Add MIT license to crates that were missing it

### DIFF
--- a/examples/plugin-for-example/Cargo.toml
+++ b/examples/plugin-for-example/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plugin-for-example"
 version = "0.1.0"
 authors = ["The Wasmer Engineering Team <enigneering@wasmer.io>"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]

--- a/lib/kernel-loader/Cargo.toml
+++ b/lib/kernel-loader/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasmer-kernel-loader"
 version = "0.1.0"
 authors = ["Heyang Zhou <zhy20000919@hotmail.com>"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]

--- a/lib/kernel-net/Cargo.toml
+++ b/lib/kernel-net/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kernel-net"
 version = "0.1.0"
 authors = ["Heyang Zhou <zhy20000919@hotmail.com>"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]

--- a/lib/llvm-backend-tests/Cargo.toml
+++ b/lib/llvm-backend-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasmer-llvm-backend-tests"
 version = "0.10.2"
 authors = ["Nick Lewycky <nick@wasmer.io>"]
+license = "MIT"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"
 publish = true
 description = "An experimental non-standard WASI extension for graphics"
+license = "MIT"
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
Ran into a few crates in this repo with our license scanner that didn't have any license attached to them.

Added MIT to be consistent with the other crates. Please adjust if not correct.