### PR TITLE
Remove signatures_raw

### DIFF
--- a/lib/runtime-c-api/src/import/emscripten.rs
+++ b/lib/runtime-c-api/src/import/emscripten.rs
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn wasmer_emscripten_call_main(
 /// `wasmer_emscripten_globals_t` from a `wasmer_module_t`.
 ///
 /// WARNING:
-///1
+///
 /// This `import_object_t` contains thin-wrappers around host system calls.
 /// Do not use this to execute untrusted code without additional sandboxing.
 #[no_mangle]


### PR DESCRIPTION
# Description
I previously added a new field to LLVMModuleCodeGenerator which wasn't necessary. The data is available in ModuleInfo which in turn is available everywhere we need it. Remove the dead field, use ModuleInfo instead.
