### PR TITLE
feat(api,vm) Improve the `vm::ImportInitializerFuncPtr` type.

### DIFF
--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -15,9 +15,9 @@ use std::fmt;
 use std::sync::Arc;
 use wasmer_engine::{Export, ExportFunction, ExportFunctionMetadata};
 use wasmer_vm::{
-    raise_user_trap, resume_panic, wasmer_call_trampoline, VMCallerCheckedAnyfunc,
-    VMDynamicFunctionContext, VMExportFunction, VMFunctionBody, VMFunctionEnvironment,
-    VMFunctionKind, VMTrampoline,
+    raise_user_trap, resume_panic, wasmer_call_trampoline, ImportInitializerFuncPtr,
+    VMCallerCheckedAnyfunc, VMDynamicFunctionContext, VMExportFunction, VMFunctionBody,
+    VMFunctionEnvironment, VMFunctionKind, VMTrampoline,
 };
 
 /// A function defined in the Wasm module
@@ -78,9 +78,7 @@ where
     Env: Clone + Sized + 'static + Send + Sync,
 {
     let import_init_function_ptr = Some(unsafe {
-        std::mem::transmute::<fn(_, _) -> Result<(), _>, fn(_, _) -> Result<(), _>>(
-            import_init_function_ptr,
-        )
+        std::mem::transmute::<_, ImportInitializerFuncPtr>(import_init_function_ptr)
     });
     let host_env_clone_fn: fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void = |ptr| {
         let env_ref: &Env = unsafe {

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -11,6 +11,7 @@ pub use inner::{FromToNativeWasmType, HostFunction, WasmTypeList, WithEnv, Witho
 pub use inner::{UnsafeMutableEnv, WithUnsafeMutableEnv};
 
 use std::cmp::max;
+use std::ffi::c_void;
 use std::fmt;
 use std::sync::Arc;
 use wasmer_engine::{Export, ExportFunction, ExportFunctionMetadata};
@@ -73,14 +74,14 @@ fn build_export_function_metadata<Env>(
         &'a mut Env,
         &'a crate::Instance,
     ) -> Result<(), crate::HostEnvInitError>,
-) -> (*mut std::ffi::c_void, ExportFunctionMetadata)
+) -> (*mut c_void, ExportFunctionMetadata)
 where
     Env: Clone + Sized + 'static + Send + Sync,
 {
     let import_init_function_ptr = Some(unsafe {
         std::mem::transmute::<_, ImportInitializerFuncPtr>(import_init_function_ptr)
     });
-    let host_env_clone_fn: fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void = |ptr| {
+    let host_env_clone_fn = |ptr: *mut c_void| -> *mut c_void {
         let env_ref: &Env = unsafe {
             ptr.cast::<Env>()
                 .as_ref()
@@ -88,7 +89,7 @@ where
         };
         Box::into_raw(Box::new(env_ref.clone())) as _
     };
-    let host_env_drop_fn: fn(*mut std::ffi::c_void) = |ptr| {
+    let host_env_drop_fn = |ptr: *mut c_void| {
         unsafe { Box::from_raw(ptr.cast::<Env>()) };
     };
     let env = Box::into_raw(Box::new(env)) as _;
@@ -159,7 +160,7 @@ impl Function {
         let address = std::ptr::null() as *const VMFunctionBody;
         let host_env = Box::into_raw(Box::new(dynamic_ctx)) as *mut _;
         let vmctx = VMFunctionEnvironment { host_env };
-        let host_env_clone_fn: fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void = |ptr| {
+        let host_env_clone_fn: fn(*mut c_void) -> *mut c_void = |ptr| {
             let duped_env: VMDynamicFunctionContext<DynamicFunctionWithoutEnv> = unsafe {
                 let ptr: *mut VMDynamicFunctionContext<DynamicFunctionWithoutEnv> = ptr as _;
                 let item: &VMDynamicFunctionContext<DynamicFunctionWithoutEnv> = &*ptr;
@@ -167,7 +168,7 @@ impl Function {
             };
             Box::into_raw(Box::new(duped_env)) as _
         };
-        let host_env_drop_fn: fn(*mut std::ffi::c_void) = |ptr: *mut std::ffi::c_void| {
+        let host_env_drop_fn: fn(*mut c_void) = |ptr: *mut c_void| {
             unsafe {
                 Box::from_raw(ptr as *mut VMDynamicFunctionContext<DynamicFunctionWithoutEnv>)
             };

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -23,7 +23,7 @@ pub type wasm_func_callback_t = unsafe extern "C" fn(
 
 #[allow(non_camel_case_types)]
 pub type wasm_func_callback_with_env_t = unsafe extern "C" fn(
-    *mut c_void,
+    env: *mut c_void,
     args: *const wasm_val_vec_t,
     results: *mut wasm_val_vec_t,
 ) -> *mut wasm_trap_t;
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
     function_type: Option<&wasm_functype_t>,
     callback: Option<wasm_func_callback_with_env_t>,
     env: *mut c_void,
-    finalizer: Option<wasm_env_finalizer_t>,
+    env_finalizer: Option<wasm_env_finalizer_t>,
 ) -> Option<Box<wasm_func_t>> {
     let store = store?;
     let function_type = function_type?;
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
     #[repr(C)]
     struct WrapperEnv {
         env: *mut c_void,
-        finalizer: Arc<Option<wasm_env_finalizer_t>>,
+        env_finalizer: Arc<Option<wasm_env_finalizer_t>>,
     }
 
     // Only relevant when using multiple threads in the C API;
@@ -115,18 +115,18 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
 
     impl Drop for WrapperEnv {
         fn drop(&mut self) {
-            if let Some(finalizer) = Arc::get_mut(&mut self.finalizer)
+            if let Some(env_finalizer) = Arc::get_mut(&mut self.env_finalizer)
                 .map(Option::take)
                 .flatten()
             {
                 if !self.env.is_null() {
-                    unsafe { (finalizer)(self.env as _) }
+                    unsafe { (env_finalizer)(self.env as _) }
                 }
             }
         }
     }
 
-    let inner_callback = move |env: &WrapperEnv, args: &[Val]| -> Result<Vec<Val>, RuntimeError> {
+    let trampoline = move |env: &WrapperEnv, args: &[Val]| -> Result<Vec<Val>, RuntimeError> {
         let processed_args: wasm_val_vec_t = args
             .into_iter()
             .map(TryInto::try_into)
@@ -167,9 +167,9 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
         func_sig,
         WrapperEnv {
             env,
-            finalizer: Arc::new(finalizer),
+            env_finalizer: Arc::new(env_finalizer),
         },
-        inner_callback,
+        trampoline,
     );
 
     Some(Box::new(wasm_func_t {

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -47,8 +47,8 @@ use wasmer_types::{
 
 /// The function pointer to call with data and an [`Instance`] pointer to
 /// finish initializing the host env.
-pub type ImportInitializerFuncPtr =
-    fn(*mut std::ffi::c_void, *const std::ffi::c_void) -> Result<(), *mut std::ffi::c_void>;
+pub type ImportInitializerFuncPtr<ResultErr = *mut ffi::c_void> =
+    fn(*mut ffi::c_void, *const ffi::c_void) -> Result<(), ResultErr>;
 
 /// A WebAssembly instance.
 ///
@@ -1146,7 +1146,7 @@ impl InstanceHandle {
                         // transmute our function pointer into one with the correct error type
                         let f = mem::transmute::<
                             &ImportInitializerFuncPtr,
-                            &fn(*mut ffi::c_void, *const ffi::c_void) -> Result<(), Err>,
+                            &ImportInitializerFuncPtr<Err>,
                         >(f);
                         f(*env, instance_ptr)?;
                     }

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -123,9 +123,9 @@ pub enum ImportFunctionEnv {
     Env {
         /// The function environment. This is not always the user-supplied
         /// env.
-        env: *mut std::ffi::c_void,
+        env: *mut ffi::c_void,
         /// A clone function for duplicating the env.
-        clone: fn(*mut std::ffi::c_void) -> *mut std::ffi::c_void,
+        clone: fn(*mut ffi::c_void) -> *mut ffi::c_void,
         /// This field is not always present. When it is present, it
         /// should be set to `None` after use to prevent double
         /// initialization.
@@ -135,7 +135,7 @@ pub enum ImportFunctionEnv {
         /// # Safety
         /// - This function must be called ina synchronized way. For
         ///   example, in the `Drop` implementation of this type.
-        destructor: unsafe fn(*mut std::ffi::c_void),
+        destructor: unsafe fn(*mut ffi::c_void),
     },
 }
 
@@ -1131,7 +1131,7 @@ impl InstanceHandle {
     /// - `instance_ptr` must point to a valid `wasmer::Instance`.
     pub unsafe fn initialize_host_envs<Err: Sized>(
         &mut self,
-        instance_ptr: *const std::ffi::c_void,
+        instance_ptr: *const ffi::c_void,
     ) -> Result<(), Err> {
         let instance_ref = self.instance.as_mut();
 


### PR DESCRIPTION
# Description

This PR is a little bit of code cleanup. Let's higlight the most important commits:

* https://github.com/wasmerio/wasmer/commit/48a5cf0b55cd4592e365fc96eed6f3fdb3913480 that re-use the `vm::ImportInitializerFuncPtr` type inside `api::externals::function`. It makes type-checking useful, and it makes code navigation much easier,
* https://github.com/wasmerio/wasmer/commit/0960f0fa7dc41708beb21a6aeeadcd98e15b1dbf that adds a new optional `ResultErr` parameter to `ImportInitializerFuncPtr`. It simplifies the intend when transmuting from `&ImportInitializerFuncPtr` to `&ImportInitializerFuncPtr<Err>` in `vm::instance`.

The diff is annotated with comments to guide the reviewer.

# Review

- ~[ ] Add a short description of the the change to the CHANGELOG.md file~ not necessary I guess?
