### PR TITLE
feat(c-api) Add `wat2wasm` to the `wasm-c-api` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## **[Unreleased]**
+- [#1636](https://github.com/wasmerio/wasmer/pull/1636) Implement `wasm_module_validate` in the Wasm C API.
 - [#1671](https://github.com/wasmerio/wasmer/pull/1671) Fix probestack firing inappropriately, and sometimes over/under allocating stack.
 - [#1657](https://github.com/wasmerio/wasmer/pull/1657) Implement `wasm_trap_t` and `wasm_frame_t` for Wasm C API; add examples in Rust and C of exiting early with a host function.
 - [#1645](https://github.com/wasmerio/wasmer/pull/1645) Move the install script to https://github.com/wasmerio/wasmer-install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## **[Unreleased]**
+- [#1635](https://github.com/wasmerio/wasmer/pull/1635) Implement `wat2wasm` in the Wasm C API.
 - [#1636](https://github.com/wasmerio/wasmer/pull/1636) Implement `wasm_module_validate` in the Wasm C API.
 - [#1671](https://github.com/wasmerio/wasmer/pull/1671) Fix probestack firing inappropriately, and sometimes over/under allocating stack.
 - [#1657](https://github.com/wasmerio/wasmer/pull/1657) Implement `wasm_trap_t` and `wasm_frame_t` for Wasm C API; add examples in Rust and C of exiting early with a host function.

--- a/Makefile
+++ b/Makefile
@@ -76,15 +76,15 @@ build-capi: build-capi-cranelift
 
 build-capi-singlepass:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features jit,singlepass,wasi
+		--no-default-features --features wat,jit,singlepass,wasi
 
 build-capi-cranelift:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features jit,cranelift,wasi
+		--no-default-features --features wat,jit,cranelift,wasi
 
 build-capi-llvm:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features jit,llvm,wasi
+		--no-default-features --features wat,jit,llvm,wasi
 
 
 ###########
@@ -112,15 +112,15 @@ test-packages:
 
 test-capi-singlepass: build-capi-singlepass
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features jit,singlepass,wasi -- --nocapture
+		--no-default-features --features wat,jit,singlepass,wasi -- --nocapture
 
 test-capi-cranelift: build-capi-cranelift
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features jit,cranelift,wasi -- --nocapture
+		--no-default-features --features wat,jit,cranelift,wasi -- --nocapture
 
 test-capi-llvm: build-capi-llvm
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features jit,llvm,wasi -- --nocapture
+		--no-default-features --features wat,jit,llvm,wasi -- --nocapture
 
 test-capi: test-capi-singlepass test-capi-cranelift test-capi-llvm
 

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -40,9 +40,11 @@ paste = "0.1"
 
 [features]
 default = [
+    "wat",
     "cranelift",
     "wasi",
 ]
+wat = ["wasmer/wat"]
 wasi = ["wasmer-wasi", "typetag", "serde"]
 engine = []
 jit = [

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -374,4 +374,5 @@ fn exclude_items_from_wasm_c_api(builder: Builder) -> Builder {
         .exclude_item("wasi_get_start_function")
         .exclude_item("wasi_get_wasi_version")
         .exclude_item("wasi_version_t")
+        .exclude_item("wat2wasm")
 }

--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -29,3 +29,5 @@ pub mod value;
 
 #[cfg(feature = "wasi")]
 pub mod wasi;
+
+pub mod wat;

--- a/lib/c-api/src/wasm_c_api/wat.rs
+++ b/lib/c-api/src/wasm_c_api/wat.rs
@@ -21,10 +21,8 @@ pub unsafe extern "C" fn wat2wasm(wat: &wasm_byte_vec_t) -> Option<Box<wasm_byte
     let mut result: Vec<u8> = result.into_owned();
     result.shrink_to_fit();
 
-    let wasm = wasm_byte_vec_t {
+    Some(Box::new(wasm_byte_vec_t {
         size: result.len(),
         data: result.as_mut_ptr(),
-    };
-
-    Some(Box::new(wasm))
+    }))
 }

--- a/lib/c-api/src/wasm_c_api/wat.rs
+++ b/lib/c-api/src/wasm_c_api/wat.rs
@@ -1,0 +1,30 @@
+use super::types::wasm_byte_vec_t;
+
+/// Parses in-memory bytes as either the WAT format, or a binary Wasm
+/// module. This is wasmer-specific.
+///
+/// In case of failure, `wat2wasm` returns `NULL`.
+#[cfg(feature = "wat")]
+#[no_mangle]
+pub unsafe extern "C" fn wat2wasm(wat: &wasm_byte_vec_t) -> Option<Box<wasm_byte_vec_t>> {
+    let wat: &[u8] = wat.into_slice()?;
+
+    let result = match wasmer::wat2wasm(wat) {
+        Ok(result) => result,
+        Err(error) => {
+            crate::error::update_last_error(error);
+
+            return None;
+        }
+    };
+
+    let mut result: Vec<u8> = result.into_owned();
+    result.shrink_to_fit();
+
+    let wasm = wasm_byte_vec_t {
+        size: result.len(),
+        data: result.as_mut_ptr(),
+    };
+
+    Some(Box::new(wasm))
+}

--- a/lib/c-api/src/wasm_c_api/wat.rs
+++ b/lib/c-api/src/wasm_c_api/wat.rs
@@ -8,21 +8,7 @@ use super::types::wasm_byte_vec_t;
 #[no_mangle]
 pub unsafe extern "C" fn wat2wasm(wat: &wasm_byte_vec_t) -> Option<Box<wasm_byte_vec_t>> {
     let wat: &[u8] = wat.into_slice()?;
+    let result: wasm_byte_vec_t = c_try!(wasmer::wat2wasm(wat)).into_owned().into();
 
-    let result = match wasmer::wat2wasm(wat) {
-        Ok(result) => result,
-        Err(error) => {
-            crate::error::update_last_error(error);
-
-            return None;
-        }
-    };
-
-    let mut result: Vec<u8> = result.into_owned();
-    result.shrink_to_fit();
-
-    Some(Box::new(wasm_byte_vec_t {
-        size: result.len(),
-        data: result.as_mut_ptr(),
-    }))
+    Some(Box::new(result))
 }

--- a/lib/c-api/tests/wasm_c_api/CMakeLists.txt
+++ b/lib/c-api/tests/wasm_c_api/CMakeLists.txt
@@ -17,9 +17,10 @@ add_executable(wasm-c-api-serialize wasm-c-api/example/serialize.c)
 add_executable(wasm-c-api-trap wasm-c-api/example/trap.c)
 
 # Our additional tests.
-add_executable(test-wasi test-wasi.c)
 add_executable(test-early-exit test-early-exit.c)
 add_executable(test-memory test-memory.c)
+add_executable(test-wasi test-wasi.c)
+add_executable(test-wat2wasm test-wat2wasm.c)
 
 include_directories(wasm-c-api/include)
 include_directories(../../)
@@ -133,11 +134,6 @@ add_test(NAME wasm-c-api-trap
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/example/
 )
 
-set_property(TARGET test-wasi PROPERTY C_STANDARD 11)
-target_link_libraries(test-wasi general ${WASMER_LIB})
-target_compile_options(test-wasi PRIVATE ${COMPILER_OPTIONS})
-add_test(test-wasi test-wasi)
-
 set_property(TARGET test-early-exit PROPERTY C_STANDARD 11)
 target_link_libraries(test-early-exit general ${WASMER_LIB})
 target_compile_options(test-early-exit PRIVATE ${COMPILER_OPTIONS})
@@ -147,3 +143,13 @@ set_property(TARGET test-memory PROPERTY C_STANDARD 11)
 target_link_libraries(test-memory general ${WASMER_LIB})
 target_compile_options(test-memory PRIVATE ${COMPILER_OPTIONS})
 add_test(test-memory test-memory)
+
+set_property(TARGET test-wasi PROPERTY C_STANDARD 11)
+target_link_libraries(test-wasi general ${WASMER_LIB})
+target_compile_options(test-wasi PRIVATE ${COMPILER_OPTIONS})
+add_test(test-wasi test-wasi)
+
+set_property(TARGET test-wat2wasm PROPERTY C_STANDARD 11)
+target_link_libraries(test-wat2wasm general ${WASMER_LIB})
+target_compile_options(test-wat2wasm PRIVATE ${COMPILER_OPTIONS})
+add_test(test-wat2wasm test-wat2wasm)

--- a/lib/c-api/tests/wasm_c_api/test-wat2wasm.c
+++ b/lib/c-api/tests/wasm_c_api/test-wat2wasm.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "wasmer_wasm.h"
+
+#define own
+
+int main(int argc, const char* argv[]) {
+  // Initialize.
+  printf("Initializing...\n");
+  wasm_engine_t* engine = wasm_engine_new();
+  wasm_store_t* store = wasm_store_new(engine);
+
+  // Getting Wasm.
+  printf("Compiling WAT to Wasm...\n");
+  
+  wasm_byte_vec_t wat = {
+    .data = "(module)",
+    .size = 8,
+  };
+  wasm_byte_vec_t *wasm = wat2wasm(&wat);
+
+  if (!wasm) {
+    printf("> Error compiler WAT to Wasm!\n");
+    return 1;
+  }
+
+  if (wasm->size != 8) {
+    printf("The Wasm size is incorrect!\n");
+    return 1;
+  }
+
+  if (!(wasm->data[0] == 0 &&
+        wasm->data[1] == 'a' &&
+        wasm->data[2] == 's' &&
+        wasm->data[3] == 'm' &&
+        wasm->data[4] == 1 &&
+        wasm->data[5] == 0 &&
+        wasm->data[6] == 0 &&
+        wasm->data[7] == 0)) {
+    printf("The Wasm data is incorrect!\n");
+    return 1;
+  }
+
+  wasm_byte_vec_delete(wasm);
+
+  // All done.
+  printf("Done.\n");
+  return 0;
+}

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -177,4 +177,12 @@ int wasmer_last_error_length(void);
  */
 int wasmer_last_error_message(char *buffer, int length);
 
+/**
+ * Parses in-memory bytes as either the WAT format, or a binary Wasm
+ * module. This is wasmer-specific.
+ *
+ * In case of failure, `wat2wasm` returns `NULL`.
+ */
+wasm_byte_vec_t *wat2wasm(const wasm_byte_vec_t *wat);
+
 #endif /* WASMER_WASM_H */


### PR DESCRIPTION
This PR adds the `wat2wasm` function to the `wasm-c-api` module.

Caveat of this patch: The `wasmer_wasm.h` seems to be written by hand. Consequently, if the `lib/c-api/` crate is compiled without the `wat` feature (which is the default), the `wat2wasm` function will still be defined in `wasmer_wasm.h`.
Proposal: We must generate the `wasmer_wasm.h` header file with the same approach than we use for `wasm.h`. It can be done in a next PR.

Thoughts @MarkMcCaskey 