### PR TITLE
Allow publishing packages without a module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,12 +1344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,26 +3062,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3097,23 +3078,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3163,15 +3129,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3253,15 +3210,6 @@ dependencies = [
  "bitflags",
  "libc",
  "mach",
- "winapi",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
  "winapi",
 ]
 
@@ -4071,16 +4019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4775,7 +4713,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typetag",
- "webc 5.0.0-rc.6",
+ "webc",
 ]
 
 [[package]]
@@ -4937,45 +4875,29 @@ dependencies = [
 
 [[package]]
 name = "wapm-targz-to-pirita"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39980ef50ab15c47dbd9b26678f06ece2341178d82e25e21e4ac68310d1f2e63"
+checksum = "1f2daf9fc40607c4a14a89220afe36e62dbb111627cb428b764d322e7c9d4493"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.0",
  "flate2",
+ "indexmap",
  "json5",
  "nuke-dir",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_cbor",
- "serde_derive",
  "serde_json",
  "sha2",
  "tar",
  "toml",
  "tracing",
+ "url",
  "validator",
- "wapm-toml 0.4.0",
- "wasmer-registry 3.1.1",
- "webc 4.1.1",
-]
-
-[[package]]
-name = "wapm-toml"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61b6d3b6a2fc171198e6378b3a9b38650e114298775a9e63401613abb6a10b3"
-dependencies = [
- "anyhow",
- "semver 1.0.17",
- "serde",
- "serde_cbor",
- "serde_derive",
- "serde_json",
- "serde_yaml 0.8.26",
- "thiserror",
- "toml",
+ "wapm-toml",
+ "wasmer-registry 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webc",
 ]
 
 [[package]]
@@ -5288,7 +5210,7 @@ dependencies = [
  "wasmer-middlewares",
  "wasmer-types",
  "wasmer-wasix",
- "webc 5.0.0-rc.6",
+ "webc",
 ]
 
 [[package]]
