### PR TITLE
wasmer-middlewares: don't force enable wasmer default features

### DIFF
--- a/lib/middlewares/Cargo.toml
+++ b/lib/middlewares/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "1.0.2" }
+wasmer = { path = "../api", version = "1.0.2", default-features = false, features = ["compiler"] }
 wasmer-types = { path = "../types", version = "1.0.2" }
 wasmer-vm = { path = "../vm", version = "1.0.2" }
 loupe = "0.1"


### PR DESCRIPTION
# Description

wasmer-middlewares doesn't need to enable all default features from wasmer
when it's included. This avoid having to build cranelift crates when llvm is used
otherwise etc.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
