### PR TITLE
Include 'extern "C"' in our C header files when included in a C++ build.

### DIFF
--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -240,6 +240,7 @@ fn new_builder(language: Language, crate_dir: &str, include_guard: &str, header:
     Builder::new()
         .with_config(cbindgen::Config {
             sort_by: cbindgen::SortKey::Name,
+            cpp_compat: true,
             ..cbindgen::Config::default()
         })
         .with_language(language)

--- a/lib/c-api/wasmer.h
+++ b/lib/c-api/wasmer.h
@@ -55,7 +55,11 @@
 #include <stdlib.h>
 
 #if defined(WASMER_WASI_ENABLED)
-enum Version {
+enum Version
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
 #if defined(WASMER_WASI_ENABLED)
   /**
    * Version cannot be detected or is unknown.
@@ -82,13 +86,19 @@ enum Version {
   Snapshot1 = 3,
 #endif
 };
+#ifndef __cplusplus
 typedef uint8_t Version;
+#endif // __cplusplus
 #endif
 
 /**
  * List of export/import kinds.
  */
-enum wasmer_import_export_kind {
+enum wasmer_import_export_kind
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
   /**
    * The export/import is a function.
    */
@@ -106,7 +116,9 @@ enum wasmer_import_export_kind {
    */
   WASM_TABLE = 3,
 };
+#ifndef __cplusplus
 typedef uint32_t wasmer_import_export_kind;
+#endif // __cplusplus
 
 /**
  * The `wasmer_result_t` enum is a type that represents either a
@@ -128,7 +140,11 @@ typedef enum {
  *
  * See `wasmer_value_t` to get a complete example.
  */
-enum wasmer_value_tag {
+enum wasmer_value_tag
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
   /**
    * Represents the `i32` WebAssembly type.
    */
@@ -146,7 +162,9 @@ enum wasmer_value_tag {
    */
   WASM_F64,
 };
+#ifndef __cplusplus
 typedef uint32_t wasmer_value_tag;
+#endif // __cplusplus
 
 typedef struct {
 
@@ -408,6 +426,10 @@ typedef struct {
   wasmer_byte_array host_file_path;
 } wasmer_wasi_map_dir_entry_t;
 #endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
 
 /**
  * Creates a new Module from the given wasm bytes.
@@ -1578,5 +1600,9 @@ wasmer_import_object_t *wasmer_wasi_generate_import_object_for_version(unsigned 
  */
 Version wasmer_wasi_get_version(const wasmer_module_t *module);
 #endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif /* WASMER_H */

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -124,6 +124,10 @@ typedef struct wasi_env_t wasi_env_t;
 typedef struct wasi_version_t wasi_version_t;
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #if defined(WASMER_WASI_ENABLED)
 void wasi_config_arg(wasi_config_t *config, const char *arg);
 #endif
@@ -566,5 +570,9 @@ const char *wasmer_version_pre(void);
  * See the module's documentation.
  */
 void wat2wasm(const wasm_byte_vec_t *wat, wasm_byte_vec_t *out);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif /* WASMER_WASM_H */


### PR DESCRIPTION
# Description
Fixes #1952

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
