### PR TITLE
Turn on testing native engine as part of make test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,9 +131,11 @@ test-llvm = [
 
 test-native = [
     "native",
+    "test-generator/test-native",
 ]
 test-jit = [
     "jit",
+    "test-generator/test-jit",
 ]
 
 # Disable trap asserts in the WAST tests. This is useful for running the tests in a

--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,13 @@ test-singlepass-jit:
 	cargo test --release $(compiler_features) --features "test-singlepass test-jit"
 
 test-cranelift-native:
-	cargo test --release $(compiler_features) --features "test-cranelift test-native test-no-traps"
+	cargo test --release $(compiler_features) --features "test-cranelift test-native"
 
 test-cranelift-jit:
 	cargo test --release $(compiler_features) --features "test-cranelift test-jit"
 
 test-llvm-native:
-	cargo test --release $(compiler_features) --features "test-llvm test-native test-no-traps"
+	cargo test --release $(compiler_features) --features "test-llvm test-native"
 
 test-llvm-jit:
 	cargo test --release $(compiler_features) --features "test-llvm test-jit"

--- a/Makefile
+++ b/Makefile
@@ -9,18 +9,14 @@ else
 endif
 
 # Which compilers we build. These have dependencies that may not on the system.
-compilers :=
+compilers := cranelift
 
 # Which engines we test. We always build all engines.
-engines :=
+engines := jit
 
 ifeq ($(ARCH), x86_64)
-	engines += jit
-	# In X64, Cranelift is enabled
-	compilers += cranelift
 	# LLVM could be enabled if not in Windows
 	ifneq ($(OS), Windows_NT)
-		engines += native
 		# Singlepass doesn't work yet on Windows
 		compilers += singlepass
 		# Autodetect LLVM from llvm-config
@@ -35,11 +31,10 @@ ifeq ($(ARCH), x86_64)
 				compilers += llvm
 			endif
 		endif
-	endif
-endif
 
-ifeq ($(ARCH), aarch64)
-	engines += native
+		# Native engine doesn't work yet on Windows
+		engines += native
+	endif
 endif
 
 compilers := $(filter-out ,$(compilers))

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build-capi-llvm:
 # Testing #
 ###########
 
-test: $(foreach compiler,$(compilers),test-$(compiler)-jit) test-packages test-examples test-deprecated
+test: $(foreach compiler,$(compilers),test-$(compiler)-jit test-$(compiler)-native) test-packages test-examples test-deprecated
 
 # Singlepass and native engine don't work together, this rule does nothing.
 test-singlepass-native:
@@ -104,13 +104,13 @@ test-singlepass-jit:
 	cargo test --release $(compiler_features) --features "test-singlepass test-jit"
 
 test-cranelift-native:
-	cargo test --release $(compiler_features) --features "test-cranelift test-native"
+	cargo test --release $(compiler_features) --features "test-cranelift test-native test-no-traps"
 
 test-cranelift-jit:
 	cargo test --release $(compiler_features) --features "test-cranelift test-jit"
 
 test-llvm-native:
-	cargo test --release $(compiler_features) --features "test-llvm test-native"
+	cargo test --release $(compiler_features) --features "test-llvm test-native test-no-traps"
 
 test-llvm-jit:
 	cargo test --release $(compiler_features) --features "test-llvm test-jit"

--- a/examples/engine_headless.rs
+++ b/examples/engine_headless.rs
@@ -147,7 +147,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_arch = "aarch64")))]
 fn test_engine_headless() -> Result<(), Box<dyn std::error::Error>> {
     main()
 }

--- a/examples/engine_native.rs
+++ b/examples/engine_native.rs
@@ -87,6 +87,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[cfg(not(target_arch = "aarch64"))]
 fn test_engine_native() -> Result<(), Box<dyn std::error::Error>> {
     main()
 }

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 wasmer-compiler = { path = "../compiler", version = "1.0.0-alpha4", features = ["translator"], default-features = false }
 wasmer-vm = { path = "../vm", version = "1.0.0-alpha4" }
 wasmer-types = { path = "../wasmer-types", version = "1.0.0-alpha4", default-features = false, features = ["std"] }
-cranelift-codegen = { version = "0.65", default-features = false }
+cranelift-codegen = { version = "0.65", default-features = false, features = ["x86", "arm64"] }
 cranelift-frontend = { version = "0.65", default-features = false }
 tracing = "0.1"
 hashbrown = { version = "0.8", optional = true }

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -38,7 +38,14 @@ fn test_trap_return() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-native"), ignore)]
+#[cfg_attr(
+    any(
+        feature = "test-singlepass",
+        feature = "test-native",
+        target_arch = "aarch64",
+    ),
+    ignore
+)]
 fn test_trap_trace() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -118,7 +125,14 @@ fn test_trap_trace_cb() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-native"), ignore)]
