### PR TITLE
feat(tracing) Introducing `wasmer-tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
  "wasmer-engine",
  "wasmer-engine-jit",
  "wasmer-engine-native",
+ "wasmer-tracing",
  "wasmer-types",
  "wasmer-vm",
  "wat",
@@ -2626,6 +2627,13 @@ dependencies = [
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-tracing"
+version = "1.0.2"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ cfg-if = "1.0"
 [workspace]
 members = [
     "lib/api",
-    "lib/cache",
     "lib/c-api",
+    "lib/cache",
     "lib/cli",
     "lib/compiler",
     "lib/compiler-cranelift",
-    "lib/compiler-singlepass",
     "lib/compiler-llvm",
+    "lib/compiler-singlepass",
     "lib/derive",
     "lib/emscripten",
     "lib/engine",
@@ -44,12 +44,13 @@ members = [
     "lib/engine-native",
     "lib/engine-object-file",
     "lib/object",
+    "lib/tracing",
     "lib/vm",
     "lib/wasi",
     "lib/wasi-experimental-io-devices",
     "lib/wasmer-types",
-    "tests/lib/wast",
     "tests/integration/cli",
+    "tests/lib/wast",
 ]
 exclude = [
     "lib/deprecated",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
+wasmer-tracing = { path = "../tracing", version = "1.0.2" }
 wasmer-vm = { path = "../vm", version = "1.0.2" }
 wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.2", optional = true }
 wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "1.0.2", optional = true }

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -9,6 +9,7 @@ use crate::WasmerEnv;
 pub use inner::{FromToNativeWasmType, HostFunction, WasmTypeList, WithEnv, WithoutEnv};
 #[cfg(feature = "deprecated")]
 pub use inner::{UnsafeMutableEnv, WithUnsafeMutableEnv};
+use wasmer_tracing as tracing;
 
 use std::cmp::max;
 use std::ffi::c_void;
@@ -621,14 +622,19 @@ impl Function {
     /// assert_eq!(sum.call(&[Value::I32(1), Value::I32(2)]).unwrap().to_vec(), vec![Value::I32(3)]);
     /// ```
     pub fn call(&self, params: &[Val]) -> Result<Box<[Val]>, RuntimeError> {
+        tracing::function_start();
+
         let mut results = vec![Val::null(); self.result_arity()];
 
         match &self.definition {
             FunctionDefinition::Wasm(wasm) => {
+                tracing::function_invoke2(params[0].unwrap_i64() as _, params[1].unwrap_i64() as _);
                 self.call_wasm(&wasm, params, &mut results)?;
             }
             _ => unimplemented!("The function definition isn't supported for the moment"),
         }
+
+        tracing::function_end();
 
         Ok(results.into_boxed_slice())
     }

--- a/lib/api/src/instance.rs
+++ b/lib/api/src/instance.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 use wasmer_engine::Resolver;
+use wasmer_tracing as tracing;
 use wasmer_vm::{InstanceHandle, VMContext};
 
 /// A WebAssembly Instance is a stateful, executable
