### PR TITLE
Add `rlib` as a crate-type for wasmer-c-api

### DIFF
--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
 wasmer = { version = "1.0.0-alpha3", path = "../api", default-features = false }


### PR DESCRIPTION
This is how `wasmer-runtime-c-api` was before and seems to fix a use
case that users relied on

Fixes an issue mentioned in #1631 

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
