### PR TITLE
fix(c-api) Rename lib's name to `wasmer`

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libxkbcommon-dev doxygen
+          sudo apt-get install -y libxkbcommon-dev
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -26,9 +26,9 @@ jobs:
           mkdir ${{ env.LLVM_DIR }}
           tar xf llvm.tar.gz --strip-components=1 -C ${{ env.LLVM_DIR }}
           echo "${{ env.LLVM_DIR }}/bin" >> $GITHUB_PATH
-          echo "LLVM_SYS_100_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
+          echo "LLVM_SYS_110_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
         env:
-          LLVM_DIR: ${{ github.workspace }}/llvm-10
+          LLVM_DIR: ${{ github.workspace }}/llvm-11
           LLVM_URL: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
       - name: Build & package documentation
         run: make package-docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,17 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
-name = "cdylib-link-lines"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317db7ea5b455731e51d7f632762716fa5c0b1098dcaa6221e55e2386d170f2"
-dependencies = [
- "serde",
- "serde_derive",
- "toml",
-]
-
-[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,7 +2399,6 @@ name = "wasmer-c-api"
 version = "2.0.0"
 dependencies = [
  "cbindgen",
- "cdylib-link-lines",
  "cfg-if 1.0.0",
  "enumset",
  "field-offset",

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ else
 endif
 
 build-docs:
-	cargo doc --release $(compiler_features) --document-private-items --no-deps --workspace
+	cargo doc --release $(compiler_features) --document-private-items --no-deps --workspace --exclude wasmer-c-api
 
 capi-setup:
 ifeq ($(IS_WINDOWS), 1)
@@ -392,7 +392,12 @@ ifeq ($(IS_WINDOWS), 1)
 endif
 
 build-docs-capi: capi-setup
+	# `wasmer-c-api` lib's name is `wasmer`. To avoid a conflict
+	# when generating the documentation, we rename it to its
+	# crate's name. Then we restore the lib's name.
+	sed -i '' -e 's/name = "wasmer" # ##lib.name##/name = "wasmer_c_api" # ##lib.name##/' lib/c-api/Cargo.toml
 	RUSTFLAGS="${RUSTFLAGS}" cargo doc --manifest-path lib/c-api/Cargo.toml --no-deps --features wat,universal,staticlib,dylib,cranelift,wasi
+	sed -i '' -e 's/name = "wasmer_c_api" # ##lib.name##/name = "wasmer" # ##lib.name##/' lib/c-api/Cargo.toml
 
 build-capi: capi-setup
 	RUSTFLAGS="${RUSTFLAGS}" cargo build --manifest-path lib/c-api/Cargo.toml --release \
@@ -584,33 +589,29 @@ package-capi:
 	cp lib/c-api/wasm.h* package/include
 	cp lib/c-api/README.md package/include/README.md
 
-	# Windows
-	if [ -f $(TARGET_DIR)/wasmer_c_api.dll ]; then \
-		cp $(TARGET_DIR)/wasmer_c_api.dll package/lib/wasmer.dll ;\
+	if [ -f $(TARGET_DIR)/wasmer.dll ]; then \
+		cp $(TARGET_DIR)/wasmer.dll package/lib/wasmer.dll ;\
 	fi
-	if [ -f $(TARGET_DIR)/wasmer_c_api.lib ]; then \
-		cp $(TARGET_DIR)/wasmer_c_api.lib package/lib/wasmer.lib ;\
-	fi
-
-	# For some reason in macOS arm64 there are issues if we copy constantly in the install_name_tool util
-	rm -f package/lib/libwasmer.dylib
-	if [ -f $(TARGET_DIR)/libwasmer_c_api.dylib ]; then \
-		cp $(TARGET_DIR)/libwasmer_c_api.dylib package/lib/libwasmer.dylib ;\
-		install_name_tool -id "@rpath/libwasmer.dylib" package/lib/libwasmer.dylib ;\
+	if [ -f $(TARGET_DIR)/wasmer.lib ]; then \
+		cp $(TARGET_DIR)/wasmer.lib package/lib/wasmer.lib ;\
 	fi
 
-	if [ -f $(TARGET_DIR)/libwasmer_c_api.so ]; then \
-		cp $(TARGET_DIR)/libwasmer_c_api.so package/lib/libwasmer.so ;\
+	if [ -f $(TARGET_DIR)/libwasmer.dylib ]; then \
+		cp $(TARGET_DIR)/libwasmer.dylib package/lib/libwasmer.dylib ;\
 	fi
-	if [ -f $(TARGET_DIR)/libwasmer_c_api.a ]; then \
-		cp $(TARGET_DIR)/libwasmer_c_api.a package/lib/libwasmer.a ;\
+
+	if [ -f $(TARGET_DIR)/libwasmer.so ]; then \
+		cp $(TARGET_DIR)/libwasmer.so package/lib/libwasmer.so ;\
+	fi
+	if [ -f $(TARGET_DIR)/libwasmer.a ]; then \
+		cp $(TARGET_DIR)/libwasmer.a package/lib/libwasmer.a ;\
 	fi
 
 package-docs: build-docs build-docs-capi
-	mkdir -p "package/docs/c"
-	cp -R target/doc package/docs/crates
-	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=crates/wasmer/index.html">' > package/docs/index.html
-	echo '<!-- Build $(SOURCE_VERSION) --><meta http-equiv="refresh" content="0; url=wasmer/index.html">' > package/docs/crates/index.html
+	mkdir -p "package/docs/crates"
+	cp -R target/doc/ package/docs/crates
+	echo '<meta http-equiv="refresh" content="0; url=crates/wasmer/index.html">' > package/docs/index.html
+	echo '<meta http-equiv="refresh" content="0; url=wasmer/index.html">' > package/docs/crates/index.html
 
 package: package-wapm package-wasmer package-minimal-headless-wasmer package-capi
 
@@ -645,13 +646,13 @@ install-capi-lib:
 	pkgver=$$(target/release/wasmer --version | cut -d\  -f2) && \
 	shortver="$${pkgver%.*}" && \
 	majorver="$${shortver%.*}" && \
-	install -Dm755 target/release/libwasmer_c_api.so "$(DESTDIR)/lib/libwasmer.so.$$pkgver" && \
+	install -Dm755 target/release/libwasmer.so "$(DESTDIR)/lib/libwasmer.so.$$pkgver" && \
 	ln -sf "libwasmer.so.$$pkgver" "$(DESTDIR)/lib/libwasmer.so.$$shortver" && \
 	ln -sf "libwasmer.so.$$pkgver" "$(DESTDIR)/lib/libwasmer.so.$$majorver" && \
 	ln -sf "libwasmer.so.$$pkgver" "$(DESTDIR)/lib/libwasmer.so"
 
 install-capi-staticlib:
-	install -Dm644 target/release/libwasmer_c_api.a "$(DESTDIR)/lib/libwasmer.a"
+	install -Dm644 target/release/libwasmer.a "$(DESTDIR)/lib/libwasmer.a"
 
 install-misc:
 	install -Dm644 LICENSE "$(DESTDIR)"/share/licenses/wasmer/LICENSE

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -12,10 +12,17 @@ readme = "README.md"
 edition = "2018"
 
 [lib]
+# The library name is `wasmer` so that we generate dylib like
+# `libwasmer.so`, `libwasmer.dylib`, `wasmer.dll` etc. But it creates
+# a conflict with the existing `wasmer` crate, see below.
+name = "wasmer" # ##lib.name##
+                # ^ DO NOT REMOVE, it's used the `Makefile`, see `build-docs-capi`.
 crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
-wasmer = { version = "2.0.0", path = "../api", default-features = false }
+# We rename `wasmer` to `wasmer-api` to avoid the conflict with this
+# library name (see `[lib]`).
+wasmer-api = { version = "2.0.0", path = "../api", default-features = false, package = "wasmer" }
 wasmer-compiler-cranelift = { version = "2.0.0", path = "../compiler-cranelift", optional = true }
 wasmer-compiler-singlepass = { version = "2.0.0", path = "../compiler-singlepass", optional = true }
 wasmer-compiler-llvm = { version = "2.0.0", path = "../compiler-llvm", optional = true }
@@ -48,7 +55,7 @@ default = [
     "wasi",
     "middlewares",
 ]
-wat = ["wasmer/wat"]
+wat = ["wasmer-api/wat"]
 wasi = ["wasmer-wasi", "typetag", "serde"]
 engine = []
 middlewares = ["wasmer-middlewares"]
@@ -65,7 +72,7 @@ staticlib = [
     "engine",
 ]
 compiler = [
-    "wasmer/compiler",
+    "wasmer-api/compiler",
     "wasmer-engine-universal/compiler",
     "wasmer-engine-dylib/compiler",
     "wasmer-engine-staticlib/compiler"
@@ -92,4 +99,3 @@ native = ["dylib"]
 
 [build-dependencies]
 cbindgen = "0.19"
-cdylib-link-lines = "0.1"

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -5,7 +5,9 @@
 
 use cbindgen::{Builder, Language};
 use std::{
-    env, fs,
+    env,
+    ffi::OsStr,
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -76,7 +78,7 @@ fn main() {
 
     build_wasm_c_api_headers(&crate_dir, &out_dir);
     build_inline_c_env_vars();
-    build_cdylib();
+    build_cdylib_link_arg();
 }
 
 /// Check whether we should build the C API headers or set `inline-c` up.
@@ -223,8 +225,103 @@ fn new_builder(language: Language, crate_dir: &str, include_guard: &str, header:
 }
 
 fn build_inline_c_env_vars() {
-    use std::ffi::OsStr;
+    let shared_object_dir = shared_object_dir();
+    let shared_object_dir = shared_object_dir.as_path().to_string_lossy();
+    let include_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
+    // The following options mean:
+    //
+    // * `-I`, add `include_dir` to include search path,
+    // * `-L`, add `shared_object_dir` to library search path,
+    // * `-D_DEBUG`, enable debug mode to enable `assert.h`.
+    // * `-D_CRT_SECURE_NO_WARNINGS`, disable security features in the
+    //   Windows C runtime, which allows to use `getenv` without any
+    //   warnings.
+    println!(
+        "cargo:rustc-env=INLINE_C_RS_CFLAGS=-I{I} -L{L} -D_DEBUG -D_CRT_SECURE_NO_WARNINGS",
+        I = include_dir,
+        L = shared_object_dir.clone(),
+    );
+
+    if let Ok(compiler_engine) = env::var("TEST") {
+        println!(
+            "cargo:rustc-env=INLINE_C_RS_TEST={test}",
+            test = compiler_engine
+        );
+    }
+
+    println!(
+        "cargo:rustc-env=INLINE_C_RS_LDFLAGS=-rpath,{shared_object_dir} {shared_object_dir}/{lib}",
+        shared_object_dir = shared_object_dir,
+        lib = if cfg!(target_os = "windows") {
+            "wasmer.dll".to_string()
+        } else if cfg!(target_os = "macos") {
+            "libwasmer.dylib".to_string()
+        } else {
+            let path = format!(
+                "{shared_object_dir}/{lib}",
+                shared_object_dir = shared_object_dir,
+                lib = "libwasmer.so"
+            );
+
+            if Path::new(path.as_str()).exists() {
+                "libwasmer.so".to_string()
+            } else {
+                "libwasmer.a".to_string()
+            }
+        }
+    );
+}
+
+fn build_cdylib_link_arg() {
+    // Code inspired by the `cdylib-link-lines` crate.
+    let mut lines = Vec::new();
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    let version_major = env::var("CARGO_PKG_VERSION_MAJOR").unwrap();
+    let version_minor = env::var("CARGO_PKG_VERSION_MINOR").unwrap();
+    let version_patch = env::var("CARGO_PKG_VERSION_PATCH").unwrap();
+    let shared_object_dir = shared_object_dir();
+
+    match (os.as_str(), env.as_str()) {
+        ("android", _) => {
+            lines.push(format!("-Wl,-soname,libwasmer.so"));
+        }
+
+        ("linux", _) | ("freebsd", _) | ("dragonfly", _) | ("netbsd", _) if env != "musl" => {
+            lines.push(format!("-Wl,-soname,libwasmer.so"));
+        }
+
+        ("macos", _) | ("ios", _) => {
+            lines.push(format!(
+                "-Wl,-install_name,@rpath/libwasmer.dylib,-current_version,{x}.{y}.{z},-compatibility_version,{x}",
+                x = version_major,
+                y = version_minor,
+                z = version_patch,
+            ));
+        }
+
+        ("windows", "gnu") => {
+            // This is only set up to work on GNU toolchain versions of Rust
+            lines.push(format!(
+                "-Wl,--out-implib,{}",
+                shared_object_dir.join(format!("wasmer.dll.a")).display()
+            ));
+            lines.push(format!(
+                "-Wl,--output-def,{}",
+                shared_object_dir.join(format!("wasmer.def")).display()
+            ));
+        }
+
+        _ => {}
+    }
+
+    for line in lines {
+        println!("cargo:rustc-cdylib-link-arg={}", line);
+    }
+}
+
+fn shared_object_dir() -> PathBuf {
     // We start from `OUT_DIR` because `cargo publish` uses a different directory
     // so traversing from `CARGO_MANIFEST_DIR` is less reliable.
     let mut shared_object_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -253,74 +350,5 @@ fn build_inline_c_env_vars() {
 
     shared_object_dir.push(env::var("PROFILE").unwrap());
 
-    let shared_object_dir = shared_object_dir.as_path().to_string_lossy();
-    let include_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-
-    // The following options mean:
-    //
-    // * `-I`, add `include_dir` to include search path,
-    // * `-L`, add `shared_object_dir` to library search path,
-    // * `-D_DEBUG`, enable debug mode to enable `assert.h`.
-    // * `-D_CRT_SECURE_NO_WARNINGS`, disable security features in the
-    //   Windows C runtime, which allows to use `getenv` without any
-    //   warnings.
-    println!(
-        "cargo:rustc-env=INLINE_C_RS_CFLAGS=-I{I} -L{L} -D_DEBUG -D_CRT_SECURE_NO_WARNINGS",
-        I = include_dir,
-        L = shared_object_dir.clone(),
-    );
-
-    if let Ok(compiler_engine) = env::var("TEST") {
-        println!(
-            "cargo:rustc-env=INLINE_C_RS_TEST={test}",
-            test = compiler_engine
-        );
-    }
-
-    println!(
-        "cargo:rustc-env=INLINE_C_RS_LDFLAGS={shared_object_dir}/{lib}",
-        shared_object_dir = shared_object_dir,
-        lib = if cfg!(target_os = "windows") {
-            "wasmer_c_api.dll".to_string()
-        } else if cfg!(target_os = "macos") {
-            "libwasmer_c_api.dylib".to_string()
-        } else {
-            let path = format!(
-                "{shared_object_dir}/{lib}",
-                shared_object_dir = shared_object_dir,
-                lib = "libwasmer_c_api.so"
-            );
-
-            if Path::new(path.as_str()).exists() {
-                "libwasmer_c_api.so".to_string()
-            } else {
-                "libwasmer_c_api.a".to_string()
-            }
-        }
-    );
-}
-
-fn build_cdylib() {
-    // Configure the `soname`, `install_name`, `current_version`,
-    // `out-implib`, `output-def` etc. for as much platforms as
-    // possible.
-    cdylib_link_lines::shared_object_link_args(
-        "wasmer",
-        &env::var("CARGO_PKG_VERSION_MAJOR").unwrap(),
-        &env::var("CARGO_PKG_VERSION_MINOR").unwrap(),
-        &env::var("CARGO_PKG_VERSION_PATCH").unwrap(),
-        &env::var("CARGO_CFG_TARGET_ARCH").unwrap(),
-        &env::var("CARGO_CFG_TARGET_OS").unwrap(),
-        &env::var("CARGO_CFG_TARGET_ENV").unwrap(),
-        "/usr/local/lib".into(),
-        env::var_os("CARGO_TARGET_DIR").map_or(
-            {
-                let manifest_dir: PathBuf = env::var_os("CARGO_MANIFEST_DIR").unwrap().into();
-                manifest_dir
-                    .join("target")
-                    .join(env::var("PROFILE").unwrap())
-            },
-            Into::into,
-        ),
-    );
+    shared_object_dir
 }

--- a/lib/c-api/src/error.rs
+++ b/lib/c-api/src/error.rs
@@ -63,7 +63,7 @@ thread_local! {
 /// # Example
 ///
 /// ```rust,no_run
-/// # use wasmer_c_api::error::{update_last_error, CApiError};
+/// # use wasmer::error::{update_last_error, CApiError};
 ///
 /// update_last_error(CApiError {
 ///     msg: "Hello, World!".to_string(),

--- a/lib/c-api/src/ordered_resolver.rs
+++ b/lib/c-api/src/ordered_resolver.rs
@@ -5,7 +5,7 @@
 //! by index and not by module and name.
 
 use std::iter::FromIterator;
-use wasmer::{Export, Exportable, Extern, Resolver};
+use wasmer_api::{Export, Exportable, Extern, Resolver};
 
 /// An `OrderedResolver` stores all the `externs` provided to an Instance
 /// in a Vec, so we can retrieve them later based on index.

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -11,7 +11,7 @@ use super::unstable::target_lexicon::wasmer_target_t;
 use crate::error::{update_last_error, CApiError};
 use cfg_if::cfg_if;
 use std::sync::Arc;
-use wasmer::Engine;
+use wasmer_api::Engine;
 #[cfg(feature = "dylib")]
 use wasmer_engine_dylib::Dylib;
 #[cfg(feature = "staticlib")]
@@ -286,7 +286,7 @@ pub struct wasm_engine_t {
 }
 
 #[cfg(feature = "compiler")]
-use wasmer::CompilerConfig;
+use wasmer_api::CompilerConfig;
 
 #[cfg(feature = "compiler")]
 fn get_default_compiler_config() -> Box<dyn CompilerConfig> {

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -6,7 +6,7 @@ use super::CApiExternTag;
 use std::convert::TryInto;
 use std::ffi::c_void;
 use std::sync::Arc;
-use wasmer::{Function, RuntimeError, Val};
+use wasmer_api::{Function, RuntimeError, Val};
 
 #[derive(Debug, Clone)]
 #[allow(non_camel_case_types)]
@@ -108,12 +108,14 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
     let func_sig = &function_type.inner().function_type;
     let num_rets = func_sig.results().len();
 
-    #[derive(wasmer::WasmerEnv, Clone)]
+    #[derive(Clone)]
     #[repr(C)]
     struct WrapperEnv {
         env: *mut c_void,
         env_finalizer: Arc<Option<wasm_env_finalizer_t>>,
     }
+
+    impl wasmer_api::WasmerEnv for WrapperEnv {}
 
     // Only relevant when using multiple threads in the C API;
     // Synchronization will be done via the C API / on the C side.

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -4,7 +4,7 @@ use super::super::value::wasm_val_t;
 use super::CApiExternTag;
 use crate::error::update_last_error;
 use std::convert::TryInto;
-use wasmer::{Global, Val};
+use wasmer_api::{Global, Val};
 
 #[allow(non_camel_case_types)]
 #[repr(C)]

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -2,7 +2,7 @@ use super::super::store::wasm_store_t;
 use super::super::types::wasm_memorytype_t;
 use super::CApiExternTag;
 use std::mem;
-use wasmer::{Memory, Pages};
+use wasmer_api::{Memory, Pages};
 
 #[allow(non_camel_case_types)]
 #[repr(C)]

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -8,7 +8,7 @@ pub use global::*;
 pub use memory::*;
 use std::mem;
 pub use table::*;
-use wasmer::{Extern, ExternType};
+use wasmer_api::{Extern, ExternType};
 
 #[allow(non_camel_case_types)]
 #[repr(transparent)]

--- a/lib/c-api/src/wasm_c_api/externals/table.rs
+++ b/lib/c-api/src/wasm_c_api/externals/table.rs
@@ -1,7 +1,7 @@
 use super::super::store::wasm_store_t;
 use super::super::types::{wasm_ref_t, wasm_table_size_t, wasm_tabletype_t};
 use super::CApiExternTag;
-use wasmer::Table;
+use wasmer_api::Table;
 
 #[allow(non_camel_case_types)]
 #[repr(C)]

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -5,7 +5,7 @@ use super::trap::wasm_trap_t;
 use crate::ordered_resolver::OrderedResolver;
 use std::mem;
 use std::sync::Arc;
-use wasmer::{Extern, Instance, InstantiationError};
+use wasmer_api::{Extern, Instance, InstantiationError};
 
 /// Opaque type representing a WebAssembly instance.
 #[allow(non_camel_case_types)]

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -6,7 +6,7 @@ use super::types::{
 use crate::error::{update_last_error, CApiError};
 use std::ptr::NonNull;
 use std::sync::Arc;
-use wasmer::Module;
+use wasmer_api::Module;
 
 /// Opaque type representing a WebAssembly module.
 #[allow(non_camel_case_types)]

--- a/lib/c-api/src/wasm_c_api/store.rs
+++ b/lib/c-api/src/wasm_c_api/store.rs
@@ -1,5 +1,5 @@
 use super::engine::wasm_engine_t;
-use wasmer::Store;
+use wasmer_api::Store;
 
 /// Opaque type representing a WebAssembly store.
 #[allow(non_camel_case_types)]

--- a/lib/c-api/src/wasm_c_api/trap.rs
+++ b/lib/c-api/src/wasm_c_api/trap.rs
@@ -1,7 +1,7 @@
 use super::store::wasm_store_t;
 use super::types::{wasm_byte_vec_t, wasm_frame_t, wasm_frame_vec_t, wasm_message_t};
 use std::ffi::CString;
-use wasmer::RuntimeError;
+use wasmer_api::RuntimeError;
 
 // opaque type which is a `RuntimeError`
 #[allow(non_camel_case_types)]

--- a/lib/c-api/src/wasm_c_api/types/export.rs
+++ b/lib/c-api/src/wasm_c_api/types/export.rs
@@ -1,5 +1,5 @@
 use super::{owned_wasm_name_t, wasm_externtype_t, wasm_name_t};
-use wasmer::ExportType;
+use wasmer_api::ExportType;
 
 #[allow(non_camel_case_types)]
 #[derive(Clone)]

--- a/lib/c-api/src/wasm_c_api/types/extern_.rs
+++ b/lib/c-api/src/wasm_c_api/types/extern_.rs
@@ -6,7 +6,7 @@ use super::{
 use std::convert::{TryFrom, TryInto};
 use std::mem;
 use thiserror::Error;
-use wasmer::ExternType;
+use wasmer_api::ExternType;
 
 #[allow(non_camel_case_types)]
 type wasm_externkind_t = u8;

--- a/lib/c-api/src/wasm_c_api/types/frame.rs
+++ b/lib/c-api/src/wasm_c_api/types/frame.rs
@@ -1,5 +1,5 @@
 use super::super::instance::wasm_instance_t;
-use wasmer::FrameInfo;
+use wasmer_api::FrameInfo;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone)]

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -1,5 +1,5 @@
 use super::{wasm_externtype_t, wasm_valtype_vec_delete, wasm_valtype_vec_t, WasmExternType};
-use wasmer::{ExternType, FunctionType, ValType};
+use wasmer_api::{ExternType, FunctionType, ValType};
 
 #[derive(Debug)]
 pub(crate) struct WasmFunctionType {

--- a/lib/c-api/src/wasm_c_api/types/global.rs
+++ b/lib/c-api/src/wasm_c_api/types/global.rs
@@ -3,7 +3,7 @@ use super::{
     wasm_valtype_t, WasmExternType,
 };
 use std::convert::TryInto;
-use wasmer::{ExternType, GlobalType};
+use wasmer_api::{ExternType, GlobalType};
 
 #[derive(Debug, Clone)]
 pub(crate) struct WasmGlobalType {

--- a/lib/c-api/src/wasm_c_api/types/import.rs
+++ b/lib/c-api/src/wasm_c_api/types/import.rs
@@ -1,5 +1,5 @@
 use super::{owned_wasm_name_t, wasm_externtype_t, wasm_name_t};
-use wasmer::ImportType;
+use wasmer_api::ImportType;
 
 #[allow(non_camel_case_types)]
 #[derive(Clone)]

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -1,5 +1,5 @@
 use super::{wasm_externtype_t, WasmExternType};
-use wasmer::{ExternType, MemoryType, Pages};
+use wasmer_api::{ExternType, MemoryType, Pages};
 
 #[derive(Debug, Clone)]
 pub(crate) struct WasmMemoryType {

--- a/lib/c-api/src/wasm_c_api/types/mutability.rs
+++ b/lib/c-api/src/wasm_c_api/types/mutability.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-use wasmer::Mutability;
+use wasmer_api::Mutability;
 
 #[allow(non_camel_case_types)]
 pub type wasm_mutability_t = u8;

--- a/lib/c-api/src/wasm_c_api/types/table.rs
+++ b/lib/c-api/src/wasm_c_api/types/table.rs
@@ -1,7 +1,7 @@
 use super::{
     wasm_externtype_t, wasm_limits_t, wasm_valtype_delete, wasm_valtype_t, WasmExternType,
 };
-use wasmer::{ExternType, TableType};
+use wasmer_api::{ExternType, TableType};
 
 #[allow(non_camel_case_types)]
 pub type wasm_table_size_t = u32;

--- a/lib/c-api/src/wasm_c_api/types/value.rs
+++ b/lib/c-api/src/wasm_c_api/types/value.rs
@@ -1,6 +1,6 @@
 use super::super::value::wasm_valkind_t;
 use std::convert::TryInto;
-use wasmer::ValType;
+use wasmer_api::ValType;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
@@ -135,7 +135,7 @@ use super::super::super::instance::wasm_instance_t;
 use super::super::parser::operator::wasmer_parser_operator_t;
 use super::wasmer_middleware_t;
 use std::sync::Arc;
-use wasmer::wasmparser::Operator;
+use wasmer_api::wasmparser::Operator;
 use wasmer_middlewares::{
     metering::{get_remaining_points, set_remaining_points, MeteringPoints},
     Metering,

--- a/lib/c-api/src/wasm_c_api/unstable/middlewares/mod.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/middlewares/mod.rs
@@ -5,7 +5,7 @@ pub mod metering;
 
 use super::super::engine::wasm_config_t;
 use std::sync::Arc;
-use wasmer::ModuleMiddleware;
+use wasmer_api::ModuleMiddleware;
 
 #[cfg(all(feature = "middlewares", not(feature = "compiler")))]
 compile_error!("The `middlewares` feature requires the `compiler` feature to be turned on");

--- a/lib/c-api/src/wasm_c_api/unstable/parser/operator.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/parser/operator.rs
@@ -1,4 +1,4 @@
-use wasmer::wasmparser::Operator;
+use wasmer_api::wasmparser::Operator;
 
 #[repr(C)]
 #[allow(non_camel_case_types)]

--- a/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
@@ -58,7 +58,7 @@ use crate::error::CApiError;
 use enumset::EnumSet;
 use std::slice;
 use std::str::{self, FromStr};
-use wasmer::{CpuFeature, Target, Triple};
+use wasmer_api::{CpuFeature, Target, Triple};
 
 /// Unstable non-standard Wasmer-specific API to represent a triple +
 /// CPU features pair.

--- a/lib/c-api/src/wasm_c_api/unstable/wasi.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/wasi.rs
@@ -9,7 +9,7 @@ use super::super::{
     wasi::wasi_env_t,
 };
 use crate::error::CApiError;
-use wasmer::Extern;
+use wasmer_api::Extern;
 use wasmer_wasi::{generate_import_object_from_env, get_wasi_version};
 
 /// Unstable non-standard type wrapping `wasm_extern_t` with the

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -1,7 +1,7 @@
 use super::types::{wasm_ref_t, wasm_valkind_enum};
 use crate::error::{update_last_error, CApiError};
 use std::convert::{TryFrom, TryInto};
-use wasmer::Val;
+use wasmer_api::Val;
 
 /// Represents the kind of values. The variants of this C enum is
 /// defined in `wasm.h` to list the following:

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -17,7 +17,7 @@ use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::slice;
-use wasmer::{Extern, NamedResolver};
+use wasmer_api::{Extern, NamedResolver};
 use wasmer_wasi::{
     generate_import_object_from_env, get_wasi_version, WasiEnv, WasiFile, WasiState,
     WasiStateBuilder, WasiVersion,

--- a/lib/c-api/src/wasm_c_api/wat.rs
+++ b/lib/c-api/src/wasm_c_api/wat.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn wat2wasm(wat: &wasm_byte_vec_t, out: &mut wasm_byte_vec
             return;
         }
     };
-    let result: wasm_byte_vec_t = match wasmer::wat2wasm(wat) {
+    let result: wasm_byte_vec_t = match wasmer_api::wat2wasm(wat) {
         Ok(val) => val.into_owned().into(),
         Err(err) => {
             crate::error::update_last_error(err);


### PR DESCRIPTION
# Description

This patch does several things.

1. For the crate `wasmer-c-api`, the library name is modified from
   `wasmer_c_api` to `wasmer` in `Cargo.toml`. That way, the new
   library files are named `libwasmer.*` rather than
   `libwasmer_c_api.*`. That's the primaly goal of this patch. The
   rest is a consequence of this point. Why do we want that? Because
   the `build.rs` script of the `wasmer-c-api` crate will configure
   the `soname` (on Linux), the `install_name` + `current_version` +
   `compatibility_version` (on macOS), and the `out-implib` +
   `output-def` (on Windows) for a library named `libwasmer`, which is
   the name we provide in the Wasmer package for the Wasmer
   libraries. If we want everything to be testable, we cannot use
   `libwasmer` in `soname` for a file named `libwasmer_c_api` for
   example. If we rename the file when packaging (as it's done prior
   this patch), we would need to re-update all those information in
   the `Makefile`. It implies to duplicate the code in 2 places. So
   let's do things right directly and only once: We want the library
   to be named `libwasmer`, let's do that.
2. For the crate `wasmer-c-api`, since the library name has been
   renamed to `wasmer`, it creates a conflict with the `wasmer` crate
   which is a dependency. Consequently, this patch also updates the
   `Cargo.toml` file to modifiy the dependency name with the special
   `package` attribute (see
   https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
   to learn more). So now, the `wasmer` refers to the `wasmer_c_api`
   crate, and `wasmer-api` refers to the `wasmer` crate.
3. The code of the `wasmer-c-api` crate is updated accordingly. The
   `WasmerEnv` derive procedural macro fails because it expects a
   crate named `wasmer` (which is now `wasmer_api`), so we implement
   the `WasmerEnv` trait by hand.
4. The patch updates the `build.rs` script of the `wasmer-c-api`
   crate:
    1. In the `build_cdylib_link_arg` function: The dependency to the
     `cdylib-link-lines` crate has been removed because the output is
     not exactly the one we expect. So we compute all the
     `cargo:rustc-cdylib-link-arg=…` lines by hand. The version number
     no longer appears in the library file name for example.
    2. In the `build_inline_c_env_vars` function: Values passed to
     `LDFLAGS` have been updated to be `libwasmer` rather than
     `libwasmer_c_api`.
    3. A new `shared_object_dir` helper function has been created
     because it's used in `build_inline_c_env_vars` and in
     `build_cdylib_link_arg`.
5. The `Makefile` has been updated:
    1. In `package-capi`, we no longer rename `libwasmer_c_api` to
     `libwasmer` since the name is correctly defined since the
     beginning now.
     Calling `install_name_tool` on macOS is no longer required since
     `install_name` is correctly set by the linker in the `build.rs`
     script of `wasmer-c-api`.
    2. In `package-docs`, some stuffs have been fixed, like the
     `SOURCE_VERSION` variable that didn't exist, so removed, or the
     `mkdir` command that was incorrect etc.
    3. In `build-docs`, the `wasmer-c-api` crate is excluded from the
     list of crates to generate the documentation for. Mostly because
     the `build-docs-capi` recipe exists, and we must use it to
     generate the documentation of `wasmer-c-api` now.
    4. In `build-docs-capi`, we generate the documentation for the
     `wasmer-c-api` crate. But `rustdoc` uses the library name for the
     directory name in the `target/doc/` directory. Since the library
     name is now `wasmer`, it creates a conflict with the `wasmer`
     crate. Consequently, we update the library name by using `sed` on
     the `Cargo.toml` file before running `cargo doc`, to finally
     restore `Cargo.toml` as it was previously.

Fixes https://github.com/wasmerio/wasmer/issues/2429.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
