### PR TITLE
Fix annotation deserializing for the Wasi and Wcgi runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version 0.4.0",
- "spin 0.9.6",
+ "spin 0.9.7",
  "stable_deref_trait",
 ]
 
@@ -3902,9 +3902,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
+checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
 dependencies = [
  "lock_api",
 ]

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -144,6 +144,7 @@ impl crate::runners::Runner for WasiRunner {
             .starts_with(webc::metadata::annotations::WASI_RUNNER_URI))
     }
 
+    #[tracing::instrument(skip(self, command, container))]
     fn run_command(
         &mut self,
         command_name: &str,

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -150,9 +150,10 @@ impl crate::runners::Runner for WasiRunner {
         command: &Command,
         container: &WapmContainer,
     ) -> Result<Self::Output, Error> {
-        let wasi = command
-            .get_annotation("wasi")?
-            .unwrap_or_else(|| Wasi::new(command_name));
+        let Annotations { wasi } = command
+            .get_annotation(webc::metadata::annotations::WASI_RUNNER_URI)?
+            .unwrap_or_default();
+        let wasi = wasi.unwrap_or_else(|| Wasi::new(command_name));
         let atom_name = &wasi.atom;
         let atom = container
             .get_atom(atom_name)
@@ -166,4 +167,9 @@ impl crate::runners::Runner for WasiRunner {
 
         Ok(())
     }
+}
+
+#[derive(Default, Debug, serde::Deserialize)]
+struct Annotations {
+    wasi: Option<Wasi>,
 }

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -59,7 +59,10 @@ impl Handler {
 
         let module = self.module.clone();
 
-        tracing::debug!("Calling into the WCGI executable");
+        tracing::debug!(
+            dialect=%self.dialect,
+            "Calling into the WCGI executable",
+        );
 
         let done = self
             .task_manager

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -40,6 +40,11 @@ impl Handler {
         tracing::debug!("Creating the WebAssembly instance");
 
         let mut request_specific_env = HashMap::new();
+
+        if self.dialect == CgiDialect::Rfc3875 {
+            // HACK(Michael-F-Bryan): this belongs in the wcgi-host crate
+            request_specific_env.insert("SCRIPT_NAME".to_string(), parts.uri.to_string());
+        }
         self.dialect
             .prepare_environment_variables(parts, &mut request_specific_env);
 

--- a/lib/wasi/src/runners/wcgi/runner.rs
+++ b/lib/wasi/src/runners/wcgi/runner.rs
@@ -41,17 +41,20 @@ impl WcgiRunner {
 
     #[tracing::instrument(skip(self, ctx))]
     fn run(&mut self, command_name: &str, ctx: &RunnerContext<'_>) -> Result<(), Error> {
-        let wasi: Wasi = ctx
+        let key = webc::metadata::annotations::WCGI_RUNNER_URI;
+        let Annotations { wasi, wcgi } = ctx
             .command()
-            .get_annotation("wasi")
-            .context("Unable to retrieve the WASI metadata")?
-            .unwrap_or_else(|| Wasi::new(command_name));
+            .get_annotation(key)
+            .with_context(|| format!("Unable to deserialize the \"{key}\" annotations"))?
+            .unwrap_or_default();
+
+        let wasi = wasi.unwrap_or_else(|| Wasi::new(command_name));
 
         let module = self
             .load_module(&wasi, ctx)
             .context("Couldn't load the module")?;
 
-        let handler = self.create_handler(module, &wasi, ctx)?;
+        let handler = self.create_handler(module, &wasi, &wcgi, ctx)?;
         let task_manager = Arc::clone(&handler.task_manager);
         let callbacks = Arc::clone(&self.config.callbacks);
 
@@ -126,11 +129,10 @@ impl WcgiRunner {
         &self,
         module: Module,
         wasi: &Wasi,
+        wcgi: &Wcgi,
         ctx: &RunnerContext<'_>,
     ) -> Result<Handler, Error> {
-        let Wcgi { dialect, .. } = ctx.command().get_annotation("wcgi")?.unwrap_or_default();
-
-        let dialect = match dialect {
+        let dialect = match &wcgi.dialect {
             Some(d) => d.parse().context("Unable to parse the CGI dialect")?,
             None => CgiDialect::Wcgi,
         };
@@ -341,6 +343,13 @@ impl Default for Config {
             store: None,
         }
     }
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct Annotations {
+    wasi: Option<Wasi>,
+    #[serde(default)]
+    wcgi: Wcgi,
 }
 
 /// Callbacks that are triggered at various points in the lifecycle of a runner


### PR DESCRIPTION
Here are a couple small fixes I added while making the [`wcgi-rust-template`](https://github.com/wasmerio/wcgi-rust-template) and [`wcgi-php-template`](https://github.com/wasmerio/wcgi-php-template) work.

The key difference is that `wapm2pirita` will nest all annotations in your `wasmer.toml` file under an extra level ([here](https://github.com/wasmerio/pirita/blob/03f0f159e244d9e2a6197c7ebd81e46463e236cc/crates/wapm-targz-to-pirita/src/transform.rs#L240-L251)). 

That means, instead of a `webc::metadata::CommandV2` looking like this

```json
{
  "runner": "https://webc.org/runner/wcgi",
  "annotations": {
    "wcgi": {
      "dialect": "rfc-3875"
    }
  }
}
```

and being able to call `command.get_annotations::<Wasi>("wasi")`, the annotations actually look like this:

```json
{
  "runner": "https://webc.org/runner/wcgi",
  "annotations": {
    "https://webc.org/runner/wcgi": {
      "wcgi": {
        "dialect": "rfc-3875"
      }
    }
  }
}
```

... and you need to create a temporary struct with the correct annotation types (e.g. `webc::metadata::annotations::Wasi` and `webc::metadata::annotations::Wcgi` in the WCGI case) so you can do `let MyAnnotations { wcgi, wasi } = command.get_annotations(webc::metadata::annotations::WCGI_BASE_URI)`.