### PR TITLE
MemoryView lifetime tied to memory and not StoreRef

### DIFF
--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -11,7 +11,7 @@ use std::slice;
 #[cfg(feature = "tracing")]
 use tracing::warn;
 use wasmer_types::Pages;
-use wasmer_vm::{InternalStoreHandle, MemoryError, StoreHandle, StoreObjects, VMExtern, VMMemory};
+use wasmer_vm::{InternalStoreHandle, MemoryError, StoreHandle, VMExtern, VMMemory};
 
 use super::MemoryView;
 
@@ -79,7 +79,7 @@ impl Memory {
 
     /// Creates a view into the memory that then allows for
     /// read and write
-    pub fn view<'a>(&self, store: &'a impl AsStoreRef) -> MemoryView<'a> {
+    pub fn view<'a>(&'a self, store: &impl AsStoreRef) -> MemoryView<'a> {
         MemoryView::new(self, store)
     }
 
@@ -169,7 +169,7 @@ impl<'a> Exportable<'a> for Memory {
 pub(crate) struct MemoryBuffer<'a> {
     pub(crate) base: *mut u8,
     pub(crate) len: usize,
-    pub(crate) marker: PhantomData<(&'a MemoryView<'a>, &'a StoreObjects)>,
+    pub(crate) marker: PhantomData<&'a MemoryView<'a>>,
 }
 
 impl<'a> MemoryBuffer<'a> {

--- a/lib/api/src/sys/externals/memory_view.rs
+++ b/lib/api/src/sys/externals/memory_view.rs
@@ -22,7 +22,7 @@ pub struct MemoryView<'a> {
 }
 
 impl<'a> MemoryView<'a> {
-    pub(crate) fn new(memory: &Memory, store: &'a impl AsStoreRef) -> Self {
+    pub(crate) fn new(memory: &'a Memory, store: &impl AsStoreRef) -> Self {
         let size = memory.handle.get(store.as_store_ref().objects()).size();
 
         let definition = memory.handle.get(store.as_store_ref().objects()).vmmemory();

--- a/lib/emscripten/src/env/mod.rs
+++ b/lib/emscripten/src/env/mod.rs
@@ -75,17 +75,15 @@ pub fn ___build_environment(mut ctx: FunctionEnvMut<EmEnv>, environ: c_int) {
     debug!("emscripten::___build_environment {}", environ);
     const MAX_ENV_VALUES: u32 = 64;
     const TOTAL_ENV_SIZE: u32 = 1024;
-    let environment =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), environ) as *mut c_int;
+    let memory = ctx.data().memory(0);
+    let environment = emscripten_memory_pointer!(memory.view(&ctx), environ) as *mut c_int;
     let (mut pool_offset, env_ptr, mut pool_ptr) = unsafe {
         let (pool_offset, _pool_slice): (u32, &mut [u8]) =
             allocate_on_stack(&mut ctx, TOTAL_ENV_SIZE as u32);
         let (env_offset, _env_slice): (u32, &mut [u8]) =
             allocate_on_stack(&mut ctx, (MAX_ENV_VALUES * 4) as u32);
-        let env_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), env_offset) as *mut c_int;
-        let pool_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), pool_offset) as *mut u8;
+        let env_ptr = emscripten_memory_pointer!(memory.view(&ctx), env_offset) as *mut c_int;
+        let pool_ptr = emscripten_memory_pointer!(memory.view(&ctx), pool_offset) as *mut u8;
         *env_ptr = pool_offset as i32;
         *environment = env_offset as i32;
 
@@ -137,8 +135,8 @@ pub fn _pathconf(ctx: FunctionEnvMut<EmEnv>, path_addr: c_int, name: c_int) -> c
         "emscripten::_pathconf {} {} - UNIMPLEMENTED",
         path_addr, name
     );
-    let _path =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), path_addr) as *const c_char;
+    let memory = ctx.data().memory(0);
+    let _path = emscripten_memory_pointer!(memory.view(&ctx), path_addr) as *const c_char;
     match name {
         0 => 32000,
         1 | 2 | 3 => 255,

--- a/lib/emscripten/src/env/unix/mod.rs
+++ b/lib/emscripten/src/env/unix/mod.rs
@@ -17,8 +17,8 @@ use wasmer::{FunctionEnvMut, WasmPtr};
 pub fn _getenv(mut ctx: FunctionEnvMut<EmEnv>, name: i32) -> u32 {
     debug!("emscripten::_getenv");
 
-    let name_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), name) as *const c_char;
+    let memory = ctx.data().memory(0);
+    let name_addr = emscripten_memory_pointer!(memory.view(&ctx), name) as *const c_char;
 
     debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
 
@@ -34,10 +34,9 @@ pub fn _getenv(mut ctx: FunctionEnvMut<EmEnv>, name: i32) -> u32 {
 pub fn _setenv(ctx: FunctionEnvMut<EmEnv>, name: c_int, value: c_int, overwrite: c_int) -> c_int {
     debug!("emscripten::_setenv");
 
-    let name_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), name) as *const c_char;
-    let value_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), value) as *const c_char;
+    let memory = ctx.data().memory(0);
+    let name_addr = emscripten_memory_pointer!(memory.view(&ctx), name) as *const c_char;
+    let value_addr = emscripten_memory_pointer!(memory.view(&ctx), value) as *const c_char;
 
     debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
     debug!("=> value({:?})", unsafe { CStr::from_ptr(value_addr) });
@@ -49,8 +48,8 @@ pub fn _setenv(ctx: FunctionEnvMut<EmEnv>, name: c_int, value: c_int, overwrite:
 pub fn _putenv(ctx: FunctionEnvMut<EmEnv>, name: c_int) -> c_int {
     debug!("emscripten::_putenv");
 
-    let name_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), name) as *const c_char;
+    let memory = ctx.data().memory(0);
+    let name_addr = emscripten_memory_pointer!(memory.view(&ctx), name) as *const c_char;
 
     debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
 
@@ -61,8 +60,8 @@ pub fn _putenv(ctx: FunctionEnvMut<EmEnv>, name: c_int) -> c_int {
 pub fn _unsetenv(ctx: FunctionEnvMut<EmEnv>, name: c_int) -> c_int {
     debug!("emscripten::_unsetenv");
 
-    let name_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), name) as *const c_char;
+    let memory = ctx.data().memory(0);
+    let name_addr = emscripten_memory_pointer!(memory.view(&ctx), name) as *const c_char;
 
     debug!("=> name({:?})", unsafe { CStr::from_ptr(name_addr) });
 
@@ -86,8 +85,9 @@ pub fn _getpwnam(mut ctx: FunctionEnvMut<EmEnv>, name_ptr: c_int) -> c_int {
         pw_shell: u32,
     }
 
+    let memory = ctx.data().memory(0);
     let name = unsafe {
-        let memory = ctx.data().memory_view(0, &ctx);
+        let memory = memory.view(&ctx);
         let memory_name_ptr = emscripten_memory_pointer!(&memory, name_ptr) as *const c_char;
         CStr::from_ptr(memory_name_ptr)
     };
