### PR TITLE
Make AsStoreRef and friends work for anything that implements Deref

### DIFF
--- a/lib/api/src/sys/store.rs
+++ b/lib/api/src/sys/store.rs
@@ -1,6 +1,9 @@
 use crate::sys::tunables::BaseTunables;
 use derivative::Derivative;
-use std::fmt;
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 #[cfg(feature = "compiler")]
 use wasmer_compiler::{AsEngineRef, Engine, EngineBuilder, EngineRef, Tunables};
 use wasmer_types::OnCalledAction;
@@ -221,13 +224,6 @@ impl AsEngineRef for Store {
 }
 
 #[cfg(feature = "compiler")]
-impl AsEngineRef for &Store {
-    fn as_engine_ref(&self) -> EngineRef<'_> {
-        EngineRef::new(&self.engine)
-    }
-}
-
-#[cfg(feature = "compiler")]
 impl AsEngineRef for StoreRef<'_> {
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef::new(&self.inner.engine)
@@ -374,21 +370,26 @@ impl AsStoreMut for StoreMut<'_> {
     }
 }
 
-impl<T: AsStoreRef> AsStoreRef for &'_ T {
+impl<P> AsStoreRef for P
+where
+    P: Deref,
+    P::Target: AsStoreRef,
+{
     fn as_store_ref(&self) -> StoreRef<'_> {
-        T::as_store_ref(*self)
+        (**self).as_store_ref()
     }
 }
-impl<T: AsStoreRef> AsStoreRef for &'_ mut T {
-    fn as_store_ref(&self) -> StoreRef<'_> {
-        T::as_store_ref(*self)
-    }
-}
-impl<T: AsStoreMut> AsStoreMut for &'_ mut T {
+
+impl<P> AsStoreMut for P
+where
+    P: DerefMut,
+    P::Target: AsStoreMut,
+{
     fn as_store_mut(&mut self) -> StoreMut<'_> {
-        T::as_store_mut(*self)
+        (**self).as_store_mut()
     }
+
     fn objects_mut(&mut self) -> &mut StoreObjects {
-        T::objects_mut(*self)
+        (**self).objects_mut()
     }
 }

--- a/lib/compiler/src/engine/engineref.rs
+++ b/lib/compiler/src/engine/engineref.rs
@@ -1,3 +1,5 @@
+use core::ops::Deref;
+
 use super::Engine;
 use crate::Tunables;
 
@@ -35,5 +37,15 @@ pub trait AsEngineRef {
 impl AsEngineRef for EngineRef<'_> {
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef { inner: self.inner }
+    }
+}
+
+impl<P> AsEngineRef for P
+where
+    P: Deref,
+    P::Target: AsEngineRef,
+{
+    fn as_engine_ref(&self) -> EngineRef<'_> {
+        (**self).as_engine_ref()
     }
 }


### PR DESCRIPTION
# Description

While updating some WAI code, I ran into a weird bug where `&mut Store` didn't implement `AsEngineRef` because we've only got an `impl AsEngineRef for &Store`.

This PR uses the `Deref` (or `DerefMut`, when applicable) trait to implement things like `AsStoreRef`, `AsStoreMut`, and `AsEngineRef` for anything that can be dereferenced to an implementation of those traits. That means we'll have the same `&Store: AsEngineRef` impl, but we'll also pick up `AsEngineRef` implementations for `Box<T>`, `Arc<T>`, and so on.