### PR TITLE
fix(runtime-c-api) Avoid casting a non-mut to mut pointer.

### DIFF
--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{update_last_error, CApiError},
     wasmer_limits_t, wasmer_result_t,
 };
-use std::{cell::Cell, ptr};
+use std::ptr;
 use wasmer_runtime::Memory;
 use wasmer_runtime_core::{
     types::MemoryDescriptor,
@@ -184,7 +184,7 @@ pub extern "C" fn wasmer_memory_data(memory: *const wasmer_memory_t) -> *mut u8 
 
     let memory = unsafe { &*(memory as *const Memory) };
 
-    memory.view::<u8>()[..].as_ptr() as *mut Cell<u8> as *mut u8
+    memory.view::<u8>()[..].as_mut_ptr() as *mut u8
 }
 
 /// Gets the size in bytes of the memory data.


### PR DESCRIPTION
Depends on #1206.

Use `slice::as_mut_ptr` to get a mutable pointer. Then casting `*mut
Cell<u8>` to `mut u8` is safe because identical bitwise.

This patch avoids casting a non-mutable pointer `slice::as_ptr` to a
mutable pointer `*mut Cell<u8>` to `*mut u8`.