### PR TITLE
Add `wasm_config_delete` to the Wasm C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 - [#2026](https://github.com/wasmerio/wasmer/pull/2010) Expose trap code of a `RuntimeError`, if it's a `Trap`.
+- [#2054](https://github.com/wasmerio/wasmer/pull/2054) Add `wasm_config_delete` to the Wasm C API.
 
 ### Changed
 - [#2042](https://github.com/wasmerio/wasmer/pull/2042) Parse more exotic environment variables in `wasmer run`.

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -131,6 +131,36 @@ pub extern "C" fn wasm_config_new() -> Box<wasm_config_t> {
     Box::new(wasm_config_t::default())
 }
 
+/// Delete a Wasmer config object.
+///
+/// This function does not need to be called if `wasm_engine_new_with_config` or
+/// another function that takes ownership of the `wasm_config_t` is called.
+///
+/// # Example
+///
+/// ```rust
+/// # use inline_c::assert_c;
+/// # fn main() {
+/// #    (assert_c! {
+/// # #include "tests/wasmer_wasm.h"
+/// #
+/// int main() {
+///     // Create the configuration.
+///     wasm_config_t* config = wasm_config_new();
+///
+///     // Delete the configuration
+///     wasm_config_delete(config);
+///
+///     return 0;
+/// }
+/// #    })
+/// #    .success();
+/// # }
+/// ```
+/// cbindgen:ignore
+#[no_mangle]
+pub extern "C" fn wasm_config_delete(_config: Option<Box<wasm_config_t>>) {}
+
 /// Updates the configuration to specify a particular compiler to use.
 ///
 /// This is a Wasmer-specific function.


### PR DESCRIPTION
Fixes 1 missing import reported in #2052 

This function is relatively new to the Wasm C API and its implementation is trivial