### PR TITLE
feat(types) Avoid allocating a `Vec` when calling `FunctionType::new`

### DIFF
--- a/lib/api/src/import_object.rs
+++ b/lib/api/src/import_object.rs
@@ -145,20 +145,6 @@ impl IntoIterator for ImportObject {
 
 impl fmt::Debug for ImportObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        enum SecretOption {
-            None,
-            Some,
-        }
-
-        impl fmt::Debug for SecretOption {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                match self {
-                    Self::None => write!(f, "None"),
-                    Self::Some => write!(f, "Some(...)"),
-                }
-            }
-        }
-
         enum SecretMap {
             Empty,
             Some(usize),

--- a/lib/wasmer-types/src/types.rs
+++ b/lib/wasmer-types/src/types.rs
@@ -238,12 +238,12 @@ impl FunctionType {
     /// Creates a new Function Type with the given parameter and return types.
     pub fn new<Params, Returns>(params: Params, returns: Returns) -> Self
     where
-        Params: Into<Vec<Type>>,
-        Returns: Into<Vec<Type>>,
+        Params: Into<Box<[Type]>>,
+        Returns: Into<Box<[Type]>>,
     {
         Self {
-            params: params.into().into_boxed_slice(),
-            results: returns.into().into_boxed_slice(),
+            params: params.into(),
+            results: returns.into(),
         }
     }
 


### PR DESCRIPTION
# Description

Sequel of https://github.com/wasmerio/wasmer/pull/2036. We can go further by defining `Params` and `Results` of `FunctionType::new` as `Into<Box<[Type]>>` directly rather than `Into<Vec<Type>>`. It simplifies the code: `params.into()` rather than `params.into().into_boxed_slice()`. I assume it doesn't allocate an intermediate vector.

Since `From<Box<[T]>>` is implemented for `Vec<T>`, I reckon it's not a BC break.

# Review

- [ ] ~Add a short description of the the change to the CHANGELOG.md file~ not necessary