@@ -96,7 +96,7 @@ pub fn _getpwnam(mut ctx: FunctionEnvMut<EmEnv>, name_ptr: c_int) -> c_int {
         let passwd = &*libc_getpwnam(name.as_ptr());
         let passwd_struct_offset = call_malloc(&mut ctx, mem::size_of::<GuestPasswd>() as _);
 
-        let memory = ctx.data().memory_view(0, &ctx);
+        let memory = memory.view(&ctx);
         let passwd_struct_ptr =
             emscripten_memory_pointer!(&memory, passwd_struct_offset) as *mut GuestPasswd;
         (*passwd_struct_ptr).pw_name = copy_cstr_into_wasm(&mut ctx, passwd.pw_name);
@@ -123,9 +123,10 @@ pub fn _getgrnam(mut ctx: FunctionEnvMut<EmEnv>, name_ptr: c_int) -> c_int {
         gr_mem: u32,
     }
 
+    let memory = ctx.data().memory(0);
     let name = unsafe {
         let memory_name_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), name_ptr) as *const c_char;
+            emscripten_memory_pointer!(memory.view(&ctx), name_ptr) as *const c_char;
         CStr::from_ptr(memory_name_ptr)
     };
 
@@ -134,8 +135,7 @@ pub fn _getgrnam(mut ctx: FunctionEnvMut<EmEnv>, name_ptr: c_int) -> c_int {
         let group_struct_offset = call_malloc(&mut ctx, mem::size_of::<GuestGroup>() as _);
 
         let group_struct_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), group_struct_offset)
-                as *mut GuestGroup;
+            emscripten_memory_pointer!(memory.view(&ctx), group_struct_offset) as *mut GuestGroup;
         (*group_struct_ptr).gr_name = copy_cstr_into_wasm(&mut ctx, group.gr_name);
         (*group_struct_ptr).gr_passwd = copy_cstr_into_wasm(&mut ctx, group.gr_passwd);
         (*group_struct_ptr).gr_gid = group.gr_gid;
