### PR TITLE
Use memmap2 in deserialize_from_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#1867](https://github.com/wasmerio/wasmer/pull/1867) Added `Metering::get_remaining_points` and `Metering::set_remaining_points` 
 * [#1881](https://github.com/wasmerio/wasmer/pull/1881) Added `UnsupportedTarget` error to `CompileError`
 * [#1908](https://github.com/wasmerio/wasmer/pull/1908) Implemented `TryFrom<Value<T>>` for `i32`/`u32`/`i64`/`u64`/`f32`/`f64`
+* [#1927](https://github.com/wasmerio/wasmer/pull/1927) Added mmap support in `Engine::deserialize_from_file` to speed up artifact loading
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,6 @@ version = "1.0.0-beta1"
 dependencies = [
  "blake3",
  "hex",
- "memmap",
  "thiserror",
  "wasmer",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b70ca2a6103ac8b665dc150b142ef0e4e89df640c9e6cf295d189c3caebe5a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2621,7 @@ dependencies = [
  "backtrace",
  "bincode",
  "lazy_static",
+ "memmap2",
  "more-asserts",
  "rustc-demangle",
  "serde",

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 wasmer = { path = "../api", version = "1.0.0-beta1", default-features = false }
-memmap = "0.7"
 hex = "0.4"
 thiserror = "1"
 blake3 = "0.3"

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -18,6 +18,7 @@ target-lexicon = { version = "0.11", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"
 rustc-demangle = "0.1"
+memmap2 = "0.1.0"
 more-asserts = "0.2"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/lib/engine/src/engine.rs
+++ b/lib/engine/src/engine.rs
@@ -2,6 +2,7 @@
 
 use crate::tunables::Tunables;
 use crate::{Artifact, DeserializeError};
+use memmap2::Mmap;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
@@ -51,8 +52,9 @@ pub trait Engine {
         &self,
         file_ref: &Path,
     ) -> Result<Arc<dyn Artifact>, DeserializeError> {
-        let bytes = std::fs::read(file_ref)?;
-        self.deserialize(&bytes)
+        let file = std::fs::File::open(file_ref)?;
+        let mmap = Mmap::map(&file)?;
+        self.deserialize(&mmap)
     }
 
     /// A unique identifier for this object.


### PR DESCRIPTION
# Description

As discussed in https://github.com/CosmWasm/cosmwasm/pull/660, we might want to use memmap in deserialize_from_file to speed up artifact loading.

This uses the fork memmap2 because https://rustsec.org/advisories/RUSTSEC-2020-0077.html

~This is based on df3a21160a9a and a CHANGELOG entry is missing, but adding it now for visibility and testing.~

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
