### PR TITLE
Fix wasmer-rust readme example

### DIFF
--- a/lib/api/README.md
+++ b/lib/api/README.md
@@ -29,10 +29,10 @@ fn main() -> anyhow::Result<()> {
     let module = Module::new(&store, &module_wat)?;
     // The module doesn't import anything, so we create an empty import object.
     let import_object = imports! {};
-    let instance = Instance::new(&module, &import_object)?;
+    let instance = Instance::new(&mut store, &module, &import_object)?;
 
     let add_one = instance.exports.get_function("add_one")?;
-    let result = add_one.call(&[Value::I32(42)])?;
+    let result = add_one.call(&mut store, &[Value::I32(42)])?;
     assert_eq!(result[0], Value::I32(43));
 
     Ok(())


### PR DESCRIPTION
# Description

This just updates the example from [`wasmer-rust`](https://crates.io/crates/wasmer)'s readme so it doesn't fail to compile. 
Both [`Instance`](https://docs.rs/wasmer/3.1.0/wasmer/struct.Instance.html) and [`Function::call()`](https://docs.rs/wasmer/3.1.0/wasmer/struct.Function.html#method.call) expect a mutable reference to a [`Store`](https://docs.rs/wasmer/3.1.0/wasmer/struct.Store.html).