### PR TITLE
Clean up host env code, add more `Send`, `Sync` bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#1894](https://github.com/wasmerio/wasmer/pull/1894) Added exports `wasmer::{CraneliftOptLevel, LLVMOptLevel}` to allow using `Cranelift::opt_level` and `LLVM::opt_level` directly via the `wasmer` crate
 
 ### Changed
+* [#1944](https://github.com/wasmerio/wasmer/pull/1944) Require `WasmerEnv` to be `Send + Sync` even in dynamic functions.
 
 ### Fixed
 

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -83,15 +83,15 @@ where
         )
     });
     let host_env_clone_fn: fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void = |ptr| {
-        let duped_env: Env = unsafe {
-            let ptr: *mut Env = ptr as _;
-            let item: &Env = &*ptr;
-            item.clone()
+        let env_ref: &Env = unsafe {
+            ptr.cast::<Env>()
+                .as_ref()
+                .expect("`ptr` to the environment is null when cloning it")
         };
-        Box::into_raw(Box::new(duped_env)) as _
+        Box::into_raw(Box::new(env_ref.clone())) as _
     };
-    let host_env_drop_fn: fn(*mut std::ffi::c_void) = |ptr: *mut std::ffi::c_void| {
-        unsafe { Box::from_raw(ptr as *mut Env) };
+    let host_env_drop_fn: fn(*mut std::ffi::c_void) = |ptr| {
+        unsafe { Box::from_raw(ptr.cast::<Env>()) };
     };
     let env = Box::into_raw(Box::new(env)) as _;
 

--- a/lib/deprecated/runtime-core/Cargo.lock
+++ b/lib/deprecated/runtime-core/Cargo.lock
@@ -1158,7 +1158,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "cfg-if 0.1.10",
  "indexmap",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "blake3",
  "hex",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "enumset",
  "raw-cpuid",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "byteorder",
  "cc",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "backtrace",
  "bincode",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-jit"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-native"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "object 0.22.0",
  "thiserror",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "backtrace",
  "cc",

--- a/lib/deprecated/runtime/Cargo.lock
+++ b/lib/deprecated/runtime/Cargo.lock
@@ -1158,7 +1158,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "cfg-if 0.1.10",
  "indexmap",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "blake3",
  "hex",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "enumset",
  "raw-cpuid",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "byteorder",
  "cc",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "backtrace",
  "bincode",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-jit"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-native"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "object 0.22.0",
  "thiserror",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "backtrace",
  "cc",


### PR DESCRIPTION
This PR contains:
- Code clean up, refactored the unsafe metadata creation into a function which can probably be safe
- Add `Send` + `Sync` bounds in some places where they should have been to begin with

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
