### PR TITLE
feat(vm) Don't clone the export in `Instance::lookup`

### DIFF
--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -284,11 +284,8 @@ impl Instance {
 
     /// Lookup an export with the given name.
     pub fn lookup(&self, field: &str) -> Option<Export> {
-        let export = if let Some(export) = self.module.exports.get(field) {
-            export.clone()
-        } else {
-            return None;
-        };
+        let export = self.module.exports.get(field)?;
+
         Some(self.lookup_by_declaration(&export))
     }
 


### PR DESCRIPTION
# Description

This patch does 2 things:

1. It simplifies the code by using `?` on an `Option`,
2. It then removes the need to clone the `export`.

# Review

- ~[ ] Add a short description of the the change to the CHANGELOG.md file~ (not sure this is necessary)
