### PR TITLE
Fixed FileSystem createdir when parent_inode is an ArcDirectory

### DIFF
--- a/lib/vfs/src/mem_fs/filesystem.rs
+++ b/lib/vfs/src/mem_fs/filesystem.rs
@@ -605,8 +605,8 @@ impl FileSystemInner {
                     Some(Node::Directory(DirectoryNode { .. })) => {
                         Ok(InodeResolution::Found(inode_of_parent))
                     }
-                    Some(Node::ArcDirectory(ArcDirectoryNode { .. })) => {
-                        Ok(InodeResolution::Found(inode_of_parent))
+                    Some(Node::ArcDirectory(ArcDirectoryNode { fs, path, .. })) => {
+                        Ok(InodeResolution::Redirect(fs.clone(), path.clone()))
                     }
                     _ => Err(FsError::BaseNotDirectory),
                 }


### PR DESCRIPTION
Fixed FileSystem createdir when parent_inode is an ArcDirectory

The `inode_of_parent(...)` shoudl return `InodeResolution::Redirect(...)` when parent is an `ArcDirectory`