### PR TITLE
Fix underflow in subtraction on global.get with float-type global.

### DIFF
--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -2978,8 +2978,7 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                         );
                         let ty = type_to_wp_type(module_info.globals[local_index].desc.ty);
                         if ty.is_float() {
-                            self.fp_stack
-                                .push(FloatValue::new(self.value_stack.len() - 1));
+                            self.fp_stack.push(FloatValue::new(self.value_stack.len()));
                         }
                         self.machine.acquire_locations(
                             a,
@@ -3003,8 +3002,7 @@ impl FunctionCodeGenerator<CodegenError> for X64FunctionCode {
                         );
                         let ty = type_to_wp_type(module_info.imported_globals[import_index].1.ty);
                         if ty.is_float() {
-                            self.fp_stack
-                                .push(FloatValue::new(self.value_stack.len() - 1));
+                            self.fp_stack.push(FloatValue::new(self.value_stack.len()));
                         }
                         self.machine.acquire_locations(
                             a,


### PR DESCRIPTION
# Description
Fix spectests-singlepass failures that appear when in debug builds (checked subtraction). The global.get opcode pushes to the fp_stack first and the value_stack second, so it shouldn't be subtracting 1 from the size of the value_stack.
