### PR TITLE
fix(c-api) `wasm_limits_t` contains `Pages`, not `Bytes` + sentinel value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## **[Unreleased]**
+- [#1690](https://github.com/wasmerio/wasmer/pull/1690) Fix `wasm_memorytype_limits` where `min` and `max` represents pages, not bytes. Additionally, fixes the max limit sentinel value.
 - [#1635](https://github.com/wasmerio/wasmer/pull/1635) Implement `wat2wasm` in the Wasm C API.
 - [#1636](https://github.com/wasmerio/wasmer/pull/1636) Implement `wasm_module_validate` in the Wasm C API.
 - [#1671](https://github.com/wasmerio/wasmer/pull/1671) Fix probestack firing inappropriately, and sometimes over/under allocating stack.

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -58,6 +58,6 @@ pub unsafe extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> *cons
 
     Box::into_raw(Box::new(wasm_limits_t {
         min: md.minimum.0 as _,
-        max: md.maximum.map(|max| max.0 as _).unwrap_or(0),
+        max: md.maximum.map(|max| max.0 as _).unwrap_or(u32::max_value()),
     }))
 }

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -39,6 +39,7 @@ pub unsafe extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm
     } else {
         Some(Pages(limits.max as _))
     };
+
     Box::new(wasm_memorytype_t {
         extern_: wasm_externtype_t {
             inner: ExternType::Memory(MemoryType::new(min_pages, max_pages, false)),
@@ -54,8 +55,9 @@ pub unsafe extern "C" fn wasm_memorytype_delete(_memorytype: Option<Box<wasm_mem
 #[no_mangle]
 pub unsafe extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> *const wasm_limits_t {
     let md = mt.as_memorytype();
+
     Box::into_raw(Box::new(wasm_limits_t {
-        min: md.minimum.bytes().0 as _,
-        max: md.maximum.map(|max| max.bytes().0 as _).unwrap_or(0),
+        min: md.minimum.0 as _,
+        max: md.maximum.map(|max| max.0 as _).unwrap_or(0),
     }))
 }

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -30,11 +30,13 @@ pub struct wasm_limits_t {
     pub(crate) max: u32,
 }
 
+const LIMITS_MAX_SENTINEL: u32 = u32::max_value();
+
 #[no_mangle]
 pub unsafe extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm_memorytype_t> {
     let min_pages = Pages(limits.min as _);
     // u32::max_value() is a sentinel value for no max specified
-    let max_pages = if limits.max == u32::max_value() {
+    let max_pages = if limits.max == LIMITS_MAX_SENTINEL {
         None
     } else {
         Some(Pages(limits.max as _))
@@ -58,6 +60,9 @@ pub unsafe extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> *cons
 
     Box::into_raw(Box::new(wasm_limits_t {
         min: md.minimum.0 as _,
-        max: md.maximum.map(|max| max.0 as _).unwrap_or(u32::max_value()),
+        max: md
+            .maximum
+            .map(|max| max.0 as _)
+            .unwrap_or(LIMITS_MAX_SENTINEL),
     }))
 }


### PR DESCRIPTION
When building a `wasm_memorytype_t` with `wasm_memorytype_new`, we
pass a `wasm_limits_t`, where `min` and `max` represent `Pages`. This
semantics is set by `wasm_memorytype_new` itself where `min` and `max`
from `wasm_limits_t` are used to compute `Pages`, which are then passed
to `MemoryType`.

Then, in `wasm_memorytype_limits`, we expect to get the same
`wasm_limits_t` given to `wasm_memorytype_new`. But it's not!

The same `MemoryType` is read, good. The `minimum` and `maximum`
fields are `Pages`, good. Then, we compute the `min` and `max` values
for the resulting `wasm_limits_t`, which receive `Page.bytes().0`, not
good! We don't want the number of bytes, but the number of pages.

This patch fixes that.

Edit: This patch also fixes the max limit sentinel value. In `wasm.h`, it is defined by `wasm_limits_max_default` (`0xffffffff`). In our code, it is correctly used in `wasm_memorytype_new`, but not in `wasm_memorytype_limits`. A new constant has been introduced: `LIMITS_MAX_SENTINEL`. Not super happy with this name though.