### PR TITLE
doc(runtime-c-api) Improve documentation of the `memory` module

### DIFF
--- a/lib/runtime-c-api/src/error.rs
+++ b/lib/runtime-c-api/src/error.rs
@@ -1,11 +1,12 @@
 //! Read runtime errors.
 
 use libc::{c_char, c_int};
-use std::cell::RefCell;
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::ptr;
-use std::slice;
+use std::{
+    cell::RefCell,
+    error::Error,
+    fmt::{self, Display, Formatter},
+    ptr, slice,
+};
 
 thread_local! {
     static LAST_ERROR: RefCell<Option<Box<dyn Error>>> = RefCell::new(None);

--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -131,9 +131,14 @@ pub struct wasmer_limits_t {
     pub max: wasmer_limit_option_t,
 }
 
+/// The `wasmer_limit_option_t` struct repreesents an optional limit
+/// for `wasmer_limits_t`.
 #[repr(C)]
 pub struct wasmer_limit_option_t {
+    /// Whether the limit is set.
     pub has_some: bool,
+
+    /// The limit value.
     pub some: u32,
 }
 

--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -107,7 +107,7 @@ pub mod table;
 pub mod trampoline;
 pub mod value;
 
-/// The `wasmer_result_t` struct is a type that represents either a
+/// The `wasmer_result_t` enum is a type that represents either a
 /// success, or a failure.
 #[allow(non_camel_case_types)]
 #[repr(C)]

--- a/lib/runtime-c-api/src/lib.rs
+++ b/lib/runtime-c-api/src/lib.rs
@@ -119,9 +119,15 @@ pub enum wasmer_result_t {
     WASMER_ERROR = 2,
 }
 
+/// The `wasmer_limits_t` struct is a type that describes a memory
+/// options. See the `wasmer_memory_t` struct or the
+/// `wasmer_memory_new()` function to get more information.
 #[repr(C)]
 pub struct wasmer_limits_t {
+    /// The minimum number of allowed pages.
     pub min: u32,
+
+    /// The maximum number of allowed pages.
     pub max: wasmer_limit_option_t,
 }
 

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -187,7 +187,15 @@ pub extern "C" fn wasmer_memory_data(memory: *const wasmer_memory_t) -> *mut u8 
     memory.view::<u8>()[..].as_ptr() as *mut Cell<u8> as *mut u8
 }
 
-/// Gets the size in bytes of a Memory
+/// Gets the size in bytes of the memory data.
+///
+/// This function returns 0 if `memory` is NULL.
+///
+/// Example:
+///
+/// ```c
+/// uint32_t memory_data_length = wasmer_memory_data_length(memory);
+/// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn wasmer_memory_data_length(mem: *mut wasmer_memory_t) -> u32 {

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -135,7 +135,7 @@ pub extern "C" fn wasmer_memory_grow(memory: *mut wasmer_memory_t, delta: u32) -
 
 /// Reads the current length (in pages) of the given memory.
 ///
-/// The function returns zero if `memory` is null.
+/// The function returns zero if `memory` is a null pointer.
 ///
 /// Example:
 ///
