### PR TITLE
Unify test running of compilers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,12 +136,16 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}-v1
+          key: ${{ matrix.build }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}-v1
+          restore-keys: |
+            ${{ matrix.build }}-${{ matrix.target }}-cargo-
       - uses: actions/cache@v2
         if: matrix.use_sccache
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
           key: ${{ matrix.build }}-${{ matrix.target }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
+          restore-keys: |
+            ${{ matrix.build }}-${{ matrix.target }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-
       - name: Install sccache
         if: matrix.use_sccache
         run: |

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,9 @@ comma := ,
 # Define the compiler Cargo features for all crates.
 compiler_features := --features $(subst $(space),$(comma),$(compilers))
 compiler_test_features := --features $(subst $(space),$(comma),$(addprefix test-,$(compilers)))
+# Define the compiler Cargo test features when using the native engine
+# We exclude singlepass for now
+native_engine_compiler_test_features := --features $(subst $(space),$(comma),$(addprefix test-,$(filter-out singlepass, $(compilers))))
 
 # Define the compiler Cargo features for the C API. It always excludes
 # LLVM for the moment.
@@ -490,7 +493,7 @@ test-jit:
 	cargo test --release --tests $(compiler_features) $(compiler_test_features) --features "test-jit"
 
 test-native:
-	cargo test --release --tests $(compiler_features) $(compiler_test_features) --features "test-native"
+	cargo test --release --tests $(compiler_features) $(native_engine_compiler_test_features) --features "test-native"
 
 test-singlepass-native:
 	cargo test --release --tests $(compiler_features) --features "test-singlepass test-native"

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,7 @@ comma := ,
 
 # Define the compiler Cargo features for all crates.
 compiler_features := --features $(subst $(space),$(comma),$(compilers))
+compiler_test_features := --features $(subst $(space),$(comma),$(addprefix test-,$(compilers)))
 
 # Define the compiler Cargo features for the C API. It always excludes
 # LLVM for the moment.
@@ -481,7 +482,15 @@ build-capi-headless-all: capi-setup
 # Testing #
 ###########
 
-test: $(foreach compiler,$(compilers),test-$(compiler)) test-packages test-examples test-deprecated
+test: test-engines test-packages test-examples test-deprecated
+
+test-engines: test-jit test-native
+
+test-jit:
+	cargo test --release --tests $(compiler_features) $(compiler_test_features) --features "test-jit"
+
+test-native:
+	cargo test --release --tests $(compiler_features) $(compiler_test_features) --features "test-native"
 
 test-singlepass-native:
 	cargo test --release --tests $(compiler_features) --features "test-singlepass test-native"

--- a/tests/compilers/middlewares.rs
+++ b/tests/compilers/middlewares.rs
@@ -1,4 +1,4 @@
-use crate::utils::get_store_with_middlewares;
+use crate::utils::{get_compilers, get_store_with_middlewares};
 use anyhow::Result;
 
 use loupe::MemoryUsage;
@@ -91,54 +91,62 @@ impl FunctionMiddleware for Fusion {
 
 #[test]
 fn middleware_basic() -> Result<()> {
-    let store = get_store_with_middlewares(std::iter::once(
-        Arc::new(Add2MulGen { value_off: 0 }) as Arc<dyn ModuleMiddleware>
-    ));
-    let wat = r#"(module
+    for compiler in get_compilers() {
+        let store = get_store_with_middlewares(
+            std::iter::once(Arc::new(Add2MulGen { value_off: 0 }) as Arc<dyn ModuleMiddleware>),
+            compiler,
+        );
+        let wat = r#"(module
         (func (export "add") (param i32 i32) (result i32)
            (i32.add (local.get 0)
                     (local.get 1)))
 )"#;
-    let module = Module::new(&store, wat).unwrap();
+        let module = Module::new(&store, wat).unwrap();
 
-    let import_object = imports! {};
+        let import_object = imports! {};
 
-    let instance = Instance::new(&module, &import_object)?;
+        let instance = Instance::new(&module, &import_object)?;
 
-    let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
-    let result = f.call(4, 6)?;
-    assert_eq!(result, 24);
+        let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
+        let result = f.call(4, 6)?;
+        assert_eq!(result, 24);
+    }
     Ok(())
 }
 
 #[test]
 fn middleware_one_to_multi() -> Result<()> {
-    let store = get_store_with_middlewares(std::iter::once(
-        Arc::new(Add2MulGen { value_off: 1 }) as Arc<dyn ModuleMiddleware>
-    ));
-    let wat = r#"(module
+    for compiler in get_compilers() {
+        let store = get_store_with_middlewares(
+            std::iter::once(Arc::new(Add2MulGen { value_off: 1 }) as Arc<dyn ModuleMiddleware>),
+            compiler,
+        );
+        let wat = r#"(module
         (func (export "add") (param i32 i32) (result i32)
            (i32.add (local.get 0)
                     (local.get 1)))
 )"#;
-    let module = Module::new(&store, wat).unwrap();
+        let module = Module::new(&store, wat).unwrap();
 
-    let import_object = imports! {};
+        let import_object = imports! {};
 
-    let instance = Instance::new(&module, &import_object)?;
+        let instance = Instance::new(&module, &import_object)?;
 
-    let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
-    let result = f.call(4, 6)?;
-    assert_eq!(result, 25);
+        let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
+        let result = f.call(4, 6)?;
+        assert_eq!(result, 25);
+    }
     Ok(())
 }
 
 #[test]
 fn middleware_multi_to_one() -> Result<()> {
-    let store = get_store_with_middlewares(std::iter::once(
-        Arc::new(FusionGen) as Arc<dyn ModuleMiddleware>
-    ));
-    let wat = r#"(module
+    for compiler in get_compilers() {
+        let store = get_store_with_middlewares(
+            std::iter::once(Arc::new(FusionGen) as Arc<dyn ModuleMiddleware>),
+            compiler,
+        );
+        let wat = r#"(module
         (func (export "testfunc") (param i32 i32) (result i32)
            (local.get 0)
            (local.get 1)
@@ -146,66 +154,73 @@ fn middleware_multi_to_one() -> Result<()> {
            (i32.add)
            (i32.mul))
 )"#;
-    let module = Module::new(&store, wat).unwrap();
+        let module = Module::new(&store, wat).unwrap();
 
-    let import_object = imports! {};
+        let import_object = imports! {};
 
-    let instance = Instance::new(&module, &import_object)?;
+        let instance = Instance::new(&module, &import_object)?;
 
-    let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("testfunc")?;
-    let result = f.call(10, 20)?;
-    assert_eq!(result, 10);
+        let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("testfunc")?;
+        let result = f.call(10, 20)?;
+        assert_eq!(result, 10);
+    }
     Ok(())
 }
 
 #[test]
 fn middleware_chain_order_1() -> Result<()> {
-    let store = get_store_with_middlewares(
-        vec![
-            Arc::new(Add2MulGen { value_off: 0 }) as Arc<dyn ModuleMiddleware>,
-            Arc::new(Add2MulGen { value_off: 2 }) as Arc<dyn ModuleMiddleware>,
-        ]
-        .into_iter(),
-    );
-    let wat = r#"(module
+    for compiler in get_compilers() {
+        let store = get_store_with_middlewares(
+            vec![
+                Arc::new(Add2MulGen { value_off: 0 }) as Arc<dyn ModuleMiddleware>,
+                Arc::new(Add2MulGen { value_off: 2 }) as Arc<dyn ModuleMiddleware>,
+            ]
+            .into_iter(),
+            compiler,
+        );
+        let wat = r#"(module
         (func (export "add") (param i32 i32) (result i32)
            (i32.add (local.get 0)
                     (local.get 1)))
 )"#;
-    let module = Module::new(&store, wat).unwrap();
+        let module = Module::new(&store, wat).unwrap();
 
-    let import_object = imports! {};
+        let import_object = imports! {};
 
-    let instance = Instance::new(&module, &import_object)?;
+        let instance = Instance::new(&module, &import_object)?;
 
-    let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
-    let result = f.call(4, 6)?;
-    assert_eq!(result, 24);
+        let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
+        let result = f.call(4, 6)?;
+        assert_eq!(result, 24);
+    }
     Ok(())
 }
 
 #[test]
 fn middleware_chain_order_2() -> Result<()> {
-    let store = get_store_with_middlewares(
-        vec![
-            Arc::new(Add2MulGen { value_off: 2 }) as Arc<dyn ModuleMiddleware>,
-            Arc::new(Add2MulGen { value_off: 0 }) as Arc<dyn ModuleMiddleware>,
-        ]
-        .into_iter(),
-    );
-    let wat = r#"(module
+    for compiler in get_compilers() {
+        let store = get_store_with_middlewares(
+            vec![
+                Arc::new(Add2MulGen { value_off: 2 }) as Arc<dyn ModuleMiddleware>,
+                Arc::new(Add2MulGen { value_off: 0 }) as Arc<dyn ModuleMiddleware>,
+            ]
+            .into_iter(),
+            compiler,
+        );
+        let wat = r#"(module
         (func (export "add") (param i32 i32) (result i32)
            (i32.add (local.get 0)
                     (local.get 1)))
 )"#;
-    let module = Module::new(&store, wat).unwrap();
+        let module = Module::new(&store, wat).unwrap();
 
-    let import_object = imports! {};
+        let import_object = imports! {};
 
-    let instance = Instance::new(&module, &import_object)?;
+        let instance = Instance::new(&module, &import_object)?;
 
-    let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
-    let result = f.call(4, 6)?;
-    assert_eq!(result, 48);
+        let f: NativeFunc<(i32, i32), i32> = instance.exports.get_native_function("add")?;
+        let result = f.call(4, 6)?;
+        assert_eq!(result, 48);
+    }
     Ok(())
 }

