### PR TITLE
Bump Rust used in CI to 1.48

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.47.0
+          toolchain: 1.48.0
           override: true
           components: rustfmt, clippy
       - run: make lint

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,26 +42,26 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu-18.04
-            rust: 1.47.0
+            rust: 1.48
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_integration_tests: true
           - build: macos-x64
             os: macos-latest
-            rust: 1.47.0
+            rust: 1.48
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             run_integration_tests: true
           - build: macos-arm64
             os: macos-11.0
-            rust: nightly
+            rust: 1.49
             target: aarch64-apple-darwin
             artifact_name: 'wasmer-darwin-arm64'
           - build: windows-x64
             os: windows-latest
-            rust: 1.47.0
+            rust: 1.48
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/windows-amd64.tar.gz'
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
@@ -69,7 +69,7 @@ jobs:
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
             random_sccache_port: true
-            rust: 1.47.0
+            rust: 1.48
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-aarch64.tar.gz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## **[Unreleased]**
 
+### Added
+
+### Changed
+- [#1985](https://github.com/wasmerio/wasmer/pull/1985) Bump minimum supported Rust version to 1.48
+
+### Fixed
+
 ## 1.0.0 - 2021-01-05
 
 ### Added


### PR DESCRIPTION
We also switch from `nightly` to `1.49` for aarch64 macos because it became a tier 2 target in `1.49`

Resolves #1986 

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
