### PR TITLE
deps: Upgrade clap to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,10 +56,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "any_ascii"
@@ -460,36 +503,57 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
  "strsim",
  "termcolor",
  "textwrap 0.16.0",
 ]
 
 [[package]]
-name = "clap-verbosity-flag"
-version = "1.0.1"
+name = "clap"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0636f9c040082f8e161555a305f8cec1a1c2828b3d981c812b8c39f4ac00c42c"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
- "clap 3.2.25",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
+dependencies = [
+ "clap 4.2.7",
  "log",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.25"
+name = "clap_builder"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex 0.4.1",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -502,6 +566,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +580,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -4702,6 +4778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "validator"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5309,7 +5391,7 @@ dependencies = [
  "cargo_metadata",
  "cfg-if 1.0.0",
  "chrono",
- "clap 3.2.25",
+ "clap 4.2.7",
  "clap-verbosity-flag",
  "colored 2.0.0",
  "dialoguer",
@@ -5398,7 +5480,7 @@ dependencies = [
  "atty",
  "bytesize",
  "cfg-if 1.0.0",
- "clap 3.2.25",
+ "clap 4.2.7",
  "colored 2.0.0",
  "distance",
  "fern",

--- a/lib/cache/src/filesystem.rs
+++ b/lib/cache/src/filesystem.rs
@@ -103,7 +103,7 @@ impl Cache for FileSystemCache {
             key.to_string()
         };
         let path = self.path.join(filename);
-        let ret = Module::deserialize_from_file(engine, path.clone());
+        let ret = Module::deserialize_from_file_checked(engine, path.clone());
         if ret.is_err() {
             // If an error occurs while deserializing then we can not trust it anymore
             // so delete the cache file

--- a/lib/cli-compiler/Cargo.toml
+++ b/lib/cli-compiler/Cargo.toml
@@ -23,7 +23,7 @@ wasmer-types = { version = "=3.3.0", path = "../types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "4.2.7", features = ["derive"] }
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand

--- a/lib/cli-compiler/Cargo.toml
+++ b/lib/cli-compiler/Cargo.toml
@@ -23,7 +23,6 @@ wasmer-types = { version = "=3.3.0", path = "../types" }
 atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
-clap = { version = "4.2.7", features = ["derive"] }
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand
@@ -37,10 +36,22 @@ target-lexicon = { version = "0.12", features = ["std"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmer-compiler-singlepass = { version = "=3.3.0", path = "../compiler-singlepass", optional = true }
 wasmer-compiler-cranelift = { version = "=3.3.0", path = "../compiler-cranelift", optional = true }
+clap = { version = "4.2.7", features = ["derive", "env"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasmer-compiler-singlepass = { version = "=3.3.0", path = "../compiler-singlepass", optional = true, default-features = false, features = ["wasm"] }
 wasmer-compiler-cranelift = { version = "=3.3.0", path = "../compiler-cranelift", optional = true, default-features = false, features = ["wasm"] }
+# NOTE: Must use different features for clap because the "color" feature does not
+# work on wasi, due to the anstream dependency not compiling.
+clap = { version = "4.2.7", default-features = false, features = [
+  "std",
+  "help",
+  "usage",
+  "error-context",
+  "suggestions",
+  "derive",
+  "env",
+]}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 unix_mode = "0.1.3"

--- a/lib/cli-compiler/src/cli.rs
+++ b/lib/cli-compiler/src/cli.rs
@@ -5,7 +5,7 @@ use crate::commands::{Config, Validate};
 use crate::error::PrettyError;
 use anyhow::Result;
 
-use clap::{ErrorKind, Parser};
+use clap::{error::ErrorKind, Parser};
 
 #[derive(Parser)]
 #[clap(

--- a/lib/cli-compiler/src/commands/compile.rs
+++ b/lib/cli-compiler/src/commands/compile.rs
@@ -15,11 +15,11 @@ use wasmer_types::{
 /// The options for the `wasmer compile` subcommand
 pub struct Compile {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     /// Output file
-    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o')]
     output: PathBuf,
 
     /// Compilation Target triple

--- a/lib/cli-compiler/src/commands/config.rs
+++ b/lib/cli-compiler/src/commands/config.rs
@@ -8,27 +8,27 @@ use std::path::PathBuf;
 /// The options for the `wasmer config` subcommand
 pub struct Config {
     /// Print the installation prefix.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     prefix: bool,
 
     /// Directory containing Wasmer executables.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     bindir: bool,
 
     /// Directory containing Wasmer headers.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     includedir: bool,
 
     /// Directory containing Wasmer libraries.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     libdir: bool,
 
     /// Libraries needed to link against Wasmer components.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     libs: bool,
 
     /// C compiler flags for files that include Wasmer headers.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     cflags: bool,
 
     /// It outputs the necessary details for compiling

--- a/lib/cli-compiler/src/commands/validate.rs
+++ b/lib/cli-compiler/src/commands/validate.rs
@@ -9,7 +9,7 @@ use wasmer_types::{is_wasm, CpuFeature, Target, Triple};
 /// The options for the `wasmer validate` subcommand
 pub struct Validate {
     /// File to validate as WebAssembly
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     #[clap(flatten)]

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -45,7 +45,7 @@ atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
 spinoff = "0.5.4"
-clap = { version = "4.2.7", features = ["derive", "env"] }
+
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand
@@ -83,6 +83,21 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ] }
 clap-verbosity-flag = "2"
 wapm-targz-to-pirita = "0.2.1"
+
+# NOTE: Must use different features for clap because the "color" feature does not
+# work on wasi due to the anstream dependency not compiling.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+clap = { version = "4.2.7", features = ["derive", "env"] }
+[target.'cfg(target_family = "wasm")'.dependencies]
+clap = { version = "4.2.7", default-features = false, features = [
+  "std",
+  "help",
+  "usage",
+  "error-context",
+  "suggestions",
+  "derive",
+  "env",
+]}
 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies]
 http_req  = { version="^0.8", default-features = false, features = ["rust-tls"] }

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -45,7 +45,7 @@ atty = "0.2"
 colored = "2.0"
 anyhow = "1.0"
 spinoff = "0.5.4"
-clap = { version = "3.2.22", features = ["derive", "env"] }
+clap = { version = "4.2.7", features = ["derive", "env"] }
 # For the function names autosuggestion
 distance = "0.4"
 # For the inspect subcommand
@@ -81,7 +81,7 @@ object = "0.30.0"
 wasm-coredump-builder = { version = "0.1.11", optional = true }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ] }
-clap-verbosity-flag = "1"
+clap-verbosity-flag = "2"
 wapm-targz-to-pirita = "0.2.1"
 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies]

--- a/lib/cli/src/cli.rs
+++ b/lib/cli/src/cli.rs
@@ -15,14 +15,14 @@ use crate::commands::{
 #[cfg(feature = "static-artifact-create")]
 use crate::commands::{CreateObj, GenCHeader};
 use crate::error::PrettyError;
-use clap::{CommandFactory, ErrorKind, Parser};
+use clap::{error::ErrorKind, CommandFactory, Parser};
 
 #[derive(Parser, Debug)]
 #[cfg_attr(
     not(feature = "headless"),
     clap(
         name = "wasmer",
-        about = "WebAssembly standalone runtime.",
+        about = concat!("wasmer ", env!("CARGO_PKG_VERSION")),
         version,
         author
     )
@@ -31,7 +31,7 @@ use clap::{CommandFactory, ErrorKind, Parser};
     feature = "headless",
     clap(
         name = "wasmer-headless",
-        about = "WebAssembly standalone runtime (headless).",
+        about = concat!("wasmer ", env!("CARGO_PKG_VERSION")),
         version,
         author
     )

--- a/lib/cli/src/commands/add.rs
+++ b/lib/cli/src/commands/add.rs
@@ -23,7 +23,6 @@ pub struct Add {
     #[clap(long, groups = &["bindings", "py"])]
     pip: bool,
     /// The packages to add (e.g. "wasmer/wasmer-pack@0.5.0" or "python/python")
-    #[clap(parse(try_from_str))]
     packages: Vec<wasmer_registry::Package>,
 }
 

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -9,11 +9,11 @@ use wasmer::*;
 /// The options for the `wasmer compile` subcommand
 pub struct Compile {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     /// Output file
-    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o')]
     output: PathBuf,
 
     /// Compilation Target triple

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -20,31 +20,31 @@ pub struct Config {
 #[derive(Debug, Parser)]
 pub struct Flags {
     /// Print the installation prefix.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     prefix: bool,
 
     /// Directory containing Wasmer executables.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     bindir: bool,
 
     /// Directory containing Wasmer headers.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     includedir: bool,
 
     /// Directory containing Wasmer libraries.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     libdir: bool,
 
     /// Libraries needed to link against Wasmer components.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     libs: bool,
 
     /// C compiler flags for files that include Wasmer headers.
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     cflags: bool,
 
     /// Print the path to the wasmer configuration file where all settings are stored
-    #[clap(long, conflicts_with = "pkg-config")]
+    #[clap(long, conflicts_with = "pkg_config")]
     config_path: bool,
 
     /// Outputs the necessary details for compiling

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -124,7 +124,9 @@ pub struct SetRegistryToken {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Parser)]
 pub struct SetUpdateNotificationsEnabled {
     /// Whether to enable update notifications
-    #[clap(name = "ENABLED", possible_values = ["true", "false"])]
+    ///
+    /// ("true" | "false")
+    #[clap(name = "ENABLED")]
     pub enabled: BoolString,
 }
 
@@ -143,7 +145,9 @@ impl std::str::FromStr for BoolString {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Parser)]
 pub struct SetTelemetryEnabled {
     /// Whether to enable telemetry
-    #[clap(name = "ENABLED", possible_values = ["true", "false"])]
+    ///
+    /// ("true" | "false")
+    #[clap(name = "ENABLED")]
     pub enabled: BoolString,
 }
 

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -26,16 +26,16 @@ const LINK_SYSTEM_LIBRARIES_UNIX: &[&str] = &["dl", "m", "pthread"];
 /// The options for the `wasmer create-exe` subcommand
 pub struct CreateExe {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     /// Output file
-    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o')]
     output: PathBuf,
 
     /// Optional directorey used for debugging: if present, will output the zig command
     /// for reproducing issues in a debug directory
-    #[clap(long, name = "DEBUG PATH", parse(from_os_str))]
+    #[clap(long, name = "DEBUG PATH")]
     debug_dir: Option<PathBuf>,
 
     /// Prefix for every input file, e.g. "wat2wasm:sha256abc123" would
@@ -73,7 +73,7 @@ pub struct CreateExe {
     #[clap(long, name = "URL_OR_RELEASE_VERSION")]
     use_wasmer_release: Option<String>,
 
-    #[clap(long, short = 'm', multiple = true, number_of_values = 1)]
+    #[clap(long, short = 'm', number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 
     /// Additional libraries to link against.

--- a/lib/cli/src/commands/create_obj.rs
+++ b/lib/cli/src/commands/create_obj.rs
@@ -14,16 +14,16 @@ use wasmer::*;
 /// The options for the `wasmer create-exe` subcommand
 pub struct CreateObj {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     /// Output file or directory if the input is a pirita file
-    #[clap(name = "OUTPUT_PATH", short = 'o', parse(from_os_str))]
+    #[clap(name = "OUTPUT_PATH", short = 'o')]
     output: PathBuf,
 
     /// Optional directorey used for debugging: if present, will
     /// output the files to a debug instead of a temp directory
-    #[clap(long, name = "DEBUG PATH", parse(from_os_str))]
+    #[clap(long, name = "DEBUG PATH")]
     debug_dir: Option<PathBuf>,
 
     /// Prefix for the function names in the input file in the compiled object file.
@@ -51,7 +51,7 @@ pub struct CreateObj {
     #[clap(long = "target")]
     target_triple: Option<Triple>,
 
-    #[clap(long, short = 'm', multiple = true, number_of_values = 1)]
+    #[clap(long, short = 'm', number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 
     #[clap(flatten)]

--- a/lib/cli/src/commands/gen_c_header.rs
+++ b/lib/cli/src/commands/gen_c_header.rs
@@ -11,7 +11,7 @@ use webc::v1::WebC;
 /// The options for the `wasmer gen-c-header` subcommand
 pub struct GenCHeader {
     /// Input file
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     /// Prefix hash (default: SHA256 of input .wasm file)
@@ -23,7 +23,7 @@ pub struct GenCHeader {
     atom: Option<String>,
 
     /// Output file
-    #[clap(name = "OUTPUT PATH", short = 'o', parse(from_os_str))]
+    #[clap(name = "OUTPUT PATH", short = 'o')]
     output: PathBuf,
 
     /// Compilation Target triple
@@ -41,7 +41,7 @@ pub struct GenCHeader {
     #[clap(long = "target")]
     target_triple: Option<Triple>,
 
-    #[clap(long, short = 'm', multiple = true, number_of_values = 1)]
+    #[clap(long, short = 'm', number_of_values = 1)]
     cpu_features: Vec<CpuFeature>,
 }
 

--- a/lib/cli/src/commands/inspect.rs
+++ b/lib/cli/src/commands/inspect.rs
@@ -9,7 +9,7 @@ use wasmer::*;
 /// The options for the `wasmer validate` subcommand
 pub struct Inspect {
     /// File to validate as WebAssembly
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     #[clap(flatten)]
@@ -22,6 +22,7 @@ impl Inspect {
         self.inner_execute()
             .context(format!("failed to inspect `{}`", self.path.display()))
     }
+
     fn inner_execute(&self) -> Result<()> {
         let (store, _compiler_type) = self.store.get_store()?;
         let module_contents = std::fs::read(&self.path)?;

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -27,7 +27,7 @@ pub(crate) use wasi::Wasi;
 #[derive(Debug, Parser, Clone)]
 pub struct Run {
     /// File to run
-    #[clap(name = "SOURCE", parse(try_from_str))]
+    #[clap(name = "SOURCE")]
     pub(crate) path: PackageSource,
     /// Options to run the file / package / URL with
     #[clap(flatten)]
@@ -84,7 +84,7 @@ pub struct RunWithoutFile {
     pub(crate) wcgi: WcgiOptions,
 
     /// Enable coredump generation after a WebAssembly trap.
-    #[clap(name = "COREDUMP PATH", long = "coredump-on-trap", parse(from_os_str))]
+    #[clap(name = "COREDUMP PATH", long = "coredump-on-trap")]
     coredump_on_trap: Option<PathBuf>,
 
     #[cfg(feature = "sys")]

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -35,7 +35,7 @@ pub struct Wasi {
     #[clap(
         long = "mapdir",
         name = "GUEST_DIR:HOST_DIR",
-        parse(try_from_str = parse_mapdir),
+        value_parser=parse_mapdir,
     )]
     pub(crate) mapped_dirs: Vec<MappedDirectory>,
 
@@ -43,7 +43,7 @@ pub struct Wasi {
     #[clap(
         long = "env",
         name = "KEY=VALUE",
-        parse(try_from_str = parse_envvar),
+        value_parser=parse_envvar,
     )]
     pub(crate) env_vars: Vec<(String, String)>,
 

--- a/lib/cli/src/commands/run_unstable.rs
+++ b/lib/cli/src/commands/run_unstable.rs
@@ -57,7 +57,7 @@ pub struct RunUnstable {
     #[clap(short, long, aliases = &["command", "invoke"])]
     entrypoint: Option<String>,
     /// Generate a coredump at this path if a WebAssembly trap occurs
-    #[clap(name = "COREDUMP PATH", long, parse(from_os_str))]
+    #[clap(name = "COREDUMP PATH", long)]
     coredump_on_trap: Option<PathBuf>,
     /// The file, URL, or package to run.
     #[clap(value_parser = PackageSource::infer)]

--- a/lib/cli/src/commands/validate.rs
+++ b/lib/cli/src/commands/validate.rs
@@ -8,7 +8,7 @@ use wasmer::*;
 /// The options for the `wasmer validate` subcommand
 pub struct Validate {
     /// File to validate as WebAssembly
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     #[clap(flatten)]

--- a/lib/cli/src/commands/wast.rs
+++ b/lib/cli/src/commands/wast.rs
@@ -9,7 +9,7 @@ use wasmer_wast::Wast as WastSpectest;
 /// The options for the `wasmer wast` subcommand
 pub struct Wast {
     /// Wast file to run
-    #[clap(name = "FILE", parse(from_os_str))]
+    #[clap(name = "FILE")]
     path: PathBuf,
 
     #[clap(flatten)]

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -48,7 +48,7 @@ pub struct CompilerOptions {
 
     /// LLVM debug directory, where IR and object files will be written to.
     #[cfg(feature = "llvm")]
-    #[clap(long, parse(from_os_str))]
+    #[clap(long)]
     llvm_debug_dir: Option<PathBuf>,
 
     #[clap(flatten)]

--- a/tests/integration/cli/tests/config.rs
+++ b/tests/integration/cli/tests/config.rs
@@ -65,17 +65,16 @@ fn wasmer_config_error() -> anyhow::Result<()> {
         .map(|s| s.trim().to_string())
         .collect::<Vec<_>>();
     #[cfg(not(windows))]
-    let expected_1 = "wasmer config --bindir --cflags";
+    let expected_1 = "Usage: wasmer config --bindir --cflags";
     #[cfg(windows)]
-    let expected_1 = "wasmer.exe config --bindir --cflags";
+    let expected_1 = "Usage: wasmer.exe config --bindir --cflags";
 
     let expected = vec![
-        "error: The argument '--bindir' cannot be used with '--pkg-config'",
+        "error: the argument '--bindir' cannot be used with '--pkg-config'",
         "",
-        "USAGE:",
         expected_1,
         "",
-        "For more information try --help",
+        "For more information, try '--help'.",
     ];
 
     assert_eq!(lines, expected);


### PR DESCRIPTION
Upgrade clap from 3.x to 4.2.7 in both the main CLI and the compiler
CLI.

Needed as a prep work for future CLI additions.

