### PR TITLE
[CI] This should setup LLVM on Windows correctly this time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,9 +119,9 @@ jobs:
           LLVM_DIR: .llvm
       - name: Configure LLVM (Windows)
         # The Custom Windows build does not contains llvm-config.exe, so need to setup manualy here
-        if: matrix.os == 'windows-x64' && matrix.llvm_url
+        if: matrix.build == 'windows-x64' && matrix.llvm_url
         run: |
-          echo LLVM_SYS_14_PREFIX="${LLVM_DIR}" >> $GITHUB_ENV
+          echo LLVM_SYS_140_PREFIX="${LLVM_DIR}" >> $GITHUB_ENV
           echo LLVM_ENABLE=1 >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm


### PR DESCRIPTION
New attempts to have the build.yaml script setup LLVM on Windows build (because llvm-config is not present there)