### PR TITLE
Enable the `cfg_doc` feature on docs.rs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.MSRV }}
+          toolchain: nightly
           target: x86_64-unknown-linux-gnu
       - run: cargo install toml-cli # toml-cli is required to run `make test-build-docs-rs`
       - name: make test-build-docs-rs

--- a/Makefile
+++ b/Makefile
@@ -454,10 +454,10 @@ test-build-docs-rs:
 			fi; \
 			printf "*** Building doc for package with manifest $$manifest_path ***\n\n"; \
 			if [ -z "$$features" ]; then \
-				$(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" || exit 1; \
+				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) +nightly doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" || exit 1; \
 			else \
 				printf "Following features are inferred from Cargo.toml: $$features\n\n\n"; \
-				$(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" --features "$$features" || exit 1; \
+				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) +nightly doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" --features "$$features" || exit 1; \
 			fi; \
 		fi; \
 	done

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -162,3 +162,4 @@ features = [
     "wasmer-artifact-create",
     "wasmer-artifact-load",
 ]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/c-api/src/lib.rs
+++ b/lib/c-api/src/lib.rs
@@ -26,6 +26,7 @@
 // Because this crate exposes a lot of C APIs which are unsafe by definition,
 // we allow unsafe without explicit safety documentation for each of them.
 #![allow(clippy::missing_safety_doc)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod error;
 pub mod wasm_c_api;

--- a/lib/cache/Cargo.toml
+++ b/lib/cache/Cargo.toml
@@ -32,3 +32,4 @@ blake3-pure = ["blake3/pure"]
 
 [package.metadata.docs.rs]
 features = ["wasmer/sys"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/cache/src/lib.rs
+++ b/lib/cache/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
 #![cfg_attr(
     feature = "cargo-clippy",
@@ -17,6 +16,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod cache;
 mod filesystem;

--- a/lib/cli-compiler/Cargo.toml
+++ b/lib/cli-compiler/Cargo.toml
@@ -78,3 +78,6 @@ cranelift = [
 debug = ["fern", "log"]
 disable-all-logging = []
 jit = []
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/cli-compiler/src/lib.rs
+++ b/lib/cli-compiler/src/lib.rs
@@ -7,8 +7,7 @@
     unused_mut,
     unused_variables,
     unused_unsafe,
-    unreachable_patterns,
-    unstable_features
+    unreachable_patterns
 )]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]

--- a/lib/cli-compiler/src/lib.rs
+++ b/lib/cli-compiler/src/lib.rs
@@ -11,6 +11,7 @@
 )]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
 extern crate anyhow;

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -188,3 +188,6 @@ bin-dir = "bin/{ bin }"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-url = "{ repo }/releases/download/v{ version }/wasmer-windows-amd64.{ archive-format }"
 bin-dir = "bin/{ bin }.exe"
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/cli/src/lib.rs
+++ b/lib/cli/src/lib.rs
@@ -7,11 +7,11 @@
     unused_mut,
     unused_variables,
     unused_unsafe,
-    unreachable_patterns,
-    unstable_features
+    unreachable_patterns
 )]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
 extern crate anyhow;

--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -40,3 +40,6 @@ wasm = ["std", "unwind"]
 unwind = ["cranelift-codegen/unwind", "gimli"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std", "wasmer-compiler/std", "wasmer-types/std"]
 core = ["hashbrown", "cranelift-codegen/core", "cranelift-frontend/core"]
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/compiler-cranelift/src/lib.rs
+++ b/lib/compiler-cranelift/src/lib.rs
@@ -22,6 +22,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(not(feature = "std"))]
 #[macro_use]

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -42,3 +42,6 @@ rustc_version = "0.4"
 
 [features]
 test = []
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/compiler-llvm/src/lib.rs
+++ b/lib/compiler-llvm/src/lib.rs
@@ -12,6 +12,7 @@
 )]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod abi;
 mod compiler;

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -43,3 +43,6 @@ core = ["hashbrown", "wasmer-types/core"]
 unwind = ["gimli"]
 sse = []
 avx = []
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/compiler-singlepass/src/lib.rs
+++ b/lib/compiler-singlepass/src/lib.rs
@@ -9,6 +9,7 @@
 //! runtime performance.
 
 #![allow(clippy::unnecessary_cast)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod address_map;
 mod arm64_decl;

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -64,3 +64,4 @@ features = [
     "wasmer-artifact-create",
     "wasmer-artifact-load",
 ]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -7,7 +7,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
     feature = "cargo-clippy",
@@ -25,6 +24,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(all(feature = "std", feature = "core"))]
 compile_error!(

--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -26,3 +26,4 @@ getrandom = "0.2"
 
 [package.metadata.docs.rs]
 features = ["wasmer/sys"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/emscripten/src/lib.rs
+++ b/lib/emscripten/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::type_complexity, clippy::unnecessary_cast)]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
 extern crate log;

--- a/lib/middlewares/Cargo.toml
+++ b/lib/middlewares/Cargo.toml
@@ -22,3 +22,6 @@ wasmer = { path = "../api", version = "=4.0.0", features = ["compiler"] }
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/middlewares/src/lib.rs
+++ b/lib/middlewares/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 pub mod metering;
 
 // The most commonly used symbol are exported at top level of the

--- a/lib/object/Cargo.toml
+++ b/lib/object/Cargo.toml
@@ -16,3 +16,6 @@ version.workspace = true
 wasmer-types = { path = "../types", version = "=4.0.0" }
 object = { version = "0.28.3", default-features = false, features = ["write"] }
 thiserror = "1.0"
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/object/src/lib.rs
+++ b/lib/object/src/lib.rs
@@ -18,6 +18,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod error;
 mod module;

