### PR TITLE
Regression test for #2721

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 
 
 #####


### PR DESCRIPTION
The wasm snippet in the test corresponds to roughly:

```rust
let name = "bananapeach";
banana(a, b, c, name.len() as _, name.as_ptr() as _, f, g, h);
```

however sometime between 2.0 and 2.1 the name pointer is no longer being
passed through as an argument. Instead a 0 gets passed in.

To make things weirder, if `name.as_ptr()` is passed through multiple
times, the second time the pointer will get passed correctly.

The fix for this issue is in #2723.