### PR TITLE
feat(c-api) Implement `wasm_importtype_delete`

### DIFF
--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -1869,6 +1869,9 @@ pub extern "C" fn wasm_importtype_type(
     unsafe { et.extern_type.as_ref() }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn wasm_importtype_delete(_importtype: Option<Box<wasm_importtype_t>>) {}
+
 impl From<ImportType> for wasm_importtype_t {
     fn from(other: ImportType) -> Self {
         (&other).into()


### PR DESCRIPTION
This PR implements `wasm_importtype_delete`. Thoughts @MarkMcCaskey?