### PR TITLE
Provide an API for unchecked wasm calls and setting trap handlers manually

### DIFF
--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -325,7 +325,8 @@ pub mod vm {
     //! The vm module re-exports wasmer-vm types.
 
     pub use wasmer_vm::{
-        Memory, MemoryError, MemoryStyle, Table, TableStyle, VMMemoryDefinition, VMTableDefinition,
+        catch_traps, Memory, MemoryError, MemoryStyle, Table, TableStyle, VMFunctionEnvironment,
+        VMMemoryDefinition, VMTableDefinition,
     };
 }
 

--- a/lib/vm/src/trap/mod.rs
+++ b/lib/vm/src/trap/mod.rs
@@ -9,6 +9,6 @@ mod traphandlers;
 pub use trapcode::TrapCode;
 pub use traphandlers::{
     catch_traps, catch_traps_with_result, raise_lib_trap, raise_user_trap, wasmer_call_trampoline,
-    Trap,
+    wasmer_call_trampoline_unchecked, Trap,
 };
 pub use traphandlers::{init_traps, resume_panic};


### PR DESCRIPTION
# Description

This is an attempt to provide an API which allows reducing syscall overhead when calling a hot wasm function, as outlined in #1922  

# Review

- [ ] Expose `wasmer::vm::catch_traps` together with `{Function, NativeFunc}::{call_unchecked, get_vmctx}` to allow reducing syscall overhead when calling a hot wasm function.
