### PR TITLE
Point to `native` versions of functions in Function docs

### DIFF
--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -69,6 +69,9 @@ pub struct Function {
 impl Function {
     /// Creates a new host `Function` (dynamic) with the provided signature.
     ///
+    /// If you know the signature of the host function at compile time,
+    /// consider using [`Function::new_native`] for less runtime overhead.
+    ///
     /// # Examples
     ///
     /// ```
@@ -133,6 +136,10 @@ impl Function {
     }
 
     /// Creates a new host `Function` (dynamic) with the provided signature and environment.
+    ///
+    /// If you know the signature of the host function at compile time,
+    /// consider using [`Function::new_native_with_env`] for less runtime
+    /// overhead.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
It's not obvious from looking at the docs for `Function` that there are native variants.  This PR makes it clear that when users are figuring out how to make functions that they're shown the `native` variants.