### PR TITLE
Add missing re-exports CompileError, WasmError and ParseCpuFeatureError

### DIFF
--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -77,7 +77,9 @@ pub use target_lexicon::{Architecture, CallingConvention, OperatingSystem, Tripl
 pub use wasmer_compiler::{
     wasmparser, CompilerConfig, FunctionMiddleware, MiddlewareReaderState, ModuleMiddleware,
 };
-pub use wasmer_compiler::{CpuFeature, Features, Target};
+pub use wasmer_compiler::{
+    CompileError, CpuFeature, Features, ParseCpuFeatureError, Target, WasmError,
+};
 pub use wasmer_engine::{
     ChainableNamedResolver, DeserializeError, Engine, Export, FrameInfo, LinkError, NamedResolver,
     NamedResolverChain, Resolver, RuntimeError, SerializeError,


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

- `ParseCpuFeatureError` belongs to `wasmer::CpuFeature`
- `CompileError` and `WasmError` belong to `wasmer::Module::new`

I wonder if `WasmResult` should be re-exported as well. I did not easily find an API in `wasmer::`, which returns it.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
