### PR TITLE
Removed all deprecated functions

### DIFF
--- a/lib/api/src/engine.rs
+++ b/lib/api/src/engine.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 #[cfg(feature = "sys")]
 pub use wasmer_compiler::{Artifact, CompilerConfig, EngineInner, Features, Tunables};
 #[cfg(feature = "sys")]
-use wasmer_types::{DeserializeError, Target};
+use wasmer_types::DeserializeError;
 
 #[cfg(feature = "js")]
 use crate::js::engine as engine_imp;
@@ -33,20 +33,6 @@ impl Engine {
     /// Returns the deterministic id of this engine
     pub fn deterministic_id(&self) -> &str {
         self.0.deterministic_id()
-    }
-
-    #[cfg(feature = "sys")]
-    /// Create a headless `Engine`
-    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
-    pub fn headless() -> Self {
-        Self(engine_imp::Engine::headless())
-    }
-
-    #[cfg(feature = "sys")]
-    /// Gets the target
-    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
-    pub fn target(&self) -> &Target {
-        self.0.target()
     }
 
     #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
@@ -110,21 +96,8 @@ impl Engine {
         file.read_to_end(&mut buffer)?;
         Ok(Arc::new(Artifact::deserialize(&self.0, buffer.as_slice())?))
     }
-
-    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
-    /// Attach a Tunable to this engine
-    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
-    pub fn set_tunables(&mut self, tunables: impl Tunables + Send + Sync + 'static) {
-        self.0.set_tunables(tunables);
-    }
-
-    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
-    /// Get a reference to attached Tunable of this engine
-    /// Will be removed in 4.0 in favor of the NativeEngineExt trait
-    pub fn tunables(&self) -> &dyn Tunables {
-        self.0.tunables()
-    }
 }
+
 impl AsEngineRef for Engine {
     #[inline]
     fn as_engine_ref(&self) -> EngineRef {

--- a/lib/api/src/engine.rs
+++ b/lib/api/src/engine.rs
@@ -13,9 +13,7 @@ use std::sync::Arc;
 #[cfg(feature = "sys")]
 pub use wasmer_compiler::{Artifact, CompilerConfig, EngineInner, Features, Tunables};
 #[cfg(feature = "sys")]
-use wasmer_types::{CompileError, DeserializeError, FunctionType, Target};
-#[cfg(feature = "sys")]
-use wasmer_vm::VMSharedSignatureIndex;
+use wasmer_types::{DeserializeError, Target};
 
 #[cfg(feature = "js")]
 use crate::js::engine as engine_imp;
@@ -26,37 +24,15 @@ pub(crate) use crate::js::engine::default_engine;
 use crate::jsc::engine as engine_imp;
 #[cfg(feature = "jsc")]
 pub(crate) use crate::jsc::engine::default_engine;
-#[cfg(feature = "sys")]
-type EngineId = str;
 
 /// The engine type
 #[derive(Clone, Debug)]
 pub struct Engine(pub(crate) engine_imp::Engine);
 
 impl Engine {
-    #[deprecated(
-        since = "3.2.0",
-        note = "engine.cloned() has been deprecated in favor of engine.clone()"
-    )]
-    /// Returns the [`Engine`].
-    pub fn cloned(&self) -> Self {
-        self.clone()
-    }
-
     /// Returns the deterministic id of this engine
     pub fn deterministic_id(&self) -> &str {
         self.0.deterministic_id()
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(all(feature = "compiler", feature = "sys"))]
-    /// Create a new `Engine` with the given config
-    pub fn new(
-        compiler_config: Box<dyn CompilerConfig>,
-        target: Target,
-        features: Features,
-    ) -> Self {
-        Self(engine_imp::Engine::new(compiler_config, target, features))
     }
 
     #[cfg(feature = "sys")]
@@ -66,73 +42,11 @@ impl Engine {
         Self(engine_imp::Engine::headless())
     }
 
-    #[deprecated(since = "3.2.0")]
-    #[cfg(feature = "sys")]
-    /// Get reference to `EngineInner`.
-    pub fn inner(&self) -> std::sync::MutexGuard<'_, EngineInner> {
-        self.0.inner()
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(feature = "sys")]
-    /// Get mutable reference to `EngineInner`.
-    pub fn inner_mut(&self) -> std::sync::MutexGuard<'_, EngineInner> {
-        self.0.inner_mut()
-    }
-
     #[cfg(feature = "sys")]
     /// Gets the target
     /// Will be removed in 4.0 in favor of the NativeEngineExt trait
     pub fn target(&self) -> &Target {
         self.0.target()
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(feature = "sys")]
-    /// Register a signature
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn register_signature(&self, func_type: &FunctionType) -> VMSharedSignatureIndex {
-        let compiler = self.0.inner();
-        compiler.signatures().register(func_type)
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(feature = "sys")]
-    /// Lookup a signature
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn lookup_signature(&self, sig: VMSharedSignatureIndex) -> Option<FunctionType> {
-        let compiler = self.0.inner();
-        compiler.signatures().lookup(sig)
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(feature = "sys")]
-    /// Validates a WebAssembly module
-    #[cfg(feature = "compiler")]
-    pub fn validate(&self, binary: &[u8]) -> Result<(), CompileError> {
-        self.0.inner().validate(binary)
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(all(feature = "sys", feature = "compiler"))]
-    #[cfg(not(target_arch = "wasm32"))]
-    /// Compile a WebAssembly binary
-    pub fn compile(&self, binary: &[u8]) -> Result<Arc<Artifact>, CompileError> {
-        Ok(Arc::new(Artifact::new(&self.0, binary, self.0.tunables())?))
-    }
-
-    #[deprecated(since = "3.2.0")]
-    #[cfg(all(feature = "sys", not(feature = "compiler")))]
-    #[cfg(not(target_arch = "wasm32"))]
-    /// Compile a WebAssembly binary
-    pub fn compile(
-        &self,
-        _binary: &[u8],
-        _tunables: &dyn Tunables,
-    ) -> Result<Arc<Artifact>, CompileError> {
-        Err(CompileError::Codegen(
-            "The Engine is operating in headless mode, so it can not compile Modules.".to_string(),
-        ))
     }
 
     #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
