### PR TITLE
wasi-experimental-io-devices: Pass through default features to wasi

### DIFF
--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -23,6 +23,9 @@ serde = "1"
 typetag = "0.1"
 
 [features]
+default = [
+    "wasmer-wasi/default"
+]
 enable-serde = [
     "wasmer-wasi/enable-serde"
 ]


### PR DESCRIPTION
Fixes cargo publish for wasmer-wasi-experimental-io-devices.