### PR TITLE
feat: Configure `soname`, `install_name`, `out-implib` etc. for the C API

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,4 @@
 rustflags = [
     # Put the VM functions in the dynamic symbol table.
     "-C", "link-arg=-Wl,-E",
-    # Fix the SONAME, required by CMake, see https://github.com/wasmerio/wasmer/issues/2429.
-    "-C", "link-arg=-Wl,-soname,libwasmer.so",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
+name = "cdylib-link-lines"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317db7ea5b455731e51d7f632762716fa5c0b1098dcaa6221e55e2386d170f2"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2410,7 @@ name = "wasmer-c-api"
 version = "2.0.0"
 dependencies = [
  "cbindgen",
+ "cdylib-link-lines",
  "cfg-if 1.0.0",
  "enumset",
  "field-offset",

--- a/lib/c-api/CHANGELOG.md
+++ b/lib/c-api/CHANGELOG.md
@@ -8,6 +8,9 @@ Looking for changes to the Wasmer CLI and the Rust API? See our [Primary Changel
 
 ## **[Unreleased]**
 
+### Added
+- [#2449](https://github.com/wasmerio/wasmer/pull/2449) Configure `soname`, `install_name`, `out-implib`, etc.
+
 ### Fixed
 - [#2444](https://github.com/wasmerio/wasmer/pull/2444) Trap's messages are always null terminated.
 

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -92,3 +92,4 @@ native = ["dylib"]
 
 [build-dependencies]
 cbindgen = "0.18"
+cdylib-link-lines = "0.1"

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -76,6 +76,7 @@ fn main() {
 
     build_wasm_c_api_headers(&crate_dir, &out_dir);
     build_inline_c_env_vars();
+    build_cdylib();
 }
 
 /// Check whether we should build the C API headers or set `inline-c` up.
@@ -296,5 +297,30 @@ fn build_inline_c_env_vars() {
                 "libwasmer_c_api.a".to_string()
             }
         }
+    );
+}
+
+fn build_cdylib() {
+    // Configure the `soname`, `install_name`, `current_version`,
+    // `out-implib`, `output-def` etc. for as much platforms as
+    // possible.
+    cdylib_link_lines::shared_object_link_args(
+        "wasmer",
+        &env::var("CARGO_PKG_VERSION_MAJOR").unwrap(),
+        &env::var("CARGO_PKG_VERSION_MINOR").unwrap(),
+        &env::var("CARGO_PKG_VERSION_PATCH").unwrap(),
+        &env::var("CARGO_CFG_TARGET_ARCH").unwrap(),
+        &env::var("CARGO_CFG_TARGET_OS").unwrap(),
+        &env::var("CARGO_CFG_TARGET_ENV").unwrap(),
+        "/usr/local/lib".into(),
+        env::var_os("CARGO_TARGET_DIR").map_or(
+            {
+                let manifest_dir: PathBuf = env::var_os("CARGO_MANIFEST_DIR").unwrap().into();
+                manifest_dir
+                    .join("target")
+                    .join(env::var("PROFILE").unwrap())
+            },
+            Into::into,
+        ),
     );
 }


### PR DESCRIPTION
# Description

Sequel of https://github.com/wasmerio/wasmer/pull/2430.

This patch uses `cdylib-link-lines` to “configure” the cdylib
correctly.

~Blocked by https://github.com/lu-zero/cdylib-link-lines/pull/4.~
Fixes https://github.com/wasmerio/wasmer/issues/2429.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
