### PR TITLE
Stack probes are not ordinary functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## **[Unreleased]**
+- [#1671](https://github.com/wasmerio/wasmer/pull/1671) Fix probestack firing inappropriately, and sometimes over/under allocating stack.
 - [#1657](https://github.com/wasmerio/wasmer/pull/1657) Implement `wasm_trap_t` and `wasm_frame_t` for Wasm C API; add examples in Rust and C of exiting early with a host function.
 - [#1645](https://github.com/wasmerio/wasmer/pull/1645) Move the install script to https://github.com/wasmerio/wasmer-install
 

--- a/lib/vm/src/libcalls.rs
+++ b/lib/vm/src/libcalls.rs
@@ -396,11 +396,10 @@ pub unsafe extern "C" fn wasmer_raise_trap(trap_code: TrapCode) -> ! {
 ///
 /// # Safety
 ///
-/// To be defined (TODO)
+/// This function does not follow the standard function ABI, and is called as
+/// part of the function prologue.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_probestack() {
-    PROBESTACK();
-}
+pub static wasmer_probestack: unsafe extern "C" fn() = PROBESTACK;
 
 /// The name of a runtime library routine.
 ///


### PR DESCRIPTION
# Description
Do not wrap PROBESTACK in a regular function. Stack probes are not ordinary functions because they are called in the middle of function prologue, and as a result can not follow the ordinary ABI rules.

Fixes #1598.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
