### PR TITLE
Update yanked crate version (crossbeam-channel 0.5.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1750,14 +1750,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 


### PR DESCRIPTION
`cargo-deny` failed with

```
error[A005]: detected yanked crate
   ┌─ /github/workspace/Cargo.lock:44:1
   │
44 │ crossbeam-channel 0.5.2 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------------------- yanked version
   │
   = crossbeam-channel v0.5.2
     └── rayon-core v1.9.1
         └── rayon v1.5.1
             ├── criterion v0.3.5
             │   ├── (dev) wasmer-cache v2.2.1
             │   │   └── wasmer-workspace v2.2.1
             │   └── (dev) wasmer-workspace v2.2.1 (*)
             ├── wasmer-compiler-cranelift v2.2.1
             │   ├── wasmer v2.2.1
             │   │   ├── wasmer-cache v2.2.1 (*)
             │   │   ├── (dev) wasmer-derive v2.2.1
             │   │   │   ├── wasmer v2.2.1 (*)
             │   │   │   └── wasmer v2.2.1 (*)
             │   │   ├── wasmer-emscripten v2.2.1
             │   │   │   └── wasmer-workspace v2.2.1 (*)
             │   │   ├── (dev) wasmer-middlewares v2.2.1
             │   │   │   └── wasmer-workspace v2.2.1 (*)
             │   │   ├── wasmer-middlewares v2.2.1 (*)
             │   │   ├── wasmer-wasi v2.2.1
             │   │   │   ├── wasmer-wast v2.2.1
             │   │   │   │   └── wasmer-workspace v2.2.1 (*)
             │   │   │   └── wasmer-workspace v2.2.1 (*)
             │   │   ├── wasmer-wast v2.2.1 (*)
             │   │   └── wasmer-workspace v2.2.1 (*)
             │   └── wasmer-workspace v2.2.1 (*)
             ├── wasmer-compiler-llvm v2.2.1
             │   ├── wasmer v2.2.1 (*)
             │   └── wasmer-workspace v2.2.1 (*)
             └── wasmer-compiler-singlepass v2.2.1
                 ├── wasmer v2.2.1 (*)
                 ├── (dev) wasmer-cache v2.2.1 (*)
                 └── wasmer-workspace v2.2.1 (*)

```