### PR TITLE
Support multiple custom sections with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1320](https://github.com/wasmerio/wasmer/pull/1320) Change `custom_sections` field in `ModuleInfo` to be more standards compliant by allowing multiple custom sections with the same name. To get the old behavior with the new API, you can add `.last().unwrap()` to accesses. For example, `module_info.custom_sections["custom_section_name"].last().unwrap()`.
 - [#1303](https://github.com/wasmerio/wasmer/pull/1303) NaN canonicalization for singlepass backend.
 - [#1305](https://github.com/wasmerio/wasmer/pull/1305) Handle panics from DynamicFunc.
 - [#1301](https://github.com/wasmerio/wasmer/pull/1301) Update supported stable Rust version to 1.41.1.

--- a/lib/runtime-core/src/module.rs
+++ b/lib/runtime-core/src/module.rs
@@ -78,7 +78,7 @@ pub struct ModuleInfo {
     pub em_symbol_map: Option<HashMap<u32, String>>,
 
     /// Custom sections.
-    pub custom_sections: HashMap<String, Vec<u8>>,
+    pub custom_sections: HashMap<String, Vec<Vec<u8>>>,
 
     /// Flag controlling whether or not debug information for use in a debugger
     /// will be generated.
@@ -102,7 +102,8 @@ impl ModuleInfo {
                 let bytes = reader.read_bytes(len)?;
                 let data = bytes.to_vec();
                 let name = name.to_string();
-                self.custom_sections.insert(name, data);
+                let entry: &mut Vec<Vec<u8>> = self.custom_sections.entry(name).or_default();
+                entry.push(data);
             }
         }
         Ok(())


### PR DESCRIPTION
The spec doesn't disallow duplicates and the [JS API spec](https://webassembly.github.io/spec/js-api/index.html#dom-module-customsections) supports them.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