@@ -195,17 +109,6 @@ impl Engine {
         // read the whole file
         file.read_to_end(&mut buffer)?;
         Ok(Arc::new(Artifact::deserialize(&self.0, buffer.as_slice())?))
-    }
-
-    #[deprecated(since = "3.2.0", note = "Use Engine::deterministic_id()")]
-    #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
-    /// A unique identifier for this object.
-    ///
-    /// This exists to allow us to compare two Engines for equality. Otherwise,
-    /// comparing two trait objects unsafely relies on implementation details
-    /// of trait representation.
-    pub fn id(&self) -> &EngineId {
-        self.deterministic_id()
     }
 
     #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]

--- a/lib/api/src/exports.rs
+++ b/lib/api/src/exports.rs
@@ -132,23 +132,6 @@ impl Exports {
         self.get(name)
     }
 
-    #[deprecated(
-        since = "3.0.0",
-        note = "get_native_function() has been renamed to get_typed_function(), just like NativeFunc has been renamed to TypedFunction."
-    )]
-    /// Get an export as a `TypedFunction`.
-    pub fn get_native_function<Args, Rets>(
-        &self,
-        store: &impl AsStoreRef,
-        name: &str,
-    ) -> Result<TypedFunction<Args, Rets>, ExportError>
-    where
-        Args: WasmTypeList,
-        Rets: WasmTypeList,
-    {
-        self.get_typed_function(store, name)
-    }
-
     /// Get an export as a `TypedFunction`.
     pub fn get_typed_function<Args, Rets>(
         &self,

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -156,20 +156,6 @@ impl Function {
         Self(function_impl::Function::new_with_env(store, env, ty, func))
     }
 
-    #[deprecated(
-        since = "3.0.0",
-        note = "new_native() has been renamed to new_typed()."
-    )]
-    /// Creates a new host `Function` from a native function.
-    pub fn new_native<F, Args, Rets>(store: &mut impl AsStoreMut, func: F) -> Self
-    where
-        F: HostFunction<(), Args, Rets, WithoutEnv> + 'static + Send + Sync,
-        Args: WasmTypeList,
-        Rets: WasmTypeList,
-    {
-        Self::new_typed(store, func)
-    }
-
     /// Creates a new host `Function` from a native function.
     pub fn new_typed<F, Args, Rets>(store: &mut impl AsStoreMut, func: F) -> Self
     where
