### PR TITLE
 fix(c-api) Trap's messages are always null terminated

### DIFF
--- a/lib/c-api/CHANGELOG.md
+++ b/lib/c-api/CHANGELOG.md
@@ -8,6 +8,11 @@ Looking for changes to the Wasmer CLI and the Rust API? See our [Primary Changel
 
 ## **[Unreleased]**
 
+### Fixed
+- [#2444](https://github.com/wasmerio/wasmer/pull/2444) Trap's messages are always null terminated.
+
+## 2.0.0 - 2020/06/16
+
 ## 2.0.0-rc1 - 2020/06/02
 
 ### Added

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn wasm_instance_new(
 ///
 /// # Example
 ///
-/// See `wasm_instance_new`.
+/// See [`wasm_instance_new`].
 #[no_mangle]
 pub unsafe extern "C" fn wasm_instance_delete(_instance: Option<Box<wasm_instance_t>>) {}
 

--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -224,6 +224,50 @@ pub mod module;
 /// cbindgen:ignore
 pub mod store;
 
+/// A trap represents an error which stores trace message with
+/// backtrace.
+///
+/// # Example
+///
+/// ```rust
+/// # use inline_c::assert_c;
+/// # fn main() {
+/// #    (assert_c! {
+/// # #include "tests/wasmer.h"
+/// #
+/// int main() {
+///     // Create an engine and a store.
+///     wasm_engine_t* engine = wasm_engine_new();
+///     wasm_store_t* store = wasm_store_new(engine);
+///
+///     // Create the trap message.
+///     wasm_message_t message;
+///     wasm_name_new_from_string_nt(&message, "foobar");
+///
+///     // Create the trap with its message.
+///     // The backtrace will be generated automatically.
+///     wasm_trap_t* trap = wasm_trap_new(store, &message);
+///     assert(trap);
+///
+///     wasm_name_delete(&message);
+///
+///     // Do something with the trap.
+///
+///     // Free everything.
+///     wasm_trap_delete(trap);
+///     wasm_store_delete(store);
+///     wasm_engine_delete(engine);
+///
+///     return 0;
+/// }
+/// #    })
+/// #    .success();
+/// # }
+/// ```
+///
+/// Usually, a trap is returned from a host function (an imported
+/// function).
+///
 /// cbindgen:ignore
 pub mod trap;
 

--- a/lib/engine/src/trap/error.rs
+++ b/lib/engine/src/trap/error.rs
@@ -158,7 +158,7 @@ impl RuntimeError {
 
     /// Returns a reference the `message` stored in `Trap`.
     pub fn message(&self) -> String {
-        format!("{}", self.inner.source)
+        self.inner.source.to_string()
     }
 
     /// Returns a list of function frames in WebAssembly code that led to this


### PR DESCRIPTION
# Description

`wasm_trap_new` expects a `wasm_message_t`. It's a type alias to
`wasm_name_t` with the exception that it represents a null-terminated
string.

When calling `wasm_trap_new`, no check was present to ensure the
string was well-formed. That's a first issue. But in the best
scenario, the string was correctly formed and was
null-terminated. This string was transformed to a Rust `String` —with
the null byte!— and passed to `RuntimeError`.

Then in `wasm_trap_message`, another null byte was pushed at the end
of the message. It's been introduced in
#1947. It results in a
doubly-null-terminated string, which is incorrect.

This patch does the following:

1. It checks that the string given to `wasm_trap_new` contains a
   null-terminated string or not, and will act accordingly. Note that
   it's possible to pass a non-null-terminated string, and it will
   still work because this detail is vicious. The idea is to get a
   well-formed `RuntimeError` in anycase.
    * If no null byte is found, the string is passed to `RuntimeError`
    as a valid Rust string,
    * If a null byte is found at the end of the string, a new string is
    passed to `RuntimeError` but without the final null byte,
    * If a null byte is found but not at the end, it's considered as an
    error,
    * If the string contains invalid UTF-8 bytes, it's considered as an
    error.
2. It updates `wasm_trap_message` to always add a null byte at the end
   of the returned owned string.
3. It adds test cases when passing a null-terminated or a
   non-null-terminated string to `wasm_trap_new` and to compare the
   results to `wasm_trap_message`.

It fixes https://github.com/wasmerio/wasmer/issues/2439.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
