### PR TITLE
Add test that shows local memory/table lifetime bug

### DIFF
--- a/lib/api/tests/instance.rs
+++ b/lib/api/tests/instance.rs
@@ -37,3 +37,54 @@ fn exports_work_after_multiple_instances_have_been_freed() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn instance_local_memory_lifetime() -> Result<()> {
+    let store = Store::default();
+
+    /*
+        let wat1 = r#"(module
+        (memory $mem 1)
+        (export "memory" (memory $mem))
+    )"#;
+        let module1 = Module::new(&store, wat1)?;
+        let instance1 = Instance::new(&module1, &imports! {})?;
+        let memory = instance1.exports.get_memory("memory")?.clone();
+        */
+
+    let memory: Memory = {
+        let wat = r#"(module
+    (memory $mem 1)
+    (export "memory" (memory $mem))
+)"#;
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        instance.exports.get_memory("memory")?.clone()
+    };
+
+    let wat = r#"(module
+    (import "env" "memory" (memory $mem 1) )
+    (func $get_at (type $get_at_t) (param $idx i32) (result i32)
+      (i32.load (local.get $idx)))
+
+    (type $get_at_t (func (param i32) (result i32)))
+    (type $set_at_t (func (param i32) (param i32)))
+    (func $set_at (type $set_at_t) (param $idx i32) (param $val i32)
+      (i32.store (local.get $idx) (local.get $val)))
+    (export "get_at" (func $get_at))
+    (export "set_at" (func $set_at))
+)"#;
+    let module = Module::new(&store, wat)?;
+    let imports = imports! {
+        "env" => {
+            "memory" => memory,
+        },
+    };
+    let instance = Instance::new(&module, &imports)?;
+    let set_at: NativeFunc<(i32, i32), ()> = instance.exports.get_native_function("set_at")?;
+    let get_at: NativeFunc<i32, i32> = instance.exports.get_native_function("get_at")?;
+    set_at.call(200, 123)?;
+    assert_eq!(get_at.call(200)?, 123);
+
+    Ok(())
+}


### PR DESCRIPTION
The issue is that we expect these things to work while the store/engine is alive but critical data is stored in the `Instance` itself and the `Instance` does not live as long as the engine/store.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
