### PR TITLE
Rework Module deserialization functions

### DIFF
--- a/lib/api/src/engine.rs
+++ b/lib/api/src/engine.rs
@@ -135,24 +135,57 @@ impl Engine {
         ))
     }
 
-    #[deprecated(since = "3.2.0")]
     #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
-    /// Deserializes a WebAssembly module
+    /// Deserializes a WebAssembly module which was previously serialized with
+    /// `Module::serialize`.
+    ///
+    /// NOTE: you should almost always prefer [`Self::deserialize`].
     ///
     /// # Safety
+    /// See [`Artifact::deserialize_unchecked`].
+    pub unsafe fn deserialize_unchecked(
+        &self,
+        bytes: &[u8],
+    ) -> Result<Arc<Artifact>, DeserializeError> {
+        Ok(Arc::new(Artifact::deserialize_unchecked(&self.0, bytes)?))
+    }
+
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// Deserializes a WebAssembly module which was previously serialized with
+    /// `Module::serialize`.
     ///
-    /// The serialized content must represent a serialized WebAssembly module.
+    /// # Safety
+    /// See [`Artifact::deserialize`].
     pub unsafe fn deserialize(&self, bytes: &[u8]) -> Result<Arc<Artifact>, DeserializeError> {
         Ok(Arc::new(Artifact::deserialize(&self.0, bytes)?))
     }
 
-    #[deprecated(since = "3.2.0")]
     #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
-    /// Deserializes a WebAssembly module from a path
+    /// Load a serialized WebAssembly module from a file and deserialize it.
+    ///
+    /// NOTE: you should almost always prefer [`Self::deserialize_from_file`].
     ///
     /// # Safety
+    /// See [`Artifact::deserialize_unchecked`].
+    pub unsafe fn deserialize_from_file_unchecked(
+        &self,
+        file_ref: &Path,
+    ) -> Result<Arc<Artifact>, DeserializeError> {
+        let mut file = std::fs::File::open(file_ref)?;
+        let mut buffer = Vec::new();
+        // read the whole file
+        file.read_to_end(&mut buffer)?;
+        Ok(Arc::new(Artifact::deserialize_unchecked(
+            &self.0,
+            buffer.as_slice(),
+        )?))
+    }
+
+    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
+    /// Load a serialized WebAssembly module from a file and deserialize it.
     ///
-    /// The file's content must represent a serialized WebAssembly module.
+    /// # Safety
+    /// See [`Artifact::deserialize`].
     pub unsafe fn deserialize_from_file(
         &self,
         file_ref: &Path,

--- a/lib/api/src/jsc/module.rs
+++ b/lib/api/src/jsc/module.rs
@@ -184,18 +184,18 @@ impl Module {
     }
 
     pub unsafe fn deserialize_unchecked(
-        _engine: &impl AsEngineRef,
-        _bytes: impl IntoBytes,
+        engine: &impl AsEngineRef,
+        bytes: impl IntoBytes,
     ) -> Result<Self, DeserializeError> {
-        return Self::from_binary(_engine, &_bytes.into_bytes())
-            .map_err(|e| DeserializeError::Compiler(e));
+        Self::deserialize(engine, bytes)
     }
 
     pub unsafe fn deserialize(
-        _engine: &impl AsEngineRef,
-        _bytes: impl IntoBytes,
+        engine: &impl AsEngineRef,
+        bytes: impl IntoBytes,
     ) -> Result<Self, DeserializeError> {
-        unimplemented!();
+        return Self::from_binary(engine, &bytes.into_bytes())
+            .map_err(|e| DeserializeError::Compiler(e));
     }
 
     pub unsafe fn deserialize_from_file_unchecked(

--- a/lib/api/src/jsc/module.rs
+++ b/lib/api/src/jsc/module.rs
@@ -183,7 +183,7 @@ impl Module {
         ));
     }
 
