### PR TITLE
Enable tokio's "net" feature in the virtual-net crate

### DIFF
--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1"
 bytes = "1.1"
 async-trait = { version = "^0.1" }
 tracing = "0.1"
-tokio = { version = "1", features = [ "sync", "macros", "io-util", "signal" ], default_features = false, optional = true }
+tokio = { version = "1", features = [ "sync", "macros", "io-util", "signal", "net" ], default_features = false, optional = true }
 libc = { version = "0.2.139", optional = true }
 
 [features]


### PR DESCRIPTION
# Description

The `virtual-net` crate doesn't enable Tokio's `net` feature so it won't compile by itself.

This fixes #4066.
