### PR TITLE
feat(c-api) Create `OrderedResolver` from a parallel iterator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,6 +2477,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "paste",
+ "rayon",
  "serde",
  "thiserror",
  "typetag",

--- a/lib/c-api/CHANGELOG.md
+++ b/lib/c-api/CHANGELOG.md
@@ -12,6 +12,7 @@ Looking for changes to the Wasmer CLI and the Rust API? See our [Primary Changel
 - [#2485](https://github.com/wasmerio/wasmer/pull/2493) Document wasm_limits_t’s members publicly.
 
 ### Added
+- [#2521](https://github.com/wasmerio/wasmer/pull/2521) Create `OrderedResolver` from a parallel iterator, which improves performances of `wasm_new_instance` when a large set of imports is given.
 - [#2449](https://github.com/wasmerio/wasmer/pull/2449) Configure `soname`, `install_name`, `out-implib`, etc.
 
 ### Changed

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1"
 typetag = { version = "0.1", optional = true }
 paste = "1.0"
+rayon = "1.5"
 
 [dev-dependencies]
 field-offset = "0.3.3"

--- a/lib/c-api/src/ordered_resolver.rs
+++ b/lib/c-api/src/ordered_resolver.rs
@@ -4,6 +4,7 @@
 //! This resolver is used in the Wasm-C-API as the imports are provided
 //! by index and not by module and name.
 
+use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::iter::FromIterator;
 use wasmer_api::{Export, Exportable, Extern, Resolver};
 
@@ -25,10 +26,16 @@ impl Resolver for OrderedResolver {
 
 impl FromIterator<Extern> for OrderedResolver {
     fn from_iter<I: IntoIterator<Item = Extern>>(iter: I) -> Self {
-        let mut externs = Vec::new();
-        for extern_ in iter {
-            externs.push(extern_);
+        OrderedResolver {
+            externs: iter.into_iter().collect(),
         }
-        OrderedResolver { externs }
+    }
+}
+
+impl FromParallelIterator<Extern> for OrderedResolver {
+    fn from_par_iter<I: IntoParallelIterator<Item = Extern>>(iter: I) -> Self {
+        OrderedResolver {
+            externs: iter.into_par_iter().collect(),
+        }
     }
 }

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -3,6 +3,7 @@ use super::module::wasm_module_t;
 use super::store::wasm_store_t;
 use super::trap::wasm_trap_t;
 use crate::ordered_resolver::OrderedResolver;
+use rayon::prelude::*;
 use std::mem;
 use std::sync::Arc;
 use wasmer_api::{Extern, Instance, InstantiationError};
@@ -51,8 +52,8 @@ pub unsafe extern "C" fn wasm_instance_new(
     let module_import_count = module_imports.len();
     let resolver: OrderedResolver = imports
         .into_slice()
-        .map(|imports| imports.iter())
-        .unwrap_or_else(|| [].iter())
+        .map(|imports| imports.par_iter())
+        .unwrap_or_else(|| [].par_iter())
         .map(|imp| Extern::from((&**imp).clone()))
         .take(module_import_count)
         .collect();


### PR DESCRIPTION
# Description

This patch adds `rayon` to `wasmer-c-api` so that we can create an
`OrderedResolver` from a `ParallelIterator`. For modules with a long
list of imports, it's interesting to parallelize the work.

Partially addresses #2506.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
