### PR TITLE
Removed call to to_vec() on assembler.finalise()

### DIFF
--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -3198,8 +3198,10 @@ pub fn gen_std_trampoline_arm64(
         ; ret
     );
 
+    let mut body = a.finalize().unwrap();
+    body.shrink_to_fit();
     Ok(FunctionBody {
-        body: a.finalize().unwrap().to_vec(),
+        body,
         unwind_info: None,
     })
 }
@@ -3353,8 +3355,10 @@ pub fn gen_std_dynamic_import_trampoline_arm64(
     // Return.
     a.emit_ret()?;
 
+    let mut body = a.finalize().unwrap();
+    body.shrink_to_fit();
     Ok(FunctionBody {
-        body: a.finalize().unwrap().to_vec(),
+        body,
         unwind_info: None,
     })
 }
@@ -3532,7 +3536,9 @@ pub fn gen_import_call_trampoline_arm64(
     }
     a.emit_b_register(GPR::X16)?;
 
-    let section_body = SectionBody::new_with_vec(a.finalize().unwrap().to_vec());
+    let mut contents = a.finalize().unwrap();
+    contents.shrink_to_fit();
+    let section_body = SectionBody::new_with_vec(contents);
 
     Ok(CustomSection {
         protection: CustomSectionProtection::ReadExecute,

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -7736,8 +7736,10 @@ impl Machine for MachineX86_64 {
 
         a.emit_ret()?;
 
+        let mut body = a.finalize().unwrap();
+        body.shrink_to_fit();
         Ok(FunctionBody {
-            body: a.finalize().unwrap().to_vec(),
+            body,
             unwind_info: None,
         })
     }
@@ -7858,8 +7860,10 @@ impl Machine for MachineX86_64 {
         // Return.
         a.emit_ret()?;
 
+        let mut body = a.finalize().unwrap();
+        body.shrink_to_fit();
         Ok(FunctionBody {
-            body: a.finalize().unwrap().to_vec(),
+            body,
             unwind_info: None,
         })
     }
@@ -8024,7 +8028,9 @@ impl Machine for MachineX86_64 {
         }
         a.emit_host_redirection(GPR::RAX)?;
 
-        let section_body = SectionBody::new_with_vec(a.finalize().unwrap().to_vec());
+        let mut contents = a.finalize().unwrap();
+        contents.shrink_to_fit();
+        let section_body = SectionBody::new_with_vec(contents);
 
         Ok(CustomSection {
             protection: CustomSectionProtection::ReadExecute,


### PR DESCRIPTION
# Description
Removed call to to_vec() on assembler.finalise()
Based on https://github.com/near/wasmer/pull/143

Note that I have not measured any speed improvment with this.