### PR TITLE
tests: Remove debug_output option from snapshot tests.

### DIFF
--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_bash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_bash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 594
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "eb83da76ee5fbab28288ecf6385c69db",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_cd_ls.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_cd_ls.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1143
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "862caddcc944cee7b673a57ec2f866e5",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_dash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_dash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 622
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "702da725f176c20024965c8830b620ae",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_echo.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_echo.snap
@@ -9,7 +9,6 @@ expression: snapshot
     "include_webcs": [],
     "cli_args": [],
     "stdin_hash": "664d0430ee33458602e580520841a2d4",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_ls.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_ls.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 477
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "ceb5d83a0368a10c813f8e05c42a3a7d",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_pipe.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_pipe.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1064
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "d83523479d9f84e9f94230d5aed27347",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_python.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_python.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 554
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "bda2b0db976f1724ef16ae1491211d52",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_catsay.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_catsay.snap
@@ -9,7 +9,6 @@ expression: snapshot
     "include_webcs": [],
     "cli_args": [],
     "stdin_hash": "ed17ce0ab9af325cceb217a26ee9b8a1",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_condvar.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_condvar.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": true,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_condvar_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_condvar_async.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": true,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_cowsay.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_cowsay.snap
@@ -9,7 +9,6 @@ expression: snapshot
     "include_webcs": [],
     "cli_args": [],
     "stdin_hash": "0d599f0ec05c3bda8c3b8a68c32a1b47",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_bash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_bash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 561
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "31837f6a5667cb17dd97f274b20281bb",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 551
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "702da725f176c20024965c8830b620ae",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dev_urandom.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dev_urandom.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 642
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "80a57e78213b40607259d3909a44b0cf",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dev_zero.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dev_zero.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 622
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "a911ff36e7a2d67baba7c3dcb45ac5c9",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo.snap
@@ -9,7 +9,6 @@ expression: snapshot
     "include_webcs": [],
     "cli_args": [],
     "stdin_hash": "f21e64a91c2b4c628da60b9a6ef26c46",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo_to_cat.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo_to_cat.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 976
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "4a75babacd4e06efe6c6594a2864f61f",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_python.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_python.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 512
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
     ],
     "cli_args": [],
     "stdin_hash": "56c581e32481cdbf1d70227f3c4b1a84",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_default_file_system_tree.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_default_file_system_tree.snap
@@ -10,7 +10,6 @@ expression: snapshot
     "cli_args": [
       "ls"
     ],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 500
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll_async.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 521
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_execve.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_execve.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 561
 expression: snapshot
 ---
 {
@@ -15,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_file_copy.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_file_copy.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 374
 expression: snapshot
 ---
 {
@@ -19,7 +18,6 @@ expression: snapshot
       "/dev/stdout"
     ],
     "stdin_hash": "49f68a5c8493ec2c0bf489821c21fc3b",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec_async.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_async.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump_fork.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump_fork.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump_fork_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_longjump_fork_async.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_minimodem_rx.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_minimodem_rx.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 499
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
       "same"
     ],
     "stdin_hash": "eeaf940b4ae9db7eb9a4f45a24989a57",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_minimodem_tx.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_minimodem_tx.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 519
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
       "same"
     ],
     "stdin_hash": "efbbebc40e07bc2365088f9506f8a5d1",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_multithreading.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_multithreading.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": true,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_multithreading_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_multithreading_async.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": true,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_pipes.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_pipes.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_process_spawn.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_process_spawn.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_process_spawn_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_process_spawn_async.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_quickjs.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_quickjs.snap
@@ -9,7 +9,6 @@ expression: snapshot
     "include_webcs": [],
     "cli_args": [],
     "stdin_hash": "7b1ec18c69fb609403f75c6e673f2d33",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_readdir_tree.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_readdir_tree.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 569
 expression: snapshot
 ---
 {
@@ -17,7 +16,6 @@ expression: snapshot
     "cli_args": [
       "/"
     ],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_signals.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_signals.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 537
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_signals_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_signals_async.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 537
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_sleep.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_sleep.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_sleep_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_sleep_async.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_stdin_stdout_stderr.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_stdin_stdout_stderr.snap
@@ -12,7 +12,6 @@ expression: snapshot
       "/dev/stderr"
     ],
     "stdin_hash": "6f1ed002ab5595859014ebf0951522d9",
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_thread_locals.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_thread_locals.snap
@@ -8,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_threaded_memory.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_threaded_memory.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 745
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": true,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_tokio.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_tokio.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 683
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_unix_pipe.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_unix_pipe.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 552
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_vfork.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_vfork.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_vfork_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_vfork_async.snap
@@ -14,7 +14,6 @@ expression: snapshot
       }
     ],
     "cli_args": [],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": false,
     "enable_async_threads": true

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_wasi_threads.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_wasi_threads.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 765
 expression: snapshot
 ---
 {
@@ -9,7 +8,6 @@ expression: snapshot
     "use_packages": [],
     "include_webcs": [],
     "cli_args": [],
-    "debug_output": true,
     "enable_threads": true,
     "enable_network": false
   },

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_web_server_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_web_server_async.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 590
 expression: snapshot
 ---
 {
@@ -16,7 +15,6 @@ expression: snapshot
       "--port",
       "7778"
     ],
-    "debug_output": false,
     "enable_threads": true,
     "enable_network": true,
     "enable_async_threads": true


### PR DESCRIPTION
This option didn't really make any sense to begin with, tracing log
output is highly variable and can change at any time depending on
internals.

It should not be included in test snapshot output.

Closes #3942
