### PR TITLE
Bump llvm

### DIFF
--- a/lib/compiler-llvm/README.md
+++ b/lib/compiler-llvm/README.md
@@ -23,20 +23,20 @@ to native speeds.
 ## Requirements
 
 The LLVM compiler requires a valid installation of LLVM in your system.
-It currently requires **LLVM 12**.
+It currently requires **LLVM 14**.
 
 
 You can install LLVM easily on your Debian-like system via this command:
 
 ```bash
 wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
-sudo bash /tmp/llvm.sh 12
+sudo bash /tmp/llvm.sh 14
 ```
 
 Or in macOS:
 
 ```bash
-brew install llvm
+brew install llvm@14
 ```
 
 Or via any of the [pre-built binaries that LLVM offers][llvm-pre-built].


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
[wasmer-compiler-llvm](https://github.com/wasmerio/wasmer/blob/master/lib/compiler-llvm/README.md) readme mentions llvm v12 as a dependency but [depends](https://github.com/wasmerio/wasmer/blob/eca880f19b02736fca817323a9a77ac98986050e/lib/compiler-llvm/Cargo.toml#L32) on llvm v14 instead. [Wasmer contribution guide](https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#llvm-dependency) also (correctly) states v14. This PR only bumps the mentioned llvm version to 14 in wasmer-compiler-llvm readme.

Tested on MacOS Ventura arm64.
