### PR TITLE
Prepare for 0.14.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## **[Unreleased]**
 
+## 0.14.1 - 2020-02-24
+
+- [#1245](https://github.com/wasmerio/wasmer/pull/1245) Use Ubuntu 16.04 in CI so that we use an earlier version of GLIBC.
 - [#1234](https://github.com/wasmerio/wasmer/pull/1234) Check for unused excluded spectest failures.
 - [#1232](https://github.com/wasmerio/wasmer/pull/1232) `wasmer-interface-types` has a WAT decoder.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "atty",
  "byteorder",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-clif-backend"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "byteorder",
  "cranelift-codegen",
@@ -1793,14 +1793,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-dev-utils"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "wasmer-emscripten"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "byteorder",
  "getrandom",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-emscripten-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "glob 0.3.0",
  "wabt",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-interface-types"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "nom",
  "wast",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-llvm-backend"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "byteorder",
  "cc",
@@ -1874,14 +1874,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middleware-common"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "wasmer-runtime-core",
 ]
 
 [[package]]
 name = "wasmer-middleware-common-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "criterion",
  "wabt",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "criterion",
  "lazy_static",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-c-api"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "cbindgen",
  "libc",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "wabt",
  "wasmer-clif-backend",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-spectests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "glob 0.3.0",
  "wabt",
@@ -1989,7 +1989,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-experimental-io-devices"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "log",
  "minifb",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-tests"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "glob 0.3.0",
  "wasmer-clif-backend",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-win-exception-handler"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"

--- a/lib/clif-backend/Cargo.toml
+++ b/lib/clif-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-clif-backend"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime Cranelift compiler backend"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
 cranelift-native = "0.52.0"
 cranelift-codegen = "0.52.0"
 cranelift-entity = "0.52.0"
@@ -37,4 +37,4 @@ version = "0.0.7"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "minwinbase", "winnt"] }
-wasmer-win-exception-handler = { path = "../win-exception-handler", version = "0.14.0" }
+wasmer-win-exception-handler = { path = "../win-exception-handler", version = "0.14.1" }

--- a/lib/dev-utils/Cargo.toml
+++ b/lib/dev-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-dev-utils"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime core library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/lib/emscripten-tests/Cargo.toml
+++ b/lib/emscripten-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten-tests"
-version = "0.14.0"
+version = "0.14.1"
 description = "Tests for our Emscripten implementation"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -9,15 +9,15 @@ publish = false
 build = "build/mod.rs"
 
 [dependencies]
-wasmer-emscripten = { path = "../emscripten", version = "0.14.0" }
-wasmer-runtime = { path = "../runtime", version = "0.14.0", default-features = false }
-wasmer-clif-backend = { path = "../clif-backend", version = "0.14.0", optional = true}
-wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.0", optional = true, features = ["test"] }
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.0", optional = true }
+wasmer-emscripten = { path = "../emscripten", version = "0.14.1" }
+wasmer-runtime = { path = "../runtime", version = "0.14.1", default-features = false }
+wasmer-clif-backend = { path = "../clif-backend", version = "0.14.1", optional = true}
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.1", optional = true, features = ["test"] }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.1", optional = true }
 
 [dev-dependencies]
 wabt = "0.9.1"
-wasmer-dev-utils = { path = "../dev-utils", version = "0.14.0"}
+wasmer-dev-utils = { path = "../dev-utils", version = "0.14.1"}
 
 [build-dependencies]
 glob = "0.3"

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime emscripten implementation library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -15,7 +15,7 @@ lazy_static = "1.4"
 libc = "0.2.60"
 log = "0.4"
 time = "0.1"
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.1"

--- a/lib/interface-types/Cargo.toml
+++ b/lib/interface-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-interface-types"
-version = "0.14.0"
+version = "0.14.1"
 description = "WebAssembly Interface Types library for Wasmer"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/lib/llvm-backend-tests/Cargo.toml
+++ b/lib/llvm-backend-tests/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 
 [dependencies]
 wabt = "0.9.1"
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
-wasmer-runtime = { path = "../runtime", version = "0.14.0" }
-wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.0", features = ["test"] }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
+wasmer-runtime = { path = "../runtime", version = "0.14.1" }
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.1", features = ["test"] }
 
 [features]

