### PR TITLE
fix unwrap error when given a no export functions wasm

### DIFF
--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -341,13 +341,17 @@ impl Run {
                     let suggested_command = format!(
                         "wasmer {} -i {} {}",
                         self.path.display(),
-                        suggested_functions.get(0).unwrap(),
+                        suggested_functions.get(0).unwrap_or(&String::new()),
                         args.join(" ")
                     );
-                    let suggestion = format!(
-                        "Similar functions found: {}.\nTry with: {}",
-                        names, suggested_command
-                    );
+                    let suggestion = if suggested_functions.len() == 0 {
+                        String::from("Can not find any export functions.")
+                    } else {
+                        format!(
+                            "Similar functions found: {}.\nTry with: {}",
+                            names, suggested_command
+                        )
+                    };
                     match e {
                         ExportError::Missing(_) => {
                             anyhow!("No export `{}` found in the module.\n{}", name, suggestion)

--- a/tests/examples/no_start.wat
+++ b/tests/examples/no_start.wat
@@ -1,0 +1,5 @@
+(module
+  (type (;0;) (func (param f64) (result i32)))
+  (func (;0;) (type 0) (param f64) (result i32)
+    unreachable))
+

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -12,6 +12,10 @@ fn test_no_imports_wat_path() -> String {
     format!("{}/{}", ASSET_PATH, "fib.wat")
 }
 
+fn test_no_start_wat_path() -> String {
+    format!("{}/{}", ASSET_PATH, "no_start.wat")
+}
+
 #[test]
 fn run_wasi_works() -> anyhow::Result<()> {
     let output = Command::new(WASMER_PATH)
@@ -39,6 +43,7 @@ fn run_wasi_works() -> anyhow::Result<()> {
 }
 
 #[test]
+
 fn run_no_imports_wasm_works() -> anyhow::Result<()> {
     let output = Command::new(WASMER_PATH)
         .arg("run")
@@ -55,5 +60,18 @@ fn run_no_imports_wasm_works() -> anyhow::Result<()> {
         );
     }
 
+    Ok(())
+}
+
+#[test]
+fn run_no_start_wasm_report_error() -> anyhow::Result<()> {
+    let output = Command::new(WASMER_PATH)
+        .arg("run")
+        .arg(test_no_start_wat_path())
+        .output()?;
+
+    assert_eq!(output.status.success(), false);
+    let result = std::str::from_utf8(&output.stderr).unwrap().to_string();
+    assert_eq!(result.contains("Can not find any export functions."), true);
     Ok(())
 }


### PR DESCRIPTION

# Description
When the wasm file contains no export functions, an unwrap crash will trigger:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', lib/cli/src/commands/run.rs:344:52
```

This fix will give a more detailed output.


