### PR TITLE
Prepare  for release of 2.0.0-rc1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -219,7 +219,7 @@ jobs:
       - name: Install Nightly Rust for Headless
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'nightly-2020-12-22'
+          toolchain: 'nightly-2021-04-25'
           target: ${{ matrix.target }}
           override: true
           components: "rust-src"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/CHANGELOG.md).
 
-
 ## **[Unreleased]**
+
+## 2.0.0-rc1 - 2020/06/02
 
 ### Added
 - [#2306](https://github.com/wasmerio/wasmer/pull/2306) Add support for the latest version of the Wasm SIMD proposal to compiler LLVM.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-c-api"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "cbindgen",
  "cfg-if 1.0.0",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "blake3",
  "criterion",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cli"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "anyhow",
  "atty",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "enumset",
  "hashbrown",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "byteorder",
  "cc",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "compiletest_rs",
  "proc-macro-error",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-emscripten"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "byteorder",
  "getrandom",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dummy"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "bincode",
  "loupe",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "cfg-if 1.0.0",
  "leb128",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-staticlib"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "bincode",
  "cfg-if 1.0.0",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "cfg-if 1.0.0",
  "leb128",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-integration-tests-cli"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "loupe",
  "wasmer",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "object",
  "thiserror",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "indexmap",
  "loupe",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "backtrace",
  "cc",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-experimental-io-devices"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "minifb",
  "ref_thread_local",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wast"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "anyhow",
  "serde",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "1.0.2"
+version = "2.0.0-rc"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-c-api"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "cbindgen",
  "cfg-if 1.0.0",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cache"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "blake3",
  "criterion",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-cli"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "anyhow",
  "atty",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "enumset",
  "hashbrown",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-llvm"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "byteorder",
  "cc",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "compiletest_rs",
  "proc-macro-error",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-emscripten"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "byteorder",
  "getrandom",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dummy"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "bincode",
  "loupe",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "cfg-if 1.0.0",
  "leb128",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-staticlib"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "bincode",
  "cfg-if 1.0.0",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "cfg-if 1.0.0",
  "leb128",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-integration-tests-cli"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "loupe",
  "wasmer",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "object",
  "thiserror",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "indexmap",
  "loupe",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "backtrace",
  "cc",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi-experimental-io-devices"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "minifb",
  "ref_thread_local",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wast"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "anyhow",
  "serde",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-workspace"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-workspace"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer workspace"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -10,21 +10,21 @@ publish = false
 autoexamples = false
 
 [dependencies]
-wasmer = { version = "1.0.2", path = "lib/api", default-features = false }
-wasmer-compiler = { version = "1.0.2", path = "lib/compiler" }
-wasmer-compiler-cranelift = { version = "1.0.2", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.2", path = "lib/compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.2", path = "lib/compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.2", path = "lib/emscripten", optional = true }
-wasmer-engine = { version = "1.0.2", path = "lib/engine" }
-wasmer-engine-universal = { version = "1.0.2", path = "lib/engine-universal", optional = true }
-wasmer-engine-dylib = { version = "1.0.2", path = "lib/engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "1.0.2", path = "lib/engine-staticlib", optional = true }
-wasmer-wasi = { version = "1.0.2", path = "lib/wasi", optional = true }
-wasmer-wast = { version = "1.0.2", path = "tests/lib/wast", optional = true }
-wasmer-cache = { version = "1.0.2", path = "lib/cache", optional = true }
-wasmer-types = { version = "1.0.2", path = "lib/types" }
-wasmer-middlewares = { version = "1.0.2", path = "lib/middlewares", optional = true }
+wasmer = { version = "2.0.0-rc", path = "lib/api", default-features = false }
+wasmer-compiler = { version = "2.0.0-rc", path = "lib/compiler" }
+wasmer-compiler-cranelift = { version = "2.0.0-rc", path = "lib/compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "2.0.0-rc", path = "lib/compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "2.0.0-rc", path = "lib/compiler-llvm", optional = true }
+wasmer-emscripten = { version = "2.0.0-rc", path = "lib/emscripten", optional = true }
+wasmer-engine = { version = "2.0.0-rc", path = "lib/engine" }
+wasmer-engine-universal = { version = "2.0.0-rc", path = "lib/engine-universal", optional = true }
+wasmer-engine-dylib = { version = "2.0.0-rc", path = "lib/engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "2.0.0-rc", path = "lib/engine-staticlib", optional = true }
+wasmer-wasi = { version = "2.0.0-rc", path = "lib/wasi", optional = true }
+wasmer-wast = { version = "2.0.0-rc", path = "tests/lib/wast", optional = true }
+wasmer-cache = { version = "2.0.0-rc", path = "lib/cache", optional = true }
+wasmer-types = { version = "2.0.0-rc", path = "lib/types" }
+wasmer-middlewares = { version = "2.0.0-rc", path = "lib/middlewares", optional = true }
 cfg-if = "1.0"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-workspace"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer workspace"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -10,21 +10,21 @@ publish = false
 autoexamples = false
 
 [dependencies]
-wasmer = { version = "2.0.0-rc", path = "lib/api", default-features = false }
-wasmer-compiler = { version = "2.0.0-rc", path = "lib/compiler" }
-wasmer-compiler-cranelift = { version = "2.0.0-rc", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.0.0-rc", path = "lib/compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "2.0.0-rc", path = "lib/compiler-llvm", optional = true }
-wasmer-emscripten = { version = "2.0.0-rc", path = "lib/emscripten", optional = true }
-wasmer-engine = { version = "2.0.0-rc", path = "lib/engine" }
-wasmer-engine-universal = { version = "2.0.0-rc", path = "lib/engine-universal", optional = true }
-wasmer-engine-dylib = { version = "2.0.0-rc", path = "lib/engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "2.0.0-rc", path = "lib/engine-staticlib", optional = true }
-wasmer-wasi = { version = "2.0.0-rc", path = "lib/wasi", optional = true }
-wasmer-wast = { version = "2.0.0-rc", path = "tests/lib/wast", optional = true }
-wasmer-cache = { version = "2.0.0-rc", path = "lib/cache", optional = true }
-wasmer-types = { version = "2.0.0-rc", path = "lib/types" }
-wasmer-middlewares = { version = "2.0.0-rc", path = "lib/middlewares", optional = true }
+wasmer = { version = "2.0.0-rc1", path = "lib/api", default-features = false }
+wasmer-compiler = { version = "2.0.0-rc1", path = "lib/compiler" }
+wasmer-compiler-cranelift = { version = "2.0.0-rc1", path = "lib/compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "2.0.0-rc1", path = "lib/compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "2.0.0-rc1", path = "lib/compiler-llvm", optional = true }
+wasmer-emscripten = { version = "2.0.0-rc1", path = "lib/emscripten", optional = true }
+wasmer-engine = { version = "2.0.0-rc1", path = "lib/engine" }
+wasmer-engine-universal = { version = "2.0.0-rc1", path = "lib/engine-universal", optional = true }
+wasmer-engine-dylib = { version = "2.0.0-rc1", path = "lib/engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "2.0.0-rc1", path = "lib/engine-staticlib", optional = true }
+wasmer-wasi = { version = "2.0.0-rc1", path = "lib/wasi", optional = true }
+wasmer-wast = { version = "2.0.0-rc1", path = "tests/lib/wast", optional = true }
+wasmer-cache = { version = "2.0.0-rc1", path = "lib/cache", optional = true }
+wasmer-types = { version = "2.0.0-rc1", path = "lib/types" }
+wasmer-middlewares = { version = "2.0.0-rc1", path = "lib/middlewares", optional = true }
 cfg-if = "1.0"
 
 [workspace]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "High-performant WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "runtime", "vm"]
@@ -11,16 +11,16 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "1.0.2" }
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.2", optional = true }
-wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "1.0.2", optional = true }
-wasmer-compiler-llvm = { path = "../compiler-llvm", version = "1.0.2", optional = true }
-wasmer-compiler = { path = "../compiler", version = "1.0.2" }
-wasmer-derive = { path = "../derive", version = "1.0.2" }
-wasmer-engine = { path = "../engine", version = "1.0.2" }
-wasmer-engine-universal = { path = "../engine-universal", version = "1.0.2", optional = true }
-wasmer-engine-dylib = { path = "../engine-dylib", version = "1.0.2", optional = true }
-wasmer-types = { path = "../types", version = "1.0.2" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.0.0-rc", optional = true }
+wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "2.0.0-rc", optional = true }
+wasmer-compiler-llvm = { path = "../compiler-llvm", version = "2.0.0-rc", optional = true }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
+wasmer-derive = { path = "../derive", version = "2.0.0-rc" }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
+wasmer-engine-universal = { path = "../engine-universal", version = "2.0.0-rc", optional = true }
+wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0-rc", optional = true }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
 indexmap = { version = "1.6", features = ["serde-1"] }
 cfg-if = "1.0"
 wat = { version = "1.0", optional = true }

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "High-performant WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "runtime", "vm"]
@@ -11,16 +11,16 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.0.0-rc", optional = true }
-wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "2.0.0-rc", optional = true }
-wasmer-compiler-llvm = { path = "../compiler-llvm", version = "2.0.0-rc", optional = true }
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
-wasmer-derive = { path = "../derive", version = "2.0.0-rc" }
-wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
-wasmer-engine-universal = { path = "../engine-universal", version = "2.0.0-rc", optional = true }
-wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0-rc", optional = true }
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.0.0-rc1", optional = true }
+wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "2.0.0-rc1", optional = true }
+wasmer-compiler-llvm = { path = "../compiler-llvm", version = "2.0.0-rc1", optional = true }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1" }
+wasmer-derive = { path = "../derive", version = "2.0.0-rc1" }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc1" }
+wasmer-engine-universal = { path = "../engine-universal", version = "2.0.0-rc1", optional = true }
+wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0-rc1", optional = true }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
 indexmap = { version = "1.6", features = ["serde-1"] }
 cfg-if = "1.0"
 wat = { version = "1.0", optional = true }

--- a/lib/c-api/CHANGELOG.md
+++ b/lib/c-api/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 Looking for changes to the Wasmer CLI and the Rust API? See our [Primary Changelog](../../CHANGELOG.md)
 
-
 ## **[Unreleased]**
+
+## 2.0.0-rc1 - 2020/06/02
 
 ### Added
 - [#2346](https://github.com/wasmerio/wasmer/pull/2346) Add missing `wasm_func_copy` function.

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-c-api"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer C API library"
 categories = ["wasm", "api-bindings"]
 keywords = ["wasm", "webassembly", "runtime"]
@@ -15,18 +15,18 @@ edition = "2018"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
-wasmer = { version = "1.0.2", path = "../api", default-features = false }
-wasmer-compiler-cranelift = { version = "1.0.2", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.2", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.2", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.2", path = "../emscripten", optional = true }
-wasmer-engine = { version = "1.0.2", path = "../engine" }
-wasmer-engine-universal = { version = "1.0.2", path = "../engine-universal", optional = true }
-wasmer-engine-dylib = { version = "1.0.2", path = "../engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "1.0.2", path = "../engine-staticlib", optional = true }
-wasmer-middlewares = { version = "1.0.2", path = "../middlewares", optional = true }
-wasmer-wasi = { version = "1.0.2", path = "../wasi", optional = true }
-wasmer-types = { version = "1.0.2", path = "../types" }
+wasmer = { version = "2.0.0-rc", path = "../api", default-features = false }
+wasmer-compiler-cranelift = { version = "2.0.0-rc", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "2.0.0-rc", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "2.0.0-rc", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "2.0.0-rc", path = "../emscripten", optional = true }
+wasmer-engine = { version = "2.0.0-rc", path = "../engine" }
+wasmer-engine-universal = { version = "2.0.0-rc", path = "../engine-universal", optional = true }
+wasmer-engine-dylib = { version = "2.0.0-rc", path = "../engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "2.0.0-rc", path = "../engine-staticlib", optional = true }
+wasmer-middlewares = { version = "2.0.0-rc", path = "../middlewares", optional = true }
+wasmer-wasi = { version = "2.0.0-rc", path = "../wasi", optional = true }
+wasmer-types = { version = "2.0.0-rc", path = "../types" }
 enumset = "1.0"
 cfg-if = "1.0"
 lazy_static = "1.4"

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-c-api"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer C API library"
 categories = ["wasm", "api-bindings"]
 keywords = ["wasm", "webassembly", "runtime"]
@@ -15,18 +15,18 @@ edition = "2018"
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
-wasmer = { version = "2.0.0-rc", path = "../api", default-features = false }
-wasmer-compiler-cranelift = { version = "2.0.0-rc", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.0.0-rc", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "2.0.0-rc", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "2.0.0-rc", path = "../emscripten", optional = true }
-wasmer-engine = { version = "2.0.0-rc", path = "../engine" }
-wasmer-engine-universal = { version = "2.0.0-rc", path = "../engine-universal", optional = true }
-wasmer-engine-dylib = { version = "2.0.0-rc", path = "../engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "2.0.0-rc", path = "../engine-staticlib", optional = true }
-wasmer-middlewares = { version = "2.0.0-rc", path = "../middlewares", optional = true }
-wasmer-wasi = { version = "2.0.0-rc", path = "../wasi", optional = true }
-wasmer-types = { version = "2.0.0-rc", path = "../types" }
+wasmer = { version = "2.0.0-rc1", path = "../api", default-features = false }
+wasmer-compiler-cranelift = { version = "2.0.0-rc1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "2.0.0-rc1", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "2.0.0-rc1", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "2.0.0-rc1", path = "../emscripten", optional = true }
+wasmer-engine = { version = "2.0.0-rc1", path = "../engine" }
+wasmer-engine-universal = { version = "2.0.0-rc1", path = "../engine-universal", optional = true }
+wasmer-engine-dylib = { version = "2.0.0-rc1", path = "../engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "2.0.0-rc1", path = "../engine-staticlib", optional = true }
+wasmer-middlewares = { version = "2.0.0-rc1", path = "../middlewares", optional = true }
+wasmer-wasi = { version = "2.0.0-rc1", path = "../wasi", optional = true }
+wasmer-types = { version = "2.0.0-rc1", path = "../types" }
 enumset = "1.0"
 cfg-if = "1.0"
 lazy_static = "1.4"

--- a/lib/c-api/wasmer.h
+++ b/lib/c-api/wasmer.h
@@ -75,11 +75,11 @@
 #define WASMER_MIDDLEWARES_ENABLED
 
 // This file corresponds to the following Wasmer version.
-#define WASMER_VERSION "1.0.2"
-#define WASMER_VERSION_MAJOR 1
+#define WASMER_VERSION "2.0.0-rc"
+#define WASMER_VERSION_MAJOR 2
 #define WASMER_VERSION_MINOR 0
-#define WASMER_VERSION_PATCH 2
-#define WASMER_VERSION_PRE ""
+#define WASMER_VERSION_PATCH 0
+#define WASMER_VERSION_PRE "rc"
 
 #endif // WASMER_H_PRELUDE
 

--- a/lib/c-api/wasmer.h
+++ b/lib/c-api/wasmer.h
@@ -75,11 +75,11 @@
 #define WASMER_MIDDLEWARES_ENABLED
 
 // This file corresponds to the following Wasmer version.
-#define WASMER_VERSION "2.0.0-rc"
+#define WASMER_VERSION "2.0.0-rc1"
 #define WASMER_VERSION_MAJOR 2
 #define WASMER_VERSION_MINOR 0
 #define WASMER_VERSION_PATCH 0
-#define WASMER_VERSION_PRE "rc"
+#define WASMER_VERSION_PRE "rc1"
 
 #endif // WASMER_H_PRELUDE
 

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cache"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Cache system for Wasmer WebAssembly runtime"
 categories = ["wasm", "caching"]
 keywords = ["wasm", "webassembly", "cache"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "1.0.2", default-features = false }
+wasmer = { path = "../api", version = "2.0.0-rc", default-features = false }
 hex = "0.4"
 thiserror = "1"
 blake3 = "0.3"
@@ -20,9 +20,9 @@ blake3 = "0.3"
 criterion = "0.3"
 tempfile = "3"
 rand = "0.8.3"
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "1.0.2" }
-wasmer-engine-universal = { path = "../engine-universal", version = "1.0.2" }
-wasmer-engine-dylib = { path = "../engine-dylib", version = "1.0.2" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.0.0-rc" }
+wasmer-engine-universal = { path = "../engine-universal", version = "2.0.0-rc" }
+wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0-rc" }
 
 [[bench]]
 name = "bench_filesystem_cache"

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cache"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Cache system for Wasmer WebAssembly runtime"
 categories = ["wasm", "caching"]
 keywords = ["wasm", "webassembly", "cache"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "2.0.0-rc", default-features = false }
+wasmer = { path = "../api", version = "2.0.0-rc1", default-features = false }
 hex = "0.4"
 thiserror = "1"
 blake3 = "0.3"
@@ -20,9 +20,9 @@ blake3 = "0.3"
 criterion = "0.3"
 tempfile = "3"
 rand = "0.8.3"
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.0.0-rc" }
-wasmer-engine-universal = { path = "../engine-universal", version = "2.0.0-rc" }
-wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0-rc" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.0.0-rc1" }
+wasmer-engine-universal = { path = "../engine-universal", version = "2.0.0-rc1" }
+wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0-rc1" }
 
 [[bench]]
 name = "bench_filesystem_cache"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cli"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer CLI"
 categories = ["wasm", "command-line-interface"]
 keywords = ["wasm", "webassembly", "cli"]
@@ -24,22 +24,22 @@ doc = false
 required-features = ["headless"]
 
 [dependencies]
-wasmer = { version = "1.0.2", path = "../api", default-features = false }
-wasmer-compiler = { version = "1.0.2", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "1.0.2", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.2", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "1.0.2", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "1.0.2", path = "../emscripten", optional = true }
-wasmer-engine = { version = "1.0.2", path = "../engine" }
-wasmer-engine-universal = { version = "1.0.2", path = "../engine-universal", optional = true }
-wasmer-engine-dylib = { version = "1.0.2", path = "../engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "1.0.2", path = "../engine-staticlib", optional = true }
-wasmer-vm = { version = "1.0.2", path = "../vm" }
-wasmer-wasi = { version = "1.0.2", path = "../wasi", default-features = false, optional = true }
-wasmer-wasi-experimental-io-devices = { version = "1.0.2", path = "../wasi-experimental-io-devices", optional = true }
-wasmer-wast = { version = "1.0.2", path = "../../tests/lib/wast", optional = true }
-wasmer-cache = { version = "1.0.2", path = "../cache", optional = true }
-wasmer-types = { version = "1.0.2", path = "../types" }
+wasmer = { version = "2.0.0-rc", path = "../api", default-features = false }
+wasmer-compiler = { version = "2.0.0-rc", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "2.0.0-rc", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "2.0.0-rc", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "2.0.0-rc", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "2.0.0-rc", path = "../emscripten", optional = true }
+wasmer-engine = { version = "2.0.0-rc", path = "../engine" }
+wasmer-engine-universal = { version = "2.0.0-rc", path = "../engine-universal", optional = true }
+wasmer-engine-dylib = { version = "2.0.0-rc", path = "../engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "2.0.0-rc", path = "../engine-staticlib", optional = true }
+wasmer-vm = { version = "2.0.0-rc", path = "../vm" }
+wasmer-wasi = { version = "2.0.0-rc", path = "../wasi", default-features = false, optional = true }
+wasmer-wasi-experimental-io-devices = { version = "2.0.0-rc", path = "../wasi-experimental-io-devices", optional = true }
+wasmer-wast = { version = "2.0.0-rc", path = "../../tests/lib/wast", optional = true }
+wasmer-cache = { version = "2.0.0-rc", path = "../cache", optional = true }
+wasmer-types = { version = "2.0.0-rc", path = "../types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-cli"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer CLI"
 categories = ["wasm", "command-line-interface"]
 keywords = ["wasm", "webassembly", "cli"]
@@ -24,22 +24,22 @@ doc = false
 required-features = ["headless"]
 
 [dependencies]
-wasmer = { version = "2.0.0-rc", path = "../api", default-features = false }
-wasmer-compiler = { version = "2.0.0-rc", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "2.0.0-rc", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.0.0-rc", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "2.0.0-rc", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "2.0.0-rc", path = "../emscripten", optional = true }
-wasmer-engine = { version = "2.0.0-rc", path = "../engine" }
-wasmer-engine-universal = { version = "2.0.0-rc", path = "../engine-universal", optional = true }
-wasmer-engine-dylib = { version = "2.0.0-rc", path = "../engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "2.0.0-rc", path = "../engine-staticlib", optional = true }
-wasmer-vm = { version = "2.0.0-rc", path = "../vm" }
-wasmer-wasi = { version = "2.0.0-rc", path = "../wasi", default-features = false, optional = true }
-wasmer-wasi-experimental-io-devices = { version = "2.0.0-rc", path = "../wasi-experimental-io-devices", optional = true }
-wasmer-wast = { version = "2.0.0-rc", path = "../../tests/lib/wast", optional = true }
-wasmer-cache = { version = "2.0.0-rc", path = "../cache", optional = true }
-wasmer-types = { version = "2.0.0-rc", path = "../types" }
+wasmer = { version = "2.0.0-rc1", path = "../api", default-features = false }
+wasmer-compiler = { version = "2.0.0-rc1", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "2.0.0-rc1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "2.0.0-rc1", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "2.0.0-rc1", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "2.0.0-rc1", path = "../emscripten", optional = true }
+wasmer-engine = { version = "2.0.0-rc1", path = "../engine" }
+wasmer-engine-universal = { version = "2.0.0-rc1", path = "../engine-universal", optional = true }
+wasmer-engine-dylib = { version = "2.0.0-rc1", path = "../engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "2.0.0-rc1", path = "../engine-staticlib", optional = true }
+wasmer-vm = { version = "2.0.0-rc1", path = "../vm" }
+wasmer-wasi = { version = "2.0.0-rc1", path = "../wasi", default-features = false, optional = true }
+wasmer-wasi-experimental-io-devices = { version = "2.0.0-rc1", path = "../wasi-experimental-io-devices", optional = true }
+wasmer-wast = { version = "2.0.0-rc1", path = "../../tests/lib/wast", optional = true }
+wasmer-cache = { version = "2.0.0-rc1", path = "../cache", optional = true }
+wasmer-types = { version = "2.0.0-rc1", path = "../types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-cranelift"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Cranelift compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "cranelift"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.2", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.2" }
-wasmer-types = { path = "../types", version = "1.0.2", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc", default-features = false, features = ["std"] }
 cranelift-entity = { version = "0.74", default-features = false }
 cranelift-codegen = { version = "0.74", default-features = false, features = ["x86", "arm64"] }
 cranelift-frontend = { version = "0.74", default-features = false }

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-cranelift"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Cranelift compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "cranelift"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
-wasmer-types = { path = "../types", version = "2.0.0-rc", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1", default-features = false, features = ["std"] }
 cranelift-entity = { version = "0.74", default-features = false }
 cranelift-codegen = { version = "0.74", default-features = false, features = ["x86", "arm64"] }
 cranelift-frontend = { version = "0.74", default-features = false }

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-llvm"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "LLVM compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "llvm"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.2", features = ["translator"] }
-wasmer-vm = { path = "../vm", version = "1.0.2" }
-wasmer-types = { path = "../types", version = "1.0.2" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
 target-lexicon = { version = "0.12", default-features = false }
 smallvec = "1.6"
 object = { version = "0.24", default-features = false, features = ["read"] }

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-llvm"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "LLVM compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "llvm"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator"] }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
 target-lexicon = { version = "0.12", default-features = false }
 smallvec = "1.6"
 object = { version = "0.24", default-features = false, features = ["read"] }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-singlepass"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Singlepass compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "singlepass"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "1.0.2", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "1.0.2" }
-wasmer-types = { path = "../types", version = "1.0.2", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc", default-features = false, features = ["std"] }
 rayon = { version = "1.5", optional = true }
 hashbrown = { version = "0.9", optional = true }
 more-asserts = "0.2"

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-singlepass"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Singlepass compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "singlepass"]
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
-wasmer-types = { path = "../types", version = "2.0.0-rc", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1", default-features = false, features = ["std"] }
 rayon = { version = "1.5", optional = true }
 hashbrown = { version = "0.9", optional = true }
 more-asserts = "0.2"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Base compiler abstraction for Wasmer WebAssembly runtime"
 categories = ["wasm", "no-std"]
 keywords = ["wasm", "webassembly", "compiler"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "1.0.2" }
-wasmer-types = { path = "../types", version = "1.0.2", default-features = false }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc", default-features = false }
 wasmparser = { version = "0.78", optional = true, default-features = false }
 target-lexicon = { version = "0.12", default-features = false }
 enumset = "1.0"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Base compiler abstraction for Wasmer WebAssembly runtime"
 categories = ["wasm", "no-std"]
 keywords = ["wasm", "webassembly", "compiler"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
-wasmer-types = { path = "../types", version = "2.0.0-rc", default-features = false }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1", default-features = false }
 wasmparser = { version = "0.78", optional = true, default-features = false }
 target-lexicon = { version = "0.12", default-features = false }
 enumset = "1.0"

--- a/lib/derive/Cargo.toml
+++ b/lib/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-derive"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer derive macros"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -17,5 +17,5 @@ proc-macro2 = "1"
 proc-macro-error = "1.0.0"
 
 [dev-dependencies]
-wasmer = { path = "../api", version = "1.0.2" }
+wasmer = { path = "../api", version = "2.0.0-rc" }
 compiletest_rs = "0.6"

--- a/lib/derive/Cargo.toml
+++ b/lib/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-derive"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer derive macros"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -17,5 +17,5 @@ proc-macro2 = "1"
 proc-macro-error = "1.0.0"
 
 [dev-dependencies]
-wasmer = { path = "../api", version = "2.0.0-rc" }
+wasmer = { path = "../api", version = "2.0.0-rc1" }
 compiletest_rs = "0.6"

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Emscripten implementation library for Wasmer WebAssembly runtime"
 categories = ["wasm", "os"]
 keywords = ["wasm", "webassembly", "abi", "emscripten", "posix"]
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 libc = "^0.2"
 log = "0.4"
 time = "0.1"
-wasmer = { path = "../api", version = "1.0.2", default-features = false }
+wasmer = { path = "../api", version = "2.0.0-rc", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.2"

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-emscripten"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Emscripten implementation library for Wasmer WebAssembly runtime"
 categories = ["wasm", "os"]
 keywords = ["wasm", "webassembly", "abi", "emscripten", "posix"]
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 libc = "^0.2"
 log = "0.4"
 time = "0.1"
-wasmer = { path = "../api", version = "2.0.0-rc", default-features = false }
+wasmer = { path = "../api", version = "2.0.0-rc1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.2"

--- a/lib/engine-dylib/Cargo.toml
+++ b/lib/engine-dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-dylib"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer Dylib Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "dylib"]
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "1.0.2" }
-wasmer-compiler = { path = "../compiler", version = "1.0.2" }
-wasmer-vm = { path = "../vm", version = "1.0.2", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", version = "1.0.2" }
-wasmer-object = { path = "../object", version = "1.0.2" }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
+wasmer-object = { path = "../object", version = "2.0.0-rc" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
 tracing = "0.1"

--- a/lib/engine-dylib/Cargo.toml
+++ b/lib/engine-dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-dylib"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer Dylib Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "dylib"]
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
-wasmer-object = { path = "../object", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc1" }
+wasmer-object = { path = "../object", version = "2.0.0-rc1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
 tracing = "0.1"

--- a/lib/engine-staticlib/Cargo.toml
+++ b/lib/engine-staticlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-staticlib"
-version = "1.0.2"
+version = "2.0.0-rc"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer Staticlib Engine"
 categories = ["wasm"]
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "1.0.2" }
-wasmer-compiler = { path = "../compiler", version = "1.0.2" }
-wasmer-vm = { path = "../vm", version = "1.0.2" }
-wasmer-engine = { path = "../engine", version = "1.0.2" }
-wasmer-object = { path = "../object", version = "1.0.2" }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
+wasmer-object = { path = "../object", version = "2.0.0-rc" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
 tracing = "0.1"

--- a/lib/engine-staticlib/Cargo.toml
+++ b/lib/engine-staticlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-staticlib"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer Staticlib Engine"
 categories = ["wasm"]
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
-wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
-wasmer-object = { path = "../object", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc1" }
+wasmer-object = { path = "../object", version = "2.0.0-rc1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
 tracing = "0.1"

--- a/lib/engine-universal/Cargo.toml
+++ b/lib/engine-universal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-universal"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer Universal Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "universal"]
@@ -11,10 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "1.0.2", features = ["enable-rkyv"] }
-wasmer-compiler = { path = "../compiler", version = "1.0.2", features = ["translator", "enable-rkyv"] }
-wasmer-vm = { path = "../vm", version = "1.0.2", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", version = "1.0.2" }
+wasmer-types = { path = "../types", version = "2.0.0-rc", features = ["enable-rkyv"] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator", "enable-rkyv"] }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "2.2"
 cfg-if = "1.0"

--- a/lib/engine-universal/Cargo.toml
+++ b/lib/engine-universal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-universal"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer Universal Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "universal"]
@@ -11,10 +11,10 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0-rc", features = ["enable-rkyv"] }
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", features = ["translator", "enable-rkyv"] }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1", features = ["enable-rkyv"] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1", features = ["translator", "enable-rkyv"] }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", version = "2.0.0-rc1" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "2.2"
 cfg-if = "1.0"

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer Engine abstraction"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine"]
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "1.0.2" }
-wasmer-compiler = { path = "../compiler", version = "1.0.2" }
-wasmer-vm = { path = "../vm", version = "1.0.2" }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
 target-lexicon = { version = "0.12", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer Engine abstraction"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine"]
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc" }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
 target-lexicon = { version = "0.12", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"

--- a/lib/middlewares/Cargo.toml
+++ b/lib/middlewares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-middlewares"
-version = "1.0.2"
+version = "2.0.0-rc"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "A collection of various useful middlewares"
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "1.0.2", default-features = false, features = ["compiler"] }
-wasmer-types = { path = "../types", version = "1.0.2" }
-wasmer-vm = { path = "../vm", version = "1.0.2" }
+wasmer = { path = "../api", version = "2.0.0-rc", default-features = false, features = ["compiler"] }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
 loupe = "0.1"
 
 [badges]

--- a/lib/middlewares/Cargo.toml
+++ b/lib/middlewares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-middlewares"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "A collection of various useful middlewares"
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "2.0.0-rc", default-features = false, features = ["compiler"] }
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
-wasmer-vm = { path = "../vm", version = "2.0.0-rc" }
+wasmer = { path = "../api", version = "2.0.0-rc1", default-features = false, features = ["compiler"] }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
+wasmer-vm = { path = "../vm", version = "2.0.0-rc1" }
 loupe = "0.1"
 
 [badges]

--- a/lib/object/Cargo.toml
+++ b/lib/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-object"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer Native Object generator"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "1.0.2" }
-wasmer-compiler = { path = "../compiler", version = "1.0.2", default-features = false, features = [
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", default-features = false, features = [
     "std",
     "translator"
 ] }

--- a/lib/object/Cargo.toml
+++ b/lib/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-object"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer Native Object generator"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
-wasmer-compiler = { path = "../compiler", version = "2.0.0-rc", default-features = false, features = [
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
+wasmer-compiler = { path = "../compiler", version = "2.0.0-rc1", default-features = false, features = [
     "std",
     "translator"
 ] }

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-types"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Wasmer Common Types"
 categories = ["wasm", "no-std", "data-structures"]
 keywords = ["wasm", "webassembly", "types"]

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-types"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Wasmer Common Types"
 categories = ["wasm", "no-std", "data-structures"]
 keywords = ["wasm", "webassembly", "types"]

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-vm"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "Runtime library support for Wasmer"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "1.0.2" }
+wasmer-types = { path = "../types", version = "2.0.0-rc" }
 region = "2.2"
 libc = { version = "^0.2", default-features = false }
 memoffset = "0.6"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-vm"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "Runtime library support for Wasmer"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0-rc" }
+wasmer-types = { path = "../types", version = "2.0.0-rc1" }
 region = "2.2"
 libc = { version = "^0.2", default-features = false }
 memoffset = "0.6"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-experimental-io-devices"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "An experimental non-standard WASI extension for graphics"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "types"]
@@ -14,7 +14,7 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
-wasmer-wasi = { version = "1.0.2", path = "../wasi" }
+wasmer-wasi = { version = "2.0.0-rc", path = "../wasi" }
 tracing = "0.1"
 minifb = "0.19"
 ref_thread_local = "0.1"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi-experimental-io-devices"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "An experimental non-standard WASI extension for graphics"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "types"]
@@ -14,7 +14,7 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
-wasmer-wasi = { version = "2.0.0-rc", path = "../wasi" }
+wasmer-wasi = { version = "2.0.0-rc1", path = "../wasi" }
 tracing = "0.1"
 minifb = "0.19"
 ref_thread_local = "0.1"

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi"
-version = "1.0.2"
+version = "2.0.0-rc"
 description = "WASI implementation library for Wasmer WebAssembly runtime"
 categories = ["wasm", "os"]
 keywords = ["wasm", "webassembly", "wasi", "sandbox", "ABI"]
@@ -21,7 +21,7 @@ getrandom = "0.2"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-wasmer = { path = "../api", version = "1.0.2", default-features = false }
+wasmer = { path = "../api", version = "2.0.0-rc", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wasi"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 description = "WASI implementation library for Wasmer WebAssembly runtime"
 categories = ["wasm", "os"]
 keywords = ["wasm", "webassembly", "wasi", "sandbox", "ABI"]
@@ -21,7 +21,7 @@ getrandom = "0.2"
 time = "0.1"
 typetag = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-wasmer = { path = "../api", version = "2.0.0-rc", default-features = false }
+wasmer = { path = "../api", version = "2.0.0-rc1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -4,8 +4,8 @@
 : "${FD:=fd}"
 
 # A script to update the version of all the crates at the same time
-PREVIOUS_VERSION='1.0.1'
-NEXT_VERSION='1.0.2'
+PREVIOUS_VERSION='1.0.2'
+NEXT_VERSION='2.0.0-rc1'
 
 # quick hack
 ${FD} Cargo.toml --exec sed -i '{}' -e "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"

--- a/scripts/windows-installer/wasmer.iss
+++ b/scripts/windows-installer/wasmer.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=Wasmer
-AppVersion=1.0.2
+AppVersion=2.0.0-rc
 DefaultDirName={pf}\Wasmer
 DefaultGroupName=Wasmer
 Compression=lzma2

--- a/scripts/windows-installer/wasmer.iss
+++ b/scripts/windows-installer/wasmer.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=Wasmer
-AppVersion=2.0.0-rc
+AppVersion=2.0.0-rc1
 DefaultDirName={pf}\Wasmer
 DefaultGroupName=Wasmer
 Compression=lzma2

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-integration-tests-cli"
-version = "1.0.2"
+version = "2.0.0-rc"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "CLI integration tests"
 repository = "https://github.com/wasmerio/wasmer"

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-integration-tests-cli"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "CLI integration tests"
 repository = "https://github.com/wasmerio/wasmer"

--- a/tests/lib/engine-dummy/Cargo.toml
+++ b/tests/lib/engine-dummy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-dummy"
-version = "1.0.2"
+version = "2.0.0-rc"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer placeholder engine"
 license = "MIT"
@@ -8,10 +8,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-wasmer-types = { path = "../../../lib/types", version = "1.0.2" }
-wasmer-compiler = { path = "../../../lib/compiler", version = "1.0.2" }
-wasmer-vm = { path = "../../../lib/vm", version = "1.0.2" }
-wasmer-engine = { path = "../../../lib/engine", version = "1.0.2" }
+wasmer-types = { path = "../../../lib/types", version = "2.0.0-rc" }
+wasmer-compiler = { path = "../../../lib/compiler", version = "2.0.0-rc" }
+wasmer-vm = { path = "../../../lib/vm", version = "2.0.0-rc" }
+wasmer-engine = { path = "../../../lib/engine", version = "2.0.0-rc" }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
 bincode = { version = "1.2", optional = true }

--- a/tests/lib/engine-dummy/Cargo.toml
+++ b/tests/lib/engine-dummy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-dummy"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "Wasmer placeholder engine"
 license = "MIT"
@@ -8,10 +8,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-wasmer-types = { path = "../../../lib/types", version = "2.0.0-rc" }
-wasmer-compiler = { path = "../../../lib/compiler", version = "2.0.0-rc" }
-wasmer-vm = { path = "../../../lib/vm", version = "2.0.0-rc" }
-wasmer-engine = { path = "../../../lib/engine", version = "2.0.0-rc" }
+wasmer-types = { path = "../../../lib/types", version = "2.0.0-rc1" }
+wasmer-compiler = { path = "../../../lib/compiler", version = "2.0.0-rc1" }
+wasmer-vm = { path = "../../../lib/vm", version = "2.0.0-rc1" }
+wasmer-engine = { path = "../../../lib/engine", version = "2.0.0-rc1" }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
 bincode = { version = "1.2", optional = true }

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wast"
-version = "1.0.2"
+version = "2.0.0-rc"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "wast testing support for wasmer"
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmer = { path = "../../../lib/api", version = "1.0.2", default-features = false, features = ["experimental-reference-types-extern-ref"] }
-wasmer-wasi = { path = "../../../lib/wasi", version = "1.0.2" }
+wasmer = { path = "../../../lib/api", version = "2.0.0-rc", default-features = false, features = ["experimental-reference-types-extern-ref"] }
+wasmer-wasi = { path = "../../../lib/wasi", version = "2.0.0-rc" }
 wast = "35.0"
 serde = "1"
 tempfile = "3"

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-wast"
-version = "2.0.0-rc"
+version = "2.0.0-rc1"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 description = "wast testing support for wasmer"
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmer = { path = "../../../lib/api", version = "2.0.0-rc", default-features = false, features = ["experimental-reference-types-extern-ref"] }
-wasmer-wasi = { path = "../../../lib/wasi", version = "2.0.0-rc" }
+wasmer = { path = "../../../lib/api", version = "2.0.0-rc1", default-features = false, features = ["experimental-reference-types-extern-ref"] }
+wasmer-wasi = { path = "../../../lib/wasi", version = "2.0.0-rc1" }
 wast = "35.0"
 serde = "1"
 tempfile = "3"


### PR DESCRIPTION
Prepared for release of 2.0.0-rc1 ; nightly for headless  issue was caught in wasmer nightly, 2021-04-25 can compile const generics (used in our dependencies) and allows the build to succeed

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
