### PR TITLE
chore(examples, emscripten): fix warnings

### DIFF
--- a/examples/platform_ios_headless.rs
+++ b/examples/platform_ios_headless.rs
@@ -12,11 +12,9 @@
 //!
 //! Ready?
 
-use std::fs::File;
 use std::path::Path;
 use std::str::FromStr;
-use tempfile::NamedTempFile;
-use wasmer::{imports, wat2wasm, Instance, Module, RuntimeError, Store, Value};
+use wasmer::{wat2wasm, Module, RuntimeError, Store};
 use wasmer_compiler::{CpuFeature, Target, Triple};
 use wasmer_compiler_cranelift::Cranelift;
 use wasmer_engine_dylib::Dylib;
@@ -60,7 +58,7 @@ i32.add)
     // Here we go. Let's serialize the compiled Wasm module in a
     // file.
     println!("Serializing module...");
-    let mut dylib_file = Path::new("./sum.dylib");
+    let dylib_file = Path::new("./sum.dylib");
     module.serialize_to_file(dylib_file)?;
 
     Ok(())

--- a/lib/emscripten/src/env/unix/mod.rs
+++ b/lib/emscripten/src/env/unix/mod.rs
@@ -247,8 +247,10 @@ pub fn _getaddrinfo(
 
             // connect list
             if let Some(prev_guest) = previous_guest_node {
-                let mut pg = prev_guest.deref(&memory).unwrap().get_mut();
+                let derefed_prev_guest = prev_guest.deref(&memory).unwrap();
+                let mut pg = derefed_prev_guest.get();
                 pg.ai_next = current_guest_node_ptr;
+                derefed_prev_guest.set(pg);
             }
 
             // update values
@@ -259,10 +261,13 @@ pub fn _getaddrinfo(
                 let host_sockaddr_ptr = (*current_host_node).ai_addr;
                 let guest_sockaddr_ptr: WasmPtr<EmSockAddr> =
                     call_malloc_with_cast(ctx, host_addrlen as _);
-                let guest_sockaddr = guest_sockaddr_ptr.deref(&memory).unwrap().get_mut();
 
-                guest_sockaddr.sa_family = (*host_sockaddr_ptr).sa_family as i16;
-                guest_sockaddr.sa_data = (*host_sockaddr_ptr).sa_data;
+                let derefed_guest_sockaddr = guest_sockaddr_ptr.deref(&memory).unwrap();
+                let mut gs = derefed_guest_sockaddr.get();
+                gs.sa_family = (*host_sockaddr_ptr).sa_family as i16;
+                gs.sa_data = (*host_sockaddr_ptr).sa_data;
+                derefed_guest_sockaddr.set(gs);
+
                 guest_sockaddr_ptr
             };
 
@@ -288,15 +293,17 @@ pub fn _getaddrinfo(
                 }
             };
 
-            let mut current_guest_node = current_guest_node_ptr.deref(&memory).unwrap().get_mut();
-            current_guest_node.ai_flags = (*current_host_node).ai_flags;
-            current_guest_node.ai_family = (*current_host_node).ai_family;
-            current_guest_node.ai_socktype = (*current_host_node).ai_socktype;
-            current_guest_node.ai_protocol = (*current_host_node).ai_protocol;
-            current_guest_node.ai_addrlen = host_addrlen;
-            current_guest_node.ai_addr = guest_sockaddr_ptr;
-            current_guest_node.ai_canonname = guest_canonname_ptr;
-            current_guest_node.ai_next = WasmPtr::new(0);
+            let derefed_current_guest_node = current_guest_node_ptr.deref(&memory).unwrap();
+            let mut cgn = derefed_current_guest_node.get();
+            cgn.ai_flags = (*current_host_node).ai_flags;
+            cgn.ai_family = (*current_host_node).ai_family;
+            cgn.ai_socktype = (*current_host_node).ai_socktype;
+            cgn.ai_protocol = (*current_host_node).ai_protocol;
+            cgn.ai_addrlen = host_addrlen;
+            cgn.ai_addr = guest_sockaddr_ptr;
+            cgn.ai_canonname = guest_canonname_ptr;
+            cgn.ai_next = WasmPtr::new(0);
+            derefed_current_guest_node.set(cgn);
 
             previous_guest_node = Some(current_guest_node_ptr);
             current_host_node = (*current_host_node).ai_next;

--- a/lib/emscripten/src/syscalls/unix.rs
+++ b/lib/emscripten/src/syscalls/unix.rs
@@ -633,7 +633,7 @@ pub fn ___syscall102(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int 
                 address.deref(&memory).unwrap().get(),
                 address_len.deref(&memory).unwrap().get()
             );
