### PR TITLE
Don't fail make install if WASMER_INSTALL_PREFIX isn't set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -657,8 +657,13 @@ install-misc:
 	install -Dm644 LICENSE "$(DESTDIR)"/share/licenses/wasmer/LICENSE
 
 install-pkgconfig:
-	unset WASMER_DIR # Make sure WASMER_INSTALL_PREFIX is set during build
-	target/release/wasmer config --pkg-config | install -Dm644 /dev/stdin "$(DESTDIR)"/lib/pkgconfig/wasmer.pc
+	# Make sure WASMER_INSTALL_PREFIX is set during build
+	unset WASMER_DIR; \
+	if pc="$$(target/release/wasmer config --pkg-config 1>/dev/null 2>/dev/null)"; then \
+		echo "$$pc" | install -Dm644 /dev/stdin "$(DESTDIR)"/lib/pkgconfig/wasmer.pc; \
+	else \
+		echo 1>&2 "WASMER_INSTALL_PREFIX was not set during build, not installing wasmer.pc"; \
+	fi
 
 install-wasmer-headless-minimal:
 	install -Dm755 target/release/wasmer-headless $(DESTDIR)/bin/wasmer-headless

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -16,7 +16,9 @@
   with `WASMER_INSTALL_PREFIX`, e.g.:
 
   ```sh
-  $ WASMER_INSTALL_PREFIX=/usr make install
+  export WASMER_INSTALL_PREFIX=/usr
+  make
+  DESTDIR=.../usr make install
   ```
 
 * In case you must build/install directly with `cargo`, make sure to


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
Fixes #2413, also improves PACKAGING.md

Alternatively, I could make it so `make install` errors out with a nice and clean error message if that variable is not set (and tells people that they're not supposed to make install themselves?), or default WASMER_INSTALL_PREFIX to `/usr/local` (at the danger of being missed, resulting in incorrect installs).

# Review
- [ ] Add a short description of the change to the CHANGELOG.md file: Seems like an irrelevant fix - Necessary?
