### PR TITLE
Fix WASI example that initialized wasi_config 2 times

### DIFF
--- a/lib/c-api/examples/wasi.c
+++ b/lib/c-api/examples/wasi.c
@@ -64,14 +64,6 @@ int main(int argc, const char* argv[]) {
 
   wasm_byte_vec_delete(&binary);
 
-  printf("Setting up WASI...\n");
-  config = wasi_config_new("example_program");
-  // TODO: error checking
-  js_string = "function greet(name) { return JSON.stringify('Hello, ' + name); }; print(greet('World'));";
-  wasi_config_arg(config, "--eval");
-  wasi_config_arg(config, js_string);
-  wasi_config_capture_stdout(config);
-
   wasi_env_t* wasi_env = wasi_env_new(store, config);
 
   if (!wasi_env) {


### PR DESCRIPTION
This fix a small memory leak in a c-api example.

This is for #3438 
Note that I tested with valgrind and found no other memory leak in the c-api examples.