### PR TITLE
Fix invoking `wasmer binfmt register` from `$PATH`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,6 +2546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unix_mode"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35abed4630bb800f02451a7428205d1f37b8e125001471bfab259beee6a587ed"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2825,7 @@ dependencies = [
  "log",
  "structopt",
  "tempfile",
+ "unix_mode",
  "wasmer",
  "wasmer-cache",
  "wasmer-compiler",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -55,6 +55,9 @@ fern = { version = "0.6", features = ["colored"], optional = true }
 log = { version = "0.4", optional = true }
 tempfile = "3"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+unix_mode = "0.1.3"
+
 [features]
 # Don't add the compiler features in default, please add them on the Makefile
 # since we might want to autoconfigure them depending on the availability on the host.

--- a/lib/cli/src/commands/binfmt.rs
+++ b/lib/cli/src/commands/binfmt.rs
@@ -43,8 +43,9 @@ fn seccheck(path: &Path) -> Result<()> {
     }
     let m = std::fs::metadata(path)
         .with_context(|| format!("Can't check permissions of {}", path.to_string_lossy()))?;
+    use unix_mode::*;
     anyhow::ensure!(
-        m.mode() & 0o2 == 0 || m.mode() & 0o1000 != 0,
+        !is_allowed(Accessor::Other, Access::Write, m.mode()) || is_sticky(m.mode()),
         "{} is world writeable and not sticky",
         path.to_string_lossy()
     );

--- a/lib/cli/src/commands/binfmt.rs
+++ b/lib/cli/src/commands/binfmt.rs
@@ -62,10 +62,8 @@ impl Binfmt {
             Register | Reregister => {
                 temp_dir = tempfile::tempdir().context("Make temporary directory")?;
                 seccheck(temp_dir.path())?;
-                let bin_path_orig: PathBuf = env::args_os()
-                    .nth(0)
-                    .map(Into::into)
-                    .filter(|p: &PathBuf| p.exists())
+                let bin_path_orig: PathBuf = env::current_exe()
+                    .and_then(|p| p.canonicalize())
                     .context("Cannot get path to wasmer executable")?;
                 let bin_path = temp_dir.path().join("wasmer-binfmt-interpreter");
                 fs::copy(&bin_path_orig, &bin_path).context("Copy wasmer binary to temp folder")?;


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
Currently, invoking `wasmer binfmt register` from `$PATH` fails. 
```
$ wasmer binfmt register 
error: Cannot get path to wasmer executable
```

(Currently, only invoking it by absolute path (`$(which wasmer) binfmt register`, e.g. as would be from a systemd unit) works.)


I also added a commit that changes some bit twiddling with file modes to a nicer semantic check, but it does add a dependency. Please tell me if you don't want that.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file - Not necessary?
