### PR TITLE
Remove __wbindgen_thread_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 ### Added
 
 ### Changed
+- [#3075](https://github.com/wasmerio/wasmer/pull/3075) Remove __wbindgen_thread_id
 
 ### Fixed
 

--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -113,12 +113,6 @@ impl From<WasiBusProcessId> for u32 {
     }
 }
 
-#[cfg(target_family = "wasm")]
-#[link(wasm_import_module = "__wbindgen_thread_xform__")]
-extern "C" {
-    fn __wbindgen_thread_id() -> u32;
-}
-
 #[derive(Debug, Clone)]
 pub struct WasiThread {
     /// ID of this thread


### PR DESCRIPTION
After talking to John, he mentioned that this function was once implemented in Wasmer, but it isn't implemented anymore, therefore preventing running wasmer-wasi using wasmer itself.

Removing this buinding should do absolutely nothing, as it's not used anywhere (anymore).

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