@@ -158,7 +158,8 @@ pub fn _gai_strerror(mut ctx: FunctionEnvMut<EmEnv>, ecode: i32) -> i32 {
     let cstr = unsafe { std::ffi::CStr::from_ptr(libc::gai_strerror(ecode)) };
     let bytes = cstr.to_bytes_with_nul();
     let string_on_guest: WasmPtr<c_char> = call_malloc_with_cast(&mut ctx, bytes.len() as _);
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let memory = memory.view(&ctx);
 
     let writer = string_on_guest.slice(&memory, bytes.len() as _).unwrap();
     for (i, byte) in bytes.iter().enumerate() {
@@ -195,10 +196,8 @@ pub fn _getaddrinfo(
     let hints = if hints_ptr.is_null() {
         None
     } else {
-        let hints_guest = hints_ptr
-            .deref(&ctx.data().memory_view(0, &ctx))
-            .read()
-            .unwrap();
+        let memory = ctx.data().memory(0);
+        let hints_guest = hints_ptr.deref(&memory.view(&ctx)).read().unwrap();
         Some(addrinfo {
             ai_flags: hints_guest.ai_flags,
             ai_family: hints_guest.ai_family,
@@ -252,7 +251,8 @@ pub fn _getaddrinfo(
 
             // connect list
             if let Some(prev_guest) = previous_guest_node {
-                let memory = ctx.data().memory_view(0, &ctx);
+                let memory = ctx.data().memory(0);
+                let memory = memory.view(&ctx);
                 let derefed_prev_guest = prev_guest.deref(&memory);
                 let mut pg = derefed_prev_guest.read().unwrap();
                 pg.ai_next = current_guest_node_ptr;
@@ -268,7 +268,8 @@ pub fn _getaddrinfo(
                 let guest_sockaddr_ptr: WasmPtr<EmSockAddr> =
                     call_malloc_with_cast(&mut ctx, host_addrlen as _);
 
-                let memory = ctx.data().memory_view(0, &ctx);
+                let memory = ctx.data().memory(0);
+                let memory = memory.view(&ctx);
                 let derefed_guest_sockaddr = guest_sockaddr_ptr.deref(&memory);
                 let mut gs = derefed_guest_sockaddr.read().unwrap();
                 gs.sa_family = (*host_sockaddr_ptr).sa_family as i16;
@@ -288,7 +289,8 @@ pub fn _getaddrinfo(
                     let guest_canonname: WasmPtr<c_char> =
                         call_malloc_with_cast(&mut ctx, str_size as _);
 
-                    let memory = ctx.data().memory_view(0, &ctx);
+                    let memory = ctx.data().memory(0);
+                    let memory = memory.view(&ctx);
                     let guest_canonname_writer =
                         guest_canonname.slice(&memory, str_size as _).unwrap();
                     for (i, b) in canonname_bytes.iter().enumerate() {
@@ -304,7 +306,8 @@ pub fn _getaddrinfo(
                 }
             };
 
-            let memory = ctx.data().memory_view(0, &ctx);
+            let memory = ctx.data().memory(0);
+            let memory = memory.view(&ctx);
             let derefed_current_guest_node = current_guest_node_ptr.deref(&memory);
             let mut cgn = derefed_current_guest_node.read().unwrap();
             cgn.ai_flags = (*current_host_node).ai_flags;
@@ -325,8 +328,9 @@ pub fn _getaddrinfo(
         head_of_list.unwrap_or_else(|| WasmPtr::new(0))
     };
 
+    let memory = ctx.data().memory(0);
     res_val_ptr
-        .deref(&ctx.data().memory_view(0, &ctx))
+        .deref(&memory.view(&ctx))
         .write(head_of_list)
         .unwrap();
 

--- a/lib/emscripten/src/env/windows/mod.rs
+++ b/lib/emscripten/src/env/windows/mod.rs
@@ -19,8 +19,9 @@ extern "C" {
 /// emscripten: _getenv // (name: *const char) -> *const c_char;
 pub fn _getenv(mut ctx: FunctionEnvMut<EmEnv>, name: u32) -> u32 {
     debug!("emscripten::_getenv");
-    let memory = ctx.data().memory_view(0, &ctx);
-    let name_string = read_string_from_wasm(&memory, name);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
+    let name_string = read_string_from_wasm(&view, name);
     debug!("=> name({:?})", name_string);
     let c_str = unsafe { getenv(name_string.as_ptr() as *const libc::c_char) };
     if c_str.is_null() {
@@ -32,10 +33,11 @@ pub fn _getenv(mut ctx: FunctionEnvMut<EmEnv>, name: u32) -> u32 {
 /// emscripten: _setenv // (name: *const char, name: *const value, overwrite: int);
 pub fn _setenv(ctx: FunctionEnvMut<EmEnv>, name: u32, value: u32, _overwrite: u32) -> c_int {
     debug!("emscripten::_setenv");
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
     // setenv does not exist on windows, so we hack it with _putenv
-    let name = read_string_from_wasm(&memory, name);
-    let value = read_string_from_wasm(&memory, value);
+    let name = read_string_from_wasm(&view, name);
+    let value = read_string_from_wasm(&view, value);
     let putenv_string = format!("{}={}", name, value);
     let putenv_cstring = CString::new(putenv_string).unwrap();
     let putenv_raw_ptr = putenv_cstring.as_ptr();
@@ -47,8 +49,9 @@ pub fn _setenv(ctx: FunctionEnvMut<EmEnv>, name: u32, value: u32, _overwrite: u3
 /// emscripten: _putenv // (name: *const char);
 pub fn _putenv(ctx: FunctionEnvMut<EmEnv>, name: c_int) -> c_int {
     debug!("emscripten::_putenv");
-    let memory = ctx.data().memory_view(0, &ctx);
-    let name_addr = emscripten_memory_pointer!(&memory, name) as *const c_char;
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
+    let name_addr = emscripten_memory_pointer!(&view, name) as *const c_char;
     debug!("=> name({:?})", unsafe {
         std::ffi::CStr::from_ptr(name_addr)
     });
@@ -58,8 +61,9 @@ pub fn _putenv(ctx: FunctionEnvMut<EmEnv>, name: c_int) -> c_int {
 /// emscripten: _unsetenv // (name: *const char);
 pub fn _unsetenv(ctx: FunctionEnvMut<EmEnv>, name: u32) -> c_int {
     debug!("emscripten::_unsetenv");
-    let memory = ctx.data().memory_view(0, &ctx);
-    let name = read_string_from_wasm(&memory, name);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
+    let name = read_string_from_wasm(&view, name);
     // no unsetenv on windows, so use putenv with an empty value
     let unsetenv_string = format!("{}=", name);
     let unsetenv_cstring = CString::new(unsetenv_string).unwrap();
@@ -88,9 +92,10 @@ pub fn _getpwnam(mut ctx: FunctionEnvMut<EmEnv>, name_ptr: c_int) -> c_int {
     // stub this in windows as it is not valid
     unsafe {
         let passwd_struct_offset = call_malloc(&mut ctx, mem::size_of::<GuestPasswd>() as _);
-        let memory = ctx.data().memory_view(0, &ctx);
+        let memory = ctx.data().memory(0);
+        let view = memory.view(&ctx);
         let passwd_struct_ptr =
-            emscripten_memory_pointer!(&memory, passwd_struct_offset) as *mut GuestPasswd;
+            emscripten_memory_pointer!(&view, passwd_struct_offset) as *mut GuestPasswd;
         (*passwd_struct_ptr).pw_name = 0;
         (*passwd_struct_ptr).pw_passwd = 0;
         (*passwd_struct_ptr).pw_gecos = 0;
@@ -120,9 +125,10 @@ pub fn _getgrnam(mut ctx: FunctionEnvMut<EmEnv>, name_ptr: c_int) -> c_int {
     // stub the group struct as it is not supported on windows
     unsafe {
         let group_struct_offset = call_malloc(&mut ctx, mem::size_of::<GuestGroup>() as _);
-        let memory = ctx.data().memory_view(0, &ctx);
+        let memory = ctx.data().memory(0);
+        let view = memory.view(&ctx);
         let group_struct_ptr =
-            emscripten_memory_pointer!(&memory, group_struct_offset) as *mut GuestGroup;
+            emscripten_memory_pointer!(&view, group_struct_offset) as *mut GuestGroup;
         (*group_struct_ptr).gr_name = 0;
         (*group_struct_ptr).gr_passwd = 0;
         (*group_struct_ptr).gr_gid = 0;

--- a/lib/emscripten/src/exec.rs
+++ b/lib/emscripten/src/exec.rs
@@ -7,7 +7,8 @@ use wasmer::{FunctionEnvMut, WasmPtr};
 
 pub fn execvp(ctx: FunctionEnvMut<EmEnv>, command_name_offset: u32, argv_offset: u32) -> i32 {
     // a single reference to re-use
-    let emscripten_memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let emscripten_memory = memory.view(&ctx);
 
     // read command name as string
     let command_name_string_vec = WasmPtr::<u8>::new(command_name_offset)

--- a/lib/emscripten/src/io/mod.rs
+++ b/lib/emscripten/src/io/mod.rs
@@ -28,9 +28,10 @@ pub fn getprotobynumber(_ctx: FunctionEnvMut<EmEnv>, _one: i32) -> i32 {
 /// sigdelset
 pub fn sigdelset(ctx: FunctionEnvMut<EmEnv>, set: i32, signum: i32) -> i32 {
     debug!("emscripten::sigdelset");
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
     #[allow(clippy::cast_ptr_alignment)]
-    let ptr = emscripten_memory_pointer!(&memory, set) as *mut i32;
+    let ptr = emscripten_memory_pointer!(&view, set) as *mut i32;
 
     unsafe { *ptr &= !(1 << (signum - 1)) }
 
@@ -40,9 +41,10 @@ pub fn sigdelset(ctx: FunctionEnvMut<EmEnv>, set: i32, signum: i32) -> i32 {
 /// sigfillset
 pub fn sigfillset(ctx: FunctionEnvMut<EmEnv>, set: i32) -> i32 {
     debug!("emscripten::sigfillset");
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
     #[allow(clippy::cast_ptr_alignment)]
-    let ptr = emscripten_memory_pointer!(&memory, set) as *mut i32;
+    let ptr = emscripten_memory_pointer!(&view, set) as *mut i32;
 
     unsafe {
         *ptr = -1;

--- a/lib/emscripten/src/io/unix.rs
+++ b/lib/emscripten/src/io/unix.rs
@@ -15,7 +15,7 @@ pub fn putchar(_ctx: FunctionEnvMut<EmEnv>, chr: i32) {
 pub fn printf(ctx: FunctionEnvMut<EmEnv>, memory_offset: i32, extra: i32) -> i32 {
     debug!("emscripten::printf {}, {}", memory_offset, extra);
     unsafe {
-        let addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), memory_offset) as _;
+        let addr = emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), memory_offset) as _;
         _printf(addr, extra)
     }
 }
@@ -23,7 +23,7 @@ pub fn printf(ctx: FunctionEnvMut<EmEnv>, memory_offset: i32, extra: i32) -> i32
 /// chroot
 pub fn chroot(ctx: FunctionEnvMut<EmEnv>, name_ptr: i32) -> i32 {
     debug!("emscripten::chroot");
-    let name = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), name_ptr) as *const i8;
+    let name = emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), name_ptr) as *const i8;
     unsafe { _chroot(name as *const _) }
 }
 
@@ -47,7 +47,7 @@ pub fn getpwuid(mut ctx: FunctionEnvMut<EmEnv>, uid: i32) -> i32 {
         let passwd = &*_getpwuid(uid as _);
         let passwd_struct_offset = call_malloc(&mut ctx, mem::size_of::<GuestPasswd>() as _);
         let passwd_struct_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), passwd_struct_offset)
+            emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), passwd_struct_offset)
                 as *mut GuestPasswd;
         assert_eq!(
             passwd_struct_ptr as usize % std::mem::align_of::<GuestPasswd>(),

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -23,9 +23,9 @@ use std::f64;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 use wasmer::{
-    imports, namespace, AsStoreMut, AsStoreRef, ExportError, Exports, Function, FunctionEnv,
-    FunctionEnvMut, FunctionType, Global, Imports, Instance, Memory, MemoryType, MemoryView,
-    Module, Pages, RuntimeError, Table, TableType, TypedFunction, Value, WasmPtr,
+    imports, namespace, AsStoreMut, ExportError, Exports, Function, FunctionEnv, FunctionEnvMut,
+    FunctionType, Global, Imports, Instance, Memory, MemoryType, Module, Pages, RuntimeError,
+    Table, TableType, TypedFunction, Value, WasmPtr,
 };
 use wasmer_types::Type as ValType;
 
@@ -106,11 +106,6 @@ impl EmEnv {
     /// Get a reference to the memory
     pub fn memory(&self, _mem_idx: u32) -> Memory {
         (&*self.memory.read().unwrap()).as_ref().cloned().unwrap()
-    }
-
-    /// Get a reference to the memory view
-    pub fn memory_view<'a>(&self, mem_idx: u32, store: &'a impl AsStoreRef) -> MemoryView<'a> {
-        self.memory(mem_idx).view(store)
     }
 
     pub fn set_functions(&mut self, funcs: EmscriptenFunctions) {

--- a/lib/emscripten/src/libc.rs
+++ b/lib/emscripten/src/libc.rs
@@ -52,7 +52,8 @@ pub fn killpg(_ctx: FunctionEnvMut<EmEnv>, _a: i32, _b: i32) -> i32 {
 #[cfg(unix)]
 pub fn pathconf(ctx: FunctionEnvMut<EmEnv>, path_ptr: i32, name: i32) -> i32 {
     debug!("emscripten::pathconf");
-    let path = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), path_ptr) as *const i8;
+    let memory = ctx.data().memory(0);
+    let path = emscripten_memory_pointer!(memory.view(&ctx), path_ptr) as *const i8;
     unsafe { libc::pathconf(path as *const _, name).try_into().unwrap() }
 }
 

--- a/lib/emscripten/src/memory.rs
+++ b/lib/emscripten/src/memory.rs
@@ -11,9 +11,9 @@ pub fn _emscripten_memcpy_big(ctx: FunctionEnvMut<EmEnv>, dest: u32, src: u32, l
         "emscripten::_emscripten_memcpy_big {}, {}, {}",
         dest, src, len
     );
-    let dest_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), dest) as *mut c_void;
-    let src_addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), src) as *mut c_void;
+    let memory = ctx.data().memory(0);
+    let dest_addr = emscripten_memory_pointer!(memory.view(&ctx), dest) as *mut c_void;
+    let src_addr = emscripten_memory_pointer!(memory.view(&ctx), src) as *mut c_void;
     unsafe {
         memcpy(dest_addr, src_addr, len as size_t);
     }
@@ -21,7 +21,8 @@ pub fn _emscripten_memcpy_big(ctx: FunctionEnvMut<EmEnv>, dest: u32, src: u32, l
 }
 
 fn get_heap_size(ctx: &FunctionEnvMut<EmEnv>) -> u32 {
-    ctx.data().memory_view(0, &ctx).size().bytes().0 as u32
+    let memory = ctx.data().memory(0);
+    memory.view(&ctx).size().bytes().0 as u32
 }
 
 /// emscripten: _emscripten_get_heap_size
@@ -43,7 +44,8 @@ fn align_up(mut val: usize, multiple: usize) -> usize {
 
 fn resize_heap(ctx: &mut FunctionEnvMut<EmEnv>, requested_size: u32) -> u32 {
     debug!("emscripten::_emscripten_resize_heap {}", requested_size);
-    let current_memory_pages = ctx.data().memory_view(0, &ctx).size();
+    let memory = ctx.data().memory(0);
+    let current_memory_pages = memory.view(&ctx).size();
     let current_memory = current_memory_pages.bytes().0 as u32;
 
     // implementation from emscripten
@@ -94,7 +96,8 @@ pub fn sbrk(mut ctx: FunctionEnvMut<EmEnv>, increment: i32) -> i32 {
 
     let dynamictop_ptr = WasmPtr::<i32>::new(top_ptr);
     let old_dynamic_top = {
-        let memory = ctx.data().memory_view(0, &ctx);
+        let memory = ctx.data().memory(0);
+        let memory = memory.view(&ctx);
         dynamictop_ptr.deref(&memory).read().unwrap()
     };
     let new_dynamic_top: i32 = old_dynamic_top + increment;
@@ -118,7 +121,8 @@ pub fn sbrk(mut ctx: FunctionEnvMut<EmEnv>, increment: i32) -> i32 {
         }
     }
     // re-borrow the top ptr
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let memory = memory.view(&ctx);
     let dynamictop_ptr = WasmPtr::<i32>::new(top_ptr).deref(&memory);
     dynamictop_ptr.write(new_dynamic_top).unwrap();
     old_dynamic_top as _
@@ -129,7 +133,8 @@ pub fn get_total_memory(ctx: FunctionEnvMut<EmEnv>) -> u32 {
     debug!("emscripten::get_total_memory");
     // instance.memories[0].current_pages()
     // TODO: Fix implementation
-    ctx.data().memory_view(0, &ctx).size().bytes().0 as u32
+    let memory = ctx.data().memory(0);
+    memory.view(&ctx).size().bytes().0 as u32
 }
 
 /// emscripten: enlargeMemory

--- a/lib/emscripten/src/signal.rs
+++ b/lib/emscripten/src/signal.rs
@@ -5,7 +5,8 @@ use wasmer::FunctionEnvMut;
 #[allow(clippy::cast_ptr_alignment)]
 pub fn _sigemptyset(ctx: FunctionEnvMut<EmEnv>, set: u32) -> i32 {
     debug!("emscripten::_sigemptyset");
-    let set_addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), set) as *mut u32;
+    let memory = ctx.data().memory(0);
+    let set_addr = emscripten_memory_pointer!(memory.view(&ctx), set) as *mut u32;
     unsafe {
         *set_addr = 0;
     }
@@ -25,7 +26,8 @@ pub fn _siginterrupt(_ctx: FunctionEnvMut<EmEnv>, _a: u32, _b: u32) -> i32 {
 #[allow(clippy::cast_ptr_alignment)]
 pub fn _sigaddset(ctx: FunctionEnvMut<EmEnv>, set: u32, signum: u32) -> i32 {
     debug!("emscripten::_sigaddset {}, {}", set, signum);
-    let set_addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), set) as *mut u32;
+    let memory = ctx.data().memory(0);
+    let set_addr = emscripten_memory_pointer!(memory.view(&ctx), set) as *mut u32;
     unsafe {
         *set_addr |= 1 << (signum - 1);
     }

--- a/lib/emscripten/src/syscalls/mod.rs
+++ b/lib/emscripten/src/syscalls/mod.rs
@@ -67,7 +67,8 @@ pub fn ___syscall3(ctx: FunctionEnvMut<EmEnv>, _which: i32, mut varargs: VarArgs
     let buf: u32 = varargs.get(&ctx);
     let count: i32 = varargs.get(&ctx);
     debug!("=> fd: {}, buf_offset: {}, count: {}", fd, buf, count);
-    let buf_addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), buf) as *mut c_void;
+    let memory = ctx.data().memory(0);
+    let buf_addr = emscripten_memory_pointer!(memory.view(&ctx), buf) as *mut c_void;
     let ret = unsafe { read(fd, buf_addr, count as _) };
     debug!("=> ret: {}", ret);
     ret as _
@@ -80,8 +81,8 @@ pub fn ___syscall4(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: VarAr
     let buf: i32 = varargs.get(&ctx);
     let count: i32 = varargs.get(&ctx);
     debug!("=> fd: {}, buf: {}, count: {}", fd, buf, count);
-    let buf_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), buf) as *const c_void;
+    let memory = ctx.data().memory(0);
+    let buf_addr = emscripten_memory_pointer!(memory.view(&ctx), buf) as *const c_void;
     unsafe { write(fd, buf_addr, count as _) as i32 }
 }
 
@@ -209,7 +210,8 @@ pub fn ___syscall42(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: VarA
     // offset to a file descriptor, which contains a read end and write end, 2 integers
     let fd_offset: u32 = varargs.get(&ctx);
 
-    let emscripten_memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let emscripten_memory = memory.view(&ctx);
 
     // convert the file descriptor into a vec with two slots
     let mut fd_vec: [c_int; 2] = WasmPtr::<[c_int; 2]>::new(fd_offset)
@@ -355,7 +357,8 @@ pub fn ___syscall183(mut ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs:
     let path = get_current_directory(ctx.as_mut());
     let path_string = path.unwrap().display().to_string();
     let len = path_string.len();
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let memory = memory.view(&ctx);
 
     let buf_writer = buf_offset.slice(&memory, len as u32 + 1).unwrap();
     for (i, byte) in path_string.bytes().enumerate() {
@@ -385,8 +388,8 @@ pub fn ___syscall192(mut ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs:
             // ENOMEM
             return -12;
         }
-        let real_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), ptr) as *const u8;
+        let memory = ctx.data().memory(0);
+        let real_ptr = emscripten_memory_pointer!(memory.view(&ctx), ptr) as *const u8;
         env::call_memset(&mut ctx, ptr, 0, len);
         for i in 0..(len as usize) {
             unsafe {
@@ -412,7 +415,8 @@ pub fn ___syscall140(ctx: FunctionEnvMut<EmEnv>, _which: i32, mut varargs: VarAr
     let whence: i32 = varargs.get(&ctx);
     let offset = offset_low;
     let ret = unsafe { lseek(fd, offset as _, whence) as i64 };
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let memory = memory.view(&ctx);
 
     let result_ptr = result_ptr_value.deref(&memory);
     result_ptr.write(ret).unwrap();
@@ -449,13 +453,11 @@ pub fn ___syscall145(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     let mut ret = 0;
     unsafe {
         for i in 0..iovcnt {
+            let memory = ctx.data().memory(0);
             let guest_iov_addr =
-                emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), (iov + i * 8))
-                    as *mut GuestIovec;
-            let iov_base = emscripten_memory_pointer!(
-                ctx.data().memory_view(0, &ctx),
-                (*guest_iov_addr).iov_base
-            ) as *mut c_void;
+                emscripten_memory_pointer!(memory.view(&ctx), (iov + i * 8)) as *mut GuestIovec;
+            let iov_base = emscripten_memory_pointer!(memory.view(&ctx), (*guest_iov_addr).iov_base)
+                as *mut c_void;
             let iov_len = (*guest_iov_addr).iov_len as _;
             // debug!("=> iov_addr: {:?}, {:?}", iov_base, iov_len);
             let curr = read(fd, iov_base, iov_len);
@@ -488,13 +490,11 @@ pub fn ___syscall146(ctx: FunctionEnvMut<EmEnv>, _which: i32, mut varargs: VarAr
     let mut ret = 0;
     for i in 0..iovcnt {
         unsafe {
+            let memory = ctx.data().memory(0);
             let guest_iov_addr =
-                emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), (iov + i * 8))
-                    as *mut GuestIovec;
-            let iov_base = emscripten_memory_pointer!(
-                ctx.data().memory_view(0, &ctx),
-                (*guest_iov_addr).iov_base
-            ) as *const c_void;
+                emscripten_memory_pointer!(memory.view(&ctx), (iov + i * 8)) as *mut GuestIovec;
+            let iov_base = emscripten_memory_pointer!(memory.view(&ctx), (*guest_iov_addr).iov_base)
+                as *const c_void;
             let iov_len = (*guest_iov_addr).iov_len as _;
             // debug!("=> iov_addr: {:?}, {:?}", iov_base, iov_len);
             let curr = write(fd, iov_base, iov_len);
@@ -522,8 +522,8 @@ pub fn ___syscall191(ctx: FunctionEnvMut<EmEnv>, _which: i32, mut varargs: VarAr
         _resource
     );
     let rlim_emptr: i32 = varargs.get(&ctx);
-    let rlim_ptr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), rlim_emptr) as *mut u8;
+    let memory = ctx.data().memory(0);
+    let rlim_ptr = emscripten_memory_pointer!(memory.view(&ctx), rlim_emptr) as *mut u8;
     let rlim = unsafe { slice::from_raw_parts_mut(rlim_ptr, 16) };
 
     // set all to RLIM_INIFINTY
@@ -727,8 +727,8 @@ pub fn ___syscall340(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
 
     if old_limit != 0 {
         // just report no limits
-        let buf_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), old_limit) as *mut u8;
+        let memory = ctx.data().memory(0);
+        let buf_ptr = emscripten_memory_pointer!(memory.view(&ctx), old_limit) as *mut u8;
         let buf = unsafe { slice::from_raw_parts_mut(buf_ptr, 16) };
 
         LittleEndian::write_i64(&mut *buf, val);

--- a/lib/emscripten/src/syscalls/unix.rs
+++ b/lib/emscripten/src/syscalls/unix.rs
@@ -202,9 +202,9 @@ pub fn ___syscall77(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: VarA
 
     let resource: c_int = varargs.get(&ctx);
     let rusage_ptr: c_int = varargs.get(&ctx);
+    let memory = ctx.data().memory(0);
     #[allow(clippy::cast_ptr_alignment)]
-    let rusage =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), rusage_ptr) as *mut rusage;
+    let rusage = emscripten_memory_pointer!(memory.view(&ctx), rusage_ptr) as *mut rusage;
     assert_eq!(8, mem::align_of_val(&rusage));
     unsafe { getrusage(resource, rusage) }
 }
@@ -312,8 +312,9 @@ pub fn ___syscall205(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     let ngroups_max: c_int = varargs.get(&ctx);
     let groups: c_int = varargs.get(&ctx);
 
+    let memory = ctx.data().memory(0);
     #[allow(clippy::cast_ptr_alignment)]
-    let gid_ptr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), groups) as *mut gid_t;
+    let gid_ptr = emscripten_memory_pointer!(memory.view(&ctx), groups) as *mut gid_t;
     assert_eq!(4, mem::align_of_val(&gid_ptr));
     let result = unsafe { getgroups(ngroups_max, gid_ptr) };
     debug!(
@@ -348,7 +349,8 @@ pub fn ___syscall219(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     let len: usize = varargs.get(&ctx);
     let advice: c_int = varargs.get(&ctx);
 
-    let addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), addr_ptr) as *mut c_void;
+    let memory = ctx.data().memory(0);
+    let addr = emscripten_memory_pointer!(memory.view(&ctx), addr_ptr) as *mut c_void;
 
     unsafe { madvise(addr, len, advice) }
 }
@@ -487,8 +489,8 @@ pub fn ___syscall54(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: VarA
         WASM_FIOCLEX | WASM_FIONBIO | WASM_TIOCGWINSZ | WASM_TIOCSPGRP | WASM_TCGETS
         | WASM_TCSETSW => {
             let argp: u32 = varargs.get(&ctx);
-            let argp_ptr =
-                emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), argp) as *mut c_void;
+            let memory = ctx.data().memory(0);
+            let argp_ptr = emscripten_memory_pointer!(memory.view(&ctx), argp) as *mut c_void;
             let translated_request = translate_ioctl(request);
             let ret = unsafe { ioctl(fd, translated_request as _, argp_ptr) };
             debug!(
@@ -522,7 +524,8 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     debug!("emscripten::___syscall102 (socketcall) {}", _which);
     let call: u32 = varargs.get(&ctx);
     let mut socket_varargs: VarArgs = varargs.get(&ctx);
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
 
     // migrating to EmSockAddr, port being separate here is nice, should update that too
     #[repr(C)]
@@ -587,7 +590,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let socket = socket_varargs.get(&ctx);
             let address: u32 = socket_varargs.get(&ctx);
             let address_len = socket_varargs.get(&ctx);
-            let address = emscripten_memory_pointer!(&memory, address) as *mut sockaddr;
+            let address = emscripten_memory_pointer!(&view, address) as *mut sockaddr;
 
             // Debug received address
             let _proper_address = address as *const GuestSockaddrIn;
@@ -612,7 +615,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let socket = socket_varargs.get(&ctx);
             let address: u32 = socket_varargs.get(&ctx);
             let address_len = socket_varargs.get(&ctx);
-            let address = emscripten_memory_pointer!(&memory, address) as *mut sockaddr;
+            let address = emscripten_memory_pointer!(&view, address) as *mut sockaddr;
             unsafe { connect(socket, address, address_len) }
         }
         4 => {
@@ -637,10 +640,10 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             debug!(
                 "=> socket: {}, address: {:?}, address_len: {}",
                 socket,
-                address.deref(&memory).read().unwrap(),
-                address_len.deref(&memory).read().unwrap()
+                address.deref(&view).read().unwrap(),
+                address_len.deref(&view).read().unwrap()
             );
-            let mut address_len_addr = address_len.deref(&memory).read().unwrap();
+            let mut address_len_addr = address_len.deref(&view).read().unwrap();
             // let mut address_len_addr: socklen_t = 0;
 
             let mut host_address: sockaddr = sockaddr {
@@ -650,7 +653,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
                 sa_len: Default::default(),
             };
             let fd = unsafe { accept(socket, &mut host_address, &mut address_len_addr) };
-            let mut address_addr = address.deref(&memory).read().unwrap();
+            let mut address_addr = address.deref(&view).read().unwrap();
 
             address_addr.sa_family = host_address.sa_family as _;
             address_addr.sa_data = host_address.sa_data;
@@ -674,7 +677,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let socket: i32 = socket_varargs.get(&ctx);
             let address: WasmPtr<EmSockAddr> = socket_varargs.get(&ctx);
             let address_len: WasmPtr<u32> = socket_varargs.get(&ctx);
-            let address_len_addr = address_len.deref(&memory).read().unwrap();
+            let address_len_addr = address_len.deref(&view).read().unwrap();
 
             let mut sock_addr_host: sockaddr = sockaddr {
                 sa_family: Default::default(),
@@ -690,7 +693,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
                 )
             };
             // translate from host data into emscripten data
-            let mut address_mut = address.deref(&memory).read().unwrap();
+            let mut address_mut = address.deref(&view).read().unwrap();
             address_mut.sa_family = sock_addr_host.sa_family as _;
             address_mut.sa_data = sock_addr_host.sa_data;
 
@@ -707,9 +710,8 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let socket = socket_varargs.get(&ctx);
             let address: u32 = socket_varargs.get(&ctx);
             let address_len: u32 = socket_varargs.get(&ctx);
-            let address = emscripten_memory_pointer!(memory, address) as *mut sockaddr;
-            let address_len_addr =
-                emscripten_memory_pointer!(memory, address_len) as *mut socklen_t;
+            let address = emscripten_memory_pointer!(view, address) as *mut sockaddr;
+            let address_len_addr = emscripten_memory_pointer!(view, address_len) as *mut socklen_t;
             unsafe { getpeername(socket, address, address_len_addr) }
         }
         11 => {
@@ -721,8 +723,8 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let len: i32 = socket_varargs.get(&ctx);
             let address: u32 = socket_varargs.get(&ctx);
             let address_len = socket_varargs.get(&ctx);
-            let buf_addr = emscripten_memory_pointer!(memory, buf) as _;
-            let address = emscripten_memory_pointer!(memory, address) as *mut sockaddr;
+            let buf_addr = emscripten_memory_pointer!(view, buf) as _;
+            let address = emscripten_memory_pointer!(view, address) as *mut sockaddr;
             unsafe { sendto(socket, buf_addr, flags, len, address, address_len) as i32 }
         }
         12 => {
@@ -734,10 +736,9 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let flags: i32 = socket_varargs.get(&ctx);
             let address: u32 = socket_varargs.get(&ctx);
             let address_len: u32 = socket_varargs.get(&ctx);
-            let buf_addr = emscripten_memory_pointer!(memory, buf) as _;
-            let address = emscripten_memory_pointer!(memory, address) as *mut sockaddr;
-            let address_len_addr =
-                emscripten_memory_pointer!(memory, address_len) as *mut socklen_t;
+            let buf_addr = emscripten_memory_pointer!(view, buf) as _;
+            let address = emscripten_memory_pointer!(view, address) as *mut sockaddr;
+            let address_len_addr = emscripten_memory_pointer!(view, address_len) as *mut socklen_t;
             unsafe {
                 recvfrom(
                     socket,
@@ -761,7 +762,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let untranslated_name: i32 = socket_varargs.get(&ctx);
             let value: u32 = socket_varargs.get(&ctx);
             let option_len: u32 = socket_varargs.get(&ctx);
-            let value_addr = emscripten_memory_pointer!(memory, value) as *const libc::c_void;
+            let value_addr = emscripten_memory_pointer!(view, value) as *const libc::c_void;
             let name: i32 = translate_socket_name_flag(untranslated_name);
 
             let ret = unsafe { setsockopt(socket, level, name, value_addr, option_len) };
@@ -779,8 +780,8 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let name: i32 = translate_socket_name_flag(untranslated_name);
             let value: u32 = socket_varargs.get(&ctx);
             let option_len: u32 = socket_varargs.get(&ctx);
-            let value_addr = emscripten_memory_pointer!(memory, value) as _;
-            let option_len_addr = emscripten_memory_pointer!(memory, option_len) as *mut socklen_t;
+            let value_addr = emscripten_memory_pointer!(view, value) as _;
+            let option_len_addr = emscripten_memory_pointer!(view, option_len) as *mut socklen_t;
             unsafe { getsockopt(socket, level, name, value_addr, option_len_addr) }
         }
         16 => {
@@ -789,7 +790,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let socket: i32 = socket_varargs.get(&ctx);
             let msg: u32 = socket_varargs.get(&ctx);
             let flags: i32 = socket_varargs.get(&ctx);
-            let msg_addr = emscripten_memory_pointer!(memory, msg) as *const msghdr;
+            let msg_addr = emscripten_memory_pointer!(view, msg) as *const msghdr;
             unsafe { sendmsg(socket, msg_addr, flags) as i32 }
         }
         17 => {
@@ -798,7 +799,7 @@ pub fn ___syscall102(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
             let socket: i32 = socket_varargs.get(&ctx);
             let msg: u32 = socket_varargs.get(&ctx);
             let flags: i32 = socket_varargs.get(&ctx);
-            let msg_addr = emscripten_memory_pointer!(memory, msg) as *mut msghdr;
+            let msg_addr = emscripten_memory_pointer!(view, msg) as *mut msghdr;
             unsafe { recvmsg(socket, msg_addr, flags) as i32 }
         }
         _ => {
@@ -860,9 +861,10 @@ pub fn ___syscall168(ctx: FunctionEnvMut<EmEnv>, _which: i32, mut varargs: VarAr
     let fds: WasmPtr<EmPollFd> = varargs.get(&ctx);
     let nfds: u32 = varargs.get(&ctx);
     let timeout: i32 = varargs.get(&ctx);
-    let memory = ctx.data().memory_view(0, &ctx);
+    let memory = ctx.data().memory(0);
+    let view = memory.view(&ctx);
 
-    let mut fds_mut = fds.deref(&memory).read().unwrap();
+    let mut fds_mut = fds.deref(&view).read().unwrap();
 
     unsafe {
         libc::poll(
@@ -885,7 +887,7 @@ pub fn ___syscall180(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     }
     let offset: i64 = varargs.get(&ctx);
 
-    let buf_ptr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), buf) as _;
+    let buf_ptr = emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), buf) as _;
 
     unsafe { pread(fd, buf_ptr, count as _, offset) as _ }
 }
@@ -902,7 +904,7 @@ pub fn ___syscall181(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     }
     let offset: i64 = varargs.get(&ctx);
 
-    let buf_ptr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), buf) as _;
+    let buf_ptr = emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), buf) as _;
     let status = unsafe { pwrite(fd, buf_ptr, count as _, offset) as _ };
     debug!(
         "=> fd: {}, buf: {}, count: {}, offset: {} = status:{}",
@@ -927,11 +929,10 @@ pub fn ___syscall114(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     let status: u32 = varargs.get(&ctx);
     let options: c_int = varargs.get(&ctx);
     let rusage: u32 = varargs.get(&ctx);
-    let status_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), status) as *mut c_int;
+    let memory = ctx.data().memory(0);
+    let status_addr = emscripten_memory_pointer!(memory.view(&ctx), status) as *mut c_int;
 
-    let rusage_addr =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), rusage) as *mut rusage;
+    let rusage_addr = emscripten_memory_pointer!(memory.view(&ctx), rusage) as *mut rusage;
     let res = unsafe { wait4(pid, status_addr, options, rusage_addr) };
     debug!(
         "=> pid: {}, status: {:?}, options: {}, rusage: {:?} = pid: {}",
@@ -964,8 +965,9 @@ pub fn ___syscall142(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     }
     assert!(exceptfds == 0, "`exceptfds` is not supporrted");
 
-    let readfds_ptr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), readfds) as _;
-    let writefds_ptr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), writefds) as _;
+    let memory = ctx.data().memory(0);
+    let readfds_ptr = emscripten_memory_pointer!(memory.view(&ctx), readfds) as _;
+    let writefds_ptr = emscripten_memory_pointer!(memory.view(&ctx), writefds) as _;
 
     unsafe { select(nfds, readfds_ptr, writefds_ptr, 0 as _, 0 as _) }
 }
@@ -1000,7 +1002,7 @@ pub fn ___syscall122(ctx: FunctionEnvMut<EmEnv>, _which: c_int, mut varargs: Var
     debug!("emscripten::___syscall122 (uname) {}", _which);
     let buf: u32 = varargs.get(&ctx);
     debug!("=> buf: {}", buf);
-    let buf_addr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), buf) as *mut utsname;
+    let buf_addr = emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), buf) as *mut utsname;
     unsafe { uname(buf_addr) }
 }
 
