### PR TITLE
feat(c-api): Implement `wasm_global_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- [#1736](https://github.com/wasmerio/wasmer/pull/1736) Implement `wasm_global_type` in the Wasm C API.
 - [#1699](https://github.com/wasmerio/wasmer/pull/1699) Update `wasm.h` to its latest version.
 - [#1685](https://github.com/wasmerio/wasmer/pull/1685) Implement `wasm_exporttype_delete` in the Wasm C API.
 - [#1725](https://github.com/wasmerio/wasmer/pull/1725) Implement `wasm_func_type` in the Wasm C API.

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -59,3 +59,8 @@ pub unsafe extern "C" fn wasm_global_same(
 ) -> bool {
     wasm_global1.inner.same(&wasm_global2.inner)
 }
+
+#[no_mangle]
+pub extern "C" fn wasm_global_type(wasm_global: &wasm_global_t) -> Box<wasm_globaltype_t> {
+    Box::new(wasm_globaltype_t::new(wasm_global.inner.ty().clone()))
+}

--- a/lib/c-api/src/wasm_c_api/types/global.rs
+++ b/lib/c-api/src/wasm_c_api/types/global.rs
@@ -20,6 +20,14 @@ impl wasm_globaltype_t {
             );
         }
     }
+
+    pub(crate) fn new(global_type: GlobalType) -> Self {
+        Self {
+            extern_: wasm_externtype_t {
+                inner: ExternType::Global(global_type),
+            },
+        }
+    }
 }
 
 wasm_declare_vec!(globaltype);
@@ -42,11 +50,10 @@ unsafe fn wasm_globaltype_new_inner(
     mutability: wasm_mutability_t,
 ) -> Option<Box<wasm_globaltype_t>> {
     let me: wasm_mutability_enum = mutability.try_into().ok()?;
-    let gd = Box::new(wasm_globaltype_t {
-        extern_: wasm_externtype_t {
-            inner: ExternType::Global(GlobalType::new((*valtype).into(), me.into())),
-        },
-    });
+    let gd = Box::new(wasm_globaltype_t::new(GlobalType::new(
+        (*valtype).into(),
+        me.into(),
+    )));
     wasm_valtype_delete(Some(valtype));
 
     Some(gd)


### PR DESCRIPTION
This patch adds a `wasm_globaltype_t::new` constructor for use by the
new `wasm_global_type` function and the existing
`wasm_globaltype_new_inner` function.

Note: `wasm_global_type` is defined here:
https://github.com/wasmerio/wasmer/blob/193d7c8ce1b744e6078269ac7a77dd53d1e4cbd6/lib/c-api/tests/wasm_c_api/wasm-c-api/include/wasm.h#L436

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
