### PR TITLE
feat(makefile) Add more `build-capi-*` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,15 +94,35 @@ build-docs-capi:
 # We use cranelift as the default backend for the capi for now
 build-capi: build-capi-cranelift-jit
 
+build-capi-singlepass:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,jit,native,object-file,singlepass,wasi
+
 build-capi-singlepass-jit:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,object-file,singlepass,wasi
+		--no-default-features --features wat,jit,singlepass,wasi
+
+build-capi-singlepass-native:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,native,singlepass,wasi
+
+build-capi-singlepass-object-file:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,object-file,singlepass,wasi
+
+build-capi-cranelift:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,jit,native,object-file,cranelift,wasi
 
 build-capi-cranelift-jit:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,object-file,cranelift,wasi
+		--no-default-features --features wat,jit,cranelift,wasi
 
 build-capi-cranelift-native:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,native,cranelift,wasi
+
+build-capi-cranelift-object-file:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features wat,native,object-file,cranelift,wasi
 
@@ -110,13 +130,21 @@ build-capi-cranelift-system-libffi:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features wat,jit,native,object-file,cranelift,wasi,system-libffi
 
+build-capi-llvm:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,jit,native,object-file,llvm,wasi
+
 build-capi-llvm-jit:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,object-file,llvm,wasi
+		--no-default-features --features wat,jit,llvm,wasi
 
 build-capi-llvm-native:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,object-file,llvm,wasi
+		--no-default-features --features wat,native,llvm,wasi
+
+build-capi-llvm-object-file:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features wat,object-file,llvm,wasi
 
 ###########
 # Testing #

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build-docs-capi:
 	cd lib/c-api/ && doxygen doxyfile
 
 # We use cranelift as the default backend for the capi for now
-build-capi: build-capi-cranelift-jit
+build-capi: build-capi-cranelift
 
 build-capi-singlepass:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -29,6 +29,9 @@
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
+// The `jit` feature has been enabled for this build.
+#define WASMER_JIT_ENABLED
+
 // The `compiler` feature has been enabled for this build.
 #define WASMER_COMPILER_ENABLED
 


### PR DESCRIPTION
# Description

The new targets are the following:

* `build-capi-<compiler-name>` to compile the C API with only one
  compiler, and 3 engines: JIT, native, and object-file.
* `build-capi-<compiler-name>-<engine-name>` to compile the C API with
  only one compiler and only one engine, defined by `engine-name`.

One question remains: What is `build-capi-cranelift-system-libffi`?

# Review

- [ ] ~Add a short description of the the change to the CHANGELOG.md file~ not necesary
