### PR TITLE
feat(llvm): Make NaN canonicalization configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,23 +973,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "inkwell"
-version = "0.1.0"
-source = "git+https://github.com/wasmerio/inkwell?branch=add-metadata-support#bc7aa32da056b0c4ede8bde50eba72103e640d8a"
-dependencies = [
- "either",
- "inkwell_internals",
- "libc",
- "llvm-sys",
- "once_cell",
- "parking_lot",
- "regex",
-]
-
-[[package]]
 name = "inkwell_internals"
 version = "0.3.0"
-source = "git+https://github.com/wasmerio/inkwell?branch=add-metadata-support#bc7aa32da056b0c4ede8bde50eba72103e640d8a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e1f71330ccec54ee62533ae88574c4169b67fb4b95cbb1196a1322582abd11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2583,7 +2570,6 @@ version = "1.0.2"
 dependencies = [
  "byteorder",
  "cc",
- "inkwell",
  "itertools 0.10.0",
  "lazy_static",
  "libc",
@@ -2598,6 +2584,7 @@ dependencies = [
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
+ "wasmer_inkwell",
 ]
 
 [[package]]
@@ -2868,6 +2855,21 @@ dependencies = [
  "wasmer-types",
  "wasmer-wasi",
  "wasmer-wast",
+]
+
+[[package]]
+name = "wasmer_inkwell"
+version = "0.2.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eca826323f39b29a38cd31c8eb33de76945c6193f30a2806c6cde6f6cd42cb1"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "parking_lot",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,9 +974,8 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fe0be1e47c0c0f3da4397693e08f5d78329ae095c25d529e12ade78420fb41"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/inkwell?branch=add-metadata-support#bc7aa32da056b0c4ede8bde50eba72103e640d8a"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -990,8 +989,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e1f71330ccec54ee62533ae88574c4169b67fb4b95cbb1196a1322582abd11"
+source = "git+https://github.com/wasmerio/inkwell?branch=add-metadata-support#bc7aa32da056b0c4ede8bde50eba72103e640d8a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -474,6 +474,7 @@ fn exclude_items_from_wasm_c_api(builder: Builder) -> Builder {
         .exclude_item("wasi_get_unordered_imports")
         .exclude_item("wasi_get_wasi_version")
         .exclude_item("wasi_version_t")
+        .exclude_item("wasm_config_canonicalize_nans")
         .exclude_item("wasm_config_push_middleware")
         .exclude_item("wasm_config_set_compiler")
         .exclude_item("wasm_config_set_engine")

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -105,6 +105,7 @@ pub struct wasm_config_t {
     compiler: wasmer_compiler_t,
     #[cfg(feature = "middlewares")]
     pub(super) middlewares: Vec<wasmer_middleware_t>,
+    pub(super) nan_canonicalization: bool,
     pub(super) features: Option<Box<wasmer_features_t>>,
     pub(super) target: Option<Box<wasmer_target_t>>,
 }
@@ -480,6 +481,10 @@ pub extern "C" fn wasm_engine_new_with_config(
             #[cfg(feature = "middlewares")]
             for middleware in config.middlewares {
                 compiler_config.push_middleware(middleware.inner);
+            }
+
+            if config.nan_canonicalization {
+                compiler_config.canonicalize_nans(true);
             }
 
             let inner: Arc<dyn Engine + Send + Sync> = match config.engine {

--- a/lib/c-api/src/wasm_c_api/unstable/engine.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/engine.rs
@@ -95,6 +95,45 @@ pub extern "C" fn wasm_config_set_features(
     config.features = Some(features);
 }
 
+/// Updates the configuration to enable NaN canonicalization.
+///
+/// This is a Wasmer-specific function.
+///
+/// # Example
+///
+/// ```rust
+/// # use inline_c::assert_c;
+/// # fn main() {
+/// #    (assert_c! {
+/// # #include "tests/wasmer_wasm.h"
+/// #
+/// int main() {
+///     // Create the configuration.
+///     wasm_config_t* config = wasm_config_new();
+///
+///     // Enable NaN canonicalization.
+///     wasm_config_canonicalize_nans(config, true);
+///
+///     // Create the engine.
+///     wasm_engine_t* engine = wasm_engine_new_with_config(config);
+///
+///     // Check we have an engine!
+///     assert(engine);
+///
+///     // Free everything.
+///     wasm_engine_delete(engine);
+///
+///     return 0;
+/// }
+/// #    })
+/// #    .success();
+/// # }
+/// ```
+#[no_mangle]
+pub extern "C" fn wasm_config_canonicalize_nans(config: &mut wasm_config_t, enable: bool) {
+    config.nan_canonicalization = enable;
+}
+
 /// Check whether the given compiler is available, i.e. part of this
 /// compiled library.
 #[no_mangle]

--- a/lib/c-api/wasmer_wasm.h
+++ b/lib/c-api/wasmer_wasm.h
@@ -772,6 +772,8 @@ bool wasi_get_unordered_imports(const wasm_store_t *store,
 enum wasi_version_t wasi_get_wasi_version(const wasm_module_t *module);
 #endif
 
+void wasm_config_canonicalize_nans(wasm_config_t *config, bool enable);
+
 void wasm_config_push_middleware(wasm_config_t *config, struct wasmer_middleware_t *middleware);
 
 #if defined(WASMER_COMPILER_ENABLED)

--- a/lib/compiler-cranelift/src/config.rs
+++ b/lib/compiler-cranelift/src/config.rs
@@ -185,6 +185,14 @@ impl CompilerConfig for Cranelift {
         self.enable_verifier = true;
     }
 
+    fn enable_nan_canonicalization(&mut self) {
+        self.enable_nan_canonicalization = true;
+    }
+
+    fn canonicalize_nans(&mut self, enable: bool) {
+        self.enable_nan_canonicalization = enable;
+    }
+
     /// Transform it into the compiler
     fn compiler(self: Box<Self>) -> Box<dyn Compiler> {
         Box::new(CraneliftCompiler::new(*self))

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -25,7 +25,8 @@ rayon = "1.5"
 loupe = "0.1"
 
 [dependencies.inkwell]
-version = "=0.1.0-beta.2"
+git = "https://github.com/wasmerio/inkwell"
+branch = "add-metadata-support"
 default-features = false
 features = ["llvm11-0", "target-x86", "target-aarch64"]
 

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -25,8 +25,8 @@ rayon = "1.5"
 loupe = "0.1"
 
 [dependencies.inkwell]
-git = "https://github.com/wasmerio/inkwell"
-branch = "add-metadata-support"
+package = "wasmer_inkwell"
+version = "0.2.0-alpha.2"
 default-features = false
 features = ["llvm11-0", "target-x86", "target-aarch64"]
 

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -85,8 +85,8 @@ impl Abi for Aarch64SystemV {
             [] => (
                 intrinsics.void_ty.fn_type(
                     param_types
-                        .map(|v| v.unwrap().into())
-                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .map(|v| v.map(Into::into))
+                        .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                         .as_slice(),
                     false,
                 ),
@@ -97,8 +97,8 @@ impl Abi for Aarch64SystemV {
                 (
                     type_to_llvm(intrinsics, single_value)?.fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -110,8 +110,8 @@ impl Abi for Aarch64SystemV {
                 (
                     context.struct_type(&[f32_ty, f32_ty], false).fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -123,8 +123,8 @@ impl Abi for Aarch64SystemV {
                 (
                     context.struct_type(&[f64_ty, f64_ty], false).fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -138,8 +138,8 @@ impl Abi for Aarch64SystemV {
                         .struct_type(&[f32_ty, f32_ty, f32_ty], false)
                         .fn_type(
                             param_types
-                                .map(|v| v.unwrap().into())
-                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .map(|v| v.map(Into::into))
+                                .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                                 .as_slice(),
                             false,
                         ),
@@ -153,8 +153,8 @@ impl Abi for Aarch64SystemV {
                         .struct_type(&[f32_ty, f32_ty, f32_ty, f32_ty], false)
                         .fn_type(
                             param_types
-                                .map(|v| v.unwrap().into())
-                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .map(|v| v.map(Into::into))
+                                .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                                 .as_slice(),
                             false,
                         ),
@@ -176,8 +176,8 @@ impl Abi for Aarch64SystemV {
                     [32, 32] => (
                         intrinsics.i64_ty.fn_type(
                             param_types
-                                .map(|v| v.unwrap().into())
-                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .map(|v| v.map(Into::into))
+                                .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                                 .as_slice(),
                             false,
                         ),
@@ -192,8 +192,8 @@ impl Abi for Aarch64SystemV {
                     | [32, 32, 32, 32] => (
                         intrinsics.i64_ty.array_type(2).fn_type(
                             param_types
-                                .map(|v| v.unwrap().into())
-                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .map(|v| v.map(Into::into))
+                                .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                                 .as_slice(),
                             false,
                         ),
@@ -225,8 +225,8 @@ impl Abi for Aarch64SystemV {
                         (
                             intrinsics.void_ty.fn_type(
                                 param_types
-                                    .map(|v| v.unwrap().into())
-                                    .collect::<Vec<BasicMetadataTypeEnum>>()
+                                    .map(|v| v.map(Into::into))
+                                    .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                                     .as_slice(),
                                 false,
                             ),

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -4,7 +4,7 @@ use inkwell::{
     attributes::{Attribute, AttributeLoc},
     builder::Builder,
     context::Context,
-    types::{BasicType, FunctionType, StructType},
+    types::{BasicMetadataTypeEnum, BasicType, FunctionType, StructType},
     values::{BasicValue, BasicValueEnum, CallSiteValue, FunctionValue, IntValue, PointerValue},
     AddressSpace,
 };
@@ -83,34 +83,51 @@ impl Abi for Aarch64SystemV {
 
         Ok(match sig.results() {
             [] => (
-                intrinsics
-                    .void_ty
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                intrinsics.void_ty.fn_type(
+                    param_types
+                        .map(|v| v.unwrap().into())
+                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .as_slice(),
+                    false,
+                ),
                 vmctx_attributes(0),
             ),
             [_] => {
                 let single_value = sig.results()[0];
                 (
-                    type_to_llvm(intrinsics, single_value)?
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    type_to_llvm(intrinsics, single_value)?.fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                     vmctx_attributes(0),
                 )
             }
             [Type::F32, Type::F32] => {
                 let f32_ty = intrinsics.f32_ty.as_basic_type_enum();
                 (
-                    context
-                        .struct_type(&[f32_ty, f32_ty], false)
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    context.struct_type(&[f32_ty, f32_ty], false).fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                     vmctx_attributes(0),
                 )
             }
             [Type::F64, Type::F64] => {
                 let f64_ty = intrinsics.f64_ty.as_basic_type_enum();
                 (
-                    context
-                        .struct_type(&[f64_ty, f64_ty], false)
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    context.struct_type(&[f64_ty, f64_ty], false).fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                     vmctx_attributes(0),
                 )
             }
@@ -119,7 +136,13 @@ impl Abi for Aarch64SystemV {
                 (
                     context
                         .struct_type(&[f32_ty, f32_ty, f32_ty], false)
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                        .fn_type(
+                            param_types
+                                .map(|v| v.unwrap().into())
+                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .as_slice(),
+                            false,
+                        ),
                     vmctx_attributes(0),
                 )
             }
@@ -128,7 +151,13 @@ impl Abi for Aarch64SystemV {
                 (
                     context
                         .struct_type(&[f32_ty, f32_ty, f32_ty, f32_ty], false)
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                        .fn_type(
+                            param_types
+                                .map(|v| v.unwrap().into())
+                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .as_slice(),
+                            false,
+                        ),
                     vmctx_attributes(0),
                 )
             }
@@ -145,9 +174,13 @@ impl Abi for Aarch64SystemV {
                     .collect::<Vec<i32>>();
                 match sig_returns_bitwidths.as_slice() {
                     [32, 32] => (
-                        intrinsics
-                            .i64_ty
-                            .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                        intrinsics.i64_ty.fn_type(
+                            param_types
+                                .map(|v| v.unwrap().into())
+                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .as_slice(),
+                            false,
+                        ),
                         vmctx_attributes(0),
                     ),
                     [32, 64]
@@ -157,10 +190,13 @@ impl Abi for Aarch64SystemV {
                     | [64, 32, 32]
                     | [32, 32, 64]
                     | [32, 32, 32, 32] => (
-                        intrinsics
-                            .i64_ty
-                            .array_type(2)
-                            .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                        intrinsics.i64_ty.array_type(2).fn_type(
+                            param_types
+                                .map(|v| v.unwrap().into())
+                                .collect::<Vec<BasicMetadataTypeEnum>>()
+                                .as_slice(),
+                            false,
+                        ),
                         vmctx_attributes(0),
                     ),
                     _ => {
@@ -187,9 +223,13 @@ impl Abi for Aarch64SystemV {
                         attributes.append(&mut vmctx_attributes(1));
 
                         (
-                            intrinsics
-                                .void_ty
-                                .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                            intrinsics.void_ty.fn_type(
+                                param_types
+                                    .map(|v| v.unwrap().into())
+                                    .collect::<Vec<BasicMetadataTypeEnum>>()
+                                    .as_slice(),
+                                false,
+                            ),
                             attributes,
                         )
                     }

--- a/lib/compiler-llvm/src/abi/x86_64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/x86_64_systemv.rs
@@ -100,8 +100,8 @@ impl Abi for X86_64SystemV {
             [] => (
                 intrinsics.void_ty.fn_type(
                     param_types
-                        .map(|v| v.unwrap().into())
-                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .map(|v| v.map(Into::into))
+                        .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                         .as_slice(),
                     false,
                 ),
@@ -112,8 +112,8 @@ impl Abi for X86_64SystemV {
                 (
                     type_to_llvm(intrinsics, single_value)?.fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -130,8 +130,8 @@ impl Abi for X86_64SystemV {
                 (
                     context.struct_type(&basic_types, false).fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -141,8 +141,8 @@ impl Abi for X86_64SystemV {
             [32, 32] if sig.results()[0] == Type::F32 && sig.results()[1] == Type::F32 => (
                 intrinsics.f32_ty.vec_type(2).fn_type(
                     param_types
-                        .map(|v| v.unwrap().into())
-                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .map(|v| v.map(Into::into))
+                        .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                         .as_slice(),
                     false,
                 ),
@@ -151,8 +151,8 @@ impl Abi for X86_64SystemV {
             [32, 32] => (
                 intrinsics.i64_ty.fn_type(
                     param_types
-                        .map(|v| v.unwrap().into())
-                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .map(|v| v.map(Into::into))
+                        .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                         .as_slice(),
                     false,
                 ),
@@ -169,8 +169,8 @@ impl Abi for X86_64SystemV {
                     )
                     .fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -187,8 +187,8 @@ impl Abi for X86_64SystemV {
                     )
                     .fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -205,8 +205,8 @@ impl Abi for X86_64SystemV {
                     )
                     .fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -223,8 +223,8 @@ impl Abi for X86_64SystemV {
                     )
                     .fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -249,8 +249,8 @@ impl Abi for X86_64SystemV {
                     )
                     .fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),
@@ -278,8 +278,8 @@ impl Abi for X86_64SystemV {
                 (
                     intrinsics.void_ty.fn_type(
                         param_types
-                            .map(|v| v.unwrap().into())
-                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .map(|v| v.map(Into::into))
+                            .collect::<Result<Vec<BasicMetadataTypeEnum>, _>>()?
                             .as_slice(),
                         false,
                     ),

--- a/lib/compiler-llvm/src/abi/x86_64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/x86_64_systemv.rs
@@ -4,7 +4,7 @@ use inkwell::{
     attributes::{Attribute, AttributeLoc},
     builder::Builder,
     context::Context,
-    types::{BasicType, FunctionType, StructType},
+    types::{BasicMetadataTypeEnum, BasicType, FunctionType, StructType},
     values::{
         BasicValue, BasicValueEnum, CallSiteValue, FloatValue, FunctionValue, IntValue,
         PointerValue, VectorValue,
@@ -98,16 +98,25 @@ impl Abi for X86_64SystemV {
 
         Ok(match sig_returns_bitwidths.as_slice() {
             [] => (
-                intrinsics
-                    .void_ty
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                intrinsics.void_ty.fn_type(
+                    param_types
+                        .map(|v| v.unwrap().into())
+                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .as_slice(),
+                    false,
+                ),
                 vmctx_attributes(0),
             ),
             [_] => {
                 let single_value = sig.results()[0];
                 (
-                    type_to_llvm(intrinsics, single_value)?
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    type_to_llvm(intrinsics, single_value)?.fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                     vmctx_attributes(0),
                 )
             }
@@ -119,23 +128,34 @@ impl Abi for X86_64SystemV {
                     .collect::<Result<_, _>>()?;
 
                 (
-                    context
-                        .struct_type(&basic_types, false)
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    context.struct_type(&basic_types, false).fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                     vmctx_attributes(0),
                 )
             }
             [32, 32] if sig.results()[0] == Type::F32 && sig.results()[1] == Type::F32 => (
-                intrinsics
-                    .f32_ty
-                    .vec_type(2)
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                intrinsics.f32_ty.vec_type(2).fn_type(
+                    param_types
+                        .map(|v| v.unwrap().into())
+                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .as_slice(),
+                    false,
+                ),
                 vmctx_attributes(0),
             ),
             [32, 32] => (
-                intrinsics
-                    .i64_ty
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                intrinsics.i64_ty.fn_type(
+                    param_types
+                        .map(|v| v.unwrap().into())
+                        .collect::<Vec<BasicMetadataTypeEnum>>()
+                        .as_slice(),
+                    false,
+                ),
                 vmctx_attributes(0),
             ),
             [32, 32, _] if sig.results()[0] == Type::F32 && sig.results()[1] == Type::F32 => (
@@ -147,7 +167,13 @@ impl Abi for X86_64SystemV {
                         ],
                         false,
                     )
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    .fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                 vmctx_attributes(0),
             ),
             [32, 32, _] => (
@@ -159,7 +185,13 @@ impl Abi for X86_64SystemV {
                         ],
                         false,
                     )
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    .fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                 vmctx_attributes(0),
             ),
             [64, 32, 32] if sig.results()[1] == Type::F32 && sig.results()[2] == Type::F32 => (
@@ -171,7 +203,13 @@ impl Abi for X86_64SystemV {
                         ],
                         false,
                     )
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    .fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                 vmctx_attributes(0),
             ),
             [64, 32, 32] => (
@@ -183,7 +221,13 @@ impl Abi for X86_64SystemV {
                         ],
                         false,
                     )
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    .fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                 vmctx_attributes(0),
             ),
             [32, 32, 32, 32] => (
@@ -203,7 +247,13 @@ impl Abi for X86_64SystemV {
                         ],
                         false,
                     )
-                    .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    .fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                 vmctx_attributes(0),
             ),
             _ => {
@@ -226,9 +276,13 @@ impl Abi for X86_64SystemV {
                 attributes.append(&mut vmctx_attributes(1));
 
                 (
-                    intrinsics
-                        .void_ty
-                        .fn_type(&param_types.collect::<Result<Vec<_>, _>>()?, false),
+                    intrinsics.void_ty.fn_type(
+                        param_types
+                            .map(|v| v.unwrap().into())
+                            .collect::<Vec<BasicMetadataTypeEnum>>()
+                            .as_slice(),
+                        false,
+                    ),
                     attributes,
                 )
             }

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -65,15 +65,6 @@ impl LLVM {
         }
     }
 
-    /// Enable NaN canonicalization.
-    ///
-    /// NaN canonicalization is useful when trying to run WebAssembly
-    /// deterministically across different architectures.
-    pub fn canonicalize_nans(&mut self, enable: bool) -> &mut Self {
-        self.enable_nan_canonicalization = enable;
-        self
-    }
-
     /// The optimization levels when optimizing the IR.
     pub fn opt_level(&mut self, opt_level: LLVMOptLevel) -> &mut Self {
         self.opt_level = opt_level;
@@ -207,6 +198,14 @@ impl CompilerConfig for LLVM {
     /// Whether to verify compiler IR.
     fn enable_verifier(&mut self) {
         self.enable_verifier = true;
+    }
+
+    fn enable_nan_canonicalization(&mut self) {
+        self.enable_nan_canonicalization = true;
+    }
+
+    fn canonicalize_nans(&mut self, enable: bool) {
+        self.enable_nan_canonicalization = enable;
     }
 
     /// Transform it into the compiler.

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -3634,7 +3634,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             Operator::I32Clz => {
                 let (input, info) = self.state.pop1_extra()?;
                 let input = self.apply_pending_canonicalization(input, info);
-                let is_zero_undef = self.intrinsics.i1_zero.as_basic_value_enum();
+                let is_zero_undef = self.intrinsics.i1_zero;
                 let res = self
                     .builder
                     .build_call(
@@ -3650,7 +3650,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             Operator::I64Clz => {
                 let (input, info) = self.state.pop1_extra()?;
                 let input = self.apply_pending_canonicalization(input, info);
-                let is_zero_undef = self.intrinsics.i1_zero.as_basic_value_enum();
+                let is_zero_undef = self.intrinsics.i1_zero;
                 let res = self
                     .builder
                     .build_call(
@@ -3666,7 +3666,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             Operator::I32Ctz => {
                 let (input, info) = self.state.pop1_extra()?;
                 let input = self.apply_pending_canonicalization(input, info);
-                let is_zero_undef = self.intrinsics.i1_zero.as_basic_value_enum();
+                let is_zero_undef = self.intrinsics.i1_zero;
                 let res = self
                     .builder
                     .build_call(
@@ -3682,7 +3682,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             Operator::I64Ctz => {
                 let (input, info) = self.state.pop1_extra()?;
                 let input = self.apply_pending_canonicalization(input, info);
-                let is_zero_undef = self.intrinsics.i1_zero.as_basic_value_enum();
+                let is_zero_undef = self.intrinsics.i1_zero;
                 let res = self
                     .builder
                     .build_call(
@@ -4646,8 +4646,6 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let ((v1, i1), (v2, i2)) = self.state.pop2_extra()?;
                 let (v1, _) = self.v128_into_f32x4(v1, i1);
                 let (v2, _) = self.v128_into_f32x4(v2, i2);
-                let v1 = v1.as_basic_value_enum();
-                let v2 = v2.as_basic_value_enum();
 
                 let v1_is_nan = self
                     .builder
@@ -4716,18 +4714,18 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let res = self.builder.build_select(
                     v1_is_nan,
-                    self.quiet_nan(v1).into_vector_value(),
+                    self.quiet_nan(v1.into()).into_vector_value(),
                     self.builder
                         .build_select(
                             v2_is_nan,
-                            self.quiet_nan(v2).into_vector_value(),
+                            self.quiet_nan(v2.into()).into_vector_value(),
                             self.builder
                                 .build_select(
                                     v1_lt_v2,
-                                    v1,
+                                    v1.into(),
                                     self.builder.build_select(
                                         v1_gt_v2,
-                                        v2,
+                                        v2.into(),
                                         self.builder.build_bitcast(
                                             self.builder.build_or(
                                                 self.builder
@@ -4774,8 +4772,6 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let ((v1, i1), (v2, i2)) = self.state.pop2_extra()?;
                 let (v1, _) = self.v128_into_f64x2(v1, i1);
                 let (v2, _) = self.v128_into_f64x2(v2, i2);
-                let v1 = v1.as_basic_value_enum();
-                let v2 = v2.as_basic_value_enum();
 
                 let v1_is_nan = self
                     .builder
@@ -4844,18 +4840,18 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let res = self.builder.build_select(
                     v1_is_nan,
-                    self.quiet_nan(v1).into_vector_value(),
+                    self.quiet_nan(v1.into()).into_vector_value(),
                     self.builder
                         .build_select(
                             v2_is_nan,
-                            self.quiet_nan(v2).into_vector_value(),
+                            self.quiet_nan(v2.into()).into_vector_value(),
                             self.builder
                                 .build_select(
                                     v1_lt_v2,
-                                    v1,
+                                    v1.into(),
                                     self.builder.build_select(
                                         v1_gt_v2,
-                                        v2,
+                                        v2.into(),
                                         self.builder.build_bitcast(
                                             self.builder.build_or(
                                                 self.builder
@@ -5120,8 +5116,6 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let ((v1, i1), (v2, i2)) = self.state.pop2_extra()?;
                 let (v1, _) = self.v128_into_f32x4(v1, i1);
                 let (v2, _) = self.v128_into_f32x4(v2, i2);
-                let v1 = v1.as_basic_value_enum();
-                let v2 = v2.as_basic_value_enum();
 
                 let v1_is_nan = self
                     .builder
@@ -5190,18 +5184,18 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let res = self.builder.build_select(
                     v1_is_nan,
-                    self.quiet_nan(v1).into_vector_value(),
+                    self.quiet_nan(v1.into()).into_vector_value(),
                     self.builder
                         .build_select(
                             v2_is_nan,
-                            self.quiet_nan(v2).into_vector_value(),
+                            self.quiet_nan(v2.into()).into_vector_value(),
                             self.builder
                                 .build_select(
                                     v1_lt_v2,
-                                    v2,
+                                    v2.into(),
                                     self.builder.build_select(
                                         v1_gt_v2,
-                                        v1,
+                                        v1.into(),
                                         self.builder.build_bitcast(
                                             self.builder.build_and(
                                                 self.builder
@@ -5249,8 +5243,6 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let ((v1, i1), (v2, i2)) = self.state.pop2_extra()?;
                 let (v1, _) = self.v128_into_f64x2(v1, i1);
                 let (v2, _) = self.v128_into_f64x2(v2, i2);
-                let v1 = v1.as_basic_value_enum();
-                let v2 = v2.as_basic_value_enum();
 
                 let v1_is_nan = self
                     .builder
@@ -5319,18 +5311,18 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let res = self.builder.build_select(
                     v1_is_nan,
-                    self.quiet_nan(v1).into_vector_value(),
+                    self.quiet_nan(v1.into()).into_vector_value(),
                     self.builder
                         .build_select(
                             v2_is_nan,
-                            self.quiet_nan(v2).into_vector_value(),
+                            self.quiet_nan(v2.into()).into_vector_value(),
                             self.builder
                                 .build_select(
                                     v1_lt_v2,
-                                    v2,
+                                    v2.into(),
                                     self.builder.build_select(
                                         v1_gt_v2,
-                                        v1,
+                                        v1.into(),
                                         self.builder.build_bitcast(
                                             self.builder.build_and(
                                                 self.builder
@@ -10946,13 +10938,11 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let mem = self
                     .intrinsics
                     .i32_ty
-                    .const_int(mem.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(mem.into(), false);
                 let segment = self
                     .intrinsics
                     .i32_ty
-                    .const_int(segment.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(segment.into(), false);
                 self.builder.build_call(
                     self.intrinsics.memory_init,
                     &[
@@ -10970,8 +10960,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let segment = self
                     .intrinsics
                     .i32_ty
-                    .const_int(segment.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(segment.into(), false);
                 self.builder.build_call(
                     self.intrinsics.data_drop,
                     &[vmctx.as_basic_value_enum().into(), segment.into()],
@@ -10994,8 +10983,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let src_index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(src.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(src.into(), false);
                 self.builder.build_call(
                     memory_copy,
                     &[
@@ -11022,8 +11010,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let mem_index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(mem.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(mem.into(), false);
                 self.builder.build_call(
                     memory_fill,
                     &[
@@ -11057,8 +11044,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(function_index.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(function_index.into(), false);
                 let value = self
                     .builder
                     .build_call(
@@ -11075,8 +11061,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let table_index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(table.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(table.into(), false);
                 let elem = self.state.pop1()?;
                 let table_get = if let Some(_) = self
                     .wasm_module
@@ -11114,8 +11099,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let table_index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(table.into(), false)
-                    .as_basic_value_enum();
+                    .const_int(table.into(), false);
                 let (elem, value) = self.state.pop2()?;
                 let value = self
                     .builder
@@ -11147,13 +11131,11 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let dst_table = self
                     .intrinsics
                     .i32_ty
-                    .const_int(dst_table as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(dst_table as u64, false);
                 let src_table = self
                     .intrinsics
                     .i32_ty
-                    .const_int(src_table as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(src_table as u64, false);
                 self.builder.build_call(
                     self.intrinsics.table_copy,
                     &[
@@ -11172,13 +11154,11 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let segment = self
                     .intrinsics
                     .i32_ty
-                    .const_int(segment as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(segment as u64, false);
                 let table = self
                     .intrinsics
                     .i32_ty
-                    .const_int(table as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(table as u64, false);
                 self.builder.build_call(
                     self.intrinsics.table_init,
                     &[
@@ -11196,8 +11176,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let segment = self
                     .intrinsics
                     .i32_ty
-                    .const_int(segment as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(segment as u64, false);
                 self.builder.build_call(
                     self.intrinsics.elem_drop,
                     &[self.ctx.basic().into(), segment.into()],
@@ -11208,8 +11187,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let table = self
                     .intrinsics
                     .i32_ty
-                    .const_int(table as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(table as u64, false);
                 let (start, elem, len) = self.state.pop3()?;
                 let elem = self
                     .builder
@@ -11242,8 +11220,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let table_index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(table_index as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(table_index as u64, false);
                 let size = self
                     .builder
                     .build_call(
@@ -11273,8 +11250,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let table_index = self
                     .intrinsics
                     .i32_ty
-                    .const_int(table_index as u64, false)
-                    .as_basic_value_enum();
+                    .const_int(table_index as u64, false);
                 let size = self
                     .builder
                     .build_call(

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -2229,7 +2229,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     func,
                     params
                         .iter()
-                        .map(|v| (*v).into())
+                        .copied()
+                        .map(Into::into)
                         .collect::<Vec<BasicMetadataValueEnum>>()
                         .as_slice(),
                     "",
@@ -2520,7 +2521,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     typed_func_ptr,
                     params
                         .iter()
-                        .map(|v| (*v).into())
+                        .copied()
+                        .map(Into::into)
                         .collect::<Vec<BasicMetadataValueEnum>>()
                         .as_slice(),
                     "indirect_call",
@@ -10935,14 +10937,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             }
             Operator::MemoryInit { segment, mem } => {
                 let (dest, src, len) = self.state.pop3()?;
-                let mem = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(mem.into(), false);
-                let segment = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(segment.into(), false);
+                let mem = self.intrinsics.i32_ty.const_int(mem.into(), false);
+                let segment = self.intrinsics.i32_ty.const_int(segment.into(), false);
                 self.builder.build_call(
                     self.intrinsics.memory_init,
                     &[
@@ -10957,10 +10953,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 );
             }
             Operator::DataDrop { segment } => {
-                let segment = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(segment.into(), false);
+                let segment = self.intrinsics.i32_ty.const_int(segment.into(), false);
                 self.builder.build_call(
                     self.intrinsics.data_drop,
                     &[vmctx.as_basic_value_enum().into(), segment.into()],
@@ -10980,10 +10973,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 };
 
                 let (dest_pos, src_pos, len) = self.state.pop3()?;
-                let src_index = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(src.into(), false);
+                let src_index = self.intrinsics.i32_ty.const_int(src.into(), false);
                 self.builder.build_call(
                     memory_copy,
                     &[
@@ -11007,10 +10997,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 };
 
                 let (dst, val, len) = self.state.pop3()?;
-                let mem_index = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(mem.into(), false);
+                let mem_index = self.intrinsics.i32_ty.const_int(mem.into(), false);
                 self.builder.build_call(
                     memory_fill,
                     &[
@@ -11058,10 +11045,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.state.push1(value);
             }
             Operator::TableGet { table } => {
-                let table_index = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(table.into(), false);
+                let table_index = self.intrinsics.i32_ty.const_int(table.into(), false);
                 let elem = self.state.pop1()?;
                 let table_get = if let Some(_) = self
                     .wasm_module
@@ -11096,10 +11080,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.state.push1(value);
             }
             Operator::TableSet { table } => {
-                let table_index = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(table.into(), false);
+                let table_index = self.intrinsics.i32_ty.const_int(table.into(), false);
                 let (elem, value) = self.state.pop2()?;
                 let value = self
                     .builder
@@ -11128,14 +11109,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 src_table,
             } => {
                 let (dst, src, len) = self.state.pop3()?;
-                let dst_table = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(dst_table as u64, false);
-                let src_table = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(src_table as u64, false);
+                let dst_table = self.intrinsics.i32_ty.const_int(dst_table as u64, false);
+                let src_table = self.intrinsics.i32_ty.const_int(src_table as u64, false);
                 self.builder.build_call(
                     self.intrinsics.table_copy,
                     &[
@@ -11151,14 +11126,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             }
             Operator::TableInit { segment, table } => {
                 let (dst, src, len) = self.state.pop3()?;
-                let segment = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(segment as u64, false);
-                let table = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(table as u64, false);
+                let segment = self.intrinsics.i32_ty.const_int(segment as u64, false);
+                let table = self.intrinsics.i32_ty.const_int(table as u64, false);
                 self.builder.build_call(
                     self.intrinsics.table_init,
                     &[
@@ -11173,10 +11142,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 );
             }
             Operator::ElemDrop { segment } => {
-                let segment = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(segment as u64, false);
+                let segment = self.intrinsics.i32_ty.const_int(segment as u64, false);
                 self.builder.build_call(
                     self.intrinsics.elem_drop,
                     &[self.ctx.basic().into(), segment.into()],
@@ -11184,10 +11150,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 );
             }
             Operator::TableFill { table } => {
-                let table = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(table as u64, false);
+                let table = self.intrinsics.i32_ty.const_int(table as u64, false);
                 let (start, elem, len) = self.state.pop3()?;
                 let elem = self
                     .builder
@@ -11217,10 +11180,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 } else {
                     (self.intrinsics.imported_table_grow, table)
                 };
-                let table_index = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(table_index as u64, false);
+                let table_index = self.intrinsics.i32_ty.const_int(table_index as u64, false);
                 let size = self
                     .builder
                     .build_call(
@@ -11247,10 +11207,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 } else {
                     (self.intrinsics.imported_table_size, table)
                 };
-                let table_index = self
-                    .intrinsics
-                    .i32_ty
-                    .const_int(table_index as u64, false);
+                let table_index = self.intrinsics.i32_ty.const_int(table_index as u64, false);
                 let size = self
                     .builder
                     .build_call(

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -12,7 +12,8 @@ use inkwell::{
     context::Context,
     module::{Linkage, Module},
     types::{
-        BasicType, BasicMetadataTypeEnum, BasicTypeEnum, FloatType, IntType, PointerType, StructType, VectorType, VoidType,
+        BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FloatType, IntType, PointerType,
+        StructType, VectorType, VoidType,
     },
     values::{
         BasicValue, BasicValueEnum, FloatValue, FunctionValue, InstructionValue, IntValue,
@@ -322,7 +323,7 @@ impl<'ctx> Intrinsics<'ctx> {
 
         let md_ty = context.metadata_type();
 
-        let i8_ptr_ty_basic= i8_ptr_ty.as_basic_type_enum();
+        let i8_ptr_ty_basic = i8_ptr_ty.as_basic_type_enum();
 
         let i1_ty_basic_md: BasicMetadataTypeEnum = i1_ty.into();
         let i32_ty_basic_md: BasicMetadataTypeEnum = i32_ty.into();
@@ -382,36 +383,76 @@ impl<'ctx> Intrinsics<'ctx> {
         let ret_i1_take_i1_i1 = i1_ty.fn_type(&[i1_ty_basic_md, i1_ty_basic_md], false);
 
         let ret_i1_take_f32_f32_md_md = i1_ty.fn_type(
-            &[f32_ty_basic_md, f32_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f32_ty_basic_md,
+                f32_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
         let ret_i1_take_f64_f64_md_md = i1_ty.fn_type(
-            &[f64_ty_basic_md, f64_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f64_ty_basic_md,
+                f64_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
         let ret_i1x4_take_f32x4_f32x4_md_md = i1x4_ty.fn_type(
-            &[f32x4_ty_basic_md, f32x4_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f32x4_ty_basic_md,
+                f32x4_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
         let ret_i1x2_take_f64x2_f64x2_md_md = i1x2_ty.fn_type(
-            &[f64x2_ty_basic_md, f64x2_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f64x2_ty_basic_md,
+                f64x2_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
 
         let ret_f32_take_f32_f32_md_md = f32_ty.fn_type(
-            &[f32_ty_basic_md, f32_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f32_ty_basic_md,
+                f32_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
         let ret_f64_take_f64_f64_md_md = f64_ty.fn_type(
-            &[f64_ty_basic_md, f64_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f64_ty_basic_md,
+                f64_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
         let ret_f32x4_take_f32x4_f32x4_md_md = f32x4_ty.fn_type(
-            &[f32x4_ty_basic_md, f32x4_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f32x4_ty_basic_md,
+                f32x4_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
         let ret_f64x2_take_f64x2_f64x2_md_md = f64x2_ty.fn_type(
-            &[f64x2_ty_basic_md, f64x2_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
+            &[
+                f64x2_ty_basic_md,
+                f64x2_ty_basic_md,
+                md_ty_basic_md,
+                md_ty_basic_md,
+            ],
             false,
         );
 
@@ -797,12 +838,18 @@ impl<'ctx> Intrinsics<'ctx> {
             ),
             table_get: module.add_function(
                 "wasmer_vm_table_get",
-                anyref_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false),
+                anyref_ty.fn_type(
+                    &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                    false,
+                ),
                 None,
             ),
             imported_table_get: module.add_function(
                 "wasmer_vm_imported_table_get",
-                anyref_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false),
+                anyref_ty.fn_type(
+                    &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                    false,
+                ),
                 None,
             ),
             table_set: module.add_function(
@@ -963,10 +1010,16 @@ impl<'ctx> Intrinsics<'ctx> {
             vmmemory_definition_current_length_element: 1,
 
             memory32_grow_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false)
+                .fn_type(
+                    &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                    false,
+                )
                 .ptr_type(AddressSpace::Generic),
             imported_memory32_grow_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false)
+                .fn_type(
+                    &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                    false,
+                )
                 .ptr_type(AddressSpace::Generic),
             memory32_size_ptr_ty: i32_ty
                 .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false)

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -12,7 +12,7 @@ use inkwell::{
     context::Context,
     module::{Linkage, Module},
     types::{
-        BasicType, BasicTypeEnum, FloatType, IntType, PointerType, StructType, VectorType, VoidType,
+        BasicType, BasicMetadataTypeEnum, BasicTypeEnum, FloatType, IntType, PointerType, StructType, VectorType, VoidType,
     },
     values::{
         BasicValue, BasicValueEnum, FloatValue, FunctionValue, InstructionValue, IntValue,
@@ -320,82 +320,98 @@ impl<'ctx> Intrinsics<'ctx> {
             i32_ty.const_int(15, false),
         ];
 
+        let md_ty = context.metadata_type();
+
+        let i8_ptr_ty_basic= i8_ptr_ty.as_basic_type_enum();
+
+        let i1_ty_basic_md: BasicMetadataTypeEnum = i1_ty.into();
+        let i32_ty_basic_md: BasicMetadataTypeEnum = i32_ty.into();
+        let i64_ty_basic_md: BasicMetadataTypeEnum = i64_ty.into();
+        let f32_ty_basic_md: BasicMetadataTypeEnum = f32_ty.into();
+        let f64_ty_basic_md: BasicMetadataTypeEnum = f64_ty.into();
+        let i8x16_ty_basic_md: BasicMetadataTypeEnum = i8x16_ty.into();
+        let i16x8_ty_basic_md: BasicMetadataTypeEnum = i16x8_ty.into();
+        let f32x4_ty_basic_md: BasicMetadataTypeEnum = f32x4_ty.into();
+        let f64x2_ty_basic_md: BasicMetadataTypeEnum = f64x2_ty.into();
+        let md_ty_basic_md: BasicMetadataTypeEnum = md_ty.into();
+
         let ctx_ty = i8_ty;
         let ctx_ptr_ty = ctx_ty.ptr_type(AddressSpace::Generic);
+        let ctx_ptr_ty_basic = ctx_ptr_ty.as_basic_type_enum();
+        let ctx_ptr_ty_basic_md: BasicMetadataTypeEnum = ctx_ptr_ty.into();
 
         let sigindex_ty = i32_ty;
 
         let anyfunc_ty = context.struct_type(
-            &[i8_ptr_ty.into(), sigindex_ty.into(), ctx_ptr_ty.into()],
+            &[i8_ptr_ty_basic, sigindex_ty.into(), ctx_ptr_ty_basic],
             false,
         );
         let funcref_ty = anyfunc_ty.ptr_type(AddressSpace::Generic);
         let externref_ty = funcref_ty;
         let anyref_ty = i8_ptr_ty;
+        let anyref_ty_basic_md: BasicMetadataTypeEnum = anyref_ty.into();
 
-        let md_ty = context.metadata_type();
-
-        let ret_i8x16_take_i8x16 = i8x16_ty.fn_type(&[i8x16_ty.into()], false);
+        let ret_i8x16_take_i8x16 = i8x16_ty.fn_type(&[i8x16_ty_basic_md], false);
         let ret_i8x16_take_i8x16_i8x16 =
-            i8x16_ty.fn_type(&[i8x16_ty.into(), i8x16_ty.into()], false);
+            i8x16_ty.fn_type(&[i8x16_ty_basic_md, i8x16_ty_basic_md], false);
         let ret_i16x8_take_i16x8_i16x8 =
-            i16x8_ty.fn_type(&[i16x8_ty.into(), i16x8_ty.into()], false);
+            i16x8_ty.fn_type(&[i16x8_ty_basic_md, i16x8_ty_basic_md], false);
 
-        let ret_i32_take_i32_i1 = i32_ty.fn_type(&[i32_ty.into(), i1_ty.into()], false);
-        let ret_i64_take_i64_i1 = i64_ty.fn_type(&[i64_ty.into(), i1_ty.into()], false);
+        let ret_i32_take_i32_i1 = i32_ty.fn_type(&[i32_ty_basic_md, i1_ty_basic_md], false);
+        let ret_i64_take_i64_i1 = i64_ty.fn_type(&[i64_ty_basic_md, i1_ty_basic_md], false);
 
-        let ret_i32_take_i32 = i32_ty.fn_type(&[i32_ty.into()], false);
-        let ret_i64_take_i64 = i64_ty.fn_type(&[i64_ty.into()], false);
+        let ret_i32_take_i32 = i32_ty.fn_type(&[i32_ty_basic_md], false);
+        let ret_i64_take_i64 = i64_ty.fn_type(&[i64_ty_basic_md], false);
 
-        let ret_f32_take_f32 = f32_ty.fn_type(&[f32_ty.into()], false);
-        let ret_f64_take_f64 = f64_ty.fn_type(&[f64_ty.into()], false);
-        let ret_f32x4_take_f32x4 = f32x4_ty.fn_type(&[f32x4_ty.into()], false);
-        let ret_f64x2_take_f64x2 = f64x2_ty.fn_type(&[f64x2_ty.into()], false);
+        let ret_f32_take_f32 = f32_ty.fn_type(&[f32_ty_basic_md], false);
+        let ret_f64_take_f64 = f64_ty.fn_type(&[f64_ty_basic_md], false);
+        let ret_f32x4_take_f32x4 = f32x4_ty.fn_type(&[f32x4_ty_basic_md], false);
+        let ret_f64x2_take_f64x2 = f64x2_ty.fn_type(&[f64x2_ty_basic_md], false);
 
-        let ret_f32_take_f32_f32 = f32_ty.fn_type(&[f32_ty.into(), f32_ty.into()], false);
-        let ret_f64_take_f64_f64 = f64_ty.fn_type(&[f64_ty.into(), f64_ty.into()], false);
+        let ret_f32_take_f32_f32 = f32_ty.fn_type(&[f32_ty_basic_md, f32_ty_basic_md], false);
+        let ret_f64_take_f64_f64 = f64_ty.fn_type(&[f64_ty_basic_md, f64_ty_basic_md], false);
         let ret_f32x4_take_f32x4_f32x4 =
-            f32x4_ty.fn_type(&[f32x4_ty.into(), f32x4_ty.into()], false);
+            f32x4_ty.fn_type(&[f32x4_ty_basic_md, f32x4_ty_basic_md], false);
         let ret_f64x2_take_f64x2_f64x2 =
-            f64x2_ty.fn_type(&[f64x2_ty.into(), f64x2_ty.into()], false);
+            f64x2_ty.fn_type(&[f64x2_ty_basic_md, f64x2_ty_basic_md], false);
 
-        let ret_f64_take_f32_md = f64_ty.fn_type(&[f32_ty.into(), md_ty.into()], false);
+        let ret_f64_take_f32_md = f64_ty.fn_type(&[f32_ty_basic_md, md_ty_basic_md], false);
         let ret_f32_take_f64_md_md =
-            f32_ty.fn_type(&[f64_ty.into(), md_ty.into(), md_ty.into()], false);
+            f32_ty.fn_type(&[f64_ty_basic_md, md_ty_basic_md, md_ty_basic_md], false);
 
-        let ret_i1_take_i1_i1 = i1_ty.fn_type(&[i1_ty.into(), i1_ty.into()], false);
+        let ret_i1_take_i1_i1 = i1_ty.fn_type(&[i1_ty_basic_md, i1_ty_basic_md], false);
 
         let ret_i1_take_f32_f32_md_md = i1_ty.fn_type(
-            &[f32_ty.into(), f32_ty.into(), md_ty.into(), md_ty.into()],
+            &[f32_ty_basic_md, f32_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
         let ret_i1_take_f64_f64_md_md = i1_ty.fn_type(
-            &[f64_ty.into(), f64_ty.into(), md_ty.into(), md_ty.into()],
+            &[f64_ty_basic_md, f64_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
         let ret_i1x4_take_f32x4_f32x4_md_md = i1x4_ty.fn_type(
-            &[f32x4_ty.into(), f32x4_ty.into(), md_ty.into(), md_ty.into()],
+            &[f32x4_ty_basic_md, f32x4_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
         let ret_i1x2_take_f64x2_f64x2_md_md = i1x2_ty.fn_type(
-            &[f64x2_ty.into(), f64x2_ty.into(), md_ty.into(), md_ty.into()],
+            &[f64x2_ty_basic_md, f64x2_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
 
         let ret_f32_take_f32_f32_md_md = f32_ty.fn_type(
-            &[f32_ty.into(), f32_ty.into(), md_ty.into(), md_ty.into()],
+            &[f32_ty_basic_md, f32_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
         let ret_f64_take_f64_f64_md_md = f64_ty.fn_type(
-            &[f64_ty.into(), f64_ty.into(), md_ty.into(), md_ty.into()],
+            &[f64_ty_basic_md, f64_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
         let ret_f32x4_take_f32x4_f32x4_md_md = f32x4_ty.fn_type(
-            &[f32x4_ty.into(), f32x4_ty.into(), md_ty.into(), md_ty.into()],
+            &[f32x4_ty_basic_md, f32x4_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
         let ret_f64x2_take_f64x2_f64x2_md_md = f64x2_ty.fn_type(
-            &[f64x2_ty.into(), f64x2_ty.into(), md_ty.into(), md_ty.into()],
+            &[f64x2_ty_basic_md, f64x2_ty_basic_md, md_ty_basic_md, md_ty_basic_md],
             false,
         );
 
@@ -716,8 +732,8 @@ impl<'ctx> Intrinsics<'ctx> {
                 "llvm.experimental.stackmap",
                 void_ty.fn_type(
                     &[
-                        i64_ty.into(), /* id */
-                        i32_ty.into(), /* numShadowBytes */
+                        i64_ty_basic_md, /* id */
+                        i32_ty_basic_md, /* numShadowBytes */
                     ],
                     true,
                 ),
@@ -729,12 +745,12 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_copy",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -744,12 +760,12 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_init",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -759,11 +775,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_fill",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        anyref_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        anyref_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -771,32 +787,32 @@ impl<'ctx> Intrinsics<'ctx> {
             ),
             table_size: module.add_function(
                 "wasmer_vm_table_size",
-                i32_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
+                i32_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             imported_table_size: module.add_function(
                 "wasmer_vm_imported_table_size",
-                i32_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
+                i32_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             table_get: module.add_function(
                 "wasmer_vm_table_get",
-                anyref_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false),
+                anyref_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             imported_table_get: module.add_function(
                 "wasmer_vm_imported_table_get",
-                anyref_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false),
+                anyref_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             table_set: module.add_function(
                 "wasmer_vm_table_set",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        anyref_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        anyref_ty_basic_md,
                     ],
                     false,
                 ),
@@ -806,10 +822,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_table_set",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        anyref_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        anyref_ty_basic_md,
                     ],
                     false,
                 ),
@@ -819,10 +835,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_grow",
                 i32_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        anyref_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        anyref_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -832,10 +848,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_table_grow",
                 i32_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        anyref_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        anyref_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -845,12 +861,12 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_memory32_init",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -860,11 +876,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_memory32_copy",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -874,11 +890,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_memory32_copy",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -888,11 +904,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_memory32_fill",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -902,11 +918,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_memory32_fill",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
-                        i32_ty.into(),
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
                     ],
                     false,
                 ),
@@ -914,49 +930,49 @@ impl<'ctx> Intrinsics<'ctx> {
             ),
             data_drop: module.add_function(
                 "wasmer_vm_data_drop",
-                void_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
+                void_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             func_ref: module.add_function(
                 "wasmer_vm_func_ref",
-                funcref_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
+                funcref_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             elem_drop: module.add_function(
                 "wasmer_vm_elem_drop",
-                void_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
+                void_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
                 None,
             ),
             throw_trap: module.add_function(
                 "wasmer_vm_raise_trap",
-                void_ty.fn_type(&[i32_ty.into()], false),
+                void_ty.fn_type(&[i32_ty_basic_md], false),
                 None,
             ),
 
             vmfunction_import_ptr_ty: context
-                .struct_type(&[i8_ptr_ty.into(), i8_ptr_ty.into()], false)
+                .struct_type(&[i8_ptr_ty_basic, i8_ptr_ty_basic], false)
                 .ptr_type(AddressSpace::Generic),
             vmfunction_import_body_element: 0,
             vmfunction_import_vmctx_element: 1,
 
             // TODO: this i64 is actually a rust usize
             vmmemory_definition_ptr_ty: context
-                .struct_type(&[i8_ptr_ty.into(), i32_ty.into()], false)
+                .struct_type(&[i8_ptr_ty_basic, i32_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
             vmmemory_definition_base_element: 0,
             vmmemory_definition_current_length_element: 1,
 
             memory32_grow_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false)
+                .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false)
                 .ptr_type(AddressSpace::Generic),
             imported_memory32_grow_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false)
+                .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md], false)
                 .ptr_type(AddressSpace::Generic),
             memory32_size_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false)
+                .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false)
                 .ptr_type(AddressSpace::Generic),
             imported_memory32_size_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false)
+                .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false)
                 .ptr_type(AddressSpace::Generic),
 
             ctx_ptr_ty,

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -320,28 +320,13 @@ impl<'ctx> Intrinsics<'ctx> {
             i32_ty.const_int(15, false),
         ];
 
-        let i1_ty_basic = i1_ty.as_basic_type_enum();
-        let i32_ty_basic = i32_ty.as_basic_type_enum();
-        let i64_ty_basic = i64_ty.as_basic_type_enum();
-        let f32_ty_basic = f32_ty.as_basic_type_enum();
-        let f64_ty_basic = f64_ty.as_basic_type_enum();
-        let i8x16_ty_basic = i8x16_ty.as_basic_type_enum();
-        let i16x8_ty_basic = i16x8_ty.as_basic_type_enum();
-        let f32x4_ty_basic = f32x4_ty.as_basic_type_enum();
-        let f64x2_ty_basic = f64x2_ty.as_basic_type_enum();
-        let i8_ptr_ty_basic = i8_ptr_ty.as_basic_type_enum();
-
         let ctx_ty = i8_ty;
         let ctx_ptr_ty = ctx_ty.ptr_type(AddressSpace::Generic);
 
         let sigindex_ty = i32_ty;
 
         let anyfunc_ty = context.struct_type(
-            &[
-                i8_ptr_ty_basic,
-                sigindex_ty.as_basic_type_enum(),
-                ctx_ptr_ty.as_basic_type_enum(),
-            ],
+            &[i8_ptr_ty.into(), sigindex_ty.into(), ctx_ptr_ty.into()],
             false,
         );
         let funcref_ty = anyfunc_ty.ptr_type(AddressSpace::Generic);
@@ -349,65 +334,68 @@ impl<'ctx> Intrinsics<'ctx> {
         let anyref_ty = i8_ptr_ty;
 
         let md_ty = context.metadata_type();
-        let md_ty_basic = md_ty.as_basic_type_enum();
 
-        let ret_i8x16_take_i8x16 = i8x16_ty.fn_type(&[i8x16_ty_basic], false);
-        let ret_i8x16_take_i8x16_i8x16 = i8x16_ty.fn_type(&[i8x16_ty_basic, i8x16_ty_basic], false);
-        let ret_i16x8_take_i16x8_i16x8 = i16x8_ty.fn_type(&[i16x8_ty_basic, i16x8_ty_basic], false);
+        let ret_i8x16_take_i8x16 = i8x16_ty.fn_type(&[i8x16_ty.into()], false);
+        let ret_i8x16_take_i8x16_i8x16 =
+            i8x16_ty.fn_type(&[i8x16_ty.into(), i8x16_ty.into()], false);
+        let ret_i16x8_take_i16x8_i16x8 =
+            i16x8_ty.fn_type(&[i16x8_ty.into(), i16x8_ty.into()], false);
 
-        let ret_i32_take_i32_i1 = i32_ty.fn_type(&[i32_ty_basic, i1_ty_basic], false);
-        let ret_i64_take_i64_i1 = i64_ty.fn_type(&[i64_ty_basic, i1_ty_basic], false);
+        let ret_i32_take_i32_i1 = i32_ty.fn_type(&[i32_ty.into(), i1_ty.into()], false);
+        let ret_i64_take_i64_i1 = i64_ty.fn_type(&[i64_ty.into(), i1_ty.into()], false);
 
-        let ret_i32_take_i32 = i32_ty.fn_type(&[i32_ty_basic], false);
-        let ret_i64_take_i64 = i64_ty.fn_type(&[i64_ty_basic], false);
+        let ret_i32_take_i32 = i32_ty.fn_type(&[i32_ty.into()], false);
+        let ret_i64_take_i64 = i64_ty.fn_type(&[i64_ty.into()], false);
 
-        let ret_f32_take_f32 = f32_ty.fn_type(&[f32_ty_basic], false);
-        let ret_f64_take_f64 = f64_ty.fn_type(&[f64_ty_basic], false);
-        let ret_f32x4_take_f32x4 = f32x4_ty.fn_type(&[f32x4_ty_basic], false);
-        let ret_f64x2_take_f64x2 = f64x2_ty.fn_type(&[f64x2_ty_basic], false);
+        let ret_f32_take_f32 = f32_ty.fn_type(&[f32_ty.into()], false);
+        let ret_f64_take_f64 = f64_ty.fn_type(&[f64_ty.into()], false);
+        let ret_f32x4_take_f32x4 = f32x4_ty.fn_type(&[f32x4_ty.into()], false);
+        let ret_f64x2_take_f64x2 = f64x2_ty.fn_type(&[f64x2_ty.into()], false);
 
-        let ret_f32_take_f32_f32 = f32_ty.fn_type(&[f32_ty_basic, f32_ty_basic], false);
-        let ret_f64_take_f64_f64 = f64_ty.fn_type(&[f64_ty_basic, f64_ty_basic], false);
-        let ret_f32x4_take_f32x4_f32x4 = f32x4_ty.fn_type(&[f32x4_ty_basic, f32x4_ty_basic], false);
-        let ret_f64x2_take_f64x2_f64x2 = f64x2_ty.fn_type(&[f64x2_ty_basic, f64x2_ty_basic], false);
+        let ret_f32_take_f32_f32 = f32_ty.fn_type(&[f32_ty.into(), f32_ty.into()], false);
+        let ret_f64_take_f64_f64 = f64_ty.fn_type(&[f64_ty.into(), f64_ty.into()], false);
+        let ret_f32x4_take_f32x4_f32x4 =
+            f32x4_ty.fn_type(&[f32x4_ty.into(), f32x4_ty.into()], false);
+        let ret_f64x2_take_f64x2_f64x2 =
+            f64x2_ty.fn_type(&[f64x2_ty.into(), f64x2_ty.into()], false);
 
-        let ret_f64_take_f32_md = f64_ty.fn_type(&[f32_ty_basic, md_ty_basic], false);
+        let ret_f64_take_f32_md = f64_ty.fn_type(&[f32_ty.into(), md_ty.into()], false);
         let ret_f32_take_f64_md_md =
-            f32_ty.fn_type(&[f64_ty_basic, md_ty_basic, md_ty_basic], false);
+            f32_ty.fn_type(&[f64_ty.into(), md_ty.into(), md_ty.into()], false);
 
-        let ret_i1_take_i1_i1 = i1_ty.fn_type(&[i1_ty_basic, i1_ty_basic], false);
+        let ret_i1_take_i1_i1 = i1_ty.fn_type(&[i1_ty.into(), i1_ty.into()], false);
 
         let ret_i1_take_f32_f32_md_md = i1_ty.fn_type(
-            &[f32_ty_basic, f32_ty_basic, md_ty_basic, md_ty_basic],
+            &[f32_ty.into(), f32_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
         let ret_i1_take_f64_f64_md_md = i1_ty.fn_type(
-            &[f64_ty_basic, f64_ty_basic, md_ty_basic, md_ty_basic],
+            &[f64_ty.into(), f64_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
         let ret_i1x4_take_f32x4_f32x4_md_md = i1x4_ty.fn_type(
-            &[f32x4_ty_basic, f32x4_ty_basic, md_ty_basic, md_ty_basic],
+            &[f32x4_ty.into(), f32x4_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
         let ret_i1x2_take_f64x2_f64x2_md_md = i1x2_ty.fn_type(
-            &[f64x2_ty_basic, f64x2_ty_basic, md_ty_basic, md_ty_basic],
+            &[f64x2_ty.into(), f64x2_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
 
         let ret_f32_take_f32_f32_md_md = f32_ty.fn_type(
-            &[f32_ty_basic, f32_ty_basic, md_ty_basic, md_ty_basic],
+            &[f32_ty.into(), f32_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
         let ret_f64_take_f64_f64_md_md = f64_ty.fn_type(
-            &[f64_ty_basic, f64_ty_basic, md_ty_basic, md_ty_basic],
+            &[f64_ty.into(), f64_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
         let ret_f32x4_take_f32x4_f32x4_md_md = f32x4_ty.fn_type(
-            &[f32x4_ty_basic, f32x4_ty_basic, md_ty_basic, md_ty_basic],
+            &[f32x4_ty.into(), f32x4_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
         let ret_f64x2_take_f64x2_f64x2_md_md = f64x2_ty.fn_type(
-            &[f64x2_ty_basic, f64x2_ty_basic, md_ty_basic, md_ty_basic],
+            &[f64x2_ty.into(), f64x2_ty.into(), md_ty.into(), md_ty.into()],
             false,
         );
 
@@ -728,8 +716,8 @@ impl<'ctx> Intrinsics<'ctx> {
                 "llvm.experimental.stackmap",
                 void_ty.fn_type(
                     &[
-                        i64_ty_basic, /* id */
-                        i32_ty_basic, /* numShadowBytes */
+                        i64_ty.into(), /* id */
+                        i32_ty.into(), /* numShadowBytes */
                     ],
                     true,
                 ),
@@ -741,12 +729,12 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_copy",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -756,12 +744,12 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_init",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -771,11 +759,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_fill",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        anyref_ty.as_basic_type_enum(),
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        anyref_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -783,38 +771,32 @@ impl<'ctx> Intrinsics<'ctx> {
             ),
             table_size: module.add_function(
                 "wasmer_vm_table_size",
-                i32_ty.fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false),
+                i32_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
                 None,
             ),
             imported_table_size: module.add_function(
                 "wasmer_vm_imported_table_size",
-                i32_ty.fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false),
+                i32_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
                 None,
             ),
             table_get: module.add_function(
                 "wasmer_vm_table_get",
-                anyref_ty.fn_type(
-                    &[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic, i32_ty_basic],
-                    false,
-                ),
+                anyref_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false),
                 None,
             ),
             imported_table_get: module.add_function(
                 "wasmer_vm_imported_table_get",
-                anyref_ty.fn_type(
-                    &[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic, i32_ty_basic],
-                    false,
-                ),
+                anyref_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false),
                 None,
             ),
             table_set: module.add_function(
                 "wasmer_vm_table_set",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        anyref_ty.as_basic_type_enum(),
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        anyref_ty.into(),
                     ],
                     false,
                 ),
@@ -824,10 +806,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_table_set",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        anyref_ty.as_basic_type_enum(),
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        anyref_ty.into(),
                     ],
                     false,
                 ),
@@ -837,10 +819,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_table_grow",
                 i32_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        anyref_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        anyref_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -850,10 +832,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_table_grow",
                 i32_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        anyref_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        anyref_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -863,12 +845,12 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_memory32_init",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -878,11 +860,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_memory32_copy",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -892,11 +874,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_memory32_copy",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -906,11 +888,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_memory32_fill",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -920,11 +902,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 "wasmer_vm_imported_memory32_fill",
                 void_ty.fn_type(
                     &[
-                        ctx_ptr_ty.as_basic_type_enum(),
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
-                        i32_ty_basic,
+                        ctx_ptr_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
+                        i32_ty.into(),
                     ],
                     false,
                 ),
@@ -932,55 +914,49 @@ impl<'ctx> Intrinsics<'ctx> {
             ),
             data_drop: module.add_function(
                 "wasmer_vm_data_drop",
-                void_ty.fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false),
+                void_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
                 None,
             ),
             func_ref: module.add_function(
                 "wasmer_vm_func_ref",
-                funcref_ty.fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false),
+                funcref_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
                 None,
             ),
             elem_drop: module.add_function(
                 "wasmer_vm_elem_drop",
-                void_ty.fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false),
+                void_ty.fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false),
                 None,
             ),
             throw_trap: module.add_function(
                 "wasmer_vm_raise_trap",
-                void_ty.fn_type(&[i32_ty_basic], false),
+                void_ty.fn_type(&[i32_ty.into()], false),
                 None,
             ),
 
             vmfunction_import_ptr_ty: context
-                .struct_type(&[i8_ptr_ty_basic, i8_ptr_ty_basic], false)
+                .struct_type(&[i8_ptr_ty.into(), i8_ptr_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
             vmfunction_import_body_element: 0,
             vmfunction_import_vmctx_element: 1,
 
             // TODO: this i64 is actually a rust usize
             vmmemory_definition_ptr_ty: context
-                .struct_type(&[i8_ptr_ty_basic, i32_ty_basic], false)
+                .struct_type(&[i8_ptr_ty.into(), i32_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
             vmmemory_definition_base_element: 0,
             vmmemory_definition_current_length_element: 1,
 
             memory32_grow_ptr_ty: i32_ty
-                .fn_type(
-                    &[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic, i32_ty_basic],
-                    false,
-                )
+                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
             imported_memory32_grow_ptr_ty: i32_ty
-                .fn_type(
-                    &[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic, i32_ty_basic],
-                    false,
-                )
+                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into(), i32_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
             memory32_size_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false)
+                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
             imported_memory32_size_ptr_ty: i32_ty
-                .fn_type(&[ctx_ptr_ty.as_basic_type_enum(), i32_ty_basic], false)
+                .fn_type(&[ctx_ptr_ty.into(), i32_ty.into()], false)
                 .ptr_type(AddressSpace::Generic),
 
             ctx_ptr_ty,

--- a/lib/compiler-singlepass/src/config.rs
+++ b/lib/compiler-singlepass/src/config.rs
@@ -38,10 +38,10 @@ impl Singlepass {
         self
     }
 
-    /// Enable NaN canonicalization.
-    ///
-    /// NaN canonicalization is useful when trying to run WebAssembly
-    /// deterministically across different architectures.
+    fn enable_nan_canonicalization(&mut self) {
+        self.enable_nan_canonicalization = true;
+    }
+
     pub fn canonicalize_nans(&mut self, enable: bool) -> &mut Self {
         self.enable_nan_canonicalization = enable;
         self

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -37,6 +37,25 @@ pub trait CompilerConfig {
         // in case they create an IR that they can verify.
     }
 
+    /// Enable NaN canonicalization.
+    ///
+    /// NaN canonicalization is useful when trying to run WebAssembly
+    /// deterministically across different architectures.
+    #[deprecated(note = "Please use the canonicalize_nans instead")]
+    fn enable_nan_canonicalization(&mut self) {
+        // By default we do nothing, each backend will need to customize this
+        // in case they create an IR that they can verify.
+    }
+
+    /// Enable NaN canonicalization.
+    ///
+    /// NaN canonicalization is useful when trying to run WebAssembly
+    /// deterministically across different architectures.
+    fn canonicalize_nans(&mut self, _enable: bool) {
+        // By default we do nothing, each backend will need to customize this
+        // in case they create an IR that they can verify.
+    }
+
     /// Gets the custom compiler config
     fn compiler(self: Box<Self>) -> Box<dyn Compiler>;
 


### PR DESCRIPTION
compiler-llvm now uses the experimental.constrained intrinsics to ensure
correct behavior on FP operations when full-canonicalization is
disabled.
    
This patch requires TheDan64/inkwell#247

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
