### PR TITLE
feat(runtime-core) Implement `ImportObjectIterator::size_hint`.

### DIFF
--- a/lib/runtime-core/src/import.rs
+++ b/lib/runtime-core/src/import.rs
@@ -192,8 +192,15 @@ pub struct ImportObjectIterator {
 
 impl Iterator for ImportObjectIterator {
     type Item = (String, String, Export);
+
     fn next(&mut self) -> Option<Self::Item> {
         self.elements.pop_front()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.elements.len();
+
+        (len, Some(len))
     }
 }
 


### PR DESCRIPTION
Because it is helpful in some circumstances.