### PR TITLE
Make full preemption an optional feature.

### DIFF
--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -110,7 +110,7 @@ pub struct CompilerConfig {
     /// Symbol information generated from emscripten; used for more detailed debug messages
     pub symbol_map: Option<HashMap<u32, String>>,
 
-    /// Optionally override the automatically determined memory bound check mode.
+    /// How to make the decision whether to emit bounds checks for memory accesses.
     pub memory_bound_check_mode: MemoryBoundCheckMode,
 
     /// Whether to generate explicit stack checks against a field in `InternalCtx`.

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -109,9 +109,24 @@ impl BackendCompilerConfig {
 pub struct CompilerConfig {
     /// Symbol information generated from emscripten; used for more detailed debug messages
     pub symbol_map: Option<HashMap<u32, String>>,
+
+    /// Optionally override the automatically determined memory bound check mode.
     pub memory_bound_check_mode: MemoryBoundCheckMode,
+
+    /// Whether to generate explicit stack checks against a field in `InternalCtx`.
     pub enforce_stack_check: bool,
+
+    /// Whether to enable state tracking. Necessary for managed mode.
     pub track_state: bool,
+
+    /// Whether to enable full preemption checkpoint generation.
+    ///
+    /// This inserts checkpoints at critical locations such as loop backedges and function calls,
+    /// allowing non-cooperative unwinding/task switching.
+    ///
+    /// When enabled there can be a small amount of runtime performance overhead.
+    pub full_preemption: bool,
+
     pub features: Features,
 
     // Target info. Presently only supported by LLVM.

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -114,7 +114,7 @@ pub struct CompilerConfig {
     pub memory_bound_check_mode: MemoryBoundCheckMode,
 
     /// Whether to generate explicit native stack checks against `stack_lower_bound` in `InternalCtx`.
-    /// 
+    ///
     /// Usually it's adequate to use hardware memory protection mechanisms such as `mprotect` on Unix to
     /// prevent stack overflow. But for low-level environments, e.g. the kernel, faults are generally
     /// not expected and relying on hardware memory protection would add too much complexity.

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -113,7 +113,11 @@ pub struct CompilerConfig {
     /// How to make the decision whether to emit bounds checks for memory accesses.
     pub memory_bound_check_mode: MemoryBoundCheckMode,
 
-    /// Whether to generate explicit stack checks against a field in `InternalCtx`.
+    /// Whether to generate explicit native stack checks against `stack_lower_bound` in `InternalCtx`.
+    /// 
+    /// Usually it's adequate to use hardware memory protection mechanisms such as `mprotect` on Unix to
+    /// prevent stack overflow. But for low-level environments, e.g. the kernel, faults are generally
+    /// not expected and relying on hardware memory protection would add too much complexity.
     pub enforce_stack_check: bool,
 
     /// Whether to enable state tracking. Necessary for managed mode.
@@ -122,7 +126,7 @@ pub struct CompilerConfig {
     /// Whether to enable full preemption checkpoint generation.
     ///
     /// This inserts checkpoints at critical locations such as loop backedges and function calls,
-    /// allowing non-cooperative unwinding/task switching.
+    /// allowing preemptive unwinding/task switching.
     ///
     /// When enabled there can be a small amount of runtime performance overhead.
     pub full_preemption: bool,

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -2105,6 +2105,10 @@ impl X64FunctionCode {
             true,
             value_size,
             |a, m, addr| {
+                // Memory moves with size < 32b do not zero upper bits.
+                if memory_sz != Size::S32 && memory_sz != Size::S64 {
+                    a.emit_xor(Size::S32, Location::GPR(compare), Location::GPR(compare));
+                }
                 a.emit_mov(memory_sz, Location::Memory(addr, 0), Location::GPR(compare));
                 a.emit_mov(stack_sz, Location::GPR(compare), ret);
                 cb(a, m, compare, value);

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -2106,7 +2106,7 @@ impl X64FunctionCode {
             value_size,
             |a, m, addr| {
                 // Memory moves with size < 32b do not zero upper bits.
-                if memory_sz != Size::S32 && memory_sz != Size::S64 {
+                if memory_sz < Size::S32 {
                     a.emit_xor(Size::S32, Location::GPR(compare), Location::GPR(compare));
                 }
                 a.emit_mov(memory_sz, Location::Memory(addr, 0), Location::GPR(compare));

--- a/src/bin/wasmer.rs
+++ b/src/bin/wasmer.rs
@@ -703,6 +703,10 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
                 symbol_map: em_symbol_map.clone(),
                 memory_bound_check_mode: MemoryBoundCheckMode::Disable,
                 enforce_stack_check: true,
+
+                // Kernel loader does not support explicit preemption checkpoints.
+                full_preemption: false,
+
                 track_state,
                 features: options.features.into_backend_features(),
                 backend_specific_config,
@@ -717,6 +721,11 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
             CompilerConfig {
                 symbol_map: em_symbol_map.clone(),
                 track_state,
+
+                // Enable full preemption if state tracking is enabled.
+                // Preemption only makes sense with state information.
+                full_preemption: track_state,
+
                 features: options.features.into_backend_features(),
                 backend_specific_config,
                 ..Default::default()
@@ -813,7 +822,7 @@ fn execute_wasm(options: &Run) -> Result<(), String> {
             LoaderName::Kernel => Box::new(
                 instance
                     .load(::wasmer_kernel_loader::KernelLoader)
-                    .map_err(|e| format!("Can't use the local loader: {:?}", e))?,
+                    .map_err(|e| format!("Can't use the kernel loader: {:?}", e))?,
             ),
         };
         println!("{:?}", ins.call(index, &args));


### PR DESCRIPTION
Full preemption requires two additional memory loads on loop backedges and function calls. This PR allows disabling full preemption at code generation time, and disables it by default.