### PR TITLE
Fix unsound mut pointer to potentially cloned Arc

### DIFF
--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -92,10 +92,7 @@ impl EmEnv {
     }
 
     pub fn set_memory(&mut self, memory: Memory) {
-        let ptr = Arc::as_ptr(&self.memory) as *mut _;
-        unsafe {
-            *ptr = Some(memory);
-        }
+        Arc::make_mut(&mut self.memory).replace(memory);
     }
 
     /// Get a reference to the memory


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Fix unsound behavior when EmEnv is cloned. Since it impls Clone, that's a valid and legal thing to do. If you clone an EmEnv, the Arcs both point at the the same Option<Memory>. It is unsound to take a mutable reference or pointer to an object while there exists another reference.

With this change, we remove the unsafe block. If EmEnv has been cloned, the Option<Memory> gets cloned in the instance you're trying to write memory to. The old instance will point at whatever it previously had.

# Review

- [ ] Add a short description of the the change to the CHANGELOG.md file
