### PR TITLE
Webc Inheritance Fixes

### DIFF
--- a/lib/wasi/src/bin_factory/exec.rs
+++ b/lib/wasi/src/bin_factory/exec.rs
@@ -62,6 +62,7 @@ pub fn spawn_exec(
 
     // If the file system has not already been union'ed then do so
     env.state.fs.conditional_union(&binary);
+    tracing::debug!("{:?}", env.state.fs);
 
     // Now run the module
     spawn_exec_module(module, store, env, runtime)

--- a/lib/wasi/src/fs/mod.rs
+++ b/lib/wasi/src/fs/mod.rs
@@ -318,7 +318,6 @@ impl FileSystem for WasiFsRoot {
 
 /// Warning, modifying these fields directly may cause invariants to break and
 /// should be considered unsafe.  These fields may be made private in a future release
-#[derive(Debug)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct WasiFs {
     //pub repo: Repo,
@@ -1390,7 +1389,7 @@ impl WasiFs {
             _ => (),
         }
         let fd = self.get_fd(fd)?;
-        debug!("fdstat: {:?}", fd);
+        trace!("fdstat: {:?}", fd);
 
         let guard = fd.inode.read();
         let deref = guard.deref();
@@ -1749,6 +1748,18 @@ impl WasiFs {
             }
         }
         Ok(())
+    }
+}
+
+impl std::fmt::Debug for WasiFs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Ok(guard) = self.current_dir.try_lock() {
+            write!(f, "current_dir={} ", guard.as_str())?;
+        } else {
+            write!(f, "current_dir=(locked) ")?;
+        }
+        write!(f, "next_fd={} ", self.next_fd.load(Ordering::Relaxed))?;
+        write!(f, "{:?}", self.root_fs)
     }
 }
 

--- a/lib/wasi/src/fs/mod.rs
+++ b/lib/wasi/src/fs/mod.rs
@@ -1389,7 +1389,6 @@ impl WasiFs {
             _ => (),
         }
         let fd = self.get_fd(fd)?;
-        trace!("fdstat: {:?}", fd);
 
         let guard = fd.inode.read();
         let deref = guard.deref();

--- a/lib/wasi/src/os/command/builtins/cmd_wasmer.rs
+++ b/lib/wasi/src/os/command/builtins/cmd_wasmer.rs
@@ -10,7 +10,7 @@ use wasmer_wasi_types::wasi::Errno;
 use crate::{
     bin_factory::{spawn_exec, BinaryPackage, ModuleCache},
     syscalls::stderr_write,
-    VirtualTaskManager, VirtualTaskManagerExt, WasiEnv, WasiRuntime,
+    VirtualTaskManagerExt, WasiEnv, WasiRuntime,
 };
 
 const HELP: &str = r#"USAGE:
@@ -74,8 +74,7 @@ impl CmdWasmer {
             env.state = Arc::new(state);
 
             // Get the binary
-            let tasks = parent_ctx.data().tasks();
-            if let Some(binary) = self.get_package(what.clone(), tasks.deref()) {
+            if let Some(binary) = self.get_package(what.clone()) {
                 // Now run the module
                 spawn_exec(binary, name, store, env, &self.runtime, &self.cache)
             } else {
@@ -98,13 +97,8 @@ impl CmdWasmer {
         }
     }
 
-    pub fn get_package(
-        &self,
-        name: String,
-        tasks: &dyn VirtualTaskManager,
-    ) -> Option<BinaryPackage> {
-        self.cache
-            .get_webc(name.as_str(), self.runtime.deref(), tasks)
+    pub fn get_package(&self, name: String) -> Option<BinaryPackage> {
+        self.cache.get_webc(name.as_str(), self.runtime.deref())
     }
 }
 

--- a/lib/wasi/src/state/env.rs
+++ b/lib/wasi/src/state/env.rs
@@ -771,7 +771,7 @@ impl WasiEnv {
         while let Some(use_package) = use_packages.pop_back() {
             if let Some(package) = cmd_wasmer
                 .as_ref()
-                .and_then(|cmd| cmd.get_package(use_package.clone(), self.tasks().deref()))
+                .and_then(|cmd| cmd.get_package(use_package.clone()))
             {
                 // If its already been added make sure the version is correct
                 let package_name = package.package_name.to_string();

--- a/lib/wasi/src/syscalls/wasi/fd_event.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_event.rs
@@ -32,7 +32,7 @@ pub fn fd_event<M: MemorySize>(
         .fs
         .create_fd(rights, rights, Fdflags::empty(), 0, inode));
 
-    debug!(
+    trace!(
         "wasi[{}:{}]::fd_event - event notifications created (fd={})",
         ctx.data().pid(),
         ctx.data().tid(),

--- a/lib/wasi/src/syscalls/wasi/fd_fdstat_get.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_fdstat_get.rs
@@ -14,7 +14,7 @@ pub fn fd_fdstat_get<M: MemorySize>(
     fd: WasiFd,
     buf_ptr: WasmPtr<Fdstat, M>,
 ) -> Errno {
-    debug!(
+    trace!(
         "wasi[{}:{}]::fd_fdstat_get: fd={}, buf_ptr={}",
         ctx.data().pid(),
         ctx.data().tid(),

--- a/lib/wasi/src/syscalls/wasi/fd_prestat_dir_name.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_prestat_dir_name.rs
@@ -22,7 +22,6 @@ pub fn fd_prestat_dir_name<M: MemorySize>(
 
     // check inode-val.is_preopened?
 
-    trace!("=> inode: {:?}", inode);
     let guard = inode.read();
     match guard.deref() {
         Kind::Dir { .. } | Kind::Root { .. } => {

--- a/lib/wasi/src/syscalls/wasi/path_filestat_get.rs
+++ b/lib/wasi/src/syscalls/wasi/path_filestat_get.rs
@@ -27,7 +27,7 @@ pub fn path_filestat_get<M: MemorySize>(
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
 
     let mut path_string = unsafe { get_input_str!(&memory, path, path_len) };
-    debug!(
+    trace!(
         "wasi[{}:{}]::path_filestat_get (fd={}, path={})",
         ctx.data().pid(),
         ctx.data().tid(),

--- a/lib/wasi/src/wapm/mod.rs
+++ b/lib/wasi/src/wapm/mod.rs
@@ -62,6 +62,8 @@ async fn fetch_webc(
             .replace(WAPM_WEBC_VERSION_TAG, version.replace('\"', "'").as_str()),
         None => WAPM_WEBC_QUERY_LAST.replace(WAPM_WEBC_QUERY_TAG, name.replace('\"', "'").as_str()),
     };
+    debug!("request: {}", url_query);
+
     let url = format!(
         "{}{}",
         WAPM_WEBC_URL,
@@ -84,6 +86,8 @@ async fn fetch_webc(
     let body = response.body.context("HTTP response with empty body")?;
     let data: WapmWebQuery =
         serde_json::from_slice(&body).context("Could not parse webc registry JSON data")?;
+    debug!("response: {:?}", data);
+
     let PiritaVersionedDownload {
         url: download_url,
         version,


### PR DESCRIPTION
- Fixed an issue where packages without commands were not loading the webc file system because it was package specific, for webc inheritence this does not make sense
- Removed some trace info which is bloating the logs
- Added some debug information for packages that are fetched

This splits out the webc related fixes from #3611.
The command additions of that PR will be added separately.
