### PR TITLE
Fix minor typo

### DIFF
--- a/lib/middlewares/src/metering.rs
+++ b/lib/middlewares/src/metering.rs
@@ -1,6 +1,6 @@
 //! `metering` is a middleware for tracking how many operators are
 //! executed in total and putting a limit on the total number of
-//! operators executed. The WebAssemblt instance execution is stopped
+//! operators executed. The WebAssembly instance execution is stopped
 //! when the limit is reached.
 //!
 //! # Example


### PR DESCRIPTION
# Description

There's a single-character typo in the metering middleware docs! (That or `WebAssemblt` is a pun that I'm not aware of)

# Review

- [ ] Add a short description of the change to the CHANGELOG.md file