### PR TITLE
Revert update to clap-beta back to structopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **[Unreleased]**
 
+### Added
+
+### Changed
+
+### Fixed
+- [#2383](https://github.com/wasmerio/wasmer/pull/2383) Fix bugs in the Wasmer CLI tool with the way `--version` and the name of the CLI tool itself were printed.
+
 ## 2.0.0-rc1 - 2020/06/02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 2.33.3",
+ "clap",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -219,7 +219,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97449daf9b8c245bcad10bbc7c9f4a37c06172c18dd5f9fac340deefc309b957"
 dependencies = [
- "clap 2.33.3",
+ "clap",
  "heck",
  "indexmap",
  "log",
@@ -280,41 +280,9 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.12.1",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -466,7 +434,7 @@ checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
 dependencies = [
  "atty",
  "cast",
- "clap 2.33.3",
+ "clap",
  "criterion-plot",
  "csv",
  "itertools 0.10.0",
@@ -1343,12 +1311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
-
-[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +1936,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,15 +2059,6 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]
@@ -2469,11 +2446,11 @@ dependencies = [
  "atty",
  "bytesize",
  "cfg-if 1.0.0",
- "clap 3.0.0-beta.2",
  "colored 2.0.0",
  "distance",
  "fern",
  "log",
+ "structopt",
  "tempfile",
  "wasmer",
  "wasmer-cache",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -43,7 +43,7 @@ wasmer-types = { version = "2.0.0-rc1", path = "../types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
-clap = { version = "3.0.0-beta.2", features = ["suggestions", "derive", "cargo", "std", "color"], default-features = false }
+structopt = { version = "0.3", features = ["suggestions"] }
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand

--- a/lib/cli/src/cli.rs
+++ b/lib/cli/src/cli.rs
@@ -10,16 +10,16 @@ use crate::commands::{Cache, Config, Inspect, Run, SelfUpdate, Validate};
 use crate::error::PrettyError;
 use anyhow::Result;
 
-use clap::{Clap, ErrorKind};
+use structopt::{clap::ErrorKind, StructOpt};
 
-#[derive(Clap)]
+#[derive(StructOpt)]
 #[cfg_attr(
     not(feature = "headless"),
-    clap(name = "wasmer", about = "WebAssembly standalone runtime.", author)
+    structopt(name = "wasmer", about = "WebAssembly standalone runtime.", author)
 )]
 #[cfg_attr(
     feature = "headless",
-    clap(
+    structopt(
         name = "wasmer-headless",
         about = "Headless WebAssembly standalone runtime.",
         author
@@ -28,43 +28,43 @@ use clap::{Clap, ErrorKind};
 /// The options for the wasmer Command Line Interface
 enum WasmerCLIOptions {
     /// Run a WebAssembly file. Formats accepted: wasm, wat
-    #[clap(name = "run")]
+    #[structopt(name = "run")]
     Run(Run),
 
     /// Wasmer cache
-    #[clap(name = "cache")]
+    #[structopt(name = "cache")]
     Cache(Cache),
 
     /// Validate a WebAssembly binary
-    #[clap(name = "validate")]
+    #[structopt(name = "validate")]
     Validate(Validate),
 
     /// Compile a WebAssembly binary
     #[cfg(feature = "compiler")]
-    #[clap(name = "compile")]
+    #[structopt(name = "compile")]
     Compile(Compile),
 
     /// Compile a WebAssembly binary into a native executable
     #[cfg(all(feature = "staticlib", feature = "compiler"))]
-    #[clap(name = "create-exe")]
+    #[structopt(name = "create-exe")]
     CreateExe(CreateExe),
 
     /// Get various configuration information needed
     /// to compile programs which use Wasmer
-    #[clap(name = "config")]
+    #[structopt(name = "config")]
     Config(Config),
 
     /// Update wasmer to the latest version
-    #[clap(name = "self-update")]
+    #[structopt(name = "self-update")]
     SelfUpdate(SelfUpdate),
 
     /// Inspect a WebAssembly file
-    #[clap(name = "inspect")]
+    #[structopt(name = "inspect")]
     Inspect(Inspect),
 
     /// Run spec testsuite
     #[cfg(feature = "wast")]
-    #[clap(name = "wast")]
+    #[structopt(name = "wast")]
     Wast(Wast),
 }
 
@@ -101,15 +101,15 @@ pub fn wasmer_main() {
     let command = args.get(1);
     let options = match command.unwrap_or(&"".to_string()).as_ref() {
         "cache" | "compile" | "config" | "create-exe" | "help" | "inspect" | "run"
-        | "self-update" | "validate" | "wast" => WasmerCLIOptions::parse(),
+        | "self-update" | "validate" | "wast" => WasmerCLIOptions::from_args(),
         _ => {
-            WasmerCLIOptions::try_parse_from(args.iter()).unwrap_or_else(|e| {
+            WasmerCLIOptions::from_iter_safe(args.iter()).unwrap_or_else(|e| {
                 match e.kind {
                     // This fixes a issue that:
                     // 1. Shows the version twice when doing `wasmer -V`
                     // 2. Shows the run help (instead of normal help) when doing `wasmer --help`
-                    ErrorKind::DisplayVersion | ErrorKind::DisplayHelp => e.exit(),
-                    _ => WasmerCLIOptions::Run(Run::parse()),
+                    ErrorKind::VersionDisplayed | ErrorKind::HelpDisplayed => e.exit(),
+                    _ => WasmerCLIOptions::Run(Run::from_args()),
                 }
             })
         }

--- a/lib/cli/src/commands/cache.rs
+++ b/lib/cli/src/commands/cache.rs
@@ -1,17 +1,17 @@
 use crate::common::get_cache_dir;
 use anyhow::{Context, Result};
-use clap::Clap;
 use std::fs;
+use structopt::StructOpt;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer cache` subcommand
 pub enum Cache {
     /// Clear the cache
-    #[clap(name = "clean")]
+    #[structopt(name = "clean")]
     Clean,
 
     /// Display the location of the cache
-    #[clap(name = "dir")]
+    #[structopt(name = "dir")]
     Dir,
 }
 

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -1,33 +1,33 @@
 use crate::store::{EngineType, StoreOptions};
 use crate::warning;
 use anyhow::{Context, Result};
-use clap::Clap;
 use std::path::PathBuf;
+use structopt::StructOpt;
 use wasmer::*;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer compile` subcommand
 pub struct Compile {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[structopt(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Output file
-    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
+    #[structopt(name = "OUTPUT PATH", short = "o", parse(from_os_str))]
     output: PathBuf,
 
     /// Output path for generated header file
-    #[clap(name = "HEADER PATH", long = "header", parse(from_os_str))]
+    #[structopt(name = "HEADER PATH", long = "header", parse(from_os_str))]
     header_path: Option<PathBuf>,
 
     /// Compilation Target triple
-    #[clap(long = "target")]
+    #[structopt(long = "target")]
     target_triple: Option<Triple>,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     store: StoreOptions,
 
-    #[clap(short = 'm', multiple = true)]
+    #[structopt(short = "m", multiple = true)]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -1,39 +1,39 @@
 use crate::VERSION;
 use anyhow::{Context, Result};
-use clap::Clap;
 use std::env;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer config` subcommand
 pub struct Config {
     /// Print the installation prefix.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[structopt(long, conflicts_with = "pkg-config")]
     prefix: bool,
 
     /// Directory containing Wasmer executables.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[structopt(long, conflicts_with = "pkg-config")]
     bindir: bool,
 
     /// Directory containing Wasmer headers.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[structopt(long, conflicts_with = "pkg-config")]
     includedir: bool,
 
     /// Directory containing Wasmer libraries.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[structopt(long, conflicts_with = "pkg-config")]
     libdir: bool,
 
     /// Libraries needed to link against Wasmer components.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[structopt(long, conflicts_with = "pkg-config")]
     libs: bool,
 
     /// C compiler flags for files that include Wasmer headers.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[structopt(long, conflicts_with = "pkg-config")]
     cflags: bool,
 
     /// It outputs the necessary details for compiling
     /// and linking a program to Wasmer, using the `pkg-config` format.
-    #[clap(long)]
+    #[structopt(long)]
     pkg_config: bool,
 }
 

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -2,39 +2,39 @@
 
 use crate::store::{CompilerOptions, EngineType};
 use anyhow::{Context, Result};
-use clap::Clap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use structopt::StructOpt;
 use wasmer::*;
 
 const WASMER_MAIN_C_SOURCE: &[u8] = include_bytes!("wasmer_create_exe_main.c");
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer create-exe` subcommand
 pub struct CreateExe {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[structopt(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Output file
-    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
+    #[structopt(name = "OUTPUT PATH", short = "o", parse(from_os_str))]
     output: PathBuf,
 
     /// Compilation Target triple
-    #[clap(long = "target")]
+    #[structopt(long = "target")]
     target_triple: Option<Triple>,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     compiler: CompilerOptions,
 
-    #[clap(short = 'm', multiple = true)]
+    #[structopt(short = "m", multiple = true)]
     cpu_features: Vec<CpuFeature>,
 
     /// Additional libraries to link against.
     /// This is useful for fixing linker errors that may occur on some systems.
-    #[clap(short = 'l', multiple = true)]
+    #[structopt(short = "l", multiple = true)]
     libraries: Vec<String>,
 }
 

--- a/lib/cli/src/commands/inspect.rs
+++ b/lib/cli/src/commands/inspect.rs
@@ -1,18 +1,18 @@
 use crate::store::StoreOptions;
 use anyhow::{Context, Result};
 use bytesize::ByteSize;
-use clap::Clap;
 use std::path::PathBuf;
+use structopt::StructOpt;
 use wasmer::*;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer validate` subcommand
 pub struct Inspect {
     /// File to validate as WebAssembly
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[structopt(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     store: StoreOptions,
 }
 

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -11,7 +11,7 @@ use wasmer::*;
 #[cfg(feature = "cache")]
 use wasmer_cache::{Cache, FileSystemCache, Hash};
 
-use clap::Clap;
+use structopt::StructOpt;
 
 #[cfg(feature = "wasi")]
 mod wasi;
@@ -19,53 +19,53 @@ mod wasi;
 #[cfg(feature = "wasi")]
 use wasi::Wasi;
 
-#[derive(Debug, Clap, Clone)]
+#[derive(Debug, StructOpt, Clone)]
 /// The options for the `wasmer run` subcommand
 pub struct Run {
     /// Disable the cache
-    #[clap(long = "disable-cache")]
+    #[structopt(long = "disable-cache")]
     disable_cache: bool,
 
     /// File to run
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[structopt(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Invoke a specified function
-    #[clap(long = "invoke", short = 'i')]
+    #[structopt(long = "invoke", short = "i")]
     invoke: Option<String>,
 
     /// The command name is a string that will override the first argument passed
     /// to the wasm program. This is used in wapm to provide nicer output in
     /// help commands and error messages of the running wasm program
-    #[clap(long = "command-name", hidden = true)]
+    #[structopt(long = "command-name", hidden = true)]
     command_name: Option<String>,
 
     /// A prehashed string, used to speed up start times by avoiding hashing the
     /// wasm module. If the specified hash is not found, Wasmer will hash the module
     /// as if no `cache-key` argument was passed.
-    #[clap(long = "cache-key", hidden = true)]
+    #[structopt(long = "cache-key", hidden = true)]
     cache_key: Option<String>,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     store: StoreOptions,
 
     // TODO: refactor WASI structure to allow shared options with Emscripten
     #[cfg(feature = "wasi")]
-    #[clap(flatten)]
+    #[structopt(flatten)]
     wasi: Wasi,
 
     /// Enable non-standard experimental IO devices
     #[cfg(feature = "io-devices")]
-    #[clap(long = "enable-io-devices")]
+    #[structopt(long = "enable-io-devices")]
     enable_experimental_io_devices: bool,
 
     /// Enable debug output
     #[cfg(feature = "debug")]
-    #[clap(long = "debug", short = 'd')]
+    #[structopt(long = "debug", short = "d")]
     debug: bool,
 
     /// Application arguments
-    #[clap(name = "--", multiple = true)]
+    #[structopt(name = "--", multiple = true)]
     args: Vec<String>,
 }
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -5,34 +5,34 @@ use std::path::PathBuf;
 use wasmer::{Instance, Module};
 use wasmer_wasi::{get_wasi_versions, WasiError, WasiState, WasiVersion};
 
-use clap::Clap;
+use structopt::StructOpt;
 
-#[derive(Debug, Clap, Clone)]
+#[derive(Debug, StructOpt, Clone)]
 /// WASI Options
 pub struct Wasi {
     /// WASI pre-opened directory
-    #[clap(long = "dir", name = "DIR", multiple = true, group = "wasi")]
+    #[structopt(long = "dir", name = "DIR", multiple = true, group = "wasi")]
     pre_opened_directories: Vec<PathBuf>,
 
     /// Map a host directory to a different location for the Wasm module
-    #[clap(long = "mapdir", name = "GUEST_DIR:HOST_DIR", multiple = true, parse(try_from_str = parse_mapdir))]
+    #[structopt(long = "mapdir", name = "GUEST_DIR:HOST_DIR", multiple = true, parse(try_from_str = parse_mapdir))]
     mapped_dirs: Vec<(String, PathBuf)>,
 
     /// Pass custom environment variables
-    #[clap(long = "env", name = "KEY=VALUE", multiple = true, parse(try_from_str = parse_envvar))]
+    #[structopt(long = "env", name = "KEY=VALUE", multiple = true, parse(try_from_str = parse_envvar))]
     env_vars: Vec<(String, String)>,
 
     /// Enable experimental IO devices
     #[cfg(feature = "experimental-io-devices")]
-    #[clap(long = "enable-experimental-io-devices")]
+    #[structopt(long = "enable-experimental-io-devices")]
     enable_experimental_io_devices: bool,
 
     /// Allow WASI modules to import multiple versions of WASI without a warning.
-    #[clap(long = "allow-multiple-wasi-versions")]
+    #[structopt(long = "allow-multiple-wasi-versions")]
     pub allow_multiple_wasi_versions: bool,
 
     /// Require WASI modules to only import 1 version of WASI.
-    #[clap(long = "deny-multiple-wasi-versions")]
+    #[structopt(long = "deny-multiple-wasi-versions")]
     pub deny_multiple_wasi_versions: bool,
 }
 

--- a/lib/cli/src/commands/self_update.rs
+++ b/lib/cli/src/commands/self_update.rs
@@ -1,11 +1,11 @@
 //! When wasmer self-update is executed, this is what gets executed
 use anyhow::{Context, Result};
-use clap::Clap;
 #[cfg(not(target_os = "windows"))]
 use std::process::{Command, Stdio};
+use structopt::StructOpt;
 
 /// The options for the `wasmer self-update` subcommand
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 pub struct SelfUpdate {}
 
 impl SelfUpdate {

--- a/lib/cli/src/commands/validate.rs
+++ b/lib/cli/src/commands/validate.rs
@@ -1,17 +1,17 @@
 use crate::store::StoreOptions;
 use anyhow::{Context, Result};
-use clap::Clap;
 use std::path::PathBuf;
+use structopt::StructOpt;
 use wasmer::*;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer validate` subcommand
 pub struct Validate {
     /// File to validate as WebAssembly
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[structopt(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     store: StoreOptions,
 }
 

--- a/lib/cli/src/commands/wast.rs
+++ b/lib/cli/src/commands/wast.rs
@@ -1,21 +1,21 @@
 //! Runs a .wast WebAssembly test suites
 use crate::store::StoreOptions;
 use anyhow::{Context, Result};
-use clap::Clap;
 use std::path::PathBuf;
+use structopt::StructOpt;
 use wasmer_wast::Wast as WastSpectest;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, StructOpt)]
 /// The options for the `wasmer wast` subcommand
 pub struct Wast {
     /// Wast file to run
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[structopt(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     store: StoreOptions,
 
-    #[clap(short, long)]
+    #[structopt(short, long)]
     /// A flag to indicate wast stop at the first error or continue.
     fail_fast: bool,
 }

--- a/lib/cli/src/common.rs
+++ b/lib/cli/src/common.rs
@@ -1,36 +1,36 @@
 //! Common module with common used structures across different
 //! commands.
 use crate::VERSION;
-use clap::Clap;
 use std::env;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
-#[derive(Debug, Clap, Clone)]
+#[derive(Debug, StructOpt, Clone)]
 /// The WebAssembly features that can be passed through the
 /// Command Line args.
 pub struct WasmFeatures {
     /// Enable support for the SIMD proposal.
-    #[clap(long = "enable-simd")]
+    #[structopt(long = "enable-simd")]
     pub simd: bool,
 
     /// Enable support for the threads proposal.
-    #[clap(long = "enable-threads")]
+    #[structopt(long = "enable-threads")]
     pub threads: bool,
 
     /// Enable support for the reference types proposal.
-    #[clap(long = "enable-reference-types")]
+    #[structopt(long = "enable-reference-types")]
     pub reference_types: bool,
 
     /// Enable support for the multi value proposal.
-    #[clap(long = "enable-multi-value")]
+    #[structopt(long = "enable-multi-value")]
     pub multi_value: bool,
 
     /// Enable support for the bulk memory proposal.
-    #[clap(long = "enable-bulk-memory")]
+    #[structopt(long = "enable-bulk-memory")]
     pub bulk_memory: bool,
 
     /// Enable support for all pre-standard proposals.
-    #[clap(long = "enable-all")]
+    #[structopt(long = "enable-all")]
     pub all: bool,
 }
 

--- a/lib/cli/src/compilers/llvm.rs
+++ b/lib/cli/src/compilers/llvm.rs
@@ -1,16 +1,16 @@
-#[derive(Debug, Clap, Clone)]
+#[derive(Debug, StructOpt, Clone)]
 /// LLVM backend flags.
 pub struct LLVMCLIOptions {
     /// Emit LLVM IR before optimization pipeline.
-    #[clap(long = "llvm-pre-opt-ir", parse(from_os_str))]
+    #[structopt(long = "llvm-pre-opt-ir", parse(from_os_str))]
     pre_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM IR after optimization pipeline.
-    #[clap(long = "llvm-post-opt-ir", parse(from_os_str))]
+    #[structopt(long = "llvm-post-opt-ir", parse(from_os_str))]
     post_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM generated native code object file.
-    #[clap(long = "llvm-object-file", parse(from_os_str))]
+    #[structopt(long = "llvm-object-file", parse(from_os_str))]
     obj_file: Option<PathBuf>,
 }
 

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -19,23 +19,23 @@ pub struct StoreOptions {
     compiler: CompilerOptions,
 
     /// Use the Universal Engine.
-    #[structopt(long, conflicts_with_all = &["dylib", "staticlib", "jit", "native", "object-file"])]
+    #[structopt(long, conflicts_with_all = &["dylib", "staticlib", "jit", "native", "object_file"])]
     universal: bool,
 
     /// Use the Dylib Engine.
-    #[structopt(long, conflicts_with_all = &["universal", "staticlib", "jit", "native", "object-file"])]
+    #[structopt(long, conflicts_with_all = &["universal", "staticlib", "jit", "native", "object_file"])]
     dylib: bool,
 
     /// Use the Staticlib Engine.
-    #[structopt(long, conflicts_with_all = &["universal", "dylib", "jit", "native", "object-file"])]
+    #[structopt(long, conflicts_with_all = &["universal", "dylib", "jit", "native", "object_file"])]
     staticlib: bool,
 
     /// Use the JIT (Universal) Engine.
-    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "native", "object-file"])]
+    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "native", "object_file"])]
     jit: bool,
 
     /// Use the Native (Dylib) Engine.
-    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "jit", "object-file"])]
+    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "jit", "object_file"])]
     native: bool,
 
     /// Use the ObjectFile (Staticlib) Engine.

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -3,70 +3,70 @@
 
 use crate::common::WasmFeatures;
 use anyhow::Result;
-use clap::Clap;
 use std::path::PathBuf;
 use std::string::ToString;
 #[allow(unused_imports)]
 use std::sync::Arc;
+use structopt::StructOpt;
 use wasmer::*;
 #[cfg(feature = "compiler")]
 use wasmer_compiler::CompilerConfig;
 
-#[derive(Debug, Clone, Clap)]
+#[derive(Debug, Clone, StructOpt)]
 /// The compiler and engine options
 pub struct StoreOptions {
-    #[clap(flatten)]
+    #[structopt(flatten)]
     compiler: CompilerOptions,
 
     /// Use the Universal Engine.
-    #[clap(long, conflicts_with_all = &["dylib", "staticlib", "jit", "native", "object-file"])]
+    #[structopt(long, conflicts_with_all = &["dylib", "staticlib", "jit", "native", "object-file"])]
     universal: bool,
 
     /// Use the Dylib Engine.
-    #[clap(long, conflicts_with_all = &["universal", "staticlib", "jit", "native", "object-file"])]
+    #[structopt(long, conflicts_with_all = &["universal", "staticlib", "jit", "native", "object-file"])]
     dylib: bool,
 
     /// Use the Staticlib Engine.
-    #[clap(long, conflicts_with_all = &["universal", "dylib", "jit", "native", "object-file"])]
+    #[structopt(long, conflicts_with_all = &["universal", "dylib", "jit", "native", "object-file"])]
     staticlib: bool,
 
     /// Use the JIT (Universal) Engine.
-    #[clap(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "native", "object-file"])]
+    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "native", "object-file"])]
     jit: bool,
 
     /// Use the Native (Dylib) Engine.
-    #[clap(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "jit", "object-file"])]
+    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "jit", "object-file"])]
     native: bool,
 
     /// Use the ObjectFile (Staticlib) Engine.
