### PR TITLE
Fix installing wasmer via cargo-binstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+## Fixed
+ - [#3369](https://github.com/wasmerio/wasmer/pull/3369) Fix installing wasmer via cargo-binstall
+
+
 ## 3.0.1 - 23/11/2022
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl https://get.wasmer.io -sSfL | sh
   * <a href="https://crates.io/crates/cargo-binstall/">Cargo binstall</a>
   
     ```sh
-    cargo binstall wasmer
+    cargo binstall wasmer-cli
     ```
 
   * <a href="https://crates.io/crates/wasmer-cli/">Cargo</a>

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -166,31 +166,26 @@ http = [
   "serde",
 ]
 
-[package.metadata.binstall]
-pkg-fmt = "tgz"
-
 [package.metadata.binstall.overrides.aarch64-apple-darwin]
-pkg-url = "{ repo }/releases/download/{ version }/wasmer-darwin-arm64.{ archive-format }"
-bin-dir = "wasmer-darwin-arm64/bin/{ bin }"
-
-#https://github.com/wasmerio/wasmer/releases/download/3.0.0-beta/wasmer-darwin-arm64.tar.gz
+pkg-url = "{ repo }/releases/download/v{ version }/wasmer-darwin-arm64.{ archive-format }"
+bin-dir = "bin/{ bin }"
 
 [package.metadata.binstall.overrides.x86_64-apple-darwin]
-pkg-url = "{ repo }/releases/download/{ version }/wasmer-darwin-amd64.{ archive-format }"
-bin-dir = "wasmer-darwin-amd64/bin/{ bin }"
+pkg-url = "{ repo }/releases/download/v{ version }/wasmer-darwin-amd64.{ archive-format }"
+bin-dir = "bin/{ bin }"
 
 [package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
-pkg-url = "{ repo }/releases/download/{ version }/wasmer-linux-aarch64.{ archive-format }"
-bin-dir = "wasmer-linux-aarch64/bin/{ bin }"
+pkg-url = "{ repo }/releases/download/v{ version }/wasmer-linux-aarch64.{ archive-format }"
+bin-dir = "bin/{ bin }"
 
 [package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
-pkg-url = "{ repo }/releases/download/{ version }/wasmer-linux-amd64.{ archive-format }"
-bin-dir = "wasmer-linux-amd64/bin/{ bin }"
+pkg-url = "{ repo }/releases/download/v{ version }/wasmer-linux-amd64.{ archive-format }"
+bin-dir = "bin/{ bin }"
 
 [package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
-pkg-url = "{ repo }/releases/download/{ version }/wasmer-linux-musl-amd64.{ archive-format }"
-bin-dir = "wasmer-linux-musl-amd64/bin/{ bin }"
+pkg-url = "{ repo }/releases/download/v{ version }/wasmer-linux-musl-amd64.{ archive-format }"
+bin-dir = "bin/{ bin }"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-url = "{ repo }/releases/download/{ version }/wasmer-windows-amd64.{ archive-format }"
-bin-dir = "wasmer-windows-amd64/bin/{ bin }.exe"
+pkg-url = "{ repo }/releases/download/v{ version }/wasmer-windows-amd64.{ archive-format }"
+bin-dir = "bin/{ bin }.exe"

--- a/lib/cli/src/commands/login.rs
+++ b/lib/cli/src/commands/login.rs
@@ -53,7 +53,7 @@ impl Login {
         let token = self.get_token_or_ask_user()?;
         match wasmer_registry::login::login_and_save_token(&self.registry, &token)? {
             Some(s) => println!("Login for WAPM user {:?} saved", s),
-            None => println!("Login for WAPM user saved"),
+            None => println!("Error: no user found on registry {:?} with token {:?}. Token saved regardless.", self.registry, token),
         }
         Ok(())
     }

--- a/lib/cli/src/commands/login.rs
+++ b/lib/cli/src/commands/login.rs
@@ -51,8 +51,11 @@ impl Login {
     /// execute [List]
     pub fn execute(&self) -> Result<(), anyhow::Error> {
         let token = self.get_token_or_ask_user()?;
-        wasmer_registry::login::login_and_save_token(&self.registry, &token)
-            .map_err(|e| anyhow::anyhow!("{e}"))
+        match wasmer_registry::login::login_and_save_token(&self.registry, &token)? {
+            Some(s) => println!("Login for WAPM user {:?} saved", s),
+            None => println!("Login for WAPM user saved"),
+        }
+        Ok(())
     }
 }
 
@@ -61,6 +64,7 @@ fn test_login_2() {
     let login = Login {
         registry: "wapm.dev".to_string(),
         token: None,
+        debug: false,
     };
 
     assert_eq!(
@@ -71,6 +75,7 @@ fn test_login_2() {
     let login = Login {
         registry: "wapm.dev".to_string(),
         token: Some("abc".to_string()),
+        debug: false,
     };
 
     assert_eq!(login.get_token_or_ask_user().unwrap(), "abc");

--- a/lib/registry/src/login.rs
+++ b/lib/registry/src/login.rs
@@ -8,12 +8,14 @@ pub fn login_and_save_token(
     #[cfg(test)] test_name: &str,
     registry: &str,
     token: &str,
-) -> Result<(), anyhow::Error> {
+) -> Result<Option<String>, anyhow::Error> {
     let registry = format_graphql(registry);
     #[cfg(test)]
-    let mut config = PartialWapmConfig::from_file(test_name).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut config = PartialWapmConfig::from_file(test_name)
+        .map_err(|e| anyhow::anyhow!("config from file: {e}"))?;
     #[cfg(not(test))]
-    let mut config = PartialWapmConfig::from_file().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut config =
+        PartialWapmConfig::from_file().map_err(|e| anyhow::anyhow!("config from file: {e}"))?;
     config.registry.set_current_registry(&registry);
     config.registry.set_login_token_for_registry(
         &config.registry.get_current_registry(),
@@ -21,16 +23,11 @@ pub fn login_and_save_token(
         UpdateRegistry::Update,
     );
     #[cfg(test)]
-    let path =
-        PartialWapmConfig::get_file_location(test_name).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let path = PartialWapmConfig::get_file_location(test_name)
+        .map_err(|e| anyhow::anyhow!("get file location: {e}"))?;
     #[cfg(not(test))]
-    let path = PartialWapmConfig::get_file_location().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let path = PartialWapmConfig::get_file_location()
+        .map_err(|e| anyhow::anyhow!("get file location: {e}"))?;
     config.save(&path)?;
-    let username = crate::utils::get_username_registry_token(&registry, token);
-    if let Some(s) = username.ok().and_then(|o| o) {
-        println!("Login for WAPM user {:?} saved", s);
-    } else {
-        println!("Login for WAPM user saved");
-    }
-    Ok(())
+    crate::utils::get_username_registry_token(&registry, token)
 }

--- a/tests/integration/cli/tests/login.rs
+++ b/tests/integration/cli/tests/login.rs
@@ -18,18 +18,31 @@ fn login_works() -> anyhow::Result<()> {
         .arg(wapm_dev_token)
         .output()?;
 
+    let stdout = std::str::from_utf8(&output.stdout)
+        .expect("stdout is not utf8! need to handle arbitrary bytes");
+
+    let stderr = std::str::from_utf8(&output.stderr)
+        .expect("stderr is not utf8! need to handle arbitrary bytes");
+
     if !output.status.success() {
         bail!(
             "wasmer login failed with: stdout: {}\n\nstderr: {}",
-            std::str::from_utf8(&output.stdout)
-                .expect("stdout is not utf8! need to handle arbitrary bytes"),
-            std::str::from_utf8(&output.stderr)
-                .expect("stderr is not utf8! need to handle arbitrary bytes")
+            stdout,
+            stderr
         );
     }
 
     let stdout_output = std::str::from_utf8(&output.stdout).unwrap();
-    assert_eq!(stdout_output, "Login for WAPM user \"ciuser\" saved\n");
+    let expected = "Login for WAPM user \"ciuser\" saved\n";
+    if stdout_output != expected {
+        println!("expected:");
+        println!("{expected}");
+        println!("got:");
+        println!("{stdout}");
+        println!("-----");
+        println!("{stderr}");
+        panic!("stdout incorrect");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

# Description

With wasmer v3.0.1, the link to release artifacts changed a little bit which breaks installing wasmer via cargo-binstall.
Also the instruction for installing wasmer via cargo-binstall in README.md is wrong.

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
