### PR TITLE
Fix trap reporting for unreachable errors in the Singlepass backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,15 +38,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -128,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550fc503a8b30d8dcbe2217ab58c3367ada2137e5df2aec91d39f4a53e4ffada"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -818,7 +809,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dd6190aad0f05ddbbf3245c54ed14ca4aa6dd32f22312b70d8f168c3e3e633"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec",
  "byteorder",
  "fallible-iterator",
  "indexmap",
@@ -1105,19 +1096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
-name = "lexical-core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
-dependencies = [
- "arrayvec 0.4.12",
- "cfg-if",
- "rustc_version",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,23 +1291,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "void",
-]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
-name = "nom"
-version = "5.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -2136,12 +2097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
-name = "static_assertions"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
-
-[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,15 +2821,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-interface-types"
-version = "0.17.0"
-dependencies = [
- "nom",
- "serde",
- "wast 8.0.0",
-]
-
-[[package]]
 name = "wasmer-kernel-loader"
 version = "0.1.0"
 dependencies = [
@@ -3022,7 +2968,7 @@ dependencies = [
  "anyhow",
  "thiserror",
  "wasmer",
- "wast 9.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -3040,15 +2986,6 @@ name = "wasmparser"
 version = "0.51.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
-
-[[package]]
-name = "wast"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9df3d716118a503b2f6bbb6ff46b21997ab0cc167b01de7a188e45e4b01e8d"
-dependencies = [
- "leb128",
-]
 
 [[package]]
 name = "wast"

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -312,8 +312,8 @@ pub mod error {
     //! Various error types returned by Wasmer APIs.
     pub use wasmer_runtime_core::backend::ExceptionCode;
     pub use wasmer_runtime_core::error::{
-        CallError, CompileError, CompileResult, CreationError, Error, LinkError, ResolveError,
-        RuntimeError,
+        CallError, CompileError, CompileResult, CreationError, Error, InvokeError, LinkError,
+        ResolveError, RuntimeError,
     };
 
     #[derive(Debug)]

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -2,8 +2,6 @@
 //!
 //! An "instance", or "instantiated module", is a compiled WebAssembly [`Module`] with its
 //! corresponding imports (via [`ImportObject`]) that is ready to execute.
-#[cfg(unix)]
-use crate::fault::{pop_code_version, push_code_version};
 use crate::{
     backend::RunnableModule,
     backing::{ImportBacking, LocalBacking},
@@ -15,12 +13,16 @@ use crate::{
     memory::Memory,
     module::{ExportIndex, Module, ModuleInfo, ModuleInner},
     sig_registry::SigRegistry,
-    state::CodeVersion,
     structures::TypedIndex,
     table::Table,
     typed_func::{Func, Wasm, WasmTypeList},
     types::{FuncIndex, FuncSig, GlobalIndex, LocalOrImport, MemoryIndex, TableIndex, Type, Value},
     vm::{self, InternalField},
+};
+#[cfg(unix)]
+use crate::{
+    fault::{pop_code_version, push_code_version},
+    state::CodeVersion,
 };
 use smallvec::{smallvec, SmallVec};
 use std::{


### PR DESCRIPTION
This PR updates to push code versions in `Instance::new` so that singlepass reports errors correctly.

This is required for the fault handler to read from the exception table and report the exception type correctly in Singlepass:

This fix does not ever pop it, it doesn't update the code in run.rs which both pushes and pops (so that may have broken too (needs investigation))

Other considerations, this logic seems to only apply to `unix`, even if tests don't fail, we should double check windows (and get the tests running there too if they're not)

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
