### PR TITLE
Use JS VM store instead of artificially replicate it

### DIFF
--- a/lib/api/src/js/externals/global.rs
+++ b/lib/api/src/js/externals/global.rs
@@ -1,8 +1,8 @@
-use crate::js::export::VMGlobal;
 use crate::js::exports::{ExportError, Exportable};
-use crate::js::externals::{Extern, VMExtern};
+use crate::js::externals::Extern;
 use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::value::Value;
+use crate::js::vm::{VMExtern, VMGlobal};
 use crate::js::wasm_bindgen_polyfill::Global as JSGlobal;
 use crate::js::GlobalType;
 use crate::js::Mutability;
@@ -95,7 +95,7 @@ impl Global {
         let js_global = JSGlobal::new(&descriptor, &value).unwrap();
         let vm_global = VMGlobal::new(js_global, global_ty);
 
-        Ok(Self::from_vm_export(store, vm_global))
+        Ok(Self::from_vm_extern(store, vm_global))
     }
 
     /// Returns the [`GlobalType`] of the `Global`.
@@ -112,7 +112,7 @@ impl Global {
     /// assert_eq!(c.ty(), &GlobalType::new(Type::I32, Mutability::Const));
     /// assert_eq!(v.ty(), &GlobalType::new(Type::I64, Mutability::Var));
     /// ```
-    pub fn ty(&self, store: &impl AsStoreRef) -> GlobalType {
+    pub fn ty(&self, _store: &impl AsStoreRef) -> GlobalType {
         self.handle.ty
     }
 
@@ -205,18 +205,14 @@ impl Global {
         Ok(())
     }
 
-    pub(crate) fn from_vm_export(store: &mut impl AsStoreMut, vm_global: VMGlobal) -> Self {
+    pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, vm_global: VMGlobal) -> Self {
         use crate::js::store::StoreObject;
         VMGlobal::list_mut(store.objects_mut()).push(vm_global.clone());
         Self { handle: vm_global }
     }
 
-    pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, internal: VMGlobal) -> Self {
-        Self { handle: internal }
-    }
-
     /// Checks whether this `Global` can be used with the given store.
-    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, _store: &impl AsStoreRef) -> bool {
         true
     }
 }

--- a/lib/api/src/js/externals/global.rs
+++ b/lib/api/src/js/externals/global.rs
@@ -1,7 +1,7 @@
 use crate::js::export::VMGlobal;
 use crate::js::exports::{ExportError, Exportable};
 use crate::js::externals::{Extern, VMExtern};
-use crate::js::store::{AsStoreMut, AsStoreRef, InternalStoreHandle, StoreHandle};
+use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::value::Value;
 use crate::js::wasm_bindgen_polyfill::Global as JSGlobal;
 use crate::js::GlobalType;
@@ -17,7 +17,7 @@ use wasm_bindgen::JsValue;
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#global-instances>
 #[derive(Debug, Clone, PartialEq)]
 pub struct Global {
-    pub(crate) handle: StoreHandle<VMGlobal>,
+    pub(crate) handle: VMGlobal,
 }
 
 impl Global {
@@ -57,7 +57,7 @@ impl Global {
 
     /// To `VMExtern`.
     pub(crate) fn to_vm_extern(&self) -> VMExtern {
-        VMExtern::Global(self.handle.internal_handle())
+        VMExtern::Global(self.handle.clone())
     }
 
     /// Create a `Global` with the initial value [`Value`] and the provided [`Mutability`].
@@ -113,7 +113,7 @@ impl Global {
     /// assert_eq!(v.ty(), &GlobalType::new(Type::I64, Mutability::Var));
     /// ```
     pub fn ty(&self, store: &impl AsStoreRef) -> GlobalType {
-        self.handle.get(store.as_store_ref().objects()).ty
+        self.handle.ty
     }
 
     /// Retrieves the current value [`Value`] that the Global has.
@@ -130,14 +130,8 @@ impl Global {
     /// ```
     pub fn get(&self, store: &impl AsStoreRef) -> Value {
         unsafe {
-            let raw = self
-                .handle
-                .get(store.as_store_ref().objects())
-                .global
-                .value()
-                .as_f64()
-                .unwrap();
-            let ty = self.handle.get(store.as_store_ref().objects()).ty;
+            let raw = self.handle.global.value().as_f64().unwrap();
+            let ty = self.handle.ty;
             Value::from_raw(store, ty.ty, raw)
         }
     }
@@ -207,33 +201,23 @@ impl Global {
                 ))
             }
         };
-        self.handle
-            .get_mut(store.objects_mut())
-            .global
-            .set_value(&new_value);
+        self.handle.global.set_value(&new_value);
         Ok(())
     }
 
     pub(crate) fn from_vm_export(store: &mut impl AsStoreMut, vm_global: VMGlobal) -> Self {
-        Self {
-            handle: StoreHandle::new(store.objects_mut(), vm_global),
-        }
+        use crate::js::store::StoreObject;
+        VMGlobal::list_mut(store.objects_mut()).push(vm_global.clone());
+        Self { handle: vm_global }
     }
 
