### PR TITLE
Ctx store rename

### DIFF
--- a/examples/early_exit.rs
+++ b/examples/early_exit.rs
@@ -66,7 +66,7 @@ fn main() -> anyhow::Result<()> {
     let module = Module::new(&store, wasm_bytes)?;
 
     // We declare the host function that we'll use to terminate execution.
-    fn early_exit(_ctx: FunctionEnvMut<()>) -> Result<(), ExitCode> {
+    fn early_exit(_env: FunctionEnvMut<()>) -> Result<(), ExitCode> {
         // This is where it happens.
         Err(ExitCode(1))
     }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -59,7 +59,7 @@ fn main() -> anyhow::Result<()> {
 
     // We define a function to act as our "env" "say_hello" function imported in the
     // Wasm program above.
-    fn say_hello_world(_ctx: FunctionEnvMut<'_, ()>) {
+    fn say_hello_world(_env: FunctionEnvMut<'_, ()>) {
         println!("Hello, world!")
     }
 

--- a/examples/imports_exports.rs
+++ b/examples/imports_exports.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // covered in more detail in other examples.
     println!("Creating the imported function...");
     let host_function_signature = FunctionType::new(vec![], vec![Type::I32]);
-    let host_function = Function::new(&mut store, &env, &host_function_signature, |_ctx, _args| {
+    let host_function = Function::new(&mut store, &env, &host_function_signature, |_env, _args| {
         Ok(vec![Value::I32(42)])
     });
 

--- a/examples/imports_function.rs
+++ b/examples/imports_function.rs
@@ -46,9 +46,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the default provided by Wasmer.
     // You can use `Store::default()` for that.
     let mut store = Store::new_with_engine(&Universal::new(Cranelift::default()).engine());
-    let mut ctx1 = FunctionEnv::new(&mut store, ());
+    let mut env1 = FunctionEnv::new(&mut store, ());
     struct MyEnv;
-    let mut ctx2 = FunctionEnv::new(&mut store, MyEnv {});
+    let mut env2 = FunctionEnv::new(&mut store, MyEnv {});
 
     println!("Compiling module...");
     // Let's compile the Wasm module.
@@ -58,9 +58,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let multiply_dynamic_signature = FunctionType::new(vec![Type::I32], vec![Type::I32]);
     let multiply_dynamic = Function::new(
         &mut store,
-        &ctx1,
+        &env1,
         &multiply_dynamic_signature,
-        |_ctx, args| {
+        |_env, args| {
             println!("Calling `multiply_dynamic`...");
 
             let result = args[0].unwrap_i32() * 2;
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     );
 
-    fn multiply(_ctx: FunctionEnvMut<MyEnv>, a: i32) -> i32 {
+    fn multiply(_env: FunctionEnvMut<MyEnv>, a: i32) -> i32 {
         println!("Calling `multiply_native`...");
         let result = a * 3;
 
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         result
     }
-    let multiply_native = Function::new_native(&mut store, &ctx2, multiply);
+    let multiply_native = Function::new_native(&mut store, &env2, multiply);
 
     // Create an import object.
     let import_object = imports! {

--- a/examples/imports_function_env.rs
+++ b/examples/imports_function_env.rs
@@ -78,11 +78,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Create the functions
-    fn get_counter(ctx: FunctionEnvMut<Env>) -> i32 {
-        *ctx.data().counter.lock().unwrap()
+    fn get_counter(env: FunctionEnvMut<Env>) -> i32 {
+        *env.data().counter.lock().unwrap()
     }
-    fn add_to_counter(mut ctx: FunctionEnvMut<Env>, add: i32) -> i32 {
-        let mut counter_ref = ctx.data_mut().counter.lock().unwrap();
+    fn add_to_counter(mut env: FunctionEnvMut<Env>, add: i32) -> i32 {
+        let mut counter_ref = env.data_mut().counter.lock().unwrap();
 
         *counter_ref += add;
         *counter_ref

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -6,7 +6,7 @@ use wasmer_compiler::Universal;
 use wasmer_compiler_cranelift::Cranelift;
 
 /// A function we'll call through a table.
-fn host_callback(_ctx: FunctionEnvMut<()>, arg1: i32, arg2: i32) -> i32 {
+fn host_callback(_env: FunctionEnvMut<()>, arg1: i32, arg2: i32) -> i32 {
     arg1 + arg2
 }
 

--- a/lib/api/src/js/exports.rs
+++ b/lib/api/src/js/exports.rs
@@ -141,14 +141,14 @@ impl Exports {
     /// Get an export as a `TypedFunction`.
     pub fn get_native_function<Args, Rets>(
         &self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         name: &str,
     ) -> Result<TypedFunction<Args, Rets>, ExportError>
     where
         Args: WasmTypeList,
         Rets: WasmTypeList,
     {
-        self.get_typed_function(ctx, name)
+        self.get_typed_function(store, name)
     }
 
     /// Get an export as a `TypedFunction`.
@@ -169,7 +169,7 @@ impl Exports {
     /// Hack to get this working with nativefunc too
     pub fn get_with_generics<'a, T, Args, Rets>(
         &'a self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         name: &str,
     ) -> Result<T, ExportError>
     where
@@ -179,7 +179,7 @@ impl Exports {
     {
         match self.map.get(name) {
             None => Err(ExportError::Missing(name.to_string())),
-            Some(extern_) => T::get_self_from_extern_with_generics(ctx, extern_),
+            Some(extern_) => T::get_self_from_extern_with_generics(store, extern_),
         }
     }
 
@@ -187,7 +187,7 @@ impl Exports {
     /// This is useful for passing data into Context data, for example.
     pub fn get_with_generics_weak<'a, T, Args, Rets>(
         &'a self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         name: &str,
     ) -> Result<T, ExportError>
     where
@@ -195,7 +195,7 @@ impl Exports {
         Rets: WasmTypeList,
         T: ExportableWithGenerics<'a, Args, Rets>,
     {
-        let out: T = self.get_with_generics(ctx, name)?;
+        let out: T = self.get_with_generics(store, name)?;
         Ok(out)
     }
 
@@ -334,7 +334,7 @@ pub trait Exportable<'a>: Sized {
 pub trait ExportableWithGenerics<'a, Args: WasmTypeList, Rets: WasmTypeList>: Sized {
     /// Get an export with the given generics.
     fn get_self_from_extern_with_generics(
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         _extern: &'a Extern,
     ) -> Result<Self, ExportError>;
 }
@@ -343,7 +343,7 @@ pub trait ExportableWithGenerics<'a, Args: WasmTypeList, Rets: WasmTypeList>: Si
 /// with empty `Args` and `Rets`.
 impl<'a, T: Exportable<'a> + Clone + 'static> ExportableWithGenerics<'a, (), ()> for T {
     fn get_self_from_extern_with_generics(
-        _ctx: &impl AsStoreRef,
+        _store: &impl AsStoreRef,
         _extern: &'a Extern,
     ) -> Result<Self, ExportError> {
         T::get_self_from_extern(_extern).map(|i| i.clone())

--- a/lib/api/src/js/externals/global.rs
+++ b/lib/api/src/js/externals/global.rs
@@ -34,8 +34,8 @@ impl Global {
     /// assert_eq!(g.get(), Value::I32(1));
     /// assert_eq!(g.ty().mutability, Mutability::Const);
     /// ```
-    pub fn new(ctx: &mut impl AsStoreMut, val: Value) -> Self {
-        Self::from_value(ctx, val, Mutability::Const).unwrap()
+    pub fn new(store: &mut impl AsStoreMut, val: Value) -> Self {
+        Self::from_value(store, val, Mutability::Const).unwrap()
     }
 
     /// Create a mutable `Global` with the initial value [`Value`].
@@ -51,17 +51,17 @@ impl Global {
     /// assert_eq!(g.get(), Value::I32(1));
     /// assert_eq!(g.ty().mutability, Mutability::Var);
     /// ```
-    pub fn new_mut(ctx: &mut impl AsStoreMut, val: Value) -> Self {
-        Self::from_value(ctx, val, Mutability::Var).unwrap()
+    pub fn new_mut(store: &mut impl AsStoreMut, val: Value) -> Self {
+        Self::from_value(store, val, Mutability::Var).unwrap()
     }
 
     /// Create a `Global` with the initial value [`Value`] and the provided [`Mutability`].
     fn from_value(
-        ctx: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         val: Value,
         mutability: Mutability,
     ) -> Result<Self, RuntimeError> {
-        if !val.is_from_store(ctx) {
+        if !val.is_from_store(store) {
             return Err(RuntimeError::new(
                 "cross-`WasmerEnv` values are not supported",
             ));
@@ -90,7 +90,7 @@ impl Global {
         let js_global = JSGlobal::new(&descriptor, &value).unwrap();
         let vm_global = VMGlobal::new(js_global, global_ty);
 
-        Ok(Self::from_vm_export(ctx, vm_global))
+        Ok(Self::from_vm_export(store, vm_global))
     }
 
     /// Returns the [`GlobalType`] of the `Global`.

--- a/lib/api/src/js/externals/mod.rs
+++ b/lib/api/src/js/externals/mod.rs
@@ -34,32 +34,32 @@ pub enum Extern {
 
 impl Extern {
     /// Return the underlying type of the inner `Extern`.
-    pub fn ty(&self, ctx: &impl AsStoreRef) -> ExternType {
+    pub fn ty(&self, store: &impl AsStoreRef) -> ExternType {
         match self {
-            Self::Function(ft) => ExternType::Function(ft.ty(ctx).clone()),
-            Self::Memory(ft) => ExternType::Memory(ft.ty(ctx)),
-            Self::Table(tt) => ExternType::Table(tt.ty(ctx)),
-            Self::Global(gt) => ExternType::Global(gt.ty(ctx)),
+            Self::Function(ft) => ExternType::Function(ft.ty(store).clone()),
+            Self::Memory(ft) => ExternType::Memory(ft.ty(store)),
+            Self::Table(tt) => ExternType::Table(tt.ty(store)),
+            Self::Global(gt) => ExternType::Global(gt.ty(store)),
         }
     }
 
     /// Create an `Extern` from an `wasmer_compiler::Export`.
-    pub fn from_vm_export(ctx: &mut impl AsStoreMut, export: Export) -> Self {
+    pub fn from_vm_export(store: &mut impl AsStoreMut, export: Export) -> Self {
         match export {
-            Export::Function(f) => Self::Function(Function::from_vm_extern(ctx, f)),
-            Export::Memory(m) => Self::Memory(Memory::from_vm_extern(ctx, m)),
-            Export::Global(g) => Self::Global(Global::from_vm_extern(ctx, g)),
-            Export::Table(t) => Self::Table(Table::from_vm_extern(ctx, t)),
+            Export::Function(f) => Self::Function(Function::from_vm_extern(store, f)),
+            Export::Memory(m) => Self::Memory(Memory::from_vm_extern(store, m)),
+            Export::Global(g) => Self::Global(Global::from_vm_extern(store, g)),
+            Export::Table(t) => Self::Table(Table::from_vm_extern(store, t)),
         }
     }
 
     /// Checks whether this `Extern` can be used with the given context.
-    pub fn is_from_store(&self, ctx: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
         match self {
-            Self::Function(val) => val.is_from_store(ctx),
-            Self::Memory(val) => val.is_from_store(ctx),
-            Self::Global(val) => val.is_from_store(ctx),
-            Self::Table(val) => val.is_from_store(ctx),
+            Self::Function(val) => val.is_from_store(store),
+            Self::Memory(val) => val.is_from_store(store),
+            Self::Global(val) => val.is_from_store(store),
+            Self::Table(val) => val.is_from_store(store),
         }
     }
 
@@ -74,12 +74,12 @@ impl Extern {
 }
 
 impl AsJs for Extern {
-    fn as_jsvalue(&self, ctx: &impl AsStoreRef) -> wasm_bindgen::JsValue {
+    fn as_jsvalue(&self, store: &impl AsStoreRef) -> wasm_bindgen::JsValue {
         match self {
-            Self::Function(_) => self.to_export().as_jsvalue(ctx),
-            Self::Global(_) => self.to_export().as_jsvalue(ctx),
-            Self::Table(_) => self.to_export().as_jsvalue(ctx),
-            Self::Memory(_) => self.to_export().as_jsvalue(ctx),
+            Self::Function(_) => self.to_export().as_jsvalue(store),
+            Self::Global(_) => self.to_export().as_jsvalue(store),
+            Self::Table(_) => self.to_export().as_jsvalue(store),
+            Self::Memory(_) => self.to_export().as_jsvalue(store),
         }
         .clone()
     }

--- a/lib/api/src/js/imports.rs
+++ b/lib/api/src/js/imports.rs
@@ -151,7 +151,7 @@ impl Imports {
     }
 
     /// Returns the `Imports` as a Javascript `Object`
-    pub fn as_jsobject(&self, ctx: &impl AsStoreRef) -> js_sys::Object {
+    pub fn as_jsobject(&self, store: &impl AsStoreRef) -> js_sys::Object {
         let imports = js_sys::Object::new();
         let namespaces: HashMap<&str, Vec<(&str, &Extern)>> =
             self.map
@@ -166,7 +166,7 @@ impl Imports {
         for (ns, exports) in namespaces.into_iter() {
             let import_namespace = js_sys::Object::new();
             for (name, ext) in exports {
-                js_sys::Reflect::set(&import_namespace, &name.into(), &ext.as_jsvalue(ctx))
+                js_sys::Reflect::set(&import_namespace, &name.into(), &ext.as_jsvalue(store))
                     .expect("Error while setting into the js namespace object");
             }
             js_sys::Reflect::set(&imports, &ns.into(), &import_namespace.into())

--- a/lib/api/src/js/js_import_object.rs
+++ b/lib/api/src/js/js_import_object.rs
@@ -53,7 +53,7 @@ impl JsImportObject {
     /// ```
     pub fn get_export(
         &self,
-        ctx: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         module: &str,
         name: &str,
     ) -> Result<Export, WasmError> {
@@ -63,7 +63,11 @@ impl JsImportObject {
             .module_imports
             .get(&(module.to_string(), name.to_string()))
         {
-            Some(extern_type) => Ok(Export::from_js_value(js_export, ctx, extern_type.clone())?),
+            Some(extern_type) => Ok(Export::from_js_value(
+                js_export,
+                store,
+                extern_type.clone(),
+            )?),
             None => Err(WasmError::Generic(format!(
                 "Name {} not found in module {}",
                 name, module

--- a/lib/api/src/js/mem_access.rs
+++ b/lib/api/src/js/mem_access.rs
@@ -61,9 +61,9 @@ pub struct WasmRef<'a, T: ValueType> {
 impl<'a, T: ValueType> WasmRef<'a, T> {
     /// Creates a new `WasmRef` at the given offset in a memory.
     #[inline]
-    pub fn new(ctx: &'a impl AsStoreRef, memory: &'a Memory, offset: u64) -> Self {
+    pub fn new(store: &'a impl AsStoreRef, memory: &'a Memory, offset: u64) -> Self {
         Self {
-            buffer: memory.buffer(ctx),
+            buffer: memory.buffer(store),
             offset,
             marker: PhantomData,
         }
@@ -160,7 +160,7 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
     /// Returns a `MemoryAccessError` if the slice length overflows.
     #[inline]
     pub fn new(
-        ctx: &'a impl AsStoreRef,
+        store: &'a impl AsStoreRef,
         memory: &'a Memory,
         offset: u64,
         len: u64,
@@ -172,7 +172,7 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         Ok(Self {
-            buffer: memory.buffer(ctx),
+            buffer: memory.buffer(store),
             offset,
             len,
             marker: PhantomData,

--- a/lib/api/src/js/native_type.rs
+++ b/lib/api/src/js/native_type.rs
@@ -11,105 +11,105 @@ use super::store::AsStoreMut;
 /// types with a context.
 pub trait NativeWasmTypeInto: NativeWasmType + Sized {
     #[doc(hidden)]
-    fn into_abi(self, ctx: &mut impl AsStoreMut) -> Self::Abi;
+    fn into_abi(self, store: &mut impl AsStoreMut) -> Self::Abi;
 
     #[doc(hidden)]
-    unsafe fn from_abi(ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self;
+    unsafe fn from_abi(store: &mut impl AsStoreMut, abi: Self::Abi) -> Self;
 
     /// Convert self to raw value representation.
-    fn into_raw(self, ctx: &mut impl AsStoreMut) -> f64;
+    fn into_raw(self, store: &mut impl AsStoreMut) -> f64;
 
     /// Convert to self from raw value representation.
     ///
     /// # Safety
     ///
-    unsafe fn from_raw(ctx: &mut impl AsStoreMut, raw: f64) -> Self;
+    unsafe fn from_raw(store: &mut impl AsStoreMut, raw: f64) -> Self;
 }
 
 impl NativeWasmTypeInto for i32 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> f64 {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> f64 {
         self.into()
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: f64) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: f64) -> Self {
         raw as _
     }
 }
 
 impl NativeWasmTypeInto for i64 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> f64 {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> f64 {
         self as _
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: f64) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: f64) -> Self {
         raw as _
     }
 }
 
 impl NativeWasmTypeInto for f32 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> f64 {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> f64 {
         self as _
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: f64) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: f64) -> Self {
         raw as _
     }
 }
 
 impl NativeWasmTypeInto for f64 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> f64 {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> f64 {
         self
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: f64) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: f64) -> Self {
         raw
     }
 }

--- a/lib/api/src/js/types.rs
+++ b/lib/api/src/js/types.rs
@@ -19,7 +19,7 @@ pub use wasmer_types::{
 //pub type Value = Value<Function>;
 
 pub trait AsJs {
-    fn as_jsvalue(&self, ctx: &impl AsStoreRef) -> JsValue;
+    fn as_jsvalue(&self, store: &impl AsStoreRef) -> JsValue;
 }
 
 #[inline]
@@ -37,7 +37,7 @@ pub fn param_from_js(ty: &ValType, js_val: &JsValue) -> Value {
 }
 
 impl AsJs for Value {
-    fn as_jsvalue(&self, ctx: &impl AsStoreRef) -> JsValue {
+    fn as_jsvalue(&self, store: &impl AsStoreRef) -> JsValue {
         match self {
             Self::I32(i) => JsValue::from_f64(*i as f64),
             Self::I64(i) => JsValue::from_f64(*i as f64),
@@ -45,7 +45,7 @@ impl AsJs for Value {
             Self::F64(f) => JsValue::from_f64(*f),
             Self::FuncRef(Some(func)) => func
                 .handle
-                .get(ctx.as_store_ref().objects())
+                .get(store.as_store_ref().objects())
                 .function
                 .clone()
                 .into(),

--- a/lib/api/src/js/value.rs
+++ b/lib/api/src/js/value.rs
@@ -82,7 +82,7 @@ impl Value {
     }
 
     /// Converts the `Value` into a `f64`.
-    pub fn as_raw(&self, ctx: &impl AsStoreRef) -> f64 {
+    pub fn as_raw(&self, store: &impl AsStoreRef) -> f64 {
         match *self {
             Self::I32(v) => v as f64,
             Self::I64(v) => v as f64,
@@ -90,7 +90,7 @@ impl Value {
             Self::F64(v) => v,
             Self::FuncRef(Some(ref f)) => f
                 .handle
-                .get(ctx.as_store_ref().objects())
+                .get(store.as_store_ref().objects())
                 .function
                 .as_f64()
                 .unwrap_or(0_f64), //TODO is this correct?
@@ -105,7 +105,7 @@ impl Value {
     ///
     /// # Safety
     ///
-    pub unsafe fn from_raw(_ctx: &impl AsStoreRef, ty: Type, raw: f64) -> Self {
+    pub unsafe fn from_raw(_store: &impl AsStoreRef, ty: Type, raw: f64) -> Self {
         match ty {
             Type::I32 => Self::I32(raw as i32),
             Type::I64 => Self::I64(raw as i64),
@@ -116,7 +116,7 @@ impl Value {
             Type::ExternRef => todo!(),
             //Self::ExternRef(
             //{
-            //VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(ctx, e)),
+            //VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(store, e)),
             //),
         }
     }
@@ -128,7 +128,7 @@ impl Value {
     ///
     /// Externref and funcref values are tied to a context and can only be used
     /// with that context.
-    pub fn is_from_store(&self, ctx: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
         match self {
             Self::I32(_)
             | Self::I64(_)
@@ -136,8 +136,8 @@ impl Value {
             | Self::F64(_)
             //| Self::ExternRef(None)
             | Self::FuncRef(None) => true,
-            //Self::ExternRef(Some(e)) => e.is_from_store(ctx),
-            Self::FuncRef(Some(f)) => f.is_from_store(ctx),
+            //Self::ExternRef(Some(e)) => e.is_from_store(store),
+            Self::FuncRef(Some(f)) => f.is_from_store(store),
         }
     }
 

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -54,7 +54,6 @@
 //!     "#;
 //!
 //!     let mut store = Store::default();
-//!     let env = FunctionEnv::new(&mut store, ());
 //!     let module = Module::new(&store, &module_wat)?;
 //!     // The module doesn't import anything, so we create an empty import object.
 //!     let import_object = imports! {};
@@ -152,11 +151,11 @@
 //!
 //! ```
 //! # use wasmer::{imports, Function, FunctionEnv, FunctionEnvMut, Memory, MemoryType, Store, Imports};
-//! # fn imports_example(mut ctx: FunctionEnv<()>, mut store: &mut Store) -> Imports {
+//! # fn imports_example(mut env: FunctionEnv<()>, mut store: &mut Store) -> Imports {
 //! let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
 //! imports! {
 //!     "env" => {
-//!          "my_function" => Function::new_native(&mut store, &ctx, |_ctx: FunctionEnvMut<()>| println!("Hello")),
+//!          "my_function" => Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| println!("Hello")),
 //!          "memory" => memory,
 //!     }
 //! }
@@ -168,7 +167,7 @@
 //!
 //! ```
 //! # use wasmer::{imports, Instance, FunctionEnv, Memory, TypedFunction, Store};
-//! # fn exports_example(mut ctx: FunctionEnv<()>, mut store: &mut Store, instance: &Instance) -> anyhow::Result<()> {
+//! # fn exports_example(mut env: FunctionEnv<()>, mut store: &mut Store, instance: &Instance) -> anyhow::Result<()> {
 //! let memory = instance.exports.get_memory("memory")?;
 //! let memory: &Memory = instance.exports.get("some_other_memory")?;
 //! let add: TypedFunction<(i32, i32), i32> = instance.exports.get_typed_function(&mut store, "add")?;

--- a/lib/api/src/sys/exports.rs
+++ b/lib/api/src/sys/exports.rs
@@ -145,20 +145,20 @@ impl Exports {
     /// Get an export as a `TypedFunction`.
     pub fn get_native_function<Args, Rets>(
         &self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         name: &str,
     ) -> Result<TypedFunction<Args, Rets>, ExportError>
     where
         Args: WasmTypeList,
         Rets: WasmTypeList,
     {
-        self.get_typed_function(ctx, name)
+        self.get_typed_function(store, name)
     }
 
     /// Get an export as a `TypedFunction`.
     pub fn get_typed_function<Args, Rets>(
         &self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         name: &str,
     ) -> Result<TypedFunction<Args, Rets>, ExportError>
     where
@@ -166,7 +166,7 @@ impl Exports {
         Rets: WasmTypeList,
     {
         self.get_function(name)?
-            .native(ctx)
+            .native(store)
             .map_err(|_| ExportError::IncompatibleType)
     }
 

--- a/lib/api/src/sys/extern_ref.rs
+++ b/lib/api/src/sys/extern_ref.rs
@@ -13,22 +13,22 @@ pub struct ExternRef {
 
 impl ExternRef {
     /// Make a new extern reference
-    pub fn new<T>(ctx: &mut impl AsStoreMut, value: T) -> Self
+    pub fn new<T>(store: &mut impl AsStoreMut, value: T) -> Self
     where
         T: Any + Send + Sync + 'static + Sized,
     {
         Self {
-            handle: StoreHandle::new(ctx.objects_mut(), VMExternObj::new(value)),
+            handle: StoreHandle::new(store.objects_mut(), VMExternObj::new(value)),
         }
     }
 
     /// Try to downcast to the given value.
-    pub fn downcast<'a, T>(&self, ctx: &'a impl AsStoreRef) -> Option<&'a T>
+    pub fn downcast<'a, T>(&self, store: &'a impl AsStoreRef) -> Option<&'a T>
     where
         T: Any + Send + Sync + 'static + Sized,
     {
         self.handle
-            .get(ctx.as_store_ref().objects())
+            .get(store.as_store_ref().objects())
             .as_ref()
             .downcast_ref::<T>()
     }
@@ -38,11 +38,11 @@ impl ExternRef {
     }
 
     pub(crate) unsafe fn from_vm_externref(
-        ctx: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         vm_externref: VMExternRef,
     ) -> Self {
         Self {
-            handle: StoreHandle::from_internal(ctx.objects_mut().id(), vm_externref.0),
+            handle: StoreHandle::from_internal(store.objects_mut().id(), vm_externref.0),
         }
     }
 
@@ -53,7 +53,7 @@ impl ExternRef {
     ///
     /// Externref and funcref values are tied to a context and can only be used
     /// with that context.
-    pub fn is_from_store(&self, ctx: &impl AsStoreRef) -> bool {
-        self.handle.store_id() == ctx.as_store_ref().objects().id()
+    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
+        self.handle.store_id() == store.as_store_ref().objects().id()
     }
 }

--- a/lib/api/src/sys/externals/mod.rs
+++ b/lib/api/src/sys/externals/mod.rs
@@ -34,32 +34,32 @@ pub enum Extern {
 
 impl Extern {
     /// Return the underlying type of the inner `Extern`.
-    pub fn ty(&self, ctx: &impl AsStoreRef) -> ExternType {
+    pub fn ty(&self, store: &impl AsStoreRef) -> ExternType {
         match self {
-            Self::Function(ft) => ExternType::Function(ft.ty(ctx)),
-            Self::Memory(ft) => ExternType::Memory(ft.ty(ctx)),
-            Self::Table(tt) => ExternType::Table(tt.ty(ctx)),
-            Self::Global(gt) => ExternType::Global(gt.ty(ctx)),
+            Self::Function(ft) => ExternType::Function(ft.ty(store)),
+            Self::Memory(ft) => ExternType::Memory(ft.ty(store)),
+            Self::Table(tt) => ExternType::Table(tt.ty(store)),
+            Self::Global(gt) => ExternType::Global(gt.ty(store)),
         }
     }
 
     /// Create an `Extern` from an `wasmer_engine::Export`.
-    pub fn from_vm_extern(ctx: &mut impl AsStoreMut, vm_extern: VMExtern) -> Self {
+    pub fn from_vm_extern(store: &mut impl AsStoreMut, vm_extern: VMExtern) -> Self {
         match vm_extern {
-            VMExtern::Function(f) => Self::Function(Function::from_vm_extern(ctx, f)),
-            VMExtern::Memory(m) => Self::Memory(Memory::from_vm_extern(ctx, m)),
-            VMExtern::Global(g) => Self::Global(Global::from_vm_extern(ctx, g)),
-            VMExtern::Table(t) => Self::Table(Table::from_vm_extern(ctx, t)),
+            VMExtern::Function(f) => Self::Function(Function::from_vm_extern(store, f)),
+            VMExtern::Memory(m) => Self::Memory(Memory::from_vm_extern(store, m)),
+            VMExtern::Global(g) => Self::Global(Global::from_vm_extern(store, g)),
+            VMExtern::Table(t) => Self::Table(Table::from_vm_extern(store, t)),
         }
     }
 
     /// Checks whether this `Extern` can be used with the given context.
-    pub fn is_from_store(&self, ctx: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
         match self {
-            Self::Function(f) => f.is_from_store(ctx),
-            Self::Global(g) => g.is_from_store(ctx),
-            Self::Memory(m) => m.is_from_store(ctx),
-            Self::Table(t) => t.is_from_store(ctx),
+            Self::Function(f) => f.is_from_store(store),
+            Self::Global(g) => g.is_from_store(store),
+            Self::Memory(m) => m.is_from_store(store),
+            Self::Table(t) => t.is_from_store(store),
         }
     }
 

--- a/lib/api/src/sys/imports.rs
+++ b/lib/api/src/sys/imports.rs
@@ -28,7 +28,7 @@ use wasmer_types::ImportError;
 ///
 /// let instance = Instance::new(&mut store, &module, &import_object).expect("Could not instantiate module.");
 ///
-/// fn foo(_ctx: FunctionEnvMut<()>, n: i32) -> i32 {
+/// fn foo(_env: FunctionEnvMut<()>, n: i32) -> i32 {
 ///     n
 /// }
 ///
@@ -101,7 +101,7 @@ impl Imports {
     /// # let mut store: Store = Default::default();
     /// # let env = FunctionEnv::new(&mut store, ());
     /// use wasmer::{StoreMut, Imports, Function, FunctionEnvMut};
-    /// fn foo(_ctx: FunctionEnvMut<()>, n: i32) -> i32 {
+    /// fn foo(_env: FunctionEnvMut<()>, n: i32) -> i32 {
     ///     n
     /// }
     /// let mut import_object = Imports::new();
@@ -305,7 +305,7 @@ mod test {
         let mut store: Store = Default::default();
         let env = FunctionEnv::new(&mut store, ());
 
-        fn func(_ctx: FunctionEnvMut<()>, arg: i32) -> i32 {
+        fn func(_env: FunctionEnvMut<()>, arg: i32) -> i32 {
             arg + 1
         }
 

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -110,26 +110,26 @@ impl Instance {
     ///  * Link errors that happen when plugging the imports into the instance
     ///  * Runtime errors that happen when running the module `start` function.
     pub fn new(
-        ctx: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         module: &Module,
         imports: &Imports,
     ) -> Result<Self, InstantiationError> {
         let imports = imports
             .imports_for_module(module)
             .map_err(InstantiationError::Link)?;
-        let mut handle = module.instantiate(ctx, &imports)?;
+        let mut handle = module.instantiate(store, &imports)?;
         let exports = module
             .exports()
             .map(|export| {
                 let name = export.name().to_string();
                 let export = handle.lookup(&name).expect("export");
-                let extern_ = Extern::from_vm_extern(ctx, export);
+                let extern_ = Extern::from_vm_extern(store, export);
                 (name, extern_)
             })
             .collect::<Exports>();
 
         let instance = Self {
-            _handle: StoreHandle::new(ctx.objects_mut(), handle),
+            _handle: StoreHandle::new(store.objects_mut(), handle),
             module: module.clone(),
             exports,
         };
@@ -148,24 +148,24 @@ impl Instance {
     ///  * Link errors that happen when plugging the imports into the instance
     ///  * Runtime errors that happen when running the module `start` function.
     pub fn new_by_index(
-        ctx: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         module: &Module,
         externs: &[Extern],
     ) -> Result<Self, InstantiationError> {
         let imports = externs.to_vec();
-        let mut handle = module.instantiate(ctx, &imports)?;
+        let mut handle = module.instantiate(store, &imports)?;
         let exports = module
             .exports()
             .map(|export| {
                 let name = export.name().to_string();
                 let export = handle.lookup(&name).expect("export");
-                let extern_ = Extern::from_vm_extern(ctx, export);
+                let extern_ = Extern::from_vm_extern(store, export);
                 (name, extern_)
             })
             .collect::<Exports>();
 
         let instance = Self {
-            _handle: StoreHandle::new(ctx.objects_mut(), handle),
+            _handle: StoreHandle::new(store.objects_mut(), handle),
             module: module.clone(),
             exports,
         };

--- a/lib/api/src/sys/mem_access.rs
+++ b/lib/api/src/sys/mem_access.rs
@@ -62,9 +62,9 @@ pub struct WasmRef<'a, T: ValueType> {
 impl<'a, T: ValueType> WasmRef<'a, T> {
     /// Creates a new `WasmRef` at the given offset in a memory.
     #[inline]
-    pub fn new(ctx: &'a impl AsStoreRef, memory: &'a Memory, offset: u64) -> Self {
+    pub fn new(store: &'a impl AsStoreRef, memory: &'a Memory, offset: u64) -> Self {
         Self {
-            buffer: memory.buffer(ctx),
+            buffer: memory.buffer(store),
             offset,
             marker: PhantomData,
         }
@@ -161,7 +161,7 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
     /// Returns a `MemoryAccessError` if the slice length overflows.
     #[inline]
     pub fn new(
-        ctx: &'a impl AsStoreRef,
+        store: &'a impl AsStoreRef,
         memory: &'a Memory,
         offset: u64,
         len: u64,
@@ -173,7 +173,7 @@ impl<'a, T: ValueType> WasmSlice<'a, T> {
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         Ok(Self {
-            buffer: memory.buffer(ctx),
+            buffer: memory.buffer(store),
             offset,
             len,
             marker: PhantomData,

--- a/lib/api/src/sys/native.rs
+++ b/lib/api/src/sys/native.rs
@@ -66,24 +66,24 @@ macro_rules! impl_native_traits {
             /// Call the typed func and return results.
             #[allow(unused_mut)]
             #[allow(clippy::too_many_arguments)]
-            pub fn call(&self, ctx: &mut impl AsStoreMut, $( $x: $x, )* ) -> Result<Rets, RuntimeError> {
+            pub fn call(&self, store: &mut impl AsStoreMut, $( $x: $x, )* ) -> Result<Rets, RuntimeError> {
                 let anyfunc = unsafe {
                     *self.func
                         .handle
-                        .get(ctx.as_store_ref().objects())
+                        .get(store.as_store_ref().objects())
                         .anyfunc
                         .as_ptr()
                         .as_ref()
                 };
                 // Ensure all parameters come from the same context.
-                if $(!FromToNativeWasmType::is_from_store(&$x, ctx) ||)* false {
+                if $(!FromToNativeWasmType::is_from_store(&$x, store) ||)* false {
                     return Err(RuntimeError::new(
                         "cross-`Context` values are not supported",
                     ));
                 }
                 // TODO: when `const fn` related features mature more, we can declare a single array
                 // of the correct size here.
-                let mut params_list = [ $( $x.to_native().into_raw(ctx) ),* ];
+                let mut params_list = [ $( $x.to_native().into_raw(store) ),* ];
                 let mut rets_list_array = Rets::empty_array();
                 let rets_list: &mut [RawValue] = rets_list_array.as_mut();
                 let using_rets_array;
@@ -99,7 +99,7 @@ macro_rules! impl_native_traits {
                 };
                 unsafe {
                     wasmer_vm::wasmer_call_trampoline(
-                        ctx.as_store_ref().signal_handler(),
+                        store.as_store_ref().signal_handler(),
                         anyfunc.vmctx,
                         anyfunc.call_trampoline,
                         anyfunc.func_ptr,
@@ -118,7 +118,7 @@ macro_rules! impl_native_traits {
                                                         num_rets);
                     }
                 }
-                Ok(unsafe { Rets::from_array(ctx, rets_list_array) })
+                Ok(unsafe { Rets::from_array(store, rets_list_array) })
                 // TODO: When the Host ABI and Wasm ABI are the same, we could do this instead:
                 // but we can't currently detect whether that's safe.
                 //

--- a/lib/api/src/sys/native_type.rs
+++ b/lib/api/src/sys/native_type.rs
@@ -12,127 +12,127 @@ use super::store::AsStoreMut;
 /// types with a context.
 pub trait NativeWasmTypeInto: NativeWasmType + Sized {
     #[doc(hidden)]
-    fn into_abi(self, ctx: &mut impl AsStoreMut) -> Self::Abi;
+    fn into_abi(self, store: &mut impl AsStoreMut) -> Self::Abi;
 
     #[doc(hidden)]
-    unsafe fn from_abi(ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self;
+    unsafe fn from_abi(store: &mut impl AsStoreMut, abi: Self::Abi) -> Self;
 
     /// Convert self to raw value representation.
-    fn into_raw(self, ctx: &mut impl AsStoreMut) -> RawValue;
+    fn into_raw(self, store: &mut impl AsStoreMut) -> RawValue;
 
     /// Convert to self from raw value representation.
     ///
     /// # Safety
     ///
-    unsafe fn from_raw(ctx: &mut impl AsStoreMut, raw: RawValue) -> Self;
+    unsafe fn from_raw(store: &mut impl AsStoreMut, raw: RawValue) -> Self;
 }
 
 impl NativeWasmTypeInto for i32 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> RawValue {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> RawValue {
         RawValue { i32: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: RawValue) -> Self {
         raw.i32
     }
 }
 
 impl NativeWasmTypeInto for i64 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> RawValue {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> RawValue {
         RawValue { i64: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: RawValue) -> Self {
         raw.i64
     }
 }
 
 impl NativeWasmTypeInto for f32 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> RawValue {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> RawValue {
         RawValue { f32: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: RawValue) -> Self {
         raw.f32
     }
 }
 
 impl NativeWasmTypeInto for f64 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> RawValue {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> RawValue {
         RawValue { f64: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: RawValue) -> Self {
         raw.f64
     }
 }
 
 impl NativeWasmTypeInto for u128 {
     #[inline]
-    unsafe fn from_abi(_ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(_store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         abi
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> RawValue {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> RawValue {
         RawValue { u128: self }
     }
 
     #[inline]
-    unsafe fn from_raw(_ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
+    unsafe fn from_raw(_store: &mut impl AsStoreMut, raw: RawValue) -> Self {
         raw.u128
     }
 }
@@ -144,24 +144,24 @@ impl NativeWasmType for ExternRef {
 
 impl NativeWasmTypeInto for Option<ExternRef> {
     #[inline]
-    unsafe fn from_abi(ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+    unsafe fn from_abi(store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
         VMExternRef::from_raw(RawValue { externref: abi })
-            .map(|e| ExternRef::from_vm_externref(ctx, e))
+            .map(|e| ExternRef::from_vm_externref(store, e))
     }
 
     #[inline]
-    fn into_abi(self, _ctx: &mut impl AsStoreMut) -> Self::Abi {
+    fn into_abi(self, _store: &mut impl AsStoreMut) -> Self::Abi {
         self.map_or(0, |e| unsafe { e.vm_externref().into_raw().externref })
     }
 
     #[inline]
-    fn into_raw(self, _ctx: &mut impl AsStoreMut) -> RawValue {
+    fn into_raw(self, _store: &mut impl AsStoreMut) -> RawValue {
         self.map_or(RawValue { externref: 0 }, |e| e.vm_externref().into_raw())
     }
 
     #[inline]
-    unsafe fn from_raw(ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
-        VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(ctx, e))
+    unsafe fn from_raw(store: &mut impl AsStoreMut, raw: RawValue) -> Self {
+        VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(store, e))
     }
 }
 
@@ -172,23 +172,25 @@ impl NativeWasmType for Function {
 
 impl NativeWasmTypeInto for Option<Function> {
     #[inline]
-    unsafe fn from_abi(ctx: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
-        VMFuncRef::from_raw(RawValue { funcref: abi }).map(|f| Function::from_vm_funcref(ctx, f))
+    unsafe fn from_abi(store: &mut impl AsStoreMut, abi: Self::Abi) -> Self {
+        VMFuncRef::from_raw(RawValue { funcref: abi }).map(|f| Function::from_vm_funcref(store, f))
     }
 
     #[inline]
-    fn into_abi(self, ctx: &mut impl AsStoreMut) -> Self::Abi {
-        self.map_or(0, |f| unsafe { f.vm_funcref(ctx).into_raw().externref })
+    fn into_abi(self, store: &mut impl AsStoreMut) -> Self::Abi {
+        self.map_or(0, |f| unsafe { f.vm_funcref(store).into_raw().externref })
     }
 
     #[inline]
-    fn into_raw(self, ctx: &mut impl AsStoreMut) -> RawValue {
-        self.map_or(RawValue { externref: 0 }, |e| e.vm_funcref(ctx).into_raw())
+    fn into_raw(self, store: &mut impl AsStoreMut) -> RawValue {
+        self.map_or(RawValue { externref: 0 }, |e| {
+            e.vm_funcref(store).into_raw()
+        })
     }
 
     #[inline]
-    unsafe fn from_raw(ctx: &mut impl AsStoreMut, raw: RawValue) -> Self {
-        VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(ctx, f))
+    unsafe fn from_raw(store: &mut impl AsStoreMut, raw: RawValue) -> Self {
+        VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(store, f))
     }
 }
 

--- a/lib/api/src/sys/ptr.rs
+++ b/lib/api/src/sys/ptr.rs
@@ -22,8 +22,8 @@ pub type WasmPtr64<T> = WasmPtr<T, Memory64>;
 /// # use wasmer::Memory;
 /// # use wasmer::WasmPtr;
 /// # use wasmer::FunctionEnvMut;
-/// pub fn host_import(mut ctx: FunctionEnvMut<()>, memory: Memory, ptr: WasmPtr<u32>) {
-///     let derefed_ptr = ptr.deref(&mut ctx, &memory);
+/// pub fn host_import(mut env: FunctionEnvMut<()>, memory: Memory, ptr: WasmPtr<u32>) {
+///     let derefed_ptr = ptr.deref(&mut env, &memory);
 ///     let inner_val: u32 = derefed_ptr.read().expect("pointer in bounds");
 ///     println!("Got {} from Wasm memory address 0x{:X}", inner_val, ptr.offset());
 ///     // update the value being pointed to
@@ -49,8 +49,8 @@ pub type WasmPtr64<T> = WasmPtr<T, Memory64>;
 ///     z: f32
 /// }
 ///
-/// fn update_vector_3(mut ctx: FunctionEnvMut<()>, memory: Memory, ptr: WasmPtr<V3>) {
-///     let derefed_ptr = ptr.deref(&mut ctx, &memory);
+/// fn update_vector_3(mut env: FunctionEnvMut<()>, memory: Memory, ptr: WasmPtr<V3>) {
+///     let derefed_ptr = ptr.deref(&mut env, &memory);
 ///     let mut inner_val: V3 = derefed_ptr.read().expect("pointer in bounds");
 ///     println!("Got {:?} from Wasm memory address 0x{:X}", inner_val, ptr.offset());
 ///     // update the value being pointed to
@@ -142,25 +142,25 @@ impl<T: ValueType, M: MemorySize> WasmPtr<T, M> {
     /// Creates a `WasmRef` from this `WasmPtr` which allows reading and
     /// mutating of the value being pointed to.
     #[inline]
-    pub fn deref<'a>(self, ctx: &'a impl AsStoreRef, memory: &'a Memory) -> WasmRef<'a, T> {
-        WasmRef::new(ctx, memory, self.offset.into())
+    pub fn deref<'a>(self, store: &'a impl AsStoreRef, memory: &'a Memory) -> WasmRef<'a, T> {
+        WasmRef::new(store, memory, self.offset.into())
     }
 
     /// Reads the address pointed to by this `WasmPtr` in a memory.
     #[inline]
-    pub fn read(self, ctx: &impl AsStoreRef, memory: &Memory) -> Result<T, MemoryAccessError> {
-        self.deref(&ctx, memory).read()
+    pub fn read(self, store: &impl AsStoreRef, memory: &Memory) -> Result<T, MemoryAccessError> {
+        self.deref(&store, memory).read()
     }
 
     /// Writes to the address pointed to by this `WasmPtr` in a memory.
     #[inline]
     pub fn write(
         self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         memory: &Memory,
         val: T,
     ) -> Result<(), MemoryAccessError> {
-        self.deref(&ctx, memory).write(val)
+        self.deref(&store, memory).write(val)
     }
 
     /// Creates a `WasmSlice` starting at this `WasmPtr` which allows reading
@@ -171,11 +171,11 @@ impl<T: ValueType, M: MemorySize> WasmPtr<T, M> {
     #[inline]
     pub fn slice<'a>(
         self,
-        ctx: &'a impl AsStoreRef,
+        store: &'a impl AsStoreRef,
         memory: &'a Memory,
         len: M::Offset,
     ) -> Result<WasmSlice<'a, T>, MemoryAccessError> {
-        WasmSlice::new(ctx, memory, self.offset.into(), len.into())
+        WasmSlice::new(store, memory, self.offset.into(), len.into())
     }
 
     /// Reads a sequence of values from this `WasmPtr` until a value that
@@ -185,14 +185,14 @@ impl<T: ValueType, M: MemorySize> WasmPtr<T, M> {
     #[inline]
     pub fn read_until(
         self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         memory: &Memory,
         mut end: impl FnMut(&T) -> bool,
     ) -> Result<Vec<T>, MemoryAccessError> {
         let mut vec = Vec::new();
         for i in 0u64.. {
             let i = M::Offset::try_from(i).map_err(|_| MemoryAccessError::Overflow)?;
-            let val = self.add_offset(i)?.deref(&ctx, memory).read()?;
+            let val = self.add_offset(i)?.deref(&store, memory).read()?;
             if end(&val) {
                 break;
             }
@@ -210,11 +210,11 @@ impl<M: MemorySize> WasmPtr<u8, M> {
     #[inline]
     pub fn read_utf8_string(
         self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         memory: &Memory,
         len: M::Offset,
     ) -> Result<String, MemoryAccessError> {
-        let vec = self.slice(&ctx, memory, len)?.read_to_vec()?;
+        let vec = self.slice(&store, memory, len)?.read_to_vec()?;
         Ok(String::from_utf8(vec)?)
     }
 
@@ -225,10 +225,10 @@ impl<M: MemorySize> WasmPtr<u8, M> {
     #[inline]
     pub fn read_utf8_string_with_nul(
         self,
-        ctx: &impl AsStoreRef,
+        store: &impl AsStoreRef,
         memory: &Memory,
     ) -> Result<String, MemoryAccessError> {
-        let vec = self.read_until(ctx, memory, |&byte| byte == 0)?;
+        let vec = self.read_until(store, memory, |&byte| byte == 0)?;
         Ok(String::from_utf8(vec)?)
     }
 }

--- a/lib/api/src/sys/value.rs
+++ b/lib/api/src/sys/value.rs
@@ -91,14 +91,14 @@ impl Value {
     }
 
     /// Converts the `Value` into a `RawValue`.
-    pub fn as_raw(&self, ctx: &impl AsStoreRef) -> RawValue {
+    pub fn as_raw(&self, store: &impl AsStoreRef) -> RawValue {
         match *self {
             Self::I32(i32) => RawValue { i32 },
             Self::I64(i64) => RawValue { i64 },
             Self::F32(f32) => RawValue { f32 },
             Self::F64(f64) => RawValue { f64 },
             Self::V128(u128) => RawValue { u128 },
-            Self::FuncRef(Some(ref f)) => f.vm_funcref(ctx).into_raw(),
+            Self::FuncRef(Some(ref f)) => f.vm_funcref(store).into_raw(),
 
             Self::FuncRef(None) => RawValue { funcref: 0 },
             Self::ExternRef(Some(ref e)) => e.vm_externref().into_raw(),
@@ -110,7 +110,7 @@ impl Value {
     ///
     /// # Safety
     ///
-    pub unsafe fn from_raw(ctx: &mut impl AsStoreMut, ty: Type, raw: RawValue) -> Self {
+    pub unsafe fn from_raw(store: &mut impl AsStoreMut, ty: Type, raw: RawValue) -> Self {
         match ty {
             Type::I32 => Self::I32(raw.i32),
             Type::I64 => Self::I64(raw.i64),
@@ -118,10 +118,10 @@ impl Value {
             Type::F64 => Self::F64(raw.f64),
             Type::V128 => Self::V128(raw.u128),
             Type::FuncRef => {
-                Self::FuncRef(VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(ctx, f)))
+                Self::FuncRef(VMFuncRef::from_raw(raw).map(|f| Function::from_vm_funcref(store, f)))
             }
             Type::ExternRef => Self::ExternRef(
-                VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(ctx, e)),
+                VMExternRef::from_raw(raw).map(|e| ExternRef::from_vm_externref(store, e)),
             ),
         }
     }
@@ -133,7 +133,7 @@ impl Value {
     ///
     /// Externref and funcref values are tied to a context and can only be used
     /// with that context.
-    pub fn is_from_store(&self, ctx: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
         match self {
             Self::I32(_)
             | Self::I64(_)
@@ -142,8 +142,8 @@ impl Value {
             | Self::V128(_)
             | Self::ExternRef(None)
             | Self::FuncRef(None) => true,
-            Self::ExternRef(Some(e)) => e.is_from_store(ctx),
-            Self::FuncRef(Some(f)) => f.is_from_store(ctx),
+            Self::ExternRef(Some(e)) => e.is_from_store(store),
+            Self::FuncRef(Some(f)) => f.is_from_store(store),
         }
     }
 

--- a/lib/api/tests/js_externals.rs
+++ b/lib/api/tests/js_externals.rs
@@ -183,13 +183,13 @@ mod js {
     fn function_new() {
         let mut store = Store::default();
         let mut env = FunctionEnv::new(&mut store, ());
-        let function = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<'_, ()>| {});
+        let function = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<'_, ()>| {});
         assert_eq!(
             function.ty(&store).clone(),
             FunctionType::new(vec![], vec![])
         );
         let function =
-            Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<'_, ()>, _a: i32| {});
+            Function::new_native(&mut store, &env, |_env: FunctionEnvMut<'_, ()>, _a: i32| {});
         assert_eq!(
             function.ty(&store).clone(),
             FunctionType::new(vec![Type::I32], vec![])
@@ -197,14 +197,14 @@ mod js {
         let function = Function::new_native(
             &mut store,
             &env,
-            |_ctx: FunctionEnvMut<'_, ()>, _a: i32, _b: i64, _c: f32, _d: f64| {},
+            |_env: FunctionEnvMut<'_, ()>, _a: i32, _b: i64, _c: f32, _d: f64| {},
         );
         assert_eq!(
             function.ty(&store).clone(),
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![])
         );
         let function =
-            Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<'_, ()>| -> i32 {
+            Function::new_native(&mut store, &env, |_env: FunctionEnvMut<'_, ()>| -> i32 {
                 1
             });
         assert_eq!(
@@ -214,7 +214,7 @@ mod js {
         let function = Function::new_native(
             &mut store,
             &env,
-            |_ctx: FunctionEnvMut<'_, ()>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
+            |_env: FunctionEnvMut<'_, ()>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
         );
         assert_eq!(
             function.ty(&store).clone(),
@@ -281,7 +281,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type = FunctionType::new(vec![Type::I32], vec![]);
@@ -289,7 +289,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type =
@@ -298,7 +298,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type = FunctionType::new(vec![], vec![Type::I32]);
@@ -306,7 +306,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type =
@@ -315,7 +315,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
 
@@ -325,7 +325,7 @@ mod js {
             &mut store,
             &env,
             function_type,
-            |_ctx: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, ()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).params(), [Type::V128]);
         assert_eq!(
@@ -349,7 +349,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type = FunctionType::new(vec![Type::I32], vec![]);
@@ -357,7 +357,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type =
@@ -366,7 +366,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type = FunctionType::new(vec![], vec![Type::I32]);
@@ -374,7 +374,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
         let function_type =
@@ -383,7 +383,7 @@ mod js {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).clone(), function_type);
 
@@ -393,7 +393,7 @@ mod js {
             &mut store,
             &env,
             function_type,
-            |_ctx: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<'_, MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&store).params(), [Type::V128]);
         assert_eq!(

--- a/lib/api/tests/js_instance.rs
+++ b/lib/api/tests/js_instance.rs
@@ -241,9 +241,9 @@ mod js {
         let mut env = FunctionEnv::new(&mut store, Env { multiplier: 3 });
 
         let imported_signature = FunctionType::new(vec![Type::I32], vec![Type::I32]);
-        let imported = Function::new(&mut store, &env, &imported_signature, |ctx, args| {
+        let imported = Function::new(&mut store, &env, &imported_signature, |env, args| {
             log!("Calling `imported`...");
-            let result = args[0].unwrap_i32() * ctx.data().multiplier;
+            let result = args[0].unwrap_i32() * env.data().multiplier;
             log!("Result of `imported`: {:?}", result);
             Ok(vec![Value::I32(result)])
         });
@@ -342,10 +342,10 @@ mod js {
             multiplier: u32,
         }
 
-        fn imported_fn(ctx: FunctionEnvMut<'_, Env>, arg: u32) -> u32 {
-            log!("inside imported_fn: ctx.data is {:?}", ctx.data());
-            // log!("inside call id is {:?}", ctx.as_store_ref().objects().id);
-            return ctx.data().multiplier * arg;
+        fn imported_fn(env: FunctionEnvMut<'_, Env>, arg: u32) -> u32 {
+            log!("inside imported_fn: env.data is {:?}", env.data());
+            // log!("inside call id is {:?}", env.as_store_ref().objects().id);
+            return env.data().multiplier * arg;
         }
 
         let mut env = FunctionEnv::new(&mut store, Env { multiplier: 3 });
@@ -401,10 +401,10 @@ mod js {
             memory: Option<Memory>,
         }
 
-        fn imported_fn(ctx: FunctionEnvMut<'_, Env>, arg: u32) -> u32 {
-            let memory: &Memory = ctx.data().memory.as_ref().unwrap();
-            let memory_val = memory.uint8view(&ctx).get_index(0);
-            return (memory_val as u32) * ctx.data().multiplier * arg;
+        fn imported_fn(env: FunctionEnvMut<'_, Env>, arg: u32) -> u32 {
+            let memory: &Memory = env.data().memory.as_ref().unwrap();
+            let memory_val = memory.uint8view(&env).get_index(0);
+            return (memory_val as u32) * env.data().multiplier * arg;
         }
 
         let mut env = FunctionEnv::new(
@@ -457,10 +457,10 @@ mod js {
         let mut env = FunctionEnv::new(&mut store, Env { multiplier: 3 });
 
         fn imported_fn(
-            ctx: FunctionEnvMut<'_, Env>,
+            env: FunctionEnvMut<'_, Env>,
             args: &[Val],
         ) -> Result<Vec<Val>, RuntimeError> {
-            let value = ctx.data().multiplier * args[0].unwrap_i32() as u32;
+            let value = env.data().multiplier * args[0].unwrap_i32() as u32;
             return Ok(vec![Val::I32(value as _)]);
         }
 
@@ -507,12 +507,12 @@ mod js {
         }
 
         fn imported_fn(
-            ctx: FunctionEnvMut<'_, Env>,
+            env: FunctionEnvMut<'_, Env>,
             args: &[Val],
         ) -> Result<Vec<Val>, RuntimeError> {
-            let memory: &Memory = ctx.data().memory.as_ref().unwrap();
-            let memory_val = memory.uint8view(&ctx).get_index(0);
-            let value = (memory_val as u32) * ctx.data().multiplier * args[0].unwrap_i32() as u32;
+            let memory: &Memory = env.data().memory.as_ref().unwrap();
+            let memory_val = memory.uint8view(&env).get_index(0);
+            let value = (memory_val as u32) * env.data().multiplier * args[0].unwrap_i32() as u32;
             return Ok(vec![Val::I32(value as _)]);
         }
 

--- a/lib/api/tests/sys_externals.rs
+++ b/lib/api/tests/sys_externals.rs
@@ -70,7 +70,7 @@ mod sys {
             maximum: None,
         };
         let env = FunctionEnv::new(&mut store, ());
-        let f = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>| {});
+        let f = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| {});
         let table = Table::new(&mut store, table_type, Value::FuncRef(Some(f)))?;
         assert_eq!(table.ty(&mut store), table_type);
 
@@ -96,7 +96,7 @@ mod sys {
             minimum: 0,
             maximum: Some(1),
         };
-        let f = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>, num: i32| {
+        let f = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>, num: i32| {
             num + 1
         });
         let table = Table::new(&mut store, table_type, Value::FuncRef(Some(f)))?;
@@ -122,7 +122,7 @@ mod sys {
             minimum: 0,
             maximum: Some(10),
         };
-        let f = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>, num: i32| {
+        let f = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>, num: i32| {
             num + 1
         });
         let table = Table::new(&mut store, table_type, Value::FuncRef(Some(f.clone())))?;
@@ -190,13 +190,13 @@ mod sys {
     fn function_new() -> Result<()> {
         let mut store = Store::default();
         let env = FunctionEnv::new(&mut store, ());
-        let function = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>| {});
+        let function = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| {});
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![])
         );
         let function =
-            Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>, _a: i32| {});
+            Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>, _a: i32| {});
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32], vec![])
@@ -204,14 +204,14 @@ mod sys {
         let function = Function::new_native(
             &mut store,
             &env,
-            |_ctx: FunctionEnvMut<()>, _a: i32, _b: i64, _c: f32, _d: f64| {},
+            |_env: FunctionEnvMut<()>, _a: i32, _b: i64, _c: f32, _d: f64| {},
         );
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![])
         );
         let function =
-            Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>| -> i32 { 1 });
+            Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| -> i32 { 1 });
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![Type::I32])
@@ -219,7 +219,7 @@ mod sys {
         let function = Function::new_native(
             &mut store,
             &env,
-            |_ctx: FunctionEnvMut<()>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
+            |_env: FunctionEnvMut<()>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
         );
         assert_eq!(
             function.ty(&mut store).clone(),
@@ -236,13 +236,13 @@ mod sys {
 
         let my_env = MyEnv {};
         let env = FunctionEnv::new(&mut store, my_env);
-        let function = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<MyEnv>| {});
+        let function = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<MyEnv>| {});
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![])
         );
         let function =
-            Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<MyEnv>, _a: i32| {});
+            Function::new_native(&mut store, &env, |_env: FunctionEnvMut<MyEnv>, _a: i32| {});
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32], vec![])
@@ -250,14 +250,14 @@ mod sys {
         let function = Function::new_native(
             &mut store,
             &env,
-            |_ctx: FunctionEnvMut<MyEnv>, _a: i32, _b: i64, _c: f32, _d: f64| {},
+            |_env: FunctionEnvMut<MyEnv>, _a: i32, _b: i64, _c: f32, _d: f64| {},
         );
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![Type::I32, Type::I64, Type::F32, Type::F64], vec![])
         );
         let function =
-            Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<MyEnv>| -> i32 { 1 });
+            Function::new_native(&mut store, &env, |_env: FunctionEnvMut<MyEnv>| -> i32 { 1 });
         assert_eq!(
             function.ty(&mut store).clone(),
             FunctionType::new(vec![], vec![Type::I32])
@@ -265,7 +265,7 @@ mod sys {
         let function = Function::new_native(
             &mut store,
             &env,
-            |_ctx: FunctionEnvMut<MyEnv>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
+            |_env: FunctionEnvMut<MyEnv>| -> (i32, i64, f32, f64) { (1, 2, 3.0, 4.0) },
         );
         assert_eq!(
             function.ty(&mut store).clone(),
@@ -285,7 +285,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![Type::I32], vec![]);
@@ -293,7 +293,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
@@ -302,7 +302,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![], vec![Type::I32]);
@@ -310,7 +310,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
@@ -319,7 +319,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
 
@@ -329,7 +329,7 @@ mod sys {
             &mut store,
             &env,
             function_type,
-            |_ctx: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<()>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).params(), [Type::V128]);
         assert_eq!(
@@ -354,7 +354,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![Type::I32], vec![]);
@@ -362,7 +362,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
@@ -371,7 +371,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type = FunctionType::new(vec![], vec![Type::I32]);
@@ -379,7 +379,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
         let function_type =
@@ -388,7 +388,7 @@ mod sys {
             &mut store,
             &env,
             &function_type,
-            |_ctx: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).clone(), function_type);
 
@@ -398,7 +398,7 @@ mod sys {
             &mut store,
             &env,
             function_type,
-            |_ctx: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
+            |_env: FunctionEnvMut<MyEnv>, _values: &[Value]| unimplemented!(),
         );
         assert_eq!(function.ty(&mut store).params(), [Type::V128]);
         assert_eq!(
@@ -413,17 +413,17 @@ mod sys {
     //     fn native_function_works() -> Result<()> {
     //         let mut store = Store::default();
     //         let env = FunctionEnv::new(&mut store, ());
-    //         let function = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>| {});
+    //         let function = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| {});
     //         let native_function: TypedFunction<(), ()> = function.native(&mut store).unwrap();
     //         let result = native_function.call(&mut store);
     //         assert!(result.is_ok());
 
     //         let function =
-    //             Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>, a: i32| -> i32 { a + 1 });
+    //             Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>, a: i32| -> i32 { a + 1 });
     //         let native_function: TypedFunction<i32, i32> = function.native(&mut store).unwrap();
     //         assert_eq!(native_function.call(&mut store, 3).unwrap(), 4);
 
-    //         fn rust_abi(_ctx: FunctionEnvMut<()>, a: i32, b: i64, c: f32, d: f64) -> u64 {
+    //         fn rust_abi(_env: FunctionEnvMut<()>, a: i32, b: i64, c: f32, d: f64) -> u64 {
     //             (a as u64 * 1000) + (b as u64 * 100) + (c as u64 * 10) + (d as u64)
     //         }
     //         let function = Function::new_native(&mut store, &env, rust_abi);
@@ -431,16 +431,16 @@ mod sys {
     //             function.native(&mut store).unwrap();
     //         assert_eq!(native_function.call(&mut store, 8, 4, 1.5, 5.).unwrap(), 8415);
 
-    //         let function = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>| -> i32 { 1 });
+    //         let function = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| -> i32 { 1 });
     //         let native_function: TypedFunction<(), i32> = function.native(&mut store).unwrap();
     //         assert_eq!(native_function.call(&mut store).unwrap(), 1);
 
-    //         let function = Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>, _a: i32| {});
+    //         let function = Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>, _a: i32| {});
     //         let native_function: TypedFunction<i32, ()> = function.native(&mut store).unwrap();
     //         assert!(native_function.call(&mut store, 4).is_ok());
 
     //         let function =
-    //             Function::new_native(&mut store, &env, |_ctx: FunctionEnvMut<()>| -> (i32, i64, f32, f64) {
+    //             Function::new_native(&mut store, &env, |_env: FunctionEnvMut<()>| -> (i32, i64, f32, f64) {
     //                 (1, 2, 3.0, 4.0)
     //             });
     //         let native_function: TypedFunction<(), (i32, i64, f32, f64)> =
@@ -516,8 +516,8 @@ mod sys {
     //             memory: Option<Memory>,
     //         }
 
-    //         fn host_function(ctx: FunctionEnvMut<MyEnv>, arg1: u32, arg2: u32) -> u32 {
-    //             ctx.data().val + arg1 + arg2
+    //         fn host_function(env: FunctionEnvMut<MyEnv>, arg1: u32, arg2: u32) -> u32 {
+    //             env.data().val + arg1 + arg2
     //         }
 
     //         let mut env = MyEnv {

--- a/lib/api/tests/sys_instance.rs
+++ b/lib/api/tests/sys_instance.rs
@@ -52,10 +52,10 @@ mod sys {
         }
 
         fn imported_fn(
-            ctx: FunctionEnvMut<Env>,
+            env: FunctionEnvMut<Env>,
             args: &[Value],
         ) -> Result<Vec<Value>, RuntimeError> {
-            let value = ctx.data().multiplier * args[0].unwrap_i32() as u32;
+            let value = env.data().multiplier * args[0].unwrap_i32() as u32;
             Ok(vec![Value::I32(value as _)])
         }
 

--- a/lib/api/tests/sys_module.rs
+++ b/lib/api/tests/sys_module.rs
@@ -194,35 +194,35 @@ mod sys {
         let env = FunctionEnv::new(&mut store, ());
         let imports = imports! {
             "host" => {
-                "host_func1" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: u64| {
+                "host_func1" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: u64| {
                     println!("host_func1: Found number {}", p);
                     assert_eq!(p, u64::max_value());
                 }),
-                "host_func2" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: u32| {
+                "host_func2" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: u32| {
                     println!("host_func2: Found number {}", p);
                     assert_eq!(p, u32::max_value());
                 }),
-                "host_func3" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: i64| {
+                "host_func3" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: i64| {
                     println!("host_func3: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func4" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: i32| {
+                "host_func4" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: i32| {
                     println!("host_func4: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func5" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: i16| {
+                "host_func5" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: i16| {
                     println!("host_func5: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func6" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: u16| {
+                "host_func6" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: u16| {
                     println!("host_func6: Found number {}", p);
                     assert_eq!(p, u16::max_value());
                 }),
-                "host_func7" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: i8| {
+                "host_func7" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: i8| {
                     println!("host_func7: Found number {}", p);
                     assert_eq!(p, -1);
                 }),
-                "host_func8" => Function::new_native(&mut store, &env,|_ctx: FunctionEnvMut<()>, p: u8| {
+                "host_func8" => Function::new_native(&mut store, &env,|_env: FunctionEnvMut<()>, p: u8| {
                     println!("host_func8: Found number {}", p);
                     assert_eq!(p, u8::max_value());
                 }),


### PR DESCRIPTION
This PR is doing a bit of cleanup on the API, examples and tests renaming the old var names from `ctx` to `env` (in case of FunctionEnv) and from `ctx` to `store` in case of store usage.
