### PR TITLE
Updated doc links for C/C++ and Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ languages**, so you can use WebAssembly _anywhere_.
 [c logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/c.svg
 [c integration]: https://github.com/wasmerio/wasmer/tree/master/lib/c-api
 [`wasmer.h` header]: https://github.com/wasmerio/wasmer/blob/master/lib/c-api/wasmer.h
-[c docs]: https://docs.rs/wasmer-c-api/*/wasmer_c_api/wasm_c_api/index.html
+[c docs]: https://docs.rs/wasmer-c-api/*/wasmer/wasm_c_api/index.html
 
 [c# logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/csharp.svg
 [c# integration]: https://github.com/migueldeicaza/WasmerSharp
@@ -164,7 +164,7 @@ languages**, so you can use WebAssembly _anywhere_.
 [python logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/python.svg
 [python integration]: https://github.com/wasmerio/wasmer-python
 [`wasmer` pypi package]: https://pypi.org/project/wasmer/
-[python docs]: https://wasmerio.github.io/wasmer-python/api/wasmer/
+[python docs]: https://wasmerio.github.io/wasmer-python/api/wasmer
 
 [go logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/go.svg
 [go integration]: https://github.com/wasmerio/wasmer-go


### PR DESCRIPTION
# Description
1. Updated link to Python documentation. Presence of `/` in the old link `https://wasmerio.github.io/wasmer-python/api/wasmer/` would lead to a 404 page.

2. Updated link to C/C++ documentation too.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
^ I am not sure if this is necessary for the proposed change. Let me know if otherwise.
