### PR TITLE
Update engine-native to look for clang-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 - [#2113](https://github.com/wasmerio/wasmer/pull/2113) Bump minimum supported Rust version to 1.49
 - [#2144](https://github.com/wasmerio/wasmer/pull/2144) Bump cranelift version to 0.70
+- [#2149](https://github.com/wasmerio/wasmer/pull/2144) `wasmer-engine-native` looks for clang-11 instead of clang-10.
 
 ### Fixed
 - [#2117](https://github.com/wasmerio/wasmer/pull/2117) Formalize API prefixes in the C API. Only unstable functions have been renamed.

--- a/lib/engine-native/src/artifact.rs
+++ b/lib/engine-native/src/artifact.rs
@@ -293,7 +293,7 @@ impl NativeArtifact {
             Triple::host().to_string(),
         );
 
-        let linker: &'static str = engine_inner.linker().into();
+        let linker = engine_inner.linker().executable();
         let output = Command::new(linker)
             .arg(&filepath)
             .arg("-o")

--- a/lib/engine-native/src/engine.rs
+++ b/lib/engine-native/src/engine.rs
@@ -177,8 +177,8 @@ impl Engine for NativeEngine {
 #[derive(Clone, Copy)]
 pub(crate) enum Linker {
     None,
-    // this should be kept in sync with the llvm version required for wasmer-compiler-llvm
     Clang11,
+    Clang10,
     Clang,
     Gcc,
 }
@@ -186,10 +186,10 @@ pub(crate) enum Linker {
 impl Linker {
     #[cfg(feature = "compiler")]
     fn find_linker(is_cross_compiling: bool) -> Self {
-        let (possibilities, requirements) = if is_cross_compiling {
+        let (possibilities, requirements): (&[_], _) = if is_cross_compiling {
             (
-                &[Linker::Clang11, Linker::Clang],
-                "at least one of `clang-11` or `clang`",
+                &[Linker::Clang11, Linker::Clang10, Linker::Clang],
+                "at least one of `clang-11`, `clang-10`, or `clang`",
             )
         } else {
             (&[Linker::Gcc], "`gcc`")
@@ -211,6 +211,7 @@ impl Linker {
         match self {
             Self::None => "",
             Self::Clang11 => "clang-11",
+            Self::Clang10 => "clang-10",
             Self::Clang => "clang",
             Self::Gcc => "gcc",
         }

--- a/lib/engine-native/src/engine.rs
+++ b/lib/engine-native/src/engine.rs
@@ -13,8 +13,6 @@ use wasmer_engine::{Artifact, DeserializeError, Engine, EngineId, Tunables};
 use wasmer_types::Features;
 use wasmer_types::FunctionType;
 use wasmer_vm::{SignatureRegistry, VMSharedSignatureIndex};
-#[cfg(feature = "compiler")]
-use which::which;
 
 /// A WebAssembly `Native` Engine.
 #[derive(Clone)]
@@ -29,22 +27,8 @@ impl NativeEngine {
     /// Create a new `NativeEngine` with the given config
     #[cfg(feature = "compiler")]
     pub fn new(compiler: Box<dyn Compiler>, target: Target, features: Features) -> Self {
-        let host_target = Triple::host();
-        let is_cross_compiling = target.triple() != &host_target;
-
-        let linker = if is_cross_compiling {
-            which(Into::<&'static str>::into(Linker::Clang10))
-                .map(|_| Linker::Clang10)
-                .or_else(|_| {
-                    which(Into::<&'static str>::into(Linker::Clang))
-                        .map(|_| Linker::Clang)
-                })
-                .expect("Nor `clang-10` or `clang` has been found, at least one of them is required for the `NativeEngine`")
-        } else {
-            which(Into::<&'static str>::into(Linker::Gcc))
-                .map(|_| Linker::Gcc)
-                .expect("`gcc` has not been found, it is required for the `NativeEngine`")
-        };
+        let is_cross_compiling = *target.triple() != Triple::host();
+        let linker = Linker::find_linker(is_cross_compiling);
 
         Self {
             inner: Arc::new(Mutex::new(NativeEngineInner {
@@ -193,16 +177,40 @@ impl Engine for NativeEngine {
 #[derive(Clone, Copy)]
 pub(crate) enum Linker {
     None,
-    Clang10,
+    // this should be kept in sync with the llvm version required for wasmer-compiler-llvm
+    Clang11,
     Clang,
     Gcc,
 }
 
-impl Into<&'static str> for Linker {
-    fn into(self) -> &'static str {
+impl Linker {
+    #[cfg(feature = "compiler")]
+    fn find_linker(is_cross_compiling: bool) -> Self {
+        let (possibilities, requirements) = if is_cross_compiling {
+            (
+                &[Linker::Clang11, Linker::Clang],
+                "at least one of `clang-11` or `clang`",
+            )
+        } else {
+            (&[Linker::Gcc], "`gcc`")
+        };
+        *possibilities
+            .iter()
+            .filter(|linker| which::which(linker.executable()).is_ok())
+            .next()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Need {} installed in order to use `NativeEngine` when {}cross-compiling",
+                    requirements,
+                    if is_cross_compiling { "" } else { "not " }
+                )
+            })
+    }
+
+    pub(crate) fn executable(self) -> &'static str {
         match self {
             Self::None => "",
-            Self::Clang10 => "clang-10",
+            Self::Clang11 => "clang-11",
             Self::Clang => "clang",
             Self::Gcc => "gcc",
         }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
It was confusing getting our CI to work since using the `apt.llvm.org/llvm.sh` to install llvm11 doesn't install a clang or clang-10 binary, so I updated `engine-native` to look for clang-11 instead of clang-10, since that would make it easy to just install one version of clang on CI and get over with it.

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
