### PR TITLE
Display human-friendly progress when starting `wasmer run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5651,6 +5651,7 @@ dependencies = [
  "flate2",
  "hex",
  "indexmap",
+ "indicatif",
  "isatty",
  "libc",
  "log",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -94,6 +94,7 @@ tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ] }
 async-trait = "0.1.68"
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
 once_cell = "1.17.1"
+indicatif = "0.17.5"
 
 # NOTE: Must use different features for clap because the "color" feature does not
 # work on wasi due to the anstream dependency not compiling.

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -126,29 +126,84 @@ unix_mode = "0.1.3"
 [features]
 # Don't add the compiler features in default, please add them on the Makefile
 # since we might want to autoconfigure them depending on the availability on the host.
-default = ["sys", "wat", "wast", "compiler", "wasmer-artifact-create", "static-artifact-create"]
+default = [
+    "sys",
+    "wat",
+    "wast",
+    "compiler",
+    "wasmer-artifact-create",
+    "static-artifact-create",
+]
 backend = []
-coredump = ["wasm-coredump-builder"]
-sys = ["compiler", "wasmer-vm"]
-jsc = ["backend", "wasmer/jsc", "wasmer/std"]
+coredump = [
+    "wasm-coredump-builder",
+]
+sys = [
+    "compiler",
+    "wasmer-vm",
+]
+jsc = [
+    "backend",
+    "wasmer/jsc",
+    "wasmer/std"
+]
 wast = ["wasmer-wast"]
-host-net = ["virtual-net/host-net"]
+host-net = [ "virtual-net/host-net" ]
 wat = ["wasmer/wat"]
-compiler = ["backend", "wasmer/compiler", "wasmer-compiler/translator", "wasmer-compiler/compiler"]
-wasmer-artifact-create = ["compiler", "wasmer/wasmer-artifact-load", "wasmer/wasmer-artifact-create", "wasmer-compiler/wasmer-artifact-load", "wasmer-compiler/wasmer-artifact-create", "wasmer-object"]
-static-artifact-create = ["compiler", "wasmer/static-artifact-load", "wasmer/static-artifact-create", "wasmer-compiler/static-artifact-load", "wasmer-compiler/static-artifact-create", "wasmer-object"]
-wasmer-artifact-load = ["compiler", "wasmer/wasmer-artifact-load", "wasmer-compiler/wasmer-artifact-load"]
-static-artifact-load = ["compiler", "wasmer/static-artifact-load", "wasmer-compiler/static-artifact-load"]
-experimental-io-devices = ["wasmer-wasix-experimental-io-devices"]
-singlepass = ["wasmer-compiler-singlepass", "compiler"]
-cranelift = ["wasmer-compiler-cranelift", "compiler"]
-llvm = ["wasmer-compiler-llvm", "compiler"]
+compiler = [
+    "backend",
+    "wasmer/compiler",
+    "wasmer-compiler/translator",
+    "wasmer-compiler/compiler"
+]
+wasmer-artifact-create = ["compiler",
+ "wasmer/wasmer-artifact-load",
+ "wasmer/wasmer-artifact-create",
+ "wasmer-compiler/wasmer-artifact-load",
+ "wasmer-compiler/wasmer-artifact-create",
+ "wasmer-object",
+ ]
+static-artifact-create = ["compiler",
+ "wasmer/static-artifact-load",
+ "wasmer/static-artifact-create",
+ "wasmer-compiler/static-artifact-load",
+ "wasmer-compiler/static-artifact-create",
+ "wasmer-object",
+ ]
+wasmer-artifact-load = ["compiler",
+ "wasmer/wasmer-artifact-load",
+ "wasmer-compiler/wasmer-artifact-load",
+ ]
+static-artifact-load = ["compiler",
+ "wasmer/static-artifact-load",
+ "wasmer-compiler/static-artifact-load",
+ ]
+experimental-io-devices = [
+    "wasmer-wasix-experimental-io-devices",
+]
+singlepass = [
+    "wasmer-compiler-singlepass",
+    "compiler",
+]
+cranelift = [
+    "wasmer-compiler-cranelift",
+    "compiler",
+]
+llvm = [
+    "wasmer-compiler-llvm",
+    "compiler",
+]
 disable-all-logging = ["wasmer-wasix/disable-all-logging", "log/release_max_level_off"]
 headless = []
 headless-minimal = ["headless", "disable-all-logging"]
 
 # Optional
-enable-serde = ["wasmer/enable-serde", "wasmer-vm/enable-serde", "wasmer-compiler/enable-serde", "wasmer-wasix/enable-serde"]
+enable-serde = [
+  "wasmer/enable-serde",
+  "wasmer-vm/enable-serde",
+  "wasmer-compiler/enable-serde",
+  "wasmer-wasix/enable-serde",
+]
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -126,84 +126,29 @@ unix_mode = "0.1.3"
 [features]
 # Don't add the compiler features in default, please add them on the Makefile
 # since we might want to autoconfigure them depending on the availability on the host.
-default = [
-    "sys",
-    "wat",
-    "wast",
-    "compiler",
-    "wasmer-artifact-create",
-    "static-artifact-create",
-]
+default = ["sys", "wat", "wast", "compiler", "wasmer-artifact-create", "static-artifact-create"]
 backend = []
-coredump = [
-    "wasm-coredump-builder",
-]
-sys = [
-    "compiler",
-    "wasmer-vm",
-]
-jsc = [
-    "backend",
-    "wasmer/jsc",
-    "wasmer/std"
-]
+coredump = ["wasm-coredump-builder"]
+sys = ["compiler", "wasmer-vm"]
+jsc = ["backend", "wasmer/jsc", "wasmer/std"]
 wast = ["wasmer-wast"]
-host-net = [ "virtual-net/host-net" ]
+host-net = ["virtual-net/host-net"]
 wat = ["wasmer/wat"]
-compiler = [
-    "backend",
-    "wasmer/compiler",
-    "wasmer-compiler/translator",
-    "wasmer-compiler/compiler"
-]
-wasmer-artifact-create = ["compiler",
- "wasmer/wasmer-artifact-load",
- "wasmer/wasmer-artifact-create",
- "wasmer-compiler/wasmer-artifact-load",
- "wasmer-compiler/wasmer-artifact-create",
- "wasmer-object",
- ]
-static-artifact-create = ["compiler",
- "wasmer/static-artifact-load",
- "wasmer/static-artifact-create",
- "wasmer-compiler/static-artifact-load",
- "wasmer-compiler/static-artifact-create",
- "wasmer-object",
- ]
-wasmer-artifact-load = ["compiler",
- "wasmer/wasmer-artifact-load",
- "wasmer-compiler/wasmer-artifact-load",
- ]
-static-artifact-load = ["compiler",
- "wasmer/static-artifact-load",
- "wasmer-compiler/static-artifact-load",
- ]
-experimental-io-devices = [
-    "wasmer-wasix-experimental-io-devices",
-]
-singlepass = [
-    "wasmer-compiler-singlepass",
-    "compiler",
-]
-cranelift = [
-    "wasmer-compiler-cranelift",
-    "compiler",
-]
-llvm = [
-    "wasmer-compiler-llvm",
-    "compiler",
-]
+compiler = ["backend", "wasmer/compiler", "wasmer-compiler/translator", "wasmer-compiler/compiler"]
+wasmer-artifact-create = ["compiler", "wasmer/wasmer-artifact-load", "wasmer/wasmer-artifact-create", "wasmer-compiler/wasmer-artifact-load", "wasmer-compiler/wasmer-artifact-create", "wasmer-object"]
+static-artifact-create = ["compiler", "wasmer/static-artifact-load", "wasmer/static-artifact-create", "wasmer-compiler/static-artifact-load", "wasmer-compiler/static-artifact-create", "wasmer-object"]
+wasmer-artifact-load = ["compiler", "wasmer/wasmer-artifact-load", "wasmer-compiler/wasmer-artifact-load"]
+static-artifact-load = ["compiler", "wasmer/static-artifact-load", "wasmer-compiler/static-artifact-load"]
+experimental-io-devices = ["wasmer-wasix-experimental-io-devices"]
+singlepass = ["wasmer-compiler-singlepass", "compiler"]
+cranelift = ["wasmer-compiler-cranelift", "compiler"]
+llvm = ["wasmer-compiler-llvm", "compiler"]
 disable-all-logging = ["wasmer-wasix/disable-all-logging", "log/release_max_level_off"]
 headless = []
 headless-minimal = ["headless", "disable-all-logging"]
 
 # Optional
-enable-serde = [
-  "wasmer/enable-serde",
-  "wasmer-vm/enable-serde",
-  "wasmer-compiler/enable-serde",
-  "wasmer-wasix/enable-serde",
-]
+enable-serde = ["wasmer/enable-serde", "wasmer-vm/enable-serde", "wasmer-compiler/enable-serde", "wasmer-wasix/enable-serde"]
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -33,7 +33,10 @@ use wasmer_registry::Package;
 use wasmer_wasix::{
     bin_factory::BinaryPackage,
     runners::{MappedDirectory, Runner},
-    runtime::{package_loader::PackageLoader, resolver::PackageSpecifier},
+    runtime::{
+        package_loader::PackageLoader,
+        resolver::{PackageSpecifier, QueryError},
+    },
     WasiError,
 };
 use wasmer_wasix::{
@@ -117,10 +120,7 @@ impl Run {
         // something that displays progress
         let monitoring_runtime = MonitoringRuntime::new(runtime, pb.clone());
 
-        let target = self
-            .input
-            .resolve_target(&monitoring_runtime, &pb)
-            .with_context(|| format!("Unable to resolve \"{}\"", self.input))?;
+        let target = self.input.resolve_target(&monitoring_runtime, &pb)?;
 
         pb.finish_and_clear();
 
@@ -841,7 +841,7 @@ impl wasmer_wasix::runtime::resolver::Source for MonitoringSource {
     async fn query(
         &self,
         package: &PackageSpecifier,
-    ) -> Result<Vec<wasmer_wasix::runtime::resolver::PackageSummary>, Error> {
+    ) -> Result<Vec<wasmer_wasix::runtime::resolver::PackageSummary>, QueryError> {
         self.progress.set_message(format!("Looking up {package}"));
         self.inner.query(package).await
     }

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -814,6 +814,22 @@ impl<R: wasmer_wasix::Runtime + Send + Sync> wasmer_wasix::Runtime for Monitorin
             progress: self.progress.clone(),
         })
     }
+
+    fn engine(&self) -> Option<wasmer::Engine> {
+        self.runtime.engine()
+    }
+
+    fn new_store(&self) -> wasmer::Store {
+        self.runtime.new_store()
+    }
+
+    fn http_client(&self) -> Option<&wasmer_wasix::http::DynHttpClient> {
+        self.runtime.http_client()
+    }
+
+    fn tty(&self) -> Option<&(dyn wasmer_wasix::os::TtyBridge + Send + Sync)> {
+        self.runtime.tty()
+    }
 }
 
 #[derive(Debug)]

--- a/lib/cli/src/logging.rs
+++ b/lib/cli/src/logging.rs
@@ -93,4 +93,16 @@ impl Output {
             clap::ColorChoice::Never => false,
         }
     }
+
+    /// Get the draw target to be used with the `indicatif` crate.
+    ///
+    /// Progress indicators won't draw anything if the user passed the `--quiet`
+    /// flag.
+    pub fn draw_target(&self) -> indicatif::ProgressDrawTarget {
+        if self.quiet {
+            return indicatif::ProgressDrawTarget::hidden();
+        }
+
+        indicatif::ProgressDrawTarget::stderr()
+    }
 }

--- a/lib/wasix/src/runtime/resolver/inputs.rs
+++ b/lib/wasix/src/runtime/resolver/inputs.rs
@@ -101,7 +101,15 @@ impl FromStr for PackageSpecifier {
 impl Display for PackageSpecifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PackageSpecifier::Registry { full_name, version } => write!(f, "{full_name}@{version}"),
+            PackageSpecifier::Registry { full_name, version } => {
+                write!(f, "{full_name}")?;
+
+                if !version.comparators.is_empty() {
+                    write!(f, "@{version}")?;
+                }
+
+                Ok(())
+            }
             PackageSpecifier::Url(url) => Display::fmt(url, f),
             PackageSpecifier::Path(path) => write!(f, "{}", path.display()),
         }

--- a/lib/wasix/src/runtime/resolver/mod.rs
+++ b/lib/wasix/src/runtime/resolver/mod.rs
@@ -16,13 +16,13 @@ pub use self::{
         Command, Dependency, DistributionInfo, PackageInfo, PackageSpecifier, PackageSummary,
         WebcHash,
     },
-    multi_source::MultiSource,
+    multi_source::{MultiSource, MultiSourceStrategy},
     outputs::{
         DependencyGraph, Edge, ItemLocation, Node, PackageId, Resolution,
         ResolvedFileSystemMapping, ResolvedPackage,
     },
-    resolve::resolve,
-    source::Source,
+    resolve::{resolve, ResolveError},
+    source::{QueryError, Source},
     wapm_source::WapmSource,
     web_source::WebSource,
 };

--- a/lib/wasix/src/runtime/resolver/multi_source.rs
+++ b/lib/wasix/src/runtime/resolver/multi_source.rs
@@ -1,10 +1,15 @@
 use std::sync::Arc;
 
-use anyhow::Error;
-
-use crate::runtime::resolver::{PackageSpecifier, PackageSummary, Source};
+use crate::runtime::resolver::{PackageSpecifier, PackageSummary, QueryError, Source};
 
 /// A [`Source`] that works by querying multiple [`Source`]s in succession.
+///
+/// # Error Handling
+///
+/// A [`Source`] implementation can return certain non-fatal errors and,
+/// depending on the [`MultiSourceStrategy`], the [`MultiSource`] can choose to
+/// deal with it in different ways. Sometimes
+///
 ///
 /// The first [`Source`] to return one or more [`Summaries`][PackageSummary]
 /// will be treated as the canonical source for that [`Dependency`][dep] and no
@@ -14,37 +19,85 @@ use crate::runtime::resolver::{PackageSpecifier, PackageSummary, Source};
 #[derive(Debug, Clone)]
 pub struct MultiSource {
     sources: Vec<Arc<dyn Source + Send + Sync>>,
+    strategy: MultiSourceStrategy,
 }
 
 impl MultiSource {
     pub const fn new() -> Self {
         MultiSource {
             sources: Vec::new(),
+            strategy: MultiSourceStrategy::default(),
         }
     }
 
     pub fn add_source(&mut self, source: impl Source + Send + Sync + 'static) -> &mut Self {
-        self.add_shared_source(Arc::new(source));
-        self
+        self.add_shared_source(Arc::new(source))
     }
 
     pub fn add_shared_source(&mut self, source: Arc<dyn Source + Send + Sync>) -> &mut Self {
         self.sources.push(source);
         self
     }
+
+    /// Override the strategy used when a [`Source`] returns a non-fatal error.
+    pub fn with_strategy(self, strategy: MultiSourceStrategy) -> Self {
+        MultiSource { strategy, ..self }
+    }
 }
 
 #[async_trait::async_trait]
 impl Source for MultiSource {
     #[tracing::instrument(level = "debug", skip_all, fields(%package))]
-    async fn query(&self, package: &PackageSpecifier) -> Result<Vec<PackageSummary>, Error> {
+    async fn query(&self, package: &PackageSpecifier) -> Result<Vec<PackageSummary>, QueryError> {
         for source in &self.sources {
-            let result = source.query(package).await?;
-            if !result.is_empty() {
-                return Ok(result);
+            match source.query(package).await {
+                Ok(summaries) => return Ok(summaries),
+                Err(QueryError::Unsupported) if self.strategy.continue_if_unsupported => continue,
+                Err(QueryError::NotFound) if self.strategy.continue_if_not_found => continue,
+                Err(QueryError::NoMatches { .. }) if self.strategy.continue_if_no_matches => {
+                    continue
+                }
+                Err(e) => return Err(e),
             }
         }
 
-        anyhow::bail!("Unable to find any packages that satisfy the query")
+        Err(QueryError::NotFound)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MultiSourceStrategy {
+    /// If encountered, treat [`QueryError::Unsupported`] as a non-fatal error
+    /// and query the next [`Source`] in turn.
+    ///
+    /// This flag is **enabled** by default.
+    pub continue_if_unsupported: bool,
+    /// If encountered, treat [`QueryError::NotFound`] as a non-fatal error and
+    /// query the next [`Source`] in turn.
+    ///
+    /// This flag is **enabled** by default and can be used to let earlier
+    /// [`Source`]s "override" later ones.
+    pub continue_if_not_found: bool,
+    /// If encountered, treat [`QueryError::NoMatches`] as a non-fatal error and
+    /// query the next [`Source`] in turn.
+    ///
+    /// This flag is **disabled** by default.
+    pub continue_if_no_matches: bool,
+}
+
+impl MultiSourceStrategy {
+    pub const fn default() -> Self {
+        MultiSourceStrategy {
+            continue_if_unsupported: true,
+            continue_if_not_found: true,
+            continue_if_no_matches: true,
+        }
+    }
+}
+
+impl Default for MultiSourceStrategy {
+    fn default() -> Self {
+        MultiSourceStrategy::default()
     }
 }

--- a/lib/wasix/src/runtime/resolver/source.rs
+++ b/lib/wasix/src/runtime/resolver/source.rs
@@ -1,6 +1,4 @@
-use std::fmt::Debug;
-
-use anyhow::Error;
+use std::fmt::{Debug, Display};
 
 use crate::runtime::resolver::{PackageSpecifier, PackageSummary};
 
@@ -12,22 +10,23 @@ pub trait Source: Sync + Debug {
     ///
     /// # Assumptions
     ///
-    /// It is not an error if there are no package versions that may satisfy
-    /// the dependency, even if the [`Source`] doesn't know of a package
-    /// with that name.
+    /// If this method returns a successful result, it is guaranteed that there
+    /// will be at least one [`PackageSummary`], otherwise implementations
+    /// should return [`QueryError::NotFound`] or [`QueryError::NoMatches`].
     ///
     /// [dep]: crate::runtime::resolver::Dependency
-    /// [reg]: crate::runtime::resolver::Registry
-    async fn query(&self, package: &PackageSpecifier) -> Result<Vec<PackageSummary>, Error>;
+    async fn query(&self, package: &PackageSpecifier) -> Result<Vec<PackageSummary>, QueryError>;
 
     /// Run [`Source::query()`] and get the [`PackageSummary`] for the latest
     /// version.
-    async fn latest(&self, pkg: &PackageSpecifier) -> Result<PackageSummary, Error> {
+    async fn latest(&self, pkg: &PackageSpecifier) -> Result<PackageSummary, QueryError> {
         let candidates = self.query(pkg).await?;
         candidates
             .into_iter()
             .max_by(|left, right| left.pkg.version.cmp(&right.pkg.version))
-            .ok_or_else(|| Error::msg("Couldn't find a package version satisfying that constraint"))
+            .ok_or(QueryError::NoMatches {
+                archived_versions: Vec::new(),
+            })
     }
 }
 
@@ -37,7 +36,60 @@ where
     D: std::ops::Deref<Target = S> + Debug + Send + Sync,
     S: Source + ?Sized + Send + Sync + 'static,
 {
-    async fn query(&self, package: &PackageSpecifier) -> Result<Vec<PackageSummary>, Error> {
+    async fn query(&self, package: &PackageSpecifier) -> Result<Vec<PackageSummary>, QueryError> {
         (**self).query(package).await
+    }
+}
+
+#[derive(Debug)]
+pub enum QueryError {
+    Unsupported,
+    NotFound,
+    NoMatches {
+        archived_versions: Vec<semver::Version>,
+    },
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for QueryError {
+    fn from(value: anyhow::Error) -> Self {
+        QueryError::Other(value)
+    }
+}
+
+impl Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryError::Unsupported => {
+                f.write_str("This type of package specifier isn't supported")
+            }
+            QueryError::NotFound => f.write_str("Not found"),
+            QueryError::NoMatches { archived_versions } => match archived_versions.as_slice() {
+                [] => f.write_str(
+                    "The package was found, but no published versions matched the constraint",
+                ),
+                [version] => write!(
+                    f,
+                    "The only version satisfying the constraint, {version}, is archived"
+                ),
+                [first, rest @ ..] => {
+                    let num_others = rest.len();
+                    write!(
+                        f,
+                        "Unable to satisfy the request. Version {first}, and {num_others} are all archived"
+                    )
+                }
+            },
+            QueryError::Other(e) => Display::fmt(e, f),
+        }
+    }
+}
+
+impl std::error::Error for QueryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            QueryError::Other(e) => Some(&**e),
+            QueryError::Unsupported | QueryError::NotFound | QueryError::NoMatches { .. } => None,
+        }
     }
 }

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -425,15 +425,15 @@ fn run_no_imports_wasm_works() {
 fn run_wasi_works_non_existent() -> anyhow::Result<()> {
     let assert = Command::new(get_wasmer_path())
         .arg("run")
-        .arg("does/not/exist")
+        .arg("does-not/exist")
         .assert()
         .failure();
 
     assert
-        .stderr(contains("error: Unable to resolve \"does/not/exist@*\""))
         .stderr(contains(
-            "╰─▶ 1: Unable to find any packages that satisfy the query",
-        ));
+            "Unable to find \"does-not/exist\" in the registry",
+        ))
+        .stderr(contains("1: Not found"));
 
     Ok(())
 }


### PR DESCRIPTION
This fixes #3981 by adding some spinners during certain parts of the startup process. 

I've mostly done this by creating a wrapper `wasmer_wasix::Runtime` implementation that will display progress bars during certain operations. Unfortunately, our current abstractions don't really expose the hooks we'd want for fine-grained progress updates like telling people how many bytes have been downloaded for a certain package, and some expensive operations (e.g. module compilation) aren't possible to hook into for reporting progress, but I guess it's better than nothing 🤷 