### PR TITLE
Wasi runner args

### DIFF
--- a/lib/wasi/src/runners/wasi_common.rs
+++ b/lib/wasi/src/runners/wasi_common.rs
@@ -251,7 +251,6 @@ mod tests {
         );
     }
 
-    /// Fixes <https://github.com/wasmerio/wasmer/issues/3789>
     #[test]
     fn mix_env_vars_from_the_webc_and_user() {
         let args = CommonWasiOptions {

--- a/lib/wasi/src/runners/wasi_common.rs
+++ b/lib/wasi/src/runners/wasi_common.rs
@@ -25,8 +25,6 @@ impl CommonWasiOptions {
         container_fs: Arc<dyn FileSystem>,
         wasi: &WasiAnnotation,
     ) -> Result<(), anyhow::Error> {
-        builder.add_args(&self.args);
-
         let fs = prepare_filesystem(&self.mapped_dirs, container_fs, |path| {
             builder.add_preopen_dir(path).map_err(Error::from)
         })?;

--- a/lib/wasi/src/runners/wasi_common.rs
+++ b/lib/wasi/src/runners/wasi_common.rs
@@ -218,6 +218,67 @@ mod tests {
 
     const PYTHON: &[u8] = include_bytes!("../../../c-api/examples/assets/python-0.1.0.wasmer");
 
+    /// Fixes <https://github.com/wasmerio/wasmer/issues/3789>
+    #[test]
+    fn mix_args_from_the_webc_and_user() {
+        let args = CommonWasiOptions {
+            args: vec!["extra".to_string(), "args".to_string()],
+            ..Default::default()
+        };
+        let mut builder = WasiEnvBuilder::new("program-name");
+        let fs = Arc::new(virtual_fs::EmptyFileSystem::default());
+        let mut annotations = WasiAnnotation::new("some-atom");
+        annotations.main_args = Some(vec![
+            "hard".to_string(),
+            "coded".to_string(),
+            "args".to_string(),
+        ]);
+
+        args.prepare_webc_env(&mut builder, fs, &annotations)
+            .unwrap();
+
+        assert_eq!(
+            builder.get_args(),
+            [
+                // the program name from
+                "program-name",
+                // from the WEBC's annotations
+                "hard",
+                "coded",
+                "args",
+                // from the user
+                "extra",
+                "args",
+            ]
+        );
+    }
+
+    /// Fixes <https://github.com/wasmerio/wasmer/issues/3789>
+    #[test]
+    fn mix_env_vars_from_the_webc_and_user() {
+        let args = CommonWasiOptions {
+            env: vec![("EXTRA".to_string(), "envs".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let mut builder = WasiEnvBuilder::new("python");
+        let fs = Arc::new(virtual_fs::EmptyFileSystem::default());
+        let mut annotations = WasiAnnotation::new("python");
+        annotations.env = Some(vec!["HARD_CODED=env-vars".to_string()]);
+
+        args.prepare_webc_env(&mut builder, fs, &annotations)
+            .unwrap();
+
+        assert_eq!(
+            builder.get_env(),
+            [
+                ("HARD_CODED".to_string(), b"env-vars".to_vec()),
+                ("EXTRA".to_string(), b"envs".to_vec()),
+            ]
+        );
+    }
+
     #[test]
     fn python_use_case() {
         let temp = TempDir::new().unwrap();

--- a/tests/integration/cli/tests/run_unstable.rs
+++ b/tests/integration/cli/tests/run_unstable.rs
@@ -17,8 +17,14 @@ use wasmer_integration_tests_cli::get_wasmer_path;
 const RUST_LOG: &str = "info,wasmer_wasi::runners=debug,virtual_fs::trace_fs=trace";
 
 fn wasmer_run_unstable() -> std::process::Command {
-    let mut cmd = std::process::Command::new(get_wasmer_path());
-    cmd.env("RUST_LOG", RUST_LOG).arg("run-unstable");
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("run")
+        .arg("--quiet")
+        .arg("--package=wasmer-cli")
+        .arg("--features=singlepass")
+        .arg("--")
+        .arg("run-unstable");
+    cmd.env("RUST_LOG", RUST_LOG);
     cmd
 }
 


### PR DESCRIPTION
Turns out we were adding arguments to the `WasiEnvBuilder` twice when setting up WASI-based runners. I'm guessing I forgot to remove the original `add_args()` line when I split out `populate_args()`.

Fixes https://github.com/wasmerio/wasmer/issues/3789.