-            let address_len_addr = unsafe { address_len.deref(&memory).unwrap().get_mut() };
+            let mut address_len_addr = address_len.deref(&memory).unwrap().get();
             // let mut address_len_addr: socklen_t = 0;
 
             let mut host_address: sockaddr = sockaddr {
@@ -642,8 +642,8 @@ pub fn ___syscall102(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int 
                 #[cfg(any(target_os = "freebsd", target_vendor = "apple"))]
                 sa_len: Default::default(),
             };
-            let fd = unsafe { accept(socket, &mut host_address, address_len_addr) };
-            let address_addr = unsafe { address.deref(&memory).unwrap().get_mut() };
+            let fd = unsafe { accept(socket, &mut host_address, &mut address_len_addr) };
+            let mut address_addr = address.deref(&memory).unwrap().get();
 
             address_addr.sa_family = host_address.sa_family as _;
             address_addr.sa_data = host_address.sa_data;
@@ -667,7 +667,7 @@ pub fn ___syscall102(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int 
             let socket: i32 = socket_varargs.get(ctx);
             let address: WasmPtr<EmSockAddr> = socket_varargs.get(ctx);
             let address_len: WasmPtr<u32> = socket_varargs.get(ctx);
-            let address_len_addr = unsafe { address_len.deref(&memory).unwrap().get_mut() };
+            let address_len_addr = address_len.deref(&memory).unwrap().get();
 
             let mut sock_addr_host: sockaddr = sockaddr {
                 sa_family: Default::default(),
@@ -683,7 +683,7 @@ pub fn ___syscall102(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> c_int 
                 )
             };
             // translate from host data into emscripten data
-            let mut address_mut = unsafe { address.deref(&memory).unwrap().get_mut() };
+            let mut address_mut = address.deref(&memory).unwrap().get();
             address_mut.sa_family = sock_addr_host.sa_family as _;
             address_mut.sa_data = sock_addr_host.sa_data;
 
@@ -857,11 +857,11 @@ pub fn ___syscall168(ctx: &EmEnv, _which: i32, mut varargs: VarArgs) -> i32 {
     let timeout: i32 = varargs.get(ctx);
     let memory = ctx.memory(0);
 
-    let fds_mut = unsafe { fds.deref(&memory).unwrap().get_mut() };
+    let mut fds_mut = fds.deref(&memory).unwrap().get();
 
     let ret = unsafe {
         libc::poll(
-            fds_mut as *mut EmPollFd as *mut libc::pollfd,
+            &mut fds_mut as *mut EmPollFd as *mut libc::pollfd,
             nfds as _,
             timeout,
         )


### PR DESCRIPTION
# Description
What a beautiful day for setting up `wasmer` project and building it from scratch! In particular, I'm interested in `emscripten` feature.
<details>
<summary>cargo build -p wasmer-emscripten</summary>
<p>

```bash
➜  wasmer git:(master) ✗ cargo build -p wasmer-emscripten
warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/env/unix/mod.rs:250:65
    |
250 |                 let mut pg = prev_guest.deref(&memory).unwrap().get_mut();
    |                                                                 ^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/env/unix/mod.rs:262:81
    |
262 |                 let guest_sockaddr = guest_sockaddr_ptr.deref(&memory).unwrap().get_mut();
    |                                                                                 ^^^^^^^

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/env/unix/mod.rs:291:89
    |
291 |             let mut current_guest_node = current_guest_node_ptr.deref(&memory).unwrap().get_mut();
    |                                                                                         ^^^^^^^

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/syscalls/unix.rs:636:81
    |
636 |             let address_len_addr = unsafe { address_len.deref(&memory).unwrap().get_mut() };
    |                                                                                 ^^^^^^^

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/syscalls/unix.rs:646:73
    |
646 |             let address_addr = unsafe { address.deref(&memory).unwrap().get_mut() };
    |                                                                         ^^^^^^^

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/syscalls/unix.rs:670:81
    |
670 |             let address_len_addr = unsafe { address_len.deref(&memory).unwrap().get_mut() };
    |                                                                                 ^^^^^^^

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/syscalls/unix.rs:686:76
    |
686 |             let mut address_mut = unsafe { address.deref(&memory).unwrap().get_mut() };
    |                                                                            ^^^^^^^

warning: use of deprecated associated function `wasmer::WasmCell::<'a, T>::get_mut`: Please use the memory-safe set method instead
   --> lib/emscripten/src/syscalls/unix.rs:860:56
    |
860 |     let fds_mut = unsafe { fds.deref(&memory).unwrap().get_mut() };
    |                                                        ^^^^^^^

warning: 8 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.45s
```

</p>
</details>  

Oh-oh, seems like we have some deprecation warnings in the codebase introduced by our own deprecation notices. How's about fixing them?

# Review

- Replace `WasmCell.get_mut()` usages with `WasmCell.get()` and `WasmCell.set()`.
- Remove unused imports and unnecessary `mut` declarations. 
