### PR TITLE
Use logs instead of timing to determine if the package cache was hit

### DIFF
--- a/lib/wasi/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasi/src/runtime/package_loader/builtin_loader.rs
@@ -79,7 +79,7 @@ impl BuiltinPackageLoader {
 
         if let Some(cached) = self.fs.lookup(hash).await? {
             // Note: We want to propagate it to the in-memory cache, too
-            tracing::debug!("Copying from the filesystem cache to the in-memory cache",);
+            tracing::debug!("Copying from the filesystem cache to the in-memory cache");
             self.in_memory.save(&cached, *hash);
             return Ok(Some(cached));
         }


### PR DESCRIPTION
I've modified the `run_test_caching_works_for_packages_with_versions` test to infer cache hits/misses via log messages rather than how long `wasmer run python/python@0.1.0` takes to run. 

It won't fix the issue mentioned in #3962, but mitigates the flaky tests we've been seeing in #3950 and other recent PRs. 