### PR TITLE
wasmer_instance_call: allow null params

### DIFF
--- a/lib/c-api/src/instance.rs
+++ b/lib/c-api/src/instance.rs
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn wasmer_instance_call(
         return wasmer_result_t::WASMER_ERROR;
     }
 
-    if params.is_null() {
+    if params_len > 0 && params.is_null() {
         update_last_error(CApiError {
             msg: "params ptr is null".to_string(),
         });


### PR DESCRIPTION
allow null params if params_len is zero

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

`wasmer_export_func_call` allows null `params` when `params_len` is zero, but `wasmer_instance_call` is not. The PR makes `wasmer_instance_call` to accept null `params` too.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
