### PR TITLE
chore: Ignore time crate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     allow:
       - dependency-type: "all"
+    ignore:
+      - dependency-name: "time"
     rebase-strategy: "auto"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The new time crate API has completely changed between 0.1 and 0.2. We are not
aware of any security concern with the actual version we use so we'll
stick with it for now.

Closes #1903

# Review

~~- [ ] Add a short description of the the change to the CHANGELOG.md file~~
