### PR TITLE
fix(api,c-api,vm) Move `.cargo/config` to `Cargo.toml`s

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.'cfg(target_os = "linux")']
-rustflags = [
-    # Put the VM functions in the dynamic symbol table.
-    "-C", "link-arg=-Wl,-E",
-]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -42,6 +42,11 @@ anyhow = "1.0"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[target.'cfg(target_os = "linux")']
+rustflags = [
+  "-C", "link-arg=-Wl,-E"
+]
+
 [features]
 default = ["wat", "default-cranelift", "default-universal"]
 compiler = [

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -47,6 +47,11 @@ paste = "1.0"
 field-offset = "0.3.3"
 inline-c = "0.1.5"
 
+[target.'cfg(target_os = "linux")']
+rustflags = [
+  "-C", "link-arg=-Wl,-E"
+]
+
 [features]
 default = [
     "wat",

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -33,6 +33,11 @@ cc = "1.0"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[target.'cfg(target_os = "linux")']
+rustflags = [
+  "-C", "link-arg=-Wl,-E"
+]
+
 [features]
 default = []
 enable-rkyv = ["rkyv"]


### PR DESCRIPTION
# Description

Rework of https://github.com/wasmerio/wasmer/pull/1939/.

We need to pass the `-Wl,-E` arguments to the linker when compiling `wasmer`, `wasmer_c_api` and `wasmer_vm`. It was done generally with a `.cargo/config.toml` file _but_ it was local to our project, i.e. it was not used when Wasmer was a dependency of another project.

So we move the content of `.cargo/config.toml` to the respective `Cargo.toml` files.

Fixes #1939.
Fixes #1928.

# Review

- [ ] ~Add a short description of the change to the CHANGELOG.md file~ not necessary I guess.
