### PR TITLE
cargo: don't pull in both universal and dylib engines

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -46,8 +46,6 @@ maintenance = { status = "actively-developed" }
 default = ["wat", "default-cranelift", "default-universal"]
 compiler = [
     "wasmer-compiler/translator",
-    "wasmer-engine-universal/compiler",
-    "wasmer-engine-dylib/compiler",
 ]
 engine = []
 universal = [


### PR DESCRIPTION
Selecting any compiler would pull in both engines due to */compiler feature propagation and there is no way to disable it.
Depending just on wasmer-compiler/translator should fix the issue and allow depending on just one engine.

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
