### PR TITLE
Rename confusing workflow name

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,14 +6,14 @@ on:
       - '!staging'
       - '!staging.tmp'
 
-name: build
+name: Coverage
 
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off"
 
 jobs:
-  lint:
+  coverage:
     name: Coverage
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

I think `Build` workflow is confusing...
The filename of this workflow is `coverage.yaml`. But, workflow name is `Build`.
In addition, what the workflow does is take coverage

How about renaming it to `coverage` instead of` Build`?
There is a sense of unity in all operations, file names, and workflow names.

Thanks.