### PR TITLE
wasmer-cli: remove wasi-experimental-io-devices from default builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+### Changed
+- #2864 wasmer-cli: remove wasi-experimental-io-devices from default builds
+
 ### Fixed
 - [#2829](https://github.com/wasmerio/wasmer/pull/2829) Improve error message oriented from JS object.
 - [#2828](https://github.com/wasmerio/wasmer/pull/2828) Fix JsImportObject resolver.

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -70,7 +70,6 @@ default = [
     "cache",
     "wasi",
     "emscripten",
-    "experimental-io-devices",
 ]
 engine = []
 universal = [


### PR DESCRIPTION
wasi-experimental-io-devices introduces extra build and possibly runtime lib
dependencies, which are unnecessary for the vast majority of users.

Closes #2863

- [x] Add a short description of the change to the CHANGELOG.md file
