### PR TITLE
Generalize these strings, stop chasing changing error messages.

### DIFF
--- a/fuzz/fuzz_targets/jit_cranelift.rs
+++ b/fuzz/fuzz_targets/jit_cranelift.rs
@@ -48,14 +48,7 @@ fuzz_target!(|module: WasmSmithModule| {
         Ok(_) => {}
         Err(e) => {
             let error_message = format!("{}", e);
-            if error_message
-                .contains("RuntimeError: memory out of bounds: data segment does not fit")
-                || error_message
-                    .contains("RuntimeError: table out of bounds: elements segment does not fit")
-                || error_message.contains(
-                    "RuntimeError: out of bounds table access: elements segment does not fit",
-                )
-            {
+            if error_message.contains("RuntimeError: ") && error_message.contains("out of bounds") {
                 return;
             }
             panic!("{}", e);

--- a/fuzz/fuzz_targets/jit_llvm.rs
+++ b/fuzz/fuzz_targets/jit_llvm.rs
@@ -48,14 +48,7 @@ fuzz_target!(|module: WasmSmithModule| {
         Ok(_) => {}
         Err(e) => {
             let error_message = format!("{}", e);
-            if error_message
-                .contains("RuntimeError: memory out of bounds: data segment does not fit")
-                || error_message
-                    .contains("RuntimeError: table out of bounds: elements segment does not fit")
-                || error_message.contains(
-                    "RuntimeError: out of bounds table access: elements segment does not fit",
-                )
-            {
+            if error_message.contains("RuntimeError: ") && error_message.contains("out of bounds") {
                 return;
             }
             panic!("{}", e);

--- a/fuzz/fuzz_targets/jit_singlepass.rs
+++ b/fuzz/fuzz_targets/jit_singlepass.rs
@@ -56,14 +56,7 @@ fuzz_target!(|module: WasmSmithModule| {
         Ok(_) => {}
         Err(e) => {
             let error_message = format!("{}", e);
-            if error_message
-                .contains("RuntimeError: memory out of bounds: data segment does not fit")
-                || error_message
-                    .contains("RuntimeError: table out of bounds: elements segment does not fit")
-                || error_message.contains(
-                    "RuntimeError: out of bounds table access: elements segment does not fit",
-                )
-            {
+            if error_message.contains("RuntimeError: ") && error_message.contains("out of bounds") {
                 return;
             }
             panic!("{}", e);

--- a/fuzz/fuzz_targets/metering.rs
+++ b/fuzz/fuzz_targets/metering.rs
@@ -62,14 +62,7 @@ fuzz_target!(|module: WasmSmithModule| {
         Ok(_) => {}
         Err(e) => {
             let error_message = format!("{}", e);
-            if error_message
-                .contains("RuntimeError: memory out of bounds: data segment does not fit")
-                || error_message
-                    .contains("RuntimeError: table out of bounds: elements segment does not fit")
-                || error_message.contains(
-                    "RuntimeError: out of bounds table access: elements segment does not fit",
-                )
-            {
+            if error_message.contains("RuntimeError: ") && error_message.contains("out of bounds") {
                 return;
             }
             panic!("{}", e);

--- a/fuzz/fuzz_targets/native_cranelift.rs
+++ b/fuzz/fuzz_targets/native_cranelift.rs
@@ -53,14 +53,7 @@ fuzz_target!(|module: WasmSmithModule| {
         Ok(_) => {}
         Err(e) => {
             let error_message = format!("{}", e);
-            if error_message
-                .contains("RuntimeError: memory out of bounds: data segment does not fit")
-                || error_message
-                    .contains("RuntimeError: table out of bounds: elements segment does not fit")
-                || error_message.contains(
-                    "RuntimeError: out of bounds table access: elements segment does not fit",
-                )
-            {
+            if error_message.contains("RuntimeError: ") && error_message.contains("out of bounds") {
                 return;
             }
             panic!("{}", e);


### PR DESCRIPTION
A runtime error encountered during instantiation has to be one of the kinds of errors that can occur during instantiation, out of bounds covers the cases like initializing memory or table entries that don't exist.