-    pub unsafe fn deserialize(
+    pub unsafe fn deserialize_unchecked(
         _engine: &impl AsEngineRef,
         _bytes: impl IntoBytes,
     ) -> Result<Self, DeserializeError> {
@@ -191,11 +191,19 @@ impl Module {
             .map_err(|e| DeserializeError::Compiler(e));
     }
 
-    pub fn deserialize_checked(
+    pub unsafe fn deserialize(
         _engine: &impl AsEngineRef,
         _bytes: impl IntoBytes,
     ) -> Result<Self, DeserializeError> {
         unimplemented!();
+    }
+
+    pub unsafe fn deserialize_from_file_unchecked(
+        engine: &impl AsEngineRef,
+        path: impl AsRef<Path>,
+    ) -> Result<Self, DeserializeError> {
+        let bytes = std::fs::read(path.as_ref())?;
+        Self::deserialize_unchecked(engine, bytes)
     }
 
     pub unsafe fn deserialize_from_file(
@@ -204,14 +212,6 @@ impl Module {
     ) -> Result<Self, DeserializeError> {
         let bytes = std::fs::read(path.as_ref())?;
         Self::deserialize(engine, bytes)
-    }
-
-    pub fn deserialize_from_file_checked(
-        engine: &impl AsEngineRef,
-        path: impl AsRef<Path>,
-    ) -> Result<Self, DeserializeError> {
-        let bytes = std::fs::read(path.as_ref())?;
-        Self::deserialize_checked(engine, bytes)
     }
 
     pub fn set_name(&mut self, name: &str) -> bool {

--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -219,9 +219,9 @@ impl Module {
         Ok(())
     }
 
-    /// Deserializes a serialized Module binary into a `Module`.
+    /// Deserializes a serialized module binary into a `Module`.
     ///
-    /// Note: You should usually prefer the safe [`Module::deserialize_checked`].
+    /// Note: You should usually prefer the safer [`Module::deserialize`].
     ///
     /// # Important
     ///
@@ -250,11 +250,13 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn deserialize(
+    pub unsafe fn deserialize_unchecked(
         engine: &impl AsEngineRef,
         bytes: impl IntoBytes,
     ) -> Result<Self, DeserializeError> {
-        Ok(Self(module_imp::Module::deserialize(engine, bytes)?))
+        Ok(Self(module_imp::Module::deserialize_unchecked(
+            engine, bytes,
+        )?))
     }
 
     /// Deserializes a serialized Module binary into a `Module`.
@@ -272,17 +274,21 @@ impl Module {
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
     /// # let mut store = Store::default();
-    /// let module = Module::deserialize_checked(&store, serialized_data)?;
+    /// let module = Module::deserialize(&store, serialized_data)?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deserialize_checked(
+    ///
+    /// # Safety
+    /// This function is inherently **unsafe**, because it loads executable code
+    /// into memory.
+    /// The loaded bytes must be trusted to contain a valid artifact previously
+    /// built with [`Self::serialize`].
+    pub unsafe fn deserialize(
         engine: &impl AsEngineRef,
         bytes: impl IntoBytes,
     ) -> Result<Self, DeserializeError> {
-        Ok(Self(module_imp::Module::deserialize_checked(
-            engine, bytes,
-        )?))
+        Ok(Self(module_imp::Module::deserialize(engine, bytes)?))
     }
 
     /// Deserializes a a serialized Module located in a `Path` into a `Module`.
@@ -298,11 +304,15 @@ impl Module {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deserialize_from_file_checked(
+    ///
+    /// # Safety
+    ///
+    /// See [`Self::deserialize`].
+    pub unsafe fn deserialize_from_file(
         engine: &impl AsEngineRef,
         path: impl AsRef<Path>,
     ) -> Result<Self, DeserializeError> {
-        Ok(Self(module_imp::Module::deserialize_from_file_checked(
+        Ok(Self(module_imp::Module::deserialize_from_file(
             engine, path,
         )?))
     }
@@ -310,9 +320,11 @@ impl Module {
     /// Deserializes a a serialized Module located in a `Path` into a `Module`.
     /// > Note: the module has to be serialized before with the `serialize` method.
     ///
+    /// You should usually prefer the safer [`Module::deserialize_from_file`].
+    ///
     /// # Safety
     ///
-    /// Please check [`Module::deserialize`].
+    /// Please check [`Module::deserialize_unchecked`].
     ///
     /// # Usage
     ///
@@ -320,15 +332,15 @@ impl Module {
     /// # use wasmer::*;
     /// # let mut store = Store::default();
     /// # fn main() -> anyhow::Result<()> {
-    /// let module = Module::deserialize_from_file(&store, path)?;
+    /// let module = Module::deserialize_from_file_unchecked(&store, path)?;
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn deserialize_from_file(
+    pub unsafe fn deserialize_from_file_unchecked(
         engine: &impl AsEngineRef,
         path: impl AsRef<Path>,
     ) -> Result<Self, DeserializeError> {
-        Ok(Self(module_imp::Module::deserialize_from_file(
+        Ok(Self(module_imp::Module::deserialize_from_file_unchecked(
             engine, path,
         )?))
     }

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -69,6 +69,15 @@ impl Module {
         self.artifact.serialize().map(|bytes| bytes.into())
     }
 
+    pub unsafe fn deserialize_unchecked(
+        engine: &impl AsEngineRef,
+        bytes: impl IntoBytes,
+    ) -> Result<Self, DeserializeError> {
+        let bytes = bytes.into_bytes();
+        let artifact = engine.as_engine_ref().engine().0.deserialize(&bytes)?;
+        Ok(Self::from_artifact(artifact))
+    }
+
     pub unsafe fn deserialize(
         engine: &impl AsEngineRef,
         bytes: impl IntoBytes,
@@ -78,16 +87,15 @@ impl Module {
         Ok(Self::from_artifact(artifact))
     }
 
-    pub fn deserialize_checked(
+    pub unsafe fn deserialize_from_file_unchecked(
         engine: &impl AsEngineRef,
-        bytes: impl IntoBytes,
+        path: impl AsRef<Path>,
     ) -> Result<Self, DeserializeError> {
-        let bytes = bytes.into_bytes();
         let artifact = engine
             .as_engine_ref()
             .engine()
             .0
-            .deserialize_checked(&bytes)?;
+            .deserialize_from_file(path.as_ref())?;
         Ok(Self::from_artifact(artifact))
     }
 
@@ -100,18 +108,6 @@ impl Module {
             .engine()
             .0
             .deserialize_from_file(path.as_ref())?;
-        Ok(Self::from_artifact(artifact))
-    }
-
-    pub fn deserialize_from_file_checked(
-        engine: &impl AsEngineRef,
-        path: impl AsRef<Path>,
-    ) -> Result<Self, DeserializeError> {
-        let artifact = engine
-            .as_engine_ref()
-            .engine()
-            .0
-            .deserialize_from_file_checked(path.as_ref())?;
         Ok(Self::from_artifact(artifact))
     }
 

--- a/lib/cache/src/filesystem.rs
+++ b/lib/cache/src/filesystem.rs
@@ -103,7 +103,7 @@ impl Cache for FileSystemCache {
             key.to_string()
         };
         let path = self.path.join(filename);
-        let ret = Module::deserialize_from_file_checked(engine, path.clone());
+        let ret = Module::deserialize_from_file(engine, path.clone());
         if ret.is_err() {
             // If an error occurs while deserializing then we can not trust it anymore
             // so delete the cache file

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -472,7 +472,7 @@ impl RunWithPathBuf {
         if wasmer_compiler::Artifact::is_deserializable(&contents) {
             let engine = wasmer_compiler::EngineBuilder::headless();
             let store = Store::new(engine);
-            let module = Module::deserialize_from_file_checked(&store, &self.path)?;
+            let module = unsafe { Module::deserialize_from_file(&store, &self.path)? };
             return Ok((store, module));
         }
         let (store, compiler_type) = self.store.get_store()?;

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -191,44 +191,56 @@ impl Engine {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    /// Deserializes a WebAssembly module
+    /// Deserializes a WebAssembly module which was previously serialized with
+    /// [`Module::serialize`].
     ///
     /// # Safety
     ///
-    /// The serialized content must represent a serialized WebAssembly module.
+    /// See [`Artifact::deserialize_unchecked`].
+    pub unsafe fn deserialize_unchecked(
+        &self,
+        bytes: &[u8],
+    ) -> Result<Arc<Artifact>, DeserializeError> {
+        Ok(Arc::new(Artifact::deserialize_unchecked(self, bytes)?))
+    }
+
+    /// Deserializes a WebAssembly module which was previously serialized with
+    /// [`Module::serialize`].
+    ///
+    /// # Safety
+    ///
+    /// See [`Artifact::deserialize`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub unsafe fn deserialize(&self, bytes: &[u8]) -> Result<Arc<Artifact>, DeserializeError> {
         Ok(Arc::new(Artifact::deserialize(self, bytes)?))
     }
 
-    /// Deserializes a WebAssembly module
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn deserialize_checked(&self, bytes: &[u8]) -> Result<Arc<Artifact>, DeserializeError> {
-        Ok(Arc::new(Artifact::deserialize_checked(self, bytes)?))
-    }
-
-    /// Deserializes a WebAssembly module from a path
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn deserialize_from_file_checked(
-        &self,
-        file_ref: &Path,
-    ) -> Result<Arc<Artifact>, DeserializeError> {
-        let contents = std::fs::read(file_ref)?;
-        self.deserialize_checked(&contents)
-    }
-
-    /// Deserialize from a file path.
+    /// Deserializes a WebAssembly module from a path.
     ///
     /// # Safety
-    ///
     /// See [`Artifact::deserialize`].
     #[cfg(not(target_arch = "wasm32"))]
     pub unsafe fn deserialize_from_file(
         &self,
         file_ref: &Path,
     ) -> Result<Arc<Artifact>, DeserializeError> {
+        let contents = std::fs::read(file_ref)?;
+        self.deserialize(&contents)
+    }
+
+    /// Deserialize from a file path.
+    ///
+    /// # Safety
+    ///
+    /// See [`Artifact::deserialize_unchecked`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub unsafe fn deserialize_from_file_unchecked(
+        &self,
+        file_ref: &Path,
+    ) -> Result<Arc<Artifact>, DeserializeError> {
         let file = std::fs::File::open(file_ref)?;
         let mmap = Mmap::map(&file)?;
-        self.deserialize(&mmap)
+        self.deserialize_unchecked(&mmap)
     }
 
     /// A unique identifier for this object.

--- a/lib/types/src/compilation/symbols.rs
+++ b/lib/types/src/compilation/symbols.rs
@@ -110,7 +110,7 @@ impl ModuleMetadata {
     /// Right now we are not doing any extra work for validation, but
     /// `rkyv` has an option to do bytecheck on the serialized data before
     /// serializing (via `rkyv::check_archived_value`).
-    pub unsafe fn deserialize(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
+    pub unsafe fn deserialize_unchecked(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
         let archived = Self::archive_from_slice(metadata_slice)?;
         Self::deserialize_from_archive(archived)
     }
@@ -118,7 +118,7 @@ impl ModuleMetadata {
     /// Deserialize a Module from a slice.
     /// The slice must have the following format:
     /// RKYV serialization (any length) + POS (8 bytes)
-    pub fn deserialize_checked(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
+    pub fn deserialize(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
         let archived = Self::archive_from_slice_checked(metadata_slice)?;
         Self::deserialize_from_archive(archived)
     }

--- a/lib/types/src/serialize.rs
+++ b/lib/types/src/serialize.rs
@@ -94,7 +94,7 @@ impl SerializableModule {
     /// Right now we are not doing any extra work for validation, but
     /// `rkyv` has an option to do bytecheck on the serialized data before
     /// serializing (via `rkyv::check_archived_value`).
-    pub unsafe fn deserialize(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
+    pub unsafe fn deserialize_unchecked(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
         let archived = Self::archive_from_slice(metadata_slice)?;
         Self::deserialize_from_archive(archived)
     }
@@ -104,7 +104,11 @@ impl SerializableModule {
     /// RKYV serialization (any length) + POS (8 bytes)
     ///
     /// Unlike [`Self::deserialize`], this function will validate the data.
-    pub fn deserialize_checked(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
+    ///
+    /// # Safety
+    /// Unsafe because it loads executable code into memory.
+    /// The loaded bytes must be trusted.
+    pub unsafe fn deserialize(metadata_slice: &[u8]) -> Result<Self, DeserializeError> {
         let archived = Self::archive_from_slice_checked(metadata_slice)?;
         Self::deserialize_from_archive(archived)
     }

--- a/lib/wasi/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasi/src/runtime/module_cache/filesystem.rs
@@ -44,7 +44,8 @@ impl ModuleCache for FileSystemCache {
 
         let uncompressed = read_compressed(&path)?;
 
-        match Module::deserialize_checked(&engine, &uncompressed) {
+        let res = unsafe { Module::deserialize(&engine, &uncompressed) };
+        match res {
             Ok(m) => Ok(m),
             Err(e) => {
                 tracing::debug!(


### PR DESCRIPTION
Rework the deserialize/deserialize_checked methods for module
deserialization.

* Make checked methods unsafe again, because loading executable memory
  Required because loading executable code into memory is inherently unsafe

* Remove _checked suffix from methods that use artifact validation, 

* Rename methods that skip artifact validation to deserialize_unchecked

Closes #3727
