### PR TITLE
WASIO extension for high-performance asynchronous I/O. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -50,6 +50,12 @@ name = "anyhow"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
+name = "arc-swap"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
 name = "arrayref"
@@ -71,7 +77,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -189,6 +195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
 name = "bytesize"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,7 +296,7 @@ checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -295,7 +307,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -415,6 +427,30 @@ checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -665,6 +701,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flurry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555b856ff32baeebd81bd19da2d35c48a73193be3ec8ae1745ae739fc99d61ee"
+dependencies = [
+ "ahash",
+ "crossbeam-epoch",
+ "num_cpus",
+ "parking_lot",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +723,117 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+
+[[package]]
+name = "futures-task"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
 
 [[package]]
 name = "generational-arena"
@@ -875,6 +1034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +1064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -952,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -961,7 +1139,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1029,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1056,7 +1234,7 @@ dependencies = [
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
- "winapi",
+ "winapi 0.3.9",
  "x11-dl",
  "xkb",
  "xkbcommon-sys",
@@ -1072,10 +1250,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+dependencies = [
+ "cfg-if",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.1",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.5",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
+
+[[package]]
+name = "net2"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "nix"
@@ -1210,7 +1463,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1237,6 +1490,38 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pin-project"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1301,6 +1586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1631,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1435,7 +1726,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1449,7 +1740,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1584,7 +1875,7 @@ dependencies = [
  "bitflags",
  "libc",
  "mach",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1593,7 +1884,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1760,10 +2051,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
+dependencies = [
+ "arc-swap",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "smallvec"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+
+[[package]]
+name = "socket2"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1852,7 +2171,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1917,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1928,6 +2247,41 @@ checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio",
+ "mio-named-pipes",
+ "mio-uds",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "tokio-macros",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2020,6 +2374,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,7 +2413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -2059,6 +2422,13 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasio"
+version = "1.0.0-alpha.1"
+dependencies = [
+ "futures",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2137,7 +2507,7 @@ dependencies = [
  "wasmer-types",
  "wasmer-vm",
  "wat",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2339,7 +2709,7 @@ dependencies = [
  "wasmer-engine",
  "wasmer-types",
  "wasmer-vm",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2393,7 +2763,7 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmer-types",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2402,16 +2772,21 @@ version = "1.0.0-alpha.1"
 dependencies = [
  "bincode",
  "byteorder",
+ "crossbeam",
+ "flurry",
+ "futures",
  "generational-arena",
  "getrandom",
  "libc",
  "serde",
  "thiserror",
  "time",
+ "tokio",
  "tracing",
  "typetag",
+ "uuid",
  "wasmer",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2593,6 +2968,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2600,6 +2981,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2613,7 +3000,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2621,6 +3008,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "x11-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "lib/wasi",
     "lib/wasi-experimental-io-devices",
     "lib/wasmer-types",
+    "lib/wasio-api",
     "tests/lib/wast",
 ]
 exclude = [

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -59,8 +59,10 @@ default = [
     "native",
     "cache",
     "wasi",
+    "wasio",
     "emscripten",
 ]
+wasio = []
 engine = []
 jit = [
     "wasmer-engine-jit",

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -21,7 +21,17 @@ getrandom = "0.1"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "0.2", features = ["full"], optional = true }
+futures = { version = "0.3", optional = true }
+crossbeam = { version = "0.7", optional = true }
+flurry = { version = "0.3", optional = true }
 wasmer = { path = "../api", version = "1.0.0-alpha.1", default-features = false }
+uuid = { version = "0.8", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
+
+[features]
+default = ["wasio", "wasio-executor-tokio"]
+wasio = []
+wasio-executor-tokio = ["tokio", "futures", "crossbeam", "flurry"]

--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -19,6 +19,9 @@ mod state;
 mod syscalls;
 mod utils;
 
+#[cfg(feature = "wasio")]
+pub mod wasio;
+
 use crate::syscalls::*;
 
 pub use crate::state::{
@@ -249,6 +252,20 @@ fn generate_import_object_snapshot0(store: &Store, env: WasiEnv) -> ImportObject
             "sock_send" => Function::new_native_with_env(store, env.clone(), sock_send),
             "sock_shutdown" => Function::new_native_with_env(store, env.clone(), sock_shutdown),
         },
+        #[cfg(feature = "wasio")]
+        "wasio_unstable" => {
+            "cancel" => Function::new_native_with_env(store, env.clone(), wasio_cancel),
+            "delay" => Function::new_native_with_env(store, env.clone(), wasio_delay),
+            "async_nop" => Function::new_native_with_env(store, env.clone(), wasio_async_nop),
+            "wait" => Function::new_native_with_env(store, env.clone(), wasio_wait),
+            "socket_create" => Function::new_native_with_env(store, env.clone(), wasio_socket_create),
+            "socket_bind" => Function::new_native_with_env(store, env.clone(), wasio_socket_bind),
+            "socket_listen" => Function::new_native_with_env(store, env.clone(), wasio_socket_listen),
+            "socket_pre_accept" => Function::new_native_with_env(store, env.clone(), wasio_socket_pre_accept),
+            "socket_accept" => Function::new_native_with_env(store, env.clone(), wasio_socket_accept),
+            "write" => Function::new_native_with_env(store, env.clone(), wasio_write),
+            "read" => Function::new_native_with_env(store, env.clone(), wasio_read),
+        },
     }
 }
 
@@ -301,6 +318,20 @@ fn generate_import_object_snapshot1(store: &Store, env: WasiEnv) -> ImportObject
             "sock_recv" => Function::new_native_with_env(store, env.clone(), sock_recv),
             "sock_send" => Function::new_native_with_env(store, env.clone(), sock_send),
             "sock_shutdown" => Function::new_native_with_env(store, env.clone(), sock_shutdown),
-        }
+        },
+        #[cfg(feature = "wasio")]
+        "wasio_unstable" => {
+            "cancel" => Function::new_native_with_env(store, env.clone(), wasio_cancel),
+            "delay" => Function::new_native_with_env(store, env.clone(), wasio_delay),
+            "async_nop" => Function::new_native_with_env(store, env.clone(), wasio_async_nop),
+            "wait" => Function::new_native_with_env(store, env.clone(), wasio_wait),
+            "socket_create" => Function::new_native_with_env(store, env.clone(), wasio_socket_create),
+            "socket_bind" => Function::new_native_with_env(store, env.clone(), wasio_socket_bind),
+            "socket_listen" => Function::new_native_with_env(store, env.clone(), wasio_socket_listen),
+            "socket_pre_accept" => Function::new_native_with_env(store, env.clone(), wasio_socket_pre_accept),
+            "socket_accept" => Function::new_native_with_env(store, env.clone(), wasio_socket_accept),
+            "write" => Function::new_native_with_env(store, env.clone(), wasio_write),
+            "read" => Function::new_native_with_env(store, env.clone(), wasio_read),
+        },
     }
 }

--- a/lib/wasi/src/ptr.rs
+++ b/lib/wasi/src/ptr.rs
@@ -60,6 +60,14 @@ impl<T: Copy + ValueType> WasmPtr<T, Item> {
     pub fn deref<'a>(self, memory: &'a Memory) -> Result<&'a Cell<T>, __wasi_errno_t> {
         self.0.deref(memory).ok_or(__WASI_EFAULT)
     }
+
+    #[inline(always)]
+    pub unsafe fn deref_mut<'a>(
+        self,
+        memory: &'a Memory,
+    ) -> Result<&'a mut Cell<T>, __wasi_errno_t> {
+        self.0.deref_mut(memory).ok_or(__WASI_EFAULT)
+    }
 }
 
 impl<T: Copy + ValueType> WasmPtr<T, Array> {
@@ -71,6 +79,16 @@ impl<T: Copy + ValueType> WasmPtr<T, Array> {
         length: u32,
     ) -> Result<&'a [Cell<T>], __wasi_errno_t> {
         self.0.deref(memory, index, length).ok_or(__WASI_EFAULT)
+    }
+
+    #[inline(always)]
+    pub unsafe fn deref_mut<'a>(
+        self,
+        memory: &'a Memory,
+        index: u32,
+        length: u32,
+    ) -> Result<&'a mut [Cell<T>], __wasi_errno_t> {
+        self.0.deref_mut(memory, index, length).ok_or(__WASI_EFAULT)
     }
 
     #[inline(always)]

--- a/lib/wasi/src/state/types.rs
+++ b/lib/wasi/src/state/types.rs
@@ -210,6 +210,11 @@ pub trait WasiFile: fmt::Debug + Send + Write + Read + Seek + 'static + Upcastab
     fn get_raw_fd(&self) -> Option<i32> {
         None
     }
+
+    /// Attempts to clone this `WasiFile` handle.
+    fn try_clone_dyn(&self) -> Option<Box<dyn WasiFile>> {
+        None
+    }
 }
 
 // Implementation of `Upcastable` taken from https://users.rust-lang.org/t/why-does-downcasting-not-work-for-subtraits/33286/7 .