--- a/tests/compilers/serialize.rs
+++ b/tests/compilers/serialize.rs
@@ -1,27 +1,30 @@
-use crate::utils::{get_headless_store, get_store};
+use crate::utils::{get_compilers, get_headless_store, get_store};
 use anyhow::Result;
 use wasmer::*;
 
 #[test]
 fn test_serialize() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module
         (func $hello (import "" "hello"))
         (func (export "run") (call $hello))
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let serialized_bytes = module.serialize()?;
-    assert!(!serialized_bytes.is_empty());
+        let module = Module::new(&store, wat)?;
+        let serialized_bytes = module.serialize()?;
+        assert!(!serialized_bytes.is_empty());
+    }
     Ok(())
 }
 
 #[test]
 fn test_deserialize() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $name
             (import "host" "sum_part" (func (param i32 i64 i32 f32 f64) (result i64)))
             (func (export "test_call") (result i64)
@@ -35,43 +38,45 @@ fn test_deserialize() -> Result<()> {
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let serialized_bytes = module.serialize()?;
+        let module = Module::new(&store, wat)?;
+        let serialized_bytes = module.serialize()?;
 
-    let headless_store = get_headless_store();
-    let deserialized_module = unsafe { Module::deserialize(&headless_store, &serialized_bytes)? };
-    assert_eq!(deserialized_module.name(), Some("name"));
-    assert_eq!(
-        deserialized_module.exports().collect::<Vec<_>>(),
-        module.exports().collect::<Vec<_>>()
-    );
-    assert_eq!(
-        deserialized_module.imports().collect::<Vec<_>>(),
-        module.imports().collect::<Vec<_>>()
-    );
+        let headless_store = get_headless_store();
+        let deserialized_module =
+            unsafe { Module::deserialize(&headless_store, &serialized_bytes)? };
+        assert_eq!(deserialized_module.name(), Some("name"));
+        assert_eq!(
+            deserialized_module.exports().collect::<Vec<_>>(),
+            module.exports().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            deserialized_module.imports().collect::<Vec<_>>(),
+            module.imports().collect::<Vec<_>>()
+        );
 
-    let func_type = FunctionType::new(
-        vec![Type::I32, Type::I64, Type::I32, Type::F32, Type::F64],
-        vec![Type::I64],
-    );
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "host" => {
-                "sum_part" => Function::new(&store, &func_type, |params| {
-                    let param_0: i64 = params[0].unwrap_i32() as i64;
-                    let param_1: i64 = params[1].unwrap_i64() as i64;
-                    let param_2: i64 = params[2].unwrap_i32() as i64;
-                    let param_3: i64 = params[3].unwrap_f32() as i64;
-                    let param_4: i64 = params[4].unwrap_f64() as i64;
-                    Ok(vec![Value::I64(param_0 + param_1 + param_2 + param_3 + param_4)])
-                })
-            }
-        },
-    )?;
+        let func_type = FunctionType::new(
+            vec![Type::I32, Type::I64, Type::I32, Type::F32, Type::F64],
+            vec![Type::I64],
+        );
+        let instance = Instance::new(
+            &module,
+            &imports! {
+                "host" => {
+                    "sum_part" => Function::new(&store, &func_type, |params| {
+                        let param_0: i64 = params[0].unwrap_i32() as i64;
+                        let param_1: i64 = params[1].unwrap_i64() as i64;
+                        let param_2: i64 = params[2].unwrap_i32() as i64;
+                        let param_3: i64 = params[3].unwrap_f32() as i64;
+                        let param_4: i64 = params[4].unwrap_f64() as i64;
+                        Ok(vec![Value::I64(param_0 + param_1 + param_2 + param_3 + param_4)])
+                    })
+                }
+            },
+        )?;
 
