### PR TITLE
Use cache in runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5921,16 +5921,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.98.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8724c724dc595495979c055f4bd8b7ed9fab1069623178a28016ae43a9666f36"
-dependencies = [
- "indexmap",
- "url",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
@@ -6076,14 +6066,14 @@ dependencies = [
 
 [[package]]
 name = "wcgi-host"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d81f49740e252e51e074deb84b931621b6c94f3a9d23764654d230388663c2"
+checksum = "e52e12306a76b04eb7646fc760c34e3db79b2f6ffad0ab63822aa521bcdfc4dc"
 dependencies = [
  "http",
  "serde",
  "tokio",
- "wasmparser 0.98.1",
+ "wasmparser 0.95.0",
  "wcgi",
 ]
 

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -128,12 +128,15 @@ impl RunUnstable {
             .get(id)
             .with_context(|| format!("Unable to get metadata for the \"{id}\" command"))?;
 
-        // TODO(Michael-F-Bryan): Refactor the wasmer_wasi::runners::Runner
-        // trait So we can check whether a command is supported by a runner
-        // without needing to go through and instantiate each one.
-
         let (store, _compiler_type) = self.store.get_store()?;
-        match command.runner.as_ref() {
+        let runner_base = command
+            .runner
+            .as_str()
+            .split_once('@')
+            .map(|(base, version)| base)
+            .unwrap_or_else(|| command.runner.as_str());
+
+        match runner_base {
             webc::metadata::annotations::EMSCRIPTEN_RUNNER_URI => {
                 let mut runner = wasmer_wasix::runners::emscripten::EmscriptenRunner::new(store);
                 runner.set_args(self.args.clone());

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -168,7 +168,9 @@ impl RunUnstable {
                     return runner.run_cmd(&container, id).context("WCGI runner failed");
                 }
             }
-            webc::metadata::annotations::WASI_RUNNER_URI => {
+            // TODO: Add this on the webc annotation itself
+            "https://webc.org/runner/wasi/command"
+            | webc::metadata::annotations::WASI_RUNNER_URI => {
                 let mut runner = wasmer_wasix::runners::wasi::WasiRunner::new(store)
                     .with_compile(move |engine, bytes| {
                         compile_wasm_cached("".to_string(), bytes, &mut cache, engine)

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -134,7 +134,7 @@ impl RunUnstable {
 
         let (store, _compiler_type) = self.store.get_store()?;
         match command.runner.as_ref() {
-            "emscripten" => {
+            webc::metadata::annotations::EMSCRIPTEN_RUNNER_URI => {
                 let mut runner = wasmer_wasix::runners::emscripten::EmscriptenRunner::new(store);
                 runner.set_args(self.args.clone());
                 if runner.can_run_command(id, command).unwrap_or(false) {
@@ -143,7 +143,7 @@ impl RunUnstable {
                         .context("Emscripten runner failed");
                 }
             }
-            "wcgi" | "https://webc.org/runner/wcgi" => {
+            webc::metadata::annotations::WCGI_RUNNER_URI => {
                 let mut runner = wasmer_wasix::runners::wcgi::WcgiRunner::new(id).with_compile(
                     move |engine, bytes| {
                         compile_wasm_cached("".to_string(), bytes, &mut cache, engine)
@@ -165,7 +165,7 @@ impl RunUnstable {
                     return runner.run_cmd(&container, id).context("WCGI runner failed");
                 }
             }
-            "wasi" | "https://webc.org/runner/wasi" => {
+            webc::metadata::annotations::WASI_RUNNER_URI => {
                 let mut runner = wasmer_wasix::runners::wasi::WasiRunner::new(store)
                     .with_compile(move |engine, bytes| {
                         compile_wasm_cached("".to_string(), bytes, &mut cache, engine)

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -165,7 +165,7 @@ impl RunUnstable {
                     return runner.run_cmd(&container, id).context("WCGI runner failed");
                 }
             }
-            "wasi" | "https://webc.org/runner/wasi" | _ => {
+            "wasi" | "https://webc.org/runner/wasi" => {
                 let mut runner = wasmer_wasix::runners::wasi::WasiRunner::new(store)
                     .with_compile(move |engine, bytes| {
                         compile_wasm_cached("".to_string(), bytes, &mut cache, engine)
@@ -180,6 +180,7 @@ impl RunUnstable {
                     return runner.run_cmd(&container, id).context("WASI runner failed");
                 }
             }
+            _ => {}
         }
 
         anyhow::bail!(

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -58,7 +58,7 @@ pin-project = "1.0.12"
 # Used by the WCGI runner
 hyper = { version = "0.14", features = ["server", "stream"], optional = true }
 wcgi = { version = "0.1.1", optional = true }
-wcgi-host = { version = "0.1.0", optional = true }
+wcgi-host = { version = "0.1.1", optional = true }
 tower-http = { version = "0.4.0", features = ["trace", "util", "catch-panic", "cors"], optional = true }
 tower = { version = "0.4.13", features = ["make", "util"], optional = true }
 

--- a/lib/wasi/src/runners/mod.rs
+++ b/lib/wasi/src/runners/mod.rs
@@ -12,7 +12,7 @@ pub mod wcgi;
 
 pub use self::{
     container::{Bindings, WapmContainer, WebcParseError, WitBindings},
-    runner::Runner,
+    runner::{CompileModule, Runner},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/lib/wasi/src/runners/runner.rs
+++ b/lib/wasi/src/runners/runner.rs
@@ -1,7 +1,10 @@
+use crate::runners::WapmContainer;
 use anyhow::Error;
+use wasmer::{Engine, Module};
 use webc::metadata::Command;
 
-use crate::runners::WapmContainer;
+/// A compile module function
+pub type CompileModule = dyn FnMut(&Engine, &[u8]) -> Result<Module, Error>;
 
 /// Trait that all runners have to implement
 pub trait Runner {

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Error};
 use serde::{Deserialize, Serialize};
-use wasmer::{Module, Store};
+use wasmer::{Engine, Module, Store};
 use webc::metadata::{annotations::Wasi, Command};
 
 use crate::{
@@ -12,13 +12,15 @@ use crate::{
     PluggableRuntime, VirtualTaskManager, WasiEnvBuilder,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct WasiRunner {
     wasi: CommonWasiOptions,
     #[serde(skip, default)]
     store: Store,
     #[serde(skip, default)]
     pub(crate) tasks: Option<Arc<dyn VirtualTaskManager>>,
+    #[serde(skip, default)]
+    compile: Option<Box<dyn FnMut(&Engine, &[u8]) -> Result<Module, Error>>>,
 }
 
 impl WasiRunner {
@@ -28,7 +30,17 @@ impl WasiRunner {
             store,
             wasi: CommonWasiOptions::default(),
             tasks: None,
+            compile: None,
         }
+    }
+
+    /// Sets the compile function
+    pub fn with_compile(
+        mut self,
+        compile: impl FnMut(&Engine, &[u8]) -> Result<Module, Error> + 'static,
+    ) -> Self {
+        self.compile = Some(Box::new(compile));
+        self
     }
 
     /// Returns the current arguments for this `WasiRunner`

--- a/lib/wasi/src/runners/wasi.rs
+++ b/lib/wasi/src/runners/wasi.rs
@@ -8,7 +8,7 @@ use wasmer::{Engine, Module, Store};
 use webc::metadata::{annotations::Wasi, Command};
 
 use crate::{
-    runners::{wasi_common::CommonWasiOptions, MappedDirectory, WapmContainer},
+    runners::{wasi_common::CommonWasiOptions, CompileModule, MappedDirectory, WapmContainer},
     PluggableRuntime, VirtualTaskManager, WasiEnvBuilder,
 };
 
@@ -20,7 +20,7 @@ pub struct WasiRunner {
     #[serde(skip, default)]
     pub(crate) tasks: Option<Arc<dyn VirtualTaskManager>>,
     #[serde(skip, default)]
-    compile: Option<Box<dyn FnMut(&Engine, &[u8]) -> Result<Module, Error>>>,
+    compile: Option<Box<CompileModule>>,
 }
 
 impl WasiRunner {

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -102,22 +102,12 @@ impl Handler {
             .in_current_span(),
         );
 
-        // use std::io::Read;
-        // use tokio::io::AsyncRead;
-        // let mut buffer = Vec::new();
-        // res_body_receiver.read_to_end(&mut buffer)?;
-        // println!("buffer: {:?}", buffer);
-
         let mut res_body_receiver = tokio::io::BufReader::new(res_body_receiver);
 
-        // res_body_receiver.fill_buf().await?;
         let parts = self
             .dialect
             .extract_response_header(&mut res_body_receiver)
             .await?;
-
-        println!("parts: {:?}", parts);
-
         let chunks = futures::stream::try_unfold(res_body_receiver, |mut r| async move {
             match r.fill_buf().await {
                 Ok(chunk) if chunk.is_empty() => Ok(None),

--- a/lib/wasi/src/runners/wcgi/handler.rs
+++ b/lib/wasi/src/runners/wcgi/handler.rs
@@ -102,12 +102,22 @@ impl Handler {
             .in_current_span(),
         );
 
+        // use std::io::Read;
+        // use tokio::io::AsyncRead;
+        // let mut buffer = Vec::new();
+        // res_body_receiver.read_to_end(&mut buffer)?;
+        // println!("buffer: {:?}", buffer);
+
         let mut res_body_receiver = tokio::io::BufReader::new(res_body_receiver);
 
+        // res_body_receiver.fill_buf().await?;
         let parts = self
             .dialect
             .extract_response_header(&mut res_body_receiver)
             .await?;
+
+        println!("parts: {:?}", parts);
+
         let chunks = futures::stream::try_unfold(res_body_receiver, |mut r| async move {
             match r.fill_buf().await {
                 Ok(chunk) if chunk.is_empty() => Ok(None),

--- a/lib/wasi/src/runners/wcgi/runner.rs
+++ b/lib/wasi/src/runners/wcgi/runner.rs
@@ -19,7 +19,7 @@ use crate::{
     runners::{
         wasi_common::CommonWasiOptions,
         wcgi::handler::{Handler, SharedState},
-        MappedDirectory, WapmContainer,
+        CompileModule, MappedDirectory, WapmContainer,
     },
     runtime::task_manager::tokio::TokioTaskManager,
     PluggableRuntime, VirtualTaskManager, WasiEnvBuilder,
@@ -28,7 +28,7 @@ use crate::{
 pub struct WcgiRunner {
     program_name: String,
     config: Config,
-    compile: Option<Box<dyn FnMut(&Engine, &[u8]) -> Result<Module, Error>>>,
+    compile: Option<Box<CompileModule>>,
 }
 
 // TODO(Michael-F-Bryan): When we rewrite the existing runner infrastructure,
@@ -195,7 +195,7 @@ impl WcgiRunner {
 
 // TODO(Michael-F-Bryan): Pass this to Runner::run() as a "&dyn RunnerContext"
 // when we rewrite the "Runner" trait.
-pub struct RunnerContext<'a> {
+struct RunnerContext<'a> {
     container: &'a WapmContainer,
     command: &'a Command,
     engine: Engine,
@@ -204,27 +204,27 @@ pub struct RunnerContext<'a> {
 
 #[allow(dead_code)]
 impl RunnerContext<'_> {
-    pub fn command(&self) -> &Command {
+    fn command(&self) -> &Command {
         self.command
     }
 
-    pub fn manifest(&self) -> &Manifest {
+    fn manifest(&self) -> &Manifest {
         self.container.manifest()
     }
 
-    pub fn engine(&self) -> &Engine {
+    fn engine(&self) -> &Engine {
         &self.engine
     }
 
-    pub fn store(&self) -> &Store {
+    fn store(&self) -> &Store {
         &self.store
     }
 
-    pub fn get_atom(&self, name: &str) -> Option<&[u8]> {
+    fn get_atom(&self, name: &str) -> Option<&[u8]> {
         self.container.get_atom(name)
     }
 
-    pub fn container_fs(&self) -> Arc<dyn FileSystem> {
+    fn container_fs(&self) -> Arc<dyn FileSystem> {
         self.container.container_fs()
     }
 }


### PR DESCRIPTION
Runners were missing cache, which caused loading times to be non-ideal when running containers.

This PR fixes it by adding a new function `with_compiler` to each of the Runners