### PR TITLE
Fix "run --invoke [function]" to behave the same as "run"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 - [#3008](https://github.com/wasmerio/wasmer/pull/3008) Add a new CI check that uses cargo public-api to track changes in the API between master and the last deployed version on crates.io
 - [#3003](https://github.com/wasmerio/wasmer/pull/3003) Remove RuntimeError::raise from public API
 - [#2999](https://github.com/wasmerio/wasmer/pull/2999) Allow `--invoke` CLI option for Emscripten files without a `main` function
+- [#2997](https://github.com/wasmerio/wasmer/pull/2997) Fix "run --invoke [function]" to behave the same as "run"
 - [#2946](https://github.com/wasmerio/wasmer/pull/2946) Remove dylib,staticlib engines in favor of a single Universal engine
 - [#2949](https://github.com/wasmerio/wasmer/pull/2949) Switch back to using custom LLVM builds on CI
 - #2892 Renamed `get_native_function` to `get_typed_function`, marked former as deprecated.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,7 @@ name = "wasmer-integration-tests-cli"
 version = "2.3.0"
 dependencies = [
  "anyhow",
+ "rand",
  "tempfile",
 ]
 

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -234,7 +234,7 @@ impl Run {
                     .call(&[])
                     .with_context(|| "failed to run _initialize function")?;
             }
-    
+
             // Do we want to invoke a function?
             if let Some(ref invoke) = self.invoke {
                 let result = self.invoke_function(&instance, invoke, &self.args)?;

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -226,8 +226,34 @@ impl Run {
         };
         #[cfg(not(feature = "wasi"))]
         let ret = {
-            let instance = Instance::new(&mut store, &module, &imports! {})?;
-            self.inner_run(ctx, instance)
+            let instance = Instance::new(&module, &imports! {})?;
+
+            // If this module exports an _initialize function, run that first.
+            if let Ok(initialize) = instance.exports.get_function("_initialize") {
+                initialize
+                    .call(&[])
+                    .with_context(|| "failed to run _initialize function")?;
+            }
+    
+            // Do we want to invoke a function?
+            if let Some(ref invoke) = self.invoke {
+                let result = self.invoke_function(&instance, invoke, &self.args)?;
+                println!(
+                    "{}",
+                    result
+                        .iter()
+                        .map(|val| val.to_string())
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                );
+            } else {
+                let start: Function = self.try_find_function(&instance, "_start", &[])?;
+                let result = start.call(&[]);
+                #[cfg(feature = "wasi")]
+                self.wasi.handle_result(result)?;
+                #[cfg(not(feature = "wasi"))]
+                result?;
+            }
         };
 
         ret

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/wasmerio/wasmer"
 edition = "2018"
 publish = false
 
+[dev-dependencies]
+rand = "0.8.5"
+
 [dependencies]
 anyhow = "1"
 tempfile = "3"


### PR DESCRIPTION
Prior to this change, `wasmer run --function _start` and `wasmer run` would behave 
differently because `wasmer run` uses the WASI environment but `--invoke` did not. 

Closes #2978.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
