### PR TITLE
Canonicalize the host path passed to `--mapdir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,9 +2810,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2842,9 +2842,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/lib/cli-compiler/src/utils.rs
+++ b/lib/cli-compiler/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions for the WebAssembly module
-use anyhow::{bail, Result};
-use std::env;
+use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
+use std::{env, path::Path};
 
 /// Whether or not Wasmer should print with color
 pub fn wasmer_should_print_color() -> bool {
@@ -12,14 +12,18 @@ pub fn wasmer_should_print_color() -> bool {
 }
 
 fn retrieve_alias_pathbuf(alias: &str, real_dir: &str) -> Result<(String, PathBuf)> {
-    let pb = PathBuf::from(&real_dir);
+    let pb = Path::new(real_dir)
+        .canonicalize()
+        .with_context(|| format!("Unable to get the absolute path for \"{real_dir}\""))?;
+
     if let Ok(pb_metadata) = pb.metadata() {
         if !pb_metadata.is_dir() {
-            bail!("\"{}\" exists, but it is not a directory", &real_dir);
+            bail!("\"{real_dir}\" exists, but it is not a directory");
         }
     } else {
-        bail!("Directory \"{}\" does not exist", &real_dir);
+        bail!("Directory \"{real_dir}\" does not exist");
     }
+
     Ok((alias.to_string(), pb))
 }
 

--- a/lib/wasix/src/runners/mod.rs
+++ b/lib/wasix/src/runners/mod.rs
@@ -23,7 +23,10 @@ use crate::runtime::{
 /// instance (the "guest").
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MappedDirectory {
+    /// The absolute path for a directory on the host filesystem.
     pub host: std::path::PathBuf,
+    /// The absolute path specifying where the host directory should be mounted
+    /// inside the guest.
     pub guest: String,
 }
 


### PR DESCRIPTION
This PR patches the logic for `--mapdir` so we always use absolute paths when mounting directories.

Ideally we wouldn't need to do this canonicalizing because the code for mounting directories should be able to handle relative paths, but this quickfix should resolve things until we do our big filesystem layer overhaul.

Fixes #4010.