### PR TITLE
feat(c-api) Use `Option<NonNull<wasm_valtype_t>>` in `wasm_valtype_kind`

### DIFF
--- a/lib/c-api/src/wasm_c_api/types/value.rs
+++ b/lib/c-api/src/wasm_c_api/types/value.rs
@@ -1,5 +1,6 @@
 use super::super::value::wasm_valkind_t;
 use std::convert::TryInto;
+use std::ptr::NonNull;
 use wasmer::ValType;
 
 #[allow(non_camel_case_types)]
@@ -83,10 +84,11 @@ pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Option<Box<wasm_valt
 pub unsafe extern "C" fn wasm_valtype_delete(_valtype: Option<Box<wasm_valtype_t>>) {}
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_valtype_kind(valtype: *const wasm_valtype_t) -> wasm_valkind_t {
-    if valtype.is_null() {
-        // TODO: handle error
-        panic!("wasm_valtype_kind: argument is null pointer");
-    }
-    return (*valtype).valkind as wasm_valkind_t;
+pub unsafe extern "C" fn wasm_valtype_kind(
+    valtype: Option<NonNull<wasm_valtype_t>>,
+) -> wasm_valkind_t {
+    valtype
+        .expect("`wasm_valtype_kind: argument is a null pointer")
+        .as_ref()
+        .valkind as wasm_valkind_t
 }

--- a/lib/c-api/src/wasm_c_api/types/value.rs
+++ b/lib/c-api/src/wasm_c_api/types/value.rs
@@ -1,6 +1,5 @@
 use super::super::value::wasm_valkind_t;
 use std::convert::TryInto;
-use std::ptr::NonNull;
 use wasmer::ValType;
 
 #[allow(non_camel_case_types)]
@@ -84,11 +83,8 @@ pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Option<Box<wasm_valt
 pub unsafe extern "C" fn wasm_valtype_delete(_valtype: Option<Box<wasm_valtype_t>>) {}
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_valtype_kind(
-    valtype: Option<NonNull<wasm_valtype_t>>,
-) -> wasm_valkind_t {
+pub unsafe extern "C" fn wasm_valtype_kind(valtype: Option<&wasm_valtype_t>) -> wasm_valkind_t {
     valtype
         .expect("`wasm_valtype_kind: argument is a null pointer")
-        .as_ref()
         .valkind as wasm_valkind_t
 }


### PR DESCRIPTION
A more Rust-FFI idiomatic way to handle null pointer.

Note: In `wasm_valtype_kind`, it's tricky to handle the error because
we _must_ return a `wasm_valtype_kind` value. For the moment, it
continues to panic, which is probably the best tradeoff.