### PR TITLE
Revert "Lower libwasmer headless size"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ build-wasmer-headless-minimal: RUSTFLAGS += -C panic=abort
 build-wasmer-headless-minimal:
 	RUSTFLAGS="${RUSTFLAGS}" xargo build --target $(HOST_TARGET) --release --manifest-path=lib/cli/Cargo.toml --no-default-features --features headless-minimal --bin wasmer-headless
 ifeq ($(IS_DARWIN), 1)
-	strip target/$(HOST_TARGET)/release/wasmer-headless
+	strip -u target/$(HOST_TARGET)/release/wasmer-headless
 else ifeq ($(IS_WINDOWS), 1)
 	strip --strip-unneeded target/$(HOST_TARGET)/release/wasmer-headless.exe
 else
@@ -455,7 +455,7 @@ build-capi-llvm-universal: capi-setup
 # Headless (we include the minimal to be able to run)
 
 build-capi-headless: capi-setup
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort" $(CARGO_BINARY) build $(CARGO_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi
 
 build-capi-headless-ios: capi-setup

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 # a conflict with the existing `wasmer` crate, see below.
 name = "wasmer" # ##lib.name##
                 # ^ DO NOT REMOVE, it's used the `Makefile`, see `build-docs-capi`.
-crate-type = ["staticlib", "cdylib"] #"cdylib", "rlib", "staticlib"]
+crate-type = ["cdylib", "rlib", "staticlib"]
 
 [dependencies]
 # We rename `wasmer` to `wasmer-api` to avoid the conflict with this

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 readme = "README.md"
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 cfg-if = "1.0"
 thiserror = "1"


### PR DESCRIPTION
Reverts wasmerio/wasmer#3123 as is causing issues on master

The tests failing are: https://github.com/wasmerio/wasmer/runs/7970836325?check_suite_focus=true
