### PR TITLE
Add extra validation to compilers & engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ name = "wasmer-engine"
 version = "2.0.0"
 dependencies = [
  "backtrace",
+ "enumset",
  "lazy_static",
  "loupe",
  "memmap2",
@@ -2919,6 +2920,7 @@ name = "wasmer-engine-dummy"
 version = "2.0.0"
 dependencies = [
  "bincode",
+ "enumset",
  "loupe",
  "serde",
  "serde_bytes",
@@ -2933,6 +2935,7 @@ name = "wasmer-engine-dylib"
 version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
+ "enumset",
  "leb128",
  "libloading",
  "loupe",
@@ -2954,6 +2957,7 @@ version = "2.0.0"
 dependencies = [
  "bincode",
  "cfg-if 1.0.0",
+ "enumset",
  "leb128",
  "libloading",
  "loupe",
@@ -2972,6 +2976,7 @@ name = "wasmer-engine-universal"
 version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
+ "enumset",
  "leb128",
  "loupe",
  "region",

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -58,6 +58,11 @@ pub enum InstantiationError {
     #[error(transparent)]
     Start(RuntimeError),
 
+    /// The module was compiled with a CPU feature that is not available on
+    /// the current host.
+    #[error("missing requires CPU features: {0:?}")]
+    CpuFeature(String),
+
     /// Error occurred when initializing the host environment.
     #[error(transparent)]
     HostEnvInitialization(HostEnvInitError),
@@ -68,6 +73,7 @@ impl From<wasmer_engine::InstantiationError> for InstantiationError {
         match other {
             wasmer_engine::InstantiationError::Link(e) => Self::Link(e),
             wasmer_engine::InstantiationError::Start(e) => Self::Start(e),
+            wasmer_engine::InstantiationError::CpuFeature(e) => Self::CpuFeature(e),
         }
     }
 }

--- a/lib/c-api/src/error.rs
+++ b/lib/c-api/src/error.rs
@@ -47,15 +47,14 @@
 //! # }
 //! ```
 
-use libc::{c_char, c_int};
+use libc::c_char;
 use std::cell::RefCell;
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::Display;
 use std::ptr::{self, NonNull};
 use std::slice;
 
 thread_local! {
-    static LAST_ERROR: RefCell<Option<Box<dyn Error>>> = RefCell::new(None);
+    static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
 }
 
 /// Rust function to register a new error.
@@ -63,24 +62,23 @@ thread_local! {
 /// # Example
 ///
 /// ```rust,no_run
-/// # use wasmer::error::{update_last_error, CApiError};
+/// # use wasmer::error::update_last_error;
 ///
-/// update_last_error(CApiError {
-///     msg: "Hello, World!".to_string(),
-/// });
+/// update_last_error("Hello, World!");
 /// ```
-pub fn update_last_error<E: Error + 'static>(err: E) {
+pub fn update_last_error<E: Display>(err: E) {
     LAST_ERROR.with(|prev| {
-        *prev.borrow_mut() = Some(Box::new(err));
+        *prev.borrow_mut() = Some(err.to_string());
     });
 }
 
 /// Retrieve the most recent error, clearing it in the process.
-pub(crate) fn take_last_error() -> Option<Box<dyn Error>> {
+pub(crate) fn take_last_error() -> Option<String> {
     LAST_ERROR.with(|prev| prev.borrow_mut().take())
 }
 
-/// Gets the length in bytes of the last error if any, zero otherwise.
+/// Gets the length in bytes of the last error if any, zero otherwise. This
+/// includes th NUL terminator byte.
 ///
 /// This can be used to dynamically allocate a buffer with the correct number of
 /// bytes needed to store a message.
@@ -89,9 +87,9 @@ pub(crate) fn take_last_error() -> Option<Box<dyn Error>> {
 ///
 /// See this module's documentation to get a complete example.
 #[no_mangle]
-pub extern "C" fn wasmer_last_error_length() -> c_int {
+pub extern "C" fn wasmer_last_error_length() -> usize {
     LAST_ERROR.with(|prev| match *prev.borrow() {
-        Some(ref err) => err.to_string().len() as c_int + 1,
+        Some(ref err) => err.len() + 1,
         None => 0,
     })
 }
@@ -121,8 +119,8 @@ pub extern "C" fn wasmer_last_error_length() -> c_int {
 #[no_mangle]
 pub unsafe extern "C" fn wasmer_last_error_message(
     buffer: Option<NonNull<c_char>>,
-    length: c_int,
-) -> c_int {
+    length: usize,
+) -> isize {
     let buffer = if let Some(buffer_inner) = buffer {
         buffer_inner
     } else {
@@ -134,8 +132,6 @@ pub unsafe extern "C" fn wasmer_last_error_message(
         Some(err) => err.to_string(),
         None => return 0,
     };
-
-    let length = length as usize;
 
     if error_message.len() >= length {
         // buffer is too small to hold the error message
@@ -154,20 +150,5 @@ pub unsafe extern "C" fn wasmer_last_error_message(
     // accidentally read into garbage.
     buffer[error_message.len()] = 0;
 
-    error_message.len() as c_int + 1
+    error_message.len() as isize + 1
 }
-
-/// Rust type to represent a C API error.
-#[derive(Debug)]
-pub struct CApiError {
-    /// The error message.
-    pub msg: String,
-}
-
-impl Display for CApiError {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", &self.msg)
-    }
-}
-
-impl Error for CApiError {}

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -9,7 +9,7 @@ pub use super::unstable::middlewares::wasm_config_push_middleware;
 #[cfg(feature = "middlewares")]
 use super::unstable::middlewares::wasmer_middleware_t;
 use super::unstable::target_lexicon::wasmer_target_t;
-use crate::error::{update_last_error, CApiError};
+use crate::error::update_last_error;
 use cfg_if::cfg_if;
 use std::sync::Arc;
 use wasmer_api::Engine;
@@ -433,13 +433,8 @@ pub extern "C" fn wasm_engine_new_with_config(
     config: Option<Box<wasm_config_t>>,
 ) -> Option<Box<wasm_engine_t>> {
     #[allow(dead_code)]
-    fn return_with_error<M>(msg: M) -> Option<Box<wasm_engine_t>>
-    where
-        M: ToString,
-    {
-        update_last_error(CApiError {
-            msg: msg.to_string(),
-        });
+    fn return_with_error(msg: &str) -> Option<Box<wasm_engine_t>> {
+        update_last_error(msg);
 
         return None;
     }

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn wasm_instance_new(
         }
 
         Err(e @ InstantiationError::CpuFeature(_)) => {
-            crate::error::update_last_error(e.to_string());
+            crate::error::update_last_error(e);
 
             return None;
         }

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -73,6 +73,12 @@ pub unsafe extern "C" fn wasm_instance_new(
             return None;
         }
 
+        Err(e @ InstantiationError::CpuFeature(_)) => {
+            crate::error::update_last_error(e.to_string());
+
+            return None;
+        }
+
         Err(InstantiationError::HostEnvInitialization(error)) => {
             crate::error::update_last_error(error);
 

--- a/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
@@ -54,7 +54,6 @@
 //! ```
 
 use super::super::types::wasm_name_t;
-use crate::error::CApiError;
 use enumset::EnumSet;
 use std::slice;
 use std::str::{self, FromStr};
@@ -153,7 +152,7 @@ pub unsafe extern "C" fn wasmer_triple_new(
     )));
 
     Some(Box::new(wasmer_triple_t {
-        inner: c_try!(Triple::from_str(triple).map_err(|e| CApiError { msg: e.to_string() })),
+        inner: c_try!(Triple::from_str(triple)),
     }))
 }
 

--- a/lib/c-api/src/wasm_c_api/unstable/wasi.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/wasi.rs
@@ -5,7 +5,6 @@ use super::super::{
     externals::wasm_extern_t, module::wasm_module_t, store::wasm_store_t, types::wasm_name_t,
     wasi::wasi_env_t,
 };
-use crate::error::CApiError;
 use wasmer_api::Extern;
 use wasmer_wasi::{generate_import_object_from_env, get_wasi_version};
 
@@ -168,11 +167,8 @@ fn wasi_get_unordered_imports_inner(
 
     let store = &store.inner;
 
-    let version = c_try!(
-        get_wasi_version(&module.inner, false).ok_or_else(|| CApiError {
-            msg: "could not detect a WASI version on the given module".to_string(),
-        })
-    );
+    let version = c_try!(get_wasi_version(&module.inner, false)
+        .ok_or("could not detect a WASI version on the given module"));
 
     let import_object = generate_import_object_from_env(store, wasi_env.inner.clone(), version);
 

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -1,5 +1,5 @@
 use super::types::{wasm_ref_t, wasm_valkind_enum};
-use crate::error::{update_last_error, CApiError};
+use crate::error::update_last_error;
 use std::convert::{TryFrom, TryInto};
 use wasmer_api::Val;
 
@@ -156,7 +156,7 @@ pub unsafe extern "C" fn wasm_val_copy(
         },
 
         Err(e) => {
-            update_last_error(CApiError { msg: e.to_string() });
+            update_last_error(e);
 
             return;
         }

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -25,9 +25,9 @@ more-asserts = "0.2"
 gimli = { version = "0.25", optional = true }
 smallvec = "1.6"
 loupe = "0.1"
+target-lexicon = { version = "0.12.2", default-features = false }
 
 [dev-dependencies]
-target-lexicon = { version = "0.12.2", default-features = false }
 cranelift-codegen = { version = "0.76", features = ["all-arch"] }
 lazy_static = "1.4"
 

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -112,10 +112,8 @@ impl Compiler for CraneliftCompiler {
 
         let probestack_trampoline_relocation_target = if target.triple().operating_system
             == OperatingSystem::Linux
-            && matches!(
-                target.triple().architecture,
-                Architecture::X86_32(_) | Architecture::X86_64
-            ) {
+            && target.triple().architecture == Architecture::X86_64
+        {
             let probestack_trampoline = CustomSection {
                 protection: CustomSectionProtection::ReadExecute,
                 // We create a jump to an absolute 64bits address

--- a/lib/compiler-cranelift/src/sink.rs
+++ b/lib/compiler-cranelift/src/sink.rs
@@ -2,12 +2,10 @@
 
 use crate::translator::{irlibcall_to_libcall, irreloc_to_relocationkind};
 use cranelift_codegen::binemit;
-#[cfg(target_arch = "x86_64")]
 use cranelift_codegen::ir::LibCall;
 use cranelift_codegen::ir::{self, ExternalName};
 use cranelift_entity::EntityRef as CraneliftEntityRef;
 use wasmer_compiler::{JumpTable, Relocation, RelocationTarget, TrapInformation};
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 use wasmer_compiler::{RelocationKind, SectionIndex};
 use wasmer_types::entity::EntityRef;
 use wasmer_types::{FunctionIndex, LocalFunctionIndex, ModuleInfo};
@@ -24,8 +22,7 @@ pub(crate) struct RelocSink<'a> {
     pub func_relocs: Vec<Relocation>,
 
     /// The section where the probestack trampoline call is located
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    pub probestack_trampoline_relocation_target: SectionIndex,
+    pub probestack_trampoline_relocation_target: Option<SectionIndex>,
 }
 
 impl<'a> binemit::RelocSink for RelocSink<'a> {
@@ -45,13 +42,12 @@ impl<'a> binemit::RelocSink for RelocSink<'a> {
                     .expect("The provided function should be local"),
             )
         } else if let ExternalName::LibCall(libcall) = *name {
-            match libcall {
-                #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-                LibCall::Probestack => {
+            match (libcall, self.probestack_trampoline_relocation_target) {
+                (LibCall::Probestack, Some(probestack_trampoline_relocation_target)) => {
                     self.func_relocs.push(Relocation {
                         kind: RelocationKind::X86CallPCRel4,
                         reloc_target: RelocationTarget::CustomSection(
-                            self.probestack_trampoline_relocation_target,
+                            probestack_trampoline_relocation_target,
                         ),
                         offset: offset,
                         addend: addend,
@@ -100,8 +96,7 @@ impl<'a> RelocSink<'a> {
     pub fn new(
         module: &'a ModuleInfo,
         func_index: FunctionIndex,
-        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-        probestack_trampoline_relocation_target: SectionIndex,
+        probestack_trampoline_relocation_target: Option<SectionIndex>,
     ) -> Self {
         let local_func_index = module
             .local_func_index(func_index)
@@ -110,7 +105,6 @@ impl<'a> RelocSink<'a> {
             module,
             local_func_index,
             func_relocs: Vec::new(),
-            #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
             probestack_trampoline_relocation_target,
         }
     }

--- a/lib/compiler-singlepass/src/config.rs
+++ b/lib/compiler-singlepass/src/config.rs
@@ -4,9 +4,7 @@
 use crate::compiler::SinglepassCompiler;
 use loupe::MemoryUsage;
 use std::sync::Arc;
-use wasmer_compiler::{
-    CallingConvention, Compiler, CompilerConfig, CpuFeature, ModuleMiddleware, Target,
-};
+use wasmer_compiler::{Compiler, CompilerConfig, CpuFeature, ModuleMiddleware, Target};
 use wasmer_types::Features;
 
 #[derive(Debug, Clone, MemoryUsage)]
@@ -15,8 +13,6 @@ pub struct Singlepass {
     pub(crate) enable_stack_check: bool,
     /// The middleware chain.
     pub(crate) middlewares: Vec<Arc<dyn ModuleMiddleware>>,
-    #[loupe(skip)]
-    pub(crate) calling_convention: CallingConvention,
 }
 
 impl Singlepass {
@@ -27,12 +23,6 @@ impl Singlepass {
             enable_nan_canonicalization: true,
             enable_stack_check: false,
             middlewares: vec![],
-            calling_convention: match Target::default().triple().default_calling_convention() {
-                Ok(CallingConvention::WindowsFastcall) => CallingConvention::WindowsFastcall,
-                Ok(CallingConvention::SystemV) => CallingConvention::SystemV,
-                //Ok(CallingConvention::AppleAarch64) => AppleAarch64,
-                _ => panic!("Unsupported Calling convention for Singlepass"),
-            },
         }
     }
 

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -483,7 +483,7 @@ macro_rules! binop_shift {
 
 macro_rules! jmp_op {
     ($ins:ident, $assembler:tt, $label:ident) => {
-        dynasm!($assembler ; $ins =>$label);
+        dynasm!($assembler ; $ins =>$label)
     }
 }
 

--- a/lib/engine-dylib/Cargo.toml
+++ b/lib/engine-dylib/Cargo.toml
@@ -25,6 +25,7 @@ tempfile = "3.1"
 which = "4.0"
 rkyv = "0.6.1"
 loupe = "0.1"
+enumset = "1.0"
 
 [features]
 # Enable the `compiler` feature if you want the engine to compile

--- a/lib/engine-dylib/src/artifact.rs
+++ b/lib/engine-dylib/src/artifact.rs
@@ -3,6 +3,7 @@
 
 use crate::engine::{DylibEngine, DylibEngineInner};
 use crate::serialize::{ArchivedModuleMetadata, ModuleMetadata};
+use enumset::EnumSet;
 use libloading::{Library, Symbol as LibrarySymbol};
 use loupe::MemoryUsage;
 use std::error::Error;
@@ -17,8 +18,8 @@ use tracing::log::error;
 #[cfg(feature = "compiler")]
 use tracing::trace;
 use wasmer_compiler::{
-    Architecture, CompileError, CompiledFunctionFrameInfo, Features, FunctionAddressMap,
-    OperatingSystem, Symbol, SymbolRegistry, Triple,
+    Architecture, CompileError, CompiledFunctionFrameInfo, CpuFeature, Features,
+    FunctionAddressMap, OperatingSystem, Symbol, SymbolRegistry, Triple,
 };
 #[cfg(feature = "compiler")]
 use wasmer_compiler::{
@@ -211,6 +212,7 @@ impl DylibArtifact {
             prefix: engine_inner.get_prefix(&data),
             data_initializers,
             function_body_lengths,
+            cpu_features: target.cpu_features().as_u64(),
         };
 
         let serialized_data = metadata.serialize()?;
@@ -798,6 +800,10 @@ impl Artifact for DylibArtifact {
 
     fn features(&self) -> &Features {
         &self.metadata.compile_info.features
+    }
+
+    fn cpu_features(&self) -> enumset::EnumSet<CpuFeature> {
+        EnumSet::from_u64(self.metadata.cpu_features)
     }
 
     fn data_initializers(&self) -> &[OwnedDataInitializer] {

--- a/lib/engine-dylib/src/serialize.rs
+++ b/lib/engine-dylib/src/serialize.rs
@@ -35,6 +35,7 @@ pub struct ModuleMetadata {
     pub data_initializers: Box<[OwnedDataInitializer]>,
     // The function body lengths (used to find function by address)
     pub function_body_lengths: PrimaryMap<LocalFunctionIndex, u64>,
+    pub cpu_features: u64,
 }
 
 pub struct ModuleMetadataSymbolRegistry<'a> {

--- a/lib/engine-staticlib/Cargo.toml
+++ b/lib/engine-staticlib/Cargo.toml
@@ -24,6 +24,7 @@ leb128 = "0.2"
 libloading = "0.7"
 tempfile = "3.1"
 loupe = "0.1"
+enumset = "1.0"
 
 [features]
 # Enable the `compiler` feature if you want the engine to compile

--- a/lib/engine-staticlib/src/artifact.rs
+++ b/lib/engine-staticlib/src/artifact.rs
@@ -3,12 +3,15 @@
 
 use crate::engine::{StaticlibEngine, StaticlibEngineInner};
 use crate::serialize::{ModuleMetadata, ModuleMetadataSymbolRegistry};
+use enumset::EnumSet;
 use loupe::MemoryUsage;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::mem;
 use std::sync::Arc;
-use wasmer_compiler::{CompileError, Features, OperatingSystem, SymbolRegistry, Triple};
+use wasmer_compiler::{
+    CompileError, CpuFeature, Features, OperatingSystem, SymbolRegistry, Triple,
+};
 #[cfg(feature = "compiler")]
 use wasmer_compiler::{
     CompileModuleInfo, Compiler, FunctionBodyData, ModuleEnvironment, ModuleMiddlewareChain,
@@ -182,6 +185,7 @@ impl StaticlibArtifact {
             prefix: engine_inner.get_prefix(&data),
             data_initializers,
             function_body_lengths,
+            cpu_features: target.cpu_features().as_u64(),
         };
 
         /*
@@ -451,6 +455,10 @@ impl Artifact for StaticlibArtifact {
 
     fn features(&self) -> &Features {
         &self.metadata.compile_info.features
+    }
+
+    fn cpu_features(&self) -> EnumSet<CpuFeature> {
+        EnumSet::from_u64(self.metadata.cpu_features)
     }
 
     fn data_initializers(&self) -> &[OwnedDataInitializer] {

--- a/lib/engine-staticlib/src/artifact.rs
+++ b/lib/engine-staticlib/src/artifact.rs
@@ -46,6 +46,7 @@ pub struct StaticlibArtifact {
     /// Length of the serialized metadata
     metadata_length: usize,
     symbol_registry: ModuleMetadataSymbolRegistry,
+    is_compiled: bool,
 }
 
 #[allow(dead_code)]
@@ -295,6 +296,7 @@ impl StaticlibArtifact {
             func_data_registry: engine_inner.func_data().clone(),
             metadata_length,
             symbol_registry,
+            is_compiled: true,
         })
     }
 
@@ -415,6 +417,7 @@ impl StaticlibArtifact {
             func_data_registry,
             metadata_length: 0,
             symbol_registry,
+            is_compiled: false,
         })
     }
 
@@ -483,6 +486,12 @@ impl Artifact for StaticlibArtifact {
     }
 
     fn preinstantiate(&self) -> Result<(), InstantiationError> {
+        if self.is_compiled {
+            panic!(
+                "a module built with the staticlib engine must be linked \
+                into the current executable"
+            );
+        }
         Ok(())
     }
 

--- a/lib/engine-staticlib/src/serialize.rs
+++ b/lib/engine-staticlib/src/serialize.rs
@@ -12,6 +12,7 @@ pub struct ModuleMetadata {
     pub data_initializers: Box<[OwnedDataInitializer]>,
     // The function body lengths (used to find function by address)
     pub function_body_lengths: PrimaryMap<LocalFunctionIndex, u64>,
+    pub cpu_features: u64,
 }
 
 #[derive(MemoryUsage)]

--- a/lib/engine-universal/Cargo.toml
+++ b/lib/engine-universal/Cargo.toml
@@ -11,8 +11,13 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.0", features = ["enable-rkyv"] }
-wasmer-compiler = { path = "../compiler", version = "2.0.0", features = ["translator", "enable-rkyv"] }
+wasmer-types = { path = "../types", version = "2.0.0", features = [
+    "enable-rkyv",
+] }
+wasmer-compiler = { path = "../compiler", version = "2.0.0", features = [
+    "translator",
+    "enable-rkyv",
+] }
 wasmer-vm = { path = "../vm", version = "2.0.0", features = ["enable-rkyv"] }
 wasmer-engine = { path = "../engine", version = "2.0.0" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
@@ -21,6 +26,7 @@ cfg-if = "1.0"
 leb128 = "0.2"
 rkyv = "0.6.1"
 loupe = "0.1"
+enumset = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winnt", "impl-default"] }

--- a/lib/engine-universal/src/artifact.rs
+++ b/lib/engine-universal/src/artifact.rs
@@ -6,9 +6,10 @@ use crate::link::link_module;
 #[cfg(feature = "compiler")]
 use crate::serialize::SerializableCompilation;
 use crate::serialize::SerializableModule;
+use enumset::EnumSet;
 use loupe::MemoryUsage;
 use std::sync::{Arc, Mutex};
-use wasmer_compiler::{CompileError, Features, Triple};
+use wasmer_compiler::{CompileError, CpuFeature, Features, Triple};
 #[cfg(feature = "compiler")]
 use wasmer_compiler::{CompileModuleInfo, ModuleEnvironment, ModuleMiddlewareChain};
 use wasmer_engine::{
@@ -128,6 +129,7 @@ impl UniversalArtifact {
             compilation: serializable_compilation,
             compile_info,
             data_initializers,
+            cpu_features: engine.target().cpu_features().as_u64(),
         };
         Self::from_parts(&mut inner_engine, serializable)
     }
@@ -305,6 +307,10 @@ impl Artifact for UniversalArtifact {
 
     fn features(&self) -> &Features {
         &self.serializable.compile_info.features
+    }
+
+    fn cpu_features(&self) -> EnumSet<CpuFeature> {
+        EnumSet::from_u64(self.serializable.cpu_features)
     }
 
     fn data_initializers(&self) -> &[OwnedDataInitializer] {

--- a/lib/engine-universal/src/serialize.rs
+++ b/lib/engine-universal/src/serialize.rs
@@ -38,6 +38,7 @@ pub struct SerializableModule {
     pub compilation: SerializableCompilation,
     pub compile_info: CompileModuleInfo,
     pub data_initializers: Box<[OwnedDataInitializer]>,
+    pub cpu_features: u64,
 }
 
 fn to_serialize_error(err: impl std::error::Error) -> SerializeError {

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = { version = "0.11" }
 lazy_static = "1.4"
 loupe = "0.1"
+enumset = "1.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/lib/engine/src/error.rs
+++ b/lib/engine/src/error.rs
@@ -91,6 +91,11 @@ pub enum InstantiationError {
     #[error(transparent)]
     Link(LinkError),
 
+    /// The module was compiled with a CPU feature that is not available on
+    /// the current host.
+    #[error("module compiled with CPU feature that is missing from host")]
+    CpuFeature(String),
+
     /// A runtime error occured while invoking the start function
     #[error(transparent)]
     Start(RuntimeError),

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -257,7 +257,9 @@ fn trap_start_function_import(config: crate::Config) -> Result<()> {
     .err()
     .unwrap();
     match err {
-        InstantiationError::Link(_) | InstantiationError::HostEnvInitialization(_) => {
+        InstantiationError::Link(_)
+        | InstantiationError::HostEnvInitialization(_)
+        | InstantiationError::CpuFeature(_) => {
             panic!("It should be a start error")
         }
         InstantiationError::Start(err) => {

--- a/tests/lib/engine-dummy/Cargo.toml
+++ b/tests/lib/engine-dummy/Cargo.toml
@@ -16,19 +16,14 @@ serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
 bincode = { version = "1.2", optional = true }
 loupe = "0.1"
+enumset = "1.0"
 
 [features]
 # Enable the `compiler` feature if you want the engine to compile
 # and not be only on headless mode.
 default = ["serialize", "compiler"]
-compiler = [
-    "wasmer-compiler/translator"
-]
-serialize = [
-    "serde",
-    "serde_bytes",
-    "bincode"
-]
+compiler = ["wasmer-compiler/translator"]
+serialize = ["serde", "serde_bytes", "bincode"]
 
 [badges]
 # TODO: publish this crate again and deprecate it

--- a/tests/lib/engine-dummy/src/artifact.rs
+++ b/tests/lib/engine-dummy/src/artifact.rs
@@ -2,13 +2,14 @@
 //! done as separate steps.
 
 use crate::engine::DummyEngine;
+use enumset::EnumSet;
 use loupe::MemoryUsage;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use wasmer_compiler::CompileError;
 #[cfg(feature = "compiler")]
 use wasmer_compiler::ModuleEnvironment;
+use wasmer_compiler::{CompileError, CpuFeature};
 use wasmer_engine::{Artifact, DeserializeError, Engine as _, SerializeError, Tunables};
 use wasmer_types::entity::{BoxedSlice, PrimaryMap};
 use wasmer_types::{
@@ -30,6 +31,7 @@ pub struct DummyArtifactMetadata {
     // Plans for that module
     pub memory_styles: PrimaryMap<MemoryIndex, MemoryStyle>,
     pub table_styles: PrimaryMap<TableIndex, TableStyle>,
+    pub cpu_features: u64,
 }
 
 /// A Dummy artifact.
@@ -104,6 +106,7 @@ impl DummyArtifact {
             data_initializers,
             memory_styles,
             table_styles,
+            cpu_features: engine.target().cpu_features().as_u64(),
         };
         Self::from_parts(&engine, metadata)
     }
@@ -209,6 +212,10 @@ impl Artifact for DummyArtifact {
 
     fn features(&self) -> &Features {
         &self.metadata.features
+    }
+
+    fn cpu_features(&self) -> EnumSet<CpuFeature> {
+        EnumSet::from_u64(self.metadata.cpu_features)
     }
 
     fn data_initializers(&self) -> &[OwnedDataInitializer] {


### PR DESCRIPTION
- Cranelift and singlepass now properly cross-compile with no dependency on the host target.
- Staticlib engine now panics if you try to run a freshly compiled module.
- CPU features used when a module was compiled are now checked against the host CPU features during instantiation.

Fixes #1567
Fixes #2590 