### PR TITLE
fix(c-api) Don't drain the entire captured stream at first read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#2056](https://github.com/wasmerio/wasmer/pull/2056) Change back to depend on the `enumset` crate instead of `wasmer_enumset`
 
 ### Fixed
+- [#2070](https://github.com/wasmerio/wasmer/pull/2070) Do not drain the entire captured stream at first read with `wasi_env_read_stdout` or `_stderr` in the C API.
 - [#2044](https://github.com/wasmerio/wasmer/pull/2044) Do not build C headers on docs.rs.
 
 ## 1.0.1 - 2021-01-12


### PR DESCRIPTION
# Description

We use `VecDeque::drain` to read the captured stream, zipped with the
given buffer. We could expect that only the yielded items from the
`drain` will be removed, but actually no. Reading [the
documentation](https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.drain):

> Note 1: The element `range` is removed even if the iterator is not
> consumed until the end.

So by using a range like `..` (as we do) will drain the entire captured stream,
whatever we read from it. Said differently, if the given buffer length
is smaller than the captured stream, the first read will drain the
entire captured stream.

This patch fixes the problem by specifying a better range:
`..min(inner_buffer.len(), oc.buffer.len())`.

With this new range, it's actually useless to increment
`num_bytes_written`, we already know ahead of time the amount of bytes
we are going to read. Consequently, the patch simplifies this code a
little bit more.

This patch also updates the `test-wasi` integration test. Previously,
`stdout` wasn't captured, so the loop using `wasi_env_read_stdout` was
doing nothing. Now we have the following output:

```
Initializing...
Loading binary...
Compiling module...
Setting up WASI...
Instantiating module...
Extracting export...
found 2 exports
Calling export...
Evaluating "function greet(name) { return JSON.stringify('Hello, ' + name); }; print(greet('World'));"
WASI Stdout: `"Hello, World"
`
Shutting down...
Done.
```

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
