### PR TITLE
Allow using get_remaining_points/set_remaining_points without the Metering instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
+- [#1941](https://github.com/wasmerio/wasmer/pull/1941) Turn `get_remaining_points`/`set_remaining_points` of the `Metering` middleware into free functions to allow using them in an ahead-of-time compilation setup
+
 ### Fixed
 
 ## 1.0.0-beta2 - 2020-12-16

--- a/lib/middlewares/src/lib.rs
+++ b/lib/middlewares/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod metering;
 
+// The most commonly used symbol are exported at top level of the module. Others are available
+// via modules, e.g. `wasmer_middlewares::metering::get_remaining_points`
 pub use metering::Metering;


### PR DESCRIPTION
# Description

In order to be able to use `get_remaining_points`/`set_remaining_points` in an ahead of time compilation scenario, those should be acessible withouht the compile time tooling. It turns out this is easy since `&self` is never used anyways.

In this PR I turn them into free function. I tried static functions first (i.e. calls like `Metering::get_remaining_points(&instance)`), but this brings users in big trouble with respect to generic arguments of `struct Metering<F: Fn(&Operator) -> u64 + Copy + Clone + Send + Sync>`. We could use a different struct for namespacing purposes (e.g. `MeteringManager::get_remaining_points(&instance)`), but this feels like Java style.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
