### PR TITLE
Get `multi.c` working in the Wasm C API

### DIFF
--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -11,6 +11,7 @@ pub use table::*;
 use wasmer::{Extern, Instance};
 
 #[allow(non_camel_case_types)]
+#[derive(Clone)]
 pub struct wasm_extern_t {
     // this is how we ensure the instance stays alive
     pub(crate) instance: Option<Arc<Instance>>,

--- a/lib/c-api/src/wasm_c_api/types/export.rs
+++ b/lib/c-api/src/wasm_c_api/types/export.rs
@@ -2,6 +2,7 @@ use super::{wasm_externtype_t, wasm_name_t};
 use wasmer::ExportType;
 
 #[allow(non_camel_case_types)]
+#[derive(Clone)]
 pub struct wasm_exporttype_t {
     name: Box<wasm_name_t>,
     extern_type: Box<wasm_externtype_t>,

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -67,7 +67,7 @@ impl Clone for WasmFunctionType {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct wasm_functype_t {
     pub(crate) extern_type: wasm_externtype_t,
@@ -111,8 +111,8 @@ pub unsafe extern "C" fn wasm_functype_new(
         .map(|val| val.as_ref().into())
         .collect::<Vec<_>>();
 
-    wasm_valtype_vec_delete(Box::into_raw(params));
-    wasm_valtype_vec_delete(Box::into_raw(results));
+    wasm_valtype_vec_delete(Some(&mut *Box::into_raw(params)));
+    wasm_valtype_vec_delete(Some(&mut *Box::into_raw(results)));
 
     Some(Box::new(wasm_functype_t::new(FunctionType::new(
         params_as_valtype,
@@ -129,9 +129,7 @@ pub unsafe extern "C" fn wasm_functype_copy(
 ) -> Option<Box<wasm_functype_t>> {
     let function_type = function_type?;
 
-    Some(Box::new(wasm_functype_t::new(
-        function_type.inner().function_type.clone(),
-    )))
+    Some(Box::new(function_type.clone()))
 }
 
 #[no_mangle]

--- a/lib/c-api/src/wasm_c_api/types/global.rs
+++ b/lib/c-api/src/wasm_c_api/types/global.rs
@@ -23,7 +23,7 @@ impl WasmGlobalType {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct wasm_globaltype_t {
     pub(crate) extern_type: wasm_externtype_t,

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -2,6 +2,7 @@ use super::{wasm_externtype_t, wasm_name_t};
 use wasmer::ImportType;
 
 #[allow(non_camel_case_types)]
+#[derive(Clone)]
 pub struct wasm_importtype_t {
     module: Box<wasm_name_t>,
     name: Box<wasm_name_t>,

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -25,7 +25,7 @@ impl WasmMemoryType {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct wasm_memorytype_t {
     pub(crate) extern_type: wasm_externtype_t,

--- a/lib/c-api/src/wasm_c_api/types/table.rs
+++ b/lib/c-api/src/wasm_c_api/types/table.rs
@@ -32,7 +32,7 @@ impl WasmTableType {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct wasm_tabletype_t {
     pub(crate) extern_type: wasm_externtype_t,

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -77,6 +77,39 @@ pub struct wasm_val_t {
     pub of: wasm_val_inner,
 }
 
+impl std::fmt::Debug for wasm_val_t {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut ds = f.debug_struct("wasm_val_t");
+        ds.field("kind", &self.kind);
+
+        match self.kind.try_into() {
+            Ok(wasm_valkind_enum::WASM_I32) => {
+                ds.field("i32", &unsafe { self.of.int32_t });
+            }
+            Ok(wasm_valkind_enum::WASM_I64) => {
+                ds.field("i64", &unsafe { self.of.int64_t });
+            }
+            Ok(wasm_valkind_enum::WASM_F32) => {
+                ds.field("f32", &unsafe { self.of.float32_t });
+            }
+            Ok(wasm_valkind_enum::WASM_F64) => {
+                ds.field("f64", &unsafe { self.of.float64_t });
+            }
+            Ok(wasm_valkind_enum::WASM_ANYREF) => {
+                ds.field("anyref", &unsafe { self.of.wref });
+            }
+
+            Ok(wasm_valkind_enum::WASM_FUNCREF) => {
+                ds.field("funcref", &unsafe { self.of.wref });
+            }
+            Err(_) => {
+                ds.field("value", &"Invalid value type");
+            }
+        }
+        ds.finish()
+    }
+}
+
 wasm_declare_vec!(val);
 
 impl Clone for wasm_val_t {

--- a/lib/c-api/tests/Makefile
+++ b/lib/c-api/tests/Makefile
@@ -20,10 +20,10 @@ CAPI_WASMER_TESTS = \
 CAPI_BASE_TESTS = \
 	wasm-c-api/example/callback			wasm-c-api/example/global				  	wasm-c-api/example/hello \
 	wasm-c-api/example/memory			wasm-c-api/example/reflect				  	wasm-c-api/example/serialize \
-	wasm-c-api/example/start			wasm-c-api/example/trap
+	wasm-c-api/example/start			wasm-c-api/example/trap				  	wasm-c-api/example/multi
 
 CAPI_BASE_TESTS_NOT_WORKING = \
-	wasm-c-api/example/finalize			wasm-c-api/example/hostref				  	wasm-c-api/example/multi \
+	wasm-c-api/example/finalize			wasm-c-api/example/hostref \
 	wasm-c-api/example/table			wasm-c-api/example/threads
 
 DEPRECATED_TESTS = \

--- a/lib/c-api/tests/wasm-c-api/example/multi.c
+++ b/lib/c-api/tests/wasm-c-api/example/multi.c
@@ -7,6 +7,19 @@
 
 #define own
 
+int wasmer_last_error_length(void);
+void wasmer_last_error_message(char*, int);
+
+// Use the last_error API to retrieve error messages
+void print_wasmer_error()
+{
+  int error_len = wasmer_last_error_length();
+  printf("Error len: `%d`\n", error_len);
+  char *error_str = malloc(error_len);
+  wasmer_last_error_message(error_str, error_len);
+  printf("Error str: `%s`\n", error_str);
+}
+
 // A function to be called from Wasm code.
 own wasm_trap_t* callback(
   const wasm_val_vec_t* args, wasm_val_vec_t* results
@@ -121,7 +134,7 @@ int main(int argc, const char* argv[]) {
   // Call.
   printf("Calling export...\n");
   wasm_val_t vals[4] = {
-    WASM_I32_VAL(1), WASM_I32_VAL(2), WASM_I32_VAL(3), WASM_I32_VAL(4)
+    WASM_I32_VAL(1), WASM_I64_VAL(2), WASM_I64_VAL(3), WASM_I32_VAL(4)
   };
   wasm_val_t res[4] = {
     WASM_INIT_VAL, WASM_INIT_VAL, WASM_INIT_VAL, WASM_INIT_VAL
@@ -130,6 +143,7 @@ int main(int argc, const char* argv[]) {
   wasm_val_vec_t results = WASM_ARRAY_VEC(res);
   if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
+    print_wasmer_error();
     return 1;
   }
 

--- a/lib/c-api/tests/wasm-c-api/example/multi.c
+++ b/lib/c-api/tests/wasm-c-api/example/multi.c
@@ -7,19 +7,6 @@
 
 #define own
 
-int wasmer_last_error_length(void);
-void wasmer_last_error_message(char*, int);
-
-// Use the last_error API to retrieve error messages
-void print_wasmer_error()
-{
-  int error_len = wasmer_last_error_length();
-  printf("Error len: `%d`\n", error_len);
-  char *error_str = malloc(error_len);
-  wasmer_last_error_message(error_str, error_len);
-  printf("Error str: `%s`\n", error_str);
-}
-
 // A function to be called from Wasm code.
 own wasm_trap_t* callback(
   const wasm_val_vec_t* args, wasm_val_vec_t* results
@@ -143,7 +130,6 @@ int main(int argc, const char* argv[]) {
   wasm_val_vec_t results = WASM_ARRAY_VEC(res);
   if (wasm_func_call(run_func, &args, &results)) {
     printf("> Error calling function!\n");
-    print_wasmer_error();
     return 1;
   }
 


### PR DESCRIPTION
Gets the `multi.c` example working.

This PR has significant overlap with #1949 due to changes in vec / boxed vec.

Changes in this PR:
- impl `Clone` more often, implement `*_copy` functions in terms of `Clone`
- clean up boxed vec behavior
- add `*_vec_copy` functions for boxed and unboxed versions
- fix a typo in `wasm-c-api/examples/multi.c`; fixed in the upstream Wasm C API here: https://github.com/WebAssembly/wasm-c-api/pull/163
- additional misc improvements

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
