### PR TITLE
feat: Implement `MemoryUsage` for `Module`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2135](https://github.com/wasmerio/wasmer/pull/2135) [Documentation](./PACKAGING.md) for linux distribution maintainers
 
 ### Changed
+- [#2200](https://github.com/wasmerio/wasmer/pull/2200) Implement `loupe::MemoryUsage` for `wasmer::Module`.
 - [#2199](https://github.com/wasmerio/wasmer/pull/2199) Implement `loupe::MemoryUsage` for `wasmer::Store`.
 - [#2140](https://github.com/wasmerio/wasmer/pull/2140) Reduce the number of dependencies in the `wasmer.dll` shared library by statically compiling CRT.
 - [#2113](https://github.com/wasmerio/wasmer/pull/2113) Bump minimum supported Rust version to 1.49

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "loupe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0700ebea6c2a63815aa6f376f1c6dac93223d7b11c4728a7f71ff951a6eca67"
+checksum = "1acf065b51eb58abbc66a07c27ec63142205d339a9f5093dc3e1d7cda3d5c9a3"
 dependencies = [
  "indexmap",
  "loupe-derive",
@@ -1167,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "loupe-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9a2f753a29753600fa1e3f5c2b311babaca3bb66929bdc37082996e9c46cfb"
+checksum = "e40881c741681f26b0f4c0261f493c8df600998807184b524e34b7e208324834"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ checksum = "f0700ebea6c2a63815aa6f376f1c6dac93223d7b11c4728a7f71ff951a6eca67"
 dependencies = [
  "loupe-derive",
  "rustversion",
+ "indexmap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,9 +1160,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0700ebea6c2a63815aa6f376f1c6dac93223d7b11c4728a7f71ff951a6eca67"
 dependencies = [
+ "indexmap",
  "loupe-derive",
  "rustversion",
- "indexmap",
 ]
 
 [[package]]

--- a/examples/tunables_limit_memory.rs
+++ b/examples/tunables_limit_memory.rs
@@ -1,8 +1,7 @@
-use std::mem;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
-use loupe::{MemoryUsage, MemoryUsageTracker};
+use loupe::MemoryUsage;
 use wasmer::{
     imports,
     vm::{self, MemoryError, MemoryStyle, TableStyle, VMMemoryDefinition, VMTableDefinition},
@@ -16,6 +15,7 @@ use wasmer_engine_jit::JIT;
 ///
 /// After adjusting the memory limits, it delegates all other logic
 /// to the base tunables.
+#[derive(MemoryUsage)]
 pub struct LimitingTunables<T: Tunables> {
     /// The maximum a linear memory is allowed to be (in Wasm pages, 64 KiB each).
     /// Since Wasmer ensures there is only none or one memory, this is practically
@@ -130,12 +130,6 @@ impl<T: Tunables> Tunables for LimitingTunables<T> {
         vm_definition_location: NonNull<VMTableDefinition>,
     ) -> Result<Arc<dyn vm::Table>, String> {
         self.base.create_vm_table(ty, style, vm_definition_location)
-    }
-}
-
-impl<T: Tunables> MemoryUsage for LimitingTunables<T> {
-    fn size_of_val(&self, _tracker: &mut dyn MemoryUsageTracker) -> usize {
-        mem::size_of_val(self)
     }
 }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -511,19 +511,20 @@ dependencies = [
 
 [[package]]
 name = "loupe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0700ebea6c2a63815aa6f376f1c6dac93223d7b11c4728a7f71ff951a6eca67"
+checksum = "1acf065b51eb58abbc66a07c27ec63142205d339a9f5093dc3e1d7cda3d5c9a3"
 dependencies = [
+ "indexmap",
  "loupe-derive",
  "rustversion",
 ]
 
 [[package]]
 name = "loupe-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9a2f753a29753600fa1e3f5c2b311babaca3bb66929bdc37082996e9c46cfb"
+checksum = "e40881c741681f26b0f4c0261f493c8df600998807184b524e34b7e208324834"
 dependencies = [
  "quote",
  "syn",

--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -1,7 +1,7 @@
 use crate::store::Store;
 use crate::types::{ExportType, ImportType};
 use crate::InstantiationError;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::fmt;
 use std::io;
 use std::path::Path;

--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -1,6 +1,7 @@
 use crate::store::Store;
 use crate::types::{ExportType, ImportType};
 use crate::InstantiationError;
+use loupe_derive::MemoryUsage;
 use std::fmt;
 use std::io;
 use std::path::Path;
@@ -30,7 +31,7 @@ pub enum IoCompileError {
 ///
 /// Cloning a module is cheap: it does a shallow copy of the compiled
 /// contents rather than a deep copy.
-#[derive(Clone)]
+#[derive(Clone, MemoryUsage)]
 pub struct Module {
     store: Store,
     artifact: Arc<dyn Artifact>,

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -5,7 +5,7 @@ use inkwell::targets::{
 };
 pub use inkwell::OptimizationLevel as LLVMOptLevel;
 use itertools::Itertools;
-use loupe::MemoryUsage;
+use loupe_derive::MemoryUsage;
 use std::fmt::Debug;
 use std::sync::Arc;
 use target_lexicon::Architecture;

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -5,7 +5,7 @@ use inkwell::targets::{
 };
 pub use inkwell::OptimizationLevel as LLVMOptLevel;
 use itertools::Itertools;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::fmt::Debug;
 use std::sync::Arc;
 use target_lexicon::Architecture;

--- a/lib/compiler/src/address_map.rs
+++ b/lib/compiler/src/address_map.rs
@@ -3,7 +3,7 @@
 
 use crate::lib::std::vec::Vec;
 use crate::sourceloc::SourceLoc;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 

--- a/lib/compiler/src/address_map.rs
+++ b/lib/compiler/src/address_map.rs
@@ -3,12 +3,13 @@
 
 use crate::lib::std::vec::Vec;
 use crate::sourceloc::SourceLoc;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
 /// Single source location to generated address mapping.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, MemoryUsage)]
 pub struct InstructionAddressMap {
     /// Original source location.
     pub srcloc: SourceLoc,
@@ -22,7 +23,7 @@ pub struct InstructionAddressMap {
 
 /// Function and its instructions addresses mappings.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, MemoryUsage)]
 pub struct FunctionAddressMap {
     /// Instructions maps.
     /// The array is sorted by the InstructionAddressMap::code_offset field.

--- a/lib/compiler/src/function.rs
+++ b/lib/compiler/src/function.rs
@@ -12,7 +12,7 @@ use crate::lib::std::vec::Vec;
 use crate::section::{CustomSection, SectionIndex};
 use crate::trap::TrapInformation;
 use crate::{CompiledFunctionUnwindInfo, FunctionAddressMap, JumpTableOffsets, Relocation};
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::PrimaryMap;

--- a/lib/compiler/src/function.rs
+++ b/lib/compiler/src/function.rs
@@ -12,6 +12,7 @@ use crate::lib::std::vec::Vec;
 use crate::section::{CustomSection, SectionIndex};
 use crate::trap::TrapInformation;
 use crate::{CompiledFunctionUnwindInfo, FunctionAddressMap, JumpTableOffsets, Relocation};
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::PrimaryMap;
@@ -22,7 +23,7 @@ use wasmer_types::{FunctionIndex, LocalFunctionIndex, SignatureIndex};
 /// This structure is only used for reconstructing
 /// the frame information after a `Trap`.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, MemoryUsage)]
 pub struct CompiledFunctionFrameInfo {
     /// The traps (in the function body).
     ///
@@ -35,7 +36,7 @@ pub struct CompiledFunctionFrameInfo {
 
 /// The function body.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, MemoryUsage)]
 pub struct FunctionBody {
     /// The function body bytes.
     #[cfg_attr(feature = "enable-serde", serde(with = "serde_bytes"))]
@@ -79,7 +80,7 @@ pub type CustomSections = PrimaryMap<SectionIndex, CustomSection>;
 /// In the future this structure may also hold other information useful
 /// for debugging.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, MemoryUsage)]
 pub struct Dwarf {
     /// The section index in the [`Compilation`] that corresponds to the exception frames.
     /// [Learn

--- a/lib/compiler/src/jump_table.rs
+++ b/lib/compiler/src/jump_table.rs
@@ -5,7 +5,7 @@
 //! [Learn more](https://en.wikipedia.org/wiki/Branch_table).
 
 use super::CodeOffset;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::{entity_impl, SecondaryMap};

--- a/lib/compiler/src/jump_table.rs
+++ b/lib/compiler/src/jump_table.rs
@@ -5,6 +5,7 @@
 //! [Learn more](https://en.wikipedia.org/wiki/Branch_table).
 
 use super::CodeOffset;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::{entity_impl, SecondaryMap};
@@ -14,7 +15,7 @@ use wasmer_types::entity::{entity_impl, SecondaryMap};
 /// `JumpTable`s are used for indirect branching and are specialized for dense,
 /// 0-based jump offsets.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, MemoryUsage)]
 pub struct JumpTable(u32);
 
 entity_impl!(JumpTable, "jt");

--- a/lib/compiler/src/module.rs
+++ b/lib/compiler/src/module.rs
@@ -1,5 +1,5 @@
 use crate::lib::std::sync::Arc;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::PrimaryMap;

--- a/lib/compiler/src/module.rs
+++ b/lib/compiler/src/module.rs
@@ -1,4 +1,5 @@
 use crate::lib::std::sync::Arc;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::PrimaryMap;
@@ -10,7 +11,7 @@ use wasmer_vm::{MemoryStyle, ModuleInfo, TableStyle};
 /// This differs from [`ModuleInfo`] because it have extra info only
 /// possible after translation (such as the features used for compiling,
 /// or the `MemoryStyle` and `TableStyle`).
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
 pub struct CompileModuleInfo {
     /// The features used for compiling the module

--- a/lib/compiler/src/relocation.rs
+++ b/lib/compiler/src/relocation.rs
@@ -13,6 +13,7 @@ use crate::lib::std::fmt;
 use crate::lib::std::vec::Vec;
 use crate::section::SectionIndex;
 use crate::{Addend, CodeOffset, JumpTable};
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::PrimaryMap;
@@ -21,7 +22,7 @@ use wasmer_vm::libcalls::LibCall;
 
 /// Relocation kinds for every ISA.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, MemoryUsage)]
 pub enum RelocationKind {
     /// absolute 4-byte
     Abs4,
@@ -79,7 +80,7 @@ impl fmt::Display for RelocationKind {
 
 /// A record of a relocation to perform.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, MemoryUsage)]
 pub struct Relocation {
     /// The relocation kind.
     pub kind: RelocationKind,
@@ -93,7 +94,7 @@ pub struct Relocation {
 
 /// Destination function. Can be either user function or some special one, like `memory.grow`.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, MemoryUsage)]
 pub enum RelocationTarget {
     /// A relocation to a function defined locally in the wasm (not an imported one).
     LocalFunc(LocalFunctionIndex),

--- a/lib/compiler/src/relocation.rs
+++ b/lib/compiler/src/relocation.rs
@@ -13,7 +13,7 @@ use crate::lib::std::fmt;
 use crate::lib::std::vec::Vec;
 use crate::section::SectionIndex;
 use crate::{Addend, CodeOffset, JumpTable};
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::PrimaryMap;

--- a/lib/compiler/src/section.rs
+++ b/lib/compiler/src/section.rs
@@ -7,7 +7,7 @@
 
 use crate::lib::std::vec::Vec;
 use crate::Relocation;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::entity_impl;

--- a/lib/compiler/src/section.rs
+++ b/lib/compiler/src/section.rs
@@ -7,13 +7,14 @@
 
 use crate::lib::std::vec::Vec;
 use crate::Relocation;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_types::entity::entity_impl;
 
 /// Index type of a Section defined inside a WebAssembly `Compilation`.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, MemoryUsage)]
 pub struct SectionIndex(u32);
 
 entity_impl!(SectionIndex);
@@ -22,7 +23,7 @@ entity_impl!(SectionIndex);
 ///
 /// Determines how a custom section may be used.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, MemoryUsage)]
 pub enum CustomSectionProtection {
     /// A custom section with read permission.
     Read,
@@ -36,7 +37,7 @@ pub enum CustomSectionProtection {
 /// This is used so compilers can store arbitrary information
 /// in the emitted module.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, MemoryUsage)]
 pub struct CustomSection {
     /// Memory protection that applies to this section.
     pub protection: CustomSectionProtection,
@@ -55,7 +56,7 @@ pub struct CustomSection {
 
 /// The bytes in the section.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, MemoryUsage)]
 pub struct SectionBody(#[cfg_attr(feature = "enable-serde", serde(with = "serde_bytes"))] Vec<u8>);
 
 impl SectionBody {

--- a/lib/compiler/src/sourceloc.rs
+++ b/lib/compiler/src/sourceloc.rs
@@ -8,7 +8,7 @@
 //! and tracing errors.
 
 use crate::lib::std::fmt;
-
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
     serde(transparent)
 )]
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, MemoryUsage)]
 pub struct SourceLoc(u32);
 
 impl SourceLoc {

--- a/lib/compiler/src/sourceloc.rs
+++ b/lib/compiler/src/sourceloc.rs
@@ -8,7 +8,7 @@
 //! and tracing errors.
 
 use crate::lib::std::fmt;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 

--- a/lib/compiler/src/target.rs
+++ b/lib/compiler/src/target.rs
@@ -3,7 +3,7 @@ use crate::error::ParseCpuFeatureError;
 use crate::lib::std::str::FromStr;
 use crate::lib::std::string::{String, ToString};
 use enumset::{EnumSet, EnumSetType};
-use loupe::MemoryUsage;
+use loupe_derive::MemoryUsage;
 pub use target_lexicon::{
     Architecture, BinaryFormat, CallingConvention, Endianness, OperatingSystem, PointerWidth,
     Triple,

--- a/lib/compiler/src/target.rs
+++ b/lib/compiler/src/target.rs
@@ -3,7 +3,7 @@ use crate::error::ParseCpuFeatureError;
 use crate::lib::std::str::FromStr;
 use crate::lib::std::string::{String, ToString};
 use enumset::{EnumSet, EnumSetType};
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 pub use target_lexicon::{
     Architecture, BinaryFormat, CallingConvention, Endianness, OperatingSystem, PointerWidth,
     Triple,

--- a/lib/compiler/src/trap.rs
+++ b/lib/compiler/src/trap.rs
@@ -1,5 +1,5 @@
 use crate::CodeOffset;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_vm::TrapCode;

--- a/lib/compiler/src/trap.rs
+++ b/lib/compiler/src/trap.rs
@@ -1,11 +1,12 @@
 use crate::CodeOffset;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use wasmer_vm::TrapCode;
 
 /// Information about trap.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, MemoryUsage)]
 pub struct TrapInformation {
     /// The offset of the trapping instruction in native code. It is relative to the beginning of the function.
     pub code_offset: CodeOffset,

--- a/lib/compiler/src/unwind.rs
+++ b/lib/compiler/src/unwind.rs
@@ -6,7 +6,7 @@
 //!
 //! [Learn more](https://en.wikipedia.org/wiki/Call_stack).
 use crate::lib::std::vec::Vec;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 

--- a/lib/compiler/src/unwind.rs
+++ b/lib/compiler/src/unwind.rs
@@ -6,6 +6,7 @@
 //!
 //! [Learn more](https://en.wikipedia.org/wiki/Call_stack).
 use crate::lib::std::vec::Vec;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +18,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [unwind info]: https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=vs-2019
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, MemoryUsage)]
 pub enum CompiledFunctionUnwindInfo {
     /// Windows UNWIND_INFO.
     WindowsX64(Vec<u8>),

--- a/lib/engine-jit/src/artifact.rs
+++ b/lib/engine-jit/src/artifact.rs
@@ -6,6 +6,7 @@ use crate::link::link_module;
 #[cfg(feature = "compiler")]
 use crate::serialize::SerializableCompilation;
 use crate::serialize::SerializableModule;
+use loupe_derive::MemoryUsage;
 use std::sync::{Arc, Mutex};
 use wasmer_compiler::{CompileError, Features, Triple};
 #[cfg(feature = "compiler")]
@@ -26,9 +27,11 @@ use wasmer_vm::{
 };
 
 /// A compiled wasm module, ready to be instantiated.
+#[derive(MemoryUsage)]
 pub struct JITArtifact {
     serializable: SerializableModule,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
+    #[memoryusage(ignore)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/lib/engine-jit/src/artifact.rs
+++ b/lib/engine-jit/src/artifact.rs
@@ -6,7 +6,7 @@ use crate::link::link_module;
 #[cfg(feature = "compiler")]
 use crate::serialize::SerializableCompilation;
 use crate::serialize::SerializableModule;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::sync::{Arc, Mutex};
 use wasmer_compiler::{CompileError, Features, Triple};
 #[cfg(feature = "compiler")]
@@ -31,7 +31,7 @@ use wasmer_vm::{
 pub struct JITArtifact {
     serializable: SerializableModule,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
-    #[memoryusage(ignore)]
+    #[loupe(skip)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/lib/engine-jit/src/serialize.rs
+++ b/lib/engine-jit/src/serialize.rs
@@ -1,4 +1,4 @@
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use wasmer_compiler::{
     CompileModuleInfo, CustomSection, Dwarf, FunctionBody, JumpTableOffsets, Relocation,

--- a/lib/engine-jit/src/serialize.rs
+++ b/lib/engine-jit/src/serialize.rs
@@ -1,3 +1,4 @@
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use wasmer_compiler::{
     CompileModuleInfo, CustomSection, Dwarf, FunctionBody, JumpTableOffsets, Relocation,
@@ -18,7 +19,7 @@ use wasmer_types::{FunctionIndex, LocalFunctionIndex, OwnedDataInitializer, Sign
 // }
 
 /// The compilation related data for a serialized modules
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, MemoryUsage)]
 pub struct SerializableCompilation {
     pub function_bodies: PrimaryMap<LocalFunctionIndex, FunctionBody>,
     pub function_relocations: PrimaryMap<LocalFunctionIndex, Vec<Relocation>>,
@@ -37,7 +38,7 @@ pub struct SerializableCompilation {
 
 /// Serializable struct that is able to serialize from and to
 /// a `JITArtifactInfo`.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, MemoryUsage)]
 pub struct SerializableModule {
     pub compilation: SerializableCompilation,
     pub compile_info: CompileModuleInfo,

--- a/lib/engine-native/src/artifact.rs
+++ b/lib/engine-native/src/artifact.rs
@@ -4,6 +4,7 @@
 use crate::engine::{NativeEngine, NativeEngineInner};
 use crate::serialize::ModuleMetadata;
 use libloading::{Library, Symbol as LibrarySymbol};
+use loupe_derive::MemoryUsage;
 use std::error::Error;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -37,10 +38,12 @@ use wasmer_vm::{
 };
 
 /// A compiled wasm module, ready to be instantiated.
+#[derive(MemoryUsage)]
 pub struct NativeArtifact {
     sharedobject_path: PathBuf,
     metadata: ModuleMetadata,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
+    #[memoryusage(ignore)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/lib/engine-native/src/artifact.rs
+++ b/lib/engine-native/src/artifact.rs
@@ -4,7 +4,7 @@
 use crate::engine::{NativeEngine, NativeEngineInner};
 use crate::serialize::ModuleMetadata;
 use libloading::{Library, Symbol as LibrarySymbol};
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::error::Error;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -43,7 +43,7 @@ pub struct NativeArtifact {
     sharedobject_path: PathBuf,
     metadata: ModuleMetadata,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
-    #[memoryusage(ignore)]
+    #[loupe(skip)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/lib/engine-native/src/engine.rs
+++ b/lib/engine-native/src/engine.rs
@@ -2,7 +2,7 @@
 
 use crate::NativeArtifact;
 use libloading::Library;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/lib/engine-native/src/engine.rs
+++ b/lib/engine-native/src/engine.rs
@@ -2,7 +2,7 @@
 
 use crate::NativeArtifact;
 use libloading::Library;
-use loupe::MemoryUsage;
+use loupe_derive::MemoryUsage;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/lib/engine-native/src/serialize.rs
+++ b/lib/engine-native/src/serialize.rs
@@ -1,10 +1,11 @@
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use wasmer_compiler::{CompileModuleInfo, SectionIndex, Symbol, SymbolRegistry};
 use wasmer_types::entity::{EntityRef, PrimaryMap};
 use wasmer_types::{FunctionIndex, LocalFunctionIndex, OwnedDataInitializer, SignatureIndex};
 
 /// Serializable struct that represents the compiled metadata.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, MemoryUsage)]
 pub struct ModuleMetadata {
     pub compile_info: CompileModuleInfo,
     pub prefix: String,

--- a/lib/engine-native/src/serialize.rs
+++ b/lib/engine-native/src/serialize.rs
@@ -1,4 +1,4 @@
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use wasmer_compiler::{CompileModuleInfo, SectionIndex, Symbol, SymbolRegistry};
 use wasmer_types::entity::{EntityRef, PrimaryMap};

--- a/lib/engine-object-file/src/artifact.rs
+++ b/lib/engine-object-file/src/artifact.rs
@@ -3,6 +3,7 @@
 
 use crate::engine::{ObjectFileEngine, ObjectFileEngineInner};
 use crate::serialize::{ModuleMetadata, ModuleMetadataSymbolRegistry};
+use loupe_derive::MemoryUsage;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::mem;
@@ -30,10 +31,12 @@ use wasmer_vm::{
 };
 
 /// A compiled wasm module, ready to be instantiated.
+#[derive(MemoryUsage)]
 pub struct ObjectFileArtifact {
     metadata: ModuleMetadata,
     module_bytes: Vec<u8>,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
+    #[memoryusage(ignore)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/lib/engine-object-file/src/artifact.rs
+++ b/lib/engine-object-file/src/artifact.rs
@@ -3,7 +3,7 @@
 
 use crate::engine::{ObjectFileEngine, ObjectFileEngineInner};
 use crate::serialize::{ModuleMetadata, ModuleMetadataSymbolRegistry};
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::mem;

--- a/lib/engine-object-file/src/artifact.rs
+++ b/lib/engine-object-file/src/artifact.rs
@@ -36,7 +36,7 @@ pub struct ObjectFileArtifact {
     metadata: ModuleMetadata,
     module_bytes: Vec<u8>,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
-    #[memoryusage(ignore)]
+    #[loupe(skip)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/lib/engine-object-file/src/serialize.rs
+++ b/lib/engine-object-file/src/serialize.rs
@@ -1,10 +1,11 @@
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use wasmer_compiler::{CompileModuleInfo, SectionIndex, Symbol, SymbolRegistry};
 use wasmer_types::entity::{EntityRef, PrimaryMap};
 use wasmer_types::{FunctionIndex, LocalFunctionIndex, OwnedDataInitializer, SignatureIndex};
 
 /// Serializable struct that represents the compiled metadata.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, MemoryUsage)]
 pub struct ModuleMetadata {
     pub compile_info: CompileModuleInfo,
     pub prefix: String,
@@ -13,6 +14,7 @@ pub struct ModuleMetadata {
     pub function_body_lengths: PrimaryMap<LocalFunctionIndex, u64>,
 }
 
+#[derive(MemoryUsage)]
 pub struct ModuleMetadataSymbolRegistry {
     pub prefix: String,
 }

--- a/lib/engine-object-file/src/serialize.rs
+++ b/lib/engine-object-file/src/serialize.rs
@@ -1,4 +1,4 @@
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use wasmer_compiler::{CompileModuleInfo, SectionIndex, Symbol, SymbolRegistry};
 use wasmer_types::entity::{EntityRef, PrimaryMap};

--- a/lib/engine/src/artifact.rs
+++ b/lib/engine/src/artifact.rs
@@ -1,6 +1,7 @@
 use crate::{
     resolve_imports, InstantiationError, Resolver, RuntimeError, SerializeError, Tunables,
 };
+use loupe::MemoryUsage;
 use std::any::Any;
 use std::fs;
 use std::path::Path;
@@ -22,7 +23,7 @@ use wasmer_vm::{
 /// The `Artifact` contains the compiled data for a given
 /// module as well as extra information needed to run the
 /// module at runtime, such as [`ModuleInfo`] and [`Features`].
-pub trait Artifact: Send + Sync + Upcastable {
+pub trait Artifact: Send + Sync + Upcastable + MemoryUsage {
     /// Return a reference-counted pointer to the module
     fn module(&self) -> Arc<ModuleInfo>;
 

--- a/lib/engine/src/serialize.rs
+++ b/lib/engine/src/serialize.rs
@@ -1,4 +1,4 @@
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::de::{Deserializer, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};

--- a/lib/engine/src/serialize.rs
+++ b/lib/engine/src/serialize.rs
@@ -1,3 +1,4 @@
+use loupe_derive::MemoryUsage;
 use serde::de::{Deserializer, Visitor};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
@@ -5,7 +6,7 @@ use std::fmt;
 use wasmer_compiler::CompiledFunctionFrameInfo;
 
 /// This is the unserialized verison of `CompiledFunctionFrameInfo`.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, MemoryUsage)]
 #[serde(transparent)]
 #[repr(transparent)]
 pub struct UnprocessedFunctionFrameInfo {
@@ -44,7 +45,7 @@ impl UnprocessedFunctionFrameInfo {
 /// of compiling at the same time that emiting the JIT.
 /// In that case, we don't need to deserialize/process anything
 /// as the data is already in memory.
-#[derive(Clone)]
+#[derive(Clone, MemoryUsage)]
 pub enum SerializableFunctionFrameInfo {
     /// The unprocessed frame info (binary)
     Unprocessed(UnprocessedFunctionFrameInfo),

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -11,7 +11,7 @@
 //! FRAME_INFO.register(module, compiled_functions);
 //! ```
 use crate::serialize::SerializableFunctionFrameInfo;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -11,6 +11,7 @@
 //! FRAME_INFO.register(module, compiled_functions);
 //! ```
 use crate::serialize::SerializableFunctionFrameInfo;
+use loupe_derive::MemoryUsage;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
@@ -44,6 +45,7 @@ pub struct GlobalFrameInfo {
 
 /// An RAII structure used to unregister a module's frame information when the
 /// module is destroyed.
+#[derive(MemoryUsage)]
 pub struct GlobalFrameInfoRegistration {
     /// The key that will be removed from the global `ranges` map when this is
     /// dropped.

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -21,7 +21,7 @@ more-asserts = "0.2"
 cfg-if = "0.1"
 backtrace = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
-loupe = "0.1"
+loupe = { version = "0.1", features = ["enable-indexmap"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "memoryapi", "errhandlingapi"] }

--- a/lib/vm/src/global.rs
+++ b/lib/vm/src/global.rs
@@ -1,11 +1,12 @@
 use crate::vmcontext::VMGlobalDefinition;
+use loupe_derive::MemoryUsage;
 use std::cell::UnsafeCell;
 use std::ptr::NonNull;
 use std::sync::Mutex;
 use thiserror::Error;
 use wasmer_types::{GlobalType, Mutability, Type, Value};
 
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 /// A Global instance
 pub struct Global {
     ty: GlobalType,

--- a/lib/vm/src/global.rs
+++ b/lib/vm/src/global.rs
@@ -1,5 +1,5 @@
 use crate::vmcontext::VMGlobalDefinition;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use std::cell::UnsafeCell;
 use std::ptr::NonNull;
 use std::sync::Mutex;

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -56,12 +56,13 @@ pub use crate::vmcontext::{
     VMTableImport, VMTrampoline,
 };
 pub use crate::vmoffsets::{TargetSharedSignatureIndex, VMOffsets};
+use loupe_derive::MemoryUsage;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// A safe wrapper around `VMFunctionBody`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, MemoryUsage)]
 #[repr(transparent)]
 pub struct FunctionBodyPtr(pub *const VMFunctionBody);
 

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::vmcontext::{
     VMTableImport, VMTrampoline,
 };
 pub use crate::vmoffsets::{TargetSharedSignatureIndex, VMOffsets};
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/vm/src/libcalls.rs
+++ b/lib/vm/src/libcalls.rs
@@ -38,6 +38,7 @@
 use crate::probestack::PROBESTACK;
 use crate::trap::{raise_lib_trap, Trap, TrapCode};
 use crate::vmcontext::VMContext;
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use wasmer_types::{DataIndex, ElemIndex, LocalMemoryIndex, MemoryIndex, TableIndex};
@@ -405,7 +406,7 @@ pub static wasmer_probestack: unsafe extern "C" fn() = PROBESTACK;
 /// The name of a runtime library routine.
 ///
 /// This list is likely to grow over time.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, MemoryUsage)]
 pub enum LibCall {
     /// ceil.f32
     CeilF32,

--- a/lib/vm/src/libcalls.rs
+++ b/lib/vm/src/libcalls.rs
@@ -38,7 +38,7 @@
 use crate::probestack::PROBESTACK;
 use crate::trap::{raise_lib_trap, Trap, TrapCode};
 use crate::vmcontext::VMContext;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use wasmer_types::{DataIndex, ElemIndex, LocalMemoryIndex, MemoryIndex, TableIndex};

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -7,6 +7,8 @@
 
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;
+use loupe::MemoryUsage;
+use loupe_derive::MemoryUsage;
 use more_asserts::assert_ge;
 use serde::{Deserialize, Serialize};
 use std::borrow::BorrowMut;
@@ -61,7 +63,7 @@ pub enum MemoryError {
 }
 
 /// Implementation styles for WebAssembly linear memory.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, MemoryUsage)]
 pub enum MemoryStyle {
     /// The actual memory can be resized and moved.
     Dynamic {
@@ -96,7 +98,7 @@ impl MemoryStyle {
 }
 
 /// Trait for implementing Wasm Memory used by Wasmer.
-pub trait Memory: fmt::Debug + Send + Sync {
+pub trait Memory: fmt::Debug + Send + Sync + MemoryUsage {
     /// Returns the memory type for this memory.
     fn ty(&self) -> &MemoryType;
 
@@ -116,7 +118,7 @@ pub trait Memory: fmt::Debug + Send + Sync {
 }
 
 /// A linear memory instance.
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 pub struct LinearMemory {
     // The underlying allocation.
     mmap: Mutex<WasmMmap>,
@@ -144,7 +146,7 @@ pub struct LinearMemory {
 
 /// A type to help manage who is responsible for the backing memory of them
 /// `VMMemoryDefinition`.
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 enum VMMemoryDefinitionOwnership {
     /// The `VMMemoryDefinition` is owned by the `Instance` and we should use
     /// its memory. This is how a local memory that's exported should be stored.
@@ -167,7 +169,7 @@ unsafe impl Send for LinearMemory {}
 /// This is correct because all internal mutability is protected by a mutex.
 unsafe impl Sync for LinearMemory {}
 
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 struct WasmMmap {
     // Our OS allocation of mmap'd memory.
     alloc: Mmap,

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -8,7 +8,6 @@
 use crate::mmap::Mmap;
 use crate::vmcontext::VMMemoryDefinition;
 use loupe::MemoryUsage;
-use loupe_derive::MemoryUsage;
 use more_asserts::assert_ge;
 use serde::{Deserialize, Serialize};
 use std::borrow::BorrowMut;

--- a/lib/vm/src/module.rs
+++ b/lib/vm/src/module.rs
@@ -5,6 +5,7 @@
 //! `wasmer::Module`.
 
 use indexmap::IndexMap;
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -19,7 +20,7 @@ use wasmer_types::{
     TableIndex, TableInitializer, TableType,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, MemoryUsage)]
 pub struct ModuleId {
     id: usize,
 }
@@ -41,7 +42,7 @@ impl Default for ModuleId {
 
 /// A translated WebAssembly module, excluding the function bodies and
 /// memory initializers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, MemoryUsage)]
 pub struct ModuleInfo {
     /// A unique identifier (within this process) for this module.
     ///

--- a/lib/vm/src/module.rs
+++ b/lib/vm/src/module.rs
@@ -5,7 +5,7 @@
 //! `wasmer::Module`.
 
 use indexmap::IndexMap;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -7,6 +7,8 @@
 
 use crate::trap::{Trap, TrapCode};
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMTableDefinition};
+use loupe::MemoryUsage;
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use std::borrow::{Borrow, BorrowMut};
 use std::cell::UnsafeCell;
@@ -17,14 +19,14 @@ use std::sync::Mutex;
 use wasmer_types::{TableType, Type as ValType};
 
 /// Implementation styles for WebAssembly tables.
-#[derive(Debug, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, MemoryUsage)]
 pub enum TableStyle {
     /// Signatures are stored in the table and checked in the caller.
     CallerChecksSignature,
 }
 
 /// Trait for implementing the interface of a Wasm table.
-pub trait Table: fmt::Debug + Send + Sync {
+pub trait Table: fmt::Debug + Send + Sync + MemoryUsage {
     /// Returns the style for this Table.
     fn style(&self) -> &TableStyle;
 
@@ -103,7 +105,7 @@ pub trait Table: fmt::Debug + Send + Sync {
 }
 
 /// A table instance.
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 pub struct LinearTable {
     // TODO: we can remove the mutex by using atomic swaps and preallocating the max table size
     vec: Mutex<Vec<VMCallerCheckedAnyfunc>>,
@@ -117,7 +119,7 @@ pub struct LinearTable {
 
 /// A type to help manage who is responsible for the backing table of the
 /// `VMTableDefinition`.
-#[derive(Debug)]
+#[derive(Debug, MemoryUsage)]
 enum VMTableDefinitionOwnership {
     /// The `VMTableDefinition` is owned by the `Instance` and we should use
     /// its table. This is how a local table that's exported should be stored.

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -8,7 +8,6 @@
 use crate::trap::{Trap, TrapCode};
 use crate::vmcontext::{VMCallerCheckedAnyfunc, VMTableDefinition};
 use loupe::MemoryUsage;
-use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use std::borrow::{Borrow, BorrowMut};
 use std::cell::UnsafeCell;

--- a/lib/vm/src/trap/trapcode.rs
+++ b/lib/vm/src/trap/trapcode.rs
@@ -5,7 +5,7 @@
 
 use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/lib/vm/src/trap/trapcode.rs
+++ b/lib/vm/src/trap/trapcode.rs
@@ -5,13 +5,14 @@
 
 use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
+use loupe_derive::MemoryUsage;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// A trap code describing the reason for a trap.
 ///
 /// All trap instructions have an explicit trap code.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize, Error)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize, Error, MemoryUsage)]
 #[repr(u32)]
 pub enum TrapCode {
     /// The current stack space was exhausted.

--- a/lib/wasmer-types/src/entity/boxed_slice.rs
+++ b/lib/wasmer-types/src/entity/boxed_slice.rs
@@ -10,6 +10,8 @@ use crate::lib::std::boxed::Box;
 use crate::lib::std::marker::PhantomData;
 use crate::lib::std::ops::{Index, IndexMut};
 use crate::lib::std::slice;
+use loupe::{MemoryUsage, MemoryUsageTracker};
+use std::mem;
 
 /// A slice mapping `K -> V` allocating dense entity references.
 ///
@@ -141,6 +143,21 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         IterMut::new(self.elems.iter_mut())
+    }
+}
+
+impl<K, V> MemoryUsage for BoxedSlice<K, V>
+where
+    K: EntityRef,
+    V: MemoryUsage,
+{
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self)
+            + self
+                .elems
+                .iter()
+                .map(|value| value.size_of_val(tracker) - mem::size_of_val(value))
+                .sum::<usize>()
     }
 }
 

--- a/lib/wasmer-types/src/entity/primary_map.rs
+++ b/lib/wasmer-types/src/entity/primary_map.rs
@@ -12,8 +12,10 @@ use crate::lib::std::marker::PhantomData;
 use crate::lib::std::ops::{Index, IndexMut};
 use crate::lib::std::slice;
 use crate::lib::std::vec::Vec;
+use loupe::{MemoryUsage, MemoryUsageTracker};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::mem;
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///
@@ -233,6 +235,21 @@ where
             elems: Vec::from_iter(iter),
             unused: PhantomData,
         }
+    }
+}
+
+impl<K, V> MemoryUsage for PrimaryMap<K, V>
+where
+    K: EntityRef,
+    V: MemoryUsage,
+{
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self)
+            + self
+                .elems
+                .iter()
+                .map(|value| value.size_of_val(tracker) - mem::size_of_val(value))
+                .sum::<usize>()
     }
 }
 

--- a/lib/wasmer-types/src/initializers.rs
+++ b/lib/wasmer-types/src/initializers.rs
@@ -1,6 +1,6 @@
 use crate::indexes::{FunctionIndex, GlobalIndex, MemoryIndex, TableIndex};
 use crate::lib::std::boxed::Box;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};

--- a/lib/wasmer-types/src/initializers.rs
+++ b/lib/wasmer-types/src/initializers.rs
@@ -1,11 +1,12 @@
 use crate::indexes::{FunctionIndex, GlobalIndex, MemoryIndex, TableIndex};
 use crate::lib::std::boxed::Box;
+use loupe_derive::MemoryUsage;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
 /// A WebAssembly table initializer.
-#[derive(Clone, Debug, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, Serialize, Deserialize, MemoryUsage)]
 pub struct TableInitializer {
     /// The index of a table to initialize.
     pub table_index: TableIndex,
@@ -19,7 +20,7 @@ pub struct TableInitializer {
 
 /// A memory index and offset within that memory where a data initialization
 /// should be performed.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct DataInitializerLocation {
     /// The index of the memory to initialize.
@@ -45,7 +46,7 @@ pub struct DataInitializer<'data> {
 
 /// As `DataInitializer` but owning the data rather than
 /// holding a reference to it
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct OwnedDataInitializer {
     /// The location where the initialization is to be performed.

--- a/lib/wasmer-types/src/types.rs
+++ b/lib/wasmer-types/src/types.rs
@@ -6,7 +6,7 @@ use crate::lib::std::string::{String, ToString};
 use crate::lib::std::vec::Vec;
 use crate::units::Pages;
 use crate::values::Value;
-use loupe::MemoryUsage;
+use loupe::{MemoryUsage, MemoryUsageTracker};
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -57,7 +57,7 @@ impl fmt::Display for Type {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, MemoryUsage)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 /// The WebAssembly V128 type
 pub struct V128(pub(crate) [u8; 16]);
@@ -95,6 +95,12 @@ impl From<&[u8]> for V128 {
         let mut buffer = [0; 16];
         buffer.copy_from_slice(slice);
         Self(buffer)
+    }
+}
+
+impl MemoryUsage for V128 {
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        self.as_slice().size_of_val(tracker)
     }
 }
 

--- a/lib/wasmer-types/src/types.rs
+++ b/lib/wasmer-types/src/types.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Type {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 /// The WebAssembly V128 type
 pub struct V128(pub(crate) [u8; 16]);
@@ -311,7 +311,7 @@ impl From<&FunctionType> for FunctionType {
 }
 
 /// Indicator of whether a global is mutable or not
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum Mutability {
     /// The global is constant and its value does not change
@@ -347,7 +347,7 @@ impl From<Mutability> for bool {
 }
 
 /// WebAssembly global.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct GlobalType {
     /// The type of the value stored in the global.
@@ -390,7 +390,7 @@ impl fmt::Display for GlobalType {
 }
 
 /// Globals are initialized via the `const` operators or by referring to another import.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum GlobalInit {
     /// An `i32.const`.
@@ -441,7 +441,7 @@ impl GlobalInit {
 /// Tables are contiguous chunks of a specific element, typically a `funcref` or
 /// an `externref`. The most common use for tables is a function table through
 /// which `call_indirect` can invoke other functions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct TableType {
     /// The type of data stored in elements of the table.
@@ -480,7 +480,7 @@ impl fmt::Display for TableType {
 ///
 /// Memories are described in units of pages (64KB) and represent contiguous
 /// chunks of addressable memory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, MemoryUsage)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct MemoryType {
     /// The minimum number of pages in the memory.

--- a/tests/lib/engine-dummy/src/artifact.rs
+++ b/tests/lib/engine-dummy/src/artifact.rs
@@ -2,6 +2,7 @@
 //! done as separate steps.
 
 use crate::engine::DummyEngine;
+use loupe_derive::MemoryUsage;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -21,6 +22,7 @@ use wasmer_vm::{
 
 /// Serializable struct for the artifact
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(MemoryUsage)]
 pub struct DummyArtifactMetadata {
     pub module: Arc<ModuleInfo>,
     pub features: Features,
@@ -34,10 +36,11 @@ pub struct DummyArtifactMetadata {
 ///
 /// This artifact will point to fake finished functions and trampolines
 /// as no functions are really compiled.
+#[derive(MemoryUsage)]
 pub struct DummyArtifact {
     metadata: DummyArtifactMetadata,
-
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
+    #[memoryusage(ignore)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,

--- a/tests/lib/engine-dummy/src/artifact.rs
+++ b/tests/lib/engine-dummy/src/artifact.rs
@@ -2,7 +2,7 @@
 //! done as separate steps.
 
 use crate::engine::DummyEngine;
-use loupe_derive::MemoryUsage;
+use loupe::MemoryUsage;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -40,7 +40,7 @@ pub struct DummyArtifactMetadata {
 pub struct DummyArtifact {
     metadata: DummyArtifactMetadata,
     finished_functions: BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>,
-    #[memoryusage(ignore)]
+    #[loupe(skip)]
     finished_function_call_trampolines: BoxedSlice<SignatureIndex, VMTrampoline>,
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSharedSignatureIndex>,


### PR DESCRIPTION
# Description

This patch implements `loupe::MemoryUsage` for `wasmer::Module`.

~This PR includes https://github.com/wasmerio/wasmer/pull/2199. To review unique patches: https://github.com/Hywan/wasmer/compare/feat-memory-usage...feat-memory-usage-module?expand=1~

# Review

- [x] Add a short description of the the change to the CHANGELOG.md file
