### PR TITLE
[CI][RISCV64] Try to use bookworm debian instead of sid

### DIFF
--- a/.github/cross-linux-riscv64/Dockerfile
+++ b/.github/cross-linux-riscv64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid AS openssl_riscv64
+FROM debian:bookworm AS openssl_riscv64
 #FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 
 # set CROSS_DOCKER_IN_DOCKER to inform `cross` that it is executed from within a container


### PR DESCRIPTION
Try to use bookworm debian instead of sid