### PR TITLE
Fix help text for `use_system_linker` option in `create_exe` CLI command

### DIFF
--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -125,7 +125,7 @@ impl UrlOrVersion {
 // Cross-compilation options with `zig`
 #[derive(Debug, Clone, Default, Parser)]
 pub(crate) struct CrossCompile {
-    /// Use the system linker instead of zig instead of zig for linking
+    /// Use the system linker instead of zig for linking
     #[clap(long)]
     use_system_linker: bool,
 


### PR DESCRIPTION
# Description

When running `wasmer create-exe --help`, the help text for `--use-system-linker` had a typo where the phrase "instead of zig" was repeated twice. This PR fixes that.