### PR TITLE
Globals are already stored inside the VMContext.

### DIFF
--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -255,7 +255,6 @@ impl Instance {
     /// Return the indexed `VMGlobalDefinition`.
     fn global_ptr(&self, index: LocalGlobalIndex) -> NonNull<VMGlobalDefinition> {
         let index = usize::try_from(index.as_u32()).unwrap();
-        // TODO:
         NonNull::new(unsafe { *self.globals_ptr().add(index) }).unwrap()
     }
 

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -909,8 +909,6 @@ impl VMBuiltinFunctionsArray {
 /// The struct here is empty, as the sizes of these fields are dynamic, and
 /// we can't describe them in Rust's type system. Sufficient memory is
 /// allocated at runtime.
-///
-/// TODO: We could move the globals into the `vmctx` allocation too.
 #[derive(Debug)]
 #[repr(C, align(16))] // align 16 since globals are aligned to that and contained inside
 pub struct VMContext {}


### PR DESCRIPTION
I claim these two TODOs are both detritus. Change my mind :wink: 