### PR TITLE
Fix aarch64 simd boolean

### DIFF
--- a/lib/api/src/sys/tunables.rs
+++ b/lib/api/src/sys/tunables.rs
@@ -54,7 +54,7 @@ impl BaseTunables {
         // wasting too much memory.
         // The Windows memory manager seems more laxed than the other ones
         // And a guard of just 1 page may not be enough is some borderline cases
-        // So using 2 pages for guard on this plateform
+        // So using 2 pages for guard on this platform
         #[cfg(target_os = "windows")]
         let dynamic_memory_offset_guard_size: u64 = 0x2_0000;
         #[cfg(not(target_os = "windows"))]

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -49,7 +49,6 @@ cranelift+dylib spec::linking
 cranelift+dylib spec::bulk
 
 # Some SIMD opperations are not yet supported by Cranelift
-cranelift+aarch64 spec::simd::simd_boolean
 cranelift spec::simd::simd_conversions
 cranelift spec::simd::simd_i16x8_extadd_pairwise_i8x16
 cranelift spec::simd::simd_i16x8_extmul_i8x16


### PR DESCRIPTION
# Description

Cranelift now support simd_boolean on aarch64, so it can be tested now.