### PR TITLE
Added Attach/Detach instance from a FunctionEnv (allow use of Instance from a function callback)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,11 @@ path = "examples/metering.rs"
 required-features = ["cranelift"]
 
 [[example]]
+name = "metering-callback"
+path = "examples/metering_callback.rs"
+required-features = ["cranelift"]
+
+[[example]]
 name = "imports-exports"
 path = "examples/imports_exports.rs"
 required-features = ["cranelift"]

--- a/docs/migration_to_3.0.0.md
+++ b/docs/migration_to_3.0.0.md
@@ -47,6 +47,8 @@ One of the main changes in 3.0.0 is that `Store` now owns all WebAssembly object
 
 If you define your own function, when the function is called it will hence need a reference to the store in order to access WebAssembly objects. This is achieved by the `StoreRef<'_>` and `StoreMut<'_>` types, which borrow from the store and provide access to its data. Furthermore, to prevent borrowing issues you can create new `StoreRef` and `StoreMut`s whenever you need to pass one at another function. This is done with the `AsStoreRef`, `AsStoreMut` traits.
 
+You can attach an instance to a FunctionEnv. After it's created, simply use `env.attach_instance(&mut store, &instance)`. Only one instance can be attached. Use `detach_instance(&mut store)` to detach any instance attached. To get the attached instance, use `env.get_instance(&store)`, or, for a `FunctionEnvMut`, simply `env.get_instance()`. This allows the use of instance from a function Callback.
+
 See the [examples] to find out how to do specific things in Wasmer 3.0.0.
 
 ## Project Structure

