### PR TITLE
Bump Rust version to 1 behind latest stable (1.50)

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49
+          toolchain: 1.50
           override: true
       - name: Install LLVM
         shell: bash

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.50
+          toolchain: "1.50"
           override: true
       - name: Install LLVM
         shell: bash

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.49
+          toolchain: 1.50
           override: true
           components: rustfmt, clippy
       - name: Install LLVM (Linux)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.50
+          toolchain: "1.50"
           override: true
           components: rustfmt, clippy
       - name: Install LLVM (Linux)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,26 +41,26 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu-18.04
-            rust: 1.49
+            rust: 1.50
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_integration_tests: true
           - build: macos-x64
             os: macos-latest
-            rust: 1.49
+            rust: 1.50
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             run_integration_tests: true
           - build: macos-arm64
             os: macos-11.0
-            rust: 1.49
+            rust: 1.50
             target: aarch64-apple-darwin
             artifact_name: 'wasmer-darwin-arm64'
           - build: windows-x64
             os: windows-latest
-            rust: 1.49
+            rust: 1.50
             # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
@@ -68,7 +68,7 @@ jobs:
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
             random_sccache_port: true
-            rust: 1.49
+            rust: 1.50
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-aarch64.tar.gz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false
@@ -289,7 +289,7 @@ jobs:
         include:
           - build: linux-musl-x64
             image: alpine:latest
-            rust: 1.49
+            rust: 1.50
             artifact_name: 'wasmer-linux-musl-amd64'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,26 +41,26 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu-18.04
-            rust: 1.50
+            rust: "1.50"
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_integration_tests: true
           - build: macos-x64
             os: macos-latest
-            rust: 1.50
+            rust: "1.50"
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             run_integration_tests: true
           - build: macos-arm64
             os: macos-11.0
-            rust: 1.50
+            rust: "1.50"
             target: aarch64-apple-darwin
             artifact_name: 'wasmer-darwin-arm64'
           - build: windows-x64
             os: windows-latest
-            rust: 1.50
+            rust: "1.50"
             # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
@@ -68,7 +68,7 @@ jobs:
           - build: linux-aarch64
             os: [self-hosted, linux, ARM64]
             random_sccache_port: true
-            rust: 1.50
+            rust: "1.50"
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-aarch64.tar.gz'
             artifact_name: 'wasmer-linux-aarch64'
             run_integration_tests: false
@@ -289,7 +289,7 @@ jobs:
         include:
           - build: linux-musl-x64
             image: alpine:latest
-            rust: 1.50
+            rust: "1.50"
             artifact_name: 'wasmer-linux-musl-amd64'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Here's the equivalent on nightly https://github.com/wasmerio/wasmer-nightly/pull/16

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
