### PR TITLE
lib/virtual-net: tokio::net::lookup_host requires host:port format

### DIFF
--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -92,7 +92,11 @@ impl VirtualNetworking for LocalNetworking {
         port: Option<u16>,
         dns_server: Option<IpAddr>,
     ) -> Result<Vec<IpAddr>> {
-        tokio::net::lookup_host(host)
+        let port = match port {
+            Some(p) => p,
+            None => 0,
+        };
+        tokio::net::lookup_host(format!("{}:{}", host, port))
             .await
             .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
             .map_err(io_err_into_net_error)

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -92,10 +92,20 @@ impl VirtualNetworking for LocalNetworking {
         port: Option<u16>,
         dns_server: Option<IpAddr>,
     ) -> Result<Vec<IpAddr>> {
-        tokio::net::lookup_host(format!("{}:{}", host, port.unwrap_or(0)))
-            .await
-            .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
-            .map_err(io_err_into_net_error)
+        tokio::net::lookup_host(
+            host.chars()
+                .find_map(|c| {
+                    if c == ':' {
+                        Some(host.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(format!("{}:{}", host, port.unwrap_or(0))),
+        )
+        .await
+        .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
+        .map_err(io_err_into_net_error)
     }
 }
 

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -92,11 +92,7 @@ impl VirtualNetworking for LocalNetworking {
         port: Option<u16>,
         dns_server: Option<IpAddr>,
     ) -> Result<Vec<IpAddr>> {
-        let port = match port {
-            Some(p) => p,
-            None => 0,
-        };
-        tokio::net::lookup_host(format!("{}:{}", host, port))
+        tokio::net::lookup_host(format!("{}:{}", host, port.unwrap_or(0)))
             .await
             .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
             .map_err(io_err_into_net_error)

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -92,20 +92,15 @@ impl VirtualNetworking for LocalNetworking {
         port: Option<u16>,
         dns_server: Option<IpAddr>,
     ) -> Result<Vec<IpAddr>> {
-        tokio::net::lookup_host(
-            host.chars()
-                .find_map(|c| {
-                    if c == ':' {
-                        Some(host.to_string())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(format!("{}:{}", host, port.unwrap_or(0))),
-        )
-        .await
-        .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
-        .map_err(io_err_into_net_error)
+        let host_to_lookup = if host.contains(':') {
+            host.to_string()
+        } else {
+            format!("{}:{}", host, port.unwrap_or(0))
+        };
+        tokio::net::lookup_host(host_to_lookup)
+            .await
+            .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
+            .map_err(io_err_into_net_error)
     }
 }
 


### PR DESCRIPTION
This PR updates the call to [`tokio::net::lookup_host`](https://docs.rs/tokio/latest/tokio/net/fn.lookup_host.html) used by [`syscalls::wasix::wasi_resolve`](https://github.com/wasmerio/wasmer/blob/master/lib/wasi/src/syscalls/wasix/resolve.rs#L23).

Prior to this PR when `tokio::net::lookup_host` is given a hostname without a port, name resolution fails with an `Errno::Inval`. When the port is added as shown in the `tokio::net::lookup_host` docs, it resolves successfully. This is kind of weird as it seems to me like the only thing necessary to look up a hostname should be the hostname itself -- the port shouldn't factor into it.
