### PR TITLE
Return 0 instead of BrokenPipe if WasiPipe cannot be read from

### DIFF
--- a/lib/wasi/src/state/pipe.rs
+++ b/lib/wasi/src/state/pipe.rs
@@ -106,12 +106,12 @@ impl Read for WasiPipe {
                 }
             }
             let rx = self.rx.lock().unwrap();
-            let data = rx.recv().map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    "the wasi pipe is not connected".to_string(),
-                )
-            })?;
+            let data = match rx.recv() {
+                Ok(o) => o,
+                Err(_) => {
+                    return Ok(0);
+                }
+            };
             self.read_buffer.replace(Bytes::from(data));
         }
     }

--- a/lib/wasi/src/state/pipe.rs
+++ b/lib/wasi/src/state/pipe.rs
@@ -2,7 +2,7 @@ use crate::syscalls::types::*;
 use crate::syscalls::{read_bytes, write_bytes};
 use bytes::{Buf, Bytes};
 use std::convert::TryInto;
-use std::io::{self, Read};
+use std::io::Read;
 use std::ops::DerefMut;
 use std::sync::mpsc;
 use std::sync::Mutex;


### PR DESCRIPTION
This is the correct behaviour, since the pipe isn't "broken", it just can't be read from anymore

Fixes #3171.