### PR TITLE
Absolute import of `Result` in derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2436](https://github.com/wasmerio/wasmer/pull/2436) Added the x86-32 bit variant support to LLVM compiler.
 
 ### Changed
-- [#2587](https://github.com/wasmerio/wasmer/pull/2587) Fixed deriving `WasmerEnv` when aliasing `Result`.
 - [#2460](https://github.com/wasmerio/wasmer/pull/2460) **breaking change** `wasmer` API usage with `no-default-features` requires now the `sys` feature to preserve old behavior.
 - [#2476](https://github.com/wasmerio/wasmer/pull/2476) Removed unncessary abstraction `ModuleInfoTranslate` from `wasmer-compiler`.
 - [#2442](https://github.com/wasmerio/wasmer/pull/2442) Improved `WasmPtr`, added `WasmCell` for host/guest interaction.
@@ -22,6 +21,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2478](https://github.com/wasmerio/wasmer/pull/2478) Rename `wasm_instance_new()`’s “traps” argument to “trap”.
 
 ### Fixed
+- [#2587](https://github.com/wasmerio/wasmer/pull/2587) Fixed deriving `WasmerEnv` when aliasing `Result`.
 - [#2518](https://github.com/wasmerio/wasmer/pull/2518) Remove temporary file used to creating an artifact when creating a Dylib engine artifact.
 - [#2494](https://github.com/wasmerio/wasmer/pull/2494) Fixed `WasmerEnv` access when using `call_indirect` with the Singlepass compiler.
 - [#2449](https://github.com/wasmerio/wasmer/pull/2449) Fixed `wasmer-c-api` used `soname`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2436](https://github.com/wasmerio/wasmer/pull/2436) Added the x86-32 bit variant support to LLVM compiler.
 
 ### Changed
+- [#2587](https://github.com/wasmerio/wasmer/pull/2587) Fixed deriving `WasmerEnv` when aliasing `Result`.
 - [#2460](https://github.com/wasmerio/wasmer/pull/2460) **breaking change** `wasmer` API usage with `no-default-features` requires now the `sys` feature to preserve old behavior.
 - [#2476](https://github.com/wasmerio/wasmer/pull/2476) Removed unncessary abstraction `ModuleInfoTranslate` from `wasmer-compiler`.
 - [#2442](https://github.com/wasmerio/wasmer/pull/2442) Improved `WasmPtr`, added `WasmCell` for host/guest interaction.

--- a/lib/derive/src/lib.rs
+++ b/lib/derive/src/lib.rs
@@ -43,7 +43,7 @@ fn impl_wasmer_env(input: &DeriveInput) -> TokenStream {
 
     set_dummy(quote! {
         impl ::wasmer::WasmerEnv for #struct_name {
-            fn init_with_instance(&mut self, instance: &::wasmer::Instance) -> Result<(), ::wasmer::HostEnvInitError> {
+            fn init_with_instance(&mut self, instance: &::wasmer::Instance) -> ::core::result::Result<(), ::wasmer::HostEnvInitError> {
                 Ok(())
             }
         }
@@ -205,7 +205,7 @@ fn derive_struct_fields(data: &DataStruct) -> (TokenStream, TokenStream) {
     }
 
     let trait_methods = quote! {
-        fn init_with_instance(&mut self, instance: &::wasmer::Instance) -> Result<(), ::wasmer::HostEnvInitError> {
+        fn init_with_instance(&mut self, instance: &::wasmer::Instance) -> ::core::result::Result<(), ::wasmer::HostEnvInitError> {
             #(#finish)*
             Ok(())
         }


### PR DESCRIPTION
# Description

When aliasing `Result` deriving `WasmerEnv` is not possible. See a minimal example of the problem below.

```rust
use wasmer::WasmerEnv;

struct Error;
type Result<T> = core::result::Result<T, Error>;

#[derive(WasmerEnv, Clone)]
struct MyEnv; // error[E0107] this type alias takes 1 generic
              // argument but 2 generic arguments were supplied
```

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
