### PR TITLE
Improvements to the tracing and logging in wasmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,6 +4890,8 @@ dependencies = [
  "time 0.3.20",
  "tldextract",
  "toml",
+ "tracing",
+ "tracing-subscriber 0.3.16",
  "unix_mode",
  "url",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,7 +4861,6 @@ dependencies = [
  "dialoguer",
  "dirs",
  "distance",
- "fern",
  "flate2",
  "hex",
  "http_req",

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
           src = self;
           buildInputs = with pkgs; [
             pkgconfig
+            libffi
+            libxml2
             openssl
             llvmPackages_14.llvm
             # Snapshot testing

--- a/lib/api/src/function_env.rs
+++ b/lib/api/src/function_env.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, marker::PhantomData};
+use std::{any::Any, fmt::Debug, marker::PhantomData};
 
 use crate::vm::VMFunctionEnvironment;
 
@@ -100,6 +100,12 @@ impl<T> Clone for FunctionEnv<T> {
 pub struct FunctionEnvMut<'a, T: 'a> {
     pub(crate) store_mut: StoreMut<'a>,
     pub(crate) func_env: FunctionEnv<T>,
+}
+
+impl<'a, T> Debug for FunctionEnvMut<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "env_mut")
+    }
 }
 
 impl<T: Send + 'static> FunctionEnvMut<'_, T> {

--- a/lib/api/src/ptr.rs
+++ b/lib/api/src/ptr.rs
@@ -278,11 +278,6 @@ impl<T: ValueType, M: MemorySize> Eq for WasmPtr<T, M> {}
 
 impl<T: ValueType, M: MemorySize> fmt::Debug for WasmPtr<T, M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "WasmPtr(offset: {}, pointer: {:#x})",
-            self.offset.into(),
-            self.offset.into()
-        )
+        write!(f, "{}(@{})", std::any::type_name::<T>(), self.offset.into())
     }
 }

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -91,6 +91,8 @@ pathdiff = "0.2.1"
 sha2 = "0.10.6"
 object = "0.30.0"
 wasm-coredump-builder = { version = "0.1.11" }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ], optional = true }
 
 [build-dependencies]
 chrono = { version = "^0.4", default-features = false, features = [ "std", "clock" ] }
@@ -111,6 +113,7 @@ default = [
     "wasmer-artifact-create",
     "static-artifact-create",
     "webc_runner",
+    "tracing"
 ]
 cache = ["wasmer-cache"]
 cache-blake3-pure = ["wasmer-cache/blake3-pure"]
@@ -167,6 +170,7 @@ debug = ["fern", "wasmer-wasi/logging"]
 disable-all-logging = ["wasmer-wasi/disable-all-logging", "log/release_max_level_off"]
 headless = []
 headless-minimal = ["headless", "disable-all-logging", "wasi"]
+tracing = [ "dep:tracing", "tracing-subscriber" ]
 
 # Optional
 enable-serde = [

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -54,8 +54,6 @@ distance = "0.4"
 # For the inspect subcommand
 bytesize = "1.0"
 cfg-if = "1.0"
-# For debug feature
-fern = { version = "0.6", features = ["colored"], optional = true }
 tempfile = "3.4.0"
 http_req  = { version="^0.8", default-features = false, features = ["rust-tls"] }
 reqwest = { version = "^0.11", default-features = false, features = ["rustls-tls", "json", "multipart"] }
@@ -166,7 +164,7 @@ llvm = [
     "wasmer-compiler-llvm",
     "compiler",
 ]
-debug = ["fern", "wasmer-wasi/logging"]
+debug = ["tracing", "wasmer-wasi/logging"]
 disable-all-logging = ["wasmer-wasi/disable-all-logging", "log/release_max_level_off"]
 headless = []
 headless-minimal = ["headless", "disable-all-logging", "wasi"]

--- a/lib/cli/src/logging.rs
+++ b/lib/cli/src/logging.rs
@@ -1,7 +1,7 @@
 //! Logging functions for the debug feature.
 
 /// Subroutine to instantiate the loggers
-#[cfg(feature = "tracing")]
+#[cfg(any(feature = "tracing", feature = "debug"))]
 pub fn set_up_logging(verbose: u8) -> Result<(), String> {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{fmt, EnvFilter};
@@ -23,76 +23,6 @@ pub fn set_up_logging(verbose: u8) -> Result<(), String> {
         .with(filter_layer)
         .with(fmt_layer)
         .init();
-
-    Ok(())
-}
-
-/// Subroutine to instantiate the loggers
-#[deprecated("please use the tracing feature instead")]
-#[cfg(not(feature = "tracing"))]
-pub fn set_up_logging(verbose: u8) -> Result<(), String> {
-    use crate::utils::wasmer_should_print_color;
-    use anyhow::Result;
-    use fern::colors::{Color, ColoredLevelConfig};
-    use std::time;
-
-    /// The debug level
-    pub type DebugLevel = log::LevelFilter;
-
-    let colors_line = ColoredLevelConfig::new()
-        .error(Color::Red)
-        .warn(Color::Yellow)
-        .trace(Color::BrightBlack);
-    let should_color = wasmer_should_print_color();
-
-    let colors_level = colors_line.info(Color::Green);
-    let level = match verbose {
-        1 => DebugLevel::Debug,
-        _ => DebugLevel::Trace,
-    };
-    let dispatch = fern::Dispatch::new()
-        .level(level)
-        .chain({
-            let base = if should_color {
-                fern::Dispatch::new().format(move |out, message, record| {
-                    let time = time::SystemTime::now().duration_since(time::UNIX_EPOCH).expect("Can't get time");
-                    out.finish(format_args!(
-                        "{color_line}[{seconds}.{millis} {level} {target}{color_line}]{ansi_close} {message}",
-                        color_line = format_args!(
-                            "\x1B[{}m",
-                            colors_line.get_color(&record.level()).to_fg_str()
-                        ),
-                        seconds = time.as_secs(),
-                        millis = time.subsec_millis(),
-                        level = colors_level.color(record.level()),
-                        target = record.target(),
-                        ansi_close = "\x1B[0m",
-                        message = message,
-                    ));
-                })
-            } else {
-                // default formatter without color
-                fern::Dispatch::new().format(move |out, message, record| {
-                    let time = time::SystemTime::now().duration_since(time::UNIX_EPOCH).expect("Can't get time");
-                    out.finish(format_args!(
-                        "[{seconds}.{millis} {level} {target}] {message}",
-                        seconds = time.as_secs(),
-                        millis = time.subsec_millis(),
-                        level = record.level(),
-                        target = record.target(),
-                        message = message,
-                    ));
-                })
-            };
-
-            base
-                .filter(|metadata| {
-                    metadata.target().starts_with("wasmer")
-                })
-                .chain(std::io::stdout())
-        });
-
-    dispatch.apply().map_err(|e| format!("{}", e))?;
 
     Ok(())
 }

--- a/lib/wasi-types/src/wasi/bindings.rs
+++ b/lib/wasi-types/src/wasi/bindings.rs
@@ -417,11 +417,7 @@ impl Errno {
 }
 impl core::fmt::Debug for Errno {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Errno")
-            .field("code", &(*self as i32))
-            .field("name", &self.name())
-            .field("message", &self.message())
-            .finish()
+        write!(f, "Errno::{}", &self.name())
     }
 }
 impl core::fmt::Display for Errno {
@@ -528,11 +524,7 @@ impl BusErrno {
 }
 impl core::fmt::Debug for BusErrno {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BusErrno")
-            .field("code", &(*self as i32))
-            .field("name", &self.name())
-            .field("message", &self.message())
-            .finish()
+        write!(f, "BusErrno::{}", &self.name())
     }
 }
 impl core::fmt::Display for BusErrno {
@@ -2163,6 +2155,14 @@ impl core::fmt::Debug for Bool {
         match self {
             Bool::False => f.debug_tuple("Bool::False").finish(),
             Bool::True => f.debug_tuple("Bool::True").finish(),
+        }
+    }
+}
+impl core::fmt::Display for Bool {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Bool::False => write!(f, "false"),
+            Bool::True => write!(f, "true"),
         }
     }
 }

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0"
 thiserror = "1"
-tracing = "0.1"
+tracing = { version = "0.1" }
 getrandom = "0.2"
 wasmer-wasi-types = { path = "../wasi-types", version = "=3.2.0-alpha.1" }
 wasmer-types = { path = "../types", version = "=3.2.0-alpha.1", default-features = false }

