### PR TITLE
Engine native (slim)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,7 +2422,7 @@ name = "wasmer"
 version = "1.0.2"
 dependencies = [
  "anyhow",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "indexmap",
  "libc",
  "loupe",
@@ -2682,7 +2682,7 @@ dependencies = [
 name = "wasmer-engine-jit"
 version = "1.0.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "leb128",
  "loupe",
  "region",
@@ -2698,7 +2698,7 @@ dependencies = [
 name = "wasmer-engine-native"
 version = "1.0.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "leb128",
  "libloading",
  "loupe",
@@ -2719,7 +2719,7 @@ name = "wasmer-engine-object-file"
 version = "1.0.2"
 dependencies = [
  "bincode",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "leb128",
  "libloading",
  "loupe",
@@ -2778,7 +2778,7 @@ version = "1.0.2"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "indexmap",
  "libc",
  "loupe",

--- a/deny.toml
+++ b/deny.toml
@@ -169,6 +169,7 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
+    { name = "cfg-if", version = "0.1.10" },
     { name = "strsim", version = "=0.8.0" },
     { name = "semver", version = "=0.9.0" },
     { name = "semver-parser", version = "=0.7.0" },

--- a/deny.toml
+++ b/deny.toml
@@ -169,7 +169,6 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    { name = "cfg-if", version = "=0.1.10" },
     { name = "strsim", version = "=0.8.0" },
     { name = "semver", version = "=0.9.0" },
     { name = "semver-parser", version = "=0.7.0" },

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -21,8 +21,8 @@ wasmer-engine = { path = "../engine", version = "1.0.2" }
 wasmer-engine-jit = { path = "../engine-jit", version = "1.0.2", optional = true }
 wasmer-engine-native = { path = "../engine-native", version = "1.0.2", optional = true }
 wasmer-types = { path = "../types", version = "1.0.2" }
-indexmap = { version = "1.4", features = ["serde-1"] }
-cfg-if = "0.1"
+indexmap = { version = "1.6", features = ["serde-1"] }
+cfg-if = "1.0"
 wat = { version = "1.0", optional = true }
 thiserror = "1.0"
 more-asserts = "0.2"

--- a/lib/engine-jit/Cargo.toml
+++ b/lib/engine-jit/Cargo.toml
@@ -17,7 +17,7 @@ wasmer-vm = { path = "../vm", version = "1.0.2", features = ["enable-rkyv"] }
 wasmer-engine = { path = "../engine", version = "1.0.2" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "2.2"
-cfg-if = "0.1"
+cfg-if = "1.0"
 leb128 = "0.2"
 rkyv = "0.6.1"
 loupe = "0.1"

--- a/lib/engine-native/Cargo.toml
+++ b/lib/engine-native/Cargo.toml
@@ -17,7 +17,7 @@ wasmer-vm = { path = "../vm", version = "1.0.2", features = ["enable-rkyv"] }
 wasmer-engine = { path = "../engine", version = "1.0.2" }
 wasmer-object = { path = "../object", version = "1.0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
-cfg-if = "0.1"
+cfg-if = "1.0"
 tracing = "0.1"
 leb128 = "0.2"
 libloading = "0.7"

--- a/lib/engine-native/src/artifact.rs
+++ b/lib/engine-native/src/artifact.rs
@@ -624,7 +624,14 @@ impl Artifact for NativeArtifact {
                 // Further reading: https://lwn.net/Articles/342330/ \
                 // "There is one little problem with that reasoning, though: NULL (zero) can
                 // actually be a valid pointer address."
-                let current_size_by_ptr = prev_pointer - fp;
+                let current_size_by_ptr = if prev_pointer != usize::MAX {
+                    prev_pointer - fp
+                }
+                else {
+                    // We assume a function will have at least 16 bits of difference with
+                    // next functions
+                    16
+                };
                 // let function_body_length = &self.metadata.function_body_lengths[index];
                 prev_pointer = fp;
                 // We choose the minimum between the function size given the pointer diff

--- a/lib/engine-object-file/Cargo.toml
+++ b/lib/engine-object-file/Cargo.toml
@@ -17,7 +17,7 @@ wasmer-vm = { path = "../vm", version = "1.0.2" }
 wasmer-engine = { path = "../engine", version = "1.0.2" }
 wasmer-object = { path = "../object", version = "1.0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
-cfg-if = "0.1"
+cfg-if = "1.0"
 tracing = "0.1"
 bincode = "1.3"
 leb128 = "0.2"

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -59,6 +59,7 @@ pub struct GlobalFrameInfoRegistration {
     key: usize,
 }
 
+#[derive(Debug)]
 struct ModuleInfoFrameInfo {
     start: usize,
     functions: BTreeMap<usize, FunctionInfo>,
@@ -74,10 +75,11 @@ impl ModuleInfoFrameInfo {
     /// Gets a function given a pc
     fn function_info(&self, pc: usize) -> Option<&FunctionInfo> {
         let (end, func) = self.functions.range(pc..).next()?;
-        if pc < func.start || *end < pc {
-            return None;
+        if func.start <= pc && pc < *end {
+            return Some(func);
+        } else {
+            None
         }
-        Some(func)
     }
 }
 
@@ -127,14 +129,12 @@ impl GlobalFrameInfo {
             }
         };
 
-        // In debug mode for now assert that we found a mapping for `pc` within
-        // the function, because otherwise something is buggy along the way and
-        // not accounting for all the instructions. This isn't super critical
-        // though so we can omit this check in release mode.
-        debug_assert!(pos.is_some(), "failed to find instruction for {:x}", pc);
-
         let instr = match pos {
             Some(pos) => instr_map.instructions[pos].srcloc,
+            // Some compilers don't emit yet the full trap information for each of
+            // the instructions (such as LLVM).
+            // In case no specific instruction is found, we return by default the
+            // start offset of the function.
             None => instr_map.start_srcloc,
         };
         let func_index = module.module.func_index(func.local_index);
@@ -161,10 +161,11 @@ impl GlobalFrameInfo {
     /// Gets a module given a pc
     fn module_info(&self, pc: usize) -> Option<&ModuleInfoFrameInfo> {
         let (end, module_info) = self.ranges.range(pc..).next()?;
-        if pc < module_info.start || *end < pc {
-            return None;
+        if module_info.start <= pc && pc < *end {
+            Some(module_info)
+        } else {
+            None
         }
-        Some(module_info)
     }
 }
 

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -203,6 +203,7 @@ pub fn register(
     let mut min = usize::max_value();
     let mut max = 0;
     let mut functions = BTreeMap::new();
+    println!("Finsihed functions, {:?}", finished_functions);
     for (
         i,
         FunctionExtent {
@@ -229,9 +230,11 @@ pub fn register(
     // First up assert that our chunk of jit functions doesn't collide with
     // any other known chunks of jit functions...
     if let Some((_, prev)) = info.ranges.range(max..).next() {
+        println!("Prev: {:?}, max: {}", prev.start, max);
         assert!(prev.start > max);
     }
     if let Some((prev_end, _)) = info.ranges.range(..=min).next_back() {
+        println!("Prev end: {:?}, min: {}", prev_end, min);
         assert!(*prev_end < min);
     }
 

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -203,7 +203,6 @@ pub fn register(
     let mut min = usize::max_value();
     let mut max = 0;
     let mut functions = BTreeMap::new();
-    println!("Finsihed functions, {:?}", finished_functions);
     for (
         i,
         FunctionExtent {
@@ -230,11 +229,9 @@ pub fn register(
     // First up assert that our chunk of jit functions doesn't collide with
     // any other known chunks of jit functions...
     if let Some((_, prev)) = info.ranges.range(max..).next() {
-        println!("Prev: {:?}, max: {}", prev.start, max);
         assert!(prev.start > max);
     }
     if let Some((prev_end, _)) = info.ranges.range(..=min).next_back() {
-        println!("Prev end: {:?}, min: {}", prev_end, min);
         assert!(*prev_end < min);
     }
 

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -75,7 +75,7 @@ impl ModuleInfoFrameInfo {
     /// Gets a function given a pc
     fn function_info(&self, pc: usize) -> Option<&FunctionInfo> {
         let (end, func) = self.functions.range(pc..).next()?;
-        if func.start <= pc && pc < *end {
+        if func.start <= pc && pc <= *end {
             return Some(func);
         } else {
             None
@@ -161,7 +161,7 @@ impl GlobalFrameInfo {
     /// Gets a module given a pc
     fn module_info(&self, pc: usize) -> Option<&ModuleInfoFrameInfo> {
         let (end, module_info) = self.ranges.range(pc..).next()?;
-        if module_info.start <= pc && pc < *end {
+        if module_info.start <= pc && pc <= *end {
             Some(module_info)
         } else {
             None

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }
 thiserror = "1.0"
-indexmap = { version = "1.4", features = ["serde-1"] }
+indexmap = { version = "1.6", features = ["serde-1"] }
 rkyv = { version = "0.6.1", optional = true }
 loupe = "0.1"
 

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -15,10 +15,10 @@ wasmer-types = { path = "../types", version = "1.0.2" }
 region = "2.2"
 libc = { version = "^0.2", default-features = false }
 memoffset = "0.6"
-indexmap = { version = "1.4", features = ["serde-1"] }
+indexmap = { version = "1.6", features = ["serde-1"] }
 thiserror = "1.0"
 more-asserts = "0.2"
-cfg-if = "0.1"
+cfg-if = "1.0"
 backtrace = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 rkyv = { version = "0.6.1", optional = true}

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -708,6 +708,11 @@ impl<'a> CallThreadState<'a> {
             return 1 as *const _;
         }
 
+        // If this fault wasn't in wasm code, then it's not our problem
+        if unsafe { !IS_WASM_PC(pc as _) } {
+            return ptr::null();
+        }
+
         // TODO: stack overflow can happen at any random time (i.e. in malloc()
         // in memory.grow) and it's really hard to determine if the cause was
         // stack overflow and if it happened in WebAssembly module.

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -708,11 +708,8 @@ impl<'a> CallThreadState<'a> {
             return 1 as *const _;
         }
 
-        let is_wasm_pc = unsafe { IS_WASM_PC(pc as _) };
-        println!("Is wasm PC: {:?} ? {:?}", pc, is_wasm_pc);
-
         // If this fault wasn't in wasm code, then it's not our problem
-        if !is_wasm_pc {
+        if unsafe { !IS_WASM_PC(pc as _) } {
             return ptr::null();
         }
 

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -708,8 +708,11 @@ impl<'a> CallThreadState<'a> {
             return 1 as *const _;
         }
 
+        let is_wasm_pc = unsafe { IS_WASM_PC(pc as _) };
+        println!("Is wasm PC: {:?} ? {:?}", pc, is_wasm_pc);
+
         // If this fault wasn't in wasm code, then it's not our problem
-        if unsafe { !IS_WASM_PC(pc as _) } {
+        if !is_wasm_pc {
             return ptr::null();
         }
 

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -45,9 +45,7 @@ llvm+jit+macos+aarch64 *
 cranelift+macos spec::skip_stack_guard_page
 cranelift+linux spec::skip_stack_guard_page
 llvm+macos      spec::skip_stack_guard_page
-
-# https://github.com/wasmerio/wasmer/issues/1722
-llvm+native spec::skip_stack_guard_page
+llvm+linux      spec::skip_stack_guard_page
 
 # TODO(https://github.com/wasmerio/wasmer/issues/1727): Traps in native engine
 cranelift+native spec::linking

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -39,13 +39,11 @@ singlepass multi_value_imports::dynamic
 # LLVM/JIT doesn't work in macOS M1. Skip all tests
 llvm+jit+macos+aarch64 *
 
-# TODO: We need to fix this. The issue happens only in Cranelift/LLVM and macOS,
-# is caused by libunwind overflowing the stack while creating the stacktrace.
+# TODO: We need to fix this. The issue is caused by libunwind overflowing
+# the stack while creating the stacktrace.
 # https://github.com/rust-lang/backtrace-rs/issues/356
-cranelift+macos spec::skip_stack_guard_page
-cranelift+linux spec::skip_stack_guard_page
-llvm+macos      spec::skip_stack_guard_page
-llvm+linux      spec::skip_stack_guard_page
+cranelift spec::skip_stack_guard_page
+llvm      spec::skip_stack_guard_page
 
 # TODO(https://github.com/wasmerio/wasmer/issues/1727): Traps in native engine
 cranelift+native spec::linking


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR is the slim version of #2272. It advances on:
* [x] Stops encoding the endian into the serialized data (rkyv already does that for us since `0.6.1`)
* [x] Sets the proper function lengths in the native engine
* [x] Catch signal traps only when the pc is originated from a Wasm function, and not in the host (fixing #2328)

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
