### PR TITLE
Upgrade cranelift to 0.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changed
 - [#2113](https://github.com/wasmerio/wasmer/pull/2113) Bump minimum supported Rust version to 1.49
+- [#2144](https://github.com/wasmerio/wasmer/pull/2144) Bump cranelift version to 0.70
 
 ### Fixed
 - [#2117](https://github.com/wasmerio/wasmer/pull/2117) Formalize API prefixes in the C API. Only unstable functions have been renamed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
- "gimli 0.23.0",
+ "gimli",
 ]
 
 [[package]]
@@ -367,25 +367,25 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9221545c0507dc08a62b2d8b5ffe8e17ac580b0a74d1813b496b8d70b070fbd0"
+checksum = "31f782ffb172d8095cbb4c6464d85432c3bcfa8609b0bb1dc27cfd35bd90e052"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9936ea608b6cd176f107037f6adbb4deac933466fc7231154f96598b2d3ab1"
+checksum = "91e0910022b490bd0a65d5baa1693b0475cdbeea1c26472343f2acea1f1f55b8"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.22.0",
+ "gimli",
  "hashbrown",
  "log",
  "regalloc",
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef2b2768568306540f4c8db3acce9105534d34c4a1e440529c1e702d7f8c8d7"
+checksum = "7cafe95cb5ac659e113549b2794a2c8d3a14f36e1a98728a6e0ea7a773be2129"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -407,24 +407,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6759012d6d19c4caec95793f052613e9d4113e925e7f14154defbac0f1d4c938"
+checksum = "8d1bd002e42cc094a131a8227d06d48df28ea3b9127e5e3bc3010e079858e9af"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86badbce14e15f52a45b666b38abe47b204969dd7f8fb7488cb55dd46b361fa6"
+checksum = "e55e9043403f0dec775f317280015150e78b2352fb947d2f37407fd4ce6311c7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608bb7656c554d0a4cf8f50c7a10b857e80306f6ff829ad6d468a7e2323c8d8"
+checksum = "0153680ebce89aac7cad90a5442bb136faacfc86ea62587a01b8e8e79f8249c9"
 dependencies = [
  "cranelift-codegen",
  "hashbrown",
@@ -864,20 +864,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 dependencies = [
  "fallible-iterator",
  "indexmap",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glob"
@@ -1628,6 +1622,7 @@ checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -2436,7 +2431,7 @@ version = "1.0.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
- "gimli 0.22.0",
+ "gimli",
  "hashbrown",
  "lazy_static",
  "more-asserts",

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -15,19 +15,19 @@ edition = "2018"
 wasmer-compiler = { path = "../compiler", version = "1.0.2", features = ["translator"], default-features = false }
 wasmer-vm = { path = "../vm", version = "1.0.2" }
 wasmer-types = { path = "../wasmer-types", version = "1.0.2", default-features = false, features = ["std"] }
-cranelift-codegen = { version = "0.68", default-features = false, features = ["x86", "arm64"] }
-cranelift-frontend = { version = "0.68", default-features = false }
+cranelift-codegen = { version = "0.70", default-features = false, features = ["x86", "arm64"] }
+cranelift-frontend = { version = "0.70", default-features = false }
 tracing = "0.1"
 hashbrown = { version = "0.9", optional = true }
 rayon = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 more-asserts = "0.2"
-gimli = { version = "0.22", optional = true }
+gimli = { version = "0.23", optional = true }
 smallvec = "1.6"
 
 [dev-dependencies]
 target-lexicon = { version = "0.11", default-features = false }
-cranelift-codegen = { version = "0.68", features = ["enable-serde", "all-arch"] }
+cranelift-codegen = { version = "0.70", features = ["enable-serde", "all-arch"] }
 lazy_static = "1.4"
 
 [badges]

--- a/lib/compiler-cranelift/src/sink.rs
+++ b/lib/compiler-cranelift/src/sink.rs
@@ -20,15 +20,6 @@ pub(crate) struct RelocSink<'a> {
 }
 
 impl<'a> binemit::RelocSink for RelocSink<'a> {
-    fn reloc_block(
-        &mut self,
-        _offset: binemit::CodeOffset,
-        _reloc: binemit::Reloc,
-        _block_offset: binemit::CodeOffset,
-    ) {
-        // This should use the `offsets` field of `ir::Function`.
-        panic!("block headers not yet implemented");
-    }
     fn reloc_external(
         &mut self,
         offset: binemit::CodeOffset,

--- a/lib/compiler-cranelift/src/trampoline/mod.rs
+++ b/lib/compiler-cranelift/src/trampoline/mod.rs
@@ -21,14 +21,6 @@ pub mod binemit {
     pub struct TrampolineRelocSink {}
 
     impl binemit::RelocSink for TrampolineRelocSink {
-        fn reloc_block(
-            &mut self,
-            _offset: binemit::CodeOffset,
-            _reloc: binemit::Reloc,
-            _block_offset: binemit::CodeOffset,
-        ) {
-            panic!("trampoline compilation should not produce block relocs");
-        }
         fn reloc_external(
             &mut self,
             _offset: binemit::CodeOffset,

--- a/lib/wasmer-types/Cargo.toml
+++ b/lib/wasmer-types/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 # We use `cranelift-entity` here because it's a lightweight dependency and it contains
 # some useful data structures
-cranelift-entity = "0.68"
+cranelift-entity = "0.70"
 serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }
 thiserror = "1.0"
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
Upgrade cranelift to 0.70 with a small breaking change to remove reloc_block from binemit::RelocSink trait. 

ref: [commit](https://github.com/bytecodealliance/wasmtime/commit/b7a93c2321c3eff101f22e426fae8b81bd21c39e)

# Review

- [X] Add a short description of the the change to the CHANGELOG.md file
