### PR TITLE
Use `js-default` feature in wai-bindgen-wasmer

### DIFF
--- a/lib/wai-bindgen-wasmer/Cargo.toml
+++ b/lib/wai-bindgen-wasmer/Cargo.toml
@@ -31,7 +31,7 @@ tracing = ["tracing-lib", "wai-bindgen-wasmer-impl/tracing"]
 async = ["async-trait", "wai-bindgen-wasmer-impl/async"]
 
 # Wasmer features
-js = ["wasmer/js", "wasmer/std"]
+js = ["wasmer/js-default"]
 sys = ["wasmer/sys"]
 
 # Wasmer compiler (with `sys` feature only)


### PR DESCRIPTION
Fixes https://github.com/wasmerio/wasmer/issues/3870

`wasm-types-polyfill` feature, which is enabled by `js-default`, is needed for type annotations.

See issue for more details.

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->
