### PR TITLE
Fix windows cache permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2427](https://github.com/wasmerio/wasmer/pull/2427) Update `loupe` to 0.1.3.
 
 ### Fixed
+- [#2454](https://github.com/wasmerio/wasmer/issues/2454) Won't set `WASMER_CACHE_DIR` for Windows.
 - [#2426](https://github.com/wasmerio/wasmer/pull/2426) Fix the `wax` script generation.
 
 ## 2.0.0 - 2021/06/16

--- a/lib/cache/src/filesystem.rs
+++ b/lib/cache/src/filesystem.rs
@@ -63,8 +63,15 @@ impl FileSystemCache {
             }
         } else {
             // Create the directory and any parent directories if they don't yet exist.
-            create_dir_all(&path)?;
-            Ok(Self { path, ext: None })
+            let res = create_dir_all(&path);
+            if res.is_err() {
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("failed to create cache directory: {}", path.display()),
+                ))
+            } else {
+                Ok(Self { path, ext: None })
+            }
         }
     }
 

--- a/scripts/windows-installer/wasmer.iss
+++ b/scripts/windows-installer/wasmer.iss
@@ -17,8 +17,6 @@ DisableWelcomePage=no
 [Registry]
 Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName: "WASMER_DIR"; \
     ValueData: "{app}"; Flags: preservestringtype
-Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName: "WASMER_CACHE_DIR"; \
-    ValueData: "{app}\cache"; Flags: preservestringtype
 
 [Files]
 Source: "..\..\package\bin\*"; DestDir: "{app}\bin"
@@ -27,9 +25,6 @@ Source: "..\..\package\lib\*"; DestDir: "{app}\lib"
 Source: "..\..\package\LICENSE"; DestDir: "{app}"
 Source: "..\..\package\ATTRIBUTIONS"; DestDir: "{app}"
 Source: "wax.cmd"; DestDir: "{app}\bin"
-
-[Dirs]
-Name: "{app}\cache"
 
 [Code]
 const EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';

--- a/scripts/windows-installer/wasmer.iss
+++ b/scripts/windows-installer/wasmer.iss
@@ -17,6 +17,8 @@ DisableWelcomePage=no
 [Registry]
 Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName: "WASMER_DIR"; \
     ValueData: "{app}"; Flags: preservestringtype
+Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName: "WASMER_CACHE_DIR"; \
+    ValueData: "{%USERPROFILE}\.wasmer\cache"; Flags: preservestringtype
 
 [Files]
 Source: "..\..\package\bin\*"; DestDir: "{app}\bin"
@@ -25,6 +27,9 @@ Source: "..\..\package\lib\*"; DestDir: "{app}\lib"
 Source: "..\..\package\LICENSE"; DestDir: "{app}"
 Source: "..\..\package\ATTRIBUTIONS"; DestDir: "{app}"
 Source: "wax.cmd"; DestDir: "{app}\bin"
+
+[Dirs]
+Name: "{%USERPROFILE}\.wasmer"
 
 [Code]
 const EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';


### PR DESCRIPTION
# Description
Fix issue #2454 , default `WASMER_CACHE_DIR` is not right for Windows.
Add more detailed messages for creating cache directory failure.

close #2454.

