### PR TITLE
Remove unused import in lib.rs example

### DIFF
--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -42,7 +42,6 @@
 //!
 //! ```rust
 //! use wasmer::{Store, Module, Instance, Value, imports};
-//! use wasmer::FunctionEnv;
 //!
 //! fn main() -> anyhow::Result<()> {
 //!     let module_wat = r#"


### PR DESCRIPTION
`FunctionEnv` isn't used in the demo code.

