### PR TITLE
feature: calling an instance function by its export index

### DIFF
--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -1058,10 +1058,13 @@ pub fn generate_emscripten_env(globals: &mut EmscriptenGlobals) -> ImportObject 
 pub fn nullfunc(ctx: &mut Ctx, _x: u32) {
     use crate::process::abort_with_message;
     debug!("emscripten::nullfunc_i {}", _x);
-    abort_with_message(ctx, "Invalid function pointer. Perhaps this is an invalid value \
+    abort_with_message(
+        ctx,
+        "Invalid function pointer. Perhaps this is an invalid value \
     (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an \
     incorrect type, which will fail? (it is worth building your source files with -Werror (\
-    warnings are errors), as warnings can indicate undefined behavior which can cause this)");
+    warnings are errors), as warnings can indicate undefined behavior which can cause this)",
+    );
 }
 
 /// The current version of this crate


### PR DESCRIPTION
# Description
Adding `Instance#call_func_with_index` and `Instance#dyn_func_with_index` public methods.
This is useful for code that references a function by its export index. 

For example: in the blockchain world, every byte that can be saved from the chain is a blessing.
So instead of storing the function name inside the Smart-Contract transaction, we could store
its index.

# Review

- [x] Calling an instance function by its export index.
- [x] Retrieving a callable function by its export index.
