### PR TITLE
Use a pool of stack for running Wasm code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
  "mach",

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -26,6 +26,7 @@ loupe = { version = "0.1", features = ["enable-indexmap"] }
 enum-iterator = "0.7.0"
 corosensei = { version = "0.1.2" }
 scopeguard = "1.1.0"
+lazy_static = "1.4.0"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 mach = "0.3.2"


### PR DESCRIPTION
Previous we would allocate a new stack on every entry into Wasm code.
This PR caches the stacks in a pool which allows them to be reused.