### PR TITLE
Fetch the pirita download URL

### DIFF
--- a/lib/registry/graphql/queries/get_package_by_command.graphql
+++ b/lib/registry/graphql/queries/get_package_by_command.graphql
@@ -7,6 +7,7 @@ query GetPackageByCommandQuery ($commandName: String!) {
       manifest
       distribution {
         downloadUrl
+        piritaDownloadUrl
       }
       package {
         displayName

--- a/lib/registry/graphql/queries/get_package_version.graphql
+++ b/lib/registry/graphql/queries/get_package_version.graphql
@@ -7,6 +7,7 @@ query GetPackageVersionQuery ($name: String!, $version: String) {
      isLastVersion
      distribution {
       downloadUrl
+      piritaDownloadUrl
      }
      manifest
   }

--- a/lib/registry/src/lib.rs
+++ b/lib/registry/src/lib.rs
@@ -47,6 +47,7 @@ pub struct PackageDownloadInfo {
     pub commands: String,
     pub manifest: String,
     pub url: String,
+    pub pirita_url: Option<String>,
 }
 
 pub fn get_package_local_dir(
@@ -317,6 +318,7 @@ pub fn query_command_from_registry(
     let package = command.package_version.package.display_name;
     let version = command.package_version.version;
     let url = command.package_version.distribution.download_url;
+    let pirita_url = command.package_version.distribution.pirita_download_url;
 
     Ok(PackageDownloadInfo {
         registry: registry_url.to_string(),
@@ -326,6 +328,7 @@ pub fn query_command_from_registry(
         manifest: command.package_version.manifest,
         commands: command_name.to_string(),
         url,
+        pirita_url,
     })
 }
 
@@ -612,6 +615,7 @@ pub fn query_package_from_registry(
             .join(", "),
 
         url: v.distribution.download_url.clone(),
+        pirita_url: v.distribution.pirita_download_url.clone(),
     })
 }
 

--- a/lib/wasi-types/regenerate.sh
+++ b/lib/wasi-types/regenerate.sh
@@ -8,13 +8,10 @@ rm -f \
 
 cat "$BASEDIR"/wit-clean/typenames.wit "$BASEDIR"/wit-clean/wasi_unstable.wit > "$BASEDIR"/wit-clean/output.wit
 
-git clone https://github.com/wasmerio/wit-bindgen --branch force-generate-structs --single-branch
+cargo install --force wai-bindgen
 git pull origin force-generate-structs
-cd wit-bindgen
-cargo build
-cd ..
 
-./wit-bindgen/target/debug/wit-bindgen rust-wasm \
+wai-bindgen rust-wasm \
     --import "$BASEDIR"/wit-clean/output.wit \
     --force-generate-structs \
     --out-dir "$BASEDIR"/src/wasi \


### PR DESCRIPTION
Add some more queries to the `wasmer-registry` crate.

I've also had to remove `lib/wasi-types/wit-bindgen` because it's a broken link to use `wai-bindgen` from crates.io, otherwise you get the following error when trying to use `wasmerio/wasmer` as a git dependency (I had to temporarily patch my `wasmer-registry` from crates.io in https://github.com/wasmerio/pirita/pull/62 to see if this PR would work).

```
    Updating git repository `https://github.com/wasmerio/wasmer`
error: failed to load source for dependency `wasmer-registy`

Caused by:
  Unable to update https://github.com/wasmerio/wasmer?branch=more-queries

Caused by:
  failed to update submodule `lib/wasi-types/wit-bindgen`

Caused by:
  no URL configured for submodule 'lib/wasi-types/wit-bindgen'; class=Submodule (17)
```