### PR TITLE
fix(wasi) Allow the `=` sign in the environment variable value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - [#1709](https://github.com/wasmerio/wasmer/pull/1709) Implement `wasm_module_name` and `wasm_module_set_name` in the Wasm(er) C API.
 - [#1700](https://github.com/wasmerio/wasmer/pull/1700) Implement `wasm_externtype_copy` in the Wasm C API.
 
+### Changed
+
+- [#1762](https://github.com/wasmerio/wasmer/pull/1762) Allow the `=` sign in a WASI environment variable value.
+
 ### Fixed
 
 - [#1718](https://github.com/wasmerio/wasmer/pull/1718) Fix panic in the API in some situations when the memory's min bound was greater than the memory's max bound.

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -334,7 +334,7 @@ impl WasiStateBuilder {
                 return Err(WasiStateCreationError::EnvironmentVariableFormatError(
                     format!(
                         "found nul byte in env var string \"{}\" (key=value)",
-                        std::str::from_utf8(env).unwrap_or("Inner error: env var is invalid_utf8!")
+                        String::from_utf8_lossy(env)
                     ),
                 ));
             }

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -93,8 +93,10 @@ fn validate_mapped_dir_alias(alias: &str) -> Result<(), WasiStateCreationError> 
 // return stdout somehow, it's unclear what that API should look like)
 impl WasiStateBuilder {
     /// Add an environment variable pair.
-    /// Environment variable keys must not contain the byte `=` (0x3d)
-    /// or nul (0x0).
+    ///
+    /// Both the key and value of an environment variable must not
+    /// contain a nul byte (`0x0`), and the key must not contain the
+    /// `=` byte (`0x3d`).
     pub fn env<Key, Value>(&mut self, key: Key, value: Value) -> &mut Self
     where
         Key: AsRef<[u8]>,
@@ -107,6 +109,7 @@ impl WasiStateBuilder {
     }
 
     /// Add an argument.
+    ///
     /// Arguments must not contain the nul (0x0) byte
     pub fn arg<Arg>(&mut self, arg: Arg) -> &mut Self
     where
@@ -118,7 +121,10 @@ impl WasiStateBuilder {
     }
 
     /// Add multiple environment variable pairs.
-    /// Keys must not contain the `=` (0x3d) or nul (0x0) byte.
+    ///
+    /// Both the key and value of the environment variables must not
+    /// contain a nul byte (`0x0`), and the key must not contain the
+    /// `=` byte (`0x3d`).
     pub fn envs<I, Key, Value>(&mut self, env_pairs: I) -> &mut Self
     where
         I: IntoIterator<Item = (Key, Value)>,
@@ -133,6 +139,7 @@ impl WasiStateBuilder {
     }
 
     /// Add multiple arguments.
+    ///
     /// Arguments must not contain the nul (0x0) byte
     pub fn args<I, Arg>(&mut self, args: I) -> &mut Self
     where
@@ -147,6 +154,7 @@ impl WasiStateBuilder {
     }
 
     /// Preopen a directory
+    ///
     /// This opens the given directory at the virtual root, `/`, and allows
     /// the WASI module to read and write to the given directory.
     pub fn preopen_dir<FilePath>(
@@ -192,7 +200,8 @@ impl WasiStateBuilder {
         Ok(self)
     }
 
-    /// Preopen a directory
+    /// Preopen a directory.
+    ///
     /// This opens the given directory at the virtual root, `/`, and allows
     /// the WASI module to read and write to the given directory.
     pub fn preopen_dirs<I, FilePath>(

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -490,17 +490,21 @@ mod test {
 
     #[test]
     fn env_var_errors() {
+        // `a=b` means key is `a` and value is `b`, which is OK.
+        // `a=b=c` means key is `a` and value is `b=c`, which is OK too.
         let output = create_wasi_state("test_prog")
-            .env("HOM=E", "/home/home")
+            .env("HOME", "/home/home=foo")
             .build();
+
         match output {
-            Err(WasiStateCreationError::EnvironmentVariableFormatError(_)) => assert!(true),
-            _ => assert!(false),
+            Err(WasiStateCreationError::EnvironmentVariableFormatError(_)) => assert!(false),
+            _ => assert!(true),
         }
 
         let output = create_wasi_state("test_prog")
             .env("HOME\0", "/home/home")
             .build();
+
         match output {
             Err(WasiStateCreationError::EnvironmentVariableFormatError(_)) => assert!(true),
             _ => assert!(false),

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -328,33 +328,15 @@ impl WasiStateBuilder {
                 }
             }
         }
+
         for env in self.envs.iter() {
-            let mut eq_seen = false;
-            for b in env.iter() {
-                match *b {
-                    b'=' => {
-                        if eq_seen {
-                            return Err(WasiStateCreationError::EnvironmentVariableFormatError(
-                                format!(
-                                    "found '=' in env var string \"{}\" (key=value)",
-                                    std::str::from_utf8(env)
-                                        .unwrap_or("Inner error: env var is invalid_utf8!")
-                                ),
-                            ));
-                        }
-                        eq_seen = true;
-                    }
-                    0 => {
-                        return Err(WasiStateCreationError::EnvironmentVariableFormatError(
-                            format!(
-                                "found nul byte in env var string \"{}\" (key=value)",
-                                std::str::from_utf8(env)
-                                    .unwrap_or("Inner error: env var is invalid_utf8!")
-                            ),
-                        ));
-                    }
-                    _ => (),
-                }
+            if env.iter().find(|&&ch| ch == 0).is_some() {
+                return Err(WasiStateCreationError::EnvironmentVariableFormatError(
+                    format!(
+                        "found nul byte in env var string \"{}\" (key=value)",
+                        std::str::from_utf8(env).unwrap_or("Inner error: env var is invalid_utf8!")
+                    ),
+                ));
             }
         }
 

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -93,7 +93,7 @@ fn validate_mapped_dir_alias(alias: &str) -> Result<(), WasiStateCreationError> 
 // return stdout somehow, it's unclear what that API should look like)
 impl WasiStateBuilder {
     /// Add an environment variable pair.
-    /// Environment variable keys and values must not contain the byte `=` (0x3d)
+    /// Environment variable keys must not contain the byte `=` (0x3d)
     /// or nul (0x0).
     pub fn env<Key, Value>(&mut self, key: Key, value: Value) -> &mut Self
     where
@@ -130,7 +130,7 @@ impl WasiStateBuilder {
     }
 
     /// Add multiple environment variable pairs.
-    /// Keys and values must not contain the `=` (0x3d) or nul (0x0) byte.
+    /// Keys must not contain the `=` (0x3d) or nul (0x0) byte.
     pub fn envs<I, Key, Value>(&mut self, env_pairs: I) -> &mut Self
     where
         I: IntoIterator<Item = (Key, Value)>,


### PR DESCRIPTION
# Description

Having `a=b` means that the environment variable key is `a`, and its
value is `b`.

Having `a=b=c` means that the key is `a` and its value is `b=c`.

It's OK to get this, e.g. within a CGI context where values can hold
strings such as `sec-ch-ua: "Chromium;v=86"` etc. See
#1708 for a longer
explanation.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file

Fixes #1708.