### PR TITLE
expose the readwrite section

### DIFF
--- a/lib/llvm-backend/cpp/object_loader.cpp
+++ b/lib/llvm-backend/cpp/object_loader.cpp
@@ -277,3 +277,11 @@ uint8_t *WasmModule::get_readwrite_ptr() const {
 size_t WasmModule::get_readwrite_size() const {
   return memory_manager->get_readwrite_section_size();
 }
+
+uint8_t *WasmModule::get_read_ptr() const {
+  return memory_manager->get_read_section_ptr();
+}
+
+size_t WasmModule::get_read_size() const {
+  return memory_manager->get_read_section_size();
+}

--- a/lib/llvm-backend/cpp/object_loader.cpp
+++ b/lib/llvm-backend/cpp/object_loader.cpp
@@ -269,3 +269,11 @@ uint8_t *WasmModule::get_code_ptr() const {
 size_t WasmModule::get_code_size() const {
   return memory_manager->get_code_size();
 }
+
+uint8_t *WasmModule::get_readwrite_ptr() const {
+  return memory_manager->get_readwrite_section_ptr();
+}
+
+size_t WasmModule::get_readwrite_size() const {
+  return memory_manager->get_readwrite_section_size();
+}

--- a/lib/llvm-backend/cpp/object_loader.hh
+++ b/lib/llvm-backend/cpp/object_loader.hh
@@ -74,6 +74,8 @@ public:
   inline size_t get_stack_map_size() const { return stack_map_size; }
   inline uint8_t *get_code_ptr() const { return (uint8_t *)code_start_ptr; }
   inline size_t get_code_size() const { return code_size; }
+  inline uint8_t *get_readwrite_section_ptr() const { return readwrite_section.base; }
+  inline size_t get_readwrite_section_size() const { return readwrite_section.size; }
 
   virtual uint8_t *allocateCodeSection(uintptr_t size, unsigned alignment,
                                        unsigned section_id,
@@ -189,6 +191,8 @@ public:
   size_t get_stack_map_size() const;
   uint8_t *get_code_ptr() const;
   size_t get_code_size() const;
+  uint8_t *get_readwrite_ptr() const;
+  size_t get_readwrite_size() const;
 
   bool _init_failed = false;
 
@@ -324,5 +328,13 @@ const uint8_t *llvm_backend_get_code_ptr(const WasmModule *module) {
 
 size_t llvm_backend_get_code_size(const WasmModule *module) {
   return module->get_code_size();
+}
+
+const uint8_t *llvm_backend_get_readwrite_ptr(const WasmModule *module) {
+  return module->get_readwrite_ptr();
+}
+
+size_t llvm_backend_get_readwrite_size(const WasmModule *module) {
+  return module->get_readwrite_size();
 }
 }

--- a/lib/llvm-backend/cpp/object_loader.hh
+++ b/lib/llvm-backend/cpp/object_loader.hh
@@ -76,6 +76,8 @@ public:
   inline size_t get_code_size() const { return code_size; }
   inline uint8_t *get_readwrite_section_ptr() const { return readwrite_section.base; }
   inline size_t get_readwrite_section_size() const { return readwrite_section.size; }
+  inline uint8_t *get_read_section_ptr() const { return read_section.base; }
+  inline size_t get_read_section_size() const { return read_section.size; }
 
   virtual uint8_t *allocateCodeSection(uintptr_t size, unsigned alignment,
                                        unsigned section_id,
@@ -193,6 +195,8 @@ public:
   size_t get_code_size() const;
   uint8_t *get_readwrite_ptr() const;
   size_t get_readwrite_size() const;
+  uint8_t *get_read_ptr() const;
+  size_t get_read_size() const;
 
   bool _init_failed = false;
 
@@ -336,5 +340,12 @@ const uint8_t *llvm_backend_get_readwrite_ptr(const WasmModule *module) {
 
 size_t llvm_backend_get_readwrite_size(const WasmModule *module) {
   return module->get_readwrite_size();
+}
+const uint8_t *llvm_backend_get_read_ptr(const WasmModule *module) {
+  return module->get_read_ptr();
+}
+
+size_t llvm_backend_get_read_size(const WasmModule *module) {
+  return module->get_read_size();
 }
 }

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -48,6 +48,8 @@ extern "C" {
     fn llvm_backend_get_stack_map_size(module: *const LLVMModule) -> usize;
     fn llvm_backend_get_code_ptr(module: *const LLVMModule) -> *const u8;
     fn llvm_backend_get_code_size(module: *const LLVMModule) -> usize;
+    fn llvm_backend_get_readwrite_ptr(module: *const LLVMModule) -> *const u8;
+    fn llvm_backend_get_readwrite_size(module: *const LLVMModule) -> usize;
 
     fn throw_trap(ty: i32) -> !;
     fn throw_breakpoint(ty: i64) -> !;
@@ -455,6 +457,15 @@ impl RunnableModule for LLVMBackend {
             std::slice::from_raw_parts(
                 llvm_backend_get_code_ptr(self.module),
                 llvm_backend_get_code_size(self.module),
+            )
+        })
+    }
+
+    fn get_readwrite_section(&self) -> Option<&[u8]> {
+        Some(unsafe {
+            std::slice::from_raw_parts(
+                llvm_backend_get_readwrite_ptr(self.module),
+                llvm_backend_get_readwrite_size(self.module),
             )
         })
     }

--- a/lib/llvm-backend/src/backend.rs
+++ b/lib/llvm-backend/src/backend.rs
@@ -50,6 +50,8 @@ extern "C" {
     fn llvm_backend_get_code_size(module: *const LLVMModule) -> usize;
     fn llvm_backend_get_readwrite_ptr(module: *const LLVMModule) -> *const u8;
     fn llvm_backend_get_readwrite_size(module: *const LLVMModule) -> usize;
+    fn llvm_backend_get_read_ptr(module: *const LLVMModule) -> *const u8;
+    fn llvm_backend_get_read_size(module: *const LLVMModule) -> usize;
 
     fn throw_trap(ty: i32) -> !;
     fn throw_breakpoint(ty: i64) -> !;
@@ -466,6 +468,15 @@ impl RunnableModule for LLVMBackend {
             std::slice::from_raw_parts(
                 llvm_backend_get_readwrite_ptr(self.module),
                 llvm_backend_get_readwrite_size(self.module),
+            )
+        })
+    }
+
+    fn get_read_section(&self) -> Option<&[u8]> {
+        Some(unsafe {
+            std::slice::from_raw_parts(
+                llvm_backend_get_read_ptr(self.module),
+                llvm_backend_get_read_size(self.module)
             )
         })
     }

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -247,6 +247,10 @@ pub trait RunnableModule: Send + Sync {
         None
     }
 
+    fn get_read_section(&self) -> Option<&[u8]> {
+        None
+    }
+
     /// Returns the beginning offsets of all functions, including import trampolines.
     fn get_offsets(&self) -> Option<Vec<usize>> {
         None

--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -243,6 +243,10 @@ pub trait RunnableModule: Send + Sync {
         None
     }
 
+    fn get_readwrite_section(&self) -> Option<&[u8]> {
+        None
+    }
+
     /// Returns the beginning offsets of all functions, including import trampolines.
     fn get_offsets(&self) -> Option<Vec<usize>> {
         None


### PR DESCRIPTION
# Description

The readwrite section is part of the code generated by LLVM, and should be accessible if we want to move things around when compiling position independent code
