### PR TITLE
[SINGLEPASS] Added a special case on SSE4.2 backend when dst == src1

### DIFF
--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -739,9 +739,12 @@ macro_rules! sse_fn {
         |emitter: &mut AssemblerX64, precision: Precision, src1: XMM, src2: XMMOrMemory, dst: XMM| {
             match src2 {
                 XMMOrMemory::XMM(x) => {
-                    assert_ne!(x, dst);
-                    move_src_to_dst(emitter, precision, src1, dst);
-                    dynasm!(emitter ; $ins Rx((dst as u8)), Rx((x as u8)))
+                    if x == dst {
+                        dynasm!(emitter ; $ins Rx((dst as u8)), Rx((src1 as u8)))
+                    } else {
+                        move_src_to_dst(emitter, precision, src1, dst);
+                        dynasm!(emitter ; $ins Rx((dst as u8)), Rx((x as u8)))
+                    }
                 }
                 XMMOrMemory::Memory(base, disp) => {
                     move_src_to_dst(emitter, precision, src1, dst);


### PR DESCRIPTION
# Description

Singlepass SSE4.2 backend have to convert 3-ways AVX operator to 2-ways SSE operator. Some cases where dst == src1 were not handled and would panic.
This should fix those cases

For ticket #3461 