### PR TITLE
Fixed Vectored IO when a partial operation occurs

### DIFF
--- a/lib/wasi/src/syscalls/wasix/sock_recv.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_recv.rs
@@ -113,7 +113,7 @@ fn sock_recv_internal<M: MemorySize>(
                     .access()
                     .map_err(mem_error_to_wasi)?;
 
-                total_read += match socket
+                let local_read = match socket
                     .recv(env.tasks().deref(), buf.as_mut_uninit(), fd.flags)
                     .await
                 {
@@ -121,6 +121,10 @@ fn sock_recv_internal<M: MemorySize>(
                     Err(_) if total_read > 0 => break,
                     Err(err) => return Err(err),
                 };
+                total_read += local_read;
+                if local_read != buf.len() {
+                    break;
+                }
             }
             Ok(total_read)
         },

--- a/lib/wasi/src/syscalls/wasix/sock_send.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_send.rs
@@ -43,7 +43,7 @@ pub fn sock_send<M: MemorySize>(
                     .map_err(mem_error_to_wasi)?
                     .access()
                     .map_err(mem_error_to_wasi)?;
-                sent += match socket
+                let local_sent = match socket
                     .send(env.tasks().deref(), buf.as_ref(), fd.flags)
                     .await
                 {
@@ -51,6 +51,10 @@ pub fn sock_send<M: MemorySize>(
                     Err(_) if sent > 0 => break,
                     Err(err) => return Err(err),
                 };
+                sent += local_sent;
+                if local_sent != buf.len() {
+                    break;
+                }
             }
             Ok(sent)
         })

--- a/lib/wasi/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasi/src/syscalls/wasix/sock_send_to.rs
@@ -54,7 +54,7 @@ pub fn sock_send_to<M: MemorySize>(
                         .map_err(mem_error_to_wasi)?
                         .access()
                         .map_err(mem_error_to_wasi)?;
-                    sent += match socket
+                    let local_sent = match socket
                         .send_to::<M>(env.tasks().deref(), buf.as_ref(), addr, fd.flags)
                         .await
                     {
@@ -62,6 +62,10 @@ pub fn sock_send_to<M: MemorySize>(
                         Err(_) if sent > 0 => break,
                         Err(err) => return Err(err),
                     };
+                    sent += local_sent;
+                    if local_sent != buf.len() {
+                        break;
+                    }
                 }
                 Ok(sent)
             },


### PR DESCRIPTION
Fixed Vectored IO when a partial operation occurs (read or write not fully filling the buffer)
help "rx" part of #2904
