### PR TITLE
Update this script so that it works on Linux.

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,5 +1,6 @@
 #! /bin/sh
 
+# How to install `fd`: https://github.com/sharkdp/fd#installation
 : "${FD:=fd}"
 
 # A script to update the version of all the crates at the same time

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,12 +1,16 @@
+#! /bin/sh
+
+: "${FD:=fd}"
+
 # A script to update the version of all the crates at the same time
 PREVIOUS_VERSION='1.0.0-alpha3'
 NEXT_VERSION='1.0.0-alpha4'
 
 # quick hack
-fd Cargo.toml --exec sed -i '' "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"
+${FD} Cargo.toml --exec sed -i '{}' -e "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"
 echo "manually check changes to Cargo.toml"
 
-fd wasmer.iss --exec sed -i '' "s/AppVersion=$PREVIOUS_VERSION/AppVersion=$NEXT_VERSION/"
+${FD} wasmer.iss --exec sed -i '{}' -e "s/AppVersion=$PREVIOUS_VERSION/AppVersion=$NEXT_VERSION/"
 echo "manually check changes to wasmer.iss"
 
 # Order to upload packages in


### PR DESCRIPTION
Make `fd` the default name of the program, but allow for the user to specify another, such as `FD=fdfind scripts/update-version.sh`.

Fix the sed command to take the filename to modify in-place and specify that the regex string is the sed-expression to execute.

# Review

 - [ ] Please check that this still works on a Mac.

