### PR TITLE
Fix the link to the `wasm.h` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ languages**, so you can use WebAssembly _anywhere_.
 | | Language | Package | Documentation |
 |-|-|-|-|
 | ![Rust logo] | [**Rust**][Rust integration] | [`wasmer` Rust crate] | [Learn][rust docs]
-| ![C logo] | [**C/C++**][C integration] | [`wasmer.h` header] | [Learn][c docs] |
+| ![C logo] | [**C/C++**][C integration] | [`wasm.h` header] | [Learn][c docs] |
 | ![C# logo] | [**C#**][C# integration] | [`WasmerSharp` NuGet package] | [Learn][c# docs] |
 | ![D logo] | [**D**][D integration] | [`wasmer` Dub package] | [Learn][d docs] |
 | ![Python logo] | [**Python**][Python integration] | [`wasmer` PyPI package] | [Learn][python docs] |
@@ -149,7 +149,7 @@ languages**, so you can use WebAssembly _anywhere_.
 
 [c logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/c.svg
 [c integration]: https://github.com/wasmerio/wasmer/tree/master/lib/c-api
-[`wasmer.h` header]: https://github.com/wasmerio/wasmer/blob/master/lib/c-api/wasmer.h
+[`wasm.h` header]: https://github.com/wasmerio/wasmer/blob/master/lib/c-api/tests/wasm-c-api/include/wasm.h
 [c docs]: https://docs.rs/wasmer-c-api/*/wasmer/wasm_c_api/index.html
 
 [c# logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/csharp.svg


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
This PR fixes the broken link to the `wasm.h` header.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
