### PR TITLE
Added a quickfix for mounting relative directories

### DIFF
--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -71,7 +71,7 @@ pub struct RunUnstable {
     #[clap(long = "stack-size")]
     stack_size: Option<usize>,
     /// The function or command to invoke.
-    #[clap(short, long, aliases = &["command", "invoke"])]
+    #[clap(short, long, aliases = &["command", "invoke", "command-name"])]
     entrypoint: Option<String>,
     /// Generate a coredump at this path if a WebAssembly trap occurs
     #[clap(name = "COREDUMP PATH", long)]

--- a/lib/wasi/src/runners/wasi_common.rs
+++ b/lib/wasi/src/runners/wasi_common.rs
@@ -147,9 +147,7 @@ fn prepare_filesystem(
 /// virtual fs layer.
 ///
 /// See <https://github.com/wasmerio/wasmer/issues/3794> for more.
-fn apply_relative_path_mounting_hack(
-    original: &Path,
-) -> PathBuf {
+fn apply_relative_path_mounting_hack(original: &Path) -> PathBuf {
     debug_assert!(original.is_relative());
 
     let mapped_path = Path::new("/").join(original);

--- a/tests/integration/cli/tests/run_unstable.rs
+++ b/tests/integration/cli/tests/run_unstable.rs
@@ -224,6 +224,28 @@ mod webc_on_disk {
                 "response generated method=GET uri=/path/to/file.txt status_code=200 OK",
             ));
     }
+
+    /// See https://github.com/wasmerio/wasmer/issues/3794
+    #[test]
+    #[cfg_attr(
+        all(target_env = "musl", target_os = "linux"),
+        ignore = "wasmer run-unstable segfaults on musl"
+    )]
+    fn issue_3794_unable_to_mount_relative_paths() {
+        let temp = TempDir::new().unwrap();
+        std::fs::copy(fixtures::python(), temp.path().join("python.webc")).unwrap();
+
+        let assert = wasmer_run_unstable()
+            .arg("wasmer/wapm2pirita@1.0.31")
+            .arg(format!("--mapdir=.:{}", temp.path().display()))
+            .arg("--")
+            .arg("dump")
+            .arg("manifest")
+            .arg("./python.webc")
+            .assert();
+
+        assert.success().stdout(contains("\"name\": \"python\""));
+    }
 }
 
 mod wasm_on_disk {

--- a/tests/integration/cli/tests/run_unstable.rs
+++ b/tests/integration/cli/tests/run_unstable.rs
@@ -233,18 +233,17 @@ mod webc_on_disk {
     )]
     fn issue_3794_unable_to_mount_relative_paths() {
         let temp = TempDir::new().unwrap();
-        std::fs::copy(fixtures::python(), temp.path().join("python.webc")).unwrap();
+        std::fs::write(temp.path().join("message.txt"), b"Hello, World!").unwrap();
 
         let assert = wasmer_run_unstable()
-            .arg("wasmer/wapm2pirita@1.0.31")
-            .arg(format!("--mapdir=.:{}", temp.path().display()))
+            .arg(fixtures::coreutils())
+            .arg(format!("--mapdir=./some-dir/:{}", temp.path().display()))
+            .arg("--command-name=cat")
             .arg("--")
-            .arg("dump")
-            .arg("manifest")
-            .arg("./python.webc")
+            .arg("./some-dir/message.txt")
             .assert();
 
-        assert.success().stdout(contains("\"name\": \"python\""));
+        assert.success().stdout(contains("Hello, World!"));
     }
 }
 
@@ -419,6 +418,13 @@ mod fixtures {
     /// A WEBC file containing the Python interpreter, compiled to WASI.
     pub fn python() -> PathBuf {
         Path::new(C_ASSET_PATH).join("python-0.1.0.wasmer")
+    }
+
+    pub fn coreutils() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("webc")
+            .join("coreutils-1.0.14-076508e5-e704-463f-b467-f3d9658fc907.webc")
     }
 
     /// A WEBC file containing `wat2wasm`, `wasm-validate`, and other helpful

--- a/tests/integration/cli/tests/run_unstable.rs
+++ b/tests/integration/cli/tests/run_unstable.rs
@@ -424,7 +424,7 @@ mod fixtures {
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests")
             .join("webc")
-            .join("coreutils-1.0.14-076508e5-e704-463f-b467-f3d9658fc907.webc")
+            .join("coreutils-1.0.16-e27dbb4f-2ef2-4b44-b46a-ddd86497c6d7.webc")
     }
 
     /// A WEBC file containing `wat2wasm`, `wasm-validate`, and other helpful


### PR DESCRIPTION
# Description

This adds a test for #3794 and a temporary fix that will make `wasmer run --mapdir .:.` work again.

The proper fix for #3794 will probably require an overhaul of the `virtual_fs::FileSystem` and `WasiFs` layers, which isn't planned for the immediate future.