### PR TITLE
Register individual FDEs for musl libc

### DIFF
--- a/lib/engine-jit/src/unwind/systemv.rs
+++ b/lib/engine-jit/src/unwind/systemv.rs
@@ -82,7 +82,8 @@ impl UnwindRegistry {
                 let len = std::ptr::read::<u32>(current as *const u32) as usize;
 
                 // Skip over the CIE
-                if current != start {
+                // We also skip to register the frame if the FDE is empty (len == 0) 
+                if current != start && len > 0 {
                     __register_frame(current);
                     self.registrations.push(current as usize);
                 }

--- a/lib/engine-jit/src/unwind/systemv.rs
+++ b/lib/engine-jit/src/unwind/systemv.rs
@@ -59,39 +59,29 @@ impl UnwindRegistry {
 
     #[allow(clippy::cast_ptr_alignment)]
     unsafe fn register_frames(&mut self, eh_frame: &[u8]) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "macos")] {
-                // On macOS, `__register_frame` takes a pointer to a single FDE
-                let start = eh_frame.as_ptr();
-                let end = start.add(eh_frame.len());
-                let mut current = start;
+        if cfg!(all(target_os = "linux", target_env = "gnu")) {
+            // On gnu (libgcc), `__register_frame` will walk the FDEs until an entry of length 0
+            let ptr = eh_frame.as_ptr();
+            __register_frame(ptr);
+            self.registrations.push(ptr as usize);
+        } else {
+            // For libunwind, `__register_frame` takes a pointer to a single FDE
+            let start = eh_frame.as_ptr();
+            let end = start.add(eh_frame.len());
+            let mut current = start;
 
-                // Walk all of the entries in the frame table and register them
-                while current < end {
-                    let len = std::ptr::read::<u32>(current as *const u32) as usize;
+            // Walk all of the entries in the frame table and register them
+            while current < end {
+                let len = std::ptr::read::<u32>(current as *const u32) as usize;
 
-                    // Skip over the CIE
-                    if current != start {
-                        __register_frame(current);
-                        self.registrations.push(current as usize);
-                    }
-
-                    // Move to the next table entry (+4 because the length itself is not inclusive)
-                    current = current.add(len + 4);
+                // Skip over the CIE
+                if current != start {
+                    __register_frame(current);
+                    self.registrations.push(current as usize);
                 }
-            } else {
-                // On other platforms, `__register_frame` will walk the FDEs until an entry of length 0
 
-                // Registering an empty `eh_frame` (i.e. which
-                // contains empty FDEs) cause problems on Linux when
-                // deregistering it. We must avoid this
-                // scenario. Usually, this is handled upstream by the
-                // compilers.
-                debug_assert_ne!(eh_frame, &[0, 0, 0, 0], "`eh_frame` seems to contain empty FDEs");
-
-                let ptr = eh_frame.as_ptr();
-                __register_frame(ptr);
-                self.registrations.push(ptr as usize);
+                // Move to the next table entry (+4 because the length itself is not inclusive)
+                current = current.add(len + 4);
             }
         }
     }

--- a/lib/engine-jit/src/unwind/systemv.rs
+++ b/lib/engine-jit/src/unwind/systemv.rs
@@ -82,8 +82,10 @@ impl UnwindRegistry {
                 let len = std::ptr::read::<u32>(current as *const u32) as usize;
 
                 // Skip over the CIE
-                // We also skip to register the frame if the FDE is empty (len == 0) 
-                if current != start && len > 0 {
+                if current != start {
+                    // If len == 0, __register_frame will be a no-op.
+                    // So rather than skip it here, we just let __register_frame
+                    // deal with empty FDEs the way they want.
                     __register_frame(current);
                     self.registrations.push(current as usize);
                 }


### PR DESCRIPTION
This PR fixes an issue when using libunwind with musl libc.
It does so by registering the FDEs individually.

This PR should fix the issue exposed here: https://github.com/wasmerio/wasmer/issues/1631#issuecomment-699124373