### PR TITLE
Update tests to use new API where easily possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,6 +2735,7 @@ dependencies = [
 name = "wasmer"
 version = "0.16.2"
 dependencies = [
+ "serde",
  "wasmer-clif-backend",
  "wasmer-llvm-backend",
  "wasmer-runtime-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,15 +91,18 @@ backend-cranelift = [
     "wasmer-clif-backend/generate-debug-information",
     "wasmer-runtime-core/generate-debug-information",
     "wasmer-runtime/cranelift",
+    "wasmer/cranelift",
 ]
 backend-llvm = [
     "wasmer-llvm-backend",
     "wasmer-runtime/llvm",
-    "wasmer-runtime-core/generate-debug-information-no-export-symbols"
+    "wasmer-runtime-core/generate-debug-information-no-export-symbols",
+    "wasmer/llvm",
 ]
 backend-singlepass = [
     "wasmer-singlepass-backend",
     "wasmer-runtime/singlepass",
+    "wasmer/singlepass",
 ]
 wasi = ["wasmer-wasi"]
 experimental-io-devices = ["wasmer-wasi-experimental-io-devices"]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 wasmer-runtime-core = { version = "0.16.2", path = "../runtime-core" }
 
 [dependencies.wasmer-singlepass-backend]

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -58,7 +58,7 @@ pub mod memory {
 }
 
 pub mod wasm {
-    //! Various types exposed by the Wasmer Runtime.
+    //! Various types exposed by the Wasmer Runtime relating to Wasm.
     //!
     //! TODO: Add index with links to sub sections
     //!
@@ -66,15 +66,25 @@ pub mod wasm {
     //!
     //! # Tables
     pub use wasmer_runtime_core::global::Global;
+    pub use wasmer_runtime_core::instance::{DynFunc, Instance};
+    pub use wasmer_runtime_core::memory::Memory;
     pub use wasmer_runtime_core::table::Table;
     pub use wasmer_runtime_core::types::{ExportDescriptor, ExternDescriptor, ImportDescriptor};
     pub use wasmer_runtime_core::types::{
         FuncSig, GlobalDescriptor, MemoryDescriptor, TableDescriptor, Type, Value,
     };
+    pub use wasmer_runtime_core::Func;
 }
 
+pub mod vm {
+    //! Various types exposed by the Wasmer Runtime relating to the VM.
+    pub use wasmer_runtime_core::vm::Ctx;
+}
+
+// TODO: `import` or `imports`?
 pub mod import {
     //! Types and functions for Wasm imports.
+    pub use wasmer_runtime_core::import::{ImportObject, LikeNamespace, Namespace};
     pub use wasmer_runtime_core::types::{ExternDescriptor, ImportDescriptor};
     pub use wasmer_runtime_core::{func, imports};
 }
@@ -99,7 +109,11 @@ pub mod types {
 
 pub mod error {
     //! Various error types returned by Wasmer APIs.
-    pub use wasmer_runtime_core::error::{CompileError, CompileResult};
+    pub use wasmer_runtime_core::backend::ExceptionCode;
+    pub use wasmer_runtime_core::error::{
+        CallError, CompileError, CompileResult, CreationError, Error, LinkError, ResolveError,
+        RuntimeError,
+    };
 
     #[derive(Debug)]
     pub enum CompileFromFileError {

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -22,10 +22,14 @@
 //!
 //! more info, what to do if you run into problems
 
+#[macro_use]
+extern crate serde;
+
 pub use crate::module::*;
 pub use wasmer_runtime_core::instance::{DynFunc, Instance};
 pub use wasmer_runtime_core::memory::Memory;
 pub use wasmer_runtime_core::table::Table;
+pub use wasmer_runtime_core::typed_func::DynamicFunc;
 pub use wasmer_runtime_core::Func;
 pub use wasmer_runtime_core::{func, imports};
 
@@ -79,6 +83,187 @@ pub mod wasm {
 pub mod vm {
     //! Various types exposed by the Wasmer Runtime relating to the VM.
     pub use wasmer_runtime_core::vm::Ctx;
+}
+
+pub mod compiler {
+    //! Types and functions for compiling wasm;
+    use crate::module::Module;
+    pub use wasmer_runtime_core::backend::{BackendCompilerConfig, Compiler, CompilerConfig};
+    pub use wasmer_runtime_core::compile_with;
+
+    /// Enum used to select which compiler should be used to generate code.
+    #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+    pub enum Backend {
+        #[cfg(feature = "singlepass")]
+        /// Singlepass backend
+        Singlepass,
+        #[cfg(feature = "cranelift")]
+        /// Cranelift backend
+        Cranelift,
+        #[cfg(feature = "llvm")]
+        /// LLVM backend
+        LLVM,
+        /// Auto backend
+        Auto,
+    }
+
+    impl Backend {
+        /// Get a list of the currently enabled (via feature flag) backends.
+        pub fn variants() -> &'static [&'static str] {
+            &[
+                #[cfg(feature = "singlepass")]
+                "singlepass",
+                #[cfg(feature = "cranelift")]
+                "cranelift",
+                #[cfg(feature = "llvm")]
+                "llvm",
+                "auto",
+            ]
+        }
+
+        /// Stable string representation of the backend.
+        /// It can be used as part of a cache key, for example.
+        pub fn to_string(&self) -> &'static str {
+            match self {
+                #[cfg(feature = "singlepass")]
+                Backend::Singlepass => "singlepass",
+                #[cfg(feature = "cranelift")]
+                Backend::Cranelift => "cranelift",
+                #[cfg(feature = "llvm")]
+                Backend::LLVM => "llvm",
+                Backend::Auto => "auto",
+            }
+        }
+    }
+
+    impl Default for Backend {
+        fn default() -> Self {
+            #[cfg(all(feature = "default-backend-singlepass", not(feature = "docs")))]
+            return Backend::Singlepass;
+
+            #[cfg(any(feature = "default-backend-cranelift", feature = "docs"))]
+            return Backend::Cranelift;
+
+            #[cfg(all(feature = "default-backend-llvm", not(feature = "docs")))]
+            return Backend::LLVM;
+        }
+    }
+
+    impl std::str::FromStr for Backend {
+        type Err = String;
+        fn from_str(s: &str) -> Result<Backend, String> {
+            match s.to_lowercase().as_str() {
+                #[cfg(feature = "singlepass")]
+                "singlepass" => Ok(Backend::Singlepass),
+                #[cfg(feature = "cranelift")]
+                "cranelift" => Ok(Backend::Cranelift),
+                #[cfg(feature = "llvm")]
+                "llvm" => Ok(Backend::LLVM),
+                "auto" => Ok(Backend::Auto),
+                _ => Err(format!("The backend {} doesn't exist", s)),
+            }
+        }
+    }
+
+    /// Compile WebAssembly binary code into a [`Module`].
+    /// This function is useful if it is necessary to
+    /// compile a module before it can be instantiated
+    /// (otherwise, the [`instantiate`] function should be used).
+    ///
+    /// [`Module`]: struct.Module.html
+    /// [`instantiate`]: fn.instantiate.html
+    ///
+    /// # Params:
+    /// * `wasm`: A `&[u8]` containing the
+    ///   binary code of the wasm module you want to compile.
+    /// # Errors:
+    /// If the operation fails, the function returns `Err(error::CompileError::...)`.
+    pub fn compile(wasm: &[u8]) -> crate::error::CompileResult<Module> {
+        wasmer_runtime_core::compile_with(&wasm[..], &default_compiler())
+    }
+
+    /// The same as `compile` but takes a `CompilerConfig` for the purpose of
+    /// changing the compiler's behavior
+    pub fn compile_with_config(
+        wasm: &[u8],
+        compiler_config: CompilerConfig,
+    ) -> crate::error::CompileResult<Module> {
+        wasmer_runtime_core::compile_with_config(&wasm[..], &default_compiler(), compiler_config)
+    }
+
+    /// The same as `compile_with_config` but takes a `Compiler` for the purpose of
+    /// changing the backend.
+    pub fn compile_with_config_with(
+        wasm: &[u8],
+        compiler_config: CompilerConfig,
+        compiler: &dyn Compiler,
+    ) -> crate::error::CompileResult<Module> {
+        wasmer_runtime_core::compile_with_config(&wasm[..], compiler, compiler_config)
+    }
+
+    /// Copied from runtime core; TODO: figure out what we want to do here
+    pub fn default_compiler() -> impl Compiler {
+        #[cfg(any(
+            all(
+                feature = "default-backend-llvm",
+                not(feature = "docs"),
+                any(
+                    feature = "default-backend-cranelift",
+                    feature = "default-backend-singlepass"
+                )
+            ),
+            all(
+                not(feature = "docs"),
+                feature = "default-backend-cranelift",
+                feature = "default-backend-singlepass"
+            )
+        ))]
+        compile_error!(
+            "The `default-backend-X` features are mutually exclusive.  Please choose just one"
+        );
+
+        #[cfg(all(feature = "default-backend-llvm", not(feature = "docs")))]
+        use wasmer_llvm_backend::LLVMCompiler as DefaultCompiler;
+
+        #[cfg(all(feature = "default-backend-singlepass", not(feature = "docs")))]
+        use wasmer_singlepass_backend::SinglePassCompiler as DefaultCompiler;
+
+        #[cfg(any(feature = "default-backend-cranelift", feature = "docs"))]
+        use wasmer_clif_backend::CraneliftCompiler as DefaultCompiler;
+
+        DefaultCompiler::new()
+    }
+
+    /// Get the `Compiler` as a trait object for the given `Backend`.
+    /// Returns `Option` because support for the requested `Compiler` may
+    /// not be enabled by feature flags.
+    ///
+    /// To get a list of the enabled backends as strings, call `Backend::variants()`.
+    pub fn compiler_for_backend(backend: Backend) -> Option<Box<dyn Compiler>> {
+        match backend {
+            #[cfg(feature = "cranelift")]
+            Backend::Cranelift => Some(Box::new(wasmer_clif_backend::CraneliftCompiler::new())),
+
+            #[cfg(any(feature = "singlepass"))]
+            Backend::Singlepass => Some(Box::new(
+                wasmer_singlepass_backend::SinglePassCompiler::new(),
+            )),
+
+            #[cfg(feature = "llvm")]
+            Backend::LLVM => Some(Box::new(wasmer_llvm_backend::LLVMCompiler::new())),
+
+            Backend::Auto => {
+                #[cfg(feature = "default-backend-singlepass")]
+                return Some(Box::new(
+                    wasmer_singlepass_backend::SinglePassCompiler::new(),
+                ));
+                #[cfg(feature = "default-backend-cranelift")]
+                return Some(Box::new(wasmer_clif_backend::CraneliftCompiler::new()));
+                #[cfg(feature = "default-backend-llvm")]
+                return Some(Box::new(wasmer_llvm_backend::LLVMCompiler::new()));
+            }
+        }
+    }
 }
 
 // TODO: `import` or `imports`?
