### PR TITLE
Revert "update blake3 to version 0.3.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.3.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861b9a725beee11d674d1880e402e5956fc0e521cc3822b5cdff380764e178bc"
+checksum = "c58fbca3e5be3b7a3c24a5ec6976a6a464490528e8fee92896fe4ee2a40b10fb"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.11"
 [dependencies.serde-bench]
 version = "0.0.7"
 [dependencies.blake3]
-version = "0.3.0"
+version = "0.2.0"
 [dependencies.digest]
 version = "0.8"
 
@@ -47,7 +47,7 @@ version = "0.8"
 winapi = { version = "0.3", features = ["memoryapi"] }
 
 [build-dependencies]
-blake3 = "0.3.0"
+blake3 = "0.2.0"
 rustc_version = "0.2"
 cc = "1.0"
 


### PR DESCRIPTION
Reverts wasmerio/wasmer#1343

We had issues when compiling blake3 on an Android target:


```
Your C compiler does not support the "-mavx512f" flag. If you are building the
"b3sum" or "bao_bin" crates, you can disable AVX-512 with "--features=pure".
Other crates might or might not support this workaround.

warning: build failed, waiting for other jobs to finish...
error: build failed
Makefile:176: recipe for target 'test-android' failed
```

https://dev.azure.com/wasmerio/wasmer/_build/results?buildId=4151&view=logs&j=dfba4ba4-8417-51b5-572c-30f3ca4c64a7&t=0a918e81-46a6-5c09-f334-b71678e1d91b

Reverting the PR