### PR TITLE
chore: Update LLVM in the documentation workflow

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "LLVM_SYS_100_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm-10
-          LLVM_URL: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/10.x/linux-amd64.tar.gz'
+          LLVM_URL: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
       - name: Build & package documentation
         run: make package-docs
       - name: Publish documentation


### PR DESCRIPTION
The documentation workflow is broken since we updated to LLVM 11. This PR fixes that.