### PR TITLE
fix(wasi) Fix the logic behind inherited/captured `stdin`, `stdout` and `stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## **[Unreleased]**
 
 ### Added
-- [#2059](https://github.com/wasmerio/wasmer/pull/2059) Ability to capture `stdin`, `stdout` and `stderr` with WASI in the C API.
+- [#2059](https://github.com/wasmerio/wasmer/pull/2059) Ability to capture `stdout` and `stderr` with WASI in the C API.
 - [#2040](https://github.com/wasmerio/wasmer/pull/2040) Add `InstanceHandle::vmoffsets` to expose the offsets of the `vmctx` region.
 - [#2026](https://github.com/wasmerio/wasmer/pull/2010) Expose trap code of a `RuntimeError`, if it's a `Trap`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## **[Unreleased]**
 
 ### Added
+- [#2059](https://github.com/wasmerio/wasmer/pull/2059) Ability to capture `stdin`, `stdout` and `stderr` with WASI in the C API.
 - [#2040](https://github.com/wasmerio/wasmer/pull/2040) Add `InstanceHandle::vmoffsets` to expose the offsets of the `vmctx` region.
 - [#2026](https://github.com/wasmerio/wasmer/pull/2010) Expose trap code of a `RuntimeError`, if it's a `Trap`.
 

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -401,13 +401,16 @@ fn exclude_items_from_deprecated(builder: Builder) -> Builder {
 fn exclude_items_from_wasm_c_api(builder: Builder) -> Builder {
     builder
         .exclude_item("wasi_config_arg")
+        .exclude_item("wasi_config_capture_stderr")
+        .exclude_item("wasi_config_capture_stdin")
+        .exclude_item("wasi_config_capture_stdout")
         .exclude_item("wasi_config_env")
-        .exclude_item("wasi_config_mapdir")
-        .exclude_item("wasi_config_preopen_dir")
         .exclude_item("wasi_config_inherit_stderr")
         .exclude_item("wasi_config_inherit_stdin")
         .exclude_item("wasi_config_inherit_stdout")
+        .exclude_item("wasi_config_mapdir")
         .exclude_item("wasi_config_new")
+        .exclude_item("wasi_config_preopen_dir")
         .exclude_item("wasi_config_t")
         .exclude_item("wasi_env_delete")
         .exclude_item("wasi_env_new")

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -153,10 +153,10 @@ pub extern "C" fn wasi_config_inherit_stderr(config: &mut wasi_config_t) {
     config.inherit_stderr = true;
 }
 
-#[no_mangle]
-pub extern "C" fn wasi_config_capture_stdin(config: &mut wasi_config_t) {
-    config.inherit_stdin = false;
-}
+//#[no_mangle]
+//pub extern "C" fn wasi_config_capture_stdin(config: &mut wasi_config_t) {
+//    config.inherit_stdin = false;
+//}
 
 #[no_mangle]
 pub extern "C" fn wasi_config_inherit_stdin(config: &mut wasi_config_t) {

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -129,6 +129,18 @@ void wasi_config_arg(wasi_config_t *config, const char *arg);
 #endif
 
 #if defined(WASMER_WASI_ENABLED)
+void wasi_config_capture_stderr(wasi_config_t *config);
+#endif
+
+#if defined(WASMER_WASI_ENABLED)
+void wasi_config_capture_stdin(wasi_config_t *config);
+#endif
+
+#if defined(WASMER_WASI_ENABLED)
+void wasi_config_capture_stdout(wasi_config_t *config);
+#endif
+
+#if defined(WASMER_WASI_ENABLED)
 void wasi_config_env(wasi_config_t *config, const char *key, const char *value);
 #endif
 

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -133,10 +133,6 @@ void wasi_config_capture_stderr(wasi_config_t *config);
 #endif
 
 #if defined(WASMER_WASI_ENABLED)
-void wasi_config_capture_stdin(wasi_config_t *config);
-#endif
-
-#if defined(WASMER_WASI_ENABLED)
 void wasi_config_capture_stdout(wasi_config_t *config);
 #endif
 


### PR DESCRIPTION
# Description

This patch is both a fix and a feature!

First, let's no longer derive from `Default` for `wasi_config_t`. By
default, we want to inherit `stdin`, `stdout` and `stderr`. The
default for `bool` is `false`; we want `true` here.

Second, let's update `wasi_config_new` to correctly set `inherit_*`
fields to `true`.

Third, lets' create `wasi_config_capture_*` functions. By default,
`std*` are inherited, so we need functions to capture them. That's the
new feature this patch introduces. The `wasi_config_inherit_*`
functions are kept for the sake of backward compatibility. Ideally, we
would want an API like `wasi_config_capture_*(capture: bool)`, but it
would duplicate the API somehow.

Fourth, let's fix `wasi_env_new`. We want to capture `stdout` and
`stderr` if and only if the `inherit_*` fields are set to
`false`. There was bug here. That's why everything was working
correctly by the way: `bool::default()` is `false`, and we have this
inverted condition here, so everything was working as expected because
of a double error. The only bug was that it wasn't possible to capture
`std*` before.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
