### PR TITLE
Remove sequencing point between the mapping steps.

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -87,81 +87,66 @@ impl LLVMCompiler {
 
         // TODO: https:/github.com/rayon-rs/rayon/issues/822
 
-        let merged_bitcode = function_body_inputs
-            .into_iter()
-            .collect::<Vec<_>>()
-            .par_iter()
-            .map_init(
-                || {
-                    let target_machine = self.config().target_machine(target);
-                    FuncTranslator::new(target_machine)
-                },
-                |func_translator, (i, input)| {
-                    let module = func_translator.translate_to_module(
-                        &compile_info.module,
-                        module_translation,
-                        i,
-                        input,
-                        self.config(),
-                        &compile_info.memory_styles,
-                        &compile_info.table_styles,
-                        symbol_registry,
-                    )?;
-                    Ok(module.write_bitcode_to_memory().as_slice().to_vec())
-                },
-            )
-            .collect::<Result<Vec<_>, CompileError>>()?
-            .into_par_iter();
+        let function_body_inputs = function_body_inputs.into_iter().collect::<Vec<_>>();
 
-        let trampolines_bitcode = compile_info
-            .module
-            .signatures
-            .iter()
-            .collect::<Vec<_>>()
-            .par_iter()
-            .map_init(
-                || {
-                    let target_machine = self.config().target_machine(target);
-                    FuncTrampoline::new(target_machine)
-                },
-                |func_trampoline, (i, sig)| {
-                    let name = symbol_registry.symbol_to_name(Symbol::FunctionCallTrampoline(*i));
-                    let module = func_trampoline.trampoline_to_module(sig, self.config(), &name)?;
-                    Ok(module.write_bitcode_to_memory().as_slice().to_vec())
-                },
-            )
-            .collect::<Result<Vec<_>, CompileError>>()?
-            .into_par_iter();
+        let merged_bitcode = function_body_inputs.par_iter().map_init(
+            || {
+                let target_machine = self.config().target_machine(target);
+                FuncTranslator::new(target_machine)
+            },
+            |func_translator, (i, input)| {
+                let module = func_translator.translate_to_module(
+                    &compile_info.module,
+                    module_translation,
+                    i,
+                    input,
+                    self.config(),
+                    &compile_info.memory_styles,
+                    &compile_info.table_styles,
+                    symbol_registry,
+                )?;
+                Ok(module.write_bitcode_to_memory().as_slice().to_vec())
+            },
+        );
 
-        let dynamic_trampolines_bitcode = compile_info
-            .module
-            .functions
-            .iter()
-            .collect::<Vec<_>>()
-            .par_iter()
-            .map_init(
-                || {
-                    let target_machine = self.config().target_machine(target);
-                    (
-                        FuncTrampoline::new(target_machine),
-                        &compile_info.module.signatures,
-                    )
-                },
-                |(func_trampoline, signatures), (i, sig)| {
-                    let sig = &signatures[**sig];
-                    let name =
-                        symbol_registry.symbol_to_name(Symbol::DynamicFunctionTrampoline(*i));
-                    let module =
-                        func_trampoline.dynamic_trampoline_to_module(sig, self.config(), &name)?;
-                    Ok(module.write_bitcode_to_memory().as_slice().to_vec())
-                },
-            )
-            .collect::<Result<Vec<_>, CompileError>>()?
-            .into_par_iter();
+        let trampolines = compile_info.module.signatures.iter().collect::<Vec<_>>();
+
+        let trampolines_bitcode = trampolines.par_iter().map_init(
+            || {
+                let target_machine = self.config().target_machine(target);
+                FuncTrampoline::new(target_machine)
+            },
+            |func_trampoline, (i, sig)| {
+                let name = symbol_registry.symbol_to_name(Symbol::FunctionCallTrampoline(*i));
+                let module = func_trampoline.trampoline_to_module(sig, self.config(), &name)?;
+                Ok(module.write_bitcode_to_memory().as_slice().to_vec())
+            },
+        );
+
+        let dynamic_trampolines = compile_info.module.functions.iter().collect::<Vec<_>>();
+
+        let dynamic_trampolines_bitcode = dynamic_trampolines.par_iter().map_init(
+            || {
+                let target_machine = self.config().target_machine(target);
+                (
+                    FuncTrampoline::new(target_machine),
+                    &compile_info.module.signatures,
+                )
+            },
+            |(func_trampoline, signatures), (i, sig)| {
+                let sig = &signatures[**sig];
+                let name = symbol_registry.symbol_to_name(Symbol::DynamicFunctionTrampoline(*i));
+                let module =
+                    func_trampoline.dynamic_trampoline_to_module(sig, self.config(), &name)?;
+                Ok(module.write_bitcode_to_memory().as_slice().to_vec())
+            },
+        );
 
         let merged_bitcode = merged_bitcode
             .chain(trampolines_bitcode)
             .chain(dynamic_trampolines_bitcode)
+            .collect::<Result<Vec<_>, CompileError>>()?
+            .into_par_iter()
             .reduce_with(|bc1, bc2| {
                 let ctx = Context::create();
                 let membuf = MemoryBuffer::create_from_memory_range(&bc1, "");


### PR DESCRIPTION
Slightly improves performance with llvm+native, for me with 24 cores, qjs.so builds go from 8.2s to 7.9s.