### PR TITLE
Fix singlepass Arm64 since #2775

### DIFF
--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -70,14 +70,19 @@ impl Compiler for SinglepassCompiler {
             }
         }
 
-        let simd_arch = if target.cpu_features().contains(CpuFeature::AVX) {
-            CpuFeature::AVX
-        } else if target.cpu_features().contains(CpuFeature::SSE42) {
-            CpuFeature::SSE42
-        } else {
-            return Err(CompileError::UnsupportedTarget(
-                "x86_64 without AVX or SSE 4.2".to_string(),
-            ));
+        let simd_arch = match target.triple().architecture {
+            Architecture::X86_64 => {
+                if target.cpu_features().contains(CpuFeature::AVX) {
+                    Some(CpuFeature::AVX)
+                } else if target.cpu_features().contains(CpuFeature::SSE42) {
+                    Some(CpuFeature::SSE42)
+                } else {
+                    return Err(CompileError::UnsupportedTarget(
+                        "x86_64 without AVX or SSE 4.2".to_string(),
+                    ));
+                }
+            }
+            _ => None,
         };
         if compile_info.features.multi_value {
             return Err(CompileError::UnsupportedFeature("multivalue".to_string()));
@@ -134,7 +139,7 @@ impl Compiler for SinglepassCompiler {
 
                 match target.triple().architecture {
                     Architecture::X86_64 => {
-                        let machine = MachineX86_64::new(Some(simd_arch));
+                        let machine = MachineX86_64::new(simd_arch);
                         let mut generator = FuncGen::new(
                             module,
                             &self.config,


### PR DESCRIPTION
# Description
PR #2775 broke Singlepass on Aarm64, since the test to check if the CPU have AVX or SSE 4.2 was done for all Architecture instead of being limited to x86_64.