### PR TITLE
feat(wasi): Add CapabilityThreading with max thread count

### DIFF
--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -59,6 +59,7 @@ impl Handler {
             .capabilities(Capabilities {
                 insecure_allow_all: true,
                 http_client: HttpClientCapabilityV1::new_allow_all(),
+                threading: Default::default(),
             })
             .runtime(Arc::new(rt))
             .sandbox_fs(self.fs()?)

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -14,7 +14,7 @@ use wasmer_vfs::{ArcFile, FsError, TmpFileSystem, VirtualFile};
 use crate::{
     bin_factory::{BinFactory, ModuleCache},
     fs::{WasiFs, WasiFsRoot, WasiInodes},
-    os::task::control_plane::{ControlPlaneError, WasiControlPlane},
+    os::task::control_plane::{ControlPlaneConfig, ControlPlaneError, WasiControlPlane},
     state::WasiState,
     syscalls::types::{__WASI_STDERR_FILENO, __WASI_STDIN_FILENO, __WASI_STDOUT_FILENO},
     Capabilities, PluggableRuntimeImplementation, WasiEnv, WasiFunctionEnv, WasiRuntime,
@@ -684,7 +684,10 @@ impl WasiEnvBuilder {
 
         let capabilities = self.capabilites;
 
-        let control_plane = WasiControlPlane::default();
+        let plane_config = ControlPlaneConfig {
+            max_task_count: capabilities.threading.max_threads,
+        };
+        let control_plane = WasiControlPlane::new(plane_config);
 
         let init = WasiEnvInit {
             state,

--- a/lib/wasi/src/state/capabilities.rs
+++ b/lib/wasi/src/state/capabilities.rs
@@ -1,9 +1,11 @@
 use crate::http::HttpClientCapabilityV1;
 
+/// Defines capabilities for a Wasi environment.
 #[derive(Clone, Debug)]
 pub struct Capabilities {
     pub insecure_allow_all: bool,
     pub http_client: HttpClientCapabilityV1,
+    pub threading: CapabilityThreadingV1,
 }
 
 impl Capabilities {
@@ -11,6 +13,7 @@ impl Capabilities {
         Self {
             insecure_allow_all: false,
             http_client: Default::default(),
+            threading: Default::default(),
         }
     }
 }
@@ -19,4 +22,13 @@ impl Default for Capabilities {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Defines threading related permissions.
+#[derive(Debug, Default, Clone)]
+pub struct CapabilityThreadingV1 {
+    /// Maximum number of threads that can be spawned.
+    ///
+    /// [`None`] means no limit.
+    pub max_threads: Option<usize>,
 }


### PR DESCRIPTION
Extends the wasi Capabilities type with a setting for threading that
configures the maximum thread count.
