### PR TITLE
fix(ci): Test and then rebuild the C API

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -143,8 +143,8 @@ jobs:
       - run: make test
       - name: Build and Test C API
         run: |
-          make build-capi
           make test-capi
+          make build-capi
         if: matrix.os != 'windows-latest'
       - name: Build C API on Windows
         run: make build-capi


### PR DESCRIPTION
Before this patch we were building the C API with the `build-capi`
target and then using the `test-capi` target to run the tests.

The `test-capi` runs the test suite against several builds of the C API
(different feature set each time).

After the tests, we packaged the C API. Conclusion: packaging the API
depended on the `test-capi` results and not on the `build-capi` results
thus avoiding us to ensure the packaged version is built with a known
feature set (adding a new test build/feature set could change the build
result).

With this patch, we first run the test (using `test-capi`) and then
rebuild the C API using `build-capi`. We know ensure the packaged
version will have a know feature set.
