### PR TITLE
A nicer error arrow head 😅

### DIFF
--- a/lib/cli/src/error.rs
+++ b/lib/cli/src/error.rs
@@ -90,7 +90,7 @@ where
                             write!(
                                 self.inner,
                                 "{}{: >2}: ",
-                                "╰─>".bold().blue(),
+                                "╰─▶".bold().blue(),
                                 format!("{}", number).bold().blue()
                             )?
                         }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

So this might be a little silly, but I thought the arrow head in the error messages can be a little bit more styled :)

<img width="155" alt="Screen Shot 1400-05-28 at 17 19 59" src="https://user-images.githubusercontent.com/2157285/130071730-80a1a6e0-41ce-4d31-9326-fb6077020c74.png">

And so I changed it to:

<img width="590" alt="Screen Shot 1400-05-28 at 17 30 42" src="https://user-images.githubusercontent.com/2157285/130073408-1922b21a-5a26-4e36-918d-5cacdb0b8a17.png">


# Review
No idea if it is even worth it...?

- [ ] Add a short description of the change to the CHANGELOG.md file
