### PR TITLE
Reenable tests for wasm32-wasi and make tests not fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,11 +196,12 @@ jobs:
         shell: bash
         run: |
           make build-wasmer
-     #- name: Build Wasmer binary on Wasm32-WASI without LLVM
-     #  if: matrix.build_wasm
-     #  shell: bash
-     #  run: |
-     #    make build-wasmer-wasm
+     - name: Build Wasmer binary on Wasm32-WASI without LLVM
+       if: matrix.build_wasm
+       shell: bash
+       run: |
+          rustup target add wasm32-wasi
+          make build-wasmer-wasm
       - name: Build Wapm binary
         run: |
           make build-wapm


### PR DESCRIPTION
Continouusly testing whether wasmer-build-wasm fails is necessary because we need to ship it in the cloudcompiler package, see https://github.com/wasmerio/wasmer/commit/842d511173d10dcf2cd738e294299d294603a036

This PR re-enables the CI test, but this time with `rustup target add wasm32-wasi` in front, so that the tests don't fail.