### PR TITLE
wasmer_instantiate: validate import params

### DIFF
--- a/lib/c-api/src/instance.rs
+++ b/lib/c-api/src/instance.rs
@@ -128,9 +128,22 @@ pub unsafe extern "C" fn wasmer_instantiate(
         });
         return wasmer_result_t::WASMER_ERROR;
     };
+
+    if imports_len > 0 && imports.is_null() {
+        update_last_error(CApiError {
+            msg: "imports ptr is null".to_string(),
+        });
+        return wasmer_result_t::WASMER_ERROR;
+    }
+
     let mut imported_memories = vec![];
     let mut instance_pointers_to_update = vec![];
-    let imports: &[wasmer_import_t] = slice::from_raw_parts(imports, imports_len as usize);
+    let imports: &[wasmer_import_t] = if imports_len == 0 {
+        &[]
+    } else {
+        slice::from_raw_parts(imports, imports_len as usize)
+    };
+
     let mut import_object = ImportObject::new();
     let mut namespaces = HashMap::new();
     for import in imports {


### PR DESCRIPTION

# Description
`std::slice::from_raw_parts` does not allow null pointer, so add null check for `imports`.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
