### PR TITLE
Reduce libwasmer-headless size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,11 @@ jobs:
         with:
           toolchain: 1.64
           target: ${{ matrix.target }}
+      - name: Install Rust nightly (to build capi-headless)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          target: ${{ matrix.metadata.target }}
       - uses: Swatinem/rust-cache@v1
         if: matrix.use_sccache != true
       - name: Install LLVM (macOS Apple Silicon)
@@ -273,6 +278,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: x86_64-pc-windows-gnu
+      - name: Install Rust nightly (to build capi-headless)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          target: x86_64-pc-windows-gnu
       - name: Install Windows-GNU target
         shell: bash
         run: |
@@ -301,9 +311,19 @@ jobs:
       - name: Build Wasmer C-API without LLVM
         shell: bash
         run: |
-          cargo build --release --target x86_64-pc-windows-gnu --manifest-path lib/c-api/Cargo.toml --no-default-features --features wat,compiler,wasi,middlewares,webc_runner --features cranelift,singlepass,wasmer-artifact-create,static-artifact-create,wasmer-artifact-load,static-artifact-load
+          make build-capi
         env:
           RUSTFLAGS: -Cpanic=abort
+          CARGO_TARGET: x86_64-pc-windows-gnu
+          ENABLE_LLVM: 0
+      - name: Build Wasmer C-API headless without LLVM
+        shell: bash
+        run: |
+          make build-capi-headless
+        env:
+          RUSTFLAGS: -Cpanic=abort
+          CARGO_TARGET: x86_64-pc-windows-gnu
+          ENABLE_LLVM: 0
       - name: Dist
         run: |
           make distribution-gnu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -263,6 +263,11 @@ jobs:
         with:
           toolchain: 1.64
           target: ${{ matrix.metadata.target }}
+      - name: Install Rust nightly (to build capi-headless)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          target: ${{ matrix.metadata.target }}
       - name: Install Windows-GNU linker
         if: ${{ matrix.metadata.build == 'windows-gnu' }}
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -617,6 +617,8 @@ ifeq ($(IS_DARWIN), 1)
 endif
 endif
 
+package-capi-headless: build-capi-headless package-capi
+
 package-capi:
 	mkdir -p "package/include"
 	mkdir -p "package/lib"

--- a/Makefile
+++ b/Makefile
@@ -451,11 +451,11 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless
 else
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
 endif
 
 build-capi-headless-ios:

--- a/Makefile
+++ b/Makefile
@@ -451,11 +451,11 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 else
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 endif
 
 build-capi-headless-ios:
@@ -695,39 +695,13 @@ package-capi:
 		cp target/$(HOST_TARGET)/release/libwasmer.a package/lib/libwasmer.a ;\
 	fi
 
-package-capi-headless: build-capi-headless
-	mkdir -p "package/include"
-	mkdir -p "package/lib"
-	cp lib/c-api/wasmer.h* package/include
-	cp lib/c-api/wasmer_wasm.h* package/include
-	cp lib/c-api/wasm.h* package/include
-	cp lib/c-api/README.md package/include/README.md
-
-	if [ -f $(TARGET_DIR)/wasmer.dll ]; then \
-		cp $(TARGET_DIR)/wasmer.dll package/lib/wasmer-headless.dll ;\
-	fi
-	if [ -f $(TARGET_DIR)/wasmer.lib ]; then \
-		cp $(TARGET_DIR)/wasmer.lib package/lib/wasmer-headless.lib ;\
-	fi
-
-	if [ -f $(TARGET_DIR)/libwasmer.dylib ]; then \
-		cp $(TARGET_DIR)/libwasmer.dylib package/lib/libwasmer-headless.dylib ;\
-	fi
-
-	if [ -f $(TARGET_DIR)/libwasmer.so ]; then \
-		cp $(TARGET_DIR)/libwasmer.so package/lib/libwasmer-headless.so ;\
-	fi
-	if [ -f $(TARGET_DIR)/libwasmer.a ]; then \
-		cp $(TARGET_DIR)/libwasmer.a package/lib/libwasmer-headless.a ;\
-	fi
-
 package-docs: build-docs build-docs-capi
 	mkdir -p "package/docs/crates"
 	cp -R target/doc/ package/docs/crates
 	echo '<meta http-equiv="refresh" content="0; url=crates/wasmer/index.html">' > package/docs/index.html
 	echo '<meta http-equiv="refresh" content="0; url=wasmer/index.html">' > package/docs/crates/index.html
 
-package: package-wasmer package-minimal-headless-wasmer package-capi package-capi-headless
+package: package-wasmer package-minimal-headless-wasmer package-capi
 
 tar-capi:
 	ls -R package


### PR DESCRIPTION
This reduces the libwasmer-headless size from 9MB to 2.4 MB by removing all panic info and using `abort()` instead, however we need to build with a custom libstd for that.