### PR TITLE
feat(c-api) Rename the `wasmer` module to `unstable`

### DIFF
--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -230,6 +230,12 @@ pub mod trap;
 /// cbindgen:ignore
 pub mod types;
 
+/// This module contains _unstable non-standard_ C API.
+///
+/// Use them at your own risks. The API is subject to change or to
+/// break without any plan to keep any compatibility :-).
+pub mod unstable;
+
 /// Possible runtime values that a WebAssembly module can either
 /// consume or produce.
 ///
@@ -276,8 +282,6 @@ pub mod version;
 
 #[cfg(feature = "wasi")]
 pub mod wasi;
-
-pub mod wasmer;
 
 /// Wasmer-specific API to transform the WAT format into Wasm bytes.
 ///

--- a/lib/c-api/src/wasm_c_api/unstable/mod.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/mod.rs
@@ -1,0 +1,1 @@
+pub mod module;

--- a/lib/c-api/src/wasm_c_api/unstable/module.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/module.rs
@@ -1,13 +1,14 @@
-//! Non-standard Wasmer-specific extensions to the Wasm C API.
+//! Unstable non-standard Wasmer-specific extensions to the Wasm C API.
 
-use super::module::wasm_module_t;
-use super::types::wasm_name_t;
+use super::super::module::wasm_module_t;
+use super::super::types::wasm_name_t;
 use std::ptr;
 use std::str;
 use std::sync::Arc;
 
-/// Non-standard Wasmer-specific API to get the module's name,
-/// otherwise `out->size` is set to `0` and `out->data` to `NULL`.
+/// Unstable non-standard Wasmer-specific API to get the module's
+/// name, otherwise `out->size` is set to `0` and `out->data` to
+/// `NULL`.
 ///
 /// # Example
 ///
@@ -72,9 +73,9 @@ pub unsafe extern "C" fn wasm_module_name(
     *out = name.as_bytes().to_vec().into();
 }
 
-/// Non-standard Wasmer-specific API to set the module's name. The
-/// function returns `true` if the name has been updated, `false`
-/// otherwise.
+/// Unstable non-standard Wasmer-specific API to set the module's
+/// name. The function returns `true` if the name has been updated,
+/// `false` otherwise.
 ///
 /// # Example
 ///

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -338,8 +338,9 @@ void wasm_config_set_compiler(wasm_config_t *config, wasmer_compiler_t compiler)
 void wasm_config_set_engine(wasm_config_t *config, wasmer_engine_t engine);
 
 /**
- * Non-standard Wasmer-specific API to get the module's name,
- * otherwise `out->size` is set to `0` and `out->data` to `NULL`.
+ * Unstable non-standard Wasmer-specific API to get the module's
+ * name, otherwise `out->size` is set to `0` and `out->data` to
+ * `NULL`.
  *
  * # Example
  *
@@ -389,9 +390,9 @@ void wasm_config_set_engine(wasm_config_t *config, wasmer_engine_t engine);
 void wasm_module_name(const wasm_module_t *module, wasm_name_t *out);
 
 /**
- * Non-standard Wasmer-specific API to set the module's name. The
- * function returns `true` if the name has been updated, `false`
- * otherwise.
+ * Unstable non-standard Wasmer-specific API to set the module's
+ * name. The function returns `true` if the name has been updated,
+ * `false` otherwise.
  *
  * # Example
  *


### PR DESCRIPTION
# Description

This patch is the first step to prepare more unstable API (like cross-compilation etc.). Nothing changes for the moment from the user perspective, it's not a breaking change. It's just a reorganisation of the code, and better documentation. Basically the `wasmer_c_api::wasm_c_api::wasmer` module has been renamed `unstable`, so that it's super clear :-).

# Review

- [ ] ~Add a short description of the the change to the CHANGELOG.md file~ not necessary
