### PR TITLE
Fix the broken link for WASI ABI

### DIFF
--- a/lib/wasi/README.md
+++ b/lib/wasi/README.md
@@ -99,5 +99,5 @@ of links that may help you:
 * [WASI C API header
   file](https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/headers/public/wasi/api.h),
 * [WASI Application Binary Interface
-  (ABI)](https://github.com/WebAssembly/WASI/blob/main/design/application-abi.md),
+  (ABI)](https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md),
   where we learn about `_start` and `_initialize` (for _reactors_) for example.


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
The link for WASI ABI was moved, so I fixed it towards the correct link. According to the [`WASI/legacy`](https://github.com/WebAssembly/WASI/blob/main/legacy/README.md), the link will be broken again after 2023. Therefore, I would suggest either removing the section or using the specific SHA for the link like the following:
https://github.com/WebAssembly/WASI/blob/8a381fb9124b3aca29755ce8e255d2eeaddb16cb/legacy/application-abi.md

Please let me know if you would like to use the SHA-based link.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
