### PR TITLE
update blake3 to version 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58fbca3e5be3b7a3c24a5ec6976a6a464490528e8fee92896fe4ee2a40b10fb"
+checksum = "861b9a725beee11d674d1880e402e5956fc0e521cc3822b5cdff380764e178bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.11"
 [dependencies.serde-bench]
 version = "0.0.7"
 [dependencies.blake3]
-version = "0.2.0"
+version = "0.3.0"
 [dependencies.digest]
 version = "0.8"
 
@@ -47,7 +47,7 @@ version = "0.8"
 winapi = { version = "0.3", features = ["memoryapi"] }
 
 [build-dependencies]
-blake3 = "0.2.0"
+blake3 = "0.3.0"
 rustc_version = "0.2"
 cc = "1.0"
 


### PR DESCRIPTION
Apologies for showing up again so soon :)

Version 0.3 switched to using assembly implementations by default, which
both perform better and build more quickly. This invokes the C compiler
from build.rs. If Wasmer would prefer to avoid that build dependency, we
could enable the new `pure` feature.