### PR TITLE
test: Test the JIT engine being dropped twice through the Store

### DIFF
--- a/lib/api/tests/store.rs
+++ b/lib/api/tests/store.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use wasmer::*;
+
+#[test]
+fn store_dropped_twice() -> Result<()> {
+    let wat = r#"(module)"#;
+
+    {
+        let store = Store::default();
+        let _module = Module::new(&store, wat)?;
+    }
+
+    {
+        let store = Store::default();
+        let _module = Module::new(&store, wat)?;
+    }
+
+    Ok(())
+}

--- a/lib/api/tests/store.rs
+++ b/lib/api/tests/store.rs
@@ -5,15 +5,11 @@ use wasmer::*;
 fn store_dropped_twice() -> Result<()> {
     let wat = r#"(module)"#;
 
-    {
-        let store = Store::default();
-        let _module = Module::new(&store, wat)?;
-    }
+    let store = Store::default();
+    let _module = Module::new(&store, wat)?;
 
-    {
-        let store = Store::default();
-        let _module = Module::new(&store, wat)?;
-    }
+    let store = Store::default();
+    let _module = Module::new(&store, wat)?;
 
     Ok(())
 }


### PR DESCRIPTION
I think we have a bug in the `engine-jit` where the `UnwindRegistry` on Linux (Ubuntu) fails when dropped twice.

This PR adds a test to check that.