### PR TITLE
Fix Windows-GNU distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,9 @@ jobs:
       - name: Dist
         run: |
           make distribution-gnu
+        env: 
+          CARGO_TARGET: x86_64-pc-windows-gnu
+          TARGET_DIR: target/x86_64-pc-windows-gnu/release
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Due to the changes in the Makefile, the `windows-gnu64` target did not include the libwasmer.a on Windows anymore, breaking any cross-compilation efforts. This has to be merged before the `-alpha` release.