### PR TITLE
fix(c-api) Fix how string's length is computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 ### Fixed
+- [#2097](https://github.com/wasmerio/wasmer/pull/2097) Fix how string's length is computed in `wasm_cpu_features_add` in the C API.
 
 ## 1.0.2 - 2021-02-04
 

--- a/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn wasm_cpu_features_add(
     let feature = c_try!(
         str::from_utf8(slice::from_raw_parts(
             feature.data,
-            feature.size + 1,
+            feature.size,
         ));
         otherwise false
     );


### PR DESCRIPTION
# Description

Obviously, it's just `feature.size`. Why did I do that…?

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
