### PR TITLE
fix(c-api) Remove memory leaks and address `TODO`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "inline-c"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05127e24c27c04b35e108635f2fe846e48152333bae2be0eab57a5e6f00dfd14"
+checksum = "6acf1564e52050c9f7102e87951265c4c8012873181998be24640cb6b5e3f77c"
 dependencies = [
  "assert_cmd",
  "cc",
@@ -2187,9 +2187,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"

--- a/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
+++ b/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
@@ -105,3 +105,24 @@ null pointer.
 Considering [the `const *T` Section][#const-t], if the pointer is not
 owned, we can either write `Option<NonNull<T>>` or `Option<&T>`. It
 has been decided to use the second pattern in all the codebase.
+
+## Destructors
+
+The `wasm.h` defines `wasm_*_delete` functions. It represents destructors.
+
+## Rust Pattern
+
+The destructors in Rust translate as follow:
+
+```rust
+#[no_mangle]
+pub unsafe extern "C" fn wasm_*_delete(_: Option<Box<wasm_*_t>>) {}
+```
+
+`Box<T>` will take the ownership of the value. It means that Rust will
+drop it automatically as soon as it goes out of the
+scope. Consequently, the “C destructors” really are the “Rust
+destructors”.
+
+The `Option` is here to handle the situation where a null pointer is
+passed to the destructor.

--- a/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
+++ b/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
@@ -39,6 +39,16 @@ By reading the code, it is clear that `wasm_importtype_new` takes the
 ownership for `module`, `name`, and `extern_type`, and that the result
 is owned by the caller.
 
+## `const *T`
+
+A constant pointer can be interpreted in C as an immutable
+pointer. Without the `own` annotation, it means the ownership is not
+transfered anywhere (see [the Ownerships Section][#ownerships]).
+
+### Rust Pattern
+
+`const *T` translates to Rust as `&T`, it's a reference.
+
 ## Null Pointer
 
 The `wasm.h` header does not say anything about null pointer. The
@@ -92,17 +102,6 @@ It returns `None` if the value is `None`, otherwise it unwraps the
 Because the function returns `Option<Box<T>>`, `None` represents a
 null pointer.
 
-## `const *T`
-
-A constant pointer can be interpreted in C as an immutable
-pointer. Without the `own` annotation, it means the ownership is not
-transfered anywhere (see [the Ownerships Section][#ownerships]).
-
-### Rust Pattern
-
-`const *T` translates to Rust as `&T`, it's a reference.
-
-Note: It could translate to `Option<NonNull<T>>` and then we could
-call `x?.as_ref()` to get a `&T`. It could also translate to
-`Option<&T>`. Whether we should use such patterns in all the codebase
-is still under discussion.
+Considering [the `const *T` Section][#const-t], if the pointer is not
+owned, we can either write `Option<NonNull<T>>` or `Option<&T>`. It
+has been decided to use the second pattern in all the codebase.

--- a/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
+++ b/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
@@ -103,5 +103,6 @@ transfered anywhere (see [the Ownerships Section][#ownerships]).
 `const *T` translates to Rust as `&T`, it's a reference.
 
 Note: It could translate to `Option<NonNull<T>>` and then we could
-call `x?.as_ref()` to get a `&T`. Whether we should use this pattern
-in all the codebase is still under discussion.
+call `x?.as_ref()` to get a `&T`. It could also translate to
+`Option<&T>`. Whether we should use such patterns in all the codebase
+is still under discussion.

--- a/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
+++ b/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
@@ -1,0 +1,107 @@
+# Development Notes
+
+## Ownerships
+
+The `wasm.h` header thankfully defines the `own` “annotation”. It
+specifies _who_ owns _what_. For example, in the following code:
+
+```c
+WASM_API_EXTERN own wasm_importtype_t* wasm_importtype_new(
+  own wasm_name_t* module, own wasm_name_t* name, own wasm_externtype_t*);
+```
+
+We must read that `wasm_importtype_new` takes the ownership of all its
+three arguments. This function is then responsible to free those
+data. We must also read that the returned value is owned by the caller
+of this function.
+
+### Rust Pattern
+
+This ownership property translates well in Rust. We have decided to
+use the `Box<T>` type to represent an owned pointer. `Box<T>` drops
+its content when it's dropped.
+
+Consequently, apart from other patterns, the code above can be written
+as follows in Rust:
+
+```rust
+#[no_mangle]
+pub extern "C" fn wasm_importtype_new(
+    module: Box<wasm_name_t>,
+    name: Box<wasm_name_t>,
+    extern_type: Box<wasm_externtype_t>,
+) -> Box<wasm_importtype_t> {
+    …
+}
+```
+
+By reading the code, it is clear that `wasm_importtype_new` takes the
+ownership for `module`, `name`, and `extern_type`, and that the result
+is owned by the caller.
+
+## Null Pointer
+
+The `wasm.h` header does not say anything about null pointer. The
+behavior we agreed on in that passing a null pointer where it is not
+expected (i.e. no where) will make the function to return null too
+without any error.
+
+### Rust Pattern
+
+A nice type property in Rust is that it is possible to write
+`Option<NonNull<T>>` to nicely handle null pointer of kind `T`. For an
+argument, it translates as follows:
+
+* When the given pointer is null, the argument holds `None`,
+* When the given pointer is not null, the arguments holds
+  `Some(NonNull<T>)`.
+
+Considering [the Ownerships Section][#ownerships], if the pointer is
+owned, we can also write `Option<Box<T>>`. This pattern is largely
+used in this codebase to represent a “nullable” owned
+pointer. Consequently, a code like:
+
+```c
+WASM_API_EXTERN own wasm_importtype_t* wasm_importtype_new(
+  own wasm_name_t* module, own wasm_name_t* name, own wasm_externtype_t*);
+```
+
+translates into Rust as:
+
+```rust
+#[no_mangle]
+pub extern "C" fn wasm_importtype_new(
+    module: Option<Box<wasm_name_t>>,
+    name: Option<Box<wasm_name_t>>,
+    extern_type: Option<Box<wasm_externtype_t>>,
+) -> Option<Box<wasm_importtype_t>> {
+    Some(Box::new(wasm_importtype_t {
+        name: name?,
+        module: module?,
+        extern_type: extern_type?,
+    }))
+}
+```
+
+What `name?` (and others) means? It is basically [the `Try` trait
+implemented for
+`Option`](https://doc.rust-lang.org/std/ops/trait.Try.html#impl-Try):
+It returns `None` if the value is `None`, otherwise it unwraps the
+`Option`.
+
+Because the function returns `Option<Box<T>>`, `None` represents a
+null pointer.
+
+## `const *T`
+
+A constant pointer can be interpreted in C as an immutable
+pointer. Without the `own` annotation, it means the ownership is not
+transfered anywhere (see [the Ownerships Section][#ownerships]).
+
+### Rust Pattern
+
+`const *T` translates to Rust as `&T`, it's a reference.
+
+Note: It could translate to `Option<NonNull<T>>` and then we could
+call `x?.as_ref()` to get a `&T`. Whether we should use this pattern
+in all the codebase is still under discussion.

--- a/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
+++ b/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Ownerships
 
-The `wasm.h` header thankfully defines the `own` “annotation”. It
+The [`wasm.h`] header thankfully defines the [`own`] “annotation”. It
 specifies _who_ owns _what_. For example, in the following code:
 
 ```c
@@ -42,7 +42,7 @@ is owned by the caller.
 ## `const *T`
 
 A constant pointer can be interpreted in C as an immutable
-pointer. Without the `own` annotation, it means the ownership is not
+pointer. Without the [`own`] annotation, it means the ownership is not
 transfered anywhere (see [the Ownerships Section][#ownerships]).
 
 ### Rust Pattern
@@ -51,7 +51,7 @@ transfered anywhere (see [the Ownerships Section][#ownerships]).
 
 ## Null Pointer
 
-The `wasm.h` header does not say anything about null pointer. The
+The [`wasm.h`] header does not say anything about null pointer. The
 behavior we agreed on in that passing a null pointer where it is not
 expected (i.e. everywhere) will make the function to return null too
 with no error.
@@ -108,7 +108,7 @@ has been decided to use the second pattern in all the codebase.
 
 ## Destructors
 
-The `wasm.h` defines `wasm_*_delete` functions. It represents destructors.
+The [`wasm.h`] defines `wasm_*_delete` functions. It represents destructors.
 
 ## Rust Pattern
 
@@ -126,3 +126,7 @@ destructors”.
 
 The `Option` is here to handle the situation where a null pointer is
 passed to the destructor.
+
+
+[`own`](https://github.com/wasmerio/wasmer/blob/f548f268f2335693b97ad7ca08af72c320daf59a/lib/c-api/tests/wasm_c_api/wasm-c-api/include/wasm.h#L46-L65)
+[`wasm.h`](https://github.com/wasmerio/wasmer/blob/f548f268f2335693b97ad7ca08af72c320daf59a/lib/c-api/tests/wasm_c_api/wasm-c-api/include/wasm.h)

--- a/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
+++ b/lib/c-api/src/wasm_c_api/DEVELOPMENT.md
@@ -43,8 +43,8 @@ is owned by the caller.
 
 The `wasm.h` header does not say anything about null pointer. The
 behavior we agreed on in that passing a null pointer where it is not
-expected (i.e. no where) will make the function to return null too
-without any error.
+expected (i.e. everywhere) will make the function to return null too
+with no error.
 
 ### Rust Pattern
 

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -7,6 +7,7 @@ use std::ffi::c_void;
 use std::sync::Arc;
 use wasmer::{Function, Instance, RuntimeError, Val};
 
+#[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub struct wasm_func_t {
     pub(crate) inner: Function,
@@ -91,12 +92,11 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
     function_type: Option<&wasm_functype_t>,
     callback: Option<wasm_func_callback_with_env_t>,
     env: *mut c_void,
-    finalizer: Option<wasm_env_finalizer_t>,
+    finalizer: wasm_env_finalizer_t,
 ) -> Option<Box<wasm_func_t>> {
     let store = store?;
     let function_type = function_type?;
     let callback = callback?;
-    let finalizer = finalizer?;
 
     let func_sig = &function_type.inner().function_type;
     let num_rets = func_sig.results().len();

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -150,10 +150,13 @@ pub unsafe extern "C" fn wasm_func_delete(_func: Option<Box<wasm_func_t>>) {}
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_func_call(
-    func: &wasm_func_t,
-    args: &wasm_val_vec_t,
+    func: Option<&wasm_func_t>,
+    args: Option<&wasm_val_vec_t>,
     results: &mut wasm_val_vec_t,
 ) -> Option<Box<wasm_trap_t>> {
+    let func = func?;
+    let args = args?;
+
     let params = args
         .into_slice()
         .map(|slice| {

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -87,13 +87,17 @@ pub unsafe extern "C" fn wasm_func_new(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_func_new_with_env(
-    store: &wasm_store_t,
-    function_type: &wasm_functype_t,
-    callback: wasm_func_callback_with_env_t,
+    store: Option<&wasm_store_t>,
+    function_type: Option<&wasm_functype_t>,
+    callback: Option<wasm_func_callback_with_env_t>,
     env: *mut c_void,
-    finalizer: wasm_env_finalizer_t,
+    finalizer: Option<wasm_env_finalizer_t>,
 ) -> Option<Box<wasm_func_t>> {
-    // TODO: handle null pointers?
+    let store = store?;
+    let function_type = function_type?;
+    let callback = callback?;
+    let finalizer = finalizer?;
+
     let func_sig = &function_type.inner().function_type;
     let num_rets = func_sig.results().len();
     let inner_callback =

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -210,6 +210,8 @@ pub unsafe extern "C" fn wasm_func_result_arity(func: &wasm_func_t) -> usize {
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_func_type(func: &wasm_func_t) -> Box<wasm_functype_t> {
-    Box::new(wasm_functype_t::new(func.inner.ty().clone()))
+pub extern "C" fn wasm_func_type(func: Option<&wasm_func_t>) -> Option<Box<wasm_functype_t>> {
+    let func = func?;
+
+    Some(Box::new(wasm_functype_t::new(func.inner.ty().clone())))
 }

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -32,11 +32,14 @@ pub type wasm_env_finalizer_t = unsafe extern "C" fn(c_void);
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_func_new(
-    store: &wasm_store_t,
-    function_type: &wasm_functype_t,
-    callback: wasm_func_callback_t,
+    store: Option<&wasm_store_t>,
+    function_type: Option<&wasm_functype_t>,
+    callback: Option<wasm_func_callback_t>,
 ) -> Option<Box<wasm_func_t>> {
-    // TODO: handle null pointers?
+    let store = store?;
+    let function_type = function_type?;
+    let callback = callback?;
+
     let func_sig = &function_type.inner().function_type;
     let num_rets = func_sig.results().len();
     let inner_callback = move |args: &[Val]| -> Result<Vec<Val>, RuntimeError> {

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -12,10 +12,14 @@ pub struct wasm_global_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_global_new(
-    store: &wasm_store_t,
-    global_type: &wasm_globaltype_t,
-    val: &wasm_val_t,
+    store: Option<&wasm_store_t>,
+    global_type: Option<&wasm_globaltype_t>,
+    val: Option<&wasm_val_t>,
 ) -> Option<Box<wasm_global_t>> {
+    let store = store?;
+    let global_type = global_type?;
+    let val = val?;
+
     let global_type = &global_type.inner().global_type;
     let wasm_val = val.try_into().ok()?;
     let store = &store.inner;

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -45,7 +45,11 @@ pub unsafe extern "C" fn wasm_global_copy(global: &wasm_global_t) -> Box<wasm_gl
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_global_get(global: &wasm_global_t, out: &mut wasm_val_t) {
+pub unsafe extern "C" fn wasm_global_get(
+    global: &wasm_global_t,
+    // own
+    out: &mut wasm_val_t,
+) {
     let value = global.inner.get();
     *out = value.try_into().unwrap();
 }

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -37,23 +37,23 @@ pub unsafe extern "C" fn wasm_global_delete(_global: Option<Box<wasm_global_t>>)
 
 // TODO: figure out if these should be deep or shallow copies
 #[no_mangle]
-pub unsafe extern "C" fn wasm_global_copy(wasm_global: &wasm_global_t) -> Box<wasm_global_t> {
+pub unsafe extern "C" fn wasm_global_copy(global: &wasm_global_t) -> Box<wasm_global_t> {
     // do shallow copy
     Box::new(wasm_global_t {
-        inner: wasm_global.inner.clone(),
+        inner: global.inner.clone(),
     })
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_global_get(wasm_global: &wasm_global_t, out: &mut wasm_val_t) {
-    let value = wasm_global.inner.get();
+pub unsafe extern "C" fn wasm_global_get(global: &wasm_global_t, out: &mut wasm_val_t) {
+    let value = global.inner.get();
     *out = value.try_into().unwrap();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_global_set(wasm_global: &mut wasm_global_t, val: &wasm_val_t) {
+pub unsafe extern "C" fn wasm_global_set(global: &mut wasm_global_t, val: &wasm_val_t) {
     let value: Val = val.try_into().unwrap();
-    wasm_global.inner.set(value);
+    global.inner.set(value);
 }
 
 #[no_mangle]
@@ -65,6 +65,6 @@ pub unsafe extern "C" fn wasm_global_same(
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_global_type(wasm_global: &wasm_global_t) -> Box<wasm_globaltype_t> {
-    Box::new(wasm_globaltype_t::new(wasm_global.inner.ty().clone()))
+pub extern "C" fn wasm_global_type(global: &wasm_global_t) -> Box<wasm_globaltype_t> {
+    Box::new(wasm_globaltype_t::new(global.inner.ty().clone()))
 }

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -1,6 +1,7 @@
 use super::super::store::wasm_store_t;
 use super::super::types::wasm_globaltype_t;
 use super::super::value::wasm_val_t;
+use crate::error::update_last_error;
 use std::convert::TryInto;
 use wasmer::{Global, Val};
 
@@ -54,10 +55,15 @@ pub unsafe extern "C" fn wasm_global_get(
     *out = value.try_into().unwrap();
 }
 
+/// Note: This function returns nothing by design but it can raise an
+/// error if setting a new value fails.
 #[no_mangle]
 pub unsafe extern "C" fn wasm_global_set(global: &mut wasm_global_t, val: &wasm_val_t) {
     let value: Val = val.try_into().unwrap();
-    global.inner.set(value);
+
+    if let Err(e) = global.inner.set(value) {
+        update_last_error(e);
+    }
 }
 
 #[no_mangle]

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -11,9 +11,12 @@ pub struct wasm_memory_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_memory_new(
-    store: &wasm_store_t,
-    memory_type: &wasm_memorytype_t,
+    store: Option<&wasm_store_t>,
+    memory_type: Option<&wasm_memorytype_t>,
 ) -> Option<Box<wasm_memory_t>> {
+    let store = store?;
+    let memory_type = memory_type?;
+
     let memory_type = memory_type.inner().memory_type.clone();
     let memory = c_try!(Memory::new(&store.inner, memory_type));
 
@@ -33,8 +36,12 @@ pub unsafe extern "C" fn wasm_memory_copy(memory: &wasm_memory_t) -> Box<wasm_me
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_memory_type(memory: &wasm_memory_t) -> Box<wasm_memorytype_t> {
-    Box::new(wasm_memorytype_t::new(memory.inner.ty().clone()))
+pub unsafe extern "C" fn wasm_memory_type(
+    memory: Option<&wasm_memory_t>,
+) -> Option<Box<wasm_memorytype_t>> {
+    let memory = memory?;
+
+    Some(Box::new(wasm_memorytype_t::new(memory.inner.ty().clone())))
 }
 
 // get a raw pointer into bytes

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -22,10 +22,10 @@ wasm_declare_boxed_vec!(extern);
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_func_as_extern(
-    func_ptr: Option<NonNull<wasm_func_t>>,
+    func: Option<NonNull<wasm_func_t>>,
 ) -> Option<Box<wasm_extern_t>> {
-    let func_ptr = func_ptr?;
-    let func = func_ptr.as_ref();
+    let func = func?;
+    let func = func.as_ref();
 
     Some(Box::new(wasm_extern_t {
         instance: func.instance.clone(),
@@ -35,13 +35,13 @@ pub unsafe extern "C" fn wasm_func_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_global_as_extern(
-    global_ptr: Option<NonNull<wasm_global_t>>,
+    global: Option<NonNull<wasm_global_t>>,
 ) -> Option<Box<wasm_extern_t>> {
-    let global_ptr = global_ptr?;
-    let global = global_ptr.as_ref();
+    let global = global?;
+    let global = global.as_ref();
 
     Some(Box::new(wasm_extern_t {
-        // update this if global does hold onto an `instance`
+        // TODO: update this if global does hold onto an `instance`
         instance: None,
         inner: Extern::Global(global.inner.clone()),
     }))
@@ -49,13 +49,13 @@ pub unsafe extern "C" fn wasm_global_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_memory_as_extern(
-    memory_ptr: Option<NonNull<wasm_memory_t>>,
+    memory: Option<NonNull<wasm_memory_t>>,
 ) -> Option<Box<wasm_extern_t>> {
-    let memory_ptr = memory_ptr?;
-    let memory = memory_ptr.as_ref();
+    let memory = memory?;
+    let memory = memory.as_ref();
 
     Some(Box::new(wasm_extern_t {
-        // update this if global does hold onto an `instance`
+        // TODO: update this if global does hold onto an `instance`
         instance: None,
         inner: Extern::Memory(memory.inner.clone()),
     }))
@@ -63,13 +63,13 @@ pub unsafe extern "C" fn wasm_memory_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_table_as_extern(
-    table_ptr: Option<NonNull<wasm_table_t>>,
+    table: Option<NonNull<wasm_table_t>>,
 ) -> Option<Box<wasm_extern_t>> {
-    let table_ptr = table_ptr?;
-    let table = table_ptr.as_ref();
+    let table = table?;
+    let table = table.as_ref();
 
     Some(Box::new(wasm_extern_t {
-        // update this if global does hold onto an `instance`
+        // TODO: update this if global does hold onto an `instance`
         instance: None,
         inner: Extern::Table(table.inner.clone()),
     }))
@@ -77,10 +77,11 @@ pub unsafe extern "C" fn wasm_table_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_func(
-    extern_ptr: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<NonNull<wasm_extern_t>>,
 ) -> Option<Box<wasm_func_t>> {
-    let extern_ptr = extern_ptr?;
-    let r#extern = extern_ptr.as_ref();
+    let r#extern = r#extern?;
+    let r#extern = r#extern.as_ref();
+
     if let Extern::Function(f) = &r#extern.inner {
         Some(Box::new(wasm_func_t {
             inner: f.clone(),
@@ -93,10 +94,11 @@ pub unsafe extern "C" fn wasm_extern_as_func(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_global(
-    extern_ptr: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<NonNull<wasm_extern_t>>,
 ) -> Option<Box<wasm_global_t>> {
-    let extern_ptr = extern_ptr?;
-    let r#extern = extern_ptr.as_ref();
+    let r#extern = r#extern?;
+    let r#extern = r#extern.as_ref();
+
     if let Extern::Global(g) = &r#extern.inner {
         Some(Box::new(wasm_global_t { inner: g.clone() }))
     } else {
@@ -106,10 +108,11 @@ pub unsafe extern "C" fn wasm_extern_as_global(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_memory(
-    extern_ptr: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<NonNull<wasm_extern_t>>,
 ) -> Option<Box<wasm_memory_t>> {
-    let extern_ptr = extern_ptr?;
-    let r#extern = extern_ptr.as_ref();
+    let r#extern = r#extern?;
+    let r#extern = r#extern.as_ref();
+
     if let Extern::Memory(m) = &r#extern.inner {
         Some(Box::new(wasm_memory_t { inner: m.clone() }))
     } else {
@@ -119,10 +122,11 @@ pub unsafe extern "C" fn wasm_extern_as_memory(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_table(
-    extern_ptr: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<NonNull<wasm_extern_t>>,
 ) -> Option<Box<wasm_table_t>> {
-    let extern_ptr = extern_ptr?;
-    let r#extern = extern_ptr.as_ref();
+    let r#extern = r#extern?;
+    let r#extern = r#extern.as_ref();
+
     if let Extern::Table(t) = &r#extern.inner {
         Some(Box::new(wasm_table_t { inner: t.clone() }))
     } else {

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -6,7 +6,6 @@ mod table;
 pub use function::*;
 pub use global::*;
 pub use memory::*;
-use std::ptr::NonNull;
 use std::sync::Arc;
 pub use table::*;
 use wasmer::{Extern, Instance};
@@ -22,10 +21,9 @@ wasm_declare_boxed_vec!(extern);
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_func_as_extern(
-    func: Option<NonNull<wasm_func_t>>,
+    func: Option<&wasm_func_t>,
 ) -> Option<Box<wasm_extern_t>> {
     let func = func?;
-    let func = func.as_ref();
 
     Some(Box::new(wasm_extern_t {
         instance: func.instance.clone(),
@@ -35,10 +33,9 @@ pub unsafe extern "C" fn wasm_func_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_global_as_extern(
-    global: Option<NonNull<wasm_global_t>>,
+    global: Option<&wasm_global_t>,
 ) -> Option<Box<wasm_extern_t>> {
     let global = global?;
-    let global = global.as_ref();
 
     Some(Box::new(wasm_extern_t {
         // TODO: update this if global does hold onto an `instance`
@@ -49,10 +46,9 @@ pub unsafe extern "C" fn wasm_global_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_memory_as_extern(
-    memory: Option<NonNull<wasm_memory_t>>,
+    memory: Option<&wasm_memory_t>,
 ) -> Option<Box<wasm_extern_t>> {
     let memory = memory?;
-    let memory = memory.as_ref();
 
     Some(Box::new(wasm_extern_t {
         // TODO: update this if global does hold onto an `instance`
@@ -63,10 +59,9 @@ pub unsafe extern "C" fn wasm_memory_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_table_as_extern(
-    table: Option<NonNull<wasm_table_t>>,
+    table: Option<&wasm_table_t>,
 ) -> Option<Box<wasm_extern_t>> {
     let table = table?;
-    let table = table.as_ref();
 
     Some(Box::new(wasm_extern_t {
         // TODO: update this if global does hold onto an `instance`
@@ -77,10 +72,9 @@ pub unsafe extern "C" fn wasm_table_as_extern(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_func(
-    r#extern: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<&wasm_extern_t>,
 ) -> Option<Box<wasm_func_t>> {
     let r#extern = r#extern?;
-    let r#extern = r#extern.as_ref();
 
     if let Extern::Function(f) = &r#extern.inner {
         Some(Box::new(wasm_func_t {
@@ -94,10 +88,9 @@ pub unsafe extern "C" fn wasm_extern_as_func(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_global(
-    r#extern: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<&wasm_extern_t>,
 ) -> Option<Box<wasm_global_t>> {
     let r#extern = r#extern?;
-    let r#extern = r#extern.as_ref();
 
     if let Extern::Global(g) = &r#extern.inner {
         Some(Box::new(wasm_global_t { inner: g.clone() }))
@@ -108,10 +101,9 @@ pub unsafe extern "C" fn wasm_extern_as_global(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_memory(
-    r#extern: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<&wasm_extern_t>,
 ) -> Option<Box<wasm_memory_t>> {
     let r#extern = r#extern?;
-    let r#extern = r#extern.as_ref();
 
     if let Extern::Memory(m) = &r#extern.inner {
         Some(Box::new(wasm_memory_t { inner: m.clone() }))
@@ -122,10 +114,9 @@ pub unsafe extern "C" fn wasm_extern_as_memory(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_as_table(
-    r#extern: Option<NonNull<wasm_extern_t>>,
+    r#extern: Option<&wasm_extern_t>,
 ) -> Option<Box<wasm_table_t>> {
     let r#extern = r#extern?;
-    let r#extern = r#extern.as_ref();
 
     if let Extern::Table(t) = &r#extern.inner {
         Some(Box::new(wasm_table_t { inner: t.clone() }))

--- a/lib/c-api/src/wasm_c_api/externals/table.rs
+++ b/lib/c-api/src/wasm_c_api/externals/table.rs
@@ -10,10 +10,13 @@ pub struct wasm_table_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_table_new(
-    store: &wasm_store_t,
-    table_type: &wasm_tabletype_t,
+    store: Option<&wasm_store_t>,
+    table_type: Option<&wasm_tabletype_t>,
     init: *const wasm_ref_t,
 ) -> Option<Box<wasm_table_t>> {
+    let store = store?;
+    let table_type = table_type?;
+
     let table_type = table_type.inner().table_type.clone();
     let init_val = todo!("get val from init somehow");
     /*
@@ -27,29 +30,26 @@ pub unsafe extern "C" fn wasm_table_new(
 pub unsafe extern "C" fn wasm_table_delete(_table: Option<Box<wasm_table_t>>) {}
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_table_copy(wasm_table: &wasm_table_t) -> Box<wasm_table_t> {
+pub unsafe extern "C" fn wasm_table_copy(table: &wasm_table_t) -> Box<wasm_table_t> {
     // do shallow copy
     Box::new(wasm_table_t {
-        inner: wasm_table.inner.clone(),
+        inner: table.inner.clone(),
     })
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_table_same(
-    wasm_table1: &wasm_table_t,
-    wasm_table2: &wasm_table_t,
-) -> bool {
-    wasm_table1.inner.same(&wasm_table2.inner)
+pub unsafe extern "C" fn wasm_table_same(table1: &wasm_table_t, table2: &wasm_table_t) -> bool {
+    table1.inner.same(&table2.inner)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_table_size(wasm_table: &wasm_table_t) -> usize {
-    wasm_table.inner.size() as _
+pub unsafe extern "C" fn wasm_table_size(table: &wasm_table_t) -> usize {
+    table.inner.size() as _
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_table_grow(
-    _wasm_table: &mut wasm_table_t,
+    _table: &mut wasm_table_t,
     _delta: wasm_table_size_t,
     _init: *mut wasm_ref_t,
 ) -> bool {

--- a/lib/c-api/src/wasm_c_api/externals/table.rs
+++ b/lib/c-api/src/wasm_c_api/externals/table.rs
@@ -16,9 +16,11 @@ pub unsafe extern "C" fn wasm_table_new(
 ) -> Option<Box<wasm_table_t>> {
     let table_type = table_type.inner().table_type.clone();
     let init_val = todo!("get val from init somehow");
+    /*
     let table = c_try!(Table::new(&store.inner, table_type, init_val));
 
     Some(Box::new(wasm_table_t { inner: table }))
+    */
 }
 
 #[no_mangle]

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -60,6 +60,7 @@ pub unsafe extern "C" fn wasm_instance_delete(_instance: Option<Box<wasm_instanc
 #[no_mangle]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &wasm_instance_t,
+    // own
     out: &mut wasm_extern_vec_t,
 ) {
     let instance = &instance.inner;

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -14,11 +14,14 @@ pub struct wasm_instance_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_instance_new(
-    _store: &wasm_store_t,
-    module: &wasm_module_t,
-    imports: &wasm_extern_vec_t,
+    _store: Option<&wasm_store_t>,
+    module: Option<&wasm_module_t>,
+    imports: Option<&wasm_extern_vec_t>,
     traps: *mut *mut wasm_trap_t,
 ) -> Option<Box<wasm_instance_t>> {
+    let module = module?;
+    let imports = imports?;
+
     let wasm_module = &module.inner;
     let module_imports = wasm_module.imports();
     let module_import_count = module_imports.len();

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -60,7 +60,6 @@ pub unsafe extern "C" fn wasm_instance_delete(_instance: Option<Box<wasm_instanc
 #[no_mangle]
 pub unsafe extern "C" fn wasm_instance_exports(
     instance: &wasm_instance_t,
-    // TODO: review types on wasm_declare_vec, handle the optional pointer part properly
     out: &mut wasm_extern_vec_t,
 ) {
     let instance = &instance.inner;
@@ -73,6 +72,7 @@ pub unsafe extern "C" fn wasm_instance_exports(
             } else {
                 None
             };
+
             Box::into_raw(Box::new(wasm_extern_t {
                 instance: Some(Arc::clone(instance)),
                 inner: r#extern.clone(),
@@ -83,6 +83,6 @@ pub unsafe extern "C" fn wasm_instance_exports(
 
     out.size = extern_vec.len();
     out.data = extern_vec.as_mut_ptr();
-    // TODO: double check that the destructor will work correctly here
+
     mem::forget(extern_vec);
 }

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -105,7 +105,6 @@ pub unsafe extern "C" fn wasm_module_exports(
     *out = exports.into();
 }
 
-// TODO: `out` is a memory leak here. `wasm_module_t` owns it.
 #[no_mangle]
 pub unsafe extern "C" fn wasm_module_imports(
     module: &wasm_module_t,
@@ -378,8 +377,6 @@ mod tests {
 
                     const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type);
                     assert(func_results && func_results->size == 0);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 {
@@ -397,8 +394,6 @@ mod tests {
                     const wasm_globaltype_t* global_type = wasm_externtype_as_globaltype_const(extern_type);
                     assert(wasm_valtype_kind(wasm_globaltype_content(global_type)) == WASM_F32);
                     assert(wasm_globaltype_mutability(global_type) == WASM_CONST);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 {
@@ -419,8 +414,6 @@ mod tests {
                     const wasm_limits_t* table_limits = wasm_tabletype_limits(table_type);
                     assert(table_limits->min == 1);
                     assert(table_limits->max == 2);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 {
@@ -439,10 +432,9 @@ mod tests {
                     const wasm_limits_t* memory_limits = wasm_memorytype_limits(memory_type);
                     assert(memory_limits->min == 3);
                     assert(memory_limits->max == 4);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
+                wasm_importtype_vec_delete(&import_types);
                 wasm_module_delete(module);
                 wasm_byte_vec_delete(wasm);
                 wasm_byte_vec_delete(&wat);

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -4,7 +4,6 @@ use super::types::{
     wasm_importtype_vec_t,
 };
 use crate::error::update_last_error;
-use std::ptr::NonNull;
 use std::sync::Arc;
 use wasmer::Module;
 
@@ -138,7 +137,7 @@ pub unsafe extern "C" fn wasm_module_imports(
 pub unsafe extern "C" fn wasm_module_deserialize(
     store: &wasm_store_t,
     bytes: *const wasm_byte_vec_t,
-) -> Option<NonNull<wasm_module_t>> {
+) -> Option<*const wasm_module_t> {
     // TODO: read config from store and use that to decide which compiler to use
 
     let byte_slice = if bytes.is_null() || (&*bytes).into_slice().is_none() {
@@ -150,11 +149,9 @@ pub unsafe extern "C" fn wasm_module_deserialize(
 
     let module = c_try!(Module::deserialize(&store.inner, byte_slice));
 
-    Some(NonNull::new_unchecked(Box::into_raw(Box::new(
-        wasm_module_t {
-            inner: Arc::new(module),
-        },
-    ))))
+    Some(Box::into_raw(Box::new(wasm_module_t {
+        inner: Arc::new(module),
+    })) as *const _)
 }
 
 #[no_mangle]

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -263,8 +263,6 @@ mod tests {
 
                     const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type);
                     assert(func_results && func_results->size == 0);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 {
@@ -279,8 +277,6 @@ mod tests {
                     const wasm_globaltype_t* global_type = wasm_externtype_as_globaltype_const(extern_type);
                     assert(wasm_valtype_kind(wasm_globaltype_content(global_type)) == WASM_I32);
                     assert(wasm_globaltype_mutability(global_type) == WASM_CONST);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 {
@@ -298,8 +294,6 @@ mod tests {
                     const wasm_limits_t* table_limits = wasm_tabletype_limits(table_type);
                     assert(table_limits->min == 0);
                     assert(table_limits->max == wasm_limits_max_default);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 {
@@ -315,8 +309,6 @@ mod tests {
                     const wasm_limits_t* memory_limits = wasm_memorytype_limits(memory_type);
                     assert(memory_limits->min == 1);
                     assert(memory_limits->max == wasm_limits_max_default);
-
-                    wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
                 wasm_exporttype_vec_delete(&export_types);

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -105,9 +105,11 @@ pub unsafe extern "C" fn wasm_module_exports(
     *out = exports.into();
 }
 
+// TODO: `out` is a memory leak here. `wasm_module_t` owns it.
 #[no_mangle]
 pub unsafe extern "C" fn wasm_module_imports(
     module: &wasm_module_t,
+    // own
     out: &mut wasm_importtype_vec_t,
 ) {
     let imports = module
@@ -441,7 +443,6 @@ mod tests {
                     wasm_externtype_delete((wasm_externtype_t*) extern_type);
                 }
 
-                wasm_importtype_vec_delete(&import_types);
                 wasm_module_delete(module);
                 wasm_byte_vec_delete(wasm);
                 wasm_byte_vec_delete(&wat);

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -105,6 +105,7 @@ pub unsafe extern "C" fn wasm_module_validate(
 #[no_mangle]
 pub unsafe extern "C" fn wasm_module_exports(
     module: &wasm_module_t,
+    // own
     out: &mut wasm_exporttype_vec_t,
 ) {
     let exports = module

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -58,12 +58,14 @@ pub struct wasm_module_t {
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn wasm_module_new(
-    store: &wasm_store_t,
-    bytes: &wasm_byte_vec_t,
+    store: Option<&wasm_store_t>,
+    bytes: Option<&wasm_byte_vec_t>,
 ) -> Option<Box<wasm_module_t>> {
-    // TODO: review lifetime of byte slice
-    let wasm_byte_slice: &[u8] = slice::from_raw_parts_mut(bytes.data, bytes.size);
-    let module = c_try!(Module::from_binary(&store.inner, wasm_byte_slice));
+    let store = store?;
+    let bytes = bytes?;
+
+    let bytes = bytes.into_slice()?;
+    let module = c_try!(Module::from_binary(&store.inner, bytes));
 
     Some(Box::new(wasm_module_t {
         inner: Arc::new(module),

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -3,7 +3,7 @@ use super::types::{
     wasm_byte_vec_t, wasm_exporttype_t, wasm_exporttype_vec_t, wasm_importtype_t,
     wasm_importtype_vec_t,
 };
-use crate::error::update_last_error;
+use crate::error::{update_last_error, CApiError};
 use std::sync::Arc;
 use wasmer::Module;
 
@@ -141,7 +141,10 @@ pub unsafe extern "C" fn wasm_module_deserialize(
     // TODO: read config from store and use that to decide which compiler to use
 
     let byte_slice = if bytes.is_null() || (&*bytes).into_slice().is_none() {
-        // TODO: error handling here
+        update_last_error(CApiError {
+            msg: "`bytes` is null or represents an empty slice".to_string(),
+        });
+
         return None;
     } else {
         (&*bytes).into_slice().unwrap()

--- a/lib/c-api/src/wasm_c_api/store.rs
+++ b/lib/c-api/src/wasm_c_api/store.rs
@@ -10,11 +10,12 @@ pub struct wasm_store_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_store_new(
-    wasm_engine_ptr: Option<NonNull<wasm_engine_t>>,
+    engine: Option<NonNull<wasm_engine_t>>,
 ) -> Option<Box<wasm_store_t>> {
-    let wasm_engine_ptr = wasm_engine_ptr?;
-    let wasm_engine = wasm_engine_ptr.as_ref();
-    let store = Store::new(&*wasm_engine.inner);
+    let engine = engine?;
+    let engine = engine.as_ref();
+
+    let store = Store::new(&*engine.inner);
 
     Some(Box::new(wasm_store_t { inner: store }))
 }

--- a/lib/c-api/src/wasm_c_api/store.rs
+++ b/lib/c-api/src/wasm_c_api/store.rs
@@ -1,5 +1,4 @@
 use super::engine::wasm_engine_t;
-use std::ptr::NonNull;
 use wasmer::Store;
 
 /// Opaque wrapper around `Store`
@@ -10,11 +9,9 @@ pub struct wasm_store_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_store_new(
-    engine: Option<NonNull<wasm_engine_t>>,
+    engine: Option<&wasm_engine_t>,
 ) -> Option<Box<wasm_store_t>> {
     let engine = engine?;
-    let engine = engine.as_ref();
-
     let store = Store::new(&*engine.inner);
 
     Some(Box::new(wasm_store_t { inner: store }))

--- a/lib/c-api/src/wasm_c_api/types/export.rs
+++ b/lib/c-api/src/wasm_c_api/types/export.rs
@@ -11,9 +11,7 @@ wasm_declare_boxed_vec!(exporttype);
 
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_new(
-    // own
     name: Option<Box<wasm_name_t>>,
-    // own
     extern_type: Option<Box<wasm_externtype_t>>,
 ) -> Option<Box<wasm_exporttype_t>> {
     Some(Box::new(wasm_exporttype_t {

--- a/lib/c-api/src/wasm_c_api/types/export.rs
+++ b/lib/c-api/src/wasm_c_api/types/export.rs
@@ -1,37 +1,39 @@
 use super::{wasm_externtype_t, wasm_name_t};
-use std::ptr::NonNull;
 use wasmer::ExportType;
 
 #[allow(non_camel_case_types)]
 pub struct wasm_exporttype_t {
-    name: NonNull<wasm_name_t>,
-    extern_type: NonNull<wasm_externtype_t>,
+    name: Box<wasm_name_t>,
+    extern_type: Box<wasm_externtype_t>,
 }
 
 wasm_declare_boxed_vec!(exporttype);
 
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_new(
-    name: NonNull<wasm_name_t>,
-    extern_type: NonNull<wasm_externtype_t>,
-) -> Box<wasm_exporttype_t> {
-    Box::new(wasm_exporttype_t { name, extern_type })
+    // own
+    name: Option<Box<wasm_name_t>>,
+    // own
+    extern_type: Option<Box<wasm_externtype_t>>,
+) -> Option<Box<wasm_exporttype_t>> {
+    Some(Box::new(wasm_exporttype_t {
+        name: name?,
+        extern_type: extern_type?,
+    }))
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_exporttype_name(et: &'static wasm_exporttype_t) -> &'static wasm_name_t {
-    unsafe { et.name.as_ref() }
+pub extern "C" fn wasm_exporttype_name(export_type: &wasm_exporttype_t) -> &wasm_name_t {
+    export_type.name.as_ref()
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_exporttype_type(
-    export_type: &'static wasm_exporttype_t,
-) -> &'static wasm_externtype_t {
-    unsafe { export_type.extern_type.as_ref() }
+pub extern "C" fn wasm_exporttype_type(export_type: &wasm_exporttype_t) -> &wasm_externtype_t {
+    export_type.extern_type.as_ref()
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_exporttype_delete(_exporttype: Option<Box<wasm_exporttype_t>>) {}
+pub extern "C" fn wasm_exporttype_delete(_export_type: Option<Box<wasm_exporttype_t>>) {}
 
 impl From<ExportType> for wasm_exporttype_t {
     fn from(other: ExportType) -> Self {
@@ -41,7 +43,6 @@ impl From<ExportType> for wasm_exporttype_t {
 
 impl From<&ExportType> for wasm_exporttype_t {
     fn from(other: &ExportType) -> Self {
-        // TODO: double check that freeing String as `Vec<u8>` is valid
         let name = {
             let mut heap_str: Box<str> = other.name().to_string().into_boxed_str();
             let char_ptr = heap_str.as_mut_ptr();
@@ -51,13 +52,11 @@ impl From<&ExportType> for wasm_exporttype_t {
                 data: char_ptr,
             };
             Box::leak(heap_str);
-            unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(name_inner))) }
+
+            Box::new(name_inner)
         };
 
-        let extern_type = {
-            let extern_type: wasm_externtype_t = other.ty().into();
-            unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(extern_type))) }
-        };
+        let extern_type = Box::new(other.ty().into());
 
         wasm_exporttype_t { name, extern_type }
     }

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -1,4 +1,6 @@
-use super::{wasm_externtype_t, wasm_valtype_t, wasm_valtype_vec_t, WasmExternType};
+use super::{
+    wasm_externtype_t, wasm_valtype_t, wasm_valtype_vec_delete, wasm_valtype_vec_t, WasmExternType,
+};
 use std::mem;
 use wasmer::{ExternType, FunctionType, ValType};
 
@@ -98,23 +100,23 @@ pub unsafe extern "C" fn wasm_functype_new(
     let params = params?;
     let results = results?;
 
-    let params: Vec<ValType> = params
-        .as_ref()
+    let params_as_valtype: Vec<ValType> = params
         .into_slice()?
-        .iter()
-        .map(|ptr| **ptr)
-        .map(Into::into)
+        .into_iter()
+        .map(|val| val.as_ref().into())
         .collect::<Vec<_>>();
-    let results: Vec<ValType> = results
-        .as_ref()
+    let results_as_valtype: Vec<ValType> = results
         .into_slice()?
         .iter()
-        .map(|ptr| **ptr)
-        .map(Into::into)
+        .map(|val| val.as_ref().into())
         .collect::<Vec<_>>();
 
+    wasm_valtype_vec_delete(Box::into_raw(params));
+    wasm_valtype_vec_delete(Box::into_raw(results));
+
     Some(Box::new(wasm_functype_t::new(FunctionType::new(
-        params, results,
+        params_as_valtype,
+        results_as_valtype,
     ))))
 }
 

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -93,10 +93,8 @@ wasm_declare_vec!(functype);
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_functype_new(
-    // own
-    params: Option<NonNull<wasm_valtype_vec_t>>,
-    // own
-    results: Option<NonNull<wasm_valtype_vec_t>>,
+    params: Option<Box<wasm_valtype_vec_t>>,
+    results: Option<Box<wasm_valtype_vec_t>>,
 ) -> Option<Box<wasm_functype_t>> {
     let params = params?;
     let results = results?;

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -1,6 +1,5 @@
 use super::{wasm_externtype_t, wasm_valtype_t, wasm_valtype_vec_t, WasmExternType};
 use std::mem;
-use std::ptr::NonNull;
 use wasmer::{ExternType, FunctionType, ValType};
 
 #[derive(Debug)]
@@ -124,12 +123,12 @@ pub unsafe extern "C" fn wasm_functype_delete(_function_type: Option<Box<wasm_fu
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_functype_copy(
-    function_type: Option<NonNull<wasm_functype_t>>,
+    function_type: Option<&wasm_functype_t>,
 ) -> Option<Box<wasm_functype_t>> {
     let function_type = function_type?;
 
     Some(Box::new(wasm_functype_t::new(
-        function_type.as_ref().inner().function_type.clone(),
+        function_type.inner().function_type.clone(),
     )))
 }
 

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -134,14 +134,18 @@ pub unsafe extern "C" fn wasm_functype_copy(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_functype_params(
-    function_type: &wasm_functype_t,
-) -> &wasm_valtype_vec_t {
-    function_type.inner().params.as_ref()
+    function_type: Option<&wasm_functype_t>,
+) -> Option<&wasm_valtype_vec_t> {
+    let function_type = function_type?;
+
+    Some(function_type.inner().params.as_ref())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_functype_results(
-    function_type: &wasm_functype_t,
-) -> &wasm_valtype_vec_t {
-    function_type.inner().results.as_ref()
+    function_type: Option<&wasm_functype_t>,
+) -> Option<&wasm_valtype_vec_t> {
+    let function_type = function_type?;
+
+    Some(function_type.inner().results.as_ref())
 }

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -138,13 +138,13 @@ pub unsafe extern "C" fn wasm_functype_copy(
 #[no_mangle]
 pub unsafe extern "C" fn wasm_functype_params(
     function_type: &wasm_functype_t,
-) -> *const wasm_valtype_vec_t {
-    function_type.inner().params.as_ref() as *const _
+) -> &wasm_valtype_vec_t {
+    function_type.inner().params.as_ref()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_functype_results(
     function_type: &wasm_functype_t,
-) -> *const wasm_valtype_vec_t {
-    function_type.inner().results.as_ref() as *const _
+) -> &wasm_valtype_vec_t {
+    function_type.inner().results.as_ref()
 }

--- a/lib/c-api/src/wasm_c_api/types/global.rs
+++ b/lib/c-api/src/wasm_c_api/types/global.rs
@@ -50,7 +50,6 @@ wasm_declare_vec!(globaltype);
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_globaltype_new(
-    // own
     valtype: Option<Box<wasm_valtype_t>>,
     mutability: wasm_mutability_t,
 ) -> Option<Box<wasm_globaltype_t>> {

--- a/lib/c-api/src/wasm_c_api/types/global.rs
+++ b/lib/c-api/src/wasm_c_api/types/global.rs
@@ -8,11 +8,17 @@ use wasmer::{ExternType, GlobalType};
 #[derive(Debug, Clone)]
 pub(crate) struct WasmGlobalType {
     pub(crate) global_type: GlobalType,
+    content: Box<wasm_valtype_t>,
 }
 
 impl WasmGlobalType {
     pub(crate) fn new(global_type: GlobalType) -> Self {
-        Self { global_type }
+        let content = Box::new(global_type.ty.into());
+
+        Self {
+            global_type,
+            content,
+        }
     }
 }
 
@@ -70,13 +76,9 @@ pub unsafe extern "C" fn wasm_globaltype_mutability(
     wasm_mutability_enum::from(global_type.inner().global_type.mutability).into()
 }
 
-// TODO: fix memory leak
-// this function leaks memory because the returned limits pointer is not owned
 #[no_mangle]
 pub unsafe extern "C" fn wasm_globaltype_content(
     global_type: &wasm_globaltype_t,
-) -> *const wasm_valtype_t {
-    let global_type = global_type.inner().global_type;
-
-    Box::into_raw(Box::new(global_type.ty.into()))
+) -> &wasm_valtype_t {
+    global_type.inner().content.as_ref()
 }

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -1,7 +1,6 @@
 use super::{wasm_externtype_t, wasm_name_t};
 use wasmer::ImportType;
 
-// TODO: improve ownership in `importtype_t` (can we safely use `Box<wasm_name_t>` here?)
 #[allow(non_camel_case_types)]
 pub struct wasm_importtype_t {
     module: Box<wasm_name_t>,

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -12,11 +12,8 @@ wasm_declare_boxed_vec!(importtype);
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_new(
-    // own
     module: Option<Box<wasm_name_t>>,
-    // own
     name: Option<Box<wasm_name_t>>,
-    // own
     extern_type: Option<Box<wasm_externtype_t>>,
 ) -> Option<Box<wasm_importtype_t>> {
     Some(Box::new(wasm_importtype_t {

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -1,49 +1,49 @@
 use super::{wasm_externtype_t, wasm_name_t};
-use std::ptr::NonNull;
 use wasmer::ImportType;
 
 // TODO: improve ownership in `importtype_t` (can we safely use `Box<wasm_name_t>` here?)
 #[allow(non_camel_case_types)]
 pub struct wasm_importtype_t {
-    pub(crate) module: NonNull<wasm_name_t>,
-    pub(crate) name: NonNull<wasm_name_t>,
-    pub(crate) extern_type: NonNull<wasm_externtype_t>,
+    module: Box<wasm_name_t>,
+    name: Box<wasm_name_t>,
+    extern_type: Box<wasm_externtype_t>,
 }
 
 wasm_declare_boxed_vec!(importtype);
 
 #[no_mangle]
 pub extern "C" fn wasm_importtype_new(
-    module: NonNull<wasm_name_t>,
-    name: NonNull<wasm_name_t>,
-    extern_type: NonNull<wasm_externtype_t>,
-) -> Box<wasm_importtype_t> {
-    Box::new(wasm_importtype_t {
-        name,
-        module,
-        extern_type,
-    })
+    // own
+    module: Option<Box<wasm_name_t>>,
+    // own
+    name: Option<Box<wasm_name_t>>,
+    // own
+    extern_type: Option<Box<wasm_externtype_t>>,
+) -> Option<Box<wasm_importtype_t>> {
+    Some(Box::new(wasm_importtype_t {
+        name: name?,
+        module: module?,
+        extern_type: extern_type?,
+    }))
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_importtype_module(et: &'static wasm_importtype_t) -> &'static wasm_name_t {
-    unsafe { et.module.as_ref() }
+pub extern "C" fn wasm_importtype_module(import_type: &wasm_importtype_t) -> &wasm_name_t {
+    import_type.module.as_ref()
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_importtype_name(et: &'static wasm_importtype_t) -> &'static wasm_name_t {
-    unsafe { et.name.as_ref() }
+pub extern "C" fn wasm_importtype_name(import_type: &wasm_importtype_t) -> &wasm_name_t {
+    import_type.name.as_ref()
 }
 
 #[no_mangle]
-pub extern "C" fn wasm_importtype_type(
-    et: &'static wasm_importtype_t,
-) -> &'static wasm_externtype_t {
-    unsafe { et.extern_type.as_ref() }
+pub extern "C" fn wasm_importtype_type(import_type: &wasm_importtype_t) -> &wasm_externtype_t {
+    import_type.extern_type.as_ref()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_importtype_delete(_importtype: Option<Box<wasm_importtype_t>>) {}
+pub unsafe extern "C" fn wasm_importtype_delete(_import_type: Option<Box<wasm_importtype_t>>) {}
 
 impl From<ImportType> for wasm_importtype_t {
     fn from(other: ImportType) -> Self {
@@ -54,6 +54,20 @@ impl From<ImportType> for wasm_importtype_t {
 impl From<&ImportType> for wasm_importtype_t {
     fn from(other: &ImportType) -> Self {
         // TODO: double check that freeing String as `Vec<u8>` is valid
+        let module = {
+            let mut heap_str: Box<str> = other.module().to_string().into_boxed_str();
+            let char_ptr = heap_str.as_mut_ptr();
+            let str_len = heap_str.bytes().len();
+            let module_inner = wasm_name_t {
+                size: str_len,
+                data: char_ptr,
+            };
+            Box::leak(heap_str);
+
+            Box::new(module_inner)
+        };
+
+        // TODO: double check that freeing String as `Vec<u8>` is valid
         let name = {
             let mut heap_str: Box<str> = other.name().to_string().into_boxed_str();
             let char_ptr = heap_str.as_mut_ptr();
@@ -63,26 +77,11 @@ impl From<&ImportType> for wasm_importtype_t {
                 data: char_ptr,
             };
             Box::leak(heap_str);
-            unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(name_inner))) }
+
+            Box::new(name_inner)
         };
 
-        // TODO: double check that freeing String as `Vec<u8>` is valid
-        let module = {
-            let mut heap_str: Box<str> = other.module().to_string().into_boxed_str();
-            let char_ptr = heap_str.as_mut_ptr();
-            let str_len = heap_str.bytes().len();
-            let name_inner = wasm_name_t {
-                size: str_len,
-                data: char_ptr,
-            };
-            Box::leak(heap_str);
-            unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(name_inner))) }
-        };
-
-        let extern_type = {
-            let extern_type: wasm_externtype_t = other.ty().into();
-            unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(extern_type))) }
-        };
+        let extern_type = Box::new(other.ty().into());
 
         wasm_importtype_t {
             name,

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -53,7 +53,6 @@ impl From<ImportType> for wasm_importtype_t {
 
 impl From<&ImportType> for wasm_importtype_t {
     fn from(other: &ImportType) -> Self {
-        // TODO: double check that freeing String as `Vec<u8>` is valid
         let module = {
             let mut heap_str: Box<str> = other.module().to_string().into_boxed_str();
             let char_ptr = heap_str.as_mut_ptr();
@@ -67,7 +66,6 @@ impl From<&ImportType> for wasm_importtype_t {
             Box::new(module_inner)
         };
 
-        // TODO: double check that freeing String as `Vec<u8>` is valid
         let name = {
             let mut heap_str: Box<str> = other.name().to_string().into_boxed_str();
             let char_ptr = heap_str.as_mut_ptr();

--- a/lib/c-api/src/wasm_c_api/types/table.rs
+++ b/lib/c-api/src/wasm_c_api/types/table.rs
@@ -57,7 +57,6 @@ wasm_declare_vec!(tabletype);
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_tabletype_new(
-    // own
     valtype: Option<Box<wasm_valtype_t>>,
     limits: &wasm_limits_t,
 ) -> Option<Box<wasm_tabletype_t>> {

--- a/lib/c-api/src/wasm_c_api/types/value.rs
+++ b/lib/c-api/src/wasm_c_api/types/value.rs
@@ -60,6 +60,12 @@ wasm_declare_boxed_vec!(valtype);
 
 impl From<wasm_valtype_t> for ValType {
     fn from(other: wasm_valtype_t) -> Self {
+        (&other).into()
+    }
+}
+
+impl From<&wasm_valtype_t> for ValType {
+    fn from(other: &wasm_valtype_t) -> Self {
         other.valkind.into()
     }
 }

--- a/lib/c-api/src/wasm_c_api/types/value.rs
+++ b/lib/c-api/src/wasm_c_api/types/value.rs
@@ -76,6 +76,7 @@ impl From<ValType> for wasm_valtype_t {
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Option<Box<wasm_valtype_t>> {
     let kind_enum = kind.try_into().ok()?;
     let valtype = wasm_valtype_t { valkind: kind_enum };
+
     Some(Box::new(valtype))
 }
 

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -1,4 +1,5 @@
 use super::types::{wasm_ref_t, wasm_valkind_enum};
+use crate::error::{update_last_error, CApiError};
 use std::convert::{TryFrom, TryInto};
 use std::ptr::NonNull;
 use wasmer::Val;
@@ -35,18 +36,36 @@ impl Clone for wasm_val_t {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_val_copy(out_ptr: *mut wasm_val_t, val: &wasm_val_t) {
-    (*out_ptr).kind = val.kind;
-    (*out_ptr).of =
-        // TODO: handle this error
-        match val.kind.try_into().unwrap() {
-            wasm_valkind_enum::WASM_I32 => wasm_val_inner { int32_t: val.of.int32_t },
-            wasm_valkind_enum::WASM_I64 => wasm_val_inner { int64_t: val.of.int64_t },
-            wasm_valkind_enum::WASM_F32 => wasm_val_inner { float32_t: val.of.float32_t },
-            wasm_valkind_enum::WASM_F64 => wasm_val_inner { float64_t: val.of.float64_t },
+pub unsafe extern "C" fn wasm_val_copy(
+    // own
+    out: &mut wasm_val_t,
+    val: &wasm_val_t,
+) {
+    out.kind = val.kind;
+    out.of = match val.kind.try_into() {
+        Ok(kind) => match kind {
+            wasm_valkind_enum::WASM_I32 => wasm_val_inner {
+                int32_t: val.of.int32_t,
+            },
+            wasm_valkind_enum::WASM_I64 => wasm_val_inner {
+                int64_t: val.of.int64_t,
+            },
+            wasm_valkind_enum::WASM_F32 => wasm_val_inner {
+                float32_t: val.of.float32_t,
+            },
+            wasm_valkind_enum::WASM_F64 => wasm_val_inner {
+                float64_t: val.of.float64_t,
+            },
             wasm_valkind_enum::WASM_ANYREF => wasm_val_inner { wref: val.of.wref },
             wasm_valkind_enum::WASM_FUNCREF => wasm_val_inner { wref: val.of.wref },
-        };
+        },
+
+        Err(e) => {
+            update_last_error(CApiError { msg: e.to_string() });
+
+            return;
+        }
+    };
 }
 
 #[no_mangle]

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -1,7 +1,6 @@
 use super::types::{wasm_ref_t, wasm_valkind_enum};
 use crate::error::{update_last_error, CApiError};
 use std::convert::{TryFrom, TryInto};
-use std::ptr::NonNull;
 use wasmer::Val;
 
 #[allow(non_camel_case_types)]
@@ -69,10 +68,10 @@ pub unsafe extern "C" fn wasm_val_copy(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_val_delete(val: Option<NonNull<wasm_val_t>>) {
+pub unsafe extern "C" fn wasm_val_delete(val: Option<&wasm_val_t>) {
     if let Some(v_inner) = val {
         // TODO: figure out where wasm_val is allocated first...
-        let _ = Box::from_raw(v_inner.as_ptr());
+        let _ = Box::from_raw(v_inner);
     }
 }
 

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -68,10 +68,10 @@ pub unsafe extern "C" fn wasm_val_copy(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_val_delete(val: Option<&wasm_val_t>) {
-    if let Some(v_inner) = val {
+pub unsafe extern "C" fn wasm_val_delete(val: Option<Box<wasm_val_t>>) {
+    if let Some(val) = val {
         // TODO: figure out where wasm_val is allocated first...
-        let _ = Box::from_raw(v_inner);
+        let _ = val;
     }
 }
 

--- a/lib/c-api/src/wasm_c_api/wasmer.rs
+++ b/lib/c-api/src/wasm_c_api/wasmer.rs
@@ -6,7 +6,11 @@ use std::str;
 use std::sync::Arc;
 
 #[no_mangle]
-pub unsafe extern "C" fn wasm_module_name(module: &wasm_module_t, out: &mut wasm_name_t) {
+pub unsafe extern "C" fn wasm_module_name(
+    module: &wasm_module_t,
+    // own
+    out: &mut wasm_name_t,
+) {
     let name = match module.inner.name() {
         Some(name) => name,
         None => return,
@@ -18,7 +22,8 @@ pub unsafe extern "C" fn wasm_module_name(module: &wasm_module_t, out: &mut wasm
 #[no_mangle]
 pub unsafe extern "C" fn wasm_module_set_name(
     module: &mut wasm_module_t,
-    name: &wasm_name_t,
+    // own
+    name: Box<wasm_name_t>,
 ) -> bool {
     let name = match name.into_slice() {
         Some(name) => match str::from_utf8(name) {

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -180,7 +180,7 @@ void wasm_config_set_engine(wasm_config_t *config, wasmer_engine_t engine);
 
 void wasm_module_name(const wasm_module_t *module, wasm_name_t *out);
 
-bool wasm_module_set_name(wasm_module_t *module, const wasm_name_t *name);
+bool wasm_module_set_name(wasm_module_t *module, wasm_name_t *name);
 
 /**
  * Gets the length in bytes of the last error if any.


### PR DESCRIPTION
~Build on top of https://github.com/wasmerio/wasmer/pull/1795. The real diff can be seen here until the base branch is merged: https://github.com/Hywan/wasmer/compare/test-c-api-inline-c-rs...Hywan:fix-c-api-memory-leaks-externs.~

This PR does several things while reviewing the entire C API. It:

* Removes several memory leaks (6 if I count correctly),
* Addresses many `TODO`s,
* Write a `DEVELOPMENT.md` document to uniformize the Rust patterns to handle C behaviors,
* Apply what is written in `DEVELOPMENT.md`,
* Allow more functions to handle null pointers,
* Remove all `rustc` warnings.