### PR TITLE
chore(ci): Allow artifcats to be kept for 3 days

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -162,7 +162,6 @@ jobs:
       - name: Package Wasmer
         run: |
           make package
-        if: needs.setup.outputs.DOING_RELEASE == '1'
       - name: Run integration tests (Windows)
         shell: cmd
         run: |
@@ -177,10 +176,10 @@ jobs:
         if: matrix.run_integration_tests && matrix.os != 'windows-latest'
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
-        if: needs.setup.outputs.DOING_RELEASE == '1'
         with:
           name: ${{ matrix.artifact_name }}
           path: dist
+          retention-days: 3
 
   release:
     needs: [setup, test]


### PR DESCRIPTION
Keeping artifacts on build could help us engage users in testing Wasmer: they'll only have to download the file directly from Github and test them.

Also, it will help us provide test versions for languages integrations by allowing us to update the library for every OS at once.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
