### PR TITLE
fix segment fault in c-api Example

### DIFF
--- a/lib/c-api/README.md
+++ b/lib/c-api/README.md
@@ -100,7 +100,6 @@ int main(int argc, const char* argv[]) {
 
     printf("Results of `sum`: %d\n", results_val[0].of.i32);
 
-    wasm_func_delete(sum_func);
     wasm_module_delete(module);
     wasm_extern_vec_delete(&exports);
     wasm_instance_delete(instance);


### PR DESCRIPTION

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
the result from wasm_extern_as_func was not marked as "own"
`sum_func` was not owned by itself, delete it will cause a double free

will close #2492