+#[cfg_attr(
+    any(
+        feature = "test-singlepass",
+        feature = "test-native",
+        target_arch = "aarch64",
+    ),
+    ignore
+)]
 fn test_trap_stack_overflow() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -153,7 +167,8 @@ fn test_trap_stack_overflow() -> Result<()> {
     any(
         feature = "test-singlepass",
         feature = "test-llvm",
-        feature = "test-native"
+        feature = "test-native",
+        target_arch = "aarch64",
     ),
     ignore
 )]
@@ -193,7 +208,8 @@ RuntimeError: unreachable
     any(
         feature = "test-singlepass",
         feature = "test-llvm",
-        feature = "test-native"
+        feature = "test-native",
+        target_arch = "aarch64",
     ),
     ignore
 )]
@@ -443,7 +459,8 @@ RuntimeError: indirect call type mismatch
     any(
         feature = "test-singlepass",
         feature = "test-llvm",
-        feature = "test-native"
+        feature = "test-native",
+        target_arch = "aarch64",
     ),
     ignore
 )]

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -37,6 +37,7 @@ fn test_trap_return() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 #[cfg_attr(feature = "test-singlepass", ignore)]
 fn test_trap_trace() -> Result<()> {
@@ -117,6 +118,7 @@ fn test_trap_trace_cb() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 #[cfg_attr(feature = "test-singlepass", ignore)]
 fn test_trap_stack_overflow() -> Result<()> {
@@ -148,6 +150,7 @@ fn test_trap_stack_overflow() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 #[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
 fn trap_display_pretty() -> Result<()> {
@@ -181,6 +184,7 @@ RuntimeError: unreachable
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 #[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
 fn trap_display_multi_module() -> Result<()> {
@@ -386,6 +390,7 @@ fn mismatched_arguments() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 #[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
 fn call_signature_mismatch() -> Result<()> {
@@ -417,6 +422,7 @@ RuntimeError: indirect call type mismatch
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 #[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
 fn start_trap_pretty() -> Result<()> {
@@ -449,6 +455,7 @@ RuntimeError: unreachable
     Ok(())
 }
 
+#[cfg(not(feature = "test-no-traps"))]
 #[test]
 fn present_after_module_drop() -> Result<()> {
     let store = get_store();

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -37,9 +37,8 @@ fn test_trap_return() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-no-traps"), ignore)]
+#[cfg_attr(any(feature = "test-singlepass", feature = "test-native"), ignore)]
 fn test_trap_trace() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -118,9 +117,8 @@ fn test_trap_trace_cb() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(feature = "test-singlepass", ignore)]
+#[cfg_attr(any(feature = "test-singlepass", feature = "test-native"), ignore)]
 fn test_trap_stack_overflow() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -150,9 +148,15 @@ fn test_trap_stack_overflow() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
+#[cfg_attr(
+    any(
+        feature = "test-singlepass",
+        feature = "test-llvm",
+        feature = "test-native"
+    ),
+    ignore
+)]
 fn trap_display_pretty() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -184,9 +188,15 @@ RuntimeError: unreachable
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
+#[cfg_attr(
+    any(
+        feature = "test-singlepass",
+        feature = "test-llvm",
+        feature = "test-native"
+    ),
+    ignore
+)]
 fn trap_display_multi_module() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -390,9 +400,15 @@ fn mismatched_arguments() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
+#[cfg_attr(
+    any(
+        feature = "test-singlepass",
+        feature = "test-llvm",
+        feature = "test-native"
+    ),
+    ignore
+)]
 fn call_signature_mismatch() -> Result<()> {
     let store = get_store();
     let binary = r#"
@@ -422,9 +438,15 @@ RuntimeError: indirect call type mismatch
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(any(feature = "test-singlepass", feature = "test-llvm"), ignore)]
+#[cfg_attr(
+    any(
+        feature = "test-singlepass",
+        feature = "test-llvm",
+        feature = "test-native"
+    ),
+    ignore
+)]
 fn start_trap_pretty() -> Result<()> {
     let store = get_store();
     let wat = r#"
@@ -455,8 +477,8 @@ RuntimeError: unreachable
     Ok(())
 }
 
-#[cfg(not(feature = "test-no-traps"))]
 #[test]
