### PR TITLE
Improved Apple Silicon & LLVM 11 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
           - build: windows-x64
             os: windows-latest
             rust: 1.48
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/windows-amd64.tar.gz'
+            # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/windows-amd64.tar.gz'
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
             run_integration_tests: true
@@ -92,12 +92,16 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - name: Install LLVM (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && !matrix.llvm_url
         shell: cmd
         run: |
           choco install llvm
+      - name: Install LLVM (macOS Apple Silicon)
+        if: matrix.os == 'macos-11.0' && !matrix.llvm_url
+        run: |
+          brew install llvm
       - name: Install LLVM
-        if: matrix.os != 'windows-latest' && matrix.os != 'macos-11.0'
+        if: matrix.llvm_url
         shell: bash
         run: |
           curl --proto '=https' --tlsv1.2 -sSf ${{ matrix.llvm_url }} -L -o llvm.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,14 @@ ifneq (, $(shell which llvm-config 2>/dev/null))
 	ifneq (, $(findstring 10,$(LLVM_VERSION)))
 		compilers += llvm
 	endif
+	ifneq (, $(findstring 11,$(LLVM_VERSION)))
+		compilers += llvm
+	endif
 else
 	ifneq (, $(shell which llvm-config-10 2>/dev/null))
+		compilers += llvm
+	endif
+	ifneq (, $(shell which llvm-config-11 2>/dev/null))
 		compilers += llvm
 	endif
 endif
@@ -297,6 +303,9 @@ else
 	if [ -d "wapm-cli" ]; then \
 		cp wapm-cli/target/release/wapm package/bin/ ;\
 	fi
+ifeq ($(UNAME_S), Darwin)
+	codesign -s - package/bin/wapm
+endif
 endif
 
 package-wasmer:
@@ -305,6 +314,9 @@ ifeq ($(OS), Windows_NT)
 	cp target/release/wasmer.exe package/bin/
 else
 	cp target/release/wasmer package/bin/
+ifeq ($(UNAME_S), Darwin)
+	codesign -s - package/bin/wasmer
+endif
 endif
 
 package-capi:

--- a/tests/compilers/native_functions.rs
+++ b/tests/compilers/native_functions.rs
@@ -162,12 +162,13 @@ fn non_native_functions_and_closures_with_no_env_work() -> Result<()> {
 }
 
 // The native ABI for functions fails when defining a function natively in
-// macos (Darwin) with the Apple Silicon ARM chip
-// TODO: Cranelift should have a good ABI for the ABI
+// macos (Darwin) with the Apple Silicon ARM chip and Cranelift.
+// We should enable it for LLVM in Apple Silicon, but now is not trivial.
+// TODO: Fix once Cranelift has a correct ABI for Apple Silicon.
 #[test]
 #[cfg_attr(
     all(
-        feature = "test-cranelift",
+        // feature = "test-cranelift",
         target_os = "macos",
         target_arch = "aarch64",
     ),

--- a/tests/compilers/utils.rs
+++ b/tests/compilers/utils.rs
@@ -42,7 +42,7 @@ pub fn get_engine(canonicalize_nans: bool) -> impl Engine {
 }
 #[cfg(feature = "test-native")]
 pub fn get_engine(canonicalize_nans: bool) -> impl Engine {
-    let mut compiler_config = get_compiler(canonicalize_nans);
+    let compiler_config = get_compiler(canonicalize_nans);
     Native::new(compiler_config).engine()
 }
 

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -36,7 +36,7 @@ fn get_store(features: Features, try_nan_canonicalization: bool) -> Store {
 
 #[cfg(feature = "test-native")]
 fn get_store(features: Features, try_nan_canonicalization: bool) -> Store {
-    let mut compiler_config = get_compiler(try_nan_canonicalization);
+    let compiler_config = get_compiler(try_nan_canonicalization);
     Store::new(&Native::new(compiler_config).features(features).engine())
 }
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
This PR:
* [x] Adds support for LLVM 11
* [x] Adds support for llvm-native in Apple Silicon
* [x] Sign the `wasmer` and `wapm` binaries in macOS (so they can run smoothly upon installation)

This PR fix #1984 and fix #1981.

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
