### PR TITLE
CI: Unset rustup override after usage instead of setting it to stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
           echo "rpath = false" >> Cargo.toml
           rustup override set nightly
           make build-wasmer-headless-minimal
-          rustup override set stable
+          rustup override unset
       - name: Build Wasmer with minimal "sys" features
         run: |
           cargo build --no-default-features --features="sys" --manifest-path=lib/api/Cargo.toml &&


### PR DESCRIPTION
Fixes the `macos-arm64` error from https://github.com/wasmerio/wasmer/issues/3055