### PR TITLE
Fix static object signature deserialization

### DIFF
--- a/lib/api/src/sys/exports.rs
+++ b/lib/api/src/sys/exports.rs
@@ -183,18 +183,6 @@ impl Exports {
         }
     }
 
-    /// Like `get_with_generics` but with a WeakReference to the `InstanceRef` internally.
-    /// This is useful for passing data into Context data, for example.
-    pub fn get_with_generics_weak<'a, T, Args, Rets>(&'a self, name: &str) -> Result<T, ExportError>
-    where
-        Args: WasmTypeList,
-        Rets: WasmTypeList,
-        T: ExportableWithGenerics<'a, Args, Rets>,
-    {
-        let out: T = self.get_with_generics(name)?;
-        Ok(out)
-    }
-
     /// Get an export as an `Extern`.
     pub fn get_extern(&self, name: &str) -> Option<&Extern> {
         self.map.get(name)

--- a/lib/api/tests/sys_externals.rs
+++ b/lib/api/tests/sys_externals.rs
@@ -475,7 +475,7 @@ mod sys {
     //                 let module = Module::new(&store, wat)?;
     //                 let instance = Instance::new(&mut store, &module, &imports! {})?;
     //                 let f: TypedFunction<(i32, i32), i32> =
-    //                     instance.exports.get_with_generics_weak("sum")?;
+    //                     instance.exports.get("sum")?;
 
     //                 assert_eq!(f.call(&mut store, 4, 5)?, 9);
     //                 f

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -679,41 +679,27 @@ impl Artifact {
         let signature_registry = engine_inner.signatures();
         let mut sig_map: BTreeMap<SignatureIndex, VMSharedSignatureIndex> = BTreeMap::new();
 
-        let num_imported_functions = metadata.compile_info.module.num_imported_functions;
-        // set up the imported functions first...
-        for i in 0..num_imported_functions {
-            let sig_idx = metadata.compile_info.module.functions[FunctionIndex::new(i)];
-            let func_type = &metadata.compile_info.module.signatures[sig_idx];
-            let vm_shared_idx = signature_registry.register(func_type);
-            sig_map.insert(sig_idx, vm_shared_idx);
-        }
         // read finished functions in order now...
         for i in 0..num_finished_functions {
-            let local_func_idx = LocalFunctionIndex::new(i);
-            let func_idx = metadata.compile_info.module.func_index(local_func_idx);
-            let sig_idx = metadata.compile_info.module.functions[func_idx];
-            let func_type = &metadata.compile_info.module.signatures[sig_idx];
-            let vm_shared_idx = signature_registry.register(func_type);
-            sig_map.insert(sig_idx, vm_shared_idx);
-
             byte_buffer[0..WORD_SIZE]
                 .clone_from_slice(&bytes[cur_offset..(cur_offset + WORD_SIZE)]);
             let fp = FunctionBodyPtr(usize::from_ne_bytes(byte_buffer) as _);
             cur_offset += WORD_SIZE;
 
             // TODO: we can read back the length here if we serialize it. This will improve debug output.
-
             finished_functions.push(fp);
         }
 
-        let mut signatures: PrimaryMap<_, VMSharedSignatureIndex> = PrimaryMap::new();
-        for i in 0..(sig_map.len()) {
-            if let Some(shared_idx) = sig_map.get(&SignatureIndex::new(i)) {
-                signatures.push(*shared_idx);
-            } else {
-                panic!("Invalid data, missing sig idx; TODO: handle this error");
-            }
-        }
+        // We register all the signatures
+        let signatures = {
+            metadata
+                .compile_info
+                .module
+                .signatures
+                .values()
+                .map(|sig| signature_registry.register(sig))
+                .collect::<PrimaryMap<_, _>>()
+        };
 
         // read trampolines in order
         let mut finished_function_call_trampolines = PrimaryMap::new();

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -15,20 +15,15 @@ use crate::{Compiler, FunctionBodyData, ModuleTranslationState};
 use crate::{Engine, EngineInner};
 use enumset::EnumSet;
 #[cfg(any(feature = "static-artifact-create", feature = "static-artifact-load"))]
-use std::collections::BTreeMap;
-#[cfg(any(feature = "static-artifact-create", feature = "static-artifact-load"))]
 use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
 #[cfg(feature = "static-artifact-create")]
 use wasmer_object::{emit_compilation, emit_data, get_object_for_target, Object};
+#[cfg(any(feature = "static-artifact-create", feature = "static-artifact-load"))]
+use wasmer_types::compilation::symbols::{ModuleMetadata, ModuleMetadataSymbolRegistry};
 use wasmer_types::entity::{BoxedSlice, PrimaryMap};
 use wasmer_types::MetadataHeader;
-#[cfg(any(feature = "static-artifact-create", feature = "static-artifact-load"))]
-use wasmer_types::{
-    compilation::symbols::{ModuleMetadata, ModuleMetadataSymbolRegistry},
-    entity::EntityRef,
-};
 use wasmer_types::{
     CompileError, CpuFeature, DataInitializer, DeserializeError, FunctionIndex, LocalFunctionIndex,
     MemoryIndex, ModuleInfo, OwnedDataInitializer, SerializableModule, SerializeError,
@@ -677,10 +672,9 @@ impl Artifact {
 
         let engine_inner = engine.inner();
         let signature_registry = engine_inner.signatures();
-        let mut sig_map: BTreeMap<SignatureIndex, VMSharedSignatureIndex> = BTreeMap::new();
 
         // read finished functions in order now...
-        for i in 0..num_finished_functions {
+        for _i in 0..num_finished_functions {
             byte_buffer[0..WORD_SIZE]
                 .clone_from_slice(&bytes[cur_offset..(cur_offset + WORD_SIZE)]);
             let fp = FunctionBodyPtr(usize::from_ne_bytes(byte_buffer) as _);


### PR DESCRIPTION
The current code was overly complex regarding signatures.

This PR simplifies it and removes the trailing `get_with_generics_weak` function in the exports