### PR TITLE
feat(vfs) Update `Metadata.len` when updating the file buffer

### DIFF
--- a/lib/vfs/src/mem_fs/file_opener.rs
+++ b/lib/vfs/src/mem_fs/file_opener.rs
@@ -85,6 +85,7 @@ impl crate::FileOpener for FileOpener {
                         // Truncate if needed.
                         if truncate {
                             file.truncate();
+                            metadata.len = 0;
                         }
 
                         // Move the cursor to the end if needed.


### PR DESCRIPTION
# Description

This patch updates `wasmer_vfs::mem_fs`  to handle `Metadata.len` correctly. The `len` value is updated when something is written in the file buffer. `len` is also updated when the file is truncated (with open options) or when the file is update with `set_len`.

It helps to fix one test in https://github.com/wasmerio/wasmer/pull/2546.