### PR TITLE
Add license field to engine-object-file crate

### DIFF
--- a/lib/engine-object-file/Cargo.toml
+++ b/lib/engine-object-file/Cargo.toml
@@ -6,6 +6,7 @@ description = "Wasmer Object File Engine"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 repository = "https://github.com/wasmerio/wasmer"
+license = "MIT"
 readme = "README.md"
 edition = "2018"
 


### PR DESCRIPTION
I had to make this change to publish this crate to crates.io, but we found that out after the release