### PR TITLE
Fixes a bug which causes libc to thrash the futex_wake_all

### DIFF
--- a/lib/wasi/src/syscalls/wasix/futex_wake.rs
+++ b/lib/wasi/src/syscalls/wasix/futex_wake.rs
@@ -33,7 +33,7 @@ pub fn futex_wake<M: MemorySize>(
             }
             true
         } else {
-            false
+            true
         }
     };
     Span::current().record("woken", woken);

--- a/lib/wasi/src/syscalls/wasix/futex_wake_all.rs
+++ b/lib/wasi/src/syscalls/wasix/futex_wake_all.rs
@@ -26,7 +26,7 @@ pub fn futex_wake_all<M: MemorySize>(
             futex.wakers.into_iter().for_each(|w| w.wake());
             true
         } else {
-            false
+            true
         }
     };
     Span::current().record("woken", woken);


### PR DESCRIPTION
The `futex_wake_all` and `futex_wake` were returning false instead of true when it successfully woke a thread in the situation where no one was actually waiting hence it was causing massive CPU spinning as libc retried. This fixes that issue and gives around 70% performance boost on measured http-server TPS .

Also the latency numbers are considerable improved

before:
```
john@AlienWorld:/prog/deploy$ wrk -t 10 -c 600 -d 60 http://localhost:9080/
Running 1m test @ http://localhost:9080/
  10 threads and 600 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    72.08ms   23.35ms 729.31ms   72.36%
    Req/Sec   812.77    239.14     1.79k    70.61%
  484912 requests in 1.00m, 708.50MB read
Requests/sec:   8067.75
Transfer/sec:     11.79MB
```

after:
```
john@AlienWorld:/prog/deploy$ wrk -t 10 -c 600 -d 60 http://localhost:9080/
Running 1m test @ http://localhost:9080/
  10 threads and 600 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    41.96ms    2.77ms  65.10ms   77.75%
    Req/Sec     1.44k    80.92     2.33k    71.36%
  858391 requests in 1.00m, 1.22GB read
Requests/sec:  14286.52
Transfer/sec:     20.87MB
```