### PR TITLE
Fixed a potential issue when renaming a file

### DIFF
--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -2656,6 +2656,18 @@ pub fn path_rename<M: MemorySize>(
         source_path.to_str().as_ref().unwrap(),
         true
     ));
+    if state
+        .fs
+        .get_inode_at_path(
+            inodes.deref_mut(),
+            new_fd,
+            target_path.to_str().as_ref().unwrap(),
+            true,
+        )
+        .is_ok()
+    {
+        return __WASI_EEXIST;
+    }
     let (source_parent_inode, source_entry_name) =
         wasi_try!(state
             .fs


### PR DESCRIPTION
Fixed a potential issue when renaming a file and the destination is from a preopened dir and already exist (for #3084)
