### PR TITLE
Prevent code coverage from running on bors branches

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,4 +1,9 @@
-on: [push]
+on:
+  push:
+    branches:
+      - '!trying'
+      - '!trying.tmp'
+      - '!staging'
 
 name: build
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,6 +4,7 @@ on:
       - '!trying'
       - '!trying.tmp'
       - '!staging'
+      - '!staging.tmp'
 
 name: build
 


### PR DESCRIPTION
This should reduce our bottleneck of  x86_64 linux machines in CI
