### PR TITLE
lib/wasi: try removing base absolute path check

### DIFF
--- a/lib/wasi/src/fs/mod.rs
+++ b/lib/wasi/src/fs/mod.rs
@@ -1298,13 +1298,12 @@ impl WasiFs {
         path: &str,
         follow_symlinks: bool,
     ) -> Result<InodeGuard, Errno> {
-        let start_inode =
-            if self.is_wasix.load(Ordering::Acquire) {
-                let (cur_inode, _) = self.get_current_dir(inodes, base)?;
-                cur_inode
-            } else {
-                self.get_fd_inode(base)?
-            };
+        let start_inode = if self.is_wasix.load(Ordering::Acquire) {
+            let (cur_inode, _) = self.get_current_dir(inodes, base)?;
+            cur_inode
+        } else {
+            self.get_fd_inode(base)?
+        };
         self.get_inode_at_path_inner(inodes, start_inode, path, 0, follow_symlinks)
     }
 

--- a/lib/wasi/src/fs/mod.rs
+++ b/lib/wasi/src/fs/mod.rs
@@ -1298,9 +1298,8 @@ impl WasiFs {
         path: &str,
         follow_symlinks: bool,
     ) -> Result<InodeGuard, Errno> {
-        let base_inode = self.get_fd_inode(base)?;
         let start_inode =
-            if !base_inode.deref().name.starts_with('/') && self.is_wasix.load(Ordering::Acquire) {
+            if self.is_wasix.load(Ordering::Acquire) {
                 let (cur_inode, _) = self.get_current_dir(inodes, base)?;
                 cur_inode
             } else {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description

We merged #3867 before everyone was fully agreed that it was the right
approach. The alternate discussed is shown here (in the initial commit of this
PR), which is to remove the `!base_inode.deref().name.starts_with('/')` portion
of the logic.

I am opening this PR to demonstrate via the new integration test I added in
#3867 (see
tests/integration/cli/tests/snapshots/snapshot__snapshot_readdir_tree.snap) how
removing that bit of logic breaks the `path_filestat_get` syscall.

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
