### PR TITLE
TmpFs Memory Usage Tracking and Limiting

### DIFF
--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -42,3 +42,5 @@ webc-fs = ["webc", "anyhow"]
 static-fs = ["webc", "anyhow"]
 enable-serde = ["typetag"]
 no-time = []
+# Enables memory tracking/limiting functionality for the in-memory filesystem.
+tracking = []

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -43,6 +43,8 @@ pub mod webc_fs;
 #[cfg(feature = "webc-fs")]
 mod webc_volume_fs;
 
+pub mod limiter;
+
 pub use arc_box_file::*;
 pub use arc_file::*;
 pub use arc_fs::*;

--- a/lib/virtual-fs/src/limiter.rs
+++ b/lib/virtual-fs/src/limiter.rs
@@ -115,7 +115,7 @@ mod tracked_vec {
     impl Drop for TrackedVec {
         fn drop(&mut self) {
             if let Some(limiter) = &self.limiter {
-                limiter.on_shrink(self.data.len());
+                limiter.on_shrink(self.data.capacity());
             }
         }
     }

--- a/lib/virtual-fs/src/limiter.rs
+++ b/lib/virtual-fs/src/limiter.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use crate::FsError;
+
+pub use self::tracked_vec::TrackedVec;
+
+/// Allows tracking and limiting the memory usage of a memfs [`FileSystem`].
+pub trait FsMemoryLimiter: Send + Sync + std::fmt::Debug {
+    fn on_grow(&self, grown_bytes: usize) -> std::result::Result<(), FsError>;
+    fn on_shrink(&self, shrunk_bytes: usize);
+}
+
+pub type DynFsMemoryLimiter = Arc<dyn FsMemoryLimiter + Send + Sync>;
+
+#[cfg(feature = "tracking")]
+mod tracked_vec {
+    use crate::FsError;
+
+    use super::DynFsMemoryLimiter;
+
+    #[derive(Debug, Clone)]
+    pub struct TrackedVec {
+        data: Vec<u8>,
+        pub(super) limiter: Option<DynFsMemoryLimiter>,
+    }
+
+    impl TrackedVec {
+        pub fn new(limiter: Option<DynFsMemoryLimiter>) -> Self {
+            Self {
+                data: Vec::new(),
+                limiter,
+            }
+        }
+
+        pub fn limiter(&self) -> Option<&DynFsMemoryLimiter> {
+            self.limiter.as_ref()
+        }
+
+        pub fn with_capacity(
+            capacity: usize,
+            limiter: Option<DynFsMemoryLimiter>,
+        ) -> Result<Self, FsError> {
+            if let Some(limiter) = &limiter {
+                limiter.on_grow(capacity)?;
+            }
+            Ok(Self {
+                data: Vec::with_capacity(capacity),
+                limiter,
+            })
+        }
+
+        pub fn clear(&mut self) {
+            self.data.clear();
+        }
+
+        pub fn append(&mut self, other: &mut Self) -> Result<(), FsError> {
+            let old_capacity = self.data.capacity();
+            self.data.append(&mut other.data);
+
+            if let Some(limiter) = &self.limiter {
+                let new = self.data.capacity() - old_capacity;
+                limiter.on_grow(new)?;
+            }
+
+            Ok(())
+        }
+
+        pub fn split_off(&mut self, at: usize) -> Result<Self, FsError> {
+            let other = self.data.split_off(at);
+
+            if let Some(limiter) = &self.limiter {
+                // NOTE: split_off leaves the original vector capacity intact, so
+                // we can just add the new length.
+                let new_len = other.capacity();
+                limiter.on_grow(new_len)?;
+            }
+
+            Ok(Self {
+                data: other,
+                limiter: self.limiter.clone(),
+            })
+        }
+
+        pub fn resize(&mut self, new_len: usize, value: u8) -> Result<(), FsError> {
+            let old_capacity = self.data.capacity();
+            self.data.resize(new_len, value);
+            if let Some(limiter) = &self.limiter {
+                let new = self.data.capacity() - old_capacity;
+                limiter.on_grow(new)?;
+            }
+            Ok(())
+        }
+
+        pub fn extend_from_slice(&mut self, other: &[u8]) -> Result<(), FsError> {
+            let old_capacity = self.data.capacity();
+            self.data.extend_from_slice(other);
+            if let Some(limiter) = &self.limiter {
+                let new = self.data.capacity() - old_capacity;
+                limiter.on_grow(new)?;
+            }
+            Ok(())
+        }
+
+        pub fn reserve_exact(&mut self, additional: usize) -> Result<(), FsError> {
+            let old_capacity = self.data.capacity();
+            self.data.reserve_exact(additional);
+            if let Some(limiter) = &self.limiter {
+                let new = self.data.capacity() - old_capacity;
+                limiter.on_grow(new)?;
+            }
+            Ok(())
+        }
+    }
+
+    impl Drop for TrackedVec {
+        fn drop(&mut self) {
+            if let Some(limiter) = &self.limiter {
+                limiter.on_shrink(self.data.len());
+            }
+        }
+    }
+
+    impl std::ops::Deref for TrackedVec {
+        type Target = [u8];
+
+        fn deref(&self) -> &Self::Target {
+            &self.data
+        }
+    }
+
+    impl std::ops::DerefMut for TrackedVec {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.data
+        }
+    }
+}
+
+#[cfg(not(feature = "tracking"))]
+mod tracked_vec {
+    use crate::FsError;
+
+    use super::DynFsMemoryLimiter;
+
+    #[derive(Debug)]
+    pub struct TrackedVec {
+        data: Vec<u8>,
+    }
+
+    impl TrackedVec {
+        pub fn new(_limiter: Option<DynFsMemoryLimiter>) -> Self {
+            Self { data: Vec::new() }
+        }
+
+        pub fn limiter(&self) -> Option<&DynFsMemoryLimiter> {
+            None
+        }
+
+        pub fn with_capacity(
+            capacity: usize,
+            _limiter: Option<DynFsMemoryLimiter>,
+        ) -> Result<Self, FsError> {
+            Ok(Self {
+                data: Vec::with_capacity(capacity),
+            })
+        }
+
+        pub fn clear(&mut self) {
+            self.data.clear();
+        }
+
+        pub fn append(&mut self, other: &mut Self) -> Result<(), FsError> {
+            self.data.append(&mut other.data);
+            Ok(())
+        }
+
+        pub fn split_off(&mut self, at: usize) -> Result<Self, FsError> {
+            let other = self.data.split_off(at);
+            Ok(Self { data: other })
+        }
+
+        pub fn resize(&mut self, new_len: usize, value: u8) -> Result<(), FsError> {
+            self.data.resize(new_len, value);
+            Ok(())
+        }
+
+        pub fn extend_from_slice(&mut self, other: &[u8]) -> Result<(), FsError> {
+            self.data.extend_from_slice(other);
+            Ok(())
+        }
+
+        pub fn reserve_exact(&mut self, additional: usize) -> Result<(), FsError> {
+            self.data.reserve_exact(additional);
+            Ok(())
+        }
+    }
+
+    impl std::ops::Deref for TrackedVec {
+        type Target = Vec<u8>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.data
+        }
+    }
+
+    impl std::ops::DerefMut for TrackedVec {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.data
+        }
+    }
+}

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -448,7 +448,7 @@ impl crate::FileOpener for FileSystem {
                 // Write lock.
                 let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
 
-                let file = File::new();
+                let file = File::new(fs.limiter.clone());
 
                 // Creating the file in the storage.
                 let inode_of_file = fs.storage.vacant_entry().key();

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -20,6 +20,10 @@ pub struct FileSystem {
 }
 
 impl FileSystem {
+    pub fn set_memory_limiter(&self, limiter: crate::limiter::DynFsMemoryLimiter) {
+        self.inner.write().unwrap().limiter = Some(limiter);
+    }
+
     pub fn new_open_options_ext(&self) -> &FileSystem {
         self
     }
@@ -539,6 +543,7 @@ impl fmt::Debug for FileSystem {
 /// indexed by their respective `Inode` in a slab.
 pub(super) struct FileSystemInner {
     pub(super) storage: Slab<Node>,
+    pub(super) limiter: Option<crate::limiter::DynFsMemoryLimiter>,
 }
 
 #[derive(Debug)]
@@ -932,7 +937,10 @@ impl Default for FileSystemInner {
             },
         }));
 
