### PR TITLE
Choose subversion of tracing crate in wasix

### DIFF
--- a/lib/wasi/Cargo.toml
+++ b/lib/wasi/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0"
 thiserror = "1"
-tracing = { version = "0.1" }
+tracing = { version = "0.1.37" }
 getrandom = "0.2"
 wasmer-wasix-types = { path = "../wasi-types", version = "0.4.0", features = [ "enable-serde" ] }
 wasmer-types = { path = "../types", version = "=3.3.0", default-features = false }


### PR DESCRIPTION
The wasix crate needs version at least 0.1.36, because of method "record" here: https://docs.rs/crate/tracing/0.1.36/source/src/span.rs

```rust
    pub fn record<Q: ?Sized, V>(&self, field: &Q, value: V) -> &Self
    where
        Q: field::AsField,
        V: field::Value,
    { ... }
```

but sys-utils is using 0.1.37, so might as well use that.


