### PR TITLE
Re-enable (most) WASIX Snapshot Tests

### DIFF
--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -571,7 +571,7 @@ fn create_obj(args: Vec<String>) -> anyhow::Result<()> {
     let wasm_path = operating_dir.as_path().join(create_exe_test_wasm_path());
 
     let object_path = operating_dir.as_path().join("wasm");
-    let output: Vec<u8> = WasmerCreateObj {
+    let _output: Vec<u8> = WasmerCreateObj {
         current_dir: operating_dir,
         wasm_path,
         output_object_path: object_path.clone(),

--- a/tests/integration/cli/tests/snapshot.rs
+++ b/tests/integration/cli/tests/snapshot.rs
@@ -267,14 +267,14 @@ fn test_snapshot_condvar() {
     assert_json_snapshot!(snapshot);
 }
 
-// // Test that the expected default directories are present.
-// #[test]
-// fn test_snapshot_default_file_system_tree() {
-//     let snapshot = TestBuilder::new()
-//         .arg("ls")
-//         .run_wasm(include_bytes!("./wasm/coreutils.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// Test that the expected default directories are present.
+#[test]
+fn test_snapshot_default_file_system_tree() {
+    let snapshot = TestBuilder::new()
+        .arg("ls")
+        .run_wasm(include_bytes!("./wasm/coreutils.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
 // TODO: figure out why this hangs on Windows and Mac OS
 #[cfg(target_os = "linux")]
@@ -303,44 +303,44 @@ fn test_snapshot_cowsay() {
 //     assert_json_snapshot!(snapshot);
 // }
 
-// // The ability to fork the current process and run a different image but retain
-// // the existing open file handles (which is needed for stdin and stdout redirection)
-// #[test]
-// fn test_snapshot_fork_and_exec() {
-//     let snapshot = TestBuilder::new()
-//         .use_coreutils()
-//         .run_wasm(include_bytes!("./wasm/example-execve.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// The ability to fork the current process and run a different image but retain
+// the existing open file handles (which is needed for stdin and stdout redirection)
+#[test]
+fn test_snapshot_fork_and_exec() {
+    let snapshot = TestBuilder::new()
+        .use_coreutils()
+        .run_wasm(include_bytes!("./wasm/example-execve.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
-// // longjmp is used by C programs that save and restore the stack at specific
-// // points - this functionality is often used for exception handling
-// #[test]
-// fn test_snapshot_longjump() {
-//     let snapshot = TestBuilder::new()
-//         .use_coreutils()
-//         .run_wasm(include_bytes!("./wasm/example-longjmp.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// longjmp is used by C programs that save and restore the stack at specific
+// points - this functionality is often used for exception handling
+#[test]
+fn test_snapshot_longjump() {
+    let snapshot = TestBuilder::new()
+        .use_coreutils()
+        .run_wasm(include_bytes!("./wasm/example-longjmp.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
-// // Another longjump test.
-// // This one is initiated from `rust` code and thus has the risk of leaking memory but uses different interfaces
-// #[test]
-// fn test_snapshot_longjump2() {
-//     let snapshot = TestBuilder::new()
-//         .use_coreutils()
-//         .run_wasm(include_bytes!("./wasm/example-stack.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// Another longjump test.
+// This one is initiated from `rust` code and thus has the risk of leaking memory but uses different interfaces
+#[test]
+fn test_snapshot_longjump2() {
+    let snapshot = TestBuilder::new()
+        .use_coreutils()
+        .run_wasm(include_bytes!("./wasm/example-stack.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
-// // Simple fork example that is a crude multi-threading implementation - used by `dash`
-// #[test]
-// fn test_snapshot_fork() {
-//     let snapshot = TestBuilder::new()
-//         .use_coreutils()
-//         .run_wasm(include_bytes!("./wasm/example-fork.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// Simple fork example that is a crude multi-threading implementation - used by `dash`
+#[test]
+fn test_snapshot_fork() {
+    let snapshot = TestBuilder::new()
+        .use_coreutils()
+        .run_wasm(include_bytes!("./wasm/example-fork.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
 // Uses the `fd_pipe` syscall to create a bidirection pipe with two file
 // descriptors then forks the process to write and read to this pipe.
@@ -352,23 +352,23 @@ fn test_snapshot_pipes() {
     assert_json_snapshot!(snapshot);
 }
 
-// // Performs a longjmp of a stack that was recorded before the fork.
-// // This test ensures that the stacks that have been recorded are preserved
-// // after a fork.
-// // The behavior is needed for `dash`
-// #[test]
-// fn test_snapshot_longjump_fork() {
-//     let snapshot = TestBuilder::new().run_wasm(include_bytes!("./wasm/example-fork-longjmp.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// Performs a longjmp of a stack that was recorded before the fork.
+// This test ensures that the stacks that have been recorded are preserved
+// after a fork.
+// The behavior is needed for `dash`
+#[test]
+fn test_snapshot_longjump_fork() {
+    let snapshot = TestBuilder::new().run_wasm(include_bytes!("./wasm/example-fork-longjmp.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
-// // full multi-threading with shared memory and shared compiled modules
-// #[test]
-// fn test_snapshot_multithreading() {
-//     let snapshot =
-//         TestBuilder::new().run_wasm(include_bytes!("./wasm/example-multi-threading.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// full multi-threading with shared memory and shared compiled modules
+#[test]
+fn test_snapshot_multithreading() {
+    let snapshot =
+        TestBuilder::new().run_wasm(include_bytes!("./wasm/example-multi-threading.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
 // full multi-threading with shared memory and shared compiled modules
 #[cfg(target_os = "linux")]
@@ -378,14 +378,14 @@ fn test_snapshot_sleep() {
     assert_json_snapshot!(snapshot);
 }
 
-// // Uses `posix_spawn` to launch a sub-process and wait on it to exit
-// #[test]
-// fn test_snapshot_process_spawn() {
-//     let snapshot = TestBuilder::new()
-//         .use_coreutils()
-//         .run_wasm(include_bytes!("./wasm/example-spawn.wasm"));
-//     assert_json_snapshot!(snapshot);
-// }
+// Uses `posix_spawn` to launch a sub-process and wait on it to exit
+#[test]
+fn test_snapshot_process_spawn() {
+    let snapshot = TestBuilder::new()
+        .use_coreutils()
+        .run_wasm(include_bytes!("./wasm/example-spawn.wasm"));
+    assert_json_snapshot!(snapshot);
+}
 
 // FIXME: re-enable - hangs on windows and macos
 // Connects to 8.8.8.8:53 over TCP to verify TCP clients work
@@ -463,11 +463,10 @@ fn test_snapshot_catsay() {
     assert_json_snapshot!(snapshot);
 }
 
-// // FIXME: not working properly, some issue with stdin piping
-// // #[test]
-// // fn test_snapshot_quickjs() {
-// //     let snapshot = TestBuilder::new()
-// //         .stdin_str("2+2*2")
-// //         .run_wasm(include_bytes!("./wasm/qjs.wasm"));
-// //     assert_json_snapshot!(snapshot);
-// // }
+#[test]
+fn test_snapshot_quickjs() {
+    let snapshot = TestBuilder::new()
+        .stdin_str("print(2+2);\n\\q\n")
+        .run_wasm(include_bytes!("./wasm/qjs.wasm"));
+    assert_json_snapshot!(snapshot);
+}

--- a/tests/integration/cli/tests/snapshot.rs
+++ b/tests/integration/cli/tests/snapshot.rs
@@ -305,6 +305,7 @@ fn test_snapshot_cowsay() {
 
 // The ability to fork the current process and run a different image but retain
 // the existing open file handles (which is needed for stdin and stdout redirection)
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn test_snapshot_fork_and_exec() {
     let snapshot = TestBuilder::new()
@@ -379,6 +380,7 @@ fn test_snapshot_sleep() {
 }
 
 // Uses `posix_spawn` to launch a sub-process and wait on it to exit
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn test_snapshot_process_spawn() {
     let snapshot = TestBuilder::new()

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork.snap
@@ -16,7 +16,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "Parent has x = 0\nChild has x = 2\n",
+      "stdout": "Parent has x = 0\nChild has x = 2\nChild(2) exited with 0\n",
       "stderr": "",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump_fork.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump_fork.snap
@@ -14,7 +14,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "Parent has x = 0\nChild has x = 2\n",
+      "stdout": "Parent has x = 0\nChild has x = 2\nChild(2) exited with 5\n",
       "stderr": "",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_process_spawn.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_process_spawn.snap
@@ -16,7 +16,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "Child pid: 2\nhi\n",
+      "stdout": "Child pid: 2\nhi\nChild status 0\n",
       "stderr": "",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_quickjs.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_quickjs.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration/cli/tests/snapshot.rs
+expression: snapshot
+---
+{
+  "spec": {
+    "name": null,
+    "wasm_hash": "44ceba0b68971110a9bc8af3349e7663",
+    "use_packages": [],
+    "cli_args": [],
+    "stdin": [
+      112,
+      114,
+      105,
+      110,
+      116,
+      40,
+      50,
+      43,
+      50,
+      41,
+      59,
+      10,
+      92,
+      113,
+      10
+    ],
+    "debug_output": false,
+    "enable_threads": true
+  },
+  "result": {
+    "Success": {
+      "stdout": "QuickJS - Type \"\\h\" for help\nqjs > \u001b[32;1mp\u001b[0m\u001b[J\u001b[D\u001b[32;1mpr\u001b[0m\u001b[J\u001b[2D\u001b[32;1mpri\u001b[0m\u001b[J\u001b[3D\u001b[32;1mprin\u001b[0m\u001b[J\u001b[4D\u001b[32;1mprint\u001b[0m\u001b[J\u001b[5D\u001b[33;1mprint\u001b[0m\u001b[32;1m(\u001b[0m\u001b[J\u001b[6D\u001b[33;1mprint\u001b[0m\u001b[32;1m(\u001b[0m\u001b[32m2\u001b[0m\u001b[J\u001b[7D\u001b[33;1mprint\u001b[0m\u001b[32;1m(\u001b[0m\u001b[32m2\u001b[0m\u001b[32;1m+\u001b[0m\u001b[J\u001b[8D\u001b[33;1mprint\u001b[0m\u001b[32;1m(\u001b[0m\u001b[32m2\u001b[0m\u001b[32;1m+\u001b[0m\u001b[32m2\u001b[0m\u001b[J\u001b[9D\u001b[33;1mprint\u001b[0m\u001b[32;1m(\u001b[0m\u001b[32m2\u001b[0m\u001b[32;1m+\u001b[0m\u001b[32m2\u001b[0m\u001b[32;1m)\u001b[0m\u001b[J\u001b[10D\u001b[33;1mprint\u001b[0m\u001b[32;1m(\u001b[0m\u001b[32m2\u001b[0m\u001b[32;1m+\u001b[0m\u001b[32m2\u001b[0m\u001b[32;1m);\u001b[0m\u001b[J\n4\n\u001b[37;1mundefined\n\u001b[0mqjs > \u001b[32;1m\\\u001b[0m\u001b[J\u001b[D\u001b[32;1m\\\u001b[0m\u001b[32;1mq\u001b[0m\u001b[J\n",
+      "stderr": "",
+      "exit_code": 0
+    }
+  }
+}


### PR DESCRIPTION
- tests: Re-enable some of the WASIX snapshot tests
- chore: Fix build warning due to unused variable

Mostly fixes #3616 