### PR TITLE
fix: Set the SONAME to `libwasmer.so` on Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,6 @@
 rustflags = [
     # Put the VM functions in the dynamic symbol table.
     "-C", "link-arg=-Wl,-E",
+    # Fix the SONAME, required by CMake, see https://github.com/wasmerio/wasmer/issues/2429.
+    "-C", "link-arg=-Wl,-soname,libwasmer.so",
 ]


### PR DESCRIPTION
# Description

See https://github.com/wasmerio/wasmer/issues/2429 for more
context.

The idea is to use our `.cargo/config.toml` file to set the SONAME
correctly to `libwasmer.so` only on Linux.

Fix #2429.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