--- a/lib/wasi/src/wasio/executor.rs
+++ b/lib/wasi/src/wasio/executor.rs
@@ -1,0 +1,46 @@
+//! Asynchronous executor for WASIO operations.
+
+use super::types::*;
+use crate::syscalls::types::*;
+use std::fmt::{self, Debug};
+
+/// The `Executor` trait.
+pub trait Executor: Send {
+    /// Enqueues an asynchronous oneshot operation.
+    ///
+    /// Returns a `CancellationToken` if the operation is successfully enqueued, and an error code otherwise.
+    fn enqueue_oneshot(
+        &self,
+        _: AsyncOneshotOperation,
+        _: UserContext,
+    ) -> Result<CancellationToken, __wasi_errno_t> {
+        Err(__WASI_ENOTSUP)
+    }
+
+    /// Enqueues an asynchronous stream operation.
+    ///
+    /// Returns a `CancellationToken` if the operation is successfully enqueued, and an error code otherwise.
+    fn enqueue_stream(
+        &self,
+        _: AsyncStreamOperation,
+        _: UserContext,
+    ) -> Result<CancellationToken, __wasi_errno_t> {
+        Err(__WASI_ENOTSUP)
+    }
+
+    /// Performs a synchronous operation.
+    fn perform(&self, _: SyncOperation) -> Result<(), __wasi_errno_t> {
+        Err(__WASI_ENOTSUP)
+    }
+
+    /// Blocks the current thread and wait for the next completed operation.
+    fn wait(&self) -> Result<(__wasi_errno_t, UserContext), __wasi_errno_t> {
+        Err(__WASI_ENOTSUP)
+    }
+}
+
+impl Debug for dyn Executor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<wasio executor>")
+    }
+}

--- a/lib/wasi/src/wasio/executor_impl/dummy.rs
+++ b/lib/wasi/src/wasio/executor_impl/dummy.rs
@@ -1,0 +1,5 @@
+use super::super::executor::Executor;
+
+pub struct DummyExecutor;
+
+impl Executor for DummyExecutor {}

--- a/lib/wasi/src/wasio/executor_impl/mod.rs
+++ b/lib/wasi/src/wasio/executor_impl/mod.rs
@@ -1,0 +1,6 @@
+//! Backing implementations of the `Executor` trait.
+
+#[cfg(feature = "wasio-executor-tokio")]
+pub mod tokio;
+
+pub mod dummy;

