### PR TITLE
test(api) Add more tests for the `.to_native` API

### DIFF
--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -210,7 +210,7 @@ impl Function {
     /// # let store = Store::default();
     /// #
     /// struct Env {
-    ///   multiplier: i32,
+    ///     multiplier: i32,
     /// };
     /// let env = Env { multiplier: 2 };
     ///
@@ -812,7 +812,20 @@ mod inner {
         #[test]
         fn test_to_native() {
             assert_eq!(7i8.to_native(), 7i32);
+            assert_eq!(7u8.to_native(), 7i32);
+            assert_eq!(7i16.to_native(), 7i32);
+            assert_eq!(7u16.to_native(), 7i32);
             assert_eq!(u32::MAX.to_native(), -1);
+        }
+
+        #[test]
+        fn test_to_native_same_size() {
+            assert_eq!(7i32.to_native(), 7i32);
+            assert_eq!(7u32.to_native(), 7i32);
+            assert_eq!(7i64.to_native(), 7i64);
+            assert_eq!(7u64.to_native(), 7i64);
+            assert_eq!(7f32.to_native(), 7f32);
+            assert_eq!(7f64.to_native(), 7f64);
         }
     }
 


### PR DESCRIPTION
Small PR that adds missing tests for the `.to_native()` API.