### PR TITLE
expose trap error from RuntimeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## **[Unreleased]**
 
 ### Added
+- [#2026](https://github.com/wasmerio/wasmer/pull/2010) Expose trap code of a `RuntimeError`, if it's a `Trap`.
 
 ### Changed
 

--- a/lib/engine/src/trap/error.rs
+++ b/lib/engine/src/trap/error.rs
@@ -207,6 +207,15 @@ impl RuntimeError {
         }
     }
 
+    /// Returns trap code, if it's a Trap
+    pub fn to_trap(self) -> Option<TrapCode> {
+        if let RuntimeErrorSource::Trap(trap_code) = self.inner.source {
+            Some(trap_code)
+        } else {
+            None
+        }
+    }
+
     /// Returns true if the `RuntimeError` is the same as T
     pub fn is<T: Error + 'static>(&self) -> bool {
         match &self.inner.source {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Internal of RuntimeError is private, user can know UserError via `downcast`, but user isn't able to tell the trap code if it's a `Trap`. This PR expose trap code via `RuntimeError#to_trap`. (And, if both downcast returns error and to_trap returns None, user will know it's a `RuntimeError::Generic`, which can be shown by `error.message()`, so there's no need to expose `RuntimeError::Generic` case)

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