--- a/lib/llvm-backend/Cargo.toml
+++ b/lib/llvm-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-llvm-backend"
-version = "0.14.0"
+version = "0.14.1"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -10,7 +10,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
 wasmparser = "0.45.0"
 smallvec = "0.6"
 goblin = "0.0.24"

--- a/lib/middleware-common-tests/Cargo.toml
+++ b/lib/middleware-common-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-middleware-common-tests"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"
@@ -8,11 +8,11 @@ license = "MIT"
 publish = false
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
-wasmer-middleware-common = { path = "../middleware-common", version = "0.14.0" }
-wasmer-clif-backend = { path = "../clif-backend", version = "0.14.0", optional = true }
-wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.0", features = ["test"], optional = true }
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.0", optional = true }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
+wasmer-middleware-common = { path = "../middleware-common", version = "0.14.1" }
+wasmer-clif-backend = { path = "../clif-backend", version = "0.14.1", optional = true }
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.1", features = ["test"], optional = true }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.1", optional = true }
 
 [features]
 clif = ["wasmer-clif-backend"]

--- a/lib/middleware-common/Cargo.toml
+++ b/lib/middleware-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-middleware-common"
-version = "0.14.0"
+version = "0.14.1"
 repository = "https://github.com/wasmerio/wasmer"
 description = "Wasmer runtime common middlewares"
 license = "MIT"
@@ -10,4 +10,4 @@ categories = ["wasm"]
 edition = "2018"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }

--- a/lib/runtime-c-api/Cargo.toml
+++ b/lib/runtime-c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime-c-api"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer C API library"
 documentation = "https://wasmerio.github.io/wasmer/c/runtime-c-api/"
 license = "MIT"
@@ -20,22 +20,22 @@ libc = "0.2.60"
 [dependencies.wasmer-runtime]
 default-features = false
 path = "../runtime"
-version = "0.14.0"
+version = "0.14.1"
 
 [dependencies.wasmer-runtime-core]
 default-features = false
 path = "../runtime-core"
-version = "0.14.0"
+version = "0.14.1"
 
 [dependencies.wasmer-wasi]
 default-features = false
 path = "../wasi"
-version = "0.14.0"
+version = "0.14.1"
 optional = true
 
 [dependencies.wasmer-emscripten]
 path = "../emscripten"
-version = "0.14.0"
+version = "0.14.1"
 optional = true
 
 [features]

--- a/lib/runtime-core-tests/Cargo.toml
+++ b/lib/runtime-core-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime-core-tests"
-version = "0.14.0"
+version = "0.14.1"
 description = "Tests for the Wasmer runtime core crate"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -9,10 +9,10 @@ publish = false
 
 [dependencies]
 wabt = "0.9.1"
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
-wasmer-clif-backend = { path = "../clif-backend", version = "0.14.0", optional = true }
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.0", optional = true }
-wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.0", features = ["test"], optional = true }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
+wasmer-clif-backend = { path = "../clif-backend", version = "0.14.1", optional = true }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.1", optional = true }
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.1", features = ["test"], optional = true }
 
 [features]
 default = ["backend-cranelift"]

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime-core"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime core library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,17 +11,17 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.0", optional = true }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.1", optional = true }
 lazy_static = "1.4"
 memmap = "0.7"
 
 [dependencies.wasmer-runtime-core]
 path = "../runtime-core"
-version = "0.14.0"
+version = "0.14.1"
 
 [dependencies.wasmer-clif-backend]
 path = "../clif-backend"
-version = "0.14.0"
+version = "0.14.1"
 optional = true
 
 # Dependencies for caching.

--- a/lib/singlepass-backend/Cargo.toml
+++ b/lib/singlepass-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-singlepass-backend"
-version = "0.14.0"
+version = "0.14.1"
 repository = "https://github.com/wasmerio/wasmer"
 description = "Wasmer runtime single pass compiler backend"
 license = "MIT"
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
 dynasm = "0.5"
 dynasmrt = "0.5"
 lazy_static = "1.4"

--- a/lib/spectests/Cargo.toml
+++ b/lib/spectests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-spectests"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer spectests library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -9,10 +9,10 @@ edition = "2018"
 
 [dependencies]
 glob = "0.3"
