### PR TITLE
Add cargo-deny action as part of our CI.

### DIFF
--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
+
+name: cargo-deny
+
+jobs:
+  deny-check:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
This adds cargo-deny with its own separate workflow file so that we can change it independently from other workflows. It runs at the same times that our lint workflow runs.