### PR TITLE
feat(api) Remove `Module::artifact`

### DIFF
--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -251,6 +251,9 @@ impl Module {
         Ok(Self::from_artifact(store, artifact))
     }
 
+    /// Low-level constructor. It must be used to build a unique
+    /// `Module`. It must not be used to build back a `Module` from an
+    /// already compiled `Artifact`.
     fn from_artifact(store: &Store, artifact: Arc<dyn Artifact>) -> Self {
         Self {
             store: store.clone(),
@@ -411,14 +414,40 @@ impl Module {
         &self.artifact.module_ref()
     }
 
-    /// Gets the [`Artifact`] used internally by the Module.
+    /// Query the artifact to fetch information from it without
+    /// extracting the artifact from the module.
+    ///
+    /// The artifact defined in the `Module` is abstracted behind `dyn
+    /// Artifact`. When querying, downcasting to a concrete artifact
+    /// type is done by inferring the type from the closure used to
+    /// query. Something like this:
+    ///
+    /// ```rust,no_run
+    /// use wasmer_engine_object_file::ObjectFileArtifact;
+    ///
+    /// let symbol_registry = unsafe {
+    ///     module.query_artifact(|artifact: &ObjectFileArtifact| {
+    ///         Some(Arc::clone(artifact.symbol_registry()))
+    ///     })
+    /// };
+    /// ```
+    ///
+    /// If downcasting the artifact to `A` fails, the method will
+    /// return `None`.
     ///
     /// This API is hidden because it's not necessarily stable;
     /// this functionality is required for some core functionality though, like
-    /// the object file engine.
+    /// the [`wasmer-engine-object-file`].
     #[doc(hidden)]
-    pub fn artifact(&self) -> &Arc<dyn Artifact> {
-        &self.artifact
+    pub unsafe fn query_artifact<A, Q, R>(&self, query: Q) -> Option<Arc<R>>
+    where
+        A: Artifact + 'static,
+        Q: FnOnce(&A) -> Option<Arc<R>>,
+        R: ?Sized,
+    {
+        let artifact_ref: &A = self.artifact.downcast_ref()?;
+
+        query(artifact_ref)
     }
 }
 
@@ -427,83 +456,5 @@ impl fmt::Debug for Module {
         f.debug_struct("Module")
             .field("name", &self.name())
             .finish()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{Cranelift, ImportObject, Instance, JIT};
-
-    const INCREMENTER_WAT: &str = r#"(module
-        (type $t0 (func (param i32) (result i32)))
-        (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
-            get_local $p0
-            i32.const 1
-            i32.add)
-    )"#;
-
-    #[test]
-    fn from_artifact_works() {
-        let wasm = wat::parse_str(INCREMENTER_WAT).unwrap();
-
-        // Compile module
-        let config = Cranelift::default();
-        let compile_time_store = Store::new(&JIT::new(config).engine());
-        let original = Module::new(&compile_time_store, &wasm).unwrap();
-
-        // Ensure original module can be executed
-        {
-            let instance = Instance::new(&original, &ImportObject::new()).unwrap();
-            let add_one = instance.exports.get_function("add_one").unwrap();
-            let result = add_one.call(&[42.into()]).unwrap();
-            assert_eq!(result[0].unwrap_i32(), 43);
-        }
-
-        // Create second module via artifact
-        let artifact: Arc<dyn Artifact> = Arc::clone(original.artifact());
-        let run_time_store = Store::new(&JIT::headless().engine());
-        let restored = Module::from_artifact(&run_time_store, artifact);
-
-        // Ensure restored module can be executed
-        {
-            let instance = Instance::new(&restored, &ImportObject::new()).unwrap();
-            let add_one = instance.exports.get_function("add_one").unwrap();
-            let result = add_one.call(&[42.into()]).unwrap();
-            assert_eq!(result[0].unwrap_i32(), 43);
-        }
-    }
-
-    #[test]
-    fn from_artifact_works_when_original_store_drops() {
-        let wasm = wat::parse_str(INCREMENTER_WAT).unwrap();
-
-        // Create artifact
-        let artifact: Arc<dyn Artifact> = {
-            // Compile module
-            let config = Cranelift::default();
-            let compile_time_store = Store::new(&JIT::new(config).engine());
-            let original = Module::new(&compile_time_store, &wasm).unwrap();
-
-            // Ensure original module can be executed
-            {
-                let instance = Instance::new(&original, &ImportObject::new()).unwrap();
-                let add_one = instance.exports.get_function("add_one").unwrap();
-                let result = add_one.call(&[42.into()]).unwrap();
-                assert_eq!(result[0].unwrap_i32(), 43);
-            }
-
-            Arc::clone(original.artifact())
-        };
-        let run_time_store = Store::new(&JIT::headless().engine());
-        let restored = Module::from_artifact(&run_time_store, artifact);
-
-        // Ensure restored module can be executed
-        {
-            let instance = Instance::new(&restored, &ImportObject::new()).unwrap();
-            let add_one = instance.exports.get_function("add_one").unwrap();
-            let result = add_one.call(&[42.into()]).unwrap();
-            assert_eq!(result[0].unwrap_i32(), 43);
-        }
     }
 }

--- a/lib/engine-jit/src/artifact.rs
+++ b/lib/engine-jit/src/artifact.rs
@@ -48,14 +48,14 @@ impl JITArtifact {
     #[cfg(feature = "compiler")]
     pub fn new(
         jit: &JITEngine,
-        data: &[u8],
+        binary: &[u8],
         tunables: &dyn Tunables,
     ) -> Result<Self, CompileError> {
         let environ = ModuleEnvironment::new();
         let mut inner_jit = jit.inner_mut();
         let features = inner_jit.features();
 
-        let translation = environ.translate(data).map_err(CompileError::Wasm)?;
+        let translation = environ.translate(binary).map_err(CompileError::Wasm)?;
 
         let memory_styles: PrimaryMap<MemoryIndex, MemoryStyle> = translation
             .module

--- a/lib/engine-object-file/src/artifact.rs
+++ b/lib/engine-object-file/src/artifact.rs
@@ -39,7 +39,7 @@ pub struct ObjectFileArtifact {
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,
     /// Length of the serialized metadata
     metadata_length: usize,
-    symbol_registry: ModuleMetadataSymbolRegistry,
+    symbol_registry: Arc<ModuleMetadataSymbolRegistry>,
 }
 
 #[allow(dead_code)]
@@ -276,7 +276,7 @@ impl ObjectFileArtifact {
                 .into_boxed_slice(),
             signatures: signatures.into_boxed_slice(),
             metadata_length,
-            symbol_registry,
+            symbol_registry: Arc::new(symbol_registry),
         })
     }
 
@@ -384,12 +384,12 @@ impl ObjectFileArtifact {
                 .into_boxed_slice(),
             signatures: signatures.into_boxed_slice(),
             metadata_length: 0,
-            symbol_registry,
+            symbol_registry: Arc::new(symbol_registry),
         })
     }
 
