### PR TITLE
feat(c-api) Do not build C headers if the env var `DOCS_RS` exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2041](https://github.com/wasmerio/wasmer/pull/2041) Documentation diagrams now have a solid white background rather than a transparent background.
 
 ### Fixed
+- [#2044](https://github.com/wasmerio/wasmer/pull/2044) Do not build C headers on docs.rs.
 
 ## 1.0.1 - 2021-01-12
 

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -1,3 +1,8 @@
+//! This build script aims at:
+//!
+//! * generating the C header files for the C API,
+//! * setting `inline-c` up.
+
 use cbindgen::{Builder, Language};
 use std::{env, fs, path::PathBuf};
 
@@ -59,9 +64,20 @@ fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    build_wasm_c_api_headers(&crate_dir, &out_dir);
-    build_wasmer_headers(&crate_dir, &out_dir);
+    if building_c_api_headers() {
+        build_wasm_c_api_headers(&crate_dir, &out_dir);
+        build_wasmer_c_api_headers(&crate_dir, &out_dir);
+    }
+
     build_inline_c_env_vars();
+}
+
+/// Check whether we should build the C API headers.
+///
+/// For the moment, it's always enabled, unless if the `DOCS_RS`
+/// environment variable is present.
+fn building_c_api_headers() -> bool {
+    env::var("DOCS_RS").is_err()
 }
 
 /// Build the header files for the `wasm_c_api` API.
@@ -126,7 +142,7 @@ fn build_wasm_c_api_headers(crate_dir: &str, out_dir: &str) {
 }
 
 /// Build the header files for the `deprecated` API.
-fn build_wasmer_headers(crate_dir: &str, out_dir: &str) {
+fn build_wasmer_c_api_headers(crate_dir: &str, out_dir: &str) {
     let mut crate_header_file = PathBuf::from(crate_dir);
     crate_header_file.push("wasmer");
 


### PR DESCRIPTION
# Description

Fix #1954.

According to https://docs.rs/about/builds, the `DOCS_RS` environment variable is set when the documentation is built from docs.rs. In this case, we must not build the C headers because it generates such error (see #1954 to learn more):

> Unable to copy the generated C bindings: `Os { code: 30, kind: Other, message: "Read-only file system" }`

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
