### PR TITLE
feat(c-api) Implement `wasm_func_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- [#1725](https://github.com/wasmerio/wasmer/pull/1725) Implement `wasm_func_type` in the Wasm C API.
 - [#1715](https://github.com/wasmerio/wasmer/pull/1715) Register errors from `wasm_module_serialize` in the Wasm C API.
 - [#1709](https://github.com/wasmerio/wasmer/pull/1709) Implement `wasm_module_name` and `wasm_module_set_name` in the Wasm(er) C API.
 - [#1700](https://github.com/wasmerio/wasmer/pull/1700) Implement `wasm_externtype_copy` in the Wasm C API.

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -1,6 +1,6 @@
 use super::super::store::wasm_store_t;
 use super::super::trap::wasm_trap_t;
-use super::super::types::{wasm_functype_t, wasm_valkind_enum};
+use super::super::types::{wasm_functype_t, wasm_functype_t, wasm_valkind_enum};
 use super::super::value::{wasm_val_inner, wasm_val_t};
 use std::convert::TryInto;
 use std::ffi::c_void;
@@ -153,4 +153,9 @@ pub unsafe extern "C" fn wasm_func_param_arity(func: &wasm_func_t) -> usize {
 #[no_mangle]
 pub unsafe extern "C" fn wasm_func_result_arity(func: &wasm_func_t) -> usize {
     func.inner.ty().results().len()
+}
+
+#[no_mangle]
+pub extern "C" fn wasm_func_type(func: &wasm_func_t) -> Box<wasm_functype_t> {
+    Box::new(wasm_functype_t::new(func.inner.ty().clone()))
 }

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -1,6 +1,6 @@
 use super::super::store::wasm_store_t;
 use super::super::trap::wasm_trap_t;
-use super::super::types::{wasm_functype_t, wasm_functype_t, wasm_valkind_enum};
+use super::super::types::{wasm_functype_t, wasm_valkind_enum};
 use super::super::value::{wasm_val_inner, wasm_val_t};
 use std::convert::TryInto;
 use std::ffi::c_void;

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -17,6 +17,14 @@ impl wasm_functype_t {
             unreachable!("data corruption: `wasm_functype_t` does not contain a function")
         }
     }
+
+    pub(crate) fn new(function_type: FunctionType) -> Self {
+        Self {
+            extern_: wasm_externtype_t {
+                inner: ExternType::Function(function_type),
+            },
+        }
+    }
 }
 
 wasm_declare_vec!(functype);
@@ -52,10 +60,9 @@ unsafe fn wasm_functype_new_inner(
         .map(Into::into)
         .collect::<Vec<_>>();
 
-    let extern_ = wasm_externtype_t {
-        inner: ExternType::Function(FunctionType::new(params, results)),
-    };
-    Some(Box::new(wasm_functype_t { extern_ }))
+    Some(Box::new(wasm_functype_t::new(FunctionType::new(
+        params, results,
+    ))))
 }
 
 #[no_mangle]


### PR DESCRIPTION
This patch creates a `wasm_functype_t::new` constructor, that is used
by the new `wasm_func_type` function, and the existing
`wasm_functype_new_inner` function.

Note: `wasm_func_type` is defined in https://github.com/wasmerio/wasmer/blob/193d7c8ce1b744e6078269ac7a77dd53d1e4cbd6/lib/c-api/tests/wasm_c_api/wasm-c-api/include/wasm.h#L421.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
