### PR TITLE
Add host directory mapping to the WasiRunner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5291,6 +5291,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sha2",
  "shellexpand",
+ "tempfile",
  "term_size",
  "termios",
  "thiserror",

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -82,6 +82,7 @@ wasm-bindgen = "0.2.74"
 [dev-dependencies]
 wasmer = { path = "../api", version = "=3.2.0-alpha.1", default-features = false, features = ["wat", "js-serializable-module"] }
 tokio = { version = "1", features = [ "sync", "macros", "rt" ], default_features = false }
+tempfile = "3.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -1,9 +1,11 @@
 //! WebC container support for running WASI modules
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
-use crate::{runners::WapmContainer, PluggableRuntimeImplementation, VirtualTaskManager};
-use crate::{WasiEnv, WasiEnvBuilder};
+use crate::{
+    runners::{wcgi::MappedDirectory, WapmContainer},
+    PluggableRuntimeImplementation, VirtualTaskManager, WasiEnvBuilder,
+};
 use anyhow::{Context, Error};
 use serde::{Deserialize, Serialize};
 use wasmer::{Module, Store};
@@ -12,6 +14,7 @@ use webc::metadata::{annotations::Wasi, Command};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WasiRunner {
     args: Vec<String>,
+    mapped_dirs: Vec<MappedDirectory>,
     #[serde(skip, default)]
     store: Store,
     #[serde(skip, default)]
@@ -24,6 +27,7 @@ impl WasiRunner {
         Self {
             args: Vec::new(),
             store,
+            mapped_dirs: Vec::new(),
             tasks: None,
         }
     }
@@ -50,6 +54,51 @@ impl WasiRunner {
         S: Into<String>,
     {
         self.args = args.into_iter().map(|s| s.into()).collect();
+    }
+
+    pub fn with_mapped_directory(
+        mut self,
+        host: impl Into<PathBuf>,
+        guest: impl Into<String>,
+    ) -> Self {
+        self.map_directory(host, guest);
+        self
+    }
+
+    pub fn map_directory(
+        &mut self,
+        host: impl Into<PathBuf>,
+        guest: impl Into<String>,
+    ) -> &mut Self {
+        self.mapped_dirs.push(MappedDirectory {
+            host: host.into(),
+            guest: guest.into(),
+        });
+        self
+    }
+
+    pub fn with_map_directories<I, H, G>(mut self, mappings: I) -> Self
+    where
+        I: IntoIterator<Item = (H, G)>,
+        H: Into<PathBuf>,
+        G: Into<String>,
+    {
+        self.map_directories(mappings);
+        self
+    }
+
+    pub fn map_directories<I, H, G>(&mut self, mappings: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (H, G)>,
+        H: Into<PathBuf>,
+        G: Into<String>,
+    {
+        let mappings = mappings.into_iter().map(|(h, g)| MappedDirectory {
+            host: h.into(),
+            guest: g.into(),
+        });
+        self.mapped_dirs.extend(mappings);
+        self
     }
 
     pub fn with_task_manager(mut self, tasks: impl VirtualTaskManager) -> Self {
@@ -108,7 +157,7 @@ fn prepare_webc_env(
     args: &[String],
 ) -> Result<WasiEnvBuilder, anyhow::Error> {
     let (filesystem, preopen_dirs) = container.container_fs();
-    let mut builder = WasiEnv::builder(command).args(args);
+    let mut builder = WasiEnvBuilder::new(command).args(args);
 
     for entry in preopen_dirs {
         builder.add_preopen_build(|p| p.directory(&entry).read(true).write(true).create(true))?;

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -25,7 +25,7 @@ use crate::{
     Capabilities, Pipe, PluggableRuntimeImplementation, VirtualTaskManager, WasiEnv,
 };
 
-/// The shared object that manages the instantiaion of WASI executables and
+/// The shared object that manages the instantiation of WASI executables and
 /// communicating with them via the CGI protocol.
 #[derive(Clone, Debug)]
 pub(crate) struct Handler(Arc<SharedState>);

--- a/lib/wasi/src/runners/wcgi/mod.rs
+++ b/lib/wasi/src/runners/wcgi/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 pub use self::runner::{Callbacks, Config, WcgiRunner};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct MappedDirectory {
     pub host: PathBuf,
     pub guest: String,

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -223,11 +223,22 @@ impl WasiEnvBuilder {
         I: IntoIterator<Item = Arg>,
         Arg: AsRef<[u8]>,
     {
-        args.into_iter().for_each(|arg| {
-            self.add_arg(arg);
-        });
+        self.add_args(args);
 
         self
+    }
+
+    /// Add multiple arguments.
+    ///
+    /// Arguments must not contain the nul (0x0) byte
+    pub fn add_args<I, Arg>(&mut self, args: I)
+    where
+        I: IntoIterator<Item = Arg>,
+        Arg: AsRef<[u8]>,
+    {
+        for arg in args {
+            self.add_arg(arg);
+        }
     }
 
     /// Get a reference to the configured arguments.
@@ -351,7 +362,7 @@ impl WasiEnvBuilder {
     /// ```
     pub fn preopen_build<F>(mut self, inner: F) -> Result<Self, WasiStateCreationError>
     where
-        F: Fn(&mut PreopenDirBuilder) -> &mut PreopenDirBuilder,
+        F: FnOnce(&mut PreopenDirBuilder) -> &mut PreopenDirBuilder,
     {
         self.add_preopen_build(inner)?;
         Ok(self)
@@ -373,7 +384,7 @@ impl WasiEnvBuilder {
     /// ```
     pub fn add_preopen_build<F>(&mut self, inner: F) -> Result<(), WasiStateCreationError>
     where
-        F: Fn(&mut PreopenDirBuilder) -> &mut PreopenDirBuilder,
+        F: FnOnce(&mut PreopenDirBuilder) -> &mut PreopenDirBuilder,
     {
         let mut pdb = PreopenDirBuilder::new();
         let po_dir = inner(&mut pdb).build()?;


### PR DESCRIPTION
This PR wires up `--mapdir` and friends for the WASI runner. The result is that implementations should see the files from all volumes in the WEBC file, plus any extra volumes specified by the user on the command-line.