### PR TITLE
Prepare for 1.0.0-alpha01.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,8 @@ dependencies = [
 [[package]]
 name = "cbindgen"
 version = "0.14.3"
-source = "git+https://github.com/eqrion/cbindgen#9d7516ef1a4f1e202be5af78fc52cad22c0f3e68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e03a705df2e735cc5486f104a48e25a8f72ae06eaea5b7753a81270ed00859"
 dependencies = [
  "clap",
  "heck",
@@ -2116,7 +2117,7 @@ checksum = "72b6c0220ded549d63860c78c38f3bcc558d1ca3f4efa74942c536ddbbb55e87"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2142,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-c-api"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "cbindgen",
  "cfg-if",
@@ -2168,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "blake3",
  "hex",
@@ -2179,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cli"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -2208,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "enumset",
  "hashbrown 0.8.1",
@@ -2225,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2244,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "byteorder",
  "cc",
@@ -2266,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -2284,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-emscripten"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "byteorder",
  "getrandom",
@@ -2297,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "backtrace",
  "bincode",
@@ -2315,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dummy"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "bincode",
  "serde",
@@ -2328,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-jit"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -2344,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-native"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -2362,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "object 0.19.0",
  "thiserror",
@@ -2372,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -2380,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -2398,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2416,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-experimental-io-devices"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "minifb",
  "ref_thread_local",
@@ -2428,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wast"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -2442,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-workspace"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
 description = "Wasmer workspace"
@@ -10,18 +10,18 @@ publish = false
 autoexamples = false
 
 [dependencies]
-wasmer = { version = "1.0.0-alpha.1", path = "lib/api", default-features = false }
-wasmer-compiler = { version = "1.0.0-alpha.1", path = "lib/compiler" }
-wasmer-compiler-cranelift = { version = "1.0.0-alpha.1", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.0-alpha.1", path = "lib/compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.0-alpha.1", path = "lib/compiler-llvm", optional = true }
-wasmer-engine = { version = "1.0.0-alpha.1", path = "lib/engine" }
-wasmer-engine-jit = { version = "1.0.0-alpha.1", path = "lib/engine-jit", optional = true }
-wasmer-engine-native = { version = "1.0.0-alpha.1", path = "lib/engine-native", optional = true }
-wasmer-wasi = { version = "1.0.0-alpha.1", path = "lib/wasi", optional = true }
-wasmer-wast = { version = "1.0.0-alpha.1", path = "tests/lib/wast", optional = true }
-wasmer-cache = { version = "1.0.0-alpha.1", path = "lib/cache", optional = true }
-wasmer-types = { version = "1.0.0-alpha.1", path = "lib/wasmer-types" }
+wasmer = { version = "1.0.0-alpha01.0", path = "lib/api", default-features = false }
+wasmer-compiler = { version = "1.0.0-alpha01.0", path = "lib/compiler" }
+wasmer-compiler-cranelift = { version = "1.0.0-alpha01.0", path = "lib/compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.0-alpha01.0", path = "lib/compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "1.0.0-alpha01.0", path = "lib/compiler-llvm", optional = true }
+wasmer-engine = { version = "1.0.0-alpha01.0", path = "lib/engine" }
+wasmer-engine-jit = { version = "1.0.0-alpha01.0", path = "lib/engine-jit", optional = true }
+wasmer-engine-native = { version = "1.0.0-alpha01.0", path = "lib/engine-native", optional = true }
+wasmer-wasi = { version = "1.0.0-alpha01.0", path = "lib/wasi", optional = true }
+wasmer-wast = { version = "1.0.0-alpha01.0", path = "tests/lib/wast", optional = true }
+wasmer-cache = { version = "1.0.0-alpha01.0", path = "lib/cache", optional = true }
+wasmer-types = { version = "1.0.0-alpha01.0", path = "lib/wasmer-types" }
 cfg-if = "0.1"
 
 [workspace]
@@ -91,6 +91,7 @@ wasi = ["wasmer-wasi"]
 # emscripten = ["wasmer-emscripten"]
 wat = ["wasmer/wat"]
 compiler = [
+    "wasmer/compiler",
     "wasmer-compiler/translator",
     "wasmer-engine-jit/compiler",
     "wasmer-engine-native/compiler"

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer runtime API"
 license = "(Apache-2.0 WITH LLVM-exception) OR MIT"
@@ -9,15 +9,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.0-alpha.1", optional = true }
-wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "1.0.0-alpha.1", optional = true }
-wasmer-compiler-llvm = { path = "../compiler-llvm", version = "1.0.0-alpha.1", optional = true }
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1" }
-wasmer-engine = { path = "../engine", version = "1.0.0-alpha.1" }
-wasmer-engine-jit = { path = "../engine-jit", version = "1.0.0-alpha.1", optional = true }
-wasmer-engine-native = { path = "../engine-native", version = "1.0.0-alpha.1", optional = true }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.0-alpha01.0", optional = true }
+wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "1.0.0-alpha01.0", optional = true }
+wasmer-compiler-llvm = { path = "../compiler-llvm", version = "1.0.0-alpha01.0", optional = true }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0" }
+wasmer-engine = { path = "../engine", version = "1.0.0-alpha01.0" }
+wasmer-engine-jit = { path = "../engine-jit", version = "1.0.0-alpha01.0", optional = true }
+wasmer-engine-native = { path = "../engine-native", version = "1.0.0-alpha01.0", optional = true }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
 indexmap = { version = "1.4", features = ["serde-1"] }
 cfg-if = "0.1"
 wat = { version = "1.0", optional = true }
@@ -30,7 +30,7 @@ winapi = "0.3"
 
 [dev-dependencies]
 # for the binary wasmer.rs
-wasmer-engine-dummy = { path = "../../tests/lib/engine-dummy", version = "1.0.0-alpha.1" }
+wasmer-engine-dummy = { path = "../../tests/lib/engine-dummy", version = "1.0.0-alpha01.0" }
 libc = { version = "^0.2.69", default-features = false }
 wat = "1.0"
 tempfile = "3.1"

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -64,11 +64,11 @@ pub use crate::types::{Val as Value, ValType as Type};
 pub use crate::utils::is_wasm;
 pub use target_lexicon::{Architecture, CallingConvention, OperatingSystem, Triple, HOST};
 #[cfg(feature = "compiler")]
-pub use wasmer_compiler::CompilerConfig;
 pub use wasmer_compiler::{
-    wasmparser, CpuFeature, Features, FunctionMiddleware, FunctionMiddlewareGenerator,
-    MiddlewareReaderState, Target,
+    wasmparser, CompilerConfig, FunctionMiddleware, FunctionMiddlewareGenerator,
+    MiddlewareReaderState,
 };
+pub use wasmer_compiler::{CpuFeature, Features, Target};
 pub use wasmer_engine::{
     ChainableNamedResolver, DeserializeError, Engine, InstantiationError, LinkError, NamedResolver,
     NamedResolverChain, Resolver, RuntimeError, SerializeError,

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-c-api"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 description = "Wasmer C API library"
 documentation = "https://wasmerio.github.io/wasmer/c-api/"
 license = "MIT"
@@ -15,17 +15,17 @@ edition = "2018"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-wasmer = { version = "1.0.0-alpha.1", path = "../api", default-features = false }
-wasmer-compiler = { version = "1.0.0-alpha.1", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "1.0.0-alpha.1", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.0-alpha.1", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.0-alpha.1", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.0-alpha.1", path = "../emscripten", optional = true }
-wasmer-engine = { version = "1.0.0-alpha.1", path = "../engine" }
-wasmer-engine-jit = { version = "1.0.0-alpha.1", path = "../engine-jit", optional = true }
-wasmer-engine-native = { version = "1.0.0-alpha.1", path = "../engine-native", optional = true }
-wasmer-wasi = { version = "1.0.0-alpha.1", path = "../wasi", optional = true }
-wasmer-types = { version = "1.0.0-alpha.1", path = "../wasmer-types" }
+wasmer = { version = "1.0.0-alpha01.0", path = "../api", default-features = false }
+wasmer-compiler = { version = "1.0.0-alpha01.0", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "1.0.0-alpha01.0", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.0-alpha01.0", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "1.0.0-alpha01.0", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "1.0.0-alpha01.0", path = "../emscripten", optional = true }
+wasmer-engine = { version = "1.0.0-alpha01.0", path = "../engine" }
+wasmer-engine-jit = { version = "1.0.0-alpha01.0", path = "../engine-jit", optional = true }
+wasmer-engine-native = { version = "1.0.0-alpha01.0", path = "../engine-native", optional = true }
+wasmer-wasi = { version = "1.0.0-alpha01.0", path = "../wasi", optional = true }
+wasmer-types = { version = "1.0.0-alpha01.0", path = "../wasmer-types" }
 cfg-if = "0.1"
 lazy_static = "1"
 libc = { version = "^0.2.69", default-features = false }
@@ -36,7 +36,7 @@ typetag = { version = "0.1", optional = true }
 paste = "0.1"
 # for generating code in the same way thot the wasm-c-api does
 # Commented out for now until we can find a solution to the exported function problem
-# wasmer-wasm-c-api = { version = "1.0.0-alpha.1", path = "crates/wasm-c-api" }
+# wasmer-wasm-c-api = { version = "1.0.0-alpha01.0", path = "crates/wasm-c-api" }
 
 [features]
 default = [
@@ -80,4 +80,4 @@ cranelift-backend = ["cranelift"]
 llvm-backend = ["llvm"]
 
 [build-dependencies]
-cbindgen = { git = "https://github.com/eqrion/cbindgen", version = "0.14" }
+cbindgen = { version = "0.14.3" }

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cache"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 description = "Cache system for WebAssembly"
 license = "MIT"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "1.0.0-alpha.1", default-features = false }
+wasmer = { path = "../api", version = "1.0.0-alpha01.0", default-features = false }
 memmap = "0.7"
 hex = "0.4"
 thiserror = "1"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cli"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
 description = "Wasmer CLI"
@@ -22,20 +22,20 @@ path = "src/bin/wasmer.rs"
 doc = false
 
 [dependencies]
-wasmer = { version = "1.0.0-alpha.1", path = "../api", default-features = false }
-wasmer-compiler = { version = "1.0.0-alpha.1", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "1.0.0-alpha.1", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.0-alpha.1", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.0-alpha.1", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.0-alpha.1", path = "../emscripten", optional = true }
-wasmer-engine = { version = "1.0.0-alpha.1", path = "../engine" }
-wasmer-engine-jit = { version = "1.0.0-alpha.1", path = "../engine-jit", optional = true }
-wasmer-engine-native = { version = "1.0.0-alpha.1", path = "../engine-native", optional = true }
-wasmer-wasi = { version = "1.0.0-alpha.1", path = "../wasi", optional = true }
-wasmer-wasi-experimental-io-devices = { version = "1.0.0-alpha.1", path = "../wasi-experimental-io-devices", optional = true }
-wasmer-wast = { version = "1.0.0-alpha.1", path = "../../tests/lib/wast", optional = true }
-wasmer-cache = { version = "1.0.0-alpha.1", path = "../cache", optional = true }
-wasmer-types = { version = "1.0.0-alpha.1", path = "../wasmer-types" }
+wasmer = { version = "1.0.0-alpha01.0", path = "../api", default-features = false }
+wasmer-compiler = { version = "1.0.0-alpha01.0", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "1.0.0-alpha01.0", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.0-alpha01.0", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "1.0.0-alpha01.0", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "1.0.0-alpha01.0", path = "../emscripten", optional = true }
+wasmer-engine = { version = "1.0.0-alpha01.0", path = "../engine" }
+wasmer-engine-jit = { version = "1.0.0-alpha01.0", path = "../engine-jit", optional = true }
+wasmer-engine-native = { version = "1.0.0-alpha01.0", path = "../engine-native", optional = true }
+wasmer-wasi = { version = "1.0.0-alpha01.0", path = "../wasi", optional = true }
+wasmer-wasi-experimental-io-devices = { version = "1.0.0-alpha01.0", path = "../wasi-experimental-io-devices", optional = true }
+wasmer-wast = { version = "1.0.0-alpha01.0", path = "../../tests/lib/wast", optional = true }
+wasmer-cache = { version = "1.0.0-alpha01.0", path = "../cache", optional = true }
+wasmer-types = { version = "1.0.0-alpha01.0", path = "../wasmer-types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0", default-features = false, features = ["std"] }
 cranelift-codegen = { version = "0.65", default-features = false }
 cranelift-frontend = { version = "0.65", default-features = false }
 tracing = "0.1"

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-llvm"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 license = "MIT"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -10,9 +10,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1", features = ["translator"] }
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
 target-lexicon = { version = "0.10", default-features = false }
 smallvec = "1"
 goblin = "0.2"

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -22,9 +22,7 @@ itertools = "0.9"
 rayon = "1.3"
 
 [dependencies.inkwell]
-#version = "0.1.0-llvm8sample"
-git = "https://github.com/theDan64/inkwell"
-rev = "fdf895777e937c974204e879cf1102cf7a727c42"
+version = "=0.1.0-llvm10sample"
 default-features = false
 features = ["llvm10-0", "target-x86", "target-aarch64"]
 

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Standalone environment support for WebAsssembly code in Singlepass"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0", default-features = false, features = ["std"] }
 rayon = "1.3"
 hashbrown = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 description = "Base compiler abstraction for WebAssembly"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1", default-features = false }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0", default-features = false }
 wasmparser = { version = "0.57", optional = true, default-features = false }
 target-lexicon = { version = "0.10", default-features = false }
 enumset = "1.0"

--- a/lib/deprecated/runtime-core/Cargo.toml
+++ b/lib/deprecated/runtime-core/Cargo.toml
@@ -14,16 +14,16 @@ edition = "2018"
 maintenance = { status = "deprecated" }
 
 [dependencies]
-wasmer-types = { path = "../../wasmer-types", version = "1.0.0-alpha.1" }
-wasmer = { path = "../../api", version = "1.0.0-alpha.1" }
-wasmer-cache = { path = "../../cache", version = "1.0.0-alpha.1" }
-wasmer-compiler = { path = "../../compiler", version = "1.0.0-alpha.1", features = ["translator"] }
-wasmer-compiler-llvm = { path = "../../compiler-llvm", version = "1.0.0-alpha.1", optional = true }
-wasmer-compiler-cranelift = { path = "../../compiler-cranelift", version = "1.0.0-alpha.1", optional = true }
-wasmer-compiler-singlepass = { path = "../../compiler-singlepass", version = "1.0.0-alpha.1", optional = true }
-wasmer-engine = { path = "../../engine", version = "1.0.0-alpha.1" }
-wasmer-engine-jit = { path = "../../engine-jit", version = "1.0.0-alpha.1" }
-wasmer-vm = { path = "../../vm", version = "1.0.0-alpha.1" }
+wasmer-types = { path = "../../wasmer-types", version = "1.0.0-alpha01.0" }
+wasmer = { path = "../../api", version = "1.0.0-alpha01.0" }
+wasmer-cache = { path = "../../cache", version = "1.0.0-alpha01.0" }
+wasmer-compiler = { path = "../../compiler", version = "1.0.0-alpha01.0", features = ["translator"] }
+wasmer-compiler-llvm = { path = "../../compiler-llvm", version = "1.0.0-alpha01.0", optional = true }
+wasmer-compiler-cranelift = { path = "../../compiler-cranelift", version = "1.0.0-alpha01.0", optional = true }
+wasmer-compiler-singlepass = { path = "../../compiler-singlepass", version = "1.0.0-alpha01.0", optional = true }
+wasmer-engine = { path = "../../engine", version = "1.0.0-alpha01.0" }
+wasmer-engine-jit = { path = "../../engine-jit", version = "1.0.0-alpha01.0" }
+wasmer-vm = { path = "../../vm", version = "1.0.0-alpha01.0" }
 lazy_static = "1.4"
 
 [build-dependencies]

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 description = "Wasmer runtime emscripten implementation library"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 libc = "^0.2.69"
 log = "0.4"
 time = "0.1"
-wasmer = { path = "../api", version = "1.0.0-alpha.1", default-features = false }
+wasmer = { path = "../api", version = "1.0.0-alpha01.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.1"

--- a/lib/engine-jit/Cargo.toml
+++ b/lib/engine-jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-jit"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer JIT Engine"
 license = "(Apache-2.0 WITH LLVM-exception) or MIT"
@@ -11,10 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1", default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-engine = { path = "../engine", version = "1.0.0-alpha.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-engine = { path = "../engine", version = "1.0.0-alpha01.0" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/lib/engine-native/Cargo.toml
+++ b/lib/engine-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-native"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer JIT Engine"
 license = "(Apache-2.0 WITH LLVM-exception) or MIT"
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1" }
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
-wasmer-engine = { path = "../engine", version = "1.0.0-alpha.1" }
-wasmer-object = { path = "../object", version = "1.0.0-alpha.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0" }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
+wasmer-engine = { path = "../engine", version = "1.0.0-alpha01.0" }
+wasmer-object = { path = "../object", version = "1.0.0-alpha01.0" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "0.1"
 tracing = "0.1"

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer Engine abstraction"
 license = "(Apache-2.0 WITH LLVM-exception) or MIT"
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1", default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.0-alpha.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0" }
+wasmer-vm = { path = "../vm", version = "1.0.0-alpha01.0" }
 target-lexicon = { version = "0.10", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"

--- a/lib/object/Cargo.toml
+++ b/lib/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-object"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer Native Object generator"
 license = "(Apache-2.0 WITH LLVM-exception) or MIT"
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha.1", default-features = false, features = [
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
+wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha01.0", default-features = false, features = [
     "std",
     "translator"
 ] }

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-vm"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Runtime library support for Wasmer"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha01.0" }
 region = "2.2"
 libc = { version = "^0.2.69", default-features = false }
 memoffset = "0.5"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-experimental-io-devices"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 edition = "2018"
 repository = "https://github.com/wasmerio/wasmer"
@@ -13,7 +13,7 @@ license = "MIT"
 maintenance = { status = "experimental" }
 
 [dependencies]
-wasmer-wasi = { version = "1.0.0-alpha.1", path = "../wasi" }
+wasmer-wasi = { version = "1.0.0-alpha01.0", path = "../wasi" }
 tracing = "0.1"
 minifb = "0.16"
 ref_thread_local = "0.0"

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 description = "Wasmer runtime WASI implementation library"
 license = "MIT"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -21,7 +21,7 @@ getrandom = "0.1"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-wasmer = { path = "../api", version = "1.0.0-alpha.1", default-features = false }
+wasmer = { path = "../api", version = "1.0.0-alpha01.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/lib/wasmer-types/Cargo.toml
+++ b/lib/wasmer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-types"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 description = "Wasmer Common Types"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,6 +1,6 @@
 # A script to update the version of all the crates at the same time
-PREVIOUS_VERSION='1.0.0-alpha.1'
-NEXT_VERSION='1.0.0-alpha.2'
+PREVIOUS_VERSION='1.0.0-alpha1.0'
+NEXT_VERSION='1.0.0-alpha01.0'
 
 # quick hack
 fd Cargo.toml --exec sed -i '' "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"

--- a/scripts/windows-installer/wasmer.iss
+++ b/scripts/windows-installer/wasmer.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=Wasmer
-AppVersion=1.0.0-alpha.1
+AppVersion=1.0.0-alpha01.0
 DefaultDirName={pf}\Wasmer
 DefaultGroupName=Wasmer
 Compression=lzma2

--- a/tests/lib/engine-dummy/Cargo.toml
+++ b/tests/lib/engine-dummy/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "wasmer-engine-dummy"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "wasmer testing utils"
 edition = "2018"
 publish = false
 
 [dependencies]
-wasmer-types = { path = "../../../lib/wasmer-types", version = "1.0.0-alpha.1" }
-wasmer-compiler = { path = "../../../lib/compiler", version = "1.0.0-alpha.1" }
-wasmer-vm = { path = "../../../lib/vm", version = "1.0.0-alpha.1" }
-wasmer-engine = { path = "../../../lib/engine", version = "1.0.0-alpha.1" }
+wasmer-types = { path = "../../../lib/wasmer-types", version = "1.0.0-alpha01.0" }
+wasmer-compiler = { path = "../../../lib/compiler", version = "1.0.0-alpha01.0" }
+wasmer-vm = { path = "../../../lib/vm", version = "1.0.0-alpha01.0" }
+wasmer-engine = { path = "../../../lib/engine", version = "1.0.0-alpha01.0" }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
 bincode = { version = "1.2", optional = true }

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wast"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha01.0"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "wast testing support for wasmer"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmer = { path = "../../../lib/api", version = "1.0.0-alpha.1", default-features = false }
-wasmer-wasi = { path = "../../../lib/wasi", version = "1.0.0-alpha.1" }
+wasmer = { path = "../../../lib/api", version = "1.0.0-alpha01.0", default-features = false }
+wasmer-wasi = { path = "../../../lib/wasi", version = "1.0.0-alpha01.0" }
 wast = "17.0"
 serde = "1"
 tempfile = "3"


### PR DESCRIPTION
This is the first alpha release of `1.0.0`: expect breaking changes.

The version suffix `alpha01.0` was chosen so that we can ship updates
that automatically update with the latter number and can prevent
auto-updates by incrementing the former number (which is not actually
a number as far as semver is concerned)

I think our release process is likely broken and we'll have to do a lot of manual work.  I'm deferring updating the changelog until later as I intend to write a decent amount there -- will update it as a separate PR after the release.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