--- a/examples/metering_callback.rs
+++ b/examples/metering_callback.rs
@@ -1,0 +1,206 @@
+//! Wasmer will let you easily run Wasm module in a Rust host.
+//!
+//! This example illustrates the basics of using Wasmer metering features:
+//!
+//!   1. How to enable metering in a module
+//!   2. How to meter a specific function call
+//!   3. How to make execution fails if cost exceeds a given limit
+//!
+//! You can run the example directly by executing in Wasmer root:
+//!
+//! ```shell
+//! cargo run --example metering_callback --release --features "cranelift"
+//! ```
+//!
+//! Ready?
+
+use anyhow::bail;
+use std::sync::Arc;
+use wasmer::wasmparser::Operator;
+use wasmer::{imports, wat2wasm, EngineBuilder, Instance, Module, Store, TypedFunction};
+use wasmer::{CompilerConfig, Function, FunctionEnv, FunctionEnvMut};
+use wasmer_compiler_cranelift::Cranelift;
+use wasmer_middlewares::{
+    metering::{get_remaining_points, set_remaining_points, MeteringPoints},
+    Metering,
+};
+
+fn main() -> anyhow::Result<()> {
+    // Let's declare the Wasm module.
+    //
+    // We are using the text representation of the module here but you can also load `.wasm`
+    // files using the `include_bytes!` macro.
+    let wasm_bytes = wat2wasm(
+        br#"
+(module
+  (func $add_one_ext (import "env" "add_one_ext") (param i32) (result i32))
+  (type $add_t (func (param i32) (result i32)))
+  (func $add_one_f (type $add_t) (param $value i32) (result i32)
+    local.get $value
+    i32.const 1
+    i32.add)
+  (func $add_one_e (type $add_t) (param $value i32) (result i32)
+    local.get $value
+    call $add_one_ext)
+  (export "add_one" (func $add_one_f))
+  (export "add_one_ext" (func $add_one_e)))
+"#,
+    )?;
+
+    // Let's define our cost function.
+    //
+    // This function will be called for each `Operator` encountered during
+    // the Wasm module execution. It should return the cost of the operator
+    // that it received as it first argument.
+    let cost_function = |operator: &Operator| -> u64 {
+        match operator {
+            Operator::LocalGet { .. } | Operator::I32Const { .. } => 1,
+            Operator::I32Add { .. } => 2,
+            _ => 0,
+        }
+    };
+
+    // Create the functions
+    fn add_one_ext(mut env: FunctionEnvMut<()>, val: i32) -> i32 {
+        let new_limit = 20;
+        let instance = env.get_instance().expect("Instance not attached").clone();
+        set_remaining_points(&mut env, &instance, new_limit);
+        val + 1
+    }
+
+    // Now let's create our metering middleware.
+    //
+    // `Metering` needs to be configured with a limit and a cost function.
+    //
+    // For each `Operator`, the metering middleware will call the cost
+    // function and subtract the cost from the remaining points.
+    let metering = Arc::new(Metering::new(10, cost_function));
+    let mut compiler_config = Cranelift::default();
+    compiler_config.push_middleware(metering);
+
+    // Create a Store.
+    //
+    // We use our previously create compiler configuration
+    // with the Universal engine.
+    let mut store = Store::new(EngineBuilder::new(compiler_config));
+
+    println!("Compiling module...");
+    // Let's compile the Wasm module.
+    let module = Module::new(&store, wasm_bytes)?;
+
+    let mut env = FunctionEnv::new(&mut store, ());
+
+    // Create an empty import object.
+    // Create an import object.
+    let import_object = imports! {
+        "env" => {
+            "add_one_ext" => Function::new_typed_with_env(&mut store, &env, add_one_ext),
+        }
+    };
+
+    println!("Instantiating module...");
+    // Let's instantiate the Wasm module.
+    let instance = Instance::new(&mut store, &module, &import_object)?;
+    env.attach_instance(&mut store, &instance);
+
+    // We now have an instance ready to be used.
+    //
+    // Our module exports a `add_one`  function. We want to
+    // measure the cost of executing this function.
+    let add_one: TypedFunction<i32, i32> = instance
+        .exports
+        .get_function("add_one")?
+        .typed(&mut store)?;
+
+    println!("Calling `add_one` function once...");
+    add_one.call(&mut store, 1)?;
+
+    // As you can see here, after the first call we have 6 remaining points.
+    //
+    // This is correct, here are the details of how it has been computed:
+    // * `local.get $value` is a `Operator::LocalGet` which costs 1 point;
+    // * `i32.const` is a `Operator::I32Const` which costs 1 point;
+    // * `i32.add` is a `Operator::I32Add` which costs 2 points.
+    let remaining_points_after_first_call = get_remaining_points(&mut store, &instance);
+    assert_eq!(
+        remaining_points_after_first_call,
+        MeteringPoints::Remaining(6)
+    );
+
+    println!(
+        "Remaining points after the first call: {:?}",
+        remaining_points_after_first_call
+    );
+
+    println!("Calling `add_one` function twice...");
+    add_one.call(&mut store, 1)?;
+
+    // We spent 4 more points with the second call.
+    // We have 2 remaining points.
+    let remaining_points_after_second_call = get_remaining_points(&mut store, &instance);
+    assert_eq!(
+        remaining_points_after_second_call,
+        MeteringPoints::Remaining(2)
+    );
+
+    println!(
+        "Remaining points after the second call: {:?}",
+        remaining_points_after_second_call
+    );
+
+    // Because calling our `add_one` function consumes 4 points,
+    // calling it a third time will fail: we already consume 8
+    // points, there are only two remaining.
+    println!("Calling `add_one` function a third time...");
+    match add_one.call(&mut store, 1) {
+        Ok(result) => {
+            bail!(
+                "Expected failure while calling `add_one`, found: {}",
+                result
+            );
+        }
+        Err(_) => {
+            println!("Calling `add_one` failed.");
+
+            // Because the last needed more than the remaining points, we should have an error.
+            let remaining_points = get_remaining_points(&mut store, &instance);
+
+            match remaining_points {
+                MeteringPoints::Remaining(..) => {
+                    bail!("No metering error: there are remaining points")
+                }
+                MeteringPoints::Exhausted => println!("Not enough points remaining"),
+            }
+        }
+    }
+
+    // Now let's see how we can set a new limit...
+    println!("Set new remaining points to 10");
+    let new_limit = 10;
+    set_remaining_points(&mut store, &instance, new_limit);
+
+    let remaining_points = get_remaining_points(&mut store, &instance);
+    assert_eq!(remaining_points, MeteringPoints::Remaining(new_limit));
+
+    println!("Remaining points: {:?}", remaining_points);
+
+    // Our module also exports a `add_one_e` function.
+    // This one set the remain_points to 20
+    let add_one_set: TypedFunction<i32, i32> = instance
+        .exports
+        .get_function("add_one_ext")?
+        .typed(&mut store)?;
+    println!("Calling `add_one_ext` function...");
+    add_one_set.call(&mut store, 1);
+    let remaining_points = get_remaining_points(&mut store, &instance);
+    assert_eq!(remaining_points, MeteringPoints::Remaining(20));
+
+    println!("Remaining points: {:?}", remaining_points);
+
+    Ok(())
+}
+
+#[test]
+fn test_metering() -> anyhow::Result<()> {
+    main()
+}

