### PR TITLE
Reuse compile-with-config, add read_custom_sections config field

### DIFF
--- a/lib/runtime-core/src/backend.rs
+++ b/lib/runtime-core/src/backend.rs
@@ -143,6 +143,11 @@ pub struct CompilerConfig {
     /// These verifications are disabled by default in 'release' builds.
     pub enable_verification: bool,
 
+    /// Should we automatically attach the custom sections to the Module?
+    ///
+    /// It's off by default as it takes more cpu and memory to read and store the sections.
+    pub read_custom_sections: bool,
+
     pub features: Features,
 
     // Target info. Presently only supported by LLVM.
@@ -164,6 +169,7 @@ impl Default for CompilerConfig {
             track_state: Default::default(),
             full_preemption: Default::default(),
             nan_canonicalization: Default::default(),
+            read_custom_sections: Default::default(),
             features: Default::default(),
             triple: Default::default(),
             cpu_name: Default::default(),

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -122,10 +122,11 @@ pub fn compile_with_config(
     compiler_config: backend::CompilerConfig,
 ) -> CompileResult<module::Module> {
     let token = backend::Token::generate();
+    let read_custom_sections = compiler_config.read_custom_sections;
     compiler
         .compile(wasm, compiler_config, token)
         .map(|mut inner| {
-            if compiler_config.read_custom_sections {
+            if read_custom_sections {
                 let inner_info: &mut crate::module::ModuleInfo = &mut inner.info;
                 inner_info.import_custom_sections(wasm).unwrap();
             }

--- a/lib/runtime-core/src/lib.rs
+++ b/lib/runtime-core/src/lib.rs
@@ -111,14 +111,7 @@ pub fn compile_with(
     wasm: &[u8],
     compiler: &dyn backend::Compiler,
 ) -> CompileResult<module::Module> {
-    let token = backend::Token::generate();
-    compiler
-        .compile(wasm, Default::default(), token)
-        .map(|mut inner| {
-            let inner_info: &mut crate::module::ModuleInfo = &mut inner.info;
-            inner_info.import_custom_sections(wasm).unwrap();
-            module::Module::new(Arc::new(inner))
-        })
+    compile_with_config(wasm, compiler, Default::default())
 }
 
 /// The same as `compile_with` but changes the compiler behavior
@@ -131,7 +124,13 @@ pub fn compile_with_config(
     let token = backend::Token::generate();
     compiler
         .compile(wasm, compiler_config, token)
-        .map(|inner| module::Module::new(Arc::new(inner)))
+        .map(|mut inner| {
+            if compiler_config.read_custom_sections {
+                let inner_info: &mut crate::module::ModuleInfo = &mut inner.info;
+                inner_info.import_custom_sections(wasm).unwrap();
+            }
+            module::Module::new(Arc::new(inner))
+        })
 }
 
 /// Perform validation as defined by the

--- a/tests/high_level_api.rs
+++ b/tests/high_level_api.rs
@@ -47,7 +47,10 @@ fn append_custom_section(
     wasm.extend(custom_section_contents);
 }
 
+// TODO: Re-enable this test once we have a way to put custom
+// configuration using the `wasmer` crate.
 #[test]
+#[ignore]
 fn custom_section_parsing_works() {
     use wasmer::{CompiledModule, Module};
     let wasm = {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR fixes #1359 and also adds a `read_custom_sections` field to the BackendConfig (so we pay no default overhead when reading custom sections).

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
