### PR TITLE
Added a supported stuff flags list thats detected when initializing a module

### DIFF
--- a/lib/wasi/src/capabilities.rs
+++ b/lib/wasi/src/capabilities.rs
@@ -1,6 +1,6 @@
 use crate::http::HttpClientCapabilityV1;
 
-/// Defines capabilities for a Wasi environment.
+/// Defines sandbox capabilities for a Wasi environment.
 #[derive(Clone, Debug)]
 pub struct Capabilities {
     pub insecure_allow_all: bool,

--- a/lib/wasi/src/state/func_env.rs
+++ b/lib/wasi/src/state/func_env.rs
@@ -74,10 +74,6 @@ impl WasiFunctionEnv {
             trace!("module::import - {}::{}", ns.module(), ns.name());
         }
 
-        let is_wasix_module = crate::utils::is_wasix_module(instance.module());
-
-        // First we get the malloc function which if it exists will be used to
-        // create the pthread_self structure
         let memory = instance.exports.get_memory("memory").map_or_else(
             |e| {
                 if let Some(memory) = memory {
@@ -93,8 +89,6 @@ impl WasiFunctionEnv {
 
         let env = self.data_mut(store);
         env.inner.replace(new_inner);
-
-        env.state.fs.set_is_wasix(is_wasix_module);
 
         // Set the base stack
         let stack_base = if let Some(stack_pointer) = env.inner().stack_pointer.clone() {

--- a/lib/wasi/src/state/mod.rs
+++ b/lib/wasi/src/state/mod.rs
@@ -18,6 +18,7 @@
 mod builder;
 mod env;
 mod func_env;
+mod supported;
 mod types;
 
 use std::{
@@ -40,6 +41,7 @@ pub use self::{
     builder::*,
     env::{WasiEnv, WasiEnvInit, WasiInstanceHandles},
     func_env::WasiFunctionEnv,
+    supported::WasiSupportedStuff,
     types::*,
 };
 pub use crate::fs::{InodeGuard, InodeWeakGuard};

--- a/lib/wasi/src/state/supported.rs
+++ b/lib/wasi/src/state/supported.rs
@@ -1,0 +1,41 @@
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+use wasmer::Module;
+
+/// This structure returns a list of capabilities that the module
+/// is capable of - this is reverse engineered from the imports
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct WasiSupportedStuff {
+    /// The module is compiled against WASIX
+    pub wasix: bool,
+    /// The module supports an externalized current directory
+    pub pwd: bool,
+    /// The module supports asynchronous threading
+    pub asyncify: bool,
+    /// The module supports signaling
+    pub signal: bool,
+    /// The module supports threading
+    pub threading: bool,
+    /// The module uses the `sock_listen()` syscall
+    pub socket_listen: bool,
+    /// The module uses the `sock_accept()` syscall
+    pub socket_accept: bool,
+}
+
+impl WasiSupportedStuff {
+    pub fn new(module: &Module) -> Self {
+        let is_wasix = crate::utils::is_wasix_module(module);
+        Self {
+            wasix: is_wasix,
+            pwd: is_wasix,
+            asyncify: module
+                .exports()
+                .any(|e| e.name() == "asyncify_start_unwind"),
+            signal: module.exports().any(|e| e.name() == "__wasm_signal"),
+            threading: module.exports().any(|e| e.name() == "wasi_thread_start"),
+            socket_listen: module.imports().any(|i| i.name() == "sock_listen"),
+            socket_accept: module.imports().any(|i| i.name() == "sock_accept"),
+        }
+    }
+}

--- a/lib/wasi/src/syscalls/wasi/path_create_directory.rs
+++ b/lib/wasi/src/syscalls/wasi/path_create_directory.rs
@@ -59,6 +59,7 @@ pub fn path_create_directory<M: MemorySize>(
         return Errno::Inval;
     }
 
+    let use_current_dir = env.inner().supported.wasix;
     let mut cur_dir_inode = working_dir.inode;
     for comp in &path_vec {
         let processing_cur_dir_inode = cur_dir_inode.clone();
@@ -94,6 +95,7 @@ pub fn path_create_directory<M: MemorySize>(
                         fd,
                         0,
                         &adjusted_path.to_string_lossy(),
+                        use_current_dir,
                     ) {
                         if adjusted_path_stat.st_filetype != Filetype::Directory {
                             return Errno::Notdir;

--- a/lib/wasi/src/syscalls/wasi/path_filestat_set_times.rs
+++ b/lib/wasi/src/syscalls/wasi/path_filestat_set_times.rs
@@ -53,11 +53,13 @@ pub fn path_filestat_set_times<M: MemorySize>(
         );
     }
 
+    let use_current_dir = env.supported().pwd;
     let file_inode = wasi_try!(state.fs.get_inode_at_path(
         inodes,
         fd,
         &path_string,
         flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
+        use_current_dir
     ));
     let stat = {
         let guard = file_inode.read();

--- a/lib/wasi/src/syscalls/wasi/path_open.rs
+++ b/lib/wasi/src/syscalls/wasi/path_open.rs
@@ -70,18 +70,20 @@ pub fn path_open<M: MemorySize>(
 
     // Convert relative paths into absolute paths
     if path_string.starts_with("./") {
-        path_string = ctx.data().state.fs.relative_path_to_absolute(path_string);
+        path_string = env.state.fs.relative_path_to_absolute(path_string);
         trace!(
             %path_string
         );
     }
 
     let path_arg = std::path::PathBuf::from(&path_string);
+    let use_current_dir = env.supported().pwd;
     let maybe_inode = state.fs.get_inode_at_path(
         inodes,
         dirfd,
         &path_string,
         dirflags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
+        use_current_dir,
     );
 
     let mut open_flags = 0;
@@ -240,7 +242,8 @@ pub fn path_open<M: MemorySize>(
                 inodes,
                 dirfd,
                 &path_arg,
-                dirflags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0
+                dirflags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
+                use_current_dir
             ));
             let new_file_host_path = {
                 let guard = parent_inode.read();

--- a/lib/wasi/src/syscalls/wasi/path_readlink.rs
+++ b/lib/wasi/src/syscalls/wasi/path_readlink.rs
@@ -45,7 +45,11 @@ pub fn path_readlink<M: MemorySize>(
         );
     }
 
-    let inode = wasi_try!(state.fs.get_inode_at_path(inodes, dir_fd, &path_str, false));
+    let use_current_dir = env.supported().pwd;
+    let inode =
+        wasi_try!(state
+            .fs
+            .get_inode_at_path(inodes, dir_fd, &path_str, false, use_current_dir));
 
     {
         let guard = inode.read();

--- a/lib/wasi/src/syscalls/wasi/path_remove_directory.rs
+++ b/lib/wasi/src/syscalls/wasi/path_remove_directory.rs
@@ -25,12 +25,17 @@ pub fn path_remove_directory<M: MemorySize>(
         );
     }
 
-    let inode = wasi_try!(state.fs.get_inode_at_path(inodes, fd, &path_str, false));
+    let use_current_dir = env.supported().pwd;
+    let inode =
+        wasi_try!(state
+            .fs
+            .get_inode_at_path(inodes, fd, &path_str, false, use_current_dir));
     let (parent_inode, childs_name) = wasi_try!(state.fs.get_parent_inode_at_path(
         inodes,
         fd,
         std::path::Path::new(&path_str),
-        false
+        false,
+        use_current_dir
     ));
 
     let host_path_to_remove = {

--- a/lib/wasi/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasi/src/syscalls/wasi/path_rename.rs
@@ -49,25 +49,36 @@ pub fn path_rename<M: MemorySize>(
     }
 
     // this is to be sure the source file is fetch from filesystem if needed
+    let use_current_dir = env.supported().pwd;
     wasi_try!(state.fs.get_inode_at_path(
         inodes,
         old_fd,
         source_path.to_str().as_ref().unwrap(),
-        true
+        true,
+        use_current_dir
     ));
     // Create the destination inode if the file exists.
-    let _ =
-        state
-            .fs
-            .get_inode_at_path(inodes, new_fd, target_path.to_str().as_ref().unwrap(), true);
-    let (source_parent_inode, source_entry_name) =
-        wasi_try!(state
-            .fs
-            .get_parent_inode_at_path(inodes, old_fd, source_path, true));
-    let (target_parent_inode, target_entry_name) =
-        wasi_try!(state
-            .fs
-            .get_parent_inode_at_path(inodes, new_fd, target_path, true));
+    let _ = state.fs.get_inode_at_path(
+        inodes,
+        new_fd,
+        target_path.to_str().as_ref().unwrap(),
+        true,
+        use_current_dir,
+    );
+    let (source_parent_inode, source_entry_name) = wasi_try!(state.fs.get_parent_inode_at_path(
+        inodes,
+        old_fd,
+        source_path,
+        true,
+        use_current_dir
+    ));
+    let (target_parent_inode, target_entry_name) = wasi_try!(state.fs.get_parent_inode_at_path(
+        inodes,
+        new_fd,
+        target_path,
+        true,
+        use_current_dir
+    ));
     let mut need_create = true;
     let host_adjusted_target_path = {
         let guard = target_parent_inode.read();

--- a/lib/wasi/src/syscalls/wasi/path_symlink.rs
+++ b/lib/wasi/src/syscalls/wasi/path_symlink.rs
@@ -38,10 +38,14 @@ pub fn path_symlink<M: MemorySize>(
 
     // get the depth of the parent + 1 (UNDER INVESTIGATION HMMMMMMMM THINK FISH ^ THINK FISH)
     let old_path_path = std::path::Path::new(&old_path_str);
-    let (source_inode, _) =
-        wasi_try!(state
-            .fs
-            .get_parent_inode_at_path(inodes, fd, old_path_path, true));
+    let use_current_dir = env.supported().pwd;
+    let (source_inode, _) = wasi_try!(state.fs.get_parent_inode_at_path(
+        inodes,
+        fd,
+        old_path_path,
+        true,
+        use_current_dir
+    ));
     let depth = state.fs.path_depth_from_fd(fd, source_inode);
 
     // depth == -1 means folder is not relative. See issue #3233.
@@ -51,10 +55,13 @@ pub fn path_symlink<M: MemorySize>(
     };
 
     let new_path_path = std::path::Path::new(&new_path_str);
-    let (target_parent_inode, entry_name) =
-        wasi_try!(state
-            .fs
-            .get_parent_inode_at_path(inodes, fd, new_path_path, true));
+    let (target_parent_inode, entry_name) = wasi_try!(state.fs.get_parent_inode_at_path(
+        inodes,
+        fd,
+        new_path_path,
+        true,
+        use_current_dir
+    ));
 
     // short circuit if anything is wrong, before we create an inode
     {

--- a/lib/wasi/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasi/src/syscalls/wasi/path_unlink_file.rs
@@ -32,12 +32,17 @@ pub fn path_unlink_file<M: MemorySize>(
         path_str = ctx.data().state.fs.relative_path_to_absolute(path_str);
     }
 
-    let inode = wasi_try!(state.fs.get_inode_at_path(inodes, fd, &path_str, false));
+    let use_current_dir = env.supported().pwd;
+    let inode =
+        wasi_try!(state
+            .fs
+            .get_inode_at_path(inodes, fd, &path_str, false, use_current_dir));
     let (parent_inode, childs_name) = wasi_try!(state.fs.get_parent_inode_at_path(
         inodes,
         fd,
         std::path::Path::new(&path_str),
-        false
+        false,
+        use_current_dir
     ));
 
     let removed_inode = {


### PR DESCRIPTION
This pull request clears up some left overs from the WASIX merge and introduces an expanded list of support flags that can be used by runtimes and supporting infrastructure around those runtimes.