### PR TITLE
fuzz: fix build error

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -276,7 +276,7 @@ impl Compiler for LLVMCompiler {
                 for (section_index, custom_section) in compiled_function.custom_sections.iter() {
                     // TODO: remove this call to clone()
                     let mut custom_section = custom_section.clone();
-                    for mut reloc in &mut custom_section.relocations {
+                    for reloc in &mut custom_section.relocations {
                         if let RelocationTarget::CustomSection(index) = reloc.reloc_target {
                             reloc.reloc_target = RelocationTarget::CustomSection(
                                 SectionIndex::from_u32(first_section + index.as_u32()),
@@ -288,7 +288,7 @@ impl Compiler for LLVMCompiler {
                         .contains(&section_index)
                     {
                         let offset = frame_section_bytes.len() as u32;
-                        for mut reloc in &mut custom_section.relocations {
+                        for reloc in &mut custom_section.relocations {
                             reloc.offset += offset;
                         }
                         frame_section_bytes.extend_from_slice(custom_section.bytes.as_slice());
@@ -303,7 +303,7 @@ impl Compiler for LLVMCompiler {
                         module_custom_sections.push(custom_section);
                     }
                 }
-                for mut reloc in &mut compiled_function.compiled_function.relocations {
+                for reloc in &mut compiled_function.compiled_function.relocations {
                     if let RelocationTarget::CustomSection(index) = reloc.reloc_target {
                         reloc.reloc_target = RelocationTarget::CustomSection(
                             SectionIndex::from_u32(first_section + index.as_u32()),


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests
-->

# Description
wasmer's oss-fuzz build was failing with following error:
```
error: variable does not need to be mutable
   --> lib/compiler-llvm/src/compiler.rs:279:25
    |
279 |                     for mut reloc in &mut custom_section.relocations {
    |                         ----^^^^^
    |                         |
    |                         help: remove this `mut`
    |
note: the lint level is defined here
   --> lib/compiler-llvm/src/lib.rs:4:5
    |
4   |     unused_mut,
    |     ^^^^^^^^^^

error: variable does not need to be mutable
   --> lib/compiler-llvm/src/compiler.rs:291:29
    |
291 |                         for mut reloc in &mut custom_section.relocations {
    |                             ----^^^^^
    |                             |
    |                             help: remove this `mut`

error: variable does not need to be mutable
   --> lib/compiler-llvm/src/compiler.rs:306:21
    |
306 |                 for mut reloc in &mut compiled_function.compiled_function.relocations {
    |                     ----^^^^^
    |                     |
    |                     help: remove this `mut`

error: could not compile `wasmer-compiler-llvm` (lib) due to 3 previous errors
```
This pr attempts to fix that by removing unused mut.
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58561
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
