### PR TITLE
feat: Attempt to help the users when migrating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,10 @@ test-universal = [
 # that raise signals because that interferes with tarpaulin.
 coverage = []
 
+# Deprecated features.
+jit = ["universal"]
+native = ["dylib"]
+
 [profile.dev]
 split-debuginfo = "unpacked"
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -100,3 +100,7 @@ default-dylib = [
 experimental-reference-types-extern-ref = [
     "wasmer-types/experimental-reference-types-extern-ref",
 ]
+
+# Deprecated features.
+jit = ["universal"]
+native = ["dylib"]

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -370,5 +370,18 @@ pub use wasmer_engine_universal::{Universal, UniversalArtifact, UniversalEngine}
 #[cfg(feature = "dylib")]
 pub use wasmer_engine_dylib::{Dylib, DylibArtifact, DylibEngine};
 
+#[cfg(any(feature = "jit", feature = "native"))]
+compile_error!(
+    r#"At least one deprecated feature has been used, and cannot not
+be used any longer. Please refer to the following table:
+
+| Deprecated feature | New feature to use instead |
+|--------------------|----------------------------|
+| `jit`              | `universal`                |
+| `native`           | `dylib`                    |
+
+"#
+);
+
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -91,10 +91,12 @@ system-libffi = ["libffi/system"]
 # TODO: Port this feature.
 #emscripten = ["wasmer-emscripten"]
 
-# This is for compatibility for old usage
+# Deprecated features.
 singlepass-backend = ["singlepass"]
 cranelift-backend = ["cranelift"]
 llvm-backend = ["llvm"]
+jit = ["universal"]
+native = ["dylib"]
 
 [build-dependencies]
 cbindgen = "0.18"

--- a/lib/c-api/src/lib.rs
+++ b/lib/c-api/src/lib.rs
@@ -43,3 +43,16 @@ pub mod deprecated;
 pub mod error;
 mod ordered_resolver;
 pub mod wasm_c_api;
+
+#[cfg(any(feature = "jit", feature = "native"))]
+compile_error!(
+    r#"At least one deprecated feature has been used, and cannot not
+be used any longer. Please refer to the following table:
+
+| Deprecated feature | New feature to use instead |
+|--------------------|----------------------------|
+| `jit`              | `universal`                |
+| `native`           | `dylib`                    |
+
+"#
+);

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -111,3 +111,7 @@ debug = ["fern", "log", "wasmer-wasi/logging"]
 disable-all-logging = ["wasmer-wasi/disable-all-logging"]
 headless = []
 headless-minimal = ["headless", "disable-all-logging", "wasi", "dylib", "universal"]
+
+# Deprecated features.
+jit = ["universal"]
+native = ["dylib"]

--- a/lib/cli/src/lib.rs
+++ b/lib/cli/src/lib.rs
@@ -30,3 +30,16 @@ pub mod utils;
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(any(feature = "jit", feature = "native"))]
+compile_error!(
+    r#"At least one deprecated feature has been used, and cannot not
+be used any longer. Please refer to the following table:
+
+| Deprecated feature | New feature to use instead |
+|--------------------|----------------------------|
+| `jit`              | `universal`                |
+| `native`           | `dylib`                    |
+
+"#
+);


### PR DESCRIPTION
This PR is a bad attempt to help the users when migrating from 1.x to 2.x. Some features have been renamed, like `jit` to `universal`, and `native` to `dylib`.

We have several solutions:

1. Either we generate a `#[deprecated]` message, but we need to alias many types (`pub type JIT = Universal; pub type JITEngine = UniversalEngine;` etc.), and to raise `#[deprecated]` notes when used. Note that it's not possible to raise a deprecation note if the type isn't used. And it's not possible to raise a deprecation note for a feature being used only (at least without the help of dirty hacks),
2. Generate a compile error that guides the user to migrate.

This PR addresses the problem with the solution number 2. But I don't like it.

In an ideal world, every crate inside Wasmer must provide a `migrations` module (or `versions`, or `changes`, or `semver`, or `changelog`, … whatever!) which itself contains modules like `1_x_to_2_x.rs`. Each of those modules would create the type aliasing, bridges between one version to another if possible, and more importantly, would contain the documentation to guide the users to migrate from one version to another. This documentation would be part of the official crate documentation, so will be readable at docs.rs for example.

What do you think?