-        Self { storage: slab }
+        Self {
+            storage: slab,
+            limiter: None,
+        }
     }
 }
 

--- a/lib/virtual-fs/src/tmp_fs.rs
+++ b/lib/virtual-fs/src/tmp_fs.rs
@@ -30,6 +30,10 @@ impl TmpFileSystem {
         Self::default()
     }
 
+    pub fn set_memory_limiter(&self, limiter: crate::limiter::DynFsMemoryLimiter) {
+        self.fs.set_memory_limiter(limiter);
+    }
+
     pub fn new_open_options_ext(&self) -> &mem_fs::FileSystem {
         self.fs.new_open_options_ext()
     }

--- a/lib/wasi/src/os/console/mod.rs
+++ b/lib/wasi/src/os/console/mod.rs
@@ -51,6 +51,7 @@ pub struct Console {
     stdout: ArcBoxFile,
     stderr: ArcBoxFile,
     capabilities: Capabilities,
+    memfs_memory_limiter: Option<virtual_fs::limiter::DynFsMemoryLimiter>,
 }
 
 impl Console {
@@ -81,6 +82,7 @@ impl Console {
             stdout: ArcBoxFile::new(Box::new(Pipe::channel().0)),
             stderr: ArcBoxFile::new(Box::new(Pipe::channel().0)),
             capabilities: Default::default(),
+            memfs_memory_limiter: None,
         }
     }
 
