### PR TITLE
Support static linking on Windows

### DIFF
--- a/lib/c-api/tests/wasm-c-api/include/wasm.h
+++ b/lib/c-api/tests/wasm-c-api/include/wasm.h
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 #ifndef WASM_API_EXTERN
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && !defined(__MINGW32__) && !defined(LIBWASM_STATIC)
 #define WASM_API_EXTERN __declspec(dllimport)
 #else
 #define WASM_API_EXTERN

--- a/lib/c-api/tests/wasm-c-api/include/wasm.hh
+++ b/lib/c-api/tests/wasm-c-api/include/wasm.hh
@@ -12,7 +12,7 @@
 #include <string>
 
 #ifndef WASM_API_EXTERN
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && !defined(__MINGW32__) && !defined(LIBWASM_STATIC)
 #define WASM_API_EXTERN __declspec(dllimport)
 #else
 #define WASM_API_EXTERN


### PR DESCRIPTION
The Wasm C API assumes all Windows builds are using a DLL. This adds a LIBWASM_STATIC define that allows for static linking. Related to https://github.com/wasmerio/wasmer/pull/3849. See upstream https://github.com/WebAssembly/wasm-c-api/pull/183.