### PR TITLE
Add check-public-api.yaml workflow

### DIFF
--- a/.github/workflows/check-public-api.yaml
+++ b/.github/workflows/check-public-api.yaml
@@ -1,0 +1,47 @@
+name: Check public API
+
+env:
+  RUST_BACKTRACE: 1
+on:
+  workflow_dispatch:
+    inputs:
+      compareMasterWithVersion:
+        required: false
+        description: 'Version to compare with (i.e. "1.0.2")'
+jobs:
+  setup:
+    name: Set up
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.setup.outputs.VERSION }}
+      SHOULD_CHECK_API: ${{ steps.setup.outputs.SHOULD_CHECK_API }}
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            profile: minimal
+            override: true
+
+      - name: Generate API change report
+        shell: bash
+        run: |
+          cargo install cargo-public-api
+          CARGO_LATEST_VERSION = git tag --list | tail -n 1
+          LATEST_VERSION=${INPUT_COMPAREMASTERWITHVERSION:=$CARGO_LATEST_VERSION}
+          cargo public-api --manifest-path=lib/api/Cargo.toml --diff-git-checkouts $LATEST_VERSION master > diff.txt
+      
+      - name: Archive change report
+        uses: actions/upload-artifact@v3
+        with:
+          name: api-diff-report
+          path: |
+            diff.txt
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ### Changed
 - [#3017](https://github.com/wasmerio/wasmer/pull/3017) Fix typo in README.md
+- [#3008](https://github.com/wasmerio/wasmer/pull/3008) Add a new CI check that uses cargo public-api to track changes in the API between master and the last deployed version on crates.io
 - [#3003](https://github.com/wasmerio/wasmer/pull/3003) Remove RuntimeError::raise from public API
 - [#2999](https://github.com/wasmerio/wasmer/pull/2999) Allow `--invoke` CLI option for Emscripten files without a `main` function
 - [#2946](https://github.com/wasmerio/wasmer/pull/2946) Remove dylib,staticlib engines in favor of a single Universal engine


### PR DESCRIPTION
WIP PR: Adds a new CI check that uses `cargo public-api` to track changes in the API between `master` and the last deployed version on crates.io.

Fixes https://github.com/wasmerio/wasmer/issues/2984

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
