### PR TITLE
fix(runtime-core) Avoid crashing when missing host functions are allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1128](https://github.com/wasmerio/wasmer/pull/1128) Fix a crash when a host function is missing and the `allow_missing_functions` flag is enabled
 - [#1097](https://github.com/wasmerio/wasmer/pull/1097) Move inline breakpoint outside of runtime backend
 - [#1095](https://github.com/wasmerio/wasmer/pull/1095) Update to cranelift 0.52.
 - [#1092](https://github.com/wasmerio/wasmer/pull/1092) Add `get_utf8_string_with_nul` to `WasmPtr` to read nul-terminated strings from memory.

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -563,7 +563,9 @@ impl Drop for ImportBacking {
     fn drop(&mut self) {
         // Properly drop the `vm::FuncCtx` in `vm::ImportedFunc`.
         for (_imported_func_index, imported_func) in (*self.vm_functions).iter_mut() {
-            let _: Box<vm::FuncCtx> = unsafe { Box::from_raw(imported_func.func_ctx.as_ptr()) };
+            if !imported_func.func_ctx.as_ptr().is_null() {
+                let _: Box<vm::FuncCtx> = unsafe { Box::from_raw(imported_func.func_ctx.as_ptr()) };
+            }
         }
     }
 }

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -560,8 +560,10 @@ impl Drop for ImportBacking {
     fn drop(&mut self) {
         // Properly drop the `vm::FuncCtx` in `vm::ImportedFunc`.
         for (_imported_func_index, imported_func) in (*self.vm_functions).iter_mut() {
-            if !imported_func.func_ctx.as_ptr().is_null() {
-                let _: Box<vm::FuncCtx> = unsafe { Box::from_raw(imported_func.func_ctx.as_ptr()) };
+            let func_ctx_ptr = imported_func.func_ctx.as_ptr();
+
+            if !func_ctx_ptr.is_null() {
+                let _: Box<vm::FuncCtx> = unsafe { Box::from_raw(func_ctx_ptr) };
             }
         }
     }

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -733,6 +733,12 @@ where
     }
 }
 
+/// Function that always fails. It can be used as a placeholder when a
+/// host function is missing for instance.
+pub(crate) fn always_trap() -> Result<(), &'static str> {
+    Err("not implemented")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -258,11 +258,6 @@ where
             _phantom: PhantomData,
         }
     }
-
-    /// Get the underlying func pointer.
-    pub fn get_vm_func(&self) -> NonNull<vm::Func> {
-        self.func
-    }
 }
 
 impl<'a, Args, Rets> Func<'a, Args, Rets, Host>
@@ -302,6 +297,11 @@ where
     /// Returns the types of the function outputs.
     pub fn returns(&self) -> &'static [Type] {
         Rets::types()
+    }
+
+    /// Get the underlying func pointer.
+    pub fn get_vm_func(&self) -> NonNull<vm::Func> {
+        self.func
     }
 }
 

--- a/lib/runtime/tests/error_propagation.rs
+++ b/lib/runtime/tests/error_propagation.rs
@@ -30,9 +30,9 @@ fn error_propagation() {
 
     let instance = module
         .instantiate(&imports! {
-          "env" => {
-              "ret_err" => Func::new(ret_err),
-          },
+            "env" => {
+                "ret_err" => Func::new(ret_err),
+            },
         })
         .unwrap();
 


### PR DESCRIPTION
Fix #1118.
Address #1121.

This PR fixes 2 things:

* When droping the import backing, check that `vm::FuncCtx` isn't null before dropping it,
* Use an `always_trap` as a placeholder host function when a host function is missing.