-    let test_call = instance.exports.get_function("test_call")?;
-    let result = test_call.call(&[])?;
-    assert_eq!(result.to_vec(), vec![Value::I64(1500)]);
+        let test_call = instance.exports.get_function("test_call")?;
+        let result = test_call.call(&[])?;
+        assert_eq!(result.to_vec(), vec![Value::I64(1500)]);
+    }
     Ok(())
 }

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -1,91 +1,94 @@
-use crate::utils::get_store;
+use crate::utils::{get_compilers, get_store};
 use anyhow::Result;
 use std::panic::{self, AssertUnwindSafe};
 use wasmer::*;
 
 #[test]
 fn test_trap_return() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module
         (func $hello (import "" "hello"))
         (func (export "run") (call $hello))
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let hello_type = FunctionType::new(vec![], vec![]);
-    let hello_func = Function::new(&store, &hello_type, |_| Err(RuntimeError::new("test 123")));
+        let module = Module::new(&store, wat)?;
+        let hello_type = FunctionType::new(vec![], vec![]);
+        let hello_func = Function::new(&store, &hello_type, |_| Err(RuntimeError::new("test 123")));
 
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "" => {
-                "hello" => hello_func
-            }
-        },
-    )?;
-    let run_func = instance
-        .exports
-        .get_function("run")
-        .expect("expected function export");
+        let instance = Instance::new(
+            &module,
+            &imports! {
+                "" => {
+                    "hello" => hello_func
+                }
+            },
+        )?;
+        let run_func = instance
+            .exports
+            .get_function("run")
+            .expect("expected function export");
 
-    let e = run_func.call(&[]).err().expect("error calling function");
+        let e = run_func.call(&[]).err().expect("error calling function");
 
-    assert_eq!(e.message(), "test 123");
+        assert_eq!(e.message(), "test 123");
+    }
 
     Ok(())
 }
 
 #[test]
 #[cfg_attr(
-    any(
-        feature = "test-singlepass",
-        feature = "test-native",
-        target_arch = "aarch64",
-        target_env = "musl",
-    ),
+    any(feature = "test-native", target_arch = "aarch64", target_env = "musl",),
     ignore
 )]
 fn test_trap_trace() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers()
