### PR TITLE
Fix use-after free with `NativeFunc`

### DIFF
--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -673,9 +673,7 @@ impl Function {
 
         Ok(NativeFunc::new(
             self.store.clone(),
-            self.exported.vm_function.address,
-            self.exported.vm_function.vmctx,
-            self.exported.vm_function.kind,
+            self.exported.clone(),
             self.definition.clone(),
         ))
     }

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -933,6 +933,7 @@ impl Drop for InstanceAllocator {
         // > "acquire" operation before deleting the object.
         //
         // [1]: https://www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html
+        dbg!("Freeing instance allocator");
         atomic::fence(atomic::Ordering::Acquire);
 
         // Now we can deallocate the instance. Note that we don't

--- a/lib/vm/src/instance.rs
+++ b/lib/vm/src/instance.rs
@@ -933,7 +933,6 @@ impl Drop for InstanceAllocator {
         // > "acquire" operation before deleting the object.
         //
         // [1]: https://www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html
-        dbg!("Freeing instance allocator");
         atomic::fence(atomic::Ordering::Acquire);
 
         // Now we can deallocate the instance. Note that we don't


### PR DESCRIPTION
Prior to this change, `NativeFunc` didn't keep the `Instance` alive.

This PR does the simple thing of storing `ExportFunction` in `NativeFunc`: this stores data isn't strictly necessary for `NativeFunc` and can be optimized to only include a subset of the fields of `ExportFunction`, however we would need better test coverage to ensure the transformation into and out of `NativeFunc` still works as expected.  I think it's a reasonable trade off to just store `ExportFunction` directly as it solves a lot of problems and is a very simple solution.

Note: The new indirect field accesses may slow down `call` on `NativeFunc`, this is overhead that may be worth avoiding by duplicating these fields in `NativeFunc`. I'll investigate that and write about it here.

I've benchmarked it and it seems that there is no overhead from the indirect field accesses.