### PR TITLE
Fix error code returned by some wasi fs syscalls for a non-existent file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2454](https://github.com/wasmerio/wasmer/issues/2454) Won't set `WASMER_CACHE_DIR` for Windows.
 - [#2426](https://github.com/wasmerio/wasmer/pull/2426) Fix the `wax` script generation.
 - [#2635](https://github.com/wasmerio/wasmer/pull/2635) Fix cross-compilation for singlepass.
+- [#2672](https://github.com/wasmerio/wasmer/pull/2672) Use `ENOENT` instead of `EINVAL` in some WASI syscalls for a non-existent file
 
 ## 2.0.0 - 2021/06/16
 

--- a/lib/wasi/src/state/mod.rs
+++ b/lib/wasi/src/state/mod.rs
@@ -766,7 +766,7 @@ impl WasiFs {
                                 .fs_backing
                                 .symlink_metadata(&file)
                                 .ok()
-                                .ok_or(__WASI_EINVAL)?;
+                                .ok_or(__WASI_ENOENT)?;
                             let file_type = metadata.file_type();
                             // we want to insert newly opened dirs and files, but not transient symlinks
                             // TODO: explain why (think about this deeply when well rested)
@@ -894,7 +894,7 @@ impl WasiFs {
                         {
                             cur_inode = *entry;
                         } else {
-                            return Err(__WASI_EINVAL);
+                            return Err(__WASI_ENOENT);
                         }
                     }
                     Kind::File { .. } => {


### PR DESCRIPTION

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

Currently, wasmer's WASI implementation returns EINVAL when a caller gives non-existent file path as a parameter.

But EINVAL should not be returned in such case and should return ENOENT instead according to POSIX.

This change affects to:

- path_filestat_get
- path_filestat_set_times
- path_link
- path_open
- path_readlink
- path_remove_directory
- path_unlink_file

You can reproduce this issue by the following code

```c
#include <stdio.h>
#include <fcntl.h>
#include <errno.h>

int main(void) {
  int ret = open("/nonexist", O_RDONLY);
  if (ret < 0) {
    int e = errno;
    perror("got error");
    printf("errno = %d\n", e);
  }
  printf("ret = %d\n", ret);
  return 0;
}
```

```console
$ # expected result
$ wasmtime run path_open.wasm  --mapdir /::./
got error: No such file or directory
errno = 44
ret = -1

$ # with the latest build of wasmer master branch
$ wasmer run path_open.wasm  --mapdir /::./
got error: Invalid argument
errno = 28
ret = -1
```

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
