### PR TITLE
Capi improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,55 +99,73 @@ build-capi: build-capi-cranelift
 
 build-capi-singlepass:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,native,object-file,singlepass,wasi
+		--no-default-features --features deprecated,wat,jit,native,object-file,singlepass,wasi
 
 build-capi-singlepass-jit:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,singlepass,wasi
+		--no-default-features --features deprecated,wat,jit,singlepass,wasi
 
 build-capi-singlepass-native:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,singlepass,wasi
+		--no-default-features --features deprecated,wat,native,singlepass,wasi
 
 build-capi-singlepass-object-file:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,object-file,singlepass,wasi
+		--no-default-features --features deprecated,wat,object-file,singlepass,wasi
 
 build-capi-cranelift:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,native,object-file,cranelift,wasi
+		--no-default-features --features deprecated,wat,jit,native,object-file,cranelift,wasi
 
 build-capi-cranelift-jit:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,cranelift,wasi
+		--no-default-features --features deprecated,wat,jit,cranelift,wasi
 
 build-capi-cranelift-native:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,cranelift,wasi
+		--no-default-features --features deprecated,wat,native,cranelift,wasi
 
 build-capi-cranelift-object-file:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,object-file,cranelift,wasi
+		--no-default-features --features deprecated,wat,native,object-file,cranelift,wasi
 
 build-capi-cranelift-system-libffi:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,native,object-file,cranelift,wasi,system-libffi
+		--no-default-features --features deprecated,wat,jit,native,object-file,cranelift,wasi,system-libffi
 
 build-capi-llvm:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,native,object-file,llvm,wasi
+		--no-default-features --features deprecated,wat,jit,native,object-file,llvm,wasi
 
 build-capi-llvm-jit:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,llvm,wasi
+		--no-default-features --features deprecated,wat,jit,llvm,wasi
 
 build-capi-llvm-native:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,llvm,wasi
+		--no-default-features --features deprecated,wat,native,llvm,wasi
 
 build-capi-llvm-object-file:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,object-file,llvm,wasi
+		--no-default-features --features deprecated,wat,object-file,llvm,wasi
+
+# Headless (we include the minimal to be able to run)
+
+build-capi-headless-jit:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features jit,wasi
+
+build-capi-headless-native:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features native,wasi
+
+build-capi-headless-object-file:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features object-file,wasi
+
+build-capi-headless-all:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features jit,native,object-file,wasi
 
 ###########
 # Testing #

