### PR TITLE
Synchronize mutable env in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## **[Unreleased]**
 
+- [#1625](https://github.com/wasmerio/wasmer/pull/1625) Synchronize mutable Env access in function calls.
+
 ## 1.0.0-alpha3 - 2020-09-14
 - [#1620](https://github.com/wasmerio/wasmer/pull/1620) Fix bug causing the Wapm binary to not be packaged with the release
 - [#1619](https://github.com/wasmerio/wasmer/pull/1619) Improve error message in engine-native when C compiler is missing

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -6,9 +6,10 @@ use crate::FunctionType;
 use crate::NativeFunc;
 use crate::RuntimeError;
 pub use inner::{FromToNativeWasmType, HostFunction, WasmTypeList, WithEnv, WithoutEnv};
-use std::cell::RefCell;
+use std::borrow::BorrowMut;
 use std::cmp::max;
 use std::fmt;
+use std::sync::Mutex;
 use wasmer_vm::{
     raise_user_trap, resume_panic, wasmer_call_trampoline, Export, ExportFunction,
     VMCallerCheckedAnyfunc, VMContext, VMDynamicFunctionContext, VMFunctionBody, VMFunctionKind,
@@ -126,7 +127,7 @@ impl Function {
         Env: Sized + 'static,
     {
         let dynamic_ctx = VMDynamicFunctionContext::from_context(VMDynamicFunctionWithEnv {
-            env: RefCell::new(env),
+            env: Mutex::new(Box::new(env)),
             func: Box::new(func),
             function_type: ty.clone(),
         });
@@ -226,7 +227,7 @@ impl Function {
         // Wasm-defined functions have a `VMContext`.
         // In the case of Host-defined functions `VMContext` is whatever environment
         // the user want to attach to the function.
-        let box_env = Box::new(env);
+        let box_env = Box::new(Mutex::new(env));
         let vmctx = Box::into_raw(box_env) as *mut _ as *mut VMContext;
         let signature = function.ty();
 
@@ -409,7 +410,6 @@ impl Function {
                 )));
             }
         }
-
         Ok(NativeFunc::new(
             self.store.clone(),
             self.exported.address,
@@ -463,6 +463,7 @@ impl VMDynamicFunction for VMDynamicFunctionWithoutEnv {
     }
 }
 
+#[repr(C)]
 pub(crate) struct VMDynamicFunctionWithEnv<Env>
 where
     Env: Sized + 'static,
@@ -470,7 +471,9 @@ where
     function_type: FunctionType,
     #[allow(clippy::type_complexity)]
     func: Box<dyn Fn(&mut Env, &[Val]) -> Result<Vec<Val>, RuntimeError> + 'static>,
-    env: RefCell<Env>,
+    // We have to box this because of the way we call the `call` function, we don't know the
+    // size of the env when calling from NativeFunc.
+    env: Mutex<Box<Env>>,
 }
 
 impl<Env> VMDynamicFunction for VMDynamicFunctionWithEnv<Env>
@@ -478,9 +481,9 @@ where
     Env: Sized + 'static,
 {
     fn call(&self, args: &[Val]) -> Result<Vec<Val>, RuntimeError> {
-        // TODO: the `&mut *self.env.as_ptr()` is likely invoking some "mild"
-        //      undefined behavior due to how it's used in the static fn call
-        unsafe { (*self.func)(&mut *self.env.as_ptr(), &args) }
+        let mut env_guard = self.env.lock().unwrap();
+        let env_mut = env_guard.borrow_mut();
+        (*self.func)(&mut **env_mut, &args)
     }
     fn function_type(&self) -> &FunctionType {
         &self.function_type
@@ -1022,7 +1025,7 @@ mod inner {
                     /// This is a function that wraps the real host
                     /// function. Its address will be used inside the
                     /// runtime.
-                    extern fn func_wrapper<$( $x, )* Rets, RetsAsResult, Env, Func>( env: &mut Env, $( $x: $x::Native, )* ) -> Rets::CStruct
+                    extern fn func_wrapper<$( $x, )* Rets, RetsAsResult, Env, Func>( env: &std::sync::Mutex<Env>, $( $x: $x::Native, )* ) -> Rets::CStruct
                     where
                         $( $x: FromToNativeWasmType, )*
                         Rets: WasmTypeList,
@@ -1030,10 +1033,14 @@ mod inner {
                         Env: Sized,
                         Func: Fn(&mut Env, $( $x ),* ) -> RetsAsResult + 'static
                     {
+                        use std::borrow::BorrowMut;
+
                         let func: &Func = unsafe { &*(&() as *const () as *const Func) };
+                        let mut env_guard = env.lock().unwrap();
+                        let env_mut: &mut Env = env_guard.borrow_mut();
 
                         let result = panic::catch_unwind(AssertUnwindSafe(|| {
-                            func(env, $( FromToNativeWasmType::from_native($x) ),* ).into_result()
+                            func(env_mut, $( FromToNativeWasmType::from_native($x) ),* ).into_result()
                         }));
 
                         match result {

--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -176,7 +176,7 @@ macro_rules! impl_native_traits {
                                     let ctx = self.vmctx as *mut VMContextWithoutEnv;
                                     unsafe { (*ctx).ctx.call(&params_list)? }
                                 } else {
-                                    type VMContextWithEnv = VMDynamicFunctionContext<VMDynamicFunctionWithEnv<std::ffi::c_void>>;
+                                    type VMContextWithEnv = VMDynamicFunctionContext<VMDynamicFunctionWithEnv<Box<std::ffi::c_void>>>;
                                     let ctx = self.vmctx as *mut VMContextWithEnv;
                                     unsafe { (*ctx).ctx.call(&params_list)? }
                                 };


### PR DESCRIPTION
Resolves #1612

This PR wraps all `Env`s in `std::sync::Mutex` ensuring that mutable access cannot happen concurrently.  This PR also fixes some undefined behavior / broken code that was accidentally working with `VMDynamicFunctionWithEnv`.

As a next step, we should design new APIs to give users more control over `Env`, by for example having an `env` and `env_mut` variation where the `env` variation passes a `&Env` allowing users to synchronize themselves if they want.  Additionally, it may be valuable to add unsafe versions of these functions for power users of the API.  Finally, we should investigate if it's possible to allow direct `&mut` access in a single threaded context with a sound API (by using trait constraints).

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
