### PR TITLE
wasi: Thread Lifecycle Fix

### DIFF
--- a/lib/wasi/src/bin_factory/exec.rs
+++ b/lib/wasi/src/bin_factory/exec.rs
@@ -1,7 +1,7 @@
 use std::{pin::Pin, sync::Arc};
 
 use crate::{
-    os::task::{thread::WasiThreadGuard, TaskJoinHandle},
+    os::task::{thread::WasiThreadRunGuard, TaskJoinHandle},
     VirtualBusError, WasiRuntimeError,
 };
 use futures::Future;
@@ -120,7 +120,7 @@ pub fn spawn_exec_module(
                     }
                 };
 
-                let thread = WasiThreadGuard::new(wasi_env.thread.clone());
+                let thread = WasiThreadRunGuard::new(wasi_env.thread.clone());
 
                 let mut wasi_env = WasiFunctionEnv::new(&mut store, wasi_env);
 

--- a/lib/wasi/src/os/task/thread.rs
+++ b/lib/wasi/src/os/task/thread.rs
@@ -96,17 +96,17 @@ pub struct WasiThread {
 /// [`Thread::set_status_running`] or [`Thread::set_status_finished`], but
 /// this guard can ensure that the thread is marked as terminated even if this
 /// is forgotten or a panic occurs.
-pub struct WasiThreadGuard {
+pub struct WasiThreadRunGuard {
     pub thread: WasiThread,
 }
 
-impl WasiThreadGuard {
+impl WasiThreadRunGuard {
     pub fn new(thread: WasiThread) -> Self {
         Self { thread }
     }
 }
 
-impl Drop for WasiThreadGuard {
+impl Drop for WasiThreadRunGuard {
     fn drop(&mut self) {
         self.thread
             .set_status_finished(Err(


### PR DESCRIPTION
Fix wasi thread lifecycle and result handling.

- refactor(wasi): Rename WasiThreadGuard to WasiThreadRunGuard
- fix(wasi): WsaiThreadRunGuard: Don't overwrite finished state