--- a/lib/wasi/src/wasio/executor_impl/tokio.rs
+++ b/lib/wasi/src/wasio/executor_impl/tokio.rs
@@ -1,0 +1,656 @@
+//! A WASIO executor backed by `tokio`.
+
+use super::super::executor::Executor;
+use super::super::socket::*;
+use super::super::types::*;
+use crate::syscalls::types::*;
+use crate::{ptr::WasmPtr, Fd, WasiFile, WasiFs, WasiFsError, ALL_RIGHTS, VIRTUAL_ROOT_FD};
+use crossbeam::channel::{unbounded, Receiver, Sender};
+use flurry::HashMap as ConcHashMap;
+use futures::future::{ready, AbortHandle, Abortable, Future, FutureExt, TryFutureExt};
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{
+    tcp::{OwnedReadHalf, OwnedWriteHalf},
+    TcpListener, TcpStream,
+};
+use tokio::runtime::Runtime;
+use tokio::stream::StreamExt;
+use tokio::sync::{mpsc, Mutex as AsyncMutex, RwLock as AsyncRwLock};
+
+/// An executor backed by the Tokio runtime.
+///
+/// Implements the `Executor` trait.
+pub struct TokioExecutor {
+    /// State of this executor.
+    ///
+    /// Wrapped in an `Arc` because asynchronous tasks may refer to this.
+    state: Arc<ExecutorState>,
+
+    /// The Tokio runtime dedicated to this executor.
+    ///
+    /// The runtime is backed by a threaded executor.
+    runtime: Runtime,
+
+    /// Thread-local completion queue.
+    ///
+    /// While asynchronously completed operations send their operations to `state.completed_rx`,
+    /// this is used for the "fast path" where the operation doesn't really need to be sent to the
+    /// asynchronous executor.
+    ///
+    /// Useful when e.g. data to read is already available and can be instantly copied to Wasm buffer.
+    local_completion: RefCell<VecDeque<(__wasi_errno_t, UserContext)>>,
+
+    /// Connection accept queue (RX).
+    ///
+    /// This is the receiver side of `state.accepted_tx`.
+    ///
+    /// TODO: One `accepted_rx` per listener socket?
+    accepted_rx: RefCell<mpsc::Receiver<(TcpStream, SocketAddr)>>,
+}
+
+/// Inner holder of executor state.
+struct ExecutorState {
+    /// Abort handles for all ongoing operations.
+    ///
+    /// The index is the `CancellationToken` and is unique across the whole lifetime of the `ExecutorState`.
+    ongoing: ConcHashMap<u64, AbortHandle>,
+
+    /// Next index for `ongoing`. Starts from 1 and monotonically increases by 1 per
+    /// new handle inserted into `ongoing`.
+    ongoing_next: AtomicU64,
+
+    /// Completed operations (TX). (return_value, user_context)
+    completed_tx: Sender<(__wasi_errno_t, UserContext)>,
+
+    /// Completed operations (RX). (return_value, user_context)
+    completed_rx: Receiver<(__wasi_errno_t, UserContext)>,
+
+    /// Connection accept queue (TX).
+    accepted_tx: mpsc::Sender<(TcpStream, SocketAddr)>,
+}
+
+impl TokioExecutor {
+    /// Creates a `TokioExecutor`.
+    pub fn new() -> TokioExecutor {
+        let (completed_tx, completed_rx) = unbounded();
+
+        // Capacity must be 1. See `AsyncStreamOperation::SocketListen`.
+        let (accepted_tx, accepted_rx) = mpsc::channel(1);
+
+        TokioExecutor {
+            state: Arc::new(ExecutorState {
+                ongoing: ConcHashMap::new(),
+                ongoing_next: AtomicU64::new(1), // index 0 is reserved for "null"
+                completed_tx,
+                completed_rx,
+                accepted_tx,
+            }),
+            runtime: Runtime::new().expect("TokioExecutor::new: cannot create Tokio runtime"), // XXX: When does the error happen?
+            local_completion: RefCell::new(VecDeque::new()),
+            accepted_rx: RefCell::new(accepted_rx),
+        }
+    }
+}
+
+impl TokioExecutor {
+    /// Spawns a oneshot operation.
+    fn spawn_oneshot(
+        &self,
+        fut: impl Future<Output = __wasi_errno_t> + Send + 'static,
+        user_context: UserContext,
+    ) -> CancellationToken {
+        // Prepare abort handle for cancellation.
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+
+        // Insert the operation into ongoing.
+        let ongoing_index = self.state.ongoing_next.fetch_add(1, Ordering::Relaxed);
+        self.state.ongoing.pin().insert(ongoing_index, abort_handle);
+        let cancel_token = CancellationToken(ongoing_index as _);
+
+        // Spawn an asynchronous task.
+        let state = self.state.clone();
+        self.runtime.spawn(async move {
+            // Wrap with abort registration.
+            let result = Abortable::new(fut, abort_registration).await;
+
+            // Cancellation token is unique. No race condition here.
+            state.ongoing.pin().remove(&ongoing_index);
+
+            // Prepare to enqueue the result.
+            let enqueued = match result {
+                Ok(return_value) => {
+                    // Operation finished before any cancellation request.
+                    (return_value, user_context)
+                }
+                Err(_) => {
+                    // Operation aborted/cancelled.
+                    (__WASI_ECANCELED, user_context)
+                }
+            };
+
+            // TX and RX are in the same struct (so we know the RX side isn't dropped), so this should never fail.
+            state.completed_tx.send(enqueued).unwrap()
+        });
+        cancel_token
+    }
+}
+
+impl Executor for TokioExecutor {
+    fn enqueue_oneshot(
+        &self,
+        op: AsyncOneshotOperation,
+        user_context: UserContext,
+    ) -> Result<CancellationToken, __wasi_errno_t> {
+        let imm_result: __wasi_errno_t = match op {
+            AsyncOneshotOperation::Nop => 0,
+            AsyncOneshotOperation::Delay(duration) => {
+                // Spawn a task to notify us after `duration`.
+                // `runtime.enter` is needed here because `delay_for` expects to be called within a Tokio runtime context.
+                return Ok(self.spawn_oneshot(
+                    self.runtime
+                        .enter(|| tokio::time::delay_for(duration).map(|_| __WASI_ESUCCESS)),
+                    user_context,
+                ));
+            }
+            AsyncOneshotOperation::Read {
+                memory,
+                fs,
+                fd,
+                ri_data,
+                ri_data_len,
+                ri_flags,
+                ro_datalen,
+                ro_flags,
+            } => {
+                let sock: AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?.clone();
+
+                // Read iovecs into local buffers, to allow the caller to deallocate them.
+                let iovecs: Vec<_> = ri_data
+                    .deref(memory, 0, ri_data_len)?
+                    .iter()
+                    .map(|x| x.get())
+                    .collect();
+
+                // FIXME: `memory` is marked as `Clone` but might not be actually be safe to clone: `grow()`.
+                let memory = memory.clone();
+
+                return Ok(
+                    self.spawn_oneshot(
+                        self.runtime.enter(|| async move {
+                            let sock_inner = sock.inner.read().await;
+                            match *sock_inner {
+                                AbstractTcpSocketInner::Stream(ref read_half, _) => {
+                                    let mut read_len: usize = 0;
+                                    for v in iovecs {
+                                        // FIXME: The vectored read semantics here is correct for streaming protocols (TCP) but not for packet
+                                        // protocols (UDP, ICMP, etc.).
+                                        let read_buffer = unsafe {
+                                            std::mem::transmute::<
+                                                &mut [std::cell::Cell<u8>],
+                                                &mut [u8],
+                                            >(
+                                                match v.buf.deref_mut(&memory, 0, v.buf_len) {
+                                                    Ok(x) => x,
+                                                    Err(e) => return __WASI_EFAULT,
+                                                },
+                                            )
+                                        };
+                                        let mut read_half = read_half.lock().await;
+                                        match read_half.read(read_buffer).await {
+                                            Ok(n) => {
+                                                read_len += n;
+                                            }
+                                            Err(e) => return from_tokio_error(e),
+                                        }
+                                    }
+
+                                    let ro_datalen = match ro_datalen.deref(&memory) {
+                                        Ok(x) => x,
+                                        Err(e) => return __WASI_EFAULT,
+                                    };
+
+                                    ro_datalen.set(read_len as u32);
+                                    __WASI_ESUCCESS
+                                }
+                                _ => __WASI_EINVAL,
+                            }
+                        }),
+                        user_context,
+                    ),
+                );
+            }
+            AsyncOneshotOperation::Write {
+                memory,
+                fs,
+                fd,
+                si_data,
+                si_data_len,
+                si_flags,
+                so_datalen,
+            } => {
+                let sock: AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?.clone();
+
+                // Read iovecs into local buffers, to allow the caller to deallocate them.
+                let iovecs: Vec<_> = si_data
+                    .deref(memory, 0, si_data_len)?
+                    .iter()
+                    .map(|x| x.get())
+                    .collect();
+
+                // FIXME: `memory` is marked as `Clone` but might not be actually be safe to clone: `grow()`.
+                let memory = memory.clone();
+
+                return Ok(self.spawn_oneshot(
+                    self.runtime.enter(|| async move {
+                        let mut data_to_write: Vec<u8> = vec![];
+
+                        for v in iovecs {
+                            let data = match v.buf.deref(&memory, 0, v.buf_len) {
+                                Ok(x) => x,
+                                Err(e) => return __WASI_EFAULT,
+                            };
+                            for b in data {
+                                data_to_write.push(b.get());
+                            }
+                        }
+
+                        let sock_inner = sock.inner.read().await;
+                        match *sock_inner {
+                            AbstractTcpSocketInner::Stream(_, ref write_half) => {
+                                let mut write_half = write_half.lock().await;
+                                match write_half.write(&data_to_write).await {
+                                    Ok(n) => {
+                                        let so_datalen = match so_datalen.deref(&memory) {
+                                            Ok(x) => x,
+                                            Err(e) => return __WASI_EFAULT,
+                                        };
+
+                                        so_datalen.set(n as u32);
+                                        __WASI_ESUCCESS
+                                    }
+                                    Err(e) => from_tokio_error(e),
+                                }
+                            }
+                            _ => __WASI_EINVAL,
+                        }
+                    }),
+                    user_context,
+                ));
+            }
+            AsyncOneshotOperation::Read {
+                memory,
+                fs,
+                fd,
+                ri_data,
+                ri_data_len,
+                ri_flags,
+                ro_datalen,
+                ro_flags
+            } => {
+                let sock: AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?.clone();
+
+                // Read iovecs into local buffers, to allow the caller to deallocate them.
+                let iovecs: Vec<_> = ri_data
+                    .deref(memory, 0, ri_data_len)?
+                    .iter()
+                    .map(|x| x.get())
+                    .collect();
+
+                // FIXME: `memory` is marked as `Clone` but might not be actually be safe to clone: `grow()`.
+                let memory = memory.clone();
+
+                return Ok(self.spawn_oneshot(
+                    self.runtime.enter(|| async move {
+
+                        // FIXME: Allow multiple iovec elements
+                        if iovecs.len() == 0 {
+                            let ro_datalen = match ro_datalen.deref(&memory) {
+                                Ok(x) => x,
+                                Err(e) => return __WASI_EFAULT,
+                            };
+                            ro_datalen.set(0);
+                            return __WASI_ESUCCESS;
+                        }
+                        let iov = &iovecs[0];
+
+                        let data = match unsafe { iov.buf.deref_mut(&memory, 0, iov.buf_len) } {
+                            Ok(x) => x,
+                            Err(e) => return __WASI_EFAULT,
+                        };
+                        let data = unsafe {
+                            std::mem::transmute::<&mut [Cell<u8>], &mut [u8]>(data)
+                        };
+
+                        let sock_inner = sock.inner.read().await;
+                        match *sock_inner {
+                            AbstractTcpSocketInner::Stream(ref read_half, _) => {
+                                let mut read_half = read_half.lock().await;
+                                match read_half.read(data).await {
+                                    Ok(n) => {
+                                        let ro_datalen = match ro_datalen.deref(&memory) {
+                                            Ok(x) => x,
+                                            Err(e) => return __WASI_EFAULT,
+                                        };
+                                        ro_datalen.set(n as u32);
+                                        __WASI_ESUCCESS
+                                    }
+                                    Err(e) => from_tokio_error(e),
+                                }
+                            }
+                            _ => __WASI_EINVAL,
+                        }
+                    }),
+                    user_context,
+                ));
+            }
+            AsyncOneshotOperation::SocketPreAccept { fs, fd } => {
+                let sock: AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?.clone();
+
+                let state = self.state.clone();
+                return Ok(self.spawn_oneshot(
+                    async move {
+                        loop {
+                            let sock_inner = sock.inner.read().await;
+                            let mut listener = match *sock_inner {
+                                AbstractTcpSocketInner::Listening(ref x) => x.lock().await,
+                                _ => break __WASI_EINVAL,
+                            };
+                            let (stream, addr) = match listener.accept().await {
+                                Ok(x) => x,
+                                Err(e) => break from_tokio_error(e),
+                            };
+                            drop(listener);
+                            drop(sock_inner);
+
+                            // Here the capacity of `accepted_tx/rx` is 1. This "serializes" the order of sending
+                            // to two different queues from different threads.
+                            match state.accepted_tx.clone().send((stream, addr)).await {
+                                Ok(()) => {}
+                                Err(_) => {
+                                    // `state` outlives `self`.
+                                    break __WASI_EAGAIN;
+                                }
+                            }
+                            break 0;
+                        }
+                    },
+                    user_context,
+                ));
+            }
+        };
+        self.local_completion
+            .borrow_mut()
+            .push_back((imm_result, user_context));
+        return Ok(CancellationToken(0));
+    }
+
+    fn enqueue_stream(
+        &self,
+        op: AsyncStreamOperation,
+        user_context: UserContext,
+    ) -> Result<CancellationToken, __wasi_errno_t> {
+        match op {}
+    }
+
+    fn perform(&self, op: SyncOperation) -> Result<(), __wasi_errno_t> {
+        match op {
+            SyncOperation::Cancel(cancel_token) => {
+                // Attempt to get the abort handle corresponding to the cancellation token.
+                //
+                // Fails if the associated task has already finished or is cancelled before. Since
+                // the cancellation token is unique, racing with completion here is fine.
+                if let Some(abort_handle) = self.state.ongoing.pin().remove(&(cancel_token.0 as _))
+                {
+                    // Send abort signal.
+                    abort_handle.abort();
+
+                    Ok(())
+                } else {
+                    Err(__WASI_EINVAL)
+                }
+            }
+            SyncOperation::SocketCreate(memory, fd_out, fs, domain, ty, _protocol) => {
+                let fd_out_cell = fd_out.deref(memory)?;
+                let socket = AbstractTcpSocket {
+                    inner: Arc::new(AsyncRwLock::new(match (domain, ty) {
+                        (x, y) if x == AF_INET && y == SOCK_STREAM => {
+                            AbstractTcpSocketInner::Undefined4
+                        }
+                        (x, y) if x == AF_INET6 && y == SOCK_STREAM => {
+                            AbstractTcpSocketInner::Undefined6
+                        }
+                        _ => return Err(__WASI_EINVAL),
+                    })),
+                };
+                let file = Box::new(socket);
+                let fd = fs
+                    .open_file_at(
+                        VIRTUAL_ROOT_FD,
+                        file,
+                        Fd::READ | Fd::WRITE,
+                        "<socket>".to_string(),
+                        ALL_RIGHTS,
+                        ALL_RIGHTS,
+                        0,
+                    )
+                    .map_err(|_| __WASI_EINVAL)?;
+                fd_out_cell.set(fd);
+                Ok(())
+            }
+            SyncOperation::SocketBind(memory, fs, fd, sockaddr_ptr, sockaddr_size) => {
+                let sock: &AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?;
+                self.runtime.handle().block_on(async {
+                    let mut sock_inner = sock.inner.write().await;
+                    match (sockaddr_size, &*sock_inner) {
+                        (16, AbstractTcpSocketInner::Undefined4) => {
+                            let sockaddr = WasmPtr::<SockaddrIn>::new(sockaddr_ptr.offset())
+                                .deref(memory)?
+                                .get();
+                            let ipaddr = Ipv4Addr::from(sockaddr.sin_addr);
+                            *sock_inner =
+                                AbstractTcpSocketInner::Binded(SocketAddr::V4(SocketAddrV4::new(
+                                    ipaddr,
+                                    sockaddr.sin_port.to_be(), // swap byteorder
+                                )));
+                            Ok(())
+                        }
+                        (28, AbstractTcpSocketInner::Undefined6) => {
+                            let sockaddr = WasmPtr::<SockaddrIn6>::new(sockaddr_ptr.offset())
+                                .deref(memory)?
+                                .get();
+                            let ipaddr = Ipv6Addr::from(sockaddr.sin6_addr);
+                            *sock_inner =
+                                AbstractTcpSocketInner::Binded(SocketAddr::V6(SocketAddrV6::new(
+                                    ipaddr,
+                                    sockaddr.sin6_port.to_be(), // swap byteorder
+                                    sockaddr.sin6_flowinfo,
+                                    sockaddr.sin6_scope_id,
+                                )));
+                            Ok(())
+                        }
+                        _ => Err(__WASI_EINVAL),
+                    }
+                })
+            }
+            SyncOperation::SocketListen { fs, fd } => {
+                let sock: &AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?;
+                self.runtime.handle().block_on(async {
+                    let mut sock_inner = sock.inner.write().await;
+                    match &*sock_inner {
+                        AbstractTcpSocketInner::Binded(addr) => {
+                            let l = TcpListener::bind(addr).map_err(from_tokio_error).await?;
+                            *sock_inner = AbstractTcpSocketInner::Listening(AsyncMutex::new(l));
+                            Ok(())
+                        }
+                        _ => Err(__WASI_EINVAL),
+                    }
+                })
+            }
+            SyncOperation::SocketAccept { memory, fs, fd_out } => {
+                match self.accepted_rx.borrow_mut().try_recv() {
+                    Ok((stream, addr)) => {
+                        let fd_out_cell = fd_out.deref(memory)?;
+                        let (r, w) = stream.into_split();
+                        let socket = AbstractTcpSocket {
+                            inner: Arc::new(AsyncRwLock::new(AbstractTcpSocketInner::Stream(
+                                AsyncMutex::new(r),
+                                AsyncMutex::new(w),
+                            ))),
+                        };
+                        let file = Box::new(socket);
+                        let socket_name = format!("<accept:{}>", uuid::Uuid::new_v4());
+                        let fd = fs
+                            .open_file_at(
+                                VIRTUAL_ROOT_FD,
+                                file,
+                                Fd::READ | Fd::WRITE,
+                                socket_name,
+                                ALL_RIGHTS,
+                                ALL_RIGHTS,
+                                0,
+                            )
+                            .map_err(|_| __WASI_EINVAL)?;
+                        fd_out_cell.set(fd);
+                        Ok(())
+                    }
+                    Err(e) => Err(__WASI_EAGAIN),
+                }
+            }
+        }
+    }
+
+    fn wait(&self) -> Result<(__wasi_errno_t, UserContext), __wasi_errno_t> {
+        if let Some(x) = self.local_completion.borrow_mut().pop_front() {
+            Ok(x)
+        } else {
+            // TX and RX are in the same struct, so this should never fail.
+            Ok(self.state.completed_rx.recv().unwrap())
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AbstractTcpSocket {
+    inner: Arc<AsyncRwLock<AbstractTcpSocketInner>>,
+}
+
+#[derive(Debug)]
+enum AbstractTcpSocketInner {
+    /// Created as an IPv4 socket, but is neither binded nor connected.
+    Undefined4,
+
+    /// Created as an IPv6 socket, but is neither binded nor connected.
+    Undefined6,
+
+    /// "Virtually" binded to a socket address.
+    Binded(SocketAddr),
+
+    /// Listening for incoming connections.
+    Listening(AsyncMutex<TcpListener>),
+
+    /// A connection is established on this socket.
+    Stream(AsyncMutex<OwnedReadHalf>, AsyncMutex<OwnedWriteHalf>),
+}
+
+impl Seek for AbstractTcpSocket {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        Err(io::Error::from(io::ErrorKind::Other)) // seek operation not supported on sockets
+    }
+}
+
+impl Read for AbstractTcpSocket {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Err(io::Error::from(io::ErrorKind::WouldBlock))
+    }
+}
+
+impl Write for AbstractTcpSocket {
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Err(io::Error::from(io::ErrorKind::WouldBlock))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl serde::Serialize for AbstractTcpSocket {
+    fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
+        unimplemented!()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AbstractTcpSocket {
+    fn deserialize<D: serde::Deserializer<'de>>(_: D) -> Result<Self, D::Error> {
+        unimplemented!()
+    }
+}
+
+#[typetag::serde]
+impl WasiFile for AbstractTcpSocket {
+    fn last_accessed(&self) -> u64 {
+        0
+    }
+    fn last_modified(&self) -> u64 {
+        0
+    }
+    fn created_time(&self) -> u64 {
+        0
+    }
+    fn size(&self) -> u64 {
+        0
+    }
+    fn set_len(&mut self, _new_size: __wasi_filesize_t) -> Result<(), WasiFsError> {
+        Err(WasiFsError::PermissionDenied)
+    }
+    fn unlink(&mut self) -> Result<(), WasiFsError> {
+        Ok(())
+    }
+
+    fn bytes_available(&self) -> Result<usize, WasiFsError> {
+        Ok(0)
+    }
+
+    #[cfg(unix)]
+    fn get_raw_fd(&self) -> Option<i32> {
+        None
+        /*
+        use std::os::unix::io::AsRawFd;
+        match *self.inner.read().unwrap() {
+            AbstractTcpSocketInner::Undefined4 | AbstractTcpSocketInner::Undefined6 => None,
+            AbstractTcpSocketInner::Listener(ref x) => Some(x.as_raw_fd()),
+            AbstractTcpSocketInner::Stream(ref x, _) => Some(x.as_raw_fd()),
+        }
+        */
+    }
+
+    #[cfg(not(unix))]
+    fn get_raw_fd(&self) -> Option<i32> {
+        unimplemented!(
+            "AbstractTcpSocket::get_raw_fd in WasiFile is not implemented for non-Unix-like targets yet"
+        );
+    }
+
+    fn try_clone_dyn(&self) -> Option<Box<dyn WasiFile>> {
+        Some(Box::new(self.clone()))
+    }
+}
+
+fn from_tokio_error(e: tokio::io::Error) -> __wasi_errno_t {
+    use tokio::io::ErrorKind;
+    match e.kind() {
+        ErrorKind::NotConnected => __WASI_ENOTCONN,
+        ErrorKind::AddrInUse => __WASI_EADDRINUSE,
+        ErrorKind::BrokenPipe => __WASI_EPIPE,
+        ErrorKind::PermissionDenied => __WASI_EPERM,
+        _ => __WASI_EINVAL,
+    }
+}

--- a/lib/wasi/src/wasio/executor_impl/tokio.rs
+++ b/lib/wasi/src/wasio/executor_impl/tokio.rs
@@ -293,7 +293,7 @@ impl Executor for TokioExecutor {
                 ri_data_len,
                 ri_flags,
                 ro_datalen,
-                ro_flags
+                ro_flags,
             } => {
                 let sock: AbstractTcpSocket = fs.get_wasi_file_as::<AbstractTcpSocket>(fd)?.clone();
 
@@ -309,7 +309,6 @@ impl Executor for TokioExecutor {
 
                 return Ok(self.spawn_oneshot(
                     self.runtime.enter(|| async move {
-
                         // FIXME: Allow multiple iovec elements
                         if iovecs.len() == 0 {
                             let ro_datalen = match ro_datalen.deref(&memory) {
@@ -325,9 +324,8 @@ impl Executor for TokioExecutor {
                             Ok(x) => x,
                             Err(e) => return __WASI_EFAULT,
                         };
-                        let data = unsafe {
-                            std::mem::transmute::<&mut [Cell<u8>], &mut [u8]>(data)
-                        };
+                        let data =
+                            unsafe { std::mem::transmute::<&mut [Cell<u8>], &mut [u8]>(data) };
 
                         let sock_inner = sock.inner.read().await;
                         match *sock_inner {

--- a/lib/wasi/src/wasio/mod.rs
+++ b/lib/wasi/src/wasio/mod.rs
@@ -1,0 +1,12 @@
+//! The WASIO extension.
+//!
+//! WASIO extends WASI to provide high-performance, fully asynchronous I/O operations.
+
+pub mod executor;
+pub mod executor_impl;
+pub mod socket;
+pub mod types;
+
+pub use self::executor::Executor;
+pub use self::executor_impl::dummy::DummyExecutor;
+pub use self::executor_impl::tokio::TokioExecutor;

--- a/lib/wasi/src/wasio/socket.rs
+++ b/lib/wasi/src/wasio/socket.rs
@@ -1,0 +1,17 @@
+use super::types::*;
+
+/// An IPv4 socket.
+pub const AF_INET: __wasio_socket_domain_t = 2;
+
+/// An IPv6 socket.
+pub const AF_INET6: __wasio_socket_domain_t = 10;
+
+/// Provides sequenced, reliable, two-way, connection-based byte streams.
+///
+/// Implies TCP when used with an IP socket.
+pub const SOCK_STREAM: __wasio_socket_type_t = 1;
+
+/// Supports datagrams (connectionless, unreliable messages of a fixed maximum length).
+///
+/// Implies UDP when used with an IP socket.
+pub const SOCK_DGRAM: __wasio_socket_type_t = 2;

--- a/lib/wasi/src/wasio/types.rs
+++ b/lib/wasi/src/wasio/types.rs
@@ -1,0 +1,158 @@
+//! Type definitions for WASIO.
+#![allow(non_camel_case_types)]
+
+use crate::{
+    ptr::{Array, WasmPtr},
+    syscalls::types::*,
+    WasiFile, WasiFs,
+};
+use std::time::Duration;
+use wasmer::{FromToNativeWasmType, Memory, ValueType};
+
+/// The cancellation token of an ongoing asynchronous operation.
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct CancellationToken(pub u64);
+
+unsafe impl ValueType for CancellationToken {}
+unsafe impl FromToNativeWasmType for CancellationToken {
+    type Native = i64;
+    fn from_native(native: Self::Native) -> Self {
+        CancellationToken(native as _)
+    }
+    fn to_native(self) -> Self::Native {
+        self.0 as _
+    }
+}
+
+/// An asynchronous oneshot operation.
+pub enum AsyncOneshotOperation<'a> {
+    /// Empty operation.
+    Nop,
+
+    /// Delays for a given duration.
+    Delay(Duration),
+
+    /// Writes data to an asynchronous file descriptor. No copies are made in userspace,
+    /// so the (WebAssembly) caller must keep the memory region alive before
+    /// this operation finishes.
+    Write {
+        memory: &'a Memory,
+        fs: &'a mut WasiFs,
+        fd: __wasi_fd_t,
+        si_data: WasmPtr<__wasi_ciovec_t, Array>,
+        si_data_len: u32,
+        si_flags: __wasi_siflags_t,
+        so_datalen: WasmPtr<u32>,
+    },
+
+    /// Reads data from an asynchronous file descriptor.
+    Read {
+        memory: &'a Memory,
+        fs: &'a mut WasiFs,
+        fd: __wasi_fd_t,
+        ri_data: WasmPtr<__wasi_ciovec_t, Array>,
+        ri_data_len: u32,
+        ri_flags: __wasi_riflags_t,
+        ro_datalen: WasmPtr<u32>,
+        ro_flags: WasmPtr<__wasi_roflags_t>,
+    },
+
+    /// Accepts a connection on a socket.
+    SocketPreAccept {
+        fs: &'a mut WasiFs,
+        fd: __wasi_fd_t, // fd
+    },
+}
+
+/// An asynchronous stream operation.
+pub enum AsyncStreamOperation {}
+
+/// An synchronous operation.
+pub enum SyncOperation<'a> {
+    /// Cancels an ongoing asynchronous operation.
+    Cancel(CancellationToken),
+
+    /// Creates an asynchronous socket.
+    SocketCreate(
+        &'a Memory,
+        WasmPtr<__wasi_fd_t>,
+        &'a mut WasiFs,
+        __wasio_socket_domain_t,
+        __wasio_socket_type_t,
+        __wasio_socket_protocol_t,
+    ),
+
+    /// Binds an asynchronous socket to an address.
+    SocketBind(
+        &'a Memory,
+        &'a mut WasiFs,
+        __wasi_fd_t,        // fd
+        WasmPtr<u8, Array>, // sockaddr
+        u32,                // sockaddr size
+    ),
+
+    /// Accepts a connection notified via a `SocketListen` stream.
+    SocketAccept {
+        memory: &'a Memory,
+        fs: &'a mut WasiFs,
+        fd_out: WasmPtr<__wasi_fd_t>, // fd
+    },
+
+    /// Starts listening on a socket.
+    SocketListen {
+        fs: &'a mut WasiFs,
+        fd: __wasi_fd_t, // fd
+    },
+}
+
+/// The user context that will be returned to WebAssembly, once a
+/// requested asynchronous operation is completed.
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct UserContext(pub u64);
+
+unsafe impl ValueType for UserContext {}
+unsafe impl FromToNativeWasmType for UserContext {
+    type Native = i64;
+    fn from_native(native: Self::Native) -> Self {
+        UserContext(native as _)
+    }
+    fn to_native(self) -> Self::Native {
+        self.0 as _
+    }
+}
+
+/// The `sockaddr_in` struct.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct SockaddrIn {
+    pub sin_family: i16,
+    pub sin_port: u16,
+    pub sin_addr: [u8; 4],
+    pub sin_zero: [u8; 8],
+}
+
+unsafe impl ValueType for SockaddrIn {}
+
+/// The `sockaddr_in6` struct.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct SockaddrIn6 {
+    pub sin6_family: i16,
+    pub sin6_port: u16,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: [u8; 16],
+    pub sin6_scope_id: u32,
+}
+
+unsafe impl ValueType for SockaddrIn6 {}
+
+/// The type of a WASIO socket domain.
+pub type __wasio_socket_domain_t = i32;
+
+/// The type of a WASIO socket type.
+pub type __wasio_socket_type_t = i32;
+
+/// The type of a WASIO socket protocol.
+pub type __wasio_socket_protocol_t = i32;

--- a/lib/wasio-api/Cargo.toml
+++ b/lib/wasio-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wasio"
+version = "1.0.0-alpha.1"
+authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
+description = "WebAssembly async I/O"
+license = "(Apache-2.0 WITH LLVM-exception) or MIT"
+categories = ["wasm"]
+keywords = ["webassembly", "async", "wasm"]
+repository = "https://github.com/wasmerio/wasmer"
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+futures = "0.3"

--- a/lib/wasio-api/Makefile
+++ b/lib/wasio-api/Makefile
@@ -1,0 +1,3 @@
+# This build the examples into wasm files
+examples:
+	cargo build --examples --target=wasm32-wasi --release

--- a/lib/wasio-api/README.md
+++ b/lib/wasio-api/README.md
@@ -1,0 +1,31 @@
+# `wasio` [![Build Status](https://img.shields.io/azure-devops/build/wasmerio/wasmer/3.svg?style=flat-square)](https://dev.azure.com/wasmerio/wasmer/_build/latest?definitionId=3&branchName=master) [![Join Wasmer Slack](https://img.shields.io/static/v1?label=Slack&message=join%20chat&color=brighgreen&style=flat-square)](https://slack.wasmer.io) [![MIT License](https://img.shields.io/github/license/wasmerio/wasmer.svg?style=flat-square)](https://github.com/wasmerio/wasmer/blob/master/LICENSE)
+
+Wasio allows using `async`/`await` syntax and while also adding
+networking capabilities, so you can use them when compiling to WebAssembly.
+
+This crate enables it's easy usage within Rust.
+
+## Example Implementation
+
+Count to 10 script:
+
+```rust
+use std::time::{Duration, SystemTime};
+use wasio::task::Task;
+use wasio::thread::delay;
+
+fn main() {
+    Task::spawn(Box::pin(root_task()));
+    wasio::executor::enter();
+}
+
+async fn root_task() {
+    const N: usize = 10;
+    println!("Counting to {}:", N);
+    for i in 0..N {
+        delay(Duration::from_millis(1000)).await;
+        println!("* {}", i + 1);
+    }
+    std::process::exit(0);
+}
+```

--- a/lib/wasio-api/examples/count_to.rs
+++ b/lib/wasio-api/examples/count_to.rs
@@ -1,0 +1,18 @@
+use std::time::{Duration, SystemTime};
+use wasio::task::Task;
+use wasio::thread::delay;
+
+fn main() {
+    Task::spawn(Box::pin(root_task()));
+    wasio::executor::enter();
+}
+
+async fn root_task() {
+    const N: usize = 10;
+    println!("Counting to {}:", N);
+    for i in 0..N {
+        delay(Duration::from_millis(1000)).await;
+        println!("* {}", i + 1);
+    }
+    std::process::exit(0);
+}

--- a/lib/wasio-api/examples/delay.rs
+++ b/lib/wasio-api/examples/delay.rs
@@ -1,0 +1,25 @@
+use std::time::Duration;
+use wasio::task::Task;
+use wasio::thread::delay;
+
+fn main() {
+    Task::spawn(Box::pin(root_task()));
+    wasio::executor::enter();
+}
+
+async fn root_task() {
+    println!("Spawning workers");
+    for i in 0..16 {
+        Task::spawn(Box::pin(worker_task(i)));
+    }
+}
+
+async fn worker_task(id: i32) {
+    println!("Worker {} started", id);
+    let mut i: i32 = 0;
+    loop {
+        println!("Hello ({}:{})", id, i);
+        i += 1;
+        delay(Duration::from_millis(1000)).await;
+    }
+}

--- a/lib/wasio-api/examples/nop.rs
+++ b/lib/wasio-api/examples/nop.rs
@@ -1,0 +1,19 @@
+use std::time::{Duration, SystemTime};
+use wasio::task::Task;
+
+fn main() {
+    Task::spawn(Box::pin(root_task()));
+    wasio::executor::enter();
+}
+
+async fn root_task() {
+    const N: usize = 10000000;
+    println!("Benchmarking");
+    let start = SystemTime::now();
+    for _ in 0..N {
+        wasio::thread::async_nop().await;
+    }
+    let end = SystemTime::now();
+    println!("Done. Time = {:?}", end.duration_since(start).unwrap());
+    std::process::exit(0);
+}

--- a/lib/wasio-api/examples/tcp_echo.rs
+++ b/lib/wasio-api/examples/tcp_echo.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+use wasio::io;
+use wasio::net;
+use wasio::task::Task;
+use wasio::thread::delay;
+use wasio::types::*;
+
+fn main() {
+    Task::spawn(Box::pin(root_task()));
+    wasio::executor::enter();
+}
+
+async fn root_task() {
+    println!("Creating socket");
+    let fd = net::socket(AF_INET, SOCK_STREAM, 0).unwrap();
+    println!("fd = {}", fd);
+
+    net::bind4(
+        fd,
+        &SockaddrIn {
+            sin_family: AF_INET as _,
+            sin_port: 9000u16.to_be(),
+            sin_addr: [0u8; 4],
+            sin_zero: [0u8; 8],
+        },
+    )
+    .unwrap();
+    println!("Binded.");
+
+    net::listen(fd).unwrap();
+    println!("Listen started.");
+
+    loop {
+        let conn = net::accept(fd).await.unwrap();
+        println!("New connection.");
+        Task::spawn(Box::pin(conn_worker(conn)));
+    }
+}
+
+async fn conn_worker(conn: __wasi_fd_t) {
+    loop {
+        let mut buf = [0u8; 128];
+        let n = match io::read(conn, &mut buf).await {
+            Ok(n) => n,
+            Err(e) => {
+                println!("read error: {:?}", e);
+                break;
+            }
+        };
+        match io::write(conn, &buf).await {
+            Ok(_) => {}
+            Err(e) => {
+                println!("write error: {:?}", e);
+                break;
+            }
+        }
+    }
+    net::close(conn);
+}

--- a/lib/wasio-api/examples/tcp_server.rs
+++ b/lib/wasio-api/examples/tcp_server.rs
@@ -1,0 +1,54 @@
+use std::time::Duration;
+use wasio::io;
+use wasio::net;
+use wasio::task::Task;
+use wasio::thread::delay;
+use wasio::types::*;
+
+fn main() {
+    Task::spawn(Box::pin(root_task()));
+    wasio::executor::enter();
+}
+
+async fn root_task() {
+    println!("Creating socket");
+    let fd = net::socket(AF_INET, SOCK_STREAM, 0).unwrap();
+    println!("fd = {}", fd);
+
+    net::bind4(
+        fd,
+        &SockaddrIn {
+            sin_family: AF_INET as _,
+            sin_port: 9000u16.to_be(),
+            sin_addr: [0u8; 4],
+            sin_zero: [0u8; 8],
+        },
+    )
+    .unwrap();
+    println!("Binded.");
+
+    net::listen(fd).unwrap();
+    println!("Listen started.");
+
+    loop {
+        let conn = net::accept(fd).await.unwrap();
+        println!("New connection.");
+        Task::spawn(Box::pin(conn_worker(conn)));
+    }
+}
+
+async fn conn_worker(conn: __wasi_fd_t) {
+    for i in 0..10 {
+        let s = format!("Hello from Wasio! (#{})\n", i);
+        match io::write(conn, s.as_bytes()).await {
+            Ok(n) => {
+                delay(Duration::from_millis(1000)).await;
+            }
+            Err(e) => {
+                println!("Connection error: {:?}", e);
+                break;
+            }
+        }
+    }
+    net::close(conn);
+}

--- a/lib/wasio-api/src/executor.rs
+++ b/lib/wasio-api/src/executor.rs
@@ -1,0 +1,100 @@
+//! Wasio core executor.
+
+use crate::sys;
+use crate::types::*;
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+pub struct Continuation {
+    result: Option<__wasi_errno_t>,
+    waker: Option<Waker>,
+}
+
+pub struct IoFuture<F> {
+    continuation: RefCell<Continuation>,
+    token: Option<CancellationToken>,
+    trigger: Option<F>,
+}
+
+impl<F: FnOnce(UserContext) -> Result<CancellationToken, __wasi_errno_t>> IoFuture<F> {
+    pub(crate) fn new(trigger: F) -> Self {
+        IoFuture {
+            continuation: RefCell::new(Continuation {
+                result: None,
+                waker: None,
+            }),
+            token: None,
+            trigger: Some(trigger),
+        }
+    }
+}
+
+impl<F: FnOnce(UserContext) -> Result<CancellationToken, __wasi_errno_t> + Unpin> Future
+    for IoFuture<F>
+{
+    type Output = __wasi_errno_t;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let result = self.continuation.borrow().result;
+        match result {
+            Some(x) => Poll::Ready(x),
+            None => {
+                if self.token.is_none() {
+                    self.continuation.borrow_mut().waker = Some(cx.waker().clone());
+                    let trigger = self.as_mut().trigger.take().unwrap();
+                    let ret = trigger(UserContext(&self.continuation as *const _ as usize as u64));
+                    match ret {
+                        Ok(ct) => {
+                            self.token = Some(ct);
+                        }
+                        Err(e) => {
+                            self.continuation.borrow_mut().result = Some(e);
+                        }
+                    }
+                }
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl<F> Drop for IoFuture<F> {
+    fn drop(&mut self) {
+        if self.continuation.borrow().result.is_none() {
+            if let Some(token) = self.token.take() {
+                unsafe {
+                    sys::cancel(token);
+                }
+            }
+        }
+    }
+}
+
+/// Enters the event loop once.
+pub fn enter_once() {
+    let mut err: __wasi_errno_t = 0;
+    let mut continuation: Option<&RefCell<Continuation>> = None;
+    unsafe {
+        assert_eq!(
+            sys::wait(&mut err, &mut continuation as *mut _ as *mut UserContext),
+            0
+        );
+    }
+    let continuation = continuation.unwrap();
+
+    let mut continuation = continuation.borrow_mut();
+    continuation.result = Some(err);
+    let waker = continuation.waker.take().unwrap();
+    drop(continuation); // drop the borrow handle
+
+    waker.wake();
+}
+
+/// Enters the event loop.
+pub fn enter() -> ! {
+    loop {
+        enter_once();
+    }
+}

--- a/lib/wasio-api/src/io.rs
+++ b/lib/wasio-api/src/io.rs
@@ -1,0 +1,48 @@
+use crate::executor::IoFuture;
+use crate::sys;
+use crate::types::*;
+
+pub async fn write(fd: __wasi_fd_t, data: &[u8]) -> Result<usize, __wasi_errno_t> {
+    let iov = __wasi_ciovec_t {
+        buf: data.as_ptr() as *mut u8,
+        buf_len: data.len() as u32,
+    };
+    let mut out_len: u32 = 0;
+    let err = IoFuture::new(move |uctx| unsafe {
+        let mut ct = CancellationToken(0);
+        let e = sys::write(fd, &iov, 1, 0, &mut out_len, uctx, &mut ct);
+        if e != 0 {
+            Err(e)
+        } else {
+            Ok(ct)
+        }
+    })
+    .await;
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(out_len as _)
+    }
+}
+pub async fn read(fd: __wasi_fd_t, data: &mut [u8]) -> Result<usize, __wasi_errno_t> {
+    let iov = __wasi_ciovec_t {
+        buf: data.as_mut_ptr(),
+        buf_len: data.len() as u32,
+    };
+    let mut out_len: u32 = 0;
+    let err = IoFuture::new(move |uctx| unsafe {
+        let mut ct = CancellationToken(0);
+        let e = sys::read(fd, &iov, 1, 0, &mut out_len, std::ptr::null_mut(), uctx, &mut ct);
+        if e != 0 {
+            Err(e)
+        } else {
+            Ok(ct)
+        }
+    })
+    .await;
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(out_len as _)
+    }
+}

--- a/lib/wasio-api/src/io.rs
+++ b/lib/wasio-api/src/io.rs
@@ -32,7 +32,16 @@ pub async fn read(fd: __wasi_fd_t, data: &mut [u8]) -> Result<usize, __wasi_errn
     let mut out_len: u32 = 0;
     let err = IoFuture::new(move |uctx| unsafe {
         let mut ct = CancellationToken(0);
-        let e = sys::read(fd, &iov, 1, 0, &mut out_len, std::ptr::null_mut(), uctx, &mut ct);
+        let e = sys::read(
+            fd,
+            &iov,
+            1,
+            0,
+            &mut out_len,
+            std::ptr::null_mut(),
+            uctx,
+            &mut ct,
+        );
         if e != 0 {
             Err(e)
         } else {

--- a/lib/wasio-api/src/lib.rs
+++ b/lib/wasio-api/src/lib.rs
@@ -1,0 +1,9 @@
+#![feature(wasi_ext)]
+
+pub mod executor;
+pub mod io;
+pub mod net;
+pub mod sys;
+pub mod task;
+pub mod thread;
+pub mod types;

--- a/lib/wasio-api/src/net.rs
+++ b/lib/wasio-api/src/net.rs
@@ -1,0 +1,91 @@
+//! Network support.
+
+use crate::executor::IoFuture;
+use crate::sys;
+use crate::types::*;
+use std::mem;
+
+pub fn socket(
+    domain: __wasio_socket_domain_t,
+    ty: __wasio_socket_type_t,
+    protocol: __wasio_socket_protocol_t,
+) -> Result<__wasi_fd_t, __wasi_errno_t> {
+    let mut fd: __wasi_fd_t = 0;
+    let err = unsafe { sys::socket_create(&mut fd, domain, ty, protocol) };
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(fd)
+    }
+}
+
+pub fn bind4(fd: __wasi_fd_t, sockaddr: &SockaddrIn) -> Result<(), __wasi_errno_t> {
+    let err = unsafe {
+        sys::socket_bind(
+            fd,
+            sockaddr as *const _ as *const u8,
+            mem::size_of::<SockaddrIn>() as u32,
+        )
+    };
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn bind6(fd: __wasi_fd_t, sockaddr: &SockaddrIn6) -> Result<(), __wasi_errno_t> {
+    let err = unsafe {
+        sys::socket_bind(
+            fd,
+            sockaddr as *const _ as *const u8,
+            mem::size_of::<SockaddrIn6>() as u32,
+        )
+    };
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn listen(fd: __wasi_fd_t) -> Result<(), __wasi_errno_t> {
+    let err = unsafe { sys::socket_listen(fd) };
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+pub async fn accept(fd: __wasi_fd_t) -> Result<__wasi_fd_t, __wasi_errno_t> {
+    let err = IoFuture::new(move |uctx| unsafe {
+        let mut ct = CancellationToken(0);
+        let e = sys::socket_pre_accept(fd, uctx, &mut ct);
+        if e != 0 {
+            Err(e)
+        } else {
+            Ok(ct)
+        }
+    })
+    .await;
+    if err != 0 {
+        return Err(err);
+    }
+
+    let mut conn_fd: __wasi_fd_t = u32::MAX;
+    let err = unsafe { sys::socket_accept(&mut conn_fd) };
+    if err != 0 {
+        Err(err)
+    } else {
+        Ok(conn_fd)
+    }
+}
+
+pub fn close(fd: __wasi_fd_t) {
+    use std::fs::File;
+    use std::os::wasi::prelude::FromRawFd;
+    unsafe {
+        File::from_raw_fd(fd);
+    }
+}

--- a/lib/wasio-api/src/sys.rs
+++ b/lib/wasio-api/src/sys.rs
@@ -1,0 +1,58 @@
+use crate::types::*;
+
+#[link(wasm_import_module = "wasio_unstable")]
+extern "C" {
+    pub(crate) fn wait(
+        error_out: *mut __wasi_errno_t,
+        user_context_out: *mut UserContext,
+    ) -> __wasi_errno_t;
+    pub(crate) fn cancel(token: CancellationToken) -> __wasi_errno_t;
+
+    pub(crate) fn delay(
+        nanoseconds: u64,
+        user_context: UserContext,
+        ct_out: *mut CancellationToken,
+    ) -> __wasi_errno_t;
+    pub(crate) fn async_nop(
+        user_context: UserContext,
+        ct_out: *mut CancellationToken,
+    ) -> __wasi_errno_t;
+
+    pub(crate) fn socket_create(
+        fd_out: *mut __wasi_fd_t,
+        domain: __wasio_socket_domain_t,
+        ty: __wasio_socket_type_t,
+        protocol: __wasio_socket_protocol_t,
+    ) -> __wasi_errno_t;
+    pub(crate) fn socket_bind(
+        fd: __wasi_fd_t,
+        sockaddr: *const u8,
+        sockaddr_size: u32,
+    ) -> __wasi_errno_t;
+    pub(crate) fn socket_listen(fd: __wasi_fd_t) -> __wasi_errno_t;
+    pub(crate) fn socket_pre_accept(
+        fd: __wasi_fd_t,
+        user_context: UserContext,
+        ct_out: *mut CancellationToken,
+    ) -> __wasi_errno_t;
+    pub(crate) fn socket_accept(fd_out: *mut __wasi_fd_t) -> __wasi_errno_t;
+    pub(crate) fn write(
+        fd: __wasi_fd_t,
+        si_data: *const __wasi_ciovec_t,
+        si_data_len: u32,
+        si_flags: __wasi_siflags_t,
+        so_datalen: *mut u32,
+        user_context: UserContext,
+        ct_out: *mut CancellationToken,
+    ) -> __wasi_errno_t;
+    pub(crate) fn read(
+        fd: __wasi_fd_t,
+        ri_data: *const __wasi_ciovec_t,
+        ri_data_len: u32,
+        ri_flags: __wasi_riflags_t,
+        ro_datalen: *mut u32,
+        ro_flags: *mut __wasi_roflags_t,
+        user_context: UserContext,
+        ct_out: *mut CancellationToken,
+    ) -> __wasi_errno_t;
+}

--- a/lib/wasio-api/src/task.rs
+++ b/lib/wasio-api/src/task.rs
@@ -1,0 +1,68 @@
+//! Borrowed from https://github.com/rustwasm/wasm-bindgen/blob/master/crates/futures/src/task/singlethread.rs .
+
+use std::cell::{Cell, RefCell};
+use std::future::Future;
+use std::mem::ManuallyDrop;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+struct Inner {
+    future: Pin<Box<dyn Future<Output = ()> + 'static>>,
+    waker: Waker,
+}
+
+pub struct Task {
+    inner: RefCell<Option<Inner>>,
+}
+
+impl Task {
+    pub fn spawn(future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
+        let this = Rc::new(Self {
+            inner: RefCell::new(None),
+        });
+
+        let waker = unsafe { Waker::from_raw(Task::into_raw_waker(Rc::clone(&this))) };
+
+        *this.inner.borrow_mut() = Some(Inner { future, waker });
+
+        Task::wake_by_ref(&this);
+    }
+
+    fn wake_by_ref(this: &Rc<Self>) {
+        let mut maybe_inner = this.inner.borrow_mut();
+        if let Some(ref mut inner) = *maybe_inner {
+            let mut cx = Context::from_waker(&inner.waker);
+            let poll = inner.future.as_mut().poll(&mut cx);
+            if let Poll::Ready(_) = poll {
+                *maybe_inner = None;
+            }
+        }
+    }
+
+    unsafe fn into_raw_waker(this: Rc<Self>) -> RawWaker {
+        unsafe fn raw_clone(ptr: *const ()) -> RawWaker {
+            let ptr = ManuallyDrop::new(Rc::from_raw(ptr as *const Task));
+            Task::into_raw_waker((*ptr).clone())
+        }
+
+        unsafe fn raw_wake(ptr: *const ()) {
+            let ptr = Rc::from_raw(ptr as *const Task);
+            Task::wake_by_ref(&ptr);
+        }
+
+        unsafe fn raw_wake_by_ref(ptr: *const ()) {
+            let ptr = ManuallyDrop::new(Rc::from_raw(ptr as *const Task));
+            Task::wake_by_ref(&ptr);
+        }
+
+        unsafe fn raw_drop(ptr: *const ()) {
+            drop(Rc::from_raw(ptr as *const Task));
+        }
+
+        const VTABLE: RawWakerVTable =
+            RawWakerVTable::new(raw_clone, raw_wake, raw_wake_by_ref, raw_drop);
+
+        RawWaker::new(Rc::into_raw(this) as *const (), &VTABLE)
+    }
+}

--- a/lib/wasio-api/src/thread.rs
+++ b/lib/wasio-api/src/thread.rs
@@ -1,0 +1,31 @@
+use crate::types::*;
+use crate::{executor::IoFuture, sys};
+use futures::Future;
+use std::convert::TryFrom;
+use std::mem::MaybeUninit;
+use std::time::Duration;
+
+pub fn delay(dur: Duration) -> impl Future<Output = __wasi_errno_t> {
+    let nanos = u64::try_from(dur.as_nanos()).unwrap();
+    IoFuture::new(move |uctx| unsafe {
+        let mut ct = CancellationToken(0);
+        let e = sys::delay(nanos, uctx, &mut ct);
+        if e != 0 {
+            Err(e)
+        } else {
+            Ok(ct)
+        }
+    })
+}
+
+pub fn async_nop() -> impl Future<Output = __wasi_errno_t> {
+    IoFuture::new(move |uctx| unsafe {
+        let mut ct = CancellationToken(0);
+        let e = sys::async_nop(uctx, &mut ct);
+        if e != 0 {
+            Err(e)
+        } else {
+            Ok(ct)
+        }
+    })
+}

--- a/lib/wasio-api/src/types.rs
+++ b/lib/wasio-api/src/types.rs
@@ -1,0 +1,156 @@
+//! Types used for WASIO APIs.
+#![allow(non_camel_case_types)]
+
+/// The cancellation token of an ongoing asynchronous operation.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct CancellationToken(pub(crate) u64);
+
+/// The user context that will be returned to WebAssembly, once a
+/// requested asynchronous operation is completed.
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct UserContext(pub u64);
+
+/// The `sockaddr_in` struct.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct SockaddrIn {
+    pub sin_family: i16,
+    pub sin_port: u16,
+    pub sin_addr: [u8; 4],
+    pub sin_zero: [u8; 8],
+}
+
+/// The `sockaddr_in6` struct.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct SockaddrIn6 {
+    pub sin6_family: i16,
+    pub sin6_port: u16,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: [u8; 16],
+    pub sin6_scope_id: u32,
+}
+
+/// The type of a WASIO socket domain.
+pub type __wasio_socket_domain_t = i32;
+
+/// An IPv4 socket.
+pub const AF_INET: __wasio_socket_domain_t = 2;
+
+/// An IPv6 socket.
+pub const AF_INET6: __wasio_socket_domain_t = 10;
+
+/// The type of a WASIO socket type.
+pub type __wasio_socket_type_t = i32;
+
+/// Provides sequenced, reliable, two-way, connection-based byte streams.
+///
+/// Implies TCP when used with an IP socket.
+pub const SOCK_STREAM: __wasio_socket_type_t = 1;
+
+/// Supports datagrams (connectionless, unreliable messages of a fixed maximum length).
+///
+/// Implies UDP when used with an IP socket.
+pub const SOCK_DGRAM: __wasio_socket_type_t = 2;
+
+/// The type of a WASIO socket protocol.
+pub type __wasio_socket_protocol_t = i32;
+
+// Start of original WASI types.
+// We should change these to libstd types if possible.
+
+/// Error number.
+pub type __wasi_errno_t = u16;
+pub const __WASI_ESUCCESS: u16 = 0;
+pub const __WASI_E2BIG: u16 = 1;
+pub const __WASI_EACCES: u16 = 2;
+pub const __WASI_EADDRINUSE: u16 = 3;
+pub const __WASI_EADDRNOTAVAIL: u16 = 4;
+pub const __WASI_EAFNOSUPPORT: u16 = 5;
+pub const __WASI_EAGAIN: u16 = 6;
+pub const __WASI_EALREADY: u16 = 7;
+pub const __WASI_EBADF: u16 = 8;
+pub const __WASI_EBADMSG: u16 = 9;
+pub const __WASI_EBUSY: u16 = 10;
+pub const __WASI_ECANCELED: u16 = 11;
+pub const __WASI_ECHILD: u16 = 12;
+pub const __WASI_ECONNABORTED: u16 = 13;
+pub const __WASI_ECONNREFUSED: u16 = 14;
+pub const __WASI_ECONNRESET: u16 = 15;
+pub const __WASI_EDEADLK: u16 = 16;
+pub const __WASI_EDESTADDRREQ: u16 = 17;
+pub const __WASI_EDOM: u16 = 18;
+pub const __WASI_EDQUOT: u16 = 19;
+pub const __WASI_EEXIST: u16 = 20;
+pub const __WASI_EFAULT: u16 = 21;
+pub const __WASI_EFBIG: u16 = 22;
+pub const __WASI_EHOSTUNREACH: u16 = 23;
+pub const __WASI_EIDRM: u16 = 24;
+pub const __WASI_EILSEQ: u16 = 25;
+pub const __WASI_EINPROGRESS: u16 = 26;
+pub const __WASI_EINTR: u16 = 27;
+pub const __WASI_EINVAL: u16 = 28;
+pub const __WASI_EIO: u16 = 29;
+pub const __WASI_EISCONN: u16 = 30;
+pub const __WASI_EISDIR: u16 = 31;
+pub const __WASI_ELOOP: u16 = 32;
+pub const __WASI_EMFILE: u16 = 33;
+pub const __WASI_EMLINK: u16 = 34;
+pub const __WASI_EMSGSIZE: u16 = 35;
+pub const __WASI_EMULTIHOP: u16 = 36;
+pub const __WASI_ENAMETOOLONG: u16 = 37;
+pub const __WASI_ENETDOWN: u16 = 38;
+pub const __WASI_ENETRESET: u16 = 39;
+pub const __WASI_ENETUNREACH: u16 = 40;
+pub const __WASI_ENFILE: u16 = 41;
+pub const __WASI_ENOBUFS: u16 = 42;
+pub const __WASI_ENODEV: u16 = 43;
+pub const __WASI_ENOENT: u16 = 44;
+pub const __WASI_ENOEXEC: u16 = 45;
+pub const __WASI_ENOLCK: u16 = 46;
+pub const __WASI_ENOLINK: u16 = 47;
+pub const __WASI_ENOMEM: u16 = 48;
+pub const __WASI_ENOMSG: u16 = 49;
+pub const __WASI_ENOPROTOOPT: u16 = 50;
+pub const __WASI_ENOSPC: u16 = 51;
+pub const __WASI_ENOSYS: u16 = 52;
+pub const __WASI_ENOTCONN: u16 = 53;
+pub const __WASI_ENOTDIR: u16 = 54;
+pub const __WASI_ENOTEMPTY: u16 = 55;
+pub const __WASI_ENOTRECOVERABLE: u16 = 56;
+pub const __WASI_ENOTSOCK: u16 = 57;
+pub const __WASI_ENOTSUP: u16 = 58;
+pub const __WASI_ENOTTY: u16 = 59;
+pub const __WASI_ENXIO: u16 = 60;
+pub const __WASI_EOVERFLOW: u16 = 61;
+pub const __WASI_EOWNERDEAD: u16 = 62;
+pub const __WASI_EPERM: u16 = 63;
+pub const __WASI_EPIPE: u16 = 64;
+pub const __WASI_EPROTO: u16 = 65;
+pub const __WASI_EPROTONOSUPPORT: u16 = 66;
+pub const __WASI_EPROTOTYPE: u16 = 67;
+pub const __WASI_ERANGE: u16 = 68;
+pub const __WASI_EROFS: u16 = 69;
+pub const __WASI_ESPIPE: u16 = 70;
+pub const __WASI_ESRCH: u16 = 71;
+pub const __WASI_ESTALE: u16 = 72;
+pub const __WASI_ETIMEDOUT: u16 = 73;
+pub const __WASI_ETXTBSY: u16 = 74;
+pub const __WASI_EXDEV: u16 = 75;
+pub const __WASI_ENOTCAPABLE: u16 = 76;
+
+/// File descriptor.
+pub type __wasi_fd_t = u32;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct __wasi_ciovec_t {
+    pub buf: *mut u8,
+    pub buf_len: u32,
+}
+
+pub type __wasi_siflags_t = u16;
+pub type __wasi_riflags_t = u16;
+pub type __wasi_roflags_t = u16;


### PR DESCRIPTION
This PR adds `async`/`await` syntax support to Rust when compiling to WebAssembly via a new framework: wasio.

Wasio is a high-performance async I/O for WebAssembly, that allows super lightweight greenthreads/coroutines running in a WebAssembly context. It also adds networking capabilities to WebAssembly 🎉

Wasio is greatly inspired by [io_uring in the Linux kernel](https://kernel.dk/io_uring.pdf)

## How to try it

Note: Wasio currently requires Rust nightly. Please do `rustup default nightly` before compiling wasio.

```shell
git clone git@github.com:wasmerio/wasmer.git
cd wasmer && git checkout wasio

# Build wasmer bin
make build-wasmer

# Make examples
cd lib/wasio-api
make exampes

# Count to 10
../../target/release/wasmer run ../../target/wasm32-wasi/release/examples/count_to.wasm

# Simple TCP Server (you can connect to it via `telnet localhost 9000`)
../../target/release/wasmer run ../../target/wasm32-wasi/release/examples/tcp_server.wasm

# TCP Echo Server (you can connect to it via `telnet localhost 9000`)
../../target/release/wasmer run ../../target/wasm32-wasi/release/examples/tcp_echo.wasm
```

Enjoy!