### PR TITLE
Fix build with only JIT enabled.

### DIFF
--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -328,7 +328,7 @@ impl StoreOptions {
     fn get_engine_with_compiler(
         &self,
         target: Target,
-        mut compiler_config: Box<dyn CompilerConfig>,
+        compiler_config: Box<dyn CompilerConfig>,
     ) -> Result<(Box<dyn Engine + Send + Sync>, EngineType)> {
         let engine_type = self.get_engine()?;
         let features = self.get_features(compiler_config.default_features_for_target(&target))?;
@@ -341,13 +341,16 @@ impl StoreOptions {
                     .engine(),
             ),
             #[cfg(feature = "native")]
-            EngineType::Native => Box::new(
-                wasmer_engine_native::Native::new(&mut *compiler_config)
-                    .target(target)
-                    .features(features)
-                    .engine(),
-            ),
-            #[cfg(not(all(feature = "jit", feature = "native",)))]
+            EngineType::Native => {
+                let mut compiler_config = compiler_config;
+                Box::new(
+                    wasmer_engine_native::Native::new(&mut *compiler_config)
+                        .target(target)
+                        .features(features)
+                        .engine(),
+                )
+            }
+            #[cfg(not(all(feature = "jit", feature = "native")))]
             engine => bail!(
                 "The `{}` engine is not included in this binary.",
                 engine.to_string()


### PR DESCRIPTION
# Description
This function doesn't build when engine-native is disabled due to an `unused_mut` warning.
