### PR TITLE
Make CLI integration tests automatically run the most up-to-date version of the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,6 +5953,7 @@ dependencies = [
  "target-lexicon 0.12.7",
  "tempfile",
  "tokio",
+ "wasmer-cli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,3 +291,14 @@ required-features = ["backend"]
 name = "features"
 path = "examples/features.rs"
 required-features = ["cranelift"]
+
+# Enable optimizations for a few crates, even for debug builds.
+#
+# This greatly speeds up debug builds because these crates are extremely slow
+# without optimizations.
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.regalloc2]
+opt-level = 2
+[profile.dev.package.wasmparser]
+opt-level = 2

--- a/Makefile
+++ b/Makefile
@@ -619,10 +619,10 @@ test-wasi-unit:
 test-wasi:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --tests $(compiler_features) -- wasi::wasitests
 
-test-integration-cli: build-wasmer build-capi package-capi-headless package distribution
+test-integration-cli: build-capi package-capi-headless package distribution
 	cp ./dist/wasmer.tar.gz ./link.tar.gz
 	rustup target add wasm32-wasi
-	WASMER_DIR=`pwd`/package $(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner --no-fail-fast -p wasmer-integration-tests-cli -- --nocapture --test-threads=1
+	WASMER_DIR=`pwd`/package $(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --no-fail-fast -p wasmer-integration-tests-cli -- --nocapture --test-threads=1
 
 # Before running this in the CI, we need to set up link.tar.gz and /cache/wasmer-[target].tar.gz
 test-integration-cli-ci:

--- a/Makefile
+++ b/Makefile
@@ -627,10 +627,10 @@ test-integration-cli: build-wasmer build-capi package-capi-headless package dist
 # Before running this in the CI, we need to set up link.tar.gz and /cache/wasmer-[target].tar.gz
 test-integration-cli-ci:
 	rustup target add wasm32-wasi
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner -p wasmer-integration-tests-cli --  --test-threads=1
+	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) -p wasmer-integration-tests-cli --  --test-threads=1
 
 test-integration-ios:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner -p wasmer-integration-tests-ios
+	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) -p wasmer-integration-tests-ios
 
 generate-wasi-tests:
 # Uncomment the following for installing the toolchain

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -32,6 +32,7 @@ tar = "0.4.38"
 flate2 = "1.0.24"
 dirs = "4.0.0"
 derivative = { version = "^2" }
+wasmer-cli = { path = "../../../lib/cli", features = ["cranelift", "compiler"] }
 
 [features]
 default = ["webc_runner"]

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -33,8 +33,3 @@ flate2 = "1.0.24"
 dirs = "4.0.0"
 derivative = { version = "^2" }
 wasmer-cli = { path = "../../../lib/cli", features = ["cranelift", "compiler"] }
-
-[features]
-default = ["webc_runner"]
-webc_runner = []
-debug = []

--- a/tests/integration/cli/src/assets.rs
+++ b/tests/integration/cli/src/assets.rs
@@ -8,16 +8,6 @@ pub const ASSET_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../test
 
 pub const WASMER_INCLUDE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../lib/c-api/");
 
-#[cfg(feature = "debug")]
-pub const WASMER_TARGET_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../target/debug/");
-#[cfg(feature = "debug")]
-pub const WASMER_TARGET_PATH_2: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../../target/",
-    env!("CARGO_BUILD_TARGET"),
-    "/debug/"
-);
-
 /* env var TARGET is set by tests/integration/cli/build.rs on compile-time */
 
 #[cfg(not(feature = "debug"))]

