### PR TITLE
Made test-build-docs-rs tests docs generation for all crates under libs, and fixed broken ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,6 +452,14 @@ test-build-docs-rs:
 		printf "Following features are inferred from Cargo.toml: $$features\n\n\n"; \
 		$(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" --features "$$features" || exit 1; \
 	done
+	for manifest_path in lib/*/Cargo.toml; do \
+		toml get "$$manifest_path" "$$manifest_docs_rs_features_path" >/dev/null 2>&1; \
+		if [ $$? -eq 0 ]; then \
+			continue; \
+		fi; \
+		printf "*** Building doc for package with manifest $$manifest_path ***\n\n"; \
+		$(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" || exit 1; \
+	done
 
 build-docs-capi:
 	# `wasmer-c-api` lib's name is `wasmer`. To avoid a conflict


### PR DESCRIPTION
This address #3826 