### PR TITLE
Improved wasmer-js api

### DIFF
--- a/lib/api/src/js/import_object.rs
+++ b/lib/api/src/js/import_object.rs
@@ -113,22 +113,29 @@ impl ImportObject {
         }
         out
     }
-}
 
-impl Into<js_sys::Object> for ImportObject {
-    fn into(self) -> js_sys::Object {
-        let guard = self.map.lock().unwrap();
+    /// Returns the `ImportObject` as a Javascript `Object`
+    pub fn as_jsobject(&self) -> js_sys::Object {
+        let guard = self.map.lock().expect("Can't get the map");
         let map = guard.borrow();
 
         let imports = js_sys::Object::new();
         for (module, ns) in map.iter() {
             let import_namespace = js_sys::Object::new();
             for (name, exp) in ns.get_namespace_exports() {
-                js_sys::Reflect::set(&import_namespace, &name.into(), exp.as_jsvalue()).unwrap();
+                js_sys::Reflect::set(&import_namespace, &name.into(), exp.as_jsvalue())
+                    .expect("Error while setting into the js namespace object");
             }
-            js_sys::Reflect::set(&imports, &module.into(), &import_namespace.into()).unwrap();
+            js_sys::Reflect::set(&imports, &module.into(), &import_namespace.into())
+                .expect("Error while setting into the js imports object");
         }
         imports
+    }
+}
+
+impl Into<js_sys::Object> for ImportObject {
+    fn into(self) -> js_sys::Object {
+        self.as_jsobject()
     }
 }
 

--- a/lib/wasi-types/Cargo.toml
+++ b/lib/wasi-types/Cargo.toml
@@ -12,6 +12,11 @@ edition = "2018"
 
 [dependencies]
 wasmer-types = { path = "../types", version = "2.0.0" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional=true }
 byteorder = "1.3"
 time = "0.1"
+
+[features]
+enable-serde = [
+    "serde",
+]

--- a/lib/wasi-types/src/file.rs
+++ b/lib/wasi-types/src/file.rs
@@ -1,4 +1,5 @@
 use crate::*;
+#[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use wasmer_types::ValueType;
@@ -93,7 +94,8 @@ pub type __wasi_filedelta_t = i64;
 
 pub type __wasi_filesize_t = u64;
 
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct __wasi_filestat_t {
     pub st_dev: __wasi_device_t,

--- a/lib/wasi-types/src/versions/snapshot0.rs
+++ b/lib/wasi-types/src/versions/snapshot0.rs
@@ -1,4 +1,5 @@
 use crate::*;
+#[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use wasmer_types::ValueType;
@@ -37,7 +38,8 @@ pub const __WASI_WHENCE_CUR: u8 = 0;
 pub const __WASI_WHENCE_END: u8 = 1;
 pub const __WASI_WHENCE_SET: u8 = 2;
 
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct __wasi_filestat_t {
     pub st_dev: __wasi_device_t,

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 cfg-if = "1.0"
 thiserror = "1"
-generational-arena = { version = "0.2", features = ["serde"] }
+generational-arena = { version = "0.2" }
 tracing = "0.1"
 getrandom = "0.2"
 wasmer-wasi-types = { path = "../wasi-types", version = "2.0.0" }
@@ -45,8 +45,8 @@ default = ["sys-default"]
 sys = ["wasmer/sys-default"]
 sys-default = ["sys", "logging", "host-fs"]
 
-js = ["wasmer/js-default", "mem-fs", "wasmer-vfs/no-time", "getrandom/js"]
-js-default = ["js"]
+js = ["wasmer/js", "mem-fs", "wasmer-vfs/no-time", "getrandom/js"]
+js-default = ["js", "wasmer/js-default"]
 test-js = ["js", "wasmer/js-default", "wasmer/wat"]
 
 host-fs = ["wasmer-vfs/host-fs"]
@@ -61,5 +61,7 @@ enable-serde = [
     "typetag",
     "serde",
     "bincode",
-    "wasmer-vfs/enable-serde"
+    "wasmer-vfs/enable-serde",
+    "generational-arena/serde",
+    "wasmer-wasi-types/enable-serde",
 ]

--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -2322,6 +2322,7 @@ pub fn path_unlink_file(
 /// Output:
 /// - `u32 nevents`
 ///     The number of events seen
+#[cfg(not(feature = "js"))]
 pub fn poll_oneoff(
     env: &WasiEnv,
     in_: WasmPtr<__wasi_subscription_t, Array>,
@@ -2507,6 +2508,17 @@ pub fn poll_oneoff(
     }
     out_ptr.set(events_seen as u32);
     __WASI_ESUCCESS
+}
+
+#[cfg(feature = "js")]
+pub fn poll_oneoff(
+    env: &WasiEnv,
+    in_: WasmPtr<__wasi_subscription_t, Array>,
+    out_: WasmPtr<__wasi_event_t, Array>,
+    nsubscriptions: u32,
+    nevents: WasmPtr<u32>,
+) -> __wasi_errno_t {
+    unimplemented!();
 }
 
 pub fn proc_exit(env: &WasiEnv, code: __wasi_exitcode_t) {


### PR DESCRIPTION
Improved Wasmer-JS API

* Create an `init_envs` function in the instance (to allow creation of the Wasm Instance in JS, and setting up on Rust/Wasmer)
* Improved serde dependency on subcrates