### PR TITLE
Bump Rust CI version to 1.49

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.48.0
+          toolchain: 1.49
           override: true
       - name: Install LLVM
         shell: bash

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.48.0
+          toolchain: 1.49
           override: true
           components: rustfmt, clippy
       - run: make lint

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,14 +42,14 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu-18.04
-            rust: 1.48
+            rust: 1.49
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_integration_tests: true
           - build: macos-x64
             os: macos-latest
-            rust: 1.48
+            rust: 1.49
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
@@ -61,7 +61,7 @@ jobs:
             artifact_name: 'wasmer-darwin-arm64'
           - build: windows-x64
             os: windows-latest
-            rust: 1.48
+            rust: 1.49
             # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
@@ -69,7 +69,7 @@ jobs:
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
             random_sccache_port: true
-            rust: 1.48
+            rust: 1.49
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-aarch64.tar.gz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 ### Changed
+- [#2113](https://github.com/wasmerio/wasmer/pull/2113) Bump minimum supported Rust version to 1.49
 
 ### Fixed
 - [#2097](https://github.com/wasmerio/wasmer/pull/2097) Fix how string's length is computed in `wasm_cpu_features_add` in the C API.


### PR DESCRIPTION
Rust [1.50 was released](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html), so we're upgrading to 1 behind latest stable, 1.49

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