@@ -161,51 +346,16 @@ pub trait CompiledModule {
     fn validate(bytes: impl AsRef<[u8]>) -> error::CompileResult<()>;
 }
 
-use wasmer_runtime_core::backend::Compiler;
-
-/// Copied from runtime core; TODO: figure out what we want to do here
-pub fn default_compiler() -> impl Compiler {
-    #[cfg(any(
-        all(
-            feature = "default-backend-llvm",
-            not(feature = "docs"),
-            any(
-                feature = "default-backend-cranelift",
-                feature = "default-backend-singlepass"
-            )
-        ),
-        all(
-            not(feature = "docs"),
-            feature = "default-backend-cranelift",
-            feature = "default-backend-singlepass"
-        )
-    ))]
-    compile_error!(
-        "The `default-backend-X` features are mutually exclusive.  Please choose just one"
-    );
-
-    #[cfg(all(feature = "default-backend-llvm", not(feature = "docs")))]
-    use wasmer_llvm_backend::LLVMCompiler as DefaultCompiler;
-
-    #[cfg(all(feature = "default-backend-singlepass", not(feature = "docs")))]
-    use wasmer_singlepass_backend::SinglePassCompiler as DefaultCompiler;
-
-    #[cfg(any(feature = "default-backend-cranelift", feature = "docs"))]
-    use wasmer_clif_backend::CraneliftCompiler as DefaultCompiler;
-
-    DefaultCompiler::new()
-}
-
 // this implementation should be moved
 impl CompiledModule for Module {
     fn new(bytes: impl AsRef<[u8]>) -> error::CompileResult<Module> {
         let bytes = bytes.as_ref();
-        wasmer_runtime_core::compile_with(bytes, &default_compiler())
+        wasmer_runtime_core::compile_with(bytes, &compiler::default_compiler())
     }
 
     fn from_binary(bytes: impl AsRef<[u8]>) -> error::CompileResult<Module> {
         let bytes = bytes.as_ref();
-        wasmer_runtime_core::compile_with(bytes, &default_compiler())
+        wasmer_runtime_core::compile_with(bytes, &compiler::default_compiler())
     }
 
     fn from_binary_unchecked(bytes: impl AsRef<[u8]>) -> error::CompileResult<Module> {

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -65,10 +65,12 @@ pub mod wasm {
     //! Various types exposed by the Wasmer Runtime relating to Wasm.
     //!
     //! TODO: Add index with links to sub sections
-    //!
+    //
     //! # Globals
     //!
     //! # Tables
+    pub use wasmer_runtime_core::backend::Features;
+    pub use wasmer_runtime_core::export::Export;
     pub use wasmer_runtime_core::global::Global;
     pub use wasmer_runtime_core::instance::{DynFunc, Instance};
     pub use wasmer_runtime_core::memory::Memory;
@@ -88,8 +90,13 @@ pub mod vm {
 pub mod compiler {
     //! Types and functions for compiling wasm;
     use crate::module::Module;
-    pub use wasmer_runtime_core::backend::{BackendCompilerConfig, Compiler, CompilerConfig};
+    pub use wasmer_runtime_core::backend::{
+        BackendCompilerConfig, Compiler, CompilerConfig, Features,
+    };
     pub use wasmer_runtime_core::compile_with;
+    #[cfg(unix)]
+    pub use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
+    pub use wasmer_runtime_core::state::CodeVersion;
 
     /// Enum used to select which compiler should be used to generate code.
     #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
@@ -264,6 +271,11 @@ pub mod compiler {
             }
         }
     }
+}
+
+pub mod codegen {
+    //! Types and functions for generating native code.
+    pub use wasmer_runtime_core::codegen::ModuleCodeGenerator;
 }
 
 // TODO: `import` or `imports`?

--- a/tests/emscripten.rs
+++ b/tests/emscripten.rs
@@ -2,8 +2,8 @@
 mod tests {
     use std::sync::Arc;
     use wabt::wat2wasm;
+    use wasmer::compiler::compile;
     use wasmer_emscripten::is_emscripten_module;
-    use wasmer_runtime::compile;
 
     #[test]
     fn should_detect_emscripten_files() {

--- a/tests/emtests/_common.rs
+++ b/tests/emtests/_common.rs
@@ -1,5 +1,5 @@
 use std::env;
-use wasmer_runtime::Backend;
+use wasmer::compiler::Backend;
 
 pub fn get_backend() -> Option<Backend> {
     #[cfg(feature = "backend-cranelift")]
@@ -41,9 +41,9 @@ macro_rules! assert_emscripten_output {
 
         let wasm_bytes = include_bytes!($file);
         let backend = $crate::emtests::_common::get_backend().expect("Please set one of `WASMER_TEST_CRANELIFT`, `WASMER_TEST_LLVM`, or `WASMER_TEST_SINGELPASS` to `1`.");
-        let compiler = wasmer_runtime::compiler_for_backend(backend).expect("The desired compiler was not found!");
+        let compiler = wasmer::compiler::compiler_for_backend(backend).expect("The desired compiler was not found!");
 
-        let module = wasmer_runtime::compile_with_config_with(&wasm_bytes[..], Default::default(), &*compiler).expect("WASM can't be compiled");
+        let module = wasmer::compiler::compile_with_config_with(&wasm_bytes[..], Default::default(), &*compiler).expect("WASM can't be compiled");
 
         let mut emscripten_globals = EmscriptenGlobals::new(&module).expect("globals are valid");
         let import_object = generate_emscripten_env(&mut emscripten_globals);
@@ -79,7 +79,7 @@ macro_rules! assert_emscripten_output {
 //     use wasmer_clif_backend::CraneliftCompiler;
 //     use wasmer_emscripten::{generate_emscripten_env, stdio::StdioCapturer, EmscriptenGlobals};
 
-//     let module = wasmer_runtime_core::compile_with(&wasm_bytes[..], &CraneliftCompiler::new())
+//     let module = wasmer::compiler::compile_with(&wasm_bytes[..], &CraneliftCompiler::new())
 //         .expect("WASM can't be compiled");
 
 //     let mut emscripten_globals = EmscriptenGlobals::new(&module);

--- a/tests/exception_handling.rs
+++ b/tests/exception_handling.rs
@@ -2,8 +2,8 @@ mod runtime_core_tests;
 
 pub mod runtime_core_exception_handling {
     use super::runtime_core_tests::{get_compiler, wat2wasm};
+    use wasmer::compiler::compile_with;
     use wasmer::imports;
-    use wasmer_runtime_core::compile_with;
 
     #[test]
     fn exception_handling_works() {

--- a/tests/exception_handling.rs
+++ b/tests/exception_handling.rs
@@ -2,7 +2,8 @@ mod runtime_core_tests;
 
 pub mod runtime_core_exception_handling {
     use super::runtime_core_tests::{get_compiler, wat2wasm};
-    use wasmer_runtime_core::{compile_with, imports};
+    use wasmer::imports;
+    use wasmer_runtime_core::compile_with;
 
     #[test]
     fn exception_handling_works() {

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -5,17 +5,14 @@ pub mod runtime_core_imports {
 
     use super::runtime_core_tests::{get_compiler, wat2wasm};
     use std::{convert::TryInto, sync::Arc};
-    use wasmer_runtime_core::{
-        compile_with,
-        error::RuntimeError,
-        global::Global,
-        imports,
-        memory::Memory,
-        typed_func::{DynamicFunc, Func},
-        types::{FuncSig, MemoryDescriptor, Type, Value},
-        units::Pages,
-        vm, DynFunc, Instance,
+    use wasmer::error::RuntimeError;
+    use wasmer::imports;
+    use wasmer::units::Pages;
+    use wasmer::vm;
+    use wasmer::wasm::{
+        DynFunc, Func, FuncSig, Global, Instance, Memory, MemoryDescriptor, Type, Value,
     };
+    use wasmer_runtime_core::{compile_with, typed_func::DynamicFunc};
 
     #[test]
     fn runtime_core_new_api_works() {

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -5,14 +5,13 @@ pub mod runtime_core_imports {
 
     use super::runtime_core_tests::{get_compiler, wat2wasm};
     use std::{convert::TryInto, sync::Arc};
+    use wasmer::compiler::compile_with;
     use wasmer::error::RuntimeError;
-    use wasmer::imports;
     use wasmer::units::Pages;
-    use wasmer::vm;
     use wasmer::wasm::{
         DynFunc, Func, FuncSig, Global, Instance, Memory, MemoryDescriptor, Type, Value,
     };
-    use wasmer_runtime_core::{compile_with, typed_func::DynamicFunc};
+    use wasmer::{imports, vm, DynamicFunc};
 
     #[test]
     fn runtime_core_new_api_works() {

--- a/tests/llvm_compile.rs
+++ b/tests/llvm_compile.rs
@@ -10,17 +10,17 @@
 )]
 
 use wabt::wat2wasm;
+use wasmer::compiler::Compiler;
 use wasmer_llvm_backend::LLVMCompiler;
-use wasmer_runtime_core::backend::Compiler;
 
 pub fn get_compiler() -> impl Compiler {
     LLVMCompiler::new()
 }
 
+use wasmer::compiler::CompilerConfig;
+use wasmer::compiler::{compile_with, compile_with_config_with, BackendCompilerConfig};
 use wasmer::imports;
 use wasmer_llvm_backend::{InkwellModule, LLVMBackendConfig, LLVMCallbacks};
-use wasmer_runtime::CompilerConfig;
-use wasmer_runtime_core::{backend::BackendCompilerConfig, compile_with, compile_with_config};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -74,7 +74,7 @@ fn crash_select_with_mismatched_pending() {
         ..Default::default()
     };
     let wasm_binary = wat2wasm(WAT.as_bytes()).expect("WAST not valid or malformed");
-    let module = compile_with_config(&wasm_binary, &get_compiler(), compiler_config).unwrap();
+    let module = compile_with_config_with(&wasm_binary, compiler_config, &get_compiler()).unwrap();
     module.instantiate(&imports! {}).unwrap();
     const LLVM: &str = r#"
   %s3 = fadd double 0.000000e+00, %s2

--- a/tests/llvm_compile.rs
+++ b/tests/llvm_compile.rs
@@ -17,8 +17,9 @@ pub fn get_compiler() -> impl Compiler {
     LLVMCompiler::new()
 }
 
+use wasmer::imports;
 use wasmer_llvm_backend::{InkwellModule, LLVMBackendConfig, LLVMCallbacks};
-use wasmer_runtime::{imports, CompilerConfig};
+use wasmer_runtime::CompilerConfig;
 use wasmer_runtime_core::{backend::BackendCompilerConfig, compile_with, compile_with_config};
 
 use std::cell::RefCell;

--- a/tests/middleware_common.rs
+++ b/tests/middleware_common.rs
@@ -2,12 +2,14 @@
 mod tests {
     use wabt::wat2wasm;
 
+    use wasmer::imports;
+    use wasmer::wasm::Func;
     use wasmer_middleware_common::metering::*;
     use wasmer_runtime_core::codegen::ModuleCodeGenerator;
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
     use wasmer_runtime_core::state::CodeVersion;
-    use wasmer_runtime_core::{backend::Compiler, compile_with, imports, Func};
+    use wasmer_runtime_core::{backend::Compiler, compile_with};
 
     #[cfg(feature = "backend-llvm")]
     use wasmer_llvm_backend::ModuleCodeGenerator as MCG;

--- a/tests/middleware_common.rs
+++ b/tests/middleware_common.rs
@@ -2,6 +2,7 @@
 mod tests {
     use wabt::wat2wasm;
 
+    use wasmer::compiler::{compile_with, Compiler};
     use wasmer::imports;
     use wasmer::wasm::Func;
     use wasmer_middleware_common::metering::*;
@@ -9,7 +10,6 @@ mod tests {
     use wasmer_runtime_core::codegen::{MiddlewareChain, StreamingCompiler};
     use wasmer_runtime_core::fault::{pop_code_version, push_code_version};
     use wasmer_runtime_core::state::CodeVersion;
-    use wasmer_runtime_core::{backend::Compiler, compile_with};
 
     #[cfg(feature = "backend-llvm")]
     use wasmer_llvm_backend::ModuleCodeGenerator as MCG;

--- a/tests/override.rs
+++ b/tests/override.rs
@@ -1,10 +1,10 @@
 use wabt::wat2wasm;
+use wasmer::compiler::compile;
 use wasmer::{
     import::ImportObject,
     wasm::{Instance, Value},
     DynFunc,
 };
-use wasmer_runtime::compile;
 
 #[test]
 fn override_works() {

--- a/tests/override.rs
+++ b/tests/override.rs
@@ -1,5 +1,10 @@
 use wabt::wat2wasm;
-use wasmer_runtime::{compile, DynFunc, ImportObject, Instance, Value};
+use wasmer::{
+    import::ImportObject,
+    wasm::{Instance, Value},
+    DynFunc,
+};
+use wasmer_runtime::compile;
 
 #[test]
 fn override_works() {

--- a/tests/runtime_core_tests/mod.rs
+++ b/tests/runtime_core_tests/mod.rs
@@ -1,5 +1,5 @@
 pub use wabt::wat2wasm;
-use wasmer_runtime_core::backend::Compiler;
+use wasmer::compiler::Compiler;
 
 #[cfg(feature = "backend-cranelift")]
 pub fn get_compiler() -> impl Compiler {

--- a/tests/spectest.rs
+++ b/tests/spectest.rs
@@ -272,6 +272,7 @@ mod tests {
     use std::str::FromStr;
     use wabt::script::{Action, Command, CommandKind, ScriptParser, Value};
     use wasmer::{
+        compiler::{compile_with_config_with, compiler_for_backend, Backend, CompilerConfig},
         error::CompileError,
         func,
         import::{ImportObject, LikeNamespace},
@@ -281,9 +282,7 @@ mod tests {
         vm::Ctx,
         wasm::{self, Global, Instance, Memory, MemoryDescriptor, Table, TableDescriptor},
     };
-    use wasmer_runtime::{
-        compile_with_config_with, compiler_for_backend, Backend, CompilerConfig, Export, Features,
-    };
+    use wasmer_runtime::{Export, Features};
 
     fn format_panic(e: &dyn std::any::Any) -> String {
         if let Some(s) = e.downcast_ref::<&str>() {

--- a/tests/spectest.rs
+++ b/tests/spectest.rs
@@ -271,14 +271,18 @@ mod tests {
     use std::path::PathBuf;
     use std::str::FromStr;
     use wabt::script::{Action, Command, CommandKind, ScriptParser, Value};
-    use wasmer_runtime::{
-        compile_with_config_with, compiler_for_backend,
+    use wasmer::{
         error::CompileError,
-        func, imports,
-        types::{ElementType, MemoryDescriptor, TableDescriptor},
+        func,
+        import::{ImportObject, LikeNamespace},
+        imports,
+        types::ElementType,
         units::Pages,
-        Backend, CompilerConfig, Ctx, Export, Features, Global, ImportObject, Instance,
-        LikeNamespace, Memory, Table,
+        vm::Ctx,
+        wasm::{self, Global, Instance, Memory, MemoryDescriptor, Table, TableDescriptor},
+    };
+    use wasmer_runtime::{
+        compile_with_config_with, compiler_for_backend, Backend, CompilerConfig, Export, Features,
     };
 
     fn format_panic(e: &dyn std::any::Any) -> String {
@@ -416,7 +420,7 @@ mod tests {
                                 &named_modules,
                                 &module,
                                 |instance| {
-                                    let params: Vec<wasmer_runtime::types::Value> =
+                                    let params: Vec<wasm::Value> =
                                         args.iter().cloned().map(convert_value).collect();
                                     instance.call(&field, &params[..])
                                 },
@@ -548,7 +552,7 @@ mod tests {
                     } => {
                         let maybe_call_result =
                             with_instance(instance.clone(), &named_modules, &module, |instance| {
-                                let params: Vec<wasmer_runtime::types::Value> =
+                                let params: Vec<wasm::Value> =
                                     args.iter().cloned().map(convert_value).collect();
                                 instance.call(&field, &params[..])
                             });
@@ -619,7 +623,7 @@ mod tests {
                     } => {
                         let maybe_call_result =
                             with_instance(instance.clone(), &named_modules, &module, |instance| {
-                                let params: Vec<wasmer_runtime::types::Value> =
+                                let params: Vec<wasm::Value> =
                                     args.iter().cloned().map(convert_value).collect();
                                 instance.call(&field, &params[..])
                             });
@@ -721,7 +725,7 @@ mod tests {
                                 } else {
                                     false
                                 };
-                                let params: Vec<wasmer_runtime::types::Value> =
+                                let params: Vec<wasm::Value> =
                                     args.iter().cloned().map(convert_value).collect();
                                 let ret = instance.call(&field, &params[..]);
                                 #[cfg(unix)]
@@ -746,7 +750,7 @@ mod tests {
                             );
                         } else {
                             let call_result = maybe_call_result.unwrap();
-                            use wasmer_runtime::error::{CallError, RuntimeError};
+                            use wasmer::error::{CallError, RuntimeError};
                             match call_result {
                                 Err(e) => match e {
                                     CallError::Resolve(_) => {
@@ -763,7 +767,7 @@ mod tests {
                                         );
                                     }
                                     CallError::Runtime(RuntimeError(e)) => {
-                                        use wasmer_runtime::ExceptionCode;
+                                        use wasmer::error::ExceptionCode;
                                         if let Some(_) = e.downcast_ref::<ExceptionCode>() {
                                             test_report.count_passed();
                                         } else {
@@ -964,7 +968,7 @@ mod tests {
                                 &named_modules,
                                 &module,
                                 |instance| {
-                                    let params: Vec<wasmer_runtime::types::Value> =
+                                    let params: Vec<wasm::Value> =
                                         args.iter().cloned().map(convert_value).collect();
                                     instance.call(&field, &params[..])
                                 },
@@ -1061,7 +1065,7 @@ mod tests {
                                 );
                             }
                             Err(e) => match e {
-                                wasmer_runtime::error::Error::LinkError(_) => {
+                                wasmer::error::Error::LinkError(_) => {
                                     test_report.count_passed();
                                 }
                                 _ => {
@@ -1120,7 +1124,7 @@ mod tests {
                     } => {
                         let maybe_call_result =
                             with_instance(instance.clone(), &named_modules, &module, |instance| {
-                                let params: Vec<wasmer_runtime::types::Value> =
+                                let params: Vec<wasm::Value> =
                                     args.iter().cloned().map(convert_value).collect();
                                 instance.call(&field, &params[..])
                             });
@@ -1183,29 +1187,29 @@ mod tests {
         Ok(test_report)
     }
 
-    fn is_canonical_nan(val: wasmer_runtime::types::Value) -> bool {
+    fn is_canonical_nan(val: wasm::Value) -> bool {
         match val {
-            wasmer_runtime::types::Value::F32(x) => x.is_canonical_nan(),
-            wasmer_runtime::types::Value::F64(x) => x.is_canonical_nan(),
+            wasm::Value::F32(x) => x.is_canonical_nan(),
+            wasm::Value::F64(x) => x.is_canonical_nan(),
             _ => panic!("value is not a float {:?}", val),
         }
     }
 
-    fn is_arithmetic_nan(val: wasmer_runtime::types::Value) -> bool {
+    fn is_arithmetic_nan(val: wasm::Value) -> bool {
         match val {
-            wasmer_runtime::types::Value::F32(x) => x.is_quiet_nan(),
-            wasmer_runtime::types::Value::F64(x) => x.is_quiet_nan(),
+            wasm::Value::F32(x) => x.is_quiet_nan(),
+            wasm::Value::F64(x) => x.is_quiet_nan(),
             _ => panic!("value is not a float {:?}", val),
         }
     }
 
-    fn value_to_hex(val: wasmer_runtime::types::Value) -> String {
+    fn value_to_hex(val: wasm::Value) -> String {
         match val {
-            wasmer_runtime::types::Value::I32(x) => format!("{:#x}", x),
-            wasmer_runtime::types::Value::I64(x) => format!("{:#x}", x),
-            wasmer_runtime::types::Value::F32(x) => format!("{:#x}", x.to_bits()),
-            wasmer_runtime::types::Value::F64(x) => format!("{:#x}", x.to_bits()),
-            wasmer_runtime::types::Value::V128(x) => format!("{:#x}", x),
+            wasm::Value::I32(x) => format!("{:#x}", x),
+            wasm::Value::I64(x) => format!("{:#x}", x),
+            wasm::Value::F32(x) => format!("{:#x}", x.to_bits()),
+            wasm::Value::F64(x) => format!("{:#x}", x.to_bits()),
+            wasm::Value::V128(x) => format!("{:#x}", x),
         }
     }
 
@@ -1218,13 +1222,13 @@ mod tests {
         V128(u128),
     }
 
-    fn convert_wasmer_value(other: wasmer_runtime::types::Value) -> SpectestValue {
+    fn convert_wasmer_value(other: wasm::Value) -> SpectestValue {
         match other {
-            wasmer_runtime::types::Value::I32(v) => SpectestValue::I32(v),
-            wasmer_runtime::types::Value::I64(v) => SpectestValue::I64(v),
-            wasmer_runtime::types::Value::F32(v) => SpectestValue::F32(v.to_bits()),
-            wasmer_runtime::types::Value::F64(v) => SpectestValue::F64(v.to_bits()),
-            wasmer_runtime::types::Value::V128(v) => SpectestValue::V128(v),
+            wasm::Value::I32(v) => SpectestValue::I32(v),
+            wasm::Value::I64(v) => SpectestValue::I64(v),
+            wasm::Value::F32(v) => SpectestValue::F32(v.to_bits()),
+            wasm::Value::F64(v) => SpectestValue::F64(v.to_bits()),
+            wasm::Value::V128(v) => SpectestValue::V128(v),
         }
     }
 
@@ -1238,13 +1242,13 @@ mod tests {
         }
     }
 
-    fn convert_value(other: Value<f32, f64>) -> wasmer_runtime::types::Value {
+    fn convert_value(other: Value<f32, f64>) -> wasm::Value {
         match other {
-            Value::I32(v) => wasmer_runtime::types::Value::I32(v),
-            Value::I64(v) => wasmer_runtime::types::Value::I64(v),
-            Value::F32(v) => wasmer_runtime::types::Value::F32(v),
-            Value::F64(v) => wasmer_runtime::types::Value::F64(v),
-            Value::V128(v) => wasmer_runtime::types::Value::V128(v),
+            Value::I32(v) => wasm::Value::I32(v),
+            Value::I64(v) => wasm::Value::I64(v),
+            Value::F32(v) => wasm::Value::F32(v),
+            Value::F64(v) => wasm::Value::F64(v),
+            Value::V128(v) => wasm::Value::V128(v),
         }
     }
 
@@ -1288,9 +1292,9 @@ mod tests {
         let memory_desc = MemoryDescriptor::new(Pages(1), Some(Pages(2)), false).unwrap();
         let memory = Memory::new(memory_desc).unwrap();
 
-        let global_i32 = Global::new(wasmer_runtime::types::Value::I32(666));
-        let global_f32 = Global::new(wasmer_runtime::types::Value::F32(666.0));
-        let global_f64 = Global::new(wasmer_runtime::types::Value::F64(666.0));
+        let global_i32 = Global::new(wasm::Value::I32(666));
+        let global_f32 = Global::new(wasm::Value::F32(666.0));
+        let global_f64 = Global::new(wasm::Value::F64(666.0));
 
         let table = Table::new(TableDescriptor {
             element: ElementType::Anyfunc,

--- a/tests/spectest.rs
+++ b/tests/spectest.rs
@@ -271,6 +271,7 @@ mod tests {
     use std::path::PathBuf;
     use std::str::FromStr;
     use wabt::script::{Action, Command, CommandKind, ScriptParser, Value};
+    use wasmer::wasm::Export;
     use wasmer::{
         compiler::{compile_with_config_with, compiler_for_backend, Backend, CompilerConfig},
         error::CompileError,
@@ -280,9 +281,10 @@ mod tests {
         types::ElementType,
         units::Pages,
         vm::Ctx,
-        wasm::{self, Global, Instance, Memory, MemoryDescriptor, Table, TableDescriptor},
+        wasm::{
+            self, Features, Global, Instance, Memory, MemoryDescriptor, Table, TableDescriptor,
+        },
     };
-    use wasmer_runtime::{Export, Features};
 
     fn format_panic(e: &dyn std::any::Any) -> String {
         if let Some(s) = e.downcast_ref::<&str>() {
@@ -694,7 +696,7 @@ mod tests {
                         let maybe_call_result =
                             with_instance(instance.clone(), &named_modules, &module, |instance| {
                                 #[cfg(unix)]
-                                use wasmer_runtime::{
+                                use wasmer::compiler::{
                                     pop_code_version, push_code_version, CodeVersion,
                                 };
 

--- a/tests/spectest_semantics.rs
+++ b/tests/spectest_semantics.rs
@@ -19,7 +19,7 @@ mod tests {
       (elem (;0;) (i32.const 0) 0))
     "#;
         let wasm_binary = wat2wasm(module_str.as_bytes()).expect("WAST not valid or malformed");
-        let module = wasmer_runtime::compile(&wasm_binary[..]).expect("WASM can't be compiled");
+        let module = wasmer::compiler::compile(&wasm_binary[..]).expect("WASM can't be compiled");
         let instance = module
             .instantiate(&ImportObject::new())
             .expect("WASM can't be instantiated");

--- a/tests/spectest_semantics.rs
+++ b/tests/spectest_semantics.rs
@@ -1,10 +1,8 @@
 #[cfg(test)]
 mod tests {
     use wabt::wat2wasm;
-    use wasmer_runtime::{
-        error::{CallError, RuntimeError},
-        ExceptionCode, ImportObject,
-    };
+    use wasmer::error::{CallError, ExceptionCode, RuntimeError};
+    use wasmer::import::ImportObject;
 
     // The semantics of stack overflow are documented at:
     // https://webassembly.org/docs/semantics/#stack-overflow

--- a/tests/wasi_serialization.rs
+++ b/tests/wasi_serialization.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
-use wasmer::{vm::Ctx, Func};
-use wasmer_runtime::compile;
+use wasmer::{compiler::compile, vm::Ctx, Func};
 use wasmer_wasi::{state::*, *};
 
 use std::ffi::c_void;

--- a/tests/wasi_serialization.rs
+++ b/tests/wasi_serialization.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
-use wasmer_runtime::{compile, Ctx, Func};
+use wasmer::{vm::Ctx, Func};
+use wasmer_runtime::compile;
 use wasmer_wasi::{state::*, *};
 
 use std::ffi::c_void;

--- a/tests/wasitests/_common.rs
+++ b/tests/wasitests/_common.rs
@@ -33,7 +33,7 @@ pub fn get_backend() -> Option<Backend> {
 macro_rules! assert_wasi_output {
     ($file:expr, $name:expr, $po_dir_args: expr, $mapdir_args:expr, $envvar_args:expr, $expected:expr) => {{
         use crate::dev_utils::stdio::StdioCapturer;
-        use wasmer_runtime::Func;
+        use wasmer::Func;
         use wasmer_wasi::{generate_import_object_for_version, get_wasi_version};
 
         let wasm_bytes = include_bytes!($file);

--- a/tests/wasitests/_common.rs
+++ b/tests/wasitests/_common.rs
@@ -1,5 +1,5 @@
 use std::env;
-use wasmer_runtime::Backend;
+use wasmer::compiler::Backend;
 
 pub fn get_backend() -> Option<Backend> {
     #[cfg(feature = "backend-cranelift")]
@@ -38,9 +38,9 @@ macro_rules! assert_wasi_output {
 
         let wasm_bytes = include_bytes!($file);
         let backend = $crate::wasitests::_common::get_backend().expect("Please set one of `WASMER_TEST_CRANELIFT`, `WASMER_TEST_LLVM`, or `WASMER_TEST_SINGELPASS` to `1`.");
-        let compiler = wasmer_runtime::compiler_for_backend(backend).expect("The desired compiler was not found!");
+        let compiler = wasmer::compiler::compiler_for_backend(backend).expect("The desired compiler was not found!");
 
-        let module = wasmer_runtime::compile_with_config_with(&wasm_bytes[..], Default::default(), &*compiler).expect("WASM can't be compiled");
+        let module = wasmer::compiler::compile_with_config_with(&wasm_bytes[..], Default::default(), &*compiler).expect("WASM can't be compiled");
 
         let wasi_version = get_wasi_version(&module, true).expect("WASI module");
 


### PR DESCRIPTION
The primary thing that wasn't updated yet is the compile and compile_with... functions.
