### PR TITLE
Make the memory.{grow,size} library calls libcalls instead of pointer-to-function fields on the Instance.

### DIFF
--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -64,6 +64,16 @@ where
     libcalls.insert("nearbyintf".to_string(), LibCall::NearestF32);
     libcalls.insert("nearbyint".to_string(), LibCall::NearestF64);
     libcalls.insert("wasmer_probestack".to_string(), LibCall::Probestack);
+    libcalls.insert("wasmer_memory32_grow".to_string(), LibCall::Memory32Grow);
+    libcalls.insert(
+        "wasmer_imported_memory32_grow".to_string(),
+        LibCall::ImportedMemory32Grow,
+    );
+    libcalls.insert("wasmer_memory32_size".to_string(), LibCall::Memory32Size);
+    libcalls.insert(
+        "wasmer_imported_memory32_size".to_string(),
+        LibCall::ImportedMemory32Size,
+    );
 
     let elf = goblin::elf::Elf::parse(&contents).map_err(map_goblin_err)?;
     let get_section_name = |section: &goblin::elf::section_header::SectionHeader| {

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -9288,9 +9288,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             Operator::MemoryGrow { mem, mem_byte: _ } => {
                 let memory_index = MemoryIndex::from_u32(mem);
                 let delta = self.state.pop1()?;
-                let grow_fn_ptr = self.ctx.memory_grow(memory_index, self.intrinsics);
+                let grow_fn = self.ctx.memory_grow(memory_index, self.intrinsics);
                 let grow = self.builder.build_call(
-                    grow_fn_ptr,
+                    grow_fn,
                     &[
                         vmctx.as_basic_value_enum(),
                         delta,
@@ -9305,9 +9305,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             }
             Operator::MemorySize { mem, mem_byte: _ } => {
                 let memory_index = MemoryIndex::from_u32(mem);
-                let size_fn_ptr = self.ctx.memory_size(memory_index, self.intrinsics);
+                let size_fn = self.ctx.memory_size(memory_index, self.intrinsics);
                 let size = self.builder.build_call(
-                    size_fn_ptr,
+                    size_fn,
                     &[
                         vmctx.as_basic_value_enum(),
                         self.intrinsics

--- a/lib/vm/src/libcalls.rs
+++ b/lib/vm/src/libcalls.rs
@@ -137,6 +137,7 @@ pub extern "C" fn wasmer_f64_nearest(x: f64) -> f64 {
 /// # Safety
 ///
 /// `vmctx` must be valid and not null.
+#[no_mangle]
 pub unsafe extern "C" fn wasmer_memory32_grow(
     vmctx: *mut VMContext,
     delta: u32,
@@ -156,6 +157,7 @@ pub unsafe extern "C" fn wasmer_memory32_grow(
 /// # Safety
 ///
 /// `vmctx` must be valid and not null.
+#[no_mangle]
 pub unsafe extern "C" fn wasmer_imported_memory32_grow(
     vmctx: *mut VMContext,
     delta: u32,
@@ -175,6 +177,7 @@ pub unsafe extern "C" fn wasmer_imported_memory32_grow(
 /// # Safety
 ///
 /// `vmctx` must be valid and not null.
+#[no_mangle]
 pub unsafe extern "C" fn wasmer_memory32_size(vmctx: *mut VMContext, memory_index: u32) -> u32 {
     let instance = (&*vmctx).instance();
     let memory_index = LocalMemoryIndex::from_u32(memory_index);
@@ -187,6 +190,7 @@ pub unsafe extern "C" fn wasmer_memory32_size(vmctx: *mut VMContext, memory_inde
 /// # Safety
 ///
 /// `vmctx` must be valid and not null.
+#[no_mangle]
 pub unsafe extern "C" fn wasmer_imported_memory32_size(
     vmctx: *mut VMContext,
     memory_index: u32,
@@ -435,8 +439,20 @@ pub enum LibCall {
     /// trunc.f32
     TruncF32,
 
-    /// frunc.f64
+    /// trunc.f64
     TruncF64,
+
+    /// memory.grow for a locally defined memory
+    Memory32Grow,
+
+    /// memory.grow for an imported memory
+    ImportedMemory32Grow,
+
+    /// memory.size for a locally defined memory
+    Memory32Size,
+
+    /// memory.size for an imported memory
+    ImportedMemory32Size,
 }
 
 impl LibCall {
@@ -453,6 +469,10 @@ impl LibCall {
             Self::RaiseTrap => wasmer_raise_trap as usize,
             Self::TruncF32 => wasmer_f32_trunc as usize,
             Self::TruncF64 => wasmer_f64_trunc as usize,
+            Self::Memory32Grow => wasmer_memory32_grow as usize,
+            Self::ImportedMemory32Grow => wasmer_imported_memory32_grow as usize,
+            Self::Memory32Size => wasmer_memory32_size as usize,
+            Self::ImportedMemory32Size => wasmer_imported_memory32_size as usize,
         }
     }
 
@@ -474,6 +494,10 @@ impl LibCall {
             Self::RaiseTrap => "wasmer_raise_trap",
             Self::TruncF32 => "wasmer_f32_trunc",
             Self::TruncF64 => "wasmer_f64_trunc",
+            Self::Memory32Grow => "wasmer_memory32_grow",
+            Self::ImportedMemory32Grow => "wasmer_imported_memory32_grow",
+            Self::Memory32Size => "wasmer_memory32_size",
+            Self::ImportedMemory32Size => "wasmer_imported_memory32_size",
         }
     }
 }


### PR DESCRIPTION
For now this keeps the fields since they are still used by cranelift and singlepass, but it ports llvm over to calling the functions directly.
