### PR TITLE
Remove unused nightly feature

### DIFF
--- a/lib/compiler-llvm/src/lib.rs
+++ b/lib/compiler-llvm/src/lib.rs
@@ -10,7 +10,6 @@
     all(not(target_os = "windows"), not(target_arch = "aarch64")),
     deny(dead_code)
 )]
-#![cfg_attr(nightly, feature(unwind_attributes))]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
 


### PR DESCRIPTION
Our `build.rs` doesn't even generate a `nightly ` cfg flag, so this code is unreachable.