### PR TITLE
Use Box<[Type]>` inside of `FunctionType`

### DIFF
--- a/lib/wasmer-types/src/types.rs
+++ b/lib/wasmer-types/src/types.rs
@@ -229,9 +229,9 @@ impl ExternType {
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct FunctionType {
     /// The parameters of the function
-    params: Vec<Type>,
+    params: Box<[Type]>,
     /// The return values of the function
-    results: Vec<Type>,
+    results: Box<[Type]>,
 }
 
 impl FunctionType {
@@ -242,8 +242,8 @@ impl FunctionType {
         Returns: Into<Vec<Type>>,
     {
         Self {
-            params: params.into(),
-            results: returns.into(),
+            params: params.into().into_boxed_slice(),
+            results: returns.into().into_boxed_slice(),
         }
     }
 


### PR DESCRIPTION
This saves 16 bytes (on 64bit systems) on the stack for each `FunctionType` and
additional space on the heap by not allowing resizing (like Vec does)

There are ways to save even more memory here but they're all heavier weight than this simple change.