+#[cfg_attr(feature = "test-native", ignore)]
 fn present_after_module_drop() -> Result<()> {
     let store = get_store();
     let module = Module::new(&store, r#"(func (export "foo") unreachable)"#)?;

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -39,7 +39,7 @@ fn test_trap_return() -> Result<()> {
 
 #[cfg(not(feature = "test-no-traps"))]
 #[test]
-#[cfg_attr(feature = "test-singlepass", ignore)]
+#[cfg_attr(any(feature = "test-singlepass", feature = "test-no-traps"), ignore)]
 fn test_trap_trace() -> Result<()> {
     let store = get_store();
     let wat = r#"

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -63,6 +63,20 @@ pub fn run_wast(wast_path: &str, compiler: &str) -> anyhow::Result<()> {
     features.multi_value(false);
     let store = get_store(features, try_nan_canonicalization);
     let mut wast = Wast::new_with_spectest(store);
+    // `bulk-memory-operations/bulk.wast` checks for a message that
+    // specifies which element is uninitialized, but our traps don't
+    // shepherd that information out.
+    wast.allow_trap_message("uninitialized element 2", "uninitialized element");
+    if cfg!(feature = "test-native") {
+        wast.allow_trap_message("call stack exhausted", "out of bounds memory access");
+        wast.allow_trap_message("indirect call type mismatch", "call stack exhausted");
+        wast.allow_trap_message("integer divide by zero", "call stack exhausted");
+        wast.allow_trap_message("integer overflow", "call stack exhausted");
+        wast.allow_trap_message("invalid conversion to integer", "call stack exhausted");
+        wast.allow_trap_message("undefined element", "call stack exhausted");
+        wast.allow_trap_message("uninitialized element", "call stack exhausted");
+        wast.allow_trap_message("unreachable", "call stack exhausted");
+    }
     if is_simd {
         // We allow this, so tests can be run properly for `simd_const` test.
         wast.allow_instantiation_failures(&[

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -67,7 +67,7 @@ pub fn run_wast(wast_path: &str, compiler: &str) -> anyhow::Result<()> {
     // specifies which element is uninitialized, but our traps don't
     // shepherd that information out.
     wast.allow_trap_message("uninitialized element 2", "uninitialized element");
-    if cfg!(feature = "test-native") {
+    if compiler == "cranelift" && cfg!(feature = "test-native") {
         wast.allow_trap_message("call stack exhausted", "out of bounds memory access");
         wast.allow_trap_message("indirect call type mismatch", "call stack exhausted");
         wast.allow_trap_message("integer divide by zero", "call stack exhausted");

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -26,6 +26,9 @@ llvm::spec::skip_stack_guard_page on darwin
 cranelift::spec::linking on native
 llvm::spec::linking on native
 
+# https://github.com/wasmerio/wasmer/issues/1722
+llvm::spec::skip_stack_guard_page on native
+
 # Frontends
 
 ## WASI

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -22,6 +22,10 @@ singlepass on windows # Singlepass is not yet supported on Windows
 cranelift::spec::skip_stack_guard_page on darwin
 llvm::spec::skip_stack_guard_page on darwin
 
+# TODO: traps in native engine
+cranelift::spec::linking on native
+llvm::spec::linking on native
+
 # Frontends
 
 ## WASI

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -30,6 +30,21 @@ llvm::spec::linking on native
 # https://github.com/wasmerio/wasmer/issues/1722
 llvm::spec::skip_stack_guard_page on native
 
+# Cranelift on arm failures
+cranelift::spec::align on aarch64
+cranelift::spec::memory_trap on aarch64
+cranelift::spec::simd::simd_bit_shift on aarch64
+cranelift::spec::simd::simd_boolean on aarch64
+cranelift::spec::simd::simd_const on aarch64
+cranelift::spec::simd::simd_i16x8_arith on aarch64
+cranelift::spec::simd::simd_i16x8_sat_arith on aarch64
+cranelift::spec::simd::simd_i32x4_arith on aarch64
+cranelift::spec::simd::simd_i64x2_arith on aarch64
+cranelift::spec::simd::simd_i8x16_arith on aarch64
+cranelift::spec::simd::simd_i8x16_sat_arith on aarch64
+cranelift::spec::simd::simd_lane on aarch64
+cranelift::spec::skip_stack_guard_page on aarch64
+
 # Frontends
 
 ## WASI

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -22,8 +22,9 @@ singlepass on windows # Singlepass is not yet supported on Windows
 cranelift::spec::skip_stack_guard_page on darwin
 llvm::spec::skip_stack_guard_page on darwin
 
-# TODO: traps in native engine
+# TODO(https://github.com/wasmerio/wasmer/issues/1727): Traps in native engine
 cranelift::spec::linking on native
+# TODO(https://github.com/wasmerio/wasmer/pull/1710): Library is dropped too soon.
 llvm::spec::linking on native
 
 # https://github.com/wasmerio/wasmer/issues/1722

--- a/tests/lib/test-generator/Cargo.toml
+++ b/tests/lib/test-generator/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 target-lexicon = "0.10"
+
+[features]
+test-native = []
+test-jit = []


### PR DESCRIPTION
Add support for "on native" and "on jit" to the ignores.txt.

Extend test-no-traps feature to cover tests/compiler/traps.rs and enable it when testing with the native engine.

Turn on testing native engine as part of make test.
