### PR TITLE
Bump minimum required LLVM version to 12

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -22,14 +22,14 @@ jobs:
       - name: Install LLVM
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf ${{ env.LLVM_URL }} -L -o llvm.tar.gz
+          curl --proto '=https' --tlsv1.2 -sSf ${{ env.LLVM_URL }} -L -o llvm.tar.xz
           mkdir ${{ env.LLVM_DIR }}
-          tar xf llvm.tar.gz --strip-components=1 -C ${{ env.LLVM_DIR }}
+          tar xf llvm.tar.xz --strip-components=1 -C ${{ env.LLVM_DIR }}
           echo "${{ env.LLVM_DIR }}/bin" >> $GITHUB_PATH
           echo "LLVM_SYS_120_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
         env:
-          LLVM_DIR: ${{ github.workspace }}/llvm-12
-          LLVM_URL: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-amd64.tar.gz'
+          LLVM_DIR: ${{ github.workspace }}/llvm-13
+          LLVM_URL: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz'
       - name: Build & package documentation
         run: make package-docs
       - name: Publish documentation

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -26,10 +26,10 @@ jobs:
           mkdir ${{ env.LLVM_DIR }}
           tar xf llvm.tar.gz --strip-components=1 -C ${{ env.LLVM_DIR }}
           echo "${{ env.LLVM_DIR }}/bin" >> $GITHUB_PATH
-          echo "LLVM_SYS_110_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
+          echo "LLVM_SYS_120_PREFIX=${{ env.LLVM_DIR }}" >> $GITHUB_ENV
         env:
-          LLVM_DIR: ${{ github.workspace }}/llvm-11
-          LLVM_URL: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
+          LLVM_DIR: ${{ github.workspace }}/llvm-12
+          LLVM_URL: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-amd64.tar.gz'
       - name: Build & package documentation
         run: make package-docs
       - name: Publish documentation

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,9 +23,9 @@ jobs:
           components: rustfmt, clippy
       - name: Install LLVM (Linux)
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-amd64.tar.gz -L -o /opt/llvm.tar.gz
+          curl --proto '=https' --tlsv1.2 -sSf https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz -L -o /opt/llvm.tar.xz
           mkdir -p /opt/llvm-12
-          tar xf /opt/llvm.tar.gz --strip-components=1 -C /opt/llvm-12
+          tar xf /opt/llvm.tar.xz --strip-components=1 -C /opt/llvm-12
           echo '/opt/llvm-12/bin' >> $GITHUB_PATH
           echo 'LLVM_SYS_120_PREFIX=/opt/llvm-12' >> $GITHUB_ENV
       - run: make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,11 +23,11 @@ jobs:
           components: rustfmt, clippy
       - name: Install LLVM (Linux)
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz -L -o /opt/llvm.tar.gz
-          mkdir -p /opt/llvm-11
-          tar xf /opt/llvm.tar.gz --strip-components=1 -C /opt/llvm-11
-          echo '/opt/llvm-11/bin' >> $GITHUB_PATH
-          echo 'LLVM_SYS_110_PREFIX=/opt/llvm-11' >> $GITHUB_ENV
+          curl --proto '=https' --tlsv1.2 -sSf https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-amd64.tar.gz -L -o /opt/llvm.tar.gz
+          mkdir -p /opt/llvm-12
+          tar xf /opt/llvm.tar.gz --strip-components=1 -C /opt/llvm-12
+          echo '/opt/llvm-12/bin' >> $GITHUB_PATH
+          echo 'LLVM_SYS_120_PREFIX=/opt/llvm-12' >> $GITHUB_ENV
       - run: make lint
         env:
           ENABLE_CRANELIFT: "1"

--- a/.github/workflows/test-sys.yaml
+++ b/.github/workflows/test-sys.yaml
@@ -42,7 +42,7 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu-18.04
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-amd64.tar.gz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-amd64.tar.gz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_test: true
@@ -51,7 +51,7 @@ jobs:
             use_sccache: true
           - build: macos-x64
             os: macos-11
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/darwin-amd64.tar.gz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/darwin-amd64.tar.gz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             run_test: true
@@ -68,7 +68,7 @@ jobs:
             run_test_capi: false
           - build: windows-x64
             os: windows-latest
-            # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
+            # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/windows-amd64.tar.gz'
             llvm_choco_version: 12.0.1
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
@@ -80,7 +80,7 @@ jobs:
           #  os: [self-hosted, linux, ARM64]
           #  random_sccache_port: true
           #  use_sccache: true
-          #  llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/linux-aarch64.tar.gz'
+          #  llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-aarch64.tar.gz'
           #  artifact_name: 'wasmer-linux-aarch64'
           #  run_integration_tests: false
           - build: linux-musl-x64
@@ -122,7 +122,7 @@ jobs:
           choco install llvm --version ${{ matrix.llvm_choco_version }} --allow-downgrade
           cd 'C:\Program Files\LLVM\'
           LLVM_DIR=$(pwd)
-          echo "LLVM_SYS_110_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
+          echo "LLVM_SYS_120_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
       - name: Install LLVM (macOS Apple Silicon)
         if: matrix.os == 'macos-11.0' && !matrix.llvm_url
         run: |
@@ -136,7 +136,7 @@ jobs:
           mkdir ${LLVM_DIR}
           tar xf llvm.tar.gz --strip-components=1 -C ${LLVM_DIR}
           echo "${LLVM_DIR}/bin" >> $GITHUB_PATH
-          echo "LLVM_SYS_110_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
+          echo "LLVM_SYS_120_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
       - name: Set up dependencies for Mac OS

