### PR TITLE
Fix clippy lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+### Fixed
+- [#2942](https://github.com/wasmerio/wasmer/pull/2942) Fix clippy lints.
 
 ## 2.3.0 - 2022/06/06
 

--- a/Makefile
+++ b/Makefile
@@ -745,11 +745,11 @@ install-wasmer-headless-minimal:
 update-testsuite:
 	git subtree pull --prefix tests/wast/spec https://github.com/WebAssembly/testsuite.git master --squash
 
-lint-packages: RUSTFLAGS += -D dead-code -D nonstandard-style -D unused-imports -D unused-mut -D unused-variables -D unused-unsafe -D unreachable-patterns -D bad-style -D improper-ctypes -D unused-allocation -D unused-comparisons -D while-true -D unconditional-recursion -D bare-trait-objects # TODO: add `-D missing-docs` # TODO: add `-D function_item_references` (not available on Rust 1.47, try when upgrading)
+lint-packages: RUSTFLAGS += -D dead-code -D nonstandard-style -D unused-imports -D unused-mut -D unused-variables -D unused-unsafe -D unreachable-patterns -D bad-style -D improper-ctypes -D unused-allocation -D unused-comparisons -D while-true -D unconditional-recursion -D bare-trait-objects -D function_item_references # TODO: add `-D missing-docs`
 lint-packages:
-	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --all $(exclude_tests)
-	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --manifest-path lib/cli/Cargo.toml $(compiler_features)
-	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --manifest-path fuzz/Cargo.toml $(compiler_features)
+	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --all -- -D clippy::all
+	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --manifest-path lib/cli/Cargo.toml $(compiler_features) -- -D clippy::all
+	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --manifest-path fuzz/Cargo.toml $(compiler_features) -- -D clippy::all
 
 lint-formatting:
 	cargo fmt --all -- --check

--- a/lib/api/src/js/ptr.rs
+++ b/lib/api/src/js/ptr.rs
@@ -145,8 +145,7 @@ impl<T, M: MemorySize> WasmPtr<T, M> {
     ///
     /// This method returns an error if an address overflow occurs.
     #[inline]
-    #[must_use]
-    pub fn add(self, offset: M::Offset) -> Result<Self, MemoryAccessError> {
+    pub fn add_offset(self, offset: M::Offset) -> Result<Self, MemoryAccessError> {
         let base = self.offset.into();
         let index = offset.into();
         let offset = index
@@ -164,8 +163,7 @@ impl<T, M: MemorySize> WasmPtr<T, M> {
     ///
     /// This method returns an error if an address overflow occurs.
     #[inline]
-    #[must_use]
-    pub fn sub(self, offset: M::Offset) -> Result<Self, MemoryAccessError> {
+    pub fn sub_offset(self, offset: M::Offset) -> Result<Self, MemoryAccessError> {
         let base = self.offset.into();
         let index = offset.into();
         let offset = index
@@ -226,7 +224,7 @@ impl<T: ValueType, M: MemorySize> WasmPtr<T, M> {
         let mut vec = Vec::new();
         for i in 0u64.. {
             let i = M::Offset::try_from(i).map_err(|_| MemoryAccessError::Overflow)?;
-            let val = self.add(i)?.deref(memory).read()?;
+            let val = self.add_offset(i)?.deref(memory).read()?;
             if end(&val) {
                 break;
             }

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -6,12 +6,12 @@
     missing_docs,
     trivial_numeric_casts,
     unused_extern_crates,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![warn(unused_import_braces)]
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::new_without_default, vtable_address_comparisons)
+    allow(clippy::new_without_default, clippy::vtable_address_comparisons)
 )]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/lib/api/src/sys/exports.rs
+++ b/lib/api/src/sys/exports.rs
@@ -170,7 +170,7 @@ impl Exports {
         T: ExportableWithGenerics<'a, Args, Rets>,
     {
         let mut out: T = self.get_with_generics(name)?;
-        out.into_weak_instance_ref();
+        out.convert_to_weak_instance_ref();
         Ok(out)
     }
 
@@ -279,7 +279,7 @@ impl IntoIterator for Exports {
     type Item = (String, Extern);
 
     fn into_iter(self) -> Self::IntoIter {
-        self.map.clone().into_iter()
+        self.map.into_iter()
     }
 }
 
@@ -311,7 +311,7 @@ pub trait Exportable<'a>: Sized {
     /// Convert the extern internally to hold a weak reference to the `InstanceRef`.
     /// This is useful for preventing cycles, for example for data stored in a
     /// type implementing `WasmerEnv`.
-    fn into_weak_instance_ref(&mut self);
+    fn convert_to_weak_instance_ref(&mut self);
 }
 
 /// A trait for accessing exports (like [`Exportable`]) but it takes generic
@@ -323,7 +323,7 @@ pub trait ExportableWithGenerics<'a, Args: WasmTypeList, Rets: WasmTypeList>: Si
     /// Convert the extern internally to hold a weak reference to the `InstanceRef`.
     /// This is useful for preventing cycles, for example for data stored in a
     /// type implementing `WasmerEnv`.
-    fn into_weak_instance_ref(&mut self);
+    fn convert_to_weak_instance_ref(&mut self);
 }
 
 /// We implement it for all concrete [`Exportable`] types (that are `Clone`)
@@ -333,7 +333,7 @@ impl<'a, T: Exportable<'a> + Clone + 'static> ExportableWithGenerics<'a, (), ()>
         T::get_self_from_extern(_extern).map(|i| i.clone())
     }
 
-    fn into_weak_instance_ref(&mut self) {
-        <Self as Exportable>::into_weak_instance_ref(self);
+    fn convert_to_weak_instance_ref(&mut self) {
+        <Self as Exportable>::convert_to_weak_instance_ref(self);
     }
 }

--- a/lib/api/src/sys/externals/global.rs
+++ b/lib/api/src/sys/externals/global.rs
@@ -254,10 +254,9 @@ impl<'a> Exportable<'a> for Global {
         }
     }
 
-    fn into_weak_instance_ref(&mut self) {
-        self.vm_global
-            .instance_ref
-            .as_mut()
-            .map(|v| *v = v.downgrade());
+    fn convert_to_weak_instance_ref(&mut self) {
+        if let Some(v) = self.vm_global.instance_ref.as_mut() {
+            *v = v.downgrade();
+        }
     }
 }

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -215,7 +215,7 @@ impl Memory {
             .checked_add(buf.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > def.current_length.try_into().unwrap() {
-            Err(MemoryAccessError::HeapOutOfBounds)?;
+            return Err(MemoryAccessError::HeapOutOfBounds);
         }
         unsafe {
             volatile_memcpy_read(def.base.add(offset as usize), buf.as_mut_ptr(), buf.len());
@@ -245,7 +245,7 @@ impl Memory {
             .checked_add(buf.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > def.current_length.try_into().unwrap() {
-            Err(MemoryAccessError::HeapOutOfBounds)?;
+            return Err(MemoryAccessError::HeapOutOfBounds);
         }
         let buf_ptr = buf.as_mut_ptr() as *mut u8;
         unsafe {
@@ -269,7 +269,7 @@ impl Memory {
             .checked_add(data.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > def.current_length.try_into().unwrap() {
-            Err(MemoryAccessError::HeapOutOfBounds)?;
+            return Err(MemoryAccessError::HeapOutOfBounds);
         }
         unsafe {
             volatile_memcpy_write(data.as_ptr(), def.base.add(offset as usize), data.len());
@@ -302,11 +302,10 @@ impl<'a> Exportable<'a> for Memory {
         }
     }
 
-    fn into_weak_instance_ref(&mut self) {
-        self.vm_memory
-            .instance_ref
-            .as_mut()
-            .map(|v| *v = v.downgrade());
+    fn convert_to_weak_instance_ref(&mut self) {
+        if let Some(v) = self.vm_memory.instance_ref.as_mut() {
+            *v = v.downgrade();
+        }
     }
 }
 

--- a/lib/api/src/sys/externals/mod.rs
+++ b/lib/api/src/sys/externals/mod.rs
@@ -70,12 +70,12 @@ impl<'a> Exportable<'a> for Extern {
         Ok(_extern)
     }
 
-    fn into_weak_instance_ref(&mut self) {
+    fn convert_to_weak_instance_ref(&mut self) {
         match self {
-            Self::Function(f) => f.into_weak_instance_ref(),
-            Self::Global(g) => g.into_weak_instance_ref(),
-            Self::Memory(m) => m.into_weak_instance_ref(),
-            Self::Table(t) => t.into_weak_instance_ref(),
+            Self::Function(f) => f.convert_to_weak_instance_ref(),
+            Self::Global(g) => g.convert_to_weak_instance_ref(),
+            Self::Memory(m) => m.convert_to_weak_instance_ref(),
+            Self::Table(t) => t.convert_to_weak_instance_ref(),
         }
     }
 }

--- a/lib/api/src/sys/externals/table.rs
+++ b/lib/api/src/sys/externals/table.rs
@@ -182,10 +182,9 @@ impl<'a> Exportable<'a> for Table {
         }
     }
 
-    fn into_weak_instance_ref(&mut self) {
-        self.vm_table
-            .instance_ref
-            .as_mut()
-            .map(|v| *v = v.downgrade());
+    fn convert_to_weak_instance_ref(&mut self) {
+        if let Some(v) = self.vm_table.instance_ref.as_mut() {
+            *v = v.downgrade();
+        }
     }
 }

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -168,7 +168,7 @@ impl Instance {
     ///  * Runtime errors that happen when running the module `start` function.
     pub fn new_by_index(module: &Module, externs: &[Extern]) -> Result<Self, InstantiationError> {
         let store = module.store();
-        let imports = externs.iter().cloned().collect::<Vec<_>>();
+        let imports = externs.to_vec();
         let handle = module.instantiate(&imports)?;
         let exports = module
             .exports()

--- a/lib/api/src/sys/mem_access.rs
+++ b/lib/api/src/sys/mem_access.rs
@@ -29,12 +29,12 @@ pub enum MemoryAccessError {
 
 impl From<MemoryAccessError> for RuntimeError {
     fn from(err: MemoryAccessError) -> Self {
-        RuntimeError::new(err.to_string())
+        Self::new(err.to_string())
     }
 }
 impl From<FromUtf8Error> for MemoryAccessError {
     fn from(_err: FromUtf8Error) -> Self {
-        MemoryAccessError::NonUtf8String
+        Self::NonUtf8String
     }
 }
 
@@ -191,6 +191,12 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
         self.len
     }
 
+    /// Returns `true` if the number of elements is 0.
+    #[inline]
+    pub fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
     /// Get a reference to the Wasm memory backing this reference.
     #[inline]
     pub fn memory(self) -> &'a Memory {
@@ -343,7 +349,7 @@ impl<'a, T: ValueType> Iterator for WasmSliceIter<'a, T> {
     type Item = WasmRef<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.slice.len() != 0 {
+        if !self.slice.is_empty() {
             let elem = self.slice.index(0);
             self.slice = self.slice.subslice(1..self.slice.len());
             Some(elem)
@@ -359,7 +365,7 @@ impl<'a, T: ValueType> Iterator for WasmSliceIter<'a, T> {
 
 impl<'a, T: ValueType> DoubleEndedIterator for WasmSliceIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.slice.len() != 0 {
+        if !self.slice.is_empty() {
             let elem = self.slice.index(self.slice.len() - 1);
             self.slice = self.slice.subslice(0..self.slice.len() - 1);
             Some(elem)

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -345,11 +345,10 @@ impl Module {
     pub fn set_name(&mut self, name: &str) -> bool {
         Arc::get_mut(&mut self.artifact)
             .and_then(|artifact| artifact.module_mut())
-            .map(|mut module_info| {
+            .map_or(false, |mut module_info| {
                 module_info.name = Some(name.to_string());
                 true
             })
-            .unwrap_or(false)
     }
 
     /// Returns an iterator over the imported types in the Module.
@@ -376,7 +375,7 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn imports<'a>(&'a self) -> ImportsIterator<impl Iterator<Item = ImportType> + 'a> {
+    pub fn imports(&self) -> ImportsIterator<impl Iterator<Item = ImportType> + '_> {
         self.artifact.module_ref().imports()
     }
 
@@ -403,7 +402,7 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn exports<'a>(&'a self) -> ExportsIterator<impl Iterator<Item = ExportType> + 'a> {
+    pub fn exports(&self) -> ExportsIterator<impl Iterator<Item = ExportType> + '_> {
         self.artifact.module_ref().exports()
     }
 
@@ -430,7 +429,7 @@ impl Module {
     /// However, the usage is highly discouraged.
     #[doc(hidden)]
     pub fn info(&self) -> &ModuleInfo {
-        &self.artifact.module_ref()
+        self.artifact.module_ref()
     }
 
     /// Gets the [`Artifact`] used internally by the Module.

--- a/lib/api/src/sys/native.rs
+++ b/lib/api/src/sys/native.rs
@@ -132,6 +132,7 @@ macro_rules! impl_native_traits {
             Rets: WasmTypeList,
         {
             /// Call the typed func and return results.
+            #[allow(clippy::too_many_arguments)]
             pub fn call(&self, $( $x: $x, )* ) -> Result<Rets, RuntimeError> {
                 if !self.is_host() {
                     // We assume the trampoline is always going to be present for
@@ -233,7 +234,7 @@ macro_rules! impl_native_traits {
                 crate::Function::get_self_from_extern(_extern)?.native().map_err(|_| crate::sys::exports::ExportError::IncompatibleType)
             }
 
-            fn into_weak_instance_ref(&mut self) {
+            fn convert_to_weak_instance_ref(&mut self) {
                 self.exported.vm_function.instance_ref.as_mut().map(|v| *v = v.downgrade());
             }
         }

--- a/lib/api/src/sys/store.rs
+++ b/lib/api/src/sys/store.rs
@@ -80,7 +80,7 @@ impl PartialEq for Store {
 
 unsafe impl TrapHandler for Store {
     fn custom_trap_handler(&self, call: &dyn Fn(&TrapHandlerFn) -> bool) -> bool {
-        if let Some(handler) = *&self.trap_handler.read().unwrap().as_ref() {
+        if let Some(handler) = self.trap_handler.read().unwrap().as_ref() {
             call(handler)
         } else {
             false

--- a/lib/api/src/sys/types.rs
+++ b/lib/api/src/sys/types.rs
@@ -37,17 +37,17 @@ impl From<Function> for Val {
 /// It provides useful functions for converting back and forth
 /// from [`Val`] into `FuncRef`.
 pub trait ValFuncRef {
-    fn into_vm_funcref(&self, store: &Store) -> Result<VMFuncRef, RuntimeError>;
+    fn into_vm_funcref(self, store: &Store) -> Result<VMFuncRef, RuntimeError>;
 
     fn from_vm_funcref(item: VMFuncRef, store: &Store) -> Self;
 
-    fn into_table_reference(&self, store: &Store) -> Result<wasmer_vm::TableElement, RuntimeError>;
+    fn into_table_reference(self, store: &Store) -> Result<wasmer_vm::TableElement, RuntimeError>;
 
     fn from_table_reference(item: wasmer_vm::TableElement, store: &Store) -> Self;
 }
 
 impl ValFuncRef for Val {
-    fn into_vm_funcref(&self, store: &Store) -> Result<VMFuncRef, RuntimeError> {
+    fn into_vm_funcref(self, store: &Store) -> Result<VMFuncRef, RuntimeError> {
         if !self.comes_from_same_store(store) {
             return Err(RuntimeError::new("cross-`Store` values are not supported"));
         }
@@ -90,13 +90,13 @@ impl ValFuncRef for Val {
         Self::FuncRef(Some(f))
     }
 
-    fn into_table_reference(&self, store: &Store) -> Result<wasmer_vm::TableElement, RuntimeError> {
+    fn into_table_reference(self, store: &Store) -> Result<wasmer_vm::TableElement, RuntimeError> {
         if !self.comes_from_same_store(store) {
             return Err(RuntimeError::new("cross-`Store` values are not supported"));
         }
         Ok(match self {
             // TODO(reftypes): review this clone
-            Self::ExternRef(extern_ref) => wasmer_vm::TableElement::ExternRef(extern_ref.clone()),
+            Self::ExternRef(extern_ref) => wasmer_vm::TableElement::ExternRef(extern_ref),
             Self::FuncRef(None) => wasmer_vm::TableElement::FuncRef(VMFuncRef::null()),
             Self::FuncRef(Some(f)) => wasmer_vm::TableElement::FuncRef(f.vm_funcref()),
             _ => return Err(RuntimeError::new("val is not reference")),

--- a/lib/artifact/src/artifact.rs
+++ b/lib/artifact/src/artifact.rs
@@ -120,13 +120,17 @@ impl MetadataHeader {
     pub const ALIGN: usize = 16;
 
     /// Creates a new header for metadata of the given length.
-    pub fn new(len: usize) -> [u8; 16] {
-        let header = MetadataHeader {
+    pub fn new(len: usize) -> Self {
+        Self {
             magic: Self::MAGIC,
             version: Self::CURRENT_VERSION,
             len: len.try_into().expect("metadata exceeds maximum length"),
-        };
-        unsafe { mem::transmute(header) }
+        }
+    }
+
+    /// Convert the header into its bytes representation.
+    pub fn into_bytes(self) -> [u8; 16] {
+        unsafe { mem::transmute(self) }
     }
 
     /// Parses the header and returns the length of the metadata following it.
@@ -143,7 +147,7 @@ impl MetadataHeader {
             })?
             .try_into()
             .unwrap();
-        let header: MetadataHeader = unsafe { mem::transmute(bytes) };
+        let header: Self = unsafe { mem::transmute(bytes) };
         if header.magic != Self::MAGIC {
             return Err(DeserializeError::Incompatible(
                 "The provided bytes were not serialized by Wasmer".to_string(),

--- a/lib/artifact/src/lib.rs
+++ b/lib/artifact/src/lib.rs
@@ -12,8 +12,7 @@
         clippy::float_arithmetic,
         clippy::mut_mut,
         clippy::nonminimal_bool,
-        clippy::option_map_unwrap_or,
-        clippy::option_map_unwrap_or_else,
+        clippy::map_unwrap_or,
         clippy::print_stdout,
         clippy::unicode_not_nfc,
         clippy::use_self

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -303,11 +303,11 @@ fn build_cdylib_link_arg() {
             // This is only set up to work on GNU toolchain versions of Rust
             lines.push(format!(
                 "-Wl,--out-implib,{}",
-                shared_object_dir.join("wasmer.dll.a".to_string()).display()
+                shared_object_dir.join("wasmer.dll.a").display()
             ));
             lines.push(format!(
                 "-Wl,--output-def,{}",
-                shared_object_dir.join("wasmer.def".to_string()).display()
+                shared_object_dir.join("wasmer.def").display()
             ));
         }
 

--- a/lib/c-api/src/error.rs
+++ b/lib/c-api/src/error.rs
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn wasmer_last_error_message(
     };
 
     let error_message = match take_last_error() {
-        Some(err) => err.to_string(),
+        Some(err) => err,
         None => return 0,
     };
 

--- a/lib/c-api/src/lib.rs
+++ b/lib/c-api/src/lib.rs
@@ -23,6 +23,9 @@
     unused_unsafe,
     unreachable_patterns
 )]
+// Because this crate exposes a lot of C APIs which are unsafe by definition,
+// we allow unsafe without explicit safety documentation for each of them.
+#![allow(clippy::missing_safety_doc)]
 
 pub mod error;
 pub mod wasm_c_api;

--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -435,8 +435,7 @@ pub extern "C" fn wasm_engine_new_with_config(
     #[allow(dead_code)]
     fn return_with_error(msg: &str) -> Option<Box<wasm_engine_t>> {
         update_last_error(msg);
-
-        return None;
+        None
     }
 
     let config = config?;

--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn wasm_func_new(
     let num_rets = func_sig.results().len();
     let inner_callback = move |args: &[Val]| -> Result<Vec<Val>, RuntimeError> {
         let processed_args: wasm_val_vec_t = args
-            .into_iter()
+            .iter()
             .map(TryInto::try_into)
             .collect::<Result<Vec<wasm_val_t>, _>>()
             .expect("Argument conversion failed")
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
 
     let trampoline = move |env: &WrapperEnv, args: &[Val]| -> Result<Vec<Val>, RuntimeError> {
         let processed_args: wasm_val_vec_t = args
-            .into_iter()
+            .iter()
             .map(TryInto::try_into)
             .collect::<Result<Vec<wasm_val_t>, _>>()
             .expect("Argument conversion failed")
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn wasm_func_call(
             for (slot, val) in results
                 .as_uninit_slice()
                 .iter_mut()
-                .zip(wasm_results.into_iter())
+                .zip(wasm_results.iter())
             {
                 *slot = MaybeUninit::new(val.try_into().expect("Results conversion failed"));
             }

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn wasm_global_same(
 
 #[no_mangle]
 pub extern "C" fn wasm_global_type(global: &wasm_global_t) -> Box<wasm_globaltype_t> {
-    Box::new(wasm_globaltype_t::new(global.inner.ty().clone()))
+    Box::new(wasm_globaltype_t::new(*global.inner.ty()))
 }
 
 #[cfg(test)]

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn wasm_memory_new(
     let store = store?;
     let memory_type = memory_type?;
 
-    let memory_type = memory_type.inner().memory_type.clone();
+    let memory_type = memory_type.inner().memory_type;
     let memory = c_try!(Memory::new(&store.inner, memory_type));
 
     Some(Box::new(wasm_memory_t::new(memory)))
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn wasm_memory_type(
 ) -> Option<Box<wasm_memorytype_t>> {
     let memory = memory?;
 
-    Some(Box::new(wasm_memorytype_t::new(memory.inner.ty().clone())))
+    Some(Box::new(wasm_memorytype_t::new(memory.inner.ty())))
 }
 
 // get a raw pointer into bytes

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -82,15 +82,9 @@ impl wasm_extern_t {
             CApiExternTag::Function => {
                 ExternType::Function(unsafe { self.inner.function.inner.ty().clone() })
             }
-            CApiExternTag::Memory => {
-                ExternType::Memory(unsafe { self.inner.memory.inner.ty().clone() })
-            }
-            CApiExternTag::Global => {
-                ExternType::Global(unsafe { self.inner.global.inner.ty().clone() })
-            }
-            CApiExternTag::Table => {
-                ExternType::Table(unsafe { self.inner.table.inner.ty().clone() })
-            }
+            CApiExternTag::Memory => ExternType::Memory(unsafe { self.inner.memory.inner.ty() }),
+            CApiExternTag::Global => ExternType::Global(unsafe { *self.inner.global.inner.ty() }),
+            CApiExternTag::Table => ExternType::Table(unsafe { *self.inner.table.inner.ty() }),
         }
     }
 }

--- a/lib/c-api/src/wasm_c_api/types/function.rs
+++ b/lib/c-api/src/wasm_c_api/types/function.rs
@@ -57,7 +57,7 @@ impl wasm_functype_t {
 
     pub(crate) fn inner(&self) -> &WasmFunctionType {
         match &self.extern_type.inner {
-            WasmExternType::Function(wasm_function_type) => &wasm_function_type,
+            WasmExternType::Function(wasm_function_type) => wasm_function_type,
             _ => {
                 unreachable!("Data corruption: `wasm_functype_t` does not contain a function type")
             }

--- a/lib/c-api/src/wasm_c_api/types/global.rs
+++ b/lib/c-api/src/wasm_c_api/types/global.rs
@@ -38,7 +38,7 @@ impl wasm_globaltype_t {
 
     pub(crate) fn inner(&self) -> &WasmGlobalType {
         match &self.extern_type.inner {
-            WasmExternType::Global(wasm_global_type) => &wasm_global_type,
+            WasmExternType::Global(wasm_global_type) => wasm_global_type,
             _ => {
                 unreachable!("Data corruption: `wasm_globaltype_t` does not contain a global type")
             }

--- a/lib/c-api/src/wasm_c_api/types/memory.rs
+++ b/lib/c-api/src/wasm_c_api/types/memory.rs
@@ -40,7 +40,7 @@ impl wasm_memorytype_t {
 
     pub(crate) fn inner(&self) -> &WasmMemoryType {
         match &self.extern_type.inner {
-            WasmExternType::Memory(wasm_memory_type) => &wasm_memory_type,
+            WasmExternType::Memory(wasm_memory_type) => wasm_memory_type,
             _ => {
                 unreachable!("Data corruption: `wasm_memorytype_t` does not contain a memory type")
             }

--- a/lib/c-api/src/wasm_c_api/types/table.rs
+++ b/lib/c-api/src/wasm_c_api/types/table.rs
@@ -47,7 +47,7 @@ impl wasm_tabletype_t {
 
     pub(crate) fn inner(&self) -> &WasmTableType {
         match &self.extern_type.inner {
-            WasmExternType::Table(wasm_table_type) => &wasm_table_type,
+            WasmExternType::Table(wasm_table_type) => wasm_table_type,
             _ => unreachable!("Data corruption: `wasm_tabletype_t` does not contain a table type"),
         }
     }

--- a/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/middlewares/metering.rs
@@ -149,7 +149,7 @@ use wasmer_middlewares::{
 /// # Example
 ///
 /// See module's documentation.
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, clippy::type_complexity)]
 pub struct wasmer_metering_t {
     pub(crate) inner: Arc<Metering<Box<dyn Fn(&Operator) -> u64 + Send + Sync>>>,
 }

--- a/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
@@ -87,7 +87,7 @@ pub extern "C" fn wasmer_target_new(
     let cpu_features = cpu_features?;
 
     Some(Box::new(wasmer_target_t {
-        inner: Target::new(triple.inner.clone(), cpu_features.inner.clone()),
+        inner: Target::new(triple.inner.clone(), cpu_features.inner),
     }))
 }
 

--- a/lib/c-api/src/wasm_c_api/value.rs
+++ b/lib/c-api/src/wasm_c_api/value.rs
@@ -116,7 +116,7 @@ impl Clone for wasm_val_t {
     fn clone(&self) -> Self {
         wasm_val_t {
             kind: self.kind,
-            of: self.of.clone(),
+            of: self.of,
         }
     }
 }

--- a/lib/c-api/src/wasm_c_api/version.rs
+++ b/lib/c-api/src/wasm_c_api/version.rs
@@ -1,8 +1,8 @@
 use lazy_static::lazy_static;
 use std::os::raw::c_char;
 
-const VERSION: &'static str = concat!(env!("CARGO_PKG_VERSION"), "\0");
-const VERSION_PRE: &'static str = concat!(env!("CARGO_PKG_VERSION_PRE"), "\0");
+const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
+const VERSION_PRE: &str = concat!(env!("CARGO_PKG_VERSION_PRE"), "\0");
 
 lazy_static! {
     static ref VERSION_MAJOR: u8 = env!("CARGO_PKG_VERSION_MAJOR")

--- a/lib/c-api/src/wasm_c_api/wat.rs
+++ b/lib/c-api/src/wasm_c_api/wat.rs
@@ -8,6 +8,9 @@ use super::types::wasm_byte_vec_t;
 /// # Example
 ///
 /// See the module's documentation.
+///
+/// # Safety
+/// This function is unsafe in order to be callable from C.
 #[cfg(feature = "wat")]
 #[no_mangle]
 pub unsafe extern "C" fn wat2wasm(wat: &wasm_byte_vec_t, out: &mut wasm_byte_vec_t) {
@@ -17,7 +20,6 @@ pub unsafe extern "C" fn wat2wasm(wat: &wasm_byte_vec_t, out: &mut wasm_byte_vec
             crate::error::update_last_error(err);
             out.data = std::ptr::null_mut();
             out.size = 0;
-            return;
         }
     };
 }

--- a/lib/cli/src/c_gen/mod.rs
+++ b/lib/cli/src/c_gen/mod.rs
@@ -124,7 +124,7 @@ impl CType {
                 // function with no, name, assume it's a function pointer
                 let ret: CType = return_value
                     .as_ref()
-                    .map(|i: &Box<CType>| (&**i).clone())
+                    .map(|i| (**i).clone())
                     .unwrap_or_default();
                 ret.generate_c(w);
                 w.push(' ');
@@ -181,7 +181,7 @@ impl CType {
             } => {
                 let ret: CType = return_value
                     .as_ref()
-                    .map(|i: &Box<CType>| (&**i).clone())
+                    .map(|i| (**i).clone())
                     .unwrap_or_default();
                 ret.generate_c(w);
                 w.push(' ');

--- a/lib/cli/src/commands/binfmt.rs
+++ b/lib/cli/src/commands/binfmt.rs
@@ -118,9 +118,8 @@ impl Binfmt {
                     .collect::<Vec<_>>()
                     .into_iter()
                     .collect::<Result<Vec<_>>>()?;
-                match (self.action, unregister.into_iter().any(|b| b)) {
-                    (Unregister, false) => bail!("Nothing unregistered"),
-                    _ => (),
+                if let (Unregister, false) = (self.action, unregister.into_iter().any(|b| b)) {
+                    bail!("Nothing unregistered");
                 }
             }
             _ => (),
@@ -139,7 +138,7 @@ impl Binfmt {
                         .open(register)
                         .context("Open binfmt misc for registration")?;
                     register
-                        .write_all(&spec)
+                        .write_all(spec)
                         .context("Couldn't register binfmt")?;
                     Ok(())
                 })

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -59,14 +59,14 @@ impl Wasi {
     pub fn get_versions(module: &Module) -> Option<BTreeSet<WasiVersion>> {
         // Get the wasi version in strict mode, so no other imports are
         // allowed.
-        get_wasi_versions(&module, true)
+        get_wasi_versions(module, true)
     }
 
     /// Checks if a given module has any WASI imports at all.
     pub fn has_wasi_imports(module: &Module) -> bool {
         // Get the wasi version in non-strict mode, so no other imports
         // are allowed
-        get_wasi_versions(&module, false).is_some()
+        get_wasi_versions(module, false).is_some()
     }
 
     /// Helper function for instantiating a module with Wasi imports for the `Run` command.
@@ -94,8 +94,8 @@ impl Wasi {
         }
 
         let mut wasi_env = wasi_state_builder.finalize()?;
-        let import_object = wasi_env.import_object_for_all_wasi_versions(&module)?;
-        let instance = Instance::new(&module, &import_object)?;
+        let import_object = wasi_env.import_object_for_all_wasi_versions(module)?;
+        let instance = Instance::new(module, &import_object)?;
         Ok(instance)
     }
 
@@ -121,7 +121,7 @@ impl Wasi {
         use std::env;
         let dir = env::var_os("WASMER_BINFMT_MISC_PREOPEN")
             .map(Into::into)
-            .unwrap_or(PathBuf::from("."));
+            .unwrap_or_else(|| PathBuf::from("."));
         Ok(Self {
             deny_multiple_wasi_versions: true,
             env_vars: env::vars().collect(),

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -242,13 +242,13 @@ impl CompilerOptions {
                         }
                         CompiledKind::FunctionCallTrampoline(func_type) => format!(
                             "trampoline_call_{}_{}",
-                            types_to_signature(&func_type.params()),
-                            types_to_signature(&func_type.results())
+                            types_to_signature(func_type.params()),
+                            types_to_signature(func_type.results())
                         ),
                         CompiledKind::DynamicFunctionTrampoline(func_type) => format!(
                             "trampoline_dynamic_{}_{}",
-                            types_to_signature(&func_type.params()),
-                            types_to_signature(&func_type.results())
+                            types_to_signature(func_type.params()),
+                            types_to_signature(func_type.results())
                         ),
                         CompiledKind::Module => "module".into(),
                     }

--- a/lib/compiler-cranelift/src/address_map.rs
+++ b/lib/compiler-cranelift/src/address_map.rs
@@ -5,7 +5,7 @@ use cranelift_codegen::Context;
 use cranelift_codegen::MachSrcLoc;
 use wasmer_compiler::{wasmparser::Range, FunctionAddressMap, InstructionAddressMap, SourceLoc};
 
-pub fn get_function_address_map<'data>(
+pub fn get_function_address_map(
     context: &Context,
     range: Range,
     body_len: usize,

--- a/lib/compiler-cranelift/src/dwarf.rs
+++ b/lib/compiler-cranelift/src/dwarf.rs
@@ -20,7 +20,7 @@ impl WriterRelocate {
             // We autodetect it, based on the host
             None => RunTimeEndian::default(),
         };
-        WriterRelocate {
+        Self {
             relocs: Vec::new(),
             writer: EndianVec::new(endianness),
         }

--- a/lib/compiler-cranelift/src/func_environ.rs
+++ b/lib/compiler-cranelift/src/func_environ.rs
@@ -744,7 +744,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     ) -> (ir::Value, ir::Value) {
         // We use an indirect call so that we don't have to patch the code at runtime.
         let pointer_type = self.pointer_type();
-        let vmctx = self.vmctx(&mut pos.func);
+        let vmctx = self.vmctx(pos.func);
         let base = pos.ins().global_value(pointer_type, vmctx);
 
         let mut mem_flags = ir::MemFlags::trusted();
@@ -834,7 +834,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         delta: ir::Value,
         init_value: ir::Value,
     ) -> WasmResult<ir::Value> {
-        let (func_sig, index_arg, func_idx) = self.get_table_grow_func(&mut pos.func, table_index);
+        let (func_sig, index_arg, func_idx) = self.get_table_grow_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, index_arg as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         let call_inst = pos.ins().call_indirect(
@@ -854,8 +854,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
     ) -> WasmResult<ir::Value> {
         let mut pos = builder.cursor();
 
-        let (func_sig, table_index_arg, func_idx) =
-            self.get_table_get_func(&mut pos.func, table_index);
+        let (func_sig, table_index_arg, func_idx) = self.get_table_get_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, table_index_arg as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         let call_inst = pos
@@ -874,8 +873,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
     ) -> WasmResult<()> {
         let mut pos = builder.cursor();
 
-        let (func_sig, table_index_arg, func_idx) =
-            self.get_table_set_func(&mut pos.func, table_index);
+        let (func_sig, table_index_arg, func_idx) = self.get_table_set_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, table_index_arg as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         pos.ins()
@@ -891,8 +889,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         val: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, table_index_arg, func_idx) =
-            self.get_table_fill_func(&mut pos.func, table_index);
+        let (func_sig, table_index_arg, func_idx) = self.get_table_fill_func(pos.func, table_index);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
 
         let table_index_arg = pos.ins().iconst(I32, table_index_arg as i64);
@@ -910,7 +907,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         mut pos: cranelift_codegen::cursor::FuncCursor<'_>,
         externref: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, func_idx) = self.get_externref_inc_func(&mut pos.func);
+        let (func_sig, func_idx) = self.get_externref_inc_func(pos.func);
         let (_vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
 
         pos.ins().call_indirect(func_sig, func_addr, &[externref]);
@@ -923,7 +920,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         mut pos: cranelift_codegen::cursor::FuncCursor<'_>,
         externref: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, func_idx) = self.get_externref_dec_func(&mut pos.func);
+        let (func_sig, func_idx) = self.get_externref_dec_func(pos.func);
         let (_vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
 
         pos.ins().call_indirect(func_sig, func_addr, &[externref]);
@@ -979,8 +976,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         //
         // prototyping with a function call though
 
-        let (func_sig, func_index_arg, func_idx) =
-            self.get_func_ref_func(&mut pos.func, func_index);
+        let (func_sig, func_index_arg, func_idx) = self.get_func_ref_func(pos.func, func_index);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
 
         let func_index_arg = pos.ins().iconst(I32, func_index_arg as i64);
@@ -1244,7 +1240,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         // so that we don't have to patch the code at runtime.
         let pointer_type = self.pointer_type();
         let sig_ref = pos.func.dfg.ext_funcs[callee].signature;
-        let vmctx = self.vmctx(&mut pos.func);
+        let vmctx = self.vmctx(pos.func);
         let base = pos.ins().global_value(pointer_type, vmctx);
 
         let mem_flags = ir::MemFlags::trusted();
@@ -1273,7 +1269,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         _heap: ir::Heap,
         val: ir::Value,
     ) -> WasmResult<ir::Value> {
-        let (func_sig, index_arg, func_idx) = self.get_memory_grow_func(&mut pos.func, index);
+        let (func_sig, index_arg, func_idx) = self.get_memory_grow_func(pos.func, index);
         let memory_index = pos.ins().iconst(I32, index_arg as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         let call_inst = pos
@@ -1288,7 +1284,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         index: MemoryIndex,
         _heap: ir::Heap,
     ) -> WasmResult<ir::Value> {
-        let (func_sig, index_arg, func_idx) = self.get_memory_size_func(&mut pos.func, index);
+        let (func_sig, index_arg, func_idx) = self.get_memory_size_func(pos.func, index);
         let memory_index = pos.ins().iconst(I32, index_arg as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         let call_inst = pos
@@ -1308,7 +1304,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, src_index, func_idx) = self.get_memory_copy_func(&mut pos.func, src_index);
+        let (func_sig, src_index, func_idx) = self.get_memory_copy_func(pos.func, src_index);
 
         let src_index_arg = pos.ins().iconst(I32, src_index as i64);
 
@@ -1329,8 +1325,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         val: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, memory_index, func_idx) =
-            self.get_memory_fill_func(&mut pos.func, memory_index);
+        let (func_sig, memory_index, func_idx) = self.get_memory_fill_func(pos.func, memory_index);
 
         let memory_index_arg = pos.ins().iconst(I32, memory_index as i64);
 
@@ -1355,7 +1350,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, func_idx) = self.get_memory_init_func(&mut pos.func);
+        let (func_sig, func_idx) = self.get_memory_init_func(pos.func);
 
         let memory_index_arg = pos.ins().iconst(I32, memory_index.index() as i64);
         let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
@@ -1372,7 +1367,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
     }
 
     fn translate_data_drop(&mut self, mut pos: FuncCursor, seg_index: u32) -> WasmResult<()> {
-        let (func_sig, func_idx) = self.get_data_drop_func(&mut pos.func);
+        let (func_sig, func_idx) = self.get_data_drop_func(pos.func);
         let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         pos.ins()
@@ -1386,7 +1381,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         table_index: TableIndex,
         _table: ir::Table,
     ) -> WasmResult<ir::Value> {
-        let (func_sig, index_arg, func_idx) = self.get_table_size_func(&mut pos.func, table_index);
+        let (func_sig, index_arg, func_idx) = self.get_table_size_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, index_arg as i64);
         let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
         let call_inst = pos
@@ -1407,7 +1402,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         len: ir::Value,
     ) -> WasmResult<()> {
         let (func_sig, dst_table_index_arg, src_table_index_arg, func_idx) =
-            self.get_table_copy_func(&mut pos.func, dst_table_index, src_table_index);
+            self.get_table_copy_func(pos.func, dst_table_index, src_table_index);
 
         let dst_table_index_arg = pos.ins().iconst(I32, dst_table_index_arg as i64);
         let src_table_index_arg = pos.ins().iconst(I32, src_table_index_arg as i64);
@@ -1440,8 +1435,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let (func_sig, table_index_arg, func_idx) =
-            self.get_table_init_func(&mut pos.func, table_index);
+        let (func_sig, table_index_arg, func_idx) = self.get_table_init_func(pos.func, table_index);
 
         let table_index_arg = pos.ins().iconst(I32, table_index_arg as i64);
         let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
@@ -1458,7 +1452,7 @@ impl<'module_environment> BaseFuncEnvironment for FuncEnvironment<'module_enviro
     }
 
     fn translate_elem_drop(&mut self, mut pos: FuncCursor, elem_index: u32) -> WasmResult<()> {
-        let (func_sig, func_idx) = self.get_elem_drop_func(&mut pos.func);
+        let (func_sig, func_idx) = self.get_elem_drop_func(pos.func);
 
         let elem_index_arg = pos.ins().iconst(I32, elem_index as i64);
 

--- a/lib/compiler-cranelift/src/translator/func_environ.rs
+++ b/lib/compiler-cranelift/src/translator/func_environ.rs
@@ -229,6 +229,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     ///
     /// The `index` provided identifies the linear memory to query, and `heap` is the heap reference
     /// returned by `make_heap` for the same index.
+    #[allow(clippy::too_many_arguments)]
     fn translate_memory_copy(
         &mut self,
         pos: FuncCursor,

--- a/lib/compiler-cranelift/src/translator/unwind.rs
+++ b/lib/compiler-cranelift/src/translator/unwind.rs
@@ -14,7 +14,7 @@ pub(crate) enum CraneliftUnwindInfo {
     WindowsX64(Vec<u8>),
     /// Dwarf FDE
     #[cfg(feature = "unwind")]
-    FDE(DwarfFDE),
+    Fde(DwarfFDE),
     /// No Unwind info attached
     None,
 }
@@ -52,7 +52,7 @@ pub(crate) fn compiled_function_unwind_info(
             unwind.emit(&mut data[..]);
             Ok(CraneliftUnwindInfo::WindowsX64(data))
         }
-        Some(UnwindInfo::SystemV(unwind)) => Ok(CraneliftUnwindInfo::FDE(unwind)),
+        Some(UnwindInfo::SystemV(unwind)) => Ok(CraneliftUnwindInfo::Fde(unwind)),
         Some(_) | None => Ok(CraneliftUnwindInfo::None),
     }
 }

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -252,7 +252,7 @@ impl Compiler for LLVMCompiler {
                         input,
                         self.config(),
                         memory_styles,
-                        &table_styles,
+                        table_styles,
                         &ShortNames {},
                     )
                 },
@@ -353,7 +353,7 @@ impl Compiler for LLVMCompiler {
                     FuncTrampoline::new(target_machine)
                 },
                 |func_trampoline, func_type| {
-                    func_trampoline.dynamic_trampoline(&func_type, self.config(), "")
+                    func_trampoline.dynamic_trampoline(func_type, self.config(), "")
                 },
             )
             .collect::<Result<Vec<_>, CompileError>>()?

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -110,6 +110,7 @@ impl LLVM {
             //
             // Since both linux and darwin use SysV ABI, this should work.
             //  but not in the case of Aarch64, there the ABI is slightly different
+            #[allow(clippy::match_single_binding)]
             match target.triple().architecture {
                 _ => wasmer_compiler::OperatingSystem::Linux,
             }
@@ -174,7 +175,7 @@ impl LLVM {
             .map(|feature| format!("+{}", feature.to_string()))
             .join(",");
 
-        let target_triple = self.target_triple(&target);
+        let target_triple = self.target_triple(target);
         let llvm_target = InkwellTarget::from_triple(&target_triple).unwrap();
         llvm_target
             .create_target_machine(

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -340,7 +340,7 @@ impl FuncTrampoline {
         }
 
         let callable_func = inkwell::values::CallableValue::try_from(func_ptr).unwrap();
-        let call_site = builder.build_call(callable_func, args_vec.as_slice().into(), "call");
+        let call_site = builder.build_call(callable_func, args_vec.as_slice(), "call");
         for (attr, attr_loc) in func_attrs {
             call_site.add_attribute(*attr_loc, *attr);
         }
@@ -475,7 +475,7 @@ impl FuncTrampoline {
                 for (idx, value) in results.iter().enumerate() {
                     let value = builder.build_bitcast(
                         *value,
-                        type_to_llvm(&intrinsics, func_sig.results()[idx])?,
+                        type_to_llvm(intrinsics, func_sig.results()[idx])?,
                         "",
                     );
                     struct_value = builder
@@ -487,9 +487,9 @@ impl FuncTrampoline {
                 builder.build_return(None);
             } else {
                 builder.build_return(Some(&self.abi.pack_values_for_register_return(
-                    &intrinsics,
+                    intrinsics,
                     &builder,
-                    &results.as_slice(),
+                    results.as_slice(),
                     &trampoline_func.get_type(),
                 )?));
             }

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -1126,7 +1126,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             cached_memory_size: HashMap::new(),
 
             // TODO: pointer width
-            offsets: VMOffsets::new(8, &wasm_module),
+            offsets: VMOffsets::new(8, wasm_module),
         }
     }
 
@@ -1435,7 +1435,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 let global_ptr = cache_builder
                     .build_bitcast(
                         global_ptr,
-                        type_to_llvm_ptr(&intrinsics, global_value_type)?,
+                        type_to_llvm_ptr(intrinsics, global_value_type)?,
                         "",
                     )
                     .into_pointer_value();
@@ -1478,6 +1478,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn local_func(
         &mut self,
         _local_function_index: LocalFunctionIndex,

--- a/lib/compiler-llvm/src/translator/state.rs
+++ b/lib/compiler-llvm/src/translator/state.rs
@@ -301,6 +301,7 @@ impl<'ctx> State<'ctx> {
         Ok((v1, v2))
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn pop2_extra(
         &mut self,
     ) -> Result<
@@ -331,6 +332,7 @@ impl<'ctx> State<'ctx> {
         Ok((v1, v2, v3))
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn pop3_extra(
         &mut self,
     ) -> Result<

--- a/lib/compiler-singlepass/src/address_map.rs
+++ b/lib/compiler-singlepass/src/address_map.rs
@@ -1,8 +1,8 @@
 use wasmer_compiler::{FunctionAddressMap, FunctionBodyData, InstructionAddressMap, SourceLoc};
 
-pub fn get_function_address_map<'data>(
+pub fn get_function_address_map(
     instructions: Vec<InstructionAddressMap>,
-    data: &FunctionBodyData<'data>,
+    data: &FunctionBodyData,
     body_len: usize,
 ) -> FunctionAddressMap {
     // Generate source loc for a function start/end to identify boundary within module.

--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -90,17 +90,14 @@ impl AbstractReg for GPR {
         self as usize > 18
     }
     fn is_reserved(self) -> bool {
-        match self.into_index() {
-            0..=16 | 19..=27 => false,
-            _ => true,
-        }
+        !matches!(self.into_index(), 0..=16 | 19..=27)
     }
     fn into_index(self) -> usize {
         self as usize
     }
     fn from_index(n: usize) -> Result<GPR, ()> {
         match n {
-            0..=31 => Ok(GPR::iterator().nth(n).unwrap().clone()),
+            0..=31 => Ok(*GPR::iterator().nth(n).unwrap()),
             _ => Err(()),
         }
     }
@@ -158,7 +155,7 @@ impl AbstractReg for NEON {
     }
     fn from_index(n: usize) -> Result<NEON, ()> {
         match n {
-            0..=31 => Ok(NEON::iterator().nth(n).unwrap().clone()),
+            0..=31 => Ok(*NEON::iterator().nth(n).unwrap()),
             _ => Err(()),
         }
     }
@@ -206,6 +203,7 @@ impl AbstractReg for NEON {
 
 /// A machine register under the x86-64 architecture.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ARM64Register {
     /// General-purpose registers.
     GPR(GPR),

--- a/lib/compiler-singlepass/src/common_decl.rs
+++ b/lib/compiler-singlepass/src/common_decl.rs
@@ -224,8 +224,7 @@ impl MachineState {
 impl MachineStateDiff {
     /// Creates a `MachineState` from the given `&FunctionStateMap`.
     pub fn _build_state(&self, m: &FunctionStateMap) -> MachineState {
-        let mut chain: Vec<&MachineStateDiff> = vec![];
-        chain.push(self);
+        let mut chain: Vec<&MachineStateDiff> = vec![self];
         let mut current = self.last;
         while let Some(x) = current {
             let that = &m.diffs[x];

--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -70,14 +70,14 @@ pub enum Condition {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 pub enum NeonOrMemory {
     NEON(NEON),
     Memory(GPR, i32),
 }
 
 #[derive(Copy, Clone, Debug)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 pub enum GPROrMemory {
     GPR(GPR),
     Memory(GPR, i32),
@@ -1165,14 +1165,14 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::Imm32(imm), Location::GPR(dst)) => {
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_64bit(imm as u64).is_some() {
+                if encode_logical_immediate_64bit(imm as u64).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; tst X(dst), imm as u64);
             }
             (Size::S64, Location::Imm64(imm), Location::GPR(dst)) => {
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_64bit(imm as u64).is_some() {
+                if encode_logical_immediate_64bit(imm as u64).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; tst X(dst), imm as u64);
@@ -1184,7 +1184,7 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::Imm32(imm), Location::GPR(dst)) => {
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_64bit(imm as u64).is_some() {
+                if encode_logical_immediate_64bit(imm as u64).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; tst W(dst), imm);
@@ -1458,7 +1458,7 @@ impl EmitterARM64 for Assembler {
                 let src1 = src1.into_index() as u32;
                 let src2 = src2 as u64;
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_64bit(src2 as u64).is_some() {
+                if encode_logical_immediate_64bit(src2 as u64).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; orr X(dst), X(src1), src2);
@@ -1467,7 +1467,7 @@ impl EmitterARM64 for Assembler {
                 let src1 = src1.into_index() as u32;
                 let src2 = src2 as u32;
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_32bit(src2).is_some() {
+                if encode_logical_immediate_32bit(src2).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; orr W(dst), W(src1), src2);
@@ -1496,7 +1496,7 @@ impl EmitterARM64 for Assembler {
                 let src1 = src1.into_index() as u32;
                 let src2 = src2 as u64;
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_64bit(src2 as u64).is_some() {
+                if encode_logical_immediate_64bit(src2 as u64).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; and X(dst), X(src1), src2);
@@ -1505,7 +1505,7 @@ impl EmitterARM64 for Assembler {
                 let src1 = src1.into_index() as u32;
                 let src2 = src2 as u32;
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_32bit(src2).is_some() {
+                if encode_logical_immediate_32bit(src2).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; and W(dst), W(src1), src2);
@@ -1534,7 +1534,7 @@ impl EmitterARM64 for Assembler {
                 let src1 = src1.into_index() as u32;
                 let src2 = src2 as u64;
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_64bit(src2 as u64).is_some() {
+                if encode_logical_immediate_64bit(src2 as u64).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; eor X(dst), X(src1), src2);
@@ -1543,7 +1543,7 @@ impl EmitterARM64 for Assembler {
                 let src1 = src1.into_index() as u32;
                 let src2 = src2 as u32;
                 let dst = dst.into_index() as u32;
-                if !encode_logical_immediate_32bit(src2).is_some() {
+                if encode_logical_immediate_32bit(src2).is_none() {
                     unreachable!();
                 }
                 dynasm!(self ; eor W(dst), W(src1), src2);
@@ -2453,6 +2453,7 @@ pub fn gen_std_trampoline_arm64(
                 );
             }
             _ => {
+                #[allow(clippy::single_match)]
                 match calling_convention {
                     CallingConvention::AppleAarch64 => {
                         match sz {
@@ -2613,6 +2614,7 @@ pub fn gen_std_dynamic_import_trampoline_arm64(
         }
     }
 
+    #[allow(clippy::match_single_binding)]
     match calling_convention {
         _ => {
             // Load target address.
@@ -2694,10 +2696,9 @@ pub fn gen_import_call_trampoline_arm64(
         .iter()
         .any(|&x| x == Type::F32 || x == Type::F64)
     {
+        #[allow(clippy::match_single_binding)]
         match calling_convention {
             _ => {
-                let mut param_locations: Vec<Location> = vec![];
-
                 // Allocate stack space for arguments.
                 let stack_offset: i32 = if sig.params().len() > 7 {
                     7 * 8
@@ -2729,26 +2730,23 @@ pub fn gen_import_call_trampoline_arm64(
                 }
 
                 // Store all arguments to the stack to prevent overwrite.
-                for i in 0..sig.params().len() {
-                    let loc = match i {
-                        0..=6 => {
-                            static PARAM_REGS: &[GPR] = &[
-                                GPR::X1,
-                                GPR::X2,
-                                GPR::X3,
-                                GPR::X4,
-                                GPR::X5,
-                                GPR::X6,
-                                GPR::X7,
-                            ];
-                            let loc = Location::Memory(GPR::XzrSp, (i * 8) as i32);
-                            a.emit_str(Size::S64, Location::GPR(PARAM_REGS[i]), loc);
-                            loc
-                        }
-                        _ => Location::Memory(GPR::XzrSp, stack_offset + ((i - 7) * 8) as i32),
-                    };
-                    param_locations.push(loc);
-                }
+                static PARAM_REGS: &[GPR] = &[
+                    GPR::X1,
+                    GPR::X2,
+                    GPR::X3,
+                    GPR::X4,
+                    GPR::X5,
+                    GPR::X6,
+                    GPR::X7,
+                ];
+                let gpr_iter = PARAM_REGS.iter().map(|r| Location::GPR(*r));
+                let memory_iter =
+                    (0i32..).map(|i| Location::Memory(GPR::XzrSp, stack_offset + i * 8));
+
+                let param_locations: Vec<Location> = gpr_iter
+                    .chain(memory_iter)
+                    .take(sig.params().len())
+                    .collect();
 
                 // Copy arguments.
                 let mut caller_stack_offset: i32 = 0;
@@ -2816,6 +2814,7 @@ pub fn gen_import_call_trampoline_arm64(
             );
             0
         };
+    #[allow(clippy::match_single_binding)]
     match calling_convention {
         _ => {
             if (offset & 7) == 0 {

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -42,14 +42,14 @@ pub enum Condition {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 pub enum XMMOrMemory {
     XMM(XMM),
     Memory(GPR, i32),
 }
 
 #[derive(Copy, Clone, Debug)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 pub enum GPROrMemory {
     GPR(GPR),
     Memory(GPR, i32),

--- a/lib/compiler-singlepass/src/location.rs
+++ b/lib/compiler-singlepass/src/location.rs
@@ -14,7 +14,7 @@ pub enum Multiplier {
     Height = 8,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Location<R, S> {
     GPR(R),

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -83,9 +83,9 @@ pub trait Machine {
     /// reserve a GPR
     fn reserve_gpr(&mut self, gpr: Self::GPR);
     /// Push used gpr to the stack. Return the bytes taken on the stack
-    fn push_used_gpr(&mut self, grps: &Vec<Self::GPR>) -> usize;
+    fn push_used_gpr(&mut self, grps: &[Self::GPR]) -> usize;
     /// Pop used gpr to the stack
-    fn pop_used_gpr(&mut self, grps: &Vec<Self::GPR>);
+    fn pop_used_gpr(&mut self, grps: &[Self::GPR]);
     /// Picks an unused SIMD register.
     ///
     /// This method does not mark the register as used
@@ -101,9 +101,9 @@ pub trait Machine {
     /// Releases a temporary XMM register.
     fn release_simd(&mut self, simd: Self::SIMD);
     /// Push used simd regs to the stack. Return bytes taken on the stack
-    fn push_used_simd(&mut self, simds: &Vec<Self::SIMD>) -> usize;
+    fn push_used_simd(&mut self, simds: &[Self::SIMD]) -> usize;
     /// Pop used simd regs to the stack
-    fn pop_used_simd(&mut self, simds: &Vec<Self::SIMD>);
+    fn pop_used_simd(&mut self, simds: &[Self::SIMD]);
     /// Return a rounded stack adjustement value (must be multiple of 16bytes on ARM64 for example)
     fn round_stack_adjust(&self, value: usize) -> usize;
     /// Set the source location of the Wasm to the given offset.
@@ -628,6 +628,7 @@ pub trait Machine {
         ret: Location<Self::GPR, Self::SIMD>,
     );
     /// i32 load
+    #[allow(clippy::too_many_arguments)]
     fn i32_load(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -639,6 +640,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 load of an unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_load_8u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -650,6 +652,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 load of an signed 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_load_8s(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -661,6 +664,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 load of an unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_load_16u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -672,6 +676,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 load of an signed 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_load_16s(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -683,6 +688,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic load
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_load(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -694,6 +700,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic load of an unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_load_8u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -705,6 +712,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic load of an unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_load_16u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -716,6 +724,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 save
+    #[allow(clippy::too_many_arguments)]
     fn i32_save(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -727,6 +736,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 save of the lower 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_save_8(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -738,6 +748,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 save of the lower 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_save_16(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -749,6 +760,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic save
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_save(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -760,6 +772,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic save of a the lower 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_save_8(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -771,6 +784,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic save of a the lower 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_save_16(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -782,6 +796,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Add with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_add(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -794,6 +809,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Add with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_add_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -806,6 +822,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Add with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_add_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -818,6 +835,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Sub with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_sub(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -830,6 +848,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Sub with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_sub_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -842,6 +861,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Sub with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_sub_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -854,6 +874,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic And with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_and(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -866,6 +887,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic And with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_and_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -878,6 +900,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic And with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_and_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -890,6 +913,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Or with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_or(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -902,6 +926,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Or with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_or_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -914,6 +939,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Or with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_or_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -926,6 +952,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Xor with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_xor(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -938,6 +965,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Xor with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_xor_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -950,6 +978,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Xor with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_xor_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -962,6 +991,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Exchange with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_xchg(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -974,6 +1004,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Exchange with u8
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_xchg_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -986,6 +1017,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Exchange with u16
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_xchg_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -998,6 +1030,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Compare and Exchange with i32
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_cmpxchg(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1011,6 +1044,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Compare and Exchange with u8
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_cmpxchg_8u(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1024,6 +1058,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i32 atomic Compare and Exchange with u16
+    #[allow(clippy::too_many_arguments)]
     fn i32_atomic_cmpxchg_16u(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1245,6 +1280,7 @@ pub trait Machine {
         ret: Location<Self::GPR, Self::SIMD>,
     );
     /// i64 load
+    #[allow(clippy::too_many_arguments)]
     fn i64_load(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1256,6 +1292,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 load of an unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_load_8u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1267,6 +1304,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 load of an signed 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_load_8s(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1278,6 +1316,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 load of an unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_load_32u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1289,6 +1328,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 load of an signed 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_load_32s(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1300,6 +1340,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 load of an signed 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_load_16u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1311,6 +1352,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 load of an signed 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_load_16s(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1322,6 +1364,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic load
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_load(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1333,6 +1376,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic load from unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_load_8u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1344,6 +1388,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic load from unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_load_16u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1355,6 +1400,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic load from unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_load_32u(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1366,6 +1412,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 save
+    #[allow(clippy::too_many_arguments)]
     fn i64_save(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1377,6 +1424,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 save of the lower 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_save_8(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1388,6 +1436,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 save of the lower 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_save_16(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1399,6 +1448,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 save of the lower 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_save_32(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1410,6 +1460,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic save
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_save(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1421,6 +1472,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic save of a the lower 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_save_8(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1432,6 +1484,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic save of a the lower 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_save_16(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1443,6 +1496,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic save of a the lower 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_save_32(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1454,6 +1508,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Add with i64
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_add(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1466,6 +1521,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Add with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_add_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1478,6 +1534,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Add with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_add_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1490,6 +1547,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Add with unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_add_32u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1502,6 +1560,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Sub with i64
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_sub(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1514,6 +1573,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Sub with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_sub_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1526,6 +1586,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Sub with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_sub_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1538,6 +1599,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Sub with unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_sub_32u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1550,6 +1612,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic And with i64
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_and(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1562,6 +1625,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic And with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_and_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1574,6 +1638,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic And with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_and_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1586,6 +1651,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic And with unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_and_32u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1598,6 +1664,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Or with i64
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_or(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1610,6 +1677,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Or with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_or_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1622,6 +1690,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Or with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_or_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1634,6 +1703,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Or with unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_or_32u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1646,6 +1716,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Xor with i64
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xor(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1658,6 +1729,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Xor with unsigned 8bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xor_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1670,6 +1742,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Xor with unsigned 16bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xor_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1682,6 +1755,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Xor with unsigned 32bits
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xor_32u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1694,6 +1768,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Exchange with i64
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xchg(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1706,6 +1781,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Exchange with u8
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xchg_8u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1718,6 +1794,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Exchange with u16
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xchg_16u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1730,6 +1807,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Exchange with u32
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_xchg_32u(
         &mut self,
         loc: Location<Self::GPR, Self::SIMD>,
@@ -1742,6 +1820,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Compare and Exchange with i32
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_cmpxchg(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1755,6 +1834,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Compare and Exchange with u8
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_cmpxchg_8u(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1768,6 +1848,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Compare and Exchange with u16
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_cmpxchg_16u(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1781,6 +1862,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// i64 atomic Compare and Exchange with u32
+    #[allow(clippy::too_many_arguments)]
     fn i64_atomic_cmpxchg_32u(
         &mut self,
         new: Location<Self::GPR, Self::SIMD>,
@@ -1795,6 +1877,7 @@ pub trait Machine {
     );
 
     /// load an F32
+    #[allow(clippy::too_many_arguments)]
     fn f32_load(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1806,6 +1889,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// f32 save
+    #[allow(clippy::too_many_arguments)]
     fn f32_save(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,
@@ -1818,6 +1902,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// load an F64
+    #[allow(clippy::too_many_arguments)]
     fn f64_load(
         &mut self,
         addr: Location<Self::GPR, Self::SIMD>,
@@ -1829,6 +1914,7 @@ pub trait Machine {
         heap_access_oob: Label,
     );
     /// f64 save
+    #[allow(clippy::too_many_arguments)]
     fn f64_save(
         &mut self,
         value: Location<Self::GPR, Self::SIMD>,

--- a/lib/compiler-singlepass/src/unwind.rs
+++ b/lib/compiler-singlepass/src/unwind.rs
@@ -37,7 +37,7 @@ impl UnwindInstructions {
     pub fn to_fde(&self, address: Address) -> UnwindFrame {
         let mut fde = FrameDescriptionEntry::new(address, self.len);
         for (offset, inst) in &self.instructions {
-            fde.add_instruction(*offset, inst.clone().into());
+            fde.add_instruction(*offset, inst.clone());
         }
         UnwindFrame::SystemV(fde)
     }

--- a/lib/compiler-singlepass/src/unwind_winx64.rs
+++ b/lib/compiler-singlepass/src/unwind_winx64.rs
@@ -95,10 +95,7 @@ impl UnwindCode {
                 reg,
                 stack_offset,
             } => {
-                let is_xmm = match self {
-                    Self::SaveXmm { .. } => true,
-                    _ => false,
-                };
+                let is_xmm = matches!(self, Self::SaveXmm { .. });
                 let (op_small, op_large) = if is_xmm {
                     (UnwindOperation::SaveXmm128, UnwindOperation::SaveXmm128Far)
                 } else {
@@ -243,7 +240,7 @@ impl UnwindInfo {
 
 const UNWIND_RBP_REG: u8 = 5;
 
-pub(crate) fn create_unwind_info_from_insts(insts: &Vec<(usize, UnwindOps)>) -> Option<UnwindInfo> {
+pub(crate) fn create_unwind_info_from_insts(insts: &[(usize, UnwindOps)]) -> Option<UnwindInfo> {
     let mut unwind_codes = vec![];
     let mut frame_register_offset = 0;
     let mut max_unwind_offset = 0;

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -261,8 +261,8 @@ impl ArgumentRegisterAllocator {
     pub fn next(&mut self, ty: Type, calling_convention: CallingConvention) -> Option<X64Register> {
         match calling_convention {
             CallingConvention::WindowsFastcall => {
-                static GPR_SEQ: &'static [GPR] = &[GPR::RCX, GPR::RDX, GPR::R8, GPR::R9];
-                static XMM_SEQ: &'static [XMM] = &[XMM::XMM0, XMM::XMM1, XMM::XMM2, XMM::XMM3];
+                static GPR_SEQ: &[GPR] = &[GPR::RCX, GPR::RDX, GPR::R8, GPR::R9];
+                static XMM_SEQ: &[XMM] = &[XMM::XMM0, XMM::XMM1, XMM::XMM2, XMM::XMM3];
                 let idx = self.n_gprs + self.n_xmms;
                 match ty {
                     Type::I32 | Type::I64 => {
@@ -290,9 +290,9 @@ impl ArgumentRegisterAllocator {
                 }
             }
             _ => {
-                static GPR_SEQ: &'static [GPR] =
+                static GPR_SEQ: &[GPR] =
                     &[GPR::RDI, GPR::RSI, GPR::RDX, GPR::RCX, GPR::R8, GPR::R9];
-                static XMM_SEQ: &'static [XMM] = &[
+                static XMM_SEQ: &[XMM] = &[
                     XMM::XMM0,
                     XMM::XMM1,
                     XMM::XMM2,

--- a/lib/compiler/src/target.rs
+++ b/lib/compiler/src/target.rs
@@ -1,4 +1,12 @@
 //! Target configuration
+
+// The clippy::use_self exception is due to a false positive indicating that
+// `CpuFeature` should be replaced by `Self`. Attaching the allowance to the
+// type itself has no effect, therefore it's disabled for the whole module.
+// Feel free to remove this allow attribute once the bug is fixed.
+// See https://github.com/rust-lang/rust-clippy/issues/6902
+#![allow(clippy::use_self)]
+
 use crate::error::ParseCpuFeatureError;
 use crate::lib::std::str::FromStr;
 use crate::lib::std::string::{String, ToString};

--- a/lib/derive/src/env/mod.rs
+++ b/lib/derive/src/env/mod.rs
@@ -137,9 +137,8 @@ fn derive_struct_fields(data: &DataStruct) -> (TokenStream, TokenStream) {
                         if optional {
                             quote_spanned! {
                                 f.span()=>
-                                    match #access_expr {
-                                        Ok(#name) => { self.#name.initialize(#name); },
-                                        Err(_) => (),
+                                    if let Ok(#name) = #access_expr {
+                                        self.#name.initialize(#name);
                                     };
                             }
                         } else {
@@ -149,43 +148,38 @@ fn derive_struct_fields(data: &DataStruct) -> (TokenStream, TokenStream) {
                                     self.#name.initialize(#name);
                             }
                         }
-                    } else {
-                        if let Some(identifier) = identifier {
-                            let mut access_expr = quote_spanned! {
-                                f.span() =>
-                                    instance.exports.get_with_generics_weak::<#inner_type, _, _>(#identifier)
+                    } else if let Some(identifier) = identifier {
+                        let mut access_expr = quote_spanned! {
+                            f.span() =>
+                                instance.exports.get_with_generics_weak::<#inner_type, _, _>(#identifier)
+                        };
+                        for alias in aliases {
+                            access_expr = quote_spanned! {
+                                f.span()=>
+                                    #access_expr .or_else(|_| instance.exports.get_with_generics_weak::<#inner_type, _, _>(#alias))
                             };
-                            for alias in aliases {
-                                access_expr = quote_spanned! {
-                                    f.span()=>
-                                        #access_expr .or_else(|_| instance.exports.get_with_generics_weak::<#inner_type, _, _>(#alias))
-                                };
-                            }
-                            let local_var =
-                                Ident::new(&format!("field_{}", field_num), identifier.span());
-                            if optional {
-                                quote_spanned! {
-                                    f.span()=>
-                                        match #access_expr {
-                                            Ok(#local_var) => {
-                                                self.#field_idx.initialize(#local_var);
-                                            },
-                                            Err(_) => (),
-                                        }
-                                }
-                            } else {
-                                quote_spanned! {
-                                    f.span()=>
-                                        let #local_var: #inner_type = #access_expr?;
-                                    self.#field_idx.initialize(#local_var);
-                                }
+                        }
+                        let local_var =
+                            Ident::new(&format!("field_{}", field_num), identifier.span());
+                        if optional {
+                            quote_spanned! {
+                                f.span()=>
+                                    if let Ok(#local_var) = #access_expr {
+                                        self.#field_idx.initialize(#local_var);
+                                    }
                             }
                         } else {
-                            abort!(
-                                span,
-                                "Expected `name` field on export attribute because field does not have a name. For example: `#[wasmer(export(name = \"wasm_ident\"))]`.",
-                            );
+                            quote_spanned! {
+                                f.span()=>
+                                    let #local_var: #inner_type = #access_expr?;
+                                self.#field_idx.initialize(#local_var);
+                            }
                         }
+                    } else {
+                        abort!(
+                            span,
+                            "Expected `name` field on export attribute because field does not have a name. For example: `#[wasmer(export(name = \"wasm_ident\"))]`.",
+                        );
                     };
 
                     finish.push(finish_tokens);

--- a/lib/derive/src/value_type.rs
+++ b/lib/derive/src/value_type.rs
@@ -98,7 +98,7 @@ pub fn impl_value_type(input: &DeriveInput) -> TokenStream {
         _ => abort!(input, "ValueType can only be derived for structs"),
     };
 
-    let zero_padding = zero_padding(&fields);
+    let zero_padding = zero_padding(fields);
 
     quote! {
         unsafe impl #impl_generics ::wasmer::ValueType for #struct_name #ty_generics #where_clause {

--- a/lib/emscripten/src/emscripten_target.rs
+++ b/lib/emscripten/src/emscripten_target.rs
@@ -116,6 +116,7 @@ pub fn _getloadavg(_ctx: &EmEnv, _loadavg: i32, _nelem: i32) -> i32 {
     debug!("emscripten::getloadavg");
     0
 }
+#[allow(clippy::too_many_arguments)]
 pub fn _getnameinfo(
     _ctx: &EmEnv,
     _addr: i32,
@@ -272,6 +273,7 @@ pub fn invoke_iiiiii(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32
         a5
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_iiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -296,6 +298,7 @@ pub fn invoke_iiiiiii(
         a6
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_iiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -322,6 +325,7 @@ pub fn invoke_iiiiiiii(
         a7
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_iiiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -350,6 +354,7 @@ pub fn invoke_iiiiiiiii(
         a8
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_iiiiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -380,6 +385,7 @@ pub fn invoke_iiiiiiiiii(
         a9
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_iiiiiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -430,6 +436,7 @@ pub fn invoke_viiiii(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32
         a5
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -454,6 +461,7 @@ pub fn invoke_viiiiii(
         a6
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -480,6 +488,7 @@ pub fn invoke_viiiiiii(
         a7
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -508,6 +517,7 @@ pub fn invoke_viiiiiiii(
         a8
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -538,6 +548,7 @@ pub fn invoke_viiiiiiiii(
         a9
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiiiiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -586,6 +597,7 @@ pub fn invoke_iiji(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32) 
     invoke!(ctx, dyn_call_iiji, dyn_call_iiji_ref, index, a1, a2, a3, a4)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_iiijj(
     ctx: &EmEnv,
     index: i32,
@@ -645,6 +657,7 @@ pub fn invoke_viiij(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32,
         a5
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiijiiii(
     ctx: &EmEnv,
     index: i32,
@@ -675,6 +688,7 @@ pub fn invoke_viiijiiii(
         a9
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viiijiiiiii(
     ctx: &EmEnv,
     index: i32,
@@ -727,6 +741,7 @@ pub fn invoke_viiji(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32,
         a5
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viijiii(
     ctx: &EmEnv,
     index: i32,
@@ -753,6 +768,7 @@ pub fn invoke_viijiii(
         a7
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viijj(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32, a5: i32, a6: i32) {
     debug!("emscripten::invoke_viijj");
     invoke_no_stack_save!(
@@ -794,6 +810,7 @@ pub fn invoke_viji(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: i32, a4: i32) 
     debug!("emscripten::invoke_viji");
     invoke_no_stack_save!(ctx, dyn_call_viji, dyn_call_viji_ref, index, a1, a2, a3, a4)
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_vijiii(
     ctx: &EmEnv,
     index: i32,
@@ -854,6 +871,7 @@ pub fn invoke_viidii(ctx: &EmEnv, index: i32, a1: i32, a2: i32, a3: f64, a4: i32
         a5
     );
 }
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_viidddddddd(
     ctx: &EmEnv,
     index: i32,

--- a/lib/emscripten/src/syscalls/unix.rs
+++ b/lib/emscripten/src/syscalls/unix.rs
@@ -452,10 +452,14 @@ pub fn ___syscall330(ctx: &EmEnv, _which: c_int, mut varargs: VarArgs) -> pid_t 
     // Set flags on newfd (https://www.gnu.org/software/libc/manual/html_node/Descriptor-Flags.html)
     let mut old_flags = unsafe { fcntl(newfd, F_GETFD, 0) };
 
-    if old_flags > 0 {
-        old_flags |= flags;
-    } else if old_flags == 0 {
-        old_flags &= !flags;
+    match old_flags {
+        f if f > 0 => {
+            old_flags |= flags;
+        }
+        0 => {
+            old_flags &= !flags;
+        }
+        _ => {}
     }
 
     unsafe {

--- a/lib/emscripten/src/utils.rs
+++ b/lib/emscripten/src/utils.rs
@@ -122,7 +122,9 @@ pub unsafe fn copy_cstr_into_wasm(ctx: &EmEnv, cstr: *const c_char) -> u32 {
     space_offset
 }
 
-pub unsafe fn allocate_on_stack<'a, T: Copy>(ctx: &'a EmEnv, count: u32) -> (u32, &'a mut [T]) {
+/// # Safety
+/// This method is unsafe because it operates directly with the slice of memory represented by the address
+pub unsafe fn allocate_on_stack<T: Copy>(ctx: &EmEnv, count: u32) -> (u32, &mut [T]) {
     let offset = get_emscripten_data(ctx)
         .stack_alloc_ref()
         .unwrap()
@@ -135,6 +137,8 @@ pub unsafe fn allocate_on_stack<'a, T: Copy>(ctx: &'a EmEnv, count: u32) -> (u32
     (offset, slice)
 }
 
+/// # Safety
+/// This method is unsafe because it uses `allocate_on_stack` which is unsafe
 pub unsafe fn allocate_cstr_on_stack<'a>(ctx: &'a EmEnv, s: &str) -> (u32, &'a [u8]) {
     let (offset, slice) = allocate_on_stack(ctx, (s.len() + 1) as u32);
 

--- a/lib/emscripten/src/varargs.rs
+++ b/lib/emscripten/src/varargs.rs
@@ -17,12 +17,9 @@ impl VarArgs {
         unsafe { (ptr as *const T).read() }
     }
 
-    // pub fn getStr<'a>(&mut self, ctx: &mut Ctx) -> &'a CStr {
     pub fn get_str(&mut self, ctx: &EmEnv) -> *const c_char {
         let ptr_addr: u32 = self.get(ctx);
-        let ptr = emscripten_memory_pointer!(ctx.memory(0), ptr_addr) as *const c_char;
-        ptr
-        // unsafe { CStr::from_ptr(ptr) }
+        emscripten_memory_pointer!(ctx.memory(0), ptr_addr) as *const c_char
     }
 }
 

--- a/lib/engine-staticlib/src/engine.rs
+++ b/lib/engine-staticlib/src/engine.rs
@@ -131,7 +131,7 @@ impl Engine for StaticlibEngine {
         binary: &[u8],
         tunables: &dyn Tunables,
     ) -> Result<Arc<dyn Artifact>, CompileError> {
-        Ok(Arc::new(StaticlibArtifact::new(&self, binary, tunables)?))
+        Ok(Arc::new(StaticlibArtifact::new(self, binary, tunables)?))
     }
 
     /// Compile a WebAssembly binary (it will fail because the `compiler` flag is disabled).
@@ -149,7 +149,7 @@ impl Engine for StaticlibEngine {
 
     /// Deserializes a WebAssembly module (binary content of a static object file)
     unsafe fn deserialize(&self, bytes: &[u8]) -> Result<Arc<dyn Artifact>, DeserializeError> {
-        Ok(Arc::new(StaticlibArtifact::deserialize(&self, &bytes)?))
+        Ok(Arc::new(StaticlibArtifact::deserialize(self, bytes)?))
     }
 
     /// Deserializes a WebAssembly module from a path
@@ -217,7 +217,7 @@ impl StaticlibEngineInner {
     #[cfg(feature = "compiler")]
     pub(crate) fn get_prefix(&self, bytes: &[u8]) -> String {
         if let Some(prefixer) = &self.prefixer {
-            prefixer(&bytes)
+            prefixer(bytes)
         } else {
             "".to_string()
         }
@@ -230,13 +230,13 @@ impl StaticlibEngineInner {
 
     /// Validate the module
     #[cfg(feature = "compiler")]
-    pub fn validate<'data>(&self, data: &'data [u8]) -> Result<(), CompileError> {
+    pub fn validate(&self, data: &[u8]) -> Result<(), CompileError> {
         self.compiler()?.validate_module(self.features(), data)
     }
 
     /// Validate the module
     #[cfg(not(feature = "compiler"))]
-    pub fn validate<'data>(&self, _data: &'data [u8]) -> Result<(), CompileError> {
+    pub fn validate(&self, _data: &[u8]) -> Result<(), CompileError> {
         Err(CompileError::Validate(
             "The `StaticlibEngine` is not compiled with compiler support, which is required for validating".to_string(),
         ))

--- a/lib/engine-universal/src/artifact.rs
+++ b/lib/engine-universal/src/artifact.rs
@@ -124,7 +124,7 @@ impl UniversalArtifact {
         link_module(
             artifact.module_ref(),
             &finished_functions,
-            artifact.get_function_relocations().clone(),
+            artifact.get_function_relocations(),
             &custom_sections,
             artifact.get_custom_section_relocations_ref(),
             artifact.get_libcall_trampolines(),

--- a/lib/engine-universal/src/code_memory.rs
+++ b/lib/engine-universal/src/code_memory.rs
@@ -40,6 +40,7 @@ impl CodeMemory {
     }
 
     /// Allocate a single contiguous block of memory for the functions and custom sections, and copy the data in place.
+    #[allow(clippy::type_complexity)]
     pub fn allocate(
         &mut self,
         functions: &[&FunctionBody],
@@ -188,7 +189,7 @@ impl CodeMemory {
             let padding = unwind_start - func_len;
             assert_eq!((func_len + padding) % 4, 0);
             let slice = remainder.split_at_mut(padding + unwind_size).0;
-            slice[padding..].copy_from_slice(&info);
+            slice[padding..].copy_from_slice(info);
         }
 
         if let Some(info) = &func.unwind_info {

--- a/lib/engine-universal/src/engine.rs
+++ b/lib/engine-universal/src/engine.rs
@@ -113,7 +113,7 @@ impl Engine for UniversalEngine {
         binary: &[u8],
         tunables: &dyn Tunables,
     ) -> Result<Arc<dyn Artifact>, CompileError> {
-        Ok(Arc::new(UniversalArtifact::new(&self, binary, tunables)?))
+        Ok(Arc::new(UniversalArtifact::new(self, binary, tunables)?))
     }
 
     /// Compile a WebAssembly binary
@@ -131,7 +131,7 @@ impl Engine for UniversalEngine {
 
     /// Deserializes a WebAssembly module
     unsafe fn deserialize(&self, bytes: &[u8]) -> Result<Arc<dyn Artifact>, DeserializeError> {
-        Ok(Arc::new(UniversalArtifact::deserialize(&self, &bytes)?))
+        Ok(Arc::new(UniversalArtifact::deserialize(self, bytes)?))
     }
 
     fn id(&self) -> &EngineId {
@@ -167,7 +167,7 @@ impl UniversalEngineInner {
     }
 
     /// Validate the module
-    pub fn validate<'data>(&self, data: &'data [u8]) -> Result<(), CompileError> {
+    pub fn validate(&self, data: &[u8]) -> Result<(), CompileError> {
         self.builder.validate(data)
     }
 

--- a/lib/engine/src/artifact.rs
+++ b/lib/engine/src/artifact.rs
@@ -62,10 +62,10 @@ pub trait Artifact: Send + Sync + Upcastable + ArtifactCreate {
         // host CPU features.
         let host_cpu_features = CpuFeature::for_host();
         if !host_cpu_features.is_superset(self.cpu_features()) {
-            Err(InstantiationError::CpuFeature(format!(
+            return Err(InstantiationError::CpuFeature(format!(
                 "{:?}",
                 self.cpu_features().difference(host_cpu_features)
-            )))?;
+            )));
         }
 
         self.preinstantiate()?;
@@ -75,7 +75,7 @@ pub trait Artifact: Send + Sync + Upcastable + ArtifactCreate {
             let mut imports = resolve_imports(
                 &module,
                 imports,
-                &self.finished_dynamic_function_trampolines(),
+                self.finished_dynamic_function_trampolines(),
                 self.memory_styles(),
                 self.table_styles(),
             )

--- a/lib/engine/src/resolver.rs
+++ b/lib/engine/src/resolver.rs
@@ -75,7 +75,7 @@ pub fn resolve_imports(
                 ImportError::UnknownImport(import_extern),
             ));
         };
-        let export_extern = get_extern_from_export(module, &resolved);
+        let export_extern = get_extern_from_export(module, resolved);
         if !export_extern.is_compatible_with(&import_extern) {
             return Err(LinkError::Import(
                 module_name.to_string(),

--- a/lib/engine/src/trap/frame_info.rs
+++ b/lib/engine/src/trap/frame_info.rs
@@ -60,14 +60,14 @@ struct ModuleInfoFrameInfo {
 
 impl ModuleInfoFrameInfo {
     fn function_debug_info(&self, local_index: LocalFunctionIndex) -> &CompiledFunctionFrameInfo {
-        &self.frame_infos.get(local_index).unwrap()
+        self.frame_infos.get(local_index).unwrap()
     }
 
     /// Gets a function given a pc
     fn function_info(&self, pc: usize) -> Option<&FunctionInfo> {
         let (end, func) = self.functions.range(pc..).next()?;
         if func.start <= pc && pc <= *end {
-            return Some(func);
+            Some(func)
         } else {
             None
         }

--- a/lib/object/src/module.rs
+++ b/lib/object/src/module.rs
@@ -100,7 +100,7 @@ pub fn emit_data(
         flags: SymbolFlags::None,
     });
     let section_id = obj.section_id(StandardSection::Data);
-    obj.add_symbol_data(symbol_id, section_id, &data, align);
+    obj.add_symbol_data(symbol_id, section_id, data, align);
 
     Ok(())
 }
@@ -150,7 +150,7 @@ pub fn emit_compilation(
     let custom_section_ids = custom_sections
         .into_iter()
         .map(|(section_index, custom_section)| {
-            if debug_index.map(|d| d == section_index).unwrap_or(false) {
+            if debug_index.map_or(false, |d| d == section_index) {
                 // If this is the debug section
                 let segment = obj.segment_name(StandardSegment::Debug).to_vec();
                 let section_id =
@@ -264,7 +264,7 @@ pub fn emit_compilation(
     }
 
     for (section_index, relocations) in custom_section_relocations.into_iter() {
-        if !debug_index.map(|d| d == section_index).unwrap_or(false) {
+        if !debug_index.map_or(false, |d| d == section_index) {
             // Skip DWARF relocations just yet
             let (section_id, symbol_id) = custom_section_ids.get(section_index).unwrap();
             all_relocations.push((*section_id, *symbol_id, relocations));

--- a/lib/types/src/archives.rs
+++ b/lib/types/src/archives.rs
@@ -15,24 +15,15 @@ impl<K: Hash + Ord + Archive + Clone, V: Archive> From<IndexMap<K, V>>
     for ArchivableIndexMap<K, V>
 {
     fn from(it: IndexMap<K, V>) -> Self {
-        let mut r = Self {
-            entries: Vec::new(),
-        };
-        for (k, v) in it.into_iter() {
-            r.entries.push((k, v));
-        }
-        r
+        let entries = it.into_iter().collect();
+        Self { entries }
     }
 }
 
-impl<K: Hash + Ord + Archive + Clone, V: Archive> Into<IndexMap<K, V>>
-    for ArchivableIndexMap<K, V>
+impl<K: Hash + Ord + Archive + Clone, V: Archive> From<ArchivableIndexMap<K, V>>
+    for IndexMap<K, V>
 {
-    fn into(self) -> IndexMap<K, V> {
-        let mut r = IndexMap::new();
-        for (k, v) in self.entries.into_iter() {
-            r.insert(k, v);
-        }
-        r
+    fn from(other: ArchivableIndexMap<K, V>) -> Self {
+        other.entries.into_iter().collect()
     }
 }

--- a/lib/types/src/entity/packed_option.rs
+++ b/lib/types/src/entity/packed_option.rs
@@ -101,9 +101,9 @@ impl<T: ReservedValue> From<Option<T>> for PackedOption<T> {
     }
 }
 
-impl<T: ReservedValue> Into<Option<T>> for PackedOption<T> {
-    fn into(self) -> Option<T> {
-        self.expand()
+impl<T: ReservedValue> From<PackedOption<T>> for Option<T> {
+    fn from(other: PackedOption<T>) -> Self {
+        other.expand()
     }
 }
 

--- a/lib/types/src/native.rs
+++ b/lib/types/src/native.rs
@@ -248,6 +248,8 @@ mod test_native_type {
 /// Trait for a Value type. A Value type is a type that is always valid and may
 /// be safely copied.
 ///
+/// # Safety
+///
 /// To maintain safety, types which implement this trait must be valid for all
 /// bit patterns. This means that it cannot contain enums, `bool`, references,
 /// etc.

--- a/lib/types/src/trapcode.rs
+++ b/lib/types/src/trapcode.rs
@@ -111,18 +111,18 @@ impl FromStr for TrapCode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "stk_ovf" => Ok(TrapCode::StackOverflow),
-            "heap_get_oob" => Ok(TrapCode::HeapAccessOutOfBounds),
-            "heap_misaligned" => Ok(TrapCode::HeapMisaligned),
-            "table_get_oob" => Ok(TrapCode::TableAccessOutOfBounds),
-            "oob" => Ok(TrapCode::OutOfBounds),
-            "icall_null" => Ok(TrapCode::IndirectCallToNull),
-            "bad_sig" => Ok(TrapCode::BadSignature),
-            "int_ovf" => Ok(TrapCode::IntegerOverflow),
-            "int_divz" => Ok(TrapCode::IntegerDivisionByZero),
-            "bad_toint" => Ok(TrapCode::BadConversionToInteger),
-            "unreachable" => Ok(TrapCode::UnreachableCodeReached),
-            "unalign_atom" => Ok(TrapCode::UnalignedAtomic),
+            "stk_ovf" => Ok(Self::StackOverflow),
+            "heap_get_oob" => Ok(Self::HeapAccessOutOfBounds),
+            "heap_misaligned" => Ok(Self::HeapMisaligned),
+            "table_get_oob" => Ok(Self::TableAccessOutOfBounds),
+            "oob" => Ok(Self::OutOfBounds),
+            "icall_null" => Ok(Self::IndirectCallToNull),
+            "bad_sig" => Ok(Self::BadSignature),
+            "int_ovf" => Ok(Self::IntegerOverflow),
+            "int_divz" => Ok(Self::IntegerDivisionByZero),
+            "bad_toint" => Ok(Self::BadConversionToInteger),
+            "unreachable" => Ok(Self::UnreachableCodeReached),
+            "unalign_atom" => Ok(Self::UnalignedAtomic),
             _ => Err(()),
         }
     }

--- a/lib/types/src/values.rs
+++ b/lib/types/src/values.rs
@@ -65,9 +65,16 @@ macro_rules! accessors {
 /// between the API and the VM internals, specifically with `wasmer_types::Value`.
 pub trait WasmValueType: std::fmt::Debug + 'static {
     /// Write the value
+    ///
+    /// # Safety
+    /// You shouldn't use this method directly as it writes the value to a mutable pointer.
     unsafe fn write_value_to(&self, p: *mut i128);
 
     /// read the value
+    ///
+    /// # Safety
+    /// It reads the value directly from a memory pointer, you need to make sure is not corrupted
+    //
     // TODO(reftypes): passing the store as `dyn Any` is a hack to work around the
     // structure of our crates. We need to talk about the store in the rest of the
     // VM (for example where this method is used) but cannot do so. Fixing this

--- a/lib/types/src/vmoffsets.rs
+++ b/lib/types/src/vmoffsets.rs
@@ -420,6 +420,7 @@ impl VMOffsets {
     }
 
     /// Return the size of `VMFuncRef`.
+    #[allow(clippy::identity_op)]
     pub const fn size_of_vm_funcref(&self) -> u8 {
         1 * self.pointer_size
     }

--- a/lib/universal-artifact/src/artifact.rs
+++ b/lib/universal-artifact/src/artifact.rs
@@ -224,7 +224,7 @@ impl ArtifactCreate for UniversalArtifactBuild {
 
         let mut metadata_binary = vec![];
         metadata_binary.extend(Self::MAGIC_HEADER);
-        metadata_binary.extend(MetadataHeader::new(serialized_data.len()));
+        metadata_binary.extend(MetadataHeader::new(serialized_data.len()).into_bytes());
         metadata_binary.extend(serialized_data);
         Ok(metadata_binary)
     }

--- a/lib/universal-artifact/src/engine.rs
+++ b/lib/universal-artifact/src/engine.rs
@@ -17,7 +17,7 @@ impl UniversalEngineBuilder {
     /// Create a new builder with pre-made components
     #[cfg(feature = "compiler")]
     pub fn new(compiler: Option<Box<dyn Compiler>>, features: Features) -> Self {
-        UniversalEngineBuilder { compiler, features }
+        Self { compiler, features }
     }
 
     /// Gets the compiler associated to this engine.
@@ -41,7 +41,7 @@ impl UniversalEngineBuilder {
 
     /// Validate the module
     #[cfg(feature = "compiler")]
-    pub fn validate<'data>(&self, data: &'data [u8]) -> Result<(), CompileError> {
+    pub fn validate(&self, data: &[u8]) -> Result<(), CompileError> {
         self.compiler()?.validate_module(self.features(), data)
     }
 

--- a/lib/universal-artifact/src/lib.rs
+++ b/lib/universal-artifact/src/lib.rs
@@ -12,8 +12,7 @@
         clippy::float_arithmetic,
         clippy::mut_mut,
         clippy::nonminimal_bool,
-        clippy::option_map_unwrap_or,
-        clippy::option_map_unwrap_or_else,
+        clippy::map_unwrap_or,
         clippy::print_stdout,
         clippy::unicode_not_nfc,
         clippy::use_self

--- a/lib/universal-artifact/src/serialize.rs
+++ b/lib/universal-artifact/src/serialize.rs
@@ -81,9 +81,9 @@ impl SerializableModule {
     ///
     /// This method is unsafe.
     /// Please check `SerializableModule::deserialize` for more details.
-    unsafe fn archive_from_slice<'a>(
-        metadata_slice: &'a [u8],
-    ) -> Result<&'a ArchivedSerializableModule, DeserializeError> {
+    unsafe fn archive_from_slice(
+        metadata_slice: &[u8],
+    ) -> Result<&ArchivedSerializableModule, DeserializeError> {
         if metadata_slice.len() < 8 {
             return Err(DeserializeError::Incompatible(
                 "invalid serialized data".into(),
@@ -92,7 +92,7 @@ impl SerializableModule {
         let mut pos: [u8; 8] = Default::default();
         pos.copy_from_slice(&metadata_slice[metadata_slice.len() - 8..metadata_slice.len()]);
         let pos: u64 = u64::from_le_bytes(pos);
-        Ok(archived_value::<SerializableModule>(
+        Ok(archived_value::<Self>(
             &metadata_slice[..metadata_slice.len() - 8],
             pos as usize,
         ))

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -33,7 +33,7 @@ use more_asserts::assert_lt;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::ffi;
 use std::fmt;
 use std::mem;
@@ -1054,7 +1054,7 @@ impl InstanceHandle {
     pub fn lookup(&self, field: &str) -> Option<VMExtern> {
         let export = self.module_ref().exports.get(field)?;
 
-        Some(self.lookup_by_declaration(&export))
+        Some(self.lookup_by_declaration(export))
     }
 
     /// Lookup an export with the given export declaration.
@@ -1289,7 +1289,7 @@ unsafe fn get_memory_slice<'instance>(
         let import = instance.imported_memory(init.location.memory_index);
         *import.definition.as_ref()
     };
-    slice::from_raw_parts_mut(memory.base, memory.current_length.try_into().unwrap())
+    slice::from_raw_parts_mut(memory.base, memory.current_length)
 }
 
 /// Compute the offset for a table element initializer.
@@ -1377,7 +1377,7 @@ fn initialize_memories(
         let start = get_memory_init_start(init, instance);
         if start
             .checked_add(init.data.len())
-            .map_or(true, |end| end > memory.current_length.try_into().unwrap())
+            .map_or(true, |end| end > memory.current_length)
         {
             return Err(Trap::lib(TrapCode::HeapAccessOutOfBounds));
         }

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(unused_import_braces)]
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::new_without_default, vtable_address_comparisons)
+    allow(clippy::new_without_default, clippy::vtable_address_comparisons)
 )]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -210,7 +210,7 @@ impl LinearMemory {
         };
 
         let base_ptr = mmap.alloc.as_mut_ptr();
-        let mem_length = memory.minimum.bytes().0.try_into().unwrap();
+        let mem_length = memory.minimum.bytes().0;
         Ok(Self {
             mmap: Mutex::new(mmap),
             maximum: memory.maximum,
@@ -255,7 +255,7 @@ impl Memory for LinearMemory {
     /// Returns the type for this memory.
     fn ty(&self) -> MemoryType {
         let minimum = self.size();
-        let mut out = self.memory.clone();
+        let mut out = self.memory;
         out.minimum = minimum;
 
         out
@@ -353,7 +353,7 @@ impl Memory for LinearMemory {
         unsafe {
             let mut md_ptr = self.get_vm_memory_definition();
             let md = md_ptr.as_mut();
-            md.current_length = new_pages.bytes().0.try_into().unwrap();
+            md.current_length = new_pages.bytes().0;
             md.base = mmap.alloc.as_mut_ptr() as _;
         }
 

--- a/lib/vm/src/sig_registry.rs
+++ b/lib/vm/src/sig_registry.rs
@@ -15,7 +15,7 @@ use wasmer_types::FunctionType;
 /// call must match. To implement this efficiently, keep a registry of all
 /// signatures, shared by all instances, so that call sites can just do an
 /// index comparison.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SignatureRegistry {
     // This structure is stored in an `Engine` and is intended to be shared
     // across many instances. Ideally instances can themselves be sent across
@@ -34,9 +34,7 @@ struct Inner {
 impl SignatureRegistry {
     /// Create a new `SignatureRegistry`.
     pub fn new() -> Self {
-        Self {
-            inner: Default::default(),
-        }
+        Default::default()
     }
 
     /// Register a signature and return its unique index.

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -318,11 +318,12 @@ impl Table for LinearTable {
         let element = match init_value {
             TableElement::ExternRef(extern_ref) => {
                 let extern_ref: VMExternRef = extern_ref.into();
+
                 // We reduce the amount we increment by because `into` prevents
                 // dropping `init_value` (which is a caller-inc'd ref).
-                (new_len as usize)
-                    .checked_sub(size as usize + 1)
-                    .map(|val| extern_ref.ref_inc_by(val));
+                if let Some(val) = (new_len as usize).checked_sub(size as usize + 1) {
+                    extern_ref.ref_inc_by(val)
+                }
                 RawTableElement { extern_ref }
             }
             TableElement::FuncRef(func_ref) => RawTableElement { func_ref },

--- a/lib/vm/src/trap/mod.rs
+++ b/lib/vm/src/trap/mod.rs
@@ -3,6 +3,8 @@
 
 //! This is the module that facilitates the usage of Traps
 //! in Wasmer Runtime
+
+#[allow(clippy::module_inception)]
 mod trap;
 mod traphandlers;
 

--- a/lib/vm/src/trap/trap.rs
+++ b/lib/vm/src/trap/trap.rs
@@ -44,7 +44,7 @@ impl Trap {
     ///
     /// Internally saves a backtrace when constructed.
     pub fn wasm(pc: usize, backtrace: Backtrace, signal_trap: Option<TrapCode>) -> Self {
-        Trap::Wasm {
+        Self::Wasm {
             pc,
             backtrace,
             signal_trap,
@@ -56,7 +56,7 @@ impl Trap {
     /// Internally saves a backtrace when constructed.
     pub fn lib(trap_code: TrapCode) -> Self {
         let backtrace = Backtrace::new_unresolved();
-        Trap::Lib {
+        Self::Lib {
             trap_code,
             backtrace,
         }
@@ -67,6 +67,6 @@ impl Trap {
     /// Internally saves a backtrace when constructed.
     pub fn oom() -> Self {
         let backtrace = Backtrace::new_unresolved();
-        Trap::OOM { backtrace }
+        Self::OOM { backtrace }
     }
 }

--- a/lib/wasi-experimental-io-devices/src/lib.rs
+++ b/lib/wasi-experimental-io-devices/src/lib.rs
@@ -239,9 +239,9 @@ impl Read for FrameBuffer {
                 FrameBufferFileType::Buffer => {
                     let mut bytes_copied = 0;
 
-                    for i in 0..buf.len() {
+                    for (i, b) in buf.iter_mut().enumerate() {
                         if let Some(byte) = fb_state.get_byte(cursor + i) {
-                            buf[i] = byte;
+                            *b = byte;
                             bytes_copied += 1;
                         } else {
                             break;
@@ -257,8 +257,8 @@ impl Read for FrameBuffer {
                     let mut bytes = resolution_data.bytes().skip(cursor);
                     let bytes_to_copy = std::cmp::min(buf.len(), bytes.clone().count());
 
-                    for i in 0..bytes_to_copy {
-                        buf[i] = bytes.next().unwrap();
+                    for byte in buf.iter_mut().take(bytes_to_copy) {
+                        *byte = bytes.next().unwrap();
                     }
 
                     self.cursor += bytes_to_copy as u32;

--- a/lib/wasi-experimental-io-devices/src/util.rs
+++ b/lib/wasi-experimental-io-devices/src/util.rs
@@ -40,24 +40,16 @@ pub fn bytes_for_input_event(input_event: InputEvent) -> (u8, [u8; 8], usize) {
                 MouseButton::Middle => MOUSE_PRESS_MIDDLE,
             };
             let x_bytes = x.to_le_bytes();
-            for i in 0..4 {
-                data[i] = x_bytes[i];
-            }
+            data[..4].clone_from_slice(&x_bytes[..4]);
             let y_bytes = y.to_le_bytes();
-            for i in 0..4 {
-                data[i + 4] = y_bytes[i];
-            }
+            data[4..8].clone_from_slice(&y_bytes[..4]);
             (tag, data, 8)
         }
         InputEvent::MouseMoved(x, y) => {
             let x_bytes = x.to_le_bytes();
-            for i in 0..4 {
-                data[i] = x_bytes[i];
-            }
+            data[..4].clone_from_slice(&x_bytes[..4]);
             let y_bytes = y.to_le_bytes();
-            for i in 0..4 {
-                data[i + 4] = y_bytes[i];
-            }
+            data[4..8].clone_from_slice(&y_bytes[..4]);
             (MOUSE_MOVE, data, 8)
         }
         InputEvent::WindowClosed => (WINDOW_CLOSED, data, 0),

--- a/lib/wasi-types/src/directory.rs
+++ b/lib/wasi-types/src/directory.rs
@@ -15,25 +15,46 @@ pub struct __wasi_dirent_t {
 }
 
 pub fn dirent_to_le_bytes(ent: &__wasi_dirent_t) -> Vec<u8> {
-    use mem::transmute;
+    let out: Vec<u8> = std::iter::empty()
+        .chain(ent.d_next.to_le_bytes())
+        .chain(ent.d_ino.to_le_bytes())
+        .chain(ent.d_namlen.to_le_bytes())
+        .chain(u32::from(ent.d_type).to_le_bytes())
+        .collect();
 
-    let mut out = Vec::with_capacity(mem::size_of::<__wasi_dirent_t>());
-    let bytes: [u8; 8] = unsafe { transmute(ent.d_next.to_le()) };
-    for &b in &bytes {
-        out.push(b);
-    }
-    let bytes: [u8; 8] = unsafe { transmute(ent.d_ino.to_le()) };
-    for &b in &bytes {
-        out.push(b);
-    }
-    let bytes: [u8; 4] = unsafe { transmute(ent.d_namlen.to_le()) };
-    for &b in &bytes {
-        out.push(b);
-    }
-    out.push(ent.d_type);
-    out.push(0);
-    out.push(0);
-    out.push(0);
     assert_eq!(out.len(), mem::size_of::<__wasi_dirent_t>());
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{__wasi_dirent_t, dirent_to_le_bytes};
+
+    #[test]
+    fn test_dirent_to_le_bytes() {
+        let s = __wasi_dirent_t {
+            d_next: 0x0123456789abcdef,
+            d_ino: 0xfedcba9876543210,
+            d_namlen: 0xaabbccdd,
+            d_type: 0x99,
+        };
+
+        assert_eq!(
+            vec![
+                // d_next
+                0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01,
+                //
+                // d_ino
+                0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe,
+                //
+                // d_namelen
+                0xdd, 0xcc, 0xbb, 0xaa,
+                //
+                // d_type
+                // plus padding
+                0x99, 0x00, 0x00, 0x00,
+            ],
+            dirent_to_le_bytes(&s)
+        );
+    }
 }

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -401,10 +401,7 @@ impl WasiStateBuilder {
             }
         }
 
-        let fs_backing = self
-            .fs_override
-            .take()
-            .unwrap_or_else(|| default_fs_backing());
+        let fs_backing = self.fs_override.take().unwrap_or_else(default_fs_backing);
 
         // self.preopens are checked in [`PreopenDirBuilder::build`]
         let mut wasi_fs = WasiFs::new_with_preopen(&self.preopens, &self.vfs_preopens, fs_backing)
@@ -441,9 +438,9 @@ impl WasiStateBuilder {
                 .iter()
                 .map(|(key, value)| {
                     let mut env = Vec::with_capacity(key.len() + value.len() + 1);
-                    env.extend_from_slice(&key);
+                    env.extend_from_slice(key);
                     env.push(b'=');
-                    env.extend_from_slice(&value);
+                    env.extend_from_slice(value);
 
                     env
                 })

--- a/lib/wasi/src/state/types.rs
+++ b/lib/wasi/src/state/types.rs
@@ -72,6 +72,7 @@ pub fn fs_error_into_wasi_err(fs_error: FsError) -> __wasi_errno_t {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)]
 pub enum PollEvent {
     /// Data available to read
     PollIn = 1,

--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -126,7 +126,7 @@ fn write_buffer_array(
 
         let data = wasi_try_mem!(new_ptr.slice(memory, sub_buffer.len() as u32));
         wasi_try_mem!(data.write_slice(sub_buffer));
-        wasi_try_mem!(wasi_try_mem!(new_ptr.add(sub_buffer.len() as u32)).write(memory, 0));
+        wasi_try_mem!(wasi_try_mem!(new_ptr.add_offset(sub_buffer.len() as u32)).write(memory, 0));
 
         current_buffer_offset += sub_buffer.len() as u32 + 1;
     }
@@ -1051,8 +1051,8 @@ pub fn fd_readdir(
             buf_len as usize - buf_idx,
             std::mem::size_of::<__wasi_dirent_t>(),
         );
-        for i in 0..upper_limit {
-            wasi_try_mem!(buf_arr.index((i + buf_idx) as u64).write(dirent_bytes[i]));
+        for (i, b) in dirent_bytes.iter().enumerate().take(upper_limit) {
+            wasi_try_mem!(buf_arr.index((i + buf_idx) as u64).write(*b));
         }
         buf_idx += upper_limit;
         if upper_limit != std::mem::size_of::<__wasi_dirent_t>() {

--- a/tests/lib/engine-dummy/src/artifact.rs
+++ b/tests/lib/engine-dummy/src/artifact.rs
@@ -105,7 +105,7 @@ impl DummyArtifact {
             table_styles,
             cpu_features: engine.target().cpu_features().as_u64(),
         };
-        Self::from_parts(&engine, metadata)
+        Self::from_parts(engine, metadata)
     }
 
     #[cfg(not(feature = "compiler"))]
@@ -127,7 +127,7 @@ impl DummyArtifact {
         let metadata: DummyArtifactMetadata = bincode::deserialize(inner_bytes)
             .map_err(|e| DeserializeError::CorruptedBinary(format!("{:?}", e)))?;
 
-        Self::from_parts(&engine, metadata).map_err(DeserializeError::Compiler)
+        Self::from_parts(engine, metadata).map_err(DeserializeError::Compiler)
     }
 
     #[cfg(not(feature = "serialize"))]

--- a/tests/lib/engine-dummy/src/engine.rs
+++ b/tests/lib/engine-dummy/src/engine.rs
@@ -21,6 +21,7 @@ extern "C" fn dummy_trampoline(
 
 /// A WebAssembly `Dummy` Engine.
 #[derive(Clone)]
+#[cfg_attr(feature = "compiler", derive(Default))]
 pub struct DummyEngine {
     signatures: Arc<SignatureRegistry>,
     func_data: Arc<FuncDataRegistry>,
@@ -32,13 +33,7 @@ pub struct DummyEngine {
 impl DummyEngine {
     #[cfg(feature = "compiler")]
     pub fn new() -> Self {
-        Self {
-            signatures: Arc::new(SignatureRegistry::new()),
-            func_data: Arc::new(FuncDataRegistry::new()),
-            features: Arc::new(Default::default()),
-            target: Arc::new(Default::default()),
-            engine_id: EngineId::default(),
-        }
+        Default::default()
     }
 
     pub fn features(&self) -> &Features {
@@ -116,12 +111,12 @@ impl Engine for DummyEngine {
         binary: &[u8],
         tunables: &dyn Tunables,
     ) -> Result<Arc<dyn Artifact>, CompileError> {
-        Ok(Arc::new(DummyArtifact::new(&self, binary, tunables)?))
+        Ok(Arc::new(DummyArtifact::new(self, binary, tunables)?))
     }
 
     /// Deserializes a WebAssembly module (binary content of a Shared Object file)
     unsafe fn deserialize(&self, bytes: &[u8]) -> Result<Arc<dyn Artifact>, DeserializeError> {
-        Ok(Arc::new(DummyArtifact::deserialize(&self, &bytes)?))
+        Ok(Arc::new(DummyArtifact::deserialize(self, bytes)?))
     }
 
     fn id(&self) -> &EngineId {

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use std::fs::{read_dir, File, OpenOptions, ReadDir};
 use std::io::{self, Read, Seek, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use wasmer::{Imports, Instance, Module, Store};
 use wasmer_vfs::{host_fs, mem_fs, FileSystem};
 use wasmer_wasi::types::{__wasi_filesize_t, __wasi_timestamp_t};
@@ -95,7 +95,7 @@ impl<'a> WasiTest<'a> {
             wasm_module.read_to_end(&mut out)?;
             out
         };
-        let module = Module::new(&store, &wasm_bytes)?;
+        let module = Module::new(store, &wasm_bytes)?;
         let (env, _tempdirs) = self.create_wasi_env(filesystem_kind)?;
         let imports = self.get_imports(store, &module, env.clone())?;
         let instance = Instance::new(&module, &imports)?;
@@ -620,14 +620,13 @@ impl VirtualFile for OutputCapturerer {
 fn map_host_fs_to_mem_fs(
     fs: &mem_fs::FileSystem,
     directory_reader: ReadDir,
-    path_prefix: &PathBuf,
+    path_prefix: &Path,
 ) -> anyhow::Result<()> {
     for entry in directory_reader {
         let entry = entry?;
         let entry_type = entry.file_type()?;
 
-        let mut path = path_prefix.clone();
-        path.push(entry.path().file_name().unwrap());
+        let path = path_prefix.join(entry.path().file_name().unwrap());
 
         if entry_type.is_dir() {
             fs.create_dir(&path)?;

--- a/tests/lib/wast/src/wast.rs
+++ b/tests/lib/wast/src/wast.rs
@@ -209,7 +209,7 @@ impl Wast {
                     Err(e) => e,
                 };
                 let error_message = format!("{:?}", err);
-                if !Self::matches_message_assert_invalid(&message, &error_message) {
+                if !Self::matches_message_assert_invalid(message, &error_message) {
                     bail!(
                         "assert_invalid: expected \"{}\", got \"{}\"",
                         message,
@@ -250,7 +250,7 @@ impl Wast {
                     Err(e) => e,
                 };
                 let error_message = format!("{:?}", err);
-                if !Self::matches_message_assert_unlinkable(&message, &error_message) {
+                if !Self::matches_message_assert_unlinkable(message, &error_message) {
                     bail!(
                         "assert_unlinkable: expected {}, got {}",
                         message,
@@ -278,7 +278,7 @@ impl Wast {
         let mut errors = Vec::with_capacity(ast.directives.len());
         for directive in ast.directives {
             let sp = directive.span();
-            if let Err(e) = self.run_directive(&test, directive) {
+            if let Err(e) = self.run_directive(test, directive) {
                 let message = format!("{}", e);
                 // If depends on an instance that doesn't exist
                 if message.contains("no previous instance found") {
@@ -317,7 +317,7 @@ impl Wast {
                 Ok(s) => ret.push_str(s),
                 Err(_) => bail!("malformed UTF-8 encoding"),
             }
-            ret.push_str(" ");
+            ret.push(' ');
         }
         let buf = wast::parser::ParseBuffer::new(&ret)?;
         let mut wat = wast::parser::parse::<wast::Wat>(&buf)?;
@@ -403,7 +403,7 @@ impl Wast {
         field: &str,
         args: &[Val],
     ) -> Result<Vec<Val>> {
-        let instance = self.get_instance(instance_name.as_deref())?;
+        let instance = self.get_instance(instance_name)?;
         let func: &Function = instance.exports.get(field)?;
         match func.call(args) {
             Ok(result) => Ok(result.into()),
@@ -413,7 +413,7 @@ impl Wast {
 
     /// Get the value of an exported global from an instance.
     fn get(&mut self, instance_name: Option<&str>, field: &str) -> Result<Vec<Val>> {
-        let instance = self.get_instance(instance_name.as_deref())?;
+        let instance = self.get_instance(instance_name)?;
         let global: &Global = instance.exports.get(field)?;
         Ok(vec![global.get()])
     }
@@ -473,8 +473,7 @@ impl Wast {
             || self
                 .match_trap_messages
                 .get(expected)
-                .map(|alternative| actual.contains(alternative))
-                .unwrap_or(false)
+                .map_or(false, |alternative| actual.contains(alternative))
     }
 
     fn val_matches(&self, actual: &Val, expected: &wast::AssertExpression) -> Result<bool> {


### PR DESCRIPTION
Fixes: #2926

# Description
* Fix all clippy lints
* Adjust `Makefile` so that the `cargo clippy` commands exit with non-zero when warnings are found

# TODO before this is ready
- [x] Describe safety in [lib/engine/src/tunables.rs:67](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/engine/src/tunables.rs#L67)
- [x] Describe safety in [lib/types/src/values.rs:70](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/types/src/values.rs#L70)
- [x] Describe safety in [lib/types/src/values.rs:76](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/types/src/values.rs#L76)
- [x] Describe safety in [lib/emscripten/src/utils.rs:126](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/emscripten/src/utils.rs#L126)
I don't know why it needs to be unsafe, can you research why?
  - The reason is the call to `unsafe slice::from_raw_parts_mut(addr, count as usize)` in line 135. Not sure if this function actually encapsulates the behavior good enough, but if it does, we could just put a `unsafe{…}` around this call and remove the `unsafe` from the function. (silwol)
- [x] Describe safety in [lib/emscripten/src/utils.rs:141](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/emscripten/src/utils.rs#L141)
We need to double check the safety of the previous method, as this one depends on it (and I believe that's why it's unsafe)
  - That appears to be the case, once the previous method is no longer marked unsafe, the `unsafe` here is no longer required either. (silwol)
- [x] Describe safety in [lib/c-api/src/wasm_c_api/wat.rs:13](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/c-api/src/wasm_c_api/wat.rs#L13)
Not sure why it's unsafe, can you research?
  - Ok, `extern "C"`, that's why. No idea why I missed that initially. :-) (silwol)
- [x] Describe safety in [lib/api/src/sys/externals/function.rs:866](https://github.com/silwol/wasmer/blob/dev/2926-fix-clippy-warnings-in-wasmer3/lib/api/src/sys/externals/function.rs#L866)
Not sure why it's unsafe, can you research?
  - I have no clear idea, just the gut feeling that it has something to do with handling the native types. Really would appreciate if we had a better description than what I could guess. (silwol)

# Review

- [x] Add a short description of the change to the CHANGELOG.md file