### PR TITLE
bump inkwell to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,24 +1736,23 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.0-beta.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2223d0eba0ae6d40a3e4680c6a3209143471e1f38b41746ea309aa36dde9f90b"
+checksum = "f6572fb91d5e09a2a40c99721bdf94ed554a74b09db684276cb1bba39e844da4"
 dependencies = [
  "either",
  "inkwell_internals",
  "libc",
  "llvm-sys",
  "once_cell",
- "parking_lot",
- "regex",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7090af3d300424caa81976b8c97bca41cd70e861272c072e188ae082fb49f9"
+checksum = "87d00c17e264ce02be5bc23d7bff959188ec7137beddd06b8b6b05a7c680ea85"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2334,7 +2333,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
@@ -2349,6 +2358,19 @@ dependencies = [
  "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3262,7 +3284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6572fb91d5e09a2a40c99721bdf94ed554a74b09db684276cb1bba39e844da4"
+checksum = "bbac11e485159a525867fb7e6aa61981453e6a72f625fde6a4ab3047b0c6dec9"
 dependencies = [
  "either",
  "inkwell_internals",

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -27,7 +27,7 @@ rayon = "1.5"
 
 [dependencies.inkwell]
 package = "inkwell"
-version = "0.1.0"
+version = "0.1.1"
 default-features = false
 features = ["llvm12-0", "target-x86", "target-aarch64"]
 

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -27,7 +27,7 @@ rayon = "1.5"
 
 [dependencies.inkwell]
 package = "inkwell"
-version = "=0.1.0-beta.4"
+version = "0.1.0"
 default-features = false
 features = ["llvm12-0", "target-x86", "target-aarch64"]
 

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -207,7 +207,7 @@ impl Abi for Aarch64SystemV {
                             .collect::<Result<_, _>>()?;
 
                         let sret = context.struct_type(&basic_types, false);
-                        let sret_ptr = sret.ptr_type(AddressSpace::Generic);
+                        let sret_ptr = sret.ptr_type(AddressSpace::default());
 
                         let param_types =
                             std::iter::once(Ok(sret_ptr.as_basic_type_enum())).chain(param_types);

--- a/lib/compiler-llvm/src/abi/x86_64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/x86_64_systemv.rs
@@ -263,7 +263,7 @@ impl Abi for X86_64SystemV {
                     .collect::<Result<_, _>>()?;
 
                 let sret = context.struct_type(&basic_types, false);
-                let sret_ptr = sret.ptr_type(AddressSpace::Generic);
+                let sret_ptr = sret.ptr_type(AddressSpace::default());
 
                 let param_types =
                     std::iter::once(Ok(sret_ptr.as_basic_type_enum())).chain(param_types);

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -59,9 +59,9 @@ impl FuncTrampoline {
                 .func_type_to_llvm(&self.ctx, &intrinsics, None, ty)?;
         let trampoline_ty = intrinsics.void_ty.fn_type(
             &[
-                intrinsics.ctx_ptr_ty.into(),                     // vmctx ptr
-                callee_ty.ptr_type(AddressSpace::Generic).into(), // callee function address
-                intrinsics.i128_ptr_ty.into(),                    // in/out values ptr
+                intrinsics.ctx_ptr_ty.into(),                       // vmctx ptr
+                callee_ty.ptr_type(AddressSpace::default()).into(), // callee function address
+                intrinsics.i128_ptr_ty.into(),                      // in/out values ptr
             ],
             false,
         );
@@ -69,7 +69,7 @@ impl FuncTrampoline {
         let trampoline_func = module.add_function(name, trampoline_ty, Some(Linkage::External));
         trampoline_func
             .as_global_value()
-            .set_section(FUNCTION_SECTION);
+            .set_section(Some(FUNCTION_SECTION));
         trampoline_func
             .as_global_value()
             .set_linkage(Linkage::DLLExport);
@@ -189,7 +189,7 @@ impl FuncTrampoline {
         }
         trampoline_func
             .as_global_value()
-            .set_section(FUNCTION_SECTION);
+            .set_section(Some(FUNCTION_SECTION));
         trampoline_func
             .as_global_value()
             .set_linkage(Linkage::DLLExport);
@@ -359,7 +359,7 @@ impl FuncTrampoline {
                 )
             };
             let ptr =
-                builder.build_pointer_cast(ptr, v.get_type().ptr_type(AddressSpace::Generic), "");
+                builder.build_pointer_cast(ptr, v.get_type().ptr_type(AddressSpace::default()), "");
             builder.build_store(ptr, *v);
             if v.get_type() == intrinsics.i128_ty.as_basic_type_enum() {
                 idx += 1;
@@ -424,12 +424,12 @@ impl FuncTrampoline {
                 ],
                 false,
             )
-            .ptr_type(AddressSpace::Generic);
+            .ptr_type(AddressSpace::default());
         let vmctx = self.abi.get_vmctx_ptr_param(&trampoline_func);
         let callee = builder
             .build_load(
                 builder
-                    .build_bitcast(vmctx, callee_ty.ptr_type(AddressSpace::Generic), "")
+                    .build_bitcast(vmctx, callee_ty.ptr_type(AddressSpace::default()), "")
                     .into_pointer_value(),
                 "",
             )

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -106,7 +106,7 @@ impl FuncTranslator {
 
         func.add_attribute(AttributeLoc::Function, intrinsics.stack_probe);
         func.set_personality_function(intrinsics.personality);
-        func.as_global_value().set_section(FUNCTION_SECTION);
+        func.as_global_value().set_section(Some(FUNCTION_SECTION));
         func.set_linkage(Linkage::DLLExport);
         func.as_global_value()
             .set_dll_storage_class(DLLStorageClass::Export);
@@ -2334,7 +2334,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 // element type.
                 let casted_table_base = self.builder.build_pointer_cast(
                     table_base,
-                    self.intrinsics.funcref_ty.ptr_type(AddressSpace::Generic),
+                    self.intrinsics.funcref_ty.ptr_type(AddressSpace::default()),
                     "casted_table_base",
                 );
 
@@ -2503,7 +2503,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let typed_func_ptr = self.builder.build_pointer_cast(
                     func_ptr,
-                    llvm_func_type.ptr_type(AddressSpace::Generic),
+                    llvm_func_type.ptr_type(AddressSpace::default()),
                     "typed_func_ptr",
                 );
 

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -40,8 +40,8 @@ pub fn type_to_llvm_ptr<'ctx>(
         Type::F32 => Ok(intrinsics.f32_ptr_ty),
         Type::F64 => Ok(intrinsics.f64_ptr_ty),
         Type::V128 => Ok(intrinsics.i128_ptr_ty),
-        Type::FuncRef => Ok(intrinsics.funcref_ty.ptr_type(AddressSpace::Generic)),
-        Type::ExternRef => Ok(intrinsics.externref_ty.ptr_type(AddressSpace::Generic)),
+        Type::FuncRef => Ok(intrinsics.funcref_ty.ptr_type(AddressSpace::default())),
+        Type::ExternRef => Ok(intrinsics.externref_ty.ptr_type(AddressSpace::default())),
     }
 }
 
@@ -304,14 +304,14 @@ impl<'ctx> Intrinsics<'ctx> {
         let f64x2_ty = f64_ty.vec_type(2);
         let i32x8_ty = i32_ty.vec_type(8);
 
-        let i8_ptr_ty = i8_ty.ptr_type(AddressSpace::Generic);
-        let i16_ptr_ty = i16_ty.ptr_type(AddressSpace::Generic);
-        let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::Generic);
-        let i64_ptr_ty = i64_ty.ptr_type(AddressSpace::Generic);
-        let i128_ptr_ty = i128_ty.ptr_type(AddressSpace::Generic);
-        let isize_ptr_ty = isize_ty.ptr_type(AddressSpace::Generic);
-        let f32_ptr_ty = f32_ty.ptr_type(AddressSpace::Generic);
-        let f64_ptr_ty = f64_ty.ptr_type(AddressSpace::Generic);
+        let i8_ptr_ty = i8_ty.ptr_type(AddressSpace::default());
+        let i16_ptr_ty = i16_ty.ptr_type(AddressSpace::default());
+        let i32_ptr_ty = i32_ty.ptr_type(AddressSpace::default());
+        let i64_ptr_ty = i64_ty.ptr_type(AddressSpace::default());
+        let i128_ptr_ty = i128_ty.ptr_type(AddressSpace::default());
+        let isize_ptr_ty = isize_ty.ptr_type(AddressSpace::default());
+        let f32_ptr_ty = f32_ty.ptr_type(AddressSpace::default());
+        let f64_ptr_ty = f64_ty.ptr_type(AddressSpace::default());
 
         let i1_zero = i1_ty.const_int(0, false);
         let i8_zero = i8_ty.const_int(0, false);
@@ -358,7 +358,7 @@ impl<'ctx> Intrinsics<'ctx> {
         let md_ty_basic_md: BasicMetadataTypeEnum = md_ty.into();
 
         let ctx_ty = i8_ty;
-        let ctx_ptr_ty = ctx_ty.ptr_type(AddressSpace::Generic);
+        let ctx_ptr_ty = ctx_ty.ptr_type(AddressSpace::default());
         let ctx_ptr_ty_basic = ctx_ptr_ty.as_basic_type_enum();
         let ctx_ptr_ty_basic_md: BasicMetadataTypeEnum = ctx_ptr_ty.into();
 
@@ -368,7 +368,7 @@ impl<'ctx> Intrinsics<'ctx> {
             &[i8_ptr_ty_basic, sigindex_ty.into(), ctx_ptr_ty_basic],
             false,
         );
-        let funcref_ty = anyfunc_ty.ptr_type(AddressSpace::Generic);
+        let funcref_ty = anyfunc_ty.ptr_type(AddressSpace::default());
         let externref_ty = funcref_ty;
         let anyref_ty = i8_ptr_ty;
         let anyref_ty_basic_md: BasicMetadataTypeEnum = anyref_ty.into();
@@ -1094,13 +1094,13 @@ impl<'ctx> Intrinsics<'ctx> {
 
             vmfunction_import_ptr_ty: context
                 .struct_type(&[i8_ptr_ty_basic, i8_ptr_ty_basic], false)
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             vmfunction_import_body_element: 0,
             vmfunction_import_vmctx_element: 1,
 
             vmmemory_definition_ptr_ty: context
                 .struct_type(&[i8_ptr_ty_basic, isize_ty.into()], false)
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             vmmemory_definition_base_element: 0,
             vmmemory_definition_current_length_element: 1,
 
@@ -1109,19 +1109,19 @@ impl<'ctx> Intrinsics<'ctx> {
                     &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             imported_memory32_grow_ptr_ty: i32_ty
                 .fn_type(
                     &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             memory32_size_ptr_ty: i32_ty
                 .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false)
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             imported_memory32_size_ptr_ty: i32_ty
                 .fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false)
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             memory32_wait32_ptr_ty: i32_ty
                 .fn_type(
                     &[
@@ -1133,7 +1133,7 @@ impl<'ctx> Intrinsics<'ctx> {
                     ],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             imported_memory32_wait32_ptr_ty: i32_ty
                 .fn_type(
                     &[
@@ -1145,7 +1145,7 @@ impl<'ctx> Intrinsics<'ctx> {
                     ],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             memory32_wait64_ptr_ty: i32_ty
                 .fn_type(
                     &[
@@ -1157,7 +1157,7 @@ impl<'ctx> Intrinsics<'ctx> {
                     ],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             imported_memory32_wait64_ptr_ty: i32_ty
                 .fn_type(
                     &[
@@ -1169,7 +1169,7 @@ impl<'ctx> Intrinsics<'ctx> {
                     ],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             memory32_notify_ptr_ty: i32_ty
                 .fn_type(
                     &[
@@ -1180,7 +1180,7 @@ impl<'ctx> Intrinsics<'ctx> {
                     ],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
             imported_memory32_notify_ptr_ty: i32_ty
                 .fn_type(
                     &[
@@ -1191,7 +1191,7 @@ impl<'ctx> Intrinsics<'ctx> {
                     ],
                     false,
                 )
-                .ptr_type(AddressSpace::Generic),
+                .ptr_type(AddressSpace::default()),
 
             ctx_ptr_ty,
         };
@@ -1316,7 +1316,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let memory_definition_ptr_ptr = cache_builder
                         .build_bitcast(
                             memory_definition_ptr_ptr,
-                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::Generic),
+                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::default()),
                             "",
                         )
                         .into_pointer_value();
@@ -1400,7 +1400,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let ptr_to_base_ptr = cache_builder
                         .build_bitcast(
                             ptr_to_base_ptr,
-                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::Generic),
+                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::default()),
                             "",
                         )
                         .into_pointer_value();
@@ -1426,7 +1426,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let definition_ptr_ptr = cache_builder
                         .build_bitcast(
                             definition_ptr_ptr,
-                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::Generic),
+                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::default()),
                             "",
                         )
                         .into_pointer_value();
@@ -1448,7 +1448,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let ptr_to_base_ptr = cache_builder
                         .build_bitcast(
                             ptr_to_base_ptr,
-                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::Generic),
+                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::default()),
                             "",
                         )
                         .into_pointer_value();
@@ -1570,7 +1570,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let global_ptr_ptr = cache_builder
                         .build_bitcast(
                             global_ptr_ptr,
-                            intrinsics.i32_ptr_ty.ptr_type(AddressSpace::Generic),
+                            intrinsics.i32_ptr_ty.ptr_type(AddressSpace::default()),
                             "",
                         )
                         .into_pointer_value();
@@ -1710,7 +1710,11 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     .unwrap();
                 let body_ptr = cache_builder.build_load(body_ptr_ptr, "");
                 let body_ptr = cache_builder
-                    .build_bitcast(body_ptr, llvm_func_type.ptr_type(AddressSpace::Generic), "")
+                    .build_bitcast(
+                        body_ptr,
+                        llvm_func_type.ptr_type(AddressSpace::default()),
+                        "",
+                    )
                     .into_pointer_value();
                 let vmctx_ptr_ptr = cache_builder
                     .build_struct_gep(
@@ -1760,7 +1764,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             let grow_fn_ptr_ptr = cache_builder
                 .build_bitcast(
                     grow_fn_ptr_ptr,
-                    grow_fn_ty.ptr_type(AddressSpace::Generic),
+                    grow_fn_ty.ptr_type(AddressSpace::default()),
                     "",
                 )
                 .into_pointer_value();
@@ -1801,7 +1805,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
                     size_fn_ptr_ptr,
-                    size_fn_ty.ptr_type(AddressSpace::Generic),
+                    size_fn_ty.ptr_type(AddressSpace::default()),
                     "",
                 )
                 .into_pointer_value();
@@ -1843,7 +1847,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
                     size_fn_ptr_ptr,
-                    size_fn_ty.ptr_type(AddressSpace::Generic),
+                    size_fn_ty.ptr_type(AddressSpace::default()),
                     "",
                 )
                 .into_pointer_value();
@@ -1885,7 +1889,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
                     size_fn_ptr_ptr,
-                    size_fn_ty.ptr_type(AddressSpace::Generic),
+                    size_fn_ty.ptr_type(AddressSpace::default()),
                     "",
                 )
                 .into_pointer_value();
@@ -1927,7 +1931,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
                     size_fn_ptr_ptr,
-                    size_fn_ty.ptr_type(AddressSpace::Generic),
+                    size_fn_ty.ptr_type(AddressSpace::default()),
                     "",
                 )
                 .into_pointer_value();
@@ -1965,13 +1969,6 @@ pub fn tbaa_label<'ctx>(
     //   https://llvm.org/docs/AliasAnalysis.html#must-may-and-no-alias-responses
 
     let context = module.get_context();
-
-    // TODO: StoreRef can't return us the lifetime from module through Deref.
-    // This could be fixed once generic_associated_types is stable.
-    let context = {
-        let context2 = &*context;
-        unsafe { std::mem::transmute::<&Context, &'ctx Context>(context2) }
-    };
 
     // `!wasmer_tbaa_root = {}`, the TBAA root node for wasmer.
     let tbaa_root = module


### PR DESCRIPTION
Bumps inkwell version, reverting the revert wasmerio/wasmer#3563 as https://github.com/TheDan64/inkwell/pull/398 is now merged

Note: we need to upgrade inkwell to 0.1.1