### PR TITLE
Add a temporary workaround for nanasess/setup-chromedriver#190

### DIFF
--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -43,6 +43,9 @@ jobs:
 
     - name: Setup Chromedriver
       uses: nanasess/setup-chromedriver@v2
+      # Temporary workaround for https://github.com/nanasess/setup-chromedriver/issues/190
+      with:
+        chromedriver-version: '114.0.5735.90'
 
     - name: Show Rust version
       run: rustc --version --verbose


### PR DESCRIPTION
This applies the suggestion from https://github.com/nanasess/setup-chromedriver/issues/190#issuecomment-1651929544. Let's see if it fixes the failing CI.

See the conversation [on Slack](https://wasmerio.slack.com/archives/C04193Z3RHS/p1690376801429999) and [this](https://github.com/wasmerio/wasmer/actions/runs/5669127141/job/15361185127?pr=4107) failing build for more context.