### PR TITLE
Fix: default-native into default-dylib

### DIFF
--- a/lib/api/src/sys/store.rs
+++ b/lib/api/src/sys/store.rs
@@ -129,7 +129,7 @@ impl Default for Store {
                 if #[cfg(feature = "default-universal")] {
                     wasmer_engine_universal::Universal::new(config)
                         .engine()
-                } else if #[cfg(feature = "default-native")] {
+                } else if #[cfg(feature = "default-dylib")] {
                     wasmer_engine_dylib::Dylib::new(config)
                         .engine()
                 } else {


### PR DESCRIPTION
This should be default-dylib because the feature default-native doesn't exist/ has been renamed.