### PR TITLE
compile in PIC mode

### DIFF
--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -8690,7 +8690,7 @@ impl<'ctx> ModuleCodeGenerator<LLVMFunctionCodeGenerator<'ctx>, LLVMBackend, Cod
                 &cpu_name.unwrap_or(TargetMachine::get_host_cpu_name().to_string()),
                 &cpu_features.unwrap_or(TargetMachine::get_host_cpu_features().to_string()),
                 OptimizationLevel::Aggressive,
-                RelocMode::Static,
+                RelocMode::PIC,
                 CodeModel::Large,
             )
             .unwrap();


### PR DESCRIPTION
# Description
this enables compiling position independent code. Linking this to #1259: if the code is moved, the read and readwrite section mist be moved as well, and stay at the same offsets relatively.