### PR TITLE
fd_write: Flush on every write to a file

### DIFF
--- a/lib/wasi/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_write.rs
@@ -145,8 +145,9 @@ fn fd_write_internal<M: MemorySize>(
                                         break;
                                     }
                                 }
-                                handle.flush().await.map_err(map_io_err)?;
-
+                                if is_stdio {
+                                    handle.flush().await.map_err(map_io_err)?;
+                                }
                                 Ok(written)
                             }
                         )?

--- a/lib/wasi/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasi/src/syscalls/wasi/fd_write.rs
@@ -145,6 +145,8 @@ fn fd_write_internal<M: MemorySize>(
                                         break;
                                     }
                                 }
+                                handle.flush().await.map_err(map_io_err)?;
+
                                 Ok(written)
                             }
                         )?

--- a/lib/wasi/tests/stdio.rs
+++ b/lib/wasi/tests/stdio.rs
@@ -52,13 +52,13 @@ async fn test_stdout() {
         (export "memory" (memory 0))
 
         ;; Write 'hello world\n' to memory at an offset of 8 bytes
-        ;; Note the trailing newline which is required for the text to appear
-        (data (i32.const 8) "hello world\n")
+        ;; No trailing newline is required since all stdio writes are flushing
+        (data (i32.const 8) "hello world")
 
         (func $main (export "_start")
             ;; Creating a new io vector within linear memory
             (i32.store (i32.const 0) (i32.const 8))  ;; iov.iov_base - This is a pointer to the start of the 'hello world\n' string
-            (i32.store (i32.const 4) (i32.const 12))  ;; iov.iov_len - The length of the 'hello world\n' string
+            (i32.store (i32.const 4) (i32.const 11))  ;; iov.iov_len - The length of the 'hello world\n' string
 
             (call $fd_write
                 (i32.const 1) ;; file_descriptor - 1 for stdout
@@ -93,7 +93,7 @@ async fn test_stdout() {
     let mut stdout_str = String::new();
     stdout_rx.read_to_string(&mut stdout_str).await.unwrap();
     let stdout_as_str = stdout_str.as_str();
-    assert_eq!(stdout_as_str, "hello world\n");
+    assert_eq!(stdout_as_str, "hello world");
 }
 
 async fn test_env() {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Previously we were only flushing the writes until we closed the file, now every write flushes.
This unfortunately will penalize performance, I am open to suggestions on how can this be avoided or minimized. 

cc @theduke @syrusakbary @ibrahim-akrab

Fixes #3790
Fixes #3814

/claim #3790