### PR TITLE
fix(wasix): Expose FileSystemMapping struct

### DIFF
--- a/lib/wasix/src/runtime/resolver/mod.rs
+++ b/lib/wasix/src/runtime/resolver/mod.rs
@@ -13,8 +13,8 @@ pub use self::{
     filesystem_source::FileSystemSource,
     in_memory_source::InMemorySource,
     inputs::{
-        Command, Dependency, DistributionInfo, PackageInfo, PackageSpecifier, PackageSummary,
-        WebcHash,
+        Command, Dependency, DistributionInfo, FileSystemMapping, PackageInfo, PackageSpecifier,
+        PackageSummary, WebcHash,
     },
     multi_source::{MultiSource, MultiSourceStrategy},
     outputs::{


### PR DESCRIPTION
The FileSystemMapping struct used in package resolution code is not
currently public, preventing users from implementing the `Source` trait
outside of this crate.

This was overlooked during the initial merge of this feature.
