### PR TITLE
chore: Keep artifacts for 1 day

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -257,6 +257,8 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: dist
+          if-no-files-found: error
+          retention-days: 1
 
   test-cross-compile-on-linux:
     name: Test cross-compile on linux


### PR DESCRIPTION
# Description

This patch will make GitHub Actions keep our artifacts for 1 day (the retention may change, depending on reviews).

# Review

~~- [ ] Add a short description of the the change to the CHANGELOG.md file~~
