### PR TITLE
chore(wasi) Remove the deprecated code

### DIFF
--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -105,13 +105,6 @@ impl WasiEnv {
         self.state.lock().unwrap()
     }
 
-    // TODO: delete this method before 1.0.0 release
-    #[doc(hidden)]
-    #[deprecated(since = "1.0.0-beta1", note = "Please use the `state` method instead")]
-    pub fn state_mut(&mut self) -> MutexGuard<WasiState> {
-        self.state.lock().unwrap()
-    }
-
     /// Get a reference to the memory
     pub fn memory(&self) -> &Memory {
         self.memory_ref()

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -361,8 +361,6 @@ impl WasiStateBuilder {
 
         // self.preopens are checked in [`PreopenDirBuilder::build`]
 
-        // this deprecation warning only applies to external callers
-        #[allow(deprecated)]
         let mut wasi_fs = WasiFs::new_with_preopen(&self.preopens)
             .map_err(WasiStateCreationError::WasiFsCreationError)?;
         // set up the file system, overriding base files and calling the setup function


### PR DESCRIPTION
# Description

This PR removes deprecated code from the `wasi` crate. With the 2.x coming soon, we no longer need this to maintain this code :-).

I don't know what to do with:

```rust
pub enum Kind {
    File {
        /// The path on the host system where the file is located
        /// This is deprecated and will be removed soon
        path: PathBuf,
```

in `state/mod.rs`. Any clue @MarkMcCaskey?