### PR TITLE
Fix support of dynamic memories in compiler-llvm.

### DIFF
--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -2,6 +2,7 @@ use crate::exports::{ExportError, Exportable};
 use crate::externals::Extern;
 use crate::store::Store;
 use crate::{MemoryType, MemoryView};
+use std::convert::TryInto;
 use std::slice;
 use std::sync::Arc;
 use wasmer_types::{Pages, ValueType};
@@ -73,7 +74,7 @@ impl Memory {
     pub unsafe fn data_unchecked_mut(&self) -> &mut [u8] {
         let definition = self.memory.vmmemory();
         let def = definition.as_ref();
-        slice::from_raw_parts_mut(def.base, def.current_length)
+        slice::from_raw_parts_mut(def.base, def.current_length.try_into().unwrap())
     }
 
     /// Returns the pointer to the raw bytes of the `Memory`.
@@ -84,7 +85,7 @@ impl Memory {
     }
 
     /// Returns the size (in bytes) of the `Memory`.
-    pub fn data_size(&self) -> usize {
+    pub fn data_size(&self) -> u32 {
         let definition = self.memory.vmmemory();
         let def = unsafe { definition.as_ref() };
         def.current_length

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -85,10 +85,10 @@ impl Memory {
     }
 
     /// Returns the size (in bytes) of the `Memory`.
-    pub fn data_size(&self) -> u32 {
+    pub fn data_size(&self) -> u64 {
         let definition = self.memory.vmmemory();
         let def = unsafe { definition.as_ref() };
-        def.current_length
+        def.current_length.into()
     }
 
     /// Returns the size (in [`Pages`]) of the `Memory`.

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1033,6 +1033,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                             format!("memory {} length", memory_index.as_u32()),
                             current_length.as_instruction_value().unwrap(),
                         );
+                        let current_length =
+                            builder.build_int_z_extend(current_length, intrinsics.i64_ty, "");
 
                         builder.build_int_compare(
                             IntPredicate::ULE,

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1000,7 +1000,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             {
                 MemoryCache::Dynamic {
                     ptr_to_base_ptr,
-                    current_length_ptr,
+                    ptr_to_current_length,
                 } => {
                     // Bounds check it.
                     let minimum = self.wasm_module.memories[memory_index].minimum;
@@ -1024,8 +1024,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     .unwrap_or_else(|| {
                         let load_offset_end = builder.build_int_add(offset, value_size_v, "");
 
-                        let current_length =
-                            builder.build_load(current_length_ptr, "").into_int_value();
+                        let current_length = builder
+                            .build_load(ptr_to_current_length, "")
+                            .into_int_value();
                         tbaa_label(
                             self.module,
                             self.intrinsics,
@@ -1053,7 +1054,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                                 intrinsics.expect_i1,
                                 &[
                                     ptr_in_bounds.as_basic_value_enum(),
-                                    intrinsics.i1_ty.const_int(1, false).as_basic_value_enum(),
+                                    intrinsics.i1_ty.const_int(1, true).as_basic_value_enum(),
                                 ],
                                 "ptr_in_bounds_expect",
                             )

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -463,7 +463,7 @@ impl<'ctx> Intrinsics<'ctx> {
 
             // TODO: this i64 is actually a rust usize
             vmmemory_definition_ptr_ty: context
-                .struct_type(&[i8_ptr_ty_basic, i64_ty_basic], false)
+                .struct_type(&[i8_ptr_ty_basic, i32_ty_basic], false)
                 .ptr_type(AddressSpace::Generic),
             vmmemory_definition_base_element: 0,
             vmmemory_definition_current_length_element: 1,

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -11,6 +11,7 @@ use more_asserts::{assert_ge, assert_le};
 use serde::{Deserialize, Serialize};
 use std::borrow::BorrowMut;
 use std::cell::UnsafeCell;
+use std::convert::TryInto;
 use std::fmt;
 use std::ptr::NonNull;
 use std::sync::Mutex;
@@ -190,7 +191,7 @@ impl LinearMemory {
             needs_signal_handlers,
             vm_memory_definition: Box::new(UnsafeCell::new(VMMemoryDefinition {
                 base: base_ptr,
-                current_length: memory.minimum.bytes().0,
+                current_length: memory.minimum.bytes().0.try_into().unwrap(),
             })),
             memory: memory.clone(),
             style: style.clone(),
@@ -213,7 +214,7 @@ impl Memory for LinearMemory {
     fn size(&self) -> Pages {
         unsafe {
             let ptr = self.vm_memory_definition.get();
-            Bytes((*ptr).current_length).into()
+            Bytes::from((*ptr).current_length).into()
         }
     }
 
@@ -292,7 +293,7 @@ impl Memory for LinearMemory {
         // update memory definition
         unsafe {
             let md = &mut *self.vm_memory_definition.get();
-            md.current_length = new_pages.bytes().0;
+            md.current_length = new_pages.bytes().0.try_into().unwrap();
             md.base = mmap.alloc.as_mut_ptr() as _;
         }
 

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -272,7 +272,7 @@ pub struct VMMemoryDefinition {
     pub base: *mut u8,
 
     /// The current logical size of this linear memory in bytes.
-    pub current_length: usize,
+    pub current_length: u32,
 }
 
 /// # Safety
@@ -301,10 +301,10 @@ impl VMMemoryDefinition {
         // https://webassembly.github.io/reference-types/core/exec/instructions.html#exec-memory-copy
         if src
             .checked_add(len)
-            .map_or(true, |n| n as usize > self.current_length)
+            .map_or(true, |n| n > self.current_length)
             || dst
                 .checked_add(len)
-                .map_or(true, |m| m as usize > self.current_length)
+                .map_or(true, |m| m > self.current_length)
         {
             return Err(Trap::new_from_runtime(TrapCode::HeapAccessOutOfBounds));
         }
@@ -334,7 +334,7 @@ impl VMMemoryDefinition {
     pub(crate) unsafe fn memory_fill(&self, dst: u32, val: u32, len: u32) -> Result<(), Trap> {
         if dst
             .checked_add(len)
-            .map_or(true, |m| m as usize > self.current_length)
+            .map_or(true, |m| m > self.current_length)
         {
             return Err(Trap::new_from_runtime(TrapCode::HeapAccessOutOfBounds));
         }

--- a/lib/vm/src/vmoffsets.rs
+++ b/lib/vm/src/vmoffsets.rs
@@ -241,7 +241,7 @@ impl VMOffsets {
 
     /// The size of the `current_length` field.
     pub const fn size_of_vmmemory_definition_current_length(&self) -> u8 {
-        4
+        self.pointer_size
     }
 
     /// Return the size of [`VMMemoryDefinition`].

--- a/lib/vm/src/vmoffsets.rs
+++ b/lib/vm/src/vmoffsets.rs
@@ -241,7 +241,7 @@ impl VMOffsets {
 
     /// The size of the `current_length` field.
     pub const fn size_of_vmmemory_definition_current_length(&self) -> u8 {
-        self.pointer_size
+        4
     }
 
     /// Return the size of [`VMMemoryDefinition`].

--- a/lib/wasmer-types/src/units.rs
+++ b/lib/wasmer-types/src/units.rs
@@ -2,6 +2,7 @@ use crate::lib::std::fmt;
 use crate::lib::std::ops::{Add, Sub};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
 
 /// WebAssembly page sizes are fixed to be 64KiB.
 /// Note: large page support may be added in an opt-in manner in the [future].
@@ -78,6 +79,12 @@ impl From<Pages> for Bytes {
 impl From<usize> for Bytes {
     fn from(other: usize) -> Self {
         Self(other)
+    }
+}
+
+impl From<u32> for Bytes {
+    fn from(other: u32) -> Self {
+        Self(other.try_into().unwrap())
     }
 }
 


### PR DESCRIPTION
Fix implementation of dynamic memory styles with compiler-llvm.

Make VMMemoryDefinition::current_length a u32, from a usize. The usize is host-specific not target-specific, and trying to use u64 causes problems with the heap in compiler-cranelift.