### PR TITLE
Rename `*Descriptor` -> `*Type` to match Wasm spec

### DIFF
--- a/examples/simple/main.rs
+++ b/examples/simple/main.rs
@@ -1,7 +1,7 @@
 use wabt::wat2wasm;
 use wasmer_runtime::{
     compile, error, func, imports,
-    types::{ElementType, MemoryDescriptor, TableDescriptor, Value},
+    types::{ElementType, MemoryType, TableType, Value},
     units::Pages,
     Ctx, Global, Memory, Table,
 };
@@ -13,12 +13,12 @@ fn main() -> error::Result<()> {
 
     let inner_module = compile(&wasm_binary)?;
 
-    let memory_desc = MemoryDescriptor::new(Pages(1), Some(Pages(1)), false).unwrap();
+    let memory_desc = MemoryType::new(Pages(1), Some(Pages(1)), false).unwrap();
     let memory = Memory::new(memory_desc).unwrap();
 
     let global = Global::new(Value::I32(42));
 
-    let table = Table::new(TableDescriptor {
+    let table = Table::new(TableType {
         element: ElementType::Anyfunc,
         minimum: 10,
         maximum: None,

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -52,7 +52,7 @@ pub mod module {
     // TODO: verify that this is the type we want to export, with extra methods on it
     pub use wasmer_runtime_core::module::Module;
     // should this be in here?
-    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternDescriptor, ImportDescriptor};
+    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternType, ImportDescriptor};
     // TODO: implement abstract module API
 }
 
@@ -76,9 +76,9 @@ pub mod wasm {
     pub use wasmer_runtime_core::memory::Memory;
     pub use wasmer_runtime_core::module::Module;
     pub use wasmer_runtime_core::table::Table;
-    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternDescriptor, ImportDescriptor};
+    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternType, ImportDescriptor};
     pub use wasmer_runtime_core::types::{
-        FuncSig, GlobalDescriptor, MemoryDescriptor, TableDescriptor, Type, Value,
+        FuncSig, GlobalType, MemoryType, TableType, Type, Value,
     };
     pub use wasmer_runtime_core::Func;
 }
@@ -285,14 +285,14 @@ pub mod import {
     pub use wasmer_runtime_core::import::{
         ImportObject, ImportObjectIterator, LikeNamespace, Namespace,
     };
-    pub use wasmer_runtime_core::types::{ExternDescriptor, ImportDescriptor};
+    pub use wasmer_runtime_core::types::{ExternType, ImportDescriptor};
     pub use wasmer_runtime_core::{func, imports};
 }
 
 pub mod export {
     //! Types and functions for Wasm exports.
     pub use wasmer_runtime_core::export::Export;
-    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternDescriptor};
+    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternType};
 }
 
 pub mod units {
@@ -303,8 +303,8 @@ pub mod units {
 pub mod types {
     //! Types used in the Wasm runtime and conversion functions.
     pub use wasmer_runtime_core::types::{
-        ElementType, FuncDescriptor, FuncSig, GlobalDescriptor, GlobalInit, MemoryDescriptor,
-        TableDescriptor, Type, Value, ValueType,
+        ElementType, FuncType, FuncSig, GlobalType, GlobalInit, MemoryType,
+        TableType, Type, Value, ValueType,
     };
 }
 

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -46,13 +46,13 @@ pub mod module {
     //! ```
     //! # use wasmer::*;
     //! # fn get_exports(module: &Module) {
-    //! let exports: Vec<ExportDescriptor> = module.exports().collect();
+    //! let exports: Vec<ExportType> = module.exports().collect();
     //! # }
     //! ```
     // TODO: verify that this is the type we want to export, with extra methods on it
     pub use wasmer_runtime_core::module::Module;
     // should this be in here?
-    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternType, ImportDescriptor};
+    pub use wasmer_runtime_core::types::{ExportType, ExternType, ImportType};
     // TODO: implement abstract module API
 }
 
@@ -76,10 +76,8 @@ pub mod wasm {
     pub use wasmer_runtime_core::memory::Memory;
     pub use wasmer_runtime_core::module::Module;
     pub use wasmer_runtime_core::table::Table;
-    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternType, ImportDescriptor};
-    pub use wasmer_runtime_core::types::{
-        FuncSig, GlobalType, MemoryType, TableType, Type, Value,
-    };
+    pub use wasmer_runtime_core::types::{ExportType, ExternType, ImportType};
+    pub use wasmer_runtime_core::types::{FuncSig, GlobalType, MemoryType, TableType, Type, Value};
     pub use wasmer_runtime_core::Func;
 }
 
