### PR TITLE
Add `build-capi-all` command to Makefile for all compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,10 @@ build-docs-capi:
 # We use cranelift as the default backend for the capi for now
 build-capi: build-capi-cranelift
 
+build-capi-all:
+	cargo build --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features deprecated,wat,jit,native,object-file,wasi $(capi_default_features) $(compiler_features)
+
 build-capi-singlepass:
 	cargo build --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features deprecated,wat,jit,native,object-file,singlepass,wasi $(capi_default_features)


### PR DESCRIPTION
This is a useful command to have, maybe it should be the default?

There are still some issues with LLVM here (need to link zlib and curses) when linking against libwasmer.

Also LLVM is not detected on my computer by the Makefile even though it builds fine

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
