### PR TITLE
bors.toml: Update status checks

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,10 +4,9 @@ status = [
     "Test on linux-x64",
     # "Test on linux-musl-x64",
     # "Test on linux-aarch64",
+    "Test on macos-arm64",
     "Test on macos-x64",
     "Test on windows-x64",
-    "Test cross-compile on linux",
-    "Test cross-compile on macos",
 ]
 required_approvals = 0
 timeout_sec = 7200


### PR DESCRIPTION
bors.toml wasn't updated with the new workflows merged in 86818452411dbeb290610f58f7ef23debf6a4ea9
and bors was timing out waiting on statuses that weren't there.