### PR TITLE
Add `--tests` flag to core test commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,22 +484,22 @@ build-capi-headless-all: capi-setup
 test: $(foreach compiler,$(compilers),test-$(compiler)) test-packages test-examples test-deprecated
 
 test-singlepass-native:
-	cargo test --release $(compiler_features) --features "test-singlepass test-native"
+	cargo test --release --tests $(compiler_features) --features "test-singlepass test-native"
 
 test-singlepass-jit:
-	cargo test --release $(compiler_features) --features "test-singlepass test-jit"
+	cargo test --release --tests $(compiler_features) --features "test-singlepass test-jit"
 
 test-cranelift-native:
-	cargo test --release $(compiler_features) --features "test-cranelift test-native"
+	cargo test --release --tests $(compiler_features) --features "test-cranelift test-native"
 
 test-cranelift-jit:
-	cargo test --release $(compiler_features) --features "test-cranelift test-jit"
+	cargo test --release --tests $(compiler_features) --features "test-cranelift test-jit"
 
 test-llvm-native:
-	cargo test --release $(compiler_features) --features "test-llvm test-native"
+	cargo test --release --tests $(compiler_features) --features "test-llvm test-native"
 
 test-llvm-jit:
-	cargo test --release $(compiler_features) --features "test-llvm test-jit"
+	cargo test --release --tests $(compiler_features) --features "test-llvm test-jit"
 
 test-singlepass: $(foreach singlepass_engine,$(filter singlepass-%,$(compilers_engines)),test-$(singlepass_engine))
 


### PR DESCRIPTION
This stops the behavior of linking every example every time we compile tests.
This saves a non-negligible amount of time.

This has some side effects like not testing benchmarks as tests, but we are not affected by that due to our project layout. So this change should be a no-op that speeds up the compilation part of tests. The speedup should be visible in CI, I'll run `bors try` to compare.
