### PR TITLE
Update lint to use the same Rust version as CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.46.0
+          toolchain: 1.47.0
           override: true
           components: rustfmt, clippy
       - run: make lint

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -144,23 +144,19 @@ impl CompilerOptions {
                     .engine(),
             ),
             #[cfg(feature = "native")]
-            EngineType::Native => {
-                Box::new(
-                    wasmer_engine_native::Native::new(compiler_config)
-                        .target(target)
-                        .features(features)
-                        .engine(),
-                )
-            }
+            EngineType::Native => Box::new(
+                wasmer_engine_native::Native::new(compiler_config)
+                    .target(target)
+                    .features(features)
+                    .engine(),
+            ),
             #[cfg(feature = "object-file")]
-            EngineType::ObjectFile => {
-                Box::new(
-                    wasmer_engine_object_file::ObjectFile::new(compiler_config)
-                        .target(target)
-                        .features(features)
-                        .engine(),
-                )
-            }
+            EngineType::ObjectFile => Box::new(
+                wasmer_engine_object_file::ObjectFile::new(compiler_config)
+                    .target(target)
+                    .features(features)
+                    .engine(),
+            ),
             #[cfg(not(all(feature = "jit", feature = "native", feature = "object-file")))]
             engine => bail!(
                 "The `{}` engine is not included in this binary.",


### PR DESCRIPTION
Forgot to this when bumping the version we use in CI, ran into an issue in a PR I'm working on, this will fix it