--- a/tests/integration/cli/src/assets.rs
+++ b/tests/integration/cli/src/assets.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 pub const C_ASSET_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -49,75 +48,6 @@ pub fn get_libwasmer_path() -> PathBuf {
     }
     if !ret.exists() {
         panic!("Could not find libwasmer path! {:?}", ret);
-    }
-    ret
-}
-
-/// Get the path to the `wasmer` executable to be used in this test.
-pub fn get_wasmer_path() -> PathBuf {
-    let mut ret = PathBuf::from(
-        env::var("WASMER_TEST_WASMER_PATH")
-            .unwrap_or_else(|_| format!("{}wasmer", WASMER_TARGET_PATH)),
-    );
-    if !ret.exists() {
-        ret = PathBuf::from(format!("{}wasmer", WASMER_TARGET_PATH_2));
-    }
-    if !ret.exists() {
-        ret = match get_repo_root_path() {
-            Some(s) => {
-                #[cfg(target_os = "windows")]
-                {
-                    s.join("target").join("release").join("wasmer.exe")
-                }
-                #[cfg(not(target_os = "windows"))]
-                {
-                    s.join("target").join("release").join("wasmer")
-                }
-            }
-            None => {
-                panic!("Could not find wasmer executable path! {:?}", ret);
-            }
-        };
-    }
-
-    if !ret.exists() {
-        ret = match get_repo_root_path() {
-            Some(s) => {
-                #[cfg(target_os = "windows")]
-                {
-                    s.join("target")
-                        .join(target_lexicon::HOST.to_string())
-                        .join("release")
-                        .join("wasmer.exe")
-                }
-                #[cfg(not(target_os = "windows"))]
-                {
-                    s.join("target")
-                        .join(target_lexicon::HOST.to_string())
-                        .join("release")
-                        .join("wasmer")
-                }
-            }
-            None => {
-                panic!("Could not find wasmer executable path! {:?}", ret);
-            }
-        };
-    }
-
-    if !ret.exists() {
-        if let Some(root) = get_repo_root_path() {
-            use std::process::Stdio;
-            let _ = std::process::Command::new("ls")
-                .arg(root.join("target"))
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit())
-                .stdin(Stdio::null())
-                .output();
-        }
-        panic!(
-            "cannot find wasmer / wasmer.exe for integration test at '{}'!",
-            ret.display()
-        );
     }
     ret
 }

--- a/tests/integration/cli/src/bin/wasmer-cli-shim.rs
+++ b/tests/integration/cli/src/bin/wasmer-cli-shim.rs
@@ -1,0 +1,8 @@
+//! A shim that makes the `wasmer` CLI available to integration tests via the
+//! [`$CARGO_BIN_EXE_wasmer-cli-shim`][var] environment variable.
+//!
+//! [var]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+
+fn main() {
+    wasmer_cli::cli::wasmer_main();
+}

