### PR TITLE
Some fixes to x86_64 Singlepass compiler, when using atomics

### DIFF
--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -3151,7 +3151,9 @@ impl Machine for MachineX86_64 {
             },
         );
     }
-    // x86_64 have a strong memory model, aligned move is guarantied to be atomic, too or from memory
+    // x86_64 have a strong memory model, so coherency between all threads (core) is garantied
+    // and aligned move is guarantied to be atomic, too or from memory
+    // so store/load an atomic is a simple mov on x86_64
     fn i32_atomic_save(
         &mut self,
         value: Location,


### PR DESCRIPTION
# Description
A few fixes and improvments on x86_64 Singlepass compiler to help handling Atomics.