### PR TITLE
doc(runtime-c-api) Setup Doxygen

### DIFF
--- a/lib/runtime-c-api/.gitignore
+++ b/lib/runtime-c-api/.gitignore
@@ -1,0 +1,1 @@
+doc/html/

--- a/lib/runtime-c-api/doc/index.md
+++ b/lib/runtime-c-api/doc/index.md
@@ -1,0 +1,125 @@
+# Wasmer Runtime C API
+
+[Wasmer] is a standalone [WebAssembly] runtime, aiming to be fully
+compatible with WASI, Emscripten, Rust and Go. [Learn
+more](https://github.com/wasmerio/wasmer).
+
+The `wasmer-runtime-c-api` crate exposes a C and a C++ API to interact
+with the Wasmer runtime. This document is the index of its
+auto-generated documentation.
+
+[Wasmer]: https://github.com/wasmerio/wasmer
+[WebAssembly]: https://webassembly.org/
+
+# Usage
+
+Since the Wasmer runtime is written in Rust, the C and C++ API are
+designed to work hand-in-hand with its shared library. The C and C++
+header files, namely [`wasmer.h`] and [`wasmer.hh`] are documented
+here. Their source code can be found in the source tree of this
+crate. They are automatically generated, and always up-to-date in this
+repository. The C and C++ header files along with the runtime shared
+libraries (`.so`, `.dylib`, `.dll`) can also be downloaded in the
+Wasmer [release page].
+
+[`wasmer.h`]: ./wasmer_8h.html
+[`wasmer.hh`]: ./wasmer_8hh.html
+[release page]: https://github.com/wasmerio/wasmer/releases
+
+Here is a simple example to use the C API:
+
+```c
+#include <stdio.h>
+#include "../wasmer.h"
+#include <assert.h>
+#include <stdint.h>
+
+int main()
+{
+    // Read the Wasm file bytes.
+    FILE *file = fopen("sum.wasm", "r");
+    fseek(file, 0, SEEK_END);
+    long len = ftell(file);
+    uint8_t *bytes = malloc(len);
+    fseek(file, 0, SEEK_SET);
+    fread(bytes, 1, len, file);
+    fclose(file);
+
+    // Prepare the imports.
+    wasmer_import_t imports[] = {};
+
+    // Instantiate!
+    wasmer_instance_t *instance = NULL;
+    wasmer_result_t instantiation_result = wasmer_instantiate(&instance, bytes, len, imports, 0);
+
+    assert(instantiation_result == WASMER_OK);
+
+    // Let's call a function.
+    // Start by preparing the arguments.
+
+    // Value of argument #1 is `7i32`.
+    wasmer_value_t argument_one;
+    argument_one.tag = WASM_I32;
+    argument_one.value.I32 = 7;
+
+    // Value of argument #2 is `8i32`.
+    wasmer_value_t argument_two;
+    argument_two.tag = WASM_I32;
+    argument_two.value.I32 = 8;
+
+    // Prepare the arguments.
+    wasmer_value_t arguments[] = {argument_one, argument_two};
+
+    // Prepare the return value.
+    wasmer_value_t result_one;
+    wasmer_value_t results[] = {result_one};
+
+    // Call the `sum` function with the prepared arguments and the return value.
+    wasmer_result_t call_result = wasmer_instance_call(instance, "sum", arguments, 2, results, 1);
+
+    // Let's display the result.
+    printf("Call result:  %d\n", call_result);
+    printf("Result: %d\n", results[0].value.I32);
+
+    // `sum(7, 8) == 15`.
+    assert(results[0].value.I32 == 15);
+    assert(call_result == WASMER_OK);
+
+    wasmer_instance_destroy(instance);
+
+    return 0;
+}
+```
+
+# Testing
+
+Tests are run using the release build of the library.  If you make
+changes or compile with non-default features, please ensure you
+rebuild in release mode for the tests to see the changes.
+
+The tests can be run via `cargo test`, such as:
+
+```sh
+$ cargo test --release -- --nocapture
+```
+
+To run tests manually, enter the `lib/runtime-c-api/tests` directory
+and run the following commands:
+
+```sh
+$ cmake .
+$ make
+$ make test
+```
+
+
+# License
+
+Wasmer is primarily distributed under the terms of the [MIT
+license][mit-license] ([LICENSE][license]).
+
+
+[wasmer_h]: ./wasmer.h
+[wasmer_hh]: ./wasmer.hh
+[mit-license]: http://opensource.org/licenses/MIT
+[license]: https://github.com/wasmerio/wasmer/blob/master/LICENSE

--- a/lib/runtime-c-api/doc/theme/css/wasmer.css
+++ b/lib/runtime-c-api/doc/theme/css/wasmer.css
@@ -1,0 +1,186 @@
+:root {
+    --primary-color: hsl(261.9, 61.9%, 16.5%);
+    --primary-negative-color: hsl(0, 0%, 100%);
+    --primary-dark-color: hsl(261.9, 61.9%, 16.5%);
+    --primary-light-color: hsl(0, 0%, 96.1%);
+    --secondary-color: hsl(241.2, 68.9%, 57.1%);
+    --secondary-light-color: hsl(241.2, 68.9%, 60%);
+    --white-color: hsl(0, 0%, 100%);
+}
+
+body {
+    overflow-y: hidden;
+}
+
+[role="header"] {
+    display: grid;
+    grid-template-areas: "a b";
+    margin-bottom: 1rem;
+    padding: .5rem 2vw;
+}
+
+[role="header"] > * {
+    margin: 0;
+    padding: 0;
+}
+
+[role="header"] > img {
+    grid-area: a;
+    max-width: 30vw;
+    max-height: 15vh;
+}
+
+[role="header"] > div {
+    grid-area: b;
+    text-align: right;
+}
+
+[role="footer"] {
+    position: fixed;
+    bottom: 0;
+    text-align: end;
+    background: var(--white-color);
+}
+
+#MSearchBox {
+    display: none;
+}
+
+#side-nav {
+    margin: 0;
+    padding-bottom: 3rem;
+}
+
+#side-nav .ui-resizable-e {
+    background: radial-gradient(var(--secondary-light-color), var(--white-color) 60%);
+}
+
+#nav-tree {
+    background: none;
+}
+
+#nav-tree .selected {
+    text-shadow: none;
+    color: var(--primary-negative-color);
+    background: var(--secondary-color);
+}
+
+#nav-sync {
+    display: none;
+}
+
+#doc-content > .header {
+    border: 0;
+    background: none;
+}
+
+#doc-content > .header > .summary {
+    font-size: small;
+}
+
+body, div, p, ul, li {
+    color: var(--primary-color);
+}
+
+#doc-content .contents p,
+#doc-content .contents ul,
+#doc-content .contents div:not(.line),
+#doc-content .contents table.memberdecls {
+    font-family: serif;
+    font-size: 1.1rem;
+}
+
+a, .contents a, .contents a:visited {
+    color: var(--secondary-color);
+}
+
+h1, .headertitle > .title {
+    color: var(--primary-color);
+    font-size: 2.5rem;
+    line-height: 2.7rem;
+}
+
+h2, .memberdecls h2, h2.groupheader {
+    color: var(--primary-color);
+    font-size: 2rem;
+    line-height: 2.5rem;
+}
+
+h2.groupheader {
+    border-color: var(--secondary-color);
+    border-bottom-style: dotted;
+    margin-bottom: 1rem !important;
+}
+
+h3, h2.memtitle {
+    font-size: 1.5rem;
+    line-height: 2rem;
+}
+
+.memberdecls [class^="separator"] {
+    display: none;
+}
+
+.memberdecls [class^="memitem"] > td,
+.memberdecls [class^="memdesc"] > td {
+    background: none;
+}
+
+.memtitle {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+}
+
+.memitem {
+    margin-left: 1rem;
+    width: calc(100% - 1rem);
+}
+
+.memtitle {
+    font-weight: bold;
+    font-family: monospace;
+}
+
+.memtitle ~ .memtitle {
+    margin-top: 1.5rem;
+}
+
+.memitem .memproto,
+.memitem .memproto .memname,
+.memitem .memdoc,
+.memitem .memdoc .definition {
+    margin: 0;
+    padding: 0;
+    box-shadow: none;
+    border: none;
+    background: none;
+}
+
+.memitem .memproto {
+    padding-left: 1rem;
+    margin: .5rem 0;
+    background: var(--primary-light-color) !important;
+}
+
+.memproto table.memname {
+    font-family: monospace;
+    font-size: .85rem;
+}
+
+table.fieldtable {
+    border-radius: 0;
+    box-shadow: none;
+}
+
+table.fieldtable th {
+    color: var(--primary-negative-color);
+    border-radius: 0;
+    background: var(--secondary-color);
+}
+
+table.fieldtable,
+table.fieldtable td {
+    border-color: var(--secondary-color) !important;
+}

