### PR TITLE
Tweak logging annotations to simplify performance troubleshooting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5011,6 +5011,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5020,12 +5030,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -30,9 +30,9 @@ thiserror = "1.0"
 more-asserts = "0.2"
 derivative = { version = "^2" }
 bytes = "1"
+tracing = { version = "0.1" }
 # - Optional shared dependencies.
 wat = { version = "=1.0.71", optional = true }
-tracing = { version = "0.1", optional = true }
 rustc-demangle = "0.1"
 shared-buffer = { workspace = true }
 

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -5,7 +5,7 @@ use crate::MemoryType;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::slice;
-#[cfg(feature = "tracing")]
+
 use tracing::warn;
 
 use wasm_bindgen::prelude::*;
@@ -217,7 +217,6 @@ impl<'a> MemoryBuffer<'a> {
             .ok_or(MemoryAccessError::Overflow)?;
         let view = unsafe { &*(self.base) };
         if end > view.length().into() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 buf.len(),
@@ -241,7 +240,6 @@ impl<'a> MemoryBuffer<'a> {
             .ok_or(MemoryAccessError::Overflow)?;
         let view = unsafe { &*(self.base) };
         if end > view.length().into() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 buf.len(),
@@ -263,7 +261,6 @@ impl<'a> MemoryBuffer<'a> {
             .ok_or(MemoryAccessError::Overflow)?;
         let view = unsafe { &mut *(self.base) };
         if end > view.length().into() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to write ({} bytes) beyond the bounds of the memory view ({} > {})",
                 data.len(),

--- a/lib/api/src/js/externals/memory_view.rs
+++ b/lib/api/src/js/externals/memory_view.rs
@@ -1,16 +1,12 @@
-use crate::mem_access::MemoryAccessError;
-use crate::store::AsStoreRef;
-use std::marker::PhantomData;
-use std::mem::MaybeUninit;
-use std::slice;
-use std::{convert::TryInto, ops::Range};
-#[cfg(feature = "tracing")]
-use tracing::warn;
+use std::{convert::TryInto, marker::PhantomData, mem::MaybeUninit, ops::Range, slice};
 use wasm_bindgen::JsCast;
-
 use wasmer_types::{Bytes, Pages};
 
-use super::memory::{Memory, MemoryBuffer};
+use crate::{
+    js::externals::memory::{Memory, MemoryBuffer},
+    mem_access::MemoryAccessError,
+    store::AsStoreRef,
+};
 
 /// A WebAssembly `memory` view.
 ///
@@ -128,8 +124,7 @@ impl<'a> MemoryView<'a> {
             .map_err(|_| MemoryAccessError::Overflow)?;
         let end = offset.checked_add(len).ok_or(MemoryAccessError::Overflow)?;
         if end > view.length() {
-            #[cfg(feature = "tracing")]
-            warn!(
+            tracing::warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 len,
                 end,
@@ -149,8 +144,7 @@ impl<'a> MemoryView<'a> {
         let view = &self.view;
         let offset: u32 = offset.try_into().map_err(|_| MemoryAccessError::Overflow)?;
         if offset >= view.length() {
-            #[cfg(feature = "tracing")]
-            warn!(
+            tracing::warn!(
                 "attempted to read beyond the bounds of the memory view ({} >= {})",
                 offset,
                 view.length()
@@ -183,8 +177,7 @@ impl<'a> MemoryView<'a> {
             .map_err(|_| MemoryAccessError::Overflow)?;
         let end = offset.checked_add(len).ok_or(MemoryAccessError::Overflow)?;
         if end > view.length() {
-            #[cfg(feature = "tracing")]
-            warn!(
+            tracing::warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 len,
                 end,
@@ -220,8 +213,7 @@ impl<'a> MemoryView<'a> {
         let view = &self.view;
         let end = offset.checked_add(len).ok_or(MemoryAccessError::Overflow)?;
         if end > view.length() {
-            #[cfg(feature = "tracing")]
-            warn!(
+            tracing::warn!(
                 "attempted to write ({} bytes) beyond the bounds of the memory view ({} > {})",
                 len,
                 end,
@@ -241,8 +233,7 @@ impl<'a> MemoryView<'a> {
         let view = &self.view;
         let offset: u32 = offset.try_into().map_err(|_| MemoryAccessError::Overflow)?;
         if offset >= view.length() {
-            #[cfg(feature = "tracing")]
-            warn!(
+            tracing::warn!(
                 "attempted to write beyond the bounds of the memory view ({} >= {})",
                 offset,
                 view.length()

--- a/lib/api/src/js/module.rs
+++ b/lib/api/src/js/module.rs
@@ -10,7 +10,6 @@ use crate::{AsEngineRef, ExportType, ImportType};
 use bytes::Bytes;
 use js_sys::{Reflect, Uint8Array, WebAssembly};
 use std::path::Path;
-#[cfg(feature = "tracing")]
 use tracing::{debug, warn};
 use wasm_bindgen::JsValue;
 use wasmer_types::{
@@ -155,10 +154,8 @@ impl Module {
             #[allow(unused_variables)]
             if let wasmer_types::ExternType::Memory(mem_ty) = import_type.ty() {
                 if resolved_import.is_some() {
-                    #[cfg(feature = "tracing")]
                     debug!("imported shared memory {:?}", &mem_ty);
                 } else {
-                    #[cfg(feature = "tracing")]
                     warn!(
                         "Error while importing {0:?}.{1:?}: memory. Expected {2:?}",
                         import_type.module(),
@@ -195,7 +192,6 @@ impl Module {
                     }
                     import_externs.push(import);
                 } else {
-                    #[cfg(feature = "tracing")]
                     warn!(
                         "import not found {}:{}",
                         import_type.module(),
@@ -227,6 +223,7 @@ impl Module {
         ));
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub unsafe fn deserialize_unchecked(
         _engine: &impl AsEngineRef,
         _bytes: impl IntoBytes,
@@ -239,6 +236,7 @@ impl Module {
         return Err(DeserializeError::Generic("You need to enable the `js-serializable-module` feature flag to deserialize a `Module`".to_string()));
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub unsafe fn deserialize(
         _engine: &impl AsEngineRef,
         _bytes: impl IntoBytes,

--- a/lib/api/src/jsc/externals/memory.rs
+++ b/lib/api/src/jsc/externals/memory.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::mem::{self, MaybeUninit};
 use std::slice;
-#[cfg(feature = "tracing")]
+
 use tracing::warn;
 
 use wasmer_types::{Pages, WASM_PAGE_SIZE};
@@ -234,7 +234,6 @@ impl<'a> MemoryBuffer<'a> {
             .checked_add(buf.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > self.len.try_into().unwrap() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 buf.len(),
@@ -258,7 +257,6 @@ impl<'a> MemoryBuffer<'a> {
             .checked_add(buf.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > self.len.try_into().unwrap() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 buf.len(),
@@ -280,7 +278,6 @@ impl<'a> MemoryBuffer<'a> {
             .checked_add(data.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > self.len.try_into().unwrap() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to write ({} bytes) beyond the bounds of the memory view ({} > {})",
                 data.len(),

--- a/lib/api/src/jsc/mem_access.rs
+++ b/lib/api/src/jsc/mem_access.rs
@@ -16,7 +16,6 @@ where
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > slice.buffer.0.len as u64 {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 total_len, end, slice.buffer.0.len
@@ -46,7 +45,6 @@ where
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > ptr.buffer.0.len as u64 {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 total_len, end, ptr.buffer.0.len

--- a/lib/api/src/jsc/mem_access.rs
+++ b/lib/api/src/jsc/mem_access.rs
@@ -16,9 +16,11 @@ where
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > slice.buffer.0.len as u64 {
-            warn!(
+            tracing::warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
-                total_len, end, slice.buffer.0.len
+                total_len,
+                end,
+                slice.buffer.0.len
             );
             return Err(MemoryAccessError::HeapOutOfBounds);
         }
@@ -45,9 +47,11 @@ where
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > ptr.buffer.0.len as u64 {
-            warn!(
+            tracing::warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
-                total_len, end, ptr.buffer.0.len
+                total_len,
+                end,
+                ptr.buffer.0.len
             );
             return Err(MemoryAccessError::HeapOutOfBounds);
         }

--- a/lib/api/src/jsc/module.rs
+++ b/lib/api/src/jsc/module.rs
@@ -12,7 +12,6 @@ use crate::{AsEngineRef, ExportType, ImportType};
 use bytes::Bytes;
 use rusty_jsc::{JSObject, JSString, JSValue};
 use std::path::Path;
-#[cfg(feature = "tracing")]
 use tracing::{debug, warn};
 use wasmer_types::{
     CompileError, DeserializeError, ExportsIterator, ExternType, FunctionType, GlobalType,
@@ -154,7 +153,6 @@ impl Module {
                         .unwrap();
                 }
             } else {
-                #[cfg(feature = "tracing")]
                 warn!(
                     "import not found {}:{}",
                     import_type.module(),

--- a/lib/api/src/jsc/vm.rs
+++ b/lib/api/src/jsc/vm.rs
@@ -8,7 +8,6 @@ use crate::store::AsStoreRef;
 use rusty_jsc::{JSObject, JSObjectCallAsFunctionCallback, JSValue};
 use std::any::Any;
 use std::fmt;
-#[cfg(feature = "tracing")]
 use tracing::trace;
 use wasmer_types::RawValue;
 use wasmer_types::{
@@ -63,7 +62,6 @@ impl VMMemory {
         let new_memory =
             crate::jsc::externals::memory::Memory::js_memory_from_type(&store, &self.ty)?;
 
-        #[cfg(feature = "tracing")]
         trace!("memory copy started");
 
         let src = crate::jsc::externals::memory_view::MemoryView::new_raw(&self.memory, store);
@@ -96,7 +94,6 @@ impl VMMemory {
             wasmer_types::MemoryError::Generic(format!("failed to copy the memory - {}", err))
         })?;
 
-        #[cfg(feature = "tracing")]
         trace!("memory copy finished (size={})", dst.size().bytes().0);
 
         Ok(Self {

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -1,18 +1,20 @@
-use super::memory_view::MemoryView;
-use crate::store::{AsStoreMut, AsStoreRef};
-use crate::sys::engine::NativeEngineExt;
-use crate::vm::VMExternMemory;
-use crate::MemoryAccessError;
-use crate::MemoryType;
-use std::convert::TryInto;
-use std::marker::PhantomData;
-use std::mem;
-use std::mem::MaybeUninit;
-use std::slice;
-#[cfg(feature = "tracing")]
+use std::{
+    convert::TryInto,
+    marker::PhantomData,
+    mem::{self, MaybeUninit},
+    slice,
+};
+
 use tracing::warn;
 use wasmer_types::Pages;
 use wasmer_vm::{LinearMemory, MemoryError, StoreHandle, VMExtern, VMMemory};
+
+use crate::{
+    store::{AsStoreMut, AsStoreRef},
+    sys::{engine::NativeEngineExt, externals::memory_view::MemoryView},
+    vm::VMExternMemory,
+    MemoryAccessError, MemoryType,
+};
 
 #[derive(Debug, Clone)]
 pub struct Memory {
@@ -125,7 +127,6 @@ impl<'a> MemoryBuffer<'a> {
             .checked_add(buf.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > self.len.try_into().unwrap() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 buf.len(),
@@ -149,7 +150,6 @@ impl<'a> MemoryBuffer<'a> {
             .checked_add(buf.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > self.len.try_into().unwrap() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 buf.len(),
@@ -171,7 +171,6 @@ impl<'a> MemoryBuffer<'a> {
             .checked_add(data.len() as u64)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > self.len.try_into().unwrap() {
-            #[cfg(feature = "tracing")]
             warn!(
                 "attempted to write ({} bytes) beyond the bounds of the memory view ({} > {})",
                 data.len(),

--- a/lib/api/src/sys/mem_access.rs
+++ b/lib/api/src/sys/mem_access.rs
@@ -1,6 +1,9 @@
-use crate::access::{RefCow, SliceCow, WasmRefAccess, WasmSliceAccess};
-use crate::{MemoryAccessError, WasmRef, WasmSlice};
 use std::mem;
+
+use crate::{
+    access::{RefCow, SliceCow, WasmRefAccess, WasmSliceAccess},
+    MemoryAccessError, WasmRef, WasmSlice,
+};
 
 impl<'a, T> WasmSliceAccess<'a, T>
 where
@@ -16,7 +19,6 @@ where
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > slice.buffer.0.len as u64 {
-            #[cfg(feature = "tracing")]
             tracing::warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 total_len,
@@ -48,7 +50,6 @@ where
             .checked_add(total_len)
             .ok_or(MemoryAccessError::Overflow)?;
         if end > ptr.buffer.0.len as u64 {
-            #[cfg(feature = "tracing")]
             tracing::warn!(
                 "attempted to read ({} bytes) beyond the bounds of the memory view ({} > {})",
                 total_len,

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -1,17 +1,17 @@
-use crate::engine::AsEngineRef;
-use bytes::Bytes;
 use std::path::Path;
 use std::sync::Arc;
-use wasmer_compiler::Artifact;
-use wasmer_compiler::ArtifactCreate;
+
+use bytes::Bytes;
+use wasmer_compiler::{Artifact, ArtifactCreate};
 use wasmer_types::{
     CompileError, DeserializeError, ExportsIterator, ImportsIterator, ModuleInfo, SerializeError,
 };
 use wasmer_types::{ExportType, ImportType};
 
-use crate::sys::engine::NativeEngineExt;
-use crate::vm::VMInstance;
-use crate::{AsStoreMut, AsStoreRef, InstantiationError, IntoBytes};
+use crate::{
+    engine::AsEngineRef, sys::engine::NativeEngineExt, vm::VMInstance, AsStoreMut, AsStoreRef,
+    InstantiationError, IntoBytes,
+};
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Module {
@@ -49,6 +49,7 @@ impl Module {
         Ok(module)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn validate(engine: &impl AsEngineRef, binary: &[u8]) -> Result<(), CompileError> {
         engine.as_engine_ref().engine().0.validate(binary)
     }
@@ -70,6 +71,7 @@ impl Module {
         self.artifact.serialize().map(|bytes| bytes.into())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub unsafe fn deserialize_unchecked(
         engine: &impl AsEngineRef,
         bytes: impl IntoBytes,
@@ -83,6 +85,7 @@ impl Module {
         Ok(Self::from_artifact(artifact))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub unsafe fn deserialize(
         engine: &impl AsEngineRef,
         bytes: impl IntoBytes,

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -105,7 +105,7 @@ sha2 = "0.10.6"
 object = "0.30.0"
 wasm-coredump-builder = { version = "0.1.11", optional = true }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 async-trait = "0.1.68"
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
 once_cell = "1.17.1"

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -94,6 +94,7 @@ impl Run {
         exit_with_wasi_exit_code(result);
     }
 
+    #[tracing::instrument(level = "debug", name = "wasmer_run", skip_all)]
     fn execute_inner(self, output: Output) -> Result<(), Error> {
         let pb = ProgressBar::new_spinner();
         pb.set_draw_target(output.draw_target());
@@ -563,6 +564,7 @@ impl PackageSource {
     ///
     /// This will try to automatically download and cache any resources from the
     /// internet.
+    #[tracing::instrument(level = "debug", skip_all)]
     fn resolve_target(
         &self,
         rt: &Arc<dyn Runtime + Send + Sync>,

--- a/lib/virtual-fs/src/overlay_fs.rs
+++ b/lib/virtual-fs/src/overlay_fs.rs
@@ -113,7 +113,6 @@ where
     S: for<'a> FileSystems<'a> + Send + Sync + 'static,
     for<'a> <<S as FileSystems<'a>>::Iter as IntoIterator>::IntoIter: Send,
 {
-    #[tracing::instrument(level = "debug", skip_all, fields(path=%path.display()))]
     fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
         let mut entries = Vec::new();
         let mut had_at_least_one_success = false;

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -276,6 +276,7 @@ pub enum WasiFsRoot {
 
 impl WasiFsRoot {
     /// Merge the contents of a filesystem into this one.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn merge(
         &self,
         other: &Arc<dyn FileSystem + Send + Sync>,
@@ -351,7 +352,7 @@ impl FileSystem for WasiFsRoot {
 
 /// Merge the contents of one filesystem into another.
 ///
-#[tracing::instrument(level = "debug", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 async fn merge_filesystems(
     source: &dyn FileSystem,
     destination: &dyn FileSystem,
@@ -503,14 +504,7 @@ impl WasiFs {
             return Ok(());
         }
 
-        match self.root_fs {
-            WasiFsRoot::Sandbox(ref sandbox_fs) => {
-                sandbox_fs.union(&binary.webc_fs);
-            }
-            WasiFsRoot::Backing(ref fs) => {
-                merge_filesystems(&binary.webc_fs, fs.deref()).await?;
-            }
-        }
+        self.root_fs.merge(&binary.webc_fs).await?;
 
         Ok(())
     }

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -133,6 +133,7 @@ static EMPTY_JOURNAL_LIST: Vec<Arc<DynJournal>> = Vec::new();
 ///
 // This function exists to provide a reusable baseline implementation for
 // implementing [`Runtime::load_module`], so custom logic can be added on top.
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn load_module(
     engine: &wasmer::Engine,
     module_cache: &(dyn ModuleCache + Send + Sync),

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -912,6 +912,7 @@ impl WasiEnvBuilder {
     }
 
     #[allow(clippy::result_large_err)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn run_with_store(self, module: Module, store: &mut Store) -> Result<(), WasiRuntimeError> {
         self.run_with_store_ext(module, ModuleHash::random(), store)
     }
@@ -978,6 +979,7 @@ impl WasiEnvBuilder {
 
     /// Start the WASI executable with async threads enabled.
     #[allow(clippy::result_large_err)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn run_with_store_async(
         self,
         module: Module,


### PR DESCRIPTION
While analysing the run time for `wasmer run`, I made a couple tweaks to our `#[tracing::instrument]` annotations so the `DEBUG` level logs are less spammy. 

I also annotated a couple sections of code that weren't previously annotated and added a `--log-format` flag that can be used to switch the log format between text and JSON. I find JSON tends to be easier to read and analyse, especially when you use a Python REPL or with `jq`.

Additionally, I've made main `wasmer` crate use `tracing` unconditionally because it doesn't make much sense to put logging behind a feature flag.