+        .iter()
+        .filter(|&&c| !matches!(c, "singlepass"))
+    {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $hello_mod
             (func (export "run") (call $hello))
             (func $hello (unreachable))
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let instance = Instance::new(&module, &imports! {})?;
-    let run_func = instance
-        .exports
-        .get_function("run")
-        .expect("expected function export");
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        let run_func = instance
+            .exports
+            .get_function("run")
+            .expect("expected function export");
 
-    let e = run_func.call(&[]).err().expect("error calling function");
+        let e = run_func.call(&[]).err().expect("error calling function");
 
-    let trace = e.trace();
-    assert_eq!(trace.len(), 2);
-    assert_eq!(trace[0].module_name(), "hello_mod");
-    assert_eq!(trace[0].func_index(), 1);
-    assert_eq!(trace[0].function_name(), Some("hello"));
-    assert_eq!(trace[1].module_name(), "hello_mod");
-    assert_eq!(trace[1].func_index(), 0);
-    assert_eq!(trace[1].function_name(), None);
-    assert!(
-        e.message().contains("unreachable"),
-        "wrong message: {}",
-        e.message()
-    );
+        let trace = e.trace();
+        assert_eq!(trace.len(), 2);
+        assert_eq!(trace[0].module_name(), "hello_mod");
+        assert_eq!(trace[0].func_index(), 1);
+        assert_eq!(trace[0].function_name(), Some("hello"));
+        assert_eq!(trace[1].module_name(), "hello_mod");
+        assert_eq!(trace[1].func_index(), 0);
+        assert_eq!(trace[1].function_name(), None);
+        assert!(
+            e.message().contains("unreachable"),
+            "wrong message: {}",
+            e.message()
+        );
+    }
 
     Ok(())
 }
 
 #[test]
 fn test_trap_trace_cb() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $hello_mod
             (import "" "throw" (func $throw))
             (func (export "run") (call $hello))
@@ -93,91 +96,90 @@ fn test_trap_trace_cb() -> Result<()> {
         )
     "#;
 
-    let fn_type = FunctionType::new(vec![], vec![]);
-    let fn_func = Function::new(&store, &fn_type, |_| Err(RuntimeError::new("cb throw")));
+        let fn_type = FunctionType::new(vec![], vec![]);
+        let fn_func = Function::new(&store, &fn_type, |_| Err(RuntimeError::new("cb throw")));
 
-    let module = Module::new(&store, wat)?;
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "" => {
-                "throw" => fn_func
-            }
-        },
-    )?;
-    let run_func = instance
-        .exports
-        .get_function("run")
-        .expect("expected function export");
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(
+            &module,
+            &imports! {
+                "" => {
+                    "throw" => fn_func
+                }
+            },
+        )?;
+        let run_func = instance
+            .exports
+            .get_function("run")
+            .expect("expected function export");
 
-    let e = run_func.call(&[]).err().expect("error calling function");
+        let e = run_func.call(&[]).err().expect("error calling function");
 
-    let trace = e.trace();
-    println!("Trace {:?}", trace);
-    // TODO: Reenable this (disabled as it was not working with llvm/singlepass)
-    // assert_eq!(trace.len(), 2);
-    // assert_eq!(trace[0].module_name(), "hello_mod");
-    // assert_eq!(trace[0].func_index(), 2);
-    // assert_eq!(trace[1].module_name(), "hello_mod");
-    // assert_eq!(trace[1].func_index(), 1);
-    assert_eq!(e.message(), "cb throw");
+        let trace = e.trace();
+        println!("Trace {:?}", trace);
+        // TODO: Reenable this (disabled as it was not working with llvm/singlepass)
+        // assert_eq!(trace.len(), 2);
+        // assert_eq!(trace[0].module_name(), "hello_mod");
+        // assert_eq!(trace[0].func_index(), 2);
+        // assert_eq!(trace[1].module_name(), "hello_mod");
+        // assert_eq!(trace[1].func_index(), 1);
+        assert_eq!(e.message(), "cb throw");
+    }
 
     Ok(())
 }
 
 #[test]
 #[cfg_attr(
-    any(
-        feature = "test-singlepass",
-        feature = "test-native",
-        target_arch = "aarch64",
-        target_env = "musl",
-    ),
+    any(feature = "test-native", target_arch = "aarch64", target_env = "musl",),
     ignore
 )]
 fn test_trap_stack_overflow() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers()
+        .iter()
+        .filter(|&&c| !matches!(c, "singlepass"))
+    {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $rec_mod
             (func $run (export "run") (call $run))
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let instance = Instance::new(&module, &imports! {})?;
-    let run_func = instance
-        .exports
-        .get_function("run")
-        .expect("expected function export");
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        let run_func = instance
+            .exports
+            .get_function("run")
+            .expect("expected function export");
 
-    let e = run_func.call(&[]).err().expect("error calling function");
+        let e = run_func.call(&[]).err().expect("error calling function");
 
-    let trace = e.trace();
-    assert!(trace.len() >= 32);
-    for i in 0..trace.len() {
-        assert_eq!(trace[i].module_name(), "rec_mod");
-        assert_eq!(trace[i].func_index(), 0);
-        assert_eq!(trace[i].function_name(), Some("run"));
+        let trace = e.trace();
+        assert!(trace.len() >= 32);
+        for i in 0..trace.len() {
+            assert_eq!(trace[i].module_name(), "rec_mod");
+            assert_eq!(trace[i].func_index(), 0);
+            assert_eq!(trace[i].function_name(), Some("run"));
+        }
+        assert!(e.message().contains("call stack exhausted"));
     }
-    assert!(e.message().contains("call stack exhausted"));
 
     Ok(())
 }
 
 #[test]
 #[cfg_attr(
-    any(
-        feature = "test-singlepass",
-        feature = "test-llvm",
-        feature = "test-native",
-        target_arch = "aarch64",
-        target_env = "musl",
-    ),
+    any(feature = "test-native", target_arch = "aarch64", target_env = "musl",),
     ignore
 )]
 fn trap_display_pretty() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers()
