### PR TITLE
fix(wapm) Fix the `wax` script generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **[Unreleased]**
 
+### Fixed
+- [#2426](https://github.com/wasmerio/wasmer/pull/2426) Fix the `wax` script generation.
+
 ## 2.0.0 - 2020/06/16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ package-wapm:
 ifneq (, $(filter 1, $(IS_DARWIN) $(IS_LINUX)))
 	if [ -d "wapm-cli" ]; then \
 		cp wapm-cli/$(TARGET_DIR)/wapm package/bin/ ;\
-		echo "#!/bin/bash\nwapm execute \"\$$@\"" > package/bin/wax ;\
+		echo -e "#!/bin/bash\nwapm execute \"\$$@\"" > package/bin/wax ;\
 		chmod +x package/bin/wax ;\
 	fi
 else


### PR DESCRIPTION
# Description

On macOS, `echo` always enables interpretation of backslach sequences
(like `\n`). On Linux, the `-e` flag must be used. Even if this `-e`
flag is absent from the macOS man's page for `echo(1)`, it is accepted
and ignored, thus we can safely use it in our `Makefile`.

To test this patch:

```sh
$ # before
$ make package-wapm
$ cat package/bin/wax
#!/bin/bash\nwapm execute "$@"
$
$ # after
$ make package-wapm
$ cat package/bin/wax
#!/bin/bash
wapm execute "$@"
```

This patch fixes #2425.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
