### PR TITLE
Bring libwasmer-headless.a from 22MiB to 7.2MiB (on my machine)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ build-wasmer-headless-minimal: RUSTFLAGS += -C panic=abort
 build-wasmer-headless-minimal:
 	RUSTFLAGS="${RUSTFLAGS}" xargo build --target $(HOST_TARGET) --release --manifest-path=lib/cli/Cargo.toml --no-default-features --features headless-minimal --bin wasmer-headless
 ifeq ($(IS_DARWIN), 1)
-	strip -u target/$(HOST_TARGET)/release/wasmer-headless
+	strip target/$(HOST_TARGET)/release/wasmer-headless
 else ifeq ($(IS_WINDOWS), 1)
 	strip --strip-unneeded target/$(HOST_TARGET)/release/wasmer-headless.exe
 else
@@ -455,8 +455,13 @@ build-capi-llvm-universal: capi-setup
 # Headless (we include the minimal to be able to run)
 
 build-capi-headless: capi-setup
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort" $(CARGO_BINARY) build $(CARGO_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+ifeq ($(CARGO_TARGET),)
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi
+else
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi
+endif
 
 build-capi-headless-ios: capi-setup
 	RUSTFLAGS="${RUSTFLAGS} -C panic=abort" cargo lipo --manifest-path lib/c-api/Cargo.toml --release \

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 # a conflict with the existing `wasmer` crate, see below.
 name = "wasmer" # ##lib.name##
                 # ^ DO NOT REMOVE, it's used the `Makefile`, see `build-docs-capi`.
-crate-type = ["cdylib", "rlib", "staticlib"]
+crate-type = ["staticlib", "cdylib"] #"cdylib", "rlib", "staticlib"]
 
 [dependencies]
 # We rename `wasmer` to `wasmer-api` to avoid the conflict with this

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -10,9 +10,6 @@ license = "MIT"
 readme = "README.md"
 edition = "2018"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
 cfg-if = "1.0"
 thiserror = "1"


### PR DESCRIPTION
By using lto optimization flags.

A qjs.wasm executable using the headless engine now weights 4.6MiB:

% du -sh qjs-he*.out
 20M    qjs-headfull.out
4.6M    qjs-headless.out

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
