### PR TITLE
Made relocations matching strictly in compiler-llvm

### DIFF
--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -163,24 +163,24 @@ where
             .map_err(map_object_err)?
             .relocations()
         {
-            let kind = match (reloc.kind(), reloc.size()) {
-                (object::RelocationKind::Absolute, 64) => RelocationKind::Abs8,
-                (object::RelocationKind::Elf(object::elf::R_X86_64_PC64), 0) => {
+            let kind = match (elf.architecture(), reloc.kind(), reloc.size()) {
+                (_, object::RelocationKind::Absolute, 64) => RelocationKind::Abs8,
+                (object::Architecture::X86_64, object::RelocationKind::Elf(object::elf::R_X86_64_PC64), 0) => {
                     RelocationKind::X86PCRel8
                 }
-                (object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G0_NC), 0) => {
+                (object::Architecture::Aarch64, object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G0_NC), 0) => {
                     RelocationKind::Arm64Movw0
                 }
-                (object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G1_NC), 0) => {
+                (object::Architecture::Aarch64, object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G1_NC), 0) => {
                     RelocationKind::Arm64Movw1
                 }
-                (object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G2_NC), 0) => {
+                (object::Architecture::Aarch64, object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G2_NC), 0) => {
                     RelocationKind::Arm64Movw2
                 }
-                (object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G3), 0) => {
+                (object::Architecture::Aarch64, object::RelocationKind::Elf(object::elf::R_AARCH64_MOVW_UABS_G3), 0) => {
                     RelocationKind::Arm64Movw3
                 }
-                (object::RelocationKind::PltRelative, 26) => RelocationKind::Arm64Call,
+                (object::Architecture::Aarch64, object::RelocationKind::PltRelative, 26) => RelocationKind::Arm64Call,
                 _ => {
                     return Err(CompileError::Codegen(format!(
                         "unknown relocation {:?}",


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Made relocations matching strictly in compiler-llvm.
I added object's architecture to matching pattern.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