@@ -178,24 +164,6 @@ impl Function {
         Rets: WasmTypeList,
     {
         Self(function_impl::Function::new_typed(store, func))
-    }
-
-    #[deprecated(
-        since = "3.0.0",
-        note = "new_native_with_env() has been renamed to new_typed_with_env()."
-    )]
-    /// Creates a new host `Function` with an environment from a native function.
-    pub fn new_native_with_env<T: Send + 'static, F, Args, Rets>(
-        store: &mut impl AsStoreMut,
-        env: &FunctionEnv<T>,
-        func: F,
-    ) -> Self
-    where
-        F: HostFunction<T, Args, Rets, WithEnv> + 'static + Send + Sync,
-        Args: WasmTypeList,
-        Rets: WasmTypeList,
-    {
-        Self::new_typed_with_env(store, env, func)
     }
 
     /// Creates a new host `Function` with an environment from a typed function.
@@ -350,20 +318,6 @@ impl Function {
 
     pub(crate) unsafe fn from_vm_funcref(store: &mut impl AsStoreMut, funcref: VMFuncRef) -> Self {
         Self(function_impl::Function::from_vm_funcref(store, funcref))
-    }
-
-    /// Transform this WebAssembly function into a native function.
-    /// See [`TypedFunction`] to learn more.
-    #[deprecated(since = "3.0.0", note = "native() has been renamed to typed().")]
-    pub fn native<Args, Rets>(
-        &self,
-        store: &impl AsStoreRef,
-    ) -> Result<TypedFunction<Args, Rets>, RuntimeError>
-    where
-        Args: WasmTypeList,
-        Rets: WasmTypeList,
-    {
-        self.typed(store)
     }
 
     /// Transform this WebAssembly function into a typed function.

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -502,14 +502,5 @@ pub use wat::parse_bytes as wat2wasm;
 #[cfg(feature = "wasmparser")]
 pub use wasmparser;
 
-// Deprecated types
-
-/// This type is deprecated, it has been replaced by TypedFunction.
-#[deprecated(
-    since = "3.0.0",
-    note = "NativeFunc has been replaced by TypedFunction"
-)]
-pub type NativeFunc<Args = (), Rets = ()> = TypedFunction<Args, Rets>;
-
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/api/src/store.rs
+++ b/lib/api/src/store.rs
@@ -75,45 +75,10 @@ impl Store {
         }
     }
 
-    #[deprecated(
-        since = "3.0.0",
-        note = "Store::new_with_engine has been deprecated in favor of Store::new"
-    )]
-    /// Creates a new `Store` with a specific [`Engine`].
-    pub fn new_with_engine(engine: impl Into<Engine>) -> Self {
-        Self::new(engine)
-    }
-
     #[cfg(feature = "sys")]
     /// Set the trap handler in this store.
     pub fn set_trap_handler(&mut self, handler: Option<Box<TrapHandlerFn<'static>>>) {
         self.inner.trap_handler = handler;
-    }
-
-    #[cfg(feature = "sys")]
-    #[deprecated(
-        since = "3.2.0",
-        note = "store.new_with_tunables() has been deprecated in favor of engine.set_tunables()"
-    )]
-    /// Creates a new `Store` with a specific [`Engine`] and [`Tunables`].
-    pub fn new_with_tunables(
-        engine: impl Into<Engine>,
-        tunables: impl Tunables + Send + Sync + 'static,
-    ) -> Self {
-        let mut engine = engine.into();
-        engine.set_tunables(tunables);
-
-        Self::new(engine)
-    }
-
-    #[cfg(feature = "sys")]
-    #[deprecated(
-        since = "3.2.0",
-        note = "store.tunables() has been deprecated in favor of store.engine().tunables()"
-    )]
-    /// Returns the [`Tunables`].
-    pub fn tunables(&self) -> &dyn Tunables {
-        self.inner.engine.tunables()
     }
 
     /// Returns the [`Engine`].
@@ -201,16 +166,6 @@ impl<'a> StoreRef<'a> {
         &self.inner.objects
     }
 
