### PR TITLE
feat(virtual-fs): Add FsError::StorageFull variant

### DIFF
--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -481,6 +481,8 @@ pub enum FsError {
     /// Directory not Empty
     #[error("directory not empty")]
     DirectoryNotEmpty,
+    #[error("storage full")]
+    StorageFull,
     /// Some other unhandled error. If you see this, it's probably a bug.
     #[error("unknown error found")]
     UnknownError,
@@ -506,6 +508,8 @@ impl From<io::Error> for FsError {
             io::ErrorKind::UnexpectedEof => FsError::UnexpectedEof,
             io::ErrorKind::WouldBlock => FsError::WouldBlock,
             io::ErrorKind::WriteZero => FsError::WriteZero,
+            // NOTE: Add this once the "io_error_more" Rust feature is stabilized
+            // io::ErrorKind::StorageFull => FsError::StorageFull,
             io::ErrorKind::Other => FsError::IOError,
             // if the following triggers, a new error type was added to this non-exhaustive enum
             _ => FsError::UnknownError,
@@ -541,6 +545,9 @@ impl From<FsError> for io::Error {
             FsError::NoDevice => io::ErrorKind::Other,
             FsError::DirectoryNotEmpty => io::ErrorKind::Other,
             FsError::UnknownError => io::ErrorKind::Other,
+            FsError::StorageFull => io::ErrorKind::Other,
+            // NOTE: Add this once the "io_error_more" Rust feature is stabilized
+            // FsError::StorageFull => io::ErrorKind::StorageFull,
         };
         kind.into()
     }

--- a/lib/wasi/src/fs/mod.rs
+++ b/lib/wasi/src/fs/mod.rs
@@ -1978,6 +1978,7 @@ pub fn fs_error_into_wasi_err(fs_error: FsError) -> Errno {
         FsError::WouldBlock => Errno::Again,
         FsError::WriteZero => Errno::Nospc,
         FsError::DirectoryNotEmpty => Errno::Notempty,
+        FsError::StorageFull => Errno::Overflow,
         FsError::Lock | FsError::UnknownError => Errno::Io,
     }
 }


### PR DESCRIPTION
Needed for some applciations, like the FsMemoryLimiter.

Followup to #3865
