### PR TITLE
compiler-cranelift: Fix typo in enum variant

### DIFF
--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -168,7 +168,7 @@ impl Compiler for CraneliftCompiler {
 
                 let (unwind_info, fde) = match compiled_function_unwind_info(&*isa, &context)? {
                     #[cfg(feature = "unwind")]
-                    CraneliftUnwindInfo::FDE(fde) => {
+                    CraneliftUnwindInfo::Fde(fde) => {
                         if dwarf_frametable.is_some() {
                             let fde = fde.to_fde(Address::Symbol {
                                 // The symbol is the kind of relocation.


### PR DESCRIPTION
Small typo prevented `wasm32` target from being built.

```
error[E0599]: no variant or associated item named `FDE` found for enum `CraneliftUnwindInfo` in the current scope
   --> lib/compiler-cranelift/src/compiler.rs:171:42
    |
171 |                     CraneliftUnwindInfo::FDE(fde) => {
    |                                          ^^^
    |                                          |
    |                                          variant or associated item not found in `CraneliftUnwindInfo`
    |                                          help: there is a variant with a similar name: `Fde`
    |
   ::: lib/compiler-cranelift/src/translator/unwind.rs:11:1
    |
11  | pub(crate) enum CraneliftUnwindInfo {
    | ----------------------------------- variant or associated item `FDE` not found here
```