### PR TITLE
Fix flag conflicts.

### DIFF
--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -8,27 +8,27 @@ use std::path::PathBuf;
 /// The options for the `wasmer config` subcommand
 pub struct Config {
     /// Print the installation prefix.
-    #[clap(long, conflicts_with = "pkg_config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     prefix: bool,
 
     /// Directory containing Wasmer executables.
-    #[clap(long, conflicts_with = "pkg_config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     bindir: bool,
 
     /// Directory containing Wasmer headers.
-    #[clap(long, conflicts_with = "pkg_config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     includedir: bool,
 
     /// Directory containing Wasmer libraries.
-    #[clap(long, conflicts_with = "pkg_config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     libdir: bool,
 
     /// Libraries needed to link against Wasmer components.
-    #[clap(long, conflicts_with = "pkg_config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     libs: bool,
 
     /// C compiler flags for files that include Wasmer headers.
-    #[clap(long, conflicts_with = "pkg_config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     cflags: bool,
 
     /// It outputs the necessary details for compiling

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -20,11 +20,11 @@ pub struct StoreOptions {
     compiler: CompilerOptions,
 
     /// Use JIT Engine.
-    #[clap(long, conflicts_with_all = &["native", "object_file"])]
+    #[clap(long, conflicts_with_all = &["native", "object-file"])]
     jit: bool,
 
     /// Use Native Engine.
-    #[clap(long, conflicts_with_all = &["jit", "object_file"])]
+    #[clap(long, conflicts_with_all = &["jit", "object-file"])]
     native: bool,
 
     /// Use ObjectFile Engine.


### PR DESCRIPTION
These strings have to refer to the flag name, not the field member name, and clap derive converts the underscores to hyphens. This was being caught by debug_asserts in clap.