+        .iter()
+        .filter(|&&c| !matches!(c, "singlepass" | "llvm"))
+    {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $m
             (func $die unreachable)
             (func call $die)
@@ -186,40 +188,39 @@ fn trap_display_pretty() -> Result<()> {
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let instance = Instance::new(&module, &imports! {})?;
-    let run_func = instance
-        .exports
-        .get_function("bar")
-        .expect("expected function export");
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        let run_func = instance
+            .exports
+            .get_function("bar")
+            .expect("expected function export");
 
-    let e = run_func.call(&[]).err().expect("error calling function");
-    assert_eq!(
-        e.to_string(),
-        "\
+        let e = run_func.call(&[]).err().expect("error calling function");
+        assert_eq!(
+            e.to_string(),
+            "\
 RuntimeError: unreachable
     at die (m[0]:0x23)
     at <unnamed> (m[1]:0x27)
     at foo (m[2]:0x2c)
     at <unnamed> (m[3]:0x31)"
-    );
+        );
+    }
     Ok(())
 }
 
 #[test]
 #[cfg_attr(
-    any(
-        feature = "test-singlepass",
-        feature = "test-llvm",
-        feature = "test-native",
-        target_arch = "aarch64",
-        target_env = "musl",
-    ),
+    any(feature = "test-native", target_arch = "aarch64", target_env = "musl",),
     ignore
 )]
 fn trap_display_multi_module() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers()
+        .iter()
+        .filter(|&&c| !matches!(c, "singlepass" | "llvm"))
+    {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $a
             (func $die unreachable)
             (func call $die)
@@ -228,35 +229,35 @@ fn trap_display_multi_module() -> Result<()> {
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let instance = Instance::new(&module, &imports! {})?;
-    let bar = instance.exports.get_function("bar")?.clone();
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        let bar = instance.exports.get_function("bar")?.clone();
 
-    let wat = r#"
+        let wat = r#"
         (module $b
             (import "" "" (func $bar))
             (func $middle call $bar)
             (func (export "bar2") call $middle)
         )
     "#;
-    let module = Module::new(&store, wat)?;
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "" => {
-                "" => bar
-            }
-        },
-    )?;
-    let bar2 = instance
-        .exports
-        .get_function("bar2")
-        .expect("expected function export");
+        let module = Module::new(&store, wat)?;
+        let instance = Instance::new(
+            &module,
+            &imports! {
+                "" => {
+                    "" => bar
+                }
+            },
+        )?;
+        let bar2 = instance
+            .exports
+            .get_function("bar2")
+            .expect("expected function export");
 
