### PR TITLE
Revert "Set SIMD flag true as default"

### DIFF
--- a/lib/types/src/features.rs
+++ b/lib/types/src/features.rs
@@ -44,8 +44,7 @@ impl Features {
             threads: false,
             // Reference types should be on by default
             reference_types: true,
-            // SIMD should be on by default
-            simd: true,
+            simd: false,
             // Bulk Memory should be on by default
             bulk_memory: true,
             // Multivalue should be on by default
@@ -250,7 +249,7 @@ mod test_features {
             Features {
                 threads: false,
                 reference_types: true,
-                simd: true,
+                simd: false,
                 bulk_memory: true,
                 multi_value: true,
                 tail_call: false,


### PR DESCRIPTION
This reverts commit 3d9656df8679c8704e8351409755b699e0efdb1a.
Just in case tests fail in master so we can merge quickly (which I don't think will be the case, in case the latest commit passes tests we can close this PR!).

Note: we can merge this PR manually, as it goes back to a version that was also green.

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
