### PR TITLE
runtime-core: setting `Func` and `FuncEnv` visibility to `pub`

### DIFF
--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -542,13 +542,13 @@ impl Ctx {
 /// `typed_func` module within the `wrap` functions, to wrap imported
 /// functions.
 #[repr(transparent)]
-pub struct Func(pub(self) *mut c_void);
+pub struct Func(pub *mut c_void);
 
 /// Represents a function environment pointer, like a captured
 /// environment of a closure. It is mostly used in the `typed_func`
 /// module within the `wrap` functions, to wrap imported functions.
 #[repr(transparent)]
-pub struct FuncEnv(pub(self) *mut c_void);
+pub struct FuncEnv(pub *mut c_void);
 
 /// Represents a function context. It is used by imported functions
 /// only.


### PR DESCRIPTION
# Description
setting `Func` and `FuncEnv` visibility to `pub` makes is possible to use `Func` in external Rust code
that wants to use the wasmer C API.

Here is an example of such usage:
https://github.com/spacemeshos/svm/blob/d77efb1f98ad24e661f20049d8fa52ad2a098864/crates/svm-runtime-c-api/src/wasmer.rs#L21

# Review
- [x] runtime-core: setting `Func` and `FuncEnv` visibility to `pub`