-    let e = bar2.call(&[]).err().expect("error calling function");
-    assert_eq!(
-        e.to_string(),
-        "\
+        let e = bar2.call(&[]).err().expect("error calling function");
+        assert_eq!(
+            e.to_string(),
+            "\
 RuntimeError: unreachable
     at die (a[0]:0x23)
     at <unnamed> (a[1]:0x27)
@@ -264,39 +265,42 @@ RuntimeError: unreachable
     at <unnamed> (a[3]:0x31)
     at middle (b[1]:0x29)
     at <unnamed> (b[2]:0x2e)"
-    );
+        );
+    }
     Ok(())
 }
 
 #[test]
 fn trap_start_function_import() -> Result<()> {
-    let store = get_store(false);
-    let binary = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let binary = r#"
         (module $a
             (import "" "" (func $foo))
             (start $foo)
         )
     "#;
 
-    let module = Module::new(&store, &binary)?;
-    let sig = FunctionType::new(vec![], vec![]);
-    let func = Function::new(&store, &sig, |_| Err(RuntimeError::new("user trap")));
-    let err = Instance::new(
-        &module,
-        &imports! {
-            "" => {
-                "" => func
+        let module = Module::new(&store, &binary)?;
+        let sig = FunctionType::new(vec![], vec![]);
+        let func = Function::new(&store, &sig, |_| Err(RuntimeError::new("user trap")));
+        let err = Instance::new(
+            &module,
+            &imports! {
+                "" => {
+                    "" => func
+                }
+            },
+        )
+        .err()
+        .unwrap();
+        match err {
+            InstantiationError::Link(_) | InstantiationError::HostEnvInitialization(_) => {
+                panic!("It should be a start error")
             }
-        },
-    )
-    .err()
-    .unwrap();
-    match err {
-        InstantiationError::Link(_) | InstantiationError::HostEnvInitialization(_) => {
-            panic!("It should be a start error")
-        }
-        InstantiationError::Start(err) => {
-            assert_eq!(err.message(), "user trap");
+            InstantiationError::Start(err) => {
+                assert_eq!(err.message(), "user trap");
+            }
         }
     }
 
@@ -305,8 +309,9 @@ fn trap_start_function_import() -> Result<()> {
 
 #[test]
 fn rust_panic_import() -> Result<()> {
-    let store = get_store(false);
-    let binary = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let binary = r#"
         (module $a
             (import "" "foo" (func $foo))
             (import "" "bar" (func $bar))
@@ -315,118 +320,121 @@ fn rust_panic_import() -> Result<()> {
         )
     "#;
 
-    let module = Module::new(&store, &binary)?;
-    let sig = FunctionType::new(vec![], vec![]);
-    let func = Function::new(&store, &sig, |_| panic!("this is a panic"));
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "" => {
-                "foo" => func,
-                "bar" => Function::new_native(&store, || panic!("this is another panic"))
-            }
-        },
-    )?;
-    let func = instance.exports.get_function("foo")?.clone();
-    let err = panic::catch_unwind(AssertUnwindSafe(|| {
-        drop(func.call(&[]));
-    }))
-    .unwrap_err();
-    assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
+        let module = Module::new(&store, &binary)?;
+        let sig = FunctionType::new(vec![], vec![]);
+        let func = Function::new(&store, &sig, |_| panic!("this is a panic"));
+        let instance = Instance::new(
+            &module,
+            &imports! {
+                "" => {
+                    "foo" => func,
+                    "bar" => Function::new_native(&store, || panic!("this is another panic"))
+                }
+            },
+        )?;
+        let func = instance.exports.get_function("foo")?.clone();
+        let err = panic::catch_unwind(AssertUnwindSafe(|| {
+            drop(func.call(&[]));
+        }))
+        .unwrap_err();
+        assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    // TODO: Reenable this (disabled as it was not working with llvm/singlepass)
-    // It doesn't work either with cranelift and `--test-threads=1`.
-    // let func = instance.exports.get_function("bar")?.clone();
-    // let err = panic::catch_unwind(AssertUnwindSafe(|| {
-    //     drop(func.call(&[]));
-    // }))
-    // .unwrap_err();
-    // assert_eq!(
-    //     err.downcast_ref::<&'static str>(),
-    //     Some(&"this is another panic")
-    // );
+        // TODO: Reenable this (disabled as it was not working with llvm/singlepass)
+        // It doesn't work either with cranelift and `--test-threads=1`.
+        // let func = instance.exports.get_function("bar")?.clone();
+        // let err = panic::catch_unwind(AssertUnwindSafe(|| {
+        //     drop(func.call(&[]));
+        // }))
+        // .unwrap_err();
+        // assert_eq!(
+        //     err.downcast_ref::<&'static str>(),
+        //     Some(&"this is another panic")
+        // );
+    }
     Ok(())
 }
 
 #[test]
 fn rust_panic_start_function() -> Result<()> {
-    let store = get_store(false);
-    let binary = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let binary = r#"
         (module $a
             (import "" "" (func $foo))
             (start $foo)
         )
     "#;
 
-    let module = Module::new(&store, &binary)?;
-    let sig = FunctionType::new(vec![], vec![]);
-    let func = Function::new(&store, &sig, |_| panic!("this is a panic"));
-    let err = panic::catch_unwind(AssertUnwindSafe(|| {
-        drop(Instance::new(
-            &module,
-            &imports! {
-                "" => {
-                    "" => func
-                }
-            },
-        ));
-    }))
-    .unwrap_err();
-    assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
+        let module = Module::new(&store, &binary)?;
+        let sig = FunctionType::new(vec![], vec![]);
+        let func = Function::new(&store, &sig, |_| panic!("this is a panic"));
+        let err = panic::catch_unwind(AssertUnwindSafe(|| {
+            drop(Instance::new(
+                &module,
+                &imports! {
+                    "" => {
+                        "" => func
+                    }
+                },
+            ));
+        }))
+        .unwrap_err();
+        assert_eq!(err.downcast_ref::<&'static str>(), Some(&"this is a panic"));
 
-    let func = Function::new_native(&store, || panic!("this is another panic"));
-    let err = panic::catch_unwind(AssertUnwindSafe(|| {
-        drop(Instance::new(
-            &module,
-            &imports! {
-                "" => {
-                    "" => func
-                }
-            },
-        ));
-    }))
-    .unwrap_err();
-    assert_eq!(
-        err.downcast_ref::<&'static str>(),
-        Some(&"this is another panic")
-    );
+        let func = Function::new_native(&store, || panic!("this is another panic"));
+        let err = panic::catch_unwind(AssertUnwindSafe(|| {
+            drop(Instance::new(
+                &module,
+                &imports! {
+                    "" => {
+                        "" => func
+                    }
+                },
+            ));
+        }))
+        .unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<&'static str>(),
+            Some(&"this is another panic")
+        );
+    }
     Ok(())
 }
 
 #[test]
 fn mismatched_arguments() -> Result<()> {
-    let store = get_store(false);
-    let binary = r#"
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let binary = r#"
         (module $a
             (func (export "foo") (param i32))
         )
     "#;
 
-    let module = Module::new(&store, &binary)?;
-    let instance = Instance::new(&module, &imports! {})?;
-    let func: &Function = instance.exports.get("foo")?;
-    assert_eq!(
-        func.call(&[]).unwrap_err().message(),
-        "Parameters of type [] did not match signature [I32] -> []"
-    );
-    assert_eq!(
-        func.call(&[Val::F32(0.0)]).unwrap_err().message(),
-        "Parameters of type [F32] did not match signature [I32] -> []",
-    );
-    assert_eq!(
-        func.call(&[Val::I32(0), Val::I32(1)])
-            .unwrap_err()
-            .message(),
-        "Parameters of type [I32, I32] did not match signature [I32] -> []"
-    );
+        let module = Module::new(&store, &binary)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        let func: &Function = instance.exports.get("foo")?;
+        assert_eq!(
+            func.call(&[]).unwrap_err().message(),
+            "Parameters of type [] did not match signature [I32] -> []"
+        );
+        assert_eq!(
+            func.call(&[Val::F32(0.0)]).unwrap_err().message(),
+            "Parameters of type [F32] did not match signature [I32] -> []",
+        );
+        assert_eq!(
+            func.call(&[Val::I32(0), Val::I32(1)])
+                .unwrap_err()
+                .message(),
+            "Parameters of type [I32, I32] did not match signature [I32] -> []"
+        );
+    }
     Ok(())
 }
 
 #[test]
 #[cfg_attr(
     any(
-        feature = "test-singlepass",
-        feature = "test-llvm",
         feature = "test-native",
         all(target_os = "macos", target_arch = "aarch64"),
         target_env = "musl",
@@ -434,8 +442,12 @@ fn mismatched_arguments() -> Result<()> {
     ignore
 )]
 fn call_signature_mismatch() -> Result<()> {
-    let store = get_store(false);
-    let binary = r#"
+    for compiler in get_compilers()
+        .iter()
+        .filter(|&&c| !matches!(c, "singlepass" | "llvm"))
+    {
+        let store = get_store(false, compiler);
+        let binary = r#"
         (module $a
             (func $foo
                 i32.const 0
@@ -448,34 +460,33 @@ fn call_signature_mismatch() -> Result<()> {
         )
     "#;
 
-    let module = Module::new(&store, &binary)?;
-    let err = Instance::new(&module, &imports! {})
-        .err()
-        .expect("expected error");
-    assert_eq!(
-        format!("{}", err),
-        "\
+        let module = Module::new(&store, &binary)?;
+        let err = Instance::new(&module, &imports! {})
+            .err()
+            .expect("expected error");
+        assert_eq!(
+            format!("{}", err),
+            "\
 RuntimeError: indirect call type mismatch
     at foo (a[0]:0x30)\
 "
-    );
+        );
+    }
     Ok(())
 }
 
 #[test]
 #[cfg_attr(
-    any(
-        feature = "test-singlepass",
-        feature = "test-llvm",
-        feature = "test-native",
-        target_arch = "aarch64",
-        target_env = "musl",
-    ),
+    any(feature = "test-native", target_arch = "aarch64", target_env = "musl",),
     ignore
 )]
 fn start_trap_pretty() -> Result<()> {
-    let store = get_store(false);
-    let wat = r#"
+    for compiler in get_compilers()
+        .iter()
+        .filter(|&&c| !matches!(c, "singlepass" | "llvm"))
+    {
+        let store = get_store(false, compiler);
+        let wat = r#"
         (module $m
             (func $die unreachable)
             (func call $die)
@@ -485,42 +496,45 @@ fn start_trap_pretty() -> Result<()> {
         )
     "#;
 
-    let module = Module::new(&store, wat)?;
-    let err = Instance::new(&module, &imports! {})
-        .err()
-        .expect("expected error");
+        let module = Module::new(&store, wat)?;
+        let err = Instance::new(&module, &imports! {})
+            .err()
+            .expect("expected error");
 
-    assert_eq!(
-        format!("{}", err),
-        "\
+        assert_eq!(
+            format!("{}", err),
+            "\
 RuntimeError: unreachable
     at die (m[0]:0x1d)
     at <unnamed> (m[1]:0x21)
     at foo (m[2]:0x26)
     at start (m[3]:0x2b)\
 "
-    );
+        );
+    }
     Ok(())
 }
 
 #[test]
 fn present_after_module_drop() -> Result<()> {
-    let store = get_store(false);
-    let module = Module::new(&store, r#"(func (export "foo") unreachable)"#)?;
-    let instance = Instance::new(&module, &imports! {})?;
-    let func: Function = instance.exports.get_function("foo")?.clone();
+    for compiler in get_compilers() {
+        let store = get_store(false, compiler);
+        let module = Module::new(&store, r#"(func (export "foo") unreachable)"#)?;
+        let instance = Instance::new(&module, &imports! {})?;
+        let func: Function = instance.exports.get_function("foo")?.clone();
 
-    println!("asserting before we drop modules");
-    assert_trap(func.call(&[]).unwrap_err());
-    drop((instance, module));
+        println!("asserting before we drop modules");
+        assert_trap(func.call(&[]).unwrap_err());
+        drop((instance, module));
 
-    println!("asserting after drop");
-    assert_trap(func.call(&[]).unwrap_err());
-    return Ok(());
+        println!("asserting after drop");
+        assert_trap(func.call(&[]).unwrap_err());
 
-    fn assert_trap(t: RuntimeError) {
-        println!("{}", t);
-        // assert_eq!(t.trace().len(), 1);
-        // assert_eq!(t.trace()[0].func_index(), 0);
+        fn assert_trap(t: RuntimeError) {
+            println!("{}", t);
+            // assert_eq!(t.trace().len(), 1);
+            // assert_eq!(t.trace()[0].func_index(), 0);
+        }
     }
+    Ok(())
 }

--- a/tests/compilers/utils.rs
+++ b/tests/compilers/utils.rs
@@ -59,8 +59,8 @@ pub fn get_engine(canonicalize_nans: bool, compiler: &str) -> impl Engine {
     JIT::new(compiler_config).engine()
 }
 #[cfg(feature = "test-native")]
-pub fn get_engine(canonicalize_nans: bool) -> impl Engine {
-    let compiler_config = get_compiler(canonicalize_nans);
+pub fn get_engine(canonicalize_nans: bool, compiler: &str) -> impl Engine {
+    let compiler_config = get_compiler(canonicalize_nans, compiler);
     Native::new(compiler_config).engine()
 }
 

--- a/tests/compilers/utils.rs
+++ b/tests/compilers/utils.rs
@@ -7,37 +7,55 @@ use wasmer_engine_jit::JIT;
 #[cfg(feature = "test-native")]
 use wasmer_engine_native::Native;
 
-pub fn get_compiler(canonicalize_nans: bool) -> impl CompilerConfig {
-    cfg_if::cfg_if! {
-        if #[cfg(any(
-            all(feature = "test-llvm", any(feature = "test-cranelift", feature = "test-singlepass")),
-            all(feature = "test-cranelift", feature = "test-singlepass")
-        ))] {
-            compile_error!("Only one compiler can be selected")
-        } else if #[cfg(feature = "test-cranelift")] {
+pub fn get_compiler(canonicalize_nans: bool, compiler: &str) -> Box<dyn CompilerConfig> {
+    #[cfg(not(any(
+        feature = "test-cranelift",
+        feature = "test-llvm",
+        feature = "test-singlepass"
+    )))]
+    compile_error!("No compiler chosen for the tests");
+    match compiler {
+        #[cfg(feature = "test-cranelift")]
+        "cranelift" => {
             let mut compiler = wasmer_compiler_cranelift::Cranelift::new();
             compiler.canonicalize_nans(canonicalize_nans);
             compiler.enable_verifier();
-            compiler
-        } else if #[cfg(feature = "test-llvm")] {
+            Box::new(compiler)
+        }
+        #[cfg(feature = "test-llvm")]
+        "llvm" => {
             let mut compiler = wasmer_compiler_llvm::LLVM::new();
             compiler.canonicalize_nans(canonicalize_nans);
             compiler.enable_verifier();
-            compiler
-        } else if #[cfg(feature = "test-singlepass")] {
+            Box::new(compiler)
+        }
+        #[cfg(feature = "test-singlepass")]
+        "singlepass" => {
             let mut compiler = wasmer_compiler_singlepass::Singlepass::new();
             compiler.canonicalize_nans(canonicalize_nans);
             compiler.enable_verifier();
-            compiler
-        } else {
-            compile_error!("No compiler chosen for the tests")
+            Box::new(compiler)
         }
