### PR TITLE
Fix context capi ci errors

### DIFF
--- a/lib/api/src/sys/externals/global.rs
+++ b/lib/api/src/sys/externals/global.rs
@@ -222,6 +222,14 @@ impl Global {
     }
 }
 
+impl std::cmp::PartialEq for Global {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl std::cmp::Eq for Global {}
+
 impl<'a> Exportable<'a> for Global {
     fn get_self_from_extern(_extern: &'a Extern) -> Result<&'a Self, ExportError> {
         match _extern {

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -239,6 +239,14 @@ impl Memory {
     }
 }
 
+impl std::cmp::PartialEq for Memory {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl std::cmp::Eq for Memory {}
+
 impl<'a> Exportable<'a> for Memory {
     fn get_self_from_extern(_extern: &'a Extern) -> Result<&'a Self, ExportError> {
         match _extern {

--- a/lib/api/src/sys/externals/table.rs
+++ b/lib/api/src/sys/externals/table.rs
@@ -196,6 +196,14 @@ impl Table {
     }
 }
 
+impl std::cmp::PartialEq for Table {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl std::cmp::Eq for Table {}
+
 impl<'a> Exportable<'a> for Table {
     fn get_self_from_extern(_extern: &'a Extern) -> Result<&'a Self, ExportError> {
         match _extern {

--- a/lib/c-api/examples/deprecated-header.c
+++ b/lib/c-api/examples/deprecated-header.c
@@ -21,6 +21,8 @@ int main(int argc, const char *argv[]) {
   printf("Initializing...\n");
   own wasm_engine_t* engine = wasm_engine_new();
   own wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // =====================
   wasm_limits_t limits1 = {

--- a/lib/c-api/examples/early-exit.c
+++ b/lib/c-api/examples/early-exit.c
@@ -29,7 +29,7 @@ void print_frame(wasm_frame_t* frame) {
 
 wasm_store_t *store = NULL;
 
-own wasm_trap_t* early_exit(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+own wasm_trap_t* early_exit(wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
   own wasm_message_t trap_message;
   wasm_name_new_from_string_nt(&trap_message, "trapping from a host import");
   own wasm_trap_t *trap = wasm_trap_new(store, &trap_message);
@@ -42,6 +42,8 @@ int main(int argc, const char *argv[]) {
   printf("Initializing...\n");
   wasm_engine_t *engine = wasm_engine_new();
   store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/examples/exports-function.c
+++ b/lib/c-api/examples/exports-function.c
@@ -20,6 +20,8 @@ int main(int argc, const char* argv[]) {
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
     wasm_store_t* store = wasm_store_new(engine);
+    wasm_context_t* ctx = wasm_context_new(store, 0);
+    wasm_store_context_set(store, ctx);
 
     printf("Compiling module...\n");
     wasm_module_t* module = wasm_module_new(store, &wasm_bytes);

--- a/lib/c-api/examples/exports-global.c
+++ b/lib/c-api/examples/exports-global.c
@@ -19,6 +19,8 @@ int main(int argc, const char* argv[]) {
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
     wasm_store_t* store = wasm_store_new(engine);
+    wasm_context_t* ctx = wasm_context_new(store, 0);
+    wasm_store_context_set(store, ctx);
 
     printf("Compiling module...\n");
     wasm_module_t* module = wasm_module_new(store, &wasm_bytes);

--- a/lib/c-api/examples/features.c
+++ b/lib/c-api/examples/features.c
@@ -26,6 +26,8 @@ int main(int argc, const char* argv[]) {
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new_with_config(config);
     wasm_store_t* store = wasm_store_new(engine);
+    wasm_context_t* ctx = wasm_context_new(store, 0);
+    wasm_store_context_set(store, ctx);
 
     printf("Compiling module...\n");
     wasm_module_t* module = wasm_module_new(store, &wasm_bytes);

--- a/lib/c-api/examples/imports-exports.c
+++ b/lib/c-api/examples/imports-exports.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "wasmer.h"
 
-wasm_trap_t* host_func_callback(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+wasm_trap_t* host_func_callback(wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
     printf("Calling back...\n> ");
 
     wasm_val_t val = WASM_I32_VAL(42);
@@ -31,6 +31,8 @@ int main(int argc, const char* argv[]) {
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
     wasm_store_t* store = wasm_store_new(engine);
+    wasm_context_t* ctx = wasm_context_new(store, 0);
+    wasm_store_context_set(store, ctx);
 
     printf("Compiling module...\n");
     wasm_module_t* module = wasm_module_new(store, &wasm_bytes);

--- a/lib/c-api/examples/instance.c
+++ b/lib/c-api/examples/instance.c
@@ -20,6 +20,8 @@ int main(int argc, const char* argv[]) {
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
     wasm_store_t* store = wasm_store_new(engine);
+    wasm_context_t* ctx = wasm_context_new(store, 0);
+    wasm_store_context_set(store, ctx);
 
     printf("Compiling module...\n");
     wasm_module_t* module = wasm_module_new(store, &wasm_bytes);

--- a/lib/c-api/examples/memory.c
+++ b/lib/c-api/examples/memory.c
@@ -28,6 +28,8 @@ int main(int argc, const char* argv[]) {
     printf("Creating the store...\n");
     wasm_engine_t* engine = wasm_engine_new();
     wasm_store_t* store = wasm_store_new(engine);
+    wasm_context_t* ctx = wasm_context_new(store, 0);
+    wasm_store_context_set(store, ctx);
 
     printf("Compiling module...\n");
     wasm_module_t* module = wasm_module_new(store, &wasm_bytes);

--- a/lib/c-api/examples/memory2.c
+++ b/lib/c-api/examples/memory2.c
@@ -20,6 +20,8 @@ int main(int argc, const char *argv[]) {
   printf("Initializing...\n");
   own wasm_engine_t* engine = wasm_engine_new();
   own wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // =====================
   wasm_limits_t limits1 = {

--- a/lib/c-api/examples/wasi.c
+++ b/lib/c-api/examples/wasi.c
@@ -28,6 +28,24 @@ int main(int argc, const char* argv[]) {
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
+  printf("Setting up WASI...\n");
+  wasi_config_t* config = wasi_config_new("example_program");
+  // TODO: error checking
+  const char* js_string = "function greet(name) { return JSON.stringify('Hello, ' + name); }; print(greet('World'));";
+  wasi_config_arg(config, "--eval");
+  wasi_config_arg(config, js_string);
+  wasi_config_capture_stdout(config);
+
+  wasi_env_t* wasi_env = wasi_env_new(config);
+  if (!wasi_env) {
+    printf("> Error building WASI env!\n");
+    print_wasmer_error();
+    return 1;
+  }
+
+  wasm_context_t* ctx = wasm_context_new(store, wasi_env);
+  wasm_store_context_set(store, ctx);
+
   // Load binary.
   printf("Loading binary...\n");
   FILE* file = fopen("assets/qjs.wasm", "r");
@@ -55,26 +73,10 @@ int main(int argc, const char* argv[]) {
   }
 
   wasm_byte_vec_delete(&binary);
-
-  printf("Setting up WASI...\n");
-  wasi_config_t* config = wasi_config_new("example_program");
-  // TODO: error checking
-  const char* js_string = "function greet(name) { return JSON.stringify('Hello, ' + name); }; print(greet('World'));";
-  wasi_config_arg(config, "--eval");
-  wasi_config_arg(config, js_string);
-  wasi_config_capture_stdout(config);
-
-  wasi_env_t* wasi_env = wasi_env_new(config);
-  if (!wasi_env) {
-    printf("> Error building WASI env!\n");
-    print_wasmer_error();
-    return 1;
-  }
-
   // Instantiate.
   printf("Instantiating module...\n");
   wasm_extern_vec_t imports;
-  bool get_imports_result = wasi_get_imports(store, module, wasi_env, &imports);
+  bool get_imports_result = wasi_get_imports(store, module, &imports);
 
   if (!get_imports_result) {
     printf("> Error getting WASI imports!\n");

--- a/lib/c-api/src/wasm_c_api/context.rs
+++ b/lib/c-api/src/wasm_c_api/context.rs
@@ -1,6 +1,6 @@
 use crate::wasm_c_api::store::wasm_store_t;
 use libc::c_void;
-use wasmer_api::Context;
+use wasmer_api::{Context, ContextMut};
 
 /// Opaque type representing a WebAssembly context.
 #[allow(non_camel_case_types)]
@@ -38,3 +38,36 @@ pub unsafe extern "C" fn wasm_context_new(
 /// See the module's documentation.
 #[no_mangle]
 pub unsafe extern "C" fn wasm_context_delete(_context: Option<Box<wasm_context_t>>) {}
+
+/// Opaque type representing a mut ref of a WebAssembly context.
+#[allow(non_camel_case_types)]
+pub struct wasm_context_ref_mut_t<'a> {
+    pub(crate) inner: ContextMut<'a, *mut c_void>,
+}
+
+/// Get the value of `wasm_context_ref_mut_t` data.
+#[no_mangle]
+pub unsafe extern "C" fn wasm_context_ref_mut_get(ctx: &wasm_context_ref_mut_t) -> *mut c_void {
+    *ctx.inner.data()
+}
+
+/// Set the value of [`ContextMut`] data.
+///
+#[no_mangle]
+pub unsafe extern "C" fn wasm_context_ref_mut_set(
+    ctx: &mut wasm_context_ref_mut_t,
+    new_val: *mut c_void,
+) {
+    *ctx.inner.data_mut() = new_val;
+}
+
+/// Deletes a WebAssembly context.
+///
+/// # Example
+///
+/// See the module's documentation.
+#[no_mangle]
+pub unsafe extern "C" fn wasm_context_ref_mut_delete(
+    _context: Option<&mut wasm_context_ref_mut_t>,
+) {
+}

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -100,6 +100,14 @@ pub unsafe extern "C" fn wasm_global_set(global: &mut wasm_global_t, val: &wasm_
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wasm_global_same(
+    wasm_global1: &wasm_global_t,
+    wasm_global2: &wasm_global_t,
+) -> bool {
+    wasm_global1.inner == wasm_global2.inner
+}
+
+#[no_mangle]
 pub extern "C" fn wasm_global_type(
     global: Option<&wasm_global_t>,
 ) -> Option<Box<wasm_globaltype_t>> {

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -54,6 +54,14 @@ pub unsafe extern "C" fn wasm_memory_copy(memory: &wasm_memory_t) -> Box<wasm_me
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wasm_memory_same(
+    wasm_memory1: &wasm_memory_t,
+    wasm_memory2: &wasm_memory_t,
+) -> bool {
+    wasm_memory1.inner == wasm_memory2.inner
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wasm_memory_type(
     memory: Option<&wasm_memory_t>,
 ) -> Option<Box<wasm_memorytype_t>> {

--- a/lib/c-api/src/wasm_c_api/externals/table.rs
+++ b/lib/c-api/src/wasm_c_api/externals/table.rs
@@ -54,6 +54,14 @@ pub unsafe extern "C" fn wasm_table_size(table: &wasm_table_t) -> usize {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn wasm_table_same(
+    wasm_table1: &wasm_table_t,
+    wasm_table2: &wasm_table_t,
+) -> bool {
+    wasm_table1.inner == wasm_table2.inner
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wasm_table_grow(
     _table: &mut wasm_table_t,
     _delta: wasm_table_size_t,

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -224,9 +224,11 @@ mod tests {
 
             // The `sum` host function implementation.
             wasm_trap_t* sum_callback(
+                wasm_context_ref_mut_t* ctx_mut,
                 const wasm_val_vec_t* arguments,
                 wasm_val_vec_t* results
             ) {
+                (void) ctx_mut;
                 wasm_val_t sum = {
                     .kind = WASM_I32,
                     .of = { arguments->data[0].of.i32 + arguments->data[1].of.i32 },

--- a/lib/c-api/tests/wasm-c-api/example/callback.c
+++ b/lib/c-api/tests/wasm-c-api/example/callback.c
@@ -7,8 +7,6 @@
 
 #define own
 
-wasm_store_t* global_store = NULL;
-
 // Print a Wasm value
 void wasm_val_print(wasm_val_t val) {
   switch (val.kind) {
@@ -37,7 +35,7 @@ void wasm_val_print(wasm_val_t val) {
 
 // A function to be called from Wasm code.
 own wasm_trap_t* print_callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n> ");
   wasm_val_print(args->data[0]);
@@ -50,9 +48,9 @@ own wasm_trap_t* print_callback(
 
 // A function closure.
 own wasm_trap_t* closure_callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
-  int i = *(int*) wasm_store_data_get(global_store);
+  int i = *(int*) wasm_context_ref_mut_get(ctx_mut);
   printf("Calling back closure...\n");
   printf("> %d\n", i);
 
@@ -66,10 +64,10 @@ int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
-  global_store = wasm_store_new(engine);
+  wasm_store_t* store = wasm_store_new(engine);
   int i = 42;
-  wasm_context_t* ctx = wasm_context_new(global_store, &i);
-  wasm_store_context_set(global_store, ctx);
+  wasm_context_t* ctx = wasm_context_new(store, &i);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");
@@ -91,7 +89,7 @@ int main(int argc, const char* argv[]) {
 
   // Compile.
   printf("Compiling module...\n");
-  own wasm_module_t* module = wasm_module_new(global_store, &binary);
+  own wasm_module_t* module = wasm_module_new(store, &binary);
   if (!module) {
     printf("> Error compiling module!\n");
     return 1;
@@ -102,10 +100,10 @@ int main(int argc, const char* argv[]) {
   // Create external print functions.
   printf("Creating callback...\n");
   own wasm_functype_t* print_type = wasm_functype_new_1_1(wasm_valtype_new_i32(), wasm_valtype_new_i32());
-  own wasm_func_t* print_func = wasm_func_new(global_store, print_type, print_callback);
+  own wasm_func_t* print_func = wasm_func_new(store, print_type, print_callback);
 
   own wasm_functype_t* closure_type = wasm_functype_new_0_1(wasm_valtype_new_i32());
-  own wasm_func_t* closure_func = wasm_func_new(global_store, closure_type, closure_callback);
+  own wasm_func_t* closure_func = wasm_func_new(store, closure_type, closure_callback);
 
   wasm_functype_delete(print_type);
   wasm_functype_delete(closure_type);
@@ -117,7 +115,7 @@ int main(int argc, const char* argv[]) {
   };
   wasm_extern_vec_t imports = WASM_ARRAY_VEC(externs);
   own wasm_instance_t* instance =
-    wasm_instance_new(global_store, module, &imports, NULL);
+    wasm_instance_new(store, module, &imports, NULL);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -162,7 +160,7 @@ int main(int argc, const char* argv[]) {
 
   // Shut down.
   printf("Shutting down...\n");
-  wasm_store_delete(global_store);
+  wasm_store_delete(store);
   wasm_engine_delete(engine);
 
   // All done.

--- a/lib/c-api/tests/wasm-c-api/example/finalize.c
+++ b/lib/c-api/tests/wasm-c-api/example/finalize.c
@@ -74,6 +74,8 @@ int main(int argc, const char* argv[]) {
   printf("Live count %d\n", live_count);
   printf("Creating store 1...\n");
   wasm_store_t* store1 = wasm_store_new(engine);
+  wasm_context_t* ctx1 = wasm_context_new(store1, 0);
+  wasm_store_context_set(store1, ctx1);
 
   printf("Running in store 1...\n");
   run_in_store(store1);
@@ -81,6 +83,8 @@ int main(int argc, const char* argv[]) {
 
   printf("Creating store 2...\n");
   wasm_store_t* store2 = wasm_store_new(engine);
+  wasm_context_t* ctx2 = wasm_context_new(store2, 0);
+  wasm_store_context_set(store2, ctx2);
 
   printf("Running in store 2...\n");
   run_in_store(store2);

--- a/lib/c-api/tests/wasm-c-api/example/global.c
+++ b/lib/c-api/tests/wasm-c-api/example/global.c
@@ -52,6 +52,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/hello.c
+++ b/lib/c-api/tests/wasm-c-api/example/hello.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* hello_callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
@@ -22,6 +22,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/hostref.c
+++ b/lib/c-api/tests/wasm-c-api/example/hostref.c
@@ -10,7 +10,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n> ");
   printf("> %p\n",
@@ -127,6 +127,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/memory.c
+++ b/lib/c-api/tests/wasm-c-api/example/memory.c
@@ -98,6 +98,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/multi.c
+++ b/lib/c-api/tests/wasm-c-api/example/multi.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n> ");
   printf("> %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu32"\n",
@@ -44,6 +44,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/reflect.c
+++ b/lib/c-api/tests/wasm-c-api/example/reflect.c
@@ -87,6 +87,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/serialize.c
+++ b/lib/c-api/tests/wasm-c-api/example/serialize.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* hello_callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
@@ -22,6 +22,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/start.c
+++ b/lib/c-api/tests/wasm-c-api/example/start.c
@@ -23,6 +23,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/table.c
+++ b/lib/c-api/tests/wasm-c-api/example/table.c
@@ -9,7 +9,7 @@
 
 // A function to be called from Wasm code.
 own wasm_trap_t* neg_callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+  wasm_context_ref_mut_t* ctx_mut, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   results->data[0].kind = WASM_I32;
@@ -78,6 +78,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/example/threads.c
+++ b/lib/c-api/tests/wasm-c-api/example/threads.c
@@ -13,7 +13,7 @@ const int N_THREADS = 10;
 const int N_REPS = 3;
 
 // A function to be called from Wasm code.
-own wasm_trap_t* callback(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+own wasm_trap_t* callback(wasm_context_ref_mut_t* ctx, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
   assert(args->data[0].kind == WASM_I32);
   printf("> Thread %d running\n", args->data[0].of.i32);
   return NULL;
@@ -31,6 +31,8 @@ void* run(void* args_abs) {
 
   // Rereate store and module.
   own wasm_store_t* store = wasm_store_new(args->engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
   own wasm_module_t* module = wasm_module_obtain(store, args->module);
 
   // Run the example N times.
@@ -119,6 +121,9 @@ int main(int argc, const char *argv[]) {
 
   // Compile and share.
   own wasm_store_t* store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
+
   own wasm_module_t* module = wasm_module_new(store, &binary);
   if (!module) {
     printf("> Error compiling module!\n");

--- a/lib/c-api/tests/wasm-c-api/example/trap.c
+++ b/lib/c-api/tests/wasm-c-api/example/trap.c
@@ -11,7 +11,7 @@ wasm_store_t* store = NULL;
 
 // A function to be called from Wasm code.
 own wasm_trap_t* fail_callback(
-  const wasm_val_vec_t* args, wasm_val_vec_t* results
+    wasm_context_ref_mut_t* ctx, const wasm_val_vec_t* args, wasm_val_vec_t* results
 ) {
   printf("Calling back...\n");
   own wasm_name_t message;
@@ -37,6 +37,8 @@ int main(int argc, const char* argv[]) {
   printf("Initializing...\n");
   wasm_engine_t* engine = wasm_engine_new();
   store = wasm_store_new(engine);
+  wasm_context_t* ctx = wasm_context_new(store, 0);
+  wasm_store_context_set(store, ctx);
 
   // Load binary.
   printf("Loading binary...\n");

--- a/lib/c-api/tests/wasm-c-api/include/wasm.h
+++ b/lib/c-api/tests/wasm-c-api/include/wasm.h
@@ -146,6 +146,7 @@ WASM_API_EXTERN own wasm_store_t* wasm_store_new(wasm_engine_t*);
 // Context
 
 WASM_DECLARE_OWN(context)
+WASM_DECLARE_OWN(context_ref_mut)
 
 WASM_API_EXTERN own void wasm_store_context_set(own wasm_store_t*, own wasm_context_t*);
 WASM_API_EXTERN own void wasm_store_data_set(own wasm_store_t*, own void*);
@@ -421,9 +422,7 @@ WASM_API_EXTERN own wasm_module_t* wasm_module_deserialize(wasm_store_t*, const 
 WASM_DECLARE_REF(func)
 
 typedef own wasm_trap_t* (*wasm_func_callback_t)(
-  const wasm_val_vec_t* args, own wasm_val_vec_t* results);
-typedef own wasm_trap_t* (*wasm_func_callback_with_env_t)(
-  void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results);
+  wasm_context_ref_mut_t*, const wasm_val_vec_t* args, own wasm_val_vec_t* results);
 
 WASM_API_EXTERN own wasm_func_t* wasm_func_new(
   wasm_store_t*, const wasm_functype_t*, wasm_func_callback_t);

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -123,6 +123,14 @@ impl<T: ContextObject> fmt::Debug for ContextHandle<T> {
     }
 }
 
+impl<T: ContextObject> PartialEq for ContextHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.internal == other.internal
+    }
+}
+
+impl<T: ContextObject> Eq for ContextHandle<T> {}
+
 impl<T: ContextObject> ContextHandle<T> {
     /// Moves the given object into a context and returns a handle to it.
     pub fn new(ctx: &mut ContextObjects, val: T) -> Self {


### PR DESCRIPTION
Some `examples/` binaries fail on CI and I didn't notice because on my panopticon macos the binaries weren't allowed to run at all. Fixed them and now all test pass 🎉 