### PR TITLE
fix(scripts) Fix publish script regarding `wasmer-c-api`

### DIFF
--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -75,7 +75,9 @@ fn main() {
 
 /// Check whether we should build the C API headers or set `inline-c` up.
 fn running_self() -> bool {
-    env::var("DOCS_RS").is_err() && env::var("_CBINDGEN_IS_RUNNING").is_err()
+    env::var("DOCS_RS").is_err()
+        && env::var("_CBINDGEN_IS_RUNNING").is_err()
+        && env::var("WASMER_PUBLISH_SCRIPT_IS_RUNNING").is_err()
 }
 
 /// Build the header files for the `wasm_c_api` API.

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -102,7 +102,7 @@ def publish_crate(crate: str):
 
     global no_dry_run
     if no_dry_run:
-        output = subprocess.run(["cargo", "publish"])
+        output = subprocess.run(["cargo", "publish"], env={'WASMER_PUBLISH_SCRIPT_IS_RUNNING': '1'})
     else:
         print("In dry-run: not publishing crate `{}`".format(crate))
 


### PR DESCRIPTION
# Description

Depends on https://github.com/wasmerio/wasmer/pull/2053 (merged).

This patch is just 2 commits:

* https://github.com/wasmerio/wasmer/commit/52daf9b8118d7677c67edb14dc2bad54776bdf54 adding the `WASMER_PUBLISH_SCRIPT_IS_RUNNING` env var when running `cargo publish`,
* https://github.com/wasmerio/wasmer/commit/4f8bc8aa00eab18ddebcdb23cb963d22e8159906 to not run `build.rs` when the `scripts/publish.py` script is running.

# Review

- [ ] ~Add a short description of the the change to the CHANGELOG.md file~ not necessary
