### PR TITLE
Allow external initialisation of __wasi_prestat_u

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 ### Fixed
+ - [#2019](https://github.com/wasmerio/wasmer/pull/2019) Made field of `wasmer_io::types::__wasi_prestat_u` public
 
 ## 1.0.1 - 2021-01-12
 

--- a/lib/wasi/src/syscalls/types.rs
+++ b/lib/wasi/src/syscalls/types.rs
@@ -256,7 +256,7 @@ unsafe impl ValueType for __wasi_prestat_u_dir_t {}
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub union __wasi_prestat_u {
-    dir: __wasi_prestat_u_dir_t,
+    pub dir: __wasi_prestat_u_dir_t,
 }
 
 impl fmt::Debug for __wasi_prestat_u {


### PR DESCRIPTION
# Description
Related to #2017, I'm doing a custom implementation of WASI. To be able to reuse the helpfully defined types, this fields needs to be public.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
