### PR TITLE
fix(c-api) Call `wasi_env_delete` manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#2056](https://github.com/wasmerio/wasmer/pull/2056) Change back to depend on the `enumset` crate instead of `wasmer_enumset`
 
 ### Fixed
+- [#2090](https://github.com/wasmerio/wasmer/pull/2090) `wasi_env_t` needs to be freed with `wasi_env_delete` in the C API.
 - [#2084](https://github.com/wasmerio/wasmer/pull/2084) Avoid calling the function environment finalizer more than once when the environment has been cloned in the C API.
 - [#2069](https://github.com/wasmerio/wasmer/pull/2069) Use the new documentation for `include/README.md` in the Wasmer package.
 - [#2042](https://github.com/wasmerio/wasmer/pull/2042) Parse more exotic environment variables in `wasmer run`.

--- a/lib/c-api/tests/test-wasi.c
+++ b/lib/c-api/tests/test-wasi.c
@@ -161,7 +161,6 @@ int main(int argc, const char* argv[]) {
 
   // Shut down.
   printf("Shutting down...\n");
-  wasi_env_delete(wasi_env);
   wasm_func_delete(run_func);
   wasi_env_delete(wasi_env);
   wasm_store_delete(store);

--- a/lib/c-api/tests/test-wasi.c
+++ b/lib/c-api/tests/test-wasi.c
@@ -161,6 +161,7 @@ int main(int argc, const char* argv[]) {
 
   // Shut down.
   printf("Shutting down...\n");
+  wasi_env_delete(wasi_env);
   wasm_func_delete(run_func);
   wasi_env_delete(wasi_env);
   wasm_store_delete(store);

--- a/lib/cli/src/commands/wasmer_create_exe_main.c
+++ b/lib/cli/src/commands/wasmer_create_exe_main.c
@@ -143,6 +143,7 @@ int main(int argc, char* argv[]) {
   
   #ifdef WASI
   bool get_imports_result = wasi_get_imports(store, module, wasi_env, &imports);
+  wasi_env_delete(wasi_env);
 
   if (!get_imports_result) {
     fprintf(stderr, "Error getting WASI imports!\n");

--- a/lib/engine-object-file/README.md
+++ b/lib/engine-object-file/README.md
@@ -87,6 +87,7 @@ int main() {
         wasm_importtype_vec_delete(&import_types);
         
         bool get_imports_result = wasi_get_imports(store, module, wasi_env, imports);
+        wasi_env_delete(wasi_env);
         if (!get_imports_result) {
                 printf("> Error getting WASI imports!\n");
                 print_wasmer_error();

--- a/tests/integration/cli/tests/object_file_engine_test_c_source.c
+++ b/tests/integration/cli/tests/object_file_engine_test_c_source.c
@@ -63,6 +63,7 @@ int main() {
   wasm_importtype_vec_delete(&import_types);
         
   bool get_imports_result = wasi_get_imports(store, module, wasi_env, &imports);
+  wasi_env_delete(wasi_env);
 
   if (!get_imports_result) {
     printf("> Error getting WASI imports!\n");


### PR DESCRIPTION
# Description

`wasi_get_imports` isn't taking ownership of `wasi_env_t` (despites
what is written in the documentation). And it must not take ownership
of it, since one could use it with the `wasi_env_read_stdout` &
sibling functions after having called `wasi_get_imports`.

Consequently, this patch calls `wasi_env_delete` to avoid leaking
memory.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
