### PR TITLE
doc(wasi-types) Mention `wasi-types` in `lib/README.md`

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -23,7 +23,8 @@ composed of a set of crates. We can group them as follows:
 * `derive` — A set of procedural macros used inside Wasmer,
 * ABI:
   * `emscripten` — Emscripten ABI implementation inside Wasmer,
-  * `wasi` — WASI ABI implementation inside Wasmer.
+  * `wasi` — WASI ABI implementation inside Wasmer:
+    * `wasi-types` — All the WASI types,
     * `wasi-experimental-io-devices` — An experimental extension of
       WASI for basic graphics.
 * `engine` — The general abstraction for creating an engine, which is


### PR DESCRIPTION
# Description

This patch updates `lib/README.md` since I forgot to do it in #2411.

# Review

- [ ] ~Add a short description of the change to the CHANGELOG.md file~ not necessary