--- a/lib/api/src/js/function_env.rs
+++ b/lib/api/src/js/function_env.rs
@@ -48,7 +48,8 @@ impl<T> FunctionEnv<T> {
     where
         T: Any + Send + 'static + Sized,
     {
-        &self.handle
+        &self
+            .handle
             .get(store.as_store_ref().objects())
             .as_ref()
             .downcast_ref::<FunctionEnvInner<T>>()
@@ -61,7 +62,8 @@ impl<T> FunctionEnv<T> {
     where
         T: Any + Send + 'static + Sized,
     {
-        &mut self.handle
+        &mut self
+            .handle
             .get_mut(store.objects_mut())
             .as_mut()
             .downcast_mut::<FunctionEnvInner<T>>()

--- a/lib/api/src/js/function_env.rs
+++ b/lib/api/src/js/function_env.rs
@@ -94,7 +94,7 @@ impl<T> FunctionEnv<T> {
             .instance = Some(unsafe { InstanceRef::from_instance(instance) });
     }
     /// Detach any instance to an FunctionEnv for a Store
-    pub fn detach_instance<'a>(&mut self, store: &'a mut impl AsStoreMut)
+    pub fn detach_instance(&mut self, store: &mut impl AsStoreMut)
     where
         T: Any + Send + 'static + Sized,
     {

--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -153,3 +153,48 @@ impl fmt::Debug for Instance {
             .finish()
     }
 }
+
+/// A handle holding an `Instance`, to be used inside Callback for example
+#[derive(Hash, PartialEq, Eq)]
+pub struct InstanceRef {
+    instance: *mut Instance,
+}
+
+unsafe impl Send for InstanceRef {}
+unsafe impl Sync for InstanceRef {}
+
+impl InstanceRef {
+    /// Create a new `InstanceHandle` pointing at the instance
+    #[allow(dead_code)]
+    pub(crate) unsafe fn from_instance(instance: &Instance) -> Self {
+        Self {
+            instance: instance as *const Instance as *mut Instance,
+        }
+    }
+    /// Return a reference to the contained `Instance`.
+    #[allow(dead_code)]
+    pub(crate) fn instance(&self) -> &Instance {
+        unsafe { &*(self.instance as *const Instance) }
+    }
+    /// Return a reference to the contained `Instance`.
+    #[allow(dead_code)]
+    pub(crate) fn instance_mut(&mut self) -> &mut Instance {
+        unsafe { &mut *self.instance }
+    }
+
+    /// Clone an InstanceRef.
+    #[allow(dead_code)]
+    pub(crate) unsafe fn clone(&self) -> Self {
+        Self {
+            instance: self.instance,
+        }
+    }
+}
+
+impl fmt::Debug for InstanceRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InstanceRef")
+            .field("ref", &self.instance)
+            .finish()
+    }
+}

--- a/lib/api/src/js/mod.rs
+++ b/lib/api/src/js/mod.rs
@@ -52,7 +52,7 @@ pub use crate::js::externals::{
 };
 pub use crate::js::function_env::{FunctionEnv, FunctionEnvMut};
 pub use crate::js::imports::Imports;
-pub use crate::js::instance::Instance;
+pub use crate::js::instance::{Instance, InstanceRef};
 pub use crate::js::mem_access::{MemoryAccessError, WasmRef, WasmSlice, WasmSliceIter};
 pub use crate::js::module::{Module, ModuleTypeHints};
 pub use crate::js::native::TypedFunction;

--- a/lib/api/src/sys/function_env.rs
+++ b/lib/api/src/sys/function_env.rs
@@ -87,7 +87,7 @@ impl<T> FunctionEnv<T> {
             .instance = Some(unsafe { InstanceRef::from_instance(instance) });
     }
     /// Detach any instance to an FunctionEnv for a Store
-    pub fn detach_instance<'a>(&mut self, store: &'a mut impl AsStoreMut)
+    pub fn detach_instance(&mut self, store: &mut impl AsStoreMut)
     where
         T: Any + Send + 'static + Sized,
     {

--- a/lib/api/src/sys/function_env.rs
+++ b/lib/api/src/sys/function_env.rs
@@ -2,7 +2,12 @@ use std::{any::Any, marker::PhantomData};
 
 use wasmer_vm::{StoreHandle, StoreObjects, VMFunctionEnvironment};
 
-use crate::{AsStoreMut, AsStoreRef, StoreMut, StoreRef};
+use crate::{AsStoreMut, AsStoreRef, Instance, InstanceRef, StoreMut, StoreRef};
+
+struct FunctionEnvInner<T> {
+    pub inner: T,
+    pub instance: Option<InstanceRef>,
+}
 
 #[derive(Debug)]
 #[repr(transparent)]
@@ -22,7 +27,10 @@ impl<T> FunctionEnv<T> {
         Self {
             handle: StoreHandle::new(
                 store.as_store_mut().objects_mut(),
-                VMFunctionEnvironment::new(value),
+                VMFunctionEnvironment::new(FunctionEnvInner {
+                    inner: value,
+                    instance: None,
+                }),
             ),
             marker: PhantomData,
         }
@@ -33,11 +41,13 @@ impl<T> FunctionEnv<T> {
     where
         T: Any + Send + 'static + Sized,
     {
-        self.handle
+        &self
+            .handle
             .get(store.as_store_ref().objects())
             .as_ref()
-            .downcast_ref::<T>()
+            .downcast_ref::<FunctionEnvInner<T>>()
             .unwrap()
+            .inner
     }
 
     /// Get the data as mutable
@@ -45,11 +55,13 @@ impl<T> FunctionEnv<T> {
     where
         T: Any + Send + 'static + Sized,
     {
-        self.handle
+        &mut self
+            .handle
             .get_mut(store.objects_mut())
             .as_mut()
-            .downcast_mut::<T>()
+            .downcast_mut::<FunctionEnvInner<T>>()
             .unwrap()
+            .inner
     }
 
     /// Convert it into a `FunctionEnvMut`
@@ -61,6 +73,44 @@ impl<T> FunctionEnv<T> {
             store_mut: store.as_store_mut(),
             func_env: self,
         }
+    }
+    /// Attach an instance to an FunctionEnv for a Store
+    pub fn attach_instance<'a>(&mut self, store: &'a mut impl AsStoreMut, instance: &Instance)
+    where
+        T: Any + Send + 'static + Sized,
+    {
+        self.handle
+            .get_mut(store.objects_mut())
+            .as_mut()
+            .downcast_mut::<FunctionEnvInner<T>>()
+            .unwrap()
+            .instance = Some(unsafe { InstanceRef::from_instance(instance) });
+    }
+    /// Detach any instance to an FunctionEnv for a Store
+    pub fn detach_instance<'a>(&mut self, store: &'a mut impl AsStoreMut)
+    where
+        T: Any + Send + 'static + Sized,
+    {
+        self.handle
+            .get_mut(store.objects_mut())
+            .as_mut()
+            .downcast_mut::<FunctionEnvInner<T>>()
+            .unwrap()
+            .instance = None;
+    }
+    /// Get the Instance attached to an FunctionEnv for a Store
+    pub fn get_instance<'a>(&self, store: &'a impl AsStoreRef) -> Option<&'a Instance>
+    where
+        T: Any + Send + 'static + Sized,
+    {
+        self.handle
+            .get(store.as_store_ref().objects())
+            .as_ref()
+            .downcast_ref::<FunctionEnvInner<T>>()
+            .unwrap()
+            .instance
+            .as_ref()
+            .map(|i| i.instance())
     }
 }
 
