### PR TITLE
Update CI script to fix deprecation notices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         run: |
           VERSION=${GITHUB_REF/refs\/tags\//}
-          echo ::set-output name=VERSION::${VERSION}
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           DOING_RELEASE=$(echo $VERSION | grep -c '^[0-9]\+\.[0-9]\+\.[0-9]\+\(-\([a-zA-Z]\+\)\?[0-9]*\)\?$' || true)
-          echo ::set-output name=DOING_RELEASE::${DOING_RELEASE}
+          echo "DOING_RELEASE::${DOING_RELEASE}" >> $GITHUB_OUTPUT
           echo $VERSION
           echo $DOING_RELEASE
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         include:
           - build: linux-x64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             artifact_name: 'wasmer-linux-amd64'
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/13.x/llvm-linux-amd64.tar.xz'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
@@ -87,12 +87,6 @@ jobs:
       TARGET: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up libstdc++ on Linux
-        if: matrix.build == 'linux-x64'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y --allow-downgrades libstdc++6=8.4.0-1ubuntu1~18.04
-          sudo apt-get install --reinstall g++-8
       - name: Set up base deps on musl
         if: matrix.build == 'linux-musl-x64'
         run: |
@@ -268,7 +262,7 @@ jobs:
 
   windows_gnu:
     name: Windows GNU
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Windows-GNU linker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           toolchain: nightly
           target: ${{ matrix.metadata.target }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: matrix.use_sccache != true
       - name: Install LLVM (macOS Apple Silicon)
         if: matrix.os == 'macos-11.0' && !matrix.llvm_url
@@ -253,7 +253,7 @@ jobs:
           TARGET: aarch64-apple-darwin
           TARGET_DIR: target/aarch64-apple-darwin/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.artifact_name }}
           path: dist
@@ -264,7 +264,7 @@ jobs:
     name: Windows GNU
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Windows-GNU linker
         shell: bash
         run: |
@@ -325,7 +325,7 @@ jobs:
           CARGO_TARGET: x86_64-pc-windows-gnu
           TARGET_DIR: target/x86_64-pc-windows-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: 'wasmer-windows-gnu64'
           path: dist
@@ -336,7 +336,7 @@ jobs:
     name: Linux aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: aarch64-unknown-linux-gnu
@@ -390,7 +390,7 @@ jobs:
           TARGET: aarch64-unknown-linux-gnu
           TARGET_DIR: target/aarch64-unknown-linux-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wasmer-linux-aarch64
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           VERSION=${GITHUB_REF/refs\/tags\//}
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           DOING_RELEASE=$(echo $VERSION | grep -c '^[0-9]\+\.[0-9]\+\.[0-9]\+\(-\([a-zA-Z]\+\)\?[0-9]*\)\?$' || true)
-          echo "DOING_RELEASE::${DOING_RELEASE}" >> $GITHUB_OUTPUT
+          echo "DOING_RELEASE=${DOING_RELEASE}" >> $GITHUB_OUTPUT
           echo $VERSION
           echo $DOING_RELEASE
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         run: |
           VERSION=${GITHUB_REF/refs\/tags\//}
-          echo "VERSION::${VERSION}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           DOING_RELEASE=$(echo $VERSION | grep -c '^[0-9]\+\.[0-9]\+\.[0-9]\+\(-\([a-zA-Z]\+\)\?[0-9]*\)\?$' || true)
-          echo "DOING_RELEASE::${DOING_RELEASE}" >> $GITHUB_OUTPUT
+          echo "DOING_RELEASE=${DOING_RELEASE}" >> $GITHUB_OUTPUT
           echo $VERSION
           echo $DOING_RELEASE
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         run: |
           VERSION=${GITHUB_REF/refs\/tags\//}
-          echo ::set-output name=VERSION::${VERSION}
+          echo "VERSION::${VERSION}" >> $GITHUB_OUTPUT
           DOING_RELEASE=$(echo $VERSION | grep -c '^[0-9]\+\.[0-9]\+\.[0-9]\+\(-\([a-zA-Z]\+\)\?[0-9]*\)\?$' || true)
-          echo ::set-output name=DOING_RELEASE::${DOING_RELEASE}
+          echo "DOING_RELEASE::${DOING_RELEASE}" >> $GITHUB_OUTPUT
           echo $VERSION
           echo $DOING_RELEASE
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,7 +114,7 @@ jobs:
     name: Test wasm build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: rustup target add wasm32-wasi
         run: rustup target add wasm32-wasi
       - name: make build-wasmer-wasm
@@ -139,7 +139,7 @@ jobs:
           }
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.61
@@ -173,7 +173,7 @@ jobs:
           TARGET_DIR: target/aarch64-unknown-linux-gnu/release
       - name: Upload Artifacts
         if: ${{ matrix.build-what.key == 'capi' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: capi-linux-aarch64
           path: dist


### PR DESCRIPTION
Removed the use of ubuntu-18.
Update some deprecated github actions.
Remove the use of `set-output`.
Also use default libstdc++ for linux-x64 on ubuntu-20

ubuntu-18 is deprecated on github, and will be removed, so this change is necessary.

The linux-x64 was using a trick to use older libstdc++ to limit dependancy. Removing this for now, ubuntu-20 is pretty standard. A workaround (maybe using other OS) may need to found later.

There are still some warning, as whywaita/actions-cache-s3@v2 is still a deprecated node.js  12 action (but the repo is active -but without bug traker anabled- so will probably be updated at some point)