### PR TITLE
Update to cbindgen 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,11 +205,13 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.14.6"
-source = "git+https://github.com/eqrion/cbindgen#1fc4cb072422e722f8bcb3af5766f84587a180c6"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df6a11bba1d7cab86c166cecf4cf8acd7d02b7b65924d81b33d27197f22ee35"
 dependencies = [
  "clap",
  "heck",
+ "indexmap",
  "log",
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ build-capi-cranelift:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features wat,jit,object-file,cranelift,wasi
 
+build-capi-cranelift-system-libffi:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,jit,object-file,cranelift,wasi,system-libffi
+
 build-capi-llvm:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features wat,jit,object-file,llvm,wasi
@@ -117,6 +121,10 @@ test-capi-singlepass: build-capi-singlepass
 test-capi-cranelift: build-capi-cranelift
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features wat,jit,cranelift,wasi -- --nocapture
+
+test-capi-cranelift-system-libffi: build-capi-cranelift-system-libffi
+	cargo test --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,jit,cranelift,wasi,system-libffi -- --nocapture
 
 test-capi-llvm: build-capi-llvm
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -88,5 +88,4 @@ cranelift-backend = ["cranelift"]
 llvm-backend = ["llvm"]
 
 [build-dependencies]
-#cbindgen = "0.14.6"
-cbindgen = { git = "https://github.com/eqrion/cbindgen", branch = "master" }
+cbindgen = "0.15"

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -77,6 +77,7 @@ llvm = [
     "wasmer-compiler-llvm",
     "compiler",
 ]
+system-libffi = ["libffi/system"]
 
 # Deprecated feature.
 # TODO: Port this feature.

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -197,6 +197,10 @@ fn build_wasmer_headers(crate_dir: &str, out_dir: &str) {
 /// Create a fresh new `Builder`, already pre-configured.
 fn new_builder(language: Language, crate_dir: &str, include_guard: &str, header: &str) -> Builder {
     Builder::new()
+        .with_config(cbindgen::Config {
+            sort_by: cbindgen::SortKey::Name,
+            ..cbindgen::Config::default()
+        })
         .with_language(language)
         .with_crate(crate_dir)
         .with_include_guard(include_guard)

--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -31,4 +31,5 @@ pub mod wasi;
 
 pub mod wasmer;
 
+#[cfg(feature = "wat")]
 pub mod wat;

--- a/lib/c-api/wasmer.hh
+++ b/lib/c-api/wasmer.hh
@@ -44,6 +44,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdlib>
+#include <ostream>
 #include <new>
 
 #if defined(WASMER_WASI_ENABLED)

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -28,6 +28,9 @@
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
+// The `jit` feature has been enabled for this build.
+#define WASMER_JIT_ENABLED
+
 // The `compiler` feature has been enabled for this build.
 #define WASMER_COMPILER_ENABLED
 


### PR DESCRIPTION
Removes a git dependency which would prevent us from publishing the C API as a crate to crates.io.

It seems that cbindgen 0.15.0 stops sorting output by default, so we now manually specify that we want that.