### PR TITLE
Fix duplicate entries in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,8 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2802](https://github.com/wasmerio/wasmer/pull/2802) Support Dylib engine with Singlepass
 - [#2836](https://github.com/wasmerio/wasmer/pull/2836) Improve TrapInformation data stored at runtime
 - [#2864](https://github.com/wasmerio/wasmer/pull/2864) `wasmer-cli`: remove wasi-experimental-io-devices from default builds
-- #2864 wasmer-cli: remove wasi-experimental-io-devices from default builds
 - [#2933](https://github.com/wasmerio/wasmer/pull/2933) Rename NativeFunc to TypedFunction.
-### Changed
-- #2868 Removed loupe crate dependency
+- [#2868](https://github.com/wasmerio/wasmer/pull/2868) Removed loupe crate dependency
 
 ### Fixed
 - [#2829](https://github.com/wasmerio/wasmer/pull/2829) Improve error message oriented from JS object.


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
Remove duplicate `Changed` title and `#2864 wasmer-cli: remove wasi-experimental-io-devices from default builds` entry from the CHANGELOG

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
