### PR TITLE
Make libwasmer.a even smaller

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
           toolchain: nightly
           target: ${{ matrix.metadata.target }}
       - name: Install Rust Source (nightly)
-        run: rustup component add rust-src --toolchain nightly-${{ matrix.metadata.target }}
+        run: rustup component add rust-src --toolchain nightly
       - uses: Swatinem/rust-cache@v1
         if: matrix.use_sccache != true
       - name: Install LLVM (macOS Apple Silicon)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
         with:
           toolchain: nightly
           target: ${{ matrix.metadata.target }}
+      - name: Install Rust Source (nightly)
+        run: rustup component add rust-src --toolchain nightly-${{ matrix.metadata.target }}
       - uses: Swatinem/rust-cache@v1
         if: matrix.use_sccache != true
       - name: Install LLVM (macOS Apple Silicon)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -268,6 +268,8 @@ jobs:
         with:
           toolchain: nightly
           target: ${{ matrix.metadata.target }}
+      - name: Install Rust Source (nightly)
+        run: rustup component add rust-src --toolchain nightly-${{ matrix.metadata.target }}
       - name: Install Windows-GNU linker
         if: ${{ matrix.metadata.build == 'windows-gnu' }}
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -269,7 +269,7 @@ jobs:
           toolchain: nightly
           target: ${{ matrix.metadata.target }}
       - name: Install Rust Source (nightly)
-        run: rustup component add rust-src --toolchain nightly-${{ matrix.metadata.target }}
+        run: rustup component add rust-src --toolchain nightly
       - name: Install Windows-GNU linker
         if: ${{ matrix.metadata.build == 'windows-gnu' }}
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build-wasmer.tar.gz
 lcov.info
 link/
 link.tar.gz
+llvm.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -451,10 +451,10 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 else
-	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -457,13 +457,6 @@ else
 	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 endif
-ifeq ($(IS_DARWIN), 1)
-	strip target/headless/$(HOST_TARGET)/release/libwasmer.dylib
-else ifeq ($(IS_WINDOWS), 1)
-	strip --strip-unneeded target/headless/$(HOST_TARGET)/release/wasmer.dll
-else
-	strip --strip-unneeded target/headless/$(HOST_TARGET)/release/libwasmer.so
-endif
 
 build-capi-headless-ios:
 	RUSTFLAGS="${RUSTFLAGS} -C panic=abort" cargo lipo --manifest-path lib/c-api/Cargo.toml --release \

--- a/Makefile
+++ b/Makefile
@@ -452,10 +452,10 @@ build-capi-llvm-universal:
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
 	RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi  --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 else
 	RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 endif
 ifeq ($(IS_DARWIN), 1)
 	strip target/headless/$(HOST_TARGET)/release/libwasmer.dylib

--- a/Makefile
+++ b/Makefile
@@ -451,10 +451,10 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 else
-	RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 endif
 ifeq ($(IS_DARWIN), 1)

--- a/Makefile
+++ b/Makefile
@@ -451,10 +451,10 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless
 else
-	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
 		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -451,11 +451,18 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi  --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 else
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C relocation-model=static -C opt-level=z -C overflow-checks=off -C panic=abort -C rpath=no -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+endif
+ifeq ($(IS_DARWIN), 1)
+	strip target/headless/$(HOST_TARGET)/release/libwasmer.dylib
+else ifeq ($(IS_WINDOWS), 1)
+	strip --strip-unneeded target/headless/$(HOST_TARGET)/release/wasmer.dll
+else
+	strip --strip-unneeded target/headless/$(HOST_TARGET)/release/libwasmer.so
 endif
 
 build-capi-headless-ios:

--- a/Makefile
+++ b/Makefile
@@ -451,11 +451,11 @@ build-capi-llvm-universal:
 
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner  --target-dir target/headless  -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 else
-	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
+	RUSTFLAGS="${RUSTFLAGS} -C panic=abort -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless  -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 endif
 
 build-capi-headless-ios:

--- a/Makefile
+++ b/Makefile
@@ -452,10 +452,10 @@ build-capi-llvm-universal:
 build-capi-headless:
 ifeq ($(CARGO_TARGET_FLAG),)
 	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build --target $(HOST_TARGET) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
 else
 	RUSTFLAGS="${RUSTFLAGS} -C opt-level=z -C overflow-checks=off -C panic=abort -C incremental=false -C codegen-units=1 -C link-dead-code -C lto -O -C embed-bitcode=yes" $(CARGO_BINARY) +nightly build $(CARGO_TARGET_FLAG) --manifest-path lib/c-api/Cargo.toml --release \
-		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+		--no-default-features --features compiler-headless,wasi,webc_runner --target-dir target/headless
 endif
 
 build-capi-headless-ios:

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -1242,9 +1242,8 @@ fn link_exe_from_dir(
         cmd.arg("-lunwind");
     }
 
-    cmd.arg("-OReleaseSafe");
+    cmd.arg("-OReleaseSmall");
     cmd.arg("-fno-compiler-rt");
-    cmd.arg("-fno-lto");
     #[cfg(target_os = "windows")]
     let out_path = directory.join("wasmer_main.exe");
     #[cfg(not(target_os = "windows"))]

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -1242,7 +1242,7 @@ fn link_exe_from_dir(
         cmd.arg("-lunwind");
     }
 
-    cmd.arg("-OReleaseSmall");
+    cmd.arg("-OReleaseSafe");
     cmd.arg("-fno-compiler-rt");
     #[cfg(target_os = "windows")]
     let out_path = directory.join("wasmer_main.exe");

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -1244,6 +1244,7 @@ fn link_exe_from_dir(
 
     cmd.arg("-OReleaseSafe");
     cmd.arg("-fno-compiler-rt");
+    cmd.arg("-fno-lto");
     #[cfg(target_os = "windows")]
     let out_path = directory.join("wasmer_main.exe");
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
This brings the libwasmer-headless.a to about 2.5 MB in size. I've experimented with building with xargo, but it doesn't get much lower than this. For quickjs, the best binary size is 4.1 MB - the object files emitted by cranelift alone are already 3.3 MB, so it's not really the libwasmer that is large.

When compining with `--singlepass`, the size rises to ~6MB, with LLVM I still need to experiment.