### PR TITLE
Handle non-200 status codes when downloading WEBC files

### DIFF
--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "dummy-waker",
  "fastrand",
  "futures",
+ "http",
  "js-sys",
  "once_cell",
  "parking_lot",

--- a/lib/wasi-web/Cargo.toml
+++ b/lib/wasi-web/Cargo.toml
@@ -41,6 +41,7 @@ dummy-waker = "^1"
 wat = "1.0"
 anyhow = "1.0.66"
 futures = "0.3.25"
+http = "0.2.9"
 
 [dependencies.parking_lot]
 version = "^0.11"

--- a/lib/wasi-web/src/common.rs
+++ b/lib/wasi-web/src/common.rs
@@ -141,7 +141,7 @@ pub async fn fetch(
     method: &str,
     _gzip: bool,
     cors_proxy: Option<String>,
-    headers: Vec<(String, String)>,
+    headers: &http::HeaderMap,
     data: Option<Vec<u8>>,
 ) -> Result<Response, anyhow::Error> {
     let mut opts = RequestInit::new();
@@ -162,7 +162,8 @@ pub async fn fetch(
 
         let set_headers = request.headers();
         for (name, val) in headers.iter() {
-            set_headers.set(name.as_str(), val.as_str()).map_err(|_| {
+            let val = String::from_utf8_lossy(val.as_bytes());
+            set_headers.set(name.as_str(), &val).map_err(|_| {
                 anyhow::anyhow!("could not apply request header: '{name}': '{val}'")
             })?;
         }

--- a/lib/wasi-web/src/glue.rs
+++ b/lib/wasi-web/src/glue.rs
@@ -9,7 +9,6 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 use wasm_bindgen::{prelude::*, JsCast};
 use wasmer_wasix::{
-    bin_factory::ModuleCache,
     capabilities::Capabilities,
     os::{Console, InputEvent, Tty, TtyOptions},
     Pipe,
@@ -38,9 +37,9 @@ pub fn main() {
     set_panic_hook();
 }
 
-pub const DEFAULT_BOOT_WEBC: &'static str = "sharrattj/bash";
+pub const DEFAULT_BOOT_WEBC: &str = "sharrattj/bash";
 //pub const DEFAULT_BOOT_WEBC: &str = "sharrattj/dash";
-pub const DEFAULT_BOOT_USES: [&'static str; 2] = ["sharrattj/coreutils", "sharrattj/catsay"];
+pub const DEFAULT_BOOT_USES: [&str; 2] = ["sharrattj/coreutils", "sharrattj/catsay"];
 
 #[wasm_bindgen]
 pub fn start() -> Result<(), JsValue> {
@@ -134,8 +133,6 @@ pub fn start() -> Result<(), JsValue> {
         tty_options,
     );
 
-    let compiled_modules = Arc::new(ModuleCache::new(None, None, false));
-
     let location = url::Url::parse(location.as_str()).unwrap();
     let mut console = if let Some(init) = location
         .query_pairs()
@@ -143,11 +140,11 @@ pub fn start() -> Result<(), JsValue> {
         .next()
         .map(|(_, val)| val.to_string())
     {
-        let mut console = Console::new(init.as_str(), runtime.clone(), compiled_modules);
+        let mut console = Console::new(init.as_str(), runtime.clone());
         console = console.with_no_welcome(true);
         console
     } else {
-        let mut console = Console::new(DEFAULT_BOOT_WEBC, runtime.clone(), compiled_modules);
+        let mut console = Console::new(DEFAULT_BOOT_WEBC, runtime.clone());
         console = console.with_uses(DEFAULT_BOOT_USES.iter().map(|a| a.to_string()).collect());
         console
     };

--- a/lib/wasi-web/src/pool.rs
+++ b/lib/wasi-web/src/pool.rs
@@ -662,7 +662,7 @@ pub fn wasm_entry_point(
         run(TaskWasmRunProperties {
             ctx,
             store,
-            result: task.result,
+            trigger_result: task.result,
         });
     };
 }

--- a/lib/wasi/src/http/client_impl.rs
+++ b/lib/wasi/src/http/client_impl.rs
@@ -1,12 +1,13 @@
-use std::string::FromUtf8Error;
 use std::sync::Arc;
 
-use crate::bindings::wasix_http_client_v1 as sys;
-use crate::{capabilities::Capabilities, Runtime};
+use http::{HeaderMap, HeaderValue};
+use url::Url;
 
 use crate::{
+    bindings::wasix_http_client_v1 as sys,
+    capabilities::Capabilities,
     http::{DynHttpClient, HttpClientCapabilityV1},
-    WasiEnv,
+    Runtime, WasiEnv,
 };
 
 impl std::fmt::Display for sys::Method<'_> {
@@ -92,11 +93,12 @@ impl sys::WasixHttpClientV1 for WasixHttpClientImpl {
             .headers
             .into_iter()
             .map(|h| {
-                let value = String::from_utf8(h.value.to_vec())?;
-                Ok((h.key.to_string(), value))
+                let value = HeaderValue::from_bytes(&h.value).map_err(|e| e.to_string())?;
+                let key =
+                    http::HeaderName::from_bytes(h.key.as_bytes()).map_err(|e| e.to_string())?;
+                Ok((key, value))
             })
-            .collect::<Result<Vec<_>, FromUtf8Error>>()
-            .map_err(|_| "non-utf8 request header")?;
+            .collect::<Result<HeaderMap, String>>()?;
 
         // FIXME: stream body...
 
@@ -108,9 +110,22 @@ impl sys::WasixHttpClientV1 for WasixHttpClientImpl {
             None => None,
         };
 
+        let method = match request.method {
+            sys::Method::Get => http::Method::GET,
+            sys::Method::Head => http::Method::HEAD,
+            sys::Method::Post => http::Method::POST,
+            sys::Method::Put => http::Method::PUT,
+            sys::Method::Delete => http::Method::DELETE,
+            sys::Method::Connect => http::Method::CONNECT,
+            sys::Method::Options => http::Method::OPTIONS,
+            sys::Method::Trace => http::Method::TRACE,
+            sys::Method::Patch => http::Method::PATCH,
+            sys::Method::Other(other) => return Err(format!("Unknown method: {other}")),
+        };
+
         let req = crate::http::HttpRequest {
-            url: request.url.to_string(),
-            method: request.method.to_string(),
+            url: Url::parse(&request.url).map_err(|e| e.to_string())?,
+            method,
             headers,
             body,
             options: crate::http::HttpRequestOptions {
@@ -128,10 +143,10 @@ impl sys::WasixHttpClientV1 for WasixHttpClientImpl {
 
         let res_headers = res
             .headers
-            .into_iter()
-            .map(|(key, value)| sys::HeaderResult {
-                key,
-                value: value.into_bytes(),
+            .iter()
+            .map(|(name, value)| sys::HeaderResult {
+                key: name.to_string(),
+                value: value.as_bytes().to_vec(),
             })
             .collect();
 
@@ -143,7 +158,7 @@ impl sys::WasixHttpClientV1 for WasixHttpClientImpl {
 
         Ok({
             sys::Response {
-                status: res.status,
+                status: res.status.as_u16(),
                 headers: res_headers,
                 body: res_body,
                 // TODO: provide redirect urls?

--- a/lib/wasi/src/http/client_impl.rs
+++ b/lib/wasi/src/http/client_impl.rs
@@ -93,7 +93,7 @@ impl sys::WasixHttpClientV1 for WasixHttpClientImpl {
             .headers
             .into_iter()
             .map(|h| {
-                let value = HeaderValue::from_bytes(&h.value).map_err(|e| e.to_string())?;
+                let value = HeaderValue::from_bytes(h.value).map_err(|e| e.to_string())?;
                 let key =
                     http::HeaderName::from_bytes(h.key.as_bytes()).map_err(|e| e.to_string())?;
                 Ok((key, value))
@@ -124,7 +124,7 @@ impl sys::WasixHttpClientV1 for WasixHttpClientImpl {
         };
 
         let req = crate::http::HttpRequest {
-            url: Url::parse(&request.url).map_err(|e| e.to_string())?,
+            url: Url::parse(request.url).map_err(|e| e.to_string())?,
             method,
             headers,
             body,

--- a/lib/wasi/src/http/reqwest.rs
+++ b/lib/wasi/src/http/reqwest.rs
@@ -30,23 +30,14 @@ impl ReqwestHttpClient {
             .build()
             .context("Failed to construct http request")?;
 
-        let response = client.execute(request).await?;
+        let mut response = client.execute(request).await?;
+        let headers = std::mem::take(response.headers_mut());
 
-        let status = response.status().as_u16();
-        let status_text = response.status().as_str().to_string();
-        // TODO: prevent redundant header copy.
-        let headers = response
-            .headers()
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_str().unwrap().to_string()))
-            .collect();
+        let status = response.status();
         let data = response.bytes().await?.to_vec();
 
         Ok(HttpResponse {
-            pos: 0usize,
-            ok: true,
             status,
-            status_text,
             redirected: false,
             body: Some(data),
             headers,

--- a/lib/wasi/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasi/src/runtime/package_loader/builtin_loader.rs
@@ -115,7 +115,9 @@ impl BuiltinPackageLoader {
                 .context(format!("The GET request to \"{url}\" failed")));
         }
 
-        let body = response.body.context("The response didn't contain a body")?;
+        let body = response
+            .body
+            .context("The response didn't contain a body")?;
 
         Ok(body.into())
     }

--- a/lib/wasi/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasi/src/runtime/package_loader/builtin_loader.rs
@@ -111,7 +111,7 @@ impl BuiltinPackageLoader {
 
         if !response.is_ok() {
             let url = &dist.webc;
-            return Err(crate::runtime::resolver::polyfills::http_error(&response)
+            return Err(crate::runtime::resolver::utils::http_error(&response)
                 .context(format!("The GET request to \"{url}\" failed")));
         }
 

--- a/lib/wasi/src/runtime/resolver/filesystem_source.rs
+++ b/lib/wasi/src/runtime/resolver/filesystem_source.rs
@@ -29,7 +29,7 @@ impl Source for FileSystemSource {
         let container = Container::from_disk(&path)
             .with_context(|| format!("Unable to parse \"{}\"", path.display()))?;
 
-        let url = crate::runtime::resolver::polyfills::url_from_file_path(&path)
+        let url = crate::runtime::resolver::utils::url_from_file_path(&path)
             .ok_or_else(|| anyhow::anyhow!("Unable to turn \"{}\" into a URL", path.display()))?;
 
         let summary = PackageSummary {

--- a/lib/wasi/src/runtime/resolver/in_memory_source.rs
+++ b/lib/wasi/src/runtime/resolver/in_memory_source.rs
@@ -170,7 +170,7 @@ mod tests {
                     entrypoint: Some("bash".to_string()),
                 },
                 dist: DistributionInfo {
-                    webc: crate::runtime::resolver::polyfills::url_from_file_path(
+                    webc: crate::runtime::resolver::utils::url_from_file_path(
                         bash.canonicalize().unwrap()
                     )
                     .unwrap(),

--- a/lib/wasi/src/runtime/resolver/inputs.rs
+++ b/lib/wasi/src/runtime/resolver/inputs.rs
@@ -139,10 +139,9 @@ impl PackageSummary {
         let path = path.as_ref().canonicalize()?;
         let container = Container::from_disk(&path)?;
         let webc_sha256 = WebcHash::for_file(&path)?;
-        let url =
-            crate::runtime::resolver::utils::url_from_file_path(&path).ok_or_else(|| {
-                anyhow::anyhow!("Unable to turn \"{}\" into a file:// URL", path.display())
-            })?;
+        let url = crate::runtime::resolver::utils::url_from_file_path(&path).ok_or_else(|| {
+            anyhow::anyhow!("Unable to turn \"{}\" into a file:// URL", path.display())
+        })?;
 
         let pkg = PackageInfo::from_manifest(container.manifest())?;
         let dist = DistributionInfo {

--- a/lib/wasi/src/runtime/resolver/inputs.rs
+++ b/lib/wasi/src/runtime/resolver/inputs.rs
@@ -140,7 +140,7 @@ impl PackageSummary {
         let container = Container::from_disk(&path)?;
         let webc_sha256 = WebcHash::for_file(&path)?;
         let url =
-            crate::runtime::resolver::polyfills::url_from_file_path(&path).ok_or_else(|| {
+            crate::runtime::resolver::utils::url_from_file_path(&path).ok_or_else(|| {
                 anyhow::anyhow!("Unable to turn \"{}\" into a file:// URL", path.display())
             })?;
 

--- a/lib/wasi/src/runtime/resolver/mod.rs
+++ b/lib/wasi/src/runtime/resolver/mod.rs
@@ -3,9 +3,9 @@ mod in_memory_source;
 mod inputs;
 mod multi_source_registry;
 mod outputs;
-pub(crate) mod utils;
 mod resolve;
 mod source;
+pub(crate) mod utils;
 mod wapm_source;
 mod web_source;
 

--- a/lib/wasi/src/runtime/resolver/mod.rs
+++ b/lib/wasi/src/runtime/resolver/mod.rs
@@ -3,7 +3,7 @@ mod in_memory_source;
 mod inputs;
 mod multi_source_registry;
 mod outputs;
-pub(crate) mod polyfills;
+pub(crate) mod utils;
 mod resolve;
 mod source;
 mod wapm_source;

--- a/lib/wasi/src/runtime/resolver/polyfills.rs
+++ b/lib/wasi/src/runtime/resolver/polyfills.rs
@@ -1,6 +1,10 @@
 use std::path::Path;
 
+use anyhow::Error;
+use http::{HeaderMap, StatusCode};
 use url::Url;
+
+use crate::http::{HttpResponse, USER_AGENT};
 
 /// Polyfill for [`Url::from_file_path()`] that works on `wasm32-unknown-unknown`.
 pub(crate) fn url_from_file_path(path: impl AsRef<Path>) -> Option<Url> {
@@ -23,6 +27,29 @@ pub(crate) fn url_from_file_path(path: impl AsRef<Path>) -> Option<Url> {
     buffer.insert_str(0, "file://");
 
     buffer.parse().ok()
+}
+
+pub(crate) fn webc_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("Accept", "application/webc".parse().unwrap());
+    headers.insert("User-Agent", USER_AGENT.parse().unwrap());
+    headers
+}
+
+pub(crate) fn http_error(response: &HttpResponse) -> Error {
+    let status = response.status;
+
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        if let Some(retry_after) = response
+            .headers
+            .get("Retry-After")
+            .and_then(|retry_after| retry_after.to_str().ok())
+        {
+            return anyhow::anyhow!("{status} (Retry After: {retry_after})");
+        }
+    }
+
+    Error::msg(status)
 }
 
 #[cfg(test)]

--- a/lib/wasi/src/runtime/resolver/utils.rs
+++ b/lib/wasi/src/runtime/resolver/utils.rs
@@ -45,6 +45,10 @@ pub(crate) fn http_error(response: &HttpResponse) -> Error {
             .get("Retry-After")
             .and_then(|retry_after| retry_after.to_str().ok())
         {
+            tracing::debug!(
+                %retry_after,
+                "Received 503 Service Unavailable while looking up a package. The backend may still be generating the *.webc file.",
+            );
             return anyhow::anyhow!("{status} (Retry After: {retry_after})");
         }
     }

--- a/lib/wasi/src/runtime/resolver/web_source.rs
+++ b/lib/wasi/src/runtime/resolver/web_source.rs
@@ -182,7 +182,7 @@ impl WebSource {
         let request = HttpRequest {
             url: url.clone(),
             method: Method::HEAD,
-            headers: super::polyfills::webc_headers(),
+            headers: super::utils::webc_headers(),
             body: None,
             options: Default::default(),
         };
@@ -190,7 +190,7 @@ impl WebSource {
         let response = self.client.request(request).await?;
 
         if !response.is_ok() {
-            return Err(super::polyfills::http_error(&response)
+            return Err(super::utils::http_error(&response)
                 .context(format!("The HEAD request to \"{url}\" failed")));
         }
 
@@ -208,14 +208,14 @@ impl WebSource {
         let request = HttpRequest {
             url: url.clone(),
             method: Method::GET,
-            headers: super::polyfills::webc_headers(),
+            headers: super::utils::webc_headers(),
             body: None,
             options: Default::default(),
         };
         let response = self.client.request(request).await?;
 
         if !response.is_ok() {
-            return Err(super::polyfills::http_error(&response)
+            return Err(super::utils::http_error(&response)
                 .context(format!("The GET request to \"{url}\" failed")));
         }
 


### PR DESCRIPTION
I've refactored the `wasmer_wasix::http` module to use more types from the `http` crate. This lets us implement a `HttpResponse::is_ok()` method in terms of the `http::StatusCode` we get back, rather than making each client implementation decide whether a request failed or not.

That means when a package has recently been released and the backend hasn't finished generating a `*.webc` file for it (which we get a 503 for), instead of seeing an error like this:

```shell
$ wasmer run-unstable https://wapm.io/wasmer/wasmer-io
error: Unable to resolve "https://wapm.io/wasmer/wasmer-io"
│   1: Unable to detect the WEBC version
╰─▶ 2: Expected the magic bytes to be "\x00webc", but found "The w"
```

You will see something like this:

```shell
$ wasmer run-unstable https://wapm.io/wasmer/wasmer-io
error: Unable to resolve "https://wapm.io/wasmer/wasmer-io"
│   1: GET request to "https://wapm.io/wasmer/wasmer-io" failed
|   2: 503 Service Unavailable (Retry after: 5 minutes)
```