### PR TITLE
fix(engine-dylib): do not keep temp file and delete it automatically

### DIFF
--- a/lib/engine-dylib/Cargo.toml
+++ b/lib/engine-dylib/Cargo.toml
@@ -18,7 +18,7 @@ wasmer-engine = { path = "../engine", version = "2.0.0" }
 wasmer-object = { path = "../object", version = "2.0.0" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
-tracing = "0.1"
+tracing = { version = "0.1", features = ["log"] }
 leb128 = "0.2"
 libloading = "0.7"
 tempfile = "3.1"

--- a/lib/engine-dylib/src/artifact.rs
+++ b/lib/engine-dylib/src/artifact.rs
@@ -58,6 +58,12 @@ pub struct DylibArtifact {
     frame_info_registration: Mutex<Option<GlobalFrameInfoRegistration>>,
 }
 
+impl Drop for DylibArtifact {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.dylib_path).expect("cannot delete the temporary artifact");
+    }
+}
+
 fn to_compile_error(err: impl Error) -> CompileError {
     CompileError::Codegen(err.to_string())
 }
@@ -231,7 +237,7 @@ impl DylibArtifact {
 
                 // Re-open it.
                 let (mut file, filepath) = file.keep().map_err(to_compile_error)?;
-                file.write(&obj_bytes).map_err(to_compile_error)?;
+                file.write_all(&obj_bytes).map_err(to_compile_error)?;
                 filepath
             }
             None => {
@@ -261,7 +267,7 @@ impl DylibArtifact {
                 let (mut file, filepath) = file.keep().map_err(to_compile_error)?;
                 let obj_bytes = obj.write().map_err(to_compile_error)?;
 
-                file.write(&obj_bytes).map_err(to_compile_error)?;
+                file.write_all(&obj_bytes).map_err(to_compile_error)?;
                 filepath
             }
         };

--- a/lib/engine-dylib/src/artifact.rs
+++ b/lib/engine-dylib/src/artifact.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use tempfile::NamedTempFile;
+use tracing::log::error;
 #[cfg(feature = "compiler")]
 use tracing::trace;
 use wasmer_compiler::{
@@ -62,7 +63,9 @@ pub struct DylibArtifact {
 impl Drop for DylibArtifact {
     fn drop(&mut self) {
         if self.is_temporary {
-            std::fs::remove_file(&self.dylib_path).expect("cannot delete the temporary artifact");
+            if let Err(err) = std::fs::remove_file(&self.dylib_path) {
+                error!("cannot delete the temporary dylib artifact: {}", err);
+            }
         }
     }
 }


### PR DESCRIPTION
close #2501

# Description
This PR plan to fix the issue #2501 
I know the implementation using Drop trait is not the best way to implement it. Maybe I need more knowledge about engine lifecycle or adding a trait method to clean any artifacts we create when using an engine. Feel free to give me more details about how I could implement this in a better way.