-    #[cfg(feature = "sys")]
-    #[deprecated(
-        since = "3.2.0",
-        note = "store.tunables() has been deprecated in favor of store.engine().tunables()"
-    )]
-    /// Returns the [`Tunables`].
-    pub fn tunables(&self) -> &dyn Tunables {
-        self.inner.engine.tunables()
-    }
-
     /// Returns the [`Engine`].
     pub fn engine(&self) -> &Engine {
         &self.inner.engine
@@ -239,16 +194,6 @@ pub struct StoreMut<'a> {
 }
 
 impl<'a> StoreMut<'a> {
-    /// Returns the [`Tunables`].
-    #[cfg(feature = "sys")]
-    #[deprecated(
-        since = "3.2.0",
-        note = "store.tunables() has been deprecated in favor of store.engine().tunables()"
-    )]
-    pub fn tunables(&self) -> &dyn Tunables {
-        self.inner.engine.tunables()
-    }
-
     /// Returns the [`Engine`].
     pub fn engine(&self) -> &Engine {
         &self.inner.engine

--- a/lib/api/src/sys/externals/function.rs
+++ b/lib/api/src/sys/externals/function.rs
@@ -1,6 +1,7 @@
 use crate::externals::function::{HostFunction, WithEnv, WithoutEnv};
 use crate::native_type::{FromToNativeWasmType, IntoResult, NativeWasmTypeInto, WasmTypeList};
 use crate::store::{AsStoreMut, AsStoreRef, StoreInner, StoreMut};
+use crate::sys::engine::NativeEngineExt;
 use crate::vm::{VMExternFunction, VMFunctionCallback};
 use crate::{FunctionEnv, FunctionEnvMut, FunctionType, RuntimeError, Value};
 use std::panic::{self, AssertUnwindSafe};

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -1,5 +1,6 @@
 use super::memory_view::MemoryView;
 use crate::store::{AsStoreMut, AsStoreRef};
+use crate::sys::engine::NativeEngineExt;
 use crate::vm::VMExternMemory;
 use crate::MemoryAccessError;
 use crate::MemoryType;

--- a/lib/api/src/sys/externals/table.rs
+++ b/lib/api/src/sys/externals/table.rs
@@ -1,4 +1,5 @@
 use crate::store::{AsStoreMut, AsStoreRef};
+use crate::sys::engine::NativeEngineExt;
 use crate::TableType;
 use crate::Value;
 use crate::{vm::VMExternTable, ExternRef, Function, RuntimeError};

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -9,6 +9,7 @@ use wasmer_types::{
 };
 use wasmer_types::{ExportType, ImportType};
 
+use crate::sys::engine::NativeEngineExt;
 use crate::vm::VMInstance;
 use crate::{AsStoreMut, AsStoreRef, InstantiationError, IntoBytes};
 

--- a/lib/api/src/sys/typed_function.rs
+++ b/lib/api/src/sys/typed_function.rs
@@ -3,6 +3,7 @@ use wasmer_types::RawValue;
 
 use crate::native_type::NativeWasmTypeInto;
 use crate::store::{AsStoreMut, AsStoreRef};
+use crate::sys::engine::NativeEngineExt;
 
 macro_rules! impl_native_traits {
     (  $( $x:ident ),* ) => {

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -19,8 +19,8 @@ use std::slice;
 #[cfg(feature = "webc_runner")]
 use wasmer_api::{AsStoreMut, Imports, Module};
 use wasmer_wasix::{
-    default_fs_backing, get_wasi_version, virtual_fs::AsyncReadExt, Pipe, VirtualTaskManager,
-    WasiEnv, WasiEnvBuilder, WasiFile, WasiFunctionEnv, WasiVersion,
+    default_fs_backing, get_wasi_version, virtual_fs::AsyncReadExt, virtual_fs::VirtualFile, Pipe,
+    VirtualTaskManager, WasiEnv, WasiEnvBuilder, WasiFunctionEnv, WasiVersion,
 };
 
 #[derive(Debug)]
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn wasi_env_read_stderr(
 
 fn read_inner(
     tasks: &dyn VirtualTaskManager,
-    wasi_file: &mut Box<dyn WasiFile + Send + Sync + 'static>,
+    wasi_file: &mut Box<dyn VirtualFile + Send + Sync + 'static>,
     inner_buffer: &mut [u8],
 ) -> isize {
     tasks.block_on(async {

--- a/lib/compiler-cranelift/src/config.rs
+++ b/lib/compiler-cranelift/src/config.rs
@@ -209,10 +209,6 @@ impl CompilerConfig for Cranelift {
         self.enable_verifier = true;
     }
 
-    fn enable_nan_canonicalization(&mut self) {
-        self.enable_nan_canonicalization = true;
-    }
-
     fn canonicalize_nans(&mut self, enable: bool) {
         self.enable_nan_canonicalization = enable;
     }

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -259,10 +259,6 @@ impl CompilerConfig for LLVM {
         self.enable_verifier = true;
     }
 
-    fn enable_nan_canonicalization(&mut self) {
-        self.enable_nan_canonicalization = true;
-    }
-
     fn canonicalize_nans(&mut self, enable: bool) {
         self.enable_nan_canonicalization = enable;
     }

--- a/lib/compiler-singlepass/src/config.rs
+++ b/lib/compiler-singlepass/src/config.rs
@@ -23,10 +23,6 @@ impl Singlepass {
         }
     }
 
-    fn enable_nan_canonicalization(&mut self) {
-        self.enable_nan_canonicalization = true;
-    }
-
     pub fn canonicalize_nans(&mut self, enable: bool) -> &mut Self {
         self.enable_nan_canonicalization = enable;
         self

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -41,16 +41,6 @@ pub trait CompilerConfig {
     ///
     /// NaN canonicalization is useful when trying to run WebAssembly
     /// deterministically across different architectures.
-    #[deprecated(note = "Please use the canonicalize_nans instead")]
-    fn enable_nan_canonicalization(&mut self) {
-        // By default we do nothing, each backend will need to customize this
-        // in case they create an IR that they can verify.
-    }
-
-    /// Enable NaN canonicalization.
-    ///
-    /// NaN canonicalization is useful when trying to run WebAssembly
-    /// deterministically across different architectures.
     fn canonicalize_nans(&mut self, _enable: bool) {
         // By default we do nothing, each backend will need to customize this
         // in case they create an IR that they can verify.

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -1533,10 +1533,3 @@ fn build_funcrefs(
         imported_func_refs.into_boxed_slice(),
     )
 }
-
-/// This type is deprecated, it has been replaced by VMinstance.
-#[deprecated(
-    since = "3.2.0",
-    note = "InstanceHandle has been replaced by VMInstance"
-)]
-pub type InstanceHandle = VMInstance;

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -45,8 +45,7 @@ pub use crate::extern_ref::{VMExternObj, VMExternRef};
 pub use crate::function_env::VMFunctionEnvironment;
 pub use crate::global::*;
 pub use crate::imports::Imports;
-#[allow(deprecated)]
-pub use crate::instance::{InstanceAllocator, InstanceHandle, VMInstance};
+pub use crate::instance::{InstanceAllocator, VMInstance};
 pub use crate::memory::{
     initialize_memory_with_data, LinearMemory, NotifyLocation, VMMemory, VMOwnedMemory,
     VMSharedMemory,
@@ -71,12 +70,6 @@ pub use wasmer_types::MemoryStyle;
 use wasmer_types::RawValue;
 pub use wasmer_types::TableStyle;
 pub use wasmer_types::{StoreId, TargetSharedSignatureIndex, VMBuiltinFunctionIndex, VMOffsets};
-
-#[deprecated(
-    since = "2.1.0",
-    note = "ModuleInfo, ExportsIterator, ImportsIterator should be imported from wasmer_types."
-)]
-pub use wasmer_types::{ExportsIterator, ImportsIterator, ModuleInfo};
 
 /// Version number of this crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -781,10 +781,10 @@ unsafe impl Sync for VMMemoryDefinition {}
 #[cfg(test)]
 mod test_vmmemory_definition {
     use super::VMMemoryDefinition;
-    use crate::ModuleInfo;
     use crate::VMOffsets;
     use memoffset::offset_of;
     use std::mem::size_of;
+    use wasmer_types::ModuleInfo;
 
     #[test]
     fn check_vmmemory_definition_offsets() {

--- a/lib/wasi/src/lib.rs
+++ b/lib/wasi/src/lib.rs
@@ -68,10 +68,6 @@ use wasmer::{
 };
 
 pub use virtual_fs;
-#[deprecated(since = "2.1.0", note = "Please use `virtual_fs::FsError`")]
-pub use virtual_fs::FsError as WasiFsError;
-#[deprecated(since = "2.1.0", note = "Please use `virtual_fs::VirtualFile`")]
-pub use virtual_fs::VirtualFile as WasiFile;
 pub use virtual_fs::{DuplexPipe, FsError, Pipe, VirtualFile, WasiBidirectionalSharedPipePair};
 pub use virtual_net;
 pub use virtual_net::{UnsupportedVirtualNetworking, VirtualNetworking};


### PR DESCRIPTION
This PR fixes #3799 by removing all deprecated functions (excepts of those introduced in Wasmer 4.0)