### PR TITLE
Allow constructing V128 from byte array

### DIFF
--- a/lib/compiler/src/translator/sections.rs
+++ b/lib/compiler/src/translator/sections.rs
@@ -239,9 +239,7 @@ pub fn parse_global_section(
             Operator::I64Const { value } => GlobalInit::I64Const(value),
             Operator::F32Const { value } => GlobalInit::F32Const(f32::from_bits(value.bits())),
             Operator::F64Const { value } => GlobalInit::F64Const(f64::from_bits(value.bits())),
-            Operator::V128Const { value } => {
-                GlobalInit::V128Const(V128::from(value.bytes().to_vec().as_slice()))
-            }
+            Operator::V128Const { value } => GlobalInit::V128Const(V128::from(*value.bytes())),
             Operator::RefNull { ty: _ } => GlobalInit::RefNullConst,
             Operator::RefFunc { function_index } => {
                 GlobalInit::RefFunc(FunctionIndex::from_u32(function_index))

--- a/lib/wasmer-types/src/types.rs
+++ b/lib/wasmer-types/src/types.rs
@@ -82,6 +82,12 @@ impl V128 {
     }
 }
 
+impl From<[u8; 16]> for V128 {
+    fn from(array: [u8; 16]) -> Self {
+        Self(array)
+    }
+}
+
 impl From<&[u8]> for V128 {
     fn from(slice: &[u8]) -> Self {
         assert_eq!(slice.len(), 16);


### PR DESCRIPTION
# Description

V128 stores 16 bytes fixed length. Constructing it from `&[u8]` turns compile-time checks into a runtime assertion, which is not ideal I guess.

With this new constructor we save a vector allocation and imcrease readability.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
