### PR TITLE
feat(c-api) Correctly implement “trap” in `wasm_func_new*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#1710](https://github.com/wasmerio/wasmer/pull/1710) Memory for function call trampolines is now owned by the Artifact.
 ### Added
 
+- [#1751](https://github.com/wasmerio/wasmer/pull/1751) Implement `wasm_trap_t` inside a function declared with `wasm_func_new_with_env` in the Wasm C API.
 - [#1741](https://github.com/wasmerio/wasmer/pull/1741) Implement `wasm_memory_type` in the Wasm C API.
 - [#1736](https://github.com/wasmerio/wasmer/pull/1736) Implement `wasm_global_type` in the Wasm C API.
 - [#1699](https://github.com/wasmerio/wasmer/pull/1699) Update `wasm.h` to its latest version.

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -60,7 +60,8 @@ pub unsafe extern "C" fn wasm_func_new(
 
         if !trap.is_null() {
             let trap: Box<wasm_trap_t> = Box::from_raw(trap);
-            RuntimeError::raise(Box::new(trap.inner));
+
+            return Err(trap.inner);
         }
 
         let processed_results = results
@@ -110,8 +111,13 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
             ]
             .into();
 
-            let _traps = callback(*env, &processed_args, &mut results);
-            // TODO: do something with `traps`
+            let trap = callback(*env, &processed_args, &mut results);
+
+            if !trap.is_null() {
+                let trap: Box<wasm_trap_t> = Box::from_raw(trap);
+
+                return Err(trap.inner);
+            }
 
             let processed_results = results
                 .into_slice()


### PR DESCRIPTION
The implementation of “trap” in `wasm_func_new` was “incorrect”. It's
more idiomatic to return a `RuntimeError` than raising it in this
case, so that we don't duplicate locations where runtime errors are
raised.

The implementation of “trap” in `wasm_func_new_with_env` was
missing. This patch implements a similar strategy than the sibling
function.

Fixes https://github.com/wasmerio/wasmer/issues/1744.