### PR TITLE
Copied trap handlers so this will compile for `aarch64-linux-android`

### DIFF
--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -210,7 +210,13 @@ cfg_if::cfg_if! {
                 } else if #[cfg(all(target_os = "linux", target_arch = "x86"))] {
                     let cx = &*(cx as *const libc::ucontext_t);
                     cx.uc_mcontext.gregs[libc::REG_EIP as usize] as *const u8
+                } else if #[cfg(all(target_os = "android", target_arch = "x86"))] {
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    cx.uc_mcontext.gregs[libc::REG_EIP as usize] as *const u8
                 } else if #[cfg(all(target_os = "linux", target_arch = "aarch64"))] {
+                    let cx = &*(cx as *const libc::ucontext_t);
+                    cx.uc_mcontext.pc as *const u8
+                } else if #[cfg(all(target_os = "android", target_arch = "aarch64"))] {
                     let cx = &*(cx as *const libc::ucontext_t);
                     cx.uc_mcontext.pc as *const u8
                 } else if #[cfg(all(target_os = "macos", target_arch = "x86_64"))] {


### PR DESCRIPTION
Attempting to compile Wasmer for android fails with an 'unsupported platform' error. These two additional cases are copied from their neighbors, but properly match against the `aarch64-linux-android` target. I don't know enough about what this code is actually doing to know if this is 'right', but it does appear to work.