@@ -1059,7 +1061,7 @@ pub fn ___syscall220(ctx: FunctionEnvMut<EmEnv>, _which: i32, mut varargs: VarAr
         fd, dirp_addr, count
     );
 
-    let dirp = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), dirp_addr) as *mut u8;
+    let dirp = emscripten_memory_pointer!(ctx.data().memory(0).view(&ctx), dirp_addr) as *mut u8;
 
     let data = &mut get_emscripten_data(&ctx);
     let opened_dirs = &mut data.as_mut().unwrap().opened_dirs;

--- a/lib/emscripten/src/syscalls/windows.rs
+++ b/lib/emscripten/src/syscalls/windows.rs
@@ -45,7 +45,8 @@ pub fn ___syscall5(mut ctx: FunctionEnvMut<EmEnv>, which: c_int, mut varargs: Va
             let _ = urandom_file.write_all(&random_bytes).unwrap();
             // put the file path string into wasm memory
             let urandom_file_offset = unsafe { copy_cstr_into_wasm(&mut ctx, ptr) };
-            let memory = ctx.data().memory_view(0, &ctx);
+            let mem = ctx.data().memory(0);
+            let memory = mem.view(&ctx);
             let raw_pointer_to_urandom_file =
                 emscripten_memory_pointer!(&memory, urandom_file_offset) as *const i8;
             let fd = unsafe { open(raw_pointer_to_urandom_file, flags, mode) };

--- a/lib/emscripten/src/time.rs
+++ b/lib/emscripten/src/time.rs
@@ -67,8 +67,9 @@ pub fn _gettimeofday(ctx: FunctionEnvMut<EmEnv>, tp: c_int, tz: c_int) -> c_int 
     unsafe {
         let now = SystemTime::now();
         let since_epoch = now.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        let memory = ctx.data().memory(0);
         let timeval_struct_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), tp) as *mut GuestTimeVal;
