### PR TITLE
Save compiled `*.wasm` files to the module cache when they are loaded directly

### DIFF
--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -585,7 +585,8 @@ impl ExecutableTarget {
                             );
                         }
 
-                        let module = Module::new(&engine, &wasm)
+                        let module = tracing::debug_span!("compiling_wasm")
+                            .in_scope(|| Module::new(&engine, &wasm))
                             .with_context(|| format!("Unable to compile \"{}\"", path.display()))?;
 
                         tasks.block_on(module_cache.save(module_hash, &engine, &module))?;

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -585,8 +585,12 @@ impl ExecutableTarget {
                             );
                         }
 
-                        Module::new(&engine, &wasm)
-                            .with_context(|| format!("Unable to compile \"{}\"", path.display()))?
+                        let module = Module::new(&engine, &wasm)
+                            .with_context(|| format!("Unable to compile \"{}\"", path.display()))?;
+
+                        tasks.block_on(module_cache.save(module_hash, &engine, &module))?;
+
+                        module
                     }
                 };
 

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -34,6 +34,7 @@ impl FileSystemCache {
 
 #[async_trait::async_trait]
 impl ModuleCache for FileSystemCache {
+    #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
         let path = self.path(key, engine.deterministic_id());
 
@@ -46,7 +47,10 @@ impl ModuleCache for FileSystemCache {
 
         let res = unsafe { Module::deserialize(&engine, uncompressed) };
         match res {
-            Ok(m) => Ok(m),
+            Ok(m) => {
+                tracing::debug!("Cache hit!");
+                Ok(m)
+            }
             Err(e) => {
                 tracing::debug!(
                     %key,
@@ -69,6 +73,7 @@ impl ModuleCache for FileSystemCache {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn save(
         &self,
         key: ModuleHash,

--- a/lib/wasix/src/runtime/module_cache/thread_local.rs
+++ b/lib/wasix/src/runtime/module_cache/thread_local.rs
@@ -28,11 +28,18 @@ impl ThreadLocalCache {
 
 #[async_trait::async_trait]
 impl ModuleCache for ThreadLocalCache {
+    #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        self.lookup(key, engine.deterministic_id())
-            .ok_or(CacheError::NotFound)
+        match self.lookup(key, engine.deterministic_id()) {
+            Some(m) => {
+                tracing::debug!("Cache hit!");
+                Ok(m)
+            }
+            None => Err(CacheError::NotFound),
+        }
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn save(
         &self,
         key: ModuleHash,


### PR DESCRIPTION
#4019 made sure we check the module cache when doing a `wasmer run whatever.wasm` but forgot to save the compiled module after a cache miss 😅 