### PR TITLE
feat(vm) Simplify pointer arithmetic by using existing helper methods

### DIFF
--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -417,11 +417,7 @@ impl Instance {
 
     /// Return the table index for the given `VMTableDefinition`.
     pub(crate) fn table_index(&self, table: &VMTableDefinition) -> LocalTableIndex {
-        let offsets = &self.offsets;
-        let begin = unsafe {
-            (&self.vmctx as *const VMContext as *const u8)
-                .add(usize::try_from(offsets.vmctx_tables_begin()).unwrap())
-        } as *const VMTableDefinition;
+        let begin: *const VMTableDefinition = self.tables_ptr() as *const _;
         let end: *const VMTableDefinition = table;
         // TODO: Use `offset_from` once it stablizes.
         let index = LocalTableIndex::new(
@@ -433,11 +429,7 @@ impl Instance {
 
     /// Return the memory index for the given `VMMemoryDefinition`.
     pub(crate) fn memory_index(&self, memory: &VMMemoryDefinition) -> LocalMemoryIndex {
-        let offsets = &self.offsets;
-        let begin = unsafe {
-            (&self.vmctx as *const VMContext as *const u8)
-                .add(usize::try_from(offsets.vmctx_memories_begin()).unwrap())
-        } as *const VMMemoryDefinition;
+        let begin: *const VMMemoryDefinition = self.memories_ptr() as *const _;
         let end: *const VMMemoryDefinition = memory;
         // TODO: Use `offset_from` once it stablizes.
         let index = LocalMemoryIndex::new(
@@ -612,7 +604,6 @@ impl Instance {
             return Err(Trap::new_from_runtime(TrapCode::TableAccessOutOfBounds));
         }
 
-        // TODO(#983): investigate replacing this get/set loop with a `memcpy`.
         for (dst, src) in (dst..dst + len).zip(src..src + len) {
             table
                 .set(dst, elem[src as usize].clone())


### PR DESCRIPTION
# Description

This patch has started by using the `Instance::vmctx_plus_offset`
method to replace the `&self.vmctx as *const VMContext as *const
u8).add(usize::try_from(offset).unwrap)` pieces of code, as it is
designed to do that.

Then I noticed that `vmctx_plus_offset` was already used by
`Instance::tables_ptr` and `Instance::memories_ptr`. Exactly what were
needed by `Instance::memory_index` and `Instance::table_index`
respectively.

So finally, this patch just updates the `memory_index` and
`table_index` method to use `memories_ptr` and `tables_ptr`. The code
stays the same, it's just much simpler.

# Review

- ~[ ] Add a short description of the the change to the CHANGELOG.md file~ (not necessary I think)