@@ -143,6 +145,14 @@ impl Console {
         self
     }
 
+    pub fn with_mem_fs_memory_limiter(
+        mut self,
+        limiter: virtual_fs::limiter::DynFsMemoryLimiter,
+    ) -> Self {
+        self.memfs_memory_limiter = Some(limiter);
+        self
+    }
+
     pub fn run(&mut self) -> Result<(TaskJoinHandle, WasiProcess), VirtualBusError> {
         // Extract the program name from the arguments
         let empty_args: Vec<&[u8]> = Vec::new();
@@ -192,6 +202,18 @@ impl Console {
 
         // TODO: no unwrap!
         let env = WasiEnv::from_init(env_init).unwrap();
+
+        if let Some(limiter) = &self.memfs_memory_limiter {
+            match &env.state.fs.root_fs {
+                crate::fs::WasiFsRoot::Sandbox(tmpfs) => {
+                    tmpfs.set_memory_limiter(limiter.clone());
+                }
+                crate::fs::WasiFsRoot::Backing(_) => {
+                    tracing::error!("tried to set a tmpfs memory limiter on a backing fs");
+                    return Err(VirtualBusError::InvokeFailed);
+                }
+            }
+        }
 
         // TODO: this should not happen here...
         // Display the welcome message


### PR DESCRIPTION
feat(virtual-fs): Add TmpFs memory tracking and limiting

Hacky implementation for tracking and limiting the memory consumption of
in-memory files of the TmpFs / mem_fs.

Ideally this would use a Vec with a custom allocator, but the allocator
APIs are currently restricted to nightly Rust.

To keep both code impact and performance impact low, a TrackedVec is
added that can hold a FsMemoryLimiter, which has callbacks for growing
and for shrinking memory.

Without the new "tracked" feature enabled, a stub impl is added, which
does not do any tracking , and hence has minimal performance impact.

This should be rewritten to a sane implementaiton soon as part of a
larger virtual-fs rewrite.

Closes #3865
