### PR TITLE
Added a test for small Stack (for #3808)

### DIFF
--- a/lib/api/src/sys/tunables.rs
+++ b/lib/api/src/sys/tunables.rs
@@ -279,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "singlepass")]
+    #[cfg(all(feature = "singlepass", not(target_os = "windows")))]
     fn check_small_stack() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{imports, wat2wasm, Engine, Instance, Module, Store};
         use wasmer_compiler_singlepass::Singlepass;
@@ -288,6 +288,7 @@ mod tests {
         // and remove all the unused local, even at optimization level "None"
         // But this test needs the huge amount of locals (1024 + a few)
         // so that the small stack is overflown (stack is only 8K, 1024 i64 local = 8K)
+        // tWindows is disable as it seems Stack frame protection is not 100% efficient
         let wasm_bytes = wat2wasm(
             br#"(module
                 (func (;0;) (result i64)

--- a/lib/api/src/sys/tunables.rs
+++ b/lib/api/src/sys/tunables.rs
@@ -207,10 +207,10 @@ mod tests {
             VMTable::from_definition(ty, style, vm_definition_location)
         }
 
-        // Will use a very small stack size of 16kb, not the 1Mb default
+        // Will use a minimum stack size of 8kb, not the 1Mb default
         fn vmconfig(&self) -> &crate::vm::VMConfig {
             &VMConfig {
-                wasm_stack_size: Some(16 * 1024),
+                wasm_stack_size: Some(8 * 1024),
             }
         }
     }
@@ -274,6 +274,172 @@ mod tests {
         let view = first_memory.view(&store);
         let x = unsafe { view.data_unchecked_mut() }[0];
         assert_eq!(x, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "singlepass")]
+    fn check_small_stack() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::{imports, wat2wasm, Engine, Instance, Module, Store};
+        use wasmer_compiler_singlepass::Singlepass;
+        // This test needs Singlepass compiler
+        // because Cranelift will optimize the webassembly file
+        // and remove all the unused local, even at optimization level "None"
+        // But this test needs the huge amount of locals (1024 + a few)
+        // so that the small stack is overflown (stack is only 8K, 1024 i64 local = 8K)
+        let wasm_bytes = wat2wasm(
+            br#"(module
+                (func (;0;) (result i64)
+                  (local i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64)
+                  i64.const 0
+                  i64.const 5555
+                  i64.add
+                  local.set 8
+                  i64.const 0
+                  i64.const 5555
+                  i64.add
+                  local.set 9
+                  i64.const 0
+                  i64.const 5555
+                  i64.add
+                  local.set 10
+                  local.get 10
+                )
+                (func $large_local (export "large_local") (result i64)
+                  (local
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+                   i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+
+                   i64
+                  )
+                  (local.set 0 (i64.const 1))
+                  (local.set 1 (i64.const 1))
+                  (local.set 2 (i64.const 1))
+                  (local.set 3 (i64.const 1))
+                  (local.set 1024 (i64.const 2))
+                  (call 0)
+                  local.set 1024
+                  local.get 6
+                  local.get 7
+                  i64.add
+                  local.get 8
+                  i64.add
+                  (call 0)
+                  local.set 10
+                  local.get 9
+                  i64.add
+                  local.get 10
+                  i64.add
+                  local.get 11
+                  i64.add
+                  local.get 12
+                  i64.add
+                  (call 0)
+                  local.set 512
+                  local.get 13
+                  i64.add
+                  local.get 14
+                  i64.add
+                  local.get 15
+                  i64.add
+                  local.get 1024
+                  i64.add
+                  local.get 0
+                  i64.add
+                )
+              )
+            "#,
+        )?;
+        let compiler = Singlepass::default();
+
+        let tunables = TinyTunables {};
+        #[allow(deprecated)]
+        let mut engine = Engine::new(compiler.into(), Default::default(), Default::default());
+        engine.set_tunables(tunables);
+        let mut store = Store::new(engine);
+        let module = Module::new(&store, wasm_bytes)?;
+        let import_object = imports! {};
+        let instance = Instance::new(&mut store, &module, &import_object)?;
+
+        let result = instance
+            .exports
+            .get_function("large_local")?
+            .call(&mut store, &[]);
+
+        println!("result = {:?}", result);
+        assert!(result.is_err());
 
         Ok(())
     }


### PR DESCRIPTION
Added a test for small Stack

for ticket #3808 

Note that the test needed to use Singlepass compiler, as Cranelift would optimized the code (even at optimisation level "None")and remove all the unused local, and so avoiding the stack overflow.