@@ -116,6 +166,19 @@ impl<T: Send + 'static> FunctionEnvMut<'_, T> {
             store_mut: self.store_mut.as_store_mut(),
             func_env: self.func_env.clone(),
         }
+    }
+
+    /// Get the Instance attached to an FunctionEnvMut
+    pub fn get_instance(&self) -> Option<&Instance> {
+        self.func_env
+            .handle
+            .get(self.store_mut.as_store_ref().objects())
+            .as_ref()
+            .downcast_ref::<FunctionEnvInner<T>>()
+            .unwrap()
+            .instance
+            .as_ref()
+            .map(|i| i.instance())
     }
 }
 

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -188,3 +188,48 @@ impl fmt::Debug for Instance {
             .finish()
     }
 }
+
+/// A handle holding an `Instance`, to be used inside Callback for example
+#[derive(Hash, PartialEq, Eq)]
+pub struct InstanceRef {
+    instance: *mut Instance,
+}
+
+unsafe impl Send for InstanceRef {}
+unsafe impl Sync for InstanceRef {}
+
+impl InstanceRef {
+    /// Create a new `InstanceHandle` pointing at the instance
+    #[allow(dead_code)]
+    pub(crate) unsafe fn from_instance(instance: &Instance) -> Self {
+        Self {
+            instance: instance as *const Instance as *mut Instance,
+        }
+    }
+    /// Return a reference to the contained `Instance`.
+    #[allow(dead_code)]
+    pub(crate) fn instance(&self) -> &Instance {
+        unsafe { &*(self.instance as *const Instance) }
+    }
+    /// Return a reference to the contained `Instance`.
+    #[allow(dead_code)]
+    pub(crate) fn instance_mut(&mut self) -> &mut Instance {
+        unsafe { &mut *self.instance }
+    }
+
+    /// Clone an InstanceRef.
+    #[allow(dead_code)]
+    pub(crate) unsafe fn clone(&self) -> Self {
+        Self {
+            instance: self.instance,
+        }
+    }
+}
+
+impl fmt::Debug for InstanceRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InstanceRef")
+            .field("ref", &self.instance)
+            .finish()
+    }
+}

--- a/lib/api/src/sys/mod.rs
+++ b/lib/api/src/sys/mod.rs
@@ -21,7 +21,7 @@ pub use crate::sys::externals::{
 };
 pub use crate::sys::function_env::{FunctionEnv, FunctionEnvMut};
 pub use crate::sys::imports::Imports;
-pub use crate::sys::instance::{Instance, InstantiationError};
+pub use crate::sys::instance::{Instance, InstanceRef, InstantiationError};
 pub use crate::sys::mem_access::{MemoryAccessError, WasmRef, WasmSlice, WasmSliceIter};
 pub use crate::sys::module::Module;
 pub use crate::sys::native::TypedFunction;


### PR DESCRIPTION
# Description
Allows the FunctionEnv to be attached/detached an instance. 
After it's created, simply use `env.attach_instance(&mut store, &instance)`. Only one instance can be attached. Use `detach_instance(&mut store)` to detach any instance attached. To get the attached instance, use `env.get_instance(&store)`, or, for a `FunctionEnvMut`, simply `env.get_instance()`. This allows the use of instance from a function Callback.