### PR TITLE
Fix compile error building lib/cli without default features and with native engine only.

### DIFF
--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -65,6 +65,8 @@ impl Compile {
             EngineType::JIT => {
                 wasmer_engine_jit::JITArtifact::get_default_extension(target.triple())
             }
+            #[cfg(not(all(feature = "native", feature = "jit")))]
+            _ => bail!("selected engine type is not compiled in"),
         };
         match self.output.extension() {
             Some(ext) => {


### PR DESCRIPTION
# Description
lib/cli should be able to build without any compilers enabled and with only the native engine. This fixes a build error in that configuration.