### PR TITLE
Fix windows cross compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,7 +2146,7 @@ dependencies = [
 name = "wasmer-win-exception-handler"
 version = "0.16.2"
 dependencies = [
- "cmake",
+ "cc",
  "libc",
  "wasmer-runtime-core",
  "winapi",

--- a/lib/win-exception-handler/Cargo.toml
+++ b/lib/win-exception-handler/Cargo.toml
@@ -13,4 +13,4 @@ winapi = { version = "0.3.8", features = ["winbase", "errhandlingapi", "minwinde
 libc = "0.2.60"
 
 [build-dependencies]
-cmake = "0.1"
+cc = "1.0"

--- a/lib/win-exception-handler/build.rs
+++ b/lib/win-exception-handler/build.rs
@@ -7,4 +7,8 @@ fn main() {
         println!("cargo:rustc-link-search=native={}", dst.display());
         println!("cargo:rustc-link-lib=static={}", project_name);
     }
+    cc::Build::new()
+        .include("exception_handling")
+        .file("exception_handling/exception_handling.c")
+        .compile("exception_handling");
 }

--- a/lib/win-exception-handler/build.rs
+++ b/lib/win-exception-handler/build.rs
@@ -1,12 +1,8 @@
 fn main() {
-    #[cfg(target_os = "windows")]
-    {
-        use cmake::Config;
-        let project_name = "exception_handling";
-        let dst = Config::new(project_name).build();
-        println!("cargo:rustc-link-search=native={}", dst.display());
-        println!("cargo:rustc-link-lib=static={}", project_name);
+    if std::env::var("CARGO_CFG_TARGET_OS").expect("TARGET_OS not specified") != "windows" {
+        return;
     }
+
     cc::Build::new()
         .include("exception_handling")
         .file("exception_handling/exception_handling.c")

--- a/lib/win-exception-handler/exception_handling/.gitignore
+++ b/lib/win-exception-handler/exception_handling/.gitignore
@@ -1,1 +1,0 @@
-cmake-build-*

--- a/lib/win-exception-handler/exception_handling/CMakeLists.txt
+++ b/lib/win-exception-handler/exception_handling/CMakeLists.txt
@@ -1,6 +1,0 @@
-cmake_minimum_required(VERSION 3.0)
-project(exception_handling C)
-
-add_library(exception_handling STATIC exception_handling.c)
-
-install(TARGETS exception_handling DESTINATION .)

--- a/lib/win-exception-handler/exception_handling/exception_handling.c
+++ b/lib/win-exception-handler/exception_handling/exception_handling.c
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <setjmp.h>
+#include <intrin.h>
 #include "exception_handling.h"
 
 #define CALL_FIRST 1


### PR DESCRIPTION
# Description
When compiling to windows from any host other than windows, the `win-exception-handler` crate would not actually compile the C code since the compilation was guarded by `#[cfg(target_os = "windows")]`, which is evaluated when the build script itself is compiled which would mean it would != windows, which would eventually cause a link error due to the missing library.

This change gets the target os via the `CARGO_CFG_TARGET_OS` environment variable, which is set by cargo when invoking the build script, and will evaluate to `windows` when actually targetting windows, no matter the host platform.

It also changed from using cmake to use the cc crate to compile the code, as cmake seemed like massive overkill for a single C file, as well as complicating cross compilation again, though I can change it back to cmake if you don't want that change.

I also fixed a warning produced by clang by adding `#include <intrin.h>`, though there was another warning due to the trampoline function pointer taking a non-const `wasmer_instance_context_t*`, but wasmer actually sending in a const *.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
