### PR TITLE
Update regex crate to 1.5+ (from 1.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -35,7 +35,7 @@ features = ["llvm12-0", "target-x86", "target-aarch64"]
 [build-dependencies]
 cc = "1.0"
 lazy_static = "1.4"
-regex = "1.3"
+regex = "1.5"
 semver = "1.0"
 rustc_version = "0.4"
 


### PR DESCRIPTION

# Description
Update regex crate as 1.5.4 as a security alert.