### PR TITLE
Make `jit` a default feature for `wasmer-wasm-c-api`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#1894](https://github.com/wasmerio/wasmer/pull/1894) Added exports `wasmer::{CraneliftOptLevel, LLVMOptLevel}` to allow using `Cranelift::opt_level` and `LLVM::opt_level` directly via the `wasmer` crate
 
 ### Changed
+* [#1955](https://github.com/wasmerio/wasmer/pull/1955) Set `jit` as a default feature of the `wasmer-wasm-c-api` crate
 
 ### Fixed
 

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -47,6 +47,7 @@ default = [
     "deprecated",
     "wat",
     "cranelift",
+    "jit",
     "wasi",
 ]
 wat = ["wasmer/wat"]


### PR DESCRIPTION
This makes `cargo build` now work with default features. It should also stop causing the header files to change when running tests.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
