### PR TITLE
Fix deserialize calls in doc comments

### DIFF
--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -238,7 +238,7 @@ impl Module {
     ///    a malicious actor could inject code into executable
     ///    memory.
     ///
-    /// And as such, the `deserialize` method is unsafe.
+    /// And as such, the `deserialize_unchecked` method is unsafe.
     ///
     /// # Usage
     ///
@@ -246,7 +246,7 @@ impl Module {
     /// # use wasmer::*;
     /// # fn main() -> anyhow::Result<()> {
     /// # let mut store = Store::default();
-    /// let module = Module::deserialize(&store, serialized_data)?;
+    /// let module = Module::deserialize_unchecked(&store, serialized_data)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -300,7 +300,7 @@ impl Module {
     /// # use wasmer::*;
     /// # let mut store = Store::default();
     /// # fn main() -> anyhow::Result<()> {
-    /// let module = Module::deserialize_from_file_checked(&store, path)?;
+    /// let module = Module::deserialize_from_file(&store, path)?;
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
The renaming in wasmer 4 should be reflected in the doc comments.
`deserialize_checked` -> `deserialize`
`deserialize` -> `deserialize_unchecked`
It was missed in a few places.