@@ -160,7 +160,7 @@ pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {
 /// Gets a pointer to the beginning of the contiguous memory data
 /// bytes.
 ///
-/// The function returns `NULL` if `memory` is NULL.
+/// The function returns `NULL` if `memory` is a null pointer.
 ///
 /// Note that when the memory grows, it can be reallocated, and thus
 /// the returned pointer can be invalidated.
@@ -189,7 +189,7 @@ pub extern "C" fn wasmer_memory_data(memory: *const wasmer_memory_t) -> *mut u8 
 
 /// Gets the size in bytes of the memory data.
 ///
-/// This function returns 0 if `memory` is NULL.
+/// This function returns 0 if `memory` is a null pointer.
 ///
 /// Example:
 ///

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -90,12 +90,22 @@ pub unsafe extern "C" fn wasmer_memory_new(
     wasmer_result_t::WASMER_OK
 }
 
-/// Grows a Memory by the given number of pages.
+/// Grows a memory by the given number of pages (of 65Kb each).
 ///
-/// Returns `wasmer_result_t::WASMER_OK` upon success.
+/// The functions return `wasmer_result_t::WASMER_OK` upon success,
+/// `wasmer_result_t::WASMER_ERROR` otherwise. Use
+/// `wasmer_last_error_length()` with `wasmer_last_error_message()` to
+/// read the error message.
 ///
-/// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
-/// and `wasmer_last_error_message` to get an error message.
+/// Example:
+///
+/// ```c
+/// wasmer_result_t result = wasmer_memory_grow(memory, 10 /* pages */);
+///
+/// if (result != WASMER_OK) {
+///     // …
+/// }
+/// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn wasmer_memory_grow(memory: *mut wasmer_memory_t, delta: u32) -> wasmer_result_t {

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -134,9 +134,14 @@ pub extern "C" fn wasmer_memory_grow(memory: *mut wasmer_memory_t, delta: u32) -
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {
+    if memory.is_null() {
+        return 0;
+    }
+
     let memory = unsafe { &*(memory as *const Memory) };
-    let Pages(len) = memory.size();
-    len
+    let Pages(length) = memory.size();
+
+    length
 }
 
 /// Gets the start pointer to the bytes within a Memory

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -18,15 +18,46 @@ use wasmer_runtime_core::{
 #[derive(Clone)]
 pub struct wasmer_memory_t;
 
-/// Creates a new Memory for the given descriptor and initializes the given
-/// pointer to pointer to a pointer to the new memory.
+/// Creates a new empty WebAssembly memory for the given descriptor.
 ///
-/// The caller owns the object and should call `wasmer_memory_destroy` to free it.
+/// The result is stored in the first argument `memory` if successful,
+/// i.e. when the function returns
+/// `wasmer_result_t::WASMER_OK`. Otherwise,
+/// `wasmer_result_t::WASMER_ERROR` is returned, and
+/// `wasmer_last_error_length()` with `wasmer_last_error_message()`
+/// must be used to read the error message.
 ///
-/// Returns `wasmer_result_t::WASMER_OK` upon success.
+/// The caller owns the memory and is responsible to free it with
+/// `wasmer_memory_destroy()`.
 ///
-/// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
-/// and `wasmer_last_error_message` to get an error message.
+/// Example:
+///
+/// ```c
+/// // 1. The memory object.
+/// wasmer_memory_t *memory = NULL;
+///
+/// // 2. The memory descriptor.
+/// wasmer_limits_t memory_descriptor = {
+///     .min = 10,
+///     .max = {
+///         .has_some = true,
+///         .some = 15,
+///     },
+/// };
+///
+/// // 3. Initialize the memory.
+/// wasmer_result_t result = wasmer_memory_new(&memory, memory_descriptor);
+///
+/// if (result != WASMER_OK) {
+///     int error_length = wasmer_last_error_length();
+///     char *error = malloc(error_length);
+///     wasmer_last_error_message(error, error_length);
+///     // Do something with `error`…
+/// }
+///
+/// // 4. Free the memory!
+/// wasmer_memory_destroy(memory);
+/// ```
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_memory_new(
     memory: *mut *mut wasmer_memory_t,

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{update_last_error, CApiError},
     wasmer_limits_t, wasmer_result_t,
 };
-use std::cell::Cell;
+use std::{cell::Cell, ptr};
 use wasmer_runtime::Memory;
 use wasmer_runtime_core::{
     types::MemoryDescriptor,
@@ -172,8 +172,13 @@ pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {
 /// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_memory_data(mem: *const wasmer_memory_t) -> *mut u8 {
-    let memory = unsafe { &*(mem as *const Memory) };
+pub extern "C" fn wasmer_memory_data(memory: *const wasmer_memory_t) -> *mut u8 {
+    if memory.is_null() {
+        return ptr::null_mut();
+    }
+
+    let memory = unsafe { &*(memory as *const Memory) };
+
     memory.view::<u8>()[..].as_ptr() as *mut Cell<u8> as *mut u8
 }
 

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -169,6 +169,11 @@ pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {
 ///
 /// ```c
 /// uint8_t *memory_data = wasmer_memory_data(memory);
+/// char *str = (char*) malloc(sizeof(char) * 7);
+///
+/// for (uint32_t nth = 0; nth < 7; ++nth) {
+///     str[nth] = (char) memory_data[nth];
+/// }
 /// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -157,7 +157,19 @@ pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {
     length
 }
 
-/// Gets the start pointer to the bytes within a Memory
+/// Gets a pointer to the beginning of the contiguous memory data
+/// bytes.
+///
+/// The function returns `NULL` if `memory` is NULL.
+///
+/// Note that when the memory grows, it can be reallocated, and thus
+/// the returned pointer can be invalidated.
+///
+/// Example:
+///
+/// ```c
+/// uint8_t *memory_data = wasmer_memory_data(memory);
+/// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn wasmer_memory_data(mem: *const wasmer_memory_t) -> *mut u8 {

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -198,10 +198,15 @@ pub extern "C" fn wasmer_memory_data(memory: *const wasmer_memory_t) -> *mut u8 
 /// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
-pub extern "C" fn wasmer_memory_data_length(mem: *mut wasmer_memory_t) -> u32 {
-    let memory = mem as *mut Memory;
-    let Bytes(len) = unsafe { (*memory).size().bytes() };
-    len as u32
+pub extern "C" fn wasmer_memory_data_length(memory: *mut wasmer_memory_t) -> u32 {
+    if memory.is_null() {
+        return 0;
+    }
+
+    let memory = unsafe { &*(memory as *const Memory) };
+    let Bytes(length) = memory.size().bytes();
+
+    length as u32
 }
 
 /// Frees memory for the given Memory

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -8,6 +8,12 @@ use wasmer_runtime_core::{
     units::{Bytes, Pages},
 };
 
+/// Opaque pointer to a `wasmer_runtime::Memory` value in Rust.
+///
+/// A `wasmer_runtime::Memory` represents a WebAssembly memory. It is
+/// possible to create one with `wasmer_memory_new()` and pass it as
+/// imports of an instance, or to read it from exports of an instance
+/// with `wasmer_export_to_memory()`.
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasmer_memory_t;

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -120,7 +120,17 @@ pub extern "C" fn wasmer_memory_grow(memory: *mut wasmer_memory_t, delta: u32) -
     }
 }
 
-/// Returns the current length in pages of the given memory
+/// Reads the current length (in pages) of the given memory.
+///
+/// The function returns zero if `memory` is null.
+///
+/// Example:
+///
+/// ```c
+/// uint32_t memory_length = wasmer_memory_length(memory);
+///
+/// printf("Memory pages length: %d\n", memory_length);
+/// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn wasmer_memory_length(memory: *const wasmer_memory_t) -> u32 {

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -209,7 +209,23 @@ pub extern "C" fn wasmer_memory_data_length(memory: *mut wasmer_memory_t) -> u32
     length as u32
 }
 
-/// Frees memory for the given Memory
+/// Frees memory for the given `wasmer_memory_t`.
+///
+/// Check the `wasmer_memory_new()` function to get a complete
+/// example.
+///
+/// If `memory` is a null pointer, this function does nothing.
+///
+/// Example:
+///
+/// ```c
+/// // Get a memory.
+/// wasmer_memory_t *memory = NULL;
+/// wasmer_result_t result = wasmer_memory_new(&memory, memory_descriptor);
+///
+/// // Destroy the memory.
+/// wasmer_memory_destroy(memory);
+/// ```
 #[allow(clippy::cast_ptr_alignment)]
 #[no_mangle]
 pub extern "C" fn wasmer_memory_destroy(memory: *mut wasmer_memory_t) {

--- a/lib/runtime-c-api/tests/test-memory.c
+++ b/lib/runtime-c-api/tests/test-memory.c
@@ -7,12 +7,13 @@
 int main()
 {
     wasmer_memory_t *memory = NULL;
-    wasmer_limits_t descriptor;
-    descriptor.min = 10;
-    wasmer_limit_option_t max;
-    max.has_some = true;
-    max.some = 15;
-    descriptor.max = max;
+    wasmer_limits_t descriptor = {
+        .min = 10,
+        .max = {
+            .has_some = true,
+            .some = 15,
+        },
+    };
     wasmer_result_t memory_result = wasmer_memory_new(&memory, descriptor);
     printf("Memory result:  %d\n", memory_result);
     assert(memory_result == WASMER_OK);

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -65,7 +65,7 @@ enum class wasmer_import_export_kind : uint32_t {
   WASM_TABLE = 3,
 };
 
-/// The `wasmer_result_t` struct is a type that represents either a
+/// The `wasmer_result_t` enum is a type that represents either a
 /// success, or a failure.
 enum class wasmer_result_t {
   /// Represents a success.
@@ -177,6 +177,12 @@ struct wasmer_export_t {
 
 };
 
+/// Opaque pointer to a `wasmer_runtime::Memory` value in Rust.
+///
+/// A `wasmer_runtime::Memory` represents a WebAssembly memory. It is
+/// possible to create one with `wasmer_memory_new()` and pass it as
+/// imports of an instance, or to read it from exports of an instance
+/// with `wasmer_export_to_memory()`.
 struct wasmer_memory_t {
 
 };
@@ -263,13 +269,22 @@ struct wasmer_instance_context_t {
 
 };
 
+/// The `wasmer_limit_option_t` struct repreesents an optional limit
+/// for `wasmer_limits_t`.
 struct wasmer_limit_option_t {
+  /// Whether the limit is set.
   bool has_some;
+  /// The limit value.
   uint32_t some;
 };
 
+/// The `wasmer_limits_t` struct is a type that describes a memory
+/// options. See the `wasmer_memory_t` struct or the
+/// `wasmer_memory_new()` function to get more information.
 struct wasmer_limits_t {
+  /// The minimum number of allowed pages.
   uint32_t min;
+  /// The maximum number of allowed pages.
   wasmer_limit_option_t max;
 };
 
@@ -920,35 +935,127 @@ int wasmer_last_error_length();
 /// ```
 int wasmer_last_error_message(char *buffer, int length);
 
-/// Gets the start pointer to the bytes within a Memory
-uint8_t *wasmer_memory_data(const wasmer_memory_t *mem);
+/// Gets a pointer to the beginning of the contiguous memory data
+/// bytes.
+///
+/// The function returns `NULL` if `memory` is a null pointer.
+///
+/// Note that when the memory grows, it can be reallocated, and thus
+/// the returned pointer can be invalidated.
+///
+/// Example:
+///
+/// ```c
+/// uint8_t *memory_data = wasmer_memory_data(memory);
+/// char *str = (char*) malloc(sizeof(char) * 7);
+///
+/// for (uint32_t nth = 0; nth < 7; ++nth) {
+///     str[nth] = (char) memory_data[nth];
+/// }
+/// ```
+uint8_t *wasmer_memory_data(const wasmer_memory_t *memory);
 
-/// Gets the size in bytes of a Memory
-uint32_t wasmer_memory_data_length(wasmer_memory_t *mem);
+/// Gets the size in bytes of the memory data.
+///
+/// This function returns 0 if `memory` is a null pointer.
+///
+/// Example:
+///
+/// ```c
+/// uint32_t memory_data_length = wasmer_memory_data_length(memory);
+/// ```
+uint32_t wasmer_memory_data_length(wasmer_memory_t *memory);
 
-/// Frees memory for the given Memory
+/// Frees memory for the given `wasmer_memory_t`.
+///
+/// Check the `wasmer_memory_new()` function to get a complete
+/// example.
+///
+/// If `memory` is a null pointer, this function does nothing.
+///
+/// Example:
+///
+/// ```c
+/// // Get a memory.
+/// wasmer_memory_t *memory = NULL;
+/// wasmer_result_t result = wasmer_memory_new(&memory, memory_descriptor);
+///
+/// // Destroy the memory.
+/// wasmer_memory_destroy(memory);
+/// ```
 void wasmer_memory_destroy(wasmer_memory_t *memory);
 
-/// Grows a Memory by the given number of pages.
+/// Grows a memory by the given number of pages (of 65Kb each).
 ///
-/// Returns `wasmer_result_t::WASMER_OK` upon success.
+/// The functions return `wasmer_result_t::WASMER_OK` upon success,
+/// `wasmer_result_t::WASMER_ERROR` otherwise. Use
+/// `wasmer_last_error_length()` with `wasmer_last_error_message()` to
+/// read the error message.
 ///
-/// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
-/// and `wasmer_last_error_message` to get an error message.
+/// Example:
+///
+/// ```c
+/// wasmer_result_t result = wasmer_memory_grow(memory, 10);
+///
+/// if (result != WASMER_OK) {
+///     // …
+/// }
+/// ```
 wasmer_result_t wasmer_memory_grow(wasmer_memory_t *memory, uint32_t delta);
 
-/// Returns the current length in pages of the given memory
+/// Reads the current length (in pages) of the given memory.
+///
+/// The function returns zero if `memory` is a null pointer.
+///
+/// Example:
+///
+/// ```c
+/// uint32_t memory_length = wasmer_memory_length(memory);
+///
+/// printf("Memory pages length: %d\n", memory_length);
+/// ```
 uint32_t wasmer_memory_length(const wasmer_memory_t *memory);
 
-/// Creates a new Memory for the given descriptor and initializes the given
-/// pointer to pointer to a pointer to the new memory.
+/// Creates a new empty WebAssembly memory for the given descriptor.
 ///
-/// The caller owns the object and should call `wasmer_memory_destroy` to free it.
+/// The result is stored in the first argument `memory` if successful,
+/// i.e. when the function returns
+/// `wasmer_result_t::WASMER_OK`. Otherwise,
+/// `wasmer_result_t::WASMER_ERROR` is returned, and
+/// `wasmer_last_error_length()` with `wasmer_last_error_message()`
+/// must be used to read the error message.
 ///
-/// Returns `wasmer_result_t::WASMER_OK` upon success.
+/// The caller owns the memory and is responsible to free it with
+/// `wasmer_memory_destroy()`.
 ///
-/// Returns `wasmer_result_t::WASMER_ERROR` upon failure. Use `wasmer_last_error_length`
-/// and `wasmer_last_error_message` to get an error message.
+/// Example:
+///
+/// ```c
+/// // 1. The memory object.
+/// wasmer_memory_t *memory = NULL;
+///
+/// // 2. The memory descriptor.
+/// wasmer_limits_t memory_descriptor = {
+///     .min = 10,
+///     .max = {
+///         .has_some = true,
+///         .some = 15,
+///     },
+/// };
+///
+/// // 3. Initialize the memory.
+/// wasmer_result_t result = wasmer_memory_new(&memory, memory_descriptor);
+///
+/// if (result != WASMER_OK) {
+///     int error_length = wasmer_last_error_length();
+///     char *error = malloc(error_length);
+///     wasmer_last_error_message(error, error_length);
+///     // Do something with `error`…
+/// }
+///
+/// // 4. Free the memory!
+/// wasmer_memory_destroy(memory);
+/// ```
 wasmer_result_t wasmer_memory_new(wasmer_memory_t **memory, wasmer_limits_t limits);
 
 /// Deserialize the given serialized module.


### PR DESCRIPTION
Address https://github.com/wasmerio/wasmer/issues/1203.

As part of the daily doc routine, this patch improves the documentation of `memory` module.

This patch also handles more null pointers.