### PR TITLE
Improve FreeBSD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+## Added
+
+- Preliminary FreeBSD support
+
+
 ## 3.0.1 - 23/11/2022
 
 ## Added

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -272,7 +272,7 @@ cfg_if::cfg_if! {
                 ))] {
                     pc = context.uc_mcontext.gregs[libc::REG_EIP as usize] as usize;
                     sp = context.uc_mcontext.gregs[libc::REG_ESP as usize] as usize;
-                } else if #[cfg(all(target_os = "freebsd", target_arch = "x86"))] {
+                } else if #[cfg(all(target_os = "freebsd", any(target_arch = "x86", target_arch = "x86_64")))] {
                     pc = context.uc_mcontext.mc_rip as usize;
                     sp = context.uc_mcontext.mc_rsp as usize;
                 } else if #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))] {


### PR DESCRIPTION
# Description

- Update `traphandlers.rs` to use the same `pc`/`sp` values for amd64 as are used for x86
- Ensure amd64 is treated the same as x86_64 in the Makefile
- Add an `IS_FREEBSD` variable to the Makefile which is pretty much the same as `IS_DARWIN`
- Update CHANGELOG.md

wasmer partially works on FreeBSD/amd64 with these few tiny changes. However, after printing the output of cowsay.wasm, it hangs for a long time (55 seconds in this example).

Using rust toolchain `1.63-x86_64-apple-darwin` (correct behavior):

```
% time ./target/release/wasmer cowsay.wasm -- hello world
 _____________
< hello world >
 -------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
               ||----w |
                ||     ||
./target/release/wasmer cowsay.wasm -- hello world  0.01s user 0.01s system 41% cpu 0.061 total
```

Using rust toolchain `1.63-x86_64-unknown-freebsd` (incorrect behavior):

```
% time ./target/release/wasmer cowsay.wasm -- hello world
 _____________
< hello world >
 -------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
               ||----w |
                ||     ||
./target/release/wasmer cowsay.wasm -- hello world  55.14s user 0.05s system 100% cpu 55.183 total
```

cowsay.wasm is https://registry-cdn.wapm.io/contents/syrusakbary/cowsay/0.2.0/target/wasm32-wasi/release/cowsay.wasm

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
