### PR TITLE
Fix the "--cflags" part of "wasmer config" in README.md

### DIFF
--- a/lib/c-api/README.md
+++ b/lib/c-api/README.md
@@ -184,9 +184,9 @@ $ wasmer config --libs
 -L/Users/myuser/.wasmer/lib -lwasmer
 ```
 
-### `wasmer config --libs`
+### `wasmer config --cflags`
 
-Libraries needed to link against Wasmer components:
+Headers needed to build against Wasmer components:
 
 ```bash
 $ wasmer config --cflags


### PR DESCRIPTION
# Description
The heading for the `wasmer config --cflags` section incorrectly mentions `--libs` and the body also incorrectly mentions linking libraries.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
