### PR TITLE
Handle overflow errors in Bytes -> Pages conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - [#1870](https://github.com/wasmerio/wasmer/pull/1870) Fixed Trap instruction address maps in Singlepass
+* [#1914](https://github.com/wasmerio/wasmer/pull/1914) Implemented `TryFrom<Bytes> for Pages` instead of `From<Bytes> for Pages` to properly handle overflow errors
 
 ## 1.0.0-beta1 - 2020-12-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,6 +2723,7 @@ version = "1.0.0-beta1"
 dependencies = [
  "cranelift-entity 0.68.0",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -318,7 +318,7 @@ impl Memory for LinearMemory {
         unsafe {
             let md_ptr = self.get_vm_memory_definition();
             let md = md_ptr.as_ref();
-            Bytes::from(md.current_length).into()
+            Bytes::from(md.current_length).try_into().unwrap()
         }
     }
 
@@ -376,7 +376,7 @@ impl Memory for LinearMemory {
                     .checked_add(guard_bytes)
                     .ok_or_else(|| MemoryError::CouldNotGrow {
                         current: new_pages,
-                        attempted_delta: Bytes(guard_bytes).into(),
+                        attempted_delta: Bytes(guard_bytes).try_into().unwrap(),
                     })?;
 
             let mut new_mmap =

--- a/lib/wasmer-types/Cargo.toml
+++ b/lib/wasmer-types/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 # some useful data structures
 cranelift-entity = "0.68"
 serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }
+thiserror = "1.0"
 
 [features]
 default = ["std", "enable-serde"]

--- a/lib/wasmer-types/src/lib.rs
+++ b/lib/wasmer-types/src/lib.rs
@@ -77,7 +77,9 @@ pub use crate::initializers::{
 pub use crate::memory_view::{Atomically, MemoryView};
 pub use crate::native::{NativeWasmType, ValueType};
 pub use crate::r#ref::{ExternRef, HostInfo, HostRef};
-pub use crate::units::{Bytes, Pages, WASM_MAX_PAGES, WASM_MIN_PAGES, WASM_PAGE_SIZE};
+pub use crate::units::{
+    Bytes, PageCountOutOfRange, Pages, WASM_MAX_PAGES, WASM_MIN_PAGES, WASM_PAGE_SIZE,
+};
 pub use crate::values::Value;
 pub use types::{
     ExportType, ExternType, FunctionType, GlobalInit, GlobalType, ImportType, MemoryType,


### PR DESCRIPTION
# Description

Before the Bytes to Pages conversion silently returned wrong results when the number of pages was too large.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
