### PR TITLE
Use a no-op package loader by default in PluggableRuntime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -2201,7 +2201,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2218,7 +2218,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     os::TtyBridge,
     runtime::{
         module_cache::ModuleCache,
-        package_loader::{BuiltinPackageLoader, PackageLoader},
+        package_loader::{PackageLoader, UnsupportedPackageLoader},
         resolver::{MultiSource, Source, WapmSource},
     },
     WasiTtyState,
@@ -129,8 +129,7 @@ impl PluggableRuntime {
         let http_client =
             crate::http::default_http_client().map(|client| Arc::new(client) as DynHttpClient);
 
-        let loader = BuiltinPackageLoader::from_env()
-            .expect("Loading the builtin resolver should never fail");
+        let loader = UnsupportedPackageLoader::default();
 
         let mut source = MultiSource::new();
         if let Some(client) = &http_client {

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     http::DynHttpClient,
     os::TtyBridge,
     runtime::{
-        module_cache::ModuleCache,
+        module_cache::{ModuleCache, ThreadLocalCache},
         package_loader::{PackageLoader, UnsupportedPackageLoader},
         resolver::{MultiSource, Source, WapmSource},
     },
@@ -39,10 +39,20 @@ where
     fn task_manager(&self) -> &Arc<dyn VirtualTaskManager>;
 
     /// A package loader.
-    fn package_loader(&self) -> Arc<dyn PackageLoader + Send + Sync>;
+    fn package_loader(&self) -> Arc<dyn PackageLoader + Send + Sync> {
+        Arc::new(UnsupportedPackageLoader::default())
+    }
 
     /// A cache for compiled modules.
-    fn module_cache(&self) -> Arc<dyn ModuleCache + Send + Sync>;
+    fn module_cache(&self) -> Arc<dyn ModuleCache + Send + Sync> {
+        // Return a cache that uses a thread-local variable. This isn't ideal
+        // because it allows silently sharing state, possibly between runtimes.
+        //
+        // That said, it means people will still get *some* level of caching
+        // because each cache returned by this default implementation will go
+        // through the same thread-local variable.
+        Arc::new(ThreadLocalCache::default())
+    }
 
     /// The package registry.
     fn source(&self) -> Arc<dyn Source + Send + Sync>;

--- a/lib/wasix/src/runtime/module_cache/thread_local.rs
+++ b/lib/wasix/src/runtime/module_cache/thread_local.rs
@@ -10,7 +10,7 @@ std::thread_local! {
 }
 
 /// A cache that will cache modules in a thread-local variable.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct ThreadLocalCache {}
 

--- a/lib/wasix/src/runtime/package_loader/mod.rs
+++ b/lib/wasix/src/runtime/package_loader/mod.rs
@@ -1,8 +1,9 @@
 mod builtin_loader;
 mod load_package_tree;
 mod types;
+mod unsupported;
 
 pub use self::{
     builtin_loader::BuiltinPackageLoader, load_package_tree::load_package_tree,
-    types::PackageLoader,
+    types::PackageLoader, unsupported::UnsupportedPackageLoader,
 };

--- a/lib/wasix/src/runtime/package_loader/unsupported.rs
+++ b/lib/wasix/src/runtime/package_loader/unsupported.rs
@@ -1,0 +1,33 @@
+use anyhow::Error;
+use webc::compat::Container;
+
+use crate::{
+    bin_factory::BinaryPackage,
+    runtime::{
+        package_loader::PackageLoader,
+        resolver::{PackageSummary, Resolution},
+    },
+};
+
+/// A [`PackageLoader`] implementation which will always error out.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct UnsupportedPackageLoader;
+
+#[async_trait::async_trait]
+impl PackageLoader for UnsupportedPackageLoader {
+    async fn load(&self, _summary: &PackageSummary) -> Result<Container, Error> {
+        Err(Error::new(Unsupported))
+    }
+
+    async fn load_package_tree(
+        &self,
+        _root: &Container,
+        _resolution: &Resolution,
+    ) -> Result<BinaryPackage, Error> {
+        Err(Error::new(Unsupported))
+    }
+}
+
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("Not supported")]
+struct Unsupported;

--- a/lib/wasix/src/runtime/package_loader/unsupported.rs
+++ b/lib/wasix/src/runtime/package_loader/unsupported.rs
@@ -29,5 +29,5 @@ impl PackageLoader for UnsupportedPackageLoader {
 }
 
 #[derive(Debug, Copy, Clone, thiserror::Error)]
-#[error("Not supported")]
+#[error("Loading of packages is not supported in this runtime (no PackageLoader configured)")]
 struct Unsupported;


### PR DESCRIPTION
# Description

This fixes the root cause of #4029 by switching `PluggableRuntime` from the `BuiltinPackageLoader` to an `UnsupportedPackageLoader` which will error out when you try to resolve a package tree. This should side-step the `.expect("Loading the builtin resolver should never fail")` @kwonoj was encountering.

I've also added default implementations for `Runtime::module_cache()` and `Runtime::package_loader()` which will return some sane values. In the case of `module_cache()`, we'll return a thread-local cache so users get some level of caching by default. For `package_loader()` I'm just returning `UnsupportedPackageLoader`.

Closes https://github.com/wasmerio/wasmer/issues/4029.