### PR TITLE
chore(cli): Remove redundant CLI feature flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,10 +396,10 @@ check-capi:
 
 
 build-wasmer:
-	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --release --manifest-path lib/cli/Cargo.toml $(compiler_features) --features="webc_runner" --bin wasmer
+	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --release --manifest-path lib/cli/Cargo.toml $(compiler_features) --bin wasmer
 
 build-wasmer-jsc:
-	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --release --manifest-path lib/cli/Cargo.toml --no-default-features --features="jsc,wat,wasi,webc_runner" --bin wasmer
+	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --release --manifest-path lib/cli/Cargo.toml --no-default-features --features="jsc,wat" --bin wasmer
 
 install-wasi-web:
 	cd lib/wasi-web && npm install || true
@@ -409,7 +409,7 @@ build-wasi-web:
 	cd lib/wasi-web && npm run build
 
 build-wasmer-debug:
-	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --features "webc_runner,debug"  --bin wasmer
+	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --bin wasmer
 
 bench:
 	$(CARGO_BINARY) bench $(CARGO_TARGET_FLAG) $(compiler_features)

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -130,13 +130,9 @@ default = [
     "sys",
     "wat",
     "wast",
-    "cache",
-    "wasi",
-    "emscripten",
     "compiler",
     "wasmer-artifact-create",
     "static-artifact-create",
-    "webc_runner",
 ]
 backend = []
 coredump = [
@@ -184,7 +180,6 @@ static-artifact-load = ["compiler",
  ]
 experimental-io-devices = [
     "wasmer-wasix-experimental-io-devices",
-    "wasi"
 ]
 singlepass = [
     "wasmer-compiler-singlepass",
@@ -200,7 +195,7 @@ llvm = [
 ]
 disable-all-logging = ["wasmer-wasix/disable-all-logging", "log/release_max_level_off"]
 headless = []
-headless-minimal = ["headless", "disable-all-logging", "wasi"]
+headless-minimal = ["headless", "disable-all-logging"]
 
 # Optional
 enable-serde = [
@@ -209,14 +204,6 @@ enable-serde = [
   "wasmer-compiler/enable-serde",
   "wasmer-wasix/enable-serde",
 ]
-
-# Deprecated. These feature flags no longer protect anything.
-cache = []
-cache-blake3-pure = []
-debug = []
-wasi = []
-emscripten = []
-webc_runner = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 colored = "2.0.0"


### PR DESCRIPTION
The CLI previously had a bunch of feature flags, which were only left in
for legacy support, but which do not change behaviour anymore.

This commit removes the feature flags in question.

(flags: webc_runner, cache, wasi, debug, emscripten, cache-blake3-pure )

Closes #3954
