### PR TITLE
Improve WasmerEnv, fix emscripten imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
 ## **[Unreleased]**
 
 ### Added
+- [#2005](https://github.com/wasmerio/wasmer/pull/2005) Added the arguments `alias` and `optional` to `WasmerEnv` derive's `export` attribute.
 
 ### Changed
 - [#1985](https://github.com/wasmerio/wasmer/pull/1985) Bump minimum supported Rust version to 1.48
 
 ### Fixed
+- [#2005](https://github.com/wasmerio/wasmer/pull/2005) Emscripten is now working again.
 
 ## 1.0.0 - 2021-01-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ test-packages:
 	cargo test -p wasmer-cli --release
 	cargo test -p wasmer-cache --release
 	cargo test -p wasmer-engine --release
+	cargo test -p wasmer-derive --release
 
 
 # The test-capi rules depend on the build-capi rules to build the .a files to

--- a/lib/api/src/env.rs
+++ b/lib/api/src/env.rs
@@ -42,6 +42,8 @@ impl From<ExportError> for HostEnvInitError {
 ///     memory: LazyInit<Memory>,
 ///     #[wasmer(export(name = "real_name"))]
 ///     func: LazyInit<NativeFunc<(i32, i32), i32>>,
+///     #[wasmer(export(optional = true, alias = "memory2", alias = "_memory2"))]
+///     optional_memory: LazyInit<Memory>,
 /// }
 ///
 /// ```
@@ -51,7 +53,16 @@ impl From<ExportError> for HostEnvInitError {
 /// `<field_name>_ref` and `<field_name>_ref_unchecked` for easy access to the
 /// data.
 ///
-/// This trait can also be implemented manually:
+/// The valid arguments to `export` are:
+/// - `name = "string"`: specify the name of this item in the Wasm module. If this is not specified, it will default to the name of the field.
+/// - `optional = true`: specify whether this export is optional. Defaults to
+/// `false`. Being optional means that if the export can't be found, the
+/// [`LazyInit`] will be left uninitialized.
+/// - `alias = "string"`: specify additional names to look for in the Wasm module.
+/// `alias` may be specified multiple times to search for multiple aliases.
+/// -------
+///
+/// This trait may also be implemented manually:
 /// ```
 /// # use wasmer::{WasmerEnv, LazyInit, Memory, Instance, HostEnvInitError};
 /// #[derive(Clone)]

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -41,8 +41,8 @@ impl Compile {
     pub(crate) fn get_recommend_extension(
         engine_type: &EngineType,
         target_triple: &Triple,
-    ) -> &'static str {
-        match engine_type {
+    ) -> Result<&'static str> {
+        Ok(match engine_type {
             #[cfg(feature = "native")]
             EngineType::Native => {
                 wasmer_engine_native::NativeArtifact::get_default_extension(target_triple)
@@ -54,8 +54,8 @@ impl Compile {
                 wasmer_engine_object_file::ObjectFileArtifact::get_default_extension(target_triple)
             }
             #[cfg(not(all(feature = "native", feature = "jit", feature = "object-file")))]
-            _ => panic!("selected engine type is not compiled in"),
-        }
+            _ => bail!("selected engine type is not compiled in"),
+        })
     }
 
     fn inner_execute(&self) -> Result<()> {
@@ -81,7 +81,7 @@ impl Compile {
             .file_stem()
             .map(|osstr| osstr.to_string_lossy().to_string())
             .unwrap_or_default();
-        let recommended_extension = Self::get_recommend_extension(&engine_type, target.triple());
+        let recommended_extension = Self::get_recommend_extension(&engine_type, target.triple())?;
         match self.output.extension() {
             Some(ext) => {
                 if ext != recommended_extension {

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -54,7 +54,7 @@ impl Compile {
                 wasmer_engine_object_file::ObjectFileArtifact::get_default_extension(target_triple)
             }
             #[cfg(not(all(feature = "native", feature = "jit", feature = "object-file")))]
-            _ => bail!("selected engine type is not compiled in"),
+            _ => panic!("selected engine type is not compiled in"),
         }
     }
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -27,12 +27,20 @@ pub struct Wasi {
     enable_experimental_io_devices: bool,
 }
 
+#[allow(dead_code)]
 impl Wasi {
     /// Gets the WASI version (if any) for the provided module
     pub fn get_version(module: &Module) -> Option<WasiVersion> {
-        // Get the wasi version on strict mode, so no other imports are
+        // Get the wasi version in strict mode, so no other imports are
         // allowed.
         get_wasi_version(&module, true)
+    }
+
+    /// Checks if a given module has any WASI imports at all.
+    pub fn has_wasi_imports(module: &Module) -> bool {
+        // Get the wasi version in non-strict mode, so no other imports
+        // are allowed
+        get_wasi_version(&module, false).is_some()
     }
 
     /// Helper function for executing Wasi from the `Run` command.

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -23,7 +23,7 @@ rayon = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 more-asserts = "0.2"
 gimli = { version = "0.22", optional = true }
-smallvec = "1.5"
+smallvec = "1.6"
 
 [dev-dependencies]
 target-lexicon = { version = "0.11", default-features = false }

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -16,7 +16,7 @@ wasmer-compiler = { path = "../compiler", version = "1.0.0", features = ["transl
 wasmer-vm = { path = "../vm", version = "1.0.0" }
 wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
 target-lexicon = { version = "0.11", default-features = false }
-smallvec = "1.5"
+smallvec = "1.6"
 goblin = "0.2"
 libc = { version = "^0.2", default-features = false }
 byteorder = "1"

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -23,7 +23,7 @@ dynasm = "1.0"
 dynasmrt = "1.0"
 lazy_static = "1.4"
 byteorder = "1.3"
-smallvec = "1.5"
+smallvec = "1.6"
 
 [dev-dependencies]
 target-lexicon = { version = "0.11", default-features = false }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -20,7 +20,7 @@ hashbrown = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
 serde_bytes = { version = "0.11", optional = true }
-smallvec = "1.5" 
+smallvec = "1.6" 
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "7.0"

--- a/lib/derive/tests/basic.rs
+++ b/lib/derive/tests/basic.rs
@@ -2,7 +2,7 @@
 
 use wasmer::{Function, Global, LazyInit, Memory, NativeFunc, Table, WasmerEnv};
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyEnv {
     num: u32,
     nums: Vec<i32>,
@@ -21,7 +21,7 @@ fn test_derive() {
     assert!(impls_wasmer_env::<MyEnv>());
 }
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyEnvWithMemory {
     num: u32,
     nums: Vec<i32>,
@@ -29,7 +29,7 @@ struct MyEnvWithMemory {
     memory: LazyInit<Memory>,
 }
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyEnvWithFuncs {
     num: u32,
     nums: Vec<i32>,
@@ -39,7 +39,7 @@ struct MyEnvWithFuncs {
     sum: LazyInit<NativeFunc<(i32, i32), i32>>,
 }
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyEnvWithEverything {
     num: u32,
     nums: Vec<i32>,
@@ -55,23 +55,23 @@ struct MyEnvWithEverything {
     functions: LazyInit<Table>,
 }
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyEnvWithLifetime<'a> {
     name: &'a str,
     #[wasmer(export(name = "memory"))]
     memory: LazyInit<Memory>,
 }
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyUnitStruct;
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyTupleStruct(u32);
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyTupleStruct2(u32, u32);
 
-#[derive(WasmerEnv)]
+#[derive(WasmerEnv, Clone)]
 struct MyTupleStructWithAttribute(#[wasmer(export(name = "memory"))] LazyInit<Memory>, u32);
 
 #[test]
@@ -84,4 +84,36 @@ fn test_derive_with_attribute() {
     assert!(impls_wasmer_env::<MyTupleStruct>());
     assert!(impls_wasmer_env::<MyTupleStruct2>());
     assert!(impls_wasmer_env::<MyTupleStructWithAttribute>());
+}
+
+#[derive(WasmerEnv, Clone)]
+struct StructWithOptionalField {
+    #[wasmer(export(optional = true))]
+    memory: LazyInit<Memory>,
+    #[wasmer(export(optional = true, name = "real_memory"))]
+    memory2: LazyInit<Memory>,
+    #[wasmer(export(optional = false))]
+    memory3: LazyInit<Memory>,
+}
+
+#[test]
+fn test_derive_with_optional() {
+    assert!(impls_wasmer_env::<StructWithOptionalField>());
+}
+
+#[derive(WasmerEnv, Clone)]
+struct StructWithAliases {
+    #[wasmer(export(alias = "_memory"))]
+    memory: LazyInit<Memory>,
+    #[wasmer(export(alias = "_real_memory", optional = true, name = "real_memory"))]
+    memory2: LazyInit<Memory>,
+    #[wasmer(export(alias = "_memory3", alias = "__memory3"))]
+    memory3: LazyInit<Memory>,
+    #[wasmer(export(alias = "_memory3", name = "memory4", alias = "__memory3"))]
+    memory4: LazyInit<Memory>,
+}
+
+#[test]
+fn test_derive_with_aliases() {
+    assert!(impls_wasmer_env::<StructWithAliases>());
 }

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -139,140 +139,140 @@ const STATIC_BASE: u32 = GLOBAL_BASE;
 pub struct EmscriptenData {
     pub globals: EmscriptenGlobalsData,
 
-    #[wasmer(export)]
+    #[wasmer(export(alias = "_malloc", optional = true))]
     pub malloc: LazyInit<NativeFunc<u32, u32>>,
-    #[wasmer(export)]
+    #[wasmer(export(alias = "_free", optional = true))]
     pub free: LazyInit<NativeFunc<u32>>,
-    #[wasmer(export)]
+    #[wasmer(export(alias = "_memalign", optional = true))]
     pub memalign: LazyInit<NativeFunc<(u32, u32), u32>>,
-    #[wasmer(export)]
+    #[wasmer(export(alias = "_memset", optional = true))]
     pub memset: LazyInit<NativeFunc<(u32, u32, u32), u32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "stackAlloc", optional = true))]
     pub stack_alloc: LazyInit<NativeFunc<u32, u32>>,
     pub jumps: Arc<Mutex<Vec<[u32; 27]>>>,
     pub opened_dirs: HashMap<i32, Box<LibcDirWrapper>>,
 
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_i", optional = true))]
     pub dyn_call_i: LazyInit<NativeFunc<i32, i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_ii", optional = true))]
     pub dyn_call_ii: LazyInit<NativeFunc<(i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iii", optional = true))]
     pub dyn_call_iii: LazyInit<NativeFunc<(i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiii", optional = true))]
     pub dyn_call_iiii: LazyInit<NativeFunc<(i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iifi", optional = true))]
     pub dyn_call_iifi: LazyInit<NativeFunc<(i32, i32, f64, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_v", optional = true))]
     pub dyn_call_v: LazyInit<NativeFunc<i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vi", optional = true))]
     pub dyn_call_vi: LazyInit<NativeFunc<(i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vii", optional = true))]
     pub dyn_call_vii: LazyInit<NativeFunc<(i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viii", optional = true))]
     pub dyn_call_viii: LazyInit<NativeFunc<(i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiii", optional = true))]
     pub dyn_call_viiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32)>>,
 
     // round 2
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_dii", optional = true))]
     pub dyn_call_dii: LazyInit<NativeFunc<(i32, i32, i32), f64>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_diiii", optional = true))]
     pub dyn_call_diiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32), f64>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiii", optional = true))]
     pub dyn_call_iiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiiii", optional = true))]
     pub dyn_call_iiiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiiiii", optional = true))]
     pub dyn_call_iiiiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiiiiii", optional = true))]
     pub dyn_call_iiiiiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiiiiiii", optional = true))]
     pub dyn_call_iiiiiiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiiiiiiii", optional = true))]
     pub dyn_call_iiiiiiiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiiiiiiiiii", optional = true))]
     pub dyn_call_iiiiiiiiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vd", optional = true))]
     pub dyn_call_vd: LazyInit<NativeFunc<(i32, f64)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiiii", optional = true))]
     pub dyn_call_viiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiiiii", optional = true))]
     pub dyn_call_viiiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiiiiii", optional = true))]
     pub dyn_call_viiiiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiiiiiii", optional = true))]
     pub dyn_call_viiiiiiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiiiiiiii", optional = true))]
     pub dyn_call_viiiiiiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiiiiiiiii", optional = true))]
     pub dyn_call_viiiiiiiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iij", optional = true))]
     pub dyn_call_iij: LazyInit<NativeFunc<(i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iji", optional = true))]
     pub dyn_call_iji: LazyInit<NativeFunc<(i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiji", optional = true))]
     pub dyn_call_iiji: LazyInit<NativeFunc<(i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_iiijj", optional = true))]
     pub dyn_call_iiijj: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_j", optional = true))]
     pub dyn_call_j: LazyInit<NativeFunc<i32, i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_ji", optional = true))]
     pub dyn_call_ji: LazyInit<NativeFunc<(i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_jii", optional = true))]
     pub dyn_call_jii: LazyInit<NativeFunc<(i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_jij", optional = true))]
     pub dyn_call_jij: LazyInit<NativeFunc<(i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_jjj", optional = true))]
     pub dyn_call_jjj: LazyInit<NativeFunc<(i32, i32, i32, i32, i32), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiij", optional = true))]
     pub dyn_call_viiij: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiijiiii", optional = true))]
     pub dyn_call_viiijiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiijiiiiii", optional = true))]
     pub dyn_call_viiijiiiiii:
         LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viij", optional = true))]
     pub dyn_call_viij: LazyInit<NativeFunc<(i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viiji", optional = true))]
     pub dyn_call_viiji: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viijiii", optional = true))]
     pub dyn_call_viijiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viijj", optional = true))]
     pub dyn_call_viijj: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vj", optional = true))]
     pub dyn_call_vj: LazyInit<NativeFunc<(i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vjji", optional = true))]
     pub dyn_call_vjji: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vij", optional = true))]
     pub dyn_call_vij: LazyInit<NativeFunc<(i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viji", optional = true))]
     pub dyn_call_viji: LazyInit<NativeFunc<(i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vijiii", optional = true))]
     pub dyn_call_vijiii: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vijj", optional = true))]
     pub dyn_call_vijj: LazyInit<NativeFunc<(i32, i32, i32, i32, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viid", optional = true))]
     pub dyn_call_viid: LazyInit<NativeFunc<(i32, i32, i32, f64)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_vidd", optional = true))]
     pub dyn_call_vidd: LazyInit<NativeFunc<(i32, i32, f64, f64)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viidii", optional = true))]
     pub dyn_call_viidii: LazyInit<NativeFunc<(i32, i32, i32, f64, i32, i32)>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "dynCall_viidddddddd", optional = true))]
     pub dyn_call_viidddddddd:
         LazyInit<NativeFunc<(i32, i32, i32, f64, f64, f64, f64, f64, f64, f64, f64)>>,
     pub temp_ret_0: i32,
 
-    #[wasmer(export)]
+    #[wasmer(export(name = "stackSave", optional = true))]
     pub stack_save: LazyInit<NativeFunc<(), i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "stackRestore", optional = true))]
     pub stack_restore: LazyInit<NativeFunc<i32>>,
-    #[wasmer(export)]
+    #[wasmer(export(name = "setThrew", alias = "_setThrew", optional = true))]
     pub set_threw: LazyInit<NativeFunc<(i32, i32)>>,
     pub mapped_dirs: HashMap<String, PathBuf>,
 }


### PR DESCRIPTION
This PR adds two new features to `WasmerEnv`:
- `alias = "alias_name"` for specifying additional names to try to find the export by
- `optional = true` for specifying that failure to find this export is okay

In addition, it fixes some breakages on emscripten introduced by migrating emscripten to `WasmerEnv` naively. I've tested this in `examples/nginx` on the `0.x` branch and Wasmer is able to run nginx again, so this resolves #1997 

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
