### PR TITLE
Fix Missing WaiterError export + Add notify/wait to fd_mmap memory

### DIFF
--- a/lib/sys-utils/Cargo.toml
+++ b/lib/sys-utils/Cargo.toml
@@ -14,6 +14,7 @@ wasmer = { path = "../api", version = "=3.2.1", default-features = false, featur
 wasmer-vm = { path = "../vm", version = "=3.2.1" }
 wasmer-types = { path = "../types", version = "=3.2.1" }
 region = { version = "3.0" }
+tracing = "0.1.37"
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "^0.2", default-features = false }

--- a/lib/sys-utils/src/memory/fd_memory/memories.rs
+++ b/lib/sys-utils/src/memory/fd_memory/memories.rs
@@ -344,6 +344,7 @@ impl LinearMemory for VMOwnedMemory {
 
     /// Owned memory can not be cloned (this will always return None)
     fn try_clone(&self) -> Option<Box<dyn LinearMemory + 'static>> {
+        tracing::warn!("trying to clone owned memory");
         None
     }
 

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -56,6 +56,9 @@ pub use crate::probestack::PROBESTACK;
 pub use crate::sig_registry::SignatureRegistry;
 pub use crate::store::{InternalStoreHandle, MaybeInstanceOwned, StoreHandle, StoreObjects};
 pub use crate::table::{TableElement, VMTable};
+#[doc(hidden)]
+pub use crate::threadconditions::ThreadConditions;
+pub use crate::threadconditions::WaiterError;
 pub use crate::trap::*;
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMDynamicFunctionContext, VMFunctionContext,

--- a/lib/vm/src/threadconditions.rs
+++ b/lib/vm/src/threadconditions.rs
@@ -5,8 +5,10 @@ use std::thread::{current, park, park_timeout, Thread};
 use std::time::Duration;
 use thiserror::Error;
 
-/// Wait/Notify error type
+/// Error that can occur during wait/notify calls.
 #[derive(Debug, Error)]
+// Non-exhaustive to allow for future variants without breaking changes!
+#[non_exhaustive]
 pub enum WaiterError {
     /// Wait/Notify is not implemented for this memory
     Unimplemented,


### PR DESCRIPTION
- Make wasmer_vm::WaiterError non_exhaustive.
- vm: Make WaiterError and ThreadConditions public
- Implement notify/wait support for fd_mmap memory


Note: WaiterError is part of the public API in the LinearMemory trait, so not making it public was an oversight.

