### PR TITLE
Fixes for wasmer login / wasmer add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
@@ -1876,6 +1887,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -3400,6 +3417,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tldextract"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec03259a0567ad58eed30812bc3e5eda8030f154abc70317ab57b14f00699ca4"
+dependencies = [
+ "idna 0.2.3",
+ "log",
+ "regex",
+ "serde_json",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "tokio"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,7 +3679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.3.0",
  "percent-encoding",
  "serde",
 ]
@@ -3995,6 +4026,7 @@ dependencies = [
  "target-lexicon 0.12.5",
  "tempdir",
  "tempfile",
+ "tldextract",
  "toml",
  "unix_mode",
  "url",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -72,6 +72,7 @@ nuke-dir = { version = "0.1.0", optional = true }
 webc = { version = "3.0.1", optional = true }
 isatty = "0.1.9"
 dialoguer = "0.10.2"
+tldextract = "0.6.0"
 
 [build-dependencies]
 chrono = { version = "^0.4", default-features = false, features = [ "std", "clock" ] }

--- a/lib/cli/src/commands/add.rs
+++ b/lib/cli/src/commands/add.rs
@@ -40,7 +40,7 @@ impl Add {
 
         let bindings = self.lookup_bindings(&registry)?;
 
-        let mut cmd = self.target()?.command(&bindings);
+        let mut cmd = self.target()?.command(&bindings)?;
 
         #[cfg(feature = "debug")]
         log::debug!("Running {cmd:?}");
@@ -156,13 +156,43 @@ impl Target {
     /// `npm.cmd` or `yarn.ps1`).
     ///
     /// See <https://github.com/wasmerio/wapm-cli/issues/291> for more.
-    fn command(self, packages: &[Bindings]) -> Command {
+    fn command(self, packages: &[Bindings]) -> Result<Command, Error> {
         let command_line = match self {
-            Target::Pip => "pip install",
-            Target::Yarn { dev: true } => "yarn add --dev",
-            Target::Yarn { dev: false } => "yarn add",
-            Target::Npm { dev: true } => "npm install --dev",
-            Target::Npm { dev: false } => "npm install",
+            Target::Pip => {
+                if Command::new("pip").arg("--version").output().is_ok() {
+                    "pip install"
+                } else if Command::new("pip3").arg("--version").output().is_ok() {
+                    "pip3 install"
+                } else if Command::new("python").arg("--version").output().is_ok() {
+                    "python -m pip install"
+                } else if Command::new("python3").arg("--version").output().is_ok() {
+                    "python3 -m pip install"
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "neither pip, pip3, python or python3 installed"
+                    ));
+                }
+            }
+            Target::Yarn { dev } => {
+                if Command::new("yarn").arg("--version").output().is_err() {
+                    return Err(anyhow::anyhow!("yarn not installed"));
+                }
+                if dev {
+                    "yarn add --dev"
+                } else {
+                    "yarn add"
+                }
+            }
+            Target::Npm { dev } => {
+                if Command::new("npm").arg("--version").output().is_err() {
+                    return Err(anyhow::anyhow!("yarn not installed"));
+                }
+                if dev {
+                    "npm install --dev"
+                } else {
+                    "npm install"
+                }
+            }
         };
         let mut command_line = command_line.to_string();
 
@@ -174,11 +204,11 @@ impl Target {
         if cfg!(windows) {
             let mut cmd = Command::new("cmd");
             cmd.arg("/C").arg(command_line);
-            cmd
+            Ok(cmd)
         } else {
             let mut cmd = Command::new("sh");
             cmd.arg("-c").arg(command_line);
-            cmd
+            Ok(cmd)
         }
     }
 }

--- a/lib/cli/src/commands/login.rs
+++ b/lib/cli/src/commands/login.rs
@@ -35,7 +35,14 @@ impl Login {
                     }
                     _ => "Please paste the login token".to_string(),
                 };
-                Input::new().with_prompt(&login_prompt).interact_text()
+                #[cfg(test)]
+                {
+                    Ok(login_prompt)
+                }
+                #[cfg(not(test))]
+                {
+                    Input::new().with_prompt(&login_prompt).interact_text()
+                }
             }
         }
     }
@@ -46,4 +53,24 @@ impl Login {
         wasmer_registry::login::login_and_save_token(&self.registry, &token)
             .map_err(|e| anyhow::anyhow!("{e}"))
     }
+}
+
+#[test]
+fn test_login_2() {
+    let login = Login {
+        registry: "wapm.dev".to_string(),
+        token: None,
+    };
+
+    assert_eq!(
+        login.get_token_or_ask_user().unwrap(),
+        "Please paste the login token for https://wapm.dev/me"
+    );
+
+    let login = Login {
+        registry: "wapm.dev".to_string(),
+        token: Some("abc".to_string()),
+    };
+
+    assert_eq!(login.get_token_or_ask_user().unwrap(), "abc");
 }


### PR DESCRIPTION
- wasmer add now accounts for python2 / python3
- wasmer login shows the correct TLD for `{url}/me`
- wasmer add doesn't panic anymore if none of `--pip`, `--yarn` or `-npm` is installed