### PR TITLE
Upgrade enumset minimum version to one that compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 ## **Unreleased**
 
 ### Changed
-- #2946 Remove dylib,staticlib engines in favor of a single Universal engine
+- [#2946](https://github.com/wasmerio/wasmer/pull/2946) Remove dylib,staticlib engines in favor of a single Universal engine
 - [#2949](https://github.com/wasmerio/wasmer/pull/2949) Switch back to using custom LLVM builds on CI
 
 ### Fixed
 - [#2963](https://github.com/wasmerio/wasmer/pull/2963) Remove accidental dependency on libwayland and libxcb in ClI
 - [#2942](https://github.com/wasmerio/wasmer/pull/2942) Fix clippy lints.
 - [#2943](https://github.com/wasmerio/wasmer/pull/2943) Fix build error on some archs by using c_char instead of i8
+- [2976](https://github.com/wasmerio/wasmer/pull/2976) Upgrade minimum enumset to one that compiles
 
 ## 2.3.0 - 2022/06/06
 

--- a/Makefile
+++ b/Makefile
@@ -704,3 +704,7 @@ lint: lint-formatting lint-packages
 
 install-local: package
 	tar -C ~/.wasmer -zxvf wasmer.tar.gz
+
+test-minimal-versions:
+	rm -f Cargo.lock
+	cargo +nightly build --tests -Z minimal-versions --all-features

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -31,7 +31,7 @@ wasmer-compiler = { version = "=2.3.0", path = "../compiler" }
 wasmer-middlewares = { version = "=2.3.0", path = "../middlewares", optional = true }
 wasmer-wasi = { version = "=2.3.0", path = "../wasi", default-features = false, features = ["host-fs", "sys"], optional = true }
 wasmer-types = { version = "=2.3.0", path = "../types" }
-enumset = "1.0"
+enumset = "1.0.2"
 cfg-if = "1.0"
 lazy_static = "1.4"
 libc = { version = "^0.2", default-features = false }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 wasmer-types = { path = "../types", version = "=2.3.0", default-features = false }
 wasmparser = { version = "0.83", optional = true, default-features = false }
 target-lexicon = { version = "0.12.2", default-features = false }
-enumset = "1.0"
+enumset = "1.0.2"
 hashbrown = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"


### PR DESCRIPTION
# Description

enumset dependency was on 1.0, but only [1.0.2 has a fix for compiling with newer syn](https://github.com/Lymia/enumset/blob/master/RELEASES.md#version-102-2021-01-25). This PR fixes that, and adds a makefile target for testing the minimal version scenario. It probably really should be added to the CI, but not sure where in the complicated setup here!

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
