### PR TITLE
feat: Allow custom manifest file paths in "wasmer publish"

### DIFF
--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -24,7 +24,9 @@ pub struct Publish {
     /// Skip validation of the uploaded package
     #[clap(long)]
     pub no_validate: bool,
-    /// Directory containing the `wasmer.toml` (defaults to current root dir)
+    /// Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
+    ///
+    /// Defaults to current working directory.
     #[clap(name = "PACKAGE_PATH")]
     pub package_path: Option<String>,
 }


### PR DESCRIPTION
Extends the "wasmer publish" command to allow specifying not just a
directory, but also a concrete "*.toml" manifest path.

This allows using manifests with a name other than the default
"wasmer.toml"

Useful for keeping multiple manifests in a single directory.

Closes #3949
