### PR TITLE
Fix Makefile with TARGET_DIR end with release folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,11 @@ ifneq (, $(TARGET))
 endif
 
 ifneq (, $(TARGET_DIR))
-	target_dir := --target-dir "$(TARGET_DIR)"
+	target_dir := --target-dir $(TARGET_DIR)
+endif
+
+ifeq (release, $(notdir $(TARGET_DIR)))
+	target_dir := --target-dir $(TARGET_DIR)/..
 endif
 
 $(info -----------)


### PR DESCRIPTION
# Description
Fix Makefile with TARGET_DIR end with release folder, to "remove" it from cargo command as a  `--release` build will go in release subfolder.