### PR TITLE
lib: api; native remove unused, engine; add dead_code

### DIFF
--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -13,12 +13,12 @@ use crate::externals::function::{
     FunctionDefinition, HostFunctionDefinition, VMDynamicFunction, VMDynamicFunctionWithEnv,
     VMDynamicFunctionWithoutEnv, WasmFunctionDefinition,
 };
-use crate::{FromToNativeWasmType, Function, FunctionType, RuntimeError, Store, WasmTypeList};
+use crate::{FromToNativeWasmType, Function, RuntimeError, Store, WasmTypeList};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use wasmer_engine::ExportFunction;
 use wasmer_types::NativeWasmType;
 use wasmer_vm::{
-    VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
+    VMDynamicFunctionContext, VMFunctionBody, VMFunctionEnvironment,
     VMFunctionKind,
 };
 

--- a/lib/engine-object-file/src/artifact.rs
+++ b/lib/engine-object-file/src/artifact.rs
@@ -42,10 +42,12 @@ pub struct ObjectFileArtifact {
     symbol_registry: ModuleMetadataSymbolRegistry,
 }
 
+#[allow(dead_code)]
 fn to_compile_error(err: impl Error) -> CompileError {
     CompileError::Codegen(format!("{}", err))
 }
 
+#[allow(dead_code)]
 const WASMER_METADATA_SYMBOL: &[u8] = b"WASMER_METADATA";
 
 impl ObjectFileArtifact {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

Remove warnings when run `cargo test`

```

warning: unused import: `FunctionType`
  --> lib/api/src/native.rs:16:45
   |
16 | use crate::{FromToNativeWasmType, Function, FunctionType, RuntimeError, Store, WasmTypeList};
   |                                             ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `VMExportFunction`
  --> lib/api/src/native.rs:21:31
   |
21 |     VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
   |              


warning: unused import: `FunctionType`
  --> lib/api/src/native.rs:16:45
   |
16 | use crate::{FromToNativeWasmType, Function, FunctionType, RuntimeError, Store, WasmTypeList};
   |                                             ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `VMExportFunction`
  --> lib/api/src/native.rs:21:31
   |
21 |     VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
   |              

```


# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
