### PR TITLE
Add cache back via sccache

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,12 +119,12 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}-v1
       # Install sccache
       - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ matrix.build }}-${{ matrix.target }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+          key: ${{ matrix.build }}-${{ matrix.target }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
       - name: Install sccache
         run: |
           if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux, macos, macos-arm64, windows, linux-aarch64]
+        build: [linux-x64, macos-x64, macos-arm64, windows-x64, linux-aarch64]
         include:
           - build: linux-x64
             os: ubuntu-18.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,7 @@ jobs:
           - build: linux
             os: ubuntu-18.04
             rust: 1.47.0
+            target: x86_64-unknown-linux-gnu
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
@@ -50,6 +51,7 @@ jobs:
           - build: macos
             os: macos-latest
             rust: 1.47.0
+            target: x86_64-apple-darwin
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
@@ -69,6 +71,7 @@ jobs:
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
             rust: 1.47.0
+            target: aarch64-unknown-linux-gnu
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-aarch64.tar.gz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,14 +40,14 @@ jobs:
       matrix:
         build: [linux, macos, macos-arm64, windows, linux-aarch64]
         include:
-          - build: linux
+          - build: linux-x64
             os: ubuntu-18.04
             rust: 1.47.0
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_integration_tests: true
-          - build: macos
+          - build: macos-x64
             os: macos-latest
             rust: 1.47.0
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/darwin-amd64.tar.gz'
@@ -59,7 +59,7 @@ jobs:
             rust: nightly
             target: aarch64-apple-darwin
             artifact_name: 'wasmer-darwin-arm64'
-          - build: windows
+          - build: windows-x64
             os: windows-latest
             rust: 1.47.0
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/windows-amd64.tar.gz'
@@ -116,12 +116,12 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}
       # Install sccache
       - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+          key: ${{ matrix.build }}-${{ matrix.target }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
           if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
@@ -140,8 +140,8 @@ jobs:
           netstat -aln | awk '
             $6 == "LISTEN" {
               if ($4 ~ "[.:][0-9]+$") {
-                split($4, a, /[:.]/);
-                port = a[length(a)];
+                n = split($4, a, /[:.]/);
+                port = a[n];
                 p[port] = 1
               }
             }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,6 @@ jobs:
           - build: linux
             os: ubuntu-18.04
             rust: 1.47.0
-            target: x86_64-unknown-linux-gnu
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
@@ -51,7 +50,6 @@ jobs:
           - build: macos
             os: macos-latest
             rust: 1.47.0
-            target: x86_64-apple-darwin
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
@@ -70,8 +68,8 @@ jobs:
             run_integration_tests: true
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
+            random_sccache_port: true
             rust: 1.47.0
-            target: aarch64-unknown-linux-gnu
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-aarch64.tar.gz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false
@@ -139,12 +137,26 @@ jobs:
         if: matrix.target
       - name: Set sccache port
         run: |
-          echo "SCCACHE_SERVER_PORT=9000" >> $GITHUB_ENV
-        if: matrix.build != 'linux-aarch64'
+          netstat -aln | awk '
+            $6 == "LISTEN" {
+              if ($4 ~ "[.:][0-9]+$") {
+                split($4, a, /[:.]/);
+                port = a[length(a)];
+                p[port] = 1
+              }
+            }
+            END {
+              for (i = 3000; i < 65000 && p[i]; i++){};
+              if (i == 65000) {exit 1};
+              print "SCCACHE_SERVER_PORT=" i
+            }
+          ' >> $GITHUB_ENV
+          # echo "SCCACHE_SERVER_PORT=9000"
+          echo "Setting random sccache port to: $SCCACHE_SERVER_PORT"
+        if: matrix.random_sccache_port
         shell: bash
       - name: Start sccache
         run: |
-          echo "Running sccache on port: $SCCACHE_SERVER_PORT"
           chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,6 +134,7 @@ jobs:
           if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
           fi
+        shell: bash
       - name: Start sccache
         run: |
           echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -118,11 +118,17 @@ jobs:
         run: |
           brew install automake
         if: matrix.os == 'macos-latest' || matrix.os == 'macos-11.0'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       # Install sccache
-      - uses: actions/cache@master
+      - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
-          key: cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+          key: ${{ runner.os }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
           echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -131,10 +131,10 @@ jobs:
           key: ${{ runner.os }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
-          echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH
-          cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
+          [ -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ] || cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
       - name: Start sccache
         run: |
+          echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
           echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -131,7 +131,9 @@ jobs:
           key: ${{ matrix.os }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
-          [ -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ] || cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
+          fi
       - name: Start sccache
         run: |
           echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ matrix.os }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+          key: ${{ matrix.os }}-${{ matrix.target }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
           if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,7 @@ jobs:
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false
     env:
-      CARGO_SCCACHE_VERSION: 0.2.13
+      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
       SCCACHE_AZURE_BLOB_CONTAINER: wasmerstoragesccacheblob
       SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
     steps:
@@ -118,6 +118,20 @@ jobs:
         run: |
           brew install automake
         if: matrix.os == 'macos-latest' || matrix.os == 'macos-11.0'
+      # Install sccache
+      - uses: actions/cache@master
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache
+          key: cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+      - name: Install sccache
+        run: |
+          echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH
+          cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
+      - name: Start sccache
+        run: |
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sscache -s
+          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       - name: Test
         run: |
           make test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -90,14 +90,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - name: Setup Rust target
-        run: |
-          cat << EOF > .cargo/config.toml
-          [build]
-          target = "${{ matrix.target }}"
-          EOF
-        if: matrix.target
-      #- uses: Swatinem/rust-cache@v1
       - name: Install LLVM (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd
@@ -135,6 +127,13 @@ jobs:
             cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache
           fi
         shell: bash
+      - name: Setup Rust target
+        run: |
+          cat << EOF > .cargo/config.toml
+          [build]
+          target = "${{ matrix.target }}"
+          EOF
+        if: matrix.target
       - name: Start sccache
         run: |
           echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -134,9 +134,13 @@ jobs:
           target = "${{ matrix.target }}"
           EOF
         if: matrix.target
+      - name: Set sccache port
+        run: |
+          echo "SCCACHE_SERVER_PORT=$RANDOM" >> $GITHUB_ENV
+        shell: bash
       - name: Start sccache
         run: |
-          echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH
+          echo "Running sccache in port: $SCCACHE_SERVER_PORT"
           chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -137,6 +137,7 @@ jobs:
       - name: Start sccache
         run: |
           echo "${{ runner.tool_cache }}/cargo-sccache/bin" >> $GITHUB_PATH
+          chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
           echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ matrix.os }}-${{ matrix.target }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
           if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: Set sccache port
         run: |
           echo "SCCACHE_SERVER_PORT=9000" >> $GITHUB_ENV
-        if: ${{ matrix.build }} != 'linux-aarch64'
+        if: matrix.build != 'linux-aarch64'
         shell: bash
       - name: Start sccache
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Start sccache
         run: |
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
-          ${{ runner.tool_cache }}/cargo-sccache/bin/sscache -s
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
           echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       - name: Test
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ runner.os }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
+          key: ${{ matrix.os }}-cargo-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}
       - name: Install sccache
         run: |
           [ -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ] || cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client,azure --root ${{ runner.tool_cache }}/cargo-sccache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -110,6 +110,9 @@ jobs:
       - name: Set up dependencies for Mac OS
         run: |
           brew install automake
+          # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
+          brew install gnu-tar
+          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest' || matrix.os == 'macos-11.0'
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -142,6 +142,7 @@ jobs:
       - name: Start sccache
         run: |
           echo "Running sccache on port: $SCCACHE_SERVER_PORT"
+          chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
           echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,12 +136,12 @@ jobs:
         if: matrix.target
       - name: Set sccache port
         run: |
-          echo "SCCACHE_SERVER_PORT=$RANDOM" >> $GITHUB_ENV
+          echo "SCCACHE_SERVER_PORT=9000" >> $GITHUB_ENV
+        if: ${{ matrix.build }} != 'linux-aarch64'
         shell: bash
       - name: Start sccache
         run: |
-          echo "Running sccache in port: $SCCACHE_SERVER_PORT"
-          chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+          echo "Running sccache on port: $SCCACHE_SERVER_PORT"
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
           echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -118,7 +118,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}
       # Install sccache
       - uses: actions/cache@v2
         with:

--- a/bors.toml
+++ b/bors.toml
@@ -1,10 +1,10 @@
 status = [
     "Audit",
     "Code lint",
-    "Test on linux",
+    "Test on linux-x64",
     "Test on linux-aarch64",
-    "Test on macos",
-    "Test on windows",
+    "Test on macos-x64",
+    "Test on windows-x64",
     "Test cross-compile on linux",
     "Test cross-compile on macos",
 ]


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR aims to improve compilation times by caching via sccache.
We are using paritytech's sccache as is more updated than mozilla's one.

I considered other options such as:
* Using Github Actions cache for target: discarded because the limit is 5Gb and given the multiple OSs used, in my local folder a clean cache is ~700Mb (just with cranelift)... estimated ~1-2Gb with all compilers included.