### PR TITLE
Remove llvm from docs.rs feature set (trouble with building)

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -155,4 +155,4 @@ js-default = ["js", "std", "wasm-types-polyfill"]
 wasm-types-polyfill = ["js", "wasmparser"]
 
 [package.metadata.docs.rs]
-features = ["compiler", "core", "cranelift", "default-compiler", "default-dylib", "default-engine", "dylib", "engine", "jit", "llvm", "native", "singlepass", "sys", "sys-default", "universal"]
+features = ["compiler", "core", "cranelift", "default-compiler", "default-dylib", "default-engine", "dylib", "engine", "jit", "native", "singlepass", "sys", "sys-default", "universal"]


### PR DESCRIPTION
Followup on #2605. It [currently](https://docs.rs/crate/wasmer/2.1.1/builds/480618) breaks the build on docs.rs, sorry for that.

There should be a way to get it added to the installed dependencies, but when I tried to reproduce [the environment](https://github.com/rust-lang/crates-build-env/blob/master/linux/packages.txt#L1015), it was already installed, yet there was a problem with `could not find native static library Polly, perhaps an -L flag is missing?`. I figure it's more trouble than it's worth.