### PR TITLE
Fix/compile not in memory

### DIFF
--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -67,6 +67,11 @@ pub enum InstantiationError {
     /// This error occurs when an import from a different store is used.
     #[error("cannot mix imports from different stores")]
     DifferentStores,
+
+    /// Import from a different Store.
+    /// This error occurs when an import from a different store is used.
+    #[error("incorrect OS or architecture")]
+    DifferentArchOS,
 }
 
 impl From<wasmer_compiler::InstantiationError> for InstantiationError {

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -320,7 +320,7 @@ impl Module {
         if !self.artifact.allocated() {
             // Return an error mentioning that the artifact is compiled for a different
             // platform. Probably need a new error
-            return Err(InstantiationError::DifferentStores);
+            return Err(InstantiationError::DifferentArchOS);
         }
         // Ensure all imports come from the same context.
         for import in imports {

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -319,7 +319,7 @@ impl Module {
     ) -> Result<VMInstance, InstantiationError> {
         if !self.artifact.allocated() {
             // Return an error mentioning that the artifact is compiled for a different
-            // platform. Probably need a new error
+            // platform.
             return Err(InstantiationError::DifferentArchOS);
         }
         // Ensure all imports come from the same context.

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -320,7 +320,7 @@ impl Module {
         if !self.artifact.allocated() {
             // Return an error mentioning that the artifact is compiled for a different
             // platform. Probably need a new error
-            return InstantiationError::DifferentStores;
+            return Err(InstantiationError::DifferentStores);
         }
         // Ensure all imports come from the same context.
         for import in imports {

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -317,6 +317,11 @@ impl Module {
         store: &mut impl AsStoreMut,
         imports: &[crate::Extern],
     ) -> Result<VMInstance, InstantiationError> {
+        if !self.artifact.allocated() {
+            // Return an error mentioning that the artifact is compiled for a different
+            // platform. Probably need a new error
+            return InstantiationError::DifferentStores;
+        }
         // Ensure all imports come from the same context.
         for import in imports {
             if !import.is_from_store(store) {

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -85,6 +85,12 @@ pub unsafe extern "C" fn wasm_instance_new(
 
             return None;
         }
+
+        Err(e @ InstantiationError::DifferentArchOS) => {
+            crate::error::update_last_error(e);
+
+            return None;
+        }
     };
 
     Some(Box::new(wasm_instance_t {

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -758,14 +758,16 @@ impl Artifact {
 
         Ok(Self {
             artifact,
-            finished_functions: finished_functions.into_boxed_slice(),
-            finished_function_call_trampolines: finished_function_call_trampolines
-                .into_boxed_slice(),
-            finished_dynamic_function_trampolines: finished_dynamic_function_trampolines
-                .into_boxed_slice(),
-            signatures: signatures.into_boxed_slice(),
-            finished_function_lengths,
-            frame_info_registration: None,
+            allocated: Some(ArtifactBuild {
+                finished_functions: finished_functions.into_boxed_slice(),
+                finished_function_call_trampolines: finished_function_call_trampolines
+                    .into_boxed_slice(),
+                finished_dynamic_function_trampolines: finished_dynamic_function_trampolines
+                    .into_boxed_slice(),
+                signatures: signatures.into_boxed_slice(),
+                finished_function_lengths,
+                frame_info_registration: None,
+            }),
         })
     }
 }

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -18,6 +18,7 @@ use enumset::EnumSet;
 use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
+use wasmer_object::object::Architecture;
 #[cfg(feature = "static-artifact-create")]
 use wasmer_object::{emit_compilation, emit_data, get_object_for_target, Object};
 #[cfg(any(feature = "static-artifact-create", feature = "static-artifact-load"))]
@@ -265,6 +266,7 @@ impl Artifact {
     pub fn register_frame_info(&self) {
         if let Some(frame_info_registration) = self
             .allocated
+            .as_ref()
             .expect("It must be allocated")
             .frame_info_registration
             .as_ref()
@@ -277,12 +279,14 @@ impl Artifact {
 
             let finished_function_extents = self
                 .allocated
+                .as_ref()
                 .expect("It must be allocated")
                 .finished_functions
                 .values()
                 .copied()
                 .zip(
                     self.allocated
+                        .as_ref()
                         .expect("It must be allocated")
                         .finished_function_lengths
                         .values()
@@ -306,6 +310,7 @@ impl Artifact {
     pub fn finished_functions(&self) -> &BoxedSlice<LocalFunctionIndex, FunctionBodyPtr> {
         &self
             .allocated
+            .as_ref()
             .expect("It must be allocated")
             .finished_functions
     }
@@ -315,6 +320,7 @@ impl Artifact {
     pub fn finished_function_call_trampolines(&self) -> &BoxedSlice<SignatureIndex, VMTrampoline> {
         &self
             .allocated
+            .as_ref()
             .expect("It must be allocated")
             .finished_function_call_trampolines
     }
@@ -326,13 +332,18 @@ impl Artifact {
     ) -> &BoxedSlice<FunctionIndex, FunctionBodyPtr> {
         &self
             .allocated
+            .as_ref()
             .expect("It must be allocated")
             .finished_dynamic_function_trampolines
     }
 
     /// Returns the associated VM signatures for this `Artifact`.
     pub fn signatures(&self) -> &BoxedSlice<SignatureIndex, VMSharedSignatureIndex> {
-        &self.allocated.expect("It must be allocated").signatures
+        &self
+            .allocated
+            .as_ref()
+            .expect("It must be allocated")
+            .signatures
     }
 
     /// Do preinstantiation logic that is executed before instantiating
@@ -758,7 +769,7 @@ impl Artifact {
 
         Ok(Self {
             artifact,
-            allocated: Some(ArtifactBuild {
+            allocated: Some(AllocatedArtifact {
                 finished_functions: finished_functions.into_boxed_slice(),
                 finished_function_call_trampolines: finished_function_call_trampolines
                     .into_boxed_slice(),

--- a/lib/types/src/compilation/target.rs
+++ b/lib/types/src/compilation/target.rs
@@ -192,6 +192,13 @@ impl Target {
     pub fn cpu_features(&self) -> &EnumSet<CpuFeature> {
         &self.cpu_features
     }
+
+    /// Check if target is a native (eq to host) or not
+    pub fn is_native(&self) -> bool {
+        let host = Triple::host();
+        host.operating_system == self.triple.operating_system
+            && host.architecture == self.triple.architecture
+    }
 }
 
 /// The default for the Target will use the HOST as the triple

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -273,6 +273,7 @@ fn trap_start_function_import(config: crate::Config) -> Result<()> {
     match err {
         InstantiationError::Link(_)
         | InstantiationError::DifferentStores
+        | InstantiationError::DifferentArchOS
         | InstantiationError::CpuFeature(_) => {
             panic!("It should be a start error")
         }


### PR DESCRIPTION
When compiling an artifact, don't load compiled result in memory if the the compilation target is not compatible with the host.

This will also help with #3508 because runtime unwind information will not be constructed when Cross-compiling.

Note that they are some small API-breaking changes here:
* A new InstantiationError::DifferentArchOS 
*  Artifact::from_parts(...) now takes a 3rd parameter (&Target of the parts)