### PR TITLE
Attempt to solve cyclic ref in WasmerEnv

### DIFF
--- a/lib/api/src/env.rs
+++ b/lib/api/src/env.rs
@@ -87,6 +87,11 @@ pub trait WasmerEnv: Clone + Send + Sync {
     fn init_with_instance(&mut self, _instance: &Instance) -> Result<(), HostEnvInitError> {
         Ok(())
     }
+
+    // TODO: this probably can't reasonably have a default unless we want to default
+    // to leaking memory
+    /// Used to prevent memory leaks with cycles when using `WasmerEnv` with exports.
+    unsafe fn dec_strong_count_if_from_same_instance(&mut self, _instance: &Instance) {}
 }
 
 impl WasmerEnv for u8 {}

--- a/lib/api/src/env.rs
+++ b/lib/api/src/env.rs
@@ -87,11 +87,6 @@ pub trait WasmerEnv: Clone + Send + Sync {
     fn init_with_instance(&mut self, _instance: &Instance) -> Result<(), HostEnvInitError> {
         Ok(())
     }
-
-    // TODO: this probably can't reasonably have a default unless we want to default
-    // to leaking memory
-    /// Used to prevent memory leaks with cycles when using `WasmerEnv` with exports.
-    unsafe fn dec_strong_count_if_from_same_instance(&mut self, _instance: &Instance) {}
 }
 
 impl WasmerEnv for u8 {}

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -725,6 +725,17 @@ impl<'a> Exportable<'a> for Function {
             _ => Err(ExportError::IncompatibleType),
         }
     }
+    unsafe fn get_self_no_increment_if_same_instance(
+        _extern: &'a Extern,
+        instance: &crate::Instance,
+    ) -> Result<Self, ExportError> {
+        let f = Self::get_self_from_extern(_extern)?.clone();
+        let vm_extern = f.exported.vm_function.clone().into();
+        if instance.same_instance_ref(&vm_extern) {
+            f.exported.vm_function.decrement_instance_ref_strong_count();
+        }
+        Ok(f)
+    }
 }
 
 impl fmt::Debug for Function {

--- a/lib/api/src/externals/global.rs
+++ b/lib/api/src/externals/global.rs
@@ -231,4 +231,15 @@ impl<'a> Exportable<'a> for Global {
             _ => Err(ExportError::IncompatibleType),
         }
     }
+    unsafe fn get_self_no_increment_if_same_instance(
+        _extern: &'a Extern,
+        instance: &crate::Instance,
+    ) -> Result<Self, ExportError> {
+        let global = Self::get_self_from_extern(_extern)?.clone();
+        let vm_extern = global.vm_global.clone().into();
+        if instance.same_instance_ref(&vm_extern) {
+            global.vm_global.decrement_instance_ref_strong_count();
+        }
+        Ok(global)
+    }
 }

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -227,6 +227,7 @@ impl Memory {
     }
 
     pub(crate) fn from_vm_export(store: &Store, vm_memory: VMMemory) -> Self {
+        //vm_memory.instance_ref = None;
         Self {
             store: store.clone(),
             vm_memory,
@@ -260,5 +261,16 @@ impl<'a> Exportable<'a> for Memory {
             Extern::Memory(memory) => Ok(memory),
             _ => Err(ExportError::IncompatibleType),
         }
+    }
+    unsafe fn get_self_no_increment_if_same_instance(
+        _extern: &'a Extern,
+        instance: &crate::Instance,
+    ) -> Result<Self, ExportError> {
+        let memory = Self::get_self_from_extern(_extern)?.clone();
+        let vm_extern = memory.vm_memory.clone().into();
+        if instance.same_instance_ref(&vm_extern) {
+            memory.vm_memory.decrement_instance_ref_strong_count();
+        }
+        Ok(memory)
     }
 }

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -72,6 +72,25 @@ impl<'a> Exportable<'a> for Extern {
         // Since this is already an extern, we can just return it.
         Ok(_extern)
     }
