### PR TITLE
Fix 'variable does not need to be mutable' warnings

### DIFF
--- a/lib/engine-universal/src/unwind/windows_x64.rs
+++ b/lib/engine-universal/src/unwind/windows_x64.rs
@@ -69,7 +69,7 @@ impl UnwindRegistry {
         self.published = true;
 
         if !self.functions.is_empty() {
-            for (base_address, mut functions) in self.functions.iter_mut() {
+            for (base_address, functions) in self.functions.iter_mut() {
                 // Windows heap allocations are 32-bit aligned, but assert just in case
                 assert_eq!(
                     (functions.as_mut_ptr() as u64) % 4,
@@ -97,7 +97,7 @@ impl Drop for UnwindRegistry {
     fn drop(&mut self) {
         if self.published {
             unsafe {
-                for mut functions in self.functions.values_mut() {
+                for functions in self.functions.values_mut() {
                     winnt::RtlDeleteFunctionTable(functions.as_mut_ptr());
                 }
             }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
When I built wasmer on Windows using the `cargo build` command, I got a couple of _the variable doesn't need to be mutable_ warnings. This PR fixes those warnings.

# Review

As this is an internal change, it shouldn't require an entry in the CHANGELOG.md file.
- [ ] Add a short description of the change to the CHANGELOG.md file