--- a/lib/runtime-c-api/doc/theme/footer.html
+++ b/lib/runtime-c-api/doc/theme/footer.html
@@ -1,0 +1,10 @@
+<!--BEGIN GENERATE_TREEVIEW-->
+<div id="nav-path" class="navpath" role="footer">
+  $generatedby
+  <a href="http://www.doxygen.org/index.html">
+    <img class="footer" src="$relpath^doxygen.png" alt="doxygen"/></a>
+  $doxygenversion
+</div>
+<!--END GENERATE_TREEVIEW-->
+</body>
+</html>

--- a/lib/runtime-c-api/doc/theme/header.html
+++ b/lib/runtime-c-api/doc/theme/header.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+    <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="content-type" content="text/javascript; charset=utf-8" />
+    <meta http-equiv="content-type" content="text/css; charset=utf-8" />
+    <meta name="viewport" content="initial-scale=1.0" />
+    <meta name="generator" content="Doxygen $doxygenversion"/>
+    <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+    <script type="text/javascript" src="$relpath^jquery.js"></script>
+    <script type="text/javascript" src="$relpath^dynsections.js"></script>
+    $treeview
+    $search
+    $mathjax
+    <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+    $extrastylesheet
+  </head>
+  <body>
+    <div id="top" role="header">
+      <!--BEGIN TITLEAREA-->
+
+      <!--BEGIN PROJECT_LOGO-->
+      <img alt="Wasmer's logo" src="$relpath^$projectlogo" />
+      <!--END PROJECT_LOGO-->
+
+      <!--BEGIN PROJECT_NAME-->
+      <div>
+        <h1>
+        $projectname
+        <!--BEGIN PROJECT_NUMBER--> — <span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
+        <!--BEGIN PROJECT_BRIEF-->
+        <span id="projectbrief">$projectbrief</span>
+        <!--END PROJECT_BRIEF-->
+        </h1>
+        <br />
+        <small>
+          <a href="https://github.com/wasmerio/wasmer"><img src="https://img.shields.io/github/stars/wasmerio/wasmer?style=social" alt="Visit the repository" /></a>
+          <a href="https://github.com/wasmerio/wasmer"><img src="https://img.shields.io/github/license/wasmerio/wasmer" alt="License" /></a>
+          <a href="https://spectrum.chat/wasmer"><img src="https://withspectrum.github.io/badge/badge.svg" alt="Join the Wasmer Community"></a>
+        </small>
+      </div>
+      <!--END PROJECT_NAME-->
+
+      <!--BEGIN DISABLE_INDEX-->
+      <!--BEGIN SEARCHENGINE-->
+      <div id="searchbox">$searchbox</div>
+      <!--END SEARCHENGINE-->
+      <!--END DISABLE_INDEX-->
+
+      <!--END TITLEAREA-->

