### PR TITLE
Revert blocking pipe behaviour to non-blocking by default

### DIFF
--- a/lib/wasi/src/state/pipe.rs
+++ b/lib/wasi/src/state/pipe.rs
@@ -91,14 +91,14 @@ impl WasiBidirectionalPipePair {
             tx: Mutex::new(tx1),
             rx: Mutex::new(rx2),
             read_buffer: None,
-            block: true,
+            block: false,
         };
 
         let pipe2 = WasiPipe {
             tx: Mutex::new(tx2),
             rx: Mutex::new(rx1),
             read_buffer: None,
-            block: true,
+            block: false,
         };
 
         WasiBidirectionalPipePair {


### PR DESCRIPTION
This fixes wasmer-js unit tests to pass again