### PR TITLE
Update link to wasmer-zig bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ qjs >
 [swift integration]: https://github.com/AlwaysRightInstitute/SwiftyWasmer
 
 [zig logo]: https://raw.githubusercontent.com/ziglang/logo/master/zig-favicon.png
-[zig integration]: https://github.com/kubkon/wasmer-zig
+[zig integration]: https://github.com/zigwasm/wasmer-zig
 
 ## Contribute
 


### PR DESCRIPTION
# Description

Just a minor update to the link pointing to `wasmer-zig` which has now been transferred to `zigwasm` org.

cc @Hywan 

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
