### PR TITLE
Put all cached artifacts under the `~/.wasmer/cache/` directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5659,6 +5659,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "predicates 3.0.3",
+ "pretty_assertions",
  "prettytable-rs",
  "regex",
  "reqwest",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -153,6 +153,7 @@ enable-serde = ["wasmer/enable-serde", "wasmer-vm/enable-serde", "wasmer-compile
 [dev-dependencies]
 assert_cmd = "2.0.11"
 predicates = "3.0.3"
+pretty_assertions = "1.3.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 colored = "2.0.0"

--- a/lib/cli/src/commands/login.rs
+++ b/lib/cli/src/commands/login.rs
@@ -9,6 +9,8 @@ use wasmer_registry::wasmer_env::{Registry, WasmerEnv, WASMER_DIR};
 /// Subcommand for listing packages
 #[derive(Debug, Clone, Parser)]
 pub struct Login {
+    // Note: This is essentially a copy of WasmerEnv except the token is
+    // accepted as a main argument instead of via --token.
     /// Set Wasmer's home directory
     #[clap(long, env = "WASMER_DIR", default_value = WASMER_DIR.as_os_str())]
     pub wasmer_dir: PathBuf,
@@ -19,6 +21,9 @@ pub struct Login {
     /// The API token to use when communicating with the registry (inferred from
     /// the environment by default)
     pub token: Option<String>,
+    /// The directory cached artefacts are saved to.
+    #[clap(long, env = "WASMER_CACHE_DIR")]
+    cache_dir: Option<PathBuf>,
 }
 
 impl Login {
@@ -61,6 +66,7 @@ impl Login {
             self.wasmer_dir.clone(),
             self.registry.clone(),
             self.token.clone(),
+            self.cache_dir.clone(),
         )
     }
 
@@ -83,6 +89,7 @@ impl Login {
 
 #[cfg(test)]
 mod tests {
+    use clap::CommandFactory;
     use tempfile::TempDir;
 
     use super::*;
@@ -94,6 +101,7 @@ mod tests {
             registry: Some("wasmer.wtf".into()),
             wasmer_dir: temp.path().to_path_buf(),
             token: None,
+            cache_dir: None,
         };
         let env = login.wasmer_env();
 
@@ -112,11 +120,45 @@ mod tests {
             registry: Some("wasmer.wtf".into()),
             wasmer_dir: temp.path().to_path_buf(),
             token: Some("abc".to_string()),
+            cache_dir: None,
         };
         let env = login.wasmer_env();
 
         let token = login.get_token_or_ask_user(&env).unwrap();
 
         assert_eq!(token, "abc");
+    }
+
+    #[test]
+    fn in_sync_with_wasmer_env() {
+        let wasmer_env = WasmerEnv::command();
+        let login = Login::command();
+
+        // All options except --token should be the same
+        let wasmer_env_opts: Vec<_> = wasmer_env
+            .get_opts()
+            .filter(|arg| arg.get_id() != "token")
+            .collect();
+        let login_opts: Vec<_> = login.get_opts().collect();
+
+        assert_eq!(wasmer_env_opts, login_opts);
+
+        // The token argument should have the same message, even if it is an
+        // argument rather than a --flag.
+        let wasmer_env_token_help = wasmer_env
+            .get_opts()
+            .find(|arg| arg.get_id() == "token")
+            .unwrap()
+            .get_help()
+            .unwrap()
+            .to_string();
+        let login_token_help = login
+            .get_positionals()
+            .find(|arg| arg.get_id() == "token")
+            .unwrap()
+            .get_help()
+            .unwrap()
+            .to_string();
+        assert_eq!(wasmer_env_token_help, login_token_help);
     }
 }

--- a/lib/cli/src/lib.rs
+++ b/lib/cli/src/lib.rs
@@ -16,6 +16,10 @@
 #[macro_use]
 extern crate anyhow;
 
+#[macro_use]
+#[cfg(test)]
+extern crate pretty_assertions;
+
 pub mod commands;
 pub mod common;
 #[macro_use]

--- a/lib/registry/src/wasmer_env.rs
+++ b/lib/registry/src/wasmer_env.rs
@@ -18,6 +18,9 @@ pub struct WasmerEnv {
     /// default)
     #[cfg_attr(feature = "clap", clap(long, env = "WASMER_REGISTRY"))]
     registry: Option<Registry>,
+    /// The directory cached artefacts are saved to.
+    #[clap(long, env = "WASMER_CACHE_DIR")]
+    cache_dir: Option<PathBuf>,
     /// The API token to use when communicating with the registry (inferred from
     /// the environment by default)
     #[cfg_attr(feature = "clap", clap(long, env = "WASMER_TOKEN"))]
@@ -25,11 +28,17 @@ pub struct WasmerEnv {
 }
 
 impl WasmerEnv {
-    pub fn new(wasmer_dir: PathBuf, registry: Option<Registry>, token: Option<String>) -> Self {
+    pub fn new(
+        wasmer_dir: PathBuf,
+        registry: Option<Registry>,
+        token: Option<String>,
+        cache_dir: Option<PathBuf>,
+    ) -> Self {
         WasmerEnv {
             wasmer_dir,
             registry,
             token,
+            cache_dir,
         }
     }
 
@@ -62,6 +71,14 @@ impl WasmerEnv {
         &self.wasmer_dir
     }
 
+    /// The directory all cached artifacts should be saved to.
+    pub fn cache_dir(&self) -> PathBuf {
+        match &self.cache_dir {
+            Some(cache_dir) => cache_dir.clone(),
+            None => self.dir().join("cache"),
+        }
+    }
+
     /// The API token for the active registry.
     pub fn token(&self) -> Option<String> {
         let config = self.config().ok()?;
@@ -76,6 +93,7 @@ impl Default for WasmerEnv {
             wasmer_dir: WASMER_DIR.clone(),
             registry: None,
             token: None,
+            cache_dir: None,
         }
     }
 }

--- a/lib/registry/src/wasmer_env.rs
+++ b/lib/registry/src/wasmer_env.rs
@@ -19,7 +19,7 @@ pub struct WasmerEnv {
     #[cfg_attr(feature = "clap", clap(long, env = "WASMER_REGISTRY"))]
     registry: Option<Registry>,
     /// The directory cached artefacts are saved to.
-    #[clap(long, env = "WASMER_CACHE_DIR")]
+    #[cfg_attr(feature = "clap", clap(long, env = "WASMER_CACHE_DIR"))]
     cache_dir: Option<PathBuf>,
     /// The API token to use when communicating with the registry (inferred from
     /// the environment by default)

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -19,12 +19,6 @@ impl FileSystemCache {
         }
     }
 
-    /// Get the directory that is typically used when caching compiled
-    /// packages inside `$WASMER_DIR`.
-    pub fn default_cache_dir(wasmer_dir: impl AsRef<Path>) -> PathBuf {
-        wasmer_dir.as_ref().join("compiled")
-    }
-
     pub fn cache_dir(&self) -> &Path {
         &self.cache_dir
     }

--- a/lib/wasix/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasix/src/runtime/package_loader/builtin_loader.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fmt::Write as _,
     io::{ErrorKind, Write as _},
-    path::{PathBuf},
+    path::PathBuf,
     sync::{Arc, RwLock},
 };
 

--- a/lib/wasix/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasix/src/runtime/package_loader/builtin_loader.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fmt::Write as _,
     io::{ErrorKind, Write as _},
-    path::{Path, PathBuf},
+    path::{PathBuf},
     sync::{Arc, RwLock},
 };
 
@@ -52,18 +52,12 @@ impl BuiltinPackageLoader {
         }
     }
 
-    /// Get the directory that is typically used when caching downloaded
-    /// packages inside `$WASMER_DIR`.
-    pub fn default_cache_dir(wasmer_dir: impl AsRef<Path>) -> PathBuf {
-        wasmer_dir.as_ref().join("checkouts")
-    }
-
     /// Create a new [`BuiltinPackageLoader`] based on `$WASMER_DIR` and the
     /// global Wasmer config.
     pub fn from_env() -> Result<Self, Error> {
         let wasmer_dir = discover_wasmer_dir().context("Unable to determine $WASMER_DIR")?;
         let client = crate::http::default_http_client().context("No HTTP client available")?;
-        let cache_dir = BuiltinPackageLoader::default_cache_dir(wasmer_dir);
+        let cache_dir = wasmer_dir.join("cache").join("");
 
         Ok(BuiltinPackageLoader::new_with_client(
             cache_dir,

--- a/lib/wasix/src/runtime/resolver/wapm_source.rs
+++ b/lib/wasix/src/runtime/resolver/wapm_source.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -39,32 +39,12 @@ impl WapmSource {
         }
     }
 
-    /// Get the directory that is typically used when caching downloaded
-    /// packages inside `$WASMER_DIR`.
-    pub fn default_cache_dir(wasmer_dir: impl AsRef<Path>) -> PathBuf {
-        wasmer_dir.as_ref().join("queries")
-    }
-
     /// Cache query results locally.
     pub fn with_local_cache(self, cache_dir: impl Into<PathBuf>, timeout: Duration) -> Self {
         WapmSource {
             cache: Some(FileSystemCache::new(cache_dir, timeout)),
             ..self
         }
-    }
-
-    /// Clean the local cache.
-    ///
-    /// This is a workaround used primarily when publishing and will probably
-    /// be removed in the future.
-    pub fn invalidate_local_cache(wasmer_dir: impl AsRef<Path>) -> Result<(), Error> {
-        let cache_dir = WapmSource::default_cache_dir(wasmer_dir);
-
-        std::fs::remove_dir_all(&cache_dir).with_context(|| {
-            format!("Unable to delete the \"{}\" directory", cache_dir.display())
-        })?;
-
-        Ok(())
     }
 
     async fn lookup_package(&self, package_name: &str) -> Result<WapmWebQuery, Error> {

--- a/lib/wasix/src/runtime/resolver/web_source.rs
+++ b/lib/wasix/src/runtime/resolver/web_source.rs
@@ -62,12 +62,6 @@ impl WebSource {
         }
     }
 
-    /// Get the directory that is typically used when caching downloaded
-    /// packages inside `$WASMER_DIR`.
-    pub fn default_cache_dir(wasmer_dir: impl AsRef<Path>) -> PathBuf {
-        wasmer_dir.as_ref().join("downloads")
-    }
-
     /// Download a package and cache it locally.
     #[tracing::instrument(level = "debug", skip_all, fields(%url))]
     async fn get_locally_cached_file(&self, url: &Url) -> Result<PathBuf, Error> {


### PR DESCRIPTION
> **DO NOT MERGE! This requires #4013 to be merged first**

I've modified the `wasmer` CLI to put all cached artefacts (compiled modules, downloaded packages, etc.) under the `~/.wasmer/cache/` directory and added a `--cache` flag to `WasmerEnv` (also settable via `$WASMER_CACHE_DIR`). This should make it easier for people to delete their cache and keep the `~/.wasmer/` directory cleaner.

Fixes #4017