### PR TITLE
Fix build doc and minimum-sys build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up libstdc++ on Linux
         if: matrix.build == 'linux-x64'
+        #llvm needs libtinfo5, and it seems it's not by default in the system now
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --allow-downgrades libstdc++6=8.4.0-1ubuntu1~18.04
           sudo apt-get install --reinstall g++-8
+          sudo apt-get install -y libncurses5
       - name: Set up base deps on musl
         if: matrix.build == 'linux-musl-x64'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,12 +89,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up libstdc++ on Linux
         if: matrix.build == 'linux-x64'
-        #llvm needs libtinfo5, and it seems it's not by default in the system now
         run: |
           sudo apt-get update -y
           sudo apt-get install -y --allow-downgrades libstdc++6=8.4.0-1ubuntu1~18.04
           sudo apt-get install --reinstall g++-8
-          sudo apt-get install -y libncurses5
       - name: Set up base deps on musl
         if: matrix.build == 'linux-musl-x64'
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,14 @@ env:
 jobs:
   lint:
     name: Code lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
+      - name: Set up libstdc++ on Linux
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --allow-downgrades libstdc++6=8.4.0-1ubuntu1~18.04
+          sudo apt-get install --reinstall g++-8
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ else ifeq ($(ENABLE_LLVM), 1)
 else ifneq (, $(shell which llvm-config-13 2>/dev/null))
 	LLVM_VERSION := $(shell llvm-config-13 --version)
 	compilers += llvm
+	# need force LLVM_SYS_120_PREFIX, or llvm_sys will not build in the case
+	export LLVM_SYS_120_PREFIX = $(shell llvm-config-13 --prefix)
 else ifneq (, $(shell which llvm-config-12 2>/dev/null))
 	LLVM_VERSION := $(shell llvm-config-12 --version)
 	compilers += llvm

--- a/lib/api/src/sys/store.rs
+++ b/lib/api/src/sys/store.rs
@@ -197,24 +197,28 @@ impl AsStoreMut for Store {
     }
 }
 
+#[cfg(feature = "compiler")]
 impl AsEngineRef for Store {
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef::new(&self.engine)
     }
 }
 
+#[cfg(feature = "compiler")]
 impl AsEngineRef for &Store {
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef::new(&self.engine)
     }
 }
 
+#[cfg(feature = "compiler")]
 impl AsEngineRef for StoreRef<'_> {
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef::new(&self.inner.engine)
     }
 }
 
+#[cfg(feature = "compiler")]
 impl AsEngineRef for StoreMut<'_> {
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef::new(&self.inner.engine)


### PR DESCRIPTION
# Description
* Fix build-doc that was not working if only LLVM-13 is installed and `llvm-config` is not available (only `llvm-config-13` is)
* Fix minimum-sys build
* Forced libncurses5 in linux-x64 OS used by [CI] for build, as the custom build of LLVM needs libtinfo5 to run.