--- a/lib/runtime-c-api/doxyfile
+++ b/lib/runtime-c-api/doxyfile
@@ -1,0 +1,339 @@
+# Doxyfile 1.8.17
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "wasmer-runtime-c-api"
+PROJECT_NUMBER         =
+PROJECT_BRIEF          = 
+PROJECT_LOGO           = ../../logo.png
+OUTPUT_DIRECTORY       = doc/
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+OUTPUT_TEXT_DIRECTION  = None
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+JAVADOC_BANNER         = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+TCL_SUBST              =
+OPTIMIZE_OUTPUT_FOR_C  = YES
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      = dox=md
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = NO
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = NO
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = doc/index.md
+INPUT                 += wasmer.h
+INPUT                 += wasmer.hh
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.h \
+                         *.hh
+RECURSIVE              = NO
+EXCLUDE                = doc
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE = doc/index.md
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = NO
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            = doc/theme/header.html
+HTML_FOOTER            = doc/theme/footer.html
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  = doc/theme/css/wasmer.css
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_SECTIONS  = YES
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = YES
+GENERATE_TREEVIEW      = YES
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = NO
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         =
+MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+LATEX_EMOJI_DIRECTORY  =
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+XML_NS_MEMB_FILE_SCOPE = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = NO
+EXPAND_ONLY_PREDEF     = NO
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = svg
+INTERACTIVE_SVG        = YES
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES


### PR DESCRIPTION
With @MarkMcCaskey, we discussed generating the documentation of `wasmer-runtime-c-api` with [Doxygen](http://www.doxygen.nl/).

This patch does the following:

1. Set up a `doxyfile`, which is the configuration file for Doxygen.
2. Set up a `doc/header.html` and `doc/footer.html` files, because Doxygen HTML output is… well, not a master piece 😉.
3. Set up a `doc/css/wasmer.css` stylesheet. I tried to mimic Wasmer color scheme. Usually, I'm not a bad designer, but Doxygen HTML output is so “alembic-ed” that it makes customizing the CSS a real challenge for the very short period of time I've.

Anyway, I believe it's an acceptable first step.

To generate the documentation:

```sh
$ doxygen doxyfile
```

And then open `doc/html/index.html`.

It looks like this:

![Screen Shot 2020-01-13 at 15 20 09](https://user-images.githubusercontent.com/946104/72263046-692ea100-3618-11ea-9feb-6dfd3244d375.png)
![Screen Shot 2020-01-13 at 15 20 25](https://user-images.githubusercontent.com/946104/72263072-70ee4580-3618-11ea-941d-fa652bd7f14e.png)
![Screen Shot 2020-01-13 at 15 20 35](https://user-images.githubusercontent.com/946104/72263082-7481cc80-3618-11ea-81e7-f4da7b71d665.png)
![Screen Shot 2020-01-13 at 15 20 57](https://user-images.githubusercontent.com/946104/72263098-78155380-3618-11ea-9cfc-16b7695c9e89.png)

The next step is to publish the documentation on Github Pages, thoughts @syrusakbary?