### PR TITLE
Enable `DynamicFunc` for closures with captured environment.

### DIFF
--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -59,3 +59,5 @@ generate-debug-information = ["wasm-debug"]
 # don't export symbols related to the GDB JIT interafce, LLVM or some other native
 # code will be providing them
 generate-debug-information-no-export-symbols = []
+# enable DynamicFunc's for closures with captured environment.
+dynamicfunc-fat-closures = []

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -349,11 +349,6 @@ impl<'a> DynamicFunc<'a> {
             }
         }
 
-        // Disable "fat" closures for possible future changes.
-        if mem::size_of::<F>() != 0 {
-            unimplemented!("DynamicFunc with captured environment is not yet supported");
-        }
-
         let mut builder = TrampolineBufferBuilder::new();
         let ctx: Box<PolymorphicContext> = Box::new(PolymorphicContext {
             arg_types: signature.params().to_vec(),

--- a/lib/runtime-core/src/typed_func.rs
+++ b/lib/runtime-core/src/typed_func.rs
@@ -349,6 +349,10 @@ impl<'a> DynamicFunc<'a> {
             }
         }
 
+        if cfg!(not(feature = "dynamicfunc-fat-closures")) && mem::size_of::<F>() != 0 {
+            unimplemented!("DynamicFunc with captured environment is disabled");
+        }
+
         let mut builder = TrampolineBufferBuilder::new();
         let ctx: Box<PolymorphicContext> = Box::new(PolymorphicContext {
             arg_types: signature.params().to_vec(),


### PR DESCRIPTION
Previously we disabled `DynamicFunc` for any non-zero-sized closures to leave space for future changes. However this feature is critical for applications that needs to bring context with host functions, like integrations with dynamic lauguages. So it might be good to enable it.

A question left is: should we put this behind a feature flag or enable it by default?

@Hywan @syrusakbary 