### PR TITLE
Fix up aarch64 release logic

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -210,7 +210,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/wasmer-linux-aarch64/wasmer-linux-aarch64.tar.gz
+          asset_path: artifacts/wasmer-linux-aarch64/wasmer-linux-arm64.tar.gz
           asset_name: wasmer-linux-aarch64.tar.gz
           asset_content_type: application/gzip
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -210,7 +210,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/wasmer-linux-aarch64/wasmer-linux-arm64.tar.gz
+          asset_path: artifacts/wasmer-linux-aarch64/wasmer-linux-aarch64.tar.gz
           asset_name: wasmer-linux-aarch64.tar.gz
           asset_content_type: application/gzip
 

--- a/scripts/binary-name.sh
+++ b/scripts/binary-name.sh
@@ -8,7 +8,7 @@ initArch() {
     # If you modify this list, please also modify install.sh
     case $ARCH in
         amd64|x86_64) ARCH="amd64";;
-        aarch64) ARCH="arm64";;
+        aarch64) ARCH="aarch64";;
         # i386) ARCH="386";;
         *) echo "Architecture ${ARCH} is not supported by this installation script"; exit 1;;
     esac


### PR DESCRIPTION
Fixed in the nightly release repo; `make package` names the file `arm64` so we rename it before uploading

