### PR TITLE
Fix CI and llvm detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,6 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf "${{ matrix.llvm_url }}" -L -o - | tar xJv -C ${LLVM_DIR}
           echo "${LLVM_DIR}/bin" >> $GITHUB_PATH
           echo "${LLVM_DIR}/usr/bin" >> $GITHUB_PATH
-          echo "LLVM_SYS_140_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
       - name: Set up dependencies for Mac OS

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,10 @@ name: test-sys
 on:
   push:
     branches:
-      - '**'
+      - master
+      - 'with-ci-.*'
+      - 'v3.0.x'
+      - 'v3.1.x'
   pull_request:
   workflow_dispatch:
     inputs:

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,10 @@ else ifneq (, $(shell which llvm-config 2>/dev/null))
 	LLVM_VERSION := $(shell llvm-config --version)
 	ifneq (, $(findstring 15,$(LLVM_VERSION)))
 		compilers += llvm
+		export LLVM_SYS_140_PREFIX = $(shell llvm-config --prefix)
 	else ifneq (, $(findstring 14,$(LLVM_VERSION)))
 		compilers += llvm
+		export LLVM_SYS_140_PREFIX = $(shell llvm-config --prefix)
 	endif
 endif
 


### PR DESCRIPTION
CI Test will only trigger on some specific branch now:
 - `main`
 - `v3.0.x`
 - `v3.1.x`
 - `with_ci-.*`

PR should still test also.

Also, detection of LLVM is improved when only `llvm-config` is available