@@ -285,14 +283,14 @@ pub mod import {
     pub use wasmer_runtime_core::import::{
         ImportObject, ImportObjectIterator, LikeNamespace, Namespace,
     };
-    pub use wasmer_runtime_core::types::{ExternType, ImportDescriptor};
+    pub use wasmer_runtime_core::types::{ExternType, ImportType};
     pub use wasmer_runtime_core::{func, imports};
 }
 
 pub mod export {
     //! Types and functions for Wasm exports.
     pub use wasmer_runtime_core::export::Export;
-    pub use wasmer_runtime_core::types::{ExportDescriptor, ExternType};
+    pub use wasmer_runtime_core::types::{ExportType, ExternType};
 }
 
 pub mod units {
@@ -303,8 +301,8 @@ pub mod units {
 pub mod types {
     //! Types used in the Wasm runtime and conversion functions.
     pub use wasmer_runtime_core::types::{
-        ElementType, FuncType, FuncSig, GlobalType, GlobalInit, MemoryType,
-        TableType, Type, Value, ValueType,
+        ElementType, FuncSig, FuncType, GlobalInit, GlobalType, MemoryType, TableType, Type, Value,
+        ValueType,
     };
 }
 

--- a/lib/clif-backend/src/code.rs
+++ b/lib/clif-backend/src/code.rs
@@ -22,7 +22,7 @@ use wasmer_runtime_core::{
     backend::{CacheGen, CompilerConfig, Token},
     cache::{Artifact, Error as CacheError},
     codegen::*,
-    memory::MemoryType,
+    memory::BackingMemoryType,
     module::{ModuleInfo, ModuleInner},
     structures::{Map, TypedIndex},
     types::{
@@ -465,7 +465,7 @@ impl FuncEnvironment for FunctionEnvironment {
         };
 
         match description.memory_type() {
-            mem_type @ MemoryType::Dynamic => {
+            mem_type @ BackingMemoryType::Dynamic => {
                 let local_memory_bound = func.create_global_value(ir::GlobalValueData::Load {
                     base: local_memory_ptr,
                     offset: (vm::LocalMemory::offset_bound() as i32).into(),
@@ -483,7 +483,7 @@ impl FuncEnvironment for FunctionEnvironment {
                     index_type: ir::types::I32,
                 }))
             }
-            mem_type @ MemoryType::Static | mem_type @ MemoryType::SharedStatic => Ok(func
+            mem_type @ BackingMemoryType::Static | mem_type @ BackingMemoryType::SharedStatic => Ok(func
                 .create_heap(ir::HeapData {
                     base: local_memory_base,
                     min_size: (description.minimum.bytes().0 as u64).into(),
@@ -879,9 +879,9 @@ impl FuncEnvironment for FunctionEnvironment {
             };
 
         let name_index = match description.memory_type() {
-            MemoryType::Dynamic => call_names::DYNAMIC_MEM_GROW,
-            MemoryType::Static => call_names::STATIC_MEM_GROW,
-            MemoryType::SharedStatic => call_names::SHARED_STATIC_MEM_GROW,
+            BackingMemoryType::Dynamic => call_names::DYNAMIC_MEM_GROW,
+            BackingMemoryType::Static => call_names::STATIC_MEM_GROW,
+            BackingMemoryType::SharedStatic => call_names::SHARED_STATIC_MEM_GROW,
         };
 
         let name = ir::ExternalName::user(namespace, name_index);
@@ -943,9 +943,9 @@ impl FuncEnvironment for FunctionEnvironment {
             };
 
         let name_index = match description.memory_type() {
-            MemoryType::Dynamic => call_names::DYNAMIC_MEM_SIZE,
-            MemoryType::Static => call_names::STATIC_MEM_SIZE,
-            MemoryType::SharedStatic => call_names::SHARED_STATIC_MEM_SIZE,
+            BackingMemoryType::Dynamic => call_names::DYNAMIC_MEM_SIZE,
+            BackingMemoryType::Static => call_names::STATIC_MEM_SIZE,
+            BackingMemoryType::SharedStatic => call_names::SHARED_STATIC_MEM_SIZE,
         };
 
         let name = ir::ExternalName::user(namespace, name_index);

--- a/lib/clif-backend/src/code.rs
+++ b/lib/clif-backend/src/code.rs
@@ -483,8 +483,8 @@ impl FuncEnvironment for FunctionEnvironment {
                     index_type: ir::types::I32,
                 }))
             }
-            mem_type @ BackingMemoryType::Static | mem_type @ BackingMemoryType::SharedStatic => Ok(func
-                .create_heap(ir::HeapData {
+            mem_type @ BackingMemoryType::Static | mem_type @ BackingMemoryType::SharedStatic => {
+                Ok(func.create_heap(ir::HeapData {
                     base: local_memory_base,
                     min_size: (description.minimum.bytes().0 as u64).into(),
                     offset_guard_size: mem_type.guard_size().into(),
@@ -492,7 +492,8 @@ impl FuncEnvironment for FunctionEnvironment {
                         bound: mem_type.bounds().unwrap().into(),
                     },
                     index_type: ir::types::I32,
-                })),
+                }))
+            }
         }
     }
 

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -30,7 +30,7 @@ use wasmer_runtime_core::{
     memory::Memory,
     module::ImportName,
     table::Table,
-    types::{ElementType, FuncSig, MemoryDescriptor, TableDescriptor, Type, Value},
+    types::{ElementType, FuncSig, MemoryType, TableType, Type, Value},
     units::Pages,
     vm::Ctx,
     DynFunc, Func, Instance, IsExport, Module,
@@ -514,10 +514,10 @@ impl EmscriptenGlobals {
         let (memory_min, memory_max, shared) = get_emscripten_memory_size(&module)?;
 
         // Memory initialization
-        let memory_type = MemoryDescriptor::new(memory_min, memory_max, shared)?;
+        let memory_type = MemoryType::new(memory_min, memory_max, shared)?;
         let memory = Memory::new(memory_type).unwrap();
 
-        let table_type = TableDescriptor {
+        let table_type = TableType {
             element: ElementType::Anyfunc,
             minimum: table_min,
             maximum: table_max,

--- a/lib/llvm-backend/src/code.rs
+++ b/lib/llvm-backend/src/code.rs
@@ -35,7 +35,7 @@ use wasmer_runtime_core::{
     backend::{CacheGen, CompilerConfig, Token},
     cache::{Artifact, Error as CacheError},
     codegen::*,
-    memory::MemoryType,
+    memory::BackingMemoryType,
     module::{ModuleInfo, ModuleInner},
     parse::{wp_type_to_type, LoadError},
     structures::{Map, TypedIndex},
@@ -8497,17 +8497,17 @@ impl<'ctx> FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator<'ct
                     LocalOrImport::Local(local_mem_index) => {
                         let mem_desc = &info.memories[local_mem_index];
                         match mem_desc.memory_type() {
-                            MemoryType::Dynamic => intrinsics.memory_grow_dynamic_local,
-                            MemoryType::Static => intrinsics.memory_grow_static_local,
-                            MemoryType::SharedStatic => intrinsics.memory_grow_shared_local,
+                            BackingMemoryType::Dynamic => intrinsics.memory_grow_dynamic_local,
+                            BackingMemoryType::Static => intrinsics.memory_grow_static_local,
+                            BackingMemoryType::SharedStatic => intrinsics.memory_grow_shared_local,
                         }
                     }
                     LocalOrImport::Import(import_mem_index) => {
                         let mem_desc = &info.imported_memories[import_mem_index].1;
                         match mem_desc.memory_type() {
-                            MemoryType::Dynamic => intrinsics.memory_grow_dynamic_import,
-                            MemoryType::Static => intrinsics.memory_grow_static_import,
-                            MemoryType::SharedStatic => intrinsics.memory_grow_shared_import,
+                            BackingMemoryType::Dynamic => intrinsics.memory_grow_dynamic_import,
+                            BackingMemoryType::Static => intrinsics.memory_grow_static_import,
+                            BackingMemoryType::SharedStatic => intrinsics.memory_grow_shared_import,
                         }
                     }
                 };
@@ -8531,17 +8531,17 @@ impl<'ctx> FunctionCodeGenerator<CodegenError> for LLVMFunctionCodeGenerator<'ct
                     LocalOrImport::Local(local_mem_index) => {
                         let mem_desc = &info.memories[local_mem_index];
                         match mem_desc.memory_type() {
-                            MemoryType::Dynamic => intrinsics.memory_size_dynamic_local,
-                            MemoryType::Static => intrinsics.memory_size_static_local,
-                            MemoryType::SharedStatic => intrinsics.memory_size_shared_local,
+                            BackingMemoryType::Dynamic => intrinsics.memory_size_dynamic_local,
+                            BackingMemoryType::Static => intrinsics.memory_size_static_local,
+                            BackingMemoryType::SharedStatic => intrinsics.memory_size_shared_local,
                         }
                     }
                     LocalOrImport::Import(import_mem_index) => {
                         let mem_desc = &info.imported_memories[import_mem_index].1;
                         match mem_desc.memory_type() {
-                            MemoryType::Dynamic => intrinsics.memory_size_dynamic_import,
-                            MemoryType::Static => intrinsics.memory_size_static_import,
-                            MemoryType::SharedStatic => intrinsics.memory_size_shared_import,
+                            BackingMemoryType::Dynamic => intrinsics.memory_size_dynamic_import,
+                            BackingMemoryType::Static => intrinsics.memory_size_static_import,
+                            BackingMemoryType::SharedStatic => intrinsics.memory_size_shared_import,
                         }
                     }
                 };

--- a/lib/llvm-backend/src/intrinsics.rs
+++ b/lib/llvm-backend/src/intrinsics.rs
@@ -20,7 +20,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use wasmer_runtime_core::{
-    memory::MemoryType,
+    memory::BackingMemoryType,
     module::ModuleInfo,
     structures::TypedIndex,
     types::{
@@ -749,13 +749,13 @@ impl<'a, 'ctx> CtxType<'a, 'ctx> {
             };
 
             match memory_type {
-                MemoryType::Dynamic => MemoryCache::Dynamic {
+                BackingMemoryType::Dynamic => MemoryCache::Dynamic {
                     ptr_to_base_ptr,
                     ptr_to_bounds,
                     minimum,
                     maximum,
                 },
-                MemoryType::Static | MemoryType::SharedStatic => {
+                BackingMemoryType::Static | BackingMemoryType::SharedStatic => {
                     let base_ptr = cache_builder
                         .build_load(ptr_to_base_ptr, "base")
                         .into_pointer_value();

--- a/lib/runtime-c-api/src/export.rs
+++ b/lib/runtime-c-api/src/export.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use libc::{c_int, c_uint};
 use std::{ptr, slice};
-use wasmer::export::{ExportDescriptor, ExternDescriptor};
+use wasmer::export::{ExportDescriptor, ExternType};
 use wasmer::wasm::{Memory, Value};
 use wasmer::{Instance, Module};
 
@@ -24,7 +24,7 @@ pub(crate) struct NamedExport {
     pub(crate) name: String,
 
     /// The export instance.
-    pub(crate) extern_descriptor: ExternDescriptor,
+    pub(crate) extern_descriptor: ExternType,
 
     /// The instance that holds the export.
     pub(crate) instance: *mut Instance,
@@ -270,10 +270,10 @@ pub unsafe extern "C" fn wasmer_export_kind(
 ) -> wasmer_import_export_kind {
     let named_export = &*(export as *mut NamedExport);
     match named_export.extern_descriptor {
-        ExternDescriptor::Table(_) => wasmer_import_export_kind::WASM_TABLE,
-        ExternDescriptor::Function { .. } => wasmer_import_export_kind::WASM_FUNCTION,
-        ExternDescriptor::Global(_) => wasmer_import_export_kind::WASM_GLOBAL,
-        ExternDescriptor::Memory(_) => wasmer_import_export_kind::WASM_MEMORY,
+        ExternType::Table(_) => wasmer_import_export_kind::WASM_TABLE,
+        ExternType::Function { .. } => wasmer_import_export_kind::WASM_FUNCTION,
+        ExternType::Global(_) => wasmer_import_export_kind::WASM_GLOBAL,
+        ExternType::Memory(_) => wasmer_import_export_kind::WASM_MEMORY,
     }
 }
 
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn wasmer_export_func_params_arity(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.extern_descriptor;
-    if let ExternDescriptor::Function(ref signature) = *export {
+    if let ExternType::Function(ref signature) = *export {
         *result = signature.params().len() as u32;
         wasmer_result_t::WASMER_OK
     } else {
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn wasmer_export_func_params(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.extern_descriptor;
-    if let ExternDescriptor::Function(ref signature) = *export {
+    if let ExternType::Function(ref signature) = *export {
         let params: &mut [wasmer_value_tag] =
             slice::from_raw_parts_mut(params, params_len as usize);
         for (i, item) in signature.params().iter().enumerate() {
@@ -347,7 +347,7 @@ pub unsafe extern "C" fn wasmer_export_func_returns(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.extern_descriptor;
-    if let ExternDescriptor::Function(ref signature) = *export {
+    if let ExternType::Function(ref signature) = *export {
         let returns: &mut [wasmer_value_tag] =
             slice::from_raw_parts_mut(returns, returns_len as usize);
         for (i, item) in signature.returns().iter().enumerate() {
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn wasmer_export_func_returns_arity(
 ) -> wasmer_result_t {
     let named_export = &*(func as *const NamedExport);
     let export = &named_export.extern_descriptor;
-    if let ExternDescriptor::Function(ref signature) = *export {
+    if let ExternType::Function(ref signature) = *export {
         *result = signature.returns().len() as u32;
         wasmer_result_t::WASMER_OK
     } else {
@@ -521,10 +521,10 @@ pub unsafe extern "C" fn wasmer_export_func_call(
 impl<'a> From<ExportDescriptor<'a>> for NamedExportDescriptor {
     fn from(ed: ExportDescriptor) -> Self {
         let kind = match ed.ty {
-            ExternDescriptor::Memory(_) => wasmer_import_export_kind::WASM_MEMORY,
-            ExternDescriptor::Global(_) => wasmer_import_export_kind::WASM_GLOBAL,
-            ExternDescriptor::Table(_) => wasmer_import_export_kind::WASM_TABLE,
-            ExternDescriptor::Function(_) => wasmer_import_export_kind::WASM_FUNCTION,
+            ExternType::Memory(_) => wasmer_import_export_kind::WASM_MEMORY,
+            ExternType::Global(_) => wasmer_import_export_kind::WASM_GLOBAL,
+            ExternType::Table(_) => wasmer_import_export_kind::WASM_TABLE,
+            ExternType::Function(_) => wasmer_import_export_kind::WASM_FUNCTION,
         };
         NamedExportDescriptor {
             name: ed.name.to_string(),

--- a/lib/runtime-c-api/src/memory.rs
+++ b/lib/runtime-c-api/src/memory.rs
@@ -5,7 +5,7 @@ use crate::{
     wasmer_limits_t, wasmer_result_t,
 };
 use std::{cell::Cell, ptr};
-use wasmer::types::MemoryDescriptor;
+use wasmer::types::MemoryType;
 use wasmer::units::{Bytes, Pages};
 use wasmer::wasm::Memory;
 
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn wasmer_memory_new(
     } else {
         None
     };
-    let desc = MemoryDescriptor::new(Pages(limits.min), max, false);
+    let desc = MemoryType::new(Pages(limits.min), max, false);
     let new_desc = match desc {
         Ok(desc) => desc,
         Err(error) => {

--- a/lib/runtime-c-api/src/table.rs
+++ b/lib/runtime-c-api/src/table.rs
@@ -1,7 +1,7 @@
 //! Create, grow, destroy tables of an instance.
 
 use crate::{error::update_last_error, wasmer_limits_t, wasmer_result_t};
-use wasmer::types::{ElementType, TableDescriptor};
+use wasmer::types::{ElementType, TableType};
 use wasmer::wasm::Table;
 
 #[repr(C)]
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn wasmer_table_new(
     } else {
         None
     };
-    let desc = TableDescriptor {
+    let desc = TableType {
         element: ElementType::Anyfunc,
         minimum: limits.min,
         maximum: max,

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -159,14 +159,14 @@ typedef struct {
 } wasmer_import_object_t;
 
 /**
- * Opaque pointer to `NamedExportDescriptor`.
+ * Opaque pointer to `NamedExportType`.
  */
 typedef struct {
 
 } wasmer_export_descriptor_t;
 
 /**
- * Opaque pointer to `NamedExportDescriptors`.
+ * Opaque pointer to `NamedExportTypes`.
  */
 typedef struct {
 

--- a/lib/runtime-c-api/wasmer.h
+++ b/lib/runtime-c-api/wasmer.h
@@ -924,7 +924,7 @@ void *wasmer_instance_context_data_get(const wasmer_instance_context_t *ctx);
  * // Allocate them and set them on the given instance.
  * my_data *data = malloc(sizeof(my_data));
  * data->… = …;
- * wasmer_instance_context_data_set(instance, (void*) my_data);
+ * wasmer_instance_context_data_set(instance, (void*) data);
  *
  * // You can read your data.
  * {

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -117,12 +117,12 @@ struct wasmer_import_object_t {
 
 };
 
-/// Opaque pointer to `NamedExportDescriptor`.
+/// Opaque pointer to `NamedExportType`.
 struct wasmer_export_descriptor_t {
 
 };
 
-/// Opaque pointer to `NamedExportDescriptors`.
+/// Opaque pointer to `NamedExportTypes`.
 struct wasmer_export_descriptors_t {
 
 };

--- a/lib/runtime-c-api/wasmer.hh
+++ b/lib/runtime-c-api/wasmer.hh
@@ -736,7 +736,7 @@ void *wasmer_instance_context_data_get(const wasmer_instance_context_t *ctx);
 /// // Allocate them and set them on the given instance.
 /// my_data *data = malloc(sizeof(my_data));
 /// data->… = …;
-/// wasmer_instance_context_data_set(instance, (void*) my_data);
+/// wasmer_instance_context_data_set(instance, (void*) data);
 ///
 /// // You can read your data.
 /// {

--- a/lib/runtime-core/src/backing.rs
+++ b/lib/runtime-core/src/backing.rs
@@ -713,7 +713,7 @@ fn import_memories(
                     memories.push(memory.clone());
                     vm_memories.push(memory.vm_local_memory());
                 } else {
-                    link_errors.push(LinkError::IncorrectMemoryDescriptor {
+                    link_errors.push(LinkError::IncorrectMemoryType {
                         namespace: namespace.to_string(),
                         name: name.to_string(),
                         expected: *expected_memory_desc,
@@ -784,7 +784,7 @@ fn import_tables(
                     vm_tables.push(table.vm_local_table());
                     tables.push(table);
                 } else {
-                    link_errors.push(LinkError::IncorrectTableDescriptor {
+                    link_errors.push(LinkError::IncorrectTableType {
                         namespace: namespace.to_string(),
                         name: name.to_string(),
                         expected: *expected_table_desc,
@@ -854,7 +854,7 @@ fn import_globals(
                     vm_globals.push(global.vm_local_global());
                     globals.push(global);
                 } else {
-                    link_errors.push(LinkError::IncorrectGlobalDescriptor {
+                    link_errors.push(LinkError::IncorrectGlobalType {
                         namespace: namespace.to_string(),
                         name: name.to_string(),
                         expected: *imported_global_desc,

--- a/lib/runtime-core/src/error.rs
+++ b/lib/runtime-core/src/error.rs
@@ -1,7 +1,7 @@
 //! The error module contains the data structures and helper functions used to implement errors that
 //! are produced and returned from the wasmer runtime core.
 use crate::backend::ExceptionCode;
-use crate::types::{FuncSig, GlobalDescriptor, MemoryDescriptor, TableDescriptor, Type};
+use crate::types::{FuncSig, GlobalType, MemoryType, TableType, Type};
 use core::borrow::Borrow;
 use std::any::Any;
 
@@ -100,37 +100,37 @@ pub enum LinkError {
         name: String,
     },
     /// The memory descriptor provided does not match the expected descriptor.
-    IncorrectMemoryDescriptor {
+    IncorrectMemoryType {
         /// Namespace.
         namespace: String,
         /// Name.
         name: String,
         /// Expected.
-        expected: MemoryDescriptor,
+        expected: MemoryType,
         /// Found.
-        found: MemoryDescriptor,
+        found: MemoryType,
     },
     /// The table descriptor provided does not match the expected descriptor.
-    IncorrectTableDescriptor {
+    IncorrectTableType {
         /// Namespace.
         namespace: String,
         /// Name.
         name: String,
         /// Expected.
-        expected: TableDescriptor,
+        expected: TableType,
         /// Found.
-        found: TableDescriptor,
+        found: TableType,
     },
     /// The global descriptor provided does not match the expected descriptor.
-    IncorrectGlobalDescriptor {
+    IncorrectGlobalType {
         /// Namespace.
         namespace: String,
         /// Name.
         name: String,
         /// Expected.
-        expected: GlobalDescriptor,
+        expected: GlobalType,
         /// Found.
-        found: GlobalDescriptor,
+        found: GlobalType,
     },
     /// A generic error with a message.
     Generic {
@@ -149,7 +149,7 @@ impl std::fmt::Display for LinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             LinkError::ImportNotFound {namespace, name} => write!(f, "Import not found, namespace: {}, name: {}", namespace, name),
-            LinkError::IncorrectGlobalDescriptor {namespace, name,expected,found} => {
+            LinkError::IncorrectGlobalType {namespace, name,expected,found} => {
                 write!(f, "Incorrect global descriptor, namespace: {}, name: {}, expected global descriptor: {:?}, found global descriptor: {:?}", namespace, name, expected, found)
             },
             LinkError::IncorrectImportSignature{namespace, name,expected,found} => {
@@ -158,10 +158,10 @@ impl std::fmt::Display for LinkError {
             LinkError::IncorrectImportType{namespace, name,expected,found} => {
                 write!(f, "Incorrect import type, namespace: {}, name: {}, expected type: {}, found type: {}", namespace, name, expected, found)
             }
-            LinkError::IncorrectMemoryDescriptor{namespace, name,expected,found} => {
+            LinkError::IncorrectMemoryType{namespace, name,expected,found} => {
                 write!(f, "Incorrect memory descriptor, namespace: {}, name: {}, expected memory descriptor: {:?}, found memory descriptor: {:?}", namespace, name, expected, found)
             },
-            LinkError::IncorrectTableDescriptor{namespace, name,expected,found} => {
+            LinkError::IncorrectTableType{namespace, name,expected,found} => {
                 write!(f, "Incorrect table descriptor, namespace: {}, name: {}, expected table descriptor: {:?}, found table descriptor: {:?}", namespace, name, expected, found)
             },
             LinkError::Generic { message } => {

--- a/lib/runtime-core/src/global.rs
+++ b/lib/runtime-core/src/global.rs
@@ -3,7 +3,7 @@
 use crate::{
     export::Export,
     import::IsExport,
-    types::{GlobalDescriptor, Type, Value},
+    types::{GlobalType, Type, Value},
     vm,
 };
 use std::{
@@ -13,7 +13,7 @@ use std::{
 
 /// A handle to a Wasm Global
 pub struct Global {
-    desc: GlobalDescriptor,
+    desc: GlobalType,
     storage: Arc<Mutex<vm::LocalGlobal>>,
 }
 
@@ -45,7 +45,7 @@ impl Global {
     }
 
     fn new_internal(value: Value, mutable: bool) -> Self {
-        let desc = GlobalDescriptor {
+        let desc = GlobalType {
             mutable,
             ty: value.ty(),
         };
@@ -66,10 +66,10 @@ impl Global {
         }
     }
 
-    /// Get the [`GlobalDescriptor`] generated for this global.
+    /// Get the [`GlobalType`] generated for this global.
     ///
-    /// [`GlobalDescriptor`]: struct.GlobalDescriptor.html
-    pub fn descriptor(&self) -> GlobalDescriptor {
+    /// [`GlobalType`]: struct.GlobalType.html
+    pub fn descriptor(&self) -> GlobalType {
         self.desc
     }
 

--- a/lib/runtime-core/src/memory/dynamic.rs
+++ b/lib/runtime-core/src/memory/dynamic.rs
@@ -2,7 +2,7 @@ use crate::error::GrowError;
 use crate::{
     error::CreationError,
     sys,
-    types::MemoryDescriptor,
+    types::MemoryType,
     units::{Bytes, Pages},
     vm,
 };
@@ -30,7 +30,7 @@ pub struct DynamicMemory {
 
 impl DynamicMemory {
     pub(super) fn new(
-        desc: MemoryDescriptor,
+        desc: MemoryType,
         local: &mut vm::LocalMemory,
     ) -> Result<Box<Self>, CreationError> {
         let min_bytes: Bytes = desc.minimum.into();

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -190,7 +190,9 @@ impl BackingMemoryType {
     pub fn guard_size(self) -> u64 {
         match self {
             BackingMemoryType::Dynamic => DYNAMIC_GUARD_SIZE as u64,
-            BackingMemoryType::Static | BackingMemoryType::SharedStatic => SAFE_STATIC_GUARD_SIZE as u64,
+            BackingMemoryType::Static | BackingMemoryType::SharedStatic => {
+                SAFE_STATIC_GUARD_SIZE as u64
+            }
         }
     }
 
@@ -198,7 +200,9 @@ impl BackingMemoryType {
     pub fn bounds(self) -> Option<u64> {
         match self {
             BackingMemoryType::Dynamic => None,
-            BackingMemoryType::Static | BackingMemoryType::SharedStatic => Some(SAFE_STATIC_HEAP_SIZE as u64),
+            BackingMemoryType::Static | BackingMemoryType::SharedStatic => {
+                Some(SAFE_STATIC_HEAP_SIZE as u64)
+            }
         }
     }
 }
@@ -363,7 +367,7 @@ impl Clone for SharedMemory {
 #[cfg(test)]
 mod memory_tests {
 
-    use super::{Memory, types, Pages};
+    use super::{types, Memory, Pages};
 
     #[test]
     fn test_initial_memory_size() {

--- a/lib/runtime-core/src/memory/mod.rs
+++ b/lib/runtime-core/src/memory/mod.rs
@@ -172,9 +172,11 @@ impl fmt::Debug for Memory {
     }
 }
 
-// TODO: add legacy MemoryType typedef for now
+/// Legacy wrapper around [`BackingMemoryType`].
+#[deprecated(note = "Please use `BackingMemoryType` instead.")]
+pub type MemoryType = BackingMemoryType;
 
-/// A kind a memory.
+/// What the underlying memory should look like.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BackingMemoryType {
     /// A dynamic memory.

--- a/lib/runtime-core/src/memory/ptr.rs
+++ b/lib/runtime-core/src/memory/ptr.rs
@@ -266,6 +266,7 @@ impl<T: Copy, Ty> fmt::Debug for WasmPtr<T, Ty> {
 mod test {
     use super::*;
     use crate::memory;
+    use crate::types;
     use crate::units::Pages;
 
     /// Ensure that memory accesses work on the edges of memory and that out of
@@ -273,8 +274,7 @@ mod test {
     #[test]
     fn wasm_ptr_memory_bounds_checks_hold() {
         // create a memory
-        let memory_descriptor =
-            memory::MemoryDescriptor::new(Pages(1), Some(Pages(1)), false).unwrap();
+        let memory_descriptor = types::MemoryType::new(Pages(1), Some(Pages(1)), false).unwrap();
         let memory = memory::Memory::new(memory_descriptor).unwrap();
 
         // test that basic access works and that len = 0 works, but oob does not

--- a/lib/runtime-core/src/memory/static_.rs
+++ b/lib/runtime-core/src/memory/static_.rs
@@ -1,5 +1,5 @@
 use crate::error::GrowError;
-use crate::{error::CreationError, sys, types::MemoryDescriptor, units::Pages, vm};
+use crate::{error::CreationError, sys, types::MemoryType, units::Pages, vm};
 
 #[doc(hidden)]
 pub const SAFE_STATIC_HEAP_SIZE: usize = 1 << 32; // 4 GiB
@@ -25,7 +25,7 @@ pub struct StaticMemory {
 
 impl StaticMemory {
     pub(in crate::memory) fn new(
-        desc: MemoryDescriptor,
+        desc: MemoryType,
         local: &mut vm::LocalMemory,
     ) -> Result<Box<Self>, CreationError> {
         let memory = {

--- a/lib/runtime-core/src/module.rs
+++ b/lib/runtime-core/src/module.rs
@@ -9,10 +9,10 @@ use crate::{
     import::ImportObject,
     structures::{Map, TypedIndex},
     types::{
-        ExportDescriptor, FuncIndex, FuncSig, GlobalDescriptor, GlobalIndex, GlobalInit,
+        ExportDescriptor, FuncIndex, FuncSig, GlobalType, GlobalIndex, GlobalInit,
         ImportDescriptor, ImportedFuncIndex, ImportedGlobalIndex, ImportedMemoryIndex,
         ImportedTableIndex, Initializer, LocalGlobalIndex, LocalMemoryIndex, LocalTableIndex,
-        MemoryDescriptor, MemoryIndex, SigIndex, TableDescriptor, TableIndex,
+        MemoryType, MemoryIndex, SigIndex, TableType, TableIndex,
     },
     Instance,
 };
@@ -37,21 +37,21 @@ pub struct ModuleInner {
 pub struct ModuleInfo {
     /// Map of memory index to memory descriptors.
     // This are strictly local and the typesystem ensures that.
-    pub memories: Map<LocalMemoryIndex, MemoryDescriptor>,
+    pub memories: Map<LocalMemoryIndex, MemoryType>,
     /// Map of global index to global descriptors.
     pub globals: Map<LocalGlobalIndex, GlobalInit>,
     /// Map of table index to table descriptors.
-    pub tables: Map<LocalTableIndex, TableDescriptor>,
+    pub tables: Map<LocalTableIndex, TableType>,
 
     /// Map of imported function index to import name.
     // These are strictly imported and the typesystem ensures that.
     pub imported_functions: Map<ImportedFuncIndex, ImportName>,
     /// Map of imported memory index to import name and memory descriptor.
-    pub imported_memories: Map<ImportedMemoryIndex, (ImportName, MemoryDescriptor)>,
+    pub imported_memories: Map<ImportedMemoryIndex, (ImportName, MemoryType)>,
     /// Map of imported table index to import name and table descriptor.
-    pub imported_tables: Map<ImportedTableIndex, (ImportName, TableDescriptor)>,
+    pub imported_tables: Map<ImportedTableIndex, (ImportName, TableType)>,
     /// Map of imported global index to import name and global descriptor.
-    pub imported_globals: Map<ImportedGlobalIndex, (ImportName, GlobalDescriptor)>,
+    pub imported_globals: Map<ImportedGlobalIndex, (ImportName, GlobalType)>,
 
     /// Map of string to export index.
     // Implementation note: this should maintain the order that the exports appear in the
@@ -322,8 +322,8 @@ pub struct ImportName {
 /// Wasm globals, and Wasm tables.
 ///
 /// Used in [`ModuleInfo`] to access function signatures ([`SigIndex`]s,
-/// [`FuncSig`]), [`GlobalInit`]s, [`MemoryDescriptor`]s, and
-/// [`TableDescriptor`]s.
+/// [`FuncSig`]), [`GlobalInit`]s, [`MemoryType`]s, and
+/// [`TableType`]s.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExportIndex {
     /// Function export index. [`FuncIndex`] is a type-safe handle referring to

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     structures::{Map, TypedIndex},
     types::{
-        ElementType, FuncIndex, FuncSig, GlobalDescriptor, GlobalIndex, GlobalInit,
-        ImportedGlobalIndex, Initializer, MemoryDescriptor, MemoryIndex, SigIndex, TableDescriptor,
+        ElementType, FuncIndex, FuncSig, GlobalType, GlobalIndex, GlobalInit,
+        ImportedGlobalIndex, Initializer, MemoryType, MemoryIndex, SigIndex, TableType,
         TableIndex, Type, Value,
     },
     units::Pages,
@@ -170,7 +170,7 @@ pub fn read_module<
                     }
                     ImportSectionEntryType::Table(table_ty) => {
                         assert_eq!(table_ty.element_type, WpType::AnyFunc);
-                        let table_desc = TableDescriptor {
+                        let table_desc = TableType {
                             element: ElementType::Anyfunc,
                             minimum: table_ty.limits.initial,
                             maximum: table_ty.limits.maximum,
@@ -182,7 +182,7 @@ pub fn read_module<
                             .push((import_name, table_desc));
                     }
                     ImportSectionEntryType::Memory(memory_ty) => {
-                        let mem_desc = MemoryDescriptor::new(
+                        let mem_desc = MemoryType::new(
                             Pages(memory_ty.limits.initial),
                             memory_ty.limits.maximum.map(Pages),
                             memory_ty.shared,
@@ -195,7 +195,7 @@ pub fn read_module<
                             .push((import_name, mem_desc));
                     }
                     ImportSectionEntryType::Global(global_ty) => {
-                        let global_desc = GlobalDescriptor {
+                        let global_desc = GlobalType {
                             mutable: global_ty.mutable,
                             ty: wp_type_to_type(global_ty.content_type)?,
                         };
@@ -211,7 +211,7 @@ pub fn read_module<
                 info.write().unwrap().func_assoc.push(sigindex);
             }
             ParserState::TableSectionEntry(table_ty) => {
-                let table_desc = TableDescriptor {
+                let table_desc = TableType {
                     element: ElementType::Anyfunc,
                     minimum: table_ty.limits.initial,
                     maximum: table_ty.limits.maximum,
@@ -220,7 +220,7 @@ pub fn read_module<
                 info.write().unwrap().tables.push(table_desc);
             }
             ParserState::MemorySectionEntry(memory_ty) => {
-                let mem_desc = MemoryDescriptor::new(
+                let mem_desc = MemoryType::new(
                     Pages(memory_ty.limits.initial),
                     memory_ty.limits.maximum.map(Pages),
                     memory_ty.shared,
@@ -445,7 +445,7 @@ pub fn read_module<
                         _ => unreachable!(),
                     }
                 };
-                let desc = GlobalDescriptor {
+                let desc = GlobalType {
                     mutable: ty.mutable,
                     ty: wp_type_to_type(ty.content_type)?,
                 };

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -11,9 +11,8 @@ use crate::{
     },
     structures::{Map, TypedIndex},
     types::{
-        ElementType, FuncIndex, FuncSig, GlobalType, GlobalIndex, GlobalInit,
-        ImportedGlobalIndex, Initializer, MemoryType, MemoryIndex, SigIndex, TableType,
-        TableIndex, Type, Value,
+        ElementType, FuncIndex, FuncSig, GlobalIndex, GlobalInit, GlobalType, ImportedGlobalIndex,
+        Initializer, MemoryIndex, MemoryType, SigIndex, TableIndex, TableType, Type, Value,
     },
     units::Pages,
 };

--- a/lib/runtime-core/src/table/anyfunc.rs
+++ b/lib/runtime-core/src/table/anyfunc.rs
@@ -3,7 +3,7 @@ use crate::{
     instance::DynFunc,
     sig_registry::SigRegistry,
     structures::TypedIndex,
-    types::{FuncSig, TableDescriptor},
+    types::{FuncSig, TableType},
     vm,
 };
 
@@ -93,7 +93,7 @@ pub struct AnyfuncTable {
 
 impl AnyfuncTable {
     pub fn new(
-        desc: TableDescriptor,
+        desc: TableType,
         local: &mut vm::LocalTable,
     ) -> Result<Box<Self>, CreationError> {
         let initial_table_backing_len = desc.minimum as usize;

--- a/lib/runtime-core/src/table/anyfunc.rs
+++ b/lib/runtime-core/src/table/anyfunc.rs
@@ -92,10 +92,7 @@ pub struct AnyfuncTable {
 }
 
 impl AnyfuncTable {
-    pub fn new(
-        desc: TableType,
-        local: &mut vm::LocalTable,
-    ) -> Result<Box<Self>, CreationError> {
+    pub fn new(desc: TableType, local: &mut vm::LocalTable) -> Result<Box<Self>, CreationError> {
         let initial_table_backing_len = desc.minimum as usize;
 
         let mut storage = Box::new(AnyfuncTable {

--- a/lib/runtime-core/src/table/mod.rs
+++ b/lib/runtime-core/src/table/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     error::CreationError,
     export::Export,
     import::IsExport,
-    types::{ElementType, TableDescriptor},
+    types::{ElementType, TableType},
     vm,
 };
 use std::{
@@ -98,23 +98,23 @@ pub enum TableStorage {
 
 /// Container with a descriptor and a reference to a table storage.
 pub struct Table {
-    desc: TableDescriptor,
+    desc: TableType,
     storage: Arc<Mutex<(TableStorage, vm::LocalTable)>>,
 }
 
 impl Table {
-    /// Create a new `Table` from a [`TableDescriptor`]
+    /// Create a new `Table` from a [`TableType`]
     ///
-    /// [`TableDescriptor`]: struct.TableDescriptor.html
+    /// [`TableType`]: struct.TableType.html
     ///
     /// Usage:
     ///
     /// ```
-    /// # use wasmer_runtime_core::types::{TableDescriptor, ElementType};
+    /// # use wasmer_runtime_core::types::{TableType, ElementType};
     /// # use wasmer_runtime_core::table::Table;
     /// # use wasmer_runtime_core::error::Result;
     /// # fn create_table() -> Result<()> {
-    /// let descriptor = TableDescriptor {
+    /// let descriptor = TableType {
     ///     element: ElementType::Anyfunc,
     ///     minimum: 10,
     ///     maximum: None,
@@ -124,7 +124,7 @@ impl Table {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(desc: TableDescriptor) -> Result<Self, CreationError> {
+    pub fn new(desc: TableType) -> Result<Self, CreationError> {
         if let Some(max) = desc.maximum {
             if max < desc.minimum {
                 return Err(CreationError::InvalidDescriptor(
@@ -149,8 +149,8 @@ impl Table {
         })
     }
 
-    /// Get the `TableDescriptor` used to create this `Table`.
-    pub fn descriptor(&self) -> TableDescriptor {
+    /// Get the `TableType` used to create this `Table`.
+    pub fn descriptor(&self) -> TableType {
         self.desc
     }
 
@@ -238,11 +238,11 @@ impl fmt::Debug for Table {
 #[cfg(test)]
 mod table_tests {
 
-    use super::{ElementType, Table, TableDescriptor};
+    use super::{ElementType, Table, TableType};
 
     #[test]
     fn test_initial_table_size() {
-        let table = Table::new(TableDescriptor {
+        let table = Table::new(TableType {
             element: ElementType::Anyfunc,
             minimum: 10,
             maximum: Some(20),

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -252,6 +252,10 @@ pub enum ElementType {
     Anyfunc,
 }
 
+/// Legacy wrapper around [`TableType`].
+#[deprecated(note = "Please use `TableType` instead.")]
+pub type TableDescriptor = TableType;
+
 /// Describes the properties of a table including the element types, minimum and optional maximum,
 /// number of elements in the table.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -286,6 +290,10 @@ pub enum Initializer {
     GetGlobal(ImportedGlobalIndex),
 }
 
+/// Legacy wrapper around [`GlobalType`].
+#[deprecated(note = "Please use `GlobalType` instead.")]
+pub type GlobalDescriptor = GlobalType;
+
 /// Describes the mutability and type of a Global
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobalType {
@@ -303,6 +311,10 @@ pub struct GlobalInit {
     /// Global initializer.
     pub init: Initializer,
 }
+
+/// Legacy wrapper around [`MemoryType`].
+#[deprecated(note = "Please use `MemoryType` instead.")]
+pub type MemoryDescriptor = MemoryType;
 
 /// A wasm memory descriptor.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]

--- a/lib/runtime-core/src/types.rs
+++ b/lib/runtime-core/src/types.rs
@@ -609,7 +609,7 @@ impl From<&GlobalType> for ExternType {
 
 /// A type describing an import that a [`Module`] needs to be instantiated.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ImportDescriptor {
+pub struct ImportType {
     /// The namespace that this import is in.
     pub namespace: String,
     /// The name of the import.
@@ -620,7 +620,7 @@ pub struct ImportDescriptor {
 
 /// Type describing an export that the [`Module`] provides.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExportDescriptor<'a> {
+pub struct ExportType<'a> {
     /// The name identifying the export.
     pub name: &'a str,
     /// The type of the export.

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -4,7 +4,7 @@ pub use crate::backing::{ImportBacking, LocalBacking, INTERNALS_SIZE};
 use crate::{
     error::CallResult,
     instance::call_func_with_index_inner,
-    memory::{Memory, MemoryType},
+    memory::{Memory, BackingMemoryType},
     module::{ModuleInfo, ModuleInner},
     sig_registry::SigRegistry,
     structures::TypedIndex,
@@ -238,17 +238,17 @@ fn get_intrinsics_for_module(m: &ModuleInfo) -> *const Intrinsics {
             LocalOrImport::Local(local_mem_index) => {
                 let mem_desc = &m.memories[local_mem_index];
                 match mem_desc.memory_type() {
-                    MemoryType::Dynamic => &INTRINSICS_LOCAL_DYNAMIC_MEMORY,
-                    MemoryType::Static => &INTRINSICS_LOCAL_STATIC_MEMORY,
-                    MemoryType::SharedStatic => &INTRINSICS_LOCAL_STATIC_MEMORY,
+                    BackingMemoryType::Dynamic => &INTRINSICS_LOCAL_DYNAMIC_MEMORY,
+                    BackingMemoryType::Static => &INTRINSICS_LOCAL_STATIC_MEMORY,
+                    BackingMemoryType::SharedStatic => &INTRINSICS_LOCAL_STATIC_MEMORY,
                 }
             }
             LocalOrImport::Import(import_mem_index) => {
                 let mem_desc = &m.imported_memories[import_mem_index].1;
                 match mem_desc.memory_type() {
-                    MemoryType::Dynamic => &INTRINSICS_IMPORTED_DYNAMIC_MEMORY,
-                    MemoryType::Static => &INTRINSICS_IMPORTED_STATIC_MEMORY,
-                    MemoryType::SharedStatic => &INTRINSICS_IMPORTED_STATIC_MEMORY,
+                    BackingMemoryType::Dynamic => &INTRINSICS_IMPORTED_DYNAMIC_MEMORY,
+                    BackingMemoryType::Static => &INTRINSICS_IMPORTED_STATIC_MEMORY,
+                    BackingMemoryType::SharedStatic => &INTRINSICS_IMPORTED_STATIC_MEMORY,
                 }
             }
         }

--- a/lib/runtime-core/src/vm.rs
+++ b/lib/runtime-core/src/vm.rs
@@ -4,7 +4,7 @@ pub use crate::backing::{ImportBacking, LocalBacking, INTERNALS_SIZE};
 use crate::{
     error::CallResult,
     instance::call_func_with_index_inner,
-    memory::{Memory, BackingMemoryType},
+    memory::{BackingMemoryType, Memory},
     module::{ModuleInfo, ModuleInner},
     sig_registry::SigRegistry,
     structures::TypedIndex,

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -128,7 +128,7 @@ pub mod wasm {
     pub use wasmer_runtime_core::global::Global;
     pub use wasmer_runtime_core::table::Table;
     pub use wasmer_runtime_core::types::{
-        FuncSig, GlobalDescriptor, MemoryDescriptor, TableDescriptor, Type, Value,
+        FuncSig, GlobalType, MemoryType, TableType, Type, Value,
     };
 }
 

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -127,9 +127,7 @@ pub mod wasm {
     //! Various types exposed by the Wasmer Runtime.
     pub use wasmer_runtime_core::global::Global;
     pub use wasmer_runtime_core::table::Table;
-    pub use wasmer_runtime_core::types::{
-        FuncSig, GlobalType, MemoryType, TableType, Type, Value,
-    };
+    pub use wasmer_runtime_core::types::{FuncSig, GlobalType, MemoryType, TableType, Type, Value};
 }
 
 pub mod error {

--- a/lib/singlepass-backend/src/codegen_x64.rs
+++ b/lib/singlepass-backend/src/codegen_x64.rs
@@ -29,7 +29,7 @@ use wasmer_runtime_core::{
     codegen::*,
     fault::{self, raw::register_preservation_trampoline},
     loader::CodeMemory,
-    memory::MemoryType,
+    memory::BackingMemoryType,
     module::{ModuleInfo, ModuleInner},
     state::{
         x64::new_machine_state, x64::X64Register, x64_decl::ArgumentRegisterAllocator,
@@ -2215,8 +2215,8 @@ impl X64FunctionCode {
         };
         let need_check = match config.memory_bound_check_mode {
             MemoryBoundCheckMode::Default => match mem_desc.memory_type() {
-                MemoryType::Dynamic => true,
-                MemoryType::Static | MemoryType::SharedStatic => false,
+                BackingMemoryType::Dynamic => true,
+                BackingMemoryType::Static | BackingMemoryType::SharedStatic => false,
             },
             MemoryBoundCheckMode::Enable => true,
             MemoryBoundCheckMode::Disable => false,

--- a/tests/high_level_api.rs
+++ b/tests/high_level_api.rs
@@ -76,7 +76,7 @@ wasmer_backends! {
 
     #[test]
     fn module_exports_are_ordered() {
-        use wasmer::types::{ElementType, FuncSig, GlobalDescriptor, TableDescriptor, Type};
+        use wasmer::types::{ElementType, FuncSig, GlobalType, TableType, Type};
         use wasmer::{export, CompiledModule, Module};
 
         let wasm = wabt::wat2wasm(TEST_WAT).unwrap();
@@ -89,7 +89,7 @@ wasmer_backends! {
             vec![
                 export::ExportDescriptor {
                     name: "test-table",
-                    ty: export::ExternDescriptor::Table(TableDescriptor {
+                    ty: export::ExternType::Table(TableType {
                         element: ElementType::Anyfunc,
                         minimum: 2,
                         maximum: None,
@@ -97,26 +97,26 @@ wasmer_backends! {
                 },
                 export::ExportDescriptor {
                     name: "test-global",
-                    ty: export::ExternDescriptor::Global(GlobalDescriptor {
+                    ty: export::ExternType::Global(GlobalType {
                         mutable: true,
                         ty: Type::I32,
                     }),
                 },
                 export::ExportDescriptor {
                     name: "ret_2",
-                    ty: export::ExternDescriptor::Function(FuncSig::new(vec![], vec![Type::I32])),
+                    ty: export::ExternType::Function(FuncSig::new(vec![], vec![Type::I32])),
                 },
                 export::ExportDescriptor {
                     name: "ret_4",
-                    ty: export::ExternDescriptor::Function(FuncSig::new(vec![], vec![Type::I32])),
+                    ty: export::ExternType::Function(FuncSig::new(vec![], vec![Type::I32])),
                 },
                 export::ExportDescriptor {
                     name: "set_test_global",
-                    ty: export::ExternDescriptor::Function(FuncSig::new(vec![Type::I32], vec![])),
+                    ty: export::ExternType::Function(FuncSig::new(vec![Type::I32], vec![])),
                 },
                 export::ExportDescriptor {
                     name: "update_outside_global",
-                    ty: export::ExternDescriptor::Function(FuncSig::new(vec![], vec![])),
+                    ty: export::ExternType::Function(FuncSig::new(vec![], vec![])),
                 },
             ]
         );

--- a/tests/high_level_api.rs
+++ b/tests/high_level_api.rs
@@ -87,7 +87,7 @@ wasmer_backends! {
         assert_eq!(
             exports,
             vec![
-                export::ExportDescriptor {
+                export::ExportType {
                     name: "test-table",
                     ty: export::ExternType::Table(TableType {
                         element: ElementType::Anyfunc,
@@ -95,26 +95,26 @@ wasmer_backends! {
                         maximum: None,
                     }),
                 },
-                export::ExportDescriptor {
+                export::ExportType {
                     name: "test-global",
                     ty: export::ExternType::Global(GlobalType {
                         mutable: true,
                         ty: Type::I32,
                     }),
                 },
-                export::ExportDescriptor {
+                export::ExportType {
                     name: "ret_2",
                     ty: export::ExternType::Function(FuncSig::new(vec![], vec![Type::I32])),
                 },
-                export::ExportDescriptor {
+                export::ExportType {
                     name: "ret_4",
                     ty: export::ExternType::Function(FuncSig::new(vec![], vec![Type::I32])),
                 },
-                export::ExportDescriptor {
+                export::ExportType {
                     name: "set_test_global",
                     ty: export::ExternType::Function(FuncSig::new(vec![Type::I32], vec![])),
                 },
-                export::ExportDescriptor {
+                export::ExportType {
                     name: "update_outside_global",
                     ty: export::ExternType::Function(FuncSig::new(vec![], vec![])),
                 },

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -7,7 +7,7 @@ use wasmer::compiler::{compile_with, compiler_for_backend, Backend};
 use wasmer::error::RuntimeError;
 use wasmer::units::Pages;
 use wasmer::wasm::{
-    DynFunc, Func, FuncSig, Global, Instance, Memory, MemoryDescriptor, Type, Value,
+    DynFunc, Func, FuncSig, Global, Instance, Memory, MemoryType, Type, Value,
 };
 use wasmer::{imports, vm, DynamicFunc};
 
@@ -203,7 +203,7 @@ fn imported_functions_forms(backend: Backend, test: &dyn Fn(&Instance)) {
     let wasm_binary = wat2wasm(MODULE.as_bytes()).expect("WAST not valid or malformed");
     let compiler = compiler_for_backend(backend).expect("Backend not recognized");
     let module = compile_with(&wasm_binary, &*compiler).unwrap();
-    let memory_descriptor = MemoryDescriptor::new(Pages(1), Some(Pages(1)), false).unwrap();
+    let memory_descriptor = MemoryType::new(Pages(1), Some(Pages(1)), false).unwrap();
     let memory = Memory::new(memory_descriptor).unwrap();
 
     memory.view()[0].set(SHIFT);

--- a/tests/imports.rs
+++ b/tests/imports.rs
@@ -6,9 +6,7 @@ use wabt::wat2wasm;
 use wasmer::compiler::{compile_with, compiler_for_backend, Backend};
 use wasmer::error::RuntimeError;
 use wasmer::units::Pages;
-use wasmer::wasm::{
-    DynFunc, Func, FuncSig, Global, Instance, Memory, MemoryType, Type, Value,
-};
+use wasmer::wasm::{DynFunc, Func, FuncSig, Global, Instance, Memory, MemoryType, Type, Value};
 use wasmer::{imports, vm, DynamicFunc};
 
 fn runtime_core_new_api_works(backend: Backend) {

--- a/tests/wast/src/spectest.rs
+++ b/tests/wast/src/spectest.rs
@@ -1,7 +1,7 @@
 use wasmer::import::ImportObject;
 use wasmer::types::ElementType;
 use wasmer::units::Pages;
-use wasmer::wasm::{Func, Global, Memory, MemoryDescriptor, Table, TableDescriptor, Value};
+use wasmer::wasm::{Func, Global, Memory, MemoryType, Table, TableType, Value};
 use wasmer::*;
 
 /// Return an instance implementing the "spectest" interface used in the
@@ -26,10 +26,10 @@ pub fn spectest_importobject() -> ImportObject {
     let global_f32 = Global::new(Value::F32(f32::from_bits(0x4426_8000)));
     let global_f64 = Global::new(Value::F64(f64::from_bits(0x4084_d000_0000_0000)));
 
-    let memory_desc = MemoryDescriptor::new(Pages(1), Some(Pages(2)), false).unwrap();
+    let memory_desc = MemoryType::new(Pages(1), Some(Pages(2)), false).unwrap();
     let memory = Memory::new(memory_desc).unwrap();
 
-    let table = Table::new(TableDescriptor {
+    let table = Table::new(TableType {
         element: ElementType::Anyfunc,
         minimum: 10,
         maximum: Some(20),


### PR DESCRIPTION
Renaming things to be better aligned with the Wasm spec.

We'll be adding compatibility definitions with a deprecated attribute where possible.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
