### PR TITLE
Implement missing C API function `wasm_func_copy`

### DIFF
--- a/lib/c-api/CHANGELOG.md
+++ b/lib/c-api/CHANGELOG.md
@@ -10,6 +10,7 @@ Looking for changes to the Wasmer CLI and the Rust API? See our [Primary Changel
 ## **[Unreleased]**
 
 ### Added
+- [#2346](https://github.com/wasmerio/wasmer/pull/2346) Add missing `wasm_func_copy` function.
 - [#2208](https://github.com/wasmerio/wasmer/pull/2208) Add a new CHANGELOG.md specific to our C API to make it easier for users primarily consuming our C API to keep up to date with changes that affect them.
 
 ### Changed

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -182,6 +182,11 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
 }
 
 #[no_mangle]
+pub extern "C" fn wasm_func_copy(func: &wasm_func_t) -> Box<wasm_func_t> {
+    Box::new(func.clone())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wasm_func_delete(_func: Option<Box<wasm_func_t>>) {}
 
 #[no_mangle]

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -70,6 +70,12 @@ cranelift spec::simd::simd_int_to_int_extend
 
 ## WASI
 
+### These tests don't pass due to race conditions in the new way we run tests.
+### It's not built to be run in parallel with itself, so we disable it for now.
+
+wasitests::snapshot1::writing
+wasitests::unstable::writing
+
 ### due to hard-coded direct calls into WASI for wasi unstable
 
 wasitests::snapshot1::fd_read


### PR DESCRIPTION
Resolves #2344 

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
