### PR TITLE
Fix typo xargo -> cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 ## Changed
 
 ## Fixed
-
+- [#3202](https://github.com/wasmerio/wasmer/pull/3202)  Fix typo so `make build-wasmer-headless-minimal` builds
 ## 3.0.0-beta.2 - 2022/09/26
 
 ## Added

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ ENABLE_LLVM ?=
 ENABLE_SINGLEPASS ?=
 
 # Which compilers we build. These have dependencies that may not be on the system.
-compilers := 
+compilers :=
 
 ##
 # Cranelift
@@ -255,7 +255,7 @@ comma := ,
 
 # Define the compiler Cargo features for all crates.
 compiler_features := --features $(subst $(space),$(comma),$(compilers)),wasmer-artifact-create,static-artifact-create,wasmer-artifact-load,static-artifact-load
-capi_compilers_engines_exclude := 
+capi_compilers_engines_exclude :=
 
 # Define the compiler Cargo features for the C API. It always excludes
 # LLVM for the moment because it causes the linker to fail since LLVM is not statically linked.
@@ -387,7 +387,7 @@ build-wasmer-wasm:
 # rpath = false
 build-wasmer-headless-minimal: RUSTFLAGS += -C panic=abort
 build-wasmer-headless-minimal:
-	RUSTFLAGS="${RUSTFLAGS}" xargo build --target $(HOST_TARGET) --release --manifest-path=lib/cli/Cargo.toml --no-default-features --features headless-minimal --bin wasmer-headless
+	RUSTFLAGS="${RUSTFLAGS}" cargo build --target $(HOST_TARGET) --release --manifest-path=lib/cli/Cargo.toml --no-default-features --features headless-minimal --bin wasmer-headless
 ifeq ($(IS_DARWIN), 1)
 	strip target/$(HOST_TARGET)/release/wasmer-headless
 else ifeq ($(IS_WINDOWS), 1)
@@ -608,7 +608,7 @@ package-capi:
 	if [ -f $(TARGET_DIR)/wasmer.dll ]; then \
 		cp $(TARGET_DIR)/wasmer.dll package/lib/wasmer.dll ;\
 	fi
-	
+
 	if [ -f $(TARGET_DIR)/wasmer.dll.lib ]; then \
 		cp $(TARGET_DIR)/wasmer.dll.lib package/lib/wasmer.dll.lib ;\
 	fi


### PR DESCRIPTION
Remove some unnecessary whitespace


# Description
Was trying to compile locally, and wanted to try out `build-wasmer-headless-minimal`, which initially failed due to a typo

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
