### PR TITLE
fix(wasi) Replace an `unwrap` by an `expect`.

### DIFF
--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -177,7 +177,7 @@ impl WasiEnv {
         &mut self,
         _mem_index: u32,
     ) -> (&Memory, MutexGuard<WasiState>) {
-        let memory = self.memory.get_memory().unwrap();
+        let memory = self.memory();
         let state = self.state.lock().unwrap();
         (memory, state)
     }


### PR DESCRIPTION
Calling `self.memory()` is better in that case because it unwraps
`self.memory.get_memory()` with the `expect` method, which provides
guidances to the user.