### PR TITLE
Remove use of `unsafe` by making the types match.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ endif
 update-testsuite:
 	git subtree pull --prefix tests/wast/spec https://github.com/WebAssembly/testsuite.git master --squash
 
-RUSTFLAGS := "-D dead-code -D nonstandard-style -D unused-imports -D unused-mut -D unused-variables -D unused-unsafe -D unreachable-patterns -D bad-style -D improper-ctypes -D unused-allocation -D unused-comparisons -D while-true -D unconditional-recursion -D bare-trait-objects" # TODO: add `-D missing-docs`
+RUSTFLAGS := "-D dead-code -D nonstandard-style -D unused-imports -D unused-mut -D unused-variables -D unused-unsafe -D unreachable-patterns -D bad-style -D improper-ctypes -D unused-allocation -D unused-comparisons -D while-true -D unconditional-recursion -D bare-trait-objects -D function_item_references" # TODO: add `-D missing-docs`
 lint:
 	cargo fmt --all -- --check
 	RUSTFLAGS=${RUSTFLAGS} cargo clippy $(compiler_features)

--- a/tests/lib/engine-dummy/src/artifact.rs
+++ b/tests/lib/engine-dummy/src/artifact.rs
@@ -15,8 +15,8 @@ use wasmer_types::{
     TableIndex,
 };
 use wasmer_vm::{
-    FunctionBodyPtr, MemoryStyle, ModuleInfo, TableStyle, VMContext, VMSharedSignatureIndex,
-    VMTrampoline,
+    FunctionBodyPtr, MemoryStyle, ModuleInfo, TableStyle, VMContext, VMFunctionBody,
+    VMSharedSignatureIndex, VMTrampoline,
 };
 
 /// Serializable struct for the artifact
@@ -45,6 +45,14 @@ pub struct DummyArtifact {
 
 extern "C" fn dummy_function(_context: *mut VMContext) {
     panic!("Dummy engine can't generate functions")
+}
+
+extern "C" fn dummy_trampoline(
+    _context: *mut VMContext,
+    _callee: *const VMFunctionBody,
+    _values: *mut u128,
+) {
+    panic!("Dummy engine can't generate trampolines")
 }
 
 impl DummyArtifact {
@@ -141,7 +149,7 @@ impl DummyArtifact {
         // We prepare the pointers for the finished function call trampolines.
         let finished_function_call_trampolines: PrimaryMap<SignatureIndex, VMTrampoline> = (0
             ..metadata.module.signatures.len())
-            .map(|_| unsafe { std::mem::transmute::<_, VMTrampoline>(&dummy_function) })
+            .map(|_| dummy_trampoline as VMTrampoline)
             .collect::<PrimaryMap<_, _>>();
 
         // We prepare the pointers for the finished dynamic function trampolines.


### PR DESCRIPTION
The dummy functions are never actually called.

Fixes a warning while building:
```
warning: taking a reference to a function item does not give a function pointer
   --> tests/lib/engine-dummy/src/artifact.rs:144:70
    |
144 |             .map(|_| unsafe { std::mem::transmute::<_, VMTrampoline>(&dummy_function) })
    |                                                                      ^^^^^^^^^^^^^^^ help: cast `dummy_function` to obtain a function pointer: `dummy_function as extern "C" fn(_)`
    |
    = note: `#[warn(function_item_references)]` on by default

warning: 1 warning emitted

```
