### PR TITLE
Use GITHUB_PATH, GITHUB_ENV in CI

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,7 +35,7 @@ jobs:
         # that are needed during the build process. Additionally, this works
         # around a bug in the 'cache' action that causes directories outside of
         # the workspace dir to be saved/restored incorrectly.
-        run: echo "::set-env name=CARGO_HOME::$(pwd)/.cargo_home"
+        run: echo "CARGO_HOME=$(pwd)/.cargo_home" >> $GITHUB_ENV
       - name: Cache
         uses: actions/cache@master
         with:
@@ -56,8 +56,8 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz -L -o llvm.tar.xz
           mkdir -p /opt/llvm-10
           tar xf llvm.tar.xz --strip-components=1 -C /opt/llvm-10
-          echo ::add-path::/opt/llvm-10/bin
-          echo ::set-env name=LLVM_SYS_100_PREFIX::/opt/llvm-10
+          echo '/opt/llvm-10/bin' >> $GITHUB_PATH
+          echo 'name=LLVM_SYS_100_PREFIX=/opt/llvm-10' >> $GITHUB_ENV
       - name: Install Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,8 +29,8 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz -L -o llvm.tar.xz
           mkdir -p /opt/llvm-10
           tar xf llvm.tar.xz --strip-components=1 -C /opt/llvm-10
-          echo ::add-path::/opt/llvm-10/bin
-          echo ::set-env name=LLVM_SYS_100_PREFIX::/opt/llvm-10
+          echo '/opt/llvm-10/bin' >> $GITHUB_PATH
+          echo 'LLVM_SYS_100_PREFIX=/opt/llvm-10' >> $GITHUB_ENV
       - name: Generate Coverage Report
         run: |
           cargo install cargo-tarpaulin

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,7 +81,7 @@ jobs:
         # that are needed during the build process. Additionally, this works
         # around a bug in the 'cache' action that causes directories outside of
         # the workspace dir to be saved/restored incorrectly.
-        run: echo "::set-env name=CARGO_HOME::$(pwd)/.cargo_home"
+        run: echo "CARGO_HOME=$(pwd)/.cargo_home" >> $GITHUB_ENV
       - name: Cache
         uses: actions/cache@master
         with:
@@ -103,13 +103,13 @@ jobs:
       #     key: cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       # - name: Install sccache
       #   run: |
-      #     echo "::add-path::${{ runner.tool_cache }}/cargo-sccache/bin"
+      #     echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH
       #     cargo install sccache --version ${{ env.CARGO_SCCACHE_VERSION }} --root ${{ runner.tool_cache }}/cargo-sccache
       # - name: Start sccache
       #   run: |
       #     ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
       #     ${{ runner.tool_cache }}/cargo-sccache/bin/sscache -s
-      #     echo "::set-env name=RUSTC_WRAPPER::${{ runner.tool_cache }}/cargo-sccache/bin/sccache"
+      #     echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       - name: Install LLVM (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd
@@ -118,17 +118,17 @@ jobs:
         # run: |
         #   curl --proto '=https' --tlsv1.2 -sSf https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe -L -o llvm-installer.exe
         #   7z x llvm-installer.exe -oC:/llvm-10
-        #   echo ::add-path::C:/llvm-10/bin
-        #   echo ::set-env name=LLVM_SYS_100_PREFIX::C:/llvm-10
-        #   echo ::set-env name=LIBCLANG_PATH::C:/llvm-10/bin/libclang.dll
+        #   echo C:/llvm-10/bin >> $GITHUB_PATH
+        #   echo "LLVM_SYS_100_PREFIX=C:/llvm-10" >> $GITHUB_ENV
+        #   echo "LIBCLANG_PATH=C:/llvm-10/bin/libclang.dll" >> $GITHUB_ENV
       - name: Install LLVM (Unix)
         if: matrix.os != 'windows-latest'
         run: |
           curl --proto '=https' --tlsv1.2 -sSf ${{ matrix.llvm_url }} -L -o llvm.tar.xz
           mkdir -p ${{ env.LLVM_DIR }}
           tar xf llvm.tar.xz --strip-components=1 -C ${{ env.LLVM_DIR }}
-          echo "::add-path::${{ env.LLVM_DIR }}/bin"
-          echo "::set-env name=LLVM_SYS_100_PREFIX::${{ env.LLVM_DIR }}"
+          echo "${{ env.LLVM_DIR }}/bin" >> $GITHUB_PATH
+          echo "LLVM_SYS_100_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm-10
       - name: Set up dependencies for Mac OS
@@ -242,7 +242,7 @@ jobs:
           path: ${{ runner.tool_cache }}/cargo-audit
           key: cargo-audit-bin-${{ env.CARGO_AUDIT_VERSION }}
       - run: |
-          echo "::add-path::${{ runner.tool_cache }}/cargo-audit/bin"
+          echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
       - run: |
           cargo install cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} --root ${{ runner.tool_cache }}/cargo-audit
           cargo audit


### PR DESCRIPTION
The old style is being deprecated, see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/