-wasmer-runtime = { path = "../runtime", version = "0.14.0", default-features = false}
-wasmer-clif-backend = { path = "../clif-backend", version = "0.14.0", optional = true}
-wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.0", features = ["test"], optional = true }
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.0", optional = true }
+wasmer-runtime = { path = "../runtime", version = "0.14.1", default-features = false}
+wasmer-clif-backend = { path = "../clif-backend", version = "0.14.1", optional = true}
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.1", features = ["test"], optional = true }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.1", optional = true }
 
 [build-dependencies]
 wabt = "0.9.1"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-experimental-io-devices"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"
@@ -14,8 +14,8 @@ maintenance = { status = "experimental" }
 [dependencies]
 log = "0.4"
 minifb = "0.13"
-wasmer-wasi = { version = "0.14.0", path = "../wasi" }
-wasmer-runtime-core = { version = "0.14.0", path = "../runtime-core" }
+wasmer-wasi = { version = "0.14.1", path = "../wasi" }
+wasmer-runtime-core = { version = "0.14.1", path = "../runtime-core" }
 ref_thread_local = "0.0"
 serde = "1"
 typetag = "0.1"

--- a/lib/wasi-tests/Cargo.toml
+++ b/lib/wasi-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-tests"
-version = "0.14.0"
+version = "0.14.1"
 description = "Tests for our WASI implementation"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -10,18 +10,18 @@ build = "build/mod.rs"
 
 [dependencies]
 # We set default features to false to be able to use the singlepass backend properly
-wasmer-runtime = { path = "../runtime", version = "0.14.0", default-features = false }
-wasmer-wasi = { path = "../wasi", version = "0.14.0" }
+wasmer-runtime = { path = "../runtime", version = "0.14.1", default-features = false }
+wasmer-wasi = { path = "../wasi", version = "0.14.1" }
 # hack to get tests to work
-wasmer-clif-backend = { path = "../clif-backend", version = "0.14.0", optional = true}
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.0", optional = true }
-wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.0", features = ["test"], optional = true }
+wasmer-clif-backend = { path = "../clif-backend", version = "0.14.1", optional = true}
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.14.1", optional = true }
+wasmer-llvm-backend = { path = "../llvm-backend", version = "0.14.1", features = ["test"], optional = true }
 
 [build-dependencies]
 glob = "0.3"
 
 [dev-dependencies]
-wasmer-dev-utils = { path = "../dev-utils", version = "0.14.0"}
+wasmer-dev-utils = { path = "../dev-utils", version = "0.14.1"}
 
 [features]
 clif = ["wasmer-clif-backend", "wasmer-runtime/default-backend-cranelift"]

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime WASI implementation library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -19,7 +19,7 @@ getrandom = "0.1"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1", features = ["derive"] }
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/lib/win-exception-handler/Cargo.toml
+++ b/lib/win-exception-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-win-exception-handler"
-version = "0.14.0"
+version = "0.14.1"
 description = "Wasmer runtime exception handling for Windows"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -8,7 +8,7 @@ repository = "https://github.com/wasmerio/wasmer"
 edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.14.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.14.1" }
 winapi = { version = "0.3.8", features = ["winbase", "errhandlingapi", "minwindef", "minwinbase", "winnt"] }
 libc = "0.2.60"
 

--- a/scripts/update_version_numbers.sh
+++ b/scripts/update_version_numbers.sh
@@ -1,5 +1,5 @@
-PREVIOUS_VERSION='0.13.1'
-NEXT_VERSION='0.14.0'
+PREVIOUS_VERSION='0.14.0'
+NEXT_VERSION='0.14.1'
 
 # quick hack
 fd Cargo.toml --exec sed -i '' "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"

--- a/src/installer/wasmer.iss
+++ b/src/installer/wasmer.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=Wasmer
-AppVersion=0.14.0
+AppVersion=0.14.1
 DefaultDirName={pf}\Wasmer
 DefaultGroupName=Wasmer
 Compression=lzma2


### PR DESCRIPTION
0.14.1 differs from 0.14.0 primarily in that the GNU/Linux build is
built on Ubuntu 16.04 instead of 18.04, meaning we'll use an earlier
version of GLIBC.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
