### PR TITLE
Added back all removed function for Engine to avoid API breaking changes

### DIFF
--- a/lib/api/src/engine.rs
+++ b/lib/api/src/engine.rs
@@ -4,11 +4,26 @@ use core::ops::Deref;
 use crate::sys::engine as engine_imp;
 #[cfg(feature = "sys")]
 pub(crate) use crate::sys::engine::default_engine;
+#[cfg(feature = "sys")]
+use std::io::Read;
+#[cfg(feature = "sys")]
+use std::path::Path;
+#[cfg(feature = "sys")]
+use std::sync::Arc;
+#[cfg(feature = "sys")]
+pub use wasmer_compiler::{Artifact, CompilerConfig, EngineInner, Features, Tunables};
+#[cfg(feature = "sys")]
+use wasmer_types::{CompileError, DeserializeError, FunctionType, Target};
+#[cfg(feature = "sys")]
+use wasmer_vm::VMSharedSignatureIndex;
 
 #[cfg(feature = "js")]
 use crate::js::engine as engine_imp;
 #[cfg(feature = "js")]
 pub(crate) use crate::js::engine::default_engine;
+
+#[cfg(feature = "sys")]
+type EngineId = str;
 
 /// The engine type
 #[derive(Clone, Debug)]
@@ -28,8 +43,148 @@ impl Engine {
     pub fn deterministic_id(&self) -> &str {
         self.0.deterministic_id()
     }
-}
 
