### PR TITLE
feat: Add the `stale` bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,7 @@ daysUntilClose: 30
 exemptLabels:
   - "🐞 bug"
 # Label to use when marking an issue as stale
-staleLabel: "🚫 won't fix"
+staleLabel: "🏚 stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 15
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "🐞 bug"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 15
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "🐞 bug"
+# Label to use when marking an issue as stale
+staleLabel: "🚫 won't fix"
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Feel free to reopen the issue if it has been closed by mistake.


### PR DESCRIPTION
# Description

This patch configures (and thus finishes the installation) of the
“stale” bot, learn more at https://probot.github.io/apps/stale/.

Note: The bot/app has been installed already.

# Review

- ~[ ] Add a short description of the change to the CHANGELOG.md file~ not needed
