### PR TITLE
fix(interface-types) Don't duplicate code in the binary encoder.

### DIFF
--- a/lib/interface-types/src/encoders/binary.rs
+++ b/lib/interface-types/src/encoders/binary.rs
@@ -170,9 +170,9 @@ where
                 outputs.to_bytes(writer)?;
             }
 
-            Type::Record(RecordType { fields }) => {
+            Type::Record(record_type) => {
                 TypeKind::Record.to_bytes(writer)?;
-                fields.to_bytes(writer)?;
+                record_type.to_bytes(writer)?;
             }
         }
 


### PR DESCRIPTION
Use the `ToBytes` implementation of `RecordType` to encode the inner
record type of a type, so that it avoids code duplication.