### PR TITLE
Use windows-2019 instead of windows-latest for CI

### DIFF
--- a/.github/workflows/test-sys.yaml
+++ b/.github/workflows/test-sys.yaml
@@ -67,7 +67,7 @@ jobs:
             run_test: false
             run_test_capi: false
           - build: windows-x64
-            os: windows-latest
+            os: windows-2019
             # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/12.x/windows-amd64.tar.gz'
             llvm_choco_version: 13.0.0
             artifact_name: 'wasmer-windows-amd64'
@@ -250,12 +250,12 @@ jobs:
           call refreshenv
           set WASMER_DIR=%CD%\package
           make test-integration
-        if: matrix.run_integration_tests && matrix.os == 'windows-latest'
+        if: matrix.run_integration_tests && matrix.os == 'windows-2019'
       - name: Run integration tests (Unix)
         run: |
           export WASMER_DIR=`pwd`/package
           make test-integration
-        if: matrix.run_integration_tests && matrix.os != 'windows-latest'
+        if: matrix.run_integration_tests && matrix.os != 'windows-2019'
       - name: Run iOS integration tests
         run: |
           rustup target add aarch64-apple-ios x86_64-apple-ios
@@ -287,7 +287,7 @@ jobs:
           #cp qjs_win_from_mac.wjit cross
           cp target/release/wasmer cross
       #- name: Cross compile from Windows
-      #  if: matrix.os == 'windows-latest'
+      #  if: matrix.os == 'windows-2019'
       #  shell: bash
       #  run: |
       #    alias wasmer=target/release/wasmer
@@ -346,7 +346,7 @@ jobs:
           
   #test-cross-compile-on-win:
   #  needs: [setup, test]
-  #  runs-on: windows-latest
+  #  runs-on: windows-2019
   #  steps:
   #    - name: Download Wasmer
   #      uses: actions/download-artifact@v2


### PR DESCRIPTION
windows-latest was recently updated to windows-2022 which seems to cause
some issues related to stack unwinding through Wasm frames.