### PR TITLE
fix(wasi) Re-organize the Cargo features

### DIFF
--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -17,47 +17,43 @@ crate-type = ["cdylib", "rlib"]
 cfg-if = "1.0"
 thiserror = "1"
 generational-arena = { version = "0.2", features = ["serde"] }
-tracing = { version = "0.1" }
-getrandom = { version = "0.2" }
-typetag = { version = "0.1", optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+tracing = "0.1"
+getrandom = "0.2"
 wasmer-wasi-types = { path = "../wasi-types", version = "2.0.0" }
 wasmer = { path = "../api", version = "2.0.0", default-features = false }
 wasmer-vfs = { path = "../vfs", version = "2.0.0", default-features = false }
-
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+typetag = { version = "0.1", optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "^0.2", default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.74"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.0"
+tracing-wasm = "0.2"
+
 [features]
-default = ["logging", "host_fs"]
-enable-serde = [
-    "typetag",
-    "serde",
-]
+default = ["sys-default"]
+
+sys = ["wasmer/sys"]
+sys-default = ["sys", "logging", "host_fs"]
+
+js = ["wasmer/js", "mem_fs", "getrandom/js"]
+js-default = ["js"]
+test-js = ["js", "wasmer/js-default", "wasmer/wat"]
+
+host_fs = ["wasmer-vfs/host_fs"]
+mem_fs = ["wasmer-vfs/mem_fs"]
+
 logging = ["tracing/log"]
 disable-all-logging = [
     "tracing/release_max_level_off",
     "tracing/max_level_off"
 ]
-host_fs = ["wasmer-vfs/host_fs"]
-mem_fs = ["wasmer-vfs/mem_fs"]
-js = [
-    "getrandom/js",
-    "mem_fs",
-    "wasmer/js",
-]
-test-js = [
-    "js",
-    "wasmer/js-default",
-    "wasmer/wat"
-]
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2"
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-tracing-wasm = { version = "0.2" }
+enable-serde = ["typetag", "serde"]

--- a/lib/wasi/src/state/mod.rs
+++ b/lib/wasi/src/state/mod.rs
@@ -176,7 +176,7 @@ pub struct WasiFs {
 pub(crate) fn default_fs_backing() -> Box<dyn wasmer_vfs::FileSystem> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "host_fs")] {
-            Box::new(wasmer_vfs::host_fs::HostFileSystem)
+            Box::new(wasmer_vfs::host_fs::FileSystem::default())
         } else if #[cfg(feature = "mem_fs")] {
             Box::new(wasmer_vfs::mem_fs::MemFileSystem::default())
         } else {

--- a/lib/wasi/src/state/types.rs
+++ b/lib/wasi/src/state/types.rs
@@ -197,9 +197,9 @@ pub(crate) fn poll(
     let mut fds = selfs
         .iter()
         .enumerate()
-        .filter_map(|(i, s)| s.get_raw_fd().map(|rfd| (i, rfd)))
+        .filter_map(|(i, s)| s.get_fd().map(|rfd| (i, rfd)))
         .map(|(i, host_fd)| libc::pollfd {
-            fd: host_fd,
+            fd: host_fd.try_into().unwrap(),
             events: poll_event_set_to_platform_poll_events(events[i]),
             revents: 0,
         })


### PR DESCRIPTION
# Description

Running `cargo check` in `lib/wasi/` generates a compiler error saying:

```
error: At least the `sys` or the `js` feature must be enabled. Please, pick one.
   --> lib/api/src/lib.rs:448:1
    |
448 | compile_error!("At least the `sys` or the `js` feature must be enabled. Please, pick one.");
```

That's because the `wasmer/sys` feature is never turned on.

This patch applies the same strategy than `wasmer` by providing `sys-default` and `js-default`, along with `sys` and `js` (this one was already present).

The rest is just cosmetic.

Address feedbacks in https://github.com/wasmerio/wasmer/pull/2491.