### PR TITLE
Rename `WasiState::new()` to `WasiState::builder()`

### DIFF
--- a/lib/wasi/src/state/mod.rs
+++ b/lib/wasi/src/state/mod.rs
@@ -264,7 +264,14 @@ impl WasiState {
     /// Create a [`WasiStateBuilder`] to construct a validated instance of
     /// [`WasiState`].
     #[allow(clippy::new_ret_no_self)]
+    #[deprecated = "Use WasiState::builder()"]
     pub fn new(program_name: impl AsRef<str>) -> WasiStateBuilder {
+        WasiState::builder(program_name)
+    }
+
+    /// Create a [`WasiStateBuilder`] to construct a validated instance of
+    /// [`WasiState`].
+    pub fn builder(program_name: impl AsRef<str>) -> WasiStateBuilder {
         create_wasi_state(program_name.as_ref())
     }
 


### PR DESCRIPTION
The typical convention is for `Foo::new()` to return an instance of `Foo` and `Foo::builder()` to return some type of builder object. Our `WasiState` type doesn't follow this convention (and explicitly `#[allow]`s the associated clippy warning), so the API can be confusing for anyone that hasn't used it before.

I've renamed the `WasiState::new()` function to `WasiState::builder()` and added a `#[deprecated]` attribute to the original `WasiState::new()` so it doesn't break Deploy.
