### PR TITLE
feat(runtime-c-api) Define the `DEPRECATED` C macro.

### DIFF
--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -24,10 +24,20 @@ fn main() {
 #  define ARCH_X86_64
 #endif
 
+// Compatibility with non-Clang compilers.
+#if !defined(__has_attribute)
+#  define __has_attribute(x) 0
+#endif
+
+// Compatibility with non-Clang compilers.
+#if !defined(__has_declspec_attribute)
+#  define __has_declspec_attribute(x) 0
+#endif
+
 // Define the `DEPRECATED` macro.
-#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
+#if defined(GCC) || defined(__GNUC__) || __has_attribute(deprecated)
 #  define DEPRECATED(message) __attribute__((deprecated(message)))
-#elif defined(MSVC)
+#elif defined(MSVC) || __has_declspec_attribute(deprecated)
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 

--- a/lib/runtime-c-api/build.rs
+++ b/lib/runtime-c-api/build.rs
@@ -14,18 +14,21 @@ fn main() {
 
     let mut pre_header = r#"
 #if !defined(WASMER_H_MACROS)
+
 #define WASMER_H_MACROS
 
-#if defined(MSVC)
-#if defined(_M_AMD64)
-#define ARCH_X86_64
-#endif
+// Define the `ARCH_X86_X64` constant.
+#if defined(MSVC) && defined(_M_AMD64)
+#  define ARCH_X86_64
+#elif (defined(GCC) || defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
+#  define ARCH_X86_64
 #endif
 
+// Define the `DEPRECATED` macro.
 #if defined(GCC) || defined(__GNUC__) || defined(__clang__)
-#if defined(__x86_64__)
-#define ARCH_X86_64
-#endif
+#  define DEPRECATED(message) __attribute__((deprecated(message)))
+#elif defined(MSVC)
+#  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
 "#
@@ -41,7 +44,7 @@ fn main() {
         pre_header += "#define WASMER_EMSCRIPTEN_ENABLED\n";
     }
 
-    // close pre header
+    // Close pre header.
     pre_header += "#endif // WASMER_H_MACROS\n";
 
     // Generate the C bindings in the `OUT_DIR`.

--- a/lib/runtime-c-api/src/import/wasi.rs
+++ b/lib/runtime-c-api/src/import/wasi.rs
@@ -11,7 +11,7 @@ pub enum Version {
     Unknown = 0,
 
     /// Latest version. See `wasmer_wasi::WasiVersion::Latest` to
-    /// leran more.
+    /// learn more.
     Latest = 1,
 
     /// `wasi_unstable`.

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -10,10 +10,20 @@
 #  define ARCH_X86_64
 #endif
 
+// Compatibility with non-Clang compilers.
+#if !defined(__has_attribute)
+#  define __has_attribute(x) 0
+#endif
+
+// Compatibility with non-Clang compilers.
+#if !defined(__has_declspec_attribute)
+#  define __has_declspec_attribute(x) 0
+#endif
+
 // Define the `DEPRECATED` macro.
-#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
+#if defined(GCC) || defined(__GNUC__) || __has_attribute(deprecated)
 #  define DEPRECATED(message) __attribute__((deprecated(message)))
-#elif defined(MSVC)
+#elif defined(MSVC) || __has_declspec_attribute(deprecated)
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -1,17 +1,20 @@
 
 #if !defined(WASMER_H_MACROS)
+
 #define WASMER_H_MACROS
 
-#if defined(MSVC)
-#if defined(_M_AMD64)
-#define ARCH_X86_64
-#endif
+// Define the `ARCH_X86_X64` constant.
+#if defined(MSVC) && defined(_M_AMD64)
+#  define ARCH_X86_64
+#elif (defined(GCC) || defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
+#  define ARCH_X86_64
 #endif
 
+// Define the `DEPRECATED` macro.
 #if defined(GCC) || defined(__GNUC__) || defined(__clang__)
-#if defined(__x86_64__)
-#define ARCH_X86_64
-#endif
+#  define DEPRECATED(message) __attribute__((deprecated(message)))
+#elif defined(MSVC)
+#  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
 #define WASMER_WASI_ENABLED

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -10,10 +10,20 @@
 #  define ARCH_X86_64
 #endif
 
+// Compatibility with non-Clang compilers.
+#if !defined(__has_attribute)
+#  define __has_attribute(x) 0
+#endif
+
+// Compatibility with non-Clang compilers.
+#if !defined(__has_declspec_attribute)
+#  define __has_declspec_attribute(x) 0
+#endif
+
 // Define the `DEPRECATED` macro.
-#if defined(GCC) || defined(__GNUC__) || defined(__clang__)
+#if defined(GCC) || defined(__GNUC__) || __has_attribute(deprecated)
 #  define DEPRECATED(message) __attribute__((deprecated(message)))
-#elif defined(MSVC)
+#elif defined(MSVC) || __has_declspec_attribute(deprecated)
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -1,17 +1,20 @@
 
 #if !defined(WASMER_H_MACROS)
+
 #define WASMER_H_MACROS
 
-#if defined(MSVC)
-#if defined(_M_AMD64)
-#define ARCH_X86_64
-#endif
+// Define the `ARCH_X86_X64` constant.
+#if defined(MSVC) && defined(_M_AMD64)
+#  define ARCH_X86_64
+#elif (defined(GCC) || defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
+#  define ARCH_X86_64
 #endif
 
+// Define the `DEPRECATED` macro.
 #if defined(GCC) || defined(__GNUC__) || defined(__clang__)
-#if defined(__x86_64__)
-#define ARCH_X86_64
-#endif
+#  define DEPRECATED(message) __attribute__((deprecated(message)))
+#elif defined(MSVC)
+#  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
 #define WASMER_WASI_ENABLED


### PR DESCRIPTION
This PR defines a cross-compiler `DEPRECATED(message)` macro. It must
be used as follows in Rust:

```rust
/// This is a documentation.
/// cbindgen:prefix=DEPRECATED("This is a deprecation message.")
pub extern "C" fn wasmer_foo() -> c_uint {
    42
}
```

It will generate the following C header:

```c
/**
 * This is a documentation.
 */
DEPRECATED("This is a deprecation message.")
unsigned int wasmer_foo();
```

And once this code is used by a C compiler, it will print something
like this (example from Clang):

```
…/test.c:…:…: error: 'wasmer_foo' is deprecated: This is a deprecation message. [-Werror,-Wdeprecated-declarations]
    unsigned int x = wasmer_foo();
                     ^
…/wasmer.h:…:…: note: 'wasmer_foo' has been explicitly marked deprecated here
DEPRECATED("This is a deprecation message.")
^
…/wasmer.h:…:…: note: expanded from macro 'DEPRECATED'
```

This is required for further deprecations.

(cf https://github.com/eqrion/cbindgen/issues/408)