### PR TITLE
Seal `HostFunctionKind`

### DIFF
--- a/lib/api/src/sys/externals/function.rs
+++ b/lib/api/src/sys/externals/function.rs
@@ -1105,7 +1105,7 @@ mod inner {
     /// the trait system to automatically generate the appropriate
     /// host functions.
     #[doc(hidden)]
-    pub trait HostFunctionKind {}
+    pub trait HostFunctionKind: private::HostFunctionKindSealed {}
 
     /// An empty struct to help Rust typing to determine
     /// when a `HostFunction` does have an environment.


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
I noticed the `HostFunctionKind` trait was clearly intended to be sealed, but it actually isn't. This PR completes the sealing pattern. Feels like this is important to include in the 3.0.0 release to avoid subtle breaking changes.

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file
