### PR TITLE
Migrate to clap from structopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 ### Added
 
 ### Changed
+- #[3079](https://github.com/wasmerio/wasmer/pull/3079) Migrate CLI tools to `clap` from `structopt`
 - [#3048](https://github.com/wasmerio/wasmer/pull/3048) Automatically publish wasmer as "cloudcompiler" package to wapm.dev on every release
 - [#3075](https://github.com/wasmerio/wasmer/pull/3075) Remove __wbindgen_thread_id
-
 - [#3072](https://github.com/wasmerio/wasmer/pull/3072) Add back `Function::*_with_env(…)` functions
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
  "clap 3.2.15",
- "heck 0.4.0",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
@@ -357,11 +357,26 @@ checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1106,15 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2378,30 +2384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,12 +2711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,6 +2995,7 @@ dependencies = [
  "atty",
  "bytesize",
  "cfg-if 1.0.0",
+ "clap 3.2.15",
  "colored 2.0.0",
  "dirs",
  "distance",
@@ -3026,7 +3003,7 @@ dependencies = [
  "http_req",
  "log",
  "serde_json",
- "structopt",
+ "target-lexicon 0.12.4",
  "tempfile",
  "unix_mode",
  "wasmer",
@@ -3079,11 +3056,12 @@ dependencies = [
  "atty",
  "bytesize",
  "cfg-if 1.0.0",
+ "clap 3.2.15",
  "colored 2.0.0",
  "distance",
  "fern",
  "log",
- "structopt",
+ "target-lexicon 0.12.4",
  "tempfile",
  "unix_mode",
  "wasmer-compiler",

--- a/lib/cli-compiler/Cargo.toml
+++ b/lib/cli-compiler/Cargo.toml
@@ -23,7 +23,7 @@ wasmer-types = { version = "=3.0.0-alpha.4", path = "../types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
-structopt = { version = "0.3", features = ["suggestions"] }
+clap = { version = "3.1", features = ["derive"] }
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand
@@ -32,6 +32,7 @@ cfg-if = "1.0"
 # For debug feature
 fern = { version = "0.6", features = ["colored"], optional = true }
 log = { version = "0.4", optional = true }
+target-lexicon = { version = "0.12", features = ["std"] }
 tempfile = "3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/lib/cli-compiler/src/commands/compile.rs
+++ b/lib/cli-compiler/src/commands/compile.rs
@@ -27,10 +27,7 @@ pub struct Compile {
     #[clap(flatten)]
     store: StoreOptions,
 
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
-    #[clap(short = 'm', multiple_occurrences = true, number_of_values = 1)]
+    #[clap(short = 'm')]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli-compiler/src/commands/compile.rs
+++ b/lib/cli-compiler/src/commands/compile.rs
@@ -1,34 +1,36 @@
 use crate::store::StoreOptions;
 use crate::warning;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
-use wasmer_compiler::ModuleEnvironment;
-use wasmer_compiler::{ArtifactBuild, ArtifactCreate};
+use wasmer_compiler::{ArtifactBuild, ArtifactCreate, ModuleEnvironment};
 use wasmer_types::entity::PrimaryMap;
 use wasmer_types::{
     CompileError, CpuFeature, MemoryIndex, MemoryStyle, TableIndex, TableStyle, Target, Triple,
 };
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer compile` subcommand
 pub struct Compile {
     /// Input file
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Output file
-    #[structopt(name = "OUTPUT PATH", short = "o", parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
     output: PathBuf,
 
     /// Compilation Target triple
-    #[structopt(long = "target")]
+    #[clap(long = "target")]
     target_triple: Option<Triple>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 
-    #[structopt(short = "m", multiple = true, number_of_values = 1)]
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
+    #[clap(short = 'm', multiple_occurrences = true, number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli-compiler/src/commands/config.rs
+++ b/lib/cli-compiler/src/commands/config.rs
@@ -1,39 +1,39 @@
 use crate::VERSION;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::env;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer config` subcommand
 pub struct Config {
     /// Print the installation prefix.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     prefix: bool,
 
     /// Directory containing Wasmer executables.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     bindir: bool,
 
     /// Directory containing Wasmer headers.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     includedir: bool,
 
     /// Directory containing Wasmer libraries.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     libdir: bool,
 
     /// Libraries needed to link against Wasmer components.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     libs: bool,
 
     /// C compiler flags for files that include Wasmer headers.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     cflags: bool,
 
     /// It outputs the necessary details for compiling
     /// and linking a program to Wasmer, using the `pkg-config` format.
-    #[structopt(long)]
+    #[clap(long)]
     pkg_config: bool,
 }
 

--- a/lib/cli-compiler/src/commands/validate.rs
+++ b/lib/cli-compiler/src/commands/validate.rs
@@ -1,18 +1,18 @@
 use crate::store::StoreOptions;
 use anyhow::{bail, Context, Result};
+use clap::Parser;
 use std::path::PathBuf;
 use std::str::FromStr;
-use structopt::StructOpt;
 use wasmer_types::{is_wasm, CpuFeature, Target, Triple};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer validate` subcommand
 pub struct Validate {
     /// File to validate as WebAssembly
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 }
 

--- a/lib/cli-compiler/src/common.rs
+++ b/lib/cli-compiler/src/common.rs
@@ -1,36 +1,36 @@
 //! Common module with common used structures across different
 //! commands.
 use crate::VERSION;
+use clap::Parser;
 use std::env;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt, Clone, Default)]
+#[derive(Debug, Parser, Clone, Default)]
 /// The WebAssembly features that can be passed through the
 /// Command Line args.
 pub struct WasmFeatures {
     /// Enable support for the SIMD proposal.
-    #[structopt(long = "enable-simd")]
+    #[clap(long = "enable-simd")]
     pub simd: bool,
 
     /// Enable support for the threads proposal.
-    #[structopt(long = "enable-threads")]
+    #[clap(long = "enable-threads")]
     pub threads: bool,
 
     /// Enable support for the reference types proposal.
-    #[structopt(long = "enable-reference-types")]
+    #[clap(long = "enable-reference-types")]
     pub reference_types: bool,
 
     /// Enable support for the multi value proposal.
-    #[structopt(long = "enable-multi-value")]
+    #[clap(long = "enable-multi-value")]
     pub multi_value: bool,
 
     /// Enable support for the bulk memory proposal.
-    #[structopt(long = "enable-bulk-memory")]
+    #[clap(long = "enable-bulk-memory")]
     pub bulk_memory: bool,
 
     /// Enable support for all pre-standard proposals.
-    #[structopt(long = "enable-all")]
+    #[clap(long = "enable-all")]
     pub all: bool,
 }
 

--- a/lib/cli-compiler/src/store.rs
+++ b/lib/cli-compiler/src/store.rs
@@ -3,10 +3,10 @@
 
 use crate::common::WasmFeatures;
 use anyhow::Result;
+use clap::Parser;
 use std::string::ToString;
 #[allow(unused_imports)]
 use std::sync::Arc;
-use structopt::StructOpt;
 use wasmer_compiler::EngineBuilder;
 use wasmer_compiler::{CompilerConfig, Features};
 use wasmer_types::{MemoryStyle, MemoryType, Pages, PointerWidth, TableStyle, TableType, Target};
@@ -84,41 +84,41 @@ impl SubsetTunables {
     }
 }
 
-#[derive(Debug, Clone, StructOpt, Default)]
+#[derive(Debug, Clone, Parser, Default)]
 /// The compiler and engine options
 pub struct StoreOptions {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     compiler: CompilerOptions,
 }
 
-#[derive(Debug, Clone, StructOpt, Default)]
+#[derive(Debug, Clone, Parser, Default)]
 /// The compiler options
 pub struct CompilerOptions {
     /// Use Singlepass compiler.
-    #[structopt(long, conflicts_with_all = &["cranelift", "llvm"])]
+    #[clap(long, conflicts_with_all = &["cranelift", "llvm"])]
     singlepass: bool,
 
     /// Use Cranelift compiler.
-    #[structopt(long, conflicts_with_all = &["singlepass", "llvm"])]
+    #[clap(long, conflicts_with_all = &["singlepass", "llvm"])]
     cranelift: bool,
 
     /// Use LLVM compiler.
-    #[structopt(long, conflicts_with_all = &["singlepass", "cranelift"])]
+    #[clap(long, conflicts_with_all = &["singlepass", "cranelift"])]
     llvm: bool,
 
     /// Enable compiler internal verification.
     #[allow(unused)]
-    #[structopt(long)]
+    #[clap(long)]
     #[allow(dead_code)]
     enable_verifier: bool,
 
     /// LLVM debug directory, where IR and object files will be written to.
     #[allow(unused)]
     #[cfg(feature = "llvm")]
-    #[cfg_attr(feature = "llvm", structopt(long, parse(from_os_str)))]
+    #[cfg_attr(feature = "llvm", clap(long, parse(from_os_str)))]
     llvm_debug_dir: Option<PathBuf>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     features: WasmFeatures,
 }
 

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -42,7 +42,7 @@ wasmer-vfs  = { version = "=3.0.0-alpha.4", path = "../vfs", default-features = 
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
-structopt = { version = "0.3", features = ["suggestions"] }
+clap = { version = "3.1", features = ["derive"] }
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand
@@ -55,6 +55,7 @@ tempfile = "3"
 http_req  = { version="^0.8", default-features = false, features = ["rust-tls"], optional = true }
 dirs = { version = "4.0", optional = true }
 serde_json = { version = "1.0", optional = true }
+target-lexicon = { version = "0.12", features = ["std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 unix_mode = "0.1.3"

--- a/lib/cli/src/cli.rs
+++ b/lib/cli/src/cli.rs
@@ -35,7 +35,6 @@ enum WasmerCLIOptions {
     #[clap(name = "run")]
     Run(Run),
 
-    // TODO: check whether this should really be a subcommand.
     /// Wasmer cache
     #[clap(subcommand, name = "cache")]
     Cache(Cache),

--- a/lib/cli/src/cli.rs
+++ b/lib/cli/src/cli.rs
@@ -14,16 +14,16 @@ use crate::commands::{Cache, Config, Inspect, Run, SelfUpdate, Validate};
 use crate::error::PrettyError;
 use anyhow::Result;
 
-use structopt::{clap::ErrorKind, StructOpt};
+use clap::{ErrorKind, Parser};
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 #[cfg_attr(
     not(feature = "headless"),
-    structopt(name = "wasmer", about = "WebAssembly standalone runtime.", author)
+    clap(name = "wasmer", about = "WebAssembly standalone runtime.", author)
 )]
 #[cfg_attr(
     feature = "headless",
-    structopt(
+    clap(
         name = "wasmer-headless",
         about = "Headless WebAssembly standalone runtime.",
         author
@@ -32,20 +32,21 @@ use structopt::{clap::ErrorKind, StructOpt};
 /// The options for the wasmer Command Line Interface
 enum WasmerCLIOptions {
     /// Run a WebAssembly file. Formats accepted: wasm, wat
-    #[structopt(name = "run")]
+    #[clap(name = "run")]
     Run(Run),
 
+    // TODO: check whether this should really be a subcommand.
     /// Wasmer cache
-    #[structopt(name = "cache")]
+    #[clap(subcommand, name = "cache")]
     Cache(Cache),
 
     /// Validate a WebAssembly binary
-    #[structopt(name = "validate")]
+    #[clap(name = "validate")]
     Validate(Validate),
 
     /// Compile a WebAssembly binary
     #[cfg(feature = "compiler")]
-    #[structopt(name = "compile")]
+    #[clap(name = "compile")]
     Compile(Compile),
 
     /// Compile a WebAssembly binary into a native executable
@@ -67,7 +68,7 @@ enum WasmerCLIOptions {
     /// qjs.exe: ELF 64-bit LSB pie executable, x86-64 ...
     /// ```
     #[cfg(any(feature = "static-artifact-create", feature = "wasmer-artifact-create"))]
-    #[structopt(name = "create-exe", verbatim_doc_comment)]
+    #[clap(name = "create-exe", verbatim_doc_comment)]
     CreateExe(CreateExe),
 
     /// Compile a WebAssembly binary into an object file
@@ -93,25 +94,25 @@ enum WasmerCLIOptions {
 
     /// Get various configuration information needed
     /// to compile programs which use Wasmer
-    #[structopt(name = "config")]
+    #[clap(name = "config")]
     Config(Config),
 
     /// Update wasmer to the latest version
-    #[structopt(name = "self-update")]
+    #[clap(name = "self-update")]
     SelfUpdate(SelfUpdate),
 
     /// Inspect a WebAssembly file
-    #[structopt(name = "inspect")]
+    #[clap(name = "inspect")]
     Inspect(Inspect),
 
     /// Run spec testsuite
     #[cfg(feature = "wast")]
-    #[structopt(name = "wast")]
+    #[clap(name = "wast")]
     Wast(Wast),
 
     /// Unregister and/or register wasmer as binfmt interpreter
     #[cfg(target_os = "linux")]
-    #[structopt(name = "binfmt")]
+    #[clap(name = "binfmt")]
     Binfmt(Binfmt),
 }
 
@@ -159,15 +160,15 @@ pub fn wasmer_main() {
     } else {
         match command.unwrap_or(&"".to_string()).as_ref() {
             "cache" | "compile" | "config" | "create-exe" | "help" | "inspect" | "run"
-            | "self-update" | "validate" | "wast" | "binfmt" => WasmerCLIOptions::from_args(),
+            | "self-update" | "validate" | "wast" | "binfmt" => WasmerCLIOptions::parse(),
             _ => {
-                WasmerCLIOptions::from_iter_safe(args.iter()).unwrap_or_else(|e| {
-                    match e.kind {
+                WasmerCLIOptions::try_parse_from(args.iter()).unwrap_or_else(|e| {
+                    match e.kind() {
                         // This fixes a issue that:
                         // 1. Shows the version twice when doing `wasmer -V`
                         // 2. Shows the run help (instead of normal help) when doing `wasmer --help`
-                        ErrorKind::VersionDisplayed | ErrorKind::HelpDisplayed => e.exit(),
-                        _ => WasmerCLIOptions::Run(Run::from_args()),
+                        ErrorKind::DisplayVersion | ErrorKind::DisplayHelp => e.exit(),
+                        _ => WasmerCLIOptions::Run(Run::parse()),
                     }
                 })
             }

--- a/lib/cli/src/commands.rs
+++ b/lib/cli/src/commands.rs
@@ -29,7 +29,7 @@ pub use wast::*;
 pub use {cache::*, config::*, inspect::*, run::*, self_update::*, validate::*};
 
 /// The kind of object format to emit.
-#[derive(Debug, Copy, Clone, structopt::StructOpt)]
+#[derive(Debug, Copy, Clone, clap::Parser)]
 #[cfg(any(feature = "static-artifact-create", feature = "wasmer-artifact-create"))]
 pub enum ObjectFormat {
     /// Serialize the entire module into an object file.

--- a/lib/cli/src/commands/binfmt.rs
+++ b/lib/cli/src/commands/binfmt.rs
@@ -1,14 +1,14 @@
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::env;
 use std::fs;
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use Action::*;
 
-#[derive(StructOpt, Clone, Copy)]
+#[derive(Parser, Clone, Copy)]
 enum Action {
     /// Register wasmer as binfmt interpreter
     Register,
@@ -22,14 +22,14 @@ enum Action {
 ///
 /// Check the wasmer repository for a systemd service definition example
 /// to automate the process at start-up.
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct Binfmt {
     // Might be better to traverse the mount list
     /// Mount point of binfmt_misc fs
-    #[structopt(long, default_value = "/proc/sys/fs/binfmt_misc/")]
+    #[clap(long, default_value = "/proc/sys/fs/binfmt_misc/")]
     binfmt_misc: PathBuf,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     action: Action,
 }
 

--- a/lib/cli/src/commands/cache.rs
+++ b/lib/cli/src/commands/cache.rs
@@ -1,17 +1,17 @@
 use crate::common::get_cache_dir;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::fs;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer cache` subcommand
 pub enum Cache {
     /// Clear the cache
-    #[structopt(name = "clean")]
+    #[clap(name = "clean")]
     Clean,
 
     /// Display the location of the cache
-    #[structopt(name = "dir")]
+    #[clap(name = "dir")]
     Dir,
 }
 

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -1,29 +1,32 @@
 use crate::store::StoreOptions;
 use crate::warning;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use wasmer::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer compile` subcommand
 pub struct Compile {
     /// Input file
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Output file
-    #[structopt(name = "OUTPUT PATH", short = "o", parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
     output: PathBuf,
 
     /// Compilation Target triple
-    #[structopt(long = "target")]
+    #[clap(long = "target")]
     target_triple: Option<Triple>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 
-    #[structopt(short = "m", multiple = true, number_of_values = 1)]
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
+    #[clap(short = 'm', multiple_occurrences = true, number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -23,10 +23,7 @@ pub struct Compile {
     #[clap(flatten)]
     store: StoreOptions,
 
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
-    #[clap(short = 'm', multiple_occurrences = true, number_of_values = 1)]
+    #[clap(short = 'm')]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -1,39 +1,39 @@
 use crate::VERSION;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::env;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer config` subcommand
 pub struct Config {
     /// Print the installation prefix.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     prefix: bool,
 
     /// Directory containing Wasmer executables.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     bindir: bool,
 
     /// Directory containing Wasmer headers.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     includedir: bool,
 
     /// Directory containing Wasmer libraries.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     libdir: bool,
 
     /// Libraries needed to link against Wasmer components.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     libs: bool,
 
     /// C compiler flags for files that include Wasmer headers.
-    #[structopt(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg-config")]
     cflags: bool,
 
     /// It outputs the necessary details for compiling
     /// and linking a program to Wasmer, using the `pkg-config` format.
-    #[structopt(long)]
+    #[clap(long)]
     pkg_config: bool,
 }
 

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -3,6 +3,7 @@
 use super::ObjectFormat;
 use crate::store::CompilerOptions;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::env;
 use std::fs;
 use std::fs::File;
@@ -10,7 +11,6 @@ use std::io::prelude::*;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use structopt::StructOpt;
 use wasmer::*;
 use wasmer_object::{emit_serialized, get_object_for_target};
 
@@ -42,32 +42,32 @@ struct CrossCompileSetup {
     library: PathBuf,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer create-exe` subcommand
 pub struct CreateExe {
     /// Input file
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Output file
-    #[structopt(name = "OUTPUT PATH", short = "o", parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
     output: PathBuf,
 
     /// Compilation Target triple
-    #[structopt(long = "target")]
+    #[clap(long = "target")]
     target_triple: Option<Triple>,
 
     // Cross-compile with `zig`
     /// Cross-compilation library path.
-    #[structopt(long = "library-path")]
+    #[clap(long = "library-path")]
     library_path: Option<PathBuf>,
 
     /// Cross-compilation tarball library path.
-    #[structopt(long = "tarball")]
+    #[clap(long = "tarball")]
     tarball: Option<PathBuf>,
 
     /// Specify `zig` binary path
-    #[structopt(long = "zig-binary-path")]
+    #[clap(long = "zig-binary-path")]
     zig_binary_path: Option<PathBuf>,
 
     /// Object format options
@@ -76,25 +76,31 @@ pub struct CreateExe {
     /// - (default) `symbols` creates an
     /// executable where all functions and metadata of the module are regular object symbols
     /// - `serialized` creates an executable where the module is zero-copy serialized as raw data
-    #[structopt(name = "OBJECT_FORMAT", long = "object-format", verbatim_doc_comment)]
+    #[clap(name = "OBJECT_FORMAT", long = "object-format", verbatim_doc_comment)]
     object_format: Option<ObjectFormat>,
 
     /// Header file for object input
     ///
     /// If given, the input `PATH` is assumed to be an object created with `wasmer create-obj` and
     /// this is its accompanying header file.
-    #[structopt(name = "HEADER", long = "header", verbatim_doc_comment)]
+    #[clap(name = "HEADER", long = "header", verbatim_doc_comment)]
     header: Option<PathBuf>,
 
-    #[structopt(short = "m", multiple = true, number_of_values = 1)]
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
+    #[clap(short = 'm', multiple_occurrences = true, number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
     /// Additional libraries to link against.
     /// This is useful for fixing linker errors that may occur on some systems.
-    #[structopt(short = "l", multiple = true, number_of_values = 1)]
+    #[clap(short = 'l', multiple_occurrences = true, number_of_values = 1)]
     libraries: Vec<String>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     compiler: CompilerOptions,
 }
 

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -86,18 +86,12 @@ pub struct CreateExe {
     #[clap(name = "HEADER", long = "header", verbatim_doc_comment)]
     header: Option<PathBuf>,
 
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
-    #[clap(short = 'm', multiple_occurrences = true, number_of_values = 1)]
+    #[clap(short = 'm')]
     cpu_features: Vec<CpuFeature>,
 
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
     /// Additional libraries to link against.
     /// This is useful for fixing linker errors that may occur on some systems.
-    #[clap(short = 'l', multiple_occurrences = true, number_of_values = 1)]
+    #[clap(short = 'l')]
     libraries: Vec<String>,
 
     #[clap(flatten)]

--- a/lib/cli/src/commands/create_obj.rs
+++ b/lib/cli/src/commands/create_obj.rs
@@ -4,6 +4,7 @@
 use super::ObjectFormat;
 use crate::{commands::PrefixerFn, store::CompilerOptions};
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::env;
 use std::fs;
 use std::fs::File;
@@ -11,25 +12,24 @@ use std::io::prelude::*;
 use std::io::BufWriter;
 use std::path::PathBuf;
 use std::process::Command;
-use structopt::StructOpt;
 use wasmer::*;
 use wasmer_object::{emit_serialized, get_object_for_target};
 
 const WASMER_SERIALIZED_HEADER: &[u8] = include_bytes!("wasmer_create_exe.h");
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer create-exe` subcommand
 pub struct CreateObj {
     /// Input file
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Output file
-    #[structopt(name = "OUTPUT_PATH", short = "o", parse(from_os_str))]
+    #[clap(name = "OUTPUT_PATH", short = 'o', parse(from_os_str))]
     output: PathBuf,
 
     /// Header output file
-    #[structopt(
+    #[clap(
         name = "OUTPUT_HEADER_PATH",
         long = "output-header-path",
         parse(from_os_str)
@@ -37,7 +37,7 @@ pub struct CreateObj {
     header_output: Option<PathBuf>,
 
     /// Compilation Target triple
-    #[structopt(long = "target")]
+    #[clap(long = "target")]
     target_triple: Option<Triple>,
 
     /// Object format options
@@ -45,13 +45,13 @@ pub struct CreateObj {
     /// This flag accepts two options: `symbols` or `serialized`.
     /// - (default) `symbols` creates an object where all functions and metadata of the module are regular object symbols
     /// - `serialized` creates an object where the module is zero-copy serialized as raw data
-    #[structopt(name = "OBJECT_FORMAT", long = "object-format", verbatim_doc_comment)]
+    #[clap(name = "OBJECT_FORMAT", long = "object-format", verbatim_doc_comment)]
     object_format: Option<ObjectFormat>,
 
-    #[structopt(short = "m", multiple = true, number_of_values = 1)]
+    #[clap(short = 'm', multiple = true, number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     compiler: CompilerOptions,
 }
 

--- a/lib/cli/src/commands/inspect.rs
+++ b/lib/cli/src/commands/inspect.rs
@@ -1,18 +1,18 @@
 use crate::store::StoreOptions;
 use anyhow::{Context, Result};
 use bytesize::ByteSize;
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use wasmer::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer validate` subcommand
 pub struct Inspect {
     /// File to validate as WebAssembly
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 }
 

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -13,7 +13,7 @@ use wasmer::*;
 use wasmer_cache::{Cache, FileSystemCache, Hash};
 use wasmer_types::Type as ValueType;
 
-use structopt::StructOpt;
+use clap::Parser;
 
 #[cfg(feature = "wasi")]
 mod wasi;
@@ -21,59 +21,59 @@ mod wasi;
 #[cfg(feature = "wasi")]
 use wasi::Wasi;
 
-#[derive(Debug, StructOpt, Clone, Default)]
+#[derive(Debug, Parser, Clone, Default)]
 /// The options for the `wasmer run` subcommand
 pub struct Run {
     /// Disable the cache
     #[cfg(feature = "cache")]
-    #[structopt(long = "disable-cache")]
+    #[clap(long = "disable-cache")]
     disable_cache: bool,
 
     /// File to run
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
     /// Invoke a specified function
-    #[structopt(long = "invoke", short = "i")]
+    #[clap(long = "invoke", short = 'i')]
     invoke: Option<String>,
 
     /// The command name is a string that will override the first argument passed
     /// to the wasm program. This is used in wapm to provide nicer output in
     /// help commands and error messages of the running wasm program
-    #[structopt(long = "command-name", hidden = true)]
+    #[clap(long = "command-name", hide = true)]
     command_name: Option<String>,
 
     /// A prehashed string, used to speed up start times by avoiding hashing the
     /// wasm module. If the specified hash is not found, Wasmer will hash the module
     /// as if no `cache-key` argument was passed.
     #[cfg(feature = "cache")]
-    #[structopt(long = "cache-key", hidden = true)]
+    #[clap(long = "cache-key", hide = true)]
     cache_key: Option<String>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 
     // TODO: refactor WASI structure to allow shared options with Emscripten
     #[cfg(feature = "wasi")]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     wasi: Wasi,
 
     /// Enable non-standard experimental IO devices
     #[cfg(feature = "io-devices")]
-    #[structopt(long = "enable-io-devices")]
+    #[clap(long = "enable-io-devices")]
     enable_experimental_io_devices: bool,
 
     /// Enable debug output
     #[cfg(feature = "debug")]
-    #[structopt(long = "debug", short = "d")]
+    #[clap(long = "debug", short = 'd')]
     debug: bool,
 
     #[cfg(feature = "debug")]
-    #[structopt(short, long, parse(from_occurrences))]
+    #[clap(short, long, parse(from_occurrences))]
     verbose: u8,
 
     /// Application arguments
-    #[structopt(value_name = "ARGS")]
+    #[clap(value_name = "ARGS")]
     args: Vec<String>,
 }
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -8,36 +8,45 @@ use wasmer_wasi::{
     WasiState, WasiVersion,
 };
 
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt, Clone, Default)]
+#[derive(Debug, Parser, Clone, Default)]
 /// WASI Options
 pub struct Wasi {
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
     /// WASI pre-opened directory
-    #[structopt(
+    #[clap(
         long = "dir",
         name = "DIR",
-        multiple = true,
+        multiple_occurrences = true,
         group = "wasi",
         number_of_values = 1
     )]
     pre_opened_directories: Vec<PathBuf>,
 
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
     /// Map a host directory to a different location for the Wasm module
-    #[structopt(
+    #[clap(
         long = "mapdir",
         name = "GUEST_DIR:HOST_DIR",
-        multiple = true,
+        multiple_occurrences = true,
         parse(try_from_str = parse_mapdir),
         number_of_values = 1,
     )]
     mapped_dirs: Vec<(String, PathBuf)>,
 
+    // TODO: multiple_values or multiple_occurrences, or both?
+    // TODO: number_of_values = 1 required? need to read some more documentation
+    // before I can be sure
     /// Pass custom environment variables
-    #[structopt(
+    #[clap(
         long = "env",
         name = "KEY=VALUE",
-        multiple = true,
+        multiple_occurrences = true,
         parse(try_from_str = parse_envvar),
     )]
     env_vars: Vec<(String, String)>,
@@ -46,16 +55,16 @@ pub struct Wasi {
     #[cfg(feature = "experimental-io-devices")]
     #[cfg_attr(
         feature = "experimental-io-devices",
-        structopt(long = "enable-experimental-io-devices")
+        clap(long = "enable-experimental-io-devices")
     )]
     enable_experimental_io_devices: bool,
 
     /// Allow WASI modules to import multiple versions of WASI without a warning.
-    #[structopt(long = "allow-multiple-wasi-versions")]
+    #[clap(long = "allow-multiple-wasi-versions")]
     pub allow_multiple_wasi_versions: bool,
 
     /// Require WASI modules to only import 1 version of WASI.
-    #[structopt(long = "deny-multiple-wasi-versions")]
+    #[clap(long = "deny-multiple-wasi-versions")]
     pub deny_multiple_wasi_versions: bool,
 }
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -13,40 +13,22 @@ use clap::Parser;
 #[derive(Debug, Parser, Clone, Default)]
 /// WASI Options
 pub struct Wasi {
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
     /// WASI pre-opened directory
-    #[clap(
-        long = "dir",
-        name = "DIR",
-        multiple_occurrences = true,
-        group = "wasi",
-        number_of_values = 1
-    )]
+    #[clap(long = "dir", name = "DIR", group = "wasi")]
     pre_opened_directories: Vec<PathBuf>,
 
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
     /// Map a host directory to a different location for the Wasm module
     #[clap(
         long = "mapdir",
         name = "GUEST_DIR:HOST_DIR",
-        multiple_occurrences = true,
         parse(try_from_str = parse_mapdir),
-        number_of_values = 1,
     )]
     mapped_dirs: Vec<(String, PathBuf)>,
 
-    // TODO: multiple_values or multiple_occurrences, or both?
-    // TODO: number_of_values = 1 required? need to read some more documentation
-    // before I can be sure
     /// Pass custom environment variables
     #[clap(
         long = "env",
         name = "KEY=VALUE",
-        multiple_occurrences = true,
         parse(try_from_str = parse_envvar),
     )]
     env_vars: Vec<(String, String)>,

--- a/lib/cli/src/commands/self_update.rs
+++ b/lib/cli/src/commands/self_update.rs
@@ -1,11 +1,11 @@
 //! When wasmer self-update is executed, this is what gets executed
 use anyhow::{Context, Result};
+use clap::Parser;
 #[cfg(not(target_os = "windows"))]
 use std::process::{Command, Stdio};
-use structopt::StructOpt;
 
 /// The options for the `wasmer self-update` subcommand
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct SelfUpdate {}
 
 impl SelfUpdate {

--- a/lib/cli/src/commands/validate.rs
+++ b/lib/cli/src/commands/validate.rs
@@ -1,17 +1,17 @@
 use crate::store::StoreOptions;
 use anyhow::{bail, Context, Result};
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use wasmer::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer validate` subcommand
 pub struct Validate {
     /// File to validate as WebAssembly
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 }
 

--- a/lib/cli/src/commands/wast.rs
+++ b/lib/cli/src/commands/wast.rs
@@ -1,21 +1,21 @@
 //! Runs a .wast WebAssembly test suites
 use crate::store::StoreOptions;
 use anyhow::{Context, Result};
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use wasmer_wast::Wast as WastSpectest;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// The options for the `wasmer wast` subcommand
 pub struct Wast {
     /// Wast file to run
-    #[structopt(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE", parse(from_os_str))]
     path: PathBuf,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     store: StoreOptions,
 
-    #[structopt(short, long)]
+    #[clap(short, long)]
     /// A flag to indicate wast stop at the first error or continue.
     fail_fast: bool,
 }

--- a/lib/cli/src/common.rs
+++ b/lib/cli/src/common.rs
@@ -1,36 +1,36 @@
 //! Common module with common used structures across different
 //! commands.
 use crate::VERSION;
+use clap::Parser;
 use std::env;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt, Clone, Default)]
+#[derive(Debug, Parser, Clone, Default)]
 /// The WebAssembly features that can be passed through the
 /// Command Line args.
 pub struct WasmFeatures {
     /// Enable support for the SIMD proposal.
-    #[structopt(long = "enable-simd")]
+    #[clap(long = "enable-simd")]
     pub simd: bool,
 
     /// Enable support for the threads proposal.
-    #[structopt(long = "enable-threads")]
+    #[clap(long = "enable-threads")]
     pub threads: bool,
 
     /// Enable support for the reference types proposal.
-    #[structopt(long = "enable-reference-types")]
+    #[clap(long = "enable-reference-types")]
     pub reference_types: bool,
 
     /// Enable support for the multi value proposal.
-    #[structopt(long = "enable-multi-value")]
+    #[clap(long = "enable-multi-value")]
     pub multi_value: bool,
 
     /// Enable support for the bulk memory proposal.
-    #[structopt(long = "enable-bulk-memory")]
+    #[clap(long = "enable-bulk-memory")]
     pub bulk_memory: bool,
 
     /// Enable support for all pre-standard proposals.
-    #[structopt(long = "enable-all")]
+    #[clap(long = "enable-all")]
     pub all: bool,
 }
 

--- a/lib/cli/src/compilers/llvm.rs
+++ b/lib/cli/src/compilers/llvm.rs
@@ -1,16 +1,16 @@
-#[derive(Debug, StructOpt, Clone)]
+#[derive(Debug, Parser, Clone)]
 /// LLVM backend flags.
 pub struct LLVMCLIOptions {
     /// Emit LLVM IR before optimization pipeline.
-    #[structopt(long = "llvm-pre-opt-ir", parse(from_os_str))]
+    #[clap(long = "llvm-pre-opt-ir", parse(from_os_str))]
     pre_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM IR after optimization pipeline.
-    #[structopt(long = "llvm-post-opt-ir", parse(from_os_str))]
+    #[clap(long = "llvm-post-opt-ir", parse(from_os_str))]
     post_opt_ir: Option<PathBuf>,
 
     /// Emit LLVM generated native code object file.
-    #[structopt(long = "llvm-object-file", parse(from_os_str))]
+    #[clap(long = "llvm-object-file", parse(from_os_str))]
     obj_file: Option<PathBuf>,
 }
 

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -5,52 +5,52 @@ use anyhow::Result;
 
 #[allow(unused_imports)]
 use crate::common::WasmFeatures;
+use clap::Parser;
 #[allow(unused_imports)]
 use std::path::PathBuf;
 use std::string::ToString;
 #[allow(unused_imports)]
 use std::sync::Arc;
-use structopt::StructOpt;
 use wasmer::*;
 #[cfg(feature = "compiler")]
 use wasmer_compiler::CompilerConfig;
 use wasmer_compiler::Engine;
 
-#[derive(Debug, Clone, StructOpt, Default)]
+#[derive(Debug, Clone, Parser, Default)]
 /// The compiler options
 pub struct StoreOptions {
     #[cfg(feature = "compiler")]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     compiler: CompilerOptions,
 }
 
 #[cfg(feature = "compiler")]
-#[derive(Debug, Clone, StructOpt, Default)]
+#[derive(Debug, Clone, Parser, Default)]
 /// The compiler options
 pub struct CompilerOptions {
     /// Use Singlepass compiler.
-    #[structopt(long, conflicts_with_all = &["cranelift", "llvm"])]
+    #[clap(long, conflicts_with_all = &["cranelift", "llvm"])]
     singlepass: bool,
 
     /// Use Cranelift compiler.
-    #[structopt(long, conflicts_with_all = &["singlepass", "llvm"])]
+    #[clap(long, conflicts_with_all = &["singlepass", "llvm"])]
     cranelift: bool,
 
     /// Use LLVM compiler.
-    #[structopt(long, conflicts_with_all = &["singlepass", "cranelift"])]
+    #[clap(long, conflicts_with_all = &["singlepass", "cranelift"])]
     llvm: bool,
 
     /// Enable compiler internal verification.
-    #[structopt(long)]
+    #[clap(long)]
     #[cfg(any(feature = "singlepass", feature = "cranelift", feature = "llvm"))]
     enable_verifier: bool,
 
     /// LLVM debug directory, where IR and object files will be written to.
     #[cfg(feature = "llvm")]
-    #[structopt(long, parse(from_os_str))]
+    #[clap(long, parse(from_os_str))]
     llvm_debug_dir: Option<PathBuf>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     features: WasmFeatures,
 }
 


### PR DESCRIPTION
Be aware that this PR is WIP for now and still has a few TODOs to be clarified before being ready.

# Description
`clap` is the designated successor for the `structopt` functionality, this PR migrates to it.

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
