### PR TITLE
Fix implementation of ValueType for __wasi_subscription_t

### DIFF
--- a/lib/wasi-types/src/subscription.rs
+++ b/lib/wasi-types/src/subscription.rs
@@ -145,7 +145,7 @@ unsafe impl ValueType for __wasi_subscription_t {
         }
         self.userdata
             .zero_padding_bytes(&mut bytes[field!(userdata)..field_end!(userdata)]);
-        zero!(field_end!(userdata), field!(u));
+        zero!(field_end!(userdata), field!(type_));
         self.type_
             .zero_padding_bytes(&mut bytes[field!(type_)..field_end!(type_)]);
         zero!(field_end!(type_), field!(u));

--- a/lib/wasi-types/src/versions/snapshot0.rs
+++ b/lib/wasi-types/src/versions/snapshot0.rs
@@ -54,7 +54,7 @@ unsafe impl ValueType for __wasi_subscription_t {
         }
         self.userdata
             .zero_padding_bytes(&mut bytes[field!(userdata)..field_end!(userdata)]);
-        zero!(field_end!(userdata), field!(u));
+        zero!(field_end!(userdata), field!(type_));
         self.type_
             .zero_padding_bytes(&mut bytes[field!(type_)..field_end!(type_)]);
         zero!(field_end!(type_), field!(u));


### PR DESCRIPTION
There was a typo in zero_padding_bytes which caused the type_ field to
be zeroed.

Fixes #2865