-    /// Get the `SymbolRegistry` used to generate the names used in the Artifact.
-    pub fn symbol_registry(&self) -> &dyn SymbolRegistry {
+    /// Get the `SymbolRegistry` used to generate the names used in the artifact.
+    pub fn symbol_registry(&self) -> &Arc<ModuleMetadataSymbolRegistry> {
         &self.symbol_registry
     }
 

--- a/lib/engine-object-file/src/lib.rs
+++ b/lib/engine-object-file/src/lib.rs
@@ -29,6 +29,7 @@ mod serialize;
 pub use crate::artifact::ObjectFileArtifact;
 pub use crate::builder::ObjectFile;
 pub use crate::engine::ObjectFileEngine;
+pub use crate::serialize::ModuleMetadataSymbolRegistry;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/engine-object-file/src/serialize.rs
+++ b/lib/engine-object-file/src/serialize.rs
@@ -13,8 +13,9 @@ pub struct ModuleMetadata {
     pub function_body_lengths: PrimaryMap<LocalFunctionIndex, u64>,
 }
 
+/// Symbol registry of the [`ModuleMetadata`].
 pub struct ModuleMetadataSymbolRegistry {
-    pub prefix: String,
+    pub(crate) prefix: String,
 }
 
 impl ModuleMetadata {


### PR DESCRIPTION
# Description

This patch removes the `Module::artifact` method since it is too
dangerous (see #1943 for more
details). This method has initially been introduced as a hack.

This patch replaces `Module::artifact` by `Module::query_artifact`
which is another hack, but less dangerous. The artifact can no longer
be extracted from the `Module`; it is only possible to query it to
fetch some information.

cc @MarkMcCaskey @webmaster128 

# Review

- [ ] ~Add a short description of the the change to the CHANGELOG.md file~ not necessary since this was a hidden feature
