### PR TITLE
Add UnsupportedTarget error to compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,6 +2595,7 @@ dependencies = [
  "rayon",
  "serde",
  "smallvec",
+ "target-lexicon",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -25,6 +25,9 @@ lazy_static = "1.4"
 byteorder = "1.3"
 smallvec = "1.5"
 
+[dev-dependencies]
+target-lexicon = { version = "0.11", default-features = false }
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -176,6 +176,7 @@ fn to_compile_error<T: ToCompileError>(x: T) -> CompileError {
 mod tests {
     use super::*;
     use std::str::FromStr;
+    use target_lexicon::triple;
     use wasmer_compiler::{CpuFeature, Features, Triple};
     use wasmer_vm::{MemoryStyle, TableStyle};
 
@@ -200,10 +201,7 @@ mod tests {
         let compiler = SinglepassCompiler::new(Singlepass::default());
 
         // Compile for win64
-        let win64 = Target::new(
-            Triple::from_str("x86_64-pc-windows-msvc").unwrap(),
-            CpuFeature::for_host(),
-        );
+        let win64 = Target::new(triple!("x86_64-pc-windows-msvc"), CpuFeature::for_host());
         let (mut info, translation, inputs) = dummy_compilation_ingredients();
         let result = compiler.compile_module(&win64, &mut info, &translation, inputs);
         match result.unwrap_err() {
@@ -212,10 +210,7 @@ mod tests {
         };
 
         // Compile for 32bit Linux
-        let linux32 = Target::new(
-            Triple::from_str("i686-unknown-linux-gnu").unwrap(),
-            CpuFeature::for_host(),
-        );
+        let linux32 = Target::new(triple!("i686-unknown-linux-gnu"), CpuFeature::for_host());
         let (mut info, translation, inputs) = dummy_compilation_ingredients();
         let result = compiler.compile_module(&linux32, &mut info, &translation, inputs);
         match result.unwrap_err() {
@@ -224,10 +219,7 @@ mod tests {
         };
 
         // Compile for win32
-        let win32 = Target::new(
-            Triple::from_str("i686-pc-windows-gnu").unwrap(),
-            CpuFeature::for_host(),
-        );
+        let win32 = Target::new(triple!("i686-pc-windows-gnu"), CpuFeature::for_host());
         let (mut info, translation, inputs) = dummy_compilation_ingredients();
         let result = compiler.compile_module(&win32, &mut info, &translation, inputs);
         match result.unwrap_err() {

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -11,11 +11,11 @@ use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIter
 use std::sync::Arc;
 use wasmer_compiler::wasmparser::BinaryReaderError;
 use wasmer_compiler::TrapInformation;
-use wasmer_compiler::{Compilation, CompileError, CompiledFunction, Compiler, SectionIndex};
 use wasmer_compiler::{
-    CompileModuleInfo, CompilerConfig, MiddlewareBinaryReader, ModuleMiddlewareChain,
-    ModuleTranslationState, Target,
+    Architecture, CompileModuleInfo, CompilerConfig, MiddlewareBinaryReader, ModuleMiddlewareChain,
+    ModuleTranslationState, OperatingSystem, Target,
 };
+use wasmer_compiler::{Compilation, CompileError, CompiledFunction, Compiler, SectionIndex};
 use wasmer_compiler::{FunctionBody, FunctionBodyData};
 use wasmer_types::entity::{EntityRef, PrimaryMap};
 use wasmer_types::{FunctionIndex, FunctionType, LocalFunctionIndex, MemoryIndex, TableIndex};
@@ -44,11 +44,19 @@ impl Compiler for SinglepassCompiler {
     /// associated relocations.
     fn compile_module(
         &self,
-        _target: &Target,
+        target: &Target,
         compile_info: &mut CompileModuleInfo,
         _module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
     ) -> Result<Compilation, CompileError> {
+        if target.triple().operating_system == OperatingSystem::Windows {
+            return Err(CompileError::UnsupportedTarget(
+                OperatingSystem::Windows.to_string(),
+            ));
+        }
+        if let Architecture::X86_32(arch) = target.triple().architecture {
+            return Err(CompileError::UnsupportedTarget(arch.to_string()));
+        }
         if compile_info.features.multi_value {
             return Err(CompileError::UnsupportedFeature("multivalue".to_string()));
         }
@@ -162,4 +170,69 @@ impl ToCompileError for CodegenError {
 
 fn to_compile_error<T: ToCompileError>(x: T) -> CompileError {
     x.to_compile_error()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use wasmer_compiler::{CpuFeature, Features, Triple};
+    use wasmer_vm::{MemoryStyle, TableStyle};
+
+    fn dummy_compilation_ingredients<'a>() -> (
+        CompileModuleInfo,
+        ModuleTranslationState,
+        PrimaryMap<LocalFunctionIndex, FunctionBodyData<'a>>,
+    ) {
+        let compile_info = CompileModuleInfo {
+            features: Features::new(),
+            module: Arc::new(ModuleInfo::new()),
+            memory_styles: PrimaryMap::<MemoryIndex, MemoryStyle>::new(),
+            table_styles: PrimaryMap::<TableIndex, TableStyle>::new(),
+        };
+        let module_translation = ModuleTranslationState::new();
+        let function_body_inputs = PrimaryMap::<LocalFunctionIndex, FunctionBodyData<'_>>::new();
+        (compile_info, module_translation, function_body_inputs)
+    }
+
+    #[test]
+    fn errors_for_unsupported_targets() {
+        let compiler = SinglepassCompiler::new(Singlepass::default());
+
+        // Compile for win64
+        let win64 = Target::new(
+            Triple::from_str("x86_64-pc-windows-msvc").unwrap(),
+            CpuFeature::for_host(),
+        );
+        let (mut info, translation, inputs) = dummy_compilation_ingredients();
+        let result = compiler.compile_module(&win64, &mut info, &translation, inputs);
+        match result.unwrap_err() {
+            CompileError::UnsupportedTarget(name) => assert_eq!(name, "windows"),
+            error => panic!("Unexpected error: {:?}", error),
+        };
+
+        // Compile for 32bit Linux
+        let linux32 = Target::new(
+            Triple::from_str("i686-unknown-linux-gnu").unwrap(),
+            CpuFeature::for_host(),
+        );
+        let (mut info, translation, inputs) = dummy_compilation_ingredients();
+        let result = compiler.compile_module(&linux32, &mut info, &translation, inputs);
+        match result.unwrap_err() {
+            CompileError::UnsupportedTarget(name) => assert_eq!(name, "i686"),
+            error => panic!("Unexpected error: {:?}", error),
+        };
+
+        // Compile for win32
+        let win32 = Target::new(
+            Triple::from_str("i686-pc-windows-gnu").unwrap(),
+            CpuFeature::for_host(),
+        );
+        let (mut info, translation, inputs) = dummy_compilation_ingredients();
+        let result = compiler.compile_module(&win32, &mut info, &translation, inputs);
+        match result.unwrap_err() {
+            CompileError::UnsupportedTarget(name) => assert_eq!(name, "windows"), // Windows should be checked before architecture
+            error => panic!("Unexpected error: {:?}", error),
+        };
+    }
 }

--- a/lib/compiler/src/error.rs
+++ b/lib/compiler/src/error.rs
@@ -32,6 +32,11 @@ pub enum CompileError {
     #[cfg_attr(feature = "std", error("Feature {0} is not yet supported"))]
     UnsupportedFeature(String),
 
+    /// The compiler cannot compile for the given target.
+    /// This can refer to the OS, the chipset or any other aspect of the target system.
+    #[cfg_attr(feature = "std", error("The target {0} is not yet supported (see https://docs.wasmer.io/ecosystem/wasmer/wasmer-features)"))]
+    UnsupportedTarget(String),
+
     /// Insufficient resources available for execution.
     #[cfg_attr(feature = "std", error("Insufficient resources: {0}"))]
     Resource(String),


### PR DESCRIPTION
Closes #1878

# Description

We can error early on for system combinations that are known to not work. This gives users a much better idea why things error and allows adapting the strategy without investing lots of time in debugging.

The different behaviour is tested here:
- **Old:** _RuntimeErr { msg: "Wasmer runtime error: RuntimeError: call stack exhausted" }_
  (CI job "Contract Development / Windows (pull_request)" in https://github.com/CosmWasm/cosmwasm/pull/504)
- **New:** _CompileErr { msg: "Could not compile: The target windows is not yet supported (see https://docs.wasmer.io/ecosystem/wasmer/wasmer-features)" }_
  (CI job "Contract Development / Windows (pull_request)" in https://github.com/CosmWasm/cosmwasm/pull/648)

Something that is not yet clear to me is if `target` is the proper OS source information and if the `Compiler` supports cross compilation where compile evironment is different from runtime environment.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