-    pub(crate) fn from_vm_extern(
-        store: &mut impl AsStoreMut,
-        internal: InternalStoreHandle<VMGlobal>,
-    ) -> Self {
-        Self {
-            handle: unsafe {
-                StoreHandle::from_internal(store.as_store_ref().objects().id(), internal)
-            },
-        }
+    pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, internal: VMGlobal) -> Self {
+        Self { handle: internal }
     }
 
     /// Checks whether this `Global` can be used with the given store.
     pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
-        self.handle.store_id() == store.as_store_ref().objects().id()
+        true
     }
 }
 

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -1,7 +1,7 @@
-use crate::js::export::VMMemory;
 use crate::js::exports::{ExportError, Exportable};
-use crate::js::externals::{Extern, VMExtern};
+use crate::js::externals::Extern;
 use crate::js::store::{AsStoreMut, AsStoreRef, StoreObjects};
+use crate::js::vm::{VMExtern, VMMemory};
 use crate::js::{MemoryAccessError, MemoryType};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
@@ -87,7 +87,7 @@ impl Memory {
     /// ```
     pub fn new(store: &mut impl AsStoreMut, ty: MemoryType) -> Result<Self, MemoryError> {
         let vm_memory = VMMemory::new(Self::new_internal(ty.clone())?, ty);
-        Ok(Self::from_vm_export(store, vm_memory))
+        Ok(Self::from_vm_extern(store, vm_memory))
     }
 
     pub(crate) fn new_internal(ty: MemoryType) -> Result<js_sys::WebAssembly::Memory, MemoryError> {
@@ -141,7 +141,7 @@ impl Memory {
     ///
     /// assert_eq!(m.ty(), mt);
     /// ```
-    pub fn ty(&self, store: &impl AsStoreRef) -> MemoryType {
+    pub fn ty(&self, _store: &impl AsStoreRef) -> MemoryType {
         self.handle.ty
     }
 
@@ -234,26 +234,22 @@ impl Memory {
         Ok(new_memory)
     }
 
-    pub(crate) fn from_vm_export(store: &mut impl AsStoreMut, vm_memory: VMMemory) -> Self {
-        Self { handle: vm_memory }
-    }
-
-    pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, internal: VMMemory) -> Self {
+    pub(crate) fn from_vm_extern(_store: &mut impl AsStoreMut, internal: VMMemory) -> Self {
         Self { handle: internal }
     }
 
     /// Attempts to clone this memory (if its clonable)
-    pub fn try_clone(&self, store: &impl AsStoreRef) -> Option<VMMemory> {
+    pub fn try_clone(&self, _store: &impl AsStoreRef) -> Option<VMMemory> {
         self.handle.try_clone()
     }
 
     /// Checks whether this `Global` can be used with the given context.
-    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, _store: &impl AsStoreRef) -> bool {
         true
     }
 
     /// Copies this memory to a new memory
-    pub fn duplicate(&mut self, store: &impl AsStoreRef) -> Result<VMMemory, MemoryError> {
+    pub fn duplicate(&mut self, _store: &impl AsStoreRef) -> Result<VMMemory, MemoryError> {
         self.handle.duplicate()
     }
 }

--- a/lib/api/src/js/externals/memory_view.rs
+++ b/lib/api/src/js/externals/memory_view.rs
@@ -27,8 +27,7 @@ pub struct MemoryView<'a> {
 
 impl<'a> MemoryView<'a> {
     pub(crate) fn new(memory: &Memory, store: &impl AsStoreRef) -> Self {
-        let memory = memory.handle.get(store.as_store_ref().objects());
-        Self::new_raw(&memory.memory)
+        Self::new_raw(&memory.handle.memory)
     }
 
     pub(crate) fn new_raw(memory: &js_sys::WebAssembly::Memory) -> Self {

--- a/lib/api/src/js/externals/memory_view.rs
+++ b/lib/api/src/js/externals/memory_view.rs
@@ -26,7 +26,7 @@ pub struct MemoryView<'a> {
 }
 
 impl<'a> MemoryView<'a> {
-    pub(crate) fn new(memory: &Memory, store: &impl AsStoreRef) -> Self {
+    pub(crate) fn new(memory: &Memory, _store: &impl AsStoreRef) -> Self {
         Self::new_raw(&memory.handle.memory)
     }
 

--- a/lib/api/src/js/externals/mod.rs
+++ b/lib/api/src/js/externals/mod.rs
@@ -10,101 +10,12 @@ pub use self::memory::{Memory, MemoryError};
 pub use self::memory_view::MemoryView;
 pub use self::table::Table;
 
-use crate::js::error::WasmError;
-use crate::js::export::{Export, VMFunction, VMGlobal, VMMemory, VMTable};
 use crate::js::exports::{ExportError, Exportable};
-use crate::js::store::StoreObject;
 use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::types::AsJs;
-use crate::js::wasm_bindgen_polyfill::Global as JsGlobal;
-use js_sys::Function as JsFunction;
-use js_sys::WebAssembly::{Memory as JsMemory, Table as JsTable};
+use crate::js::vm::VMExtern;
 use std::fmt;
-use wasm_bindgen::{JsCast, JsValue};
 use wasmer_types::ExternType;
-
-/// The value of an export passed from one instance to another.
-pub enum VMExtern {
-    /// A function export value.
-    Function(VMFunction),
-
-    /// A table export value.
-    Table(VMTable),
-
-    /// A memory export value.
-    Memory(VMMemory),
-
-    /// A global export value.
-    Global(VMGlobal),
-}
-
-impl VMExtern {
-    /// Return the export as a `JSValue`.
-    pub fn as_jsvalue<'context>(&self, store: &'context impl AsStoreRef) -> JsValue {
-        match self {
-            Self::Memory(js_wasm_memory) => js_wasm_memory.memory.clone().into(),
-            Self::Function(js_func) => js_func.function.clone().into(),
-            Self::Table(js_wasm_table) => js_wasm_table.table.clone().into(),
-            Self::Global(js_wasm_global) => js_wasm_global.global.clone().into(),
-        }
-    }
-
-    /// Convert a `JsValue` into an `Export` within a given `Context`.
-    pub fn from_js_value(
-        val: JsValue,
-        store: &mut impl AsStoreMut,
-        extern_type: ExternType,
-    ) -> Result<Self, WasmError> {
-        match extern_type {
-            ExternType::Memory(memory_type) => {
-                if val.is_instance_of::<JsMemory>() {
-                    Ok(Self::Memory(VMMemory::new(
-                        val.unchecked_into::<JsMemory>(),
-                        memory_type,
-                    )))
-                } else {
-                    Err(WasmError::TypeMismatch(
-                        val.js_typeof()
-                            .as_string()
-                            .map(Into::into)
-                            .unwrap_or("unknown".into()),
-                        "Memory".into(),
-                    ))
-                }
-            }
-            ExternType::Global(global_type) => {
-                if val.is_instance_of::<JsGlobal>() {
-                    Ok(Self::Global(VMGlobal::new(
-                        val.unchecked_into::<JsGlobal>(),
-                        global_type,
-                    )))
-                } else {
-                    panic!("Extern type doesn't match js value type");
-                }
-            }
-            ExternType::Function(function_type) => {
-                if val.is_instance_of::<JsFunction>() {
-                    Ok(Self::Function(VMFunction::new(
-                        val.unchecked_into::<JsFunction>(),
-                        function_type,
-                    )))
-                } else {
-                    panic!("Extern type doesn't match js value type");
-                }
-            }
-            ExternType::Table(table_type) => {
-                if val.is_instance_of::<JsTable>() {
-                    Ok(Self::Table(VMTable::new(
-                        val.unchecked_into::<JsTable>(),
-                        table_type,
-                    )))
-                } else {
-                    panic!("Extern type doesn't match js value type");
-                }
-            }
-        }
-    }
-}
 
 /// An `Extern` is the runtime representation of an entity that
 /// can be imported or exported.
@@ -162,24 +73,15 @@ impl Extern {
             Self::Table(val) => val.is_from_store(store),
         }
     }
-
-    fn to_export(&self) -> Export {
-        match self {
-            Self::Function(val) => Export::Function(val.handle.clone()),
-            Self::Memory(val) => Export::Memory(val.handle.clone()),
-            Self::Global(val) => Export::Global(val.handle.clone()),
-            Self::Table(val) => Export::Table(val.handle.clone()),
-        }
-    }
 }
 
 impl AsJs for Extern {
     fn as_jsvalue(&self, store: &impl AsStoreRef) -> wasm_bindgen::JsValue {
         match self {
-            Self::Function(_) => self.to_export().as_jsvalue(store),
-            Self::Global(_) => self.to_export().as_jsvalue(store),
-            Self::Table(_) => self.to_export().as_jsvalue(store),
-            Self::Memory(_) => self.to_export().as_jsvalue(store),
+            Self::Function(_) => self.to_vm_extern().as_jsvalue(store),
+            Self::Global(_) => self.to_vm_extern().as_jsvalue(store),
+            Self::Table(_) => self.to_vm_extern().as_jsvalue(store),
+            Self::Memory(_) => self.to_vm_extern().as_jsvalue(store),
         }
         .clone()
     }

--- a/lib/api/src/js/externals/table.rs
+++ b/lib/api/src/js/externals/table.rs
@@ -1,8 +1,8 @@
-use crate::js::export::{VMFunction, VMTable};
 use crate::js::exports::{ExportError, Exportable};
-use crate::js::externals::{Extern, VMExtern};
+use crate::js::externals::Extern;
 use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::value::Value;
+use crate::js::vm::{VMExtern, VMFunction, VMTable};
 use crate::js::RuntimeError;
 use crate::js::{FunctionType, TableType};
 use js_sys::Function;
@@ -74,7 +74,7 @@ impl Table {
     }
 
     /// Returns the [`TableType`] of the `Table`.
-    pub fn ty(&self, store: &impl AsStoreRef) -> TableType {
+    pub fn ty(&self, _store: &impl AsStoreRef) -> TableType {
         self.handle.ty
     }
 
@@ -83,7 +83,7 @@ impl Table {
         if let Some(func) = self.handle.table.get(index).ok() {
             let ty = FunctionType::new(vec![], vec![]);
             let vm_function = VMFunction::new(func, ty);
-            let function = crate::js::externals::Function::from_vm_export(store, vm_function);
+            let function = crate::js::externals::Function::from_vm_extern(store, vm_function);
             Some(Value::FuncRef(Some(function)))
         } else {
             None
@@ -102,7 +102,7 @@ impl Table {
     }
 
     /// Retrieves the size of the `Table` (in elements)
-    pub fn size(&self, store: &impl AsStoreRef) -> u32 {
+    pub fn size(&self, _store: &impl AsStoreRef) -> u32 {
         self.handle.table.length()
     }
 
@@ -142,12 +142,12 @@ impl Table {
         unimplemented!("Table.copy is not natively supported in Javascript");
     }
 
-    pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, internal: VMTable) -> Self {
+    pub(crate) fn from_vm_extern(_store: &mut impl AsStoreMut, internal: VMTable) -> Self {
         Self { handle: internal }
     }
 
     /// Checks whether this `Table` can be used with the given context.
-    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
+    pub fn is_from_store(&self, _store: &impl AsStoreRef) -> bool {
         true
     }
 
@@ -161,7 +161,7 @@ impl Table {
     #[doc(hidden)]
     pub unsafe fn get_vm_table<'context>(
         &'context self,
-        store: &'context impl AsStoreRef,
+        _store: &'context impl AsStoreRef,
     ) -> &'context VMTable {
         &self.handle
     }

--- a/lib/api/src/js/externals/table.rs
+++ b/lib/api/src/js/externals/table.rs
@@ -1,7 +1,7 @@
 use crate::js::export::{VMFunction, VMTable};
 use crate::js::exports::{ExportError, Exportable};
 use crate::js::externals::{Extern, VMExtern};
-use crate::js::store::{AsStoreMut, AsStoreRef, InternalStoreHandle, StoreHandle};
+use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::value::Value;
 use crate::js::RuntimeError;
 use crate::js::{FunctionType, TableType};
@@ -18,7 +18,7 @@ use js_sys::Function;
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#table-instances>
 #[derive(Debug, Clone, PartialEq)]
 pub struct Table {
-    pub(crate) handle: StoreHandle<VMTable>,
+    pub(crate) handle: VMTable,
 }
 
 fn set_table_item(table: &VMTable, item_index: u32, item: &Function) -> Result<(), RuntimeError> {
@@ -30,12 +30,7 @@ fn get_function(store: &mut impl AsStoreMut, val: Value) -> Result<Function, Run
         return Err(RuntimeError::new("cannot pass Value across contexts"));
     }
     match val {
-        Value::FuncRef(Some(ref func)) => Ok(func
-            .handle
-            .get(&store.as_store_ref().objects())
-            .function
-            .clone()
-            .into()),
+        Value::FuncRef(Some(ref func)) => Ok(func.handle.function.clone().into()),
         // Only funcrefs is supported by the spec atm
         _ => unimplemented!(),
     }
@@ -70,30 +65,22 @@ impl Table {
             set_table_item(&table, i, &func)?;
         }
 
-        Ok(Self {
-            handle: StoreHandle::new(store.objects_mut(), table),
-        })
+        Ok(Self { handle: table })
     }
 
     /// To `VMExtern`.
     pub fn to_vm_extern(&self) -> VMExtern {
-        VMExtern::Table(self.handle.internal_handle())
+        VMExtern::Table(self.handle.clone())
     }
 
     /// Returns the [`TableType`] of the `Table`.
     pub fn ty(&self, store: &impl AsStoreRef) -> TableType {
-        self.handle.get(store.as_store_ref().objects()).ty
+        self.handle.ty
     }
 
     /// Retrieves an element of the table at the provided `index`.
     pub fn get(&self, store: &mut impl AsStoreMut, index: u32) -> Option<Value> {
-        if let Some(func) = self
-            .handle
-            .get(store.as_store_ref().objects())
-            .table
-            .get(index)
-            .ok()
-        {
+        if let Some(func) = self.handle.table.get(index).ok() {
             let ty = FunctionType::new(vec![], vec![]);
             let vm_function = VMFunction::new(func, ty);
             let function = crate::js::externals::Function::from_vm_export(store, vm_function);
@@ -111,15 +98,12 @@ impl Table {
         val: Value,
     ) -> Result<(), RuntimeError> {
         let item = get_function(store, val)?;
-        set_table_item(self.handle.get_mut(store.objects_mut()), index, &item)
+        set_table_item(&self.handle, index, &item)
     }
 
     /// Retrieves the size of the `Table` (in elements)
     pub fn size(&self, store: &impl AsStoreRef) -> u32 {
-        self.handle
-            .get(store.as_store_ref().objects())
-            .table
-            .length()
+        self.handle.table.length()
     }
 
     /// Grows the size of the `Table` by `delta`, initializating
@@ -158,20 +142,13 @@ impl Table {
         unimplemented!("Table.copy is not natively supported in Javascript");
     }
 
-    pub(crate) fn from_vm_extern(
-        store: &mut impl AsStoreMut,
-        internal: InternalStoreHandle<VMTable>,
-    ) -> Self {
-        Self {
-            handle: unsafe {
-                StoreHandle::from_internal(store.as_store_ref().objects().id(), internal)
-            },
-        }
+    pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, internal: VMTable) -> Self {
+        Self { handle: internal }
     }
 
     /// Checks whether this `Table` can be used with the given context.
     pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
-        self.handle.store_id() == store.as_store_ref().objects().id()
+        true
     }
 
     /// Get access to the backing VM value for this extern. This function is for
@@ -183,10 +160,10 @@ impl Table {
     /// make breaking changes to it at any time or remove this method.
     #[doc(hidden)]
     pub unsafe fn get_vm_table<'context>(
-        &self,
+        &'context self,
         store: &'context impl AsStoreRef,
     ) -> &'context VMTable {
-        self.handle.get(store.as_store_ref().objects())
+        &self.handle
     }
 }
 

--- a/lib/api/src/js/imports.rs
+++ b/lib/api/src/js/imports.rs
@@ -6,6 +6,7 @@ use crate::js::exports::Exports;
 use crate::js::module::Module;
 use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::types::AsJs;
+use crate::js::vm::VMExtern;
 use crate::js::ExternType;
 use crate::Extern;
 use std::collections::HashMap;
@@ -206,7 +207,6 @@ impl Imports {
         module: &Module,
         object: js_sys::Object,
     ) -> Result<Self, WasmError> {
-        use crate::js::externals::VMExtern;
         let module_imports: HashMap<(String, String), ExternType> = module
             .imports()
             .map(|import| {
@@ -457,162 +457,4 @@ mod test {
         assert!(happy.is_some());
         assert!(small.is_some());
     }
-    // fn namespace() {
-    //     let mut store = Store::default();
-    //     let g1 = Global::new(&store, Val::I32(0));
-    //     let namespace = namespace! {
-    //         "happy" => g1
-    //     };
-    //     let imports1 = imports! {
-    //         "dog" => namespace
-    //     };
-
-    //     let happy_dog_entry = imports1.get_export("dog", "happy").unwrap();
-
-    //     assert!(
-    //         if let Export::Global(happy_dog_global) = happy_dog_entry.to_export() {
-    //             happy_dog_global.ty.ty == Type::I32
-    //         } else {
-    //             false
-    //         }
-    //     );
-    // }
-
-    // fn imports_macro_allows_trailing_comma_and_none() {
-    //     use crate::js::Function;
-
-    //     let mut store = Default::default();
-
-    //     fn func(arg: i32) -> i32 {
-    //         arg + 1
-    //     }
-
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func" => Function::new_typed(&store, func),
-    //         },
-    //     };
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func" => Function::new_typed(&store, func),
-    //         }
-    //     };
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func" => Function::new_typed(&store, func),
-    //         },
-    //         "abc" => {
-    //             "def" => Function::new_typed(&store, func),
-    //         }
-    //     };
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func" => Function::new_typed(&store, func)
-    //         },
-    //     };
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func" => Function::new_typed(&store, func)
-    //         }
-    //     };
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func1" => Function::new_typed(&store, func),
-    //             "func2" => Function::new_typed(&store, func)
-    //         }
-    //     };
-    //     let _ = imports! {
-    //         "env" => {
-    //             "func1" => Function::new_typed(&store, func),
-    //             "func2" => Function::new_typed(&store, func),
-    //         }
-    //     };
-    // }
-
-    // fn chaining_works() {
-    //     let mut store = Store::default();
-    //     let g = Global::new(&store, Val::I32(0));
-
-    //     let mut imports1 = imports! {
-    //         "dog" => {
-    //             "happy" => g.clone()
-    //         }
-    //     };
-
-    //     let imports2 = imports! {
-    //         "dog" => {
-    //             "small" => g.clone()
-    //         },
-    //         "cat" => {
-    //             "small" => g.clone()
-    //         }
-    //     };
-
-    //     imports1.extend(&imports2);
-
-    //     let small_cat_export = imports1.get_export("cat", "small");
-    //     assert!(small_cat_export.is_some());
-
-    //     let happy = imports1.get_export("dog", "happy");
-    //     let small = imports1.get_export("dog", "small");
-    //     assert!(happy.is_some());
-    //     assert!(small.is_some());
-    // }
-
-    // fn extending_conflict_overwrites() {
-    //     let mut store = Store::default();
-    //     let g1 = Global::new(&store, Val::I32(0));
-    //     let g2 = Global::new(&store, Val::F32(0.));
-
-    //     let mut imports1 = imports! {
-    //         "dog" => {
-    //             "happy" => g1,
-    //         },
-    //     };
-
-    //     let imports2 = imports! {
-    //         "dog" => {
-    //             "happy" => g2,
-    //         },
-    //     };
-
-    //     imports1.extend(&imports2);
-    //     let happy_dog_entry = imports1.get_export("dog", "happy").unwrap();
-
-    //     assert!(
-    //         if let Export::Global(happy_dog_global) = happy_dog_entry.to_export() {
-    //             happy_dog_global.ty.ty == Type::F32
-    //         } else {
-    //             false
-    //         }
-    //     );
-
-    //     // now test it in reverse
-    //     let mut store = Store::default();
-    //     let g1 = Global::new(&store, Val::I32(0));
-    //     let g2 = Global::new(&store, Val::F32(0.));
-
-    //     let imports1 = imports! {
-    //         "dog" => {
-    //             "happy" => g1,
-    //         },
-    //     };
-
-    //     let mut imports2 = imports! {
-    //         "dog" => {
-    //             "happy" => g2,
-    //         },
-    //     };
-
-    //     imports2.extend(&imports1);
-    //     let happy_dog_entry = imports2.get_export("dog", "happy").unwrap();
-
-    //     assert!(
-    //         if let Export::Global(happy_dog_global) = happy_dog_entry.to_export() {
-    //             happy_dog_global.ty.ty == Type::I32
-    //         } else {
-    //             false
-    //         }
-    //     );
-    // }
 }

--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -4,6 +4,7 @@ use crate::js::externals::Extern;
 use crate::js::imports::Imports;
 use crate::js::module::Module;
 use crate::js::store::{AsStoreMut, AsStoreRef};
+use crate::js::vm::VMExtern;
 use js_sys::WebAssembly;
 use std::fmt;
 
@@ -68,7 +69,6 @@ impl Instance {
 
         let mut self_instance = Self::from_module_and_instance(store, module, instance)?;
         self_instance.ensure_memory_export(store, externs);
-        //self_instance.init_envs(&imports.iter().map(Extern::to_export).collect::<Vec<_>>())?;
         Ok(self_instance)
     }
 
@@ -108,8 +108,6 @@ impl Instance {
         module: &Module,
         instance: WebAssembly::Instance,
     ) -> Result<Self, InstantiationError> {
-        use crate::js::externals::VMExtern;
-
         let instance_exports = instance.exports();
 
         let exports = module
@@ -140,6 +138,7 @@ impl Instance {
     /// This will check the memory is correctly setup
     /// If the memory is imported then also export it for backwards compatibility reasons
     /// (many will assume the memory is always exported) - later we can remove this
+    /// TODO: This is trialing from WASIX, we should remove this or move it to the wasmer-wasi crate
     pub fn ensure_memory_export(&mut self, store: &mut impl AsStoreMut, externs: Vec<Extern>) {
         if self.exports.get_memory("memory").is_err() {
             if let Some(memory) = externs
@@ -161,7 +160,7 @@ impl Instance {
     #[doc(hidden)]
     pub fn raw<'context>(
         &'context self,
-        store: &'context impl AsStoreRef,
+        _store: &'context impl AsStoreRef,
     ) -> &'context WebAssembly::Instance {
         &self.handle
     }

--- a/lib/api/src/js/mod.rs
+++ b/lib/api/src/js/mod.rs
@@ -61,7 +61,7 @@ pub use crate::js::ptr::{Memory32, Memory64, MemorySize, WasmPtr, WasmPtr64};
 pub use crate::js::trap::RuntimeError;
 
 pub use crate::js::store::{
-    AsStoreMut, AsStoreRef, Store, StoreHandle, StoreMut, StoreObject, StoreObjects, StoreRef,
+    AsStoreMut, AsStoreRef, Store, StoreHandle, StoreMut, StoreObjects, StoreRef,
 };
 pub use crate::js::types::ValType as Type;
 pub use crate::js::types::{

--- a/lib/api/src/js/mod.rs
+++ b/lib/api/src/js/mod.rs
@@ -24,7 +24,6 @@ mod lib {
 }
 
 pub(crate) mod error;
-mod export;
 mod exports;
 mod externals;
 mod function_env;
@@ -41,10 +40,10 @@ mod store;
 mod trap;
 mod types;
 mod value;
+mod vm;
 mod wasm_bindgen_polyfill;
 
 pub use crate::js::error::{DeserializeError, InstantiationError, SerializeError};
-pub use crate::js::export::Export;
 pub use crate::js::exports::{ExportError, Exportable, Exports, ExportsIterator};
 pub use crate::js::externals::{
     Extern, FromToNativeWasmType, Function, Global, HostFunction, Memory, MemoryError, MemoryView,
@@ -70,11 +69,6 @@ pub use crate::js::types::{
 };
 pub use crate::js::value::Value;
 pub use crate::js::value::Value as Val;
-
-pub mod vm {
-    //! The `vm` module re-exports wasmer-vm types.
-    pub use crate::js::export::VMMemory;
-}
 
 pub use wasmer_types::is_wasm;
 // TODO: OnCalledAction is needed for asyncify. It will be refactored with https://github.com/wasmerio/wasmer/issues/3451

--- a/lib/api/src/js/module.rs
+++ b/lib/api/src/js/module.rs
@@ -246,7 +246,7 @@ impl Module {
         &self,
         store: &mut impl AsStoreMut,
         imports: &Imports,
-    ) -> Result<(crate::StoreHandle<WebAssembly::Instance>, Vec<Extern>), RuntimeError> {
+    ) -> Result<(WebAssembly::Instance, Vec<Extern>), RuntimeError> {
         // Ensure all imports come from the same store.
         if imports
             .into_iter()
@@ -324,11 +324,8 @@ impl Module {
             // the error for us, so we don't need to handle it
         }
         Ok((
-            crate::StoreHandle::new(
-                store.as_store_mut().objects_mut(),
-                WebAssembly::Instance::new(&self.module, &imports_object)
-                    .map_err(|e: JsValue| -> RuntimeError { e.into() })?,
-            ),
+            WebAssembly::Instance::new(&self.module, &imports_object)
+                .map_err(|e: JsValue| -> RuntimeError { e.into() })?,
             import_externs,
         ))
     }

--- a/lib/api/src/js/module.rs
+++ b/lib/api/src/js/module.rs
@@ -645,7 +645,7 @@ impl Module {
     pub fn custom_sections<'a>(&'a self, name: &'a str) -> impl Iterator<Item = Box<[u8]>> + 'a {
         WebAssembly::Module::custom_sections(&self.module, name)
             .iter()
-            .map(move |(buf_val)| {
+            .map(move |buf_val| {
                 let typebuf: js_sys::Uint8Array = js_sys::Uint8Array::new(&buf_val);
                 typebuf.to_vec().into_boxed_slice()
             })

--- a/lib/api/src/js/native.rs
+++ b/lib/api/src/js/native.rs
@@ -13,9 +13,9 @@ use crate::js::externals::Function;
 use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::{FromToNativeWasmType, RuntimeError, WasmTypeList};
 // use std::panic::{catch_unwind, AssertUnwindSafe};
-use crate::js::export::VMFunction;
 use crate::js::types::param_from_js;
 use crate::js::types::AsJs;
+use crate::js::vm::VMFunction;
 use js_sys::Array;
 use std::iter::FromIterator;
 use wasm_bindgen::JsValue;
@@ -38,7 +38,7 @@ where
     Rets: WasmTypeList,
 {
     #[allow(dead_code)]
-    pub(crate) fn new<T>(store: &mut impl AsStoreMut, vm_function: VMFunction) -> Self {
+    pub(crate) fn new<T>(_store: &mut impl AsStoreMut, vm_function: VMFunction) -> Self {
         Self {
             handle: vm_function,
             _phantom: PhantomData,

--- a/lib/api/src/js/native.rs
+++ b/lib/api/src/js/native.rs
@@ -10,7 +10,7 @@
 use std::marker::PhantomData;
 
 use crate::js::externals::Function;
-use crate::js::store::{AsStoreMut, AsStoreRef, StoreHandle};
+use crate::js::store::{AsStoreMut, AsStoreRef};
 use crate::js::{FromToNativeWasmType, RuntimeError, WasmTypeList};
 // use std::panic::{catch_unwind, AssertUnwindSafe};
 use crate::js::export::VMFunction;
@@ -25,7 +25,7 @@ use wasmer_types::RawValue;
 /// (using the Native ABI).
 #[derive(Clone)]
 pub struct TypedFunction<Args = (), Rets = ()> {
-    pub(crate) handle: StoreHandle<VMFunction>,
+    pub(crate) handle: VMFunction,
     _phantom: PhantomData<(Args, Rets)>,
 }
 
@@ -40,7 +40,7 @@ where
     #[allow(dead_code)]
     pub(crate) fn new<T>(store: &mut impl AsStoreMut, vm_function: VMFunction) -> Self {
         Self {
-            handle: StoreHandle::new(store.as_store_mut().objects_mut(), vm_function),
+            handle: vm_function,
             _phantom: PhantomData,
         }
     }
@@ -78,7 +78,7 @@ macro_rules! impl_native_traits {
                     let mut r;
                     // TODO: This loop is needed for asyncify. It will be refactored with https://github.com/wasmerio/wasmer/issues/3451
                     loop {
-                        r = self.handle.get(store.as_store_ref().objects()).function.apply(
+                        r = self.handle.function.apply(
                             &JsValue::UNDEFINED,
                             &Array::from_iter(params_list.iter())
                         );

--- a/lib/api/src/js/store.rs
+++ b/lib/api/src/js/store.rs
@@ -205,16 +205,11 @@ pub use objects::{StoreHandle, StoreId, StoreObjects};
 mod objects {
     use wasm_bindgen::JsValue;
 
-    use crate::js::{
-        export::{VMFunction, VMGlobal, VMMemory, VMTable},
-        function_env::VMFunctionEnvironment,
-    };
+    use crate::js::{function_env::VMFunctionEnvironment, vm::VMGlobal};
     use std::{
-        cell::UnsafeCell,
         fmt,
         marker::PhantomData,
         num::{NonZeroU64, NonZeroUsize},
-        ptr::NonNull,
         sync::atomic::{AtomicU64, Ordering},
     };
 

--- a/lib/api/src/js/types.rs
+++ b/lib/api/src/js/types.rs
@@ -44,12 +44,7 @@ impl AsJs for Value {
             Self::F32(f) => JsValue::from_f64(*f as f64),
             Self::F64(f) => JsValue::from_f64(*f),
             Self::V128(f) => JsValue::from_f64(*f as f64),
-            Self::FuncRef(Some(func)) => func
-                .handle
-                .get(store.as_store_ref().objects())
-                .function
-                .clone()
-                .into(),
+            Self::FuncRef(Some(func)) => func.handle.function.clone().into(),
             Self::FuncRef(None) => JsValue::null(),
         }
     }

--- a/lib/api/src/js/types.rs
+++ b/lib/api/src/js/types.rs
@@ -37,7 +37,7 @@ pub fn param_from_js(ty: &ValType, js_val: &JsValue) -> Value {
 }
 
 impl AsJs for Value {
-    fn as_jsvalue(&self, store: &impl AsStoreRef) -> JsValue {
+    fn as_jsvalue(&self, _store: &impl AsStoreRef) -> JsValue {
         match self {
             Self::I32(i) => JsValue::from_f64(*i as f64),
             Self::I64(i) => JsValue::from_f64(*i as f64),

--- a/lib/api/src/js/value.rs
+++ b/lib/api/src/js/value.rs
@@ -94,12 +94,7 @@ impl Value {
             Self::F32(v) => v as f64,
             Self::F64(v) => v,
             Self::V128(v) => v as f64,
-            Self::FuncRef(Some(ref f)) => f
-                .handle
-                .get(store.as_store_ref().objects())
-                .function
-                .as_f64()
-                .unwrap_or(0_f64), //TODO is this correct?
+            Self::FuncRef(Some(ref f)) => f.handle.function.as_f64().unwrap_or(0_f64), //TODO is this correct?
 
             Self::FuncRef(None) => 0_f64,
             //Self::ExternRef(Some(ref e)) => unsafe { *e.address().0 } as .into_raw(),

--- a/lib/api/src/js/value.rs
+++ b/lib/api/src/js/value.rs
@@ -87,7 +87,7 @@ impl Value {
     }
 
     /// Converts the `Value` into a `f64`.
-    pub fn as_raw(&self, store: &impl AsStoreRef) -> f64 {
+    pub fn as_raw(&self, _store: &impl AsStoreRef) -> f64 {
         match *self {
             Self::I32(v) => v as f64,
             Self::I64(v) => v as f64,


### PR DESCRIPTION
Use JS VM store instead of artificially replicate it.
Right now all the JS VMs use a single store (v8 isolates, for example) per process. We were replicating the store unnecessarily in Rust, when we can just leverage that store.

This PR should bring some relative speed ups on the outer interface of Wasmer (for example, when doing function calls) or getting exports of an instance