### PR TITLE
Prepare for 0.17.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## **[Unreleased]**
 
+## 0.17.1 - 2020-06-24
+
 - [#1439](https://github.com/wasmerio/wasmer/pull/1439) Move `wasmer-interface-types` into its own repository
 
 ## 0.17.0 - 2020-05-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generate-emscripten-tests"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "glob 0.3.0",
  "tempfile",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "generate-wasi-tests"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "glob 0.3.0",
  "serde",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "serde",
  "wasmer-clif-backend",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-bin"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-clif-backend"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "byteorder",
  "cranelift-codegen",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-emscripten"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "byteorder",
  "getrandom",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-llvm-backend"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "byteorder",
  "cc",
@@ -2851,14 +2851,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middleware-common"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "wasmer-runtime-core",
 ]
 
 [[package]]
 name = "wasmer-runtime"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "criterion",
  "lazy_static",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-c-api"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cbindgen",
  "libc",
@@ -2887,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bincode",
  "blake3",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-experimental-io-devices"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "log",
  "minifb",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wast"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-win-exception-handler"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-bin"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 publish = true
@@ -12,21 +12,21 @@ license = "MIT"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-wasmer-runtime-core = { version = "0.17.0", path = "../runtime-core" }
+wasmer-runtime-core = { version = "0.17.1", path = "../runtime-core" }
 
 [dependencies.wasmer-singlepass-backend]
 path = "../singlepass-backend"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 [dependencies.wasmer-llvm-backend]
 path = "../llvm-backend"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 [dependencies.wasmer-clif-backend]
 path = "../clif-backend"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 [features]

--- a/lib/clif-backend/Cargo.toml
+++ b/lib/clif-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-clif-backend"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime Cranelift compiler backend"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1" }
 cranelift-native = "0.59.0"
 cranelift-codegen = "0.59.0"
 cranelift-entity = "0.59.0"
@@ -38,7 +38,7 @@ version = "0.0.7"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "minwinbase", "winnt"] }
-wasmer-win-exception-handler = { path = "../win-exception-handler", version = "0.17.0" }
+wasmer-win-exception-handler = { path = "../win-exception-handler", version = "0.17.1" }
 
 [features]
 generate-debug-information = ["wasm-debug"]

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime emscripten implementation library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -15,7 +15,7 @@ lazy_static = "1.4"
 libc = "0.2.60"
 log = "0.4"
 time = "0.1"
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1" }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.1"

--- a/lib/llvm-backend/Cargo.toml
+++ b/lib/llvm-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-llvm-backend"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime LLVM compiler backend"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0", features = ["generate-debug-information-no-export-symbols"] }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1", features = ["generate-debug-information-no-export-symbols"] }
 wasmparser = "0.51.3"
 smallvec = "1"
 goblin = "0.1"

--- a/lib/middleware-common/Cargo.toml
+++ b/lib/middleware-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-middleware-common"
-version = "0.17.0"
+version = "0.17.1"
 repository = "https://github.com/wasmerio/wasmer"
 description = "Wasmer runtime common middlewares"
 license = "MIT"
@@ -10,4 +10,4 @@ categories = ["wasm"]
 edition = "2018"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1" }

--- a/lib/runtime-c-api/Cargo.toml
+++ b/lib/runtime-c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime-c-api"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer C API library"
 documentation = "https://wasmerio.github.io/wasmer/c/runtime-c-api/"
 license = "MIT"
@@ -20,22 +20,22 @@ libc = "0.2.60"
 [dependencies.wasmer]
 default-features = false
 path = "../api"
-version = "0.17.0"
+version = "0.17.1"
 
 [dependencies.wasmer-runtime-core]
 default-features = false
 path = "../runtime-core"
-version = "0.17.0"
+version = "0.17.1"
 
 [dependencies.wasmer-wasi]
 default-features = false
 path = "../wasi"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 [dependencies.wasmer-emscripten]
 path = "../emscripten"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 [features]