--- a/lib/wasi/src/os/task/process.rs
+++ b/lib/wasi/src/os/task/process.rs
@@ -28,7 +28,7 @@ use super::{
 };
 
 /// Represents the ID of a sub-process
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WasiProcessId(u32);
 
 impl WasiProcessId {
@@ -62,6 +62,12 @@ impl From<WasiProcessId> for u32 {
 }
 
 impl std::fmt::Display for WasiProcessId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Debug for WasiProcessId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/lib/wasi/src/os/task/thread.rs
+++ b/lib/wasi/src/os/task/thread.rs
@@ -22,7 +22,7 @@ use super::{
 };
 
 /// Represents the ID of a WASI thread
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WasiThreadId(u32);
 
 impl WasiThreadId {
@@ -62,6 +62,12 @@ impl From<WasiThreadId> for u32 {
 }
 
 impl std::fmt::Display for WasiThreadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Debug for WasiThreadId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/lib/wasi/src/syscalls/wasi/args_get.rs
+++ b/lib/wasi/src/syscalls/wasi/args_get.rs
@@ -10,12 +10,12 @@ use crate::syscalls::*;
 /// - `char *argv_buf`
 ///     A pointer to a buffer to write the argument string data.
 ///
+#[instrument(level = "debug", skip_all, ret)]
 pub fn args_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     argv: WasmPtr<WasmPtr<u8, M>, M>,
     argv_buf: WasmPtr<u8, M>,
 ) -> Errno {
-    debug!("wasi[{}:{}]::args_get", ctx.data().pid(), ctx.data().tid());
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
 
@@ -27,7 +27,7 @@ pub fn args_get<M: MemorySize>(
     let result = write_buffer_array(&memory, &args, argv, argv_buf);
 
     debug!(
-        "=> args:\n{}",
+        "args:\n{}",
         state
             .args
             .iter()

--- a/lib/wasi/src/syscalls/wasi/args_sizes_get.rs
+++ b/lib/wasi/src/syscalls/wasi/args_sizes_get.rs
@@ -8,16 +8,12 @@ use crate::syscalls::*;
 ///     The number of arguments.
 /// - `size_t *argv_buf_size`
 ///     The size of the argument string data.
+#[instrument(level = "debug", skip_all, ret)]
 pub fn args_sizes_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     argc: WasmPtr<M::Offset, M>,
     argv_buf_size: WasmPtr<M::Offset, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::args_sizes_get",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
 
@@ -31,7 +27,7 @@ pub fn args_sizes_get<M: MemorySize>(
     wasi_try_mem!(argc.write(argc_val));
     wasi_try_mem!(argv_buf_size.write(argv_buf_size_val));
 
-    debug!("=> argc={}, argv_buf_size={}", argc_val, argv_buf_size_val);
+    debug!("argc={}, argv_buf_size={}", argc_val, argv_buf_size_val);
 
     Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasi/clock_res_get.rs
+++ b/lib/wasi/src/syscalls/wasi/clock_res_get.rs
@@ -9,16 +9,12 @@ use crate::syscalls::*;
 /// Output:
 /// - `Timestamp *resolution`
 ///     The resolution of the clock in nanoseconds
+#[instrument(level = "trace", skip_all, ret)]
 pub fn clock_res_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     clock_id: Snapshot0Clockid,
     resolution: WasmPtr<Timestamp, M>,
 ) -> Errno {
-    trace!(
-        "wasi[{}:{}]::clock_res_get",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
 

--- a/lib/wasi/src/syscalls/wasi/clock_time_get.rs
+++ b/lib/wasi/src/syscalls/wasi/clock_time_get.rs
@@ -11,18 +11,13 @@ use crate::syscalls::*;
 /// Output:
 /// - `Timestamp *time`
 ///     The value of the clock in nanoseconds
+#[instrument(level = "trace", skip_all, fields(clock_id, precision), ret)]
 pub fn clock_time_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     clock_id: Snapshot0Clockid,
     precision: Timestamp,
     time: WasmPtr<Timestamp, M>,
 ) -> Errno {
-    /*
-    debug!(
-        "wasi::clock_time_get clock_id: {}, precision: {}",
-        clock_id as u8, precision
-    );
-    */
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
 
@@ -34,13 +29,5 @@ pub fn clock_time_get<M: MemorySize>(
         }
     };
     wasi_try_mem!(time.write(&memory, t_out as Timestamp));
-
-    /*
-    trace!(
-        "time: {} => {}",
-        wasi_try_mem!(time.deref(&memory).read()),
-        result
-    );
-    */
     Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasi/clock_time_set.rs
+++ b/lib/wasi/src/syscalls/wasi/clock_time_set.rs
@@ -8,16 +8,12 @@ use crate::syscalls::*;
 ///     The ID of the clock to query
 /// - `Timestamp *time`
 ///     The value of the clock in nanoseconds
+#[instrument(level = "trace", skip_all, fields(clock_id, time), ret)]
 pub fn clock_time_set<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     clock_id: Snapshot0Clockid,
     time: Timestamp,
 ) -> Errno {
-    trace!(
-        "wasi::clock_time_set clock_id: {:?}, time: {}",
-        clock_id,
-        time
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
 
@@ -30,6 +26,5 @@ pub fn clock_time_set<M: MemorySize>(
 
     let mut guard = env.state.clock_offset.lock().unwrap();
     guard.insert(clock_id, t_offset);
-
     Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasi/environ_get.rs
+++ b/lib/wasi/src/syscalls/wasi/environ_get.rs
@@ -9,18 +9,14 @@ use crate::syscalls::*;
 ///     A pointer to a buffer to write the environment variable pointers.
 /// - `char *environ_buf`
 ///     A pointer to a buffer to write the environment variable string data.
+#[instrument(level = "debug", skip_all, ret)]
 pub fn environ_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     environ: WasmPtr<WasmPtr<u8, M>, M>,
     environ_buf: WasmPtr<u8, M>,
 ) -> Errno {
-    debug!(
-        "wasi::environ_get. Environ: {:?}, environ_buf: {:?}",
-        environ, environ_buf
-    );
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
-    trace!(" -> State envs: {:?}", state.envs);
 
     write_buffer_array(&memory, &*state.envs, environ, environ_buf)
 }

--- a/lib/wasi/src/syscalls/wasi/environ_sizes_get.rs
+++ b/lib/wasi/src/syscalls/wasi/environ_sizes_get.rs
@@ -8,16 +8,12 @@ use crate::syscalls::*;
 ///     The number of environment variables.
 /// - `size_t *environ_buf_size`
 ///     The size of the environment variable string data.
+#[instrument(level = "trace", skip_all, ret)]
 pub fn environ_sizes_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     environ_count: WasmPtr<M::Offset, M>,
     environ_buf_size: WasmPtr<M::Offset, M>,
 ) -> Errno {
-    trace!(
-        "wasi[{}:{}]::environ_sizes_get",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
 
@@ -32,9 +28,8 @@ pub fn environ_sizes_get<M: MemorySize>(
     wasi_try_mem!(environ_buf_size.write(env_buf_size));
 
     trace!(
-        "env_var_count: {}, env_buf_size: {}",
-        env_var_count,
-        env_buf_size
+        %env_var_count,
+        %env_buf_size
     );
 
     Errno::Success

--- a/lib/wasi/src/syscalls/wasi/fd_advise.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_advise.rs
@@ -12,6 +12,7 @@ use crate::syscalls::*;
 ///     The length from the offset to which the advice applies
 /// - `__wasi_advice_t advice`
 ///     The advice to give
+#[instrument(level = "debug", skip_all, fields(fd, offset, len, advice), ret)]
 pub fn fd_advise(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -19,13 +20,6 @@ pub fn fd_advise(
     len: Filesize,
     advice: Advice,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_advise: fd={}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd
-    );
-
     // this is used for our own benefit, so just returning success is a valid
     // implementation for now
     Errno::Success

--- a/lib/wasi/src/syscalls/wasi/fd_allocate.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_allocate.rs
@@ -10,17 +10,13 @@ use crate::syscalls::*;
 ///     The offset from the start marking the beginning of the allocation
 /// - `Filesize len`
 ///     The length from the offset marking the end of the allocation
+#[instrument(level = "debug", skip_all, fields(fd, offset, len), ret)]
 pub fn fd_allocate(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     offset: Filesize,
     len: Filesize,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_allocate",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (_, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let fd_entry = wasi_try!(state.fs.get_fd(fd));
@@ -52,7 +48,7 @@ pub fn fd_allocate(
         }
     }
     inode.stat.write().unwrap().st_size = new_size;
-    debug!("New file size: {}", new_size);
+    debug!(%new_size);
 
     Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_close.rs
@@ -12,14 +12,8 @@ use crate::syscalls::*;
 ///     If `fd` is a directory
 /// - `Errno::Badf`
 ///     If `fd` is invalid or not open
+#[instrument(level = "debug", skip_all, fields(fd), ret, err)]
 pub fn fd_close(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::fd_close: fd={}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd
-    );
-
     let env = ctx.data();
     let (_, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     wasi_try_ok!(state.fs.close_fd(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_datasync.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_datasync.rs
@@ -6,12 +6,8 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `Fd fd`
 ///     The file descriptor to sync
+#[instrument(level = "debug", skip_all, fields(fd), ret, err)]
 pub fn fd_datasync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::fd_datasync",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let state = env.state.clone();
     let fd_entry = wasi_try_ok!(state.fs.get_fd(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_dup.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_dup.rs
@@ -9,17 +9,17 @@ use crate::syscalls::*;
 /// Outputs:
 /// - `Fd fd`
 ///   The new file handle that is a duplicate of the original
+#[instrument(level = "debug", skip_all, fields(fd, ret_fd = field::Empty), ret)]
 pub fn fd_dup<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     ret_fd: WasmPtr<WasiFd, M>,
 ) -> Errno {
-    debug!("wasi[{}:{}]::fd_dup", ctx.data().pid(), ctx.data().tid());
-
     let env = ctx.data();
     let (memory, state) = env.get_memory_and_wasi_state(&ctx, 0);
     let fd = wasi_try!(state.fs.clone_fd(fd));
 
+    Span::current().record("ret_fd", fd);
     wasi_try_mem!(ret_fd.write(&memory, fd));
 
     Errno::Success

--- a/lib/wasi/src/syscalls/wasi/fd_event.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_event.rs
@@ -3,14 +3,13 @@ use crate::{fs::NotificationInner, syscalls::*};
 
 /// ### `fd_event()`
 /// Creates a file handle for event notifications
+#[instrument(level = "debug", skip_all, fields(initial_val, ret_fd = field::Empty), ret)]
 pub fn fd_event<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     initial_val: u64,
     flags: EventFdFlags,
     ret_fd: WasmPtr<WasiFd, M>,
 ) -> Errno {
-    debug!("wasi[{}:{}]::fd_event", ctx.data().pid(), ctx.data().tid());
-
     let env = ctx.data();
     let (memory, state, mut inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
 
@@ -32,12 +31,7 @@ pub fn fd_event<M: MemorySize>(
         .fs
         .create_fd(rights, rights, Fdflags::empty(), 0, inode));
 
-    trace!(
-        "wasi[{}:{}]::fd_event - event notifications created (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd
-    );
+    Span::current().record("ret_fd", fd);
     wasi_try_mem!(ret_fd.write(&memory, fd));
 
     Errno::Success

--- a/lib/wasi/src/syscalls/wasi/fd_fdstat_get.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_fdstat_get.rs
@@ -9,18 +9,12 @@ use crate::syscalls::*;
 /// Output:
 /// - `Fdstat *buf`
 ///     The location where the metadata will be written
+#[instrument(level = "trace", skip_all, fields(fd), ret)]
 pub fn fd_fdstat_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     buf_ptr: WasmPtr<Fdstat, M>,
 ) -> Errno {
-    trace!(
-        "wasi[{}:{}]::fd_fdstat_get: fd={}, buf_ptr={}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-        buf_ptr.offset()
-    );
     let env = ctx.data();
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
     let stat = wasi_try!(state.fs.fdstat(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_fdstat_set_flags.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_fdstat_set_flags.rs
@@ -8,19 +8,12 @@ use crate::syscalls::*;
 ///     The file descriptor to apply the new flags to
 /// - `Fdflags flags`
 ///     The flags to apply to `fd`
+#[instrument(level = "debug", skip_all, fields(fd), ret, err)]
 pub fn fd_fdstat_set_flags(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     flags: Fdflags,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::fd_fdstat_set_flags (fd={}, flags={:?})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-        flags
-    );
-
     {
         let env = ctx.data();
         let (_, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
@@ -29,13 +22,6 @@ pub fn fd_fdstat_set_flags(
         let inode = fd_entry.inode.clone();
 
         if !fd_entry.rights.contains(Rights::FD_FDSTAT_SET_FLAGS) {
-            debug!(
-                "wasi[{}:{}]::fd_fdstat_set_flags (fd={}, flags={:?}) - access denied",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                fd,
-                flags
-            );
             return Ok(Errno::Access);
         }
     }

--- a/lib/wasi/src/syscalls/wasi/fd_fdstat_set_rights.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_fdstat_set_rights.rs
@@ -10,17 +10,13 @@ use crate::syscalls::*;
 ///     The rights to apply to `fd`
 /// - `Rights fs_rights_inheriting`
 ///     The inheriting rights to apply to `fd`
+#[instrument(level = "debug", skip_all, fields(fd), ret)]
 pub fn fd_fdstat_set_rights(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     fs_rights_base: Rights,
     fs_rights_inheriting: Rights,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_fdstat_set_rights",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (_, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let mut fd_map = state.fs.fd_map.write().unwrap();

--- a/lib/wasi/src/syscalls/wasi/fd_filestat_get.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_filestat_get.rs
@@ -9,6 +9,7 @@ use crate::syscalls::*;
 /// Output:
 /// - `Filestat *buf`
 ///     Where the metadata from `fd` will be written
+#[instrument(level = "debug", skip_all, fields(fd), ret)]
 pub fn fd_filestat_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -30,11 +31,6 @@ pub(crate) fn fd_filestat_get_internal<M: MemorySize>(
     fd: WasiFd,
     buf: WasmPtr<Filestat, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_filestat_get: fd={fd}",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
     let fd_entry = wasi_try!(state.fs.get_fd(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_filestat_set_size.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_filestat_set_size.rs
@@ -8,16 +8,12 @@ use crate::syscalls::*;
 ///     File descriptor to adjust
 /// - `Filesize st_size`
 ///     New size that `fd` will be set to
+#[instrument(level = "debug", skip_all, fields(fd, st_size), ret)]
 pub fn fd_filestat_set_size(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     st_size: Filesize,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_filestat_set_size",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (_, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let fd_entry = wasi_try!(state.fs.get_fd(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_filestat_set_times.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_filestat_set_times.rs
@@ -10,6 +10,7 @@ use crate::syscalls::*;
 ///     Last modified time
 /// - `Fstflags fst_flags`
 ///     Bit-vector for controlling which times get set
+#[instrument(level = "debug", skip_all, fields(fd, st_atim, st_mtim), ret)]
 pub fn fd_filestat_set_times(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -17,11 +18,6 @@ pub fn fd_filestat_set_times(
     st_mtim: Timestamp,
     fst_flags: Fstflags,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_filestat_set_times",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (_, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let fd_entry = wasi_try!(state.fs.get_fd(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_prestat_dir_name.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_prestat_dir_name.rs
@@ -11,7 +11,6 @@ pub fn fd_prestat_dir_name<M: MemorySize>(
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let path_chars = wasi_try_mem!(path.slice(&memory, path_len));
-    Span::current().record("path", get_input_str!(&memory, path, path_len).as_str());
 
     let inode = wasi_try!(state.fs.get_fd_inode(fd));
 

--- a/lib/wasi/src/syscalls/wasi/fd_prestat_dir_name.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_prestat_dir_name.rs
@@ -13,6 +13,7 @@ pub fn fd_prestat_dir_name<M: MemorySize>(
     let path_chars = wasi_try_mem!(path.slice(&memory, path_len));
 
     let inode = wasi_try!(state.fs.get_fd_inode(fd));
+    Span::current().record("path", inode.name.as_ref());
 
     // check inode-val.is_preopened?
 

--- a/lib/wasi/src/syscalls/wasi/fd_prestat_get.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_prestat_get.rs
@@ -9,27 +9,17 @@ use crate::syscalls::*;
 /// Output:
 /// - `__wasi_prestat *buf`
 ///     Where the metadata will be written
+#[instrument(level = "trace", skip_all, fields(fd), ret)]
 pub fn fd_prestat_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     buf: WasmPtr<Prestat, M>,
 ) -> Errno {
-    trace!(
-        "wasi[{}:{}]::fd_prestat_get: fd={}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd
-    );
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
 
     let prestat_ptr = buf.deref(&memory);
-    wasi_try_mem!(
-        prestat_ptr.write(wasi_try!(state.fs.prestat_fd(fd).map_err(|code| {
-            debug!("fd_prestat_get failed (fd={}) - errno={}", fd, code);
-            code
-        })))
-    );
+    wasi_try_mem!(prestat_ptr.write(wasi_try!(state.fs.prestat_fd(fd))));
 
     Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasi/fd_renumber.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_renumber.rs
@@ -8,14 +8,8 @@ use crate::syscalls::*;
 ///     File descriptor to copy
 /// - `Fd to`
 ///     Location to copy file descriptor to
+#[instrument(level = "debug", skip_all, fields(from, to), ret)]
 pub fn fd_renumber(ctx: FunctionEnvMut<'_, WasiEnv>, from: WasiFd, to: WasiFd) -> Errno {
-    debug!(
-        "wasi[{}:{}]::fd_renumber(from={}, to={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        from,
-        to
-    );
     if from == to {
         return Errno::Success;
     }

--- a/lib/wasi/src/syscalls/wasi/fd_seek.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_seek.rs
@@ -13,6 +13,7 @@ use crate::syscalls::*;
 /// Output:
 /// - `Filesize *fd`
 ///     The new offset relative to the start of the file
+#[instrument(level = "trace", skip_all, fields(fd, offset, whence), ret)]
 pub fn fd_seek<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -20,15 +21,6 @@ pub fn fd_seek<M: MemorySize>(
     whence: Whence,
     newoffset: WasmPtr<Filesize, M>,
 ) -> Result<Errno, WasiError> {
-    trace!(
-        "wasi[{}:{}]::fd_seek: fd={}, offset={} from={:?}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-        offset,
-        whence,
-    );
-
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 
     let env = ctx.data();
@@ -123,11 +115,7 @@ pub fn fd_seek<M: MemorySize>(
     wasi_try_mem_ok!(new_offset_ref.write(new_offset));
 
     trace!(
-        "wasi[{}:{}]::fd_seek: fd={}, new_offset={}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-        new_offset,
+        %new_offset,
     );
 
     Ok(Errno::Success)

--- a/lib/wasi/src/syscalls/wasi/fd_sync.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_sync.rs
@@ -10,9 +10,8 @@ use crate::syscalls::*;
 /// TODO: figure out which errors this should return
 /// - `Errno::Perm`
 /// - `Errno::Notcapable`
+#[instrument(level = "debug", skip_all, fields(fd), ret)]
 pub fn fd_sync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
-    debug!("wasi[{}:{}]::fd_sync", ctx.data().pid(), ctx.data().tid());
-    debug!("=> fd={}", fd);
     let env = ctx.data();
     let (_, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let fd_entry = wasi_try_ok!(state.fs.get_fd(fd));

--- a/lib/wasi/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_write.rs
@@ -15,6 +15,7 @@ use crate::syscalls::*;
 ///     Number of bytes written
 /// Errors:
 ///
+#[instrument(level = "trace", skip_all, fields(fd, nwritten = field::Empty), ret, err)]
 pub fn fd_write<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -22,13 +23,6 @@ pub fn fd_write<M: MemorySize>(
     iovs_len: M::Offset,
     nwritten: WasmPtr<M::Offset, M>,
 ) -> Result<Errno, WasiError> {
-    trace!(
-        "wasi[{}:{}]::fd_write: fd={}",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-    );
-
     let offset = {
         let mut env = ctx.data();
         let state = env.state.clone();
@@ -55,6 +49,7 @@ pub fn fd_write<M: MemorySize>(
 /// Output:
 /// - `u32 *nwritten`
 ///     Number of bytes written
+#[instrument(level = "trace", skip_all, fields(fd, offset, nwritten = field::Empty), ret, err)]
 pub fn fd_pwrite<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -63,14 +58,6 @@ pub fn fd_pwrite<M: MemorySize>(
     offset: Filesize,
     nwritten: WasmPtr<M::Offset, M>,
 ) -> Result<Errno, WasiError> {
-    trace!(
-        "wasi[{}:{}]::fd_pwrite (fd={}, offset={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-        offset,
-    );
-
     fd_write_internal::<M>(ctx, fd, iovs, iovs_len, offset as usize, nwritten, false)
 }
 
@@ -260,6 +247,7 @@ fn fd_write_internal<M: MemorySize>(
         }
         bytes_written
     };
+    Span::current().record("nwritten", bytes_written);
 
     let memory = env.memory_view(&ctx);
     let nwritten_ref = nwritten.deref(&memory);

--- a/lib/wasi/src/syscalls/wasi/mod.rs
+++ b/lib/wasi/src/syscalls/wasi/mod.rs
@@ -83,3 +83,5 @@ pub use poll_oneoff::*;
 pub use proc_exit::*;
 pub use proc_raise::*;
 pub use random_get::*;
+
+use tracing::{debug_span, field, instrument, trace_span, Span};

--- a/lib/wasi/src/syscalls/wasi/path_filestat_get.rs
+++ b/lib/wasi/src/syscalls/wasi/path_filestat_get.rs
@@ -15,6 +15,7 @@ use crate::syscalls::*;
 /// Output:
 /// - `__wasi_file_stat_t *buf`
 ///     The location where the metadata will be stored
+#[instrument(level = "trace", skip_all, fields(fd, path = field::Empty))]
 pub fn path_filestat_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -27,24 +28,12 @@ pub fn path_filestat_get<M: MemorySize>(
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
 
     let mut path_string = unsafe { get_input_str!(&memory, path, path_len) };
-    trace!(
-        "wasi[{}:{}]::path_filestat_get (fd={}, path={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fd,
-        path_string
-    );
 
     // Convert relative paths into absolute paths
     if path_string.starts_with("./") {
         path_string = ctx.data().state.fs.relative_path_to_absolute(path_string);
-        trace!(
-            "wasi[{}:{}]::rel_to_abs (name={}))",
-            ctx.data().pid(),
-            ctx.data().tid(),
-            path_string
-        );
     }
+    Span::current().record("path", path_string.as_str());
 
     let stat = wasi_try!(path_filestat_get_internal(
         &memory,
@@ -87,8 +76,6 @@ pub(crate) fn path_filestat_get_internal(
     if !root_dir.rights.contains(Rights::PATH_FILESTAT_GET) {
         return Err(Errno::Access);
     }
-    debug!("=> base_fd: {}, path: {}", fd, path_string);
-
     let file_inode = state.fs.get_inode_at_path(
         inodes,
         fd,

--- a/lib/wasi/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasi/src/syscalls/wasi/path_unlink_file.rs
@@ -10,17 +10,13 @@ use crate::syscalls::*;
 ///     Array of UTF-8 bytes representing the path
 /// - `u32 path_len`
 ///     The number of bytes in the `path` array
+#[instrument(level = "debug", skip_all, fields(fd, path = field::Empty), ret)]
 pub fn path_unlink_file<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     path: WasmPtr<u8, M>,
     path_len: M::Offset,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::path_unlink_file",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let (memory, mut state, inodes) = env.get_memory_and_wasi_state_and_inodes(&ctx, 0);
 
@@ -29,17 +25,11 @@ pub fn path_unlink_file<M: MemorySize>(
         return Errno::Access;
     }
     let mut path_str = unsafe { get_input_str!(&memory, path, path_len) };
-    debug!("Requested file: {}", path_str);
+    Span::current().record("path", path_str.as_str());
 
     // Convert relative paths into absolute paths
     if path_str.starts_with("./") {
         path_str = ctx.data().state.fs.relative_path_to_absolute(path_str);
-        trace!(
-            "wasi[{}:{}]::rel_to_abs (name={}))",
-            ctx.data().pid(),
-            ctx.data().tid(),
-            path_str
-        );
     }
 
     let inode = wasi_try!(state.fs.get_inode_at_path(inodes, fd, &path_str, false));

--- a/lib/wasi/src/syscalls/wasi/poll_oneoff.rs
+++ b/lib/wasi/src/syscalls/wasi/poll_oneoff.rs
@@ -22,6 +22,7 @@ use crate::{
 /// Output:
 /// - `u32 nevents`
 ///     The number of events seen
+#[instrument(level = "trace", skip_all, fields(timeout_ns = field::Empty, fd_guards = field::Empty, seen = field::Empty), ret, err)]
 pub fn poll_oneoff<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     in_: WasmPtr<Subscription, M>,
@@ -49,12 +50,6 @@ pub fn poll_oneoff<M: MemorySize>(
     let triggered_events = match triggered_events {
         Ok(a) => a,
         Err(err) => {
-            tracing::trace!(
-                "wasi[{}:{}]::poll_oneoff errno={}",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                err
-            );
             return Ok(err);
         }
     };
@@ -105,14 +100,7 @@ impl<'a> Future for PollBatch<'a> {
                 Poll::Pending => {}
                 Poll::Ready(e) => {
                     for evt in e {
-                        tracing::trace!(
-                            "wasi[{}:{}]::poll_oneoff triggered_fd (fd={}, userdata={}, type={:?})",
-                            pid,
-                            tid,
-                            fd,
-                            evt.userdata,
-                            evt.type_,
-                        );
+                        tracing::trace!(fd, userdata = evt.userdata, ty = evt.type_ as u8,);
                         evts.push(evt);
                     }
                 }
@@ -149,12 +137,6 @@ pub(crate) fn poll_oneoff_internal(
     // Determine if we are in silent polling mode
     let mut env = ctx.data();
     let state = ctx.data().state.deref();
-    trace!(
-        "wasi[{}:{}]::poll_oneoff (nsubscriptions={})",
-        pid,
-        tid,
-        subs.len(),
-    );
 
     // These are used when we capture what clocks (timeouts) are being
     // subscribed too
@@ -222,23 +204,14 @@ pub(crate) fn poll_oneoff_internal(
                     // If the timeout duration is zero then this is an immediate check rather than
                     // a sleep itself
                     if clock_info.timeout == 0 {
-                        tracing::trace!("wasi[{}:{}]::poll_oneoff nonblocking", pid, tid,);
                         time_to_sleep = Some(Duration::ZERO);
                     } else {
-                        tracing::trace!(
-                            "wasi[{}:{}]::poll_oneoff clock_id={:?} (userdata={}, timeout={})",
-                            pid,
-                            tid,
-                            clock_info.clock_id,
-                            s.userdata,
-                            clock_info.timeout
-                        );
                         time_to_sleep = Some(Duration::from_nanos(clock_info.timeout));
                         clock_subs.push((clock_info, s.userdata));
                     }
                     continue;
                 } else {
-                    error!("Polling not implemented for these clocks yet");
+                    error!("polling not implemented for these clocks yet");
                     return Ok(Err(Errno::Inval));
                 }
             }
@@ -289,15 +262,15 @@ pub(crate) fn poll_oneoff_internal(
                             }
                         }
                     };
-                    tracing::trace!(
-                        "wasi[{}:{}]::poll_oneoff wait_for_fd={} type={:?}",
-                        pid,
-                        tid,
-                        fd,
-                        wasi_file_ref
-                    );
                     fd_guards.push(wasi_file_ref);
                 }
+            }
+
+            if fd_guards.len() > 10 {
+                let small_list: Vec<_> = fd_guards.iter().take(10).collect();
+                tracing::Span::current().record("fd_guards", format!("{:?}...", small_list));
+            } else {
+                tracing::Span::current().record("fd_guards", format!("{:?}", fd_guards));
             }
 
             fd_guards
@@ -305,17 +278,12 @@ pub(crate) fn poll_oneoff_internal(
 
         if let Some(time_to_sleep) = time_to_sleep.as_ref() {
             if *time_to_sleep == Duration::ZERO {
-                tracing::trace!("wasi[{}:{}]::poll_oneoff non_blocking", pid, tid,);
+                Span::current().record("timeout_ns", "nonblocking");
             } else {
-                tracing::trace!(
-                    "wasi[{}:{}]::poll_oneoff wait_for_timeout={}",
-                    pid,
-                    tid,
-                    time_to_sleep.as_millis()
-                );
+                Span::current().record("timeout_ns", time_to_sleep.as_millis());
             }
         } else {
-            tracing::trace!("wasi[{}:{}]::poll_oneoff wait_for_infinite", pid, tid,);
+            Span::current().record("timeout_ns", "infinite");
         }
 
         // Block polling the file descriptors
@@ -330,22 +298,13 @@ pub(crate) fn poll_oneoff_internal(
     match ret {
         Ok(evts) => {
             // If its a timeout then return an event for it
-            tracing::trace!(
-                "wasi[{}:{}]::poll_oneoff seen={}",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                evts.len()
-            );
+            Span::current().record("seen", evts.len());
             Ok(Ok(evts))
         }
         Err(Errno::Timedout) => {
             // The timeout has triggerred so lets add that event
             if clock_subs.is_empty() && time_to_sleep != Some(Duration::ZERO) {
-                tracing::warn!(
-                    "wasi[{}:{}]::poll_oneoff triggered_timeout (without any clock subscriptions)",
-                    pid,
-                    tid
-                );
+                tracing::warn!("triggered_timeout (without any clock subscriptions)",);
             }
             let mut evts = Vec::new();
             for (clock_info, userdata) in clock_subs {
@@ -355,12 +314,12 @@ pub(crate) fn poll_oneoff_internal(
                     type_: Eventtype::Clock,
                     u: EventUnion { clock: 0 },
                 };
-                tracing::trace!(
-                    "wasi[{}:{}]::poll_oneoff triggered_clock id={:?} (userdata={})",
-                    pid,
-                    tid,
-                    clock_info.clock_id,
-                    evt.userdata,
+                Span::current().record(
+                    "seen",
+                    &format!(
+                        "clock(id={},userdata={})",
+                        clock_info.clock_id as u32, evt.userdata
+                    ),
                 );
                 evts.push(evt);
             }

--- a/lib/wasi/src/syscalls/wasi/proc_raise.rs
+++ b/lib/wasi/src/syscalls/wasi/proc_raise.rs
@@ -7,13 +7,8 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `Signal`
 ///   Signal to be raised for this process
+#[instrument(level = "debug", skip_all, fields(sig), ret, err)]
 pub fn proc_raise(mut ctx: FunctionEnvMut<'_, WasiEnv>, sig: Signal) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::proc_raise (sig={:?})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sig
-    );
     let env = ctx.data();
     env.process.signal_process(sig);
 
@@ -34,12 +29,6 @@ pub fn proc_raise_interval(
     interval: Timestamp,
     repeat: Bool,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::proc_raise_interval (sig={:?})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sig
-    );
     let env = ctx.data();
     let interval = match interval {
         0 => None,

--- a/lib/wasi/src/syscalls/wasi/random_get.rs
+++ b/lib/wasi/src/syscalls/wasi/random_get.rs
@@ -8,17 +8,12 @@ use crate::syscalls::*;
 ///     A pointer to a buffer where the random bytes will be written
 /// - `size_t buf_len`
 ///     The number of bytes that will be written
+#[instrument(level = "trace", skip_all, fields(buf_len), ret)]
 pub fn random_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     buf: WasmPtr<u8, M>,
     buf_len: M::Offset,
 ) -> Errno {
-    trace!(
-        "wasi[{}:{}]::random_get(buf_len={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        buf_len
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let buf_len64: u64 = buf_len.into();

--- a/lib/wasi/src/syscalls/wasix/callback_reactor.rs
+++ b/lib/wasi/src/syscalls/wasix/callback_reactor.rs
@@ -7,6 +7,7 @@ use crate::syscalls::*;
 /// ### Parameters
 ///
 /// * `name` - Name of the function that will be invoked
+#[instrument(level = "debug", skip_all, fields(name = field::Empty, funct_is_some = field::Empty), ret, err)]
 pub fn callback_reactor<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     name: WasmPtr<u8, M>,
@@ -15,12 +16,7 @@ pub fn callback_reactor<M: MemorySize>(
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let name = unsafe { name.read_utf8_string(&memory, name_len)? };
-    debug!(
-        "wasi[{}:{}]::callback_reactor (name={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        name
-    );
+    Span::current().record("name", name.as_str());
 
     let funct = env
         .inner()
@@ -28,6 +24,7 @@ pub fn callback_reactor<M: MemorySize>(
         .exports
         .get_typed_function(&ctx, &name)
         .ok();
+    Span::current().record("funct_is_some", funct.is_some());
 
     ctx.data_mut().inner_mut().react = funct;
     Ok(())

--- a/lib/wasi/src/syscalls/wasix/callback_thread.rs
+++ b/lib/wasi/src/syscalls/wasix/callback_thread.rs
@@ -7,6 +7,7 @@ use crate::syscalls::*;
 /// ### Parameters
 ///
 /// * `name` - Name of the function that will be invoked
+#[instrument(level = "debug", skip_all, fields(name = field::Empty, funct_is_some = field::Empty), ret ,err)]
 pub fn callback_thread<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     name: WasmPtr<u8, M>,
@@ -14,13 +15,9 @@ pub fn callback_thread<M: MemorySize>(
 ) -> Result<(), MemoryAccessError> {
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
     let name = unsafe { name.read_utf8_string(&memory, name_len)? };
-    debug!(
-        "wasi[{}:{}]::callback_spawn (name={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        name
-    );
+    Span::current().record("name", name.as_str());
 
     let funct = env
         .inner()
@@ -28,6 +25,7 @@ pub fn callback_thread<M: MemorySize>(
         .exports
         .get_typed_function(&ctx, &name)
         .ok();
+    Span::current().record("funct_is_some", funct.is_some());
 
     ctx.data_mut().inner_mut().thread_spawn = funct;
     Ok(())

--- a/lib/wasi/src/syscalls/wasix/chdir.rs
+++ b/lib/wasi/src/syscalls/wasix/chdir.rs
@@ -3,6 +3,7 @@ use crate::syscalls::*;
 
 /// ### `chdir()`
 /// Sets the current working directory
+#[instrument(level = "debug", skip_all, fields(name = field::Empty), ret)]
 pub fn chdir<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     path: WasmPtr<u8, M>,
@@ -11,12 +12,7 @@ pub fn chdir<M: MemorySize>(
     let env = ctx.data();
     let (memory, mut state) = env.get_memory_and_wasi_state(&ctx, 0);
     let path = unsafe { get_input_str!(&memory, path, path_len) };
-    debug!(
-        "wasi[{}:{}]::chdir [{}]",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        path
-    );
+    Span::current().record("path", path.as_str());
 
     // Check if the directory exists
     if state.fs.root_fs.read_dir(Path::new(path.as_str())).is_err() {

--- a/lib/wasi/src/syscalls/wasix/futex_wake.rs
+++ b/lib/wasi/src/syscalls/wasix/futex_wake.rs
@@ -8,6 +8,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `futex` - Memory location that holds a futex that others may be waiting on
+#[instrument(level = "trace", skip_all, fields(futex_idx = field::Empty, woken = field::Empty), ret)]
 pub fn futex_wake<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     futex_ptr: WasmPtr<u32, M>,
@@ -18,8 +19,9 @@ pub fn futex_wake<M: MemorySize>(
     let state = env.state.deref();
 
     let pointer: u64 = wasi_try!(futex_ptr.offset().try_into().map_err(|_| Errno::Overflow));
-    let mut woken = false;
+    Span::current().record("futex_idx", pointer);
 
+    let mut woken = false;
     let woken = {
         let mut guard = state.futexs.lock().unwrap();
         if let Some(futex) = guard.get_mut(&pointer) {
@@ -34,22 +36,7 @@ pub fn futex_wake<M: MemorySize>(
             false
         }
     };
-    if woken {
-        trace!(
-            %woken,
-            "wasi[{}:{}]::futex_wake(offset={})",
-            ctx.data().pid(),
-            ctx.data().tid(),
-            futex_ptr.offset()
-        );
-    } else {
-        trace!(
-            "wasi[{}:{}]::futex_wake(offset={}) - nothing waiting",
-            ctx.data().pid(),
-            ctx.data().tid(),
-            futex_ptr.offset()
-        );
-    }
+    Span::current().record("woken", woken);
 
     let woken = match woken {
         false => Bool::False,

--- a/lib/wasi/src/syscalls/wasix/mod.rs
+++ b/lib/wasi/src/syscalls/wasix/mod.rs
@@ -141,3 +141,5 @@ pub use thread_sleep::*;
 pub use thread_spawn::*;
 pub use tty_get::*;
 pub use tty_set::*;
+
+use tracing::{debug_span, field, instrument, trace_span, Span};

--- a/lib/wasi/src/syscalls/wasix/port_addr_add.rs
+++ b/lib/wasi/src/syscalls/wasix/port_addr_add.rs
@@ -7,18 +7,17 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `addr` - Address to be added
+#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret, err)]
 pub fn port_addr_add<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_cidr_t, M>,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_addr_add",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
     let cidr = wasi_try_ok!(crate::net::read_cidr(&memory, ip));
+    Span::current().record("ip", &format!("{:?}", cidr));
+
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async {
         net.ip_add(cidr.ip, cidr.prefix)

--- a/lib/wasi/src/syscalls/wasix/port_addr_clear.rs
+++ b/lib/wasi/src/syscalls/wasix/port_addr_clear.rs
@@ -3,12 +3,8 @@ use crate::syscalls::*;
 
 /// ### `port_addr_clear()`
 /// Clears all the addresses on the local port
+#[instrument(level = "debug", skip_all, ret, err)]
 pub fn port_addr_clear(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_addr_clear",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async {

--- a/lib/wasi/src/syscalls/wasix/port_addr_remove.rs
+++ b/lib/wasi/src/syscalls/wasix/port_addr_remove.rs
@@ -7,18 +7,17 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `addr` - Address to be removed
+#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret, err)]
 pub fn port_addr_remove<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_addr_t, M>,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_addr_remove",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
     let ip = wasi_try_ok!(crate::net::read_ip(&memory, ip));
+    Span::current().record("ip", &format!("{:?}", ip));
+
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async {
         net.ip_remove(ip).map_err(net_error_into_wasi_err)

--- a/lib/wasi/src/syscalls/wasix/port_dhcp_acquire.rs
+++ b/lib/wasi/src/syscalls/wasix/port_dhcp_acquire.rs
@@ -3,12 +3,8 @@ use crate::syscalls::*;
 
 /// ### `port_dhcp_acquire()`
 /// Acquires a set of IP addresses using DHCP
+#[instrument(level = "debug", skip_all, ret, err)]
 pub fn port_dhcp_acquire(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_dhcp_acquire",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let net = env.net().clone();
     let tasks = env.tasks().clone();

--- a/lib/wasi/src/syscalls/wasix/port_gateway_set.rs
+++ b/lib/wasi/src/syscalls/wasix/port_gateway_set.rs
@@ -7,18 +7,16 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `addr` - Address of the default gateway
+#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret, err)]
 pub fn port_gateway_set<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_addr_t, M>,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_gateway_set",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
     let ip = wasi_try_ok!(crate::net::read_ip(&memory, ip));
+    Span::current().record("ip", &format!("{:?}", ip));
 
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async {

--- a/lib/wasi/src/syscalls/wasix/port_mac.rs
+++ b/lib/wasi/src/syscalls/wasix/port_mac.rs
@@ -3,11 +3,11 @@ use crate::syscalls::*;
 
 /// ### `port_mac()`
 /// Returns the MAC address of the local port
+#[instrument(level = "debug", skip_all, fields(max = field::Empty), ret, err)]
 pub fn port_mac<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ret_mac: WasmPtr<__wasi_hardwareaddress_t, M>,
 ) -> Result<Errno, WasiError> {
-    debug!("wasi[{}:{}]::port_mac", ctx.data().pid(), ctx.data().tid());
     let mut env = ctx.data();
     let mut memory = env.memory_view(&ctx);
 
@@ -17,6 +17,8 @@ pub fn port_mac<M: MemorySize>(
     })?);
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
+    Span::current().record("mac", hex::encode(mac.as_ref()).as_str());
 
     let mac = __wasi_hardwareaddress_t { octs: mac };
     wasi_try_mem_ok!(ret_mac.write(&memory, mac));

--- a/lib/wasi/src/syscalls/wasix/port_route_clear.rs
+++ b/lib/wasi/src/syscalls/wasix/port_route_clear.rs
@@ -3,12 +3,8 @@ use crate::syscalls::*;
 
 /// ### `port_route_clear()`
 /// Clears all the routes in the local port
+#[instrument(level = "debug", skip_all, ret, err)]
 pub fn port_route_clear(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_route_clear",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async {

--- a/lib/wasi/src/syscalls/wasix/port_route_remove.rs
+++ b/lib/wasi/src/syscalls/wasix/port_route_remove.rs
@@ -3,18 +3,16 @@ use crate::syscalls::*;
 
 /// ### `port_route_remove()`
 /// Removes an existing route from the local port
+#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret, err)]
 pub fn port_route_remove<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_addr_t, M>,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_route_remove",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
     let ip = wasi_try_ok!(crate::net::read_ip(&memory, ip));
+    Span::current().record("ip", &format!("{:?}", ip));
 
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async {

--- a/lib/wasi/src/syscalls/wasix/port_unbridge.rs
+++ b/lib/wasi/src/syscalls/wasix/port_unbridge.rs
@@ -3,12 +3,8 @@ use crate::syscalls::*;
 
 /// ### `port_unbridge()`
 /// Disconnects from a remote network
+#[instrument(level = "debug", skip_all, ret, err)]
 pub fn port_unbridge(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::port_unbridge",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     let env = ctx.data();
     let net = env.net().clone();
     wasi_try_ok!(__asyncify(&mut ctx, None, async move {

--- a/lib/wasi/src/syscalls/wasix/proc_fork.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_fork.rs
@@ -7,6 +7,7 @@ use wasmer::vm::VMMemory;
 /// Forks the current process into a new subprocess. If the function
 /// returns a zero then its the new subprocess. If it returns a positive
 /// number then its the current process and the $pid represents the child.
+#[instrument(level = "debug", skip_all, fields(copy_memory, pid = field::Empty), ret, err)]
 pub fn proc_fork<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     mut copy_memory: Bool,
@@ -15,39 +16,10 @@ pub fn proc_fork<M: MemorySize>(
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 
     // If we were just restored then we need to return the value instead
-    let fork_op = if copy_memory == Bool::True {
-        "fork"
-    } else {
-        "vfork"
-    };
     if handle_rewind::<M>(&mut ctx) {
-        let env = ctx.data();
-        let memory = env.memory_view(&ctx);
-        let ret_pid = wasi_try_mem_ok!(pid_ptr.read(&memory));
-        if ret_pid == 0 {
-            trace!(
-                "wasi[{}:{}]::proc_{} - entering child",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                fork_op
-            );
-        } else {
-            trace!(
-                "wasi[{}:{}]::proc_{} - entering parent(child={})",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                fork_op,
-                ret_pid
-            );
-        }
         return Ok(Errno::Success);
     }
-    trace!(
-        "wasi[{}:{}]::proc_{} - capturing",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        fork_op
-    );
+    trace!("capturing",);
 
     // Fork the environment which will copy all the open file handlers
     // and associate a new context but otherwise shares things like the
@@ -56,11 +28,7 @@ pub fn proc_fork<M: MemorySize>(
     let (mut child_env, mut child_handle) = match ctx.data().fork() {
         Ok(p) => p,
         Err(err) => {
-            debug!(
-                pid=%ctx.data().pid(),
-                tid=%ctx.data().tid(),
-                "could not fork process: {err}"
-            );
+            debug!("could not fork process: {err}");
             // TODO: evaluate the appropriate error code, document it in the spec.
             return Ok(Errno::Perm);
         }
@@ -119,10 +87,7 @@ pub fn proc_fork<M: MemorySize>(
             ) {
                 Errno::Success => OnCalledAction::InvokeAgain,
                 err => {
-                    warn!(
-                        "{} failed - could not rewind the stack - errno={}",
-                        fork_op, err
-                    );
+                    warn!("failed - could not rewind the stack - errno={}", err);
                     OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Fault as u32)))
                 }
             }
@@ -135,6 +100,13 @@ pub fn proc_fork<M: MemorySize>(
 
     // Perform the unwind action
     unwind::<M, _>(ctx, move |mut ctx, mut memory_stack, rewind_stack| {
+        let span = debug_span!(
+            "unwind",
+            memory_stack_len = memory_stack.len(),
+            rewind_stack_len = rewind_stack.len()
+        );
+        let _span_guard = span.enter();
+
         // Grab all the globals and serialize them
         let store_data = crate::utils::store::capture_snapshot(&mut ctx.as_store_mut())
             .serialize()
@@ -146,25 +118,13 @@ pub fn proc_fork<M: MemorySize>(
         let fork_memory: VMMemory = match env
             .memory()
             .try_clone(&ctx)
-            .ok_or_else(|| {
-                error!(
-                    "wasi[{}:{}]::{} failed - the memory could not be cloned",
-                    ctx.data().pid(),
-                    ctx.data().tid(),
-                    fork_op
-                );
-                MemoryError::Generic("the memory could not be cloned".to_string())
-            })
+            .ok_or_else(|| MemoryError::Generic("the memory could not be cloned".to_string()))
             .and_then(|mut memory| memory.duplicate())
         {
             Ok(memory) => memory.into(),
             Err(err) => {
                 warn!(
-                    "wasi[{}:{}]::{} failed - could not fork the memory - {}",
-                    ctx.data().pid(),
-                    ctx.data().tid(),
-                    fork_op,
-                    err
+                    %err
                 );
                 return OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Fault as u32)));
             }
@@ -208,16 +168,13 @@ pub fn proc_fork<M: MemorySize>(
                     import_object.define("env", "memory", memory.clone());
                     memory
                 } else {
-                    error!(
-                        "wasi[{}:{}]::wasm instantiate failed - no memory supplied",
-                        pid, tid
-                    );
+                    error!("wasm instantiate failed - no memory supplied",);
                     return;
                 };
                 let instance = match Instance::new(&mut store, &module, &import_object) {
                     Ok(a) => a,
                     Err(err) => {
-                        error!("wasi[{}:{}]::wasm instantiate error ({})", pid, tid, err);
+                        error!("wasm instantiate error ({})", err);
                         return;
                     }
                 };
@@ -230,12 +187,7 @@ pub fn proc_fork<M: MemorySize>(
 
                 // Rewind the stack and carry on
                 {
-                    trace!(
-                        "wasi[{}:{}]::{}: rewinding child",
-                        ctx.data(&store).pid(),
-                        ctx.data(&store).tid(),
-                        fork_op
-                    );
+                    trace!("rewinding child");
                     let ctx = ctx.env.clone().into_mut(&mut store);
                     match rewind::<M>(
                         ctx,
@@ -245,7 +197,10 @@ pub fn proc_fork<M: MemorySize>(
                     ) {
                         Errno::Success => OnCalledAction::InvokeAgain,
                         err => {
-                            warn!("wasi[{}:{}]::wasm rewind failed - could not rewind the stack - errno={}", pid, tid, err);
+                            warn!(
+                                "wasm rewind failed - could not rewind the stack - errno={}",
+                                err
+                            );
                             return;
                         }
                     };
@@ -254,31 +209,15 @@ pub fn proc_fork<M: MemorySize>(
                 // Invoke the start function
                 let mut ret = Errno::Success;
                 if ctx.data(&store).thread.is_main() {
-                    trace!(
-                        "wasi[{}:{}]::{}: re-invoking main",
-                        ctx.data(&store).pid(),
-                        ctx.data(&store).tid(),
-                        fork_op
-                    );
+                    trace!("re-invoking main");
                     let start = ctx.data(&store).inner().start.clone().unwrap();
                     start.call(&mut store);
                 } else {
-                    trace!(
-                        "wasi[{}:{}]::{}: re-invoking thread_spawn",
-                        ctx.data(&store).pid(),
-                        ctx.data(&store).tid(),
-                        fork_op
-                    );
+                    trace!("re-invoking thread_spawn");
                     let start = ctx.data(&store).inner().thread_spawn.clone().unwrap();
                     start.call(&mut store, 0, 0);
                 }
-                trace!(
-                    "wasi[{}:{}]::proc_{} - child exited (code = {})",
-                    ctx.data(&store).pid(),
-                    ctx.data(&store).tid(),
-                    fork_op,
-                    ret
-                );
+                trace!("child exited (code = {})", ret);
 
                 // Clean up the environment
                 ctx.cleanup((&mut store), Some(ret as ExitCode));
@@ -293,9 +232,7 @@ pub fn proc_fork<M: MemorySize>(
                 .task_wasm(Box::new(task), store, module, spawn_type)
                 .map_err(|err| {
                     warn!(
-                        "wasi[{}:{}]::failed to fork as the process could not be spawned - {}",
-                        ctx.data().pid(),
-                        ctx.data().tid(),
+                        "failed to fork as the process could not be spawned - {}",
                         err
                     );
                     err
@@ -308,12 +245,7 @@ pub fn proc_fork<M: MemorySize>(
         let process = OwnedTaskStatus::default();
 
         {
-            trace!(
-                "wasi[{}:{}]::spawned sub-process (pid={})",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                child_pid.raw()
-            );
+            trace!("spawned sub-process (pid={})", child_pid.raw());
             let mut inner = ctx.data().process.write();
             inner.bus_processes.insert(child_pid, process.handle());
         }
@@ -325,7 +257,11 @@ pub fn proc_fork<M: MemorySize>(
             // Make sure its within the "active" part of the memory stack
             let offset = env.stack_base - pid_offset;
             if offset as usize > memory_stack.len() {
-                warn!("{} failed - the return value (pid) is outside of the active part of the memory stack ({} vs {})", fork_op, offset, memory_stack.len());
+                warn!(
+                        "failed - the return value (pid) is outside of the active part of the memory stack ({} vs {})",
+                        offset,
+                        memory_stack.len()
+                    );
                 return OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Fault as u32)));
             }
 
@@ -336,7 +272,9 @@ pub fn proc_fork<M: MemorySize>(
             let pbytes = &mut memory_stack[pstart..pend];
             pbytes.clone_from_slice(&val_bytes);
         } else {
-            warn!("{} failed - the return value (pid) is not being returned on the stack - which is not supported", fork_op);
+            warn!(
+                    "failed - the return value (pid) is not being returned on the stack - which is not supported"
+                );
             return OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Fault as u32)));
         }
 
@@ -349,10 +287,7 @@ pub fn proc_fork<M: MemorySize>(
         ) {
             Errno::Success => OnCalledAction::InvokeAgain,
             err => {
-                warn!(
-                    "{} failed - could not rewind the stack - errno={}",
-                    fork_op, err
-                );
+                warn!("failed - could not rewind the stack - errno={}", err);
                 OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Fault as u32)))
             }
         }

--- a/lib/wasi/src/syscalls/wasix/proc_id.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_id.rs
@@ -3,12 +3,14 @@ use crate::syscalls::*;
 
 /// ### `proc_id()`
 /// Returns the handle of the current process
+#[instrument(level = "debug", skip_all, fields(pid = field::Empty), ret)]
 pub fn proc_id<M: MemorySize>(ctx: FunctionEnvMut<'_, WasiEnv>, ret_pid: WasmPtr<Pid, M>) -> Errno {
-    debug!("wasi[{}:{}]::getpid", ctx.data().pid(), ctx.data().tid());
-
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
+
     let pid = env.process.pid();
+    Span::current().record("pid", pid.raw());
+
     wasi_try_mem!(ret_pid.write(&memory, pid.raw() as Pid));
     Errno::Success
 }

--- a/lib/wasi/src/syscalls/wasix/proc_parent.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_parent.rs
@@ -3,21 +3,22 @@ use crate::syscalls::*;
 
 /// ### `proc_parent()`
 /// Returns the parent handle of the supplied process
+#[instrument(level = "debug", skip_all, fields(pid, parent = field::Empty), ret)]
 pub fn proc_parent<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     pid: Pid,
     ret_parent: WasmPtr<Pid, M>,
 ) -> Errno {
-    debug!("wasi[{}:{}]::getppid", ctx.data().pid(), ctx.data().tid());
-
     let env = ctx.data();
     let pid: WasiProcessId = pid.into();
     if pid == env.process.pid() {
         let memory = env.memory_view(&ctx);
+        Span::current().record("parent", env.process.ppid().raw());
         wasi_try_mem!(ret_parent.write(&memory, env.process.ppid().raw() as Pid));
         Errno::Success
     } else if let Some(process) = env.control_plane.get_process(pid) {
         let memory = env.memory_view(&ctx);
+        Span::current().record("parent", process.pid().raw());
         wasi_try_mem!(ret_parent.write(&memory, process.pid().raw() as Pid));
         Errno::Success
     } else {

--- a/lib/wasi/src/syscalls/wasix/proc_signal.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_signal.rs
@@ -8,19 +8,12 @@ use crate::syscalls::*;
 ///
 /// * `pid` - Handle of the child process to wait on
 /// * `sig` - Signal to send the child process
+#[instrument(level = "trace", skip_all, fields(pid, sig), ret, err)]
 pub fn proc_signal<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     pid: Pid,
     sig: Signal,
 ) -> Result<Errno, WasiError> {
-    trace!(
-        "wasi[{}:{}]::proc_signal(pid={}, sig={:?})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        pid,
-        sig
-    );
-
     let process = {
         let pid: WasiProcessId = pid.into();
         ctx.data().control_plane.get_process(pid)

--- a/lib/wasi/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasi/src/syscalls/wasix/proc_spawn.rs
@@ -22,6 +22,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// Returns a bus process id that can be used to invoke calls
+#[instrument(level = "debug", skip_all, fields(name = field::Empty, working_dir = field::Empty), ret, err)]
 pub fn proc_spawn<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     name: WasmPtr<u8, M>,
@@ -45,19 +46,13 @@ pub fn proc_spawn<M: MemorySize>(
     let args = unsafe { get_input_str_bus_ok!(&memory, args, args_len) };
     let preopen = unsafe { get_input_str_bus_ok!(&memory, preopen, preopen_len) };
     let working_dir = unsafe { get_input_str_bus_ok!(&memory, working_dir, working_dir_len) };
-    debug!(
-        "wasi[{}:{}]::process_spawn (name={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        name
-    );
+
+    Span::current()
+        .record("name", name.as_str())
+        .record("working_dir", working_dir.as_str());
 
     if chroot == Bool::True {
-        warn!(
-            "wasi[{}:{}]::chroot is not currently supported",
-            ctx.data().pid(),
-            ctx.data().tid()
-        );
+        warn!("chroot is not currently supported",);
         return Ok(BusErrno::Unsupported);
     }
 
@@ -133,9 +128,7 @@ pub fn proc_spawn_internal(
         if !preopen.is_empty() {
             for preopen in preopen {
                 warn!(
-                    "wasi[{}:{}]::preopens are not yet supported for spawned processes [{}]",
-                    ctx.data().pid(),
-                    ctx.data().tid(),
+                    "preopens are not yet supported for spawned processes [{}]",
                     preopen
                 );
             }
@@ -181,13 +174,7 @@ pub fn proc_spawn_internal(
                         .create_fd_ext(rights, rights, Fdflags::empty(), 0, inode2, fd)
                         .map_err(|_| BusErrno::Internal)?;
 
-                    trace!(
-                        "wasi[{}:{}]::fd_pipe (fd1={}, fd2={})",
-                        ctx.data().pid(),
-                        ctx.data().tid(),
-                        pipe,
-                        fd
-                    );
+                    trace!("fd_pipe (fd1={}, fd2={})", pipe, fd);
                     Ok(OptionFd {
                         tag: OptionTag::Some,
                         fd: pipe,
@@ -234,12 +221,7 @@ pub fn proc_spawn_internal(
             Ok(a) => a,
             Err(err) => {
                 if err != VirtualBusError::NotFound {
-                    error!(
-                        "wasi[{}:{}]::proc_spawn - builtin failed - {}",
-                        ctx.data().pid(),
-                        ctx.data().tid(),
-                        err
-                    );
+                    error!("builtin failed - {}", err);
                 }
                 // Now we actually spawn the process
                 let child_work =

--- a/lib/wasi/src/syscalls/wasix/resolve.rs
+++ b/lib/wasi/src/syscalls/wasix/resolve.rs
@@ -19,6 +19,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// The number of IP addresses returned during the DNS resolution.
+#[instrument(level = "debug", skip_all, fields(host = field::Empty, port), ret, err)]
 pub fn resolve<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     host: WasmPtr<u8, M>,
@@ -34,13 +35,7 @@ pub fn resolve<M: MemorySize>(
         let memory = env.memory_view(&ctx);
         unsafe { get_input_str_ok!(&memory, host, host_len) }
     };
-
-    debug!(
-        "wasi[{}:{}]::resolve (host={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        host_str
-    );
+    Span::current().record("host", host_str.as_str());
 
     let port = if port > 0 { Some(port) } else { None };
 

--- a/lib/wasi/src/syscalls/wasix/sched_yield.rs
+++ b/lib/wasi/src/syscalls/wasix/sched_yield.rs
@@ -3,6 +3,7 @@ use crate::syscalls::*;
 
 /// ### `sched_yield()`
 /// Yields execution of the thread
+#[instrument(level = "trace", skip_all, ret, err)]
 pub fn sched_yield(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
     //trace!("wasi[{}:{}]::sched_yield", ctx.data().pid(), ctx.data().tid());
     thread_sleep_internal(ctx, 0)

--- a/lib/wasi/src/syscalls/wasix/sock_addr_peer.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_addr_peer.rs
@@ -12,24 +12,19 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `fd` - Socket that the address is bound to
+#[instrument(level = "debug", skip_all, fields(sock, addr = field::Empty), ret)]
 pub fn sock_addr_peer<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     ro_addr: WasmPtr<__wasi_addr_port_t, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_addr_peer (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let addr = wasi_try!(__sock_actor(
         &mut ctx,
         sock,
         Rights::empty(),
         |socket, _| socket.addr_peer()
     ));
+    Span::current().record("addr", &format!("{:?}", addr));
 
     let env = ctx.data();
     let memory = env.memory_view(&ctx);

--- a/lib/wasi/src/syscalls/wasix/sock_bind.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_bind.rs
@@ -9,22 +9,18 @@ use crate::syscalls::*;
 ///
 /// * `fd` - File descriptor of the socket to be bind
 /// * `addr` - Address to bind the socket to
+#[instrument(level = "debug", skip_all, fields(sock, addr = field::Empty), ret)]
 pub fn sock_bind<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     addr: WasmPtr<__wasi_addr_port_t, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_bind (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let addr = wasi_try!(crate::net::read_ip_port(&memory, addr));
     let addr = SocketAddr::new(addr.0, addr.1);
+    Span::current().record("addr", &format!("{:?}", addr));
+
     let net = env.net().clone();
 
     let tasks = ctx.data().tasks().clone();

--- a/lib/wasi/src/syscalls/wasix/sock_get_opt_flag.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_get_opt_flag.rs
@@ -9,20 +9,13 @@ use crate::syscalls::*;
 ///
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be retrieved
+#[instrument(level = "debug", skip_all, fields(sock, opt), ret)]
 pub fn sock_get_opt_flag<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     opt: Sockoption,
     ret_flag: WasmPtr<Bool, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_get_opt_flag(fd={}, ty={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock,
-        opt
-    );
-
     let option: crate::net::socket::WasiSocketOption = opt.into();
     let flag = wasi_try!(__sock_actor(
         &mut ctx,

--- a/lib/wasi/src/syscalls/wasix/sock_get_opt_size.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_get_opt_size.rs
@@ -9,19 +9,13 @@ use crate::syscalls::*;
 ///
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be retrieved
+#[instrument(level = "debug", skip_all, fields(sock, opt), ret)]
 pub fn sock_get_opt_size<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     opt: Sockoption,
     ret_size: WasmPtr<Filesize, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_get_opt_size(fd={}, ty={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock,
-        opt
-    );
     let size = wasi_try!(__sock_actor(
         &mut ctx,
         sock,

--- a/lib/wasi/src/syscalls/wasix/sock_get_opt_time.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_get_opt_time.rs
@@ -8,20 +8,13 @@ use crate::{net::socket::TimeType, syscalls::*};
 ///
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be retrieved
+#[instrument(level = "debug", skip_all, fields(sock, opt), ret)]
 pub fn sock_get_opt_time<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     opt: Sockoption,
     ret_time: WasmPtr<OptionTimestamp, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_get_opt_time(fd={}, ty={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock,
-        opt
-    );
-
     let ty = match opt {
         Sockoption::RecvTimeout => TimeType::ReadTimeout,
         Sockoption::SendTimeout => TimeType::WriteTimeout,

--- a/lib/wasi/src/syscalls/wasix/sock_join_multicast_v4.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_join_multicast_v4.rs
@@ -9,19 +9,13 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to joined
 /// * `interface` - Interface that will join
+#[instrument(level = "debug", skip_all, fields(sock), ret)]
 pub fn sock_join_multicast_v4<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     multiaddr: WasmPtr<__wasi_addr_ip4_t, M>,
     iface: WasmPtr<__wasi_addr_ip4_t, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_join_multicast_v4 (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let multiaddr = wasi_try!(crate::net::read_ip_v4(&memory, multiaddr));

--- a/lib/wasi/src/syscalls/wasix/sock_join_multicast_v6.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_join_multicast_v6.rs
@@ -9,19 +9,13 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to joined
 /// * `interface` - Interface that will join
+#[instrument(level = "debug", skip_all, fields(sock, iface), ret)]
 pub fn sock_join_multicast_v6<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     multiaddr: WasmPtr<__wasi_addr_ip6_t, M>,
     iface: u32,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_join_multicast_v6 (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let multiaddr = wasi_try!(crate::net::read_ip_v6(&memory, multiaddr));

--- a/lib/wasi/src/syscalls/wasix/sock_leave_multicast_v4.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_leave_multicast_v4.rs
@@ -9,19 +9,13 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to leave
 /// * `interface` - Interface that will left
+#[instrument(level = "debug", skip_all, fields(sock), ret)]
 pub fn sock_leave_multicast_v4<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     multiaddr: WasmPtr<__wasi_addr_ip4_t, M>,
     iface: WasmPtr<__wasi_addr_ip4_t, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_leave_multicast_v4 (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let multiaddr = wasi_try!(crate::net::read_ip_v4(&memory, multiaddr));

--- a/lib/wasi/src/syscalls/wasix/sock_leave_multicast_v6.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_leave_multicast_v6.rs
@@ -9,19 +9,13 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to leave
 /// * `interface` - Interface that will left
+#[instrument(level = "debug", skip_all, fields(sock, iface), ret)]
 pub fn sock_leave_multicast_v6<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     multiaddr: WasmPtr<__wasi_addr_ip6_t, M>,
     iface: u32,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_leave_multicast_v6 (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let multiaddr = wasi_try!(crate::net::read_ip_v6(&memory, multiaddr));

--- a/lib/wasi/src/syscalls/wasix/sock_listen.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_listen.rs
@@ -13,18 +13,12 @@ use crate::syscalls::*;
 ///
 /// * `fd` - File descriptor of the socket to be bind
 /// * `backlog` - Maximum size of the queue for pending connections
+#[instrument(level = "debug", skip_all, fields(sock, backlog), ret)]
 pub fn sock_listen<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     backlog: M::Offset,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_listen (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let env = ctx.data();
     let net = env.net().clone();
     let backlog: usize = wasi_try!(backlog.try_into().map_err(|_| Errno::Inval));

--- a/lib/wasi/src/syscalls/wasix/sock_recv.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_recv.rs
@@ -16,6 +16,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// Number of bytes stored in ri_data and message flags.
+#[instrument(level = "trace", skip_all, fields(sock, nread = field::Empty), ret, err)]
 pub fn sock_recv<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
@@ -41,30 +42,21 @@ pub fn sock_recv<M: MemorySize>(
     let mut ret = Errno::Success;
     let bytes_read = match res {
         Ok(bytes_read) => {
-            debug!(
+            trace!(
                 %bytes_read,
-                "wasi[{}:{}]::sock_recv (fd={}, flags={:?})",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                sock,
-                ri_flags
             );
             bytes_read
         }
         Err(err) => {
             let socket_err = err.name();
-            debug!(
+            trace!(
                 %socket_err,
-                "wasi[{}:{}]::sock_recv (fd={}, flags={:?})",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                sock,
-                ri_flags
             );
             ret = err;
             0
         }
     };
+    Span::current().record("nread", bytes_read);
 
     let env = ctx.data();
     let memory = env.memory_view(&ctx);

--- a/lib/wasi/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_send_to.rs
@@ -15,6 +15,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// Number of bytes transmitted.
+#[instrument(level = "trace", skip_all, fields(sock, addr, nsent = field::Empty), ret, err)]
 pub fn sock_send_to<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
@@ -24,12 +25,6 @@ pub fn sock_send_to<M: MemorySize>(
     addr: WasmPtr<__wasi_addr_port_t, M>,
     ret_data_len: WasmPtr<M::Offset, M>,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::sock_send_to (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
     let env = ctx.data();
     let memory = env.memory_view(&ctx);
     let iovs_arr = wasi_try_mem_ok!(si_data.slice(&memory, si_data_len));
@@ -39,6 +34,7 @@ pub fn sock_send_to<M: MemorySize>(
         wasi_try_ok!(read_ip_port(&memory, addr))
     };
     let addr = SocketAddr::new(addr_ip, addr_port);
+    Span::current().record("addr", &format!("{:?}", addr));
 
     let bytes_written = {
         wasi_try_ok!(__sock_asyncify(
@@ -66,6 +62,7 @@ pub fn sock_send_to<M: MemorySize>(
             },
         ))
     };
+    Span::current().record("nsent", bytes_written);
 
     let memory = env.memory_view(&ctx);
     let bytes_written: M::Offset =

--- a/lib/wasi/src/syscalls/wasix/sock_set_opt_flag.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_set_opt_flag.rs
@@ -10,21 +10,13 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be set
 /// * `flag` - Value to set the option to
+#[instrument(level = "debug", skip_all, fields(sock, opt, flag), ret)]
 pub fn sock_set_opt_flag(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     opt: Sockoption,
     flag: Bool,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_set_opt_flag(fd={}, ty={}, flag={:?})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock,
-        opt,
-        flag
-    );
-
     let flag = match flag {
         Bool::False => false,
         Bool::True => true,

--- a/lib/wasi/src/syscalls/wasix/sock_set_opt_size.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_set_opt_size.rs
@@ -10,20 +10,13 @@ use crate::{net::socket::TimeType, syscalls::*};
 /// * `fd` - Socket descriptor
 /// * `opt` - Socket option to be set
 /// * `size` - Buffer size
+#[instrument(level = "debug", skip_all, fields(sock, opt, size), ret)]
 pub fn sock_set_opt_size(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
     opt: Sockoption,
     size: Filesize,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_set_opt_size(fd={}, ty={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock,
-        opt
-    );
-
     let ty = match opt {
         Sockoption::RecvTimeout => TimeType::ReadTimeout,
         Sockoption::SendTimeout => TimeType::WriteTimeout,

--- a/lib/wasi/src/syscalls/wasix/sock_shutdown.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_shutdown.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `how` - Which channels on the socket to shut down.
-#[instrument(level = "debug", skip-all, fields(sock), ret)]
+#[instrument(level = "debug", skip_all, fields(sock), ret)]
 pub fn sock_shutdown(mut ctx: FunctionEnvMut<'_, WasiEnv>, sock: WasiFd, how: SdFlags) -> Errno {
     let both = __WASI_SHUT_RD | __WASI_SHUT_WR;
     let how = match how {

--- a/lib/wasi/src/syscalls/wasix/sock_shutdown.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_shutdown.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `how` - Which channels on the socket to shut down.
-#[instrument(level = "debug", ret)]
+#[instrument(level = "debug", skip-all, fields(sock), ret)]
 pub fn sock_shutdown(mut ctx: FunctionEnvMut<'_, WasiEnv>, sock: WasiFd, how: SdFlags) -> Errno {
     let both = __WASI_SHUT_RD | __WASI_SHUT_WR;
     let how = match how {

--- a/lib/wasi/src/syscalls/wasix/sock_shutdown.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_shutdown.rs
@@ -8,14 +8,8 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `how` - Which channels on the socket to shut down.
+#[instrument(level = "debug", ret)]
 pub fn sock_shutdown(mut ctx: FunctionEnvMut<'_, WasiEnv>, sock: WasiFd, how: SdFlags) -> Errno {
-    debug!(
-        "wasi[{}:{}]::sock_shutdown (fd={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        sock
-    );
-
     let both = __WASI_SHUT_RD | __WASI_SHUT_WR;
     let how = match how {
         __WASI_SHUT_RD => std::net::Shutdown::Read,

--- a/lib/wasi/src/syscalls/wasix/stack_checkpoint.rs
+++ b/lib/wasi/src/syscalls/wasix/stack_checkpoint.rs
@@ -4,6 +4,7 @@ use crate::syscalls::*;
 /// ### `stack_checkpoint()`
 /// Creates a snapshot of the current stack which allows it to be restored
 /// later using its stack hash.
+#[instrument(level = "trace", skip_all, ret, err)]
 pub fn stack_checkpoint<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     snapshot_ptr: WasmPtr<StackSnapshot, M>,
@@ -15,26 +16,13 @@ pub fn stack_checkpoint<M: MemorySize>(
         let memory = env.memory_view(&ctx);
         let ret_val = wasi_try_mem_ok!(ret_val.read(&memory));
         if ret_val == 0 {
-            trace!(
-                "wasi[{}:{}]::stack_checkpoint - execution resumed",
-                ctx.data().pid(),
-                ctx.data().tid(),
-            );
+            trace!("execution resumed",);
         } else {
-            trace!(
-                "wasi[{}:{}]::stack_checkpoint - restored - (ret={})",
-                ctx.data().pid(),
-                ctx.data().tid(),
-                ret_val
-            );
+            trace!("restored - (ret={})", ret_val);
         }
         return Ok(Errno::Success);
     }
-    trace!(
-        "wasi[{}:{}]::stack_checkpoint - capturing",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
+    trace!("capturing",);
 
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 
@@ -54,10 +42,7 @@ pub fn stack_checkpoint<M: MemorySize>(
     // it correctly hashes
     if let Err(err) = snapshot_ptr.write(&memory, StackSnapshot { hash: 0, user: 0 }) {
         warn!(
-            "wasi[{}:{}]::failed to write to stack snapshot return variable - {}",
-            env.pid(),
-            env.tid(),
-            err
+            %err
         );
     }
 
@@ -133,25 +118,14 @@ pub fn stack_checkpoint<M: MemorySize>(
             &rewind_stack[..],
             &store_data[..],
         );
-        trace!(
-            "wasi[{}:{}]::stack_recorded (hash={}, user={})",
-            ctx.data().pid(),
-            ctx.data().tid(),
-            snapshot.hash,
-            snapshot.user
-        );
+        trace!(hash = snapshot.hash, user = snapshot.user);
 
         // Save the stack snapshot
         let env = ctx.data();
         let memory = env.memory_view(&ctx);
         let snapshot_ptr: WasmPtr<StackSnapshot, M> = WasmPtr::new(snapshot_offset);
         if let Err(err) = snapshot_ptr.write(&memory, snapshot) {
-            warn!(
-                "wasi[{}:{}]::failed checkpoint - could not save stack snapshot - {}",
-                env.pid(),
-                env.tid(),
-                err
-            );
+            warn!("could not save stack snapshot - {}", err);
             return OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Fault as u32)));
         }
 
@@ -167,8 +141,8 @@ pub fn stack_checkpoint<M: MemorySize>(
             Errno::Success => OnCalledAction::InvokeAgain,
             err => {
                 warn!(
-                    "wasi[{}:{}]::failed checkpoint - could not rewind the stack - errno={}",
-                    pid, tid, err
+                    "failed checkpoint - could not rewind the stack - errno={}",
+                    err
                 );
                 OnCalledAction::Trap(Box::new(WasiError::Exit(err as u32)))
             }

--- a/lib/wasi/src/syscalls/wasix/thread_exit.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_exit.rs
@@ -10,14 +10,10 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `rval` - The exit code returned by the process.
+#[instrument(level = "debug", skip_all, fields(exitcode), ret, err)]
 pub fn thread_exit(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     exitcode: ExitCode,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::thread_exit",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
     Err(WasiError::Exit(exitcode))
 }

--- a/lib/wasi/src/syscalls/wasix/thread_id.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_id.rs
@@ -4,20 +4,14 @@ use crate::syscalls::*;
 /// ### `thread_id()`
 /// Returns the index of the current thread
 /// (threads indices are sequencial from zero)
+#[instrument(level = "trace", skip_all, fields(tid = field::Empty), ret)]
 pub fn thread_id<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     ret_tid: WasmPtr<Tid, M>,
 ) -> Errno {
-    /*
-    trace!(
-        "wasi[{}:{}]::thread_id",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
-    */
-
     let env = ctx.data();
     let tid: Tid = env.thread.tid().into();
+    Span::current().record("tid", tid);
     let memory = env.memory_view(&ctx);
     wasi_try_mem!(ret_tid.write(&memory, tid));
     Errno::Success

--- a/lib/wasi/src/syscalls/wasix/thread_join.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_join.rs
@@ -8,17 +8,11 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `tid` - Handle of the thread to wait on
+#[instrument(level = "debug", skip_all, fields(join_tid), ret, err)]
 pub fn thread_join(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     join_tid: Tid,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        %join_tid,
-        "wasi[{}:{}]::thread_join",
-        ctx.data().pid(),
-        ctx.data().tid(),
-    );
-
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 
     let env = ctx.data();

--- a/lib/wasi/src/syscalls/wasix/thread_local_create.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_local_create.rs
@@ -10,17 +10,12 @@ use crate::syscalls::*;
 ///
 /// * `user_data` - User data that will be passed to the destructor
 ///   when the thread variable goes out of scope
+#[instrument(level = "trace", skip_all, fields(user_data), ret)]
 pub fn thread_local_create<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     user_data: TlUser,
     ret_key: WasmPtr<TlKey, M>,
 ) -> Errno {
-    trace!(
-        "wasi[{}:{}]::thread_local_create (user_data={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        user_data
-    );
     let env = ctx.data();
 
     let key = {

--- a/lib/wasi/src/syscalls/wasix/thread_local_destroy.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_local_destroy.rs
@@ -9,13 +9,8 @@ use crate::syscalls::*;
 /// * `user_data` - User data that will be passed to the destructor
 ///   when the thread variable goes out of scope
 /// * `key` - Thread key that was previously created
+#[instrument(level = "trace", skip_all, fields(key), ret)]
 pub fn thread_local_destroy(mut ctx: FunctionEnvMut<'_, WasiEnv>, key: TlKey) -> Errno {
-    trace!(
-        "wasi[{}:{}]::thread_local_destroy (key={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        key
-    );
     let process = ctx.data().process.clone();
     let mut inner = process.write();
 

--- a/lib/wasi/src/syscalls/wasix/thread_local_get.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_local_get.rs
@@ -7,12 +7,12 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `key` - Thread key that this local variable that was previous set
+#[instrument(level = "trace", skip_all, fields(key, val = field::Empty), ret)]
 pub fn thread_local_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     key: TlKey,
     ret_val: WasmPtr<TlVal, M>,
 ) -> Errno {
-    //trace!("wasi[{}:{}]::thread_local_get (key={})", ctx.data().pid(), ctx.data().tid(), key);
     let env = ctx.data();
 
     let val = {
@@ -21,6 +21,8 @@ pub fn thread_local_get<M: MemorySize>(
         guard.thread_local.get(&(current_thread, key)).copied()
     };
     let val = val.unwrap_or_default();
+    Span::current().record("val", val);
+
     let memory = env.memory_view(&ctx);
     wasi_try_mem!(ret_val.write(&memory, val));
     Errno::Success

--- a/lib/wasi/src/syscalls/wasix/thread_local_set.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_local_set.rs
@@ -8,8 +8,8 @@ use crate::syscalls::*;
 ///
 /// * `key` - Thread key that this local variable will be associated with
 /// * `val` - Value to be set for the thread local variable
+#[instrument(level = "trace", skip_all, fields(key, val), ret)]
 pub fn thread_local_set(ctx: FunctionEnvMut<'_, WasiEnv>, key: TlKey, val: TlVal) -> Errno {
-    //trace!("wasi[{}:{}]::thread_local_set (key={}, val={})", ctx.data().pid(), ctx.data().tid(), key, val);
     let env = ctx.data();
 
     let current_thread = ctx.data().thread.tid();

--- a/lib/wasi/src/syscalls/wasix/thread_parallelism.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_parallelism.rs
@@ -4,21 +4,17 @@ use crate::syscalls::*;
 /// ### `thread_parallelism()`
 /// Returns the available parallelism which is normally the
 /// number of available cores that can run concurrently
+#[instrument(level = "debug", skip_all, fields(parallelism), ret)]
 pub fn thread_parallelism<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     ret_parallelism: WasmPtr<M::Offset, M>,
 ) -> Errno {
-    debug!(
-        "wasi[{}:{}]::thread_parallelism",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
-
     let env = ctx.data();
     let parallelism = wasi_try!(env.tasks().thread_parallelism().map_err(|err| {
         let err: Errno = err.into();
         err
     }));
+    Span::current().record("parallelism", parallelism);
     let parallelism: M::Offset = wasi_try!(parallelism.try_into().map_err(|_| Errno::Overflow));
     let memory = env.memory_view(&ctx);
     wasi_try_mem!(ret_parallelism.write(&memory, parallelism));

--- a/lib/wasi/src/syscalls/wasix/thread_signal.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_signal.rs
@@ -7,18 +7,12 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `Signal`
 ///   Signal to be raised for this process
+#[instrument(level = "debug", skip_all, fields(tid, sig), ret, err)]
 pub fn thread_signal(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     tid: Tid,
     sig: Signal,
 ) -> Result<Errno, WasiError> {
-    debug!(
-        "wasi[{}:{}]::thread_signal(tid={}, sig={:?})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        tid,
-        sig
-    );
     {
         let tid: WasiThreadId = tid.into();
         ctx.data().process.signal_thread(&tid, sig);

--- a/lib/wasi/src/syscalls/wasix/thread_sleep.rs
+++ b/lib/wasi/src/syscalls/wasix/thread_sleep.rs
@@ -7,6 +7,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `duration` - Amount of time that the thread should sleep
+#[instrument(level = "debug", skip_all, fields(duration), ret, err)]
 pub fn thread_sleep(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     duration: Timestamp,
@@ -18,13 +19,6 @@ pub(crate) fn thread_sleep_internal(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     duration: Timestamp,
 ) -> Result<Errno, WasiError> {
-    /*
-    trace!(
-        "wasi[{}:{}]::thread_sleep",
-        ctx.data().pid(),
-        ctx.data().tid()
-    );
-    */
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 
     let env = ctx.data();

--- a/lib/wasi/src/syscalls/wasix/tty_get.rs
+++ b/lib/wasi/src/syscalls/wasix/tty_get.rs
@@ -3,11 +3,11 @@ use crate::syscalls::*;
 
 /// ### `tty_get()`
 /// Retrieves the current state of the TTY
+#[instrument(level = "debug", skip_all, ret)]
 pub fn tty_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     tty_state: WasmPtr<Tty, M>,
 ) -> Errno {
-    debug!("wasi[{}:{}]::tty_get", ctx.data().pid(), ctx.data().tid());
     let env = ctx.data();
 
     let env = ctx.data();

--- a/lib/wasi/src/syscalls/wasix/tty_set.rs
+++ b/lib/wasi/src/syscalls/wasix/tty_set.rs
@@ -3,12 +3,11 @@ use crate::syscalls::*;
 
 /// ### `tty_set()`
 /// Updates the properties of the rect
+#[instrument(level = "debug", skip_all, ret)]
 pub fn tty_set<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     tty_state: WasmPtr<Tty, M>,
 ) -> Errno {
-    debug!("wasi::tty_set");
-
     let env = ctx.data();
     let bridge = if let Some(t) = env.runtime.tty() {
         t
@@ -22,12 +21,9 @@ pub fn tty_set<M: MemorySize>(
     let line_buffered = state.line_buffered;
     let line_feeds = true;
     debug!(
-        "wasi[{}:{}]::tty_set(echo={}, line_buffered={}, line_feeds={})",
-        ctx.data().pid(),
-        ctx.data().tid(),
-        echo,
-        line_buffered,
-        line_feeds
+        %echo,
+        %line_buffered,
+        %line_feeds
     );
 
     let state = crate::os::tty::WasiTtyState {


### PR DESCRIPTION
- Now using the fmt subscriber for improved formatting
- Using spans on all syscalls
- Added recorded fields on the spans instead trace and debug macros
- Adding timing on all syscall