### PR TITLE
update blake3 to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58fbca3e5be3b7a3c24a5ec6976a6a464490528e8fee92896fe4ee2a40b10fb"
+checksum = "7bd3c29b0e8eedf3a4424b8b2ee09518fc9e95b7efe257000c356827e6353584"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -39,7 +39,7 @@ version = "0.11"
 [dependencies.serde-bench]
 version = "0.0.7"
 [dependencies.blake3]
-version = "0.2.0"
+version = "0.3.1"
 [dependencies.digest]
 version = "0.8"
 
@@ -47,7 +47,7 @@ version = "0.8"
 winapi = { version = "0.3", features = ["memoryapi"] }
 
 [build-dependencies]
-blake3 = "0.2.0"
+blake3 = "0.3.1"
 rustc_version = "0.2"
 cc = "1.0"
 


### PR DESCRIPTION
Version 0.3.0 caused problems because it required a C compiler with
AVX-512 support, which broke Android x86 cross-compilation. Version
0.3.1 automatically falls back to a pure Rust build when the C compiler
either doesn't exist or doesn't support the flags we need.