### PR TITLE
Disable 'Test integration CLI' on CI for the Windows platform as it's not working at all

### DIFF
--- a/.github/workflows/test-sys.yaml
+++ b/.github/workflows/test-sys.yaml
@@ -210,17 +210,17 @@ jobs:
           TARGET: ${{ matrix.target }}
           TARGET_DIR: target/${{ matrix.target }}/release
           CARGO_TARGET: --target ${{ matrix.target }}
-      - name: Test integration CLI
-        if: matrix.run_test && matrix.os == 'windows-2019'
-        shell: bash
-        run: |
-          make && make build-wasmer && make build-capi && make package-capi && make package
-          export WASMER_DIR=`pwd`/package
-          make test-integration-cli
-        env:
-          TARGET: x86_64-pc-windows-msvc
-          TARGET_DIR: target/x86_64-pc-windows-msvc/release
-          CARGO_TARGET: --target x86_64-pc-windows-msvc
+      #- name: Test integration CLI
+      #  if: matrix.run_test && matrix.os == 'windows-2019'
+      #  shell: bash
+      #  run: |
+      #    make && make build-wasmer && make build-capi && make package-capi && make package
+      #    export WASMER_DIR=`pwd`/package
+      #    make test-integration-cli
+      #  env:
+      #    TARGET: x86_64-pc-windows-msvc
+      #    TARGET_DIR: target/x86_64-pc-windows-msvc/release
+      #    CARGO_TARGET: --target x86_64-pc-windows-msvc
       - name: Test
         if: matrix.run_test && matrix.os != 'windows-2019'
         run: |


### PR DESCRIPTION
# Description
Disable 'Test integration CLI' on CI for the Windows platform as it's not working at all
To be re-enabled later when it's fixed for this platform
