### PR TITLE
docs: point to wasmer-zig integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ qjs >
 | ![R logo] | [**R**][R integration] | *no published package* | [Docs][r docs] |
 | ![Postgres logo] | [**Postgres**][Postgres integration] | *no published package* | [Docs][postgres docs] |
 |  | [**Swift**][Swift integration] | *no published package* | |
+| ![Zig logo] | [**Zig**][Zig integration] | *no published package* | |
 
 [👋 Missing a language?](https://github.com/wasmerio/wasmer/issues/new?assignees=&labels=%F0%9F%8E%89+enhancement&template=---feature-request.md&title=)
 
@@ -169,6 +170,9 @@ qjs >
 [postgres docs]: https://github.com/wasmerio/wasmer-postgres#usage--documentation
 
 [swift integration]: https://github.com/AlwaysRightInstitute/SwiftyWasmer
+
+[zig logo]: https://raw.githubusercontent.com/ziglang/logo/master/zig-favicon.png
+[zig integration]: https://github.com/kubkon/wasmer-zig
 
 ## Contribute
 


### PR DESCRIPTION
# Description

Even though @Luukdegram and I just started working on Wasmer integration in Zig, I thought it might be a good idea to point everyone to the project early so that we involve as many contributors as possible, and perhaps, open a nice comms channel between Zig and Wasmer. So, this short PR is doing just that: pointing to [wasmer-zig] integration in the docs.

A couple of words on the integration and the direction we want this to go. Currently, the integration shows off a minimal working build system and example rewritten verbatim from the official Wasmer C API tutorial ([the link]). For the end result, we want this integration to be on par with Rust's, C's, or Go's integration hosted by Wasmer. While we are here, this might be a daft question so excuse me if it is, but is there any reason why you prefer exposing `wasm.h` primitives such as `wasm_instance_t` in your integration rather than `wasmer_instance_t`? In general, what would be the ideal direction to take here in your opinion? Currently, wasmer-zig exposes the latter and I'm wondering if we should expose one or the other, or (probably ideally) both?

[wasmer-zig]: https://github.com/kubkon/wasmer-zig
[the link]: https://wasmerio.github.io/wasmer/c/

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
