### PR TITLE
Export the VM functions when building on ARM.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,4 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-  "-C", "link-arg=-Wl,-E"
-]
-
-[target.aarch64-unknown-linux-gnu]
+[target.'cfg(target_os = "linux")']
 rustflags = [
   "-C", "link-arg=-Wl,-E"
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,8 @@
 rustflags = [
   "-C", "link-arg=-Wl,-E"
 ]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = [
+  "-C", "link-arg=-Wl,-E"
+]


### PR DESCRIPTION
This is needed to be able to run engine-native built object files on aarch64 linux.
