### PR TITLE
fix(ci): Link against an older version of libstdc++

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,9 +41,9 @@ jobs:
         build: [linux, macos, windows, linux-aarch64]
         include:
           - build: linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             rust: 1.46.0
-            llvm_url: 'https://github.com/wasmerio/llvm-build/releases/download/10.x/Ubuntu1910_Release.tar.xz'
+            llvm_url: 'https://github.com/wasmerio/llvm-build/releases/download/10.x/Ubuntu1604_Release.tar.xz'
             # llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
             artifact_name: 'wasmer-linux-amd64'
             run_integration_tests: true
@@ -70,6 +70,12 @@ jobs:
       SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
     steps:
       - uses: actions/checkout@v2
+      - name: Set up libstdc++ on Linux
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --allow-downgrades libstdc++6=8.4.0-1ubuntu1~18.04
+          sudo apt-get install --reinstall g++-8
+        if: matrix.os == 'ubuntu-18.04'
       - name: Install Rust ${{ matrix.rust }}
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
_This PR replaces #1746_

This should the compatibility of the wasmer binary across Linux
distributions.

Closes #1745

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This patch changes the build environment so that we have an older version of `libstdc++` to link to.

To make the built stable over time, I changed `ubuntu-latest` to `ubuntu-18.04` so that if Github changes the alias it will have no impact on our builds.

I also had to use the LLVM build from Ubuntu 16.04.

Here is the state of the binary produced with this patch:

| Distribution | State | Details |
|-------------|:----:|---------|
| Debian Bullseye | ✅ ||
| Debian Buster (10) | ✅ ||
| Debian Stretch (9 - **EOS**) | ❌ | only provides `GLIBC` up until `2.24` and `GLIBCXX` up until `3.4.22` |
| Ubuntu Focal (20.04) | ✅ ||
| Ubuntu Bionic (18.04) | ✅ ||
| Ubuntu Xenial (16.04 - **EOS Apr-2021**) | ❌ | only provides `GLIBC` up until `2.23` and `GLIBCXX` up until `3.4.21` |
| CentOS 8 | ✅ ||
| CentOS 7 | ❌ | only provides `GLIBC` up until `2.17` and `GLIBCXX` up until `3.4.19` |