### PR TITLE
Support --invoke option for emscripten files without _start function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ### Changed
 - [#3003](https://github.com/wasmerio/wasmer/pull/3003) Remove RuntimeError::raise from public API
+- [#2999](https://github.com/wasmerio/wasmer/pull/2999) Allow `--invoke` CLI option for Emscripten files without a `main` function
 - [#2946](https://github.com/wasmerio/wasmer/pull/2946) Remove dylib,staticlib engines in favor of a single Universal engine
 - [#2949](https://github.com/wasmerio/wasmer/pull/2949) Switch back to using custom LLVM builds on CI
 

--- a/Makefile
+++ b/Makefile
@@ -539,7 +539,7 @@ test-examples:
 	$(CARGO_BINARY) test $(CARGO_TARGET) --release $(compiler_features) --features wasi --examples
 
 test-integration:
-	$(CARGO_BINARY) test $(CARGO_TARGET) -p wasmer-integration-tests-cli
+	$(CARGO_BINARY) test $(CARGO_TARGET) --no-fail-fast -p wasmer-integration-tests-cli
 
 test-integration-ios:
 	$(CARGO_BINARY) test $(CARGO_TARGET) -p wasmer-integration-tests-ios

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -105,9 +105,6 @@ impl Run {
             };
             // TODO: refactor this
             if is_emscripten_module(&module) {
-                if self.invoke.is_some() {
-                    bail!("--invoke is not supported with emscripten modules");
-                }
                 let mut emscripten_globals = EmscriptenGlobals::new(module.store(), &module)
                     .map_err(|e| anyhow!("{}", e))?;
                 let mut em_env = EmEnv::new(&emscripten_globals.data, Default::default());
@@ -137,7 +134,7 @@ impl Run {
                         self.path.to_str().unwrap()
                     },
                     self.args.iter().map(|arg| arg.as_str()).collect(),
-                    None, //run.em_entrypoint.clone(),
+                    self.invoke.clone(),
                 )?;
                 return Ok(());
             }

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -16,46 +16,6 @@ fn test_no_start_wat_path() -> String {
     format!("{}/{}", ASSET_PATH, "no_start.wat")
 }
 
-// This test verifies that "wasmer run --invoke _start module.emscripten.wat"
-// works the same as "wasmer run module.emscripten.wat" (without --invoke).
-#[test]
-fn run_invoke_works_with_nomain_emscripten() -> anyhow::Result<()> {
-    // In this example the function "wasi_unstable.arg_sizes_get"
-    // is a function that is imported from the WASI env.
-    let emscripten_wat = include_bytes("");
-    let random = rand::random::<u64>();
-    let module_file = std::env::temp_dir().join(&format!("{random}.emscripten.wat"));
-    std::fs::write(&module_file, wasi_wat.as_bytes()).unwrap();
-    let output = Command::new(WASMER_PATH)
-        .arg("run")
-        .arg(&module_file)
-        .output()?;
-
-    let stderr = std::str::from_utf8(&output.stderr).unwrap().to_string();
-    let success = output.status.success();
-    if !success {
-        println!("ERROR in 'wasmer run [module.emscripten.wat]':\r\n{stderr}");
-        panic!();
-    }
-
-    let output = Command::new(WASMER_PATH)
-        .arg("run")
-        .arg("--invoke")
-        .arg("_start")
-        .arg(&module_file)
-        .output()?;
-
-    let stderr = std::str::from_utf8(&output.stderr).unwrap().to_string();
-    let success = output.status.success();
-    if !success {
-        println!("ERROR in 'wasmer run --invoke _start [module.emscripten.wat]':\r\n{stderr}");
-        panic!();
-    }
-
-    std::fs::remove_file(&module_file).unwrap();
-    Ok(())
-}
-
 #[test]
 fn run_wasi_works() -> anyhow::Result<()> {
     let output = Command::new(WASMER_PATH)

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -16,6 +16,46 @@ fn test_no_start_wat_path() -> String {
     format!("{}/{}", ASSET_PATH, "no_start.wat")
 }
 
+// This test verifies that "wasmer run --invoke _start module.emscripten.wat"
+// works the same as "wasmer run module.emscripten.wat" (without --invoke).
+#[test]
+fn run_invoke_works_with_nomain_emscripten() -> anyhow::Result<()> {
+    // In this example the function "wasi_unstable.arg_sizes_get"
+    // is a function that is imported from the WASI env.
+    let emscripten_wat = include_bytes("");
+    let random = rand::random::<u64>();
+    let module_file = std::env::temp_dir().join(&format!("{random}.emscripten.wat"));
+    std::fs::write(&module_file, wasi_wat.as_bytes()).unwrap();
+    let output = Command::new(WASMER_PATH)
+        .arg("run")
+        .arg(&module_file)
+        .output()?;
+
+    let stderr = std::str::from_utf8(&output.stderr).unwrap().to_string();
+    let success = output.status.success();
+    if !success {
+        println!("ERROR in 'wasmer run [module.emscripten.wat]':\r\n{stderr}");
+        panic!();
+    }
+
+    let output = Command::new(WASMER_PATH)
+        .arg("run")
+        .arg("--invoke")
+        .arg("_start")
+        .arg(&module_file)
+        .output()?;
+
+    let stderr = std::str::from_utf8(&output.stderr).unwrap().to_string();
+    let success = output.status.success();
+    if !success {
+        println!("ERROR in 'wasmer run --invoke _start [module.emscripten.wat]':\r\n{stderr}");
+        panic!();
+    }
+
+    std::fs::remove_file(&module_file).unwrap();
+    Ok(())
+}
+
 #[test]
 fn run_wasi_works() -> anyhow::Result<()> {
     let output = Command::new(WASMER_PATH)


### PR DESCRIPTION
When running emscripten files, the CLI now supports the `--invoke` option to invoke a function by name.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
