### PR TITLE
Fix trap tracking

### DIFF
--- a/lib/compiler/src/engine/trap/frame_info.rs
+++ b/lib/compiler/src/engine/trap/frame_info.rs
@@ -65,10 +65,8 @@ impl ModuleInfoFrameInfo {
 
     /// Gets a function given a pc
     fn function_info(&self, pc: usize) -> Option<&FunctionInfo> {
-        // the +1 is to avoid selecting an interval that end with pc,
-        // as end should be non-inclusive
-        let (end, func) = self.functions.range((pc + 1)..).next()?;
-        if func.start <= pc && pc < *end {
+        let (end, func) = self.functions.range(pc..).next()?;
+        if func.start <= pc && pc <= *end {
             Some(func)
         } else {
             None
@@ -153,10 +151,8 @@ impl GlobalFrameInfo {
 
     /// Gets a module given a pc
     fn module_info(&self, pc: usize) -> Option<&ModuleInfoFrameInfo> {
-        // the +1 is to avoid selecting an interval that end with pc,
-        // as end should be non-inclusive
-        let (end, module_info) = self.ranges.range((pc + 1)..).next()?;
-        if module_info.start <= pc && pc < *end {
+        let (end, module_info) = self.ranges.range(pc..).next()?;
+        if module_info.start <= pc && pc <= *end {
             Some(module_info)
         } else {
             None
@@ -207,7 +203,7 @@ pub fn register(
     ) in finished_functions.iter()
     {
         let start = **start as usize;
-        let end = start + len;
+        let end = start + len - 1;
         min = cmp::min(min, start);
         max = cmp::max(max, end);
         let func = FunctionInfo {

--- a/lib/compiler/src/engine/trap/frame_info.rs
+++ b/lib/compiler/src/engine/trap/frame_info.rs
@@ -65,8 +65,10 @@ impl ModuleInfoFrameInfo {
 
     /// Gets a function given a pc
     fn function_info(&self, pc: usize) -> Option<&FunctionInfo> {
-        let (end, func) = self.functions.range(pc..).next()?;
-        if func.start <= pc && pc <= *end {
+        // the +1 is to avoid selecting an interval that end with pc,
+        // as end should be non-inclusive
+        let (end, func) = self.functions.range((pc + 1)..).next()?;
+        if func.start <= pc && pc < *end {
             Some(func)
         } else {
             None
@@ -151,8 +153,10 @@ impl GlobalFrameInfo {
 
     /// Gets a module given a pc
     fn module_info(&self, pc: usize) -> Option<&ModuleInfoFrameInfo> {
-        let (end, module_info) = self.ranges.range(pc..).next()?;
-        if module_info.start <= pc && pc <= *end {
+        // the +1 is to avoid selecting an interval that end with pc,
+        // as end should be non-inclusive
+        let (end, module_info) = self.ranges.range((pc + 1)..).next()?;
+        if module_info.start <= pc && pc < *end {
             Some(module_info)
         } else {
             None

--- a/lib/compiler/src/engine/trap/frame_info.rs
+++ b/lib/compiler/src/engine/trap/frame_info.rs
@@ -203,6 +203,7 @@ pub fn register(
     ) in finished_functions.iter()
     {
         let start = **start as usize;
+        // end is "last byte" of the function code
         let end = start + len - 1;
         min = cmp::min(min, start);
         max = cmp::max(max, end);

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -6,18 +6,22 @@ singlepass spec::simd # Singlepass doesn't support yet SIMD (no one asked for th
 ## Unwinding is not properly implemented in Singlepass
 # Needs investigation
 singlepass+aarch64+macos traps::test_trap_trace
+cranelift+aarch64+macos    traps::test_trap_trace
 llvm+aarch64    traps::test_trap_trace
 singlepass+aarch64+macos traps::test_trap_stack_overflow # Need to investigate
 singlepass+aarch64+macos traps::trap_display_pretty
 llvm       traps::trap_display_pretty
+cranelift+aarch64+macos    traps::trap_display_pretty
 singlepass+aarch64+macos traps::trap_display_multi_module
 llvm       traps::trap_display_multi_module
+cranelift+aarch64+macos    traps::trap_display_multi_module
 windows+singlepass   traps::trap_display_multi_module
 singlepass traps::call_signature_mismatch   # Need to investigate, get foo (a[0]:0x33) instead of 0x30 for inderect call
 llvm       traps::call_signature_mismatch
 macos+aarch64    traps::call_signature_mismatch
 singlepass+aarch64+macos traps::start_trap_pretty
 llvm       traps::start_trap_pretty
+cranelift+aarch64+macos    traps::start_trap_pretty
 
 # Also neither LLVM nor Cranelift currently implement stack probing on AArch64.
 # https://github.com/wasmerio/wasmer/issues/2808

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -6,22 +6,18 @@ singlepass spec::simd # Singlepass doesn't support yet SIMD (no one asked for th
 ## Unwinding is not properly implemented in Singlepass
 # Needs investigation
 singlepass+aarch64+macos traps::test_trap_trace
-cranelift+aarch64    traps::test_trap_trace
+llvm+aarch64    traps::test_trap_trace
 singlepass+aarch64+macos traps::test_trap_stack_overflow # Need to investigate
-cranelift+aarch64    traps::test_trap_stack_overflow # Need to investigate
 singlepass+aarch64+macos traps::trap_display_pretty
 llvm       traps::trap_display_pretty
-cranelift+aarch64    traps::trap_display_pretty
 singlepass+aarch64+macos traps::trap_display_multi_module
 llvm       traps::trap_display_multi_module
-cranelift+aarch64    traps::trap_display_multi_module
 windows+singlepass   traps::trap_display_multi_module
 singlepass traps::call_signature_mismatch   # Need to investigate, get foo (a[0]:0x33) instead of 0x30 for inderect call
 llvm       traps::call_signature_mismatch
 macos+aarch64    traps::call_signature_mismatch
 singlepass+aarch64+macos traps::start_trap_pretty
 llvm       traps::start_trap_pretty
-cranelift+aarch64    traps::start_trap_pretty
 
 # Also neither LLVM nor Cranelift currently implement stack probing on AArch64.
 # https://github.com/wasmerio/wasmer/issues/2808


### PR DESCRIPTION
# Description
Ajusted how trap tracking information are retrieve at runtime, fixing cranelift+aarch64 trap test like #2847 

There are still issues on aarch64+macos with the pretty print of trap.