+            emscripten_memory_pointer!(memory.view(&ctx), tp) as *mut GuestTimeVal;
 
         (*timeval_struct_ptr).tv_sec = since_epoch.as_secs() as _;
         (*timeval_struct_ptr).tv_usec = since_epoch.subsec_nanos() as _;
@@ -108,8 +109,9 @@ pub fn _clock_gettime(ctx: FunctionEnvMut<EmEnv>, clk_id: clockid_t, tp: c_int) 
     };
 
     unsafe {
+        let memory = ctx.data().memory(0);
         let timespec_struct_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), tp) as *mut GuestTimeSpec;
+            emscripten_memory_pointer!(memory.view(&ctx), tp) as *mut GuestTimeSpec;
         (*timespec_struct_ptr).tv_sec = (duration / 1_000_000_000) as _;
         (*timespec_struct_ptr).tv_nsec = (duration % 1_000_000_000) as _;
     }
@@ -178,8 +180,8 @@ pub fn _tvset(mut _ctx: FunctionEnvMut<EmEnv>) {
 /// formats time as a C string
 #[allow(clippy::cast_ptr_alignment)]
 unsafe fn fmt_time(ctx: FunctionEnvMut<EmEnv>, time: u32) -> *const c_char {
-    let date =
-        &*(emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), time) as *mut guest_tm);
+    let memory = ctx.data().memory(0);
+    let date = &*(emscripten_memory_pointer!(memory.view(&ctx), time) as *mut guest_tm);
 
     let days = vec!["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
     let months = vec![
@@ -241,9 +243,9 @@ pub fn _localtime(mut ctx: FunctionEnvMut<EmEnv>, time_p: u32) -> c_int {
     // NOTE: emscripten seems to want tzset() called in this function
     //      https://stackoverflow.com/questions/19170721/real-time-awareness-of-timezone-change-in-localtime-vs-localtime-r
 
+    let memory = ctx.data().memory(0);
     let timespec = unsafe {
-        let time_p_addr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), time_p) as *mut i64;
+        let time_p_addr = emscripten_memory_pointer!(memory.view(&ctx), time_p) as *mut i64;
         let seconds = *time_p_addr;
         time::OffsetDateTime::from_unix_timestamp(seconds)
     };
@@ -251,8 +253,7 @@ pub fn _localtime(mut ctx: FunctionEnvMut<EmEnv>, time_p: u32) -> c_int {
     unsafe {
         let tm_struct_offset = env::call_malloc(&mut ctx, mem::size_of::<guest_tm>() as _);
         let tm_struct_ptr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), tm_struct_offset)
-                as *mut guest_tm;
+            emscripten_memory_pointer!(memory.view(&ctx), tm_struct_offset) as *mut guest_tm;
         // debug!(
         //     ">>>>>>> time = {}, {}, {}, {}, {}, {}, {}, {}",
         //     result_tm.tm_sec, result_tm.tm_min, result_tm.tm_hour, result_tm.tm_mday,
@@ -281,9 +282,9 @@ pub fn _localtime_r(ctx: FunctionEnvMut<EmEnv>, time_p: u32, result: u32) -> c_i
     // NOTE: emscripten seems to want tzset() called in this function
     //      https://stackoverflow.com/questions/19170721/real-time-awareness-of-timezone-change-in-localtime-vs-localtime-r
 
+    let memory = ctx.data().memory(0);
     unsafe {
-        let seconds =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), time_p) as *const i32;
+        let seconds = emscripten_memory_pointer!(memory.view(&ctx), time_p) as *const i32;
         let timespec = time::OffsetDateTime::from_unix_timestamp_nanos(*seconds as _);
 
         // debug!(
