### PR TITLE
Fixed feature comment with incorrect description

### DIFF
--- a/lib/types/src/features.rs
+++ b/lib/types/src/features.rs
@@ -168,10 +168,10 @@ impl Features {
         self
     }
 
-    /// Configures whether the WebAssembly tail-call proposal will
+    /// Configures whether the WebAssembly module linking proposal will
     /// be enabled.
     ///
-    /// The [WebAssembly tail-call proposal][proposal] is not
+    /// The [WebAssembly module linking proposal][proposal] is not
     /// currently fully standardized and is undergoing development.
     /// Support for this feature can be enabled through this method for
     /// appropriate WebAssembly modules.


### PR DESCRIPTION
# Description
Looks like a copy paste error, the description and link looked correct and linked to the correct location, just the top of the comment was the same as the feature flag just above.

I didn't run the tests or formatter with these changes as the line length is still less than line 176, so no additional wrapping should occur and no behavior was changed.

# Review

If you do want a remark in the changelog about a comment I can update that, this seemed very minor so I figure it's not worth it. I also made the change in the github code viewer, so changing multiple files through that may get interesting, but if it's requested I'll append to the changelog.