### PR TITLE
Fix argument parsing of --dir and --mapdir

### DIFF
--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -27,7 +27,7 @@ pub struct Compile {
     #[structopt(flatten)]
     store: StoreOptions,
 
-    #[structopt(short = "m", multiple = true)]
+    #[structopt(short = "m", multiple = true, number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -29,12 +29,12 @@ pub struct CreateExe {
     #[structopt(flatten)]
     compiler: CompilerOptions,
 
-    #[structopt(short = "m", multiple = true)]
+    #[structopt(short = "m", multiple = true, number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 
     /// Additional libraries to link against.
     /// This is useful for fixing linker errors that may occur on some systems.
-    #[structopt(short = "l", multiple = true)]
+    #[structopt(short = "l", multiple = true, number_of_values = 1)]
     libraries: Vec<String>,
 }
 

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -68,7 +68,7 @@ pub struct Run {
     verbose: u8,
 
     /// Application arguments
-    #[structopt(name = "--", multiple = true)]
+    #[structopt(value_name = "ARGS")]
     args: Vec<String>,
 }
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -11,15 +11,32 @@ use structopt::StructOpt;
 /// WASI Options
 pub struct Wasi {
     /// WASI pre-opened directory
-    #[structopt(long = "dir", name = "DIR", multiple = true, group = "wasi")]
+    #[structopt(
+        long = "dir",
+        name = "DIR",
+        multiple = true,
+        group = "wasi",
+        number_of_values = 1
+    )]
     pre_opened_directories: Vec<PathBuf>,
 
     /// Map a host directory to a different location for the Wasm module
-    #[structopt(long = "mapdir", name = "GUEST_DIR:HOST_DIR", multiple = true, parse(try_from_str = parse_mapdir))]
+    #[structopt(
+        long = "mapdir",
+        name = "GUEST_DIR:HOST_DIR",
+        multiple = true,
+        parse(try_from_str = parse_mapdir),
+        number_of_values = 1,
+    )]
     mapped_dirs: Vec<(String, PathBuf)>,
 
     /// Pass custom environment variables
-    #[structopt(long = "env", name = "KEY=VALUE", multiple = true, parse(try_from_str = parse_envvar))]
+    #[structopt(
+        long = "env",
+        name = "KEY=VALUE",
+        multiple = true,
+        parse(try_from_str = parse_envvar),
+    )]
     env_vars: Vec<(String, String)>,
 
     /// Enable experimental IO devices


### PR DESCRIPTION
Previously in "wasmer --dir foo bar.wasm" the "bar.wasm" was being
treated as another directory instead of the module to run.

Fixes #2445

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