-    #[clap(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "jit", "native"])]
+    #[structopt(long, hidden = true, conflicts_with_all = &["universal", "dylib", "staticlib", "jit", "native"])]
     object_file: bool,
 }
 
-#[derive(Debug, Clone, Clap)]
+#[derive(Debug, Clone, StructOpt)]
 /// The compiler options
 pub struct CompilerOptions {
     /// Use Singlepass compiler.
-    #[clap(long, conflicts_with_all = &["cranelift", "llvm"])]
+    #[structopt(long, conflicts_with_all = &["cranelift", "llvm"])]
     singlepass: bool,
 
     /// Use Cranelift compiler.
-    #[clap(long, conflicts_with_all = &["singlepass", "llvm"])]
+    #[structopt(long, conflicts_with_all = &["singlepass", "llvm"])]
     cranelift: bool,
 
     /// Use LLVM compiler.
-    #[clap(long, conflicts_with_all = &["singlepass", "cranelift"])]
+    #[structopt(long, conflicts_with_all = &["singlepass", "cranelift"])]
     llvm: bool,
 
     /// Enable compiler internal verification.
-    #[clap(long)]
+    #[structopt(long)]
     enable_verifier: bool,
 
     /// LLVM debug directory, where IR and object files will be written to.
-    #[clap(long, parse(from_os_str))]
+    #[structopt(long, parse(from_os_str))]
     llvm_debug_dir: Option<PathBuf>,
 
-    #[clap(flatten)]
+    #[structopt(flatten)]
     features: WasmFeatures,
 }
 

