### PR TITLE
Added the 32 bit variant of x86 to generate a target machine for inkwell

### DIFF
--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -137,14 +137,16 @@ impl LLVM {
         let cpu_features = &target.cpu_features();
 
         match triple.architecture {
-            Architecture::X86_64 => InkwellTarget::initialize_x86(&InitializationConfig {
-                asm_parser: true,
-                asm_printer: true,
-                base: true,
-                disassembler: true,
-                info: true,
-                machine_code: true,
-            }),
+            Architecture::X86_64 | Architecture::X86_32(_) => {
+                InkwellTarget::initialize_x86(&InitializationConfig {
+                    asm_parser: true,
+                    asm_printer: true,
+                    base: true,
+                    disassembler: true,
+                    info: true,
+                    machine_code: true,
+                })
+            }
             Architecture::Aarch64(_) => InkwellTarget::initialize_aarch64(&InitializationConfig {
                 asm_parser: true,
                 asm_printer: true,


### PR DESCRIPTION
Extended the match on X86_64 to include the X86_32 and all of its
architectures.

This allows the following program to run on a 32 bit windows VM:
```
fn main() -> Result<(), Box<dyn std::error::Error>> {
    use wasmer::{imports, Instance, Module, Store, Value};

    let module_wat = r#"
    (module
    (type $t0 (func (param i32) (result i32)))
    (func $add_one (export "add_one") (type $t0) (param $p0 i32) (result i32)
        get_local $p0
        i32.const 1
        i32.add))
    "#;

    let store = Store::default();
    let module = Module::new(&store, &module_wat)?;
    // The module doesn't import anything, so we create an empty import object.
    let import_object = imports! {};
    let instance = Instance::new(&module, &import_object)?;

    let add_one = instance.exports.get_function("add_one")?;
    let result = add_one.call(&[Value::I32(42)])?;
    assert_eq!(result[0], Value::I32(43));

    dbg!(&result[0]);
    Ok(())
}
```
