### PR TITLE
Begin work on fixing up vec_uninit code in wasm_c_api

### DIFF
--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -3,6 +3,7 @@ mod global;
 mod memory;
 mod table;
 
+use crate::wasm_c_api::traits::UninitDefault;
 pub use function::*;
 pub use global::*;
 pub use memory::*;
@@ -16,6 +17,14 @@ pub struct wasm_extern_t {
     // this is how we ensure the instance stays alive
     pub(crate) instance: Option<Arc<Instance>>,
     pub(crate) inner: Extern,
+}
+
+unsafe impl UninitDefault for wasm_extern_t {
+    unsafe fn uninit_default(mem: *mut Self) {
+        let zeroed_memory = std::mem::MaybeUninit::zeroed().as_ptr();
+        (*mem).instance = None;
+        std::ptr::copy(zeroed_memory, mem, 1);
+    }
 }
 
 wasm_declare_boxed_vec!(extern);

--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -33,3 +33,6 @@ pub mod wasmer;
 
 #[cfg(feature = "wat")]
 pub mod wat;
+
+/// cbindgen:ignore
+pub(crate) mod traits;

--- a/lib/c-api/src/wasm_c_api/traits.rs
+++ b/lib/c-api/src/wasm_c_api/traits.rs
@@ -1,0 +1,18 @@
+//! Traits used to improve the safety / correctness of our C API implementation.
+//! These types are not exposed to the C API.
+
+/// Used to get a type when uninitialized memory is required.
+///
+/// This is useful for types that are not valid for arbitrary bit patterns.
+/// For example types that contain `NonNull` must ensure that those fields
+/// are not all-zero.
+pub(crate) unsafe trait UninitDefault {
+    /// Returns
+    unsafe fn uninit_default(mem: *mut Self);
+}
+
+unsafe impl<T: Default> UninitDefault for T {
+    unsafe fn uninit_default(mem: *mut Self) {
+        *mem = Self::default();
+    }
+}

--- a/lib/c-api/src/wasm_c_api/types/export.rs
+++ b/lib/c-api/src/wasm_c_api/types/export.rs
@@ -1,4 +1,5 @@
 use super::{wasm_externtype_t, wasm_name_t};
+use crate::wasm_c_api::traits::UninitDefault;
 use std::ptr::NonNull;
 use wasmer::ExportType;
 
@@ -9,7 +10,20 @@ pub struct wasm_exporttype_t {
 
     /// If `true`, `name` and `extern_type` will be dropped by
     /// `wasm_exporttype_t::drop`.
+    // TODO: use an enum instead with owned and non-owned values so that this
+    // type can't be misused.
     owns_fields: bool,
+}
+
+unsafe impl UninitDefault for wasm_exporttype_t {
+    unsafe fn uninit_default(mem: *mut Self) {
+        let uninit = Self {
+            name: NonNull::dangling(),
+            extern_type: NonNull::dangling(),
+            owns_fields: false,
+        };
+        std::ptr::copy(&uninit, mem, 1);
+    }
 }
 
 wasm_declare_boxed_vec!(exporttype);

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -1,4 +1,5 @@
 use super::{wasm_externtype_t, wasm_name_t};
+use crate::wasm_c_api::traits::UninitDefault;
 use std::ptr::NonNull;
 use wasmer::ImportType;
 
@@ -8,6 +9,17 @@ pub struct wasm_importtype_t {
     pub(crate) module: NonNull<wasm_name_t>,
     pub(crate) name: NonNull<wasm_name_t>,
     pub(crate) extern_type: NonNull<wasm_externtype_t>,
+}
+
+unsafe impl UninitDefault for wasm_importtype_t {
+    unsafe fn uninit_default(mem: *mut Self) {
+        let uninit = Self {
+            module: NonNull::dangling(),
+            name: NonNull::dangling(),
+            extern_type: NonNull::dangling(),
+        };
+        std::ptr::copy(&uninit, mem, 1);
+    }
 }
 
 wasm_declare_boxed_vec!(importtype);

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -23,6 +23,15 @@ pub struct wasm_val_t {
     pub of: wasm_val_inner,
 }
 
+impl Default for wasm_val_t {
+    fn default() -> Self {
+        Self {
+            kind: 0, // i32
+            of: wasm_val_inner { int32_t: 0 },
+        }
+    }
+}
+
 wasm_declare_vec!(val);
 
 impl Clone for wasm_val_t {


### PR DESCRIPTION
PR intentionally unfinished. Before continuing, I want to discuss the fix with @Hywan . The solution in this PR is more correct than what we had before but it has some major problems, namely that users from the C API can't safely free an uninitialized vec due to the way uninit is being used here.

I think the most correct solution that we can have here is to avoid using higher level Rust types and probably alloc and dealloc slabs of memory directly, not involving `Drop` at all... this may have other side effects though.  Some types in vecs now have `Arc` to keep `Instance` alive, avoiding `Drop` may cause problems if the vec itself owns these types.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
