### PR TITLE
Use the wasm_bindgen_downcast crate for downcasting JsValues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,9 +3208,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3816,6 +3816,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-downcast"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dac026d43bcca6e7ce1c0956ba68f59edf6403e8e930a5d891be72c31a44340"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "wasm-bindgen-downcast-macros",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,6 +3952,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "wasm-bindgen",
+ "wasm-bindgen-downcast",
  "wasm-bindgen-test",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -62,6 +62,7 @@ macro-wasmer-universal-test = { version = "3.0.2", path = "./macro-wasmer-univer
 # - Mandatory dependencies for `js`.
 wasmer-types = { path = "../types", version = "=3.0.2", default-features = false, features = ["std"] }
 wasm-bindgen = "0.2.74"
+wasm-bindgen-downcast = { version = "0.1.1" }
 js-sys = "0.3.51"
 #web-sys = { version = "0.3.51", features = [ "console" ] }
 wasmer-derive = { path = "../derive", version = "=3.0.2" }


### PR DESCRIPTION
We need this because `@wasmer/wasi` gets minified, which breaks the `JsValue -> WasmerRuntimeError` downcast in the same way that was mentioned in https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-1167895291. 

The [`wasm-bindgen-downcast`](https://github.com/wasmerio/wasm-bindgen-downcast) crate works by associating a unique JavaScript `Symbol` with each Rust type implementing the `DowncastJS` trait. That gives us something we can check before downcasting a `JsValue` back to a `WasmerRuntimeError`.

The underlying issue is that `@wasmer/wasi` implements the `exit()` syscall by raising a `WasmerRuntimeError` with the exit code  as a JavaScript exception and catching it from the outside. To get the exit code back, we try to downcast the `JsValue` we caught back to a `WasmerRuntimeError`, but because the minifier renamed `"WasmerRuntimeError"` to `"H"`, the string-based `generic_of_jsval()` downcast doesn't work. 

Using symbols fixes this issue because a symbol is guaranteed to be unique and unchanging once you create it (`wasm-bindgen-downcast` stores it in a `once-cell`).

See https://github.com/wasmerio/wasmer-js/pull/310 for a much more in-depth explanation of the issue.