### PR TITLE
Recompute `Memory::ty`, make it return by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2135](https://github.com/wasmerio/wasmer/pull/2135) [Documentation](./PACKAGING.md) for linux distribution maintainers
 
 ### Changed
+- [#2293](https://github.com/wasmerio/wasmer/pull/2293) The `Memory::ty` trait method now returns `MemoryType` by value. `wasmer_vm::LinearMemory` now recomputes `MemoryType`'s `minimum` field when accessing its type. This behavior is what's expected by the latest spectests. `wasmer::Memory::ty` has also been updated to follow suit, it now returns `MemoryType` by value.
 - [#2251](https://github.com/wasmerio/wasmer/pull/2251) Wasmer CLI will now execute WASI modules with multiple WASI namespaces in them by default. Use `--allow-multiple-wasi-versions` to suppress the warning and use `--deny-multiple-wasi-versions` to make it an error.
 - [#2201](https://github.com/wasmerio/wasmer/pull/2201) Implement `loupe::MemoryUsage` for `wasmer::Instance`.
 - [#2200](https://github.com/wasmerio/wasmer/pull/2200) Implement `loupe::MemoryUsage` for `wasmer::Module`.

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -73,7 +73,7 @@ impl Memory {
     ///
     /// assert_eq!(m.ty(), &mt);
     /// ```
-    pub fn ty(&self) -> &MemoryType {
+    pub fn ty(&self) -> MemoryType {
         self.vm_memory.from.ty()
     }
 

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -71,7 +71,7 @@ impl Memory {
     /// let mt = MemoryType::new(1, None, false);
     /// let m = Memory::new(&store, mt).unwrap();
     ///
-    /// assert_eq!(m.ty(), &mt);
+    /// assert_eq!(m.ty(), mt);
     /// ```
     pub fn ty(&self) -> MemoryType {
         self.vm_memory.from.ty()

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -41,7 +41,7 @@ impl Extern {
     pub fn ty(&self) -> ExternType {
         match self {
             Self::Function(ft) => ExternType::Function(ft.ty().clone()),
-            Self::Memory(ft) => ExternType::Memory(*ft.ty()),
+            Self::Memory(ft) => ExternType::Memory(ft.ty()),
             Self::Table(tt) => ExternType::Table(*tt.ty()),
             Self::Global(gt) => ExternType::Global(*gt.ty()),
         }

--- a/lib/api/tests/externals.rs
+++ b/lib/api/tests/externals.rs
@@ -144,7 +144,7 @@ fn memory_new() -> Result<()> {
     };
     let memory = Memory::new(&store, memory_type)?;
     assert_eq!(memory.size(), Pages(0));
-    assert_eq!(*memory.ty(), memory_type);
+    assert_eq!(memory.ty(), memory_type);
     Ok(())
 }
 
@@ -209,7 +209,7 @@ fn function_new() -> Result<()> {
 fn function_new_env() -> Result<()> {
     let store = Store::default();
     #[derive(Clone, WasmerEnv)]
-    struct MyEnv {};
+    struct MyEnv {}
 
     let my_env = MyEnv {};
     let function = Function::new_native_with_env(&store, my_env.clone(), |_env: &MyEnv| {});
@@ -281,7 +281,7 @@ fn function_new_dynamic() -> Result<()> {
 fn function_new_dynamic_env() -> Result<()> {
     let store = Store::default();
     #[derive(Clone, WasmerEnv)]
-    struct MyEnv {};
+    struct MyEnv {}
     let my_env = MyEnv {};
 
     // Using &FunctionType signature

--- a/lib/engine/src/resolver.rs
+++ b/lib/engine/src/resolver.rs
@@ -113,7 +113,7 @@ fn get_extern_from_export(_module: &ModuleInfo, export: &Export) -> ExternType {
     match export {
         Export::Function(ref f) => ExternType::Function(f.vm_function.signature.clone()),
         Export::Table(ref t) => ExternType::Table(*t.ty()),
-        Export::Memory(ref m) => ExternType::Memory(*m.ty()),
+        Export::Memory(ref m) => ExternType::Memory(m.ty()),
         Export::Global(ref g) => {
             let global = g.from.ty();
             ExternType::Global(*global)

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -140,7 +140,7 @@ unsafe impl Sync for VMMemory {}
 
 impl VMMemory {
     /// Get the type for this exported memory
-    pub fn ty(&self) -> &MemoryType {
+    pub fn ty(&self) -> MemoryType {
         self.from.ty()
     }
 

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -105,7 +105,7 @@ impl MemoryStyle {
 /// Trait for implementing Wasm Memory used by Wasmer.
 pub trait Memory: fmt::Debug + Send + Sync + MemoryUsage {
     /// Returns the memory type for this memory.
-    fn ty(&self) -> &MemoryType;
+    fn ty(&self) -> MemoryType;
 
     /// Returns the memory style for this memory.
     fn style(&self) -> &MemoryStyle;
@@ -310,8 +310,12 @@ impl LinearMemory {
 
 impl Memory for LinearMemory {
     /// Returns the type for this memory.
-    fn ty(&self) -> &MemoryType {
-        &self.memory
+    fn ty(&self) -> MemoryType {
+        let minimum = self.size();
+        let mut out = self.memory.clone();
+        out.minimum = minimum;
+
+        out
     }
 
     /// Returns the memory style for this memory.


### PR DESCRIPTION
Part of #2268 , gets the updated `imports.wast` passing with all compilers

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
