### PR TITLE
Fix build error on some archs by using c_char instead of i8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ### Fixed
 - [#2942](https://github.com/wasmerio/wasmer/pull/2942) Fix clippy lints.
+- [#2943](https://github.com/wasmerio/wasmer/pull/2943) Fix build error on some archs by using c_char instead of i8
 
 ## 2.3.0 - 2022/06/06
 

--- a/lib/emscripten/src/exec.rs
+++ b/lib/emscripten/src/exec.rs
@@ -1,5 +1,6 @@
 use crate::varargs::VarArgs;
 use crate::EmEnv;
+use libc::c_char;
 use libc::execvp as libc_execvp;
 use std::ffi::CString;
 use wasmer::WasmPtr;
@@ -27,7 +28,7 @@ pub fn execvp(ctx: &EmEnv, command_name_offset: u32, argv_offset: u32) -> i32 {
             CString::new(vec).unwrap()
         })
         .collect();
-    let mut argv: Vec<*const i8> = arg_strings.iter().map(|s| s.as_ptr()).collect();
+    let mut argv: Vec<*const c_char> = arg_strings.iter().map(|s| s.as_ptr()).collect();
 
     // push a nullptr on to the end of the args array
     argv.push(std::ptr::null());


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