+        _ => panic!("Unsupported compiler `{}`!", compiler),
     }
 }
 
+const ENABLED_COMPILERS: &'static [&str] = &[
+    #[cfg(feature = "test-cranelift")]
+    "cranelift",
+    #[cfg(feature = "test-llvm")]
+    "llvm",
+    #[cfg(feature = "test-singlepass")]
+    "singlepass",
+];
+
+pub fn get_compilers() -> &'static [&'static str] {
+    &ENABLED_COMPILERS[..]
+}
+
 #[cfg(feature = "test-jit")]
-pub fn get_engine(canonicalize_nans: bool) -> impl Engine {
-    let compiler_config = get_compiler(canonicalize_nans);
+pub fn get_engine(canonicalize_nans: bool, compiler: &str) -> impl Engine {
+    let compiler_config = get_compiler(canonicalize_nans, compiler);
     JIT::new(compiler_config).engine()
 }
 #[cfg(feature = "test-native")]
@@ -46,14 +64,15 @@ pub fn get_engine(canonicalize_nans: bool) -> impl Engine {
     Native::new(compiler_config).engine()
 }
 
-pub fn get_store(canonicalize_nans: bool) -> Store {
-    Store::new(&get_engine(canonicalize_nans))
+pub fn get_store(canonicalize_nans: bool, compiler: &str) -> Store {
+    Store::new(&get_engine(canonicalize_nans, compiler))
 }
 
 pub fn get_store_with_middlewares<I: Iterator<Item = Arc<dyn ModuleMiddleware>>>(
     middlewares: I,
+    compiler: &str,
 ) -> Store {
-    let mut compiler_config = get_compiler(false);
+    let mut compiler_config = get_compiler(false, compiler);
     for x in middlewares {
         compiler_config.push_middleware(x);
     }

--- a/tests/compilers/wasi.rs
+++ b/tests/compilers/wasi.rs
@@ -22,7 +22,7 @@ pub fn run_wasi(wast_path: &str, base_dir: &str, compiler: &str) -> anyhow::Resu
         "Running wasi wast `{}` with the {} compiler",
         wast_path, compiler
     );
-    let store = get_store(true);
+    let store = get_store(true, compiler);
 
     let source = {
         let mut out = String::new();

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -29,8 +29,8 @@ fn _native_prefixer(bytes: &[u8]) -> String {
 }
 
 #[cfg(feature = "test-jit")]
-fn get_store(features: Features, try_nan_canonicalization: bool) -> Store {
-    let compiler_config = get_compiler(try_nan_canonicalization);
+fn get_store(features: Features, try_nan_canonicalization: bool, compiler: &str) -> Store {
+    let compiler_config = get_compiler(try_nan_canonicalization, compiler);
     Store::new(&JIT::new(compiler_config).features(features).engine())
 }
 
@@ -55,10 +55,10 @@ pub fn run_wast(wast_path: &str, compiler: &str) -> anyhow::Result<()> {
     if is_simd {
         features.simd(true);
     }
-    if cfg!(feature = "test-singlepass") {
+    if cfg!(feature = "test-singlepass") && compiler == "singlepass" {
         features.multi_value(false);
     }
-    let store = get_store(features, try_nan_canonicalization);
+    let store = get_store(features, try_nan_canonicalization, compiler);
     let mut wast = Wast::new_with_spectest(store);
     // `bulk-memory-operations/bulk.wast` checks for a message that
     // specifies which element is uninitialized, but our traps don't

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -35,8 +35,8 @@ fn get_store(features: Features, try_nan_canonicalization: bool, compiler: &str)
 }
 
 #[cfg(feature = "test-native")]
-fn get_store(features: Features, try_nan_canonicalization: bool) -> Store {
-    let compiler_config = get_compiler(try_nan_canonicalization);
+fn get_store(features: Features, try_nan_canonicalization: bool, compiler: &str) -> Store {
+    let compiler_config = get_compiler(try_nan_canonicalization, compiler);
     Store::new(&Native::new(compiler_config).features(features).engine())
 }
 


### PR DESCRIPTION
The idea behind this PR is to spend less time compiling in CI and just run all of our tests in parallel directly.

There are still a couple of rough edges, but it works. It's higher priority to do this for the C API but here it is for our core tests. This should improve caching and the performance of our CI tests.

We still require 2 compilation steps rather than 1 for this part, but hopefully we can still see some of the benefits of this