### PR TITLE
Apply CGI environment variables in the correct order

### DIFF
--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -29,7 +29,6 @@ use wasmer_wasix::runners::{MappedDirectory, Runner, WapmContainer};
 use webc::metadata::Manifest;
 use webc_v4::DirOrFile;
 
-use crate::logging;
 use crate::{
     store::StoreOptions,
     wasmer_home::{DownloadCached, ModuleCache, WasmerHome},
@@ -59,9 +58,6 @@ pub struct RunUnstable {
     input: PackageSource,
     /// Command-line arguments passed to the package
     args: Vec<String>,
-    /// Enable debug output
-    #[clap(long = "debug", short = 'd')]
-    pub(crate) debug: bool,
 }
 
 impl RunUnstable {
@@ -80,11 +76,6 @@ impl RunUnstable {
             ExecutableTarget::WebAssembly(wasm) => self.execute_wasm(&target, &wasm, &mut store),
             ExecutableTarget::Webc(container) => self.execute_webc(&target, &container, &mut store),
         };
-
-        if self.debug {
-            let level = log::LevelFilter::Debug;
-            logging::set_up_logging(level);
-        }
 
         if let Err(e) = &result {
             if let Some(coredump) = &self.coredump_on_trap {
@@ -614,11 +605,6 @@ impl Default for Callbacks {
 }
 
 impl wasmer_wasix::runners::wcgi::Callbacks for Callbacks {
-    /// A callback that is called whenever the server starts.
-    fn started(&self, config: &wasmer_wasix::runners::wcgi::Config, _abort: wasmer_wasix::runners::wcgi::AbortHandle) {
-        println!("WCGI Server running at http://{}/", config.addr);
-    }
-
     fn on_stderr(&self, raw_message: &[u8]) {
         if let Ok(mut stderr) = self.stderr.lock() {
             // If the WCGI runner printed any log messages we want to make sure

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -25,7 +25,7 @@ use wasmer::{
 use wasmer_cache::Cache;
 use wasmer_compiler::ArtifactBuild;
 use wasmer_registry::Package;
-use wasmer_wasix::runners::{MappedDirectory, Runner, WapmContainer};
+use wasmer_wasix::runners::{wcgi::AbortHandle, MappedDirectory, Runner, WapmContainer};
 use webc::metadata::Manifest;
 use webc_v4::DirOrFile;
 
@@ -158,7 +158,7 @@ impl RunUnstable {
             .addr(self.wcgi.addr)
             .envs(self.wasi.env_vars.clone())
             .map_directories(self.wasi.mapped_dirs.clone())
-            .callbacks(Callbacks::default());
+            .callbacks(Callbacks::new(self.wcgi.addr));
         if self.wasi.forward_host_env {
             runner.config().forward_host_env();
         }
@@ -594,17 +594,23 @@ impl Default for WcgiOptions {
 #[derive(Debug)]
 struct Callbacks {
     stderr: Mutex<LineWriter<std::io::Stderr>>,
+    addr: SocketAddr,
 }
 
-impl Default for Callbacks {
-    fn default() -> Self {
-        Self {
+impl Callbacks {
+    fn new(addr: SocketAddr) -> Self {
+        Callbacks {
             stderr: Mutex::new(LineWriter::new(std::io::stderr())),
+            addr,
         }
     }
 }
 
 impl wasmer_wasix::runners::wcgi::Callbacks for Callbacks {
+    fn started(&self, _abort: AbortHandle) {
+        println!("WCGI Server running at http://{}/", self.addr);
+    }
+
     fn on_stderr(&self, raw_message: &[u8]) {
         if let Ok(mut stderr) = self.stderr.lock() {
             // If the WCGI runner printed any log messages we want to make sure

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -29,6 +29,7 @@ use wasmer_wasix::runners::{MappedDirectory, Runner, WapmContainer};
 use webc::metadata::Manifest;
 use webc_v4::DirOrFile;
 
+use crate::logging;
 use crate::{
     store::StoreOptions,
     wasmer_home::{DownloadCached, ModuleCache, WasmerHome},
@@ -58,6 +59,9 @@ pub struct RunUnstable {
     input: PackageSource,
     /// Command-line arguments passed to the package
     args: Vec<String>,
+    /// Enable debug output
+    #[clap(long = "debug", short = 'd')]
+    pub(crate) debug: bool,
 }
 
 impl RunUnstable {
@@ -76,6 +80,11 @@ impl RunUnstable {
             ExecutableTarget::WebAssembly(wasm) => self.execute_wasm(&target, &wasm, &mut store),
             ExecutableTarget::Webc(container) => self.execute_webc(&target, &container, &mut store),
         };
+
+        if self.debug {
+            let level = log::LevelFilter::Debug;
+            logging::set_up_logging(level);
+        }
 
         if let Err(e) = &result {
             if let Some(coredump) = &self.coredump_on_trap {
@@ -605,6 +614,11 @@ impl Default for Callbacks {
 }
 
 impl wasmer_wasix::runners::wcgi::Callbacks for Callbacks {
+    /// A callback that is called whenever the server starts.
+    fn started(&self, config: &wasmer_wasix::runners::wcgi::Config, _abort: wasmer_wasix::runners::wcgi::AbortHandle) {
+        println!("WCGI Server running at http://{}/", config.addr);
+    }
+
     fn on_stderr(&self, raw_message: &[u8]) {
         if let Ok(mut stderr) = self.stderr.lock() {
             // If the WCGI runner printed any log messages we want to make sure

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -122,9 +122,9 @@ impl WasiRunner {
         program_name: &str,
         wasi: &Wasi,
     ) -> Result<WasiEnvBuilder, anyhow::Error> {
-        let mut builder =
-            self.wasi
-                .prepare_webc_env(container.container_fs(), program_name, wasi)?;
+        let mut builder = WasiEnvBuilder::new(program_name);
+        self.wasi
+            .prepare_webc_env(&mut builder, container.container_fs(), wasi)?;
 
         if let Some(tasks) = &self.tasks {
             let rt = PluggableRuntime::new(Arc::clone(tasks));

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -41,10 +41,6 @@ impl Handler {
 
         let mut request_specific_env = HashMap::new();
 
-        if self.dialect == CgiDialect::Rfc3875 {
-            // HACK(Michael-F-Bryan): this belongs in the wcgi-host crate
-            request_specific_env.insert("SCRIPT_NAME".to_string(), parts.uri.to_string());
-        }
         self.dialect
             .prepare_environment_variables(parts, &mut request_specific_env);
 

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -39,15 +39,21 @@ impl Handler {
 
         tracing::debug!("Creating the WebAssembly instance");
 
-        let mut request_specific_env = HashMap::new();
+        let mut builder = WasiEnvBuilder::new(&self.program_name);
 
+        // Note: We want to apply the CGI environment variables *before*
+        // anything specified by WASI annotations so users get a chance to
+        // override things like $DOCUMENT_ROOT and $SCRIPT_FILENAME.
+        let mut request_specific_env = HashMap::new();
         self.dialect
             .prepare_environment_variables(parts, &mut request_specific_env);
+        builder.add_envs(request_specific_env);
+
+        (self.setup_builder)(&mut builder)?;
 
         let rt = PluggableRuntime::new(Arc::clone(&self.task_manager));
 
-        let builder = (self.setup_builder)()?
-            .envs(request_specific_env)
+        let builder = builder
             .stdin(Box::new(req_body_receiver))
             .stdout(Box::new(res_body_sender))
             .stderr(Box::new(stderr_sender))
@@ -201,13 +207,16 @@ async fn consume_stderr(
     }
 }
 
+type SetupBuilder = Box<dyn Fn(&mut WasiEnvBuilder) -> Result<(), anyhow::Error> + Send + Sync>;
+
 #[derive(derivative::Derivative)]
 #[derivative(Debug)]
 pub(crate) struct SharedState {
     pub(crate) module: Module,
     pub(crate) dialect: CgiDialect,
+    pub(crate) program_name: String,
     #[derivative(Debug = "ignore")]
-    pub(crate) setup_builder: Box<dyn Fn() -> Result<WasiEnvBuilder, anyhow::Error> + Send + Sync>,
+    pub(crate) setup_builder: SetupBuilder,
     #[derivative(Debug = "ignore")]
     pub(crate) callbacks: Arc<dyn Callbacks>,
     #[derivative(Debug = "ignore")]

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -41,15 +41,15 @@ impl Handler {
 
         let mut builder = WasiEnvBuilder::new(&self.program_name);
 
-        // Note: We want to apply the CGI environment variables *before*
+        (self.setup_builder)(&mut builder)?;
+
+        // Note: We want to apply the CGI environment variables *after*
         // anything specified by WASI annotations so users get a chance to
         // override things like $DOCUMENT_ROOT and $SCRIPT_FILENAME.
         let mut request_specific_env = HashMap::new();
         self.dialect
             .prepare_environment_variables(parts, &mut request_specific_env);
         builder.add_envs(request_specific_env);
-
-        (self.setup_builder)(&mut builder)?;
 
         let rt = PluggableRuntime::new(Arc::clone(&self.task_manager));
 

--- a/lib/wasi/src/runners/wcgi/mod.rs
+++ b/lib/wasi/src/runners/wcgi/mod.rs
@@ -2,3 +2,4 @@ mod handler;
 mod runner;
 
 pub use self::runner::{Callbacks, Config, WcgiRunner};
+pub use futures::future::AbortHandle;

--- a/lib/wasi/src/runners/wcgi/mod.rs
+++ b/lib/wasi/src/runners/wcgi/mod.rs
@@ -1,4 +1,4 @@
 mod handler;
 mod runner;
 
-pub use self::runner::{Callbacks, Config, WcgiRunner};
+pub use self::runner::{Callbacks, Config, WcgiRunner, AbortHandle};

--- a/lib/wasi/src/runners/wcgi/mod.rs
+++ b/lib/wasi/src/runners/wcgi/mod.rs
@@ -1,4 +1,4 @@
 mod handler;
 mod runner;
 
-pub use self::runner::{Callbacks, Config, WcgiRunner, AbortHandle};
+pub use self::runner::{Callbacks, Config, WcgiRunner};

--- a/lib/wasi/src/runners/wcgi/runner.rs
+++ b/lib/wasi/src/runners/wcgi/runner.rs
@@ -1,7 +1,7 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{Context, Error};
-pub use futures::future::AbortHandle;
+use futures::future::AbortHandle;
 use http::{Request, Response};
 use hyper::Body;
 use tower::{make::Shared, ServiceBuilder};
@@ -86,7 +86,7 @@ impl WcgiRunner {
                 let (shutdown, abort_handle) =
                     futures::future::abortable(futures::future::pending::<()>());
 
-                callbacks.started(&self.config, abort_handle);
+                callbacks.started(abort_handle);
 
                 hyper::Server::bind(&address)
                     .serve(Shared::new(service))
@@ -249,7 +249,7 @@ impl crate::runners::Runner for WcgiRunner {
 pub struct Config {
     task_manager: Option<Arc<dyn VirtualTaskManager>>,
     wasi: CommonWasiOptions,
-    pub addr: SocketAddr,
+    addr: SocketAddr,
     #[derivative(Debug = "ignore")]
     callbacks: Arc<dyn Callbacks>,
     store: Option<Arc<Store>>,
@@ -356,7 +356,7 @@ struct Annotations {
 /// and any WebAssembly instances it may start.
 pub trait Callbacks: Send + Sync + 'static {
     /// A callback that is called whenever the server starts.
-    fn started(&self, _config: &Config, _abort: AbortHandle) {}
+    fn started(&self, _abort: AbortHandle) {}
 
     /// Data was written to stderr by an instance.
     fn on_stderr(&self, _stderr: &[u8]) {}


### PR DESCRIPTION
This PR does the following:
* [x] Allows receiving a `--debug`/`-d` flag to the run-unstable subcommand
* [x] Removes the `SCRIPT_NAME` hack (it should be done by the package annotation)
* [x] Prints the server where things are running (I got so lost before that I had no idea in which port it was running)