### PR TITLE
fix: Use fallback home directory detection in config commands.

### DIFF
--- a/lib/cli-compiler/src/commands/config.rs
+++ b/lib/cli-compiler/src/commands/config.rs
@@ -46,10 +46,15 @@ impl Config {
     fn inner_execute(&self) -> Result<()> {
         let key = "WASMER_DIR";
         let wasmer_dir = env::var(key)
-            .or_else(|e| {
-                option_env!("WASMER_INSTALL_PREFIX")
-                    .map(str::to_string)
-                    .ok_or(e)
+            .ok()
+            .or_else(|| option_env!("WASMER_INSTALL_PREFIX").map(str::to_string))
+            .or_else(|| {
+                // Allowing deprecated function home_dir since it works fine,
+                // and will never be removed from std.
+                #[allow(deprecated)]
+                let dir = std::env::home_dir()?.join(".wasmer").to_str()?.to_string();
+
+                Some(dir)
             })
             .context(format!(
                 "failed to retrieve the {} environment variables",


### PR DESCRIPTION
Use a standard wasmer install directory if the usual detection methods
fail.

Closes #3869 .