@@ -5308,7 +5230,7 @@ dependencies = [
  "blake3",
  "criterion",
  "hex",
- "rand 0.8.5",
+ "rand",
  "tempfile",
  "thiserror",
  "wasmer",
@@ -5394,8 +5316,7 @@ dependencies = [
  "wasmer-wasm-interface",
  "wasmer-wast",
  "wasmparser 0.51.4",
- "webc 4.1.1",
- "webc 5.0.0-rc.6",
+ "webc",
 ]
 
 [[package]]
@@ -5574,7 +5495,7 @@ dependencies = [
  "object 0.30.3",
  "predicates 2.1.5",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "tar",
@@ -5607,39 +5528,6 @@ dependencies = [
 
 [[package]]
 name = "wasmer-registry"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982286807bf43d2522a9f6139f9c2570df45d5a32148460226ccbc7edfb3ee13"
-dependencies = [
- "anyhow",
- "dirs",
- "filetime",
- "flate2",
- "fs_extra",
- "futures-util",
- "graphql_client",
- "hex",
- "log",
- "lzma-rs",
- "regex",
- "reqwest",
- "semver 1.0.17",
- "serde",
- "serde_json",
- "tar",
- "tempdir",
- "thiserror",
- "tldextract",
- "tokio",
- "toml",
- "url",
- "wapm-toml 0.2.2",
- "webc 3.0.1",
- "whoami",
-]
-
-[[package]]
-name = "wasmer-registry"
 version = "4.1.0"
 dependencies = [
  "anyhow",
@@ -5655,7 +5543,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lzma-rs",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "semver 1.0.17",
@@ -5669,7 +5557,43 @@ dependencies = [
  "toml",
  "url",
  "wasmer-toml",
- "webc 5.0.0-rc.6",
+ "webc",
+ "whoami",
+]
+
+[[package]]
+name = "wasmer-registry"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cdae8472f28a3bd4f15f7a838278db9262e9cdb5d38684e9a9a2765c0c29da"
+dependencies = [
+ "anyhow",
+ "console",
+ "dirs",
+ "filetime",
+ "flate2",
+ "fs_extra",
+ "futures-util",
+ "graphql_client",
+ "hex",
+ "indicatif",
+ "lazy_static",
+ "log",
+ "lzma-rs",
+ "regex",
+ "reqwest",
+ "semver 1.0.17",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tldextract",
+ "tokio",
+ "toml",
+ "url",
+ "wasmer-toml",
+ "webc",
  "whoami",
 ]
 
@@ -5768,7 +5692,7 @@ dependencies = [
  "linked_hash_set",
  "once_cell",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_cbor",
@@ -5803,7 +5727,7 @@ dependencies = [
  "wasmer-wasix-types",
  "wcgi",
  "wcgi-host",
- "webc 5.0.0-rc.6",
+ "webc",
  "weezl",
  "winapi",
 ]
@@ -6099,52 +6023,6 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef87e7b955d5d1feaa8697ae129f1a9ce8859e151574ad3baceae9413b48d2f0"
-dependencies = [
- "anyhow",
- "base64 0.13.1",
- "indexmap",
- "leb128",
- "lexical-sort",
- "memchr",
- "memmap2",
- "path-clean",
- "rand 0.8.5",
- "serde",
- "serde_cbor",
- "serde_json",
- "sha2",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "webc"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af0f2f0b6bf2e4366375c3cd6635aef1a2eb66cd02454d79525aa7eecf0751"
-dependencies = [
- "anyhow",
- "base64 0.13.1",
- "byteorder",
- "indexmap",
- "leb128",
- "lexical-sort",
- "memchr",
- "path-clean",
- "rand 0.8.5",
- "serde",
- "serde_cbor",
- "serde_json",
- "sha2",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "webc"
 version = "5.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa158c77bd41040f4b9a4b91be63446885ce9b04bc9a5bb457fa586e7a8c9815"
@@ -6159,7 +6037,7 @@ dependencies = [
  "memmap2",
  "once_cell",
  "path-clean",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4775,7 +4775,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typetag",
- "webc 5.0.0-rc.5",
+ "webc 5.0.0-rc.6",
 ]
 
 [[package]]
@@ -5288,7 +5288,7 @@ dependencies = [
  "wasmer-middlewares",
  "wasmer-types",
  "wasmer-wasix",
- "webc 5.0.0-rc.5",
+ "webc 5.0.0-rc.6",
 ]
 
 [[package]]
@@ -5395,7 +5395,7 @@ dependencies = [
  "wasmer-wast",
  "wasmparser 0.51.4",
  "webc 4.1.1",
- "webc 5.0.0-rc.5",
+ "webc 5.0.0-rc.6",
 ]
 
 [[package]]
@@ -5669,7 +5669,7 @@ dependencies = [
  "toml",
  "url",
  "wasmer-toml",
- "webc 5.0.0-rc.5",
+ "webc 5.0.0-rc.6",
  "whoami",
 ]
 
@@ -5803,7 +5803,7 @@ dependencies = [
  "wasmer-wasix-types",
  "wcgi",
  "wcgi-host",
- "webc 5.0.0-rc.5",
+ "webc 5.0.0-rc.6",
  "weezl",
  "winapi",
 ]
@@ -6145,9 +6145,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.0.0-rc.5"
+version = "5.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418bfd8fc298ce60295203a6960d53af48c8e10c5a021a5e7db8bc06c4830148"
+checksum = "aa158c77bd41040f4b9a4b91be63446885ce9b04bc9a5bb457fa586e7a8c9815"
 dependencies = [
  "anyhow",
  "base64 0.21.0",

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -32,7 +32,7 @@ wasmer-middlewares = { version = "=3.2.0-beta.1", path = "../middlewares", optio
 wasmer-wasix = { version = "0.1.0", path = "../wasi", features = ["host-fs", "host-vnet"], optional = true }
 wasmer-types = { version = "=3.2.0-beta.1", path = "../types" }
 virtual-fs = { version = "0.1.0", path = "../vfs", optional = true, default-features = false, features = ["static-fs"] }
-webc = { version = "5.0.0-rc.5", optional = true }
+webc = { version = "5.0.0-rc.6", optional = true }
 enumset = "1.0.2"
 cfg-if = "1.0"
 lazy_static = "1.4"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -66,7 +66,7 @@ regex = "1.6.0"
 toml = "0.5.9"
 url = "2.3.1"
 libc = { version = "^0.2", default-features = false }
-webc = { version = "5.0.0-rc.5" }
+webc = { version = "5.0.0-rc.6" }
 # HACK(Michael-F-Bryan): Remove this once a new version of wapm-targz-to-pirita
 # is published that doesn't have a public dependency on webc
 webc_v4 = { version = "4", package = "webc" }

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -67,9 +67,6 @@ toml = "0.5.9"
 url = "2.3.1"
 libc = { version = "^0.2", default-features = false }
 webc = { version = "5.0.0-rc.6" }
-# HACK(Michael-F-Bryan): Remove this once a new version of wapm-targz-to-pirita
-# is published that doesn't have a public dependency on webc
-webc_v4 = { version = "4", package = "webc" }
 isatty = "0.1.9"
 dialoguer = "0.10.2"
 tldextract = "0.6.0"
@@ -91,7 +88,7 @@ wasm-coredump-builder = { version = "0.1.11" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ] }
 clap-verbosity-flag = "1"
-wapm-targz-to-pirita = "0.1.7"
+wapm-targz-to-pirita = "0.2.0"
 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies]
 http_req  = { version="^0.8", default-features = false, features = ["rust-tls"] }

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -303,7 +303,7 @@ fn compile_directory_to_webc(dir: &Path) -> Result<Vec<u8>, Error> {
     }
 
     let functions = wapm_targz_to_pirita::TransformManifestFunctions::default();
-    wapm_targz_to_pirita::generate_webc_file(files, &dir.to_path_buf(), None, &functions)
+    wapm_targz_to_pirita::generate_webc_file(files, dir, None, &functions)
 }
 
 fn load_files_from_disk(files: &mut FileMap, dir: &Path, base: &Path) -> Result<(), Error> {

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -26,8 +26,7 @@ use wasmer_cache::Cache;
 use wasmer_compiler::ArtifactBuild;
 use wasmer_registry::Package;
 use wasmer_wasix::runners::{MappedDirectory, Runner, WapmContainer};
-use webc::metadata::Manifest;
-use webc_v4::DirOrFile;
+use webc::{metadata::Manifest, v1::DirOrFile};
 
 use crate::{
     store::StoreOptions,
@@ -291,7 +290,7 @@ fn compile_directory_to_webc(dir: &Path) -> Result<Vec<u8>, Error> {
     let mut files = BTreeMap::new();
     load_files_from_disk(&mut files, dir, dir)?;
 
-    let wasmer_toml = webc_v4::DirOrFile::File("wasmer.toml".into());
+    let wasmer_toml = DirOrFile::File("wasmer.toml".into());
     if let Some(toml_data) = files.remove(&wasmer_toml) {
         // HACK(Michael-F-Bryan): The version of wapm-targz-to-pirita we are
         // using doesn't know we renamed "wapm.toml" to "wasmer.toml", so we
@@ -317,11 +316,11 @@ fn load_files_from_disk(files: &mut FileMap, dir: &Path, base: &Path) -> Result<
 
         if path.is_dir() {
             load_files_from_disk(files, &path, base)?;
-            files.insert(webc_v4::DirOrFile::Dir(relative_path), Vec::new());
+            files.insert(DirOrFile::Dir(relative_path), Vec::new());
         } else if path.is_file() {
             let data = std::fs::read(&path)
                 .with_context(|| format!("Unable to read \"{}\"", path.display()))?;
-            files.insert(webc_v4::DirOrFile::File(relative_path), data);
+            files.insert(DirOrFile::File(relative_path), data);
         }
     }
     Ok(())

--- a/lib/registry/Cargo.toml
+++ b/lib/registry/Cargo.toml
@@ -24,7 +24,7 @@ tar = "0.4.38"
 flate2 = "1.0.24"
 semver = "1.0.14"
 lzma-rs = "0.2.0"
-webc = { version = "5.0.0-rc.5", features = ["mmap"] }
+webc = { version = "5.0.0-rc.6", features = ["mmap"] }
 hex = "0.4.3"
 tokio = "1.24.0"
 log = "0.4.17"

--- a/lib/vfs/Cargo.toml
+++ b/lib/vfs/Cargo.toml
@@ -11,7 +11,7 @@ libc = { version = "^0.2", default-features = false, optional = true }
 thiserror = "1"
 tracing = { version = "0.1" }
 typetag = { version = "0.1", optional = true }
-webc = { version = "5.0.0-rc.5", optional = true }
+webc = { version = "5.0.0-rc.6", optional = true }
 slab = { version = "0.4" }
 derivative = "2.2.0"
 anyhow = { version = "1.0.66", optional = true }

--- a/lib/vfs/src/overlay_fs.rs
+++ b/lib/vfs/src/overlay_fs.rs
@@ -734,7 +734,7 @@ mod tests {
 
     fn load_webc(bytes: &'static [u8]) -> WebcFileSystem<WebCOwned> {
         let options = ParseOptions::default();
-        let webc = WebCOwned::parse(bytes.into(), &options).unwrap();
+        let webc = WebCOwned::parse(bytes, &options).unwrap();
         WebcFileSystem::init_all(Arc::new(webc))
     }
 

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -28,7 +28,7 @@ bincode = { version = "1.3" }
 chrono = { version = "^0.4", default-features = false, features = [ "wasmbind", "std", "clock" ], optional = true }
 derivative = { version = "^2" }
 bytes = "1"
-webc = { version = "5.0.0-rc.5", default-features = false }
+webc = { version = "5.0.0-rc.6", default-features = false }
 serde_cbor = { version = "0.11.2", optional = true }
 anyhow = { version = "1.0.66" }
 lazy_static = "1.4"

--- a/lib/wasi/src/runners/container.rs
+++ b/lib/wasi/src/runners/container.rs
@@ -28,7 +28,7 @@ impl WapmContainer {
     pub fn from_bytes(bytes: Bytes) -> std::result::Result<Self, WebcParseError> {
         match webc::detect(bytes.as_ref())? {
             Version::V1 => {
-                let webc = WebCOwned::parse(bytes.into(), &ParseOptions::default())?;
+                let webc = WebCOwned::parse(bytes, &ParseOptions::default())?;
                 Ok(WapmContainer {
                     repr: Repr::V1Owned(Arc::new(webc)),
                 })

--- a/lib/wasi/src/runners/emscripten.rs
+++ b/lib/wasi/src/runners/emscripten.rs
@@ -63,7 +63,7 @@ impl crate::runners::Runner for EmscriptenRunner {
             atom: atom_name,
             main_args,
             ..
-        } = command.get_annotation("emscripten")?.unwrap_or_default();
+        } = command.annotation("emscripten")?.unwrap_or_default();
         let atom_name = atom_name.context("The atom name is required")?;
         let atom_bytes = container
             .get_atom(&atom_name)

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -151,7 +151,7 @@ impl crate::runners::Runner for WasiRunner {
         container: &WapmContainer,
     ) -> Result<Self::Output, Error> {
         let wasi = command
-            .get_annotation("wasi")?
+            .annotation("wasi")?
             .unwrap_or_else(|| Wasi::new(command_name));
         let atom_name = &wasi.atom;
         let atom = container

--- a/lib/wasi/src/runners/wcgi/runner.rs
+++ b/lib/wasi/src/runners/wcgi/runner.rs
@@ -43,7 +43,7 @@ impl WcgiRunner {
     fn run(&mut self, command_name: &str, ctx: &RunnerContext<'_>) -> Result<(), Error> {
         let wasi: Wasi = ctx
             .command()
-            .get_annotation("wasi")
+            .annotation("wasi")
             .context("Unable to retrieve the WASI metadata")?
             .unwrap_or_else(|| Wasi::new(command_name));
 
@@ -128,7 +128,7 @@ impl WcgiRunner {
         wasi: &Wasi,
         ctx: &RunnerContext<'_>,
     ) -> Result<Handler, Error> {
-        let Wcgi { dialect, .. } = ctx.command().get_annotation("wcgi")?.unwrap_or_default();
+        let Wcgi { dialect, .. } = ctx.command().annotation("wcgi")?.unwrap_or_default();
 
         let dialect = match dialect {
             Some(d) => d.parse().context("Unable to parse the CGI dialect")?,


### PR DESCRIPTION
Removes the check that requires a module to be specified when publishing
a package.

Removed because modules should not be mandatory - packages with just a
file system, or with a command that uses the module of a dependency are
perfectly valid.

