### PR TITLE
Improve parallelism of llvm builds with native or object file engine.

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -157,7 +157,9 @@ impl LLVMCompiler {
             .collect::<Result<Vec<_>, CompileError>>()?
             .into_par_iter();
 
-        let merged_bitcode = merged_bitcode.chain(trampolines_bitcode).chain(dynamic_trampolines_bitcode)
+        let merged_bitcode = merged_bitcode
+            .chain(trampolines_bitcode)
+            .chain(dynamic_trampolines_bitcode)
             .reduce_with(|bc1, bc2| {
                 let ctx = Context::create();
                 let membuf = MemoryBuffer::create_from_memory_range(&bc1, "");


### PR DESCRIPTION
On my 24 core system, a 21.5s build of qjs.so (llvm + native) is reduced to an 8.2s build.