### PR TITLE
Rename wasm_instance_new()’s “traps” argument to “trap”.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 ## **[Unreleased]**
 
 ### Changed
+- [#2478](https://github.com/wasmerio/wasmer/pull/2478) Rename `traps` input to `wasm_instance_new()` to `trap`.
+
 - [#2427](https://github.com/wasmerio/wasmer/pull/2427) Update `loupe` to 0.1.3.
 
 ### Fixed

--- a/lib/c-api/examples/features.c
+++ b/lib/c-api/examples/features.c
@@ -40,8 +40,8 @@ int main(int argc, const char* argv[]) {
 
     printf("Instantiating module...\n");
     wasm_extern_vec_t imports = WASM_EMPTY_VEC;
-    wasm_trap_t* traps = NULL;
-    wasm_instance_t* instance = wasm_instance_new(store, module, &imports,&traps);
+    wasm_trap_t* trap = NULL;
+    wasm_instance_t* instance = wasm_instance_new(store, module, &imports,&trap);
 
     if (!instance) {
         printf("> Error instantiating module!\n");
@@ -67,7 +67,7 @@ int main(int argc, const char* argv[]) {
     wasm_val_vec_t arguments_as_array = WASM_ARRAY_VEC(arguments);
     wasm_val_vec_t results_as_array = WASM_ARRAY_VEC(results);
 
-    wasm_trap_t* trap = wasm_func_call(swap, &arguments_as_array, &results_as_array);
+    trap = wasm_func_call(swap, &arguments_as_array, &results_as_array);
 
     if (trap != NULL) {
         printf("> Failed to call `swap`.\n");

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -275,9 +275,9 @@ mod tests {
                 assert(module);
 
                 wasm_extern_vec_t imports = WASM_EMPTY_VEC;
-                wasm_trap_t* traps = NULL;
+                wasm_trap_t* trap = NULL;
 
-                wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &traps);
+                wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &trap);
                 assert(instance);
 
                 wasm_extern_vec_t exports;

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -25,7 +25,7 @@ pub struct wasm_instance_t {
 /// 2. Runtime errors that happen when running the module `start`
 ///    function.
 ///
-/// Failures are stored in the `traps` argument; the program doesn't
+/// The failure is stored in the `trap` argument; the program doesn't
 /// panic.
 ///
 /// # Notes
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn wasm_instance_new(
     _store: Option<&wasm_store_t>,
     module: Option<&wasm_module_t>,
     imports: Option<&wasm_extern_vec_t>,
-    traps: *mut *mut wasm_trap_t,
+    trap: *mut *mut wasm_trap_t,
 ) -> Option<Box<wasm_instance_t>> {
     let module = module?;
     let imports = imports?;
@@ -67,8 +67,8 @@ pub unsafe extern "C" fn wasm_instance_new(
         }
 
         Err(InstantiationError::Start(runtime_error)) => {
-            let trap: Box<wasm_trap_t> = Box::new(runtime_error.into());
-            *traps = Box::into_raw(trap);
+            let this_trap: Box<wasm_trap_t> = Box::new(runtime_error.into());
+            *trap = Box::into_raw(this_trap);
 
             return None;
         }
@@ -124,9 +124,9 @@ pub unsafe extern "C" fn wasm_instance_delete(_instance: Option<Box<wasm_instanc
 ///
 ///     // Instantiate the module.
 ///     wasm_extern_vec_t imports = WASM_EMPTY_VEC;
-///     wasm_trap_t* traps = NULL;
+///     wasm_trap_t* trap = NULL;
 ///
-///     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &traps);
+///     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &trap);
 ///     assert(instance);
 ///
 ///     // Read the exports.
@@ -252,8 +252,8 @@ mod tests {
                 wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
 
                 // Instantiate the module.
-                wasm_trap_t* traps = NULL;
-                wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &traps);
+                wasm_trap_t* trap = NULL;
+                wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &trap);
 
                 assert(instance);
 
@@ -273,7 +273,7 @@ mod tests {
                 wasm_val_vec_t arguments_as_array = WASM_ARRAY_VEC(arguments);
                 wasm_val_vec_t results_as_array = WASM_ARRAY_VEC(results);
 
-                wasm_trap_t* trap = wasm_func_call(run_function, &arguments_as_array, &results_as_array);
+                trap = wasm_func_call(run_function, &arguments_as_array, &results_as_array);
 
                 assert(trap == NULL);
                 assert(results[0].of.i32 == 2);

--- a/lib/c-api/src/wasm_c_api/mod.rs
+++ b/lib/c-api/src/wasm_c_api/mod.rs
@@ -102,9 +102,9 @@ pub mod externals;
 ///
 ///     // Instantiate the module.
 ///     wasm_extern_vec_t imports = WASM_EMPTY_VEC;
-///     wasm_trap_t* traps = NULL;
+///     wasm_trap_t* trap = NULL;
 ///
-///     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &traps);
+///     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &trap);
 ///     assert(instance);
 ///
 ///     // Now do something with the instance, like calling the

--- a/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
@@ -66,8 +66,8 @@
 //!     
 //!     // Instantiate the module.
 //!     wasm_extern_vec_t imports = WASM_EMPTY_VEC;
-//!     wasm_trap_t* traps = NULL;
-//!     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &traps);
+//!     wasm_trap_t* trap = NULL;
+//!     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &trap);
 //!     assert(instance);
 //!     
 //!     // Here we go. At this step, we will get the `add_two` exported function, and
@@ -88,7 +88,7 @@
 //!
 //!     // Let's call `add_two` for the first time!
 //!     {
-//!         wasm_trap_t* trap = wasm_func_call(add_two, &arguments_as_array, &results_as_array);
+//!         trap = wasm_func_call(add_two, &arguments_as_array, &results_as_array);
 //!         assert(trap == NULL);
 //!         assert(results[0].of.i32 == 42);
 //!
@@ -99,7 +99,7 @@
 //!
 //!     // Let's call `add_two` for the second time!
 //!     {
-//!         wasm_trap_t* trap = wasm_func_call(add_two, &arguments_as_array, &results_as_array);
+//!         trap = wasm_func_call(add_two, &arguments_as_array, &results_as_array);
 //!         assert(trap == NULL);
 //!         assert(results[0].of.i32 == 42);
 //!
@@ -110,7 +110,7 @@
 //!
 //!     // Let's call `add_two` for the third time!
 //!     {
-//!         wasm_trap_t* trap = wasm_func_call(add_two, &arguments_as_array, &results_as_array);
+//!         trap = wasm_func_call(add_two, &arguments_as_array, &results_as_array);
 //!         // Oh, it failed!
 //!         assert(trap != NULL);
 //!
@@ -269,8 +269,8 @@ pub extern "C" fn wasmer_metering_points_are_exhausted(instance: &wasm_instance_
 ///     assert(module);
 ///     
 ///     wasm_extern_vec_t imports = WASM_EMPTY_VEC;
-///     wasm_trap_t* traps = NULL;
-///     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &traps);
+///     wasm_trap_t* trap = NULL;
+///     wasm_instance_t* instance = wasm_instance_new(store, module, &imports, &trap);
 ///     assert(instance);
 ///
 ///     // Read the number of points.


### PR DESCRIPTION
Issue #2472

# Description

This clarifies a bit how to properly use the error-handling mechanism in `wasm_instance_new()`, which only produces 0 or 1 traps, not 2+ as the name “traps” implies.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
