### PR TITLE
Pin to a specific version of wapm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ else
 endif
 endif
 
-WAPM_VERSION = master # v0.5.0
+WAPM_VERSION = v0.5.1
 get-wapm:
 	[ -d "wapm-cli" ] || git clone --branch $(WAPM_VERSION) https://github.com/wasmerio/wapm-cli.git
 


### PR DESCRIPTION
Just tagged wapm 0.5.1, this pins to a specific version of wapm.