+    unsafe fn get_self_no_increment_if_same_instance(
+        _extern: &'a Extern,
+        instance: &crate::Instance,
+    ) -> Result<Self, ExportError> {
+        match _extern {
+            Self::Function(_) => {
+                Function::get_self_no_increment_if_same_instance(_extern, instance).map(Into::into)
+            }
+            Self::Global(_) => {
+                Global::get_self_no_increment_if_same_instance(_extern, instance).map(Into::into)
+            }
+            Self::Memory(_) => {
+                Memory::get_self_no_increment_if_same_instance(_extern, instance).map(Into::into)
+            }
+            Self::Table(_) => {
+                Table::get_self_no_increment_if_same_instance(_extern, instance).map(Into::into)
+            }
+        }
+    }
 }
 
 impl StoreObject for Extern {

--- a/lib/api/src/externals/table.rs
+++ b/lib/api/src/externals/table.rs
@@ -159,4 +159,15 @@ impl<'a> Exportable<'a> for Table {
             _ => Err(ExportError::IncompatibleType),
         }
     }
+    unsafe fn get_self_no_increment_if_same_instance(
+        _extern: &'a Extern,
+        instance: &crate::Instance,
+    ) -> Result<Self, ExportError> {
+        let table = Self::get_self_from_extern(_extern)?.clone();
+        let vm_extern = table.vm_table.clone().into();
+        if instance.same_instance_ref(&vm_extern) {
+            table.vm_table.decrement_instance_ref_strong_count();
+        }
+        Ok(table)
+    }
 }

--- a/lib/api/src/instance.rs
+++ b/lib/api/src/instance.rs
@@ -164,6 +164,11 @@ impl Instance {
     pub fn vmctx_ptr(&self) -> *mut VMContext {
         self.handle.lock().unwrap().vmctx_ptr()
     }
+
+    pub(crate) fn same_instance_ref(&self, vm_extern: &wasmer_vm::VMExtern) -> bool {
+        let guard = self.handle.lock().unwrap();
+        guard.same_instance_ref(vm_extern)
+    }
 }
 
 impl fmt::Debug for Instance {

--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -208,6 +208,14 @@ macro_rules! impl_native_traits {
                 use crate::exports::Exportable;
                 crate::Function::get_self_from_extern(_extern)?.native().map_err(|_| crate::exports::ExportError::IncompatibleType)
             }
+            unsafe fn get_self_with_generics_no_increment_if_same_instance(_extern: &'a crate::externals::Extern, instance: &crate::Instance) -> Result<Self, crate::exports::ExportError> {
+                let f = Self::get_self_from_extern_with_generics(_extern)?;
+                let vm_extern = f.exported.vm_function.clone().into();
+                if instance.same_instance_ref(&vm_extern) {
+                    f.exported.vm_function.decrement_instance_ref_strong_count();
+                }
+                Ok(f)
+            }
         }
     };
 }

