### PR TITLE
Move ContextObjects to Store

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -101,6 +101,7 @@ default-llvm = ["default-compiler", "llvm"]
 engine = ["sys"]
 universal = [
     "engine",
+    "wasmer-compiler/universal_engine"
 ]
 default-engine = []
 default-universal = [

--- a/lib/api/src/js/context.rs
+++ b/lib/api/src/js/context.rs
@@ -6,7 +6,6 @@ use crate::Store;
 /// wrap the actual context in a box.
 pub(crate) struct ContextInner<T> {
     pub(crate) objects: ContextObjects,
-    pub(crate) store: Store,
     pub(crate) data: T,
 }
 
@@ -35,11 +34,10 @@ pub struct Context<T> {
 impl<T> Context<T> {
     /// Creates a new context with the given host state.
     // TODO: Eliminate the Store type and move its functionality into Engine.
-    pub fn new(store: &Store, data: T) -> Self {
+    pub fn new(data: T) -> Self {
         Self {
             inner: Box::new(ContextInner {
                 objects: Default::default(),
-                store: store.clone(),
                 data,
             }),
         }
@@ -58,11 +56,6 @@ impl<T> Context<T> {
     /// Drops the context and returns the host state that was stored in it.
     pub fn into_data(self) -> T {
         self.inner.data
-    }
-
-    /// Returns a reference to the `Store` of this context.
-    pub fn store(&self) -> &Store {
-        &self.inner.store
     }
 }
 
@@ -347,7 +340,7 @@ mod objects {
         }
 
         /// Returns the ID of the context associated with the handle.
-        pub fn context_id(&self) -> ContextId {
+        pub fn store_id(&self) -> ContextId {
             self.id
         }
 

--- a/lib/api/src/js/context.rs
+++ b/lib/api/src/js/context.rs
@@ -1,11 +1,8 @@
-#![allow(dead_code)]
-use crate::Store;
-
 /// We require the context to have a fixed memory address for its lifetime since
 /// various bits of the VM have raw pointers that point back to it. Hence we
 /// wrap the actual context in a box.
 pub(crate) struct ContextInner<T> {
-    pub(crate) objects: ContextObjects,
+    pub(crate) objects: StoreObjects,
     pub(crate) data: T,
 }
 
@@ -69,15 +66,6 @@ impl<'a, T> ContextRef<'a, T> {
     pub fn data(&self) -> &'a T {
         &self.inner.data
     }
-
-    /// Returns a reference to the `Store` of this context.
-    pub fn store(&self) -> &Store {
-        &self.inner.store
-    }
-
-    pub(crate) fn objects(&self) -> &'a ContextObjects {
-        &self.inner.objects
-    }
 }
 
 /// A temporary handle to a [`Context`].
@@ -96,13 +84,8 @@ impl<T> ContextMut<'_, T> {
         &mut self.inner.data
     }
 
-    pub(crate) fn objects_mut(&mut self) -> &mut ContextObjects {
+    pub(crate) fn objects_mut(&mut self) -> &mut StoreObjects {
         &mut self.inner.objects
-    }
-
-    /// Returns a reference to the `Store` of this context.
-    pub fn store(&self) -> &Store {
-        &self.inner.store
     }
 
     /// Returns the raw pointer of the context
@@ -202,9 +185,9 @@ mod objects {
     /// context. This is used to check that a handle is always used with the
     /// correct context.
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    pub struct ContextId(NonZeroU64);
+    pub struct StoreId(NonZeroU64);
 
-    impl Default for ContextId {
+    impl Default for StoreId {
         // Allocates a unique ID for a new context.
         fn default() -> Self {
             // No overflow checking is needed here: overflowing this would take
@@ -216,19 +199,19 @@ mod objects {
 
     /// Trait to represent an object managed by a context. This is implemented on
     /// the VM types managed by the context.
-    pub trait ContextObject: Sized {
-        fn list(ctx: &ContextObjects) -> &Vec<Self>;
-        fn list_mut(ctx: &mut ContextObjects) -> &mut Vec<Self>;
+    pub trait StoreObject: Sized {
+        fn list(ctx: &StoreObjects) -> &Vec<Self>;
+        fn list_mut(ctx: &mut StoreObjects) -> &mut Vec<Self>;
     }
 
     macro_rules! impl_context_object {
     ($($field:ident => $ty:ty,)*) => {
         $(
-            impl ContextObject for $ty {
-                fn list(ctx: &ContextObjects) -> &Vec<Self> {
+            impl StoreObject for $ty {
+                fn list(ctx: &StoreObjects) -> &Vec<Self> {
                     &ctx.$field
                 }
-                fn list_mut(ctx: &mut ContextObjects) -> &mut Vec<Self> {
+                fn list_mut(ctx: &mut StoreObjects) -> &mut Vec<Self> {
                     &mut ctx.$field
                 }
             }
@@ -246,8 +229,8 @@ mod objects {
 
     /// Set of objects managed by a context.
     #[derive(Default)]
-    pub struct ContextObjects {
-        id: ContextId,
+    pub struct StoreObjects {
+        id: StoreId,
         memories: Vec<VMMemory>,
         tables: Vec<VMTable>,
         globals: Vec<VMGlobal>,
@@ -255,19 +238,19 @@ mod objects {
         instances: Vec<js_sys::WebAssembly::Instance>,
     }
 
-    impl ContextObjects {
+    impl StoreObjects {
         /// Returns the ID of this context.
-        pub fn id(&self) -> ContextId {
+        pub fn id(&self) -> StoreId {
             self.id
         }
 
         /// Returns a pair of mutable references from two handles.
         ///
         /// Panics if both handles point to the same object.
-        pub fn get_2_mut<T: ContextObject>(
+        pub fn get_2_mut<T: StoreObject>(
             &mut self,
-            a: InternalContextHandle<T>,
-            b: InternalContextHandle<T>,
+            a: InternalStoreHandle<T>,
+            b: InternalStoreHandle<T>,
         ) -> (&mut T, &mut T) {
             assert_ne!(a.index(), b.index());
             let list = T::list_mut(self);
@@ -285,17 +268,17 @@ mod objects {
     ///
     /// Internally this is just an integer index into a context. A reference to the
     /// context must be passed in separately to access the actual object.
-    pub struct ContextHandle<T> {
-        id: ContextId,
-        internal: InternalContextHandle<T>,
+    pub struct StoreHandle<T> {
+        id: StoreId,
+        internal: InternalStoreHandle<T>,
     }
 
-    impl<T> core::cmp::PartialEq for ContextHandle<T> {
+    impl<T> core::cmp::PartialEq for StoreHandle<T> {
         fn eq(&self, other: &Self) -> bool {
             self.id == other.id
         }
     }
-    impl<T> Clone for ContextHandle<T> {
+    impl<T> Clone for StoreHandle<T> {
         fn clone(&self) -> Self {
             Self {
                 id: self.id,
@@ -304,90 +287,90 @@ mod objects {
         }
     }
 
-    impl<T: ContextObject> fmt::Debug for ContextHandle<T> {
+    impl<T: StoreObject> fmt::Debug for StoreHandle<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("ContextHandle")
+            f.debug_struct("StoreHandle")
                 .field("id", &self.id)
                 .field("internal", &self.internal.index())
                 .finish()
         }
     }
 
-    impl<T: ContextObject> ContextHandle<T> {
+    impl<T: StoreObject> StoreHandle<T> {
         /// Moves the given object into a context and returns a handle to it.
-        pub fn new(ctx: &mut ContextObjects, val: T) -> Self {
+        pub fn new(ctx: &mut StoreObjects, val: T) -> Self {
             Self {
                 id: ctx.id,
-                internal: InternalContextHandle::new(ctx, val),
+                internal: InternalStoreHandle::new(ctx, val),
             }
         }
 
         /// Returns a reference to the object that this handle points to.
-        pub fn get<'a>(&self, ctx: &'a ContextObjects) -> &'a T {
+        pub fn get<'a>(&self, ctx: &'a StoreObjects) -> &'a T {
             assert_eq!(self.id, ctx.id, "object used with the wrong context");
             self.internal.get(ctx)
         }
 
         /// Returns a mutable reference to the object that this handle points to.
-        pub fn get_mut<'a>(&self, ctx: &'a mut ContextObjects) -> &'a mut T {
+        pub fn get_mut<'a>(&self, ctx: &'a mut StoreObjects) -> &'a mut T {
             assert_eq!(self.id, ctx.id, "object used with the wrong context");
             self.internal.get_mut(ctx)
         }
 
         /// Returns the internal handle contains within this handle.
-        pub fn internal_handle(&self) -> InternalContextHandle<T> {
+        pub fn internal_handle(&self) -> InternalStoreHandle<T> {
             self.internal
         }
 
         /// Returns the ID of the context associated with the handle.
-        pub fn store_id(&self) -> ContextId {
+        pub fn store_id(&self) -> StoreId {
             self.id
         }
 
-        /// Constructs a `ContextHandle` from a `ContextId` and an `InternalContextHandle`.
+        /// Constructs a `StoreHandle` from a `StoreId` and an `InternalStoreHandle`.
         ///
         /// # Safety
-        /// Handling `InternalContextHandle` values is unsafe because they do not track context ID.
-        pub unsafe fn from_internal(id: ContextId, internal: InternalContextHandle<T>) -> Self {
+        /// Handling `InternalStoreHandle` values is unsafe because they do not track context ID.
+        pub unsafe fn from_internal(id: StoreId, internal: InternalStoreHandle<T>) -> Self {
             Self { id, internal }
         }
     }
 
     /// Internal handle to an object owned by the current context.
     ///
-    /// Unlike `ContextHandle` this does not track the context ID: it is only
+    /// Unlike `StoreHandle` this does not track the context ID: it is only
     /// intended to be used within objects already owned by a context.
     #[repr(transparent)]
-    pub struct InternalContextHandle<T> {
-        // Use a NonZero here to reduce the size of Option<InternalContextHandle>.
+    pub struct InternalStoreHandle<T> {
+        // Use a NonZero here to reduce the size of Option<InternalStoreHandle>.
         idx: NonZeroUsize,
         marker: PhantomData<fn() -> T>,
     }
 
-    impl<T> Clone for InternalContextHandle<T> {
+    impl<T> Clone for InternalStoreHandle<T> {
         fn clone(&self) -> Self {
             *self
         }
     }
-    impl<T> Copy for InternalContextHandle<T> {}
+    impl<T> Copy for InternalStoreHandle<T> {}
 
-    impl<T> fmt::Debug for InternalContextHandle<T> {
+    impl<T> fmt::Debug for InternalStoreHandle<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("InternalContextHandle")
+            f.debug_struct("InternalStoreHandle")
                 .field("idx", &self.idx)
                 .finish()
         }
     }
-    impl<T> PartialEq for InternalContextHandle<T> {
+    impl<T> PartialEq for InternalStoreHandle<T> {
         fn eq(&self, other: &Self) -> bool {
             self.idx == other.idx
         }
     }
-    impl<T> Eq for InternalContextHandle<T> {}
+    impl<T> Eq for InternalStoreHandle<T> {}
 
-    impl<T: ContextObject> InternalContextHandle<T> {
+    impl<T: StoreObject> InternalStoreHandle<T> {
         /// Moves the given object into a context and returns a handle to it.
-        pub fn new(ctx: &mut ContextObjects, val: T) -> Self {
+        pub fn new(ctx: &mut StoreObjects, val: T) -> Self {
             let list = T::list_mut(ctx);
             let idx = NonZeroUsize::new(list.len() + 1).unwrap();
             list.push(val);
@@ -398,12 +381,12 @@ mod objects {
         }
 
         /// Returns a reference to the object that this handle points to.
-        pub fn get<'a>(&self, ctx: &'a ContextObjects) -> &'a T {
+        pub fn get<'a>(&self, ctx: &'a StoreObjects) -> &'a T {
             &T::list(ctx)[self.idx.get() - 1]
         }
 
         /// Returns a mutable reference to the object that this handle points to.
-        pub fn get_mut<'a>(&self, ctx: &'a mut ContextObjects) -> &'a mut T {
+        pub fn get_mut<'a>(&self, ctx: &'a mut StoreObjects) -> &'a mut T {
             &mut T::list_mut(ctx)[self.idx.get() - 1]
         }
 

--- a/lib/api/src/js/export.rs
+++ b/lib/api/src/js/export.rs
@@ -101,22 +101,10 @@ impl Export {
     /// Return the export as a `JSValue`.
     pub fn as_jsvalue<'context>(&self, ctx: &'context impl AsContextRef) -> &'context JsValue {
         match self {
-            Self::Memory(js_wasm_memory) => js_wasm_memory
-                .get(ctx.as_context_ref().objects())
-                .memory
-                .as_ref(),
-            Self::Function(js_func) => js_func
-                .get(ctx.as_context_ref().objects())
-                .function
-                .as_ref(),
-            Self::Table(js_wasm_table) => js_wasm_table
-                .get(ctx.as_context_ref().objects())
-                .table
-                .as_ref(),
-            Self::Global(js_wasm_global) => js_wasm_global
-                .get(ctx.as_context_ref().objects())
-                .global
-                .as_ref(),
+            Self::Memory(js_wasm_memory) => js_wasm_memory.get(store.objects()).memory.as_ref(),
+            Self::Function(js_func) => js_func.get(store.objects()).function.as_ref(),
+            Self::Table(js_wasm_table) => js_wasm_table.get(store.objects()).table.as_ref(),
+            Self::Global(js_wasm_global) => js_wasm_global.get(store.objects()).global.as_ref(),
         }
     }
 
@@ -130,7 +118,7 @@ impl Export {
             ExternType::Memory(memory_type) => {
                 if val.is_instance_of::<Memory>() {
                     Ok(Self::Memory(InternalContextHandle::new(
-                        &mut ctx.as_context_mut().objects_mut(),
+                        &mut store.objects_mut(),
                         VMMemory::new(val.unchecked_into::<Memory>(), memory_type),
                     )))
                 } else {
@@ -146,7 +134,7 @@ impl Export {
             ExternType::Global(global_type) => {
                 if val.is_instance_of::<Global>() {
                     Ok(Self::Global(InternalContextHandle::new(
-                        &mut ctx.as_context_mut().objects_mut(),
+                        &mut store.objects_mut(),
                         VMGlobal::new(val.unchecked_into::<Global>(), global_type),
                     )))
                 } else {
@@ -156,7 +144,7 @@ impl Export {
             ExternType::Function(function_type) => {
                 if val.is_instance_of::<Function>() {
                     Ok(Self::Function(InternalContextHandle::new(
-                        &mut ctx.as_context_mut().objects_mut(),
+                        &mut store.objects_mut(),
                         VMFunction::new(val.unchecked_into::<Function>(), function_type),
                     )))
                 } else {
@@ -166,7 +154,7 @@ impl Export {
             ExternType::Table(table_type) => {
                 if val.is_instance_of::<Table>() {
                     Ok(Self::Table(InternalContextHandle::new(
-                        &mut ctx.as_context_mut().objects_mut(),
+                        &mut store.objects_mut(),
                         VMTable::new(val.unchecked_into::<Table>(), table_type),
                     )))
                 } else {

--- a/lib/api/src/js/export.rs
+++ b/lib/api/src/js/export.rs
@@ -1,4 +1,4 @@
-use crate::js::context::{AsContextMut, AsContextRef, InternalContextHandle};
+use crate::js::context::{AsContextMut, AsContextRef, InternalStoreHandle};
 use crate::js::error::WasmError;
 use crate::js::wasm_bindgen_polyfill::Global;
 use js_sys::Function;
@@ -85,16 +85,16 @@ impl fmt::Debug for VMFunction {
 #[derive(Debug, Clone)]
 pub enum Export {
     /// A function export value.
-    Function(InternalContextHandle<VMFunction>),
+    Function(InternalStoreHandle<VMFunction>),
 
     /// A table export value.
-    Table(InternalContextHandle<VMTable>),
+    Table(InternalStoreHandle<VMTable>),
 
     /// A memory export value.
-    Memory(InternalContextHandle<VMMemory>),
+    Memory(InternalStoreHandle<VMMemory>),
 
     /// A global export value.
-    Global(InternalContextHandle<VMGlobal>),
+    Global(InternalStoreHandle<VMGlobal>),
 }
 
 impl Export {
@@ -117,7 +117,7 @@ impl Export {
         match extern_type {
             ExternType::Memory(memory_type) => {
                 if val.is_instance_of::<Memory>() {
-                    Ok(Self::Memory(InternalContextHandle::new(
+                    Ok(Self::Memory(InternalStoreHandle::new(
                         &mut store.objects_mut(),
                         VMMemory::new(val.unchecked_into::<Memory>(), memory_type),
                     )))
@@ -133,7 +133,7 @@ impl Export {
             }
             ExternType::Global(global_type) => {
                 if val.is_instance_of::<Global>() {
-                    Ok(Self::Global(InternalContextHandle::new(
+                    Ok(Self::Global(InternalStoreHandle::new(
                         &mut store.objects_mut(),
                         VMGlobal::new(val.unchecked_into::<Global>(), global_type),
                     )))
@@ -143,7 +143,7 @@ impl Export {
             }
             ExternType::Function(function_type) => {
                 if val.is_instance_of::<Function>() {
-                    Ok(Self::Function(InternalContextHandle::new(
+                    Ok(Self::Function(InternalStoreHandle::new(
                         &mut store.objects_mut(),
                         VMFunction::new(val.unchecked_into::<Function>(), function_type),
                     )))
@@ -153,7 +153,7 @@ impl Export {
             }
             ExternType::Table(table_type) => {
                 if val.is_instance_of::<Table>() {
-                    Ok(Self::Table(InternalContextHandle::new(
+                    Ok(Self::Table(InternalStoreHandle::new(
                         &mut store.objects_mut(),
                         VMTable::new(val.unchecked_into::<Table>(), table_type),
                     )))

--- a/lib/api/src/js/exports.rs
+++ b/lib/api/src/js/exports.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 ///
 /// ```should_panic
 /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value, ExportError};
-/// # let store = Store::default();
+/// # let mut store = Store::default();
 /// # let wasm_bytes = wat2wasm(r#"
 /// # (module
 /// #   (global $one (export "glob") f32 (f32.const 1)))
@@ -35,7 +35,7 @@ use thiserror::Error;
 ///
 /// ```should_panic
 /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value, ExportError};
-/// # let store = Store::default();
+/// # let mut store = Store::default();
 /// # let wasm_bytes = wat2wasm("(module)".as_bytes()).unwrap();
 /// # let module = Module::new(&store, wasm_bytes).unwrap();
 /// # let import_object = imports! {};

--- a/lib/api/src/js/externals/function.rs
+++ b/lib/api/src/js/externals/function.rs
@@ -71,7 +71,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{Function, FunctionType, Type, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let signature = FunctionType::new(vec![Type::I32, Type::I32], vec![Type::I32]);
     ///
@@ -85,7 +85,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{Function, FunctionType, Type, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// const I32_I32_TO_I32: ([Type; 2], [Type; 1]) = ([Type::I32, Type::I32], [Type::I32]);
     ///
@@ -166,7 +166,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{Store, Function};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// fn sum(a: i32, b: i32) -> i32 {
     ///     a + b
@@ -208,7 +208,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{Function, Store, Type};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// fn sum(a: i32, b: i32) -> i32 {
     ///     a + b
@@ -229,7 +229,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{Function, Store, Type};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// fn sum(a: i32, b: i32) -> i32 {
     ///     a + b
@@ -249,7 +249,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{Function, Store, Type};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// fn sum(a: i32, b: i32) -> i32 {
     ///     a + b
@@ -275,7 +275,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -353,7 +353,7 @@ impl Function {
     ///
     /// ```
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -379,7 +379,7 @@ impl Function {
     ///
     /// ```should_panic
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -403,7 +403,7 @@ impl Function {
     ///
     /// ```should_panic
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)

--- a/lib/api/src/js/externals/function.rs
+++ b/lib/api/src/js/externals/function.rs
@@ -1,6 +1,6 @@
 pub use self::inner::{FromToNativeWasmType, HostFunction, WasmTypeList};
 use crate::js::context::{
-    AsContextMut, AsContextRef, ContextHandle, ContextMut, InternalContextHandle,
+    AsContextMut, AsContextRef, ContextMut, InternalStoreHandle, StoreHandle,
 };
 use crate::js::exports::{ExportError, Exportable};
 use crate::js::externals::Extern;
@@ -58,7 +58,7 @@ fn results_to_js_array(values: &[Value]) -> Array {
 ///   [Closures as host functions tracking issue](https://github.com/wasmerio/wasmer/issues/1840)
 #[derive(Clone, PartialEq)]
 pub struct Function {
-    pub(crate) handle: ContextHandle<VMFunction>,
+    pub(crate) handle: StoreHandle<VMFunction>,
 }
 
 impl Function {
@@ -198,7 +198,7 @@ impl Function {
         let ty = function.ty();
         let vm_function = VMFunction::new(binded_func, ty);
         Self {
-            handle: ContextHandle::new(store.objects_mut(), vm_function),
+            handle: StoreHandle::new(store.objects_mut(), vm_function),
         }
     }
 
@@ -333,16 +333,16 @@ impl Function {
 
     pub(crate) fn from_vm_export(ctx: &mut impl AsContextMut, vm_function: VMFunction) -> Self {
         Self {
-            handle: ContextHandle::new(store.objects_mut(), vm_function),
+            handle: StoreHandle::new(store.objects_mut(), vm_function),
         }
     }
 
     pub(crate) fn from_vm_extern(
         ctx: &mut impl AsContextMut,
-        internal: InternalContextHandle<VMFunction>,
+        internal: InternalStoreHandle<VMFunction>,
     ) -> Self {
         Self {
-            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
+            handle: unsafe { StoreHandle::from_internal(store.objects().id(), internal) },
         }
     }
 

--- a/lib/api/src/js/externals/global.rs
+++ b/lib/api/src/js/externals/global.rs
@@ -1,4 +1,4 @@
-use crate::js::context::{AsContextMut, AsContextRef, ContextHandle, InternalContextHandle};
+use crate::js::context::{AsContextMut, AsContextRef, InternalStoreHandle, StoreHandle};
 use crate::js::export::VMGlobal;
 use crate::js::exports::{ExportError, Exportable};
 use crate::js::externals::Extern;
@@ -17,7 +17,7 @@ use wasm_bindgen::JsValue;
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#global-instances>
 #[derive(Debug, Clone, PartialEq)]
 pub struct Global {
-    pub(crate) handle: ContextHandle<VMGlobal>,
+    pub(crate) handle: StoreHandle<VMGlobal>,
 }
 
 impl Global {
@@ -220,16 +220,16 @@ impl Global {
 
     pub(crate) fn from_vm_export(ctx: &mut impl AsContextMut, vm_global: VMGlobal) -> Self {
         Self {
-            handle: ContextHandle::new(store.objects_mut(), vm_global),
+            handle: StoreHandle::new(store.objects_mut(), vm_global),
         }
     }
 
     pub(crate) fn from_vm_extern(
         ctx: &mut impl AsContextMut,
-        internal: InternalContextHandle<VMGlobal>,
+        internal: InternalStoreHandle<VMGlobal>,
     ) -> Self {
         Self {
-            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
+            handle: unsafe { StoreHandle::from_internal(store.objects().id(), internal) },
         }
     }
 

--- a/lib/api/src/js/externals/global.rs
+++ b/lib/api/src/js/externals/global.rs
@@ -27,7 +27,7 @@ impl Global {
     ///
     /// ```
     /// # use wasmer::{Global, Mutability, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let g = Global::new(&store, Value::I32(1));
     ///
@@ -44,7 +44,7 @@ impl Global {
     ///
     /// ```
     /// # use wasmer::{Global, Mutability, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let g = Global::new_mut(&store, Value::I32(1));
     ///
@@ -99,7 +99,7 @@ impl Global {
     ///
     /// ```
     /// # use wasmer::{Global, Mutability, Store, Type, Value, GlobalType};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let c = Global::new(&store, Value::I32(1));
     /// let v = Global::new_mut(&store, Value::I64(1));
@@ -117,7 +117,7 @@ impl Global {
     ///
     /// ```
     /// # use wasmer::{Global, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let g = Global::new(&store, Value::I32(1));
     ///
@@ -152,7 +152,7 @@ impl Global {
     ///
     /// ```
     /// # use wasmer::{Global, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let g = Global::new_mut(&store, Value::I32(1));
     ///
@@ -169,7 +169,7 @@ impl Global {
     ///
     /// ```should_panic
     /// # use wasmer::{Global, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let g = Global::new(&store, Value::I32(1));
     ///
@@ -180,7 +180,7 @@ impl Global {
     ///
     /// ```should_panic
     /// # use wasmer::{Global, Store, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let g = Global::new(&store, Value::I32(1));
     ///

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -98,7 +98,7 @@ impl Memory {
     ///
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let m = Memory::new(&store, MemoryType::new(1, None, false)).unwrap();
     /// ```
@@ -123,7 +123,7 @@ impl Memory {
     ///
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let mt = MemoryType::new(1, None, false);
     /// let m = Memory::new(&store, mt).unwrap();
@@ -157,7 +157,7 @@ impl Memory {
     ///
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let m = Memory::new(&store, MemoryType::new(1, None, false)).unwrap();
     ///
@@ -181,7 +181,7 @@ impl Memory {
     ///
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value, WASM_MAX_PAGES};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let m = Memory::new(&store, MemoryType::new(1, Some(3), false)).unwrap();
     /// let p = m.grow(2).unwrap();
@@ -197,7 +197,7 @@ impl Memory {
     ///
     /// ```should_panic
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value, WASM_MAX_PAGES};
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let m = Memory::new(&store, MemoryType::new(1, Some(1), false)).unwrap();
     ///

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -1,5 +1,5 @@
 use crate::js::context::{
-    AsContextMut, AsContextRef, ContextHandle, ContextObjects, InternalContextHandle,
+    AsContextMut, AsContextRef, InternalStoreHandle, StoreHandle, StoreObjects,
 };
 use crate::js::export::VMMemory;
 use crate::js::exports::{ExportError, Exportable};
@@ -80,7 +80,7 @@ extern "C" {
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances>
 #[derive(Debug, Clone)]
 pub struct Memory {
-    pub(crate) handle: ContextHandle<VMMemory>,
+    pub(crate) handle: StoreHandle<VMMemory>,
     #[allow(dead_code)]
     view: js_sys::Uint8Array,
 }
@@ -245,18 +245,18 @@ impl Memory {
     pub(crate) fn from_vm_export(ctx: &mut impl AsContextMut, vm_memory: VMMemory) -> Self {
         let view = js_sys::Uint8Array::new(&vm_memory.memory.buffer());
         Self {
-            handle: ContextHandle::new(store.objects_mut(), vm_memory),
+            handle: StoreHandle::new(store.objects_mut(), vm_memory),
             view,
         }
     }
 
     pub(crate) fn from_vm_extern(
         ctx: &mut impl AsContextMut,
-        internal: InternalContextHandle<VMMemory>,
+        internal: InternalStoreHandle<VMMemory>,
     ) -> Self {
         let view = js_sys::Uint8Array::new(&internal.get(store.objects()).memory.buffer());
         Self {
-            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
+            handle: unsafe { StoreHandle::from_internal(store.objects().id(), internal) },
             view,
         }
     }
@@ -372,7 +372,7 @@ impl<'a> Exportable<'a> for Memory {
 #[derive(Copy, Clone)]
 pub(crate) struct MemoryBuffer<'a> {
     base: *mut js_sys::Uint8Array,
-    marker: PhantomData<(&'a Memory, &'a ContextObjects)>,
+    marker: PhantomData<(&'a Memory, &'a StoreObjects)>,
 }
 
 impl<'a> MemoryBuffer<'a> {

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -131,7 +131,7 @@ impl Memory {
     /// assert_eq!(m.ty(), mt);
     /// ```
     pub fn ty(&self, ctx: &impl AsContextRef) -> MemoryType {
-        self.handle.get(ctx.as_context_ref().objects()).ty
+        self.handle.get(store.objects()).ty
     }
 
     /// Returns the pointer to the raw bytes of the `Memory`.
@@ -143,11 +143,7 @@ impl Memory {
     /// Returns the size (in bytes) of the `Memory`.
     pub fn data_size(&self, ctx: &impl AsContextRef) -> u64 {
         js_sys::Reflect::get(
-            &self
-                .handle
-                .get(ctx.as_context_ref().objects())
-                .memory
-                .buffer(),
+            &self.handle.get(store.objects()).memory.buffer(),
             &"byteLength".into(),
         )
         .unwrap()
@@ -169,11 +165,7 @@ impl Memory {
     /// ```
     pub fn size(&self, ctx: &impl AsContextRef) -> Pages {
         let bytes = js_sys::Reflect::get(
-            &self
-                .handle
-                .get(ctx.as_context_ref().objects())
-                .memory
-                .buffer(),
+            &self.handle.get(store.objects()).memory.buffer(),
             &"byteLength".into(),
         )
         .unwrap()
@@ -240,13 +232,7 @@ impl Memory {
     /// Used by tests
     #[doc(hidden)]
     pub fn uint8view(&self, ctx: &impl AsContextRef) -> js_sys::Uint8Array {
-        js_sys::Uint8Array::new(
-            &self
-                .handle
-                .get(ctx.as_context_ref().objects())
-                .memory
-                .buffer(),
-        )
+        js_sys::Uint8Array::new(&self.handle.get(store.objects()).memory.buffer())
     }
 
     pub(crate) fn buffer<'a>(&'a self, _ctx: &'a impl AsContextRef) -> MemoryBuffer<'a> {
@@ -259,7 +245,7 @@ impl Memory {
     pub(crate) fn from_vm_export(ctx: &mut impl AsContextMut, vm_memory: VMMemory) -> Self {
         let view = js_sys::Uint8Array::new(&vm_memory.memory.buffer());
         Self {
-            handle: ContextHandle::new(ctx.as_context_mut().objects_mut(), vm_memory),
+            handle: ContextHandle::new(store.objects_mut(), vm_memory),
             view,
         }
     }
@@ -268,12 +254,9 @@ impl Memory {
         ctx: &mut impl AsContextMut,
         internal: InternalContextHandle<VMMemory>,
     ) -> Self {
-        let view =
-            js_sys::Uint8Array::new(&internal.get(ctx.as_context_ref().objects()).memory.buffer());
+        let view = js_sys::Uint8Array::new(&internal.get(store.objects()).memory.buffer());
         Self {
-            handle: unsafe {
-                ContextHandle::from_internal(ctx.as_context_ref().objects().id(), internal)
-            },
+            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
             view,
         }
     }
@@ -370,9 +353,9 @@ impl Memory {
         Ok(())
     }
 
-    /// Checks whether this `Global` can be used with the given context.
-    pub fn is_from_context(&self, ctx: &impl AsContextRef) -> bool {
-        self.handle.context_id() == ctx.as_context_ref().objects().id()
+    /// Checks whether this `Global` can be used with the given store.
+    pub fn is_from_store(&self, ctx: &impl AsContextRef) -> bool {
+        self.handle.store_id() == store.objects().id()
     }
 }
 

--- a/lib/api/src/js/externals/mod.rs
+++ b/lib/api/src/js/externals/mod.rs
@@ -53,13 +53,13 @@ impl Extern {
         }
     }
 
-    /// Checks whether this `Extern` can be used with the given context.
-    pub fn is_from_context(&self, ctx: &impl AsContextRef) -> bool {
+    /// Checks whether this `Extern` can be used with the given store.
+    pub fn is_from_store(&self, ctx: &impl AsContextRef) -> bool {
         match self {
-            Self::Function(val) => val.is_from_context(ctx),
-            Self::Memory(val) => val.is_from_context(ctx),
-            Self::Global(val) => val.is_from_context(ctx),
-            Self::Table(val) => val.is_from_context(ctx),
+            Self::Function(val) => val.is_from_store(ctx),
+            Self::Memory(val) => val.is_from_store(ctx),
+            Self::Global(val) => val.is_from_store(ctx),
+            Self::Table(val) => val.is_from_store(ctx),
         }
     }
 

--- a/lib/api/src/js/externals/table.rs
+++ b/lib/api/src/js/externals/table.rs
@@ -1,4 +1,4 @@
-use crate::js::context::{AsContextMut, AsContextRef, ContextHandle, InternalContextHandle};
+use crate::js::context::{AsContextMut, AsContextRef, InternalStoreHandle, StoreHandle};
 use crate::js::export::{VMFunction, VMTable};
 use crate::js::exports::{ExportError, Exportable};
 use crate::js::externals::Extern;
@@ -18,7 +18,7 @@ use js_sys::Function;
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#table-instances>
 #[derive(Debug, Clone, PartialEq)]
 pub struct Table {
-    pub(crate) handle: ContextHandle<VMTable>,
+    pub(crate) handle: StoreHandle<VMTable>,
 }
 
 fn set_table_item(table: &VMTable, item_index: u32, item: &Function) -> Result<(), RuntimeError> {
@@ -68,7 +68,7 @@ impl Table {
         }
 
         Ok(Self {
-            handle: ContextHandle::new(ctx.objects_mut(), table),
+            handle: StoreHandle::new(ctx.objects_mut(), table),
         })
     }
 
@@ -137,10 +137,10 @@ impl Table {
 
     pub(crate) fn from_vm_extern(
         ctx: &mut impl AsContextMut,
-        internal: InternalContextHandle<VMTable>,
+        internal: InternalStoreHandle<VMTable>,
     ) -> Self {
         Self {
-            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
+            handle: unsafe { StoreHandle::from_internal(store.objects().id(), internal) },
         }
     }
 

--- a/lib/api/src/js/imports.rs
+++ b/lib/api/src/js/imports.rs
@@ -235,7 +235,7 @@ impl fmt::Debug for Imports {
 ///
 /// ```
 /// # use wasmer::{Function, Store};
-/// # let store = Store::default();
+/// # let mut store = Store::default();
 /// use wasmer::imports;
 ///
 /// let import_object = imports! {
@@ -300,7 +300,7 @@ mod test {
     use crate::js::export::Export;
     use wasm_bindgen_test::*;
     fn namespace() {
-        let store = Store::default();
+        let mut store = Store::default();
         let g1 = Global::new(&store, Val::I32(0));
         let namespace = namespace! {
             "happy" => g1
@@ -372,7 +372,7 @@ mod test {
     }
 
     fn chaining_works() {
-        let store = Store::default();
+        let mut store = Store::default();
         let g = Global::new(&store, Val::I32(0));
 
         let mut imports1 = imports! {
@@ -402,7 +402,7 @@ mod test {
     }
 
     fn extending_conflict_overwrites() {
-        let store = Store::default();
+        let mut store = Store::default();
         let g1 = Global::new(&store, Val::I32(0));
         let g2 = Global::new(&store, Val::F32(0.));
 
@@ -430,7 +430,7 @@ mod test {
         );
 
         // now test it in reverse
-        let store = Store::default();
+        let mut store = Store::default();
         let g1 = Global::new(&store, Val::I32(0));
         let g2 = Global::new(&store, Val::F32(0.));
 

--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -1,4 +1,4 @@
-use crate::js::context::{AsContextMut, AsContextRef, ContextHandle};
+use crate::js::context::{AsContextMut, AsContextRef, StoreHandle};
 use crate::js::error::InstantiationError;
 use crate::js::export::Export;
 use crate::js::exports::Exports;
@@ -18,7 +18,7 @@ use std::fmt;
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#module-instances>
 #[derive(Clone)]
 pub struct Instance {
-    _handle: ContextHandle<WebAssembly::Instance>,
+    _handle: StoreHandle<WebAssembly::Instance>,
     module: Module,
     #[allow(dead_code)]
     imports: Imports,
@@ -66,7 +66,7 @@ impl Instance {
         imports: &Imports,
     ) -> Result<Self, InstantiationError> {
         let import_copy = imports.clone();
-        let (instance, _imports): (ContextHandle<WebAssembly::Instance>, Vec<Extern>) = module
+        let (instance, _imports): (StoreHandle<WebAssembly::Instance>, Vec<Extern>) = module
             .instantiate(&mut ctx.as_context_mut(), imports)
             .map_err(|e| InstantiationError::Start(e))?;
 
@@ -87,7 +87,7 @@ impl Instance {
     pub fn from_module_and_instance(
         ctx: &mut impl AsContextMut,
         module: &Module,
-        instance: ContextHandle<WebAssembly::Instance>,
+        instance: StoreHandle<WebAssembly::Instance>,
         imports: Imports,
     ) -> Result<Self, InstantiationError> {
         let instance_exports = instance.get(store.objects()).exports();

--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -90,7 +90,7 @@ impl Instance {
         instance: ContextHandle<WebAssembly::Instance>,
         imports: Imports,
     ) -> Result<Self, InstantiationError> {
-        let instance_exports = instance.get(ctx.as_context_ref().objects()).exports();
+        let instance_exports = instance.get(store.objects()).exports();
         let exports = module
             .exports()
             .map(|export_type| {
@@ -130,7 +130,7 @@ impl Instance {
         &self,
         ctx: &'context impl AsContextRef,
     ) -> &'context WebAssembly::Instance {
-        &self._handle.get(ctx.as_context_ref().objects())
+        &self._handle.get(store.objects())
     }
 }
 

--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -41,7 +41,7 @@ impl Instance {
     /// ```
     /// # use wasmer::{imports, Store, Module, Global, Value, Instance};
     /// # fn main() -> anyhow::Result<()> {
-    /// let store = Store::default();
+    /// let mut store = Store::default();
     /// let module = Module::new(&store, "(module)")?;
     /// let imports = imports!{
     ///   "host" => {

--- a/lib/api/src/js/module.rs
+++ b/lib/api/src/js/module.rs
@@ -94,7 +94,7 @@ impl Module {
     /// ```
     /// use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = "(module)";
     /// let module = Module::new(&store, wat)?;
     /// # Ok(())
@@ -106,7 +106,7 @@ impl Module {
     /// ```
     /// use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// // The following is the same as:
     /// // (module
     /// //   (type $t0 (func (param i32) (result i32)))
@@ -280,7 +280,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = "(module $moduleName)";
     /// let module = Module::new(&store, wat)?;
     /// assert_eq!(module.name(), Some("moduleName"));
@@ -323,7 +323,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = "(module)";
     /// let mut module = Module::new(&store, wat)?;
     /// assert_eq!(module.name(), None);
@@ -358,7 +358,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = r#"(module
     ///     (import "host" "func1" (func))
     ///     (import "host" "func2" (func))
@@ -456,7 +456,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = r#"(module
     ///     (func (export "namedfunc"))
     ///     (memory (export "namedmemory") 1)

--- a/lib/api/src/js/module.rs
+++ b/lib/api/src/js/module.rs
@@ -1,4 +1,4 @@
-use crate::js::context::{AsContextMut, ContextHandle};
+use crate::js::context::{AsContextMut, StoreHandle};
 #[cfg(feature = "wat")]
 use crate::js::error::WasmError;
 use crate::js::error::{CompileError, InstantiationError};
@@ -219,7 +219,7 @@ impl Module {
         &self,
         ctx: &mut impl AsContextMut,
         imports: &Imports,
-    ) -> Result<(ContextHandle<WebAssembly::Instance>, Vec<Extern>), RuntimeError> {
+    ) -> Result<(StoreHandle<WebAssembly::Instance>, Vec<Extern>), RuntimeError> {
         // Ensure all imports come from the same context.
         if imports
             .into_iter()
@@ -261,7 +261,7 @@ impl Module {
             // the error for us, so we don't need to handle it
         }
         Ok((
-            ContextHandle::new(
+            StoreHandle::new(
                 store.objects_mut(),
                 WebAssembly::Instance::new(&self.module, &imports_object)
                     .map_err(|e: JsValue| -> RuntimeError { e.into() })?,

--- a/lib/api/src/js/native.rs
+++ b/lib/api/src/js/native.rs
@@ -38,7 +38,7 @@ where
     #[allow(dead_code)]
     pub(crate) fn new<T>(ctx: &mut impl AsContextMut<Data = T>, vm_function: VMFunction) -> Self {
         Self {
-            handle: ContextHandle::new(ctx.as_context_mut().objects_mut(), vm_function),
+            handle: ContextHandle::new(store.objects_mut(), vm_function),
             _phantom: PhantomData,
         }
     }
@@ -65,7 +65,7 @@ macro_rules! impl_native_traits {
             $( $x: FromToNativeWasmType + crate::js::NativeWasmTypeInto, )*
             {
                 let params_list: Vec<JsValue> = vec![ $( JsValue::from_f64($x.into_raw(ctx))),* ];
-                let results = self.handle.get(ctx.as_context_ref().objects()).function.apply(
+                let results = self.handle.get(store.objects()).function.apply(
                     &JsValue::UNDEFINED,
                     &Array::from_iter(params_list.iter())
                 )?;

--- a/lib/api/src/js/native.rs
+++ b/lib/api/src/js/native.rs
@@ -9,7 +9,7 @@
 //! ```
 use std::marker::PhantomData;
 
-use crate::js::context::{AsContextMut, AsContextRef, ContextHandle};
+use crate::js::context::{AsContextMut, AsContextRef, StoreHandle};
 use crate::js::externals::Function;
 use crate::js::{FromToNativeWasmType, RuntimeError, WasmTypeList};
 // use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -23,7 +23,7 @@ use wasm_bindgen::JsValue;
 /// (using the Native ABI).
 #[derive(Clone)]
 pub struct TypedFunction<Args = (), Rets = ()> {
-    pub(crate) handle: ContextHandle<VMFunction>,
+    pub(crate) handle: StoreHandle<VMFunction>,
     _phantom: PhantomData<(Args, Rets)>,
 }
 
@@ -38,7 +38,7 @@ where
     #[allow(dead_code)]
     pub(crate) fn new<T>(ctx: &mut impl AsContextMut<Data = T>, vm_function: VMFunction) -> Self {
         Self {
-            handle: ContextHandle::new(store.objects_mut(), vm_function),
+            handle: StoreHandle::new(store.objects_mut(), vm_function),
             _phantom: PhantomData,
         }
     }

--- a/lib/api/src/js/types.rs
+++ b/lib/api/src/js/types.rs
@@ -43,12 +43,7 @@ impl AsJs for Value {
             Self::I64(i) => JsValue::from_f64(*i as f64),
             Self::F32(f) => JsValue::from_f64(*f as f64),
             Self::F64(f) => JsValue::from_f64(*f),
-            Self::FuncRef(Some(func)) => func
-                .handle
-                .get(ctx.as_context_ref().objects())
-                .function
-                .clone()
-                .into(),
+            Self::FuncRef(Some(func)) => func.handle.get(store.objects()).function.clone().into(),
             Self::FuncRef(None) => JsValue::null(),
         }
     }

--- a/lib/api/src/js/value.rs
+++ b/lib/api/src/js/value.rs
@@ -90,7 +90,7 @@ impl Value {
             Self::F64(v) => v,
             Self::FuncRef(Some(ref f)) => f
                 .handle
-                .get(ctx.as_context_ref().objects())
+                .get(store.objects())
                 .function
                 .as_f64()
                 .unwrap_or(0_f64), //TODO is this correct?
@@ -121,14 +121,14 @@ impl Value {
         }
     }
 
-    /// Checks whether a value can be used with the given context.
+    /// Checks whether a value can be used with the given store.
     ///
     /// Primitive (`i32`, `i64`, etc) and null funcref/externref values are not
     /// tied to a context and can be freely shared between contexts.
     ///
     /// Externref and funcref values are tied to a context and can only be used
     /// with that context.
-    pub fn is_from_context(&self, ctx: &impl AsContextRef) -> bool {
+    pub fn is_from_store(&self, ctx: &impl AsContextRef) -> bool {
         match self {
             Self::I32(_)
             | Self::I64(_)
@@ -136,8 +136,8 @@ impl Value {
             | Self::F64(_)
             //| Self::ExternRef(None)
             | Self::FuncRef(None) => true,
-            //Self::ExternRef(Some(e)) => e.is_from_context(ctx),
-            Self::FuncRef(Some(f)) => f.is_from_context(ctx),
+            //Self::ExternRef(Some(e)) => e.is_from_store(ctx),
+            Self::FuncRef(Some(f)) => f.is_from_store(ctx),
         }
     }
 

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -54,7 +54,7 @@
 //!     "#;
 //!
 //!     let store = Store::default();
-//!     let mut ctx = WasmerContext::new(&store, ());
+//!     let ctx = WasmerContext::new(&store, ());
 //!     let module = Module::new(&store, &module_wat)?;
 //!     // The module doesn't import anything, so we create an empty import object.
 //!     let import_object = imports! {};

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -53,8 +53,8 @@
 //!         i32.add))
 //!     "#;
 //!
-//!     let store = Store::default();
-//!     let ctx = WasmerContext::new(&store, ());
+//!     let mut store = Store::default();
+//!     let ctx = WasmerContext::new(&mut store, ());
 //!     let module = Module::new(&store, &module_wat)?;
 //!     // The module doesn't import anything, so we create an empty import object.
 //!     let import_object = imports! {};
@@ -151,13 +151,12 @@
 //! [`imports`] macro:
 //!
 //! ```
-//! # use wasmer::{imports, Function, Memory, MemoryType, Store, Imports};
-//! # use wasmer::ContextMut;
-//! # fn imports_example(mut ctx: ContextMut<()>, store: &Store) -> Imports {
-//! let memory = Memory::new(&mut ctx, MemoryType::new(1, None, false)).unwrap();
+//! # use wasmer::{imports, Function, Memory, MemoryType, Store, Imports, Context};
+//! # fn imports_example(ctx: Context<()>, mut store: &mut Store) -> Imports {
+//! let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
 //! imports! {
 //!     "env" => {
-//!          "my_function" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>| println!("Hello")),
+//!          "my_function" => Function::new_native(&mut store, &ctx, |_ctx: &mut ()| println!("Hello")),
 //!          "memory" => memory,
 //!     }
 //! }
@@ -168,12 +167,12 @@
 //! from any instance via `instance.exports`:
 //!
 //! ```
-//! # use wasmer::{imports, Instance, Function, Memory, TypedFunction, ContextMut};
-//! # fn exports_example(mut ctx: ContextMut<()>, instance: &Instance) -> anyhow::Result<()> {
+//! # use wasmer::{imports, Instance, Function, Memory, TypedFunction, Store};
+//! # fn exports_example(mut store: Store, instance: &Instance) -> anyhow::Result<()> {
 //! let memory = instance.exports.get_memory("memory")?;
 //! let memory: &Memory = instance.exports.get("some_other_memory")?;
-//! let add: TypedFunction<(i32, i32), i32> = instance.exports.get_typed_function(&mut ctx, "add")?;
-//! let result = add.call(&mut ctx, 5, 37)?;
+//! let add: TypedFunction<(i32, i32), i32> = instance.exports.get_typed_function(&mut store, "add")?;
+//! let result = add.call(&mut store, 5, 37)?;
 //! assert_eq!(result, 42);
 //! # Ok(())
 //! # }
@@ -395,7 +394,7 @@
 //!         i32.const 1
 //!         i32.add))
 //!     "#;
-//!     let store = Store::default();
+//!     let mut store = Store::default();
 //!     let module = Module::new(&store, &module_wat).unwrap();
 //!     // The module doesn't import anything, so we create an empty import object.
 //!     let import_object = imports! {};

--- a/lib/api/src/sys/context.rs
+++ b/lib/api/src/sys/context.rs
@@ -5,6 +5,7 @@ use wasmer_vm::{StoreHandle, VMFunctionContext};
 use crate::Store;
 
 #[derive(Debug)]
+#[repr(transparent)]
 /// An opaque reference to a function context.
 pub struct Context<T> {
     handle: StoreHandle<VMFunctionContext>,
@@ -15,7 +16,7 @@ impl<T> Context<T> {
     /// Make a new extern reference
     pub fn new(store: &mut Store, value: T) -> Self
     where
-        T: Any + Send + Sync + 'static + Sized,
+        T: Any + Send + 'static + Sized,
     {
         Self {
             handle: StoreHandle::new(store.objects_mut(), VMFunctionContext::new(value)),
@@ -36,7 +37,7 @@ impl<T> Context<T> {
     }
 
     /// Try to downcast to the given value.
-    pub fn downcast_mut<'a>(&mut self, store: &'a mut Store) -> &'a mut T
+    pub fn downcast_mut<'a>(&self, store: &'a mut Store) -> &'a mut T
     where
         T: Any + Send + 'static + Sized,
     {

--- a/lib/api/src/sys/context.rs
+++ b/lib/api/src/sys/context.rs
@@ -1,166 +1,58 @@
-/// We require the context to have a fixed memory address for its lifetime since
-/// various bits of the VM have raw pointers that point back to it. Hence we
-/// wrap the actual context in a box.
-pub(crate) struct ContextInner<T> {
-    pub(crate) data: T,
-}
+use std::{any::Any, marker::PhantomData};
 
-/// A context containing a set of WebAssembly instances, along with host state.
-///
-/// All WebAssembly instances must exist within a context. In the majority of
-/// cases each instance will have its own context, but it is possible to have
-/// multiple instances in a context when these instances need to interact with
-/// each other, for example sharing a memory between instances or calling
-/// functions in another instance.
-///
-/// The lifetimes of run-time WebAssembly objects, notably [`Instance`],
-/// [`Memory`], [`Global`], [`Table`] and [`Function`] is tied to a context:
-/// the backing memory for these objects is only freed when the context is
-/// freed.
-///
-/// The `T` generic parameter allows arbitrary data to be attached to a context.
-/// This data can be accessed using the [`Context::data`] and
-/// [`Context::data_mut`] methods. Host functions defined using
-/// [`Function::new`] and [`Function::new_native`] receive
-/// a reference to the context when they are called.
+use wasmer_vm::{StoreHandle, VMFunctionContext};
+
+use crate::Store;
+
+#[derive(Debug)]
+/// An opaque reference to a function context.
 pub struct Context<T> {
-    pub(crate) inner: Box<ContextInner<T>>,
+    handle: StoreHandle<VMFunctionContext>,
+    _phantom: PhantomData<T>,
 }
 
 impl<T> Context<T> {
-    /// Creates a new context with the given host state.
-    // TODO: Eliminate the Store type and move its functionality into Engine.
-    pub fn new(data: T) -> Self {
+    /// Make a new extern reference
+    pub fn new(store: &mut Store, value: T) -> Self
+    where
+        T: Any + Send + Sync + 'static + Sized,
+    {
         Self {
-            inner: Box::new(ContextInner { data }),
+            handle: StoreHandle::new(store.objects_mut(), VMFunctionContext::new(value)),
+            _phantom: PhantomData,
         }
     }
 
-    /// Returns a reference to the host state in this context.
-    pub fn data(&self) -> &T {
-        &self.inner.data
+    /// Try to downcast to the given value.
+    pub fn downcast<'a>(&self, store: &'a Store) -> &'a T
+    where
+        T: Any + Send + 'static + Sized,
+    {
+        self.handle
+            .get(store.objects())
+            .as_ref()
+            .downcast_ref::<T>()
+            .unwrap()
     }
 
-    /// Returns a mutable- reference to the host state in this context.
-    pub fn data_mut(&mut self) -> &mut T {
-        &mut self.inner.data
-    }
-
-    /// Drops the context and returns the host state that was stored in it.
-    pub fn into_data(self) -> T {
-        self.inner.data
-    }
-
-    /// For use with the C API
-    /// # Safety
-    ///
-    /// This is unsafe.
-    pub unsafe fn transmute_data<U>(&mut self) -> &mut Context<U> {
-        core::mem::transmute::<&mut Self, &mut Context<U>>(self)
-    }
-}
-
-/// A temporary handle to a [`Context`].
-pub struct ContextRef<'a, T: 'a> {
-    inner: &'a ContextInner<T>,
-}
-
-impl<'a, T> ContextRef<'a, T> {
-    /// Returns a reference to the host state in this context.
-    pub fn data(&self) -> &'a T {
-        &self.inner.data
+    /// Try to downcast to the given value.
+    pub fn downcast_mut<'a>(&mut self, store: &'a mut Store) -> &'a mut T
+    where
+        T: Any + Send + 'static + Sized,
+    {
+        self.handle
+            .get_mut(store.objects_mut())
+            .as_mut()
+            .downcast_mut::<T>()
+            .unwrap()
     }
 }
 
-/// A temporary handle to a [`Context`].
-pub struct ContextMut<'a, T: 'a> {
-    inner: &'a mut ContextInner<T>,
-}
-
-impl<T> ContextMut<'_, T> {
-    /// Returns a reference to the host state in this context.
-    pub fn data(&self) -> &T {
-        &self.inner.data
-    }
-
-    /// Returns a mutable- reference to the host state in this context.
-    pub fn data_mut(&mut self) -> &mut T {
-        &mut self.inner.data
-    }
-
-    pub(crate) fn as_raw(&self) -> *mut ContextInner<T> {
-        self.inner as *const ContextInner<T> as *mut ContextInner<T>
-    }
-
-    pub(crate) unsafe fn from_raw(raw: *mut ContextInner<T>) -> Self {
-        Self { inner: &mut *raw }
-    }
-}
-
-/// Helper trait for a value that is convertible to a [`ContextRef`].
-pub trait AsContextRef {
-    /// Host state associated with the [`Context`].
-    type Data;
-
-    /// Returns a `ContextRef` pointing to the underlying context.
-    fn as_context_ref(&self) -> ContextRef<'_, Self::Data>;
-}
-
-/// Helper trait for a value that is convertible to a [`ContextMut`].
-pub trait AsContextMut: AsContextRef {
-    /// Returns a `ContextMut` pointing to the underlying context.
-    fn as_context_mut(&mut self) -> ContextMut<'_, Self::Data>;
-}
-
-impl<T> AsContextRef for Context<T> {
-    type Data = T;
-
-    fn as_context_ref(&self) -> ContextRef<'_, Self::Data> {
-        ContextRef { inner: &self.inner }
-    }
-}
-impl<T> AsContextMut for Context<T> {
-    fn as_context_mut(&mut self) -> ContextMut<'_, Self::Data> {
-        ContextMut {
-            inner: &mut self.inner,
+impl<T> Clone for Context<T> {
+    fn clone(&self) -> Self {
+        Self {
+            handle: self.handle.clone(),
+            _phantom: self._phantom,
         }
-    }
-}
-impl<T> AsContextRef for ContextRef<'_, T> {
-    type Data = T;
-
-    fn as_context_ref(&self) -> ContextRef<'_, Self::Data> {
-        ContextRef { inner: self.inner }
-    }
-}
-impl<T> AsContextRef for ContextMut<'_, T> {
-    type Data = T;
-
-    fn as_context_ref(&self) -> ContextRef<'_, Self::Data> {
-        ContextRef { inner: self.inner }
-    }
-}
-impl<T> AsContextMut for ContextMut<'_, T> {
-    fn as_context_mut(&mut self) -> ContextMut<'_, Self::Data> {
-        ContextMut { inner: self.inner }
-    }
-}
-impl<T: AsContextRef> AsContextRef for &'_ T {
-    type Data = T::Data;
-
-    fn as_context_ref(&self) -> ContextRef<'_, Self::Data> {
-        T::as_context_ref(*self)
-    }
-}
-impl<T: AsContextRef> AsContextRef for &'_ mut T {
-    type Data = T::Data;
-
-    fn as_context_ref(&self) -> ContextRef<'_, Self::Data> {
-        T::as_context_ref(*self)
-    }
-}
-impl<T: AsContextMut> AsContextMut for &'_ mut T {
-    fn as_context_mut(&mut self) -> ContextMut<'_, Self::Data> {
-        T::as_context_mut(*self)
     }
 }

--- a/lib/api/src/sys/exports.rs
+++ b/lib/api/src/sys/exports.rs
@@ -19,8 +19,8 @@ use thiserror::Error;
 /// ```should_panic
 /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value, ExportError};
 /// # use wasmer::Context as WasmerContext;
-/// # let store = Store::default();
-/// # let ctx = WasmerContext::new(&store, ());
+/// # let mut store = Store::default();
+/// # let ctx = WasmerContext::new(&mut store, ());
 /// # let wasm_bytes = wat2wasm(r#"
 /// # (module
 /// #   (global $one (export "glob") f32 (f32.const 1)))
@@ -38,8 +38,8 @@ use thiserror::Error;
 /// ```should_panic
 /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value, ExportError};
 /// # use wasmer::Context as WasmerContext;
-/// # let store = Store::default();
-/// # let ctx = WasmerContext::new(&store, ());
+/// # let mut store = Store::default();
+/// # let ctx = WasmerContext::new(&mut store, ());
 /// # let wasm_bytes = wat2wasm("(module)".as_bytes()).unwrap();
 /// # let module = Module::new(&store, wasm_bytes).unwrap();
 /// # let import_object = imports! {};

--- a/lib/api/src/sys/exports.rs
+++ b/lib/api/src/sys/exports.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value, ExportError};
 /// # use wasmer::Context as WasmerContext;
 /// # let store = Store::default();
-/// # let mut ctx = WasmerContext::new(&store, ());
+/// # let ctx = WasmerContext::new(&store, ());
 /// # let wasm_bytes = wat2wasm(r#"
 /// # (module
 /// #   (global $one (export "glob") f32 (f32.const 1)))
@@ -39,7 +39,7 @@ use thiserror::Error;
 /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value, ExportError};
 /// # use wasmer::Context as WasmerContext;
 /// # let store = Store::default();
-/// # let mut ctx = WasmerContext::new(&store, ());
+/// # let ctx = WasmerContext::new(&store, ());
 /// # let wasm_bytes = wat2wasm("(module)".as_bytes()).unwrap();
 /// # let module = Module::new(&store, wasm_bytes).unwrap();
 /// # let import_object = imports! {};

--- a/lib/api/src/sys/exports.rs
+++ b/lib/api/src/sys/exports.rs
@@ -1,4 +1,4 @@
-use super::context::AsContextRef;
+use super::store::Store;
 use crate::sys::externals::{Extern, Function, Global, Memory, Table};
 use crate::sys::native::TypedFunction;
 use crate::sys::WasmTypeList;
@@ -145,20 +145,20 @@ impl Exports {
     /// Get an export as a `TypedFunction`.
     pub fn get_native_function<Args, Rets>(
         &self,
-        ctx: &impl AsContextRef,
+        store: &Store,
         name: &str,
     ) -> Result<TypedFunction<Args, Rets>, ExportError>
     where
         Args: WasmTypeList,
         Rets: WasmTypeList,
     {
-        self.get_typed_function(ctx, name)
+        self.get_typed_function(store, name)
     }
 
     /// Get an export as a `TypedFunction`.
     pub fn get_typed_function<Args, Rets>(
         &self,
-        ctx: &impl AsContextRef,
+        store: &Store,
         name: &str,
     ) -> Result<TypedFunction<Args, Rets>, ExportError>
     where
@@ -166,7 +166,7 @@ impl Exports {
         Rets: WasmTypeList,
     {
         self.get_function(name)?
-            .native(ctx)
+            .native(store)
             .map_err(|_| ExportError::IncompatibleType)
     }
 

--- a/lib/api/src/sys/extern_ref.rs
+++ b/lib/api/src/sys/extern_ref.rs
@@ -1,3 +1,4 @@
+use crate::sys::Store;
 use std::any::Any;
 
 use wasmer_vm::{ContextHandle, VMExternObj, VMExternRef};
@@ -13,22 +14,22 @@ pub struct ExternRef {
 
 impl ExternRef {
     /// Make a new extern reference
-    pub fn new<T>(ctx: &mut impl AsContextMut, value: T) -> Self
+    pub fn new<T>(store: &mut Store, value: T) -> Self
     where
         T: Any + Send + Sync + 'static + Sized,
     {
         Self {
-            handle: ContextHandle::new(ctx.as_context_mut().objects_mut(), VMExternObj::new(value)),
+            handle: ContextHandle::new(store.objects_mut(), VMExternObj::new(value)),
         }
     }
 
     /// Try to downcast to the given value.
-    pub fn downcast<'a, T>(&self, ctx: &'a impl AsContextRef) -> Option<&'a T>
+    pub fn downcast<'a, T>(&self, store: &'a Store) -> Option<&'a T>
     where
         T: Any + Send + Sync + 'static + Sized,
     {
         self.handle
-            .get(ctx.as_context_ref().objects())
+            .get(store.objects())
             .as_ref()
             .downcast_ref::<T>()
     }
@@ -37,26 +38,20 @@ impl ExternRef {
         VMExternRef(self.handle.internal_handle())
     }
 
-    pub(crate) unsafe fn from_vm_externref(
-        ctx: &mut impl AsContextMut,
-        vm_externref: VMExternRef,
-    ) -> Self {
+    pub(crate) unsafe fn from_vm_externref(store: &Store, vm_externref: VMExternRef) -> Self {
         Self {
-            handle: ContextHandle::from_internal(
-                ctx.as_context_mut().objects_mut().id(),
-                vm_externref.0,
-            ),
+            handle: ContextHandle::from_internal(store.objects().id(), vm_externref.0),
         }
     }
 
-    /// Checks whether this `ExternRef` can be used with the given context.
+    /// Checks whether this `ExternRef` can be used with the given store.
     ///
     /// Primitive (`i32`, `i64`, etc) and null funcref/externref values are not
     /// tied to a context and can be freely shared between contexts.
     ///
     /// Externref and funcref values are tied to a context and can only be used
     /// with that context.
-    pub fn is_from_context(&self, ctx: &impl AsContextRef) -> bool {
-        self.handle.context_id() == ctx.as_context_ref().objects().id()
+    pub fn is_from_store(&self, store: &Store) -> bool {
+        self.handle.store_id() == store.objects().id()
     }
 }

--- a/lib/api/src/sys/extern_ref.rs
+++ b/lib/api/src/sys/extern_ref.rs
@@ -1,15 +1,13 @@
 use crate::sys::Store;
 use std::any::Any;
 
-use wasmer_vm::{ContextHandle, VMExternObj, VMExternRef};
-
-use super::context::{AsContextMut, AsContextRef};
+use wasmer_vm::{StoreHandle, VMExternObj, VMExternRef};
 
 #[derive(Debug, Clone)]
 #[repr(transparent)]
 /// An opaque reference to some data. This reference can be passed through Wasm.
 pub struct ExternRef {
-    handle: ContextHandle<VMExternObj>,
+    handle: StoreHandle<VMExternObj>,
 }
 
 impl ExternRef {
@@ -19,7 +17,7 @@ impl ExternRef {
         T: Any + Send + Sync + 'static + Sized,
     {
         Self {
-            handle: ContextHandle::new(store.objects_mut(), VMExternObj::new(value)),
+            handle: StoreHandle::new(store.objects_mut(), VMExternObj::new(value)),
         }
     }
 
@@ -40,7 +38,7 @@ impl ExternRef {
 
     pub(crate) unsafe fn from_vm_externref(store: &Store, vm_externref: VMExternRef) -> Self {
         Self {
-            handle: ContextHandle::from_internal(store.objects().id(), vm_externref.0),
+            handle: StoreHandle::from_internal(store.objects().id(), vm_externref.0),
         }
     }
 

--- a/lib/api/src/sys/externals/function.rs
+++ b/lib/api/src/sys/externals/function.rs
@@ -52,8 +52,8 @@ impl Function {
     /// ```
     /// # use wasmer::{Function, FunctionType, Type, Store, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// #
     /// let signature = FunctionType::new(vec![Type::I32, Type::I32], vec![Type::I32]);
     ///
@@ -68,7 +68,7 @@ impl Function {
     /// ```
     /// # use wasmer::{Function, FunctionType, Type, Store, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// const I32_I32_TO_I32: ([Type; 2], [Type; 1]) = ([Type::I32, Type::I32], [Type::I32]);
     ///
@@ -160,16 +160,16 @@ impl Function {
     /// # Example
     ///
     /// ```
-    /// # use wasmer::{ContextMut, Store, Function};
+    /// # use wasmer::{Store, Function};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let ctx = WasmerContext::new(&mut store, ());
     /// #
-    /// fn sum(_ctx: ContextMut<()>, a: i32, b: i32) -> i32 {
+    /// fn sum(_ctx: &mut (), a: i32, b: i32) -> i32 {
     ///     a + b
     /// }
     ///
-    /// let f = Function::new_native(&mut ctx, sum);
+    /// let f = Function::new_native(&mut store, ctx, sum);
     /// ```
     pub fn new_native<T: Send + 'static, F, Args, Rets>(
         store: &mut Store,
@@ -220,16 +220,16 @@ impl Function {
     /// # Example
     ///
     /// ```
-    /// # use wasmer::{ContextMut, Function, Store, Type};
+    /// # use wasmer::{Function, Store, Type};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// #
-    /// fn sum(_ctx: ContextMut<()>, a: i32, b: i32) -> i32 {
+    /// fn sum(_ctx: &mut (), a: i32, b: i32) -> i32 {
     ///     a + b
     /// }
     ///
-    /// let f = Function::new_native(&mut ctx, sum);
+    /// let f = Function::new_native(&mut store, &ctx, sum);
     ///
     /// assert_eq!(f.ty(&mut ctx).params(), vec![Type::I32, Type::I32]);
     /// assert_eq!(f.ty(&mut ctx).results(), vec![Type::I32]);
@@ -318,16 +318,16 @@ impl Function {
     /// # Example
     ///
     /// ```
-    /// # use wasmer::{ContextMut, Function, Store, Type};
+    /// # use wasmer::{Function, Store, Type};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// #
-    /// fn sum(_ctx: ContextMut<()>, a: i32, b: i32) -> i32 {
+    /// fn sum(_ctx: &mut (), a: i32, b: i32) -> i32 {
     ///     a + b
     /// }
     ///
-    /// let f = Function::new_native(&mut ctx, sum);
+    /// let f = Function::new_native(&mut store, &ctx, sum);
     ///
     /// assert_eq!(f.param_arity(&mut ctx), 2);
     /// ```
@@ -340,16 +340,16 @@ impl Function {
     /// # Example
     ///
     /// ```
-    /// # use wasmer::{ContextMut, Function, Store, Type};
+    /// # use wasmer::{Function, Store, Type};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// #
-    /// fn sum(_ctx: ContextMut<()>, a: i32, b: i32) -> i32 {
+    /// fn sum(_ctx: &mut (), a: i32, b: i32) -> i32 {
     ///     a + b
     /// }
     ///
-    /// let f = Function::new_native(&mut ctx, sum);
+    /// let f = Function::new_native(&mut store, &ctx, sum);
     ///
     /// assert_eq!(f.result_arity(&mut ctx), 1);
     /// ```
@@ -370,8 +370,8 @@ impl Function {
     /// ```
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -436,8 +436,8 @@ impl Function {
     /// ```
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, TypedFunction, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -464,8 +464,8 @@ impl Function {
     /// ```should_panic
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, TypedFunction, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -490,8 +490,8 @@ impl Function {
     /// ```should_panic
     /// # use wasmer::{imports, wat2wasm, Function, Instance, Module, Store, Type, TypedFunction, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let ctx = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let ctx = WasmerContext::new(&mut store, ());
     /// # let wasm_bytes = wat2wasm(r#"
     /// # (module
     /// #   (func (export "sum") (param $x i32) (param $y i32) (result i32)
@@ -1262,8 +1262,8 @@ mod inner {
         /*
         #[test]
         fn test_from_array() {
-            let store = Store::default();
-            let ctx = WasmerContext::new(&store, ());
+            let mut store = Store::default();
+            let ctx = WasmerContext::new(&mut store, ());
             assert_eq!(<()>::from_array(&mut ctx, []), ());
             assert_eq!(<i32>::from_array(&mut ctx, [RawValue{i32: 1}]), (1i32));
             assert_eq!(<(i32, i64)>::from_array(&mut ctx, [RawValue{i32:1}, RawValue{i64:2}]), (1i32, 2i64));
@@ -1280,8 +1280,8 @@ mod inner {
 
         #[test]
         fn test_into_array() {
-            let store = Store::default();
-            let ctx = WasmerContext::new(&store, ());
+            let mut store = Store::default();
+            let ctx = WasmerContext::new(&mut store, ());
             assert_eq!(().into_array(&mut ctx), [0i128; 0]);
             assert_eq!((1i32).into_array(&mut ctx), [1i32]);
             assert_eq!((1i32, 2i64).into_array(&mut ctx), [RawValue{i32: 1}, RawValue{i64: 2}]);
@@ -1300,8 +1300,8 @@ mod inner {
         /*
         #[test]
         fn test_from_c_struct() {
-            let store = Store::default();
-            let ctx = WasmerContext::new(&store, ());
+            let mut store = Store::default();
+            let ctx = WasmerContext::new(&mut store, ());
             assert_eq!(<()>::from_c_struct(&mut ctx, S0()), ());
             assert_eq!(<i32>::from_c_struct(&mut ctx, S1(1)), (1i32));
             assert_eq!(<(i32, i64)>::from_c_struct(&mut ctx, S2(1, 2)), (1i32, 2i64));
@@ -1361,8 +1361,8 @@ mod inner {
 
             #[test]
             fn test_function_types() {
-                let store = Store::default();
-                let ctx = WasmerContext::new(&store, ());
+                let mut store = Store::default();
+                let ctx = WasmerContext::new(&mut store, ());
                 use wasmer_types::FunctionType;
                 assert_eq!(
                     StaticFunction::new(func).ty(&mut ctx),

--- a/lib/api/src/sys/externals/global.rs
+++ b/lib/api/src/sys/externals/global.rs
@@ -1,4 +1,3 @@
-use crate::sys::context::{AsContextMut, AsContextRef};
 use crate::sys::exports::{ExportError, Exportable};
 use crate::sys::externals::Extern;
 use crate::sys::value::Value;
@@ -6,7 +5,7 @@ use crate::sys::GlobalType;
 use crate::sys::Mutability;
 use crate::sys::RuntimeError;
 use crate::sys::Store;
-use wasmer_vm::{ContextHandle, InternalContextHandle, VMExtern, VMGlobal};
+use wasmer_vm::{InternalStoreHandle, StoreHandle, VMExtern, VMGlobal};
 
 /// A WebAssembly `global` instance.
 ///
@@ -16,7 +15,7 @@ use wasmer_vm::{ContextHandle, InternalContextHandle, VMExtern, VMGlobal};
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#global-instances>
 #[derive(Debug, Clone)]
 pub struct Global {
-    handle: ContextHandle<VMGlobal>,
+    handle: StoreHandle<VMGlobal>,
 }
 
 impl Global {
@@ -74,7 +73,7 @@ impl Global {
         }
 
         Ok(Self {
-            handle: ContextHandle::new(store.objects_mut(), global),
+            handle: StoreHandle::new(store.objects_mut(), global),
         })
     }
 
@@ -185,10 +184,10 @@ impl Global {
 
     pub(crate) fn from_vm_extern(
         store: &mut Store,
-        internal: InternalContextHandle<VMGlobal>,
+        internal: InternalStoreHandle<VMGlobal>,
     ) -> Self {
         Self {
-            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
+            handle: unsafe { StoreHandle::from_internal(store.objects().id(), internal) },
         }
     }
 

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -41,7 +41,7 @@ impl Memory {
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// #
     /// let m = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
     /// ```
@@ -93,8 +93,8 @@ impl Memory {
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let mut store = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let mut store = WasmerContext::new(&mut store, ());
     /// #
     /// let m = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
     ///
@@ -112,8 +112,8 @@ impl Memory {
     /// ```
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value, WASM_MAX_PAGES};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let mut store = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let mut store = WasmerContext::new(&mut store, ());
     /// #
     /// let m = Memory::new(&mut store, MemoryType::new(1, Some(3), false)).unwrap();
     /// let p = m.grow(&mut store, 2).unwrap();
@@ -130,8 +130,8 @@ impl Memory {
     /// ```should_panic
     /// # use wasmer::{Memory, MemoryType, Pages, Store, Type, Value, WASM_MAX_PAGES};
     /// # use wasmer::Context as WasmerContext;
-    /// # let store = Store::default();
-    /// # let mut store = WasmerContext::new(&store, ());
+    /// # let mut store = Store::default();
+    /// # let mut store = WasmerContext::new(&mut store, ());
     /// #
     /// let m = Memory::new(&mut store, MemoryType::new(1, Some(1), false)).unwrap();
     ///

--- a/lib/api/src/sys/externals/mod.rs
+++ b/lib/api/src/sys/externals/mod.rs
@@ -11,10 +11,9 @@ pub use self::table::Table;
 
 use crate::sys::exports::{ExportError, Exportable};
 use crate::sys::ExternType;
+use crate::sys::Store;
 use std::fmt;
 use wasmer_vm::VMExtern;
-
-use super::context::{AsContextMut, AsContextRef};
 
 /// An `Extern` is the runtime representation of an entity that
 /// can be imported or exported.
@@ -34,32 +33,32 @@ pub enum Extern {
 
 impl Extern {
     /// Return the underlying type of the inner `Extern`.
-    pub fn ty(&self, ctx: &impl AsContextRef) -> ExternType {
+    pub fn ty(&self, store: &Store) -> ExternType {
         match self {
-            Self::Function(ft) => ExternType::Function(ft.ty(ctx)),
-            Self::Memory(ft) => ExternType::Memory(ft.ty(ctx)),
-            Self::Table(tt) => ExternType::Table(tt.ty(ctx)),
-            Self::Global(gt) => ExternType::Global(gt.ty(ctx)),
+            Self::Function(ft) => ExternType::Function(ft.ty(store)),
+            Self::Memory(ft) => ExternType::Memory(ft.ty(store)),
+            Self::Table(tt) => ExternType::Table(tt.ty(store)),
+            Self::Global(gt) => ExternType::Global(gt.ty(store)),
         }
     }
 
     /// Create an `Extern` from an `wasmer_engine::Export`.
-    pub fn from_vm_extern(ctx: &mut impl AsContextMut, vm_extern: VMExtern) -> Self {
+    pub fn from_vm_extern(store: &mut Store, vm_extern: VMExtern) -> Self {
         match vm_extern {
-            VMExtern::Function(f) => Self::Function(Function::from_vm_extern(ctx, f)),
-            VMExtern::Memory(m) => Self::Memory(Memory::from_vm_extern(ctx, m)),
-            VMExtern::Global(g) => Self::Global(Global::from_vm_extern(ctx, g)),
-            VMExtern::Table(t) => Self::Table(Table::from_vm_extern(ctx, t)),
+            VMExtern::Function(f) => Self::Function(Function::from_vm_extern(store, f)),
+            VMExtern::Memory(m) => Self::Memory(Memory::from_vm_extern(store, m)),
+            VMExtern::Global(g) => Self::Global(Global::from_vm_extern(store, g)),
+            VMExtern::Table(t) => Self::Table(Table::from_vm_extern(store, t)),
         }
     }
 
-    /// Checks whether this `Extern` can be used with the given context.
-    pub fn is_from_context(&self, ctx: &impl AsContextRef) -> bool {
+    /// Checks whether this `Extern` can be used with the given store.
+    pub fn is_from_store(&self, store: &Store) -> bool {
         match self {
-            Self::Function(f) => f.is_from_context(ctx),
-            Self::Global(g) => g.is_from_context(ctx),
-            Self::Memory(m) => m.is_from_context(ctx),
-            Self::Table(t) => t.is_from_context(ctx),
+            Self::Function(f) => f.is_from_store(store),
+            Self::Global(g) => g.is_from_store(store),
+            Self::Memory(m) => m.is_from_store(store),
+            Self::Table(t) => t.is_from_store(store),
         }
     }
 

--- a/lib/api/src/sys/externals/table.rs
+++ b/lib/api/src/sys/externals/table.rs
@@ -4,7 +4,7 @@ use crate::sys::RuntimeError;
 use crate::sys::Store;
 use crate::sys::TableType;
 use crate::{ExternRef, Function, Value};
-use wasmer_vm::{ContextHandle, InternalContextHandle, TableElement, VMExtern, VMTable};
+use wasmer_vm::{InternalStoreHandle, StoreHandle, TableElement, VMExtern, VMTable};
 
 /// A WebAssembly `table` instance.
 ///
@@ -17,7 +17,7 @@ use wasmer_vm::{ContextHandle, InternalContextHandle, TableElement, VMExtern, VM
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#table-instances>
 #[derive(Debug, Clone)]
 pub struct Table {
-    handle: ContextHandle<VMTable>,
+    handle: StoreHandle<VMTable>,
 }
 
 fn set_table_item(
@@ -65,7 +65,7 @@ impl Table {
     /// This function will construct the `Table` using the store
     /// [`BaseTunables`][crate::sys::BaseTunables].
     pub fn new(store: &mut Store, ty: TableType, init: Value) -> Result<Self, RuntimeError> {
-        let item = value_to_table_element(&mut store, init)?;
+        let item = value_to_table_element(store, init)?;
         let tunables = store.tunables();
         let style = tunables.table_style(&ty);
         let mut table = tunables
@@ -78,7 +78,7 @@ impl Table {
         }
 
         Ok(Self {
-            handle: ContextHandle::new(store.objects_mut(), table),
+            handle: StoreHandle::new(store.objects_mut(), table),
         })
     }
 
@@ -157,10 +157,10 @@ impl Table {
 
     pub(crate) fn from_vm_extern(
         store: &mut Store,
-        internal: InternalContextHandle<VMTable>,
+        internal: InternalStoreHandle<VMTable>,
     ) -> Self {
         Self {
-            handle: unsafe { ContextHandle::from_internal(store.objects().id(), internal) },
+            handle: unsafe { StoreHandle::from_internal(store.objects().id(), internal) },
         }
     }
 

--- a/lib/api/src/sys/imports.rs
+++ b/lib/api/src/sys/imports.rs
@@ -16,10 +16,10 @@ use wasmer_types::ImportError;
 ///
 /// # Usage:
 /// ```no_run
-/// use wasmer::{ContextMut, Exports, Module, Instance, imports, Imports, Function};
-/// # fn foo_test(mut ctx: ContextMut<()>, module: Module) {
+/// use wasmer::{Store, Context, Exports, Module, Instance, imports, Imports, Function};
+/// # fn foo_test(mut ctx: Context<()>, mut store: Store, module: Module) {
 ///
-/// let host_fn = Function::new_native(&mut ctx, foo);
+/// let host_fn = Function::new_native(&mut store, &ctx, foo);
 /// let import_object: Imports = imports! {
 ///     "env" => {
 ///         "foo" => host_fn,
@@ -28,7 +28,7 @@ use wasmer_types::ImportError;
 ///
 /// let instance = Instance::new(&mut ctx, &module, &import_object).expect("Could not instantiate module.");
 ///
-/// fn foo(_ctx: ContextMut<()>, n: i32) -> i32 {
+/// fn foo(_ctx: &mut (), n: i32) -> i32 {
 ///     n
 /// }
 ///
@@ -99,9 +99,9 @@ impl Imports {
     /// ```no_run
     /// # use wasmer::Context as WasmerContext;
     /// # let store = Default::default();
-    /// # let ctx = WasmerContext::new(&store, ());
-    /// use wasmer::{ContextMut, Imports, Function};
-    /// fn foo(_ctx: ContextMut<()>, n: i32) -> i32 {
+    /// # let ctx = WasmerContext::new(&mut store, ());
+    /// use wasmer::{Imports, Function};
+    /// fn foo(_ctx: &mut (), n: i32) -> i32 {
     ///     n
     /// }
     /// let mut import_object = Imports::new();
@@ -210,10 +210,10 @@ impl fmt::Debug for Imports {
 /// # Usage
 ///
 /// ```
-/// # use wasmer::{ContextMut, Function, Store};
+/// # use wasmer::{Function, Store};
 /// # use wasmer::Context as WasmerContext;
-/// # let store = Store::default();
-/// # let ctx = WasmerContext::new(&store, ());
+/// # let mut store = Store::default();
+/// # let ctx = WasmerContext::new(&mut store, ());
 /// use wasmer::imports;
 ///
 /// let import_object = imports! {
@@ -222,7 +222,7 @@ impl fmt::Debug for Imports {
 ///     },
 /// };
 ///
-/// fn foo(_ctx: ContextMut<()>, n: i32) -> i32 {
+/// fn foo(_ctx: &mut (), n: i32) -> i32 {
 ///     n
 /// }
 /// ```
@@ -280,8 +280,8 @@ mod test {
     /*
     #[test]
     fn namespace() {
-        let store = Store::default();
-        let ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
+        let ctx = WasmerContext::new(&mut store, ());
         let g1 = Global::new(&mut ctx, Value::I32(0));
         let namespace = namespace! {
             "happy" => g1

--- a/lib/api/src/sys/imports.rs
+++ b/lib/api/src/sys/imports.rs
@@ -307,7 +307,7 @@ mod test {
         use crate::sys::Function;
         use crate::sys::Store;
 
-        let store: Store = Default::default();
+        let mut store: Store = Default::default();
         let mut ctx = WasmerContext::new(());
 
         fn func(_ctx: ContextMut<()>, arg: i32) -> i32 {

--- a/lib/api/src/sys/imports.rs
+++ b/lib/api/src/sys/imports.rs
@@ -305,9 +305,10 @@ mod test {
     fn imports_macro_allows_trailing_comma_and_none() {
         use crate::sys::ContextMut;
         use crate::sys::Function;
+        use crate::sys::Store;
 
-        let store = Default::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let store: Store = Default::default();
+        let mut ctx = WasmerContext::new(());
 
         fn func(_ctx: ContextMut<()>, arg: i32) -> i32 {
             arg + 1
@@ -315,52 +316,51 @@ mod test {
 
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut ctx, func),
+                "func" => Function::new_native(&mut store, &mut ctx, func),
             },
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut ctx, func),
+                "func" => Function::new_native(&mut store, &mut ctx, func),
             }
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut ctx, func),
+                "func" => Function::new_native(&mut store, &mut ctx, func),
             },
             "abc" => {
-                "def" => Function::new_native(&mut ctx, func),
+                "def" => Function::new_native(&mut store, &mut ctx, func),
             }
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut ctx, func)
+                "func" => Function::new_native(&mut store, &mut ctx, func)
             },
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut ctx, func)
+                "func" => Function::new_native(&mut store, &mut ctx, func)
             }
         };
         let _ = imports! {
             "env" => {
-                "func1" => Function::new_native(&mut ctx, func),
-                "func2" => Function::new_native(&mut ctx, func)
+                "func1" => Function::new_native(&mut store, &mut ctx, func),
+                "func2" => Function::new_native(&mut store, &mut ctx, func)
             }
         };
         let _ = imports! {
             "env" => {
-                "func1" => Function::new_native(&mut ctx, func),
-                "func2" => Function::new_native(&mut ctx, func),
+                "func1" => Function::new_native(&mut store, &mut ctx, func),
+                "func2" => Function::new_native(&mut store, &mut ctx, func),
             }
         };
     }
 
     #[test]
     fn chaining_works() {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
 
-        let g = Global::new(&mut ctx, Value::I32(0));
+        let g = Global::new(&mut store, Value::I32(0));
 
         let mut imports1 = imports! {
             "dog" => {
@@ -390,10 +390,10 @@ mod test {
 
     #[test]
     fn extending_conflict_overwrites() {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let g1 = Global::new(&mut ctx, Value::I32(0));
-        let g2 = Global::new(&mut ctx, Value::I64(0));
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(());
+        let g1 = Global::new(&mut store, Value::I32(0));
+        let g2 = Global::new(&mut store, Value::I64(0));
 
         let mut imports1 = imports! {
             "dog" => {
@@ -419,10 +419,9 @@ mod test {
         );
         */
         // now test it in reverse
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let g1 = Global::new(&mut ctx, Value::I32(0));
-        let g2 = Global::new(&mut ctx, Value::I64(0));
+        let mut store = Store::default();
+        let g1 = Global::new(&mut store, Value::I32(0));
+        let g2 = Global::new(&mut store, Value::I64(0));
 
         let imports1 = imports! {
             "dog" => {

--- a/lib/api/src/sys/imports.rs
+++ b/lib/api/src/sys/imports.rs
@@ -303,55 +303,54 @@ mod test {
     */
     #[test]
     fn imports_macro_allows_trailing_comma_and_none() {
-        use crate::sys::ContextMut;
         use crate::sys::Function;
         use crate::sys::Store;
 
         let mut store: Store = Default::default();
-        let mut ctx = WasmerContext::new(());
+        let mut ctx = WasmerContext::new(&mut store, ());
 
-        fn func(_ctx: ContextMut<()>, arg: i32) -> i32 {
+        fn func(&mut _ctx: &mut (), arg: i32) -> i32 {
             arg + 1
         }
 
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut store, &mut ctx, func),
+                "func" => Function::new_native(&mut store, &ctx, func),
             },
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut store, &mut ctx, func),
+                "func" => Function::new_native(&mut store, &ctx, func),
             }
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut store, &mut ctx, func),
+                "func" => Function::new_native(&mut store, &ctx, func),
             },
             "abc" => {
-                "def" => Function::new_native(&mut store, &mut ctx, func),
+                "def" => Function::new_native(&mut store, &ctx, func),
             }
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut store, &mut ctx, func)
+                "func" => Function::new_native(&mut store, &ctx, func)
             },
         };
         let _ = imports! {
             "env" => {
-                "func" => Function::new_native(&mut store, &mut ctx, func)
+                "func" => Function::new_native(&mut store, &ctx, func)
             }
         };
         let _ = imports! {
             "env" => {
-                "func1" => Function::new_native(&mut store, &mut ctx, func),
-                "func2" => Function::new_native(&mut store, &mut ctx, func)
+                "func1" => Function::new_native(&mut store, &ctx, func),
+                "func2" => Function::new_native(&mut store, &ctx, func)
             }
         };
         let _ = imports! {
             "env" => {
-                "func1" => Function::new_native(&mut store, &mut ctx, func),
-                "func2" => Function::new_native(&mut store, &mut ctx, func),
+                "func1" => Function::new_native(&mut store, &ctx, func),
+                "func2" => Function::new_native(&mut store, &ctx, func),
             }
         };
     }
@@ -391,7 +390,6 @@ mod test {
     #[test]
     fn extending_conflict_overwrites() {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(());
         let g1 = Global::new(&mut store, Value::I32(0));
         let g2 = Global::new(&mut store, Value::I64(0));
 

--- a/lib/api/src/sys/imports.rs
+++ b/lib/api/src/sys/imports.rs
@@ -99,7 +99,7 @@ impl Imports {
     /// ```no_run
     /// # use wasmer::Context as WasmerContext;
     /// # let store = Default::default();
-    /// # let mut ctx = WasmerContext::new(&store, ());
+    /// # let ctx = WasmerContext::new(&store, ());
     /// use wasmer::{ContextMut, Imports, Function};
     /// fn foo(_ctx: ContextMut<()>, n: i32) -> i32 {
     ///     n
@@ -213,7 +213,7 @@ impl fmt::Debug for Imports {
 /// # use wasmer::{ContextMut, Function, Store};
 /// # use wasmer::Context as WasmerContext;
 /// # let store = Store::default();
-/// # let mut ctx = WasmerContext::new(&store, ());
+/// # let ctx = WasmerContext::new(&store, ());
 /// use wasmer::imports;
 ///
 /// let import_object = imports! {
@@ -281,7 +281,7 @@ mod test {
     #[test]
     fn namespace() {
         let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let ctx = WasmerContext::new(&store, ());
         let g1 = Global::new(&mut ctx, Value::I32(0));
         let namespace = namespace! {
             "happy" => g1
@@ -307,7 +307,7 @@ mod test {
         use crate::sys::Store;
 
         let mut store: Store = Default::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
 
         fn func(&mut _ctx: &mut (), arg: i32) -> i32 {
             arg + 1

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -88,8 +88,8 @@ impl Instance {
     /// # use wasmer::{imports, Store, Module, Global, Value, Instance};
     /// # use wasmer::Context as WasmerContext;
     /// # fn main() -> anyhow::Result<()> {
-    /// let store = Store::default();
-    /// let ctx = WasmerContext::new(&store, ());
+    /// let mut store = Store::default();
+    /// let ctx = WasmerContext::new(&mut store, ());
     /// let module = Module::new(&store, "(module)")?;
     /// let imports = imports!{
     ///   "host" => {

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -89,7 +89,7 @@ impl Instance {
     /// # use wasmer::Context as WasmerContext;
     /// # fn main() -> anyhow::Result<()> {
     /// let store = Store::default();
-    /// let mut ctx = WasmerContext::new(&store, ());
+    /// let ctx = WasmerContext::new(&store, ());
     /// let module = Module::new(&store, "(module)")?;
     /// let imports = imports!{
     ///   "host" => {

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -6,9 +6,7 @@ use crate::sys::Store;
 use crate::sys::{LinkError, RuntimeError};
 use std::fmt;
 use thiserror::Error;
-use wasmer_vm::{ContextHandle, InstanceHandle};
-
-use super::context::AsContextMut;
+use wasmer_vm::{InstanceHandle, StoreHandle};
 
 /// A WebAssembly Instance is a stateful, executable
 /// instance of a WebAssembly [`Module`].
@@ -20,7 +18,7 @@ use super::context::AsContextMut;
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#module-instances>
 #[derive(Clone)]
 pub struct Instance {
-    _handle: ContextHandle<InstanceHandle>,
+    _handle: StoreHandle<InstanceHandle>,
     module: Module,
     /// The exports for an instance.
     pub exports: Exports,
@@ -130,7 +128,7 @@ impl Instance {
             .collect::<Exports>();
 
         let instance = Self {
-            _handle: ContextHandle::new(store.objects_mut(), handle),
+            _handle: StoreHandle::new(store.objects_mut(), handle),
             module: module.clone(),
             exports,
         };
@@ -166,7 +164,7 @@ impl Instance {
             .collect::<Exports>();
 
         let instance = Self {
-            _handle: ContextHandle::new(store.objects_mut(), handle),
+            _handle: StoreHandle::new(store.objects_mut(), handle),
             module: module.clone(),
             exports,
         };

--- a/lib/api/src/sys/mem_access.rs
+++ b/lib/api/src/sys/mem_access.rs
@@ -12,7 +12,6 @@ use std::{
 use thiserror::Error;
 use wasmer_types::ValueType;
 
-use super::context::AsContextRef;
 use super::externals::memory::MemoryBuffer;
 use super::store::Store;
 

--- a/lib/api/src/sys/mem_access.rs
+++ b/lib/api/src/sys/mem_access.rs
@@ -14,6 +14,7 @@ use wasmer_types::ValueType;
 
 use super::context::AsContextRef;
 use super::externals::memory::MemoryBuffer;
+use super::store::Store;
 
 /// Error for invalid [`Memory`] access.
 #[derive(Clone, Copy, Debug, Error)]
@@ -62,9 +63,9 @@ pub struct WasmRef<'a, T: ValueType> {
 impl<'a, T: ValueType> WasmRef<'a, T> {
     /// Creates a new `WasmRef` at the given offset in a memory.
     #[inline]
-    pub fn new(ctx: &'a impl AsContextRef, memory: &'a Memory, offset: u64) -> Self {
+    pub fn new(store: &'a Store, memory: &'a Memory, offset: u64) -> Self {
         Self {
-            buffer: memory.buffer(ctx),
+            buffer: memory.buffer(store),
             offset,
             marker: PhantomData,
         }
@@ -161,7 +162,7 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
     /// Returns a `MemoryAccessError` if the slice length overflows.
     #[inline]
     pub fn new(
-        ctx: &'a impl AsContextRef,
+        store: &'a Store,
         memory: &'a Memory,
         offset: u64,
         len: u64,
@@ -173,7 +174,7 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         Ok(Self {
-            buffer: memory.buffer(ctx),
+            buffer: memory.buffer(store),
             offset,
             len,
             marker: PhantomData,

--- a/lib/api/src/sys/mod.rs
+++ b/lib/api/src/sys/mod.rs
@@ -13,7 +13,7 @@ mod store;
 mod tunables;
 mod value;
 
-pub use crate::sys::context::{AsContextMut, AsContextRef, Context, ContextMut, ContextRef};
+pub use crate::sys::context::Context;
 pub use crate::sys::exports::{ExportError, Exportable, Exports, ExportsIterator};
 pub use crate::sys::extern_ref::ExternRef;
 pub use crate::sys::externals::{

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -282,14 +282,15 @@ impl Module {
             }
         }
 
+        let (tunables, objects) = store.tunables_and_objects_mut();
         unsafe {
             let mut instance_handle = self.artifact.instantiate(
-                store.tunables(),
+                tunables,
                 &imports
                     .iter()
                     .map(crate::Extern::to_vm_extern)
                     .collect::<Vec<_>>(),
-                store.objects_mut(),
+                objects,
             )?;
 
             // After the instance handle is created, we need to initialize

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -78,7 +78,7 @@ impl Module {
     /// ```
     /// use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = "(module)";
     /// let module = Module::new(&store, wat)?;
     /// # Ok(())
@@ -90,7 +90,7 @@ impl Module {
     /// ```
     /// use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// // The following is the same as:
     /// // (module
     /// //   (type $t0 (func (param i32) (result i32)))
@@ -185,7 +185,7 @@ impl Module {
     /// ```ignore
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let module = Module::from_file(&store, "path/to/foo.wasm")?;
     /// let serialized = module.serialize()?;
     /// # Ok(())
@@ -203,7 +203,7 @@ impl Module {
     /// ```ignore
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # let module = Module::from_file(&store, "path/to/foo.wasm")?;
     /// module.serialize_to_file("path/to/foo.so")?;
     /// # Ok(())
@@ -231,7 +231,7 @@ impl Module {
     /// ```ignore
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let module = Module::deserialize(&store, serialized_data)?;
     /// # Ok(())
     /// # }
@@ -252,7 +252,7 @@ impl Module {
     ///
     /// ```ignore
     /// # use wasmer::*;
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// # fn main() -> anyhow::Result<()> {
     /// let module = Module::deserialize_from_file(&store, path)?;
     /// # Ok(())
@@ -315,7 +315,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = "(module $moduleName)";
     /// let module = Module::new(&store, wat)?;
     /// assert_eq!(module.name(), Some("moduleName"));
@@ -338,7 +338,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = "(module)";
     /// let mut module = Module::new(&store, wat)?;
     /// assert_eq!(module.name(), None);
@@ -366,7 +366,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = r#"(module
     ///     (import "host" "func1" (func))
     ///     (import "host" "func2" (func))
@@ -394,7 +394,7 @@ impl Module {
     /// ```
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
-    /// # let store = Store::default();
+    /// # let mut store = Store::default();
     /// let wat = r#"(module
     ///     (func (export "namedfunc"))
     ///     (memory (export "namedmemory") 1)

--- a/lib/api/src/sys/native.rs
+++ b/lib/api/src/sys/native.rs
@@ -10,8 +10,7 @@
 use std::marker::PhantomData;
 
 use crate::sys::{
-    AsContextMut, FromToNativeWasmType, Function, NativeWasmTypeInto, RuntimeError, Store,
-    WasmTypeList,
+    FromToNativeWasmType, Function, NativeWasmTypeInto, RuntimeError, Store, WasmTypeList,
 };
 use wasmer_types::RawValue;
 
@@ -67,7 +66,7 @@ macro_rules! impl_native_traits {
             /// Call the typed func and return results.
             #[allow(unused_mut)]
             #[allow(clippy::too_many_arguments)]
-            pub fn call(&self, store: &mut Store, ctx: &mut impl AsContextMut, $( $x: $x, )* ) -> Result<Rets, RuntimeError> {
+            pub fn call(&self, store: &mut Store, $( $x: $x, )* ) -> Result<Rets, RuntimeError> {
                 let anyfunc = unsafe {
                     *self.func
                         .handle

--- a/lib/api/src/sys/native_type.rs
+++ b/lib/api/src/sys/native_type.rs
@@ -6,133 +6,133 @@ use wasmer_vm::{VMExternRef, VMFuncRef};
 
 use crate::{ExternRef, Function};
 
-use super::context::AsContextMut;
+use super::store::Store;
 
 /// `NativeWasmTypeInto` performs conversions from and into `NativeWasmType`
 /// types with a context.
 pub trait NativeWasmTypeInto: NativeWasmType + Sized {
     #[doc(hidden)]
-    fn into_abi(self, ctx: &mut impl AsContextMut) -> Self::Abi;
+    fn into_abi(self, store: &mut Store) -> Self::Abi;
 
     #[doc(hidden)]
-    unsafe fn from_abi(ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self;
+    unsafe fn from_abi(store: &mut Store, abi: Self::Abi) -> Self;
 
     /// Convert self to raw value representation.
-    fn into_raw(self, ctx: &mut impl AsContextMut) -> RawValue;
+    fn into_raw(self, store: &mut Store) -> RawValue;
 
     /// Convert to self from raw value representation.
     ///
     /// # Safety
     ///
-    unsafe fn from_raw(ctx: &mut impl AsContextMut, raw: RawValue) -> Self;
+    unsafe fn from_raw(store: &mut Store, raw: RawValue) -> Self;
 }
 
 impl NativeWasmTypeInto for i32 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut Store, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsContextMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsContextMut) -> RawValue {
+    fn into_raw(self, _store: &mut Store) -> RawValue {
         RawValue { i32: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut Store, raw: RawValue) -> Self {
         raw.i32
     }
 }
 
 impl NativeWasmTypeInto for i64 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut Store, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsContextMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsContextMut) -> RawValue {
+    fn into_raw(self, _store: &mut Store) -> RawValue {
         RawValue { i64: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut Store, raw: RawValue) -> Self {
         raw.i64
     }
 }
 
 impl NativeWasmTypeInto for f32 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut Store, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsContextMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsContextMut) -> RawValue {
+    fn into_raw(self, _store: &mut Store) -> RawValue {
         RawValue { f32: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut Store, raw: RawValue) -> Self {
         raw.f32
     }
 }
 
 impl NativeWasmTypeInto for f64 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut Store, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsContextMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsContextMut) -> RawValue {
+    fn into_raw(self, _store: &mut Store) -> RawValue {
         RawValue { f64: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut Store, raw: RawValue) -> Self {
         raw.f64
     }
 }
 
 impl NativeWasmTypeInto for u128 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut Store, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsContextMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut Store) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsContextMut) -> RawValue {
+    fn into_raw(self, _store: &mut Store) -> RawValue {
         RawValue { u128: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut Store, raw: RawValue) -> Self {
         raw.u128
     }
 }
@@ -144,24 +144,24 @@ impl NativeWasmType for ExternRef {
 
 impl NativeWasmTypeInto for Option<ExternRef> {
     #[inline]
-    unsafe fn from_abi(ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(store: &mut Store, abi: Self::Abi) -> Self {
         VMExternRef::from_raw(RawValue { externref: abi })
-            .map(|e| ExternRef::from_vm_externref(ctx, e))
+            .map(|e| ExternRef::from_vm_externref(store, e))
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsContextMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut Store) -> Self::Abi {
         self.map_or(0, |e| unsafe { e.vm_externref().into_raw().externref })
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsContextMut) -> RawValue {
+    fn into_raw(self, _store: &mut Store) -> RawValue {
         self.map_or(RawValue { externref: 0 }, |e| e.vm_externref().into_raw())
     }
 
     #[inline]
-    unsafe fn from_raw(ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
-        VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(ctx, e))
+    unsafe fn from_raw(store: &mut Store, raw: RawValue) -> Self {
+        VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(store, e))
     }
 }
 
@@ -172,23 +172,25 @@ impl NativeWasmType for Function {
 
 impl NativeWasmTypeInto for Option<Function> {
     #[inline]
-    unsafe fn from_abi(ctx: &mut impl AsContextMut, abi: Self::Abi) -> Self {
-        VMFuncRef::from_raw(RawValue { funcref: abi }).map(|f| Function::from_vm_funcref(ctx, f))
+    unsafe fn from_abi(store: &mut Store, abi: Self::Abi) -> Self {
+        VMFuncRef::from_raw(RawValue { funcref: abi }).map(|f| Function::from_vm_funcref(store, f))
     }
 
     #[inline]
-    fn into_abi(self, ctx: &mut impl AsContextMut) -> Self::Abi {
-        self.map_or(0, |f| unsafe { f.vm_funcref(ctx).into_raw().externref })
+    fn into_abi(self, store: &mut Store) -> Self::Abi {
+        self.map_or(0, |f| unsafe { f.vm_funcref(store).into_raw().externref })
     }
 
     #[inline]
-    fn into_raw(self, ctx: &mut impl AsContextMut) -> RawValue {
-        self.map_or(RawValue { externref: 0 }, |e| e.vm_funcref(ctx).into_raw())
+    fn into_raw(self, store: &mut Store) -> RawValue {
+        self.map_or(RawValue { externref: 0 }, |e| {
+            e.vm_funcref(store).into_raw()
+        })
     }
 
     #[inline]
-    unsafe fn from_raw(ctx: &mut impl AsContextMut, raw: RawValue) -> Self {
-        VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(ctx, f))
+    unsafe fn from_raw(store: &mut Store, raw: RawValue) -> Self {
+        VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(store, f))
     }
 }
 

--- a/lib/api/src/sys/value.rs
+++ b/lib/api/src/sys/value.rs
@@ -110,7 +110,7 @@ impl Value {
     ///
     /// # Safety
     ///
-    pub unsafe fn from_raw(store: &Store, ty: Type, raw: RawValue) -> Self {
+    pub unsafe fn from_raw(store: &mut Store, ty: Type, raw: RawValue) -> Self {
         match ty {
             Type::I32 => Self::I32(raw.i32),
             Type::I64 => Self::I64(raw.i64),

--- a/lib/api/src/sys/value.rs
+++ b/lib/api/src/sys/value.rs
@@ -9,8 +9,7 @@ use wasmer_vm::VMFuncRef;
 use crate::ExternRef;
 use crate::Function;
 
-use super::context::AsContextMut;
-use super::context::AsContextRef;
+use super::store::Store;
 
 pub use wasmer_types::RawValue;
 
@@ -92,14 +91,14 @@ impl Value {
     }
 
     /// Converts the `Value` into a `RawValue`.
-    pub fn as_raw(&self, ctx: &impl AsContextRef) -> RawValue {
+    pub fn as_raw(&self, store: &Store) -> RawValue {
         match *self {
             Self::I32(i32) => RawValue { i32 },
             Self::I64(i64) => RawValue { i64 },
             Self::F32(f32) => RawValue { f32 },
             Self::F64(f64) => RawValue { f64 },
             Self::V128(u128) => RawValue { u128 },
-            Self::FuncRef(Some(ref f)) => f.vm_funcref(ctx).into_raw(),
+            Self::FuncRef(Some(ref f)) => f.vm_funcref(store).into_raw(),
 
             Self::FuncRef(None) => RawValue { funcref: 0 },
             Self::ExternRef(Some(ref e)) => e.vm_externref().into_raw(),
@@ -111,7 +110,7 @@ impl Value {
     ///
     /// # Safety
     ///
-    pub unsafe fn from_raw(ctx: &mut impl AsContextMut, ty: Type, raw: RawValue) -> Self {
+    pub unsafe fn from_raw(store: &Store, ty: Type, raw: RawValue) -> Self {
         match ty {
             Type::I32 => Self::I32(raw.i32),
             Type::I64 => Self::I64(raw.i64),
@@ -119,22 +118,22 @@ impl Value {
             Type::F64 => Self::F64(raw.f64),
             Type::V128 => Self::V128(raw.u128),
             Type::FuncRef => {
-                Self::FuncRef(VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(ctx, f)))
+                Self::FuncRef(VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(store, f)))
             }
             Type::ExternRef => Self::ExternRef(
-                VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(ctx, e)),
+                VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(store, e)),
             ),
         }
     }
 
-    /// Checks whether a value can be used with the given context.
+    /// Checks whether a value can be used with the given store.
     ///
     /// Primitive (`i32`, `i64`, etc) and null funcref/externref values are not
     /// tied to a context and can be freely shared between contexts.
     ///
     /// Externref and funcref values are tied to a context and can only be used
     /// with that context.
-    pub fn is_from_context(&self, ctx: &impl AsContextRef) -> bool {
+    pub fn is_from_store(&self, store: &Store) -> bool {
         match self {
             Self::I32(_)
             | Self::I64(_)
@@ -143,8 +142,8 @@ impl Value {
             | Self::V128(_)
             | Self::ExternRef(None)
             | Self::FuncRef(None) => true,
-            Self::ExternRef(Some(e)) => e.is_from_context(ctx),
-            Self::FuncRef(Some(f)) => f.is_from_context(ctx),
+            Self::ExternRef(Some(e)) => e.is_from_store(store),
+            Self::FuncRef(Some(f)) => f.is_from_store(store),
         }
     }
 

--- a/lib/api/tests/js_instance.rs
+++ b/lib/api/tests/js_instance.rs
@@ -45,7 +45,7 @@ mod js {
         let instance = Instance::new(&mut ctx, &module, &import_object).unwrap();
 
         let memory = instance.exports.get_memory("mem").unwrap();
-        assert!(memory.is_from_context(&ctx));
+        assert!(memory.is_from_store(&ctx));
         assert_eq!(memory.ty(&ctx), MemoryType::new(Pages(1), None, false));
         assert_eq!(memory.size(&ctx), Pages(1));
         assert_eq!(memory.data_size(&ctx), 65536);
@@ -344,7 +344,7 @@ mod js {
 
         fn imported_fn(ctx: ContextMut<'_, Env>, arg: u32) -> u32 {
             log!("inside imported_fn: ctx.data is {:?}", ctx.data());
-            // log!("inside call id is {:?}", ctx.as_context_ref().objects().id);
+            // log!("inside call id is {:?}", store.objects().id);
             return ctx.data().multiplier * arg;
         }
 

--- a/lib/api/tests/sys_externals.rs
+++ b/lib/api/tests/sys_externals.rs
@@ -90,7 +90,7 @@ mod sys {
     #[ignore]
     fn table_get() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let table_type = TableType {
             ty: Type::FuncRef,
             minimum: 0,
@@ -114,7 +114,7 @@ mod sys {
     #[test]
     fn table_grow() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let table_type = TableType {
             ty: Type::FuncRef,
             minimum: 0,
@@ -143,7 +143,7 @@ mod sys {
     #[test]
     fn memory_new() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let memory_type = MemoryType {
             shared: false,
             minimum: Pages(0),
@@ -158,7 +158,7 @@ mod sys {
     #[test]
     fn memory_grow() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let desc = MemoryType::new(Pages(10), Some(Pages(16)), false);
         let memory = Memory::new(&mut store, desc)?;
         assert_eq!(memory.size(&mut store), Pages(10));
@@ -187,7 +187,7 @@ mod sys {
     #[test]
     fn function_new() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let function = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| {});
         assert_eq!(
             function.ty(&mut store).clone(),
@@ -230,7 +230,7 @@ mod sys {
         struct MyEnv {}
 
         let my_env = MyEnv {};
-        let mut ctx = WasmerContext::new(&mut store, my_env);
+        let ctx = WasmerContext::new(&mut store, my_env);
         let function = Function::new_native(&mut store, &ctx, |_ctx: &mut MyEnv| {});
         assert_eq!(
             function.ty(&mut store).clone(),
@@ -270,7 +270,7 @@ mod sys {
     #[test]
     fn function_new_dynamic() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
 
         // Using &FunctionType signature
         let function_type = FunctionType::new(vec![], vec![]);
@@ -339,7 +339,7 @@ mod sys {
         #[derive(Clone)]
         struct MyEnv {}
         let my_env = MyEnv {};
-        let mut ctx = WasmerContext::new(&mut store, my_env);
+        let ctx = WasmerContext::new(&mut store, my_env);
 
         // Using &FunctionType signature
         let function_type = FunctionType::new(vec![], vec![]);
@@ -405,7 +405,7 @@ mod sys {
     //     #[test]
     //     fn native_function_works() -> Result<()> {
     //         let mut store = Store::default();
-    //         let mut ctx = WasmerContext::new(&mut store, ());
+    //         let ctx = WasmerContext::new(&mut store, ());
     //         let function = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| {});
     //         let native_function: TypedFunction<(), ()> = function.native(&mut store).unwrap();
     //         let result = native_function.call(&mut store);
@@ -446,7 +446,7 @@ mod sys {
     //     #[test]
     //     fn function_outlives_instance() -> Result<()> {
     //         let mut store = Store::default();
-    //         let mut ctx = WasmerContext::new(&mut store, ());
+    //         let ctx = WasmerContext::new(&mut store, ());
     //         let wat = r#"(module
     //   (type $sum_t (func (param i32 i32) (result i32)))
     //   (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
@@ -474,7 +474,7 @@ mod sys {
     //         #[test]
     //         fn weak_instance_ref_externs_after_instance() -> Result<()> {
     //             let mut store = Store::default();
-    //             let mut ctx = WasmerContext::new(&mut store, ());
+    //             let ctx = WasmerContext::new(&mut store, ());
     //             let wat = r#"(module
     //       (memory (export "mem") 1)
     //       (type $sum_t (func (param i32 i32) (result i32)))
@@ -517,7 +517,7 @@ mod sys {
     //             val: 5,
     //             memory: None,
     //         };
-    //         let mut ctx = WasmerContext::new(&mut store, env);
+    //         let ctx = WasmerContext::new(&mut store, env);
 
     //         let result = host_function(ctx.as_context_mut(), 7, 9);
     //         assert_eq!(result, 21);

--- a/lib/api/tests/sys_externals.rs
+++ b/lib/api/tests/sys_externals.rs
@@ -6,20 +6,19 @@ mod sys {
 
     #[test]
     fn global_new() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let global = Global::new(&mut ctx, Value::I32(10));
+        let mut store = Store::default();
+        let global = Global::new(&mut store, Value::I32(10));
         assert_eq!(
-            global.ty(&mut ctx),
+            global.ty(&mut store),
             GlobalType {
                 ty: Type::I32,
                 mutability: Mutability::Const
             }
         );
 
-        let global_mut = Global::new_mut(&mut ctx, Value::I32(10));
+        let global_mut = Global::new_mut(&mut store, Value::I32(10));
         assert_eq!(
-            global_mut.ty(&mut ctx),
+            global_mut.ty(&mut store),
             GlobalType {
                 ty: Type::I32,
                 mutability: Mutability::Var
@@ -31,51 +30,49 @@ mod sys {
 
     #[test]
     fn global_get() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let global_i32 = Global::new(&mut ctx, Value::I32(10));
-        assert_eq!(global_i32.get(&mut ctx), Value::I32(10));
-        let global_i64 = Global::new(&mut ctx, Value::I64(20));
-        assert_eq!(global_i64.get(&mut ctx), Value::I64(20));
-        let global_f32 = Global::new(&mut ctx, Value::F32(10.0));
-        assert_eq!(global_f32.get(&mut ctx), Value::F32(10.0));
-        let global_f64 = Global::new(&mut ctx, Value::F64(20.0));
-        assert_eq!(global_f64.get(&mut ctx), Value::F64(20.0));
+        let mut store = Store::default();
+        let global_i32 = Global::new(&mut store, Value::I32(10));
+        assert_eq!(global_i32.get(&mut store), Value::I32(10));
+        let global_i64 = Global::new(&mut store, Value::I64(20));
+        assert_eq!(global_i64.get(&mut store), Value::I64(20));
+        let global_f32 = Global::new(&mut store, Value::F32(10.0));
+        assert_eq!(global_f32.get(&mut store), Value::F32(10.0));
+        let global_f64 = Global::new(&mut store, Value::F64(20.0));
+        assert_eq!(global_f64.get(&mut store), Value::F64(20.0));
 
         Ok(())
     }
 
     #[test]
     fn global_set() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let global_i32 = Global::new(&mut ctx, Value::I32(10));
+        let mut store = Store::default();
+        let global_i32 = Global::new(&mut store, Value::I32(10));
         // Set on a constant should error
-        assert!(global_i32.set(&mut ctx, Value::I32(20)).is_err());
+        assert!(global_i32.set(&mut store, Value::I32(20)).is_err());
 
-        let global_i32_mut = Global::new_mut(&mut ctx, Value::I32(10));
+        let global_i32_mut = Global::new_mut(&mut store, Value::I32(10));
         // Set on different type should error
-        assert!(global_i32_mut.set(&mut ctx, Value::I64(20)).is_err());
+        assert!(global_i32_mut.set(&mut store, Value::I64(20)).is_err());
 
         // Set on same type should succeed
-        global_i32_mut.set(&mut ctx, Value::I32(20))?;
-        assert_eq!(global_i32_mut.get(&mut ctx), Value::I32(20));
+        global_i32_mut.set(&mut store, Value::I32(20))?;
+        assert_eq!(global_i32_mut.get(&mut store), Value::I32(20));
 
         Ok(())
     }
 
     #[test]
     fn table_new() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
         let table_type = TableType {
             ty: Type::FuncRef,
             minimum: 0,
             maximum: None,
         };
-        let f = Function::new_native(&mut ctx, |_ctx: ContextMut<()>| {});
-        let table = Table::new(&mut ctx, table_type, Value::FuncRef(Some(f)))?;
-        assert_eq!(table.ty(&mut ctx), table_type);
+        let ctx = WasmerContext::new(&mut store, ());
+        let f = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| {});
+        let table = Table::new(&mut store, table_type, Value::FuncRef(Some(f)))?;
+        assert_eq!(table.ty(&mut store), table_type);
 
         // Anyrefs not yet supported
         // let table_type = TableType {
@@ -92,17 +89,17 @@ mod sys {
     #[test]
     #[ignore]
     fn table_get() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(&mut store, ());
         let table_type = TableType {
             ty: Type::FuncRef,
             minimum: 0,
             maximum: Some(1),
         };
-        let f = Function::new_native(&mut ctx, |_ctx: ContextMut<()>, num: i32| num + 1);
-        let table = Table::new(&mut ctx, table_type, Value::FuncRef(Some(f)))?;
-        assert_eq!(table.ty(&mut ctx), table_type);
-        let _elem = table.get(&mut ctx, 0).unwrap();
+        let f = Function::new_native(&mut store, &ctx, |_ctx: &mut (), num: i32| num + 1);
+        let table = Table::new(&mut store, table_type, Value::FuncRef(Some(f)))?;
+        assert_eq!(table.ty(&mut store), table_type);
+        let _elem = table.get(&mut store, 0).unwrap();
         // assert_eq!(elem.funcref().unwrap(), f);
         Ok(())
     }
@@ -116,21 +113,21 @@ mod sys {
 
     #[test]
     fn table_grow() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(&mut store, ());
         let table_type = TableType {
             ty: Type::FuncRef,
             minimum: 0,
             maximum: Some(10),
         };
-        let f = Function::new_native(&mut ctx, |_ctx: ContextMut<()>, num: i32| num + 1);
-        let table = Table::new(&mut ctx, table_type, Value::FuncRef(Some(f.clone())))?;
+        let f = Function::new_native(&mut store, &ctx, |_ctx: &mut (), num: i32| num + 1);
+        let table = Table::new(&mut store, table_type, Value::FuncRef(Some(f.clone())))?;
         // Growing to a bigger maximum should return None
-        let old_len = table.grow(&mut ctx, 12, Value::FuncRef(Some(f.clone())));
+        let old_len = table.grow(&mut store, 12, Value::FuncRef(Some(f.clone())));
         assert!(old_len.is_err());
 
         // Growing to a bigger maximum should return None
-        let old_len = table.grow(&mut ctx, 5, Value::FuncRef(Some(f)))?;
+        let old_len = table.grow(&mut store, 5, Value::FuncRef(Some(f)))?;
         assert_eq!(old_len, 0);
 
         Ok(())
@@ -145,32 +142,32 @@ mod sys {
 
     #[test]
     fn memory_new() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(&mut store, ());
         let memory_type = MemoryType {
             shared: false,
             minimum: Pages(0),
             maximum: Some(Pages(10)),
         };
-        let memory = Memory::new(&mut ctx, memory_type)?;
-        assert_eq!(memory.size(&mut ctx), Pages(0));
-        assert_eq!(memory.ty(&mut ctx), memory_type);
+        let memory = Memory::new(&mut store, memory_type)?;
+        assert_eq!(memory.size(&mut store), Pages(0));
+        assert_eq!(memory.ty(&mut store), memory_type);
         Ok(())
     }
 
     #[test]
     fn memory_grow() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(&mut store, ());
         let desc = MemoryType::new(Pages(10), Some(Pages(16)), false);
-        let memory = Memory::new(&mut ctx, desc)?;
-        assert_eq!(memory.size(&mut ctx), Pages(10));
+        let memory = Memory::new(&mut store, desc)?;
+        assert_eq!(memory.size(&mut store), Pages(10));
 
-        let result = memory.grow(&mut ctx, Pages(2)).unwrap();
+        let result = memory.grow(&mut store, Pages(2)).unwrap();
         assert_eq!(result, Pages(10));
-        assert_eq!(memory.size(&mut ctx), Pages(12));
+        assert_eq!(memory.size(&mut store), Pages(12));
 
-        let result = memory.grow(&mut ctx, Pages(10));
+        let result = memory.grow(&mut store, Pages(10));
         assert_eq!(
             result,
             Err(MemoryError::CouldNotGrow {
@@ -180,7 +177,7 @@ mod sys {
         );
 
         let bad_desc = MemoryType::new(Pages(15), Some(Pages(10)), false);
-        let bad_result = Memory::new(&mut ctx, bad_desc);
+        let bad_result = Memory::new(&mut store, bad_desc);
 
         assert!(matches!(bad_result, Err(MemoryError::InvalidMemory { .. })));
 
@@ -189,37 +186,38 @@ mod sys {
 
     #[test]
     fn function_new() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<_>| {});
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(&mut store, ());
+        let function = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| {});
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![])
         );
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<_>, _a: i32| {});
+        let function = Function::new_native(&mut store, &ctx, |_ctx: &mut (), _a: i32| {});
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32], vec![])
         );
         let function = Function::new_native(
-            &mut ctx,
-            |_ctx: ContextMut<_>, _a: i32, _b: i64, _c: f32, _d: f64| {},
+            &mut store,
+            &ctx,
+            |_ctx: &mut (), _a: i32, _b: i64, _c: f32, _d: f64| {},
         );
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![])
         );
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<_>| -> i32 { 1 });
+        let function = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| -> i32 { 1 });
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![Type::I32])
         );
         let function =
-            Function::new_native(&mut ctx, |_ctx: ContextMut<_>| -> (i32, i64, f32, f64) {
+            Function::new_native(&mut store, &ctx, |_ctx: &mut ()| -> (i32, i64, f32, f64) {
                 (1, 2, 3.0, 4.0)
             });
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![Type::I32, Type::I64, Type::F32, Type::F64])
         );
         Ok(())
@@ -227,41 +225,43 @@ mod sys {
 
     #[test]
     fn function_new_env() -> Result<()> {
-        let store = Store::default();
+        let mut store = Store::default();
         #[derive(Clone)]
         struct MyEnv {}
 
         let my_env = MyEnv {};
-        let mut ctx = WasmerContext::new(&store, my_env);
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<MyEnv>| {});
+        let mut ctx = WasmerContext::new(&mut store, my_env);
+        let function = Function::new_native(&mut store, &ctx, |_ctx: &mut MyEnv| {});
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![])
         );
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<MyEnv>, _a: i32| {});
+        let function = Function::new_native(&mut store, &ctx, |_ctx: &mut MyEnv, _a: i32| {});
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32], vec![])
         );
         let function = Function::new_native(
-            &mut ctx,
-            |_ctx: ContextMut<MyEnv>, _a: i32, _b: i64, _c: f32, _d: f64| {},
+            &mut store,
+            &ctx,
+            |_ctx: &mut MyEnv, _a: i32, _b: i64, _c: f32, _d: f64| {},
         );
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![])
         );
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<MyEnv>| -> i32 { 1 });
+        let function = Function::new_native(&mut store, &ctx, |_ctx: &mut MyEnv| -> i32 { 1 });
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![Type::I32])
         );
         let function = Function::new_native(
-            &mut ctx,
-            |_ctx: ContextMut<MyEnv>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
+            &mut store,
+            &ctx,
+            |_ctx: &mut MyEnv| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
         );
         assert_eq!(
-            function.ty(&mut ctx).clone(),
+            function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![Type::I32, Type::I64, Type::F32, Type::F64])
         );
         Ok(())
@@ -269,58 +269,64 @@ mod sys {
 
     #[test]
     fn function_new_dynamic() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut store = Store::default();
+        let mut ctx = WasmerContext::new(&mut store, ());
 
         // Using &FunctionType signature
         let function_type = FunctionType::new(vec![], vec![]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<()>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut (), _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![Type::I32], vec![]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<()>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut (), _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<()>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut (), _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![], vec![Type::I32]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<()>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut (), _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
             FunctionType::new(vec![], vec![Type::I32, Type::I64, Type::F32, Type::F64]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<()>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut (), _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
 
         // Using array signature
         let function_type = ([Type::V128], [Type::I32, Type::F32, Type::F64]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             function_type,
-            |_ctx: ContextMut<()>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut (), _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).params(), [Type::V128]);
+        assert_eq!(function.ty(&mut store).params(), [Type::V128]);
         assert_eq!(
-            function.ty(&mut ctx).results(),
+            function.ty(&mut store).results(),
             [Type::I32, Type::F32, Type::F64]
         );
 
@@ -329,193 +335,199 @@ mod sys {
 
     #[test]
     fn function_new_dynamic_env() -> Result<()> {
-        let store = Store::default();
+        let mut store = Store::default();
         #[derive(Clone)]
         struct MyEnv {}
         let my_env = MyEnv {};
-        let mut ctx = WasmerContext::new(&store, my_env);
+        let mut ctx = WasmerContext::new(&mut store, my_env);
 
         // Using &FunctionType signature
         let function_type = FunctionType::new(vec![], vec![]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut MyEnv, _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![Type::I32], vec![]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut MyEnv, _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut MyEnv, _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![], vec![Type::I32]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut MyEnv, _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
             FunctionType::new(vec![], vec![Type::I32, Type::I64, Type::F32, Type::F64]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             &function_type,
-            |_ctx: ContextMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut MyEnv, _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).clone(), function_type);
+        assert_eq!(function.ty(&mut store).clone(), function_type);
 
         // Using array signature
         let function_type = ([Type::V128], [Type::I32, Type::F32, Type::F64]);
         let function = Function::new(
-            &mut ctx,
+            &mut store,
+            &ctx,
             function_type,
-            |_ctx: ContextMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_ctx: &mut MyEnv, _values: &[Value]| unimplemented!(),
         );
-        assert_eq!(function.ty(&mut ctx).params(), [Type::V128]);
+        assert_eq!(function.ty(&mut store).params(), [Type::V128]);
         assert_eq!(
-            function.ty(&mut ctx).results(),
+            function.ty(&mut store).results(),
             [Type::I32, Type::F32, Type::F64]
         );
 
         Ok(())
     }
 
-    #[test]
-    fn native_function_works() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<()>| {});
-        let native_function: TypedFunction<(), ()> = function.native(&mut ctx).unwrap();
-        let result = native_function.call(&mut ctx);
-        assert!(result.is_ok());
+    //     #[test]
+    //     fn native_function_works() -> Result<()> {
+    //         let mut store = Store::default();
+    //         let mut ctx = WasmerContext::new(&mut store, ());
+    //         let function = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| {});
+    //         let native_function: TypedFunction<(), ()> = function.native(&mut store).unwrap();
+    //         let result = native_function.call(&mut store);
+    //         assert!(result.is_ok());
 
-        let function =
-            Function::new_native(&mut ctx, |_ctx: ContextMut<()>, a: i32| -> i32 { a + 1 });
-        let native_function: TypedFunction<i32, i32> = function.native(&mut ctx).unwrap();
-        assert_eq!(native_function.call(&mut ctx, 3).unwrap(), 4);
+    //         let function =
+    //             Function::new_native(&mut store, &ctx, |_ctx: &mut (), a: i32| -> i32 { a + 1 });
+    //         let native_function: TypedFunction<i32, i32> = function.native(&mut store).unwrap();
+    //         assert_eq!(native_function.call(&mut store, 3).unwrap(), 4);
 
-        fn rust_abi(_ctx: ContextMut<()>, a: i32, b: i64, c: f32, d: f64) -> u64 {
-            (a as u64 * 1000) + (b as u64 * 100) + (c as u64 * 10) + (d as u64)
-        }
-        let function = Function::new_native(&mut ctx, rust_abi);
-        let native_function: TypedFunction<(i32, i64, f32, f64), u64> =
-            function.native(&mut ctx).unwrap();
-        assert_eq!(native_function.call(&mut ctx, 8, 4, 1.5, 5.).unwrap(), 8415);
+    //         fn rust_abi(_ctx: &mut (), a: i32, b: i64, c: f32, d: f64) -> u64 {
+    //             (a as u64 * 1000) + (b as u64 * 100) + (c as u64 * 10) + (d as u64)
+    //         }
+    //         let function = Function::new_native(&mut store, &ctx, rust_abi);
+    //         let native_function: TypedFunction<(i32, i64, f32, f64), u64> =
+    //             function.native(&mut store).unwrap();
+    //         assert_eq!(native_function.call(&mut store, 8, 4, 1.5, 5.).unwrap(), 8415);
 
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<()>| -> i32 { 1 });
-        let native_function: TypedFunction<(), i32> = function.native(&mut ctx).unwrap();
-        assert_eq!(native_function.call(&mut ctx).unwrap(), 1);
+    //         let function = Function::new_native(&mut store, &ctx, |_ctx: &mut ()| -> i32 { 1 });
+    //         let native_function: TypedFunction<(), i32> = function.native(&mut store).unwrap();
+    //         assert_eq!(native_function.call(&mut store).unwrap(), 1);
 
-        let function = Function::new_native(&mut ctx, |_ctx: ContextMut<()>, _a: i32| {});
-        let native_function: TypedFunction<i32, ()> = function.native(&mut ctx).unwrap();
-        assert!(native_function.call(&mut ctx, 4).is_ok());
+    //         let function = Function::new_native(&mut store, &ctx, |_ctx: &mut (), _a: i32| {});
+    //         let native_function: TypedFunction<i32, ()> = function.native(&mut store).unwrap();
+    //         assert!(native_function.call(&mut store, 4).is_ok());
 
-        let function =
-            Function::new_native(&mut ctx, |_ctx: ContextMut<()>| -> (i32, i64, f32, f64) {
-                (1, 2, 3.0, 4.0)
-            });
-        let native_function: TypedFunction<(), (i32, i64, f32, f64)> =
-            function.native(&mut ctx).unwrap();
-        assert_eq!(native_function.call(&mut ctx).unwrap(), (1, 2, 3.0, 4.0));
+    //         let function =
+    //             Function::new_native(&mut store, &ctx, |_ctx: &mut ()| -> (i32, i64, f32, f64) {
+    //                 (1, 2, 3.0, 4.0)
+    //             });
+    //         let native_function: TypedFunction<(), (i32, i64, f32, f64)> =
+    //             function.native(&mut store).unwrap();
+    //         assert_eq!(native_function.call(&mut store).unwrap(), (1, 2, 3.0, 4.0));
 
-        Ok(())
-    }
+    //         Ok(())
+    //     }
 
-    #[test]
-    fn function_outlives_instance() -> Result<()> {
-        let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
-        let wat = r#"(module
-  (type $sum_t (func (param i32 i32) (result i32)))
-  (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.add)
-  (export "sum" (func $sum_f)))
-"#;
+    //     #[test]
+    //     fn function_outlives_instance() -> Result<()> {
+    //         let mut store = Store::default();
+    //         let mut ctx = WasmerContext::new(&mut store, ());
+    //         let wat = r#"(module
+    //   (type $sum_t (func (param i32 i32) (result i32)))
+    //   (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
+    //     local.get $x
+    //     local.get $y
+    //     i32.add)
+    //   (export "sum" (func $sum_f)))
+    // "#;
 
-        let f = {
-            let module = Module::new(&store, wat)?;
-            let instance = Instance::new(&mut ctx, &module, &imports! {})?;
-            let f: TypedFunction<(i32, i32), i32> =
-                instance.exports.get_typed_function(&mut ctx, "sum")?;
+    //         let f = {
+    //             let module = Module::new(&store, wat)?;
+    //             let instance = Instance::new(&mut store, &module, &imports! {})?;
+    //             let f: TypedFunction<(i32, i32), i32> =
+    //                 instance.exports.get_typed_function(&mut store, "sum")?;
 
-            assert_eq!(f.call(&mut ctx, 4, 5)?, 9);
-            f
-        };
+    //             assert_eq!(f.call(&mut store, 4, 5)?, 9);
+    //             f
+    //         };
 
-        assert_eq!(f.call(&mut ctx, 4, 5)?, 9);
+    //         assert_eq!(f.call(&mut store, 4, 5)?, 9);
 
-        Ok(())
-    }
-    /*
-        #[test]
-        fn weak_instance_ref_externs_after_instance() -> Result<()> {
-            let store = Store::default();
-            let mut ctx = WasmerContext::new(&store, ());
-            let wat = r#"(module
-      (memory (export "mem") 1)
-      (type $sum_t (func (param i32 i32) (result i32)))
-      (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
-        local.get $x
-        local.get $y
-        i32.add)
-      (export "sum" (func $sum_f)))
-    "#;
+    //         Ok(())
+    //     }
+    //     /*
+    //         #[test]
+    //         fn weak_instance_ref_externs_after_instance() -> Result<()> {
+    //             let mut store = Store::default();
+    //             let mut ctx = WasmerContext::new(&mut store, ());
+    //             let wat = r#"(module
+    //       (memory (export "mem") 1)
+    //       (type $sum_t (func (param i32 i32) (result i32)))
+    //       (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
+    //         local.get $x
+    //         local.get $y
+    //         i32.add)
+    //       (export "sum" (func $sum_f)))
+    //     "#;
 
-            let f = {
-                let module = Module::new(&store, wat)?;
-                let instance = Instance::new(&mut ctx, &module, &imports! {})?;
-                let f: TypedFunction<(i32, i32), i32> =
-                    instance.exports.get_with_generics_weak("sum")?;
+    //             let f = {
+    //                 let module = Module::new(&store, wat)?;
+    //                 let instance = Instance::new(&mut store, &module, &imports! {})?;
+    //                 let f: TypedFunction<(i32, i32), i32> =
+    //                     instance.exports.get_with_generics_weak("sum")?;
 
-                assert_eq!(f.call(&mut ctx, 4, 5)?, 9);
-                f
-            };
+    //                 assert_eq!(f.call(&mut store, 4, 5)?, 9);
+    //                 f
+    //             };
 
-            assert_eq!(f.call(&mut ctx, 4, 5)?, 9);
+    //             assert_eq!(f.call(&mut store, 4, 5)?, 9);
 
-            Ok(())
-        }
-        */
-    #[test]
-    fn manually_generate_wasmer_env() -> Result<()> {
-        let store = Store::default();
-        #[derive(Clone)]
-        struct MyEnv {
-            val: u32,
-            memory: Option<Memory>,
-        }
+    //             Ok(())
+    //         }
+    //         */
+    //     #[test]
+    //     fn manually_generate_wasmer_env() -> Result<()> {
+    //         let mut store = Store::default();
+    //         #[derive(Clone)]
+    //         struct MyEnv {
+    //             val: u32,
+    //             memory: Option<Memory>,
+    //         }
 
-        fn host_function(ctx: ContextMut<MyEnv>, arg1: u32, arg2: u32) -> u32 {
-            ctx.data().val + arg1 + arg2
-        }
+    //         fn host_function(ctx: &mut MyEnv, arg1: u32, arg2: u32) -> u32 {
+    //             ctx.data().val + arg1 + arg2
+    //         }
 
-        let mut env = MyEnv {
-            val: 5,
-            memory: None,
-        };
-        let mut ctx = WasmerContext::new(&store, env);
+    //         let mut env = MyEnv {
+    //             val: 5,
+    //             memory: None,
+    //         };
+    //         let mut ctx = WasmerContext::new(&mut store, env);
 
-        let result = host_function(ctx.as_context_mut(), 7, 9);
-        assert_eq!(result, 21);
+    //         let result = host_function(ctx.as_context_mut(), 7, 9);
+    //         assert_eq!(result, 21);
 
-        let memory = Memory::new(&mut ctx, MemoryType::new(0, None, false))?;
-        ctx.data_mut().memory = Some(memory);
+    //         let memory = Memory::new(&mut store, MemoryType::new(0, None, false))?;
+    //         ctx.data_mut().memory = Some(memory);
 
-        let result = host_function(ctx.as_context_mut(), 1, 2);
-        assert_eq!(result, 8);
+    //         let result = host_function(ctx.as_context_mut(), 1, 2);
+    //         assert_eq!(result, 8);
 
-        Ok(())
-    }
+    //         Ok(())
+    //     }
 }

--- a/lib/api/tests/sys_instance.rs
+++ b/lib/api/tests/sys_instance.rs
@@ -7,7 +7,7 @@ mod sys {
     #[test]
     fn exports_work_after_multiple_instances_have_been_freed() -> Result<()> {
         let store = Store::default();
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut ctx = WasmerContext::new(());
         let module = Module::new(
             &store,
             "
@@ -22,7 +22,7 @@ mod sys {
         )?;
 
         let imports = Imports::new();
-        let instance = Instance::new(&mut ctx, &module, &imports)?;
+        let instance = Instance::new(&mut store, &module, &imports)?;
         let instance2 = instance.clone();
         let instance3 = instance.clone();
 
@@ -35,7 +35,7 @@ mod sys {
 
         // All instances have been dropped, but `sum` continues to work!
         assert_eq!(
-            sum.call(&mut ctx, &[Value::I32(1), Value::I32(2)])?
+            sum.call(&mut store, &mut ctx, &[Value::I32(1), Value::I32(2)])?
                 .into_vec(),
             vec![Value::I32(3)],
         );
@@ -57,12 +57,12 @@ mod sys {
         }
 
         let env = Env { multiplier: 3 };
-        let mut ctx = WasmerContext::new(&store, env);
+        let mut ctx = WasmerContext::new(env);
         let imported_signature = FunctionType::new(vec![Type::I32], vec![Type::I32]);
-        let imported = Function::new(&mut ctx, imported_signature, imported_fn);
+        let imported = Function::new(&mut store, &mut ctx, imported_signature, imported_fn);
 
         let expected = vec![Value::I32(12)].into_boxed_slice();
-        let result = imported.call(&mut ctx, &[Value::I32(4)])?;
+        let result = imported.call(&mut store, &mut ctx, &[Value::I32(4)])?;
         assert_eq!(result, expected);
 
         Ok(())

--- a/lib/api/tests/sys_instance.rs
+++ b/lib/api/tests/sys_instance.rs
@@ -7,7 +7,7 @@ mod sys {
     #[test]
     fn exports_work_after_multiple_instances_have_been_freed() -> Result<()> {
         let mut store = Store::default();
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let module = Module::new(
             &store,
             "
@@ -57,9 +57,9 @@ mod sys {
         }
 
         let env = Env { multiplier: 3 };
-        let mut ctx = WasmerContext::new(&mut store, env);
+        let ctx = WasmerContext::new(&mut store, env);
         let imported_signature = FunctionType::new(vec![Type::I32], vec![Type::I32]);
-        let imported = Function::new(&mut store, &mut ctx, imported_signature, imported_fn);
+        let imported = Function::new(&mut store, &ctx, imported_signature, imported_fn);
 
         let expected = vec![Value::I32(12)].into_boxed_slice();
         let result = imported.call(&mut store, &[Value::I32(4)])?;

--- a/lib/api/tests/sys_module.rs
+++ b/lib/api/tests/sys_module.rs
@@ -191,38 +191,38 @@ mod sys {
           (call 7 (i32.const -1)))
 )"#;
         let module = Module::new(&store, wat)?;
-        let mut ctx = WasmerContext::new(&mut store, ());
+        let ctx = WasmerContext::new(&mut store, ());
         let imports = imports! {
             "host" => {
-                "host_func1" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u64| {
+                "host_func1" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: u64| {
                     println!("host_func1: Found number {}", p);
                     assert_eq!(p, u64::max_value());
                 }),
-                "host_func2" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u32| {
+                "host_func2" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: u32| {
                     println!("host_func2: Found number {}", p);
                     assert_eq!(p, u32::max_value());
                 }),
-                "host_func3" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i64| {
+                "host_func3" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: i64| {
                     println!("host_func3: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func4" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i32| {
+                "host_func4" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: i32| {
                     println!("host_func4: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func5" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i16| {
+                "host_func5" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: i16| {
                     println!("host_func5: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func6" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u16| {
+                "host_func6" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: u16| {
                     println!("host_func6: Found number {}", p);
                     assert_eq!(p, u16::max_value());
                 }),
-                "host_func7" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i8| {
+                "host_func7" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: i8| {
                     println!("host_func7: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func8" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u8| {
+                "host_func8" => Function::new_native(&mut store, &ctx, |_ctx: &mut (), p: u8| {
                     println!("host_func8: Found number {}", p);
                     assert_eq!(p, u8::max_value());
                 }),

--- a/lib/api/tests/sys_module.rs
+++ b/lib/api/tests/sys_module.rs
@@ -191,38 +191,38 @@ mod sys {
           (call 7 (i32.const -1)))
 )"#;
         let module = Module::new(&store, wat)?;
-        let mut ctx = WasmerContext::new(&store, ());
+        let mut ctx = WasmerContext::new(());
         let imports = imports! {
             "host" => {
-                "host_func1" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: u64| {
+                "host_func1" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u64| {
                     println!("host_func1: Found number {}", p);
                     assert_eq!(p, u64::max_value());
                 }),
-                "host_func2" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: u32| {
+                "host_func2" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u32| {
                     println!("host_func2: Found number {}", p);
                     assert_eq!(p, u32::max_value());
                 }),
-                "host_func3" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: i64| {
+                "host_func3" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i64| {
                     println!("host_func3: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func4" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: i32| {
+                "host_func4" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i32| {
                     println!("host_func4: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func5" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: i16| {
+                "host_func5" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i16| {
                     println!("host_func5: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func6" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: u16| {
+                "host_func6" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u16| {
                     println!("host_func6: Found number {}", p);
                     assert_eq!(p, u16::max_value());
                 }),
-                "host_func7" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: i8| {
+                "host_func7" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i8| {
                     println!("host_func7: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func8" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, p: u8| {
+                "host_func8" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u8| {
                     println!("host_func8: Found number {}", p);
                     assert_eq!(p, u8::max_value());
                 }),
@@ -255,14 +255,14 @@ mod sys {
             .exports
             .get_typed_function(&mut ctx, "call_host_func8")?;
 
-        f1.call(&mut ctx)?;
-        f2.call(&mut ctx)?;
-        f3.call(&mut ctx)?;
-        f4.call(&mut ctx)?;
-        f5.call(&mut ctx)?;
-        f6.call(&mut ctx)?;
-        f7.call(&mut ctx)?;
-        f8.call(&mut ctx)?;
+        f1.call(&mut store, &mut ctx)?;
+        f2.call(&mut store, &mut ctx)?;
+        f3.call(&mut store, &mut ctx)?;
+        f4.call(&mut store, &mut ctx)?;
+        f5.call(&mut store, &mut ctx)?;
+        f6.call(&mut store, &mut ctx)?;
+        f7.call(&mut store, &mut ctx)?;
+        f8.call(&mut store, &mut ctx)?;
 
         Ok(())
     }

--- a/lib/api/tests/sys_module.rs
+++ b/lib/api/tests/sys_module.rs
@@ -162,7 +162,7 @@ mod sys {
 
     #[test]
     fn calling_host_functions_with_negative_values_works() -> Result<()> {
-        let store = Store::default();
+        let mut store = Store::default();
         let wat = r#"(module
     (import "host" "host_func1" (func (param i64)))
     (import "host" "host_func2" (func (param i32)))
@@ -191,78 +191,78 @@ mod sys {
           (call 7 (i32.const -1)))
 )"#;
         let module = Module::new(&store, wat)?;
-        let mut ctx = WasmerContext::new(());
+        let mut ctx = WasmerContext::new(&mut store, ());
         let imports = imports! {
             "host" => {
-                "host_func1" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u64| {
+                "host_func1" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u64| {
                     println!("host_func1: Found number {}", p);
                     assert_eq!(p, u64::max_value());
                 }),
-                "host_func2" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u32| {
+                "host_func2" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u32| {
                     println!("host_func2: Found number {}", p);
                     assert_eq!(p, u32::max_value());
                 }),
-                "host_func3" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i64| {
+                "host_func3" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i64| {
                     println!("host_func3: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func4" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i32| {
+                "host_func4" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i32| {
                     println!("host_func4: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func5" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i16| {
+                "host_func5" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i16| {
                     println!("host_func5: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func6" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u16| {
+                "host_func6" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u16| {
                     println!("host_func6: Found number {}", p);
                     assert_eq!(p, u16::max_value());
                 }),
-                "host_func7" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: i8| {
+                "host_func7" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: i8| {
                     println!("host_func7: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func8" => Function::new_native(&mut store, &mut ctx, |_ctx: ContextMut<()>, p: u8| {
+                "host_func8" => Function::new_native(&mut store, &mut ctx, |_ctx: &mut (), p: u8| {
                     println!("host_func8: Found number {}", p);
                     assert_eq!(p, u8::max_value());
                 }),
             }
         };
-        let instance = Instance::new(&mut ctx, &module, &imports)?;
+        let instance = Instance::new(&mut store, &module, &imports)?;
 
         let f1: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func1")?;
+            .get_typed_function(&store, "call_host_func1")?;
         let f2: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func2")?;
+            .get_typed_function(&store, "call_host_func2")?;
         let f3: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func3")?;
+            .get_typed_function(&store, "call_host_func3")?;
         let f4: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func4")?;
+            .get_typed_function(&store, "call_host_func4")?;
         let f5: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func5")?;
+            .get_typed_function(&store, "call_host_func5")?;
         let f6: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func6")?;
+            .get_typed_function(&store, "call_host_func6")?;
         let f7: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func7")?;
+            .get_typed_function(&store, "call_host_func7")?;
         let f8: TypedFunction<(), ()> = instance
             .exports
-            .get_typed_function(&mut ctx, "call_host_func8")?;
+            .get_typed_function(&store, "call_host_func8")?;
 
-        f1.call(&mut store, &mut ctx)?;
-        f2.call(&mut store, &mut ctx)?;
-        f3.call(&mut store, &mut ctx)?;
-        f4.call(&mut store, &mut ctx)?;
-        f5.call(&mut store, &mut ctx)?;
-        f6.call(&mut store, &mut ctx)?;
-        f7.call(&mut store, &mut ctx)?;
-        f8.call(&mut store, &mut ctx)?;
+        f1.call(&mut store)?;
+        f2.call(&mut store)?;
+        f3.call(&mut store)?;
+        f4.call(&mut store)?;
+        f5.call(&mut store)?;
+        f6.call(&mut store)?;
+        f7.call(&mut store)?;
+        f8.call(&mut store)?;
 
         Ok(())
     }

--- a/lib/api/tests/sys_reference_types.rs
+++ b/lib/api/tests/sys_reference_types.rs
@@ -25,10 +25,10 @@ mod sys {
         #[derive(Clone, Debug)]
         pub struct Env(Arc<AtomicBool>);
         let env = Env(Arc::new(AtomicBool::new(false)));
-        let mut ctx = WasmerContext::new(&mut store, env);
+        let ctx = WasmerContext::new(&mut store, env);
         let imports = imports! {
             "env" => {
-                "func_ref_identity" => Function::new(&mut store, &mut ctx, FunctionType::new([Type::FuncRef], [Type::FuncRef]), |_ctx: &mut Env, values: &[Value]| -> Result<Vec<_>, _> {
+                "func_ref_identity" => Function::new(&mut store, &ctx, FunctionType::new([Type::FuncRef], [Type::FuncRef]), |_ctx: &mut Env, values: &[Value]| -> Result<Vec<_>, _> {
                     Ok(vec![values[0].clone()])
                 })
             },
@@ -44,7 +44,7 @@ mod sys {
             panic!("funcref not found!");
         }
 
-        let func_to_call = Function::new_native(&mut store, &mut ctx, |mut ctx: &mut Env| -> i32 {
+        let func_to_call = Function::new_native(&mut store, &ctx, |mut ctx: &mut Env| -> i32 {
             ctx.0.store(true, Ordering::SeqCst);
             343
         });
@@ -78,7 +78,7 @@ mod sys {
     //           (call $func_ref_call (ref.func $product)))
     // )"#;
     //         let module = Module::new(&store, wat)?;
-    //         let mut ctx = WasmerContext::new(&mut store, ());
+    //         let ctx = WasmerContext::new(&mut store, ());
     //         fn func_ref_call(
     //             mut ctx: &mut (),
     //             values: &[Value],
@@ -133,7 +133,7 @@ mod sys {
         #[test]
         fn extern_ref_passed_and_returned() -> Result<()> {
             let store = Store::default();
-            let mut ctx = WasmerContext::new(&store, ());
+            let ctx = WasmerContext::new(&store, ());
             let wat = r#"(module
         (func $extern_ref_identity (import "env" "extern_ref_identity") (param externref) (result externref))
         (func $extern_ref_identity_native (import "env" "extern_ref_identity_native") (param externref) (result externref))

--- a/lib/api/tests/sys_reference_types.rs
+++ b/lib/api/tests/sys_reference_types.rs
@@ -9,7 +9,7 @@ mod sys {
 
     #[test]
     fn func_ref_passed_and_returned() -> Result<()> {
-        let store = Store::default();
+        let mut store = Store::default();
         let wat = r#"(module
     (import "env" "func_ref_identity" (func (param funcref) (result funcref)))
     (type $ret_i32_ty (func (result i32)))
@@ -25,111 +25,110 @@ mod sys {
         #[derive(Clone, Debug)]
         pub struct Env(Arc<AtomicBool>);
         let env = Env(Arc::new(AtomicBool::new(false)));
-        let mut ctx = WasmerContext::new(env);
+        let mut ctx = WasmerContext::new(&mut store, env);
         let imports = imports! {
             "env" => {
-                "func_ref_identity" => Function::new(&mut store, &mut ctx, FunctionType::new([Type::FuncRef], [Type::FuncRef]), |_ctx: ContextMut<Env>, values: &[Value]| -> Result<Vec<_>, _> {
+                "func_ref_identity" => Function::new(&mut store, &mut ctx, FunctionType::new([Type::FuncRef], [Type::FuncRef]), |_ctx: &mut Env, values: &[Value]| -> Result<Vec<_>, _> {
                     Ok(vec![values[0].clone()])
                 })
             },
         };
 
-        let instance = Instance::new(&mut ctx, &module, &imports)?;
+        let instance = Instance::new(&mut store, &module, &imports)?;
 
         let f: &Function = instance.exports.get_function("run")?;
-        let results = f.call(&mut store, &mut ctx, &[]).unwrap();
+        let results = f.call(&mut store, &[]).unwrap();
         if let Value::FuncRef(fr) = &results[0] {
             assert!(fr.is_none());
         } else {
             panic!("funcref not found!");
         }
 
-        let func_to_call =
-            Function::new_native(&mut store, &mut ctx, |mut ctx: ContextMut<Env>| -> i32 {
-                ctx.data_mut().0.store(true, Ordering::SeqCst);
-                343
-            });
+        let func_to_call = Function::new_native(&mut store, &mut ctx, |mut ctx: &mut Env| -> i32 {
+            ctx.0.store(true, Ordering::SeqCst);
+            343
+        });
         let call_set_value: &Function = instance.exports.get_function("call_set_value")?;
         let results: Box<[Value]> =
-            call_set_value.call(&mut store, &mut ctx, &[Value::FuncRef(Some(func_to_call))])?;
-        assert!(ctx.data().0.load(Ordering::SeqCst));
+            call_set_value.call(&mut store, &[Value::FuncRef(Some(func_to_call))])?;
+        assert!(ctx.downcast(&store).0.load(Ordering::SeqCst));
         assert_eq!(&*results, &[Value::I32(343)]);
 
         Ok(())
     }
 
-    #[test]
-    fn func_ref_passed_and_called() -> Result<()> {
-        let store = Store::default();
-        let wat = r#"(module
-    (func $func_ref_call (import "env" "func_ref_call") (param funcref) (result i32))
-    (type $ret_i32_ty (func (result i32)))
-    (table $table (export "table") 2 2 funcref)
+    //     #[test]
+    //     fn func_ref_passed_and_called() -> Result<()> {
+    //         let mut store = Store::default();
+    //         let wat = r#"(module
+    //     (func $func_ref_call (import "env" "func_ref_call") (param funcref) (result i32))
+    //     (type $ret_i32_ty (func (result i32)))
+    //     (table $table (export "table") 2 2 funcref)
 
-    (func $product (param $x i32) (param $y i32) (result i32)
-          (i32.mul (local.get $x) (local.get $y)))
-    ;; TODO: figure out exactly why this statement is needed
-    (elem declare func $product)
-    (func (export "call_set_value") (param $fr funcref) (result i32)
-          (table.set $table (i32.const 0) (local.get $fr))
-          (call_indirect $table (type $ret_i32_ty) (i32.const 0)))
-    (func (export "call_func") (param $fr funcref) (result i32)
-          (call $func_ref_call (local.get $fr)))
-    (func (export "call_host_func_with_wasm_func") (result i32)
-          (call $func_ref_call (ref.func $product)))
-)"#;
-        let module = Module::new(&store, wat)?;
-        let mut ctx = WasmerContext::new(());
-        fn func_ref_call(
-            mut ctx: ContextMut<()>,
-            values: &[Value],
-        ) -> Result<Vec<Value>, RuntimeError> {
-            // TODO: look into `Box<[Value]>` being returned breakage
-            let f = values[0].unwrap_funcref().as_ref().unwrap();
-            let f: TypedFunction<(i32, i32), i32> = f.native(&mut store)?;
-            Ok(vec![Value::I32(f.call(&mut ctx, 7, 9)?)])
-        }
+    //     (func $product (param $x i32) (param $y i32) (result i32)
+    //           (i32.mul (local.get $x) (local.get $y)))
+    //     ;; TODO: figure out exactly why this statement is needed
+    //     (elem declare func $product)
+    //     (func (export "call_set_value") (param $fr funcref) (result i32)
+    //           (table.set $table (i32.const 0) (local.get $fr))
+    //           (call_indirect $table (type $ret_i32_ty) (i32.const 0)))
+    //     (func (export "call_func") (param $fr funcref) (result i32)
+    //           (call $func_ref_call (local.get $fr)))
+    //     (func (export "call_host_func_with_wasm_func") (result i32)
+    //           (call $func_ref_call (ref.func $product)))
+    // )"#;
+    //         let module = Module::new(&store, wat)?;
+    //         let mut ctx = WasmerContext::new(&mut store, ());
+    //         fn func_ref_call(
+    //             mut ctx: &mut (),
+    //             values: &[Value],
+    //         ) -> Result<Vec<Value>, RuntimeError> {
+    //             // TODO: look into `Box<[Value]>` being returned breakage
+    //             let f = values[0].unwrap_funcref().as_ref().unwrap();
+    //             let f: TypedFunction<(i32, i32), i32> = f.native(&store)?;
+    //             Ok(vec![Value::I32(f.call(&mut store, 7, 9)?)])
+    //         }
 
-        let imports = imports! {
-            "env" => {
-                "func_ref_call" => Function::new(
-                    &mut store,
-                    &mut ctx,
-                    FunctionType::new([Type::FuncRef], [Type::I32]),
-                    func_ref_call
-                ),
-                // TODO(reftypes): this should work
-                /*
-                "func_ref_call_native" => Function::new_native(&store, |f: Function| -> Result<i32, RuntimeError> {
-                    let f: TypedFunction::<(i32, i32), i32> = f.native()?;
-                    f.call(7, 9)
-                })
-                */
-            },
-        };
+    //         let imports = imports! {
+    //             "env" => {
+    //                 "func_ref_call" => Function::new(
+    //                     &mut store,
+    //                     &mut ctx,
+    //                     FunctionType::new([Type::FuncRef], [Type::I32]),
+    //                     func_ref_call
+    //                 ),
+    //                 // TODO(reftypes): this should work
+    //                 /*
+    //                 "func_ref_call_native" => Function::new_native(&store, |f: Function| -> Result<i32, RuntimeError> {
+    //                     let f: TypedFunction::<(i32, i32), i32> = f.native()?;
+    //                     f.call(7, 9)
+    //                 })
+    //                 */
+    //             },
+    //         };
 
-        let instance = Instance::new(&mut ctx, &module, &imports)?;
-        {
-            fn sum(_ctx: ContextMut<()>, a: i32, b: i32) -> i32 {
-                a + b
-            }
-            let sum_func = Function::new_native(&mut store, &mut ctx, sum);
+    //         let instance = Instance::new(&mut store, &module, &imports)?;
+    //         {
+    //             fn sum(_ctx: &mut (), a: i32, b: i32) -> i32 {
+    //                 a + b
+    //             }
+    //             let sum_func = Function::new_native(&mut store, &mut ctx, sum);
 
-            let call_func: &Function = instance.exports.get_function("call_func")?;
-            let result = call_func.call(&mut store, &mut ctx, &[Value::FuncRef(Some(sum_func))])?;
-            assert_eq!(result[0].unwrap_i32(), 16);
-        }
+    //             let call_func: &Function = instance.exports.get_function("call_func")?;
+    //             let result = call_func.call(&mut store, &[Value::FuncRef(Some(sum_func))])?;
+    //             assert_eq!(result[0].unwrap_i32(), 16);
+    //         }
 
-        {
-            let f: TypedFunction<(), i32> = instance
-                .exports
-                .get_typed_function(&mut store, "call_host_func_with_wasm_func")?;
-            let result = f.call(&mut store, &mut ctx)?;
-            assert_eq!(result, 63);
-        }
+    //         {
+    //             let f: TypedFunction<(), i32> = instance
+    //                 .exports
+    //                 .get_typed_function(&mut store, "call_host_func_with_wasm_func")?;
+    //             let result = f.call(&mut store)?;
+    //             assert_eq!(result, 63);
+    //         }
 
-        Ok(())
-    }
+    //         Ok(())
+    //     }
     /*
         #[test]
         fn extern_ref_passed_and_returned() -> Result<()> {
@@ -156,7 +155,7 @@ mod sys {
                     "extern_ref_identity" => Function::new(&mut ctx, FunctionType::new([Type::ExternRef], [Type::ExternRef]), |_ctx, values| -> Result<Vec<_>, _> {
                         Ok(vec![values[0].clone()])
                     }),
-                    "extern_ref_identity_native" => Function::new_native(&mut ctx, |_ctx: ContextMut<()>, er: ExternRef| -> ExternRef {
+                    "extern_ref_identity_native" => Function::new_native(&mut ctx, |_ctx: &mut (), er: ExternRef| -> ExternRef {
                         er
                     }),
                     "get_new_extern_ref" => Function::new(&mut ctx, FunctionType::new([], [Type::ExternRef]), |_ctx, _| -> Result<Vec<_>, _> {

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -4,7 +4,7 @@ use crate::{ArtifactCreate, Upcastable};
 use wasmer_types::entity::BoxedSlice;
 use wasmer_types::{DataInitializer, FunctionIndex, LocalFunctionIndex, SignatureIndex};
 use wasmer_vm::{
-    ContextObjects, FunctionBodyPtr, InstanceAllocator, InstanceHandle, TrapHandler, VMExtern,
+    FunctionBodyPtr, InstanceAllocator, InstanceHandle, StoreObjects, TrapHandler, VMExtern,
     VMSharedSignatureIndex, VMTrampoline,
 };
 
@@ -51,7 +51,7 @@ pub trait Artifact: Send + Sync + Upcastable + ArtifactCreate {
         &self,
         tunables: &dyn Tunables,
         imports: &[VMExtern],
-        context: &mut ContextObjects,
+        context: &mut StoreObjects,
     ) -> Result<InstanceHandle, InstantiationError> {
         // Validate the CPU features this module was compiled with against the
         // host CPU features.

--- a/lib/compiler/src/engine/resolver.rs
+++ b/lib/compiler/src/engine/resolver.rs
@@ -8,7 +8,7 @@ use wasmer_types::{
 };
 
 use wasmer_vm::{
-    ContextObjects, FunctionBodyPtr, Imports, MemoryStyle, TableStyle, VMExtern, VMFunctionBody,
+    FunctionBodyPtr, Imports, MemoryStyle, StoreObjects, TableStyle, VMExtern, VMFunctionBody,
     VMFunctionImport, VMFunctionKind, VMGlobalImport, VMMemoryImport, VMTableImport,
 };
 
@@ -35,7 +35,7 @@ fn get_extern_from_import(module: &ModuleInfo, import_index: &ImportIndex) -> Ex
 }
 
 /// Get an `ExternType` given an export (and Engine signatures in case is a function).
-fn get_extern_type(context: &ContextObjects, extern_: &VMExtern) -> ExternType {
+fn get_extern_type(context: &StoreObjects, extern_: &VMExtern) -> ExternType {
     match extern_ {
         VMExtern::Function(f) => ExternType::Function(f.get(context).signature.clone()),
         VMExtern::Table(t) => ExternType::Table(*t.get(context).ty()),
@@ -54,7 +54,7 @@ fn get_extern_type(context: &ContextObjects, extern_: &VMExtern) -> ExternType {
 pub fn resolve_imports(
     module: &ModuleInfo,
     imports: &[VMExtern],
-    context: &ContextObjects,
+    context: &StoreObjects,
     finished_dynamic_function_trampolines: &BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     memory_styles: &PrimaryMap<MemoryIndex, MemoryStyle>,
     _table_styles: &PrimaryMap<TableIndex, TableStyle>,

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -1,259 +1,27 @@
-use std::{
-    cell::UnsafeCell,
-    fmt,
-    marker::PhantomData,
-    num::{NonZeroU64, NonZeroUsize},
-    ptr::NonNull,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::any::Any;
 
-use crate::VMExternObj;
-
-use crate::{InstanceHandle, VMFunction, VMGlobal, VMMemory, VMTable};
-
-/// Unique ID to identify a context.
-///
-/// Every handle to an object managed by a context also contains the ID of the
-/// context. This is used to check that a handle is always used with the
-/// correct context.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct ContextId(NonZeroU64);
-
-impl Default for ContextId {
-    // Allocates a unique ID for a new context.
-    fn default() -> Self {
-        // No overflow checking is needed here: overflowing this would take
-        // thousands of years.
-        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
-        Self(NonZeroU64::new(NEXT_ID.fetch_add(1, Ordering::Relaxed)).unwrap())
-    }
+/// Underlying Context used by a `VMFunction`.
+pub struct VMFunctionContext {
+    contents: Box<dyn Any + Send + 'static>,
 }
 
-/// Trait to represent an object managed by a context. This is implemented on
-/// the VM types managed by the context.
-pub trait ContextObject: Sized {
-    fn list(ctx: &ContextObjects) -> &Vec<Self>;
-    fn list_mut(ctx: &mut ContextObjects) -> &mut Vec<Self>;
-}
-macro_rules! impl_context_object {
-    ($($field:ident => $ty:ty,)*) => {
-        $(
-            impl ContextObject for $ty {
-                fn list(ctx: &ContextObjects) -> &Vec<Self> {
-                    &ctx.$field
-                }
-                fn list_mut(ctx: &mut ContextObjects) -> &mut Vec<Self> {
-                    &mut ctx.$field
-                }
-            }
-        )*
-    };
-}
-impl_context_object! {
-    functions => VMFunction,
-    tables => VMTable,
-    globals => VMGlobal,
-    instances => InstanceHandle,
-    memories => VMMemory,
-    extern_objs => VMExternObj,
-}
-
-/// Set of objects managed by a context.
-#[derive(Default)]
-pub struct ContextObjects {
-    id: ContextId,
-    memories: Vec<VMMemory>,
-    tables: Vec<VMTable>,
-    globals: Vec<VMGlobal>,
-    functions: Vec<VMFunction>,
-    instances: Vec<InstanceHandle>,
-    extern_objs: Vec<VMExternObj>,
-}
-
-impl ContextObjects {
-    /// Returns the ID of this context.
-    pub fn id(&self) -> ContextId {
-        self.id
-    }
-
-    /// Returns a pair of mutable references from two handles.
-    ///
-    /// Panics if both handles point to the same object.
-    pub fn get_2_mut<T: ContextObject>(
-        &mut self,
-        a: InternalContextHandle<T>,
-        b: InternalContextHandle<T>,
-    ) -> (&mut T, &mut T) {
-        assert_ne!(a.index(), b.index());
-        let list = T::list_mut(self);
-        if a.index() < b.index() {
-            let (low, high) = list.split_at_mut(b.index());
-            (&mut low[a.index()], &mut high[0])
-        } else {
-            let (low, high) = list.split_at_mut(a.index());
-            (&mut high[0], &mut low[a.index()])
-        }
-    }
-}
-
-/// Handle to an object managed by a context.
-///
-/// Internally this is just an integer index into a context. A reference to the
-/// context must be passed in separately to access the actual object.
-pub struct ContextHandle<T> {
-    id: ContextId,
-    internal: InternalContextHandle<T>,
-}
-
-impl<T> Clone for ContextHandle<T> {
-    fn clone(&self) -> Self {
+impl VMFunctionContext {
+    /// Wraps the given value to expose it to Wasm code as a function context.
+    pub fn new(val: impl Any + Send + 'static) -> Self {
         Self {
-            id: self.id,
-            internal: self.internal,
-        }
-    }
-}
-
-impl<T: ContextObject> fmt::Debug for ContextHandle<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ContextHandle")
-            .field("id", &self.id)
-            .field("internal", &self.internal.index())
-            .finish()
-    }
-}
-
-impl<T: ContextObject> PartialEq for ContextHandle<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.internal == other.internal
-    }
-}
-
-impl<T: ContextObject> Eq for ContextHandle<T> {}
-
-impl<T: ContextObject> ContextHandle<T> {
-    /// Moves the given object into a context and returns a handle to it.
-    pub fn new(ctx: &mut ContextObjects, val: T) -> Self {
-        Self {
-            id: ctx.id,
-            internal: InternalContextHandle::new(ctx, val),
+            contents: Box::new(val),
         }
     }
 
-    /// Returns a reference to the object that this handle points to.
-    pub fn get<'a>(&self, ctx: &'a ContextObjects) -> &'a T {
-        assert_eq!(self.id, ctx.id, "object used with the wrong context");
-        self.internal.get(ctx)
+    #[allow(clippy::should_implement_trait)]
+    /// Returns a reference to the underlying value.
+    pub fn as_ref(&self) -> &(dyn Any + Send + 'static) {
+        &*self.contents
     }
 
-    /// Returns a mutable reference to the object that this handle points to.
-    pub fn get_mut<'a>(&self, ctx: &'a mut ContextObjects) -> &'a mut T {
-        assert_eq!(self.id, ctx.id, "object used with the wrong context");
-        self.internal.get_mut(ctx)
-    }
-
-    /// Returns the internal handle contains within this handle.
-    pub fn internal_handle(&self) -> InternalContextHandle<T> {
-        self.internal
-    }
-
-    /// Returns the ID of the context associated with the handle.
-    pub fn store_id(&self) -> ContextId {
-        self.id
-    }
-
-    /// Constructs a `ContextHandle` from a `ContextId` and an `InternalContextHandle`.
-    ///
-    /// # Safety
-    /// Handling `InternalContextHandle` values is unsafe because they do not track context ID.
-    pub unsafe fn from_internal(id: ContextId, internal: InternalContextHandle<T>) -> Self {
-        Self { id, internal }
-    }
-}
-
-/// Internal handle to an object owned by the current context.
-///
-/// Unlike `ContextHandle` this does not track the context ID: it is only
-/// intended to be used within objects already owned by a context.
-#[repr(transparent)]
-pub struct InternalContextHandle<T> {
-    // Use a NonZero here to reduce the size of Option<InternalContextHandle>.
-    idx: NonZeroUsize,
-    marker: PhantomData<fn() -> T>,
-}
-
-impl<T> Clone for InternalContextHandle<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<T> Copy for InternalContextHandle<T> {}
-
-impl<T> fmt::Debug for InternalContextHandle<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InternalContextHandle")
-            .field("idx", &self.idx)
-            .finish()
-    }
-}
-impl<T> PartialEq for InternalContextHandle<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.idx == other.idx
-    }
-}
-impl<T> Eq for InternalContextHandle<T> {}
-
-impl<T: ContextObject> InternalContextHandle<T> {
-    /// Moves the given object into a context and returns a handle to it.
-    pub fn new(ctx: &mut ContextObjects, val: T) -> Self {
-        let list = T::list_mut(ctx);
-        let idx = NonZeroUsize::new(list.len() + 1).unwrap();
-        list.push(val);
-        Self {
-            idx,
-            marker: PhantomData,
-        }
-    }
-
-    /// Returns a reference to the object that this handle points to.
-    pub fn get<'a>(&self, ctx: &'a ContextObjects) -> &'a T {
-        &T::list(ctx)[self.idx.get() - 1]
-    }
-
-    /// Returns a mutable reference to the object that this handle points to.
-    pub fn get_mut<'a>(&self, ctx: &'a mut ContextObjects) -> &'a mut T {
-        &mut T::list_mut(ctx)[self.idx.get() - 1]
-    }
-
-    pub(crate) fn index(&self) -> usize {
-        self.idx.get()
-    }
-
-    pub(crate) fn from_index(idx: usize) -> Option<Self> {
-        NonZeroUsize::new(idx).map(|idx| Self {
-            idx,
-            marker: PhantomData,
-        })
-    }
-}
-
-/// Data used by the generated code is generally located inline within the
-/// `VMContext` for items defined in an instance. Host-defined objects are
-/// allocated separately and owned directly by the context.
-pub enum MaybeInstanceOwned<T> {
-    /// The data is owned here.
-    Host(Box<UnsafeCell<T>>),
-
-    /// The data is stored inline in the `VMContext` of an instance.
-    Instance(NonNull<T>),
-}
-
-impl<T> MaybeInstanceOwned<T> {
-    /// Returns underlying pointer to the VM data.
-    pub fn as_ptr(&self) -> NonNull<T> {
-        match self {
-            MaybeInstanceOwned::Host(p) => unsafe { NonNull::new_unchecked(p.get()) },
-            MaybeInstanceOwned::Instance(p) => *p,
-        }
+    #[allow(clippy::should_implement_trait)]
+    /// Returns a mutable reference to the underlying value.
+    pub fn as_mut(&mut self) -> &mut (dyn Any + Send + 'static) {
+        &mut *self.contents
     }
 }

--- a/lib/vm/src/context.rs
+++ b/lib/vm/src/context.rs
@@ -158,7 +158,7 @@ impl<T: ContextObject> ContextHandle<T> {
     }
 
     /// Returns the ID of the context associated with the handle.
-    pub fn context_id(&self) -> ContextId {
+    pub fn store_id(&self) -> ContextId {
         self.id
     }
 

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -1,9 +1,9 @@
 // This file contains code from external sources.
 // Attributions: https://github.com/wasmerio/wasmer/blob/master/ATTRIBUTIONS.md
 
-use crate::context::InternalContextHandle;
 use crate::global::VMGlobal;
 use crate::memory::VMMemory;
+use crate::store::InternalStoreHandle;
 use crate::table::VMTable;
 use crate::vmcontext::VMFunctionKind;
 use crate::{MaybeInstanceOwned, VMCallerCheckedAnyfunc};
@@ -13,16 +13,16 @@ use wasmer_types::FunctionType;
 /// The value of an export passed from one instance to another.
 pub enum VMExtern {
     /// A function export value.
-    Function(InternalContextHandle<VMFunction>),
+    Function(InternalStoreHandle<VMFunction>),
 
     /// A table export value.
-    Table(InternalContextHandle<VMTable>),
+    Table(InternalStoreHandle<VMTable>),
 
     /// A memory export value.
-    Memory(InternalContextHandle<VMMemory>),
+    Memory(InternalStoreHandle<VMMemory>),
 
     /// A global export value.
-    Global(InternalContextHandle<VMGlobal>),
+    Global(InternalStoreHandle<VMGlobal>),
 }
 
 /// A function export value.

--- a/lib/vm/src/extern_ref.rs
+++ b/lib/vm/src/extern_ref.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use wasmer_types::RawValue;
 
-use crate::context::InternalContextHandle;
+use crate::store::InternalStoreHandle;
 
 /// Underlying object referenced by a `VMExternRef`.
 pub struct VMExternObj {
@@ -27,7 +27,7 @@ impl VMExternObj {
 /// Represents an opaque reference to any data within WebAssembly.
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy)]
-pub struct VMExternRef(pub InternalContextHandle<VMExternObj>);
+pub struct VMExternRef(pub InternalStoreHandle<VMExternObj>);
 
 impl VMExternRef {
     /// Converts the `VMExternRef` into a `RawValue`.
@@ -42,6 +42,6 @@ impl VMExternRef {
     /// # Safety
     /// `raw` must be a valid `VMExternRef` instance.
     pub unsafe fn from_raw(raw: RawValue) -> Option<Self> {
-        InternalContextHandle::from_index(raw.externref).map(Self)
+        InternalStoreHandle::from_index(raw.externref).map(Self)
     }
 }

--- a/lib/vm/src/global.rs
+++ b/lib/vm/src/global.rs
@@ -1,4 +1,4 @@
-use crate::{context::MaybeInstanceOwned, vmcontext::VMGlobalDefinition};
+use crate::{store::MaybeInstanceOwned, vmcontext::VMGlobalDefinition};
 use std::{cell::UnsafeCell, ptr::NonNull};
 use wasmer_types::GlobalType;
 

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -30,6 +30,7 @@ mod memory;
 mod mmap;
 mod probestack;
 mod sig_registry;
+mod store;
 mod table;
 mod trap;
 mod vmcontext;
@@ -38,9 +39,7 @@ pub mod libcalls;
 
 use std::ptr::NonNull;
 
-pub use crate::context::{
-    ContextHandle, ContextId, ContextObjects, InternalContextHandle, MaybeInstanceOwned,
-};
+pub use crate::context::VMFunctionContext;
 pub use crate::export::*;
 pub use crate::extern_ref::{VMExternObj, VMExternRef};
 pub use crate::global::*;
@@ -50,6 +49,9 @@ pub use crate::memory::{MemoryError, VMMemory};
 pub use crate::mmap::Mmap;
 pub use crate::probestack::PROBESTACK;
 pub use crate::sig_registry::SignatureRegistry;
+pub use crate::store::{
+    InternalStoreHandle, MaybeInstanceOwned, StoreHandle, StoreId, StoreObjects,
+};
 pub use crate::table::{TableElement, VMTable};
 pub use crate::trap::*;
 pub use crate::vmcontext::{

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -6,7 +6,7 @@
 //! `Memory` is to WebAssembly linear memories what `Table` is to WebAssembly tables.
 
 use crate::vmcontext::VMMemoryDefinition;
-use crate::{context::MaybeInstanceOwned, mmap::Mmap};
+use crate::{mmap::Mmap, store::MaybeInstanceOwned};
 use more_asserts::assert_ge;
 use std::cell::UnsafeCell;
 use std::convert::TryInto;

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -1,0 +1,261 @@
+use std::{
+    cell::UnsafeCell,
+    fmt,
+    marker::PhantomData,
+    num::{NonZeroU64, NonZeroUsize},
+    ptr::NonNull,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use crate::VMExternObj;
+
+use crate::{InstanceHandle, VMFunction, VMFunctionContext, VMGlobal, VMMemory, VMTable};
+
+/// Unique ID to identify a Store.
+///
+/// Every handle to an object managed by a Store also contains the ID of the
+/// Store. This is used to check that a handle is always used with the
+/// correct Store.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct StoreId(NonZeroU64);
+
+impl Default for StoreId {
+    // Allocates a unique ID for a new Store.
+    fn default() -> Self {
+        // No overflow checking is needed here: overflowing this would take
+        // thousands of years.
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        Self(NonZeroU64::new(NEXT_ID.fetch_add(1, Ordering::Relaxed)).unwrap())
+    }
+}
+
+/// Trait to represent an object managed by a Store. This is implemented on
+/// the VM types managed by the Store.
+pub trait StoreObject: Sized {
+    fn list(ctx: &StoreObjects) -> &Vec<Self>;
+    fn list_mut(ctx: &mut StoreObjects) -> &mut Vec<Self>;
+}
+macro_rules! impl_store_object {
+    ($($field:ident => $ty:ty,)*) => {
+        $(
+            impl StoreObject for $ty {
+                fn list(ctx: &StoreObjects) -> &Vec<Self> {
+                    &ctx.$field
+                }
+                fn list_mut(ctx: &mut StoreObjects) -> &mut Vec<Self> {
+                    &mut ctx.$field
+                }
+            }
+        )*
+    };
+}
+impl_store_object! {
+    functions => VMFunction,
+    tables => VMTable,
+    globals => VMGlobal,
+    instances => InstanceHandle,
+    memories => VMMemory,
+    extern_objs => VMExternObj,
+    contexts => VMFunctionContext,
+}
+
+/// Set of objects managed by a Store.
+#[derive(Default)]
+pub struct StoreObjects {
+    id: StoreId,
+    memories: Vec<VMMemory>,
+    tables: Vec<VMTable>,
+    globals: Vec<VMGlobal>,
+    functions: Vec<VMFunction>,
+    instances: Vec<InstanceHandle>,
+    extern_objs: Vec<VMExternObj>,
+    contexts: Vec<VMFunctionContext>,
+}
+
+impl StoreObjects {
+    /// Returns the ID of this Store.
+    pub fn id(&self) -> StoreId {
+        self.id
+    }
+
+    /// Returns a pair of mutable references from two handles.
+    ///
+    /// Panics if both handles point to the same object.
+    pub fn get_2_mut<T: StoreObject>(
+        &mut self,
+        a: InternalStoreHandle<T>,
+        b: InternalStoreHandle<T>,
+    ) -> (&mut T, &mut T) {
+        assert_ne!(a.index(), b.index());
+        let list = T::list_mut(self);
+        if a.index() < b.index() {
+            let (low, high) = list.split_at_mut(b.index());
+            (&mut low[a.index()], &mut high[0])
+        } else {
+            let (low, high) = list.split_at_mut(a.index());
+            (&mut high[0], &mut low[a.index()])
+        }
+    }
+}
+
+/// Handle to an object managed by a Store.
+///
+/// Internally this is just an integer index into a Store. A reference to the
+/// Store must be passed in separately to access the actual object.
+pub struct StoreHandle<T> {
+    id: StoreId,
+    internal: InternalStoreHandle<T>,
+}
+
+impl<T> Clone for StoreHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            internal: self.internal,
+        }
+    }
+}
+
+impl<T: StoreObject> fmt::Debug for StoreHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoreHandle")
+            .field("id", &self.id)
+            .field("internal", &self.internal.index())
+            .finish()
+    }
+}
+
+impl<T: StoreObject> PartialEq for StoreHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.internal == other.internal
+    }
+}
+
+impl<T: StoreObject> Eq for StoreHandle<T> {}
+
+impl<T: StoreObject> StoreHandle<T> {
+    /// Moves the given object into a Store and returns a handle to it.
+    pub fn new(ctx: &mut StoreObjects, val: T) -> Self {
+        Self {
+            id: ctx.id,
+            internal: InternalStoreHandle::new(ctx, val),
+        }
+    }
+
+    /// Returns a reference to the object that this handle points to.
+    pub fn get<'a>(&self, ctx: &'a StoreObjects) -> &'a T {
+        assert_eq!(self.id, ctx.id, "object used with the wrong Store");
+        self.internal.get(ctx)
+    }
+
+    /// Returns a mutable reference to the object that this handle points to.
+    pub fn get_mut<'a>(&self, ctx: &'a mut StoreObjects) -> &'a mut T {
+        assert_eq!(self.id, ctx.id, "object used with the wrong Store");
+        self.internal.get_mut(ctx)
+    }
+
+    /// Returns the internal handle contains within this handle.
+    pub fn internal_handle(&self) -> InternalStoreHandle<T> {
+        self.internal
+    }
+
+    /// Returns the ID of the Store associated with the handle.
+    pub fn store_id(&self) -> StoreId {
+        self.id
+    }
+
+    /// Constructs a `StoreHandle` from a `StoreId` and an `InternalStoreHandle`.
+    ///
+    /// # Safety
+    /// Handling `InternalStoreHandle` values is unsafe because they do not track Store ID.
+    pub unsafe fn from_internal(id: StoreId, internal: InternalStoreHandle<T>) -> Self {
+        Self { id, internal }
+    }
+}
+
+/// Internal handle to an object owned by the current Store.
+///
+/// Unlike `StoreHandle` this does not track the Store ID: it is only
+/// intended to be used within objects already owned by a Store.
+#[repr(transparent)]
+pub struct InternalStoreHandle<T> {
+    // Use a NonZero here to reduce the size of Option<InternalStoreHandle>.
+    idx: NonZeroUsize,
+    marker: PhantomData<fn() -> T>,
+}
+
+impl<T> Clone for InternalStoreHandle<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for InternalStoreHandle<T> {}
+
+impl<T> fmt::Debug for InternalStoreHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InternalStoreHandle")
+            .field("idx", &self.idx)
+            .finish()
+    }
+}
+impl<T> PartialEq for InternalStoreHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.idx == other.idx
+    }
+}
+impl<T> Eq for InternalStoreHandle<T> {}
+
+impl<T: StoreObject> InternalStoreHandle<T> {
+    /// Moves the given object into a Store and returns a handle to it.
+    pub fn new(ctx: &mut StoreObjects, val: T) -> Self {
+        let list = T::list_mut(ctx);
+        let idx = NonZeroUsize::new(list.len() + 1).unwrap();
+        list.push(val);
+        Self {
+            idx,
+            marker: PhantomData,
+        }
+    }
+
+    /// Returns a reference to the object that this handle points to.
+    pub fn get<'a>(&self, ctx: &'a StoreObjects) -> &'a T {
+        &T::list(ctx)[self.idx.get() - 1]
+    }
+
+    /// Returns a mutable reference to the object that this handle points to.
+    pub fn get_mut<'a>(&self, ctx: &'a mut StoreObjects) -> &'a mut T {
+        &mut T::list_mut(ctx)[self.idx.get() - 1]
+    }
+
+    pub(crate) fn index(&self) -> usize {
+        self.idx.get()
+    }
+
+    pub(crate) fn from_index(idx: usize) -> Option<Self> {
+        NonZeroUsize::new(idx).map(|idx| Self {
+            idx,
+            marker: PhantomData,
+        })
+    }
+}
+
+/// Data used by the generated code is generally located inline within the
+/// `VMContext` for items defined in an instance. Host-defined objects are
+/// allocated separately and owned directly by the Store.
+pub enum MaybeInstanceOwned<T> {
+    /// The data is owned here.
+    Host(Box<UnsafeCell<T>>),
+
+    /// The data is stored inline in the `VMContext` of an instance.
+    Instance(NonNull<T>),
+}
+
+impl<T> MaybeInstanceOwned<T> {
+    /// Returns underlying pointer to the VM data.
+    pub fn as_ptr(&self) -> NonNull<T> {
+        match self {
+            MaybeInstanceOwned::Host(p) => unsafe { NonNull::new_unchecked(p.get()) },
+            MaybeInstanceOwned::Instance(p) => *p,
+        }
+    }
+}

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -5,7 +5,7 @@
 //!
 //! `Table` is to WebAssembly tables what `Memory` is to WebAssembly linear memories.
 
-use crate::context::MaybeInstanceOwned;
+use crate::store::MaybeInstanceOwned;
 use crate::vmcontext::VMTableDefinition;
 use crate::Trap;
 use crate::VMExternRef;

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -4,10 +4,10 @@
 //! This file declares `VMContext` and several related structs which contain
 //! fields that compiled wasm code accesses directly.
 
-use crate::context::InternalContextHandle;
 use crate::global::VMGlobal;
 use crate::instance::Instance;
 use crate::memory::VMMemory;
+use crate::store::InternalStoreHandle;
 use crate::trap::{Trap, TrapCode};
 use crate::VMFunctionBody;
 use crate::VMTable;
@@ -69,7 +69,7 @@ pub struct VMFunctionImport {
     pub environment: VMFunctionEnvironment,
 
     /// Handle to the `VMFunction` in the context.
-    pub handle: InternalContextHandle<VMFunction>,
+    pub handle: InternalStoreHandle<VMFunction>,
 }
 
 #[cfg(test)]
@@ -191,7 +191,7 @@ pub struct VMTableImport {
     pub definition: NonNull<VMTableDefinition>,
 
     /// Handle to the `VMTable` in the context.
-    pub handle: InternalContextHandle<VMTable>,
+    pub handle: InternalStoreHandle<VMTable>,
 }
 
 #[cfg(test)]
@@ -226,7 +226,7 @@ pub struct VMMemoryImport {
     pub definition: NonNull<VMMemoryDefinition>,
 
     /// A handle to the `Memory` that owns the memory description.
-    pub handle: InternalContextHandle<VMMemory>,
+    pub handle: InternalStoreHandle<VMMemory>,
 }
 
 #[cfg(test)]
@@ -265,7 +265,7 @@ pub struct VMGlobalImport {
     pub definition: NonNull<VMGlobalDefinition>,
 
     /// A handle to the `Global` that owns the global description.
-    pub handle: InternalContextHandle<VMGlobal>,
+    pub handle: InternalStoreHandle<VMGlobal>,
 }
 
 /// # Safety


### PR DESCRIPTION
This PR moves the `ContextObjects` from `Context` to `Store` (we'll need to rename from `ContextObjects` to `WasmObjects`, as is a more precise name).

This PR has not yet ported the externals/Function code yet fully