### PR TITLE
Feature/singlepass windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ ifneq ($(ENABLE_SINGLEPASS), 0)
 	ifeq ($(ENABLE_SINGLEPASS), 1)
 		compilers += singlepass
 	# … otherwise, we try to check whether Singlepass works on this host.
-	else ifneq (, $(filter 1, $(IS_DARWIN) $(IS_LINUX)))
+	else ifneq (, $(filter 1, $(IS_DARWIN) $(IS_LINUX) $(IS_WINDOWS)))
 		ifeq ($(IS_AMD64), 1)
 			compilers += singlepass
 		endif

--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -6696,7 +6696,7 @@ impl<'a> FuncGen<'a> {
                 if self.control_stack.is_empty() {
                     self.assembler.emit_label(frame.label);
                     self.machine
-                        .finalize_locals(&mut self.assembler, &self.locals);
+                    .finalize_locals(&mut self.assembler, &self.locals, self.config.calling_convention);
                     self.assembler.emit_mov(
                         Size::S64,
                         Location::GPR(GPR::RBP),

--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -9050,7 +9050,7 @@ pub fn gen_import_call_trampoline(
                     static PARAM_REGS: &[GPR] = &[GPR::RDX, GPR::R8, GPR::R9];
                     Location::GPR(PARAM_REGS[i])
                 }
-                _ => Location::Memory(GPR::RSP, 32 + 8 + ((i-3) * 8) as i32),   // will not be used anyway
+                _ => Location::Memory(GPR::RSP, 32 + 8 + ((i - 3) * 8) as i32), // will not be used anyway
             };
             param_locations.push(loc);
         }

--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -6695,8 +6695,11 @@ impl<'a> FuncGen<'a> {
 
                 if self.control_stack.is_empty() {
                     self.assembler.emit_label(frame.label);
-                    self.machine
-                    .finalize_locals(&mut self.assembler, &self.locals, self.config.calling_convention);
+                    self.machine.finalize_locals(
+                        &mut self.assembler,
+                        &self.locals,
+                        self.config.calling_convention,
+                    );
                     self.assembler.emit_mov(
                         Size::S64,
                         Location::GPR(GPR::RBP),

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -255,7 +255,7 @@ mod tests {
         let (mut info, translation, inputs) = dummy_compilation_ingredients();
         let result = compiler.compile_module(&win32, &mut info, &translation, inputs);
         match result.unwrap_err() {
-            CompileError::UnsupportedTarget(name) => assert_eq!(name, "windows"), // Windows should be checked before architecture
+            CompileError::UnsupportedTarget(name) => assert_eq!(name, "i686"), // Windows should be checked before architecture
             error => panic!("Unexpected error: {:?}", error),
         };
     }

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -57,11 +57,11 @@ impl Compiler for SinglepassCompiler {
         _module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
     ) -> Result<Compilation, CompileError> {
-        if target.triple().operating_system == OperatingSystem::Windows {
+        /*if target.triple().operating_system == OperatingSystem::Windows {
             return Err(CompileError::UnsupportedTarget(
                 OperatingSystem::Windows.to_string(),
             ));
-        }
+        }*/
         if let Architecture::X86_32(arch) = target.triple().architecture {
             return Err(CompileError::UnsupportedTarget(arch.to_string()));
         }
@@ -219,13 +219,13 @@ mod tests {
         let compiler = SinglepassCompiler::new(Singlepass::default());
 
         // Compile for win64
-        let win64 = Target::new(triple!("x86_64-pc-windows-msvc"), CpuFeature::for_host());
+        /*let win64 = Target::new(triple!("x86_64-pc-windows-msvc"), CpuFeature::for_host());
         let (mut info, translation, inputs) = dummy_compilation_ingredients();
         let result = compiler.compile_module(&win64, &mut info, &translation, inputs);
         match result.unwrap_err() {
             CompileError::UnsupportedTarget(name) => assert_eq!(name, "windows"),
             error => panic!("Unexpected error: {:?}", error),
-        };
+        };*/
 
         // Compile for 32bit Linux
         let linux32 = Target::new(triple!("i686-unknown-linux-gnu"), CpuFeature::for_host());

--- a/lib/compiler-singlepass/src/config.rs
+++ b/lib/compiler-singlepass/src/config.rs
@@ -4,7 +4,9 @@
 use crate::compiler::SinglepassCompiler;
 use loupe::MemoryUsage;
 use std::sync::Arc;
-use wasmer_compiler::{Compiler, CompilerConfig, CpuFeature, ModuleMiddleware, Target};
+use wasmer_compiler::{
+    CallingConvention, Compiler, CompilerConfig, CpuFeature, ModuleMiddleware, Target,
+};
 use wasmer_types::Features;
 
 #[derive(Debug, Clone, MemoryUsage)]
@@ -13,6 +15,8 @@ pub struct Singlepass {
     pub(crate) enable_stack_check: bool,
     /// The middleware chain.
     pub(crate) middlewares: Vec<Arc<dyn ModuleMiddleware>>,
+    #[loupe(skip)]
+    pub(crate) calling_convention: CallingConvention,
 }
 
 impl Singlepass {
@@ -23,6 +27,12 @@ impl Singlepass {
             enable_nan_canonicalization: true,
             enable_stack_check: false,
             middlewares: vec![],
+            calling_convention: match Target::default().triple().default_calling_convention() {
+                Ok(CallingConvention::WindowsFastcall) => CallingConvention::WindowsFastcall,
+                Ok(CallingConvention::SystemV) => CallingConvention::SystemV,
+                //Ok(CallingConvention::AppleAarch64) => AppleAarch64,
+                _ => panic!("Unsupported Calling convention for Singlepass"),
+            },
         }
     }
 

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -1400,7 +1400,7 @@ impl Emitter for Assembler {
     }
 
     fn emit_bkpt(&mut self) {
-        dynasm!(self ; int 0x3);
+        dynasm!(self ; int3);
     }
 
     fn emit_host_redirection(&mut self, target: GPR) {

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 use std::cmp;
 use std::collections::HashSet;
 use wasmer_compiler::wasmparser::Type as WpType;
-use wasmer_compiler::{CallingConvention, Target};
+use wasmer_compiler::CallingConvention;
 
 const NATIVE_PAGE_SIZE: usize = 4096;
 

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -521,6 +521,17 @@ impl Machine {
         }
     }
 
+    #[cfg(target_os = "windows")]
+    pub fn get_param_location(idx: usize) -> Location {
+        match idx {
+            0 => Location::GPR(GPR::RCX),
+            1 => Location::GPR(GPR::RDX),
+            2 => Location::GPR(GPR::R8),
+            3 => Location::GPR(GPR::R9),
+            _ => Location::Memory(GPR::RBP, (16 + 32 + (idx - 4) * 8) as i32),
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
     pub fn get_param_location(idx: usize) -> Location {
         match idx {
             0 => Location::GPR(GPR::RDI),

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -6,6 +6,7 @@ use smallvec::SmallVec;
 use std::cmp;
 use std::collections::HashSet;
 use wasmer_compiler::wasmparser::Type as WpType;
+use wasmer_compiler::{CallingConvention, Target};
 
 const NATIVE_PAGE_SIZE: usize = 4096;
 
@@ -330,6 +331,7 @@ impl Machine {
         a: &mut E,
         n: usize,
         n_params: usize,
+        calling_convention: CallingConvention,
     ) -> Vec<Location> {
         // Determine whether a local should be allocated on the stack.
         fn is_local_on_stack(idx: usize) -> bool {
@@ -432,7 +434,7 @@ impl Machine {
         // Locals are allocated on the stack from higher address to lower address,
         // so we won't skip the stack guard page here.
         for i in 0..n_params {
-            let loc = Self::get_param_location(i + 1);
+            let loc = Self::get_param_location(i + 1, calling_convention);
             match loc {
                 Location::GPR(_) => {
                     a.emit_mov(Size::S64, loc, locations[i]);
@@ -454,7 +456,7 @@ impl Machine {
         // Load vmctx into R15.
         a.emit_mov(
             Size::S64,
-            Self::get_param_location(0),
+            Self::get_param_location(0, calling_convention),
             Location::GPR(GPR::R15),
         );
 
@@ -521,26 +523,24 @@ impl Machine {
         }
     }
 
-    #[cfg(target_os = "windows")]
-    pub fn get_param_location(idx: usize) -> Location {
-        match idx {
-            0 => Location::GPR(GPR::RCX),
-            1 => Location::GPR(GPR::RDX),
-            2 => Location::GPR(GPR::R8),
-            3 => Location::GPR(GPR::R9),
-            _ => Location::Memory(GPR::RBP, (16 + 32 + (idx - 4) * 8) as i32),
-        }
-    }
-    #[cfg(not(target_os = "windows"))]
-    pub fn get_param_location(idx: usize) -> Location {
-        match idx {
-            0 => Location::GPR(GPR::RDI),
-            1 => Location::GPR(GPR::RSI),
-            2 => Location::GPR(GPR::RDX),
-            3 => Location::GPR(GPR::RCX),
-            4 => Location::GPR(GPR::R8),
-            5 => Location::GPR(GPR::R9),
-            _ => Location::Memory(GPR::RBP, (16 + (idx - 6) * 8) as i32),
+    pub fn get_param_location(idx: usize, calling_convention: CallingConvention) -> Location {
+        match calling_convention {
+            CallingConvention::WindowsFastcall => match idx {
+                0 => Location::GPR(GPR::RCX),
+                1 => Location::GPR(GPR::RDX),
+                2 => Location::GPR(GPR::R8),
+                3 => Location::GPR(GPR::R9),
+                _ => Location::Memory(GPR::RBP, (16 + 32 + (idx - 4) * 8) as i32),
+            },
+            _ => match idx {
+                0 => Location::GPR(GPR::RDI),
+                1 => Location::GPR(GPR::RSI),
+                2 => Location::GPR(GPR::RDX),
+                3 => Location::GPR(GPR::RCX),
+                4 => Location::GPR(GPR::R8),
+                5 => Location::GPR(GPR::R9),
+                _ => Location::Memory(GPR::RBP, (16 + (idx - 6) * 8) as i32),
+            },
         }
     }
 }

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -529,7 +529,12 @@ impl Machine {
         locations
     }
 
-    pub fn finalize_locals<E: Emitter>(&mut self, a: &mut E, locations: &[Location], calling_convention: CallingConvention) {
+    pub fn finalize_locals<E: Emitter>(
+        &mut self,
+        a: &mut E,
+        locations: &[Location],
+        calling_convention: CallingConvention,
+    ) {
         // Unwind stack to the "save area".
         a.emit_lea(
             Size::S64,

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -2,6 +2,7 @@
 
 use crate::common_decl::{MachineState, MachineValue, RegisterIndex};
 use std::collections::BTreeMap;
+use wasmer_compiler::{CallingConvention, Target};
 use wasmer_types::Type;
 
 /// General-purpose registers.
@@ -170,73 +171,75 @@ pub struct ArgumentRegisterAllocator {
 
 impl ArgumentRegisterAllocator {
     /// Allocates a register for argument type `ty`. Returns `None` if no register is available for this type.
-    #[cfg(target_os = "windows")]
-    pub fn next(&mut self, ty: Type) -> Option<X64Register> {
-        static GPR_SEQ: &'static [GPR] = &[GPR::RCX, GPR::RDX, GPR::R8, GPR::R9];
-        static XMM_SEQ: &'static [XMM] = &[XMM::XMM0, XMM::XMM1, XMM::XMM2, XMM::XMM3];
-        let idx = self.n_gprs + self.n_xmms;
-        match ty {
-            Type::I32 | Type::I64 => {
-                if idx < 4 {
-                    let gpr = GPR_SEQ[idx];
-                    self.n_gprs += 1;
-                    Some(X64Register::GPR(gpr))
-                } else {
-                    None
+    pub fn next(&mut self, ty: Type, calling_convention: CallingConvention) -> Option<X64Register> {
+        match calling_convention {
+            CallingConvention::WindowsFastcall => {
+                static GPR_SEQ: &'static [GPR] = &[GPR::RCX, GPR::RDX, GPR::R8, GPR::R9];
+                static XMM_SEQ: &'static [XMM] = &[XMM::XMM0, XMM::XMM1, XMM::XMM2, XMM::XMM3];
+                let idx = self.n_gprs + self.n_xmms;
+                match ty {
+                    Type::I32 | Type::I64 => {
+                        if idx < 4 {
+                            let gpr = GPR_SEQ[idx];
+                            self.n_gprs += 1;
+                            Some(X64Register::GPR(gpr))
+                        } else {
+                            None
+                        }
+                    }
+                    Type::F32 | Type::F64 => {
+                        if idx < 4 {
+                            let xmm = XMM_SEQ[idx];
+                            self.n_xmms += 1;
+                            Some(X64Register::XMM(xmm))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => todo!(
+                        "ArgumentRegisterAllocator::next: Unsupported type: {:?}",
+                        ty
+                    ),
                 }
             }
-            Type::F32 | Type::F64 => {
-                if idx < 4 {
-                    let xmm = XMM_SEQ[idx];
-                    self.n_xmms += 1;
-                    Some(X64Register::XMM(xmm))
-                } else {
-                    None
+            _ => {
+                static GPR_SEQ: &'static [GPR] =
+                    &[GPR::RDI, GPR::RSI, GPR::RDX, GPR::RCX, GPR::R8, GPR::R9];
+                static XMM_SEQ: &'static [XMM] = &[
+                    XMM::XMM0,
+                    XMM::XMM1,
+                    XMM::XMM2,
+                    XMM::XMM3,
+                    XMM::XMM4,
+                    XMM::XMM5,
+                    XMM::XMM6,
+                    XMM::XMM7,
+                ];
+                match ty {
+                    Type::I32 | Type::I64 => {
+                        if self.n_gprs < GPR_SEQ.len() {
+                            let gpr = GPR_SEQ[self.n_gprs];
+                            self.n_gprs += 1;
+                            Some(X64Register::GPR(gpr))
+                        } else {
+                            None
+                        }
+                    }
+                    Type::F32 | Type::F64 => {
+                        if self.n_xmms < XMM_SEQ.len() {
+                            let xmm = XMM_SEQ[self.n_xmms];
+                            self.n_xmms += 1;
+                            Some(X64Register::XMM(xmm))
+                        } else {
+                            None
+                        }
+                    }
+                    _ => todo!(
+                        "ArgumentRegisterAllocator::next: Unsupported type: {:?}",
+                        ty
+                    ),
                 }
             }
-            _ => todo!(
-                "ArgumentRegisterAllocator::next: Unsupported type: {:?}",
-                ty
-            ),
-        }
-    }
-    #[cfg(not(target_os = "windows"))]
-    pub fn next(&mut self, ty: Type) -> Option<X64Register> {
-        static GPR_SEQ: &'static [GPR] =
-            &[GPR::RDI, GPR::RSI, GPR::RDX, GPR::RCX, GPR::R8, GPR::R9];
-        static XMM_SEQ: &'static [XMM] = &[
-            XMM::XMM0,
-            XMM::XMM1,
-            XMM::XMM2,
-            XMM::XMM3,
-            XMM::XMM4,
-            XMM::XMM5,
-            XMM::XMM6,
-            XMM::XMM7,
-        ];
-        match ty {
-            Type::I32 | Type::I64 => {
-                if self.n_gprs < GPR_SEQ.len() {
-                    let gpr = GPR_SEQ[self.n_gprs];
-                    self.n_gprs += 1;
-                    Some(X64Register::GPR(gpr))
-                } else {
-                    None
-                }
-            }
-            Type::F32 | Type::F64 => {
-                if self.n_xmms < XMM_SEQ.len() {
-                    let xmm = XMM_SEQ[self.n_xmms];
-                    self.n_xmms += 1;
-                    Some(X64Register::XMM(xmm))
-                } else {
-                    None
-                }
-            }
-            _ => todo!(
-                "ArgumentRegisterAllocator::next: Unsupported type: {:?}",
-                ty
-            ),
         }
     }
 }

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -2,7 +2,7 @@
 
 use crate::common_decl::{MachineState, MachineValue, RegisterIndex};
 use std::collections::BTreeMap;
-use wasmer_compiler::{CallingConvention, Target};
+use wasmer_compiler::CallingConvention;
 use wasmer_types::Type;
 
 /// General-purpose registers.

--- a/lib/vm/src/trap/handlers.c
+++ b/lib/vm/src/trap/handlers.c
@@ -14,7 +14,11 @@
 // doesn't need to touch the kernel signal handling routines.
 // In case of macOS, stackoverflow
 #if defined(CFG_TARGET_OS_WINDOWS)
-#define platform_setjmp(buf) setjmp(buf)
+// On Windows, default setjmp/longjmp sequence will try to unwind the stack
+// it's fine most of the time, but not for JIT'd code that may not respect stack ordring
+// Using a special setjmp here, with NULL as second parameter to disable that behaviour
+// and have a regular simple setjmp/longjmp sequence
+#define platform_setjmp(buf) __intrinsic_setjmp(buf, NULL)
 #define platform_longjmp(buf, arg) longjmp(buf, arg)
 #define platform_jmp_buf jmp_buf
 #elif defined(CFG_TARGET_OS_MACOS)

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -2,7 +2,6 @@
 singlepass spec::multi_value # Singlepass has not implemented multivalue (functions that returns "structs"/"tuples")
 singlepass spec::simd # Singlepass doesn't support yet SIMD (no one asked for this feature)
 
-singlepass+windows * # We might need to add support for Windows calling convention from host to wasm (Company showed interest to sponsor)
 singlepass+dylib * # It needs to add support for PIC in Singlepass. Not implemented at the moment
 windows+dylib * # This might be trivial to fix?
 musl+dylib * # Dynamic loading not supported in Musl

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -46,6 +46,7 @@ llvm+dylib+macos+aarch64 * # Tests seem to be randomly failing
 # https://github.com/rust-lang/backtrace-rs/issues/356
 cranelift+aarch64 spec::skip_stack_guard_page # This is skipped for ARM, not fully fixed yet
 llvm+aarch64      spec::skip_stack_guard_page # This is skipped for ARM, not fully fixed yet
+singlepass+windows spec::skip_stack_guard_page # Needs investigation.
 cranelift+windows spec::skip_stack_guard_page # Needs investigation. Issue: `STATUS_ACCESS_VIOLATION` trap happened
 cranelift+macos   spec::skip_stack_guard_page # Needs investigation. process didn't exit successfully: (signal: 6, SIGABRT: process abort signal)
 llvm+macos        spec::skip_stack_guard_page # Needs investigation. process didn't exit successfully: (signal: 6, SIGABRT: process abort signal)


### PR DESCRIPTION
# Description

Added Windows x86_64 support to SinglePass Compiler.

Compared to System V ABI, the Windows ABI changed the way argument are send to function in the following way:
1. Only the 4 1st arguments can be send in register.
2. The argument will go in XMM reg is Float or Double, or in GPR for anything else
3. Regs are RCX/XMM0, RDX/XMM1, R8/XMM2 and R9/XMM3
4. Other argument go to the stack
5. There is 32bytes also reserved in the stack to shadow the 4 arguments if the callee function needs too

