### PR TITLE
Re-add "dylib" to the list of default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ default = [
     "wat",
     "wast",
     "universal",
+    "dylib",
     "staticlib",
     "cache",
     "wasi",

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -50,6 +50,7 @@ singlepass+windows spec::skip_stack_guard_page # Needs investigation.
 cranelift+windows spec::skip_stack_guard_page # Needs investigation. Issue: `STATUS_ACCESS_VIOLATION` trap happened
 cranelift+macos   spec::skip_stack_guard_page # Needs investigation. process didn't exit successfully: (signal: 6, SIGABRT: process abort signal)
 llvm+macos        spec::skip_stack_guard_page # Needs investigation. process didn't exit successfully: (signal: 6, SIGABRT: process abort signal)
+dylib             spec::skip_stack_guard_page # Missing trap information in dylibs
 
 
 # TODO(https://github.com/wasmerio/wasmer/issues/1727): Traps in dylib engine


### PR DESCRIPTION
It was previously accidentally removed from this list.