### PR TITLE
If memory maximum is between bounds, make it static

### DIFF
--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -345,7 +345,7 @@ impl MemoryDescriptor {
             (true, None) => {
                 return Err("Maximum number of pages is required for shared memory".to_string())
             }
-            (false, Some(max)) if max <= STATIC_MEMORY_BOUND => MemoryType::Static,
+            (false, Some(Pages(max))) if max <= STATIC_MEMORY_BOUND => MemoryType::Static,
             (false, _) => MemoryType::Dynamic,
         })
     }

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -335,21 +335,12 @@ impl MemoryDescriptor {
 
     /// Detect the memory type given the Maximum pages and it's shared attribute
     pub fn detect_memory_type(maximum: Option<Pages>, shared: bool) -> Result<MemoryType, String> {
-        if shared {
-            if maximum.is_none() {
-                return Err("Max number of pages is required for shared memory".to_string());
-            }
-            Ok(MemoryType::SharedStatic)
-        }
-        else {
-            // If the maximum memory is within bounds, we make it static
-            if maximum.is_some() && maximum.unwrap().0 <= STATIC_MEMORY_BOUND {
-                Ok(MemoryType::Static)
-            }
-            else {
-                Ok(MemoryType::Dynamic)
-            }
-        }
+        Ok(match (shared, maximum) {
+            (true, Some(_)) => MemoryType::SharedStatic,
+            (true, None) => return Err("Maximum number of pages is required for shared memory".to_string()),
+            (false, Some(maximum)) if maximum <= STATIC_MEMORY_BOUND => MemoryType::Static,
+            (false, _) => MemoryType::Dynamic,
+        })
     }
 
     /// Returns the `MemoryType` for this descriptor.

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -345,7 +345,7 @@ impl MemoryDescriptor {
             (true, None) => {
                 return Err("Maximum number of pages is required for shared memory".to_string())
             }
-            (false, Some(maximum)) if maximum <= STATIC_MEMORY_BOUND => MemoryType::Static,
+            (false, Some(max)) if max <= STATIC_MEMORY_BOUND => MemoryType::Static,
             (false, _) => MemoryType::Dynamic,
         })
     }

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -1,7 +1,12 @@
 //! The runtime types modules represent type used within the wasm runtime and helper functions to
 //! convert to other represenations.
 
-use crate::{memory::MemoryType, module::ModuleInfo, structures::TypedIndex, units::{Pages, STATIC_MEMORY_BOUND}};
+use crate::{
+    memory::MemoryType,
+    module::ModuleInfo,
+    structures::TypedIndex,
+    units::{Pages, STATIC_MEMORY_BOUND},
+};
 use std::{borrow::Cow, convert::TryFrom};
 
 /// Represents a WebAssembly type.
@@ -337,7 +342,9 @@ impl MemoryDescriptor {
     pub fn detect_memory_type(maximum: Option<Pages>, shared: bool) -> Result<MemoryType, String> {
         Ok(match (shared, maximum) {
             (true, Some(_)) => MemoryType::SharedStatic,
-            (true, None) => return Err("Maximum number of pages is required for shared memory".to_string()),
+            (true, None) => {
+                return Err("Maximum number of pages is required for shared memory".to_string())
+            }
             (false, Some(maximum)) if maximum <= STATIC_MEMORY_BOUND => MemoryType::Static,
             (false, _) => MemoryType::Dynamic,
         })

--- a/lib/runtime-core/src/units.rs
+++ b/lib/runtime-core/src/units.rs
@@ -6,13 +6,24 @@ use std::{
     ops::{Add, Sub},
 };
 
-/// The page size in bytes of a wasm page.
-pub const WASM_PAGE_SIZE: usize = 65_536;
-/// The max number of wasm pages allowed.
-pub const WASM_MAX_PAGES: usize = 65_536;
+/// The page size in bytes of a wasm page
+pub const WASM_PAGE_SIZE: usize = 0x10000;
+/// The max number of wasm pages allowed before we run
+/// out of index space
+pub const WASM_MAX_PAGES: usize = 0x10000;
 // From emscripten resize_heap implementation
 /// The minimum number of wasm pages allowed.
 pub const WASM_MIN_PAGES: usize = 256;
+
+#[cfg(target_pointer_width = "32")]
+/// The wasm pages of the bound for static memories (32 bits)
+/// That way we can skip bounds check
+pub const STATIC_MEMORY_BOUND: u32 = 0x4000;
+
+#[cfg(target_pointer_width = "64")]
+/// The wasm pages of the bound for static memories (64 bits)
+/// That way we can skip bounds check
+pub const STATIC_MEMORY_BOUND: u32 = 0x10000;
 
 /// Units of WebAssembly pages (as specified to be 65,536 bytes).
 #[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR improves clif compilation speed in some cases up to 3x. Runtime speed about 40% faster.

## With the patch:
Compilation (3.376s)
```
➜  wasmer git:(master) ✗ ./target/release/wasmer cache clean && time WAPM_RUNTIME=./target/release/wasmer wax hello-go
Hello world!
WAPM_RUNTIME=./target/release/wasmer wax hello-go  8.04s user 0.18s system 243% cpu 3.376 total
```

Coremark (14549 iterations/sec)
```
➜  rusty_v8 git:(master) ✗ time ../wasmer/target/release/wasmer /var/folders/l5/vjn0dbf96fx3rd6d2vx2mcxm0000gn/T/wax/vshymanskyy/coremark@0.0.1/wapm_packages/vshymanskyy/coremark@0.0.1/build/coremark.wasm --disable-cache
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 13746
Total time (secs): 13.746000
Iterations/Sec   : 14549.687182
Iterations       : 200000
Compiler version : Clang 9.0.0 (https://github.com/llvm/llvm-project 0399d5a9682b3cef71c653373e38890c63c4c365)
Compiler flags   : -O3   -lrt
Memory location  : HEAP
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x4983
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 14549.687182 / Clang 9.0.0 (https://github.com/llvm/llvm-project 0399d5a9682b3cef71c653373e38890c63c4c365) -O3   -lrt / HEAP
../wasmer/target/release/wasmer  --disable-cache  21.34s user 0.06s system 99% cpu 21.452 total
```

## Without the patch:
Compilation (8.947s)
```
➜  wasmer git:(master) ✗ wasmer cache clean && time wax hello-go
Hello world!
wax hello-go  17.16s user 0.30s system 195% cpu 8.947 total
```

Coremark (10083 iterations/sec)
```
➜  rusty_v8 git:(master) ✗ wax coremark
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 19835
Total time (secs): 19.835000
Iterations/Sec   : 10083.186287
Iterations       : 200000
Compiler version : Clang 9.0.0 (https://github.com/llvm/llvm-project 0399d5a9682b3cef71c653373e38890c63c4c365)
Compiler flags   : -O3   -lrt
Memory location  : HEAP
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x4983
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 10083.186287 / Clang 9.0.0 (https://github.com/llvm/llvm-project 0399d5a9682b3cef71c653373e38890c63c4c365) -O3   -lrt / HEAP
```

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
