### PR TITLE
Interrupt signal propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## **[Unreleased]**
+- [#1496](https://github.com/wasmerio/wasmer/pull/1496) Propagate interrupt signal(SIGINT) to previous signal handler
 
 ## 0.17.1 - 2020-06-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "0fde55d2a2bfaa4c9668bbc63f531fbdeee3ffe188f4662511ce2c22b3eedebe"
 
 [[package]]
 name = "cfg-if"

--- a/lib/runtime-core/src/fault.rs
+++ b/lib/runtime-core/src/fault.rs
@@ -474,7 +474,7 @@ extern "C" fn sigint_handler(
                 call_signal_handler(SIGINT, _siginfo, _ucontext, &prev_handler);
             }
             None => {
-                if INTERRUPT_SIGNAL_DELIVERED.swap(true, Ordering::SeqCst) {
+                if !INTERRUPT_SIGNAL_DELIVERED.swap(true, Ordering::SeqCst) {
                     eprintln!(
                     "Got another SIGINTTT before trap is triggered on WebAssembly side, aborting"
                 );

--- a/lib/runtime-core/src/fault.rs
+++ b/lib/runtime-core/src/fault.rs
@@ -475,8 +475,8 @@ extern "C" fn sigint_handler(
             None => {
                 if !INTERRUPT_SIGNAL_DELIVERED.swap(true, Ordering::SeqCst) {
                     eprintln!(
-                    "Got another SIGINT before trap is triggered on WebAssembly side, aborting"
-                );
+                        "Got another SIGINT before trap is triggered on WebAssembly side, aborting"
+                    );
                     process::abort();
                 }
 

--- a/lib/runtime-core/src/fault.rs
+++ b/lib/runtime-core/src/fault.rs
@@ -273,7 +273,6 @@ unsafe fn call_signal_handler(
 ) {
     match sig_action.handler() {
         SigHandler::SigDfl => {
-            eprintln!("Calling previous SIGINT handler");
             sigaction(sig, sig_action).unwrap();
             return;
         }
@@ -476,7 +475,7 @@ extern "C" fn sigint_handler(
             None => {
                 if !INTERRUPT_SIGNAL_DELIVERED.swap(true, Ordering::SeqCst) {
                     eprintln!(
-                    "Got another SIGINTTT before trap is triggered on WebAssembly side, aborting"
+                    "Got another SIGINT before trap is triggered on WebAssembly side, aborting"
                 );
                     process::abort();
                 }

--- a/lib/runtime-core/src/fault.rs
+++ b/lib/runtime-core/src/fault.rs
@@ -512,7 +512,7 @@ unsafe fn install_sighandler() {
         SaFlags::SA_ONSTACK,
         SigSet::empty(),
     );
-    SIGINT_SYS_HANDLER = sigaction(SIGINT, &sa_interrupt).ok();
+    SIGINT_SYS_HANDLER = Some(sigaction(SIGINT, &sa_interrupt).unwrap());
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
If we embed wasmer to a process, wasmer will override interrupt(SIGINT) signal handler. In result, previous signal handler will not be called when SIGINT is fired, and if it gets fired again, process will be stopped by process::abort() which leads to output a long stack trace.

Related Issue: https://github.com/wasmerio/wasmer/issues/842

# Review
- [x] Add a short description of the the change to the CHANGELOG.md file