### PR TITLE
Bump CI Rust version to 1.47.0

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux
             os: ubuntu-latest
-            rust: 1.46.0
+            rust: 1.47.0
     env:
       CARGO_SCCACHE_VERSION: 0.2.13
       SCCACHE_AZURE_BLOB_CONTAINER: wasmerstoragesccacheblob

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
         include:
           - build: linux
             os: ubuntu-18.04
-            rust: 1.46.0
+            rust: 1.47.0
             llvm_url: 'https://github.com/wasmerio/llvm-build/releases/download/10.x/Ubuntu1604_Release.tar.xz'
             # llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
             artifact_name: 'wasmer-linux-amd64'
@@ -50,20 +50,20 @@ jobs:
             run_integration_tests: true
           - build: macos
             os: macos-latest
-            rust: 1.46.0
+            rust: 1.47.0
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz'
             artifact_name: 'wasmer-macos-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             run_integration_tests: true
           - build: windows
             os: windows-latest
-            rust: 1.46.0
+            rust: 1.47.0
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
             run_integration_tests: true
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
-            rust: 1.46.0
+            rust: 1.47.0
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+- [#1830](https://github.com/wasmerio/wasmer/pull/1830) Minimum supported Rust version bumped to 1.47.0
 - [#1810](https://github.com/wasmerio/wasmer/pull/1810) Make the `state` field of `WasiEnv` public
 
 ### Fixed


### PR DESCRIPTION
Because 1.48.0 was released today

bumped for wasmer nightly: https://github.com/wasmerio/wasmer-nightly/commit/a4640f18a973f5eeaa147312a19b38abedb82fb9

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
