### PR TITLE
Fix warning about zero-sized FDEs.

### DIFF
--- a/lib/engine-jit/src/unwind/systemv.rs
+++ b/lib/engine-jit/src/unwind/systemv.rs
@@ -82,10 +82,8 @@ impl UnwindRegistry {
                 let len = std::ptr::read::<u32>(current as *const u32) as usize;
 
                 // Skip over the CIE
-                if current != start {
-                    // If len == 0, __register_frame will be a no-op.
-                    // So rather than skip it here, we just let __register_frame
-                    // deal with empty FDEs the way they want.
+                // LLVM's libunwind emits a warning on zero-sized FDEs.
+                if current != start && len != 0 {
                     __register_frame(current);
                     self.registrations.push(current as usize);
                 }

--- a/lib/engine-jit/src/unwind/systemv.rs
+++ b/lib/engine-jit/src/unwind/systemv.rs
@@ -81,8 +81,8 @@ impl UnwindRegistry {
             while current < end {
                 let len = std::ptr::read::<u32>(current as *const u32) as usize;
 
-                // Skip over the CIE
-                // LLVM's libunwind emits a warning on zero-sized FDEs.
+                // Skip over the CIE and zero-length FDEs.
+                // LLVM's libunwind emits a warning on zero-length FDEs.
                 if current != start && len != 0 {
                     __register_frame(current);
                     self.registrations.push(current as usize);


### PR DESCRIPTION
# Description
The LLVM implementation of libunwind API will emit a warning when `__register_frame` is called with a zero-size FDE. There's usually only one at the end of a CIE, but just skip any that come up.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
