### PR TITLE
upgrade the blake3 dependency to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.1.5"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
+checksum = "c58fbca3e5be3b7a3c24a5ec6976a6a464490528e8fee92896fe4ee2a40b10fb"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.11"
 [dependencies.serde-bench]
 version = "0.0.7"
 [dependencies.blake3]
-version = "0.1.0"
+version = "0.2.0"
 [dependencies.digest]
 version = "0.8"
 
@@ -47,7 +47,7 @@ version = "0.8"
 winapi = { version = "0.3", features = ["memoryapi"] }
 
 [build-dependencies]
-blake3 = "0.1.0"
+blake3 = "0.2.0"
 rustc_version = "0.2"
 cc = "1.0"
 


### PR DESCRIPTION
Version 0.2 makes assembly implementations available. They're off by default, and I haven't enabled them here, because they require the build machine to have a C toolchain installed. But if that's already a requirement for Wasmer, we could enable them with the `"c"` feature, for both better runtime performance and faster build times.