### PR TITLE
chore: Update `loupe` from 0.1.1 to 0.1.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "loupe"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acf065b51eb58abbc66a07c27ec63142205d339a9f5093dc3e1d7cda3d5c9a3"
+checksum = "d79b0cc3aa7552a59274f642a0a6e7419b7f5438aba06a0a82825918ba69f0e6"
 dependencies = [
  "indexmap",
  "loupe-derive",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "loupe"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acf065b51eb58abbc66a07c27ec63142205d339a9f5093dc3e1d7cda3d5c9a3"
+checksum = "d79b0cc3aa7552a59274f642a0a6e7419b7f5438aba06a0a82825918ba69f0e6"
 dependencies = [
  "indexmap",
  "loupe-derive",


### PR DESCRIPTION
# Description

This new release of `loupe` contais this https://github.com/wasmerio/loupe/pull/15, which should fix `wasmer-nightly` :-).


# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
