### PR TITLE
Reenable create-exe tests

### DIFF
--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -257,14 +257,8 @@ fn test_create_exe_with_precompiled_works_1() {
 
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_works() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let operating_dir: PathBuf = temp_dir.path().to_owned();
@@ -301,14 +295,8 @@ fn create_exe_works() -> anyhow::Result<()> {
 /// Tests that "-c" and "-- -c" are treated differently
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_works_multi_command_args_handling() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let operating_dir: PathBuf = temp_dir.path().to_owned();
@@ -373,14 +361,8 @@ fn create_exe_works_multi_command_args_handling() -> anyhow::Result<()> {
 
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_works_multi_command() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let operating_dir: PathBuf = temp_dir.path().to_owned();
@@ -436,14 +418,8 @@ fn create_exe_works_multi_command() -> anyhow::Result<()> {
 
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_works_with_file() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let operating_dir: PathBuf = temp_dir.path().to_owned();
@@ -509,12 +485,6 @@ fn create_exe_works_with_file() -> anyhow::Result<()> {
 // see https://github.com/wasmerio/wasmer/issues/3459
 #[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_serialized_works() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let operating_dir: PathBuf = temp_dir.path().to_owned();
@@ -697,42 +667,24 @@ fn create_exe_with_object_input(args: Vec<String>) -> anyhow::Result<()> {
 
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_with_object_input_default() -> anyhow::Result<()> {
     create_exe_with_object_input(vec![])
 }
 
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_with_object_input_symbols() -> anyhow::Result<()> {
     create_exe_with_object_input(vec!["--object-format".to_string(), "symbols".to_string()])
 }
 
 // Ignored because of -lunwind linker issue on Windows
 // see https://github.com/wasmerio/wasmer/issues/3459
-// #[cfg_attr(target_os = "windows", ignore)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
-// Test temporarily ignored during the release of 3.2.0-alpha
-// because create-exe links to the old libwasmer.a which expects
-// MetadataHeader::VERSION == 1, but we want to upgrade to version 2.
-//
-// https://github.com/wasmerio/wasmer/issues/3513
-#[ignore]
 fn create_exe_with_object_input_serialized() -> anyhow::Result<()> {
     create_exe_with_object_input(vec![
         "--object-format".to_string(),


### PR DESCRIPTION
Fixes https://github.com/wasmerio/wasmer/issues/3513.

Might fail for now since `3.2.0-alpha.1` isn't released yet.