### PR TITLE
Fixed WASI fd_read syscall when reading multiple iovs and read is partial (for #2904)

### DIFF
--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -124,13 +124,18 @@ pub(crate) fn read_bytes<T: Read, M: MemorySize>(
     for iov in iovs_arr.iter() {
         let iov_inner = iov.read().map_err(mem_error_to_wasi)?;
         raw_bytes.clear();
-        raw_bytes.resize(from_offset::<M>(iov_inner.buf_len)?, 0);
-        bytes_read += reader.read(&mut raw_bytes).map_err(map_io_err)?;
+        let to_read = from_offset::<M>(iov_inner.buf_len)?;
+        raw_bytes.resize(to_read, 0);
+        let has_read = reader.read(&mut raw_bytes).map_err(map_io_err)?;
 
         let buf = WasmPtr::<u8, M>::new(iov_inner.buf)
             .slice(ctx, memory, iov_inner.buf_len)
             .map_err(mem_error_to_wasi)?;
         buf.write_slice(&raw_bytes).map_err(mem_error_to_wasi)?;
+        bytes_read += has_read;
+        if has_read != to_read {
+            return Ok(bytes_read);
+        }
     }
     Ok(bytes_read)
 }
@@ -1113,7 +1118,7 @@ pub fn fd_read<M: MemorySize>(
     trace!("wasi::fd_read: fd={}", fd);
     let env = ctx.data();
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(0);
-
+//let iovs_len = if iovs_len > M::Offset::from(1u32) { M::Offset::from(1u32) } else { iovs_len };
     let iovs_arr = wasi_try_mem_ok!(iovs.slice(&ctx, memory, iovs_len));
     let nread_ref = nread.deref(&ctx, memory);
 
@@ -1240,7 +1245,6 @@ pub fn fd_read<M: MemorySize>(
             bytes_read
         }
     };
-
     let bytes_read: M::Offset = wasi_try_ok!(bytes_read.try_into().map_err(|_| __WASI_EOVERFLOW));
     wasi_try_mem_ok!(nread_ref.write(bytes_read));
 

--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -1118,7 +1118,7 @@ pub fn fd_read<M: MemorySize>(
     trace!("wasi::fd_read: fd={}", fd);
     let env = ctx.data();
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(0);
-//let iovs_len = if iovs_len > M::Offset::from(1u32) { M::Offset::from(1u32) } else { iovs_len };
+    //let iovs_len = if iovs_len > M::Offset::from(1u32) { M::Offset::from(1u32) } else { iovs_len };
     let iovs_arr = wasi_try_mem_ok!(iovs.slice(&ctx, memory, iovs_len));
     let nread_ref = nread.deref(&ctx, memory);
 


### PR DESCRIPTION
# Description
Fixed an issue with WASI fd_read: when reading on multiple iovs, if a read is partial (so not all the wanted bytes are read), the function would still continue to try reading on subsequent iov (eventualy reading more bytes but not in the right place).