### PR TITLE
Remove RuntimeError::raise from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 ## **Unreleased**
 
 ### Changed
+- [#3003](https://github.com/wasmerio/wasmer/pull/3003) Remove RuntimeError::raise from public API
 - [#2946](https://github.com/wasmerio/wasmer/pull/2946) Remove dylib,staticlib engines in favor of a single Universal engine
 - [#2949](https://github.com/wasmerio/wasmer/pull/2949) Switch back to using custom LLVM builds on CI
 

--- a/lib/api/src/js/trap.rs
+++ b/lib/api/src/js/trap.rs
@@ -64,7 +64,7 @@ impl RuntimeError {
 
     /// Raises a custom user Error
     #[deprecated(since = "2.1.1", note = "return a Result from host functions instead")]
-    pub fn raise(error: Box<dyn Error + Send + Sync>) -> ! {
+    pub(crate) fn raise(error: Box<dyn Error + Send + Sync>) -> ! {
         let error = Self::user(error);
         let js_error: JsValue = error.into();
         wasm_bindgen::throw_val(js_error)

--- a/lib/compiler/src/engine/trap/error.rs
+++ b/lib/compiler/src/engine/trap/error.rs
@@ -3,7 +3,7 @@ use backtrace::Backtrace;
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
-use wasmer_vm::{raise_user_trap, Trap, TrapCode};
+use wasmer_vm::{Trap, TrapCode};
 
 /// A struct representing an aborted instruction execution, with a message
 /// indicating the cause.
@@ -104,12 +104,6 @@ impl RuntimeError {
                 backtrace,
             } => Self::new_with_trace(&info, None, RuntimeErrorSource::Trap(trap_code), backtrace),
         }
-    }
-
-    /// Raises a custom user Error
-    #[deprecated(since = "2.1.1", note = "return a Result from host functions instead")]
-    pub fn raise(error: Box<dyn Error + Send + Sync>) -> ! {
-        unsafe { raise_user_trap(error) }
     }
 
     /// Creates a custom user Error.


### PR DESCRIPTION
Removes RuntimeError::raise (function was already depreceated for a relatively long time).

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
