### PR TITLE
doc(c-api) Use the last `README.md`, not the deprecated one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@
 - [#2054](https://github.com/wasmerio/wasmer/pull/2054) Add `wasm_config_delete` to the Wasm C API.
 
 ### Changed
-- [#2042](https://github.com/wasmerio/wasmer/pull/2042) Parse more exotic environment variables in `wasmer run`.
-- [#2041](https://github.com/wasmerio/wasmer/pull/2041) Documentation diagrams now have a solid white background rather than a transparent background.
 - [#2056](https://github.com/wasmerio/wasmer/pull/2056) Change back to depend on the `enumset` crate instead of `wasmer_enumset`
 
 ### Fixed
+- [#2069](https://github.com/wasmerio/wasmer/pull/2069) Use the new documentation for `include/README.md` in the Wasmer package.
+- [#2042](https://github.com/wasmerio/wasmer/pull/2042) Parse more exotic environment variables in `wasmer run`.
+- [#2041](https://github.com/wasmerio/wasmer/pull/2041) Documentation diagrams now have a solid white background rather than a transparent background.
 - [#2044](https://github.com/wasmerio/wasmer/pull/2044) Do not build C headers on docs.rs.
 
 ## 1.0.1 - 2021-01-12

--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ package-capi:
 	cp lib/c-api/wasmer.h* package/include
 	cp lib/c-api/wasmer_wasm.h* package/include
 	cp lib/c-api/wasm.h* package/include
-	cp lib/c-api/doc/deprecated/index.md package/include/README.md
+	cp lib/c-api/README.md package/include/README.md
 ifeq ($(OS), Windows_NT)
 	cp target/release/wasmer_c_api.dll package/lib
 	cp target/release/wasmer_c_api.lib package/lib


### PR DESCRIPTION
# Description

This patch updates the `README.md` used in the `include/` directory of the packaged C API. We must use the last `lib/c-api/README.md` rather than the `lib/c-api/doc/deprecated/index.md` file. That's a mistake.

Also, I wonder why `wasmer_c_api.{dll|lib)` on Windows isn't renamed to `wasmer.{dll|lib}` as we do for ther other platforms?

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
