### PR TITLE
Disable wasm build in build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,11 +196,11 @@ jobs:
         shell: bash
         run: |
           make build-wasmer
-      - name: Build Wasmer binary on Wasm32-WASI without LLVM
-        if: matrix.build_wasm
-        shell: bash
-        run: |
-          make build-wasmer-wasm
+     #- name: Build Wasmer binary on Wasm32-WASI without LLVM
+     #  if: matrix.build_wasm
+     #  shell: bash
+     #  run: |
+     #    make build-wasmer-wasm
       - name: Build Wapm binary
         run: |
           make build-wapm


### PR DESCRIPTION
Wasm build was added unnecessarily in the build github action in
4710a2af2e5100dd46733e0799a8d3f0418ebeb9

The wasm build is not currently part of the binary assets of a release,
so this commits disable it.

By the way, the wasm build fails because the wasm32-wasi target is
not added with rustup before the `make build-wasmer-wasm` is called.
