### PR TITLE
Use exact version for Wasmer crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
 name = "arbitrary"
@@ -87,7 +87,7 @@ checksum = "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe"
 dependencies = [
  "bstr",
  "doc-comment",
- "predicates 2.1.0",
+ "predicates 2.1.1",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -171,9 +171,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake3"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526c210b4520e416420759af363083471656e819a75e831b8d2c9d5a584f2413"
+checksum = "882e99e4a0cb2ae6cb6e442102e8e6b7131718d94110e64c3e6a34ea9b106f37"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -181,6 +181,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "constant_time_eq",
  "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -206,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytecheck"
@@ -326,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.46"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
 dependencies = [
  "cc",
 ]
@@ -400,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "constant_time_eq"
@@ -519,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -540,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -553,12 +562,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -665,11 +683,14 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
+ "block-buffer",
+ "crypto-common",
  "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -794,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
+checksum = "44a5d80251b806a14cd3e4e1a582e912d5cbf6904ab19fdefbd7a56adca088e1"
 dependencies = [
  "serde",
 ]
@@ -806,6 +827,15 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fern"
@@ -878,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -897,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1024,9 +1054,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
@@ -1098,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367fed6750ff2a5bcb967a631528303bb85631f167a75eb1bf7762d57eb7678"
+checksum = "aa2f6fdbc5fd6457ae78e0313ba2eb5cb509655bbcfe8c577096cdbae8ff621c"
 dependencies = [
  "ctor",
  "ghost",
@@ -1129,9 +1159,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1173,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -1259,9 +1289,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4647a11b578fead29cdbb34d4adef8dd3dc35b876c9c6d5240d83f205abfe96e"
+checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
 dependencies = [
  "libc",
 ]
@@ -1376,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1479,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pkg-config"
@@ -1519,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
@@ -1538,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "itertools",
@@ -1549,15 +1579,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1607,9 +1637,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1636,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1821,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.28"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631f7d2a2854abb66724f492ce5256e79685a673dc210ac022194cedd5c914d3"
+checksum = "49a37de5dfc60bae2d94961dacd03c7b80e426b66a99fa1b17799570dbdd8f96"
 dependencies = [
  "bytecheck",
  "hashbrown 0.11.2",
@@ -1835,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.28"
+version = "0.7.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c067e650861a749720952aed722fb344449bc95de33e6456d426f5c7d44f71c0"
+checksum = "719d447dd0e84b23cee6cb5b32d97e21efb112a3e3c636c8da36647b938475a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2003,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
@@ -2031,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2042,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2075,9 +2105,18 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sharded-slab"
@@ -2102,9 +2141,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2184,9 +2223,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2207,10 +2246,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.82"
+name = "subtle"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "syn"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2242,13 +2287,13 @@ checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2276,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "test-generator"
@@ -2442,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
+checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
 dependencies = [
  "lazy_static",
  "matchers",
@@ -2468,12 +2513,12 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d664de8ea7e531ad4c0f5a834f20b8cb2b8e6dfe88d05796ee7887518ed67b9"
+checksum = "f04343ff86b62ca40bd5dca986aadf4f10c152a9ebe9a869e456b60fa85afd3f"
 dependencies = [
  "glob",
- "lazy_static",
+ "once_cell",
  "serde",
  "serde_json",
  "termcolor",
@@ -2482,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "typetag"
@@ -2565,9 +2610,9 @@ checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -2609,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2619,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2634,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2646,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2656,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2669,15 +2714,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f1aa7971fdf61ef0f353602102dbea75a56e225ed036c1e3740564b91e6b7e"
+checksum = "45c8d417d87eefa0087e62e3c75ad086be39433449e2961add9a5d9ce5acc2f1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -2689,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006f79628dfeb96a86d4db51fbf1344cd7fd8408f06fc9aa3c84913a4789688"
+checksum = "d0e560d44db5e73b69a9757a15512fe7e1ef93ed2061c928871a4025798293dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3224,18 +3269,18 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmparser"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
+checksum = "0559cc0f1779240d6f894933498877ea94f693d84f3ee39c9a9932c6c312bd70"
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00ad4a51ba74183137c776ab37dea50b9f71db7454d7b654c2ba69ac5d9b223"
+checksum = "6d7e1e9d5e3540363f038518bc21f568caabaad20d4e371deabe37424ef15a8d"
 dependencies = [
  "anyhow",
- "wasmparser 0.81.0",
+ "wasmparser 0.82.0",
 ]
 
 [[package]]
@@ -3257,12 +3302,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.0.40"
+name = "wast"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
+checksum = "e9bbbd53432b267421186feee3e52436531fa69a7cfee9403f5204352df3dd05"
 dependencies = [
- "wast 38.0.1",
+ "leb128",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab98ed25494f97c69f28758617f27c3e92e5336040b5c3a14634f2dd3fe61830"
+dependencies = [
+ "wast 39.0.0",
 ]
 
 [[package]]
@@ -3337,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,22 +10,22 @@ publish = false
 autoexamples = false
 
 [dependencies]
-wasmer = { version = "2.1.1", path = "lib/api", default-features = false }
-wasmer-compiler = { version = "2.1.1", path = "lib/compiler" }
-wasmer-compiler-cranelift = { version = "2.1.1", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.1.1", path = "lib/compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "2.1.1", path = "lib/compiler-llvm", optional = true }
-wasmer-emscripten = { version = "2.1.1", path = "lib/emscripten", optional = true }
-wasmer-engine = { version = "2.1.1", path = "lib/engine" }
-wasmer-engine-universal = { version = "2.1.1", path = "lib/engine-universal", optional = true }
-wasmer-engine-dylib = { version = "2.1.1", path = "lib/engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "2.1.1", path = "lib/engine-staticlib", optional = true }
-wasmer-wasi = { version = "2.1.1", path = "lib/wasi", optional = true }
-wasmer-wast = { version = "2.1.1", path = "tests/lib/wast", optional = true }
-wasi-test-generator = { version = "2.1.1", path = "tests/wasi-wast", optional = true }
-wasmer-cache = { version = "2.1.1", path = "lib/cache", optional = true }
-wasmer-types = { version = "2.1.1", path = "lib/types" }
-wasmer-middlewares = { version = "2.1.1", path = "lib/middlewares", optional = true }
+wasmer = { version = "=2.1.1", path = "lib/api", default-features = false }
+wasmer-compiler = { version = "=2.1.1", path = "lib/compiler" }
+wasmer-compiler-cranelift = { version = "=2.1.1", path = "lib/compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "=2.1.1", path = "lib/compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "=2.1.1", path = "lib/compiler-llvm", optional = true }
+wasmer-emscripten = { version = "=2.1.1", path = "lib/emscripten", optional = true }
+wasmer-engine = { version = "=2.1.1", path = "lib/engine" }
+wasmer-engine-universal = { version = "=2.1.1", path = "lib/engine-universal", optional = true }
+wasmer-engine-dylib = { version = "=2.1.1", path = "lib/engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "=2.1.1", path = "lib/engine-staticlib", optional = true }
+wasmer-wasi = { version = "=2.1.1", path = "lib/wasi", optional = true }
+wasmer-wast = { version = "=2.1.1", path = "tests/lib/wast", optional = true }
+wasi-test-generator = { version = "=2.1.1", path = "tests/wasi-wast", optional = true }
+wasmer-cache = { version = "=2.1.1", path = "lib/cache", optional = true }
+wasmer-types = { version = "=2.1.1", path = "lib/types" }
+wasmer-middlewares = { version = "=2.1.1", path = "lib/middlewares", optional = true }
 cfg-if = "1.0"
 
 [workspace]

--- a/deny.toml
+++ b/deny.toml
@@ -144,7 +144,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "deny"
+multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -32,19 +32,19 @@ wat = { version = "1.0", optional = true }
 # Dependencies and Development Dependencies for `sys`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # - Mandatory dependencies for `sys`.
-wasmer-vm = { path = "../vm", version = "2.1.1" }
-wasmer-compiler = { path = "../compiler", version = "2.1.1" }
-wasmer-derive = { path = "../derive", version = "2.1.1" }
-wasmer-engine = { path = "../engine", version = "2.1.1" }
-wasmer-types = { path = "../types", version = "2.1.1" }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1" }
+wasmer-derive = { path = "../derive", version = "=2.1.1" }
+wasmer-engine = { path = "../engine", version = "=2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
 target-lexicon = { version = "0.12.2", default-features = false }
 loupe = "0.1"
 # - Optional dependencies for `sys`.
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.1.1", optional = true }
-wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "2.1.1", optional = true }
-wasmer-compiler-llvm = { path = "../compiler-llvm", version = "2.1.1", optional = true }
-wasmer-engine-universal = { path = "../engine-universal", version = "2.1.1", optional = true }
-wasmer-engine-dylib = { path = "../engine-dylib", version = "2.1.1", optional = true }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "=2.1.1", optional = true }
+wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "=2.1.1", optional = true }
+wasmer-compiler-llvm = { path = "../compiler-llvm", version = "=2.1.1", optional = true }
+wasmer-engine-universal = { path = "../engine-universal", version = "=2.1.1", optional = true }
+wasmer-engine-dylib = { path = "../engine-dylib", version = "=2.1.1", optional = true }
 # - Mandatory dependencies for `sys` on Windows.
 [target.'cfg(all(not(target_arch = "wasm32"), target_os = "windows"))'.dependencies]
 winapi = "0.3"
@@ -57,10 +57,10 @@ anyhow = "1.0"
 # Dependencies and Develoment Dependencies for `js`.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # - Mandatory dependencies for `js`.
-wasmer-types = { path = "../types", version = "2.1.1", default-features = false, features = ["std"] }
+wasmer-types = { path = "../types", version = "=2.1.1", default-features = false, features = ["std"] }
 wasm-bindgen = "0.2.74"
 js-sys = "0.3.51"
-wasmer-derive = { path = "../derive", version = "2.1.1" }
+wasmer-derive = { path = "../derive", version = "=2.1.1" }
 # - Optional dependencies for `js`.
 wasmparser = { version = "0.78", default-features = false, optional = true }
 hashbrown = { version = "0.11", optional = true }

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -22,18 +22,18 @@ crate-type = ["cdylib", "rlib", "staticlib"]
 [dependencies]
 # We rename `wasmer` to `wasmer-api` to avoid the conflict with this
 # library name (see `[lib]`).
-wasmer-api = { version = "2.1.1", path = "../api", default-features = false, features = ["sys"], package = "wasmer" }
-wasmer-compiler-cranelift = { version = "2.1.1", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.1.1", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "2.1.1", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "2.1.1", path = "../emscripten", optional = true }
-wasmer-engine = { version = "2.1.1", path = "../engine" }
-wasmer-engine-universal = { version = "2.1.1", path = "../engine-universal", optional = true }
-wasmer-engine-dylib = { version = "2.1.1", path = "../engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "2.1.1", path = "../engine-staticlib", optional = true }
-wasmer-middlewares = { version = "2.1.1", path = "../middlewares", optional = true }
-wasmer-wasi = { version = "2.1.1", path = "../wasi", default-features = false, features = ["host-fs", "sys"], optional = true }
-wasmer-types = { version = "2.1.1", path = "../types" }
+wasmer-api = { version = "=2.1.1", path = "../api", default-features = false, features = ["sys"], package = "wasmer" }
+wasmer-compiler-cranelift = { version = "=2.1.1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "=2.1.1", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "=2.1.1", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "=2.1.1", path = "../emscripten", optional = true }
+wasmer-engine = { version = "=2.1.1", path = "../engine" }
+wasmer-engine-universal = { version = "=2.1.1", path = "../engine-universal", optional = true }
+wasmer-engine-dylib = { version = "=2.1.1", path = "../engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "=2.1.1", path = "../engine-staticlib", optional = true }
+wasmer-middlewares = { version = "=2.1.1", path = "../middlewares", optional = true }
+wasmer-wasi = { version = "=2.1.1", path = "../wasi", default-features = false, features = ["host-fs", "sys"], optional = true }
+wasmer-types = { version = "=2.1.1", path = "../types" }
 enumset = "1.0"
 cfg-if = "1.0"
 lazy_static = "1.4"

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "2.1.1", default-features = false, features = ["sys"] }
+wasmer = { path = "../api", version = "=2.1.1", default-features = false, features = ["sys"] }
 hex = "0.4"
 thiserror = "1"
 blake3 = "1.0"
@@ -20,9 +20,9 @@ blake3 = "1.0"
 criterion = "0.3"
 tempfile = "3"
 rand = "0.8.3"
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "2.1.1" }
-wasmer-engine-universal = { path = "../engine-universal", version = "2.1.1" }
-wasmer-engine-dylib = { path = "../engine-dylib", version = "2.1.1" }
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "=2.1.1" }
+wasmer-engine-universal = { path = "../engine-universal", version = "=2.1.1" }
+wasmer-engine-dylib = { path = "../engine-dylib", version = "=2.1.1" }
 
 [features]
 blake3-pure = ["blake3/pure"]

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -24,23 +24,23 @@ doc = false
 required-features = ["headless"]
 
 [dependencies]
-wasmer = { version = "2.1.1", path = "../api", default-features = false }
-wasmer-compiler = { version = "2.1.1", path = "../compiler" }
-wasmer-compiler-cranelift = { version = "2.1.1", path = "../compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.1.1", path = "../compiler-singlepass", optional = true }
-wasmer-compiler-llvm = { version = "2.1.1", path = "../compiler-llvm", optional = true }
-wasmer-emscripten = { version = "2.1.1", path = "../emscripten", optional = true }
-wasmer-engine = { version = "2.1.1", path = "../engine" }
-wasmer-engine-universal = { version = "2.1.1", path = "../engine-universal", optional = true }
-wasmer-engine-dylib = { version = "2.1.1", path = "../engine-dylib", optional = true }
-wasmer-engine-staticlib = { version = "2.1.1", path = "../engine-staticlib", optional = true }
-wasmer-vm = { version = "2.1.1", path = "../vm" }
-wasmer-wasi = { version = "2.1.1", path = "../wasi", optional = true }
-wasmer-wasi-experimental-io-devices = { version = "2.1.1", path = "../wasi-experimental-io-devices", optional = true }
-wasmer-wast = { version = "2.1.1", path = "../../tests/lib/wast", optional = true }
-wasmer-cache = { version = "2.1.1", path = "../cache", optional = true }
-wasmer-types = { version = "2.1.1", path = "../types" }
-wasmer-vfs  = { version = "2.1.1", path = "../vfs", default-features = false, features = ["host-fs"] }
+wasmer = { version = "=2.1.1", path = "../api", default-features = false }
+wasmer-compiler = { version = "=2.1.1", path = "../compiler" }
+wasmer-compiler-cranelift = { version = "=2.1.1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-singlepass = { version = "=2.1.1", path = "../compiler-singlepass", optional = true }
+wasmer-compiler-llvm = { version = "=2.1.1", path = "../compiler-llvm", optional = true }
+wasmer-emscripten = { version = "=2.1.1", path = "../emscripten", optional = true }
+wasmer-engine = { version = "=2.1.1", path = "../engine" }
+wasmer-engine-universal = { version = "=2.1.1", path = "../engine-universal", optional = true }
+wasmer-engine-dylib = { version = "=2.1.1", path = "../engine-dylib", optional = true }
+wasmer-engine-staticlib = { version = "=2.1.1", path = "../engine-staticlib", optional = true }
+wasmer-vm = { version = "=2.1.1", path = "../vm" }
+wasmer-wasi = { version = "=2.1.1", path = "../wasi", optional = true }
+wasmer-wasi-experimental-io-devices = { version = "=2.1.1", path = "../wasi-experimental-io-devices", optional = true }
+wasmer-wast = { version = "=2.1.1", path = "../../tests/lib/wast", optional = true }
+wasmer-cache = { version = "=2.1.1", path = "../cache", optional = true }
+wasmer-types = { version = "=2.1.1", path = "../types" }
+wasmer-vfs  = { version = "=2.1.1", path = "../vfs", default-features = false, features = ["host-fs"] }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "2.1.1", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "2.1.1" }
-wasmer-types = { path = "../types", version = "2.1.1", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1", default-features = false, features = ["std"] }
 cranelift-entity = { version = "0.76", default-features = false }
 cranelift-codegen = { version = "0.76", default-features = false, features = ["x86", "arm64"] }
 cranelift-frontend = { version = "0.76", default-features = false }

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "2.1.1", features = ["translator"] }
-wasmer-vm = { path = "../vm", version = "2.1.1" }
-wasmer-types = { path = "../types", version = "2.1.1" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1", features = ["translator"] }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
 target-lexicon = { version = "0.12.2", default-features = false }
 smallvec = "1.6"
 object = { version = "0.27", default-features = false, features = ["read"] }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", version = "2.1.1", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", version = "2.1.1" }
-wasmer-types = { path = "../types", version = "2.1.1", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1", default-features = false, features = ["std"] }
 rayon = { version = "1.5", optional = true }
 hashbrown = { version = "0.11", optional = true }
 more-asserts = "0.2"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", version = "2.1.1" }
-wasmer-types = { path = "../types", version = "2.1.1", default-features = false }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1", default-features = false }
 wasmparser = { version = "0.78", optional = true, default-features = false }
 target-lexicon = { version = "0.12.2", default-features = false }
 enumset = "1.0"

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 libc = "^0.2"
 log = "0.4"
 time = { version = "0.2", features = ["std"] }
-wasmer = { path = "../api", version = "2.1.1", default-features = false, features = ["sys"] }
+wasmer = { path = "../api", version = "=2.1.1", default-features = false, features = ["sys"] }
 
 [target.'cfg(windows)'.dependencies]
 getrandom = "0.2"

--- a/lib/engine-dylib/Cargo.toml
+++ b/lib/engine-dylib/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1" }
-wasmer-compiler = { path = "../compiler", version = "2.1.1" }
-wasmer-vm = { path = "../vm", version = "2.1.1", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", version = "2.1.1" }
-wasmer-object = { path = "../object", version = "2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1" }
+wasmer-vm = { path = "../vm", version = "=2.1.1", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", version = "=2.1.1" }
+wasmer-object = { path = "../object", version = "=2.1.1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
 tracing = { version = "0.1", features = ["log"] }

--- a/lib/engine-staticlib/Cargo.toml
+++ b/lib/engine-staticlib/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1" }
-wasmer-compiler = { path = "../compiler", version = "2.1.1" }
-wasmer-vm = { path = "../vm", version = "2.1.1" }
-wasmer-engine = { path = "../engine", version = "2.1.1" }
-wasmer-object = { path = "../object", version = "2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1" }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
+wasmer-engine = { path = "../engine", version = "=2.1.1" }
+wasmer-object = { path = "../object", version = "=2.1.1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 cfg-if = "1.0"
 tracing = "0.1"

--- a/lib/engine-universal/Cargo.toml
+++ b/lib/engine-universal/Cargo.toml
@@ -11,15 +11,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1", features = [
+wasmer-types = { path = "../types", version = "=2.1.1", features = [
     "enable-rkyv",
 ] }
-wasmer-compiler = { path = "../compiler", version = "2.1.1", features = [
+wasmer-compiler = { path = "../compiler", version = "=2.1.1", features = [
     "translator",
     "enable-rkyv",
 ] }
-wasmer-vm = { path = "../vm", version = "2.1.1", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", version = "2.1.1" }
+wasmer-vm = { path = "../vm", version = "=2.1.1", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", version = "=2.1.1" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "3.0"
 cfg-if = "1.0"

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1" }
-wasmer-compiler = { path = "../compiler", version = "2.1.1" }
-wasmer-vm = { path = "../vm", version = "2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1" }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
 target-lexicon = { version = "0.12.2", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"

--- a/lib/middlewares/Cargo.toml
+++ b/lib/middlewares/Cargo.toml
@@ -11,13 +11,13 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer = { path = "../api", version = "2.1.1", default-features = false, features = ["compiler"] }
-wasmer-types = { path = "../types", version = "2.1.1" }
-wasmer-vm = { path = "../vm", version = "2.1.1" }
+wasmer = { path = "../api", version = "=2.1.1", default-features = false, features = ["compiler"] }
+wasmer-types = { path = "../types", version = "=2.1.1" }
+wasmer-vm = { path = "../vm", version = "=2.1.1" }
 loupe = "0.1"
 
 [dev-dependencies]
-wasmer = { path = "../api", version = "2.1.1", features = ["compiler"] }
+wasmer = { path = "../api", version = "=2.1.1", features = ["compiler"] }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/lib/object/Cargo.toml
+++ b/lib/object/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1" }
-wasmer-compiler = { path = "../compiler", version = "2.1.1", default-features = false, features = [
+wasmer-types = { path = "../types", version = "=2.1.1" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.1", default-features = false, features = [
     "std",
     "translator"
 ] }

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
 region = "3.0"
 libc = { version = "^0.2", default-features = false }
 memoffset = "0.6"

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 maintenance = { status = "experimental" }
 
 [dependencies]
-wasmer-wasi = { version = "2.1.1", path = "../wasi", default-features=false }
+wasmer-wasi = { version = "=2.1.1", path = "../wasi", default-features=false }
 tracing = "0.1"
 minifb = "0.19"
 nix = "0.20.2"

--- a/lib/wasi-types/Cargo.toml
+++ b/lib/wasi-types/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.1.1" }
+wasmer-types = { path = "../types", version = "=2.1.1" }
 serde = { version = "1.0", features = ["derive"], optional=true }
 byteorder = "1.3"
 time = "0.2"

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -19,9 +19,9 @@ thiserror = "1"
 generational-arena = { version = "0.2" }
 tracing = "0.1"
 getrandom = "0.2"
-wasmer-wasi-types = { path = "../wasi-types", version = "2.1.1" }
-wasmer = { path = "../api", version = "2.1.1", default-features = false }
-wasmer-vfs = { path = "../vfs", version = "2.1.1", default-features = false }
+wasmer-wasi-types = { path = "../wasi-types", version = "=2.1.1" }
+wasmer = { path = "../api", version = "=2.1.1", default-features = false }
+wasmer-vfs = { path = "../vfs", version = "=2.1.1", default-features = false }
 typetag = { version = "0.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 bincode = { version = "1.3", optional = true }

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -8,7 +8,8 @@ PREVIOUS_VERSION='2.1.0'
 NEXT_VERSION='2.1.1'
 
 # quick hack
-${FD} Cargo.toml --exec sed -i '{}' -e "s/version = \"$PREVIOUS_VERSION\"/version = \"$NEXT_VERSION\"/"
+${FD} Cargo.toml --exec sed -i '{}' -e "s/ version = \"$PREVIOUS_VERSION\"/ version = \"$NEXT_VERSION\"/"
+${FD} Cargo.toml --exec sed -i '{}' -e "s/ version = \"=$PREVIOUS_VERSION\"/ version = \"=$NEXT_VERSION\"/"
 echo "manually check changes to Cargo.toml"
 
 ${FD} wasmer.iss --exec sed -i '{}' -e "s/AppVersion=$PREVIOUS_VERSION/AppVersion=$NEXT_VERSION/"
@@ -16,7 +17,7 @@ echo "manually check changes to wasmer.iss"
 
 # Re-generate lock files
 cargo generate-lockfile
-cargo generate-lockfile --manifest-path wasmer-test
+cargo generate-lockfile --manifest-path wasmer-test/Cargo.toml
 
 # Order to upload packages in
 ## wasmer-types

--- a/tests/lib/engine-dummy/Cargo.toml
+++ b/tests/lib/engine-dummy/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-wasmer-types = { path = "../../../lib/types", version = "2.1.1" }
-wasmer-compiler = { path = "../../../lib/compiler", version = "2.1.1" }
-wasmer-vm = { path = "../../../lib/vm", version = "2.1.1" }
-wasmer-engine = { path = "../../../lib/engine", version = "2.1.1" }
+wasmer-types = { path = "../../../lib/types", version = "=2.1.1" }
+wasmer-compiler = { path = "../../../lib/compiler", version = "=2.1.1" }
+wasmer-vm = { path = "../../../lib/vm", version = "=2.1.1" }
+wasmer-engine = { path = "../../../lib/engine", version = "=2.1.1" }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_bytes = { version = "0.11", optional = true }
 bincode = { version = "1.2", optional = true }

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmer = { path = "../../../lib/api", version = "2.1.1", default-features = false, features = ["experimental-reference-types-extern-ref"] }
-wasmer-wasi = { path = "../../../lib/wasi", version = "2.1.1" }
-wasmer-vfs = { path = "../../../lib/vfs", version = "2.1.1" }
+wasmer = { path = "../../../lib/api", version = "=2.1.1", default-features = false, features = ["experimental-reference-types-extern-ref"] }
+wasmer-wasi = { path = "../../../lib/wasi", version = "=2.1.1" }
+wasmer-vfs = { path = "../../../lib/vfs", version = "=2.1.1" }
 wast = "38.0"
 serde = "1"
 tempfile = "3"


### PR DESCRIPTION
We don't guarantee API compatibility between internal Wasmer crates when making minor version bumps. This will avoid issues like #2749 in the future.
