### PR TITLE
Regenerate bindings using wai-bindgen (requires MSRV 1.64)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,17 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3726,6 +3715,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "wai-bindgen-gen-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd16a4dc5fb71faaa3d21530a1d004b7fc88f0bf70cda6f5c4099220254d947b"
+dependencies = [
+ "anyhow",
+ "wai-parser",
+]
+
+[[package]]
+name = "wai-bindgen-gen-rust"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17625f823712dd6eff5656b4308842b7aeac9eca429f6eea36443d4305cadf7d"
+dependencies = [
+ "heck 0.3.3",
+ "wai-bindgen-gen-core",
+]
+
+[[package]]
+name = "wai-bindgen-gen-rust-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757fbff15d11d0578ee879cea209b111bd09f8b39346c7b212a7e7f52585d2f7"
+dependencies = [
+ "heck 0.3.3",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-rust",
+]
+
+[[package]]
+name = "wai-parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a24cfad91494925ba41c6a03bd7d092eb3c3cdbccf4ef680b06831030bd7a69"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "pulldown-cmark",
+ "unicode-normalization",
+ "unicode-xid",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4429,13 +4462,13 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "time",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-rust",
+ "wai-bindgen-gen-rust-wasm",
+ "wai-parser",
  "wasmer",
  "wasmer-derive",
  "wasmer-types",
- "wasmer-wit-bindgen-gen-core",
- "wasmer-wit-bindgen-gen-rust-wasm",
- "wasmer-wit-bindgen-rust",
- "wasmer-wit-parser",
 ]
 
 [[package]]
@@ -4450,73 +4483,6 @@ dependencies = [
  "wasmer-vfs",
  "wasmer-wasi",
  "wast 38.0.1",
-]
-
-[[package]]
-name = "wasmer-wit-bindgen-gen-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8aa5be5ae5d61f5e151dc2c0e603093fe28395d2083b65ef7a3547844054fe"
-dependencies = [
- "anyhow",
- "wasmer-wit-parser",
-]
-
-[[package]]
-name = "wasmer-wit-bindgen-gen-rust"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438bce7c4589842bf100cc9b312443a9b5fc6440e58ab0b8c114e460219c3c3b"
-dependencies = [
- "heck 0.3.3",
- "wasmer-wit-bindgen-gen-core",
-]
-
-[[package]]
-name = "wasmer-wit-bindgen-gen-rust-wasm"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505f5168cfee591840e13e158a5c5e2f95d6df1df710839021564f36bee7bafc"
-dependencies = [
- "heck 0.3.3",
- "wasmer-wit-bindgen-gen-core",
- "wasmer-wit-bindgen-gen-rust",
-]
-
-[[package]]
-name = "wasmer-wit-bindgen-rust"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968747f1271f74aab9b70d9c5d4921db9bd13b4ec3ba5506506e6e7dc58c918c"
-dependencies = [
- "async-trait",
- "bitflags",
- "wasmer-wit-bindgen-rust-impl",
-]
-
-[[package]]
-name = "wasmer-wit-bindgen-rust-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd26fe00d08bd2119870b017d13413dfbd51e7750b6634d649fc7a7bbc057b85"
-dependencies = [
- "proc-macro2",
- "syn",
- "wasmer-wit-bindgen-gen-core",
- "wasmer-wit-bindgen-gen-rust-wasm",
-]
-
-[[package]]
-name = "wasmer-wit-parser"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46c9a15086be8a2eb3790613902b9d3a9a687833b17cd021de263a20378585a"
-dependencies = [
- "anyhow",
- "id-arena",
- "pulldown-cmark",
- "unicode-normalization",
- "unicode-xid",
 ]
 
 [[package]]

--- a/lib/wasi-types/Cargo.toml
+++ b/lib/wasi-types/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wit-bindgen-rust = { package = "wasmer-wit-bindgen-rust", version = "0.1.1" }
-wit-bindgen-rust-wasm = { package = "wasmer-wit-bindgen-gen-rust-wasm", version = "0.1.1" }
-wit-bindgen-core = { package = "wasmer-wit-bindgen-gen-core", version = "0.1.1" }
-wit-parser = { package = "wasmer-wit-parser", version = "0.1.1" }
+wai-bindgen-gen-rust = "0.2.1"
+wai-bindgen-gen-rust-wasm = "0.2.1"
+wai-bindgen-gen-core = "0.2.1"
+wai-parser = "0.2.1"
 wasmer-types = { path = "../types", version = "=3.0.2" }
 wasmer-derive = { path = "../derive", version = "=3.0.2" }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/lib/wasi-types/regenerate.sh
+++ b/lib/wasi-types/regenerate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xe
+
 BASEDIR=$(dirname "$0")
 
 rm -f \
@@ -8,8 +10,11 @@ rm -f \
 
 cat "$BASEDIR"/wit-clean/typenames.wit "$BASEDIR"/wit-clean/wasi_unstable.wit > "$BASEDIR"/wit-clean/output.wit
 
-cargo install --force wai-bindgen
-git pull origin force-generate-structs
+if ! command -v wai-bindgen &>/dev/null; then
+    echo "Error: wai-bindgen isn't installed."
+    echo 'Please install it with "cargo install wai-bindgen-cli --version 0.2.2" and try again.'
+    exit 1
+fi
 
 wai-bindgen rust-wasm \
     --import "$BASEDIR"/wit-clean/output.wit \

