### PR TITLE
Add TypedSelect support to Singlepass + LLVM

### DIFF
--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -2022,7 +2022,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 }
             }
 
-            Operator::Select => {
+            // `TypedSelect` must be used for extern refs so ref counting should
+            // be done with TypedSelect. But otherwise they're the same.
+            Operator::TypedSelect { .. } | Operator::Select => {
                 let ((v1, i1), (v2, i2), (cond, _)) = self.state.pop3_extra()?;
                 // We don't bother canonicalizing 'cond' here because we only
                 // compare it to zero, and that's invariant under

--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -5525,7 +5525,9 @@ impl<'a> FuncGen<'a> {
                     }
                 }
             }
-            Operator::Select => {
+            // `TypedSelect` must be used for extern refs so ref counting should
+            // be done with TypedSelect. But otherwise they're the same.
+            Operator::TypedSelect { .. } | Operator::Select => {
                 let cond = self.pop_value_released();
                 let v_b = self.pop_value_released();
                 let v_a = self.pop_value_released();


### PR DESCRIPTION
Part of #2268, we missed these in the reftypes PR. `TypedSelect` is the same as `Select` but it specifies a type statically. We only handle this in the Cranelift compiler because we ref count when it's an ExternRef. ExternRefs must use `TypedSelect`. Because we haven't implemented extern ref counting in llvm or singlepass yet, we just make it the same as select.

This fixes one of the failing spec tests in #2268