### PR TITLE
chore: Publish documentation from master branch 

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - 'master'
+
+name: Documentation
+
+jobs:
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libxkbcommon-dev doxygen
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0
+          override: true
+      - name: Build & package documentation
+        run: make package-docs
+      - name: Publish documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./package/docs

--- a/Makefile
+++ b/Makefile
@@ -383,11 +383,11 @@ endif
 
 package-docs: build-docs build-docs-capi
 	mkdir -p "package/docs"
-	mkdir -p "package/docs/c"
+	mkdir -p "package/docs/c/runtime-c-api"
 	cp -R target/doc package/docs/crates
-	cp -R lib/c-api/doc/html package/docs/c-api
-	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=rust/wasmer_vm/index.html">' > package/docs/index.html
-	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=wasmer_vm/index.html">' > package/docs/crates/index.html
+	cp -R lib/c-api/doc/deprecated/html/ package/docs/c/runtime-c-api
+	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=crates/wasmer/index.html">' > package/docs/index.html
+	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=wasmer/index.html">' > package/docs/crates/index.html
 
 package: package-wapm package-wasmer package-minimal-headless-wasmer package-capi
 
@@ -437,10 +437,3 @@ lint: lint-formatting lint-packages
 
 install-local: package
 	tar -C ~/.wasmer -zxvf wasmer.tar.gz
-
-publish-docs:
-	git clone -b "gh-pages" --depth=1 https://wasmerbot:$(GITHUB_DOCS_TOKEN)@github.com/wasmerio/wasmer.git api-docs-repo
-	cp -R package/docs/* api-docs-repo/
-	cd api-docs-repo && git add index.html crates/* c-api/*
-	cd api-docs-repo && (git diff-index --quiet HEAD || git commit -m "Publishing GitHub Pages")
-	# cd api-docs-repo && git push origin gh-pages

--- a/lib/c-api/doc/deprecated/index.md
+++ b/lib/c-api/doc/deprecated/index.md
@@ -104,7 +104,7 @@ int main()
 
 You can check more examples of how to use the Wasmer C API here:
 
-https://docs.wasmer.io/integrations/c/examples
+https://docs.wasmer.io/integrations/examples
 
 ## pkg-config
 


### PR DESCRIPTION
# Description

A documentation is published on https://wasmerio.github.io/wasmer/ from master but it is not up to date anymore.

This PR adds a `documentation` workflow to automatically publish the doc on each push on master.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
