### PR TITLE
Added `externs_vec` method to the ImportObject

### DIFF
--- a/lib/api/src/sys/import_object.rs
+++ b/lib/api/src/sys/import_object.rs
@@ -2,6 +2,7 @@
 //! manipulate and access a wasm module's imports including memories, tables, globals, and
 //! functions.
 use crate::Exports;
+use crate::Extern;
 use std::borrow::{Borrow, BorrowMut};
 use std::collections::VecDeque;
 use std::collections::{hash_map::Entry, HashMap};
@@ -115,6 +116,24 @@ impl ImportObject {
     pub fn get_namespace_exports(&self, name: &str) -> Option<Exports> {
         let map = self.map.lock().unwrap();
         map.get(name).and_then(|ns| ns.as_exports())
+    }
+
+    /// Returns the externs
+    pub fn externs_vec(&self) -> Vec<(String, String, Extern)> {
+        let mut out = Vec::new();
+        let guard = self.map.lock().unwrap();
+        let map = guard.borrow();
+        for (namespace, ns) in map.iter() {
+            match ns.as_exports() {
+                Some(exports) => {
+                    for (name, extern_) in exports.iter() {
+                        out.push((namespace.clone(), name.clone(), extern_.clone()));
+                    }
+                }
+                None => {}
+            }
+        }
+        out
     }
 
     fn get_objects(&self) -> VecDeque<((String, String), Export)> {

--- a/lib/api/src/sys/import_object.rs
+++ b/lib/api/src/sys/import_object.rs
@@ -118,7 +118,7 @@ impl ImportObject {
         map.get(name).and_then(|ns| ns.as_exports())
     }
 
-    /// Returns the externs
+    /// Returns a list of all externs defined in all namespaces.
     pub fn externs_vec(&self) -> Vec<(String, String, Extern)> {
         let mut out = Vec::new();
         let guard = self.map.lock().unwrap();


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

This PR is needed to be able to consume the ImportObject in a more sane way than using `Exports` using `Extern` instead (since `Export` is Engine related, and `Extern` is API related).