--- a/lib/wasi-types/src/wasi/bindings.rs
+++ b/lib/wasi-types/src/wasi/bindings.rs
@@ -534,7 +534,7 @@ pub mod output {
   }
   
   impl std::error::Error for BusErrno{}
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// File descriptor rights, determining which actions may be performed.
     pub struct Rights: u64 {
       /// The right to invoke `fd_datasync`.
@@ -770,7 +770,7 @@ pub mod output {
       }
     }
   }
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// File descriptor flags.
     pub struct Fdflags: u8 {
       /// Append mode: Data written to the file is always appended to the file's end.
@@ -812,7 +812,7 @@ pub mod output {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
       f.debug_struct("Fdstat").field("fs-filetype", &self.fs_filetype).field("fs-flags", &self.fs_flags).field("fs-rights-base", &self.fs_rights_base).field("fs-rights-inheriting", &self.fs_rights_inheriting).finish()}
   }
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// Which file time attributes to adjust.
     /// TODO: wit appears to not have support for flags repr
     /// (@witx repr u16)
@@ -834,7 +834,7 @@ pub mod output {
               Self { bits }
         }
   }
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// Flags determining the method of how paths are resolved.
     /// TODO: wit appears to not have support for flags repr
     /// (@witx repr u32)
@@ -850,7 +850,7 @@ pub mod output {
               Self { bits }
         }
   }
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// Open flags used by `path_open`.
     /// TODO: wit appears to not have support for flags repr
     /// (@witx repr u16)
@@ -904,7 +904,7 @@ pub mod output {
       }
     }
   }
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// Flags determining how to interpret the timestamp provided in
     /// `subscription-clock::timeout`.
     pub struct Subclockflags: u8 {
@@ -977,7 +977,7 @@ pub mod output {
       }
     }
   }
-  wit_bindgen_rust::bitflags::bitflags! {
+  wai_bindgen_rust::bitflags::bitflags! {
     /// The state of the file descriptor subscribed to with
     /// `eventtype::fd_read` or `eventtype::fd_write`.
     pub struct Eventrwflags: u8 {

--- a/lib/wasi-types/src/wasi/extra.rs
+++ b/lib/wasi-types/src/wasi/extra.rs
@@ -531,7 +531,7 @@ impl core::fmt::Display for BusErrno {
 }
 
 impl std::error::Error for BusErrno {}
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// File descriptor rights, determining which actions may be performed.
   pub struct Rights: u64 {
     /// The right to invoke `fd_datasync`.
@@ -749,7 +749,7 @@ impl core::fmt::Debug for Advice {
         }
     }
 }
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// File descriptor flags.
   pub struct Fdflags: u16 {
     /// Append mode: Data written to the file is always appended to the file's end.
@@ -797,7 +797,7 @@ impl core::fmt::Debug for Fdstat {
             .finish()
     }
 }
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// Which file time attributes to adjust.
   /// TODO: wit appears to not have support for flags repr
   /// (@witx repr u16)
@@ -819,7 +819,7 @@ impl Fstflags {
         Self { bits }
     }
 }
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// Flags determining the method of how paths are resolved.
   /// TODO: wit appears to not have support for flags repr
   /// (@witx repr u32)
@@ -835,7 +835,7 @@ impl Lookup {
         Self { bits }
     }
 }
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// Open flags used by `path_open`.
   /// TODO: wit appears to not have support for flags repr
   /// (@witx repr u16)
@@ -883,7 +883,7 @@ impl core::fmt::Debug for Eventtype {
         }
     }
 }
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// Flags determining how to interpret the timestamp provided in
   /// `subscription-clock::timeout`.
   pub struct Subclockflags: u16 {
@@ -967,7 +967,7 @@ impl core::fmt::Debug for Preopentype {
         }
     }
 }
-wit_bindgen_rust::bitflags::bitflags! {
+wai_bindgen_rust::bitflags::bitflags! {
   /// The state of the file descriptor subscribed to with
   /// `eventtype::fd_read` or `eventtype::fd_write`.
   pub struct Eventrwflags: u16 {


### PR DESCRIPTION
Note: This depends on https://github.com/wasmerio/wai/pull/20 and a v0.2.2 release of `wai-bindgen-cli`! It also requires bumping our MSRV to 1.64.

In https://github.com/wasmerio/wasmer/commit/c1b2b08bd19a4d524d056be86e2ad8ef193a60ca, we accidentally updated the `regenerate.sh` script to run `cargo install wai-bindgen` instead of `wai-bindgen-cli` (the crate with the executable). 

That version of the `wai-bindgen` CLI also didn't include https://github.com/wasmerio/wai/commit/fbea20fecaaa280841d35fcc5962f1ead572cfc4 which adds a `--force-generate-structs` flag to the `wai-bindgen rust-wasm ...` sub-command.

This PR updates the `regenerate.sh` script to prompt users to install `wai-bindgen-cli` with the desired version if they haven't already. I've also regenerated the types to make sure `--force-generate-structs` works as intended.

Closes https://github.com/wasmerio/wasmer/issues/3387.