### PR TITLE
feat(c-api) Reduce the size of `libwasmer_c_api` by 23% + include `wasmer_wasm.h` inside the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,10 @@ test-llvm = [
 # context where signal handling is a problem, such as tarpaulin for code coverage.
 test-no-traps = ["wasmer-wast/test-no-traps"]
 
+[profile.release.package.wasmer-c-api]
+opt-level = "z"
+codegen-units = 1
+
 [[bench]]
 name = "static_and_dynamic_functions"
 harness = false

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ package-capi:
 	mkdir -p "package/include"
 	mkdir -p "package/lib"
 	cp lib/c-api/wasmer.h* package/include
+	cp lib/c-api/wasmer_wasm.h* package/include
 	cp lib/c-api/doc/index.md package/include/README.md
 ifeq ($(OS), Windows_NT)
 	cp target/release/wasmer_c_api.dll package/lib

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,28 @@ build-capi: build-capi-cranelift
 build-capi-singlepass:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features jit,singlepass,wasi
+	${MAKE} strip-capi
 
 build-capi-cranelift:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features jit,cranelift,wasi
+	${MAKE} strip-capi
 
 build-capi-llvm:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features jit,llvm,wasi
+	${MAKE} strip-capi
+
+strip-capi:
+ifeq ($(OS), Windows_NT)
+	# How to strip on Windows?
+else
+ifeq ($(UNAME_S), Darwin)
+	strip -x target/release/libwasmer_c_api.dylib
+else
+	strip -x target/release/libwasmer_c_api.so
+endif
+endif
 
 
 ###########


### PR DESCRIPTION
This PR does 2 things. Yes, that's not ideal, but it's 2 small things.

1. Reduce the size of the `libwsmer_c_api`. On my machine, it drops from 4.8.Mib to 3.7Mib.
2. Include the `wasmer_wasm.h` file inside the Wasmer packages.