### PR TITLE
For WASIX program, removed the mapdir(".", "/") (for #4027)

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -206,7 +206,6 @@ impl Wasi {
                 .sandbox_fs(root_fs)
                 .preopen_dir(Path::new("/"))
                 .unwrap()
-                .map_dir(".", "/")?
         } else {
             builder
                 .fs(default_fs_backing())


### PR DESCRIPTION
The initalisation code for WASIX program on the CLI ende the init of the filesystem with a `mapdir(".", "/")?` that was supposed to add an alias from `.` to `/`.
But the alias makes little sense as-is, and the side effect was to add a preopen folder "." which was breaking wasix-libc programs.
Removing this mapdir doesn't seems to have any adverse side effect (conanicalization of relative folder is not using this mapdir to work)"