### PR TITLE
Fix conditional build for get_default_compiler_config of C-Api

### DIFF
--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -289,7 +289,7 @@ pub struct wasm_engine_t {
 #[cfg(feature = "compiler")]
 use wasmer_api::CompilerConfig;
 
-#[cfg(feature = "compiler")]
+#[cfg(all(feature = "compiler", any(feature = "universal", feature = "dylib")))]
 fn get_default_compiler_config() -> Box<dyn CompilerConfig> {
     cfg_if! {
         if #[cfg(feature = "cranelift")] {


### PR DESCRIPTION
# Description
Fixed conditional build condition for `get_default_compiler_config(...)`

Fixes #2839 