### PR TITLE
Make sure docs.rs enables features like singlepass and llvm

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -153,3 +153,6 @@ js = []
 js-default = ["js", "std", "wasm-types-polyfill"]
 
 wasm-types-polyfill = ["js", "wasmparser"]
+
+[package.metadata.docs.rs]
+features = ["compiler", "core", "cranelift", "default-compiler", "default-dylib", "default-engine", "dylib", "engine", "jit", "llvm", "native", "singlepass", "sys", "sys-default", "universal"]


### PR DESCRIPTION
The docs for the compilers like [`Singlepass`](https://docs.rs/wasmer/2.0.0/wasmer/struct.Singlepass.html) are missing from docs.rs because the features are not in default. This should fix that for the next release.