### PR TITLE
Added access to the raw Wasm instance

### DIFF
--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -173,6 +173,12 @@ impl Instance {
     pub fn store(&self) -> &Store {
         self.module.store()
     }
+
+    /// Returns the inner WebAssembly Instance
+    #[doc(hidden)]
+    pub fn raw(&self) -> &WebAssembly::Instance {
+        &self.instance
+    }
 }
 
 impl fmt::Debug for Instance {


### PR DESCRIPTION
In order to solve this issue in wasmer-js we need to expose access to the underlying WebAssembly instance:

https://github.com/wasmerio/wasmer-js/issues/284
