### PR TITLE
Upgrade docker-run-action to v3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -294,7 +294,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: addnab/docker-run-action@v1
+      - uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.image }}
           options: -v ${{ github.workspace }}:/work


### PR DESCRIPTION
From the [release notes](https://github.com/addnab/docker-run-action/blob/main/RELEASES.md) it seems possible that running on v3 may reduce some of the massive slowdown we've seen on this step recently. It's a worth a try in any case 🤷 