### PR TITLE
Remove wasi conditional compilation from wasmer-registry

### DIFF
--- a/lib/registry/src/config.rs
+++ b/lib/registry/src/config.rs
@@ -2,15 +2,7 @@ use graphql_client::GraphQLQuery;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
-#[cfg(not(test))]
-use std::env;
 use std::path::{Path, PathBuf};
-
-pub static GLOBAL_CONFIG_FILE_NAME: &str = if cfg!(target_os = "wasi") {
-    "/.private/wapm.toml"
-} else {
-    "wapm.toml"
-};
 
 #[derive(Deserialize, Default, Serialize, Debug, PartialEq, Eq)]
 pub struct PartialWapmConfig {
@@ -23,12 +15,10 @@ pub struct PartialWapmConfig {
     pub registry: Registries,
 
     /// Whether or not telemetry is enabled.
-    #[cfg(feature = "telemetry")]
     #[serde(default)]
     pub telemetry: Telemetry,
 
     /// Whether or not updated notifications are enabled.
-    #[cfg(feature = "update-notifications")]
     #[serde(default)]
     pub update_notifications: UpdateNotifications,
 
@@ -51,8 +41,7 @@ pub struct UpdateNotifications {
     pub enabled: String,
 }
 
-#[cfg(feature = "telemetry")]
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Default)]
 pub struct Telemetry {
     pub enabled: String,
 }
@@ -284,7 +273,7 @@ impl PartialWapmConfig {
     #[cfg(not(test))]
     pub fn get_folder() -> Result<PathBuf, String> {
         Ok(
-            if let Some(folder_str) = env::var("WASMER_DIR").ok().filter(|s| !s.is_empty()) {
+            if let Some(folder_str) = std::env::var("WASMER_DIR").ok().filter(|s| !s.is_empty()) {
                 let folder = PathBuf::from(folder_str);
                 std::fs::create_dir_all(folder.clone())
                     .map_err(|e| format!("cannot create config directory: {e}"))?;
@@ -307,12 +296,12 @@ impl PartialWapmConfig {
 
     #[cfg(test)]
     pub fn get_file_location(test_name: &str) -> Result<PathBuf, String> {
-        Ok(Self::get_folder(test_name)?.join(GLOBAL_CONFIG_FILE_NAME))
+        Ok(Self::get_folder(test_name)?.join(crate::GLOBAL_CONFIG_FILE_NAME))
     }
 
     #[cfg(not(test))]
     pub fn get_file_location() -> Result<PathBuf, String> {
-        Ok(Self::get_folder()?.join(GLOBAL_CONFIG_FILE_NAME))
+        Ok(Self::get_folder()?.join(crate::GLOBAL_CONFIG_FILE_NAME))
     }
 }
 

--- a/lib/registry/src/graphql.rs
+++ b/lib/registry/src/graphql.rs
@@ -1,13 +1,10 @@
 use graphql_client::*;
-#[cfg(not(target_os = "wasi"))]
 use reqwest::{
     blocking::{multipart::Form, Client},
     header::USER_AGENT,
 };
 use std::env;
 use std::time::Duration;
-#[cfg(target_os = "wasi")]
-use {wasm_bus_reqwest::prelude::header::*, wasm_bus_reqwest::prelude::*};
 
 pub(crate) mod proxy {
     //! Code for dealing with setting things up to proxy network requests
@@ -28,9 +25,7 @@ pub(crate) mod proxy {
     pub fn maybe_set_up_proxy_blocking(
         builder: reqwest::blocking::ClientBuilder,
     ) -> anyhow::Result<reqwest::blocking::ClientBuilder> {
-        #[cfg(not(target_os = "wasi"))]
         use anyhow::Context;
-        #[cfg(not(target_os = "wasi"))]
         if let Some(proxy) = maybe_set_up_proxy_inner()
             .map_err(|e| anyhow::anyhow!("{e}"))
             .context("install_webc_package: failed to setup proxy for reqwest Client")?
@@ -43,9 +38,7 @@ pub(crate) mod proxy {
     pub fn maybe_set_up_proxy(
         builder: reqwest::ClientBuilder,
     ) -> anyhow::Result<reqwest::ClientBuilder> {
-        #[cfg(not(target_os = "wasi"))]
         use anyhow::Context;
-        #[cfg(not(target_os = "wasi"))]
         if let Some(proxy) = maybe_set_up_proxy_inner()
             .map_err(|e| anyhow::anyhow!("{e}"))
             .context("install_webc_package: failed to setup proxy for reqwest Client")?
@@ -106,12 +99,6 @@ pub(crate) mod proxy {
     }
 }
 
-#[cfg(target_os = "wasi")]
-pub fn whoami_distro() -> String {
-    whoami::os().to_lowercase()
-}
-
-#[cfg(not(target_os = "wasi"))]
 pub fn whoami_distro() -> String {
     whoami::distro().to_lowercase()
 }

--- a/lib/registry/src/lib.rs
+++ b/lib/registry/src/lib.rs
@@ -33,11 +33,7 @@ pub use crate::{
     queries::get_bindings_query::ProgrammingLanguage,
 };
 
-pub static GLOBAL_CONFIG_FILE_NAME: &str = if cfg!(target_os = "wasi") {
-    "/.private/wapm.toml"
-} else {
-    "wapm.toml"
-};
+pub static GLOBAL_CONFIG_FILE_NAME: &str = "wapm.toml";
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct PackageDownloadInfo {


### PR DESCRIPTION
The `wasmer-registry` crate can't compile to WASI at the moment because `wasm-bus` (used by `wasm-bus-reqwest`) is broken, and WASI doesn't support networking even if the crate compiled. I'm removing the code hidden behind `#[cfg(target_os = "wasi")]` because it's dead code at the moment.

I've also removed the conditional compilation for `feature = "telemetry"` and `feature = "update-notifications"` because this crate doesn't actually have any features. I think it should be fine to include those fields all the time because they are part of the config format, and let upstream (i.e. `wasmer-cli`) decide whether it wants to enable code for telemetry and undate notifications.