### PR TITLE
Fix broken link to runtime-c-api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ qjs >
 
 [c logo]: ./assets/languages/c.svg
 [c integration]: https://github.com/wasmerio/wasmer/tree/master/lib/c-api
-[`wasmer.h` headers]: https://wasmerio.github.io/wasmer/c/runtime-c-api/
-[c docs]: https://wasmerio.github.io/wasmer/c/runtime-c-api/
+[`wasmer.h` headers]: https://wasmerio.github.io/wasmer/c/runtime-c-api/html/
+[c docs]: https://wasmerio.github.io/wasmer/c/runtime-c-api/html/
 
 [c# logo]: ./assets/languages/csharp.svg
 [c# integration]: https://github.com/migueldeicaza/WasmerSharp

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ qjs >
 
 [c logo]: ./assets/languages/c.svg
 [c integration]: https://github.com/wasmerio/wasmer/tree/master/lib/c-api
-[`wasmer.h` headers]: https://wasmerio.github.io/wasmer/c/runtime-c-api/html/
-[c docs]: https://wasmerio.github.io/wasmer/c/runtime-c-api/html/
+[`wasmer.h` headers]: https://wasmerio.github.io/wasmer/c/
+[c docs]: https://wasmerio.github.io/wasmer/c/
 
 [c# logo]: ./assets/languages/csharp.svg
 [c# integration]: https://github.com/migueldeicaza/WasmerSharp


### PR DESCRIPTION
# Description

This fixes the broken links to the C/C++ documentation in the Readme

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