--- a/lib/runtime-core/Cargo.toml
+++ b/lib/runtime-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime-core"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime core library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-runtime"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,17 +11,17 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.17.0", optional = true }
+wasmer-singlepass-backend = { path = "../singlepass-backend", version = "0.17.1", optional = true }
 lazy_static = "1.4"
 memmap = "0.7"
 
 [dependencies.wasmer-runtime-core]
 path = "../runtime-core"
-version = "0.17.0"
+version = "0.17.1"
 
 [dependencies.wasmer-clif-backend]
 path = "../clif-backend"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 # Dependencies for caching.
@@ -39,7 +39,7 @@ wabt = "0.9.1"
 
 [dependencies.wasmer-llvm-backend]
 path = "../llvm-backend"
-version = "0.17.0"
+version = "0.17.1"
 optional = true
 
 [features]

--- a/lib/singlepass-backend/Cargo.toml
+++ b/lib/singlepass-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-singlepass-backend"
-version = "0.17.0"
+version = "0.17.1"
 repository = "https://github.com/wasmerio/wasmer"
 description = "Wasmer runtime single pass compiler backend"
 license = "MIT"
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1" }
 dynasm = "0.5"
 dynasmrt = "0.5"
 lazy_static = "1.4"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-experimental-io-devices"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"
@@ -14,8 +14,8 @@ maintenance = { status = "experimental" }
 [dependencies]
 log = "0.4"
 minifb = "0.13"
-wasmer-wasi = { version = "0.17.0", path = "../wasi" }
-wasmer-runtime-core = { version = "0.17.0", path = "../runtime-core" }
+wasmer-wasi = { version = "0.17.1", path = "../wasi" }
+wasmer-runtime-core = { version = "0.17.1", path = "../runtime-core" }
 ref_thread_local = "0.0"
 serde = "1"
 typetag = "0.1"

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime WASI implementation library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -20,7 +20,7 @@ getrandom = "0.1"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1", features = ["derive"] }
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/lib/win-exception-handler/Cargo.toml
+++ b/lib/win-exception-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-win-exception-handler"
-version = "0.17.0"
+version = "0.17.1"
 description = "Wasmer runtime exception handling for Windows"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -8,7 +8,7 @@ repository = "https://github.com/wasmerio/wasmer"
 edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
-wasmer-runtime-core = { path = "../runtime-core", version = "0.17.0" }
+wasmer-runtime-core = { path = "../runtime-core", version = "0.17.1" }
 winapi = { version = "0.3.8", features = ["winbase", "errhandlingapi", "minwindef", "minwinbase", "winnt"] }
 libc = "0.2.60"
 

--- a/scripts/update_version_numbers.sh
+++ b/scripts/update_version_numbers.sh
@@ -1,5 +1,5 @@
-PREVIOUS_VERSION='0.16.2'
-NEXT_VERSION='0.17.0'
+PREVIOUS_VERSION='0.17.0'
+NEXT_VERSION='0.17.1'
 
 # quick hack
 fd Cargo.toml --exec sed -i '' "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"

--- a/src/installer/wasmer.iss
+++ b/src/installer/wasmer.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=Wasmer
-AppVersion=0.17.0
+AppVersion=0.17.1
 DefaultDirName={pf}\Wasmer
 DefaultGroupName=Wasmer
 Compression=lzma2

--- a/tests/generate-emscripten-tests/Cargo.toml
+++ b/tests/generate-emscripten-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate-emscripten-tests"
-version = "0.17.0"
+version = "0.17.1"
 description = "Tests for our Emscripten implementation"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/tests/generate-wasi-tests/Cargo.toml
+++ b/tests/generate-wasi-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate-wasi-tests"
-version = "0.17.0"
+version = "0.17.1"
 description = "Tests for our WASI implementation"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/tests/wast/Cargo.toml
+++ b/tests/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wast"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "wast testing support for wasmer"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -12,6 +12,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.19"
-wasmer = { path = "../../lib/api", version = "0.17.0" }
+wasmer = { path = "../../lib/api", version = "0.17.1" }
 wast = "9.0.0"
 thiserror = "1.0.15"


### PR DESCRIPTION
Shipping a patch release ensuring that a bug fix intended to be included in `0.17.0` is shipped (`dbg!` print statement is apparently in `0.17.0` release)

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
