### PR TITLE
Restore Support For All Wasi Clock Types

### DIFF
--- a/lib/wasi/src/syscalls/mod.rs
+++ b/lib/wasi/src/syscalls/mod.rs
@@ -370,7 +370,7 @@ pub fn args_sizes_get<M: MemorySize>(
 ///     The resolution of the clock in nanoseconds
 pub fn clock_res_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     resolution: WasmPtr<Timestamp, M>,
 ) -> Errno {
     trace!("wasi::clock_res_get");
@@ -378,10 +378,7 @@ pub fn clock_res_get<M: MemorySize>(
     let memory = env.memory_view(&ctx);
 
     let out_addr = resolution.deref(&memory);
-    let t_out = wasi_try!(platform_clock_res_get(
-        Snapshot0Clockid::from(clock_id),
-        out_addr
-    ));
+    let t_out = wasi_try!(platform_clock_res_get(clock_id, out_addr));
     wasi_try_mem!(resolution.write(&memory, t_out as Timestamp));
     Errno::Success
 }
@@ -398,7 +395,7 @@ pub fn clock_res_get<M: MemorySize>(
 ///     The value of the clock in nanoseconds
 pub fn clock_time_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     precision: Timestamp,
     time: WasmPtr<Timestamp, M>,
 ) -> Errno {
@@ -409,10 +406,7 @@ pub fn clock_time_get<M: MemorySize>(
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
 
-    let t_out = wasi_try!(platform_clock_time_get(
-        Snapshot0Clockid::from(clock_id),
-        precision
-    ));
+    let t_out = wasi_try!(platform_clock_time_get(clock_id, precision));
     wasi_try_mem!(time.write(&memory, t_out as Timestamp));
 
     let result = Errno::Success;

--- a/lib/wasi/src/syscalls/wasi.rs
+++ b/lib/wasi/src/syscalls/wasi.rs
@@ -2,7 +2,7 @@
 use crate::{WasiEnv, WasiError, WasiState, WasiThread};
 use wasmer::{Memory, Memory32, MemorySize, StoreMut, WasmPtr, WasmSlice};
 use wasmer_wasi_types::{
-    wasi::{Errno, Event, Fd as WasiFd, Filesize, Fstflags, Fstflags, Timestamp, Whence, Clockid},
+    wasi::{Errno, Event, Fd as WasiFd, Filesize, Fstflags, Fstflags, Timestamp, Whence, Snapshot0Clockid},
     types::*,
 };
 
@@ -27,7 +27,7 @@ pub(crate) fn args_sizes_get(
 
 pub(crate) fn clock_res_get(
     ctx: FunctionEnvMut<WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     resolution: WasmPtr<Timestamp, MemoryType>,
 ) -> Errno {
     super::clock_res_get::<MemoryType>(ctx, clock_id, resolution)
@@ -35,7 +35,7 @@ pub(crate) fn clock_res_get(
 
 pub(crate) fn clock_time_get(
     ctx: FunctionEnvMut<WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     precision: Timestamp,
     time: WasmPtr<Timestamp, MemoryType>,
 ) -> Errno {

--- a/lib/wasi/src/syscalls/wasix32.rs
+++ b/lib/wasi/src/syscalls/wasix32.rs
@@ -5,8 +5,8 @@ use wasmer_wasi_types::types::*;
 use wasmer_wasi_types::wasi::{
     Addressfamily, Advice, Bid, BusDataFormat, BusErrno, BusHandles, Cid, Clockid, Dircookie,
     Errno, Event, EventFdFlags, Fd, Fdflags, Fdstat, Filesize, Filestat, Fstflags, Pid, Prestat,
-    Rights, Sockoption, Sockstatus, Socktype, Streamsecurity, Subscription, Tid, Timestamp, Tty,
-    Whence,
+    Rights, Snapshot0Clockid, Sockoption, Sockstatus, Socktype, Streamsecurity, Subscription, Tid,
+    Timestamp, Tty, Whence,
 };
 
 type MemoryType = Memory32;
@@ -30,7 +30,7 @@ pub(crate) fn args_sizes_get(
 
 pub(crate) fn clock_res_get(
     ctx: FunctionEnvMut<WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     resolution: WasmPtr<Timestamp, MemoryType>,
 ) -> Errno {
     super::clock_res_get::<MemoryType>(ctx, clock_id, resolution)
@@ -38,7 +38,7 @@ pub(crate) fn clock_res_get(
 
 pub(crate) fn clock_time_get(
     ctx: FunctionEnvMut<WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     precision: Timestamp,
     time: WasmPtr<Timestamp, MemoryType>,
 ) -> Errno {

--- a/lib/wasi/src/syscalls/wasix64.rs
+++ b/lib/wasi/src/syscalls/wasix64.rs
@@ -5,8 +5,8 @@ use wasmer_wasi_types::types::*;
 use wasmer_wasi_types::wasi::{
     Addressfamily, Advice, Bid, BusDataFormat, BusErrno, BusHandles, Cid, Clockid, Dircookie,
     Errno, Event, EventFdFlags, Fd, Fdflags, Fdstat, Filesize, Filestat, Fstflags, Pid, Prestat,
-    Rights, Sockoption, Sockstatus, Socktype, Streamsecurity, Subscription, Tid, Timestamp, Tty,
-    Whence,
+    Rights, Snapshot0Clockid, Sockoption, Sockstatus, Socktype, Streamsecurity, Subscription, Tid,
+    Timestamp, Tty, Whence,
 };
 
 type MemoryType = Memory64;
@@ -30,7 +30,7 @@ pub(crate) fn args_sizes_get(
 
 pub(crate) fn clock_res_get(
     ctx: FunctionEnvMut<WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     resolution: WasmPtr<Timestamp, MemoryType>,
 ) -> Errno {
     super::clock_res_get::<MemoryType>(ctx, clock_id, resolution)
@@ -38,7 +38,7 @@ pub(crate) fn clock_res_get(
 
 pub(crate) fn clock_time_get(
     ctx: FunctionEnvMut<WasiEnv>,
-    clock_id: Clockid,
+    clock_id: Snapshot0Clockid,
     precision: Timestamp,
     time: WasmPtr<Timestamp, MemoryType>,
 ) -> Errno {


### PR DESCRIPTION
- fix(wasi): Enables support for all Wasi clock types

# Description

Enables support for the wasi process and thread time clock types (2 and 3).

These were already implemented, but not correctly wired up due to a
duplication of the Clockid type.

This commit switches to using the correct Snapshot0Clockid everywhere.

In the future the "enum Clockid" should be removed, but that was not
done in this commit because currently the ./regenerate.sh script is
broken.

Closes #3384 .