### PR TITLE
Fix make-test-integration CLI producing files when running locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,7 @@ name = "wasmer-integration-tests-cli"
 version = "3.2.0-alpha.1"
 dependencies = [
  "anyhow",
+ "dirs",
  "flate2",
  "object 0.30.3",
  "pretty_assertions",

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -19,6 +19,7 @@ tempfile = "3"
 target-lexicon = "0.12.5"
 tar = "0.4.38"
 flate2 = "1.0.24"
+dirs = "4.0.0"
 
 [features]
 default = ["webc_runner"]

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -164,8 +164,10 @@ fn test_cross_compile_python_windows() -> anyhow::Result<()> {
             output.arg("-o");
             output.arg(python_wasmer_path.clone());
             output.arg(format!("--{c}"));
-            output.arg("--debug-dir");
-            output.arg(format!("{t}-{c}"));
+            if std::env::var("GITHUB_TOKEN").is_ok() {
+                output.arg("--debug-dir");
+                output.arg(format!("{t}-{c}"));
+            }
 
             if t.contains("x86_64") && *c == "singlepass" {
                 output.arg("-m");


### PR DESCRIPTION
When running make test-integration-cli, I don't want it to produce files locally, but in the CI I want to see the debug output in case something goes wrong with Zig.