### PR TITLE
C API: u8 in Rust corresponds to unsigned char* in C

### DIFF
--- a/lib/c-api/tests/wasm-c-api/include/wasm.h
+++ b/lib/c-api/tests/wasm-c-api/include/wasm.h
@@ -479,7 +479,7 @@ WASM_API_EXTERN own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_mem
 
 WASM_API_EXTERN own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
 
-WASM_API_EXTERN byte_t* wasm_memory_data(wasm_memory_t*);
+WASM_API_EXTERN unsigned char* wasm_memory_data(wasm_memory_t*);
 WASM_API_EXTERN size_t wasm_memory_data_size(const wasm_memory_t*);
 
 WASM_API_EXTERN wasm_memory_pages_t wasm_memory_size(const wasm_memory_t*);


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

wasm_memory_data returns type is [*mut u8](https://github.com/wasmerio/wasmer/blob/c9e658e25e4a4d915ef2663188360751125a095a/lib/c-api/src/wasm_c_api/externals/memory.rs#L65) which corresponds in C to `unsigned char *`. `byte_t` is used in the C API to represent `*mut u8` but it is an [alias for char](https://github.com/wasmerio/wasmer/blob/c9e658e25e4a4d915ef2663188360751125a095a/lib/c-api/tests/wasm-c-api/include/wasm.h#L37).
When compiling, we get the following warning:
```
warning: pointer targets in initialization of ‘uint8_t *’ {aka ‘unsigned char *’} from ‘byte_t *’ {aka ‘char *’} differ in signedness [-Wpointer-sign]
  572 |    uint8_t* x420 = wasm_memory_data(x419);
```

This MR changes the return type from `byte_t` to `unsigned char`.