### PR TITLE
Update wast crate, ignores.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,7 +2701,7 @@ dependencies = [
  "typetag",
  "wasmer",
  "wasmer-wasi",
- "wast 24.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -2751,15 +2751,6 @@ checksum = "6c7a8b20306d43c09c2c34e0ef68bf2959a11b01a5cae35e4c5dc1e7145547b6"
 
 [[package]]
 name = "wast"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff1e3bd3ad0b2ee7784add89c30dc96b89a54b43e5d6d95d774eda1863b3500"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wast"
 version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
@@ -2773,7 +2764,7 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec280a739b69173e0ffd12c1658507996836ba4e992ed9bc1e5385a0bd72a02"
 dependencies = [
- "wast 35.0.2",
+ "wast",
 ]
 
 [[package]]

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -2,9 +2,6 @@
 singlepass::spec::multi_value
 singlepass::spec::simd
 
-## SIMD in Cranelift 0.67 has a small bug
-cranelift::spec::simd::simd_f64x2_arith
-
 singlepass on windows # Singlepass is not yet supported on Windows
 
 # TODO: We need to fix this. The issue happens only in Cranelift/LLVM and macOS,
@@ -100,7 +97,6 @@ wasitests::snapshot1::unix_open_special_files on windows
 # bulk memory
 cranelift::spec::bulk
 # new simd
-cranelift::spec::simd::simd_align
 cranelift::spec::simd::simd_conversions
 cranelift::spec::simd::simd_f32x4_pmin_pmax
 cranelift::spec::simd::simd_f32x4_rounding
@@ -109,7 +105,6 @@ cranelift::spec::simd::simd_f64x2_rounding
 cranelift::spec::simd::simd_i16x8_extadd_pairwise_i8x16
 cranelift::spec::simd::simd_i16x8_extmul_i8x16
 cranelift::spec::simd::simd_i16x8_q15mulr_sat_s
-cranelift::spec::simd::simd_i16x8_sat_arith
 cranelift::spec::simd::simd_i32x4_dot_i16x8
 cranelift::spec::simd::simd_i32x4_extadd_pairwise_i16x8
 cranelift::spec::simd::simd_i32x4_extmul_i16x8
@@ -118,24 +113,18 @@ cranelift::spec::simd::simd_i64x2_arith2
 cranelift::spec::simd::simd_i64x2_cmp
 cranelift::spec::simd::simd_i64x2_extmul_i32x4
 cranelift::spec::simd::simd_i8x16_arith2
-cranelift::spec::simd::simd_i8x16_sat_arith
 cranelift::spec::simd::simd_int_to_int_extend
-cranelift::spec::simd::simd_load
 cranelift::spec::simd::simd_load16_lane
 cranelift::spec::simd::simd_load32_lane
 cranelift::spec::simd::simd_load64_lane
 cranelift::spec::simd::simd_load8_lane
-cranelift::spec::simd::simd_load_extend
-cranelift::spec::simd::simd_load_splat
 cranelift::spec::simd::simd_load_zero
-cranelift::spec::simd::simd_splat
 cranelift::spec::simd::simd_store16_lane
 cranelift::spec::simd::simd_store32_lane
 cranelift::spec::simd::simd_store64_lane
 cranelift::spec::simd::simd_store8_lane
 
 # new simd
-llvm::spec::simd::simd_align
 llvm::spec::simd::simd_conversions
 llvm::spec::simd::simd_f32x4_pmin_pmax
 llvm::spec::simd::simd_f32x4_rounding
@@ -144,7 +133,6 @@ llvm::spec::simd::simd_f64x2_rounding
 llvm::spec::simd::simd_i16x8_extadd_pairwise_i8x16
 llvm::spec::simd::simd_i16x8_extmul_i8x16
 llvm::spec::simd::simd_i16x8_q15mulr_sat_s
-llvm::spec::simd::simd_i16x8_sat_arith
 llvm::spec::simd::simd_i32x4_dot_i16x8
 llvm::spec::simd::simd_i32x4_extadd_pairwise_i16x8
 llvm::spec::simd::simd_i32x4_extmul_i16x8
@@ -153,17 +141,11 @@ llvm::spec::simd::simd_i64x2_arith2
 llvm::spec::simd::simd_i64x2_cmp
 llvm::spec::simd::simd_i64x2_extmul_i32x4
 llvm::spec::simd::simd_i8x16_arith2
-llvm::spec::simd::simd_i8x16_sat_arith
 llvm::spec::simd::simd_int_to_int_extend
-llvm::spec::simd::simd_load
 llvm::spec::simd::simd_load16_lane
 llvm::spec::simd::simd_load32_lane
 llvm::spec::simd::simd_load64_lane
 llvm::spec::simd::simd_load8_lane
-llvm::spec::simd::simd_load_extend
-llvm::spec::simd::simd_load_splat
-llvm::spec::simd::simd_load_zero
-llvm::spec::simd::simd_splat
 llvm::spec::simd::simd_store16_lane
 llvm::spec::simd::simd_store32_lane
 llvm::spec::simd::simd_store64_lane

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -95,7 +95,7 @@ wasitests::snapshot1::unix_open_special_files on windows
 # Updated spectests
 
 # bulk memory
-cranelift::spec::bulk
+cranelift::spec::bulk on native
 # new simd
 cranelift::spec::simd::simd_conversions
 cranelift::spec::simd::simd_f32x4_pmin_pmax

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 anyhow = "1.0"
 wasmer = { path = "../../../lib/api", version = "1.0.2", default-features = false, features = ["experimental-reference-types-extern-ref"] }
 wasmer-wasi = { path = "../../../lib/wasi", version = "1.0.2" }
-wast = "24.0"
+wast = "35.0"
 serde = "1"
 tempfile = "3"
 thiserror = "1.0"


### PR DESCRIPTION
Some of the SIMD failures were not due to changed semantics, simply changed representations and were failing with parse errors at the wast level. Updating wast resolves this issue and lets us shrink ignores.txt