### PR TITLE
fix(vm) Fix the memory_grow test on Windows (with a bigger page guard)

### DIFF
--- a/lib/api/src/sys/tunables.rs
+++ b/lib/api/src/sys/tunables.rs
@@ -52,13 +52,19 @@ impl BaseTunables {
 
         // Allocate a small guard to optimize common cases but without
         // wasting too much memory.
+        // The Windows memory manager seems more laxed than the other ones
+        // And a guard of just 1 page may not be enough is some borderline cases
+        // So using 2 pages for guard on this plateform
+        #[cfg(target_os = "windows")]
+        let dynamic_memory_offset_guard_size: u64 = 0x2_0000;
+        #[cfg(not(target_os = "windows"))]
         let dynamic_memory_offset_guard_size: u64 = 0x1_0000;
 
         if let OperatingSystem::Windows = triple.operating_system {
             // For now, use a smaller footprint on Windows so that we don't
             // outstrip the paging file.
             static_memory_bound = min(static_memory_bound, 0x100.into());
-            static_memory_offset_guard_size = min(static_memory_offset_guard_size, 0x10000);
+            static_memory_offset_guard_size = min(static_memory_offset_guard_size, 0x20000);
         }
 
         Self {

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -35,9 +35,6 @@ cranelift  multi_value_imports::dylib
 singlepass multi_value_imports::dylib
 singlepass multi_value_imports::dynamic
 
-# Memory load doesn't trap as expected when out out bounds in Windows
-windows+cranelift spec::memory_grow
-
 # LLVM/Universal doesn't work in macOS M1. Skip all tests
 llvm+universal+macos+aarch64 *
 


### PR DESCRIPTION
# Description
Fix the memory_grow test under Windows.

The test was failling randomly, at the step with a dynamic memory block of size 0, when trying a read/write at pagesize offset, so just outside the pagegard in that case.
It seems windows memory manager may map a writable page just after the newly alocated block, so using a "2 pages" guard size on windows to avoid this issue.