### PR TITLE
Remove "test-no-traps" cfg! feature from test-generator, use a runtime bool instead.

### DIFF
--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,15 +1,15 @@
 [cranelift_coverage]
-features = "cranelift,singlepass,llvm,test-no-traps,test-cranelift"
+features = "cranelift,singlepass,llvm,coverage,test-cranelift,test-jit"
 examples = ["early-exit", "engine-jit", "engine-native", "engine-headless", "cross-compilation", "compiler-cranelift", "exported-function", "wasi"]
 release = true
 
 [llvm_coverage]
-features = "cranelift,singlepass,llvm,test-no-traps,test-llvm"
+features = "cranelift,singlepass,llvm,coverage,test-llvm,test-jit"
 examples = ["compiler-llvm"]
 release = true
 
 [singlepass_coverage]
-features = "cranelift,singlepass,llvm,test-no-traps,test-singlepass"
+features = "cranelift,singlepass,llvm,coverage,test-singlepass,test-jit"
 examples = ["compiler-singlepass"]
 release = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ test-jit = [
     "jit",
 ]
 
-# Disable trap asserts in the WAST tests. This is useful for running the tests in a
-# context where signal handling is a problem, such as tarpaulin for code coverage.
-test-no-traps = ["wasmer-wast/test-no-traps"]
+# Specifies that we're running in coverage testing mode. This disables tests
+# that raise signals because that interferes with tarpaulin.
+coverage = []
 
 [[bench]]
 name = "static_and_dynamic_functions"

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -59,10 +59,14 @@ pub fn run_wast(wast_path: &str, compiler: &str) -> anyhow::Result<()> {
     if is_simd {
         features.simd(true);
     }
-    #[cfg(feature = "test-singlepass")]
-    features.multi_value(false);
+    if cfg!(feature = "test-singlepass") {
+        features.multi_value(false);
+    }
     let store = get_store(features, try_nan_canonicalization);
     let mut wast = Wast::new_with_spectest(store);
+    if cfg!(feature = "coverage") {
+        wast.disable_assert_and_exhaustion();
+    }
     if is_simd {
         // We allow this, so tests can be run properly for `simd_const` test.
         wast.allow_instantiation_failures(&[

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -23,7 +23,6 @@ typetag = "0.1"
 [features]
 default = ["wat"]
 wat = ["wasmer/wat"]
-test-no-traps = [] 
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Rename "test-no-traps" feature to "coverage".

Update .tarpaulin.toml to set coverage and also set test-jit (to fix breakage introduced in #1712).
