### PR TITLE
Include implementation details when generating our documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ dep-graph:
 	cargo deps --optional-deps --filter wasmer-wasi wasmer-wasi-tests wasmer-kernel-loader wasmer-dev-utils wasmer-llvm-backend wasmer-emscripten wasmer-emscripten-tests wasmer-runtime-core wasmer-runtime wasmer-middleware-common wasmer-middleware-common-tests wasmer-singlepass-backend wasmer-clif-backend wasmer --manifest-path Cargo.toml | dot -Tpng > wasmer_depgraph.png
 
 docs:
-	cargo doc --features=backend-singlepass,backend-cranelift,backend-llvm,docs,wasi,managed --all --no-deps
+	cargo doc --features=backend-singlepass,backend-cranelift,backend-llvm,docs,wasi,managed --workspace --document-private-items --no-deps
 	cd lib/runtime-c-api/ && doxygen doxyfile && cd ..
 	mkdir -p api-docs
 	mkdir -p api-docs/c


### PR DESCRIPTION
In passing, replace deprecated flag --all with equivalent flag --workspace.
