### PR TITLE
Revert change of Ubuntu 18.04 to 16.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
 
   - job: clippy_lint
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-16.04"
     steps:
       - checkout: self
       - template: .azure/install-rust.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         linux:
-          imageName: "ubuntu-18.04"
+          imageName: "ubuntu-16.04"
           rust_toolchain: nightly-2019-12-19
         mac:
           imageName: "macos-10.14"
@@ -88,7 +88,7 @@ jobs:
 
   - job: Check
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-16.04"
     variables:
       rust_toolchain: nightly-2019-12-19
     condition: in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/staging', 'refs/heads/trying')
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         linux:
-          imageName: "ubuntu-18.04"
+          imageName: "ubuntu-16.04"
           rust_toolchain: nightly-2019-12-19
         mac:
           imageName: "macos-10.14"
@@ -178,7 +178,7 @@ jobs:
     strategy:
       matrix:
         linux:
-          imageName: "ubuntu-18.04"
+          imageName: "ubuntu-16.04"
           rust_toolchain: nightly-2019-12-19
         mac:
           imageName: "macos-10.14"
@@ -234,7 +234,7 @@ jobs:
 
   - job: Build_Docs
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-16.04"
     variables:
       rust_toolchain: nightly-2019-12-19
     condition: in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/staging', 'refs/heads/trying')
@@ -309,7 +309,7 @@ jobs:
       - Build_Docs
     displayName: Deploy API Documentation to GitHub
     pool:
-      vmImage: "ubuntu-18.04"
+      vmImage: "ubuntu-16.04"
     condition: in(variables['Build.SourceBranch'], 'refs/heads/master')
     steps:
       - checkout: self


### PR DESCRIPTION
I didn't document why I changed it to 18.04 in #1163 ; making this PR to run CI and find out why.

It looks like CI is passing!  I have no idea why I updated to 18.04.  Perhaps I misread [the support table](https://wiki.ubuntu.com/Releases) and thought 16.04 no longer had standard support.

Either way, this PR seems good to merge.

This PR will fix wapm-cli's CI which can't run Wasmer 0.14.0 on Ubuntu 16.04 due to a GLIBC version issue:

```/home/vsts/.wasmer/bin/wasmer: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /home/vsts/.wasmer/bin/wasmer)```

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
