### PR TITLE
Remove to_wasm_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#1941](https://github.com/wasmerio/wasmer/pull/1941) Turn `get_remaining_points`/`set_remaining_points` of the `Metering` middleware into free functions to allow using them in an ahead-of-time compilation setup
 * [#1955](https://github.com/wasmerio/wasmer/pull/1955) Set `jit` as a default feature of the `wasmer-wasm-c-api` crate
 * [#1944](https://github.com/wasmerio/wasmer/pull/1944) Require `WasmerEnv` to be `Send + Sync` even in dynamic functions.
+* [#1963](https://github.com/wasmerio/wasmer/pull/1963) Deprecated `to_wasm_error` in favour of `impl From<BinaryReaderError> for WasmError`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [#1941](https://github.com/wasmerio/wasmer/pull/1941) Turn `get_remaining_points`/`set_remaining_points` of the `Metering` middleware into free functions to allow using them in an ahead-of-time compilation setup
 * [#1955](https://github.com/wasmerio/wasmer/pull/1955) Set `jit` as a default feature of the `wasmer-wasm-c-api` crate
 * [#1944](https://github.com/wasmerio/wasmer/pull/1944) Require `WasmerEnv` to be `Send + Sync` even in dynamic functions.
-* [#1963](https://github.com/wasmerio/wasmer/pull/1963) Deprecated `to_wasm_error` in favour of `impl From<BinaryReaderError> for WasmError`
+* [#1963](https://github.com/wasmerio/wasmer/pull/1963) Removed `to_wasm_error` in favour of `impl From<BinaryReaderError> for WasmError`
 
 ### Fixed
 

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -45,7 +45,7 @@ use smallvec::SmallVec;
 use std::vec::Vec;
 
 use wasmer_compiler::wasmparser::{MemoryImmediate, Operator};
-use wasmer_compiler::{to_wasm_error, WasmResult};
+use wasmer_compiler::WasmResult;
 use wasmer_compiler::{wasm_unsupported, ModuleTranslationState};
 use wasmer_types::{FunctionIndex, GlobalIndex, MemoryIndex, SignatureIndex, TableIndex};
 
@@ -383,10 +383,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::BrIf { relative_depth } => translate_br_if(*relative_depth, builder, state),
         Operator::BrTable { table } => {
-            let mut depths = table
-                .targets()
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(to_wasm_error)?;
+            let mut depths = table.targets().collect::<Result<Vec<_>, _>>()?;
             let default = depths.pop().unwrap().0;
             let mut min_depth = default;
             for (depth, _) in depths.iter() {

--- a/lib/compiler-cranelift/src/translator/func_translator.rs
+++ b/lib/compiler-cranelift/src/translator/func_translator.rs
@@ -19,8 +19,8 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use tracing::info;
 use wasmer_compiler::wasmparser;
 use wasmer_compiler::{
-    to_wasm_error, wasm_unsupported, MiddlewareBinaryReader, ModuleMiddlewareChain,
-    ModuleTranslationState, WasmResult,
+    wasm_unsupported, MiddlewareBinaryReader, ModuleMiddlewareChain, ModuleTranslationState,
+    WasmResult,
 };
 use wasmer_types::LocalFunctionIndex;
 
@@ -174,11 +174,11 @@ fn parse_local_decls<FE: FuncEnvironment + ?Sized>(
     environ: &mut FE,
 ) -> WasmResult<()> {
     let mut next_local = num_params;
-    let local_count = reader.read_local_count().map_err(to_wasm_error)?;
+    let local_count = reader.read_local_count()?;
 
     for _ in 0..local_count {
         builder.set_srcloc(cur_srcloc(reader));
-        let (count, ty) = reader.read_local_decl().map_err(to_wasm_error)?;
+        let (count, ty) = reader.read_local_decl()?;
         declare_locals(builder, count, ty, &mut next_local, environ)?;
     }
 
@@ -239,7 +239,7 @@ fn parse_function_body<FE: FuncEnvironment + ?Sized>(
     // Keep going until the final `End` operator which pops the outermost block.
     while !state.control_stack.is_empty() {
         builder.set_srcloc(cur_srcloc(&reader));
-        let op = reader.read_operator().map_err(to_wasm_error)?;
+        let op = reader.read_operator()?;
         environ.before_translate_operator(&op, builder, state)?;
         translate_operator(module_translation_state, &op, builder, state, environ)?;
         environ.after_translate_operator(&op, builder, state)?;

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -26,8 +26,8 @@ use crate::config::{CompiledKind, LLVM};
 use crate::object_file::{load_object_file, CompiledFunction};
 use wasmer_compiler::wasmparser::{MemoryImmediate, Operator};
 use wasmer_compiler::{
-    to_wasm_error, wptype_to_type, CompileError, FunctionBodyData, MiddlewareBinaryReader,
-    ModuleMiddlewareChain, ModuleTranslationState, RelocationTarget, Symbol, SymbolRegistry,
+    wptype_to_type, CompileError, FunctionBodyData, MiddlewareBinaryReader, ModuleMiddlewareChain,
+    ModuleTranslationState, RelocationTarget, Symbol, SymbolRegistry,
 };
 use wasmer_types::entity::PrimaryMap;
 use wasmer_types::{
@@ -182,9 +182,9 @@ impl FuncTranslator {
         }
 
         let mut locals = vec![];
-        let num_locals = reader.read_local_count().map_err(to_wasm_error)?;
+        let num_locals = reader.read_local_count()?;
         for _ in 0..num_locals {
-            let (count, ty) = reader.read_local_decl().map_err(to_wasm_error)?;
+            let (count, ty) = reader.read_local_decl()?;
             let ty = wptype_to_type(ty).map_err(to_compile_error)?;
             let ty = type_to_llvm(&intrinsics, ty)?;
             for _ in 0..count {
@@ -224,7 +224,7 @@ impl FuncTranslator {
 
         while fcg.state.has_control_frames() {
             let pos = reader.current_position() as u32;
-            let op = reader.read_operator().map_err(to_wasm_error)?;
+            let op = reader.read_operator()?;
             fcg.translate_operator(op, pos)?;
         }
 
@@ -1530,10 +1530,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     .get_insert_block()
                     .ok_or_else(|| CompileError::Codegen("not currently in a block".to_string()))?;
 
-                let mut label_depths = table
-                    .targets()
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(to_wasm_error)?;
+                let mut label_depths = table.targets().collect::<Result<Vec<_>, _>>()?;
                 let default_depth = label_depths.pop().unwrap().0;
 
                 let index = self.state.pop1()?;

--- a/lib/compiler/src/error.rs
+++ b/lib/compiler/src/error.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 pub enum CompileError {
     /// A Wasm translation error occured.
     #[cfg_attr(feature = "std", error("WebAssembly translation error: {0}"))]
-    Wasm(#[cfg_attr(feature = "std", from)] WasmError),
+    Wasm(WasmError),
 
     /// A compilation error occured.
     #[cfg_attr(feature = "std", error("Compilation error: {0}"))]
@@ -40,6 +40,12 @@ pub enum CompileError {
     /// Insufficient resources available for execution.
     #[cfg_attr(feature = "std", error("Insufficient resources: {0}"))]
     Resource(String),
+}
+
+impl From<WasmError> for CompileError {
+    fn from(original: WasmError) -> Self {
+        Self::Wasm(original)
+    }
 }
 
 /// A WebAssembly translation error.

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -84,10 +84,13 @@ pub use crate::target::{
     PointerWidth, Target, Triple,
 };
 #[cfg(feature = "translator")]
+#[allow(deprecated)]
+pub use crate::translator::to_wasm_error;
+#[cfg(feature = "translator")]
 pub use crate::translator::{
-    to_wasm_error, translate_module, wptype_to_type, FunctionBodyData, FunctionMiddleware,
-    MiddlewareBinaryReader, MiddlewareReaderState, ModuleEnvironment, ModuleInfoTranslation,
-    ModuleMiddleware, ModuleMiddlewareChain, ModuleTranslationState,
+    translate_module, wptype_to_type, FunctionBodyData, FunctionMiddleware, MiddlewareBinaryReader,
+    MiddlewareReaderState, ModuleEnvironment, ModuleInfoTranslation, ModuleMiddleware,
+    ModuleMiddlewareChain, ModuleTranslationState,
 };
 pub use crate::trap::TrapInformation;
 pub use crate::unwind::CompiledFunctionUnwindInfo;

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -84,9 +84,6 @@ pub use crate::target::{
     PointerWidth, Target, Triple,
 };
 #[cfg(feature = "translator")]
-#[allow(deprecated)]
-pub use crate::translator::to_wasm_error;
-#[cfg(feature = "translator")]
 pub use crate::translator::{
     translate_module, wptype_to_type, FunctionBodyData, FunctionMiddleware, MiddlewareBinaryReader,
     MiddlewareReaderState, ModuleEnvironment, ModuleInfoTranslation, ModuleMiddleware,

--- a/lib/compiler/src/translator/error.rs
+++ b/lib/compiler/src/translator/error.rs
@@ -8,10 +8,17 @@ macro_rules! wasm_unsupported {
     ($($arg:tt)*) => { $crate::WasmError::Unsupported(format!($($arg)*)) }
 }
 
-/// Converts a Wasm binary reading error to a runtime Wasm error
-pub fn to_wasm_error(e: BinaryReaderError) -> WasmError {
-    WasmError::InvalidWebAssembly {
-        message: e.message().into(),
-        offset: e.offset(),
+impl From<BinaryReaderError> for WasmError {
+    fn from(original: BinaryReaderError) -> Self {
+        Self::InvalidWebAssembly {
+            message: original.message().into(),
+            offset: original.offset(),
+        }
     }
+}
+
+/// Converts a Wasm binary reading error to a runtime Wasm error
+#[deprecated(since = "1.0.0-beta3", note = "Use WasmError::from")]
+pub fn to_wasm_error(e: BinaryReaderError) -> WasmError {
+    e.into()
 }

--- a/lib/compiler/src/translator/error.rs
+++ b/lib/compiler/src/translator/error.rs
@@ -1,4 +1,4 @@
-use crate::WasmError;
+use crate::{CompileError, WasmError};
 use wasmparser::BinaryReaderError;
 
 /// Return an `Err(WasmError::Unsupported(msg))` where `msg` the string built by calling `format!`
@@ -13,6 +13,46 @@ impl From<BinaryReaderError> for WasmError {
         Self::InvalidWebAssembly {
             message: original.message().into(),
             offset: original.offset(),
+        }
+    }
+}
+
+impl From<BinaryReaderError> for CompileError {
+    fn from(original: BinaryReaderError) -> Self {
+        // `From` does not seem to be transitive by default, so we convert
+        // BinaryReaderError -> WasmError -> CompileError
+        Self::from(WasmError::from(original))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmparser::BinaryReader;
+
+    #[test]
+    fn can_convert_binary_reader_error_to_wasm_error() {
+        let mut reader = BinaryReader::new(b"\0\0\0\0");
+        let binary_reader_error = reader.read_bytes(10).unwrap_err();
+        match WasmError::from(binary_reader_error) {
+            WasmError::InvalidWebAssembly { message, offset } => {
+                assert_eq!(message, "Unexpected EOF");
+                assert_eq!(offset, 0);
+            }
+            err => panic!("Unexpected error: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn can_convert_binary_reader_error_to_compile_error() {
+        let mut reader = BinaryReader::new(b"\0\0\0\0");
+        let binary_reader_error = reader.read_bytes(10).unwrap_err();
+        match CompileError::from(binary_reader_error) {
+            CompileError::Wasm(WasmError::InvalidWebAssembly { message, offset }) => {
+                assert_eq!(message, "Unexpected EOF");
+                assert_eq!(offset, 0);
+            }
+            err => panic!("Unexpected error: {:?}", err),
         }
     }
 }

--- a/lib/compiler/src/translator/error.rs
+++ b/lib/compiler/src/translator/error.rs
@@ -16,9 +16,3 @@ impl From<BinaryReaderError> for WasmError {
         }
     }
 }
-
-/// Converts a Wasm binary reading error to a runtime Wasm error
-#[deprecated(since = "1.0.0-beta3", note = "Use WasmError::from")]
-pub fn to_wasm_error(e: BinaryReaderError) -> WasmError {
-    e.into()
-}

--- a/lib/compiler/src/translator/mod.rs
+++ b/lib/compiler/src/translator/mod.rs
@@ -14,8 +14,6 @@ mod error;
 mod sections;
 
 pub use self::environ::{FunctionBodyData, ModuleEnvironment, ModuleInfoTranslation};
-#[allow(deprecated)]
-pub use self::error::to_wasm_error;
 pub use self::middleware::{
     FunctionMiddleware, MiddlewareBinaryReader, MiddlewareReaderState, ModuleMiddleware,
     ModuleMiddlewareChain,

--- a/lib/compiler/src/translator/mod.rs
+++ b/lib/compiler/src/translator/mod.rs
@@ -14,6 +14,7 @@ mod error;
 mod sections;
 
 pub use self::environ::{FunctionBodyData, ModuleEnvironment, ModuleInfoTranslation};
+#[allow(deprecated)]
 pub use self::error::to_wasm_error;
 pub use self::middleware::{
     FunctionMiddleware, MiddlewareBinaryReader, MiddlewareReaderState, ModuleMiddleware,


### PR DESCRIPTION
# Description

This is a code style improvement that came up when working on #1962 but is independent of that.

Should I remove `to_wasm_error` or keep it as deprecated?

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