@@ -292,8 +293,7 @@ pub fn _localtime_r(ctx: FunctionEnvMut<EmEnv>, time_p: u32, result: u32) -> c_i
         //     result_tm.tm_mon, result_tm.tm_year, result_tm.tm_wday, result_tm.tm_yday,
         // );
 
-        let result_addr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), result) as *mut guest_tm;
+        let result_addr = emscripten_memory_pointer!(memory.view(&ctx), result) as *mut guest_tm;
 
         (*result_addr).tm_sec = timespec.second() as _;
         (*result_addr).tm_min = timespec.minute() as _;
@@ -317,8 +317,8 @@ pub fn _time(ctx: FunctionEnvMut<EmEnv>, time_p: u32) -> i32 {
     debug!("emscripten::_time {}", time_p);
 
     unsafe {
-        let time_p_addr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), time_p) as *mut i64;
+        let memory = ctx.data().memory(0);
+        let time_p_addr = emscripten_memory_pointer!(memory.view(&ctx), time_p) as *mut i64;
         libc_time(time_p_addr) as i32 // TODO review i64
     }
 }
@@ -347,8 +347,8 @@ pub fn _timegm(ctx: FunctionEnvMut<EmEnv>, time_ptr: u32) -> i32 {
     debug!("emscripten::_timegm {}", time_ptr);
 
     unsafe {
-        let time_p_addr =
-            emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), time_ptr) as *mut guest_tm;
+        let memory = ctx.data().memory(0);
+        let time_p_addr = emscripten_memory_pointer!(memory.view(&ctx), time_ptr) as *mut guest_tm;
 
         let x: *mut c_char = CString::new("").expect("CString::new failed").into_raw();
         let mut rust_tm = libc_tm {
@@ -405,13 +405,13 @@ pub fn _strftime(
         s_ptr, maxsize, format_ptr, tm_ptr
     );
 
+    let memory = ctx.data().memory(0);
     #[allow(clippy::cast_ptr_alignment)]
-    let s = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), s_ptr) as *mut c_char;
+    let s = emscripten_memory_pointer!(memory.view(&ctx), s_ptr) as *mut c_char;
     #[allow(clippy::cast_ptr_alignment)]
