### PR TITLE
Added call unchecked to the functions

### DIFF
--- a/benches/static_and_dynamic_functions.rs
+++ b/benches/static_and_dynamic_functions.rs
@@ -106,7 +106,10 @@ pub fn run_basic_static_function(store: &Store, compiler_name: &str, c: &mut Cri
     );
 
     c.bench_function(
-        &format!("basic static func with many args {} [unchecked]", compiler_name),
+        &format!(
+            "basic static func with many args {} [unchecked]",
+            compiler_name
+        ),
         |b| unsafe {
             store
                 .catch_traps(|| {

--- a/benches/static_and_dynamic_functions.rs
+++ b/benches/static_and_dynamic_functions.rs
@@ -50,7 +50,7 @@ pub fn run_basic_static_function(store: &Store, compiler_name: &str, c: &mut Cri
     });
 
     c.bench_function(
-        &format!("basic static func [unchecked] {}", compiler_name),
+        &format!("basic static func {} [unchecked]", compiler_name),
         |b| unsafe {
             store
                 .catch_traps(|| {
@@ -106,7 +106,7 @@ pub fn run_basic_static_function(store: &Store, compiler_name: &str, c: &mut Cri
     );
 
     c.bench_function(
-        &format!("basic static func with many args {}", compiler_name),
+        &format!("basic static func with many args {} [unchecked]", compiler_name),
         |b| unsafe {
             store
                 .catch_traps(|| {
@@ -146,7 +146,7 @@ pub fn run_basic_dynamic_function(store: &Store, compiler_name: &str, c: &mut Cr
     });
 
     c.bench_function(
-        &format!("basic dynfunc [unchecked] {}", compiler_name),
+        &format!("basic dynfunc {} [unchecked]", compiler_name),
         |b| unsafe {
             store
                 .catch_traps(|| {

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -622,9 +622,11 @@ impl Function {
     /// #
     /// let sum = instance.exports.get_function("sum").unwrap();
     ///
-    /// store.catch_traps(|| unsafe {
-    ///   assert_eq!(sum.call_unchecked(&[Value::I32(1), Value::I32(2)]).unwrap().to_vec(), vec![Value::I32(3)]);
-    /// });
+    /// unsafe {
+    ///   store.catch_traps(|| {
+    ///     assert_eq!(sum.call_unchecked(&[Value::I32(1), Value::I32(2)]).unwrap().to_vec(), vec![Value::I32(3)]);
+    ///   });
+    /// }
     /// ```
     pub unsafe fn call_unchecked(&self, params: &[Val]) -> Result<Box<[Val]>, RuntimeError> {
         if let Some(trampoline) = self.exported.vm_function.call_trampoline {

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -481,7 +481,7 @@ impl Function {
 
         // Call the trampoline.
         unsafe {
-            if unchecked {
+            if !unchecked {
                 wasmer_call_trampoline(
                     &self.store,
                     self.exported.vm_function.vmctx,

--- a/lib/api/src/native.rs
+++ b/lib/api/src/native.rs
@@ -158,7 +158,7 @@ macro_rules! impl_native_traits {
                         }
                         else {
                             wasmer_vm::wasmer_call_trampoline_unchecked(
-                                &self.store,
+                                self.vmctx(),
                                 trampoline,
                                 self.address(),
                                 args_rets.as_mut_ptr() as *mut u8,

--- a/lib/api/src/store.rs
+++ b/lib/api/src/store.rs
@@ -47,11 +47,11 @@ impl Store {
     /// # Safety
     ///
     /// Highly unsafe since `closure` won't have any dtors run.
-    pub unsafe fn catch_traps<F>(&self, mut closure: F) -> Result<(), RuntimeError>
+    pub unsafe fn catch_traps<F>(&self, closure: F) -> Result<(), RuntimeError>
     where
         F: FnMut(),
     {
-        Ok(catch_traps(self.trap_handler(), closure)?)
+        Ok(catch_traps(self, closure)?)
     }
 
     /// Creates a new `Store` with a specific [`Engine`] and [`Tunables`].

--- a/lib/api/src/store.rs
+++ b/lib/api/src/store.rs
@@ -46,7 +46,7 @@ impl Store {
     ///
     /// # Safety
     ///
-    /// Highly unsafe since `closure` won't have any dtors run.
+    /// Highly unsafe since `closure` won't have any destructors run.
     pub unsafe fn catch_traps<F>(&self, closure: F) -> Result<(), RuntimeError>
     where
         F: FnMut(),

--- a/lib/object/src/module.rs
+++ b/lib/object/src/module.rs
@@ -186,7 +186,12 @@ pub fn emit_compilation(
                     section: SymbolSection::Section(section_id),
                     flags: SymbolFlags::None,
                 });
-                obj.add_symbol_data(symbol_id, section_id, custom_section.bytes.as_slice(), align);
+                obj.add_symbol_data(
+                    symbol_id,
+                    section_id,
+                    custom_section.bytes.as_slice(),
+                    align,
+                );
                 (section_id, symbol_id)
             }
         })

--- a/lib/vm/src/trap/mod.rs
+++ b/lib/vm/src/trap/mod.rs
@@ -9,6 +9,6 @@ mod traphandlers;
 pub use trapcode::TrapCode;
 pub use traphandlers::{
     catch_traps, catch_traps_with_result, raise_lib_trap, raise_user_trap, wasmer_call_trampoline,
-    TlsRestore, Trap, TrapHandler, TrapHandlerFn,
+    wasmer_call_trampoline_unchecked, TlsRestore, Trap, TrapHandler, TrapHandlerFn,
 };
 pub use traphandlers::{init_traps, resume_panic};

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -573,7 +573,7 @@ pub unsafe fn wasmer_call_trampoline_unchecked(
 ///
 /// # Safety
 ///
-/// Highly unsafe since `closure` won't have any dtors run.
+/// Highly unsafe since `closure` won't have any destructors run.
 pub unsafe fn catch_traps<F>(trap_handler: &dyn TrapHandler, mut closure: F) -> Result<(), Trap>
 where
     F: FnMut(),


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR resolves #1922 by adding a new method to `Store`: `catch_traps` and two new methods to `Function` and `NativeFunction`: `call_unchecked` so unsafe unchecked calls can be done.

```rust
unsafe {
  store.catch_traps(|| {
    assert_eq!(sum.call_unchecked(&[Value::I32(1), Value::I32(2)]).unwrap().to_vec(), vec![Value::I32(3)]);
  });
}
```

## Benchmarking

This are the timings in of `make bench` in my laptop (macOS M1 2020):
* Static function: 138ns -> 3ns
* Dynamic function: 240ns -> 100ns

```
basic static func llvm
                        time:   [136.39 ns 137.16 ns 138.08 ns]

basic static func llvm [unchecked]
                        time:   [3.0288 ns 3.0381 ns 3.0485 ns]

basic static func with many args llvm
                        time:   [149.08 ns 149.28 ns 149.50 ns]

basic static func with many args llvm [unchecked]
                        time:   [15.919 ns 16.085 ns 16.290 ns]

basic dynfunc llvm
                        time:   [242.52 ns 244.49 ns 247.13 ns]

basic dynfunc llvm [unchecked]
                        time:   [101.92 ns 103.36 ns 104.93 ns]
```