### PR TITLE
fix(ci) Clean up Windows artifacts, installer, LLVM etc.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -360,7 +360,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/wasmer-windows-amd64/WasmerInstaller.exe
-          asset_name: wasmer-windows-installer.exe
+          asset_name: wasmer-windows.exe
           asset_content_type: application/vnd.microsoft.portable-executable
 
       - name: Upload Release Asset Windows

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -369,9 +369,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/wasmer-windows-amd64/wasmer.tar.gz
-          asset_name: wasmer-windows-amd64.tar.gz
-          asset_content_type: application/gzip
+          asset_path: artifacts/wasmer-windows-amd64/wasmer.zip
+          asset_name: wasmer-windows-amd64.zip
+          asset_content_type: application/zip
 
       - name: Upload Release Asset Linux amd64
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
           - build: windows-x64
             os: windows-latest
             rust: 1.48
-            # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
             run_integration_tests: true
@@ -91,11 +91,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - name: Install LLVM (Windows)
-        if: matrix.os == 'windows-latest' && !matrix.llvm_url
-        shell: cmd
-        run: |
-          choco install llvm
       - name: Install LLVM (macOS Apple Silicon)
         if: matrix.os == 'macos-11.0' && !matrix.llvm_url
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -357,9 +357,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/wasmer-windows-amd64/WasmerInstaller.exe
-          asset_name: wasmer-windows.exe
+          asset_name: wasmer-windows-installer.exe
           asset_content_type: application/vnd.microsoft.portable-executable
       - name: Upload Release Asset Linux amd64
         id: upload-release-asset-linux-amd64

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -341,6 +341,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -351,8 +352,8 @@ jobs:
           release_name: Release ${{ needs.setup.outputs.VERSION }}
           draft: true
           prerelease: false
-      - name: Upload Release Asset Windows
-        id: upload-release-asset-windows
+
+      - name: Upload Release Asset Windows Installer
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -361,8 +362,18 @@ jobs:
           asset_path: artifacts/wasmer-windows-amd64/WasmerInstaller.exe
           asset_name: wasmer-windows-installer.exe
           asset_content_type: application/vnd.microsoft.portable-executable
+
+      - name: Upload Release Asset Windows
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/wasmer-windows-amd64/wasmer.tar.gz
+          asset_name: wasmer-windows-amd64.tar.gz
+          asset_content_type: application/gzip
+
       - name: Upload Release Asset Linux amd64
-        id: upload-release-asset-linux-amd64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -371,8 +382,8 @@ jobs:
           asset_path: artifacts/wasmer-linux-amd64/wasmer.tar.gz
           asset_name: wasmer-linux-amd64.tar.gz
           asset_content_type: application/gzip
+
       - name: Upload Release Asset Mac amd64
-        id: upload-release-asset-mac-amd64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -381,8 +392,8 @@ jobs:
           asset_path: artifacts/wasmer-darwin-amd64/wasmer.tar.gz
           asset_name: wasmer-darwin-amd64.tar.gz
           asset_content_type: application/gzip
+
       - name: Upload Release Asset Mac arm64
-        id: upload-release-asset-mac-arm64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -391,8 +402,8 @@ jobs:
           asset_path: artifacts/wasmer-darwin-arm64/wasmer.tar.gz
           asset_name: wasmer-darwin-arm64.tar.gz
           asset_content_type: application/gzip
+
       - name: Upload Release Asset Linux aarch64
-        id: upload-release-asset-linux-aarch64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -414,9 +414,12 @@ distribution: package
 ifeq ($(OS), Windows_NT)
 	iscc scripts/windows-installer/wasmer.iss
 	cp scripts/windows-installer/WasmerInstaller.exe dist/
-endif
+	cd package && zip -r ../wasmer.zip . && cd -
+	mv wasmer.zip dist/
+else
 	tar -C package -zcvf wasmer.tar.gz bin lib include LICENSE ATTRIBUTIONS
 	mv wasmer.tar.gz dist/
+endif
 
 #################
 # Miscellaneous #

--- a/Makefile
+++ b/Makefile
@@ -415,8 +415,6 @@ ifeq ($(OS), Windows_NT)
 	iscc scripts/windows-installer/wasmer.iss
 	cp scripts/windows-installer/WasmerInstaller.exe dist/
 else
-	cp LICENSE package/LICENSE
-	cp ATTRIBUTIONS.md package/ATTRIBUTIONS
 	tar -C package -zcvf wasmer.tar.gz bin lib include LICENSE ATTRIBUTIONS
 	mv wasmer.tar.gz dist/
 endif

--- a/Makefile
+++ b/Makefile
@@ -414,10 +414,9 @@ distribution: package
 ifeq ($(OS), Windows_NT)
 	iscc scripts/windows-installer/wasmer.iss
 	cp scripts/windows-installer/WasmerInstaller.exe dist/
-else
+endif
 	tar -C package -zcvf wasmer.tar.gz bin lib include LICENSE ATTRIBUTIONS
 	mv wasmer.tar.gz dist/
-endif
 
 #################
 # Miscellaneous #


### PR DESCRIPTION
# Description

1.  7ff16b4, First, we need to use our own LLVM built for Windows. This has been commited by error, see https://github.com/wasmerio/wasmer/pull/2008#discussion_r555588703.
2. 3946f3c, Second, we copy the `ATTRIBUTIONS` and `LICENSE` files twice. That's useless :-).
3. efff2c8 ,  Third, as discussed with @MarkMcCaskey, we want to rename `wasmer-windows.exe` to `wasmer-windows-installer.exe` for the sake of clarity.
4. 1a03e88, Fourth, let's create a `wasmer.tar.gz` archive for Windows.
5. 67e8679, Fiveth, let's upload the `wasmer.tar.gz` archive for Windows.
6. cf0c56c, Use `wasmer.zip` on Windows because it's difficult to untar+ungzip on this OS (as discused with @MarkMcCaskey).

# Review

- [ ] ~Add a short description of the the change to the CHANGELOG.md file~ not necessary
