### PR TITLE
Generic unique identifiers.

### DIFF
--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -23,6 +23,7 @@
     unreachable_patterns
 )]
 #![cfg_attr(nightly, feature(unwind_attributes))]
+#![cfg_attr(nightly, feature(const_fn))] // this should be removed
 #![doc(html_favicon_url = "https://wasmer.io/static/icons/favicon.ico")]
 #![doc(html_logo_url = "https://avatars3.githubusercontent.com/u/44205449?s=200&v=4")]
 
@@ -69,6 +70,8 @@ pub mod fault;
 pub mod state;
 #[cfg(feature = "managed")]
 pub mod tiering;
+#[macro_use]
+pub mod unique_id;
 
 use self::error::CompileResult;
 #[doc(inline)]

--- a/lib/runtime-core/src/unique_id.rs
+++ b/lib/runtime-core/src/unique_id.rs
@@ -1,0 +1,78 @@
+//! Unique identifiers.
+
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Once,
+};
+
+/// The backing structure providing configuration and storage for a UniqueId.
+pub trait UniqueIdBacking {
+    /// Returns the maximum amount of unique ids.
+    fn get_size() -> usize;
+
+    /// Returns the backing counter for the unique id.
+    fn get_counter() -> &'static AtomicUsize;
+}
+
+/// Defines a unique ID category.
+#[macro_export]
+macro_rules! define_unique_id_category {
+    ($name:ident, $max:expr) => {
+        /// Automatically generated unique ID category.
+        pub struct $name;
+        impl $crate::unique_id::UniqueIdBacking for $name {
+            fn get_size() -> usize {
+                $max
+            }
+
+            fn get_counter() -> &'static ::std::sync::atomic::AtomicUsize {
+                static COUNTER: ::std::sync::atomic::AtomicUsize =
+                    ::std::sync::atomic::AtomicUsize::new(0);
+                &COUNTER
+            }
+        }
+    };
+}
+
+/// A unique identifier.
+pub struct UniqueId<B: UniqueIdBacking> {
+    /// Init once field.
+    init: Once,
+    /// Inner field.
+    inner: UnsafeCell<usize>,
+    _phantom: PhantomData<B>,
+}
+
+unsafe impl<B: UniqueIdBacking> Send for UniqueId<B> {}
+unsafe impl<B: UniqueIdBacking> Sync for UniqueId<B> {}
+
+impl<B: UniqueIdBacking> UniqueId<B> {
+    /// Allocate and return a `UniqueId`.
+    pub const fn allocate() -> UniqueId<B> {
+        UniqueId {
+            init: Once::new(),
+            inner: UnsafeCell::new(::std::usize::MAX),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get the index of this `UniqueId`.
+    pub fn index(&self) -> usize {
+        let inner: *mut usize = self.inner.get();
+        self.init.call_once(|| {
+            let counter = B::get_counter();
+            let idx = counter.fetch_add(1, Ordering::SeqCst);
+            if idx >= B::get_size() {
+                counter.fetch_sub(1, Ordering::SeqCst);
+                panic!("at most {} unique IDs are supported", B::get_size());
+            } else {
+                unsafe {
+                    *inner = idx;
+                }
+            }
+        });
+        unsafe { *inner }
+    }
+}


### PR DESCRIPTION
This PR adds a generic unique identifier implementation that can be used for e.g. middleware `InternalField`s and backend IDs.

TODO:

- [ ] Make it work on stable (macros?)
- [ ] Tests