### PR TITLE
chores(tests) Switched to test-log as test-env-log is deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,22 +2275,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
-name = "test-env-log"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877189d680101869f65ef94168105d6c188b3a143c13a2d42cf8a09c4c704f8a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "test-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.2",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb78caec569a40f42c078c798c0e35b922d9054ec28e166f0d6ac447563d91a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3180,8 +3180,8 @@ dependencies = [
  "rustc_version 0.4.0",
  "serial_test",
  "tempfile",
- "test-env-log",
  "test-generator",
+ "test-log",
  "tracing",
  "tracing-subscriber",
  "wasi-test-generator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ compiler-test-derive = { path = "tests/lib/compiler-test-derive" }
 tempfile = "3.1"
 loupe = "0.1"
 # For logging tests using the `RUST_LOG=debug` when testing
-test-env-log = { version = "0.2", default-features = false, features = ["trace"] }
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 

--- a/tests/lib/compiler-test-derive/src/lib.rs
+++ b/tests/lib/compiler-test-derive/src/lib.rs
@@ -85,7 +85,7 @@ pub fn compiler_test(attrs: TokenStream, input: TokenStream) -> TokenStream {
         new_sig.ident = test_name;
         new_sig.inputs = ::syn::punctuated::Punctuated::new();
         let f = quote! {
-            #[test_env_log::test]
+            #[test_log::test]
             #attrs
             #[cfg(feature = #engine_feature_name)]
             #new_sig {

--- a/tests/lib/compiler-test-derive/src/tests.rs
+++ b/tests/lib/compiler-test-derive/src/tests.rs
@@ -54,7 +54,7 @@ gen_tests! {
             #[cfg(feature = "singlepass")]
             mod singlepass {
                 use super::*;
-                #[test_env_log::test]
+                #[test_log::test]
                 #[cold]
                 #[cfg(feature = "universal")]
                 fn universal() {
@@ -63,7 +63,7 @@ gen_tests! {
                         crate::Compiler::Singlepass
                     ))
                 }
-                #[test_env_log::test]
+                #[test_log::test]
                 #[cold]
                 #[cfg(feature = "dylib")]
                 fn dylib() {
@@ -77,7 +77,7 @@ gen_tests! {
             #[cfg(feature = "cranelift")]
             mod cranelift {
                 use super::*;
-                #[test_env_log::test]
+                #[test_log::test]
                 #[cold]
                 #[cfg(feature = "universal")]
                 fn universal() {
@@ -86,7 +86,7 @@ gen_tests! {
                         crate::Compiler::Cranelift
                     ))
                 }
-                #[test_env_log::test]
+                #[test_log::test]
                 #[cold]
                 #[cfg(feature = "dylib")]
                 fn dylib() {
@@ -100,7 +100,7 @@ gen_tests! {
             #[cfg(feature = "llvm")]
             mod llvm {
                 use super::*;
-                #[test_env_log::test]
+                #[test_log::test]
                 #[cold]
                 #[cfg(feature = "universal")]
                 fn universal() {
@@ -109,7 +109,7 @@ gen_tests! {
                         crate::Compiler::LLVM
                     ))
                 }
-                #[test_env_log::test]
+                #[test_log::test]
                 #[cold]
                 #[cfg(feature = "dylib")]
                 fn dylib() {


### PR DESCRIPTION
# Description

Switches to test-log as test-env-log is deprecated

