### PR TITLE
feat(c-api) Reduce the number of dependencies by statically compiling CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,13 @@
 [target.'cfg(target_os = "linux")']
 rustflags = [
-  "-C", "link-arg=-Wl,-E"
+    # Put the VM functions in the dynamic symbol table.
+    "-C", "link-arg=-Wl,-E",
+]
+
+[target.'cfg(target_os = "windows")']
+rustflags = [
+    # Enable `libwasmer` to be statically linked against the C Runtime
+    # Libraries (CRT) to reduce the number of dependencies inside the
+    # DLL.
+    "-C", "target-feature=+crt-static",
 ]


### PR DESCRIPTION
# Description

This patch adds the `-Ctarget-feature=+crt-static` flag when compiling
`libwasmer` on Windows. The goal is twofold: Reducing the number of
dependencies, and improving the portability of `libwasmer.dll` on more
Windows instances.

Before:

```sh
$ objdump --all-headers wasmer.dll | rg 'DLL Name'
    DLL Name: bcrypt.dll
    DLL Name: ADVAPI32.dll
    DLL Name: KERNEL32.dll
    DLL Name: VCRUNTIME140.dll
    DLL Name: api-ms-win-crt-heap-l1-1-0.dll
    DLL Name: api-ms-win-crt-runtime-l1-1-0.dll
    DLL Name: api-ms-win-crt-math-l1-1-0.dll
    DLL Name: api-ms-win-crt-string-l1-1-0.dll
```

After:

```sh
$ objdump --all-headers wasmer.dll | rg 'DLL Name'
    DLL Name: bcrypt.dll
    DLL Name: ADVAPI32.dll
    DLL Name: KERNEL32.dll
```

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
