### PR TITLE
Add makefile command for building minimal headless wasmer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,24 @@ build-wasmer:
 build-wasmer-debug:
 	cargo build --manifest-path lib/cli/Cargo.toml $(compiler_features)
 
+# For best results ensure the release profile looks like the following
+# in Cargo.toml:
+# [profile.release]
+# opt-level = 'z'
+# debug = false
+# debug-assertions = false
+# overflow-checks = false
+# lto = true
+# panic = 'abort'
+# incremental = false
+# codegen-units = 1
+# rpath = false
+build-wasmer-headless-minimal:
+	HOST_TARGET=$$(rustup show | grep 'Default host: ' | cut -d':' -f2 | tr -d ' ') ;\
+  echo $$HOST_TARGET ;\
+	xargo build -v --target $$HOST_TARGET --release --manifest-path=lib/cli/Cargo.toml --no-default-features --features disable-all-logging,native,wasi ;\
+	strip target/$$HOST_TARGET/release/wasmer
+
 WAPM_VERSION = master # v0.5.0
 get-wapm:
 	[ -d "wapm-cli" ] || git clone --branch $(WAPM_VERSION) https://github.com/wasmerio/wapm-cli.git

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -28,7 +28,7 @@ wasmer-engine-jit = { version = "1.0.0", path = "../engine-jit", optional = true
 wasmer-engine-native = { version = "1.0.0", path = "../engine-native", optional = true }
 wasmer-engine-object-file = { version = "1.0.0", path = "../engine-object-file", optional = true }
 wasmer-vm = { version = "1.0.0", path = "../vm" }
-wasmer-wasi = { version = "1.0.0", path = "../wasi", optional = true }
+wasmer-wasi = { version = "1.0.0", path = "../wasi", default-features = false, optional = true }
 wasmer-wasi-experimental-io-devices = { version = "1.0.0", path = "../wasi-experimental-io-devices", optional = true }
 wasmer-wast = { version = "1.0.0", path = "../../tests/lib/wast", optional = true }
 wasmer-cache = { version = "1.0.0", path = "../cache", optional = true }
@@ -105,4 +105,5 @@ llvm = [
     "wasmer-compiler-llvm",
     "compiler",
 ]
-debug = ["fern", "log"]
+debug = ["fern", "log", "wasmer-wasi/logging"]
+disable-all-logging = ["wasmer-wasi/disable-all-logging"]

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.3"
 thiserror = "1"
 generational-arena = { version = "0.2", features = ["serde"] }
 libc = { version = "^0.2", default-features = false }
-tracing = { version = "0.1", features = ["log"] }
+tracing = { version = "0.1" }
 getrandom = "0.2"
 time = "0.1"
 typetag = "0.1"
@@ -25,3 +25,8 @@ wasmer = { path = "../api", version = "1.0.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
+
+[features]
+default = ["logging"]
+logging = ["tracing/log"]
+disable-all-logging = ["tracing/release_max_level_off", "tracing/max_level_off"]


### PR DESCRIPTION
Currently requires modifying `Cargo.toml` for best results. I spent a while trying to work around that with `RUSTFLAGS`, but due to building `std` with `xargo`, `RUSTFLAGS` cannot be used here it seems... it applies the flags to `std` and the flags are incompatible (i.e. `lto` with libraries)

doesn't build without a bug fix from #1993 ; we can always just include that in this PR too though

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
