### PR TITLE
feat(c-api) Implement `wasm_memory_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- [#1741](https://github.com/wasmerio/wasmer/pull/1741) Implement `wasm_memory_type` in the Wasm C API.
 - [#1736](https://github.com/wasmerio/wasmer/pull/1736) Implement `wasm_global_type` in the Wasm C API.
 - [#1699](https://github.com/wasmerio/wasmer/pull/1699) Update `wasm.h` to its latest version.
 - [#1685](https://github.com/wasmerio/wasmer/pull/1685) Implement `wasm_exporttype_delete` in the Wasm C API.

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -25,16 +25,16 @@ pub unsafe extern "C" fn wasm_memory_delete(_memory: Option<Box<wasm_memory_t>>)
 
 // TODO: figure out if these should be deep or shallow copies
 #[no_mangle]
-pub unsafe extern "C" fn wasm_memory_copy(wasm_memory: &wasm_memory_t) -> Box<wasm_memory_t> {
+pub unsafe extern "C" fn wasm_memory_copy(memory: &wasm_memory_t) -> Box<wasm_memory_t> {
     // do shallow copy
     Box::new(wasm_memory_t {
-        inner: wasm_memory.inner.clone(),
+        inner: memory.inner.clone(),
     })
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_memory_type(_memory_ptr: &wasm_memory_t) -> *mut wasm_memorytype_t {
-    todo!("wasm_memory_type")
+pub unsafe extern "C" fn wasm_memory_type(memory: &wasm_memory_t) -> Box<wasm_memorytype_t> {
+    Box::new(wasm_memorytype_t::new(memory.inner.ty().clone()))
 }
 
 // get a raw pointer into bytes

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -18,6 +18,14 @@ impl wasm_memorytype_t {
             );
         }
     }
+
+    pub(crate) fn new(memory_type: MemoryType) -> Self {
+        Self {
+            extern_: wasm_externtype_t {
+                inner: ExternType::Memory(memory_type),
+            },
+        }
+    }
 }
 
 wasm_declare_vec!(memorytype);
@@ -42,11 +50,9 @@ pub unsafe extern "C" fn wasm_memorytype_new(limits: &wasm_limits_t) -> Box<wasm
         Some(Pages(limits.max as _))
     };
 
-    Box::new(wasm_memorytype_t {
-        extern_: wasm_externtype_t {
-            inner: ExternType::Memory(MemoryType::new(min_pages, max_pages, false)),
-        },
-    })
+    Box::new(wasm_memorytype_t::new(MemoryType::new(
+        min_pages, max_pages, false,
+    )))
 }
 
 #[no_mangle]


### PR DESCRIPTION
This patch implements the `wasm_memory_type` function for the Wasm C API (previously implemented with a `todo!`).

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