--- a/.github/workflows/test-sys.yaml
+++ b/.github/workflows/test-sys.yaml
@@ -42,7 +42,7 @@ jobs:
         include:
           - build: linux-x64
             os: ubuntu-18.04
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/linux-amd64.tar.gz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz'
             artifact_name: 'wasmer-linux-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             run_test: true
@@ -51,7 +51,7 @@ jobs:
             use_sccache: true
           - build: macos-x64
             os: macos-11
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/darwin-amd64.tar.gz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             run_test: true
@@ -69,7 +69,7 @@ jobs:
           - build: windows-x64
             os: windows-latest
             # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/windows-amd64.tar.gz'
-            llvm_choco_version: 12.0.1
+            llvm_choco_version: 13.0.0
             artifact_name: 'wasmer-windows-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
             run_integration_tests: true
@@ -131,10 +131,10 @@ jobs:
         if: matrix.llvm_url
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf ${{ matrix.llvm_url }} -L -o llvm.tar.gz
+          curl --proto '=https' --tlsv1.2 -sSf ${{ matrix.llvm_url }} -L -o llvm.tar.xz
           LLVM_DIR=$(pwd)/${{ env.LLVM_DIR }}
           mkdir ${LLVM_DIR}
-          tar xf llvm.tar.gz --strip-components=1 -C ${LLVM_DIR}
+          tar xf llvm.tar.xz --strip-components=1 -C ${LLVM_DIR}
           echo "${LLVM_DIR}/bin" >> $GITHUB_PATH
           echo "LLVM_SYS_120_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "llvm-sys"
-version = "110.0.2"
+version = "120.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7cc88ba864d592f52132ed3a19a97118fe16c92a63961f54b0ab7279c5407f"
+checksum = "b4a810627ac62b396f5fd2214ba9bbd8748d4d6efdc4d2c1c1303ea7a75763ce"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Makefile
+++ b/Makefile
@@ -134,23 +134,18 @@ ifneq ($(ENABLE_LLVM), 0)
 		LLVM_VERSION := $(shell llvm-config --version)
 
 		# If findstring is not empty, then it have found the value
-		ifneq (, $(findstring 12,$(LLVM_VERSION)))
+		ifneq (, $(findstring 13,$(LLVM_VERSION)))
 			compilers += llvm
-		else ifneq (, $(findstring 11,$(LLVM_VERSION)))
-			compilers += llvm
-		else ifneq (, $(findstring 10,$(LLVM_VERSION)))
+		else ifneq (, $(findstring 12,$(LLVM_VERSION)))
 			compilers += llvm
 		endif
 	# … or try to autodetect LLVM from `llvm-config-<version>`.
 	else
-		ifneq (, $(shell which llvm-config-12 2>/dev/null))
+		ifneq (, $(shell which llvm-config-13 2>/dev/null))
+			LLVM_VERSION := $(shell llvm-config-13 --version)
+			compilers += llvm
+		else ifneq (, $(shell which llvm-config-12 2>/dev/null))
 			LLVM_VERSION := $(shell llvm-config-12 --version)
-			compilers += llvm
-		else ifneq (, $(shell which llvm-config-11 2>/dev/null))
-			LLVM_VERSION := $(shell llvm-config-11 --version)
-			compilers += llvm
-		else ifneq (, $(shell which llvm-config-10 2>/dev/null))
-			LLVM_VERSION := $(shell llvm-config-10 --version)
 			compilers += llvm
 		endif
 	endif

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -28,7 +28,7 @@ loupe = "0.1"
 package = "inkwell"
 version = "0.1.0-beta.4"
 default-features = false
-features = ["llvm11-0", "target-x86", "target-aarch64"]
+features = ["llvm12-0", "target-x86", "target-aarch64"]
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/compiler-llvm/README.md
+++ b/lib/compiler-llvm/README.md
@@ -24,14 +24,14 @@ to native speeds.
 ## Requirements
 
 The LLVM compiler requires a valid installation of LLVM in your system.
-It currently requires **LLVM 11**.
+It currently requires **LLVM 12**.
 
 
 You can install LLVM easily on your Debian-like system via this command:
 
 ```bash
 wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
-sudo bash /tmp/llvm.sh 11
+sudo bash /tmp/llvm.sh 12
 ```
 
 Or in macOS:

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -4,7 +4,7 @@ use inkwell::{
     attributes::{Attribute, AttributeLoc},
     builder::Builder,
     context::Context,
-    types::{BasicMetadataTypeEnum, BasicType, FunctionType, StructType},
+    types::{AnyType, BasicMetadataTypeEnum, BasicType, FunctionType, StructType},
     values::{BasicValue, BasicValueEnum, CallSiteValue, FunctionValue, IntValue, PointerValue},
     AddressSpace,
 };
@@ -206,17 +206,16 @@ impl Abi for Aarch64SystemV {
                             .map(|&ty| type_to_llvm(intrinsics, ty))
                             .collect::<Result<_, _>>()?;
 
-                        let sret = context
-                            .struct_type(&basic_types, false)
-                            .ptr_type(AddressSpace::Generic);
+                        let sret = context.struct_type(&basic_types, false);
+                        let sret_ptr = sret.ptr_type(AddressSpace::Generic);
 
                         let param_types =
-                            std::iter::once(Ok(sret.as_basic_type_enum())).chain(param_types);
+                            std::iter::once(Ok(sret_ptr.as_basic_type_enum())).chain(param_types);
 
                         let mut attributes = vec![(
-                            context.create_enum_attribute(
+                            context.create_type_attribute(
                                 Attribute::get_named_enum_kind_id("sret"),
-                                0,
+                                sret.as_any_type_enum(),
                             ),
                             AttributeLoc::Param(0),
                         )];


### PR DESCRIPTION
This fixes a crash with LLVM versions >=12. The crash is caused by a breaking change in the IR in LLVM 12, specifically regarding the `sret` parameter attribute.