--- a/lib/derive/src/lib.rs
+++ b/lib/derive/src/lib.rs
@@ -136,12 +136,12 @@ fn derive_struct_fields(data: &DataStruct) -> (TokenStream, TokenStream) {
                             identifier.unwrap_or_else(|| LitStr::new(&name_str, name.span()));
                         let mut access_expr = quote_spanned! {
                             f.span() =>
-                                instance.exports.get_with_generics::<#inner_type, _, _>(#item_name)
+                                unsafe { instance.exports.get_with_generics_unowned::<#inner_type, _, _>(#item_name, instance) }
                         };
                         for alias in aliases {
                             access_expr = quote_spanned! {
                                 f.span()=>
-                                    #access_expr .or_else(|_| instance.exports.get_with_generics::<#inner_type, _, _>(#alias))
+                                    #access_expr .or_else(|_| unsafe { instance.exports.get_with_generics_unowned::<#inner_type, _, _>(#alias, instance) })
                             };
                         }
                         if optional {
@@ -163,12 +163,14 @@ fn derive_struct_fields(data: &DataStruct) -> (TokenStream, TokenStream) {
                         if let Some(identifier) = identifier {
                             let mut access_expr = quote_spanned! {
                                 f.span() =>
-                                    instance.exports.get_with_generics::<#inner_type, _, _>(#identifier)
+                                    unsafe {
+                                    instance.exports.get_with_generics_unowned::<#inner_type, _, _>(#identifier, instance)
+                                    }
                             };
                             for alias in aliases {
                                 access_expr = quote_spanned! {
                                     f.span()=>
-                                        #access_expr .or_else(|_| instance.exports.get_with_generics::<#inner_type, _, _>(#alias))
+                                        #access_expr .or_else(|_| unsafe { instance.exports.get_with_generics_unowned::<#inner_type, _, _>(#alias, instance) })
                                 };
                             }
                             let local_var =

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -26,6 +26,17 @@ pub enum VMExtern {
     Global(VMGlobal),
 }
 
+impl VMExtern {
+    pub(crate) fn get_instance_ref(&self) -> Option<&InstanceRef> {
+        match self {
+            Self::Function(f) => f.instance_ref.as_ref(),
+            Self::Table(t) => t.instance_ref.as_ref(),
+            Self::Memory(m) => m.instance_ref.as_ref(),
+            Self::Global(g) => g.instance_ref.as_ref(),
+        }
+    }
+}
+
 /// A function export value.
 #[derive(Debug, Clone, PartialEq, MemoryUsage)]
 pub struct VMFunction {
@@ -53,6 +64,15 @@ pub struct VMFunction {
     /// A “reference” to the instance through the
     /// `InstanceRef`. `None` if it is a host function.
     pub instance_ref: Option<InstanceRef>,
+}
+
+impl VMFunction {
+    /// TODO: document this
+    pub unsafe fn decrement_instance_ref_strong_count(&self) {
+        self.instance_ref
+            .as_ref()
+            .map(|ir| ir.decrement_strong_count());
+    }
 }
 
 /// # Safety
@@ -107,6 +127,12 @@ impl VMTable {
     pub fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.from, &other.from)
     }
+    /// TODO: document this
+    pub unsafe fn decrement_instance_ref_strong_count(&self) {
+        self.instance_ref
+            .as_ref()
+            .map(|ir| ir.decrement_strong_count());
+    }
 }
 
 impl From<VMTable> for VMExtern {
@@ -153,6 +179,12 @@ impl VMMemory {
     pub fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.from, &other.from)
     }
+    /// TODO: document this
+    pub unsafe fn decrement_instance_ref_strong_count(&self) {
+        self.instance_ref
+            .as_ref()
+            .map(|ir| ir.decrement_strong_count());
+    }
 }
 
 impl From<VMMemory> for VMExtern {
@@ -188,6 +220,13 @@ impl VMGlobal {
     /// Returns whether or not the two `VMGlobal`s refer to the same Global.
     pub fn same(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.from, &other.from)
+    }
+
+    /// TODO: document this
+    pub unsafe fn decrement_instance_ref_strong_count(&self) {
+        self.instance_ref
+            .as_ref()
+            .map(|ir| ir.decrement_strong_count());
     }
 }
 

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -1261,6 +1261,17 @@ impl InstanceHandle {
         }
         Ok(())
     }
+
+    /// TODO: document this
+    pub fn same_instance_ref(&self, _extern: &VMExtern) -> bool {
+        let other = if let Some(ir) = _extern.get_instance_ref() {
+            ir
+        } else {
+            return false;
+        };
+
+        *other == self.instance
+    }
 }
 
 /// Compute the offset for a memory data initializer.

--- a/lib/vm/src/instance/ref.rs
+++ b/lib/vm/src/instance/ref.rs
@@ -112,6 +112,14 @@ impl InstanceRef {
     pub(super) unsafe fn as_mut(&mut self) -> &mut Instance {
         self.instance.as_mut()
     }
+
+    /// TODO: document this
+    pub(crate) unsafe fn decrement_strong_count(&self) {
+        if self.strong.fetch_sub(1, atomic::Ordering::Release) != 1 {
+            return;
+        }
+        panic!("Invalid manual decrement of `InstanceRef` count!");
+    }
 }
 
 /// TODO: Review this super carefully.


### PR DESCRIPTION
Trying to fix #2304

I'm not sure we want to go with the strategy in this PR, it's very low level and unsafe. The idea is to decrement the strong count of `InstanceRef` for each export in the Env because in the context of host functions, anything coming from the same instance is guaranteed to be alive. We must preserve the property that cloning these types then increments the `InstanceRef` count though, so we can't get rid of it entirely. Additionally we have to handle the case of something being re-exported, so we can't assume that if something is exported from an Instance that it's owned by that Instance.

The PR currently gets stuck in an infinite loop during instantiation.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
