### PR TITLE
Fix #2389. Replace `Rip` with `Eip` for windows

### DIFF
--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -340,8 +340,14 @@ cfg_if::cfg_if! {
                     Some(info) => info,
                     None => return EXCEPTION_CONTINUE_SEARCH,
                 };
+                #[cfg(target_pointer_width = "32")]
+                let pc = (*(*exception_info).ContextRecord).Eip as *const u8;
+
+                #[cfg(target_pointer_width = "64")]
+                let pc = (*(*exception_info).ContextRecord).Rip as *const u8;
+
                 let jmp_buf = info.handle_trap(
-                    (*(*exception_info).ContextRecord).Eip as *const u8,
+                    pc,
                     record.ExceptionCode == EXCEPTION_STACK_OVERFLOW,
                     // TODO: fix the signal trap associated to memory access in Windows
                     None,

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -341,7 +341,7 @@ cfg_if::cfg_if! {
                     None => return EXCEPTION_CONTINUE_SEARCH,
                 };
                 let jmp_buf = info.handle_trap(
-                    (*(*exception_info).ContextRecord).Rip as *const u8,
+                    (*(*exception_info).ContextRecord).Eip as *const u8,
                     record.ExceptionCode == EXCEPTION_STACK_OVERFLOW,
                     // TODO: fix the signal trap associated to memory access in Windows
                     None,


### PR DESCRIPTION
`Rip` does not exist, `Eip`.
This now seems to compile, but for me it generates an error during
linking, but I'm not sure if that's just me. But this at least fixes the compilation part of the error.

Namely: 
```sh
error: linking with `link.exe` failed: exit code: 1120
  |
  = note: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.26.28801\\bin\\HostX64\\x86\\link.exe" "/NOLOGO" "/NXCOMPAT" "/LARGEADDRESSAWARE" "/SAFESEH" "/LIBPATH:C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.0.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.1.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.10.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.11.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.12.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.13.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.14.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.15.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.2.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.3.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.4.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.5.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.6.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.7.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.8.rcgu.o" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.server.cmreyrda-cgu.9.rcgu.o" "/OUT:C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.exe" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\server.4m1mdzavaiax9yz3.rcgu.o" "/OPT:REF,NOICF" "/DEBUG" "/NATVIS:C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\liballoc.natvis" "/NATVIS:C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libstd.natvis" "/LIBPATH:C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps" "/LIBPATH:C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\debug\\deps" "/LIBPATH:C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\build\\libsqlite3-sys-2fc0e5334063042c\\out" "/LIBPATH:C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\build\\wasmer-vm-3c6b616faa0f448d\\out" "/LIBPATH:C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfp_ffi-77030558cdde9ff9.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer-1ee5d397c82ebbde.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_engine_universal-aa8b909046e02ad8.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_compiler_cranelift-95d6aa374bad2404.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcranelift_frontend-7636d9ec84c98fa4.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcranelift_codegen-2d40267ee2a702a4.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libregalloc-30f467c7faf412f8.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librustc_hash-e2b81e8e309a7b32.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libgimli-c0e3b50314ad9915.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libstable_deref_trait-5077a39547cf296b.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcranelift_codegen_shared-6eea791e01e66dc6.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcranelift_bforest-8cfab48edffb321d.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcranelift_entity-a454ca57794937f8.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_compiler_singlepass-97bb30766a0d5b6e.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librayon-a77aed85ebcc13b6.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librayon_core-1f47fd80c335100d.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libeither-44079386c65ebd7a.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libdynasmrt-c85fe7752a5ffe02.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwat-d78281bc86d345e9.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwast-17d576c120cc2c14.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libleb128-c30a4a61e027c687.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_engine-2285d39bd1b39078.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmemmap2-f20012dbcc470448.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_compiler-d3f08fce7e9c1c15.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libserde_bytes-c12e170995276c33.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtarget_lexicon-5de1c1426f2a6591.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libenumset-38c1a812692792b0.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_vm-9ed9d889308b432e.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libregion-60bebc9e70635ab1.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libbacktrace-368a6b9f1f621abc.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librustc_demangle-5d31a0de0dd7b984.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmore_asserts-ee717cde1c2ac219.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmparser-8025aeeb20e4a385.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwasmer_types-cb7580d4b44b0853.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librkyv-aa014f3e4e73b95b.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libseahash-9f3213c621e1c670.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libptr_meta-fab2982e5abe6aa8.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libloupe-ea83d9c243cd5b2b.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libthiserror-c8f65b8267703707.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtripc-80055dafb610b790.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwinreg-9e0bbe9d5ac5025a.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures-1a6d0c6155bf7045.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_executor-588f89652eca798d.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtracing_subscriber-9a2513d6639fd9f6.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libchrono-2050a705c7255bf7.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libnum_integer-b31572311a7bb61d.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\liblibc-fd16268526d8ccf6.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libthread_local-6f763025889b9143.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libsharded_slab-2ce5b0f074506848.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtracing_serde-1636527e9a317486.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtracing_log-6e0839763c916ca7.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libansi_term-b1ed052213d09a20.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmatchers-09e84e7a8427b969.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libregex_automata-f1933a28134b17e2.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libregex-49d4129b84e31af6.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libaho_corasick-973b4f80c4f2a442.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libregex_syntax-c04bbffd0060c52e.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtipc_ffi-1f935e01d76b266f.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtower-28d3dfffd43f5bed.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libindexmap-6f8583b5221cd98a.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libhdrhistogram-9b37f11c66bfe59d.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_channel-4c9ab2286710959f.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_utils-41ecc14f457ab863.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcfg_if-3889f8e54b75e699.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libbase64-52edda2b8b91c1e8.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libflate2-ca9b0ab597b179a9.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libminiz_oxide-931b5ca57cf16119.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libadler-4004ee0324455942.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrc32fast-8604a42856172273.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libbyteorder-a084cce03f68c825.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libnum_traits-4eaf0f8a98c8367f.rlib" 
"C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libnom-d8cba8fd461fced7.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtokio_util-0a6468380a971502.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtokio-4672ca4e4473e711.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libnum_cpus-87f5110b8f1cf040.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libonce_cell-95e395b1494994fd.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmio-6ca7b31cade1327c.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmiow-1b664cb5da8e8bf9.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libntapi-dee2ddb75b90a2c3.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librand-6a9160223b09ebaa.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librand_chacha-48bdf754287dd333.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libppv_lite86-c8db49d8133d53ea.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librand_core-495e7de9cc537aa0.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libgetrandom-09330cb5cb9737f0.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_util-94db3a6e2b175218.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmemchr-4cebd71400121497.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_io-3f697826b5fa79ff.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libslab-6ff10fa5b4b8d8b1.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_channel-c6f26692ddf9b0cd.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_sink-2daba9898ddfebe6.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_task-35e12cdc31a8de37.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libpin_utils-100a777278607f97.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtower_service-89a164f7b35a6684.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libpin_project-d0cf975494c4e8cb.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfutures_core-fbfc11e0e2223fd4.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtower_layer-351bae38fe5d4c68.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libjson_patch-13aee43df980c1e4.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtreediff-b64a59149fbbfe3b.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libserde_json-34ad18aed21ea21e.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libryu-5e032125b93abd3f.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libitoa-6d78dd00eee8acb3.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libserde-8d0fbab856480e16.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam-ef6cda79f24a90ca.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_channel-e47c637f80b9a029.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_deque-1b62194d848954d9.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_queue-532c860712ea6048.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_epoch-16a1d8e2dd5e6400.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libmemoffset-d3e04c25c4572065.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcrossbeam_utils-b6c47d58455f43d1.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtracing-9cee05b52ba9994f.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libpin_project_lite-bd03cfae7cebce8c.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libtracing_core-732e594807d87a32.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\liblog-4bda925b6c929469.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\liblazy_static-2c9c44cb1c8bafc7.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libparking_lot-9f2e2ce9b1c6a1db.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libparking_lot_core-07949cf174e3d482.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libwinapi-4f8ac8b1dc3eea34.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\liblock_api-75e0af1abc12f40f.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libscopeguard-494caeac5027a63d.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libinstant-b0620f3ff3ca73a3.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libcfg_if-2423740df8fa3ff5.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\librusqlite-b773340f1c7c4f22.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libbitflags-3fac91fb2ac4a803.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libsmallvec-833e1c59f9ca5c1a.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfallible_streaming_iterator-996c54a492376263.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libfallible_iterator-171ca03af2bbb001.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libhashlink-ddc292bf8b83187a.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libhashbrown-d14c71435348f6f0.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libahash-9c29c70ed8ac709f.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\liblibsqlite3_sys-07236aac0f5aa37e.rlib" "C:\\Users\\Midas\\Desktop\\projects\\dbs2\\server\\target\\i686-pc-windows-msvc\\debug\\deps\\libbytes-9cae09a2fb325637.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libstd-d45e67536d520076.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libpanic_unwind-6497635c75958983.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\librustc_demangle-3a7f4b1aeb03bc95.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libhashbrown-a806b6c40d332edf.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\librustc_std_workspace_alloc-ace53c0a70b8aabd.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libunwind-bbdf08526241c5b4.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libcfg_if-e839ba3146a0b030.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\liblibc-4a394edaf7c0cd40.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\liballoc-3c20f909c11f5db6.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\librustc_std_workspace_core-f3ed237e3b5fa8ee.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libcore-74d8d6b7006f0dab.rlib" "C:\\Users\\Midas\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\i686-pc-windows-msvc\\lib\\libcompiler_builtins-ca3f43bc2da96203.rlib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "ntdll.lib" "bcrypt.lib" "advapi32.lib" "cfgmgr32.lib" "credui.lib" "gdi32.lib" "kernel32.lib" "msimg32.lib" "mswsock.lib" "ntdll.lib" "opengl32.lib" "secur32.lib" "synchronization.lib" "user32.lib" "winspool.lib" "ws2_32.lib" "advapi32.lib" "ws2_32.lib" "userenv.lib" "msvcrt.lib"
  = note: libwasmer_vm-9ed9d889308b432e.rlib(wasmer_vm-9ed9d889308b432e.wasmer_vm.9szxqbdm-cgu.15.rcgu.o) : error LNK2001: unresolved external symbol ___rust_probestack
          libwasmer_vm-9ed9d889308b432e.rlib(wasmer_vm-9ed9d889308b432e.wasmer_vm.9szxqbdm-cgu.8.rcgu.o) : error LNK2001: unresolved external symbol ___rust_probestack
          C:\Users\Midas\Desktop\projects\dbs2\server\target\i686-pc-windows-msvc\debug\deps\server.exe : fatal error LNK1120: 1 unresolved externals
```

