### PR TITLE
Make InstanceHandle not clonable to avoid thread data races

### DIFF
--- a/lib/api/src/instance.rs
+++ b/lib/api/src/instance.rs
@@ -4,6 +4,7 @@ use crate::module::Module;
 use crate::store::Store;
 use crate::InstantiationError;
 use std::fmt;
+use std::sync::Arc;
 use wasmer_engine::Resolver;
 use wasmer_vm::InstanceHandle;
 
@@ -17,7 +18,7 @@ use wasmer_vm::InstanceHandle;
 /// Spec: https://webassembly.github.io/spec/core/exec/runtime.html#module-instances
 #[derive(Clone)]
 pub struct Instance {
-    handle: InstanceHandle,
+    handle: Arc<InstanceHandle>,
     module: Module,
     /// The exports for an instance.
     pub exports: Exports,
@@ -86,7 +87,7 @@ impl Instance {
             .collect::<Exports>();
 
         Ok(Instance {
-            handle,
+            handle: Arc::new(handle),
             module: module.clone(),
             exports,
         })

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -767,7 +767,14 @@ pub struct InstanceHandle {
 }
 
 /// # Safety
-/// This is safe because there is no thread-specific logic in `InstanceHandle`.
+/// 
+/// This is safe because there is no thread-specific logic in `InstanceHandle`,
+/// and because `InstanceHandle` is not clonable.
+/// 
+/// If `InstanceHandle` could be cloned, then other issues appear as reported by:
+/// * https://github.com/wasmerio/wasmer/issues/1630
+/// * https://github.com/wasmerio/wasmer/issues/1632
+/// 
 /// TODO: this needs extra review
 unsafe impl Send for InstanceHandle {}
 

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -769,7 +769,7 @@ pub struct InstanceHandle {
 /// # Safety
 /// 
 /// This is safe because there is no thread-specific logic in `InstanceHandle`,
-/// and because `InstanceHandle` is not clonable.
+/// and because `InstanceHandle` is neither clonable nor sync.
 /// 
 /// If `InstanceHandle` could be cloned, then other issues appear as reported by:
 /// * https://github.com/wasmerio/wasmer/issues/1630

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -1073,14 +1073,6 @@ impl InstanceHandle {
     }
 }
 
-impl Clone for InstanceHandle {
-    fn clone(&self) -> Self {
-        Self {
-            instance: self.instance,
-        }
-    }
-}
-
 // TODO: uncomment this, as we need to store the handles
 // in the store, and once the store is dropped, then the instances
 // will too.

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -771,7 +771,7 @@ pub struct InstanceHandle {
 /// This is safe because there is no thread-specific logic in `InstanceHandle`,
 /// and because `InstanceHandle` is neither clonable nor sync.
 /// 
-/// If `InstanceHandle` could be cloned, then other issues appear as reported by:
+/// If `InstanceHandle` could be cloned and/or would be sync, then other issues appear as reported by:
 /// * https://github.com/wasmerio/wasmer/issues/1630
 /// * https://github.com/wasmerio/wasmer/issues/1632
 /// 

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -767,14 +767,14 @@ pub struct InstanceHandle {
 }
 
 /// # Safety
-/// 
+///
 /// This is safe because there is no thread-specific logic in `InstanceHandle`,
 /// and because `InstanceHandle` is neither clonable nor sync.
-/// 
+///
 /// If `InstanceHandle` could be cloned and/or would be sync, then other issues appear as reported by:
 /// * https://github.com/wasmerio/wasmer/issues/1630
 /// * https://github.com/wasmerio/wasmer/issues/1632
-/// 
+///
 /// TODO: this needs extra review
 unsafe impl Send for InstanceHandle {}
 

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -771,7 +771,8 @@ pub struct InstanceHandle {
 /// This is safe because there is no thread-specific logic in `InstanceHandle`,
 /// and because `InstanceHandle` is neither clonable nor sync.
 ///
-/// If `InstanceHandle` could be cloned and/or would be sync, then other issues appear as reported by:
+/// If `InstanceHandle` could be cloned and/or would be sync, then other issues
+/// appear as reported by:
 /// * https://github.com/wasmerio/wasmer/issues/1630
 /// * https://github.com/wasmerio/wasmer/issues/1632
 ///


### PR DESCRIPTION
This PR is trying to fix the underlying issues that caused #1632 and #1630 by making InstanceHandle not clonable.

The PR needs extra review.