### PR TITLE
Update nightly version used for release artifact builds

### DIFF
--- a/.github/workflows/test-sys.yaml
+++ b/.github/workflows/test-sys.yaml
@@ -220,7 +220,7 @@ jobs:
       - name: Install Nightly Rust for Headless
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'nightly-2021-04-25'
+          toolchain: 'nightly-2021-11-01'
           target: ${{ matrix.target }}
           override: true
           components: "rust-src"


### PR DESCRIPTION
This is needed since we updated our Rust version to 1.56.