### PR TITLE
lib/wasi-types: add Socktype::Unused shim value

### DIFF
--- a/lib/wasi-types/schema/wasi/typenames.wit
+++ b/lib/wasi-types/schema/wasi/typenames.wit
@@ -703,8 +703,8 @@ enum socktype {
     /// socktype::dgram enum variant, can't have that same value). the same
     /// hack is in wasix-libc.
     unused,
-    dgram,
     %stream,
+    dgram,
     raw,
     seqpacket,
 }

--- a/lib/wasi-types/schema/wasi/typenames.wit
+++ b/lib/wasi-types/schema/wasi/typenames.wit
@@ -695,6 +695,14 @@ record subscription-fs-readwrite {
 // }
 
 enum socktype {
+    /// the unused variant is used to maintain backward compatibility with
+    /// older libc-based applications that were written where there is no
+    /// socket type variant with a '0' value (for example, cpython has a
+    /// macro definition used in a case arm alongside SOCK_DGRAM with the value
+    /// '0', which means SOCK_DGRAM, ultimately corresponding to this
+    /// socktype::dgram enum variant, can't have that same value). the same
+    /// hack is in wasix-libc.
+    unused,
     dgram,
     %stream,
     raw,

--- a/lib/wasi-types/src/wasi/bindings.rs
+++ b/lib/wasi-types/src/wasi/bindings.rs
@@ -1042,8 +1042,8 @@ impl core::fmt::Debug for SubscriptionFsReadwrite {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Socktype {
     Unused,
-    Dgram,
     Stream,
+    Dgram,
     Raw,
     Seqpacket,
 }
@@ -3044,8 +3044,8 @@ unsafe impl wasmer::FromToNativeWasmType for Socktype {
 
     fn from_native(n: Self::Native) -> Self {
         match n {
-            1 => Self::Dgram,
-            2 => Self::Stream,
+            1 => Self::Stream,
+            2 => Self::Dgram,
             3 => Self::Raw,
             4 => Self::Seqpacket,
 

--- a/lib/wasi-types/src/wasi/bindings.rs
+++ b/lib/wasi-types/src/wasi/bindings.rs
@@ -1041,6 +1041,7 @@ impl core::fmt::Debug for SubscriptionFsReadwrite {
 #[repr(u16)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Socktype {
+    Unused,
     Dgram,
     Stream,
     Raw,
@@ -1049,6 +1050,7 @@ pub enum Socktype {
 impl core::fmt::Debug for Socktype {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Socktype::Unused => f.debug_tuple("Socktype::Unused").finish(),
             Socktype::Dgram => f.debug_tuple("Socktype::Dgram").finish(),
             Socktype::Stream => f.debug_tuple("Socktype::Stream").finish(),
             Socktype::Raw => f.debug_tuple("Socktype::Raw").finish(),
@@ -3042,10 +3044,10 @@ unsafe impl wasmer::FromToNativeWasmType for Socktype {
 
     fn from_native(n: Self::Native) -> Self {
         match n {
-            0 => Self::Dgram,
-            1 => Self::Stream,
-            2 => Self::Raw,
-            3 => Self::Seqpacket,
+            1 => Self::Dgram,
+            2 => Self::Stream,
+            3 => Self::Raw,
+            4 => Self::Seqpacket,
 
             q => todo!("could not serialize number {q} to enum Socktype"),
         }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

In wasix-libc we derive the value of the C macro `SOCK_DGRAM` and `SOCK_STREAM` from the `sock_type` enum in [wasix-witx](https://github.com/john-sharratt/wasix-witx). This `sock_type` witx enum corresponds roughly to the Wasmer [`socktype` enum](https://github.com/wasmerio/wasmer/blob/fbe784a6893b62ca0f961153e9dfdbbbc2374d24/lib/wasi-types/schema/wasi/typenames.wit#L697-L702).

The problem with these corresponding enums as-written is that they result in a `SOCK_DGRAM` value of 0. This doesn't work for cpython (and potentially other programs depending on libc) because the value `0` is used for a cpython-specific macro that is used in a switch case arm alongside `SOCK_DGRAM`:

* [cpython's `GAI_ANY` macro defined as 0](https://github.com/python/cpython/blob/2f369cafeeb4a4886b00396abd8a5f33e555e1c3/Modules/getaddrinfo.c#L68)
* [cpython's `GAI_ANY` used next to `SOCK_DGRAM` in a switch block](https://github.com/python/cpython/blob/2f369cafeeb4a4886b00396abd8a5f33e555e1c3/Modules/getaddrinfo.c#L355-368)

This cpython hack seems likely to me to be replicated elsewhere in the open source world and implies that most libc implementations likely don't have any `SOCK_*` macros with the value `0`.

This PR is paired with a corresponding [wasix-witx PR](https://github.com/john-sharratt/wasix-witx/pull/1). Both PRs utilize the same hack: introduce a shim enum variant to ensure that none of the other variants take the value `0`.

