### PR TITLE
Added a simple divide by zero trap wast test (for #1899)

### DIFF
--- a/tests/wast/wasmer/README.md
+++ b/tests/wast/wasmer/README.md
@@ -7,7 +7,7 @@ by the standard WebAssembly spectests.
 ## NaN canonicalization: `nan-canonicalization.wast`
 
 This is an extra set of tests that assure that operations with NaNs
-are deterministic regarless of the environment/chipset where it executes in.
+are deterministic regardless of the environment/chipset where it executes in.
 
 ## Call Indirect Spilled Stack: `call-indirect-spilledd-stack.wast`
 
@@ -28,3 +28,7 @@ This is a simple factorial program.
 
 Stack space for a structure returning function call should be allocated once up
 front, not once in each call.
+
+## Divide by Zero: `divide.wast`
+
+This is a simple test to check that a divide by zero is correctly trapped

--- a/tests/wast/wasmer/divide.wast
+++ b/tests/wast/wasmer/divide.wast
@@ -1,0 +1,4 @@
+(module
+  (func (export "div_s") (param $x i64) (param $y i64) (result i64) (i64.div_s (local.get $x) (local.get $y)))
+)
+(assert_trap (invoke "div_s" (i64.const 1) (i64.const 0)) "integer divide by zero")


### PR DESCRIPTION
# Description
Added a simple "divide by zero" wast test, for #1899 , as the trap information are correctly tracked on singlepass now