--- a/lib/registry/Cargo.toml
+++ b/lib/registry/Cargo.toml
@@ -50,3 +50,7 @@ whoami = "1.2.3"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
+
+[package.metadata.docs.rs]
+features = ["build-package"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/registry/src/lib.rs
+++ b/lib/registry/src/lib.rs
@@ -7,6 +7,7 @@
 //! $ make update-graphql-schema
 //! curl -sSfL https://registry.wasmer.io/graphql/schema.graphql > lib/registry/graphql/schema.graphql
 //! ```
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod api;
 mod client;

--- a/lib/sys-utils/Cargo.toml
+++ b/lib/sys-utils/Cargo.toml
@@ -26,3 +26,6 @@ wasmer-wasix = { path = "../wasix", version = "0.9.0" }
 wasmer = { path = "../api", version = "=4.0.0", default-features = false, features = ["sys", "compiler", "cranelift"] }
 tracing-subscriber = { version = "0.3.16", features = ["fmt"] }
 tracing = "0.1.37"
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/sys-utils/src/lib.rs
+++ b/lib/sys-utils/src/lib.rs
@@ -1,1 +1,2 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 pub mod memory;

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -32,3 +32,6 @@ default = ["std"]
 std = []
 core = []
 enable-serde = ["serde", "serde/std", "serde_bytes", "indexmap/serde-1"]
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -6,7 +6,6 @@
 
 #![deny(missing_docs, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
 #![cfg_attr(
@@ -21,6 +20,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[cfg(all(feature = "std", feature = "core"))]
 compile_error!(

--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -49,3 +49,6 @@ enable-serde = ["typetag"]
 no-time = []
 # Enables memory tracking/limiting functionality for the in-memory filesystem.
 tracking = []
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -19,3 +19,7 @@ libc = { version = "0.2.139", optional = true }
 
 [features]
 host-net = [ "tokio", "libc" ]
+
+[package.metadata.docs.rs]
+features = ["host-net"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 use std::fmt;
 use std::mem::MaybeUninit;
 use std::net::IpAddr;

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -48,3 +48,6 @@ maintenance = { status = "actively-developed" }
 [features]
 default = []
 enable-serde = ["serde", "indexmap/serde-1", "wasmer-types/enable-serde" ]
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -19,6 +19,7 @@
         clippy::use_self
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod export;
 mod extern_ref;

--- a/lib/wai-bindgen-wasmer/Cargo.toml
+++ b/lib/wai-bindgen-wasmer/Cargo.toml
@@ -43,3 +43,4 @@ llvm = ["wasmer/llvm"]
 
 [package.metadata.docs.rs]
 features = ["wasmer/sys"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/wai-bindgen-wasmer/src/lib.rs
+++ b/lib/wai-bindgen-wasmer/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 pub use wai_bindgen_wasmer_impl::{export, import};
 
 #[cfg(feature = "async")]

--- a/lib/wasi-experimental-io-devices/Cargo.toml
+++ b/lib/wasi-experimental-io-devices/Cargo.toml
@@ -43,3 +43,4 @@ link_external_libs = [
 
 [package.metadata.docs.rs]
 features = ["wasmer/sys"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/wasi-experimental-io-devices/src/lib.rs
+++ b/lib/wasi-experimental-io-devices/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 #[cfg(feature = "link_external_libs")]
 #[path = "link-ext.rs"]
 pub mod link_ext;

--- a/lib/wasi-types/Cargo.toml
+++ b/lib/wasi-types/Cargo.toml
@@ -39,3 +39,4 @@ enable-serde = ["serde", "wasmer-types/serde"]
 
 [package.metadata.docs.rs]
 features = ["wasmer/sys"]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/wasi-types/src/lib.rs
+++ b/lib/wasi-types/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod asyncify;
 pub mod types;

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -139,4 +139,8 @@ disable-all-logging = ["tracing/release_max_level_off", "tracing/max_level_off"]
 enable-serde = ["typetag", "virtual-fs/enable-serde", "wasmer-wasix-types/enable-serde"]
 
 [package.metadata.docs.rs]
-features = ["wasmer/sys"]
+features = [
+    "wasmer/sys", "webc_runner", "webc_runner_rt_wasi", "webc_runner_rt_wcgi",
+    "webc_runner_rt_emscripten", "sys-default",
+]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/wasix/src/lib.rs
+++ b/lib/wasix/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 //! Wasmer's WASI implementation
 //!

--- a/lib/wasm-interface/Cargo.toml
+++ b/lib/wasm-interface/Cargo.toml
@@ -24,3 +24,6 @@ wat = "1.0"
 validation = ["wasmparser"]
 binary_encode = ["bincode"]
 default = ["validation"]
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/lib/wasm-interface/src/lib.rs
+++ b/lib/wasm-interface/src/lib.rs
@@ -3,6 +3,7 @@
 //!
 //! wasm interfaces ensure wasm modules conform to a specific shape
 //! they do this by asserting on the imports and exports of the module.
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod interface;
 pub mod interface_matcher;

--- a/tests/lib/wast/src/lib.rs
+++ b/tests/lib/wast/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![deny(unstable_features)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
 #![cfg_attr(
     feature = "cargo-clippy",


### PR DESCRIPTION
# Description

This PR makes sure docs.rs enables the `doc_cfg` and `auto_doc_cfg` features (see https://github.com/rust-lang/rust/issues/43781) when generating documentation.

I was checking this locally using the following command:

```console
$ RUSTFLAGS="--cfg=docsrs" RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly d --package=wasmer-wasix --open
```

It doesn't 100% work for the `wasmer` crate because the way we use `#[cfg]` to switch between backing implementations screws things up, but the other crates with simpler conditional compilation stories are documented as expected. I'm not *too* concerned though, because #4033 will fix things properly.

Fixes #4039.