### PR TITLE
Fix build of windows dlls from linux with engine-native + compiler-llvm.

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -4,7 +4,7 @@ use crate::translator::FuncTranslator;
 use crate::CompiledFunctionKind;
 use inkwell::context::Context;
 use inkwell::memory_buffer::MemoryBuffer;
-use inkwell::module::Module;
+use inkwell::module::{Linkage, Module};
 use inkwell::targets::FileType;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use wasmer_compiler::{
@@ -187,6 +187,8 @@ impl LLVMCompiler {
         let metadata_gv =
             merged_module.add_global(metadata_init.get_type(), None, "WASMER_METADATA");
         metadata_gv.set_initializer(&metadata_init);
+        metadata_gv.set_linkage(Linkage::DLLExport);
+        metadata_gv.set_dll_storage_class(inkwell::DLLStorageClass::Export);
 
         if self.config().enable_verifier {
             merged_module.verify().unwrap();

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -1,6 +1,7 @@
 use crate::config::LLVM;
 use crate::trampoline::FuncTrampoline;
 use crate::translator::FuncTranslator;
+use crate::CompiledFunctionKind;
 use inkwell::context::Context;
 use inkwell::memory_buffer::MemoryBuffer;
 use inkwell::module::Module;
@@ -194,6 +195,12 @@ impl LLVMCompiler {
         let memory_buffer = target_machine
             .write_to_memory_buffer(&merged_module, FileType::Object)
             .unwrap();
+        if let Some(ref callbacks) = self.config.callbacks {
+            callbacks.obj_memory_buffer(
+                &CompiledFunctionKind::Local(function_body_inputs.iter().next().unwrap().0),
+                &memory_buffer,
+            );
+        }
 
         Ok(memory_buffer.as_slice().to_vec())
     }

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -6,6 +6,7 @@ use inkwell::context::Context;
 use inkwell::memory_buffer::MemoryBuffer;
 use inkwell::module::{Linkage, Module};
 use inkwell::targets::FileType;
+use inkwell::DLLStorageClass;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use wasmer_compiler::{
     Compilation, CompileError, CompileModuleInfo, Compiler, CustomSection, CustomSectionProtection,
@@ -188,7 +189,7 @@ impl LLVMCompiler {
             merged_module.add_global(metadata_init.get_type(), None, "WASMER_METADATA");
         metadata_gv.set_initializer(&metadata_init);
         metadata_gv.set_linkage(Linkage::DLLExport);
-        metadata_gv.set_dll_storage_class(inkwell::DLLStorageClass::Export);
+        metadata_gv.set_dll_storage_class(DLLStorageClass::Export);
 
         if self.config().enable_verifier {
             merged_module.verify().unwrap();

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -66,6 +66,12 @@ impl FuncTrampoline {
         trampoline_func
             .as_global_value()
             .set_section(FUNCTION_SECTION);
+        trampoline_func
+            .as_global_value()
+            .set_linkage(Linkage::DLLExport);
+        trampoline_func
+            .as_global_value()
+            .set_dll_storage_class(inkwell::DLLStorageClass::Export);
         generate_trampoline(trampoline_func, ty, &callee_attrs, &self.ctx, &intrinsics)?;
 
         if let Some(ref callbacks) = config.callbacks {
@@ -182,6 +188,12 @@ impl FuncTrampoline {
         trampoline_func
             .as_global_value()
             .set_section(FUNCTION_SECTION);
+        trampoline_func
+            .as_global_value()
+            .set_linkage(Linkage::DLLExport);
+        trampoline_func
+            .as_global_value()
+            .set_dll_storage_class(inkwell::DLLStorageClass::Export);
         generate_dynamic_trampoline(trampoline_func, ty, &self.ctx, &intrinsics)?;
 
         if let Some(ref callbacks) = config.callbacks {

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -13,7 +13,7 @@ use inkwell::{
     targets::{FileType, TargetMachine},
     types::BasicType,
     values::{BasicValue, FunctionValue},
-    AddressSpace,
+    AddressSpace, DLLStorageClass,
 };
 use std::cmp;
 use std::convert::TryInto;
@@ -71,7 +71,7 @@ impl FuncTrampoline {
             .set_linkage(Linkage::DLLExport);
         trampoline_func
             .as_global_value()
-            .set_dll_storage_class(inkwell::DLLStorageClass::Export);
+            .set_dll_storage_class(DLLStorageClass::Export);
         generate_trampoline(trampoline_func, ty, &callee_attrs, &self.ctx, &intrinsics)?;
 
         if let Some(ref callbacks) = config.callbacks {
@@ -193,7 +193,7 @@ impl FuncTrampoline {
             .set_linkage(Linkage::DLLExport);
         trampoline_func
             .as_global_value()
-            .set_dll_storage_class(inkwell::DLLStorageClass::Export);
+            .set_dll_storage_class(DLLStorageClass::Export);
         generate_dynamic_trampoline(trampoline_func, ty, &self.ctx, &intrinsics)?;
 
         if let Some(ref callbacks) = config.callbacks {

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -112,6 +112,9 @@ impl FuncTranslator {
         func.add_attribute(AttributeLoc::Function, intrinsics.stack_probe);
         func.set_personality_function(intrinsics.personality);
         func.as_global_value().set_section(FUNCTION_SECTION);
+        func.set_linkage(Linkage::DLLExport);
+        func.as_global_value()
+            .set_dll_storage_class(inkwell::DLLStorageClass::Export);
 
         let entry = self.ctx.append_basic_block(func, "entry");
         let start_of_code = self.ctx.append_basic_block(func, "start_of_code");

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -18,7 +18,7 @@ use inkwell::{
         BasicValue, BasicValueEnum, FloatValue, FunctionValue, InstructionOpcode, InstructionValue,
         IntValue, PhiValue, PointerValue, VectorValue,
     },
-    AddressSpace, AtomicOrdering, AtomicRMWBinOp, FloatPredicate, IntPredicate,
+    AddressSpace, AtomicOrdering, AtomicRMWBinOp, DLLStorageClass, FloatPredicate, IntPredicate,
 };
 use smallvec::SmallVec;
 
@@ -114,7 +114,7 @@ impl FuncTranslator {
         func.as_global_value().set_section(FUNCTION_SECTION);
         func.set_linkage(Linkage::DLLExport);
         func.as_global_value()
-            .set_dll_storage_class(inkwell::DLLStorageClass::Export);
+            .set_dll_storage_class(DLLStorageClass::Export);
 
         let entry = self.ctx.append_basic_block(func, "entry");
         let start_of_code = self.ctx.append_basic_block(func, "start_of_code");

--- a/lib/engine-native/src/artifact.rs
+++ b/lib/engine-native/src/artifact.rs
@@ -269,7 +269,7 @@ impl NativeArtifact {
             vec![]
         };
         let target_args = match (target_triple.operating_system, is_cross_compiling) {
-            (OperatingSystem::Windows, true) => vec!["-Wl,/force:unresolved"],
+            (OperatingSystem::Windows, true) => vec!["-Wl,/force:unresolved,/noentry"],
             (OperatingSystem::Windows, false) => vec!["-Wl,-undefined,dynamic_lookup"],
             _ => vec!["-nostartfiles", "-Wl,-undefined,dynamic_lookup"],
         };


### PR DESCRIPTION
# Description
The experimental interface between engine-native and compiler-llvm allows llvm to emit an object file and build a shared object out of it that engine-native will dlopen, or LoadLibraryW on windows. This PR fixes the problems we run into producing a dll file with cross-compilation toolchain.

There are other bugs in compiler-llvm which mean that with this PR applied we produce DLLs that don't work on windows, but those are cross-platform bugs fixed in #1557 .

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
