### PR TITLE
Added version to the wasmer cli

### DIFF
--- a/lib/cli/src/cli.rs
+++ b/lib/cli/src/cli.rs
@@ -19,13 +19,19 @@ use clap::{ErrorKind, Parser};
 #[derive(Parser)]
 #[cfg_attr(
     not(feature = "headless"),
-    clap(name = "wasmer", about = "WebAssembly standalone runtime.", author)
+    clap(
+        name = "wasmer",
+        about = "WebAssembly standalone runtime.",
+        version,
+        author
+    )
 )]
 #[cfg_attr(
     feature = "headless",
     clap(
         name = "wasmer-headless",
-        about = "Headless WebAssembly standalone runtime.",
+        about = "WebAssembly standalone runtime (headless).",
+        version,
         author
     )
 )]


### PR DESCRIPTION
WAPM update checks (and our install script) were failing because `wasmer --version` was not working (we accidentally removed version on #3079 )

This PR brings it back