### PR TITLE
Have make targets install-capi-lib,install-pkgconfig work without building the wasmer binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#2942](https://github.com/wasmerio/wasmer/pull/2942) Fix clippy lints.
 - [#2943](https://github.com/wasmerio/wasmer/pull/2943) Fix build error on some archs by using c_char instead of i8
 - [2976](https://github.com/wasmerio/wasmer/pull/2976) Upgrade minimum enumset to one that compiles
+- [2988](https://github.com/wasmerio/wasmer/pull/2988) Have make targets install-capi-lib,install-pkgconfig work without building the wasmer binary
 
 ## 2.3.0 - 2022/06/06
 


### PR DESCRIPTION
# Description

1. modified target `install-capi-lib` to detect version without requiring the binary being built.
2. added separate install target for library: `install-capi` instead of using `install` for both binary and library
3. added target `install-capi-pkgconfig` that outputs this example `.pc` file if the binary is missing:

   ```pc
   prefix=/usr/local
   includedir=${prefix}/include
   libdir=${prefix}/lib

   Name: wasmer
   Description: The Wasmer library for running WebAssembly
   Version: 2.3.0
   Cflags: -I${prefix}/include
   Libs: -L${prefix}/lib -lwasmer
   ```

Fixes #2541

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