--- a/Makefile
+++ b/Makefile
@@ -216,27 +216,27 @@ test-capi: $(foreach compiler_engine,$(test_compilers_engines),test-capi-$(compi
 
 test-capi-singlepass-jit: build-capi-singlepass-jit
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,singlepass,wasi -- --nocapture
+		--no-default-features --features deprecated,wat,jit,singlepass,wasi -- --nocapture
 
 test-capi-cranelift-jit: build-capi-cranelift-jit
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,cranelift,wasi -- --nocapture
+		--no-default-features --features deprecated,wat,jit,cranelift,wasi -- --nocapture
 
 test-capi-cranelift-native: build-capi-cranelift-native
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,cranelift,wasi -- --nocapture
+		--no-default-features --features deprecated,wat,native,cranelift,wasi -- --nocapture
 
 test-capi-cranelift-jit-system-libffi:
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,cranelift,wasi,system-libffi -- --nocapture
+		--no-default-features --features deprecated,wat,jit,cranelift,wasi,system-libffi -- --nocapture
 
 test-capi-llvm-jit:
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,jit,llvm,wasi -- --nocapture
+		--no-default-features --features deprecated,wat,jit,llvm,wasi -- --nocapture
 
 test-capi-llvm-native:
 	cargo test --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features wat,native,llvm,wasi -- --nocapture
+		--no-default-features --features deprecated,wat,native,llvm,wasi -- --nocapture
 
 test-wasi-unit:
 	cargo test --manifest-path lib/wasi/Cargo.toml --release

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -30,7 +30,7 @@ wasmer-types = { version = "1.0.0-alpha5", path = "../wasmer-types" }
 cfg-if = "1.0"
 lazy_static = "1"
 libc = { version = "^0.2", default-features = false }
-libffi = { version = "0.9" }
+libffi = { version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1"
 typetag = { version = "0.1", optional = true }
@@ -44,6 +44,7 @@ inline-c = "0.1.2"
 
 [features]
 default = [
+    "deprecated",
     "wat",
     "cranelift",
     "wasi",
@@ -51,6 +52,7 @@ default = [
 wat = ["wasmer/wat"]
 wasi = ["wasmer-wasi", "typetag", "serde"]
 engine = []
+deprecated = ["libffi"]
 jit = [
     "wasmer-engine-jit",
     "engine",

--- a/lib/c-api/src/lib.rs
+++ b/lib/c-api/src/lib.rs
@@ -30,6 +30,7 @@
     unreachable_patterns
 )]
 
+#[cfg(feature = "deprecated")]
 pub mod deprecated;
 pub mod error;
 mod ordered_resolver;

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -13,6 +13,7 @@ use wasmer_engine_object_file::ObjectFile;
 ///
 /// This is a Wasmer-specific type with Wasmer-specific functions for
 /// manipulating it.
+#[cfg(feature = "compiler")]
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub enum wasmer_compiler_t {
@@ -21,6 +22,7 @@ pub enum wasmer_compiler_t {
     SINGLEPASS = 2,
 }
 
+#[cfg(feature = "compiler")]
 impl Default for wasmer_compiler_t {
     fn default() -> Self {
         cfg_if! {
@@ -72,6 +74,7 @@ impl Default for wasmer_engine_t {
 #[derive(Debug, Default)]
 #[repr(C)]
 pub struct wasm_config_t {
+    #[cfg(feature = "compiler")]
     compiler: wasmer_compiler_t,
     engine: wasmer_engine_t,
 }
@@ -85,6 +88,7 @@ pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
 }
 
 /// Configure the compiler to use.
+#[cfg(feature = "compiler")]
 #[no_mangle]
 pub extern "C" fn wasm_config_set_compiler(
     config: &mut wasm_config_t,
@@ -190,6 +194,7 @@ pub unsafe extern "C" fn wasm_engine_delete(_engine: Option<Box<wasm_engine_t>>)
 pub extern "C" fn wasm_engine_new_with_config(
     config: Box<wasm_config_t>,
 ) -> Option<Box<wasm_engine_t>> {
+    #[allow(dead_code)]
     fn return_with_error<M>(msg: M) -> Option<Box<wasm_engine_t>>
     where
         M: ToString,

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -74,9 +74,9 @@ impl Default for wasmer_engine_t {
 #[derive(Debug, Default)]
 #[repr(C)]
 pub struct wasm_config_t {
+    engine: wasmer_engine_t,
     #[cfg(feature = "compiler")]
     compiler: wasmer_compiler_t,
-    engine: wasmer_engine_t,
 }
 
 /// Create a new Wasmer configuration.

--- a/lib/c-api/tests/deprecated_tests.rs
+++ b/lib/c-api/tests/deprecated_tests.rs
@@ -3,6 +3,7 @@ mod test_c_helpers;
 use test_c_helpers::compile_with_cmake_and_run_test;
 
 #[test]
+#[cfg(feature = "deprecated")]
 fn test_deprecated_c_api() {
     let project_tests_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/deprecated/");
 

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -32,6 +32,9 @@
 // The `jit` feature has been enabled for this build.
 #define WASMER_JIT_ENABLED
 
+// The `compiler` feature has been enabled for this build.
+#define WASMER_COMPILER_ENABLED
+
 // The `wasi` feature has been enabled for this build.
 #define WASMER_WASI_ENABLED
 

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -32,9 +32,6 @@
 // The `jit` feature has been enabled for this build.
 #define WASMER_JIT_ENABLED
 
-// The `compiler` feature has been enabled for this build.
-#define WASMER_COMPILER_ENABLED
-
 // The `wasi` feature has been enabled for this build.
 #define WASMER_WASI_ENABLED
 
@@ -55,6 +52,7 @@
 #include <stdlib.h>
 #include "wasm.h"
 
+#if defined(WASMER_COMPILER_ENABLED)
 /**
  * Kind of compilers that can be used by the engines.
  *
@@ -66,6 +64,7 @@ typedef enum {
   LLVM = 1,
   SINGLEPASS = 2,
 } wasmer_compiler_t;
+#endif
 
 /**
  * Kind of engines that can be used by the store.
@@ -168,10 +167,12 @@ wasm_func_t *wasi_get_start_function(wasm_instance_t *instance);
 wasi_version_t wasi_get_wasi_version(const wasm_module_t *module);
 #endif
 
+#if defined(WASMER_COMPILER_ENABLED)
 /**
  * Configure the compiler to use.
  */
 void wasm_config_set_compiler(wasm_config_t *config, wasmer_compiler_t compiler);
+#endif
 
 /**
  * Configure the engine to use.


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR improves:
* [x] Adds a `deprecated` feature to the wasm-c-api to ship the deprecated API (having `libffi` as a optional dependency)
* [x] Adds commands to build the wasm-c-api in headless mode

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
