### PR TITLE
Add WindowClosed event to experimental fb

### DIFF
--- a/lib/wasi-experimental-io-devices/src/lib.rs
+++ b/lib/wasi-experimental-io-devices/src/lib.rs
@@ -114,6 +114,9 @@ impl FrameBufferState {
 
     pub fn fill_input_buffer(&mut self) -> Option<()> {
         let keys_pressed = self.keys_pressed.iter().cloned().collect::<Vec<Key>>();
+        if !self.window.is_open() {
+            self.push_input_event(InputEvent::WindowClosed)?;
+        }
         for key in keys_pressed {
             if self.window.is_key_released(key) {
                 self.keys_pressed.remove(&key);

--- a/lib/wasi-experimental-io-devices/src/util.rs
+++ b/lib/wasi-experimental-io-devices/src/util.rs
@@ -6,6 +6,7 @@ pub const KEY_RELEASE: u8 = 3;
 pub const MOUSE_PRESS_LEFT: u8 = 4;
 pub const MOUSE_PRESS_RIGHT: u8 = 5;
 pub const MOUSE_PRESS_MIDDLE: u8 = 7;
+pub const WINDOW_CLOSED: u8 = 8;
 
 use minifb::{Key, MouseButton};
 
@@ -15,6 +16,7 @@ pub enum InputEvent {
     KeyRelease(Key),
     MouseEvent(u32, u32, MouseButton),
     MouseMoved(u32, u32),
+    WindowClosed,
 }
 
 /// Returns the tag as the first return value
@@ -58,6 +60,7 @@ pub fn bytes_for_input_event(input_event: InputEvent) -> (u8, [u8; 8], usize) {
             }
             (MOUSE_MOVE, data, 8)
         }
+        InputEvent::WindowClosed => (WINDOW_CLOSED, data, 0),
     }
 }
 


### PR DESCRIPTION
Allows things to behave properly and know when the window closes