### PR TITLE
Fix: get wasi versions right

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -39,17 +39,17 @@ pub struct Wasi {
 #[allow(dead_code)]
 impl Wasi {
     /// Gets the WASI version (if any) for the provided module
-    pub fn get_versions(module: &Module) -> Option<BTreeSet<WasiVersion>> {
+    pub fn get_versions(module: &Module) -> BTreeSet<WasiVersion> {
         // Get the wasi version in strict mode, so no other imports are
         // allowed.
-        get_wasi_versions(&module, true)
+        get_wasi_versions(&module)
     }
 
     /// Checks if a given module has any WASI imports at all.
     pub fn has_wasi_imports(module: &Module) -> bool {
         // Get the wasi version in non-strict mode, so no other imports
         // are allowed
-        get_wasi_versions(&module, false).is_some()
+        !get_wasi_versions(&module).is_empty()
     }
 
     /// Helper function for executing Wasi from the `Run` command.

--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -84,8 +84,7 @@ impl WasiEnv {
         &mut self,
         module: &Module,
     ) -> Result<Box<dyn NamedResolver>, WasiError> {
-        let wasi_versions =
-            get_wasi_versions(module, false).ok_or(WasiError::UnknownWasiVersion)?;
+        let wasi_versions = get_wasi_versions(module);
 
         let mut resolver: Box<dyn NamedResolver> = { Box::new(()) };
         for version in wasi_versions.iter() {
@@ -93,6 +92,7 @@ impl WasiEnv {
                 generate_import_object_from_env(module.store(), self.clone(), *version);
             resolver = Box::new(new_import_object.chain_front(resolver));
         }
+
         Ok(resolver)
     }
 

--- a/lib/wasi/src/utils.rs
+++ b/lib/wasi/src/utils.rs
@@ -123,17 +123,19 @@ pub fn get_wasi_versions(module: &Module, strict: bool) -> Option<BTreeSet<WasiV
     let mut out = BTreeSet::new();
     let imports = module.imports().functions().map(|f| f.module().to_owned());
 
-    let mut non_wasi_seen = false;
+    let mut non_wasi_seen = true;
     for ns in imports {
         match ns.as_str() {
             SNAPSHOT0_NAMESPACE => {
+                non_wasi_seen = false;
                 out.insert(WasiVersion::Snapshot0);
             }
             SNAPSHOT1_NAMESPACE => {
+                non_wasi_seen = false;
                 out.insert(WasiVersion::Snapshot1);
             }
             _ => {
-                non_wasi_seen = true;
+                // noop
             }
         }
     }

--- a/lib/wasi/src/utils.rs
+++ b/lib/wasi/src/utils.rs
@@ -115,23 +115,17 @@ pub fn get_wasi_version(module: &Module, strict: bool) -> Option<WasiVersion> {
     }
 }
 
-/// Like [`get_wasi_version`] but detects multiple WASI versions in a single module.
-/// Thus `strict` behaves differently in this function as multiple versions are
-/// always supported. `strict` indicates whether non-WASI imports should trigger a
-/// failure or be ignored.
-pub fn get_wasi_versions(module: &Module, strict: bool) -> Option<BTreeSet<WasiVersion>> {
+/// Returns the wasi versions found in `module`
+pub fn get_wasi_versions(module: &Module) -> BTreeSet<WasiVersion> {
     let mut out = BTreeSet::new();
     let imports = module.imports().functions().map(|f| f.module().to_owned());
 
-    let mut non_wasi_seen = true;
     for ns in imports {
         match ns.as_str() {
             SNAPSHOT0_NAMESPACE => {
-                non_wasi_seen = false;
                 out.insert(WasiVersion::Snapshot0);
             }
             SNAPSHOT1_NAMESPACE => {
-                non_wasi_seen = false;
                 out.insert(WasiVersion::Snapshot1);
             }
             _ => {
@@ -139,11 +133,8 @@ pub fn get_wasi_versions(module: &Module, strict: bool) -> Option<BTreeSet<WasiV
             }
         }
     }
-    if strict && non_wasi_seen {
-        None
-    } else {
-        Some(out)
-    }
+
+    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

The following sample code should have the right wasi_version.

```wast
(module
  (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
  (type (;1;) (func (param i32 i32 i32 i32)))
  (import "wasi_snapshot_preview1" "fd_write" (func (;0;) (type 0)))
  (import "env" "abort" (func (;1;) (type 1)))
)
```

Related Issue: #2226 