### PR TITLE
feat(api) Faster `Exports::from_iter`

### DIFF
--- a/lib/api/src/exports.rs
+++ b/lib/api/src/exports.rs
@@ -244,12 +244,9 @@ where
 
 impl FromIterator<(String, Extern)> for Exports {
     fn from_iter<I: IntoIterator<Item = (String, Extern)>>(iter: I) -> Self {
-        // TODO: Move into IndexMap collect
-        let mut exports = Self::new();
-        for (name, extern_) in iter {
-            exports.insert(name, extern_);
+        Self {
+            map: Arc::new(IndexMap::from_iter(iter)),
         }
-        exports
     }
 }
 


### PR DESCRIPTION
# Description

Instead of creating a new `Exports` with `Exports::new` and inserting
all pair `(String, Extern)` one after the other with
`Exports::insert`, this patch updates the code to create an `Exports`
directly with its `map` field built with `IndexMap::from_iter`, so
that we avoid calling `Arc::get_mut(…).unwrap().insert(…)` for every
pair.

# Review

- ~[ ] Add a short description of the the change to the CHANGELOG.md file~ (not sure it's necessary)
