### PR TITLE
Prepare for 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 ## **[Unreleased]**
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## 1.0.1 - 2021-01-12
+
+### Added
 - [#2005](https://github.com/wasmerio/wasmer/pull/2005) Added the arguments `alias` and `optional` to `WasmerEnv` derive's `export` attribute.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ## 1.0.1 - 2021-01-12
 
+This release includes a breaking change in the API (changing the trait `enumset::EnumsetType` to `wasmer_enumset::EnumSetType` and changing `enumset::EnumSet` in signatures to `wasmer_enumset::EnumSet` to work around a breaking change introduced by `syn`) but is being released as a minor version because `1.0.0` is also in a broken state due to a breaking change introduced by `syn` which affects `enumset` and thus `wasmer`.
+
+This change is unlikely to affect any users of `wasmer`, but if it does please change uses of the `enumset` crate to the `wasmer_enumset` crate where possible.
+
 ### Added
 - [#2005](https://github.com/wasmerio/wasmer/pull/2005) Added the arguments `alias` and `optional` to `WasmerEnv` derive's `export` attribute.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cfg-if 0.1.10",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-c-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cbindgen",
  "cfg-if 1.0.0",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake3",
  "hex",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "hashbrown 0.9.1",
  "raw-cpuid",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-codegen 0.67.0",
  "cranelift-codegen 0.68.0",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "cc",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "compiletest_rs",
  "proc-macro-error",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-emscripten"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "getrandom 0.2.0",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "bincode",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dummy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "serde",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-jit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-native"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-object-file"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-integration-tests-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "wasmer",
  "wasmer-types",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "object",
  "thiserror",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-entity 0.68.0",
  "serde",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-experimental-io-devices"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "minifb",
  "ref_thread_local",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wast"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-workspace"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer workspace"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -10,21 +10,21 @@ publish = false
 autoexamples = false
 
 [dependencies]
-wasmer = { version = "1.0.0", path = "lib/api", default-features = false }
-wasmer-compiler = { version = "1.0.0", path = "lib/compiler" }
-wasmer-compiler-cranelift = { version = "1.0.0", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.0", path = "lib/compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.0", path = "lib/compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.0", path = "lib/emscripten", optional = true }
-wasmer-engine = { version = "1.0.0", path = "lib/engine" }
-wasmer-engine-jit = { version = "1.0.0", path = "lib/engine-jit", optional = true }
-wasmer-engine-native = { version = "1.0.0", path = "lib/engine-native", optional = true }
-wasmer-engine-object-file = { version = "1.0.0", path = "lib/engine-object-file", optional = true }
-wasmer-wasi = { version = "1.0.0", path = "lib/wasi", optional = true }
-wasmer-wast = { version = "1.0.0", path = "tests/lib/wast", optional = true }
-wasmer-cache = { version = "1.0.0", path = "lib/cache", optional = true }
-wasmer-types = { version = "1.0.0", path = "lib/wasmer-types" }
-wasmer-middlewares = { version = "1.0.0", path = "lib/middlewares", optional = true }
+wasmer = { version = "1.0.1", path = "lib/api", default-features = false }
+wasmer-compiler = { version = "1.0.1", path = "lib/compiler" }
+wasmer-compiler-cranelift = { version = "1.0.1", path = "lib/compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.1", path = "lib/compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "1.0.1", path = "lib/compiler-llvm", optional = true }
+wasmer-emscripten = { version = "1.0.1", path = "lib/emscripten", optional = true }
+wasmer-engine = { version = "1.0.1", path = "lib/engine" }
+wasmer-engine-jit = { version = "1.0.1", path = "lib/engine-jit", optional = true }
+wasmer-engine-native = { version = "1.0.1", path = "lib/engine-native", optional = true }
+wasmer-engine-object-file = { version = "1.0.1", path = "lib/engine-object-file", optional = true }
+wasmer-wasi = { version = "1.0.1", path = "lib/wasi", optional = true }
+wasmer-wast = { version = "1.0.1", path = "tests/lib/wast", optional = true }
+wasmer-cache = { version = "1.0.1", path = "lib/cache", optional = true }
+wasmer-types = { version = "1.0.1", path = "lib/wasmer-types" }
+wasmer-middlewares = { version = "1.0.1", path = "lib/middlewares", optional = true }
 cfg-if = "1.0"
 
 [workspace]

--- a/docs/migration_to_1.0.0.md
+++ b/docs/migration_to_1.0.0.md
@@ -340,11 +340,11 @@ you'll be able to delegate most of the work to Wasmer:
 ``` 
 
 [examples]: https://docs.wasmer.io/integrations/examples
-[wasmer]: https://crates.io/crates/wasmer/1.0.0
-[wasmer-wasi]: https://crates.io/crates/wasmer-wasi/1.0.0
-[wasmer-emscripten]: https://crates.io/crates/wasmer-emscripten/1.0.0
-[wasmer-engine]: https://crates.io/crates/wasmer-engine/1.0.0
-[wasmer-compiler]: https://crates.io/crates/wasmer-compiler/1.0.0
+[wasmer]: https://crates.io/crates/wasmer
+[wasmer-wasi]: https://crates.io/crates/wasmer-wasi
+[wasmer-emscripten]: https://crates.io/crates/wasmer-emscripten
+[wasmer-engine]: https://crates.io/crates/wasmer-engine
+[wasmer-compiler]: https://crates.io/crates/wasmer-compiler
 [wasmer.io]: https://wasmer.io
 [wasmer-nightly]: https://github.com/wasmerio/wasmer-nightly/
 [getting-started]: https://docs.wasmer.io/ecosystem/wasmer/getting-started

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "1.0.0"
+version = "1.0.1"
 description = "High-performant WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "runtime", "vm"]
@@ -11,16 +11,16 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.0", optional = true }
-wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "1.0.0", optional = true }
-wasmer-compiler-llvm = { path = "../compiler-llvm", version = "1.0.0", optional = true }
-wasmer-compiler = { path = "../compiler", version = "1.0.0" }
-wasmer-derive = { path = "../derive", version = "1.0.0" }
-wasmer-engine = { path = "../engine", version = "1.0.0" }
-wasmer-engine-jit = { path = "../engine-jit", version = "1.0.0", optional = true }
-wasmer-engine-native = { path = "../engine-native", version = "1.0.0", optional = true }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.1", optional = true }
+wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "1.0.1", optional = true }
+wasmer-compiler-llvm = { path = "../compiler-llvm", version = "1.0.1", optional = true }
+wasmer-compiler = { path = "../compiler", version = "1.0.1" }
+wasmer-derive = { path = "../derive", version = "1.0.1" }
+wasmer-engine = { path = "../engine", version = "1.0.1" }
+wasmer-engine-jit = { path = "../engine-jit", version = "1.0.1", optional = true }
+wasmer-engine-native = { path = "../engine-native", version = "1.0.1", optional = true }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
 indexmap = { version = "1.4", features = ["serde-1"] }
 cfg-if = "0.1"
 wat = { version = "1.0", optional = true }

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-c-api"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer C API library"
 categories = ["wasm", "api-bindings"]
 keywords = ["wasm", "webassembly", "runtime"]
@@ -15,18 +15,18 @@ edition = "2018"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
-wasmer = { version = "1.0.0", path = "../api", default-features = false }
-wasmer-compiler = { version = "1.0.0", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "1.0.0", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.0", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.0", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.0", path = "../emscripten", optional = true }
-wasmer-engine = { version = "1.0.0", path = "../engine" }
-wasmer-engine-jit = { version = "1.0.0", path = "../engine-jit", optional = true }
-wasmer-engine-native = { version = "1.0.0", path = "../engine-native", optional = true }
-wasmer-engine-object-file = { version = "1.0.0", path = "../engine-object-file", optional = true }
-wasmer-wasi = { version = "1.0.0", path = "../wasi", optional = true }
-wasmer-types = { version = "1.0.0", path = "../wasmer-types" }
+wasmer = { version = "1.0.1", path = "../api", default-features = false }
+wasmer-compiler = { version = "1.0.1", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "1.0.1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.1", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "1.0.1", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "1.0.1", path = "../emscripten", optional = true }
+wasmer-engine = { version = "1.0.1", path = "../engine" }
+wasmer-engine-jit = { version = "1.0.1", path = "../engine-jit", optional = true }
+wasmer-engine-native = { version = "1.0.1", path = "../engine-native", optional = true }
+wasmer-engine-object-file = { version = "1.0.1", path = "../engine-object-file", optional = true }
+wasmer-wasi = { version = "1.0.1", path = "../wasi", optional = true }
+wasmer-types = { version = "1.0.1", path = "../wasmer-types" }
 cfg-if = "1.0"
 lazy_static = "1.4"
 libc = { version = "^0.2", default-features = false }
@@ -37,7 +37,7 @@ typetag = { version = "0.1", optional = true }
 paste = "1.0"
 # for generating code in the same way thot the wasm-c-api does
 # Commented out for now until we can find a solution to the exported function problem
-# wasmer-wasm-c-api = { version = "1.0.0", path = "crates/wasm-c-api" }
+# wasmer-wasm-c-api = { version = "1.0.1", path = "crates/wasm-c-api" }
 
 [dev-dependencies]
 inline-c = "0.1.4"

--- a/lib/c-api/wasmer.h
+++ b/lib/c-api/wasmer.h
@@ -32,10 +32,10 @@
 #define WASMER_WASI_ENABLED
 
 // This file corresponds to the following Wasmer version.
-#define WASMER_VERSION "1.0.0"
+#define WASMER_VERSION "1.0.1"
 #define WASMER_VERSION_MAJOR 1
 #define WASMER_VERSION_MINOR 0
-#define WASMER_VERSION_PATCH 0
+#define WASMER_VERSION_PATCH 1
 #define WASMER_VERSION_PRE ""
 
 #endif // WASMER_H_PRELUDE

--- a/lib/c-api/wasmer.hh
+++ b/lib/c-api/wasmer.hh
@@ -32,10 +32,10 @@
 #define WASMER_WASI_ENABLED
 
 // This file corresponds to the following Wasmer version.
-#define WASMER_VERSION "1.0.0"
+#define WASMER_VERSION "1.0.1"
 #define WASMER_VERSION_MAJOR 1
 #define WASMER_VERSION_MINOR 0
-#define WASMER_VERSION_PATCH 0
+#define WASMER_VERSION_PATCH 1
 #define WASMER_VERSION_PRE ""
 
 #endif // WASMER_H_PRELUDE

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -39,10 +39,10 @@
 #define WASMER_WASI_ENABLED
 
 // This file corresponds to the following Wasmer version.
-#define WASMER_VERSION "1.0.0"
+#define WASMER_VERSION "1.0.1"
 #define WASMER_VERSION_MAJOR 1
 #define WASMER_VERSION_MINOR 0
-#define WASMER_VERSION_PATCH 0
+#define WASMER_VERSION_PATCH 1
 #define WASMER_VERSION_PRE ""
 
 #endif // WASMER_WASM_H_PRELUDE

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cache"
-version = "1.0.0"
+version = "1.0.1"
 description = "Cache system for Wasmer WebAssembly runtime"
 categories = ["wasm", "caching"]
 keywords = ["wasm", "webassembly", "cache"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "1.0.0", default-features = false }
+wasmer = { path = "../api", version = "1.0.1", default-features = false }
 hex = "0.4"
 thiserror = "1"
 blake3 = "0.3"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cli"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer CLI"
 categories = ["wasm", "command-line-interface"]
 keywords = ["wasm", "webassembly", "cli"]
@@ -17,22 +17,22 @@ path = "src/bin/wasmer.rs"
 doc = false
 
 [dependencies]
-wasmer = { version = "1.0.0", path = "../api", default-features = false }
-wasmer-compiler = { version = "1.0.0", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "1.0.0", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.0", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.0", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.0", path = "../emscripten", optional = true }
-wasmer-engine = { version = "1.0.0", path = "../engine" }
-wasmer-engine-jit = { version = "1.0.0", path = "../engine-jit", optional = true }
-wasmer-engine-native = { version = "1.0.0", path = "../engine-native", optional = true }
-wasmer-engine-object-file = { version = "1.0.0", path = "../engine-object-file", optional = true }
-wasmer-vm = { version = "1.0.0", path = "../vm" }
-wasmer-wasi = { version = "1.0.0", path = "../wasi", default-features = false, optional = true }
-wasmer-wasi-experimental-io-devices = { version = "1.0.0", path = "../wasi-experimental-io-devices", optional = true }
-wasmer-wast = { version = "1.0.0", path = "../../tests/lib/wast", optional = true }
-wasmer-cache = { version = "1.0.0", path = "../cache", optional = true }
-wasmer-types = { version = "1.0.0", path = "../wasmer-types" }
+wasmer = { version = "1.0.1", path = "../api", default-features = false }
+wasmer-compiler = { version = "1.0.1", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "1.0.1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.1", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "1.0.1", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "1.0.1", path = "../emscripten", optional = true }
+wasmer-engine = { version = "1.0.1", path = "../engine" }
+wasmer-engine-jit = { version = "1.0.1", path = "../engine-jit", optional = true }
+wasmer-engine-native = { version = "1.0.1", path = "../engine-native", optional = true }
+wasmer-engine-object-file = { version = "1.0.1", path = "../engine-object-file", optional = true }
+wasmer-vm = { version = "1.0.1", path = "../vm" }
+wasmer-wasi = { version = "1.0.1", path = "../wasi", default-features = false, optional = true }
+wasmer-wasi-experimental-io-devices = { version = "1.0.1", path = "../wasi-experimental-io-devices", optional = true }
+wasmer-wast = { version = "1.0.1", path = "../../tests/lib/wast", optional = true }
+wasmer-cache = { version = "1.0.1", path = "../cache", optional = true }
+wasmer-types = { version = "1.0.1", path = "../wasmer-types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0"
+version = "1.0.1"
 description = "Cranelift compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "cranelift"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.0", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "1.0.1", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1", default-features = false, features = ["std"] }
 cranelift-codegen = { version = "0.68", default-features = false, features = ["x86", "arm64"] }
 cranelift-frontend = { version = "0.68", default-features = false }
 tracing = "0.1"

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-llvm"
-version = "1.0.0"
+version = "1.0.1"
 description = "LLVM compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "llvm"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.0", features = ["translator"] }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
+wasmer-compiler = { path = "../compiler", version = "1.0.1", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
 target-lexicon = { version = "0.11", default-features = false }
 smallvec = "1.6"
 goblin = "0.2"

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0"
+version = "1.0.1"
 description = "Singlepass compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "singlepass"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.0", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "1.0.1", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1", default-features = false, features = ["std"] }
 rayon = "1.5"
 hashbrown = { version = "0.9", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler"
-version = "1.0.0"
+version = "1.0.1"
 description = "Base compiler abstraction for Wasmer WebAssembly runtime"
 categories = ["wasm", "no-std"]
 keywords = ["wasm", "webassembly", "compiler"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0", default-features = false }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1", default-features = false }
 wasmparser = { version = "0.65", optional = true, default-features = false }
 target-lexicon = { version = "0.11", default-features = false }
 wasmer_enumset = "1.0"

--- a/lib/deprecated/runtime-core/Cargo.lock
+++ b/lib/deprecated/runtime-core/Cargo.lock
@@ -1136,7 +1136,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cfg-if 0.1.10",
  "indexmap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake3",
  "hex",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "raw-cpuid",
  "serde",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "cc",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "bincode",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-jit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-native"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "object 0.22.0",
  "thiserror",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "cc",

--- a/lib/deprecated/runtime-core/Cargo.toml
+++ b/lib/deprecated/runtime-core/Cargo.toml
@@ -14,16 +14,16 @@ edition = "2018"
 maintenance = { status = "deprecated" }
 
 [dependencies]
-wasmer-types = { path = "../../wasmer-types", version = "1.0.0" }
-wasmer = { path = "../../api", version = "1.0.0", features = ["deprecated"] }
-wasmer-cache = { path = "../../cache", version = "1.0.0" }
-wasmer-compiler = { path = "../../compiler", version = "1.0.0", features = ["translator"] }
-wasmer-compiler-llvm = { path = "../../compiler-llvm", version = "1.0.0", optional = true }
-wasmer-compiler-cranelift = { path = "../../compiler-cranelift", version = "1.0.0", optional = true }
-wasmer-compiler-singlepass = { path = "../../compiler-singlepass", version = "1.0.0", optional = true }
-wasmer-engine = { path = "../../engine", version = "1.0.0" }
-wasmer-engine-jit = { path = "../../engine-jit", version = "1.0.0" }
-wasmer-vm = { path = "../../vm", version = "1.0.0" }
+wasmer-types = { path = "../../wasmer-types", version = "1.0.1" }
+wasmer = { path = "../../api", version = "1.0.1", features = ["deprecated"] }
+wasmer-cache = { path = "../../cache", version = "1.0.1" }
+wasmer-compiler = { path = "../../compiler", version = "1.0.1", features = ["translator"] }
+wasmer-compiler-llvm = { path = "../../compiler-llvm", version = "1.0.1", optional = true }
+wasmer-compiler-cranelift = { path = "../../compiler-cranelift", version = "1.0.1", optional = true }
+wasmer-compiler-singlepass = { path = "../../compiler-singlepass", version = "1.0.1", optional = true }
+wasmer-engine = { path = "../../engine", version = "1.0.1" }
+wasmer-engine-jit = { path = "../../engine-jit", version = "1.0.1" }
+wasmer-vm = { path = "../../vm", version = "1.0.1" }
 lazy_static = "1.4"
 
 [build-dependencies]

--- a/lib/deprecated/runtime/Cargo.lock
+++ b/lib/deprecated/runtime/Cargo.lock
@@ -1136,7 +1136,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cfg-if 0.1.10",
  "indexmap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake3",
  "hex",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "raw-cpuid",
  "serde",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "cc",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "bincode",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-jit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-native"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "cfg-if 0.1.10",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "object 0.22.0",
  "thiserror",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "cc",

--- a/lib/derive/Cargo.toml
+++ b/lib/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-derive"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer derive macros"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -17,5 +17,5 @@ proc-macro2 = "1"
 proc-macro-error = "1.0.0"
 
 [dev-dependencies]
-wasmer = { path = "../api", version = "1.0.0" }
+wasmer = { path = "../api", version = "1.0.1" }
 compiletest_rs = "0.5"

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten"
-version = "1.0.0"
+version = "1.0.1"
 description = "Emscripten implementation library for Wasmer WebAssembly runtime"
 categories = ["wasm", "os"]
 keywords = ["wasm", "webassembly", "abi", "emscripten", "posix"]
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 libc = "^0.2"
 log = "0.4"
 time = "0.1"
-wasmer = { path = "../api", version = "1.0.0", default-features = false }
+wasmer = { path = "../api", version = "1.0.1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.2"

--- a/lib/engine-jit/Cargo.toml
+++ b/lib/engine-jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-jit"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer JIT Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "jit"]
@@ -11,10 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0", features = ["translator"] }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-engine = { path = "../engine", version = "1.0.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
+wasmer-compiler = { path = "../compiler", version = "1.0.1", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-engine = { path = "../engine", version = "1.0.1" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "2.2"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/lib/engine-native/Cargo.toml
+++ b/lib/engine-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-native"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer Native Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "native"]
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0" }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-engine = { path = "../engine", version = "1.0.0" }
-wasmer-object = { path = "../object", version = "1.0.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
+wasmer-compiler = { path = "../compiler", version = "1.0.1" }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-engine = { path = "../engine", version = "1.0.1" }
+wasmer-object = { path = "../object", version = "1.0.1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "0.1"
 tracing = "0.1"

--- a/lib/engine-object-file/Cargo.toml
+++ b/lib/engine-object-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-object-file"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer Object File Engine"
 categories = ["wasm"]
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0" }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
-wasmer-engine = { path = "../engine", version = "1.0.0" }
-wasmer-object = { path = "../object", version = "1.0.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
+wasmer-compiler = { path = "../compiler", version = "1.0.1" }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
+wasmer-engine = { path = "../engine", version = "1.0.1" }
+wasmer-object = { path = "../object", version = "1.0.1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "0.1"
 tracing = "0.1"

--- a/lib/engine-object-file/README.md
+++ b/lib/engine-object-file/README.md
@@ -1,6 +1,6 @@
 # Wasmer Engine Object File
 
-This is an [engine](https://crates.io/crates/wasmer-engine) for the [wasmer](https://crates.io/crates/wasmer/1.0.0) WebAssembly VM.
+This is an [engine](https://crates.io/crates/wasmer-engine) for the [wasmer](https://crates.io/crates/wasmer) WebAssembly VM.
 
 This engine is used to produce a native object file that can be linked
 against providing a sandboxed WebAssembly runtime environment for the

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer Engine abstraction"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine"]
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0" }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
+wasmer-compiler = { path = "../compiler", version = "1.0.1" }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
 target-lexicon = { version = "0.11", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"

--- a/lib/middlewares/Cargo.toml
+++ b/lib/middlewares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-middlewares"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "A collection of various useful middlewares"
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "1.0.0" }
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
-wasmer-vm = { path = "../vm", version = "1.0.0" }
+wasmer = { path = "../api", version = "1.0.1" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
+wasmer-vm = { path = "../vm", version = "1.0.1" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/lib/object/Cargo.toml
+++ b/lib/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-object"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer Native Object generator"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
-wasmer-compiler = { path = "../compiler", version = "1.0.0", default-features = false, features = [
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
+wasmer-compiler = { path = "../compiler", version = "1.0.1", default-features = false, features = [
     "std",
     "translator"
 ] }

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-vm"
-version = "1.0.0"
+version = "1.0.1"
 description = "Runtime library support for Wasmer"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../wasmer-types", version = "1.0.0" }
+wasmer-types = { path = "../wasmer-types", version = "1.0.1" }
 region = "2.2"
 libc = { version = "^0.2", default-features = false }
 memoffset = "0.6"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-experimental-io-devices"
-version = "1.0.0"
+version = "1.0.1"
 description = "An experimental non-standard WASI extension for graphics"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "types"]
@@ -14,7 +14,7 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
-wasmer-wasi = { version = "1.0.0", path = "../wasi" }
+wasmer-wasi = { version = "1.0.1", path = "../wasi" }
 tracing = "0.1"
 minifb = "0.19"
 ref_thread_local = "0.0"

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi"
-version = "1.0.0"
+version = "1.0.1"
 description = "WASI implementation library for Wasmer WebAssembly runtime"
 categories = ["wasm", "os"]
 keywords = ["wasm", "webassembly", "wasi", "sandbox", "ABI"]
@@ -21,7 +21,7 @@ getrandom = "0.2"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-wasmer = { path = "../api", version = "1.0.0", default-features = false }
+wasmer = { path = "../api", version = "1.0.1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/lib/wasmer-types/Cargo.toml
+++ b/lib/wasmer-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-types"
-version = "1.0.0"
+version = "1.0.1"
 description = "Wasmer Common Types"
 categories = ["wasm", "no-std", "data-structures"]
 keywords = ["wasm", "webassembly", "types"]

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 # TODO: find this automatically
-target_version = "1.0.0"
+target_version = "1.0.1"
 
 # TODO: generate this by parsing toml files
 dep_graph = {

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -4,8 +4,8 @@
 : "${FD:=fd}"
 
 # A script to update the version of all the crates at the same time
-PREVIOUS_VERSION='1.0.0-rc1'
-NEXT_VERSION='1.0.0'
+PREVIOUS_VERSION='1.0.0'
+NEXT_VERSION='1.0.1'
 
 # quick hack
 ${FD} Cargo.toml --exec sed -i '{}' -e "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"

--- a/scripts/windows-installer/wasmer.iss
+++ b/scripts/windows-installer/wasmer.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=Wasmer
-AppVersion=1.0.0
+AppVersion=1.0.1
 DefaultDirName={pf}\Wasmer
 DefaultGroupName=Wasmer
 Compression=lzma2

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-integration-tests-cli"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "CLI integration tests"
 repository = "https://github.com/wasmerio/wasmer"

--- a/tests/lib/engine-dummy/Cargo.toml
+++ b/tests/lib/engine-dummy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-dummy"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer placeholder engine"
 license = "MIT"
@@ -8,10 +8,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-wasmer-types = { path = "../../../lib/wasmer-types", version = "1.0.0" }
-wasmer-compiler = { path = "../../../lib/compiler", version = "1.0.0" }
-wasmer-vm = { path = "../../../lib/vm", version = "1.0.0" }
-wasmer-engine = { path = "../../../lib/engine", version = "1.0.0" }
+wasmer-types = { path = "../../../lib/wasmer-types", version = "1.0.1" }
+wasmer-compiler = { path = "../../../lib/compiler", version = "1.0.1" }
+wasmer-vm = { path = "../../../lib/vm", version = "1.0.1" }
+wasmer-engine = { path = "../../../lib/engine", version = "1.0.1" }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
 bincode = { version = "1.2", optional = true }

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wast"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "wast testing support for wasmer"
 license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmer = { path = "../../../lib/api", version = "1.0.0", default-features = false }
-wasmer-wasi = { path = "../../../lib/wasi", version = "1.0.0" }
+wasmer = { path = "../../../lib/api", version = "1.0.1", default-features = false }
+wasmer-wasi = { path = "../../../lib/wasi", version = "1.0.1" }
 wast = "24.0"
 serde = "1"
 tempfile = "3"


### PR DESCRIPTION
Technically includes a breaking change, changing `enumset` -> `wasmer_enumset` meaning a trait on a public item has now changed, however due to the `syn` bug, `1.0.0` is effectively broken as-is and this is required to get things working again.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
