### PR TITLE
Replace RuntimeError::raise with RuntimeError::custom

### DIFF
--- a/examples/early_exit.rs
+++ b/examples/early_exit.rs
@@ -62,9 +62,9 @@ fn main() -> anyhow::Result<()> {
     let module = Module::new(&store, wasm_bytes)?;
 
     // We declare the host function that we'll use to terminate execution.
-    fn early_exit() {
+    fn early_exit() -> Result<(), RuntimeError> {
         // This is where it happens.
-        RuntimeError::raise(Box::new(ExitCode(1)));
+        Err(RuntimeError::custom(Box::new(ExitCode(1))))
     }
 
     // Create an import object.

--- a/lib/api/src/js/externals/function.rs
+++ b/lib/api/src/js/externals/function.rs
@@ -644,6 +644,7 @@ impl wasmer_types::WasmValueType for Function {
 /// This private inner module contains the low-level implementation
 /// for `Function` and its siblings.
 mod inner {
+    use super::RuntimeError;
     use super::VMFunctionBody;
     use std::array::TryFromSliceError;
     use std::convert::{Infallible, TryInto};
@@ -1125,6 +1126,7 @@ mod inner {
                         }));
                         match result {
                             Ok(Ok(result)) => return result.into_c_struct(),
+                            Ok(Err(trap)) => RuntimeError::raise(Box::new(trap)),
                             _ => unimplemented!(),
                             // Ok(Err(trap)) => unsafe { raise_user_trap(Box::new(trap)) },
                             // Err(panic) => unsafe { resume_panic(panic) },
@@ -1170,6 +1172,7 @@ mod inner {
                         }));
                         match result {
                             Ok(Ok(result)) => return result.into_c_struct(),
+                            Ok(Err(trap)) => RuntimeError::raise(Box::new(trap)),
                             _ => unimplemented!(),
                             // Ok(Err(trap)) => unsafe { raise_user_trap(Box::new(trap)) },
                             // Err(panic) => unsafe { resume_panic(panic) },

--- a/lib/api/tests/js_instance.rs
+++ b/lib/api/tests/js_instance.rs
@@ -690,8 +690,8 @@ mod js {
 
         impl std::error::Error for ExitCode {}
 
-        fn early_exit() {
-            RuntimeError::raise(Box::new(ExitCode(1)));
+        fn early_exit() -> Result<(), RuntimeError> {
+            Err(RuntimeError::custom(Box::new(ExitCode(1))))
         }
 
         let import_object = imports! {

--- a/lib/emscripten/src/jmp.rs
+++ b/lib/emscripten/src/jmp.rs
@@ -59,16 +59,14 @@ impl Error for LongJumpRet {}
 /// _longjmp
 // This function differs from the js implementation, it should return Result<(), &'static str>
 #[allow(unreachable_code)]
-pub fn _longjmp(ctx: &EmEnv, env_addr: i32, val: c_int) {
+pub fn _longjmp(ctx: &EmEnv, env_addr: i32, val: c_int) -> Result<(), RuntimeError> {
     let val = if val == 0 { 1 } else { val };
     get_emscripten_data(ctx)
         .set_threw_ref()
         .expect("set_threw is None")
         .call(env_addr, val)
         .expect("set_threw failed to call");
-    // TODO: return Err("longjmp")
-    RuntimeError::raise(Box::new(LongJumpRet));
-    unreachable!();
+    Err(RuntimeError::custom(Box::new(LongJumpRet)))
 }
 
 // extern "C" {

--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -2521,10 +2521,9 @@ pub fn poll_oneoff(
     unimplemented!();
 }
 
-pub fn proc_exit(env: &WasiEnv, code: __wasi_exitcode_t) {
+pub fn proc_exit(env: &WasiEnv, code: __wasi_exitcode_t) -> Result<(), RuntimeError> {
     debug!("wasi::proc_exit, {}", code);
-    RuntimeError::raise(Box::new(WasiError::Exit(code)));
-    unreachable!();
+    Err(RuntimeError::custom(Box::new(WasiError::Exit(code))))
 }
 
 pub fn proc_raise(env: &WasiEnv, sig: __wasi_signal_t) -> __wasi_errno_t {


### PR DESCRIPTION
`RuntimeError::raise` should not be exposed to user code since it perfoms a `longjmp` internally which is unsound if there are any destructors on the stack. Instead a custom error type should be returned using `RuntimeError::custom` which can be passed through WASM code and later retrieved using `RuntimeError::downcast`.