### PR TITLE
Fix singlepass on  arm64 that was trying to emit a sub opcode with a constant as destination (for #2959)

### DIFF
--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -1017,8 +1017,8 @@ impl MachineARM64 {
                 self.assembler.emit_sub(
                     Size::S64,
                     Location::GPR(tmp_bound),
-                    Location::GPR(tmp_bound),
                     Location::Imm32(value_size as _),
+                    Location::GPR(tmp_bound),
                 )?;
             } else {
                 let tmp2 = self.acquire_temp_gpr().ok_or(CodegenError {


### PR DESCRIPTION
# Description

Fix singlepass/machine_arm64 that was trying to emit a sub opcode with a constant as destination (for #2959)