### PR TITLE
Remove native feature entry from docs.rs metadata

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -126,4 +126,4 @@ static-artifact-load = ["wasmer-compiler/static-artifact-load"]
 static-artifact-create = ["wasmer-compiler/static-artifact-create"]
 
 [package.metadata.docs.rs]
-features = ["compiler", "core", "cranelift", "engine", "jit", "native", "singlepass", "sys", "sys-default" ]
+features = ["compiler", "core", "cranelift", "engine", "jit", "singlepass", "sys", "sys-default" ]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -126,4 +126,17 @@ static-artifact-load = ["wasmer-compiler/static-artifact-load"]
 static-artifact-create = ["wasmer-compiler/static-artifact-create"]
 
 [package.metadata.docs.rs]
-features = ["compiler", "core", "cranelift", "engine", "jit", "singlepass", "sys", "sys-default" ]
+features = [
+    "compiler",
+    "core",
+    "cranelift",
+    "engine",
+    "jit",
+    "singlepass",
+    "static-artifact-create",
+    "static-artifact-load",
+    "sys",
+    "sys-default",
+    "wasmer-artifact-create",
+    "wasmer-artifact-load",
+]

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -55,3 +55,11 @@ enable-serde = ["serde", "serde_bytes", "wasmer-types/enable-serde"]
 
 [badges]
 maintenance = { status = "experimental" }
+
+[package.metadata.docs.rs]
+features = [
+    "static-artifact-create",
+    "static-artifact-load",
+    "wasmer-artifact-create",
+    "wasmer-artifact-load",
+]


### PR DESCRIPTION
The native feature is no longer present, but was still in the list of
features to be enabled when building the documentation for docs.rs,
causing the build there to fail. Removal should re-enable the build of
the documentation for docs.rs.

Closes: #3066