### PR TITLE
ci: Remove deleted vbus crate from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,6 @@ jobs:
         run: |
           cargo build --no-default-features --features="sys" --manifest-path=lib/api/Cargo.toml &&
           cargo build --manifest-path=lib/cache/Cargo.toml &&
-          cargo build --manifest-path=lib/vbus/Cargo.toml
       - name: Dist
         if: matrix.build != 'macos-arm64'
         run: |


### PR DESCRIPTION
The vbus crate was removed in the wasix merge.

This was forgotten in #3422 .