### PR TITLE
Fix OSX static library packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ ifeq ($(OS), Windows_NT)
 else
 ifeq ($(UNAME_S), Darwin)
 	cp target/release/libwasmer_runtime_c_api.dylib ./capi/lib/libwasmer.dylib
-	cp target/release/libwasmer_runtime_c_api.dylib ./capi/lib/libwasmer.a
+	cp target/release/libwasmer_runtime_c_api.a ./capi/lib/libwasmer.a
 	# Fix the rpath for the dylib
 	install_name_tool -id "@rpath/libwasmer.dylib" ./capi/lib/libwasmer.dylib
 else


### PR DESCRIPTION
Resolves #1316 

We should prioritize setting up the post-release testing we discussed so we can catch these types of mistakes.