### PR TITLE
feat(c-api) Implement `wasm_module_validate`

### DIFF
--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -2,8 +2,7 @@ use super::super::store::wasm_store_t;
 use super::super::types::wasm_globaltype_t;
 use super::super::value::wasm_val_t;
 use std::convert::TryInto;
-use std::ptr::NonNull;
-use wasmer::{Global, Store, Val};
+use wasmer::{Global, Val};
 
 #[allow(non_camel_case_types)]
 pub struct wasm_global_t {
@@ -13,14 +12,13 @@ pub struct wasm_global_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_global_new(
-    store_ptr: Option<NonNull<wasm_store_t>>,
+    store: &wasm_store_t,
     gt: &wasm_globaltype_t,
     val: &wasm_val_t,
 ) -> Option<Box<wasm_global_t>> {
     let gt = gt.as_globaltype();
     let wasm_val = val.try_into().ok()?;
-    let store_ptr: NonNull<Store> = store_ptr?.cast::<Store>();
-    let store = store_ptr.as_ref();
+    let store = &store.inner;
     let global = if gt.mutability.is_mutable() {
         Global::new_mut(store, wasm_val)
     } else {

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -1,8 +1,7 @@
 use super::super::store::wasm_store_t;
 use super::super::types::wasm_memorytype_t;
 use std::mem;
-use std::ptr::NonNull;
-use wasmer::{Memory, Pages, Store};
+use wasmer::{Memory, Pages};
 
 #[allow(non_camel_case_types)]
 pub struct wasm_memory_t {
@@ -12,14 +11,12 @@ pub struct wasm_memory_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_memory_new(
-    store_ptr: Option<NonNull<wasm_store_t>>,
+    store: &wasm_store_t,
     mt: &wasm_memorytype_t,
 ) -> Option<Box<wasm_memory_t>> {
     let md = mt.as_memorytype().clone();
-    let store_ptr: NonNull<Store> = store_ptr?.cast::<Store>();
-    let store = store_ptr.as_ref();
+    let memory = c_try!(Memory::new(&store.inner, md));
 
-    let memory = c_try!(Memory::new(store, md));
     Some(Box::new(wasm_memory_t { inner: memory }))
 }
 

--- a/lib/c-api/src/wasm_c_api/externals/table.rs
+++ b/lib/c-api/src/wasm_c_api/externals/table.rs
@@ -1,7 +1,6 @@
 use super::super::store::wasm_store_t;
 use super::super::types::{wasm_ref_t, wasm_table_size_t, wasm_tabletype_t};
-use std::ptr::NonNull;
-use wasmer::{Store, Table};
+use wasmer::Table;
 
 #[allow(non_camel_case_types)]
 pub struct wasm_table_t {
@@ -11,17 +10,14 @@ pub struct wasm_table_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_table_new(
-    store_ptr: Option<NonNull<wasm_store_t>>,
+    store: &wasm_store_t,
     tt: &wasm_tabletype_t,
     init: *const wasm_ref_t,
 ) -> Option<Box<wasm_table_t>> {
     let tt = tt.as_tabletype().clone();
-    let store_ptr: NonNull<Store> = store_ptr?.cast::<Store>();
-    let store = store_ptr.as_ref();
-
     let init_val = todo!("get val from init somehow");
+    let table = c_try!(Table::new(&store.inner, tt, init_val));
 
-    let table = c_try!(Table::new(store, tt, init_val));
     Some(Box::new(wasm_table_t { inner: table }))
 }
 

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -4,7 +4,6 @@ use super::store::wasm_store_t;
 use super::trap::wasm_trap_t;
 use crate::ordered_resolver::OrderedResolver;
 use std::mem;
-use std::ptr::NonNull;
 use std::sync::Arc;
 use wasmer::{Extern, Instance};
 
@@ -52,7 +51,7 @@ unsafe fn argument_import_iter(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_instance_new(
-    store: Option<NonNull<wasm_store_t>>,
+    _store: &wasm_store_t,
     module: &wasm_module_t,
     imports: *const *const wasm_extern_t,
     // own

--- a/lib/c-api/src/wasm_c_api/store.rs
+++ b/lib/c-api/src/wasm_c_api/store.rs
@@ -4,25 +4,20 @@ use wasmer::Store;
 
 /// Opaque wrapper around `Store`
 #[allow(non_camel_case_types)]
-pub struct wasm_store_t {}
+pub struct wasm_store_t {
+    pub(crate) inner: Store,
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_store_new(
     wasm_engine_ptr: Option<NonNull<wasm_engine_t>>,
-) -> Option<NonNull<wasm_store_t>> {
+) -> Option<Box<wasm_store_t>> {
     let wasm_engine_ptr = wasm_engine_ptr?;
     let wasm_engine = wasm_engine_ptr.as_ref();
     let store = Store::new(&*wasm_engine.inner);
-    Some(NonNull::new_unchecked(
-        Box::into_raw(Box::new(store)) as *mut wasm_store_t
-    ))
+
+    Some(Box::new(wasm_store_t { inner: store }))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_store_delete(wasm_store: Option<NonNull<wasm_store_t>>) {
-    if let Some(s_inner) = wasm_store {
-        // this should not leak memory:
-        // we should double check it to make sure though
-        let _: Box<Store> = Box::from_raw(s_inner.cast::<Store>().as_ptr());
-    }
-}
+pub unsafe extern "C" fn wasm_store_delete(_store: Option<Box<wasm_store_t>>) {}


### PR DESCRIPTION
This PR implements `wasm_module_validate`.

It returns a bool, but it populates the error handler too. I took the liberty to update the `c_try!` macro to return any kind of value, so that it is generic over the returned type of the function using `c_try!`.