### PR TITLE
Use "wasmer --version --verbose" in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -18,7 +18,7 @@ Copy and paste the result of executing the following in your shell, so we can kn
 -->
 
 ```sh
-echo "`wasmer -V` | `rustc -V` | `uname -m`"
+wasmer --version --verbose && echo && rustc --version --verbose
 ```
 
 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -18,7 +18,7 @@ Copy and paste the result of executing the following in your shell, so we can kn
 -->
 
 ```sh
-wasmer --version --verbose && echo && rustc --version --verbose
+wasmer -vV; rustc -vV
 ```
 
 


### PR DESCRIPTION
# Description

Now that the `wasmer` CLI can show more verbose version information (#3215), we should ask people to use it when creating tickets.

Before:

```console
$ echo "`wasmer -V` | `rustc -V` | `uname -m`"
wasmer 3.0.2 | rustc 1.63.0 (4b91a6ea7 2022-08-08) | x86_64
```

After: 

```console
$ wasmer -vV; rustc -vV
wasmer 3.0.2 (5287c 2022-11-27)
binary: wasmer-cli
commit-hash: 5287c4f1253f66f428066d35eef0825fe827cff3
commit-date: 2022-11-27
host: x86_64-unknown-linux-gnu
compiler: singlepass,cranelift,llvm
rustc 1.63.0 (4b91a6ea7 2022-08-08)
binary: rustc
commit-hash: 4b91a6ea7258a947e59c6522cd5898e7c0a6a88f
commit-date: 2022-08-08
host: x86_64-unknown-linux-gnu
release: 1.63.0
LLVM version: 14.0.5
```

Fixes #3412.
