### PR TITLE
WIP attempt to make an Export wrapper type

### DIFF
--- a/lib/api/src/exports.rs
+++ b/lib/api/src/exports.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::iter::{ExactSizeIterator, FromIterator};
 use std::sync::Arc;
 use thiserror::Error;
-use wasmer_vm::Export;
+use wasmer_vm::EngineExport;
 
 /// The `ExportError` can happen when trying to get a specific
 /// export [`Extern`] from the [`Instance`] exports.
@@ -264,11 +264,11 @@ impl FromIterator<(String, Extern)> for Exports {
 }
 
 impl LikeNamespace for Exports {
-    fn get_namespace_export(&self, name: &str) -> Option<Export> {
+    fn get_namespace_export(&self, name: &str) -> Option<EngineExport> {
         self.map.get(name).map(|is_export| is_export.to_export())
     }
 
-    fn get_namespace_exports(&self) -> Vec<(String, Export)> {
+    fn get_namespace_exports(&self) -> Vec<(String, EngineExport)> {
         self.map
             .iter()
             .map(|(k, v)| (k.clone(), v.to_export()))
@@ -284,7 +284,7 @@ pub trait Exportable<'a>: Sized {
     /// can be used while instantiating the [`Module`].
     ///
     /// [`Module`]: crate::Module
-    fn to_export(&self) -> Export;
+    fn to_export(&self) -> EngineExport;
 
     /// Implementation of how to get the export corresponding to the implementing type
     /// from an [`Instance`] by name.

--- a/lib/api/src/exports.rs
+++ b/lib/api/src/exports.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::iter::{ExactSizeIterator, FromIterator};
 use std::sync::Arc;
 use thiserror::Error;
-use wasmer_vm::EngineExport;
+use wasmer_engine::EngineExport;
 
 /// The `ExportError` can happen when trying to get a specific
 /// export [`Extern`] from the [`Instance`] exports.

--- a/lib/api/src/exports.rs
+++ b/lib/api/src/exports.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::iter::{ExactSizeIterator, FromIterator};
 use std::sync::Arc;
 use thiserror::Error;
-use wasmer_engine::EngineExport;
+use wasmer_engine::Export;
 
 /// The `ExportError` can happen when trying to get a specific
 /// export [`Extern`] from the [`Instance`] exports.
@@ -264,11 +264,11 @@ impl FromIterator<(String, Extern)> for Exports {
 }
 
 impl LikeNamespace for Exports {
-    fn get_namespace_export(&self, name: &str) -> Option<EngineExport> {
+    fn get_namespace_export(&self, name: &str) -> Option<Export> {
         self.map.get(name).map(|is_export| is_export.to_export())
     }
 
-    fn get_namespace_exports(&self) -> Vec<(String, EngineExport)> {
+    fn get_namespace_exports(&self) -> Vec<(String, Export)> {
         self.map
             .iter()
             .map(|(k, v)| (k.clone(), v.to_export()))
@@ -284,7 +284,7 @@ pub trait Exportable<'a>: Sized {
     /// can be used while instantiating the [`Module`].
     ///
     /// [`Module`]: crate::Module
-    fn to_export(&self) -> EngineExport;
+    fn to_export(&self) -> Export;
 
     /// Implementation of how to get the export corresponding to the implementing type
     /// from an [`Instance`] by name.

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -12,10 +12,10 @@ pub use inner::{UnsafeMutableEnv, WithUnsafeMutableEnv};
 
 use std::cmp::max;
 use std::fmt;
+use wasmer_engine::{EngineExport, EngineExportFunction};
 use wasmer_vm::{
-    raise_user_trap, resume_panic, wasmer_call_trampoline, EngineExport, EngineExportFunction,
-    ExportFunction, VMCallerCheckedAnyfunc, VMDynamicFunctionContext, VMFunctionBody,
-    VMFunctionEnvironment, VMFunctionKind, VMTrampoline,
+    raise_user_trap, resume_panic, wasmer_call_trampoline, ExportFunction, VMCallerCheckedAnyfunc,
+    VMDynamicFunctionContext, VMFunctionBody, VMFunctionEnvironment, VMFunctionKind, VMTrampoline,
 };
 
 /// A function defined in the Wasm module

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -14,8 +14,9 @@ use std::cmp::max;
 use std::fmt;
 use wasmer_engine::{EngineExport, EngineExportFunction};
 use wasmer_vm::{
-    raise_user_trap, resume_panic, wasmer_call_trampoline, ExportFunction, VMCallerCheckedAnyfunc,
-    VMDynamicFunctionContext, VMFunctionBody, VMFunctionEnvironment, VMFunctionKind, VMTrampoline,
+    raise_user_trap, resume_panic, wasmer_call_trampoline, VMCallerCheckedAnyfunc,
+    VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
+    VMFunctionKind, VMTrampoline,
 };
 
 /// A function defined in the Wasm module
@@ -97,7 +98,7 @@ impl Function {
             definition: FunctionDefinition::Host(HostFunctionDefinition { has_env: false }),
             exported: EngineExportFunction {
                 function_ptr: None,
-                function: ExportFunction {
+                function: VMExportFunction {
                     address,
                     kind: VMFunctionKind::Dynamic,
                     vmctx,
@@ -159,7 +160,7 @@ impl Function {
             definition: FunctionDefinition::Host(HostFunctionDefinition { has_env: true }),
             exported: EngineExportFunction {
                 function_ptr,
-                function: ExportFunction {
+                function: VMExportFunction {
                     address,
                     kind: VMFunctionKind::Dynamic,
                     vmctx,
@@ -209,7 +210,7 @@ impl Function {
                 // TODO: figure out what's going on in this function: it takes an `Env`
                 // param but also marks itself as not having an env
                 function_ptr: None,
-                function: ExportFunction {
+                function: VMExportFunction {
                     address,
                     vmctx,
                     signature,
@@ -275,7 +276,7 @@ impl Function {
             definition: FunctionDefinition::Host(HostFunctionDefinition { has_env: true }),
             exported: EngineExportFunction {
                 function_ptr,
-                function: ExportFunction {
+                function: VMExportFunction {
                     address,
                     kind: VMFunctionKind::Static,
                     vmctx,
@@ -324,7 +325,7 @@ impl Function {
             definition: FunctionDefinition::Host(HostFunctionDefinition { has_env: true }),
             exported: EngineExportFunction {
                 function_ptr,
-                function: ExportFunction {
+                function: VMExportFunction {
                     address,
                     kind: VMFunctionKind::Static,
                     vmctx,

--- a/lib/api/src/externals/global.rs
+++ b/lib/api/src/externals/global.rs
@@ -7,7 +7,7 @@ use crate::Mutability;
 use crate::RuntimeError;
 use std::fmt;
 use std::sync::Arc;
-use wasmer_engine::EngineExport;
+use wasmer_engine::{Export, ExportGlobal};
 use wasmer_vm::{Global as RuntimeGlobal, VMExportGlobal};
 
 /// A WebAssembly `global` instance.
@@ -181,10 +181,10 @@ impl Global {
         Ok(())
     }
 
-    pub(crate) fn from_export(store: &Store, wasmer_export: VMExportGlobal) -> Self {
+    pub(crate) fn from_export(store: &Store, wasmer_export: ExportGlobal) -> Self {
         Self {
             store: store.clone(),
-            global: wasmer_export.from,
+            global: wasmer_export.vm_global.from,
         }
     }
 
@@ -216,9 +216,11 @@ impl fmt::Debug for Global {
 }
 
 impl<'a> Exportable<'a> for Global {
-    fn to_export(&self) -> EngineExport {
-        VMExportGlobal {
-            from: self.global.clone(),
+    fn to_export(&self) -> Export {
+        ExportGlobal {
+            vm_global: VMExportGlobal {
+                from: self.global.clone(),
+            },
         }
         .into()
     }

--- a/lib/api/src/externals/global.rs
+++ b/lib/api/src/externals/global.rs
@@ -8,7 +8,7 @@ use crate::RuntimeError;
 use std::fmt;
 use std::sync::Arc;
 use wasmer_engine::EngineExport;
-use wasmer_vm::{ExportGlobal, Global as RuntimeGlobal};
+use wasmer_vm::{Global as RuntimeGlobal, VMExportGlobal};
 
 /// A WebAssembly `global` instance.
 ///
@@ -181,7 +181,7 @@ impl Global {
         Ok(())
     }
 
-    pub(crate) fn from_export(store: &Store, wasmer_export: ExportGlobal) -> Self {
+    pub(crate) fn from_export(store: &Store, wasmer_export: VMExportGlobal) -> Self {
         Self {
             store: store.clone(),
             global: wasmer_export.from,
@@ -217,7 +217,7 @@ impl fmt::Debug for Global {
 
 impl<'a> Exportable<'a> for Global {
     fn to_export(&self) -> EngineExport {
-        ExportGlobal {
+        VMExportGlobal {
             from: self.global.clone(),
         }
         .into()

--- a/lib/api/src/externals/global.rs
+++ b/lib/api/src/externals/global.rs
@@ -7,7 +7,7 @@ use crate::Mutability;
 use crate::RuntimeError;
 use std::fmt;
 use std::sync::Arc;
-use wasmer_vm::{Export, ExportGlobal, Global as RuntimeGlobal};
+use wasmer_vm::{EngineExport, ExportGlobal, Global as RuntimeGlobal};
 
 /// A WebAssembly `global` instance.
 ///
@@ -215,7 +215,7 @@ impl fmt::Debug for Global {
 }
 
 impl<'a> Exportable<'a> for Global {
-    fn to_export(&self) -> Export {
+    fn to_export(&self) -> EngineExport {
         ExportGlobal {
             from: self.global.clone(),
         }

--- a/lib/api/src/externals/global.rs
+++ b/lib/api/src/externals/global.rs
@@ -7,7 +7,8 @@ use crate::Mutability;
 use crate::RuntimeError;
 use std::fmt;
 use std::sync::Arc;
-use wasmer_vm::{EngineExport, ExportGlobal, Global as RuntimeGlobal};
+use wasmer_engine::EngineExport;
+use wasmer_vm::{ExportGlobal, Global as RuntimeGlobal};
 
 /// A WebAssembly `global` instance.
 ///

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -7,7 +7,7 @@ use std::slice;
 use std::sync::Arc;
 use wasmer_engine::EngineExport;
 use wasmer_types::{Pages, ValueType};
-use wasmer_vm::{ExportMemory, Memory as RuntimeMemory, MemoryError};
+use wasmer_vm::{Memory as RuntimeMemory, MemoryError, VMExportMemory};
 
 /// A WebAssembly `memory` instance.
 ///
@@ -221,7 +221,7 @@ impl Memory {
         unsafe { MemoryView::new(base as _, length as u32) }
     }
 
-    pub(crate) fn from_export(store: &Store, wasmer_export: ExportMemory) -> Self {
+    pub(crate) fn from_export(store: &Store, wasmer_export: VMExportMemory) -> Self {
         Self {
             store: store.clone(),
             memory: wasmer_export.from,
@@ -247,7 +247,7 @@ impl Memory {
 
 impl<'a> Exportable<'a> for Memory {
     fn to_export(&self) -> EngineExport {
-        ExportMemory {
+        VMExportMemory {
             from: self.memory.clone(),
         }
         .into()

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::slice;
 use std::sync::Arc;
 use wasmer_types::{Pages, ValueType};
-use wasmer_vm::{Export, ExportMemory, Memory as RuntimeMemory, MemoryError};
+use wasmer_vm::{EngineExport, ExportMemory, Memory as RuntimeMemory, MemoryError};
 
 /// A WebAssembly `memory` instance.
 ///
@@ -245,7 +245,7 @@ impl Memory {
 }
 
 impl<'a> Exportable<'a> for Memory {
-    fn to_export(&self) -> Export {
+    fn to_export(&self) -> EngineExport {
         ExportMemory {
             from: self.memory.clone(),
         }

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -5,7 +5,7 @@ use crate::{MemoryType, MemoryView};
 use std::convert::TryInto;
 use std::slice;
 use std::sync::Arc;
-use wasmer_engine::EngineExport;
+use wasmer_engine::{Export, ExportMemory};
 use wasmer_types::{Pages, ValueType};
 use wasmer_vm::{Memory as RuntimeMemory, MemoryError, VMExportMemory};
 
@@ -221,10 +221,10 @@ impl Memory {
         unsafe { MemoryView::new(base as _, length as u32) }
     }
 
-    pub(crate) fn from_export(store: &Store, wasmer_export: VMExportMemory) -> Self {
+    pub(crate) fn from_export(store: &Store, wasmer_export: ExportMemory) -> Self {
         Self {
             store: store.clone(),
-            memory: wasmer_export.from,
+            memory: wasmer_export.vm_memory.from,
         }
     }
 
@@ -246,9 +246,11 @@ impl Memory {
 }
 
 impl<'a> Exportable<'a> for Memory {
-    fn to_export(&self) -> EngineExport {
-        VMExportMemory {
-            from: self.memory.clone(),
+    fn to_export(&self) -> Export {
+        ExportMemory {
+            vm_memory: VMExportMemory {
+                from: self.memory.clone(),
+            },
         }
         .into()
     }

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -5,8 +5,9 @@ use crate::{MemoryType, MemoryView};
 use std::convert::TryInto;
 use std::slice;
 use std::sync::Arc;
+use wasmer_engine::EngineExport;
 use wasmer_types::{Pages, ValueType};
-use wasmer_vm::{EngineExport, ExportMemory, Memory as RuntimeMemory, MemoryError};
+use wasmer_vm::{ExportMemory, Memory as RuntimeMemory, MemoryError};
 
 /// A WebAssembly `memory` instance.
 ///

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -17,7 +17,7 @@ use crate::exports::{ExportError, Exportable};
 use crate::store::{Store, StoreObject};
 use crate::ExternType;
 use std::fmt;
-use wasmer_engine::EngineExport;
+use wasmer_engine::Export;
 
 /// An `Extern` is the runtime representation of an entity that
 /// can be imported or exported.
@@ -47,18 +47,18 @@ impl Extern {
     }
 
     /// Create an `Extern` from an `Export`.
-    pub fn from_export(store: &Store, export: EngineExport) -> Self {
+    pub fn from_export(store: &Store, export: Export) -> Self {
         match export {
-            EngineExport::Function(f) => Self::Function(Function::from_export(store, f)),
-            EngineExport::Memory(m) => Self::Memory(Memory::from_export(store, m)),
-            EngineExport::Global(g) => Self::Global(Global::from_export(store, g)),
-            EngineExport::Table(t) => Self::Table(Table::from_export(store, t)),
+            Export::Function(f) => Self::Function(Function::from_export(store, f)),
+            Export::Memory(m) => Self::Memory(Memory::from_export(store, m)),
+            Export::Global(g) => Self::Global(Global::from_export(store, g)),
+            Export::Table(t) => Self::Table(Table::from_export(store, t)),
         }
     }
 }
 
 impl<'a> Exportable<'a> for Extern {
-    fn to_export(&self) -> EngineExport {
+    fn to_export(&self) -> Export {
         match self {
             Self::Function(f) => f.to_export(),
             Self::Global(g) => g.to_export(),

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -17,7 +17,7 @@ use crate::exports::{ExportError, Exportable};
 use crate::store::{Store, StoreObject};
 use crate::ExternType;
 use std::fmt;
-use wasmer_vm::{EngineExport, Export};
+use wasmer_engine::EngineExport;
 
 /// An `Extern` is the runtime representation of an entity that
 /// can be imported or exported.
@@ -47,12 +47,12 @@ impl Extern {
     }
 
     /// Create an `Extern` from an `Export`.
-    pub fn from_export(store: &Store, export: Export) -> Self {
+    pub fn from_export(store: &Store, export: EngineExport) -> Self {
         match export {
-            Export::Function(f) => Self::Function(Function::from_export(store, f)),
-            Export::Memory(m) => Self::Memory(Memory::from_export(store, m)),
-            Export::Global(g) => Self::Global(Global::from_export(store, g)),
-            Export::Table(t) => Self::Table(Table::from_export(store, t)),
+            EngineExport::Function(f) => Self::Function(Function::from_export(store, f)),
+            EngineExport::Memory(m) => Self::Memory(Memory::from_export(store, m)),
+            EngineExport::Global(g) => Self::Global(Global::from_export(store, g)),
+            EngineExport::Table(t) => Self::Table(Table::from_export(store, t)),
         }
     }
 }

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -17,7 +17,7 @@ use crate::exports::{ExportError, Exportable};
 use crate::store::{Store, StoreObject};
 use crate::ExternType;
 use std::fmt;
-use wasmer_vm::Export;
+use wasmer_vm::{EngineExport, Export};
 
 /// An `Extern` is the runtime representation of an entity that
 /// can be imported or exported.
@@ -58,7 +58,7 @@ impl Extern {
 }
 
 impl<'a> Exportable<'a> for Extern {
-    fn to_export(&self) -> Export {
+    fn to_export(&self) -> EngineExport {
         match self {
             Self::Function(f) => f.to_export(),
             Self::Global(g) => g.to_export(),

--- a/lib/api/src/externals/table.rs
+++ b/lib/api/src/externals/table.rs
@@ -5,7 +5,8 @@ use crate::types::{Val, ValFuncRef};
 use crate::RuntimeError;
 use crate::TableType;
 use std::sync::Arc;
-use wasmer_vm::{EngineExport, ExportTable, Table as RuntimeTable, VMCallerCheckedAnyfunc};
+use wasmer_engine::EngineExport;
+use wasmer_vm::{ExportTable, Table as RuntimeTable, VMCallerCheckedAnyfunc};
 
 /// A WebAssembly `table` instance.
 ///

--- a/lib/api/src/externals/table.rs
+++ b/lib/api/src/externals/table.rs
@@ -5,7 +5,7 @@ use crate::types::{Val, ValFuncRef};
 use crate::RuntimeError;
 use crate::TableType;
 use std::sync::Arc;
-use wasmer_vm::{Export, ExportTable, Table as RuntimeTable, VMCallerCheckedAnyfunc};
+use wasmer_vm::{EngineExport, ExportTable, Table as RuntimeTable, VMCallerCheckedAnyfunc};
 
 /// A WebAssembly `table` instance.
 ///
@@ -153,7 +153,7 @@ impl Table {
 }
 
 impl<'a> Exportable<'a> for Table {
-    fn to_export(&self) -> Export {
+    fn to_export(&self) -> EngineExport {
         ExportTable {
             from: self.table.clone(),
         }

--- a/lib/api/src/externals/table.rs
+++ b/lib/api/src/externals/table.rs
@@ -6,7 +6,7 @@ use crate::RuntimeError;
 use crate::TableType;
 use std::sync::Arc;
 use wasmer_engine::EngineExport;
-use wasmer_vm::{ExportTable, Table as RuntimeTable, VMCallerCheckedAnyfunc};
+use wasmer_vm::{Table as RuntimeTable, VMCallerCheckedAnyfunc, VMExportTable};
 
 /// A WebAssembly `table` instance.
 ///
@@ -140,7 +140,7 @@ impl Table {
         Ok(())
     }
 
-    pub(crate) fn from_export(store: &Store, wasmer_export: ExportTable) -> Self {
+    pub(crate) fn from_export(store: &Store, wasmer_export: VMExportTable) -> Self {
         Self {
             store: store.clone(),
             table: wasmer_export.from,
@@ -155,7 +155,7 @@ impl Table {
 
 impl<'a> Exportable<'a> for Table {
     fn to_export(&self) -> EngineExport {
-        ExportTable {
+        VMExportTable {
             from: self.table.clone(),
         }
         .into()

--- a/lib/api/src/externals/table.rs
+++ b/lib/api/src/externals/table.rs
@@ -5,7 +5,7 @@ use crate::types::{Val, ValFuncRef};
 use crate::RuntimeError;
 use crate::TableType;
 use std::sync::Arc;
-use wasmer_engine::EngineExport;
+use wasmer_engine::{Export, ExportTable};
 use wasmer_vm::{Table as RuntimeTable, VMCallerCheckedAnyfunc, VMExportTable};
 
 /// A WebAssembly `table` instance.
@@ -140,10 +140,10 @@ impl Table {
         Ok(())
     }
 
-    pub(crate) fn from_export(store: &Store, wasmer_export: VMExportTable) -> Self {
+    pub(crate) fn from_export(store: &Store, wasmer_export: ExportTable) -> Self {
         Self {
             store: store.clone(),
-            table: wasmer_export.from,
+            table: wasmer_export.vm_table.from,
         }
     }
 
@@ -154,9 +154,11 @@ impl Table {
 }
 
 impl<'a> Exportable<'a> for Table {
-    fn to_export(&self) -> EngineExport {
-        VMExportTable {
-            from: self.table.clone(),
+    fn to_export(&self) -> Export {
+        ExportTable {
+            vm_table: VMExportTable {
+                from: self.table.clone(),
+            },
         }
         .into()
     }

--- a/lib/api/src/import_object.rs
+++ b/lib/api/src/import_object.rs
@@ -6,8 +6,7 @@ use std::collections::VecDeque;
 use std::collections::{hash_map::Entry, HashMap};
 use std::fmt;
 use std::sync::{Arc, Mutex};
-use wasmer_engine::NamedResolver;
-use wasmer_vm::EngineExport;
+use wasmer_engine::{EngineExport, NamedResolver};
 
 /// The `LikeNamespace` trait represents objects that act as a namespace for imports.
 /// For example, an `Instance` or `Namespace` could be
@@ -265,7 +264,6 @@ mod test {
     use crate::{Global, Store, Val};
     use wasmer_engine::ChainableNamedResolver;
     use wasmer_types::Type;
-    use wasmer_vm::Export;
 
     #[test]
     fn chaining_works() {
@@ -319,11 +317,13 @@ mod test {
         let resolver = imports1.chain_front(imports2);
         let happy_dog_entry = resolver.resolve_by_name("dog", "happy").unwrap();
 
-        assert!(if let Export::Global(happy_dog_global) = happy_dog_entry {
-            happy_dog_global.from.ty().ty == Type::I64
-        } else {
-            false
-        });
+        assert!(
+            if let EngineExport::Global(happy_dog_global) = happy_dog_entry {
+                happy_dog_global.from.ty().ty == Type::I64
+            } else {
+                false
+            }
+        );
 
         // now test it in reverse
         let store = Store::default();
@@ -345,11 +345,13 @@ mod test {
         let resolver = imports1.chain_back(imports2);
         let happy_dog_entry = resolver.resolve_by_name("dog", "happy").unwrap();
 
-        assert!(if let Export::Global(happy_dog_global) = happy_dog_entry {
-            happy_dog_global.from.ty().ty == Type::I32
-        } else {
-            false
-        });
+        assert!(
+            if let EngineExport::Global(happy_dog_global) = happy_dog_entry {
+                happy_dog_global.from.ty().ty == Type::I32
+            } else {
+                false
+            }
+        );
     }
 
     #[test]
@@ -365,11 +367,13 @@ mod test {
 
         let happy_dog_entry = imports1.resolve_by_name("dog", "happy").unwrap();
 
-        assert!(if let Export::Global(happy_dog_global) = happy_dog_entry {
-            happy_dog_global.from.ty().ty == Type::I32
-        } else {
-            false
-        });
+        assert!(
+            if let EngineExport::Global(happy_dog_global) = happy_dog_entry {
+                happy_dog_global.from.ty().ty == Type::I32
+            } else {
+                false
+            }
+        );
     }
 
     #[test]

--- a/lib/api/src/import_object.rs
+++ b/lib/api/src/import_object.rs
@@ -7,16 +7,16 @@ use std::collections::{hash_map::Entry, HashMap};
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use wasmer_engine::NamedResolver;
-use wasmer_vm::Export;
+use wasmer_vm::EngineExport;
 
 /// The `LikeNamespace` trait represents objects that act as a namespace for imports.
 /// For example, an `Instance` or `Namespace` could be
 /// considered namespaces that could provide imports to an instance.
 pub trait LikeNamespace {
     /// Gets an export by name.
-    fn get_namespace_export(&self, name: &str) -> Option<Export>;
+    fn get_namespace_export(&self, name: &str) -> Option<EngineExport>;
     /// Gets all exports in the namespace.
-    fn get_namespace_exports(&self) -> Vec<(String, Export)>;
+    fn get_namespace_exports(&self) -> Vec<(String, EngineExport)>;
 }
 
 /// All of the import data used when instantiating.
@@ -59,7 +59,7 @@ impl ImportObject {
     /// let mut import_object = ImportObject::new();
     /// import_object.get_export("module", "name");
     /// ```
-    pub fn get_export(&self, module: &str, name: &str) -> Option<Export> {
+    pub fn get_export(&self, module: &str, name: &str) -> Option<EngineExport> {
         let guard = self.map.lock().unwrap();
         let map_ref = guard.borrow();
         if map_ref.contains_key(module) {
@@ -102,7 +102,7 @@ impl ImportObject {
         }
     }
 
-    fn get_objects(&self) -> VecDeque<((String, String), Export)> {
+    fn get_objects(&self) -> VecDeque<((String, String), EngineExport)> {
         let mut out = VecDeque::new();
         let guard = self.map.lock().unwrap();
         let map = guard.borrow();
@@ -116,18 +116,18 @@ impl ImportObject {
 }
 
 impl NamedResolver for ImportObject {
-    fn resolve_by_name(&self, module: &str, name: &str) -> Option<Export> {
+    fn resolve_by_name(&self, module: &str, name: &str) -> Option<EngineExport> {
         self.get_export(module, name)
     }
 }
 
 /// Iterator for an `ImportObject`'s exports.
 pub struct ImportObjectIterator {
-    elements: VecDeque<((String, String), Export)>,
+    elements: VecDeque<((String, String), EngineExport)>,
 }
 
 impl Iterator for ImportObjectIterator {
-    type Item = ((String, String), Export);
+    type Item = ((String, String), EngineExport);
     fn next(&mut self) -> Option<Self::Item> {
         self.elements.pop_front()
     }
@@ -135,7 +135,7 @@ impl Iterator for ImportObjectIterator {
 
 impl IntoIterator for ImportObject {
     type IntoIter = ImportObjectIterator;
-    type Item = ((String, String), Export);
+    type Item = ((String, String), EngineExport);
 
     fn into_iter(self) -> Self::IntoIter {
         ImportObjectIterator {

--- a/lib/api/src/instance.rs
+++ b/lib/api/src/instance.rs
@@ -119,7 +119,7 @@ impl Instance {
             .map(|export| {
                 let name = export.name().to_string();
                 let export = handle.lookup(&name).expect("export");
-                let extern_ = Extern::from_export(store, export);
+                let extern_ = Extern::from_export(store, export.into());
                 (name, extern_)
             })
             .collect::<Exports>();

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -80,8 +80,8 @@ pub use wasmer_compiler::{
 };
 pub use wasmer_compiler::{CpuFeature, Features, Target};
 pub use wasmer_engine::{
-    ChainableNamedResolver, DeserializeError, Engine, FrameInfo, LinkError, NamedResolver,
-    NamedResolverChain, Resolver, RuntimeError, SerializeError,
+    ChainableNamedResolver, DeserializeError, Engine, EngineExport, FrameInfo, LinkError,
+    NamedResolver, NamedResolverChain, Resolver, RuntimeError, SerializeError,
 };
 pub use wasmer_types::{
     Atomically, Bytes, GlobalInit, LocalFunctionIndex, MemoryView, Pages, ValueType,

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -80,8 +80,8 @@ pub use wasmer_compiler::{
 };
 pub use wasmer_compiler::{CpuFeature, Features, Target};
 pub use wasmer_engine::{
-    ChainableNamedResolver, DeserializeError, Engine, EngineExport, FrameInfo, LinkError,
-    NamedResolver, NamedResolverChain, Resolver, RuntimeError, SerializeError,
+    ChainableNamedResolver, DeserializeError, Engine, Export, FrameInfo, LinkError, NamedResolver,
+    NamedResolverChain, Resolver, RuntimeError, SerializeError,
 };
 pub use wasmer_types::{
     Atomically, Bytes, GlobalInit, LocalFunctionIndex, MemoryView, Pages, ValueType,

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -89,7 +89,7 @@ pub use wasmer_types::{
 };
 
 // TODO: should those be moved into wasmer::vm as well?
-pub use wasmer_vm::{raise_user_trap, Export, MemoryError};
+pub use wasmer_vm::{raise_user_trap, MemoryError, VMExport};
 pub mod vm {
     //! We use the vm module for re-exporting wasmer-vm types
 

--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -18,7 +18,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use wasmer_engine::EngineExportFunction;
 use wasmer_types::NativeWasmType;
 use wasmer_vm::{
-    ExportFunction, VMDynamicFunctionContext, VMFunctionBody, VMFunctionEnvironment, VMFunctionKind,
+    VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
+    VMFunctionKind,
 };
 
 /// A WebAssembly function that can be called natively
@@ -59,7 +60,7 @@ where
 }
 
 /*
-impl<Args, Rets> From<&NativeFunc<Args, Rets>> for ExportFunction
+impl<Args, Rets> From<&NativeFunc<Args, Rets>> for VMExportFunction
 where
     Args: WasmTypeList,
     Rets: WasmTypeList,
@@ -86,7 +87,7 @@ where
         Self {
             // TODO:
             function_ptr: None,
-            function: ExportFunction {
+            function: VMExportFunction {
                 address: other.address,
                 vmctx: other.vmctx,
                 signature,
@@ -110,7 +111,7 @@ where
             exported: EngineExportFunction {
                 // TODO:
                 function_ptr: None,
-                function: ExportFunction {
+                function: VMExportFunction {
                     address: other.address,
                     vmctx: other.vmctx,
                     signature,

--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -15,10 +15,10 @@ use crate::externals::function::{
 };
 use crate::{FromToNativeWasmType, Function, FunctionType, RuntimeError, Store, WasmTypeList};
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use wasmer_engine::EngineExportFunction;
 use wasmer_types::NativeWasmType;
 use wasmer_vm::{
-    EngineExportFunction, ExportFunction, VMDynamicFunctionContext, VMFunctionBody,
-    VMFunctionEnvironment, VMFunctionKind,
+    ExportFunction, VMDynamicFunctionContext, VMFunctionBody, VMFunctionEnvironment, VMFunctionKind,
 };
 
 /// A WebAssembly function that can be called natively

--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -15,7 +15,7 @@ use crate::externals::function::{
 };
 use crate::{FromToNativeWasmType, Function, FunctionType, RuntimeError, Store, WasmTypeList};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use wasmer_engine::EngineExportFunction;
+use wasmer_engine::ExportFunction;
 use wasmer_types::NativeWasmType;
 use wasmer_vm::{
     VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
@@ -30,7 +30,7 @@ pub struct NativeFunc<Args = (), Rets = ()> {
     address: *const VMFunctionBody,
     vmctx: VMFunctionEnvironment,
     arg_kind: VMFunctionKind,
-    // exported: EngineExportFunction,
+    // exported: ExportFunction,
     _phantom: PhantomData<(Args, Rets)>,
 }
 
@@ -77,7 +77,7 @@ where
     }
 }*/
 
-impl<Args, Rets> From<&NativeFunc<Args, Rets>> for EngineExportFunction
+impl<Args, Rets> From<&NativeFunc<Args, Rets>> for ExportFunction
 where
     Args: WasmTypeList,
     Rets: WasmTypeList,
@@ -86,8 +86,8 @@ where
         let signature = FunctionType::new(Args::wasm_types(), Rets::wasm_types());
         Self {
             // TODO:
-            function_ptr: None,
-            function: VMExportFunction {
+            import_init_function_ptr: None,
+            vm_function: VMExportFunction {
                 address: other.address,
                 vmctx: other.vmctx,
                 signature,
@@ -108,10 +108,10 @@ where
         Self {
             store: other.store,
             definition: other.definition,
-            exported: EngineExportFunction {
+            exported: ExportFunction {
                 // TODO:
-                function_ptr: None,
-                function: VMExportFunction {
+                import_init_function_ptr: None,
+                vm_function: VMExportFunction {
                     address: other.address,
                     vmctx: other.vmctx,
                     signature,

--- a/lib/api/src/types.rs
+++ b/lib/api/src/types.rs
@@ -73,17 +73,19 @@ impl ValFuncRef for Val {
             .engine()
             .lookup_signature(item.type_index)
             .expect("Signature not found in store");
-        let export = wasmer_vm::ExportFunction {
-            address: item.func_ptr,
-            signature,
+        let export = wasmer_vm::EngineExportFunction {
             // TODO:
             // figure out if we ever need a value here: need testing with complicated import patterns
             function_ptr: None,
-            // All functions in tables are already Static (as dynamic functions
-            // are converted to use the trampolines with static signatures).
-            kind: wasmer_vm::VMFunctionKind::Static,
-            vmctx: item.vmctx,
-            call_trampoline: None,
+            function: wasmer_vm::ExportFunction {
+                address: item.func_ptr,
+                signature,
+                // All functions in tables are already Static (as dynamic functions
+                // are converted to use the trampolines with static signatures).
+                kind: wasmer_vm::VMFunctionKind::Static,
+                vmctx: item.vmctx,
+                call_trampoline: None,
+            },
         };
         let f = Function::from_export(store, export);
         Self::FuncRef(f)

--- a/lib/api/src/types.rs
+++ b/lib/api/src/types.rs
@@ -73,11 +73,11 @@ impl ValFuncRef for Val {
             .engine()
             .lookup_signature(item.type_index)
             .expect("Signature not found in store");
-        let export = wasmer_engine::EngineExportFunction {
+        let export = wasmer_engine::ExportFunction {
             // TODO:
             // figure out if we ever need a value here: need testing with complicated import patterns
-            function_ptr: None,
-            function: wasmer_vm::VMExportFunction {
+            import_init_function_ptr: None,
+            vm_function: wasmer_vm::VMExportFunction {
                 address: item.func_ptr,
                 signature,
                 // All functions in tables are already Static (as dynamic functions

--- a/lib/api/src/types.rs
+++ b/lib/api/src/types.rs
@@ -73,7 +73,7 @@ impl ValFuncRef for Val {
             .engine()
             .lookup_signature(item.type_index)
             .expect("Signature not found in store");
-        let export = wasmer_vm::EngineExportFunction {
+        let export = wasmer_engine::EngineExportFunction {
             // TODO:
             // figure out if we ever need a value here: need testing with complicated import patterns
             function_ptr: None,

--- a/lib/api/src/types.rs
+++ b/lib/api/src/types.rs
@@ -77,7 +77,7 @@ impl ValFuncRef for Val {
             // TODO:
             // figure out if we ever need a value here: need testing with complicated import patterns
             function_ptr: None,
-            function: wasmer_vm::ExportFunction {
+            function: wasmer_vm::VMExportFunction {
                 address: item.func_ptr,
                 signature,
                 // All functions in tables are already Static (as dynamic functions

--- a/lib/c-api/src/ordered_resolver.rs
+++ b/lib/c-api/src/ordered_resolver.rs
@@ -1,11 +1,11 @@
 //! Ordered Resolvers are a custom kind of [`Resolver`] that retrieves
-//! `Export`s based on the index of the import, and not the module or name.
+//! `EngineExport`s based on the index of the import, and not the module or name.
 //!
 //! This resolver is used in the Wasm-C-API as the imports are provided
 //! by index and not by module and name.
 
 use std::iter::FromIterator;
-use wasmer::{Export, Exportable, Extern, Resolver};
+use wasmer::{EngineExport, Exportable, Extern, Resolver};
 
 /// An `OrderedResolver` stores all the `externs` provided to an Instance
 /// in a Vec, so we can retrieve them later based on index.
@@ -16,7 +16,7 @@ pub struct OrderedResolver {
 }
 
 impl Resolver for OrderedResolver {
-    fn resolve(&self, index: u32, _module: &str, _name: &str) -> Option<Export> {
+    fn resolve(&self, index: u32, _module: &str, _name: &str) -> Option<EngineExport> {
         self.externs
             .get(index as usize)
             .map(|extern_| extern_.to_export())

--- a/lib/c-api/src/ordered_resolver.rs
+++ b/lib/c-api/src/ordered_resolver.rs
@@ -5,7 +5,7 @@
 //! by index and not by module and name.
 
 use std::iter::FromIterator;
-use wasmer::{EngineExport, Exportable, Extern, Resolver};
+use wasmer::{Export, Exportable, Extern, Resolver};
 
 /// An `OrderedResolver` stores all the `externs` provided to an Instance
 /// in a Vec, so we can retrieve them later based on index.
@@ -16,7 +16,7 @@ pub struct OrderedResolver {
 }
 
 impl Resolver for OrderedResolver {
-    fn resolve(&self, index: u32, _module: &str, _name: &str) -> Option<EngineExport> {
+    fn resolve(&self, index: u32, _module: &str, _name: &str) -> Option<Export> {
         self.externs
             .get(index as usize)
             .map(|extern_| extern_.to_export())

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -29,9 +29,6 @@
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
-// The `jit` feature has been enabled for this build.
-#define WASMER_JIT_ENABLED
-
 // The `compiler` feature has been enabled for this build.
 #define WASMER_COMPILER_ENABLED
 

--- a/lib/deprecated/runtime-core/src/export.rs
+++ b/lib/deprecated/runtime-core/src/export.rs
@@ -1,4 +1,4 @@
 pub use crate::new::{
+    wasmer::Export as RuntimeExport,
     wasmer::{Exportable, Extern as Export},
-    wasmer_vm::Export as RuntimeExport,
 };

--- a/lib/deprecated/runtime-core/src/global.rs
+++ b/lib/deprecated/runtime-core/src/global.rs
@@ -87,7 +87,7 @@ impl From<&new::wasmer::Global> for Global {
 }
 
 impl<'a> new::wasmer::Exportable<'a> for Global {
-    fn to_export(&self) -> new::wasmer_vm::Export {
+    fn to_export(&self) -> new::wasmer::Export {
         self.new_global.to_export()
     }
 

--- a/lib/deprecated/runtime-core/src/import.rs
+++ b/lib/deprecated/runtime-core/src/import.rs
@@ -30,11 +30,11 @@ impl Namespace {
 }
 
 impl LikeNamespace for Namespace {
-    fn get_namespace_export(&self, name: &str) -> Option<new::wasmer_vm::Export> {
+    fn get_namespace_export(&self, name: &str) -> Option<new::wasmer::Export> {
         self.exports.new_exports.get_namespace_export(name)
     }
 
-    fn get_namespace_exports(&self) -> Vec<(String, new::wasmer_vm::Export)> {
+    fn get_namespace_exports(&self) -> Vec<(String, new::wasmer::Export)> {
         self.exports.new_exports.get_namespace_exports()
     }
 }

--- a/lib/deprecated/runtime-core/src/instance.rs
+++ b/lib/deprecated/runtime-core/src/instance.rs
@@ -222,11 +222,11 @@ impl Instance {
 }
 
 impl LikeNamespace for Instance {
-    fn get_namespace_export(&self, name: &str) -> Option<new::wasmer_vm::Export> {
+    fn get_namespace_export(&self, name: &str) -> Option<new::wasmer::Export> {
         self.exports.new_exports.get_namespace_export(name)
     }
 
-    fn get_namespace_exports(&self) -> Vec<(String, new::wasmer_vm::Export)> {
+    fn get_namespace_exports(&self) -> Vec<(String, new::wasmer::Export)> {
         self.exports.new_exports.get_namespace_exports()
     }
 }
@@ -256,11 +256,11 @@ impl Exports {
 }
 
 impl LikeNamespace for Exports {
-    fn get_namespace_export(&self, name: &str) -> Option<new::wasmer_vm::Export> {
+    fn get_namespace_export(&self, name: &str) -> Option<new::wasmer::Export> {
         self.new_exports.get_namespace_export(name)
     }
 
-    fn get_namespace_exports(&self) -> Vec<(String, new::wasmer_vm::Export)> {
+    fn get_namespace_exports(&self) -> Vec<(String, new::wasmer::Export)> {
         self.new_exports.get_namespace_exports()
     }
 }

--- a/lib/deprecated/runtime-core/src/memory.rs
+++ b/lib/deprecated/runtime-core/src/memory.rs
@@ -9,8 +9,8 @@ pub mod ptr {
     pub use crate::new::wasmer::{Array, Item, WasmPtr};
 }
 
-pub use new::wasmer_types::MemoryType as MemoryDescriptor;
 pub use new::wasmer::{Atomically, MemoryView};
+pub use new::wasmer_types::MemoryType as MemoryDescriptor;
 pub use new::wasmer_vm::MemoryStyle as MemoryType;
 
 /// A Wasm linear memory.
@@ -108,7 +108,7 @@ impl From<&new::wasmer::Memory> for Memory {
 }
 
 impl<'a> new::wasmer::Exportable<'a> for Memory {
-    fn to_export(&self) -> new::wasmer_vm::Export {
+    fn to_export(&self) -> new::wasmer::Export {
         self.new_memory.to_export()
     }
 

--- a/lib/deprecated/runtime-core/src/table.rs
+++ b/lib/deprecated/runtime-core/src/table.rs
@@ -70,7 +70,7 @@ impl From<&new::wasmer::Table> for Table {
 }
 
 impl<'a> new::wasmer::Exportable<'a> for Table {
-    fn to_export(&self) -> new::wasmer_vm::Export {
+    fn to_export(&self) -> new::wasmer::Export {
         self.new_table.to_export()
     }
 

--- a/lib/deprecated/runtime-core/src/typed_func.rs
+++ b/lib/deprecated/runtime-core/src/typed_func.rs
@@ -201,7 +201,7 @@ where
     Args: WasmTypeList,
     Rets: WasmTypeList,
 {
-    fn to_export(&self) -> new::wasmer_vm::Export {
+    fn to_export(&self) -> new::wasmer::Export {
         self.new_function.to_export()
     }
 
@@ -312,7 +312,7 @@ impl From<&new::wasmer::Function> for DynamicFunc {
 }
 
 impl<'a> new::wasmer::Exportable<'a> for DynamicFunc {
-    fn to_export(&self) -> new::wasmer_vm::Export {
+    fn to_export(&self) -> new::wasmer::Export {
         self.new_function.to_export()
     }
 

--- a/lib/engine/src/export.rs
+++ b/lib/engine/src/export.rs
@@ -1,0 +1,103 @@
+use wasmer_vm::{
+    ImportInitializerFuncPtr, VMExport, VMExportFunction, VMExportGlobal, VMExportMemory,
+    VMExportTable,
+};
+
+/// The value of an export passed from one instance to another.
+#[derive(Debug, Clone)]
+pub enum Export {
+    /// A function export value.
+    Function(ExportFunction),
+
+    /// A table export value.
+    Table(ExportTable),
+
+    /// A memory export value.
+    Memory(ExportMemory),
+
+    /// A global export value.
+    Global(ExportGlobal),
+}
+
+impl From<Export> for VMExport {
+    fn from(other: Export) -> Self {
+        match other {
+            Export::Function(ExportFunction { vm_function, .. }) => VMExport::Function(vm_function),
+            Export::Memory(ExportMemory { vm_memory }) => VMExport::Memory(vm_memory),
+            Export::Table(ExportTable { vm_table }) => VMExport::Table(vm_table),
+            Export::Global(ExportGlobal { vm_global }) => VMExport::Global(vm_global),
+        }
+    }
+}
+
+impl From<VMExport> for Export {
+    fn from(other: VMExport) -> Self {
+        match other {
+            VMExport::Function(vm_function) => Export::Function(ExportFunction {
+                vm_function,
+                import_init_function_ptr: None,
+            }),
+            VMExport::Memory(vm_memory) => Export::Memory(ExportMemory { vm_memory }),
+            VMExport::Table(vm_table) => Export::Table(ExportTable { vm_table }),
+            VMExport::Global(vm_global) => Export::Global(ExportGlobal { vm_global }),
+        }
+    }
+}
+
+/// A function export value with an extra function pointer to initialize
+/// host environments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExportFunction {
+    /// The VM function, containing most of the data.
+    pub vm_function: VMExportFunction,
+    /// Function pointer to `WasmerEnv::init_with_instance(&mut self, instance: &Instance)`.
+    ///
+    /// This function is called to finish setting up the environment after
+    /// we create the `api::Instance`.
+    pub import_init_function_ptr: Option<ImportInitializerFuncPtr>,
+}
+
+impl From<ExportFunction> for Export {
+    fn from(func: ExportFunction) -> Self {
+        Self::Function(func)
+    }
+}
+
+/// A table export value.
+#[derive(Debug, Clone)]
+pub struct ExportTable {
+    /// The VM table, containing info about the table.
+    pub vm_table: VMExportTable,
+}
+
+impl From<ExportTable> for Export {
+    fn from(table: ExportTable) -> Self {
+        Self::Table(table)
+    }
+}
+
+/// A memory export value.
+#[derive(Debug, Clone)]
+pub struct ExportMemory {
+    /// The VM memory, containing info about the table.
+    pub vm_memory: VMExportMemory,
+}
+
+impl From<ExportMemory> for Export {
+    fn from(memory: ExportMemory) -> Self {
+        Self::Memory(memory)
+    }
+}
+
+/// A global export value.
+#[derive(Debug, Clone)]
+pub struct ExportGlobal {
+    /// The VM global, containing info about the global.
+    pub vm_global: VMExportGlobal,
+}
+
+impl From<ExportGlobal> for Export {
+    fn from(global: ExportGlobal) -> Self {
+        Self::Global(global)
+    }
+}

--- a/lib/engine/src/lib.rs
+++ b/lib/engine/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::engine::{Engine, EngineId};
 pub use crate::error::{
     DeserializeError, ImportError, InstantiationError, LinkError, SerializeError,
 };
-pub use crate::export::{EngineExport, EngineExportFunction};
+pub use crate::export::{Export, ExportFunction, ExportGlobal, ExportMemory, ExportTable};
 pub use crate::resolver::{
     resolve_imports, ChainableNamedResolver, NamedResolver, NamedResolverChain, NullResolver,
     Resolver,

--- a/lib/engine/src/lib.rs
+++ b/lib/engine/src/lib.rs
@@ -23,6 +23,7 @@
 mod artifact;
 mod engine;
 mod error;
+mod export;
 mod resolver;
 mod serialize;
 mod trap;
@@ -33,6 +34,7 @@ pub use crate::engine::{Engine, EngineId};
 pub use crate::error::{
     DeserializeError, ImportError, InstantiationError, LinkError, SerializeError,
 };
+pub use crate::export::{EngineExport, EngineExportFunction};
 pub use crate::resolver::{
     resolve_imports, ChainableNamedResolver, NamedResolver, NamedResolverChain, NullResolver,
     Resolver,

--- a/lib/engine/src/resolver.rs
+++ b/lib/engine/src/resolver.rs
@@ -1,13 +1,13 @@
 //! Define the `Resolver` trait, allowing custom resolution for external
 //! references.
 
-use crate::{ImportError, LinkError};
+use crate::{EngineExport, ImportError, LinkError};
 use more_asserts::assert_ge;
 use wasmer_types::entity::{BoxedSlice, EntityRef, PrimaryMap};
 use wasmer_types::{ExternType, FunctionIndex, ImportIndex, MemoryIndex, TableIndex};
 
 use wasmer_vm::{
-    EngineExport, FunctionBodyPtr, Imports, MemoryStyle, ModuleInfo, TableStyle, VMFunctionBody,
+    FunctionBodyPtr, Imports, MemoryStyle, ModuleInfo, TableStyle, VMFunctionBody,
     VMFunctionImport, VMFunctionKind, VMGlobalImport, VMMemoryImport, VMTableImport,
 };
 

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -10,23 +10,23 @@ use wasmer_types::{FunctionType, MemoryType, TableType};
 
 /// The value of an export passed from one instance to another.
 #[derive(Debug, Clone)]
-pub enum Export {
+pub enum VMExport {
     /// A function export value.
-    Function(ExportFunction),
+    Function(VMExportFunction),
 
     /// A table export value.
-    Table(ExportTable),
+    Table(VMExportTable),
 
     /// A memory export value.
-    Memory(ExportMemory),
+    Memory(VMExportMemory),
 
     /// A global export value.
-    Global(ExportGlobal),
+    Global(VMExportGlobal),
 }
 
 /// A function export value.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ExportFunction {
+pub struct VMExportFunction {
     /// The address of the native-code function.
     pub address: *const VMFunctionBody,
     /// Pointer to the containing `VMContext`.
@@ -43,20 +43,20 @@ pub struct ExportFunction {
 /// # Safety
 /// There is no non-threadsafe logic directly in this type. Calling the function
 /// may not be threadsafe.
-unsafe impl Send for ExportFunction {}
+unsafe impl Send for VMExportFunction {}
 /// # Safety
-/// The members of an ExportFunction are immutable after construction.
-unsafe impl Sync for ExportFunction {}
+/// The members of an VMExportFunction are immutable after construction.
+unsafe impl Sync for VMExportFunction {}
 
-impl From<ExportFunction> for Export {
-    fn from(func: ExportFunction) -> Self {
+impl From<VMExportFunction> for VMExport {
+    fn from(func: VMExportFunction) -> Self {
         Self::Function(func)
     }
 }
 
 /// A table export value.
 #[derive(Debug, Clone)]
-pub struct ExportTable {
+pub struct VMExportTable {
     /// Pointer to the containing `Table`.
     pub from: Arc<dyn Table>,
 }
@@ -65,14 +65,14 @@ pub struct ExportTable {
 /// This is correct because there is no non-threadsafe logic directly in this type;
 /// correct use of the raw table from multiple threads via `definition` requires `unsafe`
 /// and is the responsibilty of the user of this type.
-unsafe impl Send for ExportTable {}
+unsafe impl Send for VMExportTable {}
 /// # Safety
 /// This is correct because the values directly in `definition` should be considered immutable
 /// and the type is both `Send` and `Clone` (thus marking it `Sync` adds no new behavior, it
 /// only makes this type easier to use)
-unsafe impl Sync for ExportTable {}
+unsafe impl Sync for VMExportTable {}
 
-impl ExportTable {
+impl VMExportTable {
     /// Get the table type for this exported table
     pub fn ty(&self) -> &TableType {
         self.from.ty()
@@ -83,21 +83,21 @@ impl ExportTable {
         self.from.style()
     }
 
-    /// Returns whether or not the two `ExportTable`s refer to the same Memory.
+    /// Returns whether or not the two `VMExportTable`s refer to the same Memory.
     pub fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.from, &other.from)
     }
 }
 
-impl From<ExportTable> for Export {
-    fn from(table: ExportTable) -> Self {
+impl From<VMExportTable> for VMExport {
+    fn from(table: VMExportTable) -> Self {
         Self::Table(table)
     }
 }
 
 /// A memory export value.
 #[derive(Debug, Clone)]
-pub struct ExportMemory {
+pub struct VMExportMemory {
     /// Pointer to the containing `Memory`.
     pub from: Arc<dyn Memory>,
 }
@@ -106,14 +106,14 @@ pub struct ExportMemory {
 /// This is correct because there is no non-threadsafe logic directly in this type;
 /// correct use of the raw memory from multiple threads via `definition` requires `unsafe`
 /// and is the responsibilty of the user of this type.
-unsafe impl Send for ExportMemory {}
+unsafe impl Send for VMExportMemory {}
 /// # Safety
 /// This is correct because the values directly in `definition` should be considered immutable
 /// and the type is both `Send` and `Clone` (thus marking it `Sync` adds no new behavior, it
 /// only makes this type easier to use)
-unsafe impl Sync for ExportMemory {}
+unsafe impl Sync for VMExportMemory {}
 
-impl ExportMemory {
+impl VMExportMemory {
     /// Get the type for this exported memory
     pub fn ty(&self) -> &MemoryType {
         self.from.ty()
@@ -124,21 +124,21 @@ impl ExportMemory {
         self.from.style()
     }
 
-    /// Returns whether or not the two `ExportMemory`s refer to the same Memory.
+    /// Returns whether or not the two `VMExportMemory`s refer to the same Memory.
     pub fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.from, &other.from)
     }
 }
 
-impl From<ExportMemory> for Export {
-    fn from(memory: ExportMemory) -> Self {
+impl From<VMExportMemory> for VMExport {
+    fn from(memory: VMExportMemory) -> Self {
         Self::Memory(memory)
     }
 }
 
 /// A global export value.
 #[derive(Debug, Clone)]
-pub struct ExportGlobal {
+pub struct VMExportGlobal {
     /// The global declaration, used for compatibility checking.
     pub from: Arc<Global>,
 }
@@ -147,22 +147,22 @@ pub struct ExportGlobal {
 /// This is correct because there is no non-threadsafe logic directly in this type;
 /// correct use of the raw global from multiple threads via `definition` requires `unsafe`
 /// and is the responsibilty of the user of this type.
-unsafe impl Send for ExportGlobal {}
+unsafe impl Send for VMExportGlobal {}
 /// # Safety
 /// This is correct because the values directly in `definition` should be considered immutable
 /// from the perspective of users of this type and the type is both `Send` and `Clone` (thus
 /// marking it `Sync` adds no new behavior, it only makes this type easier to use)
-unsafe impl Sync for ExportGlobal {}
+unsafe impl Sync for VMExportGlobal {}
 
-impl ExportGlobal {
-    /// Returns whether or not the two `ExportGlobal`s refer to the same Global.
+impl VMExportGlobal {
+    /// Returns whether or not the two `VMExportGlobal`s refer to the same Global.
     pub fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.from, &other.from)
     }
 }
 
-impl From<ExportGlobal> for Export {
-    fn from(global: ExportGlobal) -> Self {
+impl From<VMExportGlobal> for VMExport {
+    fn from(global: VMExportGlobal) -> Self {
         Self::Global(global)
     }
 }

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -11,6 +11,22 @@ use wasmer_types::{FunctionType, MemoryType, TableType};
 
 /// The value of an export passed from one instance to another.
 #[derive(Debug, Clone)]
+pub enum EngineExport {
+    /// A function export value.
+    Function(EngineExportFunction),
+
+    /// A table export value.
+    Table(ExportTable),
+
+    /// A memory export value.
+    Memory(ExportMemory),
+
+    /// A global export value.
+    Global(ExportGlobal),
+}
+
+/// The value of an export passed from one instance to another.
+#[derive(Debug, Clone)]
 pub enum Export {
     /// A function export value.
     Function(ExportFunction),
@@ -25,6 +41,18 @@ pub enum Export {
     Global(ExportGlobal),
 }
 
+/// TODO:
+#[derive(Debug, Clone, PartialEq)]
+pub struct EngineExportFunction {
+    /// TODO:
+    pub function: ExportFunction,
+    /// Function pointer to `WasmerEnv::init_with_instance(&mut self, instance: &Instance)`.
+    ///
+    /// This function is called to finish setting up the environment after
+    /// we create the `api::Instance`.
+    pub function_ptr: Option<ImportInitializerFuncPtr>,
+}
+
 /// A function export value.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExportFunction {
@@ -32,13 +60,6 @@ pub struct ExportFunction {
     pub address: *const VMFunctionBody,
     /// Pointer to the containing `VMContext`.
     pub vmctx: VMFunctionEnvironment,
-    /// Function pointer to `WasmerEnv::init_with_instance(&mut self, instance: &Instance)`.
-    ///
-    /// This function is called to finish setting up the environment after
-    /// we create the `api::Instance`.
-    // META: if you have a better idea of how to get this function to where it
-    // needs to be, please let me know.
-    pub function_ptr: Option<ImportInitializerFuncPtr>,
     /// The function type, used for compatibility checking.
     pub signature: FunctionType,
     /// The function kind (specifies the calling convention for the function).
@@ -55,6 +76,12 @@ unsafe impl Send for ExportFunction {}
 /// # Safety
 /// The members of an ExportFunction are immutable after construction.
 unsafe impl Sync for ExportFunction {}
+
+impl From<EngineExportFunction> for EngineExport {
+    fn from(func: EngineExportFunction) -> Self {
+        Self::Function(func)
+    }
+}
 
 impl From<ExportFunction> for Export {
     fn from(func: ExportFunction) -> Self {
@@ -103,6 +130,12 @@ impl From<ExportTable> for Export {
     }
 }
 
+impl From<ExportTable> for EngineExport {
+    fn from(table: ExportTable) -> Self {
+        Self::Table(table)
+    }
+}
+
 /// A memory export value.
 #[derive(Debug, Clone)]
 pub struct ExportMemory {
@@ -144,6 +177,12 @@ impl From<ExportMemory> for Export {
     }
 }
 
+impl From<ExportMemory> for EngineExport {
+    fn from(memory: ExportMemory) -> Self {
+        Self::Memory(memory)
+    }
+}
+
 /// A global export value.
 #[derive(Debug, Clone)]
 pub struct ExportGlobal {
@@ -170,6 +209,12 @@ impl ExportGlobal {
 }
 
 impl From<ExportGlobal> for Export {
+    fn from(global: ExportGlobal) -> Self {
+        Self::Global(global)
+    }
+}
+
+impl From<ExportGlobal> for EngineExport {
     fn from(global: ExportGlobal) -> Self {
         Self::Global(global)
     }

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -2,28 +2,11 @@
 // Attributions: https://github.com/wasmerio/wasmer/blob/master/ATTRIBUTIONS.md
 
 use crate::global::Global;
-use crate::instance::ImportInitializerFuncPtr;
 use crate::memory::{Memory, MemoryStyle};
 use crate::table::{Table, TableStyle};
 use crate::vmcontext::{VMFunctionBody, VMFunctionEnvironment, VMFunctionKind, VMTrampoline};
 use std::sync::Arc;
 use wasmer_types::{FunctionType, MemoryType, TableType};
-
-/// The value of an export passed from one instance to another.
-#[derive(Debug, Clone)]
-pub enum EngineExport {
-    /// A function export value.
-    Function(EngineExportFunction),
-
-    /// A table export value.
-    Table(ExportTable),
-
-    /// A memory export value.
-    Memory(ExportMemory),
-
-    /// A global export value.
-    Global(ExportGlobal),
-}
 
 /// The value of an export passed from one instance to another.
 #[derive(Debug, Clone)]
@@ -39,18 +22,6 @@ pub enum Export {
 
     /// A global export value.
     Global(ExportGlobal),
-}
-
-/// TODO:
-#[derive(Debug, Clone, PartialEq)]
-pub struct EngineExportFunction {
-    /// TODO:
-    pub function: ExportFunction,
-    /// Function pointer to `WasmerEnv::init_with_instance(&mut self, instance: &Instance)`.
-    ///
-    /// This function is called to finish setting up the environment after
-    /// we create the `api::Instance`.
-    pub function_ptr: Option<ImportInitializerFuncPtr>,
 }
 
 /// A function export value.
@@ -76,12 +47,6 @@ unsafe impl Send for ExportFunction {}
 /// # Safety
 /// The members of an ExportFunction are immutable after construction.
 unsafe impl Sync for ExportFunction {}
-
-impl From<EngineExportFunction> for EngineExport {
-    fn from(func: EngineExportFunction) -> Self {
-        Self::Function(func)
-    }
-}
 
 impl From<ExportFunction> for Export {
     fn from(func: ExportFunction) -> Self {
@@ -130,12 +95,6 @@ impl From<ExportTable> for Export {
     }
 }
 
-impl From<ExportTable> for EngineExport {
-    fn from(table: ExportTable) -> Self {
-        Self::Table(table)
-    }
-}
-
 /// A memory export value.
 #[derive(Debug, Clone)]
 pub struct ExportMemory {
@@ -177,12 +136,6 @@ impl From<ExportMemory> for Export {
     }
 }
 
-impl From<ExportMemory> for EngineExport {
-    fn from(memory: ExportMemory) -> Self {
-        Self::Memory(memory)
-    }
-}
-
 /// A global export value.
 #[derive(Debug, Clone)]
 pub struct ExportGlobal {
@@ -209,12 +162,6 @@ impl ExportGlobal {
 }
 
 impl From<ExportGlobal> for Export {
-    fn from(global: ExportGlobal) -> Self {
-        Self::Global(global)
-    }
-}
-
-impl From<ExportGlobal> for EngineExport {
     fn from(global: ExportGlobal) -> Self {
         Self::Global(global)
     }

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -4,7 +4,7 @@
 //! An `Instance` contains all the runtime state used by execution of a
 //! wasm module (except its callstack and register state). An
 //! `InstanceHandle` is a reference-counting handle for an `Instance`.
-use crate::export::{EngineExport, Export};
+use crate::export::Export;
 use crate::global::Global;
 use crate::imports::Imports;
 use crate::memory::{Memory, MemoryError};
@@ -16,7 +16,7 @@ use crate::vmcontext::{
     VMMemoryDefinition, VMMemoryImport, VMSharedSignatureIndex, VMTableDefinition, VMTableImport,
     VMTrampoline,
 };
-use crate::{EngineExportFunction, ExportFunction, ExportGlobal, ExportMemory, ExportTable};
+use crate::{ExportFunction, ExportGlobal, ExportMemory, ExportTable};
 use crate::{FunctionBodyPtr, ModuleInfo, VMOffsets};
 use memoffset::offset_of;
 use more_asserts::assert_lt;
@@ -65,7 +65,7 @@ cfg_if::cfg_if! {
 
 /// The function pointer to call with data and an [`Instance`] pointer to
 /// finish initializing the host env.
-pub(crate) type ImportInitializerFuncPtr =
+pub type ImportInitializerFuncPtr =
     fn(*mut std::ffi::c_void, *const std::ffi::c_void) -> Result<(), *mut std::ffi::c_void>;
 
 /// This type holds thunks (delayed computations) for initializing the imported
@@ -320,7 +320,7 @@ impl Instance {
         match export {
             ExportIndex::Function(index) => {
                 let sig_index = &self.module.functions[*index];
-                let (address, vmctx, function_ptr) =
+                let (address, vmctx, _function_ptr) =
                     if let Some(def_index) = self.module.local_func_index(*index) {
                         (
                             self.functions[def_index].0 as *const _,
@@ -1174,7 +1174,6 @@ impl InstanceHandle {
         use std::ffi;
         let instance = &mut *self.instance;
         for (func, env) in instance.import_initializers.drain(..) {
-            dbg!(func, env);
             if let Some(ref f) = func {
                 // transmute our function pointer into one with the correct error type
                 let f = std::mem::transmute::<

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -39,7 +39,7 @@ pub mod libcalls;
 pub use crate::export::*;
 pub use crate::global::*;
 pub use crate::imports::Imports;
-pub use crate::instance::InstanceHandle;
+pub use crate::instance::{ImportInitializerFuncPtr, InstanceHandle};
 pub use crate::memory::{LinearMemory, Memory, MemoryError, MemoryStyle};
 pub use crate::mmap::Mmap;
 pub use crate::module::{ExportsIterator, ImportsIterator, ModuleInfo};


### PR DESCRIPTION
Based on feedback on that PR, creating a wrapper type for `ExportFunction`: in order to make it more clear which is which, I also made an `EngineExport` and followed the code to where that needed to live... it seems that we'll just end up replacing all uses of `Export` with `EngineExport` in the API and that seemed wrong, looking for feedback here.