### PR TITLE
Expose wasmer::{CraneliftOptLevel, LLVMOptLevel}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## **[Unreleased]**
 
+### Added
+
+* [#1894](https://github.com/wasmerio/wasmer/pull/1894) Added exports `wasmer::{CraneliftOptLevel, LLVMOptLevel}` to allow using `Cranelift::opt_level` and `LLVM::opt_level` directly via the `wasmer` crate
+
+### Changed
+
+### Fixed
+
 ## 1.0.0-beta2 - 2020-12-16
 
 ### Added

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -355,7 +355,7 @@ let store = Store::new(&engine);
 pub use wasmer_compiler_singlepass::Singlepass;
 
 #[cfg(feature = "cranelift")]
-pub use wasmer_compiler_cranelift::Cranelift;
+pub use wasmer_compiler_cranelift::{Cranelift, CraneliftOptLevel};
 
 #[cfg(feature = "llvm")]
 pub use wasmer_compiler_llvm::LLVM;

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -358,7 +358,7 @@ pub use wasmer_compiler_singlepass::Singlepass;
 pub use wasmer_compiler_cranelift::{Cranelift, CraneliftOptLevel};
 
 #[cfg(feature = "llvm")]
-pub use wasmer_compiler_llvm::LLVM;
+pub use wasmer_compiler_llvm::{LLVMOptLevel, LLVM};
 
 #[cfg(feature = "jit")]
 pub use wasmer_engine_jit::{JITArtifact, JITEngine, JIT};

--- a/lib/compiler-cranelift/src/config.rs
+++ b/lib/compiler-cranelift/src/config.rs
@@ -11,7 +11,7 @@ use wasmer_compiler::{
 /// Possible optimization levels for the Cranelift codegen backend.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
-pub enum OptLevel {
+pub enum CraneliftOptLevel {
     /// No optimizations performed, minimizes compilation time by disabling most
     /// optimizations.
     None,
@@ -33,7 +33,7 @@ pub struct Cranelift {
     enable_verifier: bool,
     enable_simd: bool,
     enable_pic: bool,
-    opt_level: OptLevel,
+    opt_level: CraneliftOptLevel,
     /// The middleware chain.
     pub(crate) middlewares: Vec<Arc<dyn ModuleMiddleware>>,
 }
@@ -45,7 +45,7 @@ impl Cranelift {
         Self {
             enable_nan_canonicalization: false,
             enable_verifier: false,
-            opt_level: OptLevel::Speed,
+            opt_level: CraneliftOptLevel::Speed,
             enable_pic: false,
             enable_simd: true,
             middlewares: vec![],
@@ -68,7 +68,7 @@ impl Cranelift {
     }
 
     /// The optimization levels when optimizing the IR.
-    pub fn opt_level(&mut self, opt_level: OptLevel) -> &mut Self {
+    pub fn opt_level(&mut self, opt_level: CraneliftOptLevel) -> &mut Self {
         self.opt_level = opt_level;
         self
     }
@@ -156,9 +156,9 @@ impl Cranelift {
             "none"
         } else {
             match self.opt_level {
-                OptLevel::None => "none",
-                OptLevel::Speed => "speed",
-                OptLevel::SpeedAndSize => "speed_and_size",
+                CraneliftOptLevel::None => "none",
+                CraneliftOptLevel::Speed => "speed",
+                CraneliftOptLevel::SpeedAndSize => "speed_and_size",
             }
         };
 

--- a/lib/compiler-cranelift/src/lib.rs
+++ b/lib/compiler-cranelift/src/lib.rs
@@ -56,7 +56,7 @@ mod trampoline;
 mod translator;
 
 pub use crate::compiler::CraneliftCompiler;
-pub use crate::config::Cranelift;
+pub use crate::config::{Cranelift, CraneliftOptLevel};
 pub use crate::debug::{ModuleInfoMemoryOffset, ModuleInfoVmctxInfo, ValueLabelsRanges};
 pub use crate::trampoline::make_trampoline_function_call;
 

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -3,7 +3,7 @@ use inkwell::targets::{
     CodeModel, InitializationConfig, RelocMode, Target as InkwellTarget, TargetMachine,
     TargetTriple,
 };
-use inkwell::OptimizationLevel;
+pub use inkwell::OptimizationLevel as LLVMOptLevel;
 use itertools::Itertools;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -41,7 +41,7 @@ pub trait LLVMCallbacks: Debug + Send + Sync {
 pub struct LLVM {
     pub(crate) enable_nan_canonicalization: bool,
     pub(crate) enable_verifier: bool,
-    pub(crate) opt_level: OptimizationLevel,
+    pub(crate) opt_level: LLVMOptLevel,
     is_pic: bool,
     pub(crate) callbacks: Option<Arc<dyn LLVMCallbacks>>,
     /// The middleware chain.
@@ -55,7 +55,7 @@ impl LLVM {
         Self {
             enable_nan_canonicalization: false,
             enable_verifier: false,
-            opt_level: OptimizationLevel::Aggressive,
+            opt_level: LLVMOptLevel::Aggressive,
             is_pic: false,
             callbacks: None,
             middlewares: vec![],
@@ -72,7 +72,7 @@ impl LLVM {
     }
 
     /// The optimization levels when optimizing the IR.
-    pub fn opt_level(&mut self, opt_level: OptimizationLevel) -> &mut Self {
+    pub fn opt_level(&mut self, opt_level: LLVMOptLevel) -> &mut Self {
         self.opt_level = opt_level;
         self
     }

--- a/lib/compiler-llvm/src/lib.rs
+++ b/lib/compiler-llvm/src/lib.rs
@@ -22,4 +22,6 @@ mod trampoline;
 mod translator;
 
 pub use crate::compiler::LLVMCompiler;
-pub use crate::config::{CompiledKind, InkwellMemoryBuffer, InkwellModule, LLVMCallbacks, LLVM};
+pub use crate::config::{
+    CompiledKind, InkwellMemoryBuffer, InkwellModule, LLVMCallbacks, LLVMOptLevel, LLVM,
+};


### PR DESCRIPTION
# Description

This is required to do something like

```rust
use wasmer::{Cranelift, CraneliftOptLevel};

let mut compiler = Cranelift::default();
compiler.opt_level(CraneliftOptLevel::None);
let engine = JIT::new(compiler).engine();
// ...
```

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
