### PR TITLE
Update `memory` Wasm C API example

### DIFF
--- a/lib/c-api/README.md
+++ b/lib/c-api/README.md
@@ -43,6 +43,7 @@ int main(int argc, const char* argv[]) {
     wasm_byte_vec_new(&wat, strlen(wat_string), wat_string);
     wasm_byte_vec_t wasm_bytes;
     wat2wasm(&wat, &wasm_bytes);
+    wasm_byte_vec_delete(&wat);
 
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
@@ -102,6 +103,7 @@ int main(int argc, const char* argv[]) {
 
     wasm_func_delete(sum_func);
     wasm_module_delete(module);
+    wasm_extern_vec_delete(&exports);
     wasm_instance_delete(instance);
     wasm_store_delete(store);
     wasm_engine_delete(engine);

--- a/lib/c-api/examples/exports-function.c
+++ b/lib/c-api/examples/exports-function.c
@@ -15,6 +15,7 @@ int main(int argc, const char* argv[]) {
     wasm_byte_vec_new(&wat, strlen(wat_string), wat_string);
     wasm_byte_vec_t wasm_bytes;
     wat2wasm(&wat, &wasm_bytes);
+    wasm_byte_vec_delete(&wat);
 
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
@@ -79,6 +80,7 @@ int main(int argc, const char* argv[]) {
     wasm_func_delete(sum_func);
     wasm_module_delete(module);
     wasm_instance_delete(instance);
+    wasm_extern_vec_delete(&exports);
     wasm_store_delete(store);
     wasm_engine_delete(engine);
 }

--- a/lib/c-api/examples/exports-global.c
+++ b/lib/c-api/examples/exports-global.c
@@ -14,6 +14,7 @@ int main(int argc, const char* argv[]) {
     wasm_byte_vec_new(&wat, strlen(wat_string), wat_string);
     wasm_byte_vec_t wasm_bytes;
     wat2wasm(&wat, &wasm_bytes);
+    wasm_byte_vec_delete(&wat);
 
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
@@ -111,6 +112,7 @@ int main(int argc, const char* argv[]) {
     wasm_global_delete(some);
     wasm_global_delete(one);
     wasm_module_delete(module);
+    wasm_extern_vec_delete(&exports);
     wasm_instance_delete(instance);
     wasm_store_delete(store);
     wasm_engine_delete(engine);

--- a/lib/c-api/examples/features.c
+++ b/lib/c-api/examples/features.c
@@ -14,6 +14,7 @@ int main(int argc, const char* argv[]) {
     wasm_byte_vec_new(&wat, strlen(wat_string), wat_string);
     wasm_byte_vec_t wasm_bytes;
     wat2wasm(&wat, &wasm_bytes);
+    wasm_byte_vec_delete(&wat);
 
     printf("Creating the config and the features...\n");
     wasm_config_t* config = wasm_config_new();
@@ -81,7 +82,8 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Got `(2, 1)`!\n");
-    
+
+    wasm_extern_vec_delete(&exports);
     wasm_module_delete(module);
     wasm_instance_delete(instance);
     wasm_store_delete(store);

--- a/lib/c-api/examples/imports-exports.c
+++ b/lib/c-api/examples/imports-exports.c
@@ -26,6 +26,7 @@ int main(int argc, const char* argv[]) {
     wasm_byte_vec_new(&wat, strlen(wat_string), wat_string);
     wasm_byte_vec_t wasm_bytes;
     wat2wasm(&wat, &wasm_bytes);
+    wasm_byte_vec_delete(&wat);
 
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
@@ -128,6 +129,7 @@ int main(int argc, const char* argv[]) {
     wasm_table_delete(table);
     wasm_memory_delete(memory);
     wasm_module_delete(module);
+    wasm_extern_vec_delete(&exports);
     wasm_instance_delete(instance);
     wasm_store_delete(store);
     wasm_engine_delete(engine);

--- a/lib/c-api/examples/instance.c
+++ b/lib/c-api/examples/instance.c
@@ -77,6 +77,7 @@ int main(int argc, const char* argv[]) {
 
     printf("Results of `add_one`: %d\n", results_val[0].of.i32);
 
+    wasm_extern_vec_delete(&exports);
     wasm_store_delete(store);
     wasm_engine_delete(engine);
 }

--- a/lib/c-api/examples/memory.c
+++ b/lib/c-api/examples/memory.c
@@ -23,6 +23,7 @@ int main(int argc, const char* argv[]) {
     wasm_byte_vec_new(&wat, strlen(wat_string), wat_string);
     wasm_byte_vec_t wasm_bytes;
     wat2wasm(&wat, &wasm_bytes);
+    wasm_byte_vec_delete(&wat);
 
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
@@ -102,6 +103,7 @@ int main(int argc, const char* argv[]) {
     wasm_func_delete(mem_size);
     wasm_func_delete(set_at);
     wasm_func_delete(get_at);
+    wasm_extern_vec_delete(&exports);
     wasm_module_delete(module);
     wasm_instance_delete(instance);
     wasm_store_delete(store);

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -145,6 +145,7 @@ mod tests {
                 wasm_instance_delete(instance);
                 wasm_byte_vec_delete(&wasm_bytes);
                 wasm_byte_vec_delete(&wat);
+                wasm_extern_vec_delete(&exports);
                 wasm_store_delete(store);
                 wasm_engine_delete(engine);
 

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -179,6 +179,7 @@ mod tests {
                 assert(wasm_extern_kind(function_copy) == WASM_EXTERN_FUNC);
 
                 wasm_extern_delete(function_copy);
+                wasm_extern_vec_delete(&exports);
                 wasm_instance_delete(instance);
                 wasm_module_delete(module);
                 wasm_byte_vec_delete(&wasm);

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -154,6 +154,7 @@ pub unsafe extern "C" fn wasm_instance_delete(_instance: Option<Box<wasm_instanc
 ///     assert(wasm_extern_kind(exports.data[3]) == WASM_EXTERN_MEMORY);
 ///
 ///     // Free everything.
+///     wasm_extern_vec_delete(&exports);
 ///     wasm_instance_delete(instance);
 ///     wasm_module_delete(module);
 ///     wasm_byte_vec_delete(&wasm);
@@ -290,6 +291,7 @@ mod tests {
                 assert(results[0].of.i32 == 2);
 
                 // Free everything.
+                wasm_extern_vec_delete(&exports);
                 wasm_instance_delete(instance);
                 wasm_func_delete(sum_function);
                 wasm_functype_delete(sum_type);

--- a/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
@@ -117,7 +117,8 @@
 //!         // There is 0 point left… they are exhausted.
 //!         assert(wasmer_metering_points_are_exhausted(instance) == true);
 //!     }
-//!     
+//!
+//!     wasm_extern_vec_delete(&exports);
 //!     wasm_instance_delete(instance);
 //!     wasm_module_delete(module);
 //!     wasm_store_delete(store);


### PR DESCRIPTION
Related to #2193

While working on this, I noticed that our implementation of the Wasm C API diverges from what `wasm.h` says in that we return owned data for `wasm_extern_as_*` and we free it with

```
    wasm_memory_delete(memory);
    wasm_func_delete(mem_size);
    wasm_func_delete(set_at);
    wasm_func_delete(get_at);
```

this data should not be `own`ed and we should not free it. I'll file a separate issue for this to follow up on.