### PR TITLE
Fix serialize FrameInfo on Dylib engine (for #1727)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2717](https://github.com/wasmerio/wasmer/pull/2717) Allow `Exports` to be modified after being cloned.
 - [#2719](https://github.com/wasmerio/wasmer/pull/2719) Fixed `wasm_importtype_new`'s Rust signature to not assume boxed vectors.
 - [#2723](https://github.com/wasmerio/wasmer/pull/2723) Fixed a bug in parameter passing in the Singlepass compiler.
+- [#2768](https://github.com/wasmerio/wasmer/pull/2768) Fixed issue with Frame Info on dylib engine.
 
 ## 2.1.0 - 2021/11/30
 

--- a/lib/engine-dylib/src/serialize.rs
+++ b/lib/engine-dylib/src/serialize.rs
@@ -6,7 +6,10 @@ use rkyv::{
 };
 use serde::{Deserialize, Serialize};
 use std::error::Error;
-use wasmer_compiler::{CompileError, CompileModuleInfo, SectionIndex, Symbol, SymbolRegistry};
+use wasmer_compiler::{
+    CompileError, CompileModuleInfo, CompiledFunctionFrameInfo, SectionIndex, Symbol,
+    SymbolRegistry,
+};
 use wasmer_engine::DeserializeError;
 use wasmer_types::entity::{EntityRef, PrimaryMap};
 use wasmer_types::{FunctionIndex, LocalFunctionIndex, OwnedDataInitializer, SignatureIndex};
@@ -29,6 +32,7 @@ fn to_compile_error(err: impl Error) -> CompileError {
 )]
 pub struct ModuleMetadata {
     pub compile_info: CompileModuleInfo,
+    pub function_frame_info: Option<PrimaryMap<LocalFunctionIndex, CompiledFunctionFrameInfo>>,
     pub prefix: String,
     pub data_initializers: Box<[OwnedDataInitializer]>,
     // The function body lengths (used to find function by address)

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -47,11 +47,6 @@ cranelift+macos   spec::skip_stack_guard_page # Needs investigation. process did
 llvm+macos        spec::skip_stack_guard_page # Needs investigation. process didn't exit successfully: (signal: 6, SIGABRT: process abort signal)
 dylib             spec::skip_stack_guard_page # Missing trap information in dylibs
 
-
-# TODO(https://github.com/wasmerio/wasmer/issues/1727): Traps in dylib engine
-cranelift+dylib spec::linking # Needs investigation
-cranelift+dylib spec::bulk # Needs investigation
-
 # Some SIMD opperations are not yet supported by Cranelift
 # Cranelift just added support for most of those recently, it might be easy to update
 cranelift spec::simd::simd_conversions


### PR DESCRIPTION
# Description

Add serialization of Frame Info (except when using llvm) for the Dylib engine, so Trap Information is still valid and the correct trap are triggered by the program.