@@ -112,6 +113,8 @@ impl Instance {
     ///  * Link errors that happen when plugging the imports into the instance
     ///  * Runtime errors that happen when running the module `start` function.
     pub fn new(module: &Module, resolver: &dyn Resolver) -> Result<Self, InstantiationError> {
+        tracing::instance_start();
+
         let store = module.store();
         let handle = module.instantiate(resolver)?;
         let exports = module
@@ -170,5 +173,11 @@ impl fmt::Debug for Instance {
         f.debug_struct("Instance")
             .field("exports", &self.exports)
             .finish()
+    }
+}
+
+impl Drop for Instance {
+    fn drop(&mut self) {
+        tracing::instance_end();
     }
 }

--- a/lib/tracing/.gitignore
+++ b/lib/tracing/.gitignore
@@ -1,0 +1,1 @@
+/src/probes.h

--- a/lib/tracing/Cargo.toml
+++ b/lib/tracing/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wasmer-tracing"
+version = "1.0.2"
+description = "Tracing API for the Wasmer runtime"
+categories = ["wasm"]
+keywords = ["wasm", "webassembly", "runtime", "vm"]
+authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
+repository = "https://github.com/wasmerio/wasmer"
+documentation = "https://docs.rs/wasmer-tracing/"
+license = "MIT"
+readme = "README.md"
+edition = "2018"
+
+[build-dependencies]
+cc = "1.0"

--- a/lib/tracing/Makefile
+++ b/lib/tracing/Makefile
@@ -1,0 +1,6 @@
+all: build-probes
+
+build-probes: src/probes.h
+
+src/probes.h: src/probes.d
+	dtrace -o src/probes.h -h -s src/probes.d

--- a/lib/tracing/build.rs
+++ b/lib/tracing/build.rs
@@ -1,0 +1,9 @@
+use cc;
+use std::process::Command;
+
+fn main() {
+    Command::new("make").status().unwrap();
+    cc::Build::new()
+        .file("src/probes_ffi.c")
+        .compile("probes_ffi");
+}

--- a/lib/tracing/scripts/tracing.d
+++ b/lib/tracing/scripts/tracing.d
@@ -1,0 +1,33 @@
+#!/usr/sbin/dtrace -s
+
+#pragma D option quiet
+
+BEGIN
+{
+        printf("From DTrace (wasmer-tracing)\n");
+}
+
+wasmer*:::instance-start
+{
+        printf("instance starts\n");
+}
+
+wasmer*:::instance-end
+{
+        printf("instance ends\n");
+}
+
+wasmer*:::function-start
+{
+        printf("function starts\n");
+}
+
+wasmer*:::function-invoke2
+{
+        printf("function invoked with arg0=%d, arg1=%d\n", arg0, arg1);
+}
+
+wasmer*:::function-end
+{
+        printf("function ends\n");
+}

--- a/lib/tracing/src/lib.rs
+++ b/lib/tracing/src/lib.rs
@@ -1,0 +1,39 @@
+use std::os::raw::c_int;
+
+extern "C" {
+    fn wasmer_tracing_probe_instance_start();
+    fn wasmer_tracing_probe_instance_end();
+    fn wasmer_tracing_probe_function_start();
+    fn wasmer_tracing_probe_function_invoke2(arg0: c_int, arg1: c_int);
+    fn wasmer_tracing_probe_function_end();
+}
+
+pub fn instance_start() {
+    unsafe {
+        wasmer_tracing_probe_instance_start();
+    }
+}
+
+pub fn instance_end() {
+    unsafe {
+        wasmer_tracing_probe_instance_end();
+    }
+}
+
+pub fn function_start() {
+    unsafe {
+        wasmer_tracing_probe_function_start();
+    }
+}
+
+pub fn function_invoke2(arg0: c_int, arg1: c_int) {
+    unsafe {
+        wasmer_tracing_probe_function_invoke2(arg0, arg1);
+    }
+}
+
+pub fn function_end() {
+    unsafe {
+        wasmer_tracing_probe_function_end();
+    }
+}

--- a/lib/tracing/src/probes.d
+++ b/lib/tracing/src/probes.d
@@ -1,0 +1,8 @@
+provider wasmer {
+         probe instance__start();
+         probe instance__end();
+
+         probe function__start();
+         probe function__invoke2(int, int);
+         probe function__end();
+};

--- a/lib/tracing/src/probes_ffi.c
+++ b/lib/tracing/src/probes_ffi.c
@@ -1,0 +1,21 @@
+#include "probes.h"
+
+void wasmer_tracing_probe_instance_start() {
+  WASMER_INSTANCE_START();
+}
+
+void wasmer_tracing_probe_instance_end() {
+  WASMER_INSTANCE_END();
+}
+
+void wasmer_tracing_probe_function_start() {
+  WASMER_FUNCTION_START();
+}
+
+void wasmer_tracing_probe_function_invoke2(int arg0, int arg1) {
+  WASMER_FUNCTION_INVOKE2(arg0, arg1);
+}
+
+void wasmer_tracing_probe_function_end() {
+  WASMER_FUNCTION_END();
+}


### PR DESCRIPTION
# Description

## Introducing `wasmer-tracing` (https://github.com/wasmerio/wasmer/commit/719f37daa48179b0161c75f7468e5552d9eb82bc)

This is a proof-of-concept, or at best a work-in-progress, of
integrating USDT probes inside Wasmer through the new `wasmer-tracing`
crate.

USDT stands for Userland Statically Defined Tracing. USDT probes are
probes originally designed by DTrace, but now sucessfully implemented
in many environments, like Darwin, Solaris, Linux, Illumos, and even
[Windows][windows-dtrace]. It allows dynamic tracing at low-cost (a
probe is a noop, except when run with `dtrace` where a special section
of the object file is read to get the real probes and to instrument
the executable code, in some cases).

USDT aren't tied to DTrace only. On Linux for example, eBPF
understands USDT probes.

The process of generating and linking the probes is automated, but the
FFI bridge (`probes_ffi.c` and `lib.rs`) must be completed by hand for
each new added probe. It's not an issue as a few number of strategic
probes are going to be implemented.

This patch provides a new crate: `wasmer-tracing`.

The current set of probes (`instance_start`, `instance_end`,
`function_start`, `function_invoke2` and `function_end`) is only
present to showcase the idea.

The `scripts/tracing.d` script showcases how to read data from those
probes to trace the execution of the VM itself with a DTrace script.

Note that for the moment, the probes —as implemented— are designed to
be used in Rust. It means we can only analyze the
compilation-step/compile-time of a Wasm module into executable code,
and some runtime operations. More work is required to implement probes
inside the executable code we generate with the compilers, i.e for the
entire execution-step/runtime (LLVM has [XRay Instrumentation] for
example, not sure it's the path we must follow but it exists).

[windows-dtrace]: https://techcommunity.microsoft.com/t5/windows-kernel-internals/dtrace-on-windows/ba-p/362902
[XRay Instrumentation]: https://www.llvm.org/docs/XRay.html

## Showcasing how to use `wasmer-tracing` (https://github.com/wasmerio/wasmer/commit/773ded6cf28945f4799ed0cc594e0d39655aa8fc)

This patch showcases `wasmer-tracing` inside `wasmer` itself. Let's
see:

```sh
$ make build-wasmer
$ sudo dtrace -l -c ./target/release/wasmer | rg wasmer
54242 wasmer38542            wasmer wasmer_tracing_probe_function_end function-end
54243 wasmer38542            wasmer wasmer_tracing_probe_function_invoke2 function-invoke2
54244 wasmer38542            wasmer wasmer_tracing_probe_function_start function-start
54245 wasmer38542            wasmer wasmer_tracing_probe_instance_end instance-end
54246 wasmer38542            wasmer wasmer_tracing_probe_instance_start instance-start
```

See, Wasmer has USDT probes now! Now, let's use the
`lib/tracing/scripts/tracing.d` script (it's not fabulous, it just
showcases the principle):

```sh
$ sudo ./lib/tracing/scripts/tracing.d -c './target/release/wasmer run ./tests/examples/add.wat --invoke add -- 39 3'
From DTrace (wasmer-tracing)
42
instance starts
function starts
function invoked with arg0=39, arg1=3
function ends
instance ends
```

The first output line (“From DTrace (wasmer-tracing)”) is from the
`tracing.d` script. The second output line (“42”) is from Wasmer (it's
the sum of 39 and 3). The rest of the output is from the `tracing.d`
script.

Notice how the `wasmer*:::function-invoke2` block receives the
arguments of the `add` exported function, inside `arg0` and `arg1`.

I'm totally aware that `wasmer` isn't the correct place to declare
probes. Ideally, the VM, the compilers and the engines are better
places. Remember that it's just to showcase `wasmer-tracing`.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
