### PR TITLE
Switch FileSystemCache to use checked artifact deserialization

### DIFF
--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -20,6 +20,7 @@ blake3 = "1.0"
 criterion = "0.3"
 tempfile = "3.4.0"
 rand = "0.8.3"
+wasmer = { path = "../api", version = "=3.3.0", default-features = false, features = ["sys", "cranelift"] }
 wasmer-compiler-singlepass = { path = "../compiler-singlepass", version = "=3.3.0" }
 
 [features]

--- a/lib/cache/src/filesystem.rs
+++ b/lib/cache/src/filesystem.rs
@@ -127,3 +127,25 @@ impl Cache for FileSystemCache {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fs_cache() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut cache = FileSystemCache::new(dir.path()).unwrap();
+
+        let engine = wasmer::Engine::default();
+
+        let bytes = include_bytes!("../../wasi/tests/envvar.wasm");
+
+        let module = Module::from_binary(&engine, bytes).unwrap();
+        let key = Hash::generate(bytes);
+
+        cache.store(key, &module).unwrap();
+        let _restored = unsafe { cache.load(&engine, key).unwrap() };
+    }
+}


### PR DESCRIPTION
We recently introduced safe artifact deserialization methods, which are a
much saner default than the unsafe variants, and only have small performance
overhead.

The CLI was switched to the the new, safe deserialization,
but the cache was not updated.

This commit and switches the FileSystemCache implementation to use the
checked deserialization variants.

NOTE: The Cache::load method should also be made safe, but that is a
breaking change.