### PR TITLE
Bump Rust CI version to 1.46.0

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux
             os: ubuntu-latest
-            rust: 1.45.0
+            rust: 1.46.0
     env:
       CARGO_SCCACHE_VERSION: 0.2.13
       SCCACHE_AZURE_BLOB_CONTAINER: wasmerstoragesccacheblob

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.0
+          toolchain: 1.46.0
           override: true
       - name: Install LLVM (Linux)
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.0
+          toolchain: 1.46.0
           override: true
           components: rustfmt, clippy
       - run: make lint

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,24 +42,24 @@ jobs:
         include:
           - build: linux
             os: ubuntu-latest
-            rust: 1.45.2
+            rust: 1.46.0
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
             artifact_name: 'wasmer-linux-amd64'
             run_integration_tests: true
           - build: macos
             os: macos-latest
-            rust: 1.45.2
+            rust: 1.46.0
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz'
             artifact_name: 'wasmer-macos-amd64'
             run_integration_tests: true
           - build: windows
             os: windows-latest
-            rust: 1.45.2
+            rust: 1.46.0
             artifact_name: 'wasmer-windows-amd64'
             run_integration_tests: true
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
-            rust: 1.45.2
+            rust: 1.46.0
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false


### PR DESCRIPTION
Because 1.47.0 https://blog.rust-lang.org/2020/10/08/Rust-1.47.html released, we bump our minimum supported version to 1.46.0, maintaining 1 version behind latest stable.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
