### PR TITLE
Remove unused `vm::TrapCode` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2135](https://github.com/wasmerio/wasmer/pull/2135) [Documentation](./PACKAGING.md) for linux distribution maintainers
 
 ### Changed
+- [#2299](https://github.com/wasmerio/wasmer/pull/2299) Unused trap codes (due to Wasm spec changes), `HeapSetterOutOfBounds` and `TableSetterOutOfBounds` were removed from `wasmer_vm::TrapCode` and the numbering of the remaining variants has been adjusted.
 - [#2293](https://github.com/wasmerio/wasmer/pull/2293) The `Memory::ty` trait method now returns `MemoryType` by value. `wasmer_vm::LinearMemory` now recomputes `MemoryType`'s `minimum` field when accessing its type. This behavior is what's expected by the latest spectests. `wasmer::Memory::ty` has also been updated to follow suit, it now returns `MemoryType` by value.
 - [#2251](https://github.com/wasmerio/wasmer/pull/2251) Wasmer CLI will now execute WASI modules with multiple WASI namespaces in them by default. Use `--allow-multiple-wasi-versions` to suppress the warning and use `--deny-multiple-wasi-versions` to make it an error.
 - [#2201](https://github.com/wasmerio/wasmer/pull/2201) Implement `loupe::MemoryUsage` for `wasmer::Instance`.

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -87,7 +87,7 @@ pub trait Table: fmt::Debug + Send + Sync + MemoryUsage {
         }
 
         if dst_index.checked_add(len).map_or(true, |m| m > self.size()) {
-            return Err(Trap::new_from_runtime(TrapCode::TableSetterOutOfBounds));
+            return Err(Trap::new_from_runtime(TrapCode::TableAccessOutOfBounds));
         }
 
         let srcs = src_index..src_index + len;

--- a/lib/vm/src/trap/trapcode.rs
+++ b/lib/vm/src/trap/trapcode.rs
@@ -37,44 +37,39 @@ pub enum TrapCode {
     /// A `heap_addr` instruction was misaligned.
     HeapMisaligned = 2,
 
-    /// Table Elements doesn't fit the table size.
-    ///
-    /// This only can happen during instantiation.
-    TableSetterOutOfBounds = 3,
-
     /// A `table_addr` instruction detected an out-of-bounds error.
-    TableAccessOutOfBounds = 4,
+    TableAccessOutOfBounds = 3,
 
     /// Other bounds checking error.
-    OutOfBounds = 5,
+    OutOfBounds = 4,
 
     /// Indirect call to a null table entry.
-    IndirectCallToNull = 6,
+    IndirectCallToNull = 5,
 
     /// Signature mismatch on indirect call.
-    BadSignature = 7,
+    BadSignature = 6,
 
     /// An integer arithmetic operation caused an overflow.
-    IntegerOverflow = 8,
+    IntegerOverflow = 7,
 
     /// An integer division by zero.
-    IntegerDivisionByZero = 9,
+    IntegerDivisionByZero = 8,
 
     /// Failed float-to-int conversion.
-    BadConversionToInteger = 10,
+    BadConversionToInteger = 9,
 
     /// Code that was supposed to have been unreachable was reached.
-    UnreachableCodeReached = 11,
+    UnreachableCodeReached = 10,
 
     /// Execution has potentially run too long and may be interrupted.
     /// This trap is resumable.
-    Interrupt = 12,
+    Interrupt = 11,
 
     /// An atomic memory access was attempted with an unaligned pointer.
-    UnalignedAtomic = 13,
+    UnalignedAtomic = 12,
 
     /// A trap indicating that the runtime was unable to allocate sufficient memory.
-    VMOutOfMemory = 14,
+    VMOutOfMemory = 13,
     // /// A user-defined trap code.
     // User(u16),
 }
@@ -86,9 +81,6 @@ impl TrapCode {
             Self::StackOverflow => "call stack exhausted",
             Self::HeapAccessOutOfBounds => "out of bounds memory access",
             Self::HeapMisaligned => "misaligned heap",
-            Self::TableSetterOutOfBounds => {
-                "out of bounds table access: elements segment does not fit"
-            }
             Self::TableAccessOutOfBounds => "undefined element: out of bounds table access",
             Self::OutOfBounds => "out of bounds",
             Self::IndirectCallToNull => "uninitialized element",
@@ -111,7 +103,6 @@ impl Display for TrapCode {
             Self::StackOverflow => "stk_ovf",
             Self::HeapAccessOutOfBounds => "heap_get_oob",
             Self::HeapMisaligned => "heap_misaligned",
-            Self::TableSetterOutOfBounds => "table_set_oob",
             Self::TableAccessOutOfBounds => "table_get_oob",
             Self::OutOfBounds => "oob",
             Self::IndirectCallToNull => "icall_null",
@@ -138,7 +129,6 @@ impl FromStr for TrapCode {
             "stk_ovf" => Ok(StackOverflow),
             "heap_get_oob" => Ok(HeapAccessOutOfBounds),
             "heap_misaligned" => Ok(HeapMisaligned),
-            "table_set_oob" => Ok(TableSetterOutOfBounds),
             "table_get_oob" => Ok(TableAccessOutOfBounds),
             "oob" => Ok(OutOfBounds),
             "icall_null" => Ok(IndirectCallToNull),
@@ -161,11 +151,10 @@ mod tests {
     use super::*;
 
     // Everything but user-defined codes.
-    const CODES: [TrapCode; 15] = [
+    const CODES: [TrapCode; 13] = [
         TrapCode::StackOverflow,
         TrapCode::HeapAccessOutOfBounds,
         TrapCode::HeapMisaligned,
-        TrapCode::TableSetterOutOfBounds,
         TrapCode::TableAccessOutOfBounds,
         TrapCode::OutOfBounds,
         TrapCode::IndirectCallToNull,

--- a/lib/vm/src/trap/trapcode.rs
+++ b/lib/vm/src/trap/trapcode.rs
@@ -27,61 +27,54 @@ pub enum TrapCode {
     /// stack guard page.
     StackOverflow = 0,
 
-    /// Memory data doesn't fit the memory size.
-    ///
-    /// This only can happen during instantiation.
-    // TODO(bulk_memory): this is currently unused, if it's not used by the bulk
-    // memory spectests then we should remove it from Wasmer.
-    HeapSetterOutOfBounds = 1,
-
     /// A `heap_addr` instruction detected an out-of-bounds error.
     ///
     /// Note that not all out-of-bounds heap accesses are reported this way;
     /// some are detected by a segmentation fault on the heap unmapped or
     /// offset-guard pages.
-    HeapAccessOutOfBounds = 2,
+    HeapAccessOutOfBounds = 1,
 
     /// A `heap_addr` instruction was misaligned.
-    HeapMisaligned = 3,
+    HeapMisaligned = 2,
 
     /// Table Elements doesn't fit the table size.
     ///
     /// This only can happen during instantiation.
-    TableSetterOutOfBounds = 4,
+    TableSetterOutOfBounds = 3,
 
     /// A `table_addr` instruction detected an out-of-bounds error.
-    TableAccessOutOfBounds = 5,
+    TableAccessOutOfBounds = 4,
 
     /// Other bounds checking error.
-    OutOfBounds = 6,
+    OutOfBounds = 5,
 
     /// Indirect call to a null table entry.
-    IndirectCallToNull = 7,
+    IndirectCallToNull = 6,
 
     /// Signature mismatch on indirect call.
-    BadSignature = 8,
+    BadSignature = 7,
 
     /// An integer arithmetic operation caused an overflow.
-    IntegerOverflow = 9,
+    IntegerOverflow = 8,
 
     /// An integer division by zero.
-    IntegerDivisionByZero = 10,
+    IntegerDivisionByZero = 9,
 
     /// Failed float-to-int conversion.
-    BadConversionToInteger = 11,
+    BadConversionToInteger = 10,
 
     /// Code that was supposed to have been unreachable was reached.
-    UnreachableCodeReached = 12,
+    UnreachableCodeReached = 11,
 
     /// Execution has potentially run too long and may be interrupted.
     /// This trap is resumable.
-    Interrupt = 13,
+    Interrupt = 12,
 
     /// An atomic memory access was attempted with an unaligned pointer.
-    UnalignedAtomic = 14,
+    UnalignedAtomic = 13,
 
     /// A trap indicating that the runtime was unable to allocate sufficient memory.
-    VMOutOfMemory = 15,
+    VMOutOfMemory = 14,
     // /// A user-defined trap code.
     // User(u16),
 }
@@ -91,7 +84,6 @@ impl TrapCode {
     pub fn message(&self) -> &str {
         match self {
             Self::StackOverflow => "call stack exhausted",
-            Self::HeapSetterOutOfBounds => "memory out of bounds: data segment does not fit",
             Self::HeapAccessOutOfBounds => "out of bounds memory access",
             Self::HeapMisaligned => "misaligned heap",
             Self::TableSetterOutOfBounds => {
@@ -117,7 +109,6 @@ impl Display for TrapCode {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let identifier = match *self {
             Self::StackOverflow => "stk_ovf",
-            Self::HeapSetterOutOfBounds => "heap_set_oob",
             Self::HeapAccessOutOfBounds => "heap_get_oob",
             Self::HeapMisaligned => "heap_misaligned",
             Self::TableSetterOutOfBounds => "table_set_oob",
@@ -145,7 +136,6 @@ impl FromStr for TrapCode {
         use self::TrapCode::*;
         match s {
             "stk_ovf" => Ok(StackOverflow),
-            "heap_set_oob" => Ok(HeapSetterOutOfBounds),
             "heap_get_oob" => Ok(HeapAccessOutOfBounds),
             "heap_misaligned" => Ok(HeapMisaligned),
             "table_set_oob" => Ok(TableSetterOutOfBounds),
@@ -173,7 +163,6 @@ mod tests {
     // Everything but user-defined codes.
     const CODES: [TrapCode; 15] = [
         TrapCode::StackOverflow,
-        TrapCode::HeapSetterOutOfBounds,
         TrapCode::HeapAccessOutOfBounds,
         TrapCode::HeapMisaligned,
         TrapCode::TableSetterOutOfBounds,


### PR DESCRIPTION
Due to the updated spectests, we no longer precheck during initialization meaning
that this trap can never be thrown

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
