### PR TITLE
This should fix CI build of CAPI Headless

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,15 +452,15 @@ build-capi-llvm-universal:
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
 	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/$(CARGO_TARGET_FLAG)/headless
+		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/$(CARGO_TARGET)/headless
 else
 	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/$(CARGO_TARGET_FLAG)/headless
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/$(CARGO_TARGET)/headless
 endif
 
 build-capi-headless-ios:
 	RUSTFLAGS="${RUSTFLAGS} -C panic=abort" cargo lipo --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/$(CARGO_TARGET_FLAG)/headless
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/$(CARGO_TARGET)/headless
 
 #####
 #


### PR DESCRIPTION
# Description
Command lines arguments are not correctly built when the Makefile is used from the CI and build CAPI Headless.