### PR TITLE
Fix CI for external collaborator PRs

### DIFF
--- a/tests/integration/cli/tests/login.rs
+++ b/tests/integration/cli/tests/login.rs
@@ -11,6 +11,10 @@ fn login_works() -> anyhow::Result<()> {
         return Ok(());
     }
     let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").expect("WAPM_DEV_TOKEN env var not set");
+    // Special case: GitHub secrets aren't visible to outside collaborators
+    if wapm_dev_token.is_empty() {
+        return Ok(());
+    }
     let output = Command::new(get_wasmer_path())
         .arg("login")
         .arg("--registry")

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -112,6 +112,10 @@ fn run_whoami_works() -> anyhow::Result<()> {
     }
 
     let ciuser_token = std::env::var("WAPM_DEV_TOKEN").expect("no CIUSER / WAPM_DEV_TOKEN token");
+    // Special case: GitHub secrets aren't visible to outside collaborators
+    if ciuser_token.is_empty() {
+        return Ok(());
+    }
 
     let output = Command::new(get_wasmer_path())
         .arg("login")


### PR DESCRIPTION
If an outside collaborator submits a pull request, GitHub sets secrets such as `WAPM_DEV_TOKEN` to an empty string, which will make the tests fail.

This PR unblocks #3439.