--- a/tests/integration/cli/tests/config.rs
+++ b/tests/integration/cli/tests/config.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use wasmer_integration_tests_cli::{get_repo_root_path, get_wasmer_path};
+use wasmer_integration_tests_cli::get_repo_root_path;
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 fn get_wasmer_dir() -> Result<PathBuf, anyhow::Error> {
     if let Ok(s) = std::env::var("WASMER_DIR") {
@@ -33,7 +35,7 @@ fn wasmer_config_multiget() -> anyhow::Result<()> {
     let bin = format!("{}", bin_path.display());
     let include = format!("-I{}", include_path.display());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--bindir")
         .arg("--cflags")
@@ -53,7 +55,7 @@ fn wasmer_config_multiget() -> anyhow::Result<()> {
 
 #[test]
 fn wasmer_config_error() -> anyhow::Result<()> {
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--bindir")
         .arg("--cflags")
@@ -65,9 +67,9 @@ fn wasmer_config_error() -> anyhow::Result<()> {
         .map(|s| s.trim().to_string())
         .collect::<Vec<_>>();
     #[cfg(not(windows))]
-    let expected_1 = "Usage: wasmer config --bindir --cflags";
+    let expected_1 = "Usage: wasmer-cli-shim config --bindir --cflags";
     #[cfg(windows)]
-    let expected_1 = "Usage: wasmer.exe config --bindir --cflags";
+    let expected_1 = "Usage: wasmer-cli-shim.exe config --bindir --cflags";
 
     let expected = vec![
         "error: the argument '--bindir' cannot be used with '--pkg-config'",
@@ -83,7 +85,7 @@ fn wasmer_config_error() -> anyhow::Result<()> {
 }
 #[test]
 fn config_works() -> anyhow::Result<()> {
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--bindir")
         .output()?;
@@ -94,7 +96,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("{}\n", bin_path.display())
     );
 
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--cflags")
         .output()?;
@@ -105,7 +107,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("-I{}\n", include_path.display())
     );
 
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--includedir")
         .output()?;
@@ -116,7 +118,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("{}\n", include_path.display())
     );
 
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--libdir")
         .output()?;
@@ -127,7 +129,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("{}\n", lib_path.display())
     );
 
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--libs")
         .output()?;
@@ -138,7 +140,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("-L{} -lwasmer\n", lib_path.display())
     );
 
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--prefix")
         .output()?;
@@ -149,7 +151,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("{}\n", wasmer_dir.display())
     );
 
-    let bindir = Command::new(get_wasmer_path())
+    let bindir = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--pkg-config")
         .output()?;
@@ -180,7 +182,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(lines, args);
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--config-path")
         .output()?;
@@ -193,7 +195,7 @@ fn config_works() -> anyhow::Result<()> {
 
     // ---- config get
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("registry.token")
@@ -201,7 +203,7 @@ fn config_works() -> anyhow::Result<()> {
 
     let original_token = String::from_utf8_lossy(&output.stdout);
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("registry.token")
@@ -210,7 +212,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(String::from_utf8_lossy(&output.stdout), "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("registry.token")
@@ -221,7 +223,7 @@ fn config_works() -> anyhow::Result<()> {
         "abc123\n".to_string()
     );
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("registry.token")
@@ -230,7 +232,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(String::from_utf8_lossy(&output.stdout), "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("registry.token")
@@ -241,7 +243,7 @@ fn config_works() -> anyhow::Result<()> {
         format!("{}\n", original_token.to_string().trim())
     );
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("registry.url")
@@ -249,7 +251,7 @@ fn config_works() -> anyhow::Result<()> {
 
     let original_url = String::from_utf8_lossy(&output.stdout);
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("registry.url")
@@ -260,7 +262,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(output_str, "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("registry.url")
@@ -272,7 +274,7 @@ fn config_works() -> anyhow::Result<()> {
         "https://registry.wapm.dev/graphql\n".to_string()
     );
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("registry.url")
@@ -282,7 +284,7 @@ fn config_works() -> anyhow::Result<()> {
     let output_str = String::from_utf8_lossy(&output.stdout);
     assert_eq!(output_str, "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("registry.url")
@@ -291,7 +293,7 @@ fn config_works() -> anyhow::Result<()> {
     let output_str = String::from_utf8_lossy(&output.stdout);
     assert_eq!(output_str, original_url.to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("telemetry.enabled")
@@ -299,7 +301,7 @@ fn config_works() -> anyhow::Result<()> {
 
     let original_output = String::from_utf8_lossy(&output.stdout);
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("telemetry.enabled")
@@ -308,7 +310,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(String::from_utf8_lossy(&output.stdout), "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("telemetry.enabled")
@@ -319,7 +321,7 @@ fn config_works() -> anyhow::Result<()> {
         "true\n".to_string()
     );
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("telemetry.enabled")
@@ -328,7 +330,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(String::from_utf8_lossy(&output.stdout), "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("telemetry.enabled")
@@ -339,7 +341,7 @@ fn config_works() -> anyhow::Result<()> {
         original_output.to_string()
     );
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("update-notifications.enabled")
@@ -347,7 +349,7 @@ fn config_works() -> anyhow::Result<()> {
 
     let original_output = String::from_utf8_lossy(&output.stdout);
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("update-notifications.enabled")
@@ -356,7 +358,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(String::from_utf8_lossy(&output.stdout), "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("update-notifications.enabled")
@@ -367,7 +369,7 @@ fn config_works() -> anyhow::Result<()> {
         "true\n".to_string()
     );
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("set")
         .arg("update-notifications.enabled")
@@ -376,7 +378,7 @@ fn config_works() -> anyhow::Result<()> {
 
     assert_eq!(String::from_utf8_lossy(&output.stdout), "".to_string());
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("config")
         .arg("get")
         .arg("update-notifications.enabled")

--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -8,6 +8,8 @@ use std::process::Command;
 use tempfile::TempDir;
 use wasmer_integration_tests_cli::*;
 
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
+
 fn create_exe_wabt_path() -> String {
     format!("{}/{}", C_ASSET_PATH, "wabt-1.0.37.wasmer")
 }
@@ -48,7 +50,7 @@ impl Default for WasmerCreateExe {
         let native_executable_path = PathBuf::from("wasm.exe");
         Self {
             current_dir: std::env::current_dir().unwrap(),
-            wasmer_path: get_wasmer_path(),
+            wasmer_path: WASMER_EXE.into(),
             wasm_path: PathBuf::from(create_exe_test_wasm_path()),
             native_executable_path,
             compiler: Compiler::Cranelift,
@@ -123,7 +125,7 @@ impl Default for WasmerCreateObj {
         let output_object_path = PathBuf::from("wasm.obj");
         Self {
             current_dir: std::env::current_dir().unwrap(),
-            wasmer_path: get_wasmer_path(),
+            wasmer_path: WASMER_EXE.into(),
             wasm_path: PathBuf::from(create_exe_test_wasm_path()),
             output_object_path,
             compiler: Compiler::Cranelift,
@@ -167,7 +169,7 @@ fn test_create_exe_with_pirita_works_1() {
     let tempdir = TempDir::new().unwrap();
     let path = tempdir.path();
     let wasm_out = path.join("out.obj");
-    let cmd = Command::new(get_wasmer_path())
+    let cmd = Command::new(WASMER_EXE)
         .arg("create-obj")
         .arg(create_exe_wabt_path())
         .arg("-o")
@@ -185,7 +187,7 @@ fn test_create_exe_with_pirita_works_1() {
 
     assert!(!cmd.status.success());
 
-    let cmd = Command::new(get_wasmer_path())
+    let cmd = Command::new(WASMER_EXE)
         .arg("create-obj")
         .arg(create_exe_wabt_path())
         .arg("--atom")
@@ -220,7 +222,7 @@ fn test_create_exe_with_precompiled_works_1() {
     let tempdir = TempDir::new().unwrap();
     let path = tempdir.path();
     let wasm_out = path.join("out.obj");
-    let _ = Command::new(get_wasmer_path())
+    let _ = Command::new(WASMER_EXE)
         .arg("create-obj")
         .arg(create_exe_test_wasm_path())
         .arg("--prefix")
@@ -242,7 +244,7 @@ fn test_create_exe_with_precompiled_works_1() {
             || names.contains(&"wasmer_function_sha123123_1".to_string())
     );
 
-    let _ = Command::new(get_wasmer_path())
+    let _ = Command::new(WASMER_EXE)
         .arg("create-obj")
         .arg(create_exe_test_wasm_path())
         .arg("-o")

--- a/tests/integration/cli/tests/gen_c_header.rs
+++ b/tests/integration/cli/tests/gen_c_header.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use std::process::Command;
-use wasmer_integration_tests_cli::get_wasmer_path;
 use wasmer_integration_tests_cli::C_ASSET_PATH;
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 fn create_exe_wabt_path() -> String {
     format!("{}/{}", C_ASSET_PATH, "wabt-1.0.37.wasmer")
@@ -19,7 +20,7 @@ fn gen_c_header_works() -> anyhow::Result<()> {
     let wasm_path = operating_dir.join(create_exe_test_wasm_path());
     let out_path = temp_dir.path().join("header.h");
 
-    let _ = Command::new(get_wasmer_path())
+    let _ = Command::new(WASMER_EXE)
         .arg("gen-c-header")
         .arg(&wasm_path)
         .arg("-o")
@@ -30,7 +31,7 @@ fn gen_c_header_works() -> anyhow::Result<()> {
     let file = std::fs::read_to_string(&out_path).expect("no header.h file");
     assert!(file.contains("wasmer_function_6f62a6bc5c8f8e3e12a54e2ecbc5674ccfe1c75f91d8e4dd6ebb3fec422a4d6c_0"), "no wasmer_function_6f62a6bc5c8f8e3e12a54e2ecbc5674ccfe1c75f91d8e4dd6ebb3fec422a4d6c_0 in file");
 
-    let _ = Command::new(get_wasmer_path())
+    let _ = Command::new(WASMER_EXE)
         .arg("gen-c-header")
         .arg(&wasm_path)
         .arg("-o")
@@ -57,7 +58,7 @@ fn gen_c_header_works_pirita() -> anyhow::Result<()> {
     let wasm_path = operating_dir.join(create_exe_wabt_path());
     let out_path = temp_dir.path().join("header.h");
 
-    let _ = Command::new(get_wasmer_path())
+    let _ = Command::new(WASMER_EXE)
         .arg("gen-c-header")
         .arg(&wasm_path)
         .arg("-o")
@@ -70,7 +71,7 @@ fn gen_c_header_works_pirita() -> anyhow::Result<()> {
     let file = std::fs::read_to_string(&out_path).expect("no header.h file");
     assert!(file.contains("wasmer_function_0f41d38dcfb5abc1fadb5e9acbc5c645e53fe4d0dd86270b72a09bfeee04d055_0"), "no wasmer_function_6f62a6bc5c8f8e3e12a54e2ecbc5674ccfe1c75f91d8e4dd6ebb3fec422a4d6c_0 in file");
 
-    let cmd = Command::new(get_wasmer_path())
+    let cmd = Command::new(WASMER_EXE)
         .arg("gen-c-header")
         .arg(&wasm_path)
         .arg("-o")

--- a/tests/integration/cli/tests/init.rs
+++ b/tests/integration/cli/tests/init.rs
@@ -1,7 +1,8 @@
 use anyhow::bail;
 
 use std::process::{Command, Stdio};
-use wasmer_integration_tests_cli::get_wasmer_path;
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 macro_rules! check_output {
     ($output:expr) => {
@@ -33,7 +34,7 @@ fn wasmer_init_works_1() -> anyhow::Result<()> {
         if token.is_empty() {
             return Ok(());
         }
-        let output = Command::new(get_wasmer_path())
+        let output = Command::new(WASMER_EXE)
             .arg("login")
             .arg("--registry")
             .arg("wapm.dev")
@@ -47,7 +48,7 @@ fn wasmer_init_works_1() -> anyhow::Result<()> {
 
     println!("wasmer login ok!");
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("init")
         .current_dir(&path)
         .output()?;
@@ -91,7 +92,7 @@ fn wasmer_init_works_2() -> anyhow::Result<()> {
         if token.is_empty() {
             return Ok(());
         }
-        let mut cmd = Command::new(get_wasmer_path());
+        let mut cmd = Command::new(WASMER_EXE);
         cmd.arg("login");
         cmd.arg("--registry");
         cmd.arg("wapm.dev");
@@ -105,7 +106,7 @@ fn wasmer_init_works_2() -> anyhow::Result<()> {
 
     println!("wasmer login ok!");
 
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("init")
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/tests/integration/cli/tests/login.rs
+++ b/tests/integration/cli/tests/login.rs
@@ -1,7 +1,8 @@
 use anyhow::bail;
 
 use std::process::Command;
-use wasmer_integration_tests_cli::get_wasmer_path;
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 #[test]
 fn login_works() -> anyhow::Result<()> {
@@ -15,7 +16,7 @@ fn login_works() -> anyhow::Result<()> {
     if wapm_dev_token.is_empty() {
         return Ok(());
     }
-    let output = Command::new(get_wasmer_path())
+    let output = Command::new(WASMER_EXE)
         .arg("login")
         .arg("--registry")
         .arg("wapm.dev")

--- a/tests/integration/cli/tests/publish.rs
+++ b/tests/integration/cli/tests/publish.rs
@@ -1,5 +1,7 @@
 use std::process::Stdio;
-use wasmer_integration_tests_cli::{get_wasmer_path, C_ASSET_PATH};
+use wasmer_integration_tests_cli::C_ASSET_PATH;
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 fn create_exe_test_wasm_path() -> String {
     format!("{}/{}", C_ASSET_PATH, "qjs.wasm")
@@ -31,7 +33,7 @@ fn wasmer_publish() -> anyhow::Result<()> {
             .replace("RANDOMVERSION3", &random3),
     )?;
 
-    let mut cmd = std::process::Command::new(get_wasmer_path());
+    let mut cmd = std::process::Command::new(WASMER_EXE);
     cmd.arg("publish");
     cmd.arg("--quiet");
     cmd.arg("--registry");
@@ -105,7 +107,7 @@ fn wasmer_init_publish() -> anyhow::Result<()> {
         .unwrap();
 
     // generate the wasmer.toml
-    let mut cmd = std::process::Command::new(get_wasmer_path());
+    let mut cmd = std::process::Command::new(WASMER_EXE);
     cmd.arg("init");
     cmd.arg("--namespace");
     cmd.arg(username);
@@ -125,7 +127,7 @@ fn wasmer_init_publish() -> anyhow::Result<()> {
     println!("{s}");
 
     // publish
-    let mut cmd = std::process::Command::new(get_wasmer_path());
+    let mut cmd = std::process::Command::new(WASMER_EXE);
     cmd.arg("publish");
     cmd.arg("--quiet");
     cmd.arg("--registry");

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -3,7 +3,9 @@
 use assert_cmd::Command;
 use predicates::str::contains;
 use std::path::{Path, PathBuf};
-use wasmer_integration_tests_cli::{get_wasmer_path, ASSET_PATH, C_ASSET_PATH};
+use wasmer_integration_tests_cli::{ASSET_PATH, C_ASSET_PATH};
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 fn wasi_test_python_path() -> PathBuf {
     Path::new(C_ASSET_PATH).join("python-0.1.0.wasmer")
@@ -30,7 +32,7 @@ fn test_no_start_wat_path() -> PathBuf {
 #[ignore]
 #[test]
 fn test_run_customlambda() {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("config")
         .arg("--bindir")
         .assert()
@@ -46,7 +48,7 @@ fn test_run_customlambda() {
     println!("checkouts path: {}", checkouts_path.display());
     let _ = std::fs::remove_dir_all(&checkouts_path);
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("https://wapm.io/ciuser/customlambda")
         // TODO: this argument should not be necessary later
@@ -58,7 +60,7 @@ fn test_run_customlambda() {
     assert.stdout("139583862445\n");
 
     // Run again to verify the caching
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("https://wapm.io/ciuser/customlambda")
         // TODO: this argument should not be necessary later
@@ -144,7 +146,7 @@ fn test_cross_compile_python_windows() {
                 Ok(_) => Some(assert_tarball_is_present_local(t).unwrap()),
                 Err(_) => None,
             };
-            let mut cmd = Command::new(get_wasmer_path());
+            let mut cmd = Command::new(WASMER_EXE);
 
             cmd.arg("create-exe");
             cmd.arg(wasi_test_python_path());
@@ -196,7 +198,7 @@ fn run_whoami_works() {
         return;
     }
 
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("login")
         .arg("--registry")
         .arg("wapm.dev")
@@ -204,7 +206,7 @@ fn run_whoami_works() {
         .assert()
         .success();
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("whoami")
         .arg("--registry")
         .arg("wapm.dev")
@@ -217,7 +219,7 @@ fn run_whoami_works() {
 
 #[test]
 fn run_wasi_works() {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg(wasi_test_wasm_path())
         .arg("--")
@@ -249,7 +251,7 @@ fn test_wasmer_create_exe_pirita_works() {
 
     println!("compiling to target {native_target}");
 
-    let mut cmd = Command::new(get_wasmer_path());
+    let mut cmd = Command::new(WASMER_EXE);
     cmd.arg("create-exe");
     cmd.arg(&python_wasmer_path);
     cmd.arg("--tarball");
@@ -292,7 +294,7 @@ fn test_wasmer_run_pirita_works() {
     let python_wasmer_path = temp_dir.path().join("python.wasmer");
     std::fs::copy(wasi_test_python_path(), &python_wasmer_path).unwrap();
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg(python_wasmer_path)
         .arg("--")
@@ -308,7 +310,7 @@ fn test_wasmer_run_pirita_works() {
 #[test]
 #[ignore]
 fn test_wasmer_run_pirita_url_works() {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("https://wapm.dev/syrusakbary/python")
         .arg("--")
@@ -337,7 +339,7 @@ fn test_wasmer_run_works_with_dir() {
     assert!(temp_dir.path().join("qjs.wasm").exists());
 
     // test with "wasmer qjs.wasm"
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg(temp_dir.path())
         .arg("--")
         .arg("--quit")
@@ -345,7 +347,7 @@ fn test_wasmer_run_works_with_dir() {
         .success();
 
     // test again with "wasmer run qjs.wasm"
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("run")
         .arg(temp_dir.path())
         .arg("--")
@@ -359,7 +361,7 @@ fn test_wasmer_run_works_with_dir() {
 #[cfg_attr(target_env = "musl", ignore)]
 #[test]
 fn test_wasmer_run_works() {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("https://wapm.io/python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
         .arg("test.py")
@@ -369,7 +371,7 @@ fn test_wasmer_run_works() {
     assert.stdout("hello\n");
 
     // same test again, but this time with "wasmer run ..."
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("https://wapm.io/python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
@@ -380,7 +382,7 @@ fn test_wasmer_run_works() {
     assert.stdout("hello\n");
 
     // set wapm.io as the current registry
-    let _ = Command::new(get_wasmer_path())
+    let _ = Command::new(WASMER_EXE)
         .arg("login")
         .arg("--registry")
         .arg("wapm.io")
@@ -390,7 +392,7 @@ fn test_wasmer_run_works() {
         .success();
 
     // same test again, but this time without specifying the registry
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
@@ -401,7 +403,7 @@ fn test_wasmer_run_works() {
     assert.stdout("hello\n");
 
     // same test again, but this time with only the command "python" (should be looked up locally)
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("_/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
@@ -414,7 +416,7 @@ fn test_wasmer_run_works() {
 
 #[test]
 fn run_no_imports_wasm_works() {
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("run")
         .arg(test_no_imports_wat_path())
         .assert()
@@ -423,7 +425,7 @@ fn run_no_imports_wasm_works() {
 
 #[test]
 fn run_wasi_works_non_existent() -> anyhow::Result<()> {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg("does-not/exist")
         .assert()
@@ -443,7 +445,7 @@ fn run_wasi_works_non_existent() -> anyhow::Result<()> {
 #[test]
 fn run_test_caching_works_for_packages() {
     // set wapm.io as the current registry
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("login")
         .arg("--registry")
         .arg("wapm.io")
@@ -452,7 +454,7 @@ fn run_test_caching_works_for_packages() {
         .assert()
         .success();
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
         .arg("test.py")
@@ -463,7 +465,7 @@ fn run_test_caching_works_for_packages() {
 
     let time = std::time::Instant::now();
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
         .arg("test.py")
@@ -479,7 +481,7 @@ fn run_test_caching_works_for_packages() {
 #[test]
 fn run_test_caching_works_for_packages_with_versions() {
     // set wapm.io as the current registry
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("login")
         .arg("--registry")
         .arg("wapm.io")
@@ -488,7 +490,7 @@ fn run_test_caching_works_for_packages_with_versions() {
         .assert()
         .success();
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("python/python@0.1.0")
         .arg(format!("--mapdir=/app:{}", ASSET_PATH))
         .arg("/app/test.py")
@@ -497,7 +499,7 @@ fn run_test_caching_works_for_packages_with_versions() {
 
     assert.stdout("hello\n");
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("python/python@0.1.0")
         .arg(format!("--mapdir=/app:{}", ASSET_PATH))
         .arg("/app/test.py")
@@ -521,7 +523,7 @@ fn run_test_caching_works_for_packages_with_versions() {
 #[ignore]
 #[test]
 fn run_test_caching_works_for_urls() {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("https://wapm.io/python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
         .arg("test.py")
@@ -532,7 +534,7 @@ fn run_test_caching_works_for_urls() {
 
     let time = std::time::Instant::now();
 
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("https://wapm.io/python/python")
         .arg(format!("--mapdir=.:{}", ASSET_PATH))
         .arg("test.py")
@@ -566,13 +568,13 @@ fn run_invoke_works_with_nomain_wasi() {
     let module_file = std::env::temp_dir().join(format!("{random}.wat"));
     std::fs::write(&module_file, wasi_wat.as_bytes()).unwrap();
 
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("run")
         .arg(&module_file)
         .assert()
         .success();
 
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("run")
         .arg("--invoke")
         .arg("_start")
@@ -585,7 +587,7 @@ fn run_invoke_works_with_nomain_wasi() {
 
 #[test]
 fn run_no_start_wasm_report_error() {
-    let assert = Command::new(get_wasmer_path())
+    let assert = Command::new(WASMER_EXE)
         .arg("run")
         .arg(test_no_start_wat_path())
         .assert()
@@ -616,7 +618,7 @@ fn test_wasmer_run_complex_url() {
         );
     }
 
-    Command::new(get_wasmer_path())
+    Command::new(WASMER_EXE)
         .arg("run")
         .arg(wasm_test_path)
         .arg("--")

--- a/tests/integration/cli/tests/run_unstable.rs
+++ b/tests/integration/cli/tests/run_unstable.rs
@@ -14,8 +14,8 @@ use predicates::str::contains;
 use rand::Rng;
 use reqwest::{blocking::Client, IntoUrl};
 use tempfile::TempDir;
-use wasmer_integration_tests_cli::get_wasmer_path;
 
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 const HTTP_GET_TIMEOUT: Duration = Duration::from_secs(5);
 
 static RUST_LOG: Lazy<String> = Lazy::new(|| {
@@ -30,14 +30,8 @@ static RUST_LOG: Lazy<String> = Lazy::new(|| {
 });
 
 fn wasmer_run_unstable() -> std::process::Command {
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.arg("run")
-        .arg("--quiet")
-        .arg("--package=wasmer-cli")
-        .arg("--features=singlepass,cranelift")
-        .arg("--color=never")
-        .arg("--")
-        .arg("run-unstable");
+    let mut cmd = std::process::Command::new(WASMER_EXE);
+    cmd.arg("run-unstable");
     cmd.env("RUST_LOG", &*RUST_LOG);
     cmd
 }
@@ -331,7 +325,7 @@ mod wasm_on_disk {
         let dest = temp.path().join("qjs.wasmu");
         let qjs = fixtures::qjs();
         // Make sure it is compiled
-        Command::new(get_wasmer_path())
+        Command::new(WASMER_EXE)
             .arg("compile")
             .arg("-o")
             .arg(&dest)

--- a/tests/integration/cli/tests/snapshot.rs
+++ b/tests/integration/cli/tests/snapshot.rs
@@ -10,9 +10,9 @@ use anyhow::Error;
 use derivative::Derivative;
 use futures::TryFutureExt;
 use insta::assert_json_snapshot;
-
 use tempfile::NamedTempFile;
-use wasmer_integration_tests_cli::get_wasmer_path;
+
+const WASMER_EXE: &str = env!("CARGO_BIN_EXE_wasmer-cli-shim");
 
 #[derive(Derivative, serde::Serialize, serde::Deserialize, Clone)]
 #[derivative(Debug, PartialEq)]
@@ -257,7 +257,7 @@ pub fn wasm_dir() -> PathBuf {
 fn wasmer_path() -> PathBuf {
     let path = std::env::var("WASMER_PATH")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| get_wasmer_path());
+        .unwrap_or_else(|_| PathBuf::from(WASMER_EXE));
     if !path.is_file() {
         panic!("Could not find wasmer binary: '{}'", path.display());
     }


### PR DESCRIPTION
Something that always annoys me is that the CLI integration tests require you to remember to recompile the `wasmer` CLI in release mode every time you want to run the test suite. This tends to be quite a) error-prone and b) slow.

I'm introducing a `wasmer-cli-shim` executable so we can use the `$CARGO_BIN_EXE_<name>` environment variable `cargo` sets when compiling integration tests. This will make sure we always run an up-to-date CLI executable because `wasmer-cli-shim` will be recompiled whenever `wasmer-cli` changes.

As a happy side-effect, this means the old `run_unstable` tests no longer need to do their defensive `cargo run --package=wasmer-cli` and can run the `wasmer-cli-shim` executable directly.

Fixes #4014.