### PR TITLE
fix(doc) `build-docs-capi` is missing the `capi_default_features` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ build-docs:
 
 build-docs-capi:
 	cd lib/c-api/doc/deprecated/ && doxygen doxyfile
-	cargo doc --manifest-path lib/c-api/Cargo.toml --no-deps --features wat,jit,object-file,native,cranelift,wasi
+	cargo doc --manifest-path lib/c-api/Cargo.toml --no-deps --features wat,jit,object-file,native,cranelift,wasi $(capi_default_features)
 
 # We use cranelift as the default backend for the capi for now
 build-capi: build-capi-cranelift

--- a/Makefile
+++ b/Makefile
@@ -399,9 +399,9 @@ endif
 
 package-docs: build-docs build-docs-capi
 	mkdir -p "package/docs"
-	mkdir -p "package/docs/c/deprecated/"
+	mkdir -p "package/docs/c/runtime-c-api"
 	cp -R target/doc package/docs/crates
-	cp -R lib/c-api/doc/deprecated/html/ package/docs/c/deprecated/
+	cp -R lib/c-api/doc/deprecated/html/ package/docs/c/runtime-c-api
 	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=crates/wasmer/index.html">' > package/docs/index.html
 	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=wasmer/index.html">' > package/docs/crates/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -399,9 +399,9 @@ endif
 
 package-docs: build-docs build-docs-capi
 	mkdir -p "package/docs"
-	mkdir -p "package/docs/c/runtime-c-api"
+	mkdir -p "package/docs/c/deprecated/"
 	cp -R target/doc package/docs/crates
-	cp -R lib/c-api/doc/deprecated/html/ package/docs/c/runtime-c-api
+	cp -R lib/c-api/doc/deprecated/html/ package/docs/c/deprecated/
 	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=crates/wasmer/index.html">' > package/docs/index.html
 	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=wasmer/index.html">' > package/docs/crates/index.html
 


### PR DESCRIPTION
# Description

This PR is twofold.

1. It fixes `make build-docs-capi` by adding the missing `$(capi_default_features)` variable,
2. ~It renames the `package/docs/c/runtime-c-api/` directory to `package/docs/c/deprecated/`.~

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
