### PR TITLE
fix: cflags emitted by `wasmer config --pkg-config` are now correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - [#2097](https://github.com/wasmerio/wasmer/pull/2097) Fix how string's length is computed in `wasm_cpu_features_add` in the C API.
+- [#2101](https://github.com/wasmerio/wasmer/pull/2101) cflags emitted by `wasmer config --pkg-config` are now correct.
 
 ## 1.0.2 - 2021-02-04
 

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -56,7 +56,7 @@ impl Config {
         let bindir = prefix.join("bin").display().to_string();
         let includedir = prefix.join("include").display().to_string();
         let libdir = prefix.join("lib").display().to_string();
-        let cflags = format!("-I{}/wasmer", includedir);
+        let cflags = format!("-I{}", includedir);
         let libs = format!("-L{} -lwasmer", libdir);
 
         if self.pkg_config {


### PR DESCRIPTION
# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