-    let format =
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), format_ptr) as *const c_char;
+    let format = emscripten_memory_pointer!(memory.view(&ctx), format_ptr) as *const c_char;
     #[allow(clippy::cast_ptr_alignment)]
-    let tm = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), tm_ptr) as *const guest_tm;
+    let tm = emscripten_memory_pointer!(memory.view(&ctx), tm_ptr) as *const guest_tm;
 
     let format_string = unsafe { std::ffi::CStr::from_ptr(format).to_str().unwrap() };
 

--- a/lib/emscripten/src/varargs.rs
+++ b/lib/emscripten/src/varargs.rs
@@ -13,7 +13,8 @@ pub struct VarArgs {
 
 impl VarArgs {
     pub fn get<T: Sized>(&mut self, ctx: &FunctionEnvMut<EmEnv>) -> T {
-        let ptr = emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), self.pointer);
+        let memory = ctx.data().memory(0);
+        let ptr = emscripten_memory_pointer!(memory.view(&ctx), self.pointer);
         self.pointer += mem::size_of::<T>() as u32;
         unsafe { (ptr as *const T).read() }
     }
@@ -21,7 +22,8 @@ impl VarArgs {
     // pub fn getStr<'a>(&mut self, ctx: &mut Ctx) -> &'a CStr {
     pub fn get_str(&mut self, ctx: &FunctionEnvMut<EmEnv>) -> *const c_char {
         let ptr_addr: u32 = self.get(ctx);
-        emscripten_memory_pointer!(ctx.data().memory_view(0, &ctx), ptr_addr) as *const c_char
+        let memory = ctx.data().memory(0);
+        emscripten_memory_pointer!(memory.view(&ctx), ptr_addr) as *const c_char
     }
 }
 


### PR DESCRIPTION
MemoryView lifetime tied to memory and not StoreRef

This make using MemoryView easier to use in Rust (with the Borrow checker) and still have some failsafe about the View lifetime.