### PR TITLE
Remove rustup build dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ ifneq (, $(filter 1, $(IS_DARWIN) $(IS_LINUX) $(IS_FREEBSD)))
 	reset := $(shell tput sgr0 2>/dev/null || echo -n '')
 endif
 
-HOST_TARGET=$(shell rustup show | grep 'Default host: ' | cut -d':' -f2 | tr -d ' ')
+HOST_TARGET=$(shell rustc -Vv | grep 'host: ' | cut -d':' -f2 | tr -d ' ')
 
 TARGET_DIR ?= target/release
 


### PR DESCRIPTION
Remove rustup build dependency. Some Rust bundles (for example in FreeBSD) don't contain rustup. This complicates compilation because Makefiles needs to be patched of rustup needs to be downloaded.

The target triple needed by Makefile can be obtained from rustc thus removing dependency on rustup.