### PR TITLE
Use Cloudflare as CI Cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,11 +61,11 @@ jobs:
             ~/.cargo/*
             ./target/*
           key: r22-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-wasmer-make-lint-linux-x64
-          aws-s3-bucket: wasmer-github-ci-cache
-          aws-access-key-id: ${{ secrets.GOOGLE_CACHE_ID }}
-          aws-secret-access-key: ${{ secrets.GOOGLE_CACHE_SECRET }}
+          aws-s3-bucket: wasmer-rust-artifacts-cache
+          aws-access-key-id: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_TOKEN }}
+          aws-secret-access-key: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_KEY }}
           aws-region: auto
-          aws-endpoint: https://storage.googleapis.com
+          aws-endpoint: https://1541b1e8a3fc6ad155ce67ef38899700.r2.cloudflarestorage.com
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - run: make lint
@@ -343,11 +343,11 @@ jobs:
             ./target/*
             $CARGO_ROOT_DIR/*
           key: r22-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-wasmer-make-build-wasmer-${{ matrix.build-what.key }}-${{ matrix.metadata.build }}
-          aws-s3-bucket: wasmer-github-ci-cache
-          aws-access-key-id: ${{ secrets.GOOGLE_CACHE_ID }}
-          aws-secret-access-key: ${{ secrets.GOOGLE_CACHE_SECRET }}
+          aws-s3-bucket: wasmer-rust-artifacts-cache
+          aws-access-key-id: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_TOKEN }}
+          aws-secret-access-key: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_KEY }}
           aws-region: auto
-          aws-endpoint: https://storage.googleapis.com
+          aws-endpoint: https://1541b1e8a3fc6ad155ce67ef38899700.r2.cloudflarestorage.com
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: Build C-API
@@ -518,11 +518,11 @@ jobs:
             ~/.cargo/*
             ./target/*
           key: r22-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-wasmer-make-test-stage-${{ matrix.stage.make }}-${{ matrix.metadata.build }}
-          aws-s3-bucket: wasmer-github-ci-cache
-          aws-access-key-id: ${{ secrets.GOOGLE_CACHE_ID }}
-          aws-secret-access-key: ${{ secrets.GOOGLE_CACHE_SECRET }}
+          aws-s3-bucket: wasmer-rust-artifacts-cache
+          aws-access-key-id: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_TOKEN }}
+          aws-secret-access-key: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_KEY }}
           aws-region: auto
-          aws-endpoint: https://storage.googleapis.com
+          aws-endpoint: https://1541b1e8a3fc6ad155ce67ef38899700.r2.cloudflarestorage.com
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
@@ -593,11 +593,11 @@ jobs:
             ~/.cargo/*
             ./target/*
           key: r22-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-wasmer-make-test-integration-cli-${{ matrix.build }}
-          aws-s3-bucket: wasmer-github-ci-cache
-          aws-access-key-id: ${{ secrets.GOOGLE_CACHE_ID }}
-          aws-secret-access-key: ${{ secrets.GOOGLE_CACHE_SECRET }}
+          aws-s3-bucket: wasmer-rust-artifacts-cache
+          aws-access-key-id: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_TOKEN }}
+          aws-secret-access-key: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_KEY }}
           aws-region: auto
-          aws-endpoint: https://storage.googleapis.com
+          aws-endpoint: https://1541b1e8a3fc6ad155ce67ef38899700.r2.cloudflarestorage.com
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: Prepare package directory


### PR DESCRIPTION
Using Google Cloud incurs very high egress cost.
