### PR TITLE
Fix cache path not being present during installation of cross-tarball

### DIFF
--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -984,6 +984,7 @@ mod http_fetch {
                     .expect("Could not join downloading thread");
                 match super::get_libwasmer_cache_path() {
                     Ok(mut cache_path) => {
+                        let _ = std::fs::create_dir_all(&cache_path);
                         cache_path.push(&filename);
                         if !cache_path.exists() {
                             if let Err(err) = std::fs::copy(&filename, &cache_path) {


### PR DESCRIPTION
If the cache path didn't exist, downloading the x86_64-linux-gnu.tar.gz tarball would fail because the /cache directory did not exist, this PR fixes that.