### PR TITLE
fix(compiler-singlepass) Fix future rustc error

### DIFF
--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -5129,11 +5129,8 @@ impl<'a> FuncGen<'a> {
                             && self.config.enable_nan_canonicalization
                             && fp.canonicalization.is_some()
                         {
-                            self.canonicalize_nan(
-                                fp.canonicalization.unwrap().to_size(),
-                                params[index],
-                                params[index],
-                            );
+                            let size = fp.canonicalization.unwrap().to_size();
+                            self.canonicalize_nan(size, params[index], params[index]);
                         }
                         self.fp_stack.pop().unwrap();
                     } else {
@@ -5230,11 +5227,8 @@ impl<'a> FuncGen<'a> {
                             && self.config.enable_nan_canonicalization
                             && fp.canonicalization.is_some()
                         {
-                            self.canonicalize_nan(
-                                fp.canonicalization.unwrap().to_size(),
-                                params[index],
-                                params[index],
-                            );
+                            let size = fp.canonicalization.unwrap().to_size();
+                            self.canonicalize_nan(size, params[index], params[index]);
                         }
                         self.fp_stack.pop().unwrap();
                     } else {


### PR DESCRIPTION
# Description

When compiling `wasmer-compiler-singlepass`, one can read an warning as:

```
warning: cannot borrow `*self` as mutable because it is also borrowed as immutable
    --> lib/compiler-singlepass/src/codegen_x64.rs:5132:29
     |
5125 |                 while let Some(fp) = self.fp_stack.last() {
     |                                      ------------- immutable borrow occurs here
...
5132 |                             self.canonicalize_nan(
     |                             ^^^^ mutable borrow occurs here
5133 |                                 fp.canonicalization.unwrap().to_size(),
     |                                 ------------------- immutable borrow later used here
     |
     = note: `#[warn(mutable_borrow_reservation_conflict)]` on by default
     = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
     = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
```

This patch fixes that now a warning, future error.

# Review

- ~[ ] Add a short description of the the change to the CHANGELOG.md file~ not necessary I guess
