### PR TITLE
clif-backend, runtime-core: fix possible deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **[Unreleased]**
 
+- [#1466](https://github.com/wasmerio/wasmer/pull/1466) Fix possible deadlock in `clif-backend` and `runtime-core`
 - [#1439](https://github.com/wasmerio/wasmer/pull/1439) Move `wasmer-interface-types` into its own repository
 
 ## 0.17.0 - 2020-05-11

--- a/lib/runtime-core/src/parse.rs
+++ b/lib/runtime-core/src/parse.rs
@@ -269,9 +269,7 @@ pub fn read_module<
                     let sig = info_read
                         .signatures
                         .get(
-                            *info
-                                .read()
-                                .unwrap()
+                            *info_read
                                 .func_assoc
                                 .get(FuncIndex::new(
                                     id as usize + info_read.imported_functions.len(),


### PR DESCRIPTION
# Description
Fixed possible deadlock caused by double read lock in clif-backend and runtime-core.
e.g.
In lib/clif-backend/src/code.rs,
There are two RwLock::read() on `self.module_info` at [L319](https://github.com/wasmerio/wasmer/blob/081f6250e69b98b9f95a8f62ad6d8386534f3279/lib/clif-backend/src/code.rs#L319) and [L337](https://github.com/wasmerio/wasmer/blob/081f6250e69b98b9f95a8f62ad6d8386534f3279/lib/clif-backend/src/code.rs#L337). 
The first read lock guard created in the match condition lives through the whole match statement, which covers the second lock.
A deadlock may happen when the two read locks are interleaved by a write lock from another thread. 
The reason is that the priority policy of `std::sync::RwLock` is 
[dependent on the underlying operating system's implementation](https://doc.rust-lang.org/std/sync/struct.RwLock.html). 
AFAIK, [Windows and macOS use fair policy](https://www.reddit.com/r/rust/comments/f4zldz/i_audited_3_different_implementation_of_async/),which leads to this kind of deadlock.

# Review
- [#1466](https://github.com/wasmerio/wasmer/pull/1466) Fix possible deadlock in `clif-backend` and `runtime-core`