### PR TITLE
deps: Bumped wasmer-deploy-cli to 0.1.18

### DIFF
--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -64,7 +64,7 @@ virtual-net = { version = "0.3.0", path = "../virtual-net" }
 
 # Wasmer-owned dependencies.
 webc = { workspace = true }
-wasmer-deploy-cli = { version = "0.1.17", default-features = false }
+wasmer-deploy-cli = { version = "0.1.18", default-features = false }
 
 # Third-party dependencies.
 


### PR DESCRIPTION
Improvements:
* "app create static-site" now checks if app/package name is available
  and warns the user
