### PR TITLE
Fix Makefile with TARGET_DIR end with release folder, removing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ ifneq (, $(TARGET_DIR))
 endif
 
 ifeq (release, $(notdir $(TARGET_DIR)))
-	target_dir := --target-dir $(TARGET_DIR)/..
+	target_dir := --target-dir $(dir $(TARGET_DIR))
 endif
 
 $(info -----------)


### PR DESCRIPTION
# Description
Fix Makefile with TARGET_DIR end with release folder, removing it completly from the `--target-dir`