### PR TITLE
Fix JsImportObject resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+### Fixed
+- [#2828](https://github.com/wasmerio/wasmer/pull/2828) Fix JsImportObject resolver.
+
 ## 2.2.1 - 2022/03/15
 
 ### Fixed

--- a/lib/api/src/js/js_import_object.rs
+++ b/lib/api/src/js/js_import_object.rs
@@ -50,7 +50,7 @@ impl JsImportObject {
     /// import_object.get_export("module", "name");
     /// ```
     pub fn get_export(&self, module: &str, name: &str) -> Option<Export> {
-        let namespace = js_sys::Reflect::get(&self.object, &name.into()).ok()?;
+        let namespace = js_sys::Reflect::get(&self.object, &module.into()).ok()?;
         let js_export = js_sys::Reflect::get(&namespace, &name.into()).ok()?;
         match self
             .module_imports


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

The `JsImportObject.get_export` implementation is apparently broken. The second argument of `WASI.instantiate` of `@wasmer/wasi` doesn't work at all due to this issue.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
