### PR TITLE
Allow unreachable_patterns in config

### DIFF
--- a/tests/compilers/config.rs
+++ b/tests/compilers/config.rs
@@ -77,7 +77,7 @@ impl Config {
                 }
                 Box::new(engine.engine())
             }
-            #[allow(dead_code)]
+            #[allow(unreachable_patterns)]
             engine => panic!(
                 "The {:?} Engine is not enabled. Please enable it using the features",
                 engine
@@ -91,7 +91,7 @@ impl Config {
             Engine::Dylib => Box::new(wasmer_engine_dylib::Dylib::headless().engine()),
             #[cfg(feature = "universal")]
             Engine::Universal => Box::new(wasmer_engine_universal::Universal::headless().engine()),
-            #[allow(dead_code)]
+            #[allow(unreachable_patterns)]
             engine => panic!(
                 "The {:?} Engine is not enabled. Please enable it using the features",
                 engine


### PR DESCRIPTION

# Description

`make test` will print out warning messages, it's safe to remove them.
```
warning: unreachable pattern
--> tests/compilers/config.rs:81:13
   |
81 |             engine => panic!(
   |             ^^^^^^
   |
   = note: `#[warn(unreachable_patterns)]` on by default

warning: unreachable pattern
  --> tests/compilers/config.rs:95:13
   |
95 |             engine => panic!(
   |             ^^^^^^
warning:: command not found
```

