### PR TITLE
Improve error message oriented from JS object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+### Fixed
+- [#2829](https://github.com/wasmerio/wasmer/pull/2829) Improve error message oriented from JS object.
+
 ## 2.2.1 - 2022/03/15
 
 ### Fixed

--- a/lib/api/src/js/trap.rs
+++ b/lib/api/src/js/trap.rs
@@ -43,7 +43,7 @@ impl fmt::Display for RuntimeErrorSource {
         match self {
             Self::Generic(s) => write!(f, "{}", s),
             Self::User(s) => write!(f, "{}", s),
-            Self::Js(s) => write!(f, "{}", s.as_string().unwrap_or("".to_string())),
+            Self::Js(s) => write!(f, "{:?}", s),
         }
     }
 }


### PR DESCRIPTION

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

`JsValue.as_string` converts the value to String iff the value is a
String itself, so the error message always failovers to empty string.
`JsValue` impls `Debug` using `JSON.stringify`, and it gives better
description of the error.


# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
