### PR TITLE
Use GNU/Linux frame registration code for FreeBSD too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Looking for changes that affect our C API? See the [C API Changelog](lib/c-api/C
 
 ## **Unreleased**
 
+## Fixed
+
+  - [#3439](https://github.com/wasmerio/wasmer/pull/3439) Use GNU/Linux frame registration code for FreeBSD too
+
 ## 3.1.0 - 12/12/2022
 
 ## Added

--- a/lib/compiler/src/engine/unwind/systemv.rs
+++ b/lib/compiler/src/engine/unwind/systemv.rs
@@ -60,7 +60,10 @@ impl UnwindRegistry {
 
     #[allow(clippy::cast_ptr_alignment)]
     unsafe fn register_frames(&mut self, eh_frame: &[u8]) {
-        if cfg!(all(target_os = "linux", target_env = "gnu")) {
+        if cfg!(any(
+            all(target_os = "linux", target_env = "gnu"),
+            target_os = "freebsd"
+        )) {
             // Registering an empty `eh_frame` (i.e. which
             // contains empty FDEs) cause problems on Linux when
             // deregistering it. We must avoid this


### PR DESCRIPTION
# Description

This change prevents a long hang when a program exits.

FreeBSD's `__deregister_frame` and `__register_frame` implementations are ported from GCC, which is why we should be using the same frame registration code for FreeBSD and GNU/Linux.

Link: https://github.com/freebsd/freebsd-src/blob/release/13.1.0/contrib/llvm-project/libunwind/src/UnwindLevel1-gcc-ext.c#L241-L299
Fixes: https://github.com/wasmerio/wasmer/issues/3373

# Review

- [x] Add a short description of the change to the CHANGELOG.md file
