### PR TITLE
PluggableRuntime Cleanup

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -11,8 +11,8 @@ use wasmer_wasix::os::tty_sys::SysTty;
 use wasmer_wasix::os::TtyBridge;
 use wasmer_wasix::types::__WASI_STDIN_FILENO;
 use wasmer_wasix::{
-    default_fs_backing, get_wasi_versions, PluggableRuntimeImplementation, WasiEnv, WasiError,
-    WasiFunctionEnv, WasiVersion,
+    default_fs_backing, get_wasi_versions, PluggableRuntime, WasiEnv, WasiError, WasiFunctionEnv,
+    WasiVersion,
 };
 
 use clap::Parser;
@@ -129,7 +129,7 @@ impl Wasi {
             .map(|(a, b)| (a.to_string(), b.to_string()))
             .collect::<HashMap<_, _>>();
 
-        let mut rt = PluggableRuntimeImplementation::default();
+        let mut rt = PluggableRuntime::default();
 
         if self.networking {
             rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -9,6 +9,7 @@ use virtual_fs::{DeviceFile, PassthruFileSystem, RootFileSystemBuilder};
 use wasmer::{AsStoreMut, Instance, Module, RuntimeError, Value};
 use wasmer_wasix::os::tty_sys::SysTty;
 use wasmer_wasix::os::TtyBridge;
+use wasmer_wasix::runtime::task_manager::tokio::TokioTaskManager;
 use wasmer_wasix::types::__WASI_STDIN_FILENO;
 use wasmer_wasix::{
     default_fs_backing, get_wasi_versions, PluggableRuntime, WasiEnv, WasiError, WasiFunctionEnv,
@@ -129,7 +130,7 @@ impl Wasi {
             .map(|(a, b)| (a.to_string(), b.to_string()))
             .collect::<HashMap<_, _>>();
 
-        let mut rt = PluggableRuntime::default();
+        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::shared()));
 
         if self.networking {
             rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());

--- a/lib/wasi/src/bin_factory/module_cache.rs
+++ b/lib/wasi/src/bin_factory/module_cache.rs
@@ -283,13 +283,13 @@ impl ModuleCache {
 #[cfg(test)]
 #[cfg(feature = "sys")]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     use tracing_subscriber::{
         filter, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
     };
 
-    use crate::PluggableRuntime;
+    use crate::{runtime::task_manager::tokio::TokioTaskManager, PluggableRuntime};
 
     use super::*;
 
@@ -306,7 +306,7 @@ mod tests {
         let mut cache = ModuleCache::new(None, None, true);
         cache.cache_time = std::time::Duration::from_millis(500);
 
-        let rt = PluggableRuntime::default();
+        let rt = PluggableRuntime::new(Arc::new(TokioTaskManager::shared()));
         let tasks = rt.task_manager();
 
         let mut store = Vec::new();

--- a/lib/wasi/src/bin_factory/module_cache.rs
+++ b/lib/wasi/src/bin_factory/module_cache.rs
@@ -289,7 +289,7 @@ mod tests {
         filter, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
     };
 
-    use crate::PluggableRuntimeImplementation;
+    use crate::PluggableRuntime;
 
     use super::*;
 
@@ -306,7 +306,7 @@ mod tests {
         let mut cache = ModuleCache::new(None, None, true);
         cache.cache_time = std::time::Duration::from_millis(500);
 
-        let rt = PluggableRuntimeImplementation::default();
+        let rt = PluggableRuntime::default();
         let tasks = rt.task_manager();
 
         let mut store = Vec::new();

--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -99,7 +99,7 @@ pub use crate::{
     },
     runtime::{
         task_manager::{VirtualTaskManager, VirtualTaskManagerExt},
-        PluggableRuntimeImplementation, SpawnedMemory, WasiRuntime,
+        PluggableRuntime, SpawnedMemory, WasiRuntime,
     },
     wapm::parse_static_webc,
 };

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::{runners::WapmContainer, PluggableRuntimeImplementation, VirtualTaskManager};
+use crate::{runners::WapmContainer, PluggableRuntime, VirtualTaskManager};
 use crate::{WasiEnv, WasiEnvBuilder};
 use anyhow::{Context, Error};
 use serde::{Deserialize, Serialize};
@@ -91,7 +91,7 @@ impl crate::runners::Runner for WasiRunner {
         let mut builder = prepare_webc_env(container, &atom_name, &self.args)?;
 
         if let Some(tasks) = &self.tasks {
-            let rt = PluggableRuntimeImplementation::new(Arc::clone(tasks));
+            let rt = PluggableRuntime::new(Arc::clone(tasks));
             builder.set_runtime(Arc::new(rt));
         }
 

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -23,7 +23,7 @@ use crate::{
     capabilities::Capabilities,
     http::HttpClientCapabilityV1,
     runners::wcgi::{Callbacks, MappedDirectory},
-    Pipe, PluggableRuntimeImplementation, VirtualTaskManager, WasiEnv,
+    Pipe, PluggableRuntime, VirtualTaskManager, WasiEnv,
 };
 
 /// The shared object that manages the instantiaion of WASI executables and
@@ -49,7 +49,7 @@ impl Handler {
         self.dialect
             .prepare_environment_variables(parts, &mut request_specific_env);
 
-        let rt = PluggableRuntimeImplementation::new(Arc::clone(&self.task_manager));
+        let rt = PluggableRuntime::new(Arc::clone(&self.task_manager));
         let builder = builder
             .envs(self.env.iter())
             .envs(request_specific_env)

--- a/lib/wasi/src/runtime/mod.rs
+++ b/lib/wasi/src/runtime/mod.rs
@@ -30,7 +30,6 @@ where
     fn task_manager(&self) -> &Arc<dyn VirtualTaskManager>;
 
     /// Get a [`wasmer::Engine`] for module compilation.
-    #[cfg(feature = "sys")]
     fn engine(&self) -> Option<wasmer::Engine> {
         None
     }
@@ -91,7 +90,6 @@ pub struct PluggableRuntime {
     pub rt: Arc<dyn VirtualTaskManager>,
     pub networking: DynVirtualNetworking,
     pub http_client: Option<DynHttpClient>,
-    #[cfg(feature = "sys")]
     pub engine: Option<wasmer::Engine>,
     #[derivative(Debug = "ignore")]
     pub tty: Option<Arc<dyn TtyBridge + Send + Sync>>,
@@ -121,7 +119,6 @@ impl PluggableRuntime {
             rt,
             networking,
             http_client,
-            #[cfg(feature = "sys")]
             engine: None,
             tty: None,
         }
@@ -134,7 +131,6 @@ impl PluggableRuntime {
         self.networking = Arc::new(net)
     }
 
-    #[cfg(feature = "sys")]
     pub fn set_engine(&mut self, engine: Option<wasmer::Engine>) {
         self.engine = engine;
     }
@@ -169,7 +165,6 @@ impl WasiRuntime for PluggableRuntime {
         self.http_client.as_ref()
     }
 
-    #[cfg(feature = "sys")]
     fn engine(&self) -> Option<wasmer::Engine> {
         self.engine.clone()
     }

--- a/lib/wasi/src/runtime/mod.rs
+++ b/lib/wasi/src/runtime/mod.rs
@@ -140,22 +140,6 @@ impl PluggableRuntime {
     }
 }
 
-impl Default for PluggableRuntime {
-    #[cfg(feature = "sys-thread")]
-    fn default() -> Self {
-        let rt = task_manager::tokio::TokioTaskManager::shared();
-        let mut s = Self::new(Arc::new(rt));
-        let engine = wasmer::Store::default().engine().clone();
-        s.engine = Some(engine);
-        s
-    }
-
-    #[cfg(not(feature = "sys-thread"))]
-    fn default() -> Self {
-        unimplemented!("Default WasiRuntime is not implemented on this target")
-    }
-}
-
 impl WasiRuntime for PluggableRuntime {
     fn networking(&self) -> &DynVirtualNetworking {
         &self.networking

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -722,9 +722,17 @@ impl WasiEnvBuilder {
             }
         }
 
-        let runtime = self
-            .runtime
-            .unwrap_or_else(|| Arc::new(PluggableRuntime::default()));
+        let runtime = self.runtime.unwrap_or_else(|| {
+            #[cfg(feature = "sys-thread")]
+            {
+                Arc::new(PluggableRuntime::new(Arc::new(crate::runtime::task_manager::tokio::TokioTaskManager::shared())))
+            }
+
+            #[cfg(not(feature = "sys-thread"))]
+            {
+                panic!("this build does not support a default runtime - specify one with WasiEnvBuilder::runtime()");
+            }
+        });
 
         let uses = self.uses;
         let map_commands = self.map_commands;

--- a/lib/wasi/src/state/builder.rs
+++ b/lib/wasi/src/state/builder.rs
@@ -20,7 +20,7 @@ use crate::{
     parse_static_webc,
     state::WasiState,
     syscalls::types::{__WASI_STDERR_FILENO, __WASI_STDIN_FILENO, __WASI_STDOUT_FILENO},
-    PluggableRuntimeImplementation, WasiEnv, WasiFunctionEnv, WasiRuntime, WasiRuntimeError,
+    PluggableRuntime, WasiEnv, WasiFunctionEnv, WasiRuntime, WasiRuntimeError,
 };
 
 use super::env::WasiEnvInit;
@@ -724,7 +724,7 @@ impl WasiEnvBuilder {
 
         let runtime = self
             .runtime
-            .unwrap_or_else(|| Arc::new(PluggableRuntimeImplementation::default()));
+            .unwrap_or_else(|| Arc::new(PluggableRuntime::default()));
 
         let uses = self.uses;
         let map_commands = self.map_commands;

--- a/lib/wasi/tests/stdio.rs
+++ b/lib/wasi/tests/stdio.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use virtual_fs::{AsyncReadExt, AsyncWriteExt};
 use wasmer::{Module, Store};
-use wasmer_wasix::{Pipe, PluggableRuntimeImplementation, WasiEnv};
+use wasmer_wasix::{Pipe, PluggableRuntime, WasiEnv};
 
 mod sys {
     #[tokio::test]
@@ -76,7 +76,7 @@ async fn test_stdout() {
     // Create the `WasiEnv`.
     let (stdout_tx, mut stdout_rx) = Pipe::channel();
 
-    let rt = PluggableRuntimeImplementation::default();
+    let rt = PluggableRuntime::default();
 
     let builder = WasiEnv::builder("command-name")
         .runtime(Arc::new(rt))
@@ -112,7 +112,7 @@ async fn test_env() {
         builder.build()
     });
 
-    let rt = PluggableRuntimeImplementation::default();
+    let rt = PluggableRuntime::default();
 
     // Create the `WasiEnv`.
     let (pipe_tx, mut pipe_rx) = Pipe::channel();
@@ -157,7 +157,7 @@ async fn test_stdin() {
     let buf = "Hello, stdin!\n".as_bytes().to_owned();
     pipe_tx.write_all(&buf[..]).await.unwrap();
 
-    let rt = PluggableRuntimeImplementation::default();
+    let rt = PluggableRuntime::default();
 
     let builder = WasiEnv::builder("command-name")
         .runtime(Arc::new(rt))

--- a/lib/wasi/tests/stdio.rs
+++ b/lib/wasi/tests/stdio.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use virtual_fs::{AsyncReadExt, AsyncWriteExt};
 use wasmer::{Module, Store};
-use wasmer_wasix::{Pipe, PluggableRuntime, WasiEnv};
+use wasmer_wasix::{Pipe, WasiEnv};
 
 mod sys {
     #[tokio::test]
@@ -76,10 +74,7 @@ async fn test_stdout() {
     // Create the `WasiEnv`.
     let (stdout_tx, mut stdout_rx) = Pipe::channel();
 
-    let rt = PluggableRuntime::default();
-
     let builder = WasiEnv::builder("command-name")
-        .runtime(Arc::new(rt))
         .args(&["Gordon"])
         .stdout(Box::new(stdout_tx));
 
@@ -112,13 +107,10 @@ async fn test_env() {
         builder.build()
     });
 
-    let rt = PluggableRuntime::default();
-
     // Create the `WasiEnv`.
     let (pipe_tx, mut pipe_rx) = Pipe::channel();
 
     let builder = WasiEnv::builder("command-name")
-        .runtime(Arc::new(rt))
         .args(&["Gordon"])
         .env("DOG", "X")
         .env("TEST", "VALUE")
@@ -157,11 +149,7 @@ async fn test_stdin() {
     let buf = "Hello, stdin!\n".as_bytes().to_owned();
     pipe_tx.write_all(&buf[..]).await.unwrap();
 
-    let rt = PluggableRuntime::default();
-
-    let builder = WasiEnv::builder("command-name")
-        .runtime(Arc::new(rt))
-        .stdin(Box::new(pipe_rx));
+    let builder = WasiEnv::builder("command-name").stdin(Box::new(pipe_rx));
 
     #[cfg(feature = "js")]
     {

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -12,8 +12,8 @@ use virtual_fs::{
 use wasmer::{FunctionEnv, Imports, Module, Store};
 use wasmer_wasix::types::wasi::{Filesize, Timestamp};
 use wasmer_wasix::{
-    generate_import_object_from_env, get_wasi_version, FsError, PluggableRuntimeImplementation,
-    VirtualFile, WasiEnv, WasiEnvBuilder, WasiRuntime, WasiVersion,
+    generate_import_object_from_env, get_wasi_version, FsError, PluggableRuntime, VirtualFile,
+    WasiEnv, WasiEnvBuilder, WasiRuntime, WasiVersion,
 };
 use wast::parser::{self, Parse, ParseBuffer, Parser};
 
@@ -100,7 +100,7 @@ impl<'a> WasiTest<'a> {
             out
         };
 
-        let mut rt = PluggableRuntimeImplementation::default();
+        let mut rt = PluggableRuntime::default();
         rt.set_engine(Some(store.engine().clone()));
 
         let tasks = rt.task_manager().runtime().clone();

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -10,6 +10,7 @@ use virtual_fs::{
     AsyncWriteExt, FileSystem, Pipe, ReadBuf, RootFileSystemBuilder,
 };
 use wasmer::{FunctionEnv, Imports, Module, Store};
+use wasmer_wasix::runtime::task_manager::tokio::TokioTaskManager;
 use wasmer_wasix::types::wasi::{Filesize, Timestamp};
 use wasmer_wasix::{
     generate_import_object_from_env, get_wasi_version, FsError, PluggableRuntime, VirtualFile,
@@ -100,7 +101,7 @@ impl<'a> WasiTest<'a> {
             out
         };
 
-        let mut rt = PluggableRuntime::default();
+        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::shared()));
         rt.set_engine(Some(store.engine().clone()));
 
         let tasks = rt.task_manager().runtime().clone();


### PR DESCRIPTION
- refactor(wasi): Rename PluggableRuntimeImplementation to PluggableRuntime
- chore: Remove a redundant feature toggle
- chore: Remove sys feature gates
- Remove PluggableRuntime::default()
