### PR TITLE
Remove "build_linux_riscv64" as a pre-requisite for running CLI integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -728,6 +728,7 @@ jobs:
           name: capi-macos-x64
           path: package/cache/wasmercache4
       - uses: actions/download-artifact@v3
+        if: false
         with:
           name: capi-linux-x64
           path: package/cache/wasmercache5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -640,7 +640,7 @@ jobs:
   test_integration_cli:
     name: CLI integration tests on ${{ matrix.build }}
     runs-on: ${{ matrix.os }}
-    needs: [build, build_linux_aarch64, build_linux_riscv64]
+    needs: [build, build_linux_aarch64]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description

We've started getting build issues in CI with the `build_riscv64` jobs because of changes in the Debian repositories. This PR removes `build_linux_riscv64` (both the C API and Wasmer CLI) as a pre-requisite for running the CLI integration tests.

We don't test the CLI for riscv at the moment, so this shouldn't be a problem.

This PR **doesn't** ignore the riscv builds completely, so `master` will still be red. It just means we can unblock PRs currently waiting for CI to pass. 

When #4002 is merged again, we should either revert this PR or update branch protections to make the job required.