### PR TITLE
Add compiler features to wai-bindgen-wasmer

### DIFF
--- a/lib/wai-bindgen-wasmer/Cargo.toml
+++ b/lib/wai-bindgen-wasmer/Cargo.toml
@@ -22,7 +22,7 @@ wasmer = { version = "=3.3.0", path = "../api", default-features = false }
 
 [features]
 # Enables generated code to emit events via the `tracing` crate whenever wasm is
-# entered and when native functions are called. Note that tracin is currently
+# entered and when native functions are called. Note that tracing is currently
 # only done for imported functions.
 tracing = ["tracing-lib", "wai-bindgen-wasmer-impl/tracing"]
 
@@ -33,6 +33,11 @@ async = ["async-trait", "wai-bindgen-wasmer-impl/async"]
 # Wasmer features
 js = ["wasmer/js", "wasmer/std"]
 sys = ["wasmer/sys"]
+
+# Wasmer compiler (with `sys` feature only)
+cranelift = ["wasmer/cranelift"]
+singlepass = ["wasmer/singlepass"]
+llvm = ["wasmer/llvm"]
 
 [package.metadata.docs.rs]
 features = ["wasmer/sys"]


### PR DESCRIPTION
# Description
Specify which compiler you want to use with a feature directly in `wai-bindgen-wasmer` .

## Current situation:
When you want to use `wai-bindgen-wasmer` with the `sys` feature, you have to separately include wasmer to specify which compiler you want to use, like this:

```
wai-bindgen-wasmer = { version = "=0.4.0", features = ["sys"]}
wasmer = {version = "=3.3.0", features = ["cranelift"]}
```

## Why this is suboptimal:
There are several reasons:

- You have to remember to do it. New people who just want to use `wai-bindgen-wasmer` would not know this and would be confused by the compiler error.
- You have to track down which specific version of wasmer to use.
- You have the decision fatigue of whether to use `wai-bindgen-wasmer::wamser` or just `wasmer` in your code.
- Your cargo setup is needlessly complicated when you are building for both native and web targets.

## With the proposed change:
You just specify which compiler you want to use directly in the `wai-bindgen-wasmer` dependency:

```
wai-bindgen-wasmer = { version = "=0.4.0", features = ["sys", "cranelift"]}
```

## Things to consider:
Should `cranelift` be enabled by default when using `sys`? It is when using wasmer directly, but I don't think that would fit here well. Alternatively, `sys` could be removed in favor of `sys-cranelift`, `sys-singlepass` and `sys-llvm` instead.

Also, is there a changelog for the `wai-vingen-wasmer` crate, or should I put this change to the main changelog?