--- a/tests/integration/cli/tests/version.rs
+++ b/tests/integration/cli/tests/version.rs
@@ -1,0 +1,62 @@
+use anyhow::bail;
+use std::process::Command;
+use wasmer_integration_tests_cli::WASMER_PATH;
+
+const WASMER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[test]
+fn version_string_is_correct() -> anyhow::Result<()> {
+    let expected_version_output = format!("wasmer {}\n", WASMER_VERSION);
+
+    let outputs = [
+        Command::new(WASMER_PATH).arg("--version").output()?,
+        Command::new(WASMER_PATH).arg("-V").output()?,
+    ];
+
+    for output in &outputs {
+        if !output.status.success() {
+            bail!(
+                "version failed with: stdout: {}\n\nstderr: {}",
+                std::str::from_utf8(&output.stdout)
+                    .expect("stdout is not utf8! need to handle arbitrary bytes"),
+                std::str::from_utf8(&output.stderr)
+                    .expect("stderr is not utf8! need to handle arbitrary bytes")
+            );
+        }
+
+        let stdout_output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(stdout_output, &expected_version_output);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn help_text_contains_version() -> anyhow::Result<()> {
+    let expected_version_output = format!("wasmer {}", WASMER_VERSION);
+
+    let outputs = [
+        Command::new(WASMER_PATH).arg("--help").output()?,
+        Command::new(WASMER_PATH).arg("-h").output()?,
+    ];
+
+    for output in &outputs {
+        if !output.status.success() {
+            bail!(
+                "version failed with: stdout: {}\n\nstderr: {}",
+                std::str::from_utf8(&output.stdout)
+                    .expect("stdout is not utf8! need to handle arbitrary bytes"),
+                std::str::from_utf8(&output.stderr)
+                    .expect("stderr is not utf8! need to handle arbitrary bytes")
+            );
+        }
+
+        let stdout_output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(
+            stdout_output.lines().next().unwrap(),
+            &expected_version_output
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Clap-beta hasn't had a release in a while and likely won't for a while longer. We're affected by bugs that have been fixed and not released. We shouldn't be depending on a beta library anyways when there's a stable equivalent. It's very understandable that the clap developers don't want to be burdened with publishing bug fixes when making major changes something in-progress -- they'd probably just end up with way more bug reports overall for things they never intended to support.

Revert #2162 

more context https://github.com/clap-rs/clap/discussions/2487#discussioncomment-821162

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
