### PR TITLE
Upgrade to webc v5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "wapm-targz-to-pirita"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2daf9fc40607c4a14a89220afe36e62dbb111627cb428b764d322e7c9d4493"
+checksum = "dac443765a5a1866a73b845afb3261d1ea8138f884603047d56e3e431fe37e34"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -6035,9 +6035,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.0.0-rc.7"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1938d2cbf3fa06c5254c27402403d24d34e1baece8edbdc2ec1ba1ebf7254803"
+checksum = "06bee486f9207604f99bfa3c95afcd03272d95db5872c6c1b11470be4390d514"
 dependencies = [
  "anyhow",
  "base64 0.21.0",

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -31,7 +31,7 @@ wasmer-emscripten = { version = "=3.2.0-beta.2", path = "../emscripten", optiona
 wasmer-middlewares = { version = "=3.2.0-beta.2", path = "../middlewares", optional = true }
 wasmer-types = { version = "=3.2.0-beta.2", path = "../types" }
 wasmer-wasix = { version = "0.2.0", path = "../wasi", features = ["host-fs", "host-vnet"], optional = true }
-webc = { version = "5.0.0-rc.7", optional = true }
+webc = { version = "5.0", optional = true }
 virtual-fs = { version = "0.1.1", path = "../vfs", optional = true, default-features = false, features = ["static-fs"] }
 enumset = "1.0.2"
 cfg-if = "1.0"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -64,7 +64,7 @@ regex = "1.6.0"
 toml = "0.5.9"
 url = "2.3.1"
 libc = { version = "^0.2", default-features = false }
-webc = { version = "5.0.0-rc.7" }
+webc = { version = "5.0" }
 isatty = "0.1.9"
 dialoguer = "0.10.2"
 tldextract = "0.6.0"
@@ -82,7 +82,7 @@ wasm-coredump-builder = { version = "0.1.11" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ] }
 clap-verbosity-flag = "1"
-wapm-targz-to-pirita = "0.2.0"
+wapm-targz-to-pirita = "0.2.1"
 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies]
 http_req  = { version="^0.8", default-features = false, features = ["rust-tls"] }

--- a/lib/registry/Cargo.toml
+++ b/lib/registry/Cargo.toml
@@ -27,7 +27,7 @@ tar = "0.4.38"
 flate2 = "1.0.24"
 semver = "1.0.14"
 lzma-rs = "0.2.0"
-webc = { version = "5.0.0-rc.7", features = ["mmap"] }
+webc = { version = "5.0", features = ["mmap"] }
 hex = "0.4.3"
 tokio = "1.24.0"
 log = "0.4.17"

--- a/lib/vfs/Cargo.toml
+++ b/lib/vfs/Cargo.toml
@@ -11,7 +11,7 @@ libc = { version = "^0.2", default-features = false, optional = true }
 thiserror = "1"
 tracing = { version = "0.1" }
 typetag = { version = "0.1", optional = true }
-webc = { version = "5.0.0-rc.7", optional = true }
+webc = { version = "5.0", optional = true }
 slab = { version = "0.4" }
 derivative = "2.2.0"
 anyhow = { version = "1.0.66", optional = true }

--- a/lib/vfs/src/webc_volume_fs.rs
+++ b/lib/vfs/src/webc_volume_fs.rs
@@ -10,7 +10,7 @@ use std::{
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use webc::{
     compat::{Container, SharedBytes, Volume},
-    v2::{PathSegmentError, PathSegments, ToPathSegments},
+    PathSegmentError, PathSegments, ToPathSegments,
 };
 
 use crate::{

--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.0.0-rc.7"
+version = "5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa158c77bd41040f4b9a4b91be63446885ce9b04bc9a5bb457fa586e7a8c9815"
 dependencies = [

--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -27,7 +27,7 @@ bincode = { version = "1.3" }
 chrono = { version = "^0.4", default-features = false, features = [ "wasmbind", "std", "clock" ], optional = true }
 derivative = { version = "^2" }
 bytes = "1"
-webc = { version = "5.0.0-rc.7", default-features = false }
+webc = { version = "5.0", default-features = false }
 serde_cbor = { version = "0.11.2", optional = true }
 anyhow = { version = "1.0.66" }
 lazy_static = "1.4"


### PR DESCRIPTION
# Description

This upgrades our `webc` dependency from the `5.0.0-rc.7` pre-release to the newly published `5.0.0` version.