### PR TITLE
Fix `wasmer compile` command for non-x86 target

### DIFF
--- a/lib/cli-compiler/src/commands/compile.rs
+++ b/lib/cli-compiler/src/commands/compile.rs
@@ -6,7 +6,8 @@ use std::path::{Path, PathBuf};
 use wasmer_compiler::{ArtifactBuild, ArtifactCreate, ModuleEnvironment};
 use wasmer_types::entity::PrimaryMap;
 use wasmer_types::{
-    CompileError, CpuFeature, MemoryIndex, MemoryStyle, TableIndex, TableStyle, Target, Triple,
+    Architecture, CompileError, CpuFeature, MemoryIndex, MemoryStyle, TableIndex, TableStyle,
+    Target, Triple,
 };
 
 #[derive(Debug, Parser)]
@@ -50,7 +51,9 @@ impl Compile {
                     .fold(CpuFeature::set(), |a, b| a | b);
                 // Cranelift requires SSE2, so we have this "hack" for now to facilitate
                 // usage
-                features |= CpuFeature::SSE2;
+                if target_triple.architecture == Architecture::X86_64 {
+                    features |= CpuFeature::SSE2;
+                }
                 Target::new(target_triple.clone(), features)
             })
             .unwrap_or_default();

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -46,7 +46,9 @@ impl Compile {
                     .fold(CpuFeature::set(), |a, b| a | b);
                 // Cranelift requires SSE2, so we have this "hack" for now to facilitate
                 // usage
-                features |= CpuFeature::SSE2;
+                if target_triple.architecture == Architecture::X86_64 {
+                    features |= CpuFeature::SSE2;
+                }
                 Target::new(target_triple.clone(), features)
             })
             .unwrap_or_default();


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Currently, `wasmer compile` command with specifying non-x86 (e.g. `aarch64-apple-darwin`) target doesn't work.
This change fixes the issue by not SSE2 to be force added for non-x86 targets.


(Codes are ported from https://github.com/wasmerio/wasmer/blob/8a6c98702f1b8b63f5ab3d1b8c094959dd325afe/lib/cli/src/commands/create_obj.rs#L80 and https://github.com/wasmerio/wasmer/blob/d4a888abed6d877d46bf040a932e693ab39940b9/lib/cli/src/commands/create_exe.rs#L151 )

Possibly relates https://github.com/wasmerio/wasmer/issues/2760#issuecomment-1045990643

## Demo

### Before
```sh
$ wasmer compile hello.wasm -o hello.wasmu
Compiler: cranelift
Target: aarch64-apple-darwin
✔ File compiled successfully to `hello.wasmu`.
$ wasmer run hello.wasmu
Hello
World!
$ wasmer compile --target aarch64-apple-darwin -o hello.wasmu hello.wasm
Compiler: cranelift
Target: aarch64-apple-darwin
✔ File compiled successfully to `hello.wasmu`.
$ wasmer run hello.wasmu 
error: failed to run `hello.wasmu`
│   1: failed to instantiate WASI module
╰─▶ 2: missing required CPU features: "EnumSet(SSE2)"
```

### After
```sh
$ wasmer compile --target aarch64-apple-darwin -o hello.wasmu hello.wasm
Compiler: cranelift
Target: aarch64-apple-darwin
✔ File compiled successfully to `hello.wasmu`.
$ wasmer run hello.wasmu 
Hello
World!
```

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
