### PR TITLE
fix(wasi): Memory leak due to cyclical WasiControlPlane references

### DIFF
--- a/lib/wasi/src/state/env.rs
+++ b/lib/wasi/src/state/env.rs
@@ -260,6 +260,7 @@ impl WasiEnvInit {
 /// The environment provided to the WASI imports.
 #[derive(Debug)]
 pub struct WasiEnv {
+    pub control_plane: WasiControlPlane,
     /// Represents the process this environment is attached to
     pub process: WasiProcess,
     /// Represents the thread this environment is attached to
@@ -312,6 +313,7 @@ impl WasiEnv {
     // Currently only used by fork/spawn related syscalls.
     pub(crate) fn duplicate(&self) -> Self {
         Self {
+            control_plane: self.control_plane.clone(),
             process: self.process.clone(),
             poll_seed: self.poll_seed,
             thread: self.thread.clone(),
@@ -330,7 +332,7 @@ impl WasiEnv {
 
     /// Forking the WasiState is used when either fork or vfork is called
     pub fn fork(&self) -> Result<(Self, WasiThreadHandle), ControlPlaneError> {
-        let process = self.process.compute.new_process()?;
+        let process = self.control_plane.new_process()?;
         let handle = process.new_thread()?;
 
         let thread = handle.as_thread();
@@ -341,6 +343,7 @@ impl WasiEnv {
         let bin_factory = self.bin_factory.clone();
 
         let new_env = Self {
+            control_plane: self.control_plane.clone(),
             process,
             thread,
             vfork: None,
@@ -379,6 +382,7 @@ impl WasiEnv {
         };
 
         let mut env = Self {
+            control_plane: init.control_plane,
             process,
             thread: thread.as_thread(),
             vfork: None,

--- a/lib/wasi/src/syscalls/wasix/proc_join.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_join.rs
@@ -76,7 +76,7 @@ pub fn proc_join<M: MemorySize>(
     // Otherwise we wait for the specific PID
     let env = ctx.data();
     let pid: WasiProcessId = pid.into();
-    let process = env.process.control_plane().get_process(pid);
+    let process = env.control_plane.get_process(pid);
     if let Some(process) = process {
         let exit_code = wasi_try_ok!(__asyncify(&mut ctx, None, async move {
             let code = process.join().await.unwrap_or(Errno::Child as u32);

--- a/lib/wasi/src/syscalls/wasix/proc_parent.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_parent.rs
@@ -15,14 +15,12 @@ pub fn proc_parent<M: MemorySize>(
     if pid == env.process.pid() {
         let memory = env.memory_view(&ctx);
         wasi_try_mem!(ret_parent.write(&memory, env.process.ppid().raw() as Pid));
+        Errno::Success
+    } else if let Some(process) = env.control_plane.get_process(pid) {
+        let memory = env.memory_view(&ctx);
+        wasi_try_mem!(ret_parent.write(&memory, process.pid().raw() as Pid));
+        Errno::Success
     } else {
-        let control_plane = env.process.control_plane();
-        if let Some(process) = control_plane.get_process(pid) {
-            let memory = env.memory_view(&ctx);
-            wasi_try_mem!(ret_parent.write(&memory, process.pid().raw() as Pid));
-        } else {
-            return Errno::Badf;
-        }
+        Errno::Badf
     }
-    Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasix/proc_signal.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_signal.rs
@@ -23,7 +23,7 @@ pub fn proc_signal<M: MemorySize>(
 
     let process = {
         let pid: WasiProcessId = pid.into();
-        ctx.data().process.compute.get_process(pid)
+        ctx.data().control_plane.get_process(pid)
     };
     if let Some(process) = process {
         process.signal_process(sig);

--- a/lib/wasi/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_spawn.rs
@@ -39,7 +39,7 @@ pub fn proc_spawn<M: MemorySize>(
     ret_handles: WasmPtr<BusHandles, M>,
 ) -> Result<BusErrno, WasiError> {
     let env = ctx.data();
-    let control_plane = env.process.control_plane();
+    let control_plane = &env.control_plane;
     let memory = env.memory_view(&ctx);
     let name = unsafe { get_input_str_bus_ok!(&memory, name, name_len) };
     let args = unsafe { get_input_str_bus_ok!(&memory, args, args_len) };


### PR DESCRIPTION
Fixed by WasiProcess just storing a Weak<> handle to the control plane.

Note: This could/should also be changed so that the WasiProcess does not
have a handle to the control plane at all, but that requires some
slightly bigger refactoring that also changes or removes the SignalHandlerAbi

Closes #3642
