### PR TITLE
Initial support for x64 windows calling convention on the single pass compiler

### DIFF
--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -956,13 +956,13 @@ impl<'a> FuncGen<'a> {
         Ok(())
     }
 
-    /// Emits a System V call sequence.
+    /// Emits a System V or Windows x64 call sequence.
     ///
     /// This function will not use RAX before `cb` is called.
     ///
     /// The caller MUST NOT hold any temporary registers allocated by `acquire_temp_gpr` when calling
     /// this function.
-    fn emit_call_sysv<I: Iterator<Item = Location>, F: FnOnce(&mut Self)>(
+    fn emit_call<I: Iterator<Item = Location>, F: FnOnce(&mut Self)>(
         &mut self,
         cb: F,
         params: I,
@@ -983,7 +983,7 @@ impl<'a> FuncGen<'a> {
                 self.machine.state.register_values[X64Register::GPR(*r).to_index().0].clone();
             if content == MachineValue::Undefined {
                 return Err(CodegenError {
-                    message: "emit_call_sysv: Undefined used_gprs content".to_string(),
+                    message: "emit_call: Undefined used_gprs content".to_string(),
                 });
             }
             self.machine.state.stack_values.push(content);
@@ -1010,7 +1010,7 @@ impl<'a> FuncGen<'a> {
                     self.machine.state.register_values[X64Register::XMM(*r).to_index().0].clone();
                 if content == MachineValue::Undefined {
                     return Err(CodegenError {
-                        message: "emit_call_sysv: Undefined used_xmms content".to_string(),
+                        message: "emit_call: Undefined used_xmms content".to_string(),
                     });
                 }
                 self.machine.state.stack_values.push(content);
@@ -1058,7 +1058,7 @@ impl<'a> FuncGen<'a> {
                             let content = self.machine.state.register_values
                                 [X64Register::GPR(x).to_index().0]
                                 .clone();
-                            // FIXME: There might be some corner cases (release -> emit_call_sysv -> acquire?) that cause this assertion to fail.
+                            // FIXME: There might be some corner cases (release -> emit_call -> acquire?) that cause this assertion to fail.
                             // Hopefully nothing would be incorrect at runtime.
 
                             //assert!(content != MachineValue::Undefined);
@@ -1074,8 +1074,7 @@ impl<'a> FuncGen<'a> {
                         Location::Memory(reg, offset) => {
                             if reg != GPR::RBP {
                                 return Err(CodegenError {
-                                    message: "emit_call_sysv loc param: unreachable code"
-                                        .to_string(),
+                                    message: "emit_call loc param: unreachable code".to_string(),
                                 });
                             }
                             self.machine
@@ -1125,7 +1124,7 @@ impl<'a> FuncGen<'a> {
                 }
                 _ => {
                     return Err(CodegenError {
-                        message: "emit_call_sysv loc: unreachable code".to_string(),
+                        message: "emit_call loc: unreachable code".to_string(),
                     })
                 }
             }
@@ -1150,7 +1149,7 @@ impl<'a> FuncGen<'a> {
 
         if (self.machine.state.stack_values.len() % 2) != 1 {
             return Err(CodegenError {
-                message: "emit_call_sysv: explicit shadow takes one slot".to_string(),
+                message: "emit_call: explicit shadow takes one slot".to_string(),
             });
         }
 
@@ -1184,7 +1183,7 @@ impl<'a> FuncGen<'a> {
             );
             if (stack_offset % 8) != 0 {
                 return Err(CodegenError {
-                    message: "emit_call_sysv: Bad restoring stack alignement".to_string(),
+                    message: "emit_call: Bad restoring stack alignement".to_string(),
                 });
             }
             for _ in 0..stack_offset / 8 {
@@ -1219,7 +1218,7 @@ impl<'a> FuncGen<'a> {
 
         if self.machine.state.stack_values.pop().unwrap() != MachineValue::ExplicitShadow {
             return Err(CodegenError {
-                message: "emit_call_sysv: Popped value is not ExplicitShadow".to_string(),
+                message: "emit_call: Popped value is not ExplicitShadow".to_string(),
             });
         }
         Ok(())
@@ -1231,7 +1230,7 @@ impl<'a> FuncGen<'a> {
         label: DynamicLabel,
         params: I,
     ) -> Result<(), CodegenError> {
-        self.emit_call_sysv(|this| this.assembler.emit_call_label(label), params)?;
+        self.emit_call(|this| this.assembler.emit_call_label(label), params)?;
         Ok(())
     }
 
@@ -5202,7 +5201,7 @@ impl<'a> FuncGen<'a> {
                     addend: 0,
                 });
 
-                // RAX is preserved on entry to `emit_call_sysv` callback.
+                // RAX is preserved on entry to `emit_call` callback.
                 // The Imm64 value is relocated by the JIT linker.
                 self.assembler.emit_mov(
                     Size::S64,
@@ -5210,7 +5209,7 @@ impl<'a> FuncGen<'a> {
                     Location::GPR(GPR::RAX),
                 );
 
-                self.emit_call_sysv(
+                self.emit_call(
                     |this| {
                         let offset = this.assembler.get_offset().0;
                         this.trap_table
@@ -5400,7 +5399,7 @@ impl<'a> FuncGen<'a> {
                 let vmcaller_checked_anyfunc_func_ptr =
                     self.vmoffsets.vmcaller_checked_anyfunc_func_ptr() as usize;
 
-                self.emit_call_sysv(
+                self.emit_call(
                     |this| {
                         if this.assembler.arch_requires_indirect_call_trampoline() {
                             this.assembler.arch_emit_indirect_call_with_trampoline(
@@ -5672,7 +5671,7 @@ impl<'a> FuncGen<'a> {
                     ),
                     Location::GPR(GPR::RAX),
                 );
-                self.emit_call_sysv(
+                self.emit_call(
                     |this| {
                         let label = this.assembler.get_label();
                         let after = this.assembler.get_label();
@@ -5717,7 +5716,7 @@ impl<'a> FuncGen<'a> {
 
                 self.machine.release_locations_only_osr_state(1);
 
-                self.emit_call_sysv(
+                self.emit_call(
                     |this| {
                         let label = this.assembler.get_label();
                         let after = this.assembler.get_label();

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -48,11 +48,6 @@ impl Compiler for SinglepassCompiler {
         _module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
     ) -> Result<Compilation, CompileError> {
-        if target.triple().operating_system == OperatingSystem::Windows {
-            return Err(CompileError::UnsupportedTarget(
-                OperatingSystem::Windows.to_string(),
-            ));
-        }
         if let Architecture::X86_32(arch) = target.triple().architecture {
             return Err(CompileError::UnsupportedTarget(arch.to_string()));
         }

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -50,7 +50,12 @@ impl Machine {
     /// This method does not mark the register as used.
     pub fn pick_gpr(&self) -> Option<GPR> {
         use GPR::*;
+
+        #[cfg(not(target_os = "windows"))]
         static REGS: &[GPR] = &[RSI, RDI, R8, R9, R10, R11];
+        #[cfg(target_os = "windows")]
+        static REGS: &[GPR] = &[RCX, RDX, R8, R9];
+
         for r in REGS {
             if !self.used_gprs.contains(r) {
                 return Some(*r);
@@ -64,7 +69,10 @@ impl Machine {
     /// This method does not mark the register as used.
     pub fn pick_temp_gpr(&self) -> Option<GPR> {
         use GPR::*;
-        static REGS: &[GPR] = &[RAX, RCX, RDX];
+        #[cfg(not(target_os = "windows"))]
+        static REGS: &[GPR] = &[RDI, RSI, RBX, R10, R11, R12, R13, R14, R15];
+        #[cfg(target_os = "windows")]
+        static REGS: &[GPR] = &[RAX, RCX, RDX, R8, R9, R10, R11];
         for r in REGS {
             if !self.used_gprs.contains(r) {
                 return Some(*r);
@@ -99,7 +107,12 @@ impl Machine {
     /// This method does not mark the register as used.
     pub fn pick_xmm(&self) -> Option<XMM> {
         use XMM::*;
+
+        #[cfg(not(target_os = "windows"))]
         static REGS: &[XMM] = &[XMM3, XMM4, XMM5, XMM6, XMM7];
+        #[cfg(target_os = "windows")]
+        static REGS: &[XMM] = &[XMM3, XMM4, XMM5];
+
         for r in REGS {
             if !self.used_xmms.contains(r) {
                 return Some(*r);
@@ -487,6 +500,7 @@ impl Machine {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     pub fn get_param_location(idx: usize) -> Location {
         match idx {
             0 => Location::GPR(GPR::RDI),
@@ -496,6 +510,17 @@ impl Machine {
             4 => Location::GPR(GPR::R8),
             5 => Location::GPR(GPR::R9),
             _ => Location::Memory(GPR::RBP, (16 + (idx - 6) * 8) as i32),
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn get_param_location(idx: usize) -> Location {
+        match idx {
+            0 => Location::GPR(GPR::RCX),
+            1 => Location::GPR(GPR::RDX),
+            2 => Location::GPR(GPR::R8),
+            3 => Location::GPR(GPR::R9),
+            _ => Location::Memory(GPR::RBP, (16 + (idx - 4) * 8) as i32),
         }
     }
 }


### PR DESCRIPTION
Hello, I started implementing some of the changes @losfair mentioned in this issue: https://github.com/wasmerio/wasmer/issues/347

Some simple functions already work but more complicated ones do not. An example of a function that doesn't work is _double_then_add_ below:
```
(module
            (func $multiply (import "env" "multiply") (param i32 i32) (result i32))
            (func (export "add") (param i32 i32) (result i32)
               (i32.add (local.get 0)
                        (local.get 1)))
            (func (export "double_then_add") (param i32 i32) (result i32)
               (i32.add (call $multiply (local.get 0) (i32.const 2))
                        (call $multiply (local.get 1) (i32.const 2))))
        )
```

This probably has to do with proper handling of the 32 byte shadow space which I haven't added.
_emit_call_sysv_ in codegen_x64.rs would have to be modified for this to work but the code has changed. @losfair mentioned a _CONSTRUCT_STACK_AND_CALL_WASM_ which doesn't seem to exist anymore.

Ideally a maintainer would take this proof of concept and complete it. But with some guidance on better workflows for debugging the generated code on windows I can implement the missing functionality.