### PR TITLE
fix(c-api) `wasi_version_t` wasn't bound correctly to C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#2056](https://github.com/wasmerio/wasmer/pull/2056) Change back to depend on the `enumset` crate instead of `wasmer_enumset`
 
 ### Fixed
+- [#2058](https://github.com/wasmerio/wasmer/pull/2058) `wasm_version_t` wasn't bound correctly to C.
 - [#2044](https://github.com/wasmerio/wasmer/pull/2044) Do not build C headers on docs.rs.
 
 ## 1.0.1 - 2021-01-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [#2056](https://github.com/wasmerio/wasmer/pull/2056) Change back to depend on the `enumset` crate instead of `wasmer_enumset`
 
 ### Fixed
-- [#2058](https://github.com/wasmerio/wasmer/pull/2058) `wasm_version_t` wasn't bound correctly to C.
+- [#2058](https://github.com/wasmerio/wasmer/pull/2058) Expose WASI versions to C correctly.
 - [#2044](https://github.com/wasmerio/wasmer/pull/2044) Do not build C headers on docs.rs.
 
 ## 1.0.1 - 2021-01-12

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -268,18 +268,18 @@ fn read_inner(wasi_file: &mut Box<dyn WasiFile>, inner_buffer: &mut [u8]) -> isi
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum wasi_version_t {
-    Latest = 0,
-    Snapshot0 = 1,
-    Snapshot1 = 2,
-    InvalidVersion = u32::max_value(),
+    LATEST = 0,
+    SNAPSHOT0 = 1,
+    SNAPSHOT1 = 2,
+    INVALID_VERSION = 4294967295, // u32::MAX,
 }
 
 impl From<WasiVersion> for wasi_version_t {
     fn from(other: WasiVersion) -> Self {
         match other {
-            WasiVersion::Snapshot0 => wasi_version_t::Snapshot0,
-            WasiVersion::Snapshot1 => wasi_version_t::Snapshot1,
-            WasiVersion::Latest => wasi_version_t::Latest,
+            WasiVersion::Snapshot0 => wasi_version_t::SNAPSHOT0,
+            WasiVersion::Snapshot1 => wasi_version_t::SNAPSHOT1,
+            WasiVersion::Latest => wasi_version_t::LATEST,
         }
     }
 }
@@ -289,10 +289,10 @@ impl TryFrom<wasi_version_t> for WasiVersion {
 
     fn try_from(other: wasi_version_t) -> Result<Self, Self::Error> {
         Ok(match other {
-            wasi_version_t::Snapshot0 => WasiVersion::Snapshot0,
-            wasi_version_t::Snapshot1 => WasiVersion::Snapshot1,
-            wasi_version_t::Latest => WasiVersion::Latest,
-            wasi_version_t::InvalidVersion => return Err("Invalid WASI version cannot be used"),
+            wasi_version_t::SNAPSHOT0 => WasiVersion::Snapshot0,
+            wasi_version_t::SNAPSHOT1 => WasiVersion::Snapshot1,
+            wasi_version_t::LATEST => WasiVersion::Latest,
+            wasi_version_t::INVALID_VERSION => return Err("Invalid WASI version cannot be used"),
         })
     }
 }
@@ -301,7 +301,7 @@ impl TryFrom<wasi_version_t> for WasiVersion {
 pub unsafe extern "C" fn wasi_get_wasi_version(module: &wasm_module_t) -> wasi_version_t {
     get_wasi_version(&module.inner, false)
         .map(Into::into)
-        .unwrap_or(wasi_version_t::InvalidVersion)
+        .unwrap_or(wasi_version_t::INVALID_VERSION)
 }
 
 /// Takes ownership of `wasi_env_t`.

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -264,13 +264,31 @@ fn read_inner(wasi_file: &mut Box<dyn WasiFile>, inner_buffer: &mut [u8]) -> isi
     }
 }
 
+/// The version of WASI. This is determined by the imports namespace
+/// string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum wasi_version_t {
+    /// Latest version.
+    ///
+    /// It's a “floating” version, i.e. it's an alias to the latest
+    /// version (for the moment, `Snapshot1`). Using this version is a
+    /// way to ensure that modules will run only if they come with the
+    /// latest WASI version (in case of security issues for instance),
+    /// by just updating the runtime.
+    ///
+    /// Note that this version is never returned by an API. It is
+    /// provided only by the user.
     LATEST = 0,
+
+    /// `wasi_unstable`.
     SNAPSHOT0 = 1,
+
+    /// `wasi_snapshot_preview1`.
     SNAPSHOT1 = 2,
+
+    /// An invalid version. It matches `u32` maximum value.
     INVALID_VERSION = 4294967295, // u32::MAX,
 }
 

--- a/lib/c-api/src/wasm_c_api/wat.rs
+++ b/lib/c-api/src/wasm_c_api/wat.rs
@@ -42,9 +42,6 @@ mod tests {
             #include "tests/wasmer_wasm.h"
 
             int main() {
-                wasm_engine_t* engine = wasm_engine_new();
-                wasm_store_t* store = wasm_store_new(engine);
-
                 wasm_byte_vec_t wat;
                 wasmer_byte_vec_new_from_string(&wat, "(module)");
                 wasm_byte_vec_t wasm;
@@ -65,8 +62,6 @@ mod tests {
 
                 wasm_byte_vec_delete(&wasm);
                 wasm_byte_vec_delete(&wat);
-                wasm_store_delete(store);
-                wasm_engine_delete(engine);
 
                 return 0;
             }
@@ -80,9 +75,6 @@ mod tests {
             #include "tests/wasmer_wasm.h"
 
             int main() {
-                wasm_engine_t* engine = wasm_engine_new();
-                wasm_store_t* store = wasm_store_new(engine);
-
                 wasm_byte_vec_t wat;
                 wasmer_byte_vec_new_from_string(&wat, "(module");
                 wasm_byte_vec_t wasm;
@@ -92,8 +84,6 @@ mod tests {
                 assert(wasmer_last_error_length() > 0);
 
                 wasm_byte_vec_delete(&wat);
-                wasm_store_delete(store);
-                wasm_engine_delete(engine);
 
                 return 0;
             }

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -62,6 +62,24 @@
 #include <stdlib.h>
 #include "wasm.h"
 
+#if defined(WASMER_WASI_ENABLED)
+enum wasi_version_t {
+#if defined(WASMER_WASI_ENABLED)
+  LATEST = 0,
+#endif
+#if defined(WASMER_WASI_ENABLED)
+  SNAPSHOT0 = 1,
+#endif
+#if defined(WASMER_WASI_ENABLED)
+  SNAPSHOT1 = 2,
+#endif
+#if defined(WASMER_WASI_ENABLED)
+  INVALID_VERSION = 4294967295,
+#endif
+};
+typedef uint32_t wasi_version_t;
+#endif
+
 #if defined(WASMER_COMPILER_ENABLED)
 /**
  * Kind of compilers that can be used by the engines.
@@ -118,10 +136,6 @@ typedef struct wasi_config_t wasi_config_t;
 
 #if defined(WASMER_WASI_ENABLED)
 typedef struct wasi_env_t wasi_env_t;
-#endif
-
-#if defined(WASMER_WASI_ENABLED)
-typedef struct wasi_version_t wasi_version_t;
 #endif
 
 #if defined(WASMER_WASI_ENABLED)

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -67,7 +67,13 @@
  * The version of WASI. This is determined by the imports namespace
  * string.
  */
-enum wasi_version_t {
+typedef enum {
+#if defined(WASMER_WASI_ENABLED)
+  /**
+   * An invalid version.
+   */
+  INVALID_VERSION = -1,
+#endif
 #if defined(WASMER_WASI_ENABLED)
   /**
    * Latest version.
@@ -95,14 +101,7 @@ enum wasi_version_t {
    */
   SNAPSHOT1 = 2,
 #endif
-#if defined(WASMER_WASI_ENABLED)
-  /**
-   * An invalid version. It matches `u32` maximum value.
-   */
-  INVALID_VERSION = 4294967295,
-#endif
-};
-typedef uint32_t wasi_version_t;
+} wasi_version_t;
 #endif
 
 #if defined(WASMER_COMPILER_ENABLED)

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -63,17 +63,42 @@
 #include "wasm.h"
 
 #if defined(WASMER_WASI_ENABLED)
+/**
+ * The version of WASI. This is determined by the imports namespace
+ * string.
+ */
 enum wasi_version_t {
 #if defined(WASMER_WASI_ENABLED)
+  /**
+   * Latest version.
+   *
+   * It's a “floating” version, i.e. it's an alias to the latest
+   * version (for the moment, `Snapshot1`). Using this version is a
+   * way to ensure that modules will run only if they come with the
+   * latest WASI version (in case of security issues for instance),
+   * by just updating the runtime.
+   *
+   * Note that this version is never returned by an API. It is
+   * provided only by the user.
+   */
   LATEST = 0,
 #endif
 #if defined(WASMER_WASI_ENABLED)
+  /**
+   * `wasi_unstable`.
+   */
   SNAPSHOT0 = 1,
 #endif
 #if defined(WASMER_WASI_ENABLED)
+  /**
+   * `wasi_snapshot_preview1`.
+   */
   SNAPSHOT1 = 2,
 #endif
 #if defined(WASMER_WASI_ENABLED)
+  /**
+   * An invalid version. It matches `u32` maximum value.
+   */
   INVALID_VERSION = 4294967295,
 #endif
 };

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -162,10 +162,6 @@ typedef struct wasi_config_t wasi_config_t;
 typedef struct wasi_env_t wasi_env_t;
 #endif
 
-#if defined(WASMER_WASI_ENABLED)
-typedef struct wasi_version_t wasi_version_t;
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus

--- a/lib/wasi/src/utils.rs
+++ b/lib/wasi/src/utils.rs
@@ -13,6 +13,7 @@ pub fn is_wasi_module(module: &Module) -> bool {
 pub enum WasiVersion {
     /// `wasi_unstable`.
     Snapshot0,
+
     /// `wasi_snapshot_preview1`.
     Snapshot1,
 


### PR DESCRIPTION
# Description

Because the enum variants weren't in uppercase _and_ because one variant (`InvalidVersion`) has a non-literal value, `cbindgen` was ignoring the variants. This patch fixes that. It's not a breaking changes since the WASI version constants weren't present in the `wasmer_wasm.h` file before.

Note: `u32::max_value()` is soft-deprecated, we should use `u32::MAX` instead. Notice that none of them works with `cbindgen`, so I've hardcoded the value of `u32::MAX` here.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
