### PR TITLE
Re-export `wasmer::EngineRef`

### DIFF
--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -446,7 +446,7 @@ pub use js::*;
 
 pub use crate::externals::{Extern, Function, Global, HostFunction, Memory, MemoryView, Table};
 pub use access::WasmSliceAccess;
-pub use engine::{AsEngineRef, Engine};
+pub use engine::{AsEngineRef, Engine, EngineRef};
 pub use errors::{InstantiationError, LinkError, RuntimeError};
 pub use exports::{ExportError, Exportable, Exports, ExportsIterator};
 pub use extern_ref::ExternRef;


### PR DESCRIPTION
Looks like this was accidentally missed when we shuffled the `wasmer` crate around in #3556.