### PR TITLE
Correct the backend name in README

### DIFF
--- a/lib/singlepass-backend/README.md
+++ b/lib/singlepass-backend/README.md
@@ -44,7 +44,7 @@ wasmer run program.wasm --backend=singlepass
 ### Usage in Wasmer Embedded
 
 If you are using Wasmer Embedded, you can specify
-the LLVM backend to the [`compile_with` function](https://docs.rs/wasmer-runtime-core/*/wasmer_runtime_core/fn.compile_with.html):
+the singlepass backend to the [`compile_with` function](https://docs.rs/wasmer-runtime-core/*/wasmer_runtime_core/fn.compile_with.html):
 
 ```rust
 use wasmer_singlepass_backend::SinglepassCompiler;


### PR DESCRIPTION
The README mistakenly said LLVM when it was referring to the singlepass backend. It's just a simple doc fix.