### PR TITLE
Update codecov.yaml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,3 +4,8 @@ coverage:
       default:
         target: auto
         threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+        base: auto


### PR DESCRIPTION
Adds a more lenient threshold for the patch diff (perhaps it should be even higher than 5%) and moves the codecov.yml file into the `.github` folder, which the codecov docs say is also okay!