+    #[deprecated(since = "3.2.0")]
+    #[cfg(all(feature = "compiler", feature = "sys"))]
+    /// Create a new `Engine` with the given config
+    pub fn new(
+        compiler_config: Box<dyn CompilerConfig>,
+        target: Target,
+        features: Features,
+    ) -> Self {
+        Self(engine_imp::Engine::new(compiler_config, target, features))
+    }
+
+    #[cfg(feature = "sys")]
+    /// Create a headless `Engine`
+    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
+    pub fn headless() -> Self {
+        Self(engine_imp::Engine::headless())
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(feature = "sys")]
+    /// Get reference to `EngineInner`.
+    pub fn inner(&self) -> std::sync::MutexGuard<'_, EngineInner> {
+        self.0.inner()
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(feature = "sys")]
+    /// Get mutable reference to `EngineInner`.
+    pub fn inner_mut(&self) -> std::sync::MutexGuard<'_, EngineInner> {
+        self.0.inner_mut()
+    }
+
+    #[cfg(feature = "sys")]
+    /// Gets the target
+    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
+    pub fn target(&self) -> &Target {
+        self.0.target()
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(feature = "sys")]
+    /// Register a signature
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn register_signature(&self, func_type: &FunctionType) -> VMSharedSignatureIndex {
+        let compiler = self.0.inner();
+        compiler.signatures().register(func_type)
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(feature = "sys")]
+    /// Lookup a signature
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn lookup_signature(&self, sig: VMSharedSignatureIndex) -> Option<FunctionType> {
+        let compiler = self.0.inner();
+        compiler.signatures().lookup(sig)
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(feature = "sys")]
+    /// Validates a WebAssembly module
+    #[cfg(feature = "compiler")]
+    pub fn validate(&self, binary: &[u8]) -> Result<(), CompileError> {
+        self.0.inner().validate(binary)
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(all(feature = "sys", feature = "compiler"))]
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Compile a WebAssembly binary
+    pub fn compile(&self, binary: &[u8]) -> Result<Arc<Artifact>, CompileError> {
+        Ok(Arc::new(Artifact::new(&self.0, binary, self.0.tunables())?))
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(all(feature = "sys", not(feature = "compiler")))]
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Compile a WebAssembly binary
+    pub fn compile(
+        &self,
+        _binary: &[u8],
+        _tunables: &dyn Tunables,
+    ) -> Result<Arc<Artifact>, CompileError> {
+        Err(CompileError::Codegen(
+            "The Engine is operating in headless mode, so it can not compile Modules.".to_string(),
+        ))
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// Deserializes a WebAssembly module
+    ///
+    /// # Safety
+    ///
+    /// The serialized content must represent a serialized WebAssembly module.
+    pub unsafe fn deserialize(&self, bytes: &[u8]) -> Result<Arc<Artifact>, DeserializeError> {
+        Ok(Arc::new(Artifact::deserialize(&self.0, bytes)?))
+    }
+
+    #[deprecated(since = "3.2.0")]
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// Deserializes a WebAssembly module from a path
+    ///
+    /// # Safety
+    ///
+    /// The file's content must represent a serialized WebAssembly module.
+    pub unsafe fn deserialize_from_file(
+        &self,
+        file_ref: &Path,
+    ) -> Result<Arc<Artifact>, DeserializeError> {
+        let mut file = std::fs::File::open(file_ref)?;
+        let mut buffer = Vec::new();
+        // read the whole file
+        file.read_to_end(&mut buffer)?;
+        Ok(Arc::new(Artifact::deserialize(&self.0, buffer.as_slice())?))
+    }
+
+    #[deprecated(since = "3.2.0", note = "Use Engine::deterministic_id()")]
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// A unique identifier for this object.
+    ///
+    /// This exists to allow us to compare two Engines for equality. Otherwise,
+    /// comparing two trait objects unsafely relies on implementation details
+    /// of trait representation.
+    pub fn id(&self) -> &EngineId {
+        self.deterministic_id()
+    }
+
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// Attach a Tunable to this engine
+    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
+    pub fn set_tunables(&mut self, tunables: impl Tunables + Send + Sync + 'static) {
+        self.0.set_tunables(tunables);
+    }
+
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// Get a reference to attached Tunable of this engine
+    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
+    pub fn tunables(&self) -> &dyn Tunables {
+        self.0.tunables()
+    }
+}
 impl AsEngineRef for Engine {
     fn as_engine_ref(&self) -> EngineRef {
         EngineRef { inner: self }

--- a/lib/api/src/store.rs
+++ b/lib/api/src/store.rs
@@ -13,8 +13,6 @@ use wasmer_vm::init_traps;
 pub use wasmer_vm::TrapHandlerFn;
 
 #[cfg(feature = "sys")]
-use crate::sys::NativeEngineExt;
-#[cfg(feature = "sys")]
 pub use wasmer_vm::{StoreHandle, StoreObjects};
 
 #[cfg(feature = "js")]

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -1,6 +1,5 @@
 use super::memory_view::MemoryView;
 use crate::store::{AsStoreMut, AsStoreRef};
-use crate::sys::NativeEngineExt;
 use crate::vm::VMExternMemory;
 use crate::MemoryAccessError;
 use crate::MemoryType;

--- a/lib/api/src/sys/externals/table.rs
+++ b/lib/api/src/sys/externals/table.rs
@@ -1,5 +1,4 @@
 use crate::store::{AsStoreMut, AsStoreRef};
-use crate::sys::NativeEngineExt;
 use crate::TableType;
 use crate::Value;
 use crate::{vm::VMExternTable, ExternRef, Function, RuntimeError};

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -1,5 +1,4 @@
 use crate::engine::AsEngineRef;
-use crate::sys::engine::NativeEngineExt;
 use bytes::Bytes;
 use std::path::Path;
 use std::sync::Arc;

--- a/lib/wasi/src/bin_factory/exec.rs
+++ b/lib/wasi/src/bin_factory/exec.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 use futures::Future;
 use tracing::*;
-#[cfg(feature = "sys")]
-use wasmer::NativeEngineExt;
 use wasmer::{FunctionEnvMut, Instance, Memory, Module, Store};
 use wasmer_wasix_types::wasi::Errno;
 

--- a/lib/wasi/src/state/env.rs
+++ b/lib/wasi/src/state/env.rs
@@ -5,8 +5,6 @@ use rand::Rng;
 use tracing::{trace, warn};
 use virtual_fs::{FsError, VirtualFile};
 use virtual_net::DynVirtualNetworking;
-#[cfg(feature = "sys")]
-use wasmer::NativeEngineExt;
 use wasmer::{
     AsStoreMut, AsStoreRef, FunctionEnvMut, Global, Instance, Memory, MemoryView, Module,
     TypedFunction,


### PR DESCRIPTION
Added back all removed function for Engine to avoid API breaking changes

Compared with 3.1.1 API, adding back the missing function.

Note that all function from `NativeEngineExt` are now shadowed by this.  So those function are not marked as deprecated to avoid the use of `NativeEngineExt::tunables(...)` for example.
Needed to removed the use of `NativeEngineExt` from many crates to satisfy clipper as a consequence.
