### PR TITLE
fix(compiler-cranelift) Don't generate an empty `FrameTable` if function body inputs is empty

### DIFF
--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -71,7 +71,12 @@ impl Compiler for CraneliftCompiler {
 
         // Generate the frametable
         #[cfg(feature = "unwind")]
-        let dwarf_frametable = {
+        let dwarf_frametable = if function_body_inputs.is_empty() {
+            // If we have no function body inputs, we don't need to
+            // construct the `FrameTable`. Constructing it, with empty
+            // FDEs will cause some issues in Linux.
+            None
+        } else {
             use std::sync::{Arc, Mutex};
             match target.triple().default_calling_convention() {
                 Ok(CallingConvention::SystemV) => {

--- a/lib/engine-jit/src/unwind/systemv.rs
+++ b/lib/engine-jit/src/unwind/systemv.rs
@@ -81,6 +81,14 @@ impl UnwindRegistry {
                 }
             } else {
                 // On other platforms, `__register_frame` will walk the FDEs until an entry of length 0
+
+                // Registering an empty `eh_frame` (i.e. which
+                // contains empty FDEs) cause problems on Linux when
+                // deregistering it. We must avoid this
+                // scenario. Usually, this is handled upstream by the
+                // compilers.
+                debug_assert_ne!(eh_frame, &[0, 0, 0, 0], "`eh_frame` seems to contain empty FDEs");
+
                 let ptr = eh_frame.as_ptr();
                 __register_frame(ptr);
                 self.registrations.push(ptr as usize);


### PR DESCRIPTION
This PR does 2 things:

1. If we have no function body inputs, we don't need to construct the
`FrameTable`. Constructing it, with empty FDEs will cause some issues
in Linux.
2. Asserting that `eh_frame` isn't empty in the JIT engine (that's a double net).