### PR TITLE
Remove cranelift from sys-default feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ### Changed
 - [#3003](https://github.com/wasmerio/wasmer/pull/3003) Remove RuntimeError::raise from public API
+- [#3004](https://github.com/wasmerio/wasmer/pull/3004) Remove cranelift from wasi/sys-default feature, making it possible to select the compiler backend when depending on wasmer-wasi
 - [#2946](https://github.com/wasmerio/wasmer/pull/2946) Remove dylib,staticlib engines in favor of a single Universal engine
 - [#2949](https://github.com/wasmerio/wasmer/pull/2949) Switch back to using custom LLVM builds on CI
 

--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,7 @@ test-capi-integration-%:
 	cd lib/c-api/examples; WASMER_CAPI_CONFIG=$(shell echo $@ | sed -e s/test-capi-integration-//) WASMER_DIR=`pwd`/../../../package make run
 
 test-wasi-unit:
-	$(CARGO_BINARY) test $(CARGO_TARGET) --manifest-path lib/wasi/Cargo.toml --release
+	$(CARGO_BINARY) test $(CARGO_TARGET) --manifest-path lib/wasi/Cargo.toml --release --features compiler-cranelift
 
 test-wasi:
 	$(CARGO_BINARY) test $(CARGO_TARGET) --release --tests $(compiler_features) -- wasi::wasitests

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -101,7 +101,9 @@ compiler = [
         "compiler",
         "wasmer-compiler-llvm",
     ]
-default-compiler = []
+    default-compiler = [
+        "wasmer-compiler/translator"
+    ]
     default-singlepass = [
         "default-compiler",
         "singlepass",
@@ -118,8 +120,9 @@ default-compiler = []
 engine = ["sys"]
 universal = [
     "engine",
+    "wasmer-compiler/universal_engine"
 ]
-default-engine = []
+default-engine = ["default-universal"]
 default-universal = [
     "default-engine",
     "universal",

--- a/lib/api/src/sys/mod.rs
+++ b/lib/api/src/sys/mod.rs
@@ -106,7 +106,7 @@ pub use wasmer_compiler_cranelift::{Cranelift, CraneliftOptLevel};
 #[cfg(feature = "llvm")]
 pub use wasmer_compiler_llvm::{LLVMOptLevel, LLVM};
 
-#[cfg(feature = "universal")]
+#[cfg(feature = "compiler")]
 pub use wasmer_compiler::{Universal, UniversalArtifact, UniversalEngine};
 
 /// Version number of this crate.

--- a/lib/api/src/sys/store.rs
+++ b/lib/api/src/sys/store.rs
@@ -1,8 +1,11 @@
 use crate::sys::tunables::BaseTunables;
 use std::fmt;
 use std::sync::{Arc, RwLock};
+#[cfg(any(feature = "compiler", feature = "default-compiler"))]
 use wasmer_compiler::CompilerConfig;
-use wasmer_compiler::{Engine, Tunables, Universal};
+#[cfg(any(feature = "compiler", feature = "default-compiler"))]
+use wasmer_compiler::Universal;
+use wasmer_compiler::{Engine, Tunables};
 use wasmer_vm::{init_traps, TrapHandler, TrapHandlerFn};
 
 /// The store represents all global state that can be manipulated by
@@ -23,6 +26,7 @@ pub struct Store {
 }
 
 impl Store {
+    #[cfg(any(feature = "compiler", feature = "default-compiler"))]
     /// Creates a new `Store` with a specific [`CompilerConfig`].
     pub fn new(compiler_config: Box<dyn CompilerConfig>) -> Self {
         let engine = Universal::new(compiler_config).engine();

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -49,7 +49,7 @@ tracing-wasm = "0.2"
 default = ["sys-default"]
 
 sys = ["wasmer/sys"]
-sys-default = ["wasmer/sys-default", "sys", "logging", "host-fs", "sys-poll", "host-vnet" ]
+sys-default = ["wasmer/sys", "wasmer/wat", "wasmer/default-engine", "sys", "logging", "host-fs", "sys-poll", "host-vnet"]
 sys-poll = []
 
 js = ["wasmer/js", "mem-fs", "wasmer-vfs/no-time", "getrandom/js", "chrono"]

--- a/lib/wasi/tests/envvar.rs
+++ b/lib/wasi/tests/envvar.rs
@@ -4,6 +4,9 @@
 
 use std::env;
 
+#[cfg(not(feature = "compiler-cranelift"))]
+compile_error! {"These tests run only with the feature \"compiler-cranelift\" enabled. Use \"--features compiler-cranelift\" to enable it."}
+
 fn get_env_var(var_name: &str) -> Result<String, env::VarError> {
     env::var(var_name)
 }

--- a/lib/wasi/tests/stdio.rs
+++ b/lib/wasi/tests/stdio.rs
@@ -3,6 +3,9 @@ use std::io::{Read, Write};
 use wasmer::{Instance, Module, Store};
 use wasmer_wasi::{Pipe, WasiState};
 
+#[cfg(not(feature = "compiler-cranelift"))]
+compile_error! {"These tests run only with the feature \"compiler-cranelift\" enabled. Use \"--features compiler-cranelift\" to enable it."}
+
 mod sys {
     #[test]
     fn test_stdout() {

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-wasmer = { path = "../../../lib/api", version = "=2.3.0", default-features = false, features = ["experimental-reference-types-extern-ref"] }
+wasmer = { path = "../../../lib/api", version = "=2.3.0", default-features = false, features = ["experimental-reference-types-extern-ref", "cranelift"] }
 wasmer-wasi = { path = "../../../lib/wasi", version = "=2.3.0" }
 wasmer-vfs = { path = "../../../lib/vfs", version = "=2.3.0" }
 wast = "38.0"


### PR DESCRIPTION
When using the Wasmer-WASI crate, the sys-default feature from wasmer is depending upon, which causes the following to conflict:

```toml
[dependencies.wasmer]
version = "2.0"
default-features=false
features=["sys" , "compiler-singlepass", "engine-universal"]

[dependencies.wasmer-wasi]
version = "2.0"
```

Because wasmer-wasi "2.0" depends on wasmer with the default features, which implies using cranelift, which conflicts with singlepass.

Fixes https://github.com/wasmerio/wasmer/issues/2882

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
