### PR TITLE
Browser cfg, smaller WASM and HTTPS redirect

### DIFF
--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -233,7 +233,7 @@ unsafe fn wasi_env_with_filesystem_inner(
     let module = &module.as_ref()?.inner;
     let imports = imports?;
 
-    let (wasi_env, import_object, runtime) = prepare_webc_env(
+    let (wasi_env, import_object) = prepare_webc_env(
         config,
         &mut store.store_mut(),
         module,
@@ -247,7 +247,6 @@ unsafe fn wasi_env_with_filesystem_inner(
     Some(Box::new(wasi_env_t {
         inner: wasi_env,
         store: store.clone(),
-        _runtime: runtime,
     }))
 }
 
@@ -259,7 +258,7 @@ fn prepare_webc_env(
     bytes: &'static u8,
     len: usize,
     package_name: &str,
-) -> Option<(WasiFunctionEnv, Imports, tokio::runtime::Runtime)> {
+) -> Option<(WasiFunctionEnv, Imports)> {
     use virtual_fs::static_fs::StaticFileSystem;
     use webc::v1::{FsEntryType, WebC};
 
@@ -316,7 +315,7 @@ fn prepare_webc_env(
     let env = builder.finalize(store).ok()?;
 
     let import_object = env.import_object(store, module).ok()?;
-    Some((env, import_object, runtime))
+    Some((env, import_object))
 }
 
 #[allow(non_camel_case_types)]

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -275,7 +275,7 @@ fn prepare_webc_env(
 
     let handle = runtime.handle().clone();
     let _guard = handle.enter();
-    let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(handle)));
+    let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(runtime)));
     rt.set_engine(Some(store_mut.engine().clone()));
 
     let slice = unsafe { std::slice::from_raw_parts(bytes, len) };
@@ -324,7 +324,6 @@ pub struct wasi_env_t {
     /// cbindgen:ignore
     pub(super) inner: WasiFunctionEnv,
     pub(super) store: StoreRef,
-    pub(super) _runtime: tokio::runtime::Runtime,
 }
 
 /// Create a new WASI environment.
@@ -349,7 +348,7 @@ pub unsafe extern "C" fn wasi_env_new(
 
     let handle = runtime.handle().clone();
     let _guard = handle.enter();
-    let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(handle)));
+    let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(runtime)));
     rt.set_engine(Some(store_mut.engine().clone()));
 
     if !config.inherit_stdout {
@@ -370,7 +369,6 @@ pub unsafe extern "C" fn wasi_env_new(
     Some(Box::new(wasi_env_t {
         inner: env,
         store: store.clone(),
-        _runtime: runtime,
     }))
 }
 

--- a/lib/cli/src/commands/run.rs
+++ b/lib/cli/src/commands/run.rs
@@ -105,9 +105,9 @@ impl Run {
 
         let _guard = handle.enter();
         let (store, _) = self.store.get_store()?;
-        let runtime =
-            self.wasi
-                .prepare_runtime(store.engine().clone(), &self.env, handle.clone())?;
+        let runtime = self
+            .wasi
+            .prepare_runtime(store.engine().clone(), &self.env, runtime)?;
 
         // This is a slow operation, so let's temporarily wrap the runtime with
         // something that displays progress

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -251,9 +251,9 @@ impl Wasi {
         &self,
         engine: Engine,
         env: &WasmerEnv,
-        handle: Handle,
+        runtime: tokio::runtime::Runtime,
     ) -> Result<impl Runtime + Send + Sync> {
-        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(handle)));
+        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(runtime)));
 
         if self.networking {
             rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());

--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "derivative",
  "dummy-waker",
  "fastrand 1.9.0",
+ "form_urlencoded",
  "futures",
  "http",
  "js-sys",

--- a/lib/wasi-web/Cargo.toml
+++ b/lib/wasi-web/Cargo.toml
@@ -22,6 +22,7 @@ wasmer-wasix = { path = "../wasix", version = "0.10.0",  default-features = fals
 wasm-bindgen = { version = "0.2", features = [ "serde-serialize" ] }
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "^0.1"
+form_urlencoded = "1.2"
 js-sys = "0.3"
 tracing = { version = "^0.1", features = [ "log", "release_max_level_info" ] }
 #tracing = { version = "^0.1", features = [ "log" ] }

--- a/lib/wasi-web/Cargo.toml
+++ b/lib/wasi-web/Cargo.toml
@@ -142,6 +142,7 @@ crate-type = ["cdylib"]
 
 [profile.dev]
 opt-level = 1
+debug = "line-tables-only"
 
 [profile.release]
 lto = true

--- a/lib/wasi-web/Cargo.toml
+++ b/lib/wasi-web/Cargo.toml
@@ -140,16 +140,15 @@ build-deps = "^0.1"
 [lib]
 crate-type = ["cdylib"]
 
+[profile.dev]
+opt-level = 1
+
+[profile.release]
+lto = true
+opt-level = 'z'
+
 [package.metadata.wasm-pack.profile.dev]
-# Should `wasm-opt` be used to further optimize the wasm binary generated after
-# the Rust compiler has finished? Using `wasm-opt` can often further decrease
-# binary size or do clever tricks that haven't made their way into LLVM yet.
-#
-# Configuration is set to `false` by default for the dev profile, but it can
-# be set to an array of strings which are explicit arguments to pass to
-# `wasm-opt`. For example `['-Os']` would optimize for size while `['-O4']`
-# would execute very expensive optimizations passes
-wasm-opt = ['--strip-debug --enable-reference-types']
+wasm-opt = false
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 debug-js-glue = true
@@ -157,11 +156,7 @@ demangle-name-section = true
 dwarf-debug-info = true
 
 [package.metadata.wasm-pack.profile.release]
-# The version of wasm-opt that wasm-pack bundles crashes on current wasm-bindgen
-# .wasm files. Current wasm-opt (version 93) crashes on the DWARF info that
-# wasm-bindgen produces. So, we'll just disable wasm-opt for now.
-wasm-opt = false #["-O4"]
-#wasm-opt = ['--strip-debug --enable-reference-types']
+wasm-opt = ['-Oz']
 
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 debug-js-glue = false

--- a/lib/wasi-web/js/index.js
+++ b/lib/wasi-web/js/index.js
@@ -1,11 +1,25 @@
 import init, { start } from '../pkg/index.js';
+import { init_cfg } from '../js/init.js';
 import 'regenerator-runtime/runtime.js'
 import './workers-polyfill.js'
+
+if (location.protocol !== 'https:') {
+  if (location.hostname !== 'localhost') {
+    location.replace(`https:${location.href.substring(location.protocol.length)}`);
+  }
+}
+
+export function init_encoded() {
+  return 'init=' + encodeURIComponent(init_cfg.init) + '&' +
+    'uses=' + encodeURIComponent(init_cfg.uses) + '&' +
+    'prompt=' + encodeURIComponent(init_cfg.prompt) + '&' +
+    'no_welcome=' + encodeURIComponent(init_cfg.no_welcome);
+}
 
 async function run() {
   Error.stackTraceLimit = 20;
   await init();
-  await start();
+  await start(init_encoded());
 }
 
 run();

--- a/lib/wasi-web/js/init.js
+++ b/lib/wasi-web/js/init.js
@@ -1,0 +1,11 @@
+export const init_cfg = {
+    init: 'sharrattj/bash',
+    uses: [
+        'sharrattj/coreutils',
+        'curl/curl',
+        'john-sharratt/catsay',
+        'python/python'
+    ],
+    prompt: 'wasmer.sh',
+    no_welcome: false
+};

--- a/lib/wasi-web/package.json
+++ b/lib/wasi-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "webpack",
-    "dev": "webpack serve"
+    "dev": "webpack serve --mode development"
   },
   "dependencies": {
     "comlink": "^4",

--- a/lib/wasi-web/public/index.html
+++ b/lib/wasi-web/public/index.html
@@ -19,6 +19,7 @@
   <link rel="icon" href="/favicon.png">
   <title>wasmer.sh</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <script src="init.js"></script>
   <script type="module" defer="defer" src="main.js"></script>
 </head>
 

--- a/lib/wasi-web/public/index.html
+++ b/lib/wasi-web/public/index.html
@@ -19,7 +19,7 @@
   <link rel="icon" href="/favicon.png">
   <title>wasmer.sh</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <script src="init.js"></script>
+  <script type="module" src="init.js"></script>
   <script type="module" defer="defer" src="main.js"></script>
 </head>
 

--- a/lib/wasi-web/wasmer.toml
+++ b/lib/wasi-web/wasmer.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'wasmer/wasmer-sh'
-version = '0.2.8'
+version = '0.2.9'
 description = 'Container that holds the wasmer.sh website.'
 
 [dependencies]

--- a/lib/wasi-web/wasmer.toml
+++ b/lib/wasi-web/wasmer.toml
@@ -1,6 +1,6 @@
 [package]
-name = 'wasmer/wasmer-sh-async'
-version = '1.0.3'
+name = 'wasmer/wasmer-sh'
+version = '0.2.8'
 description = 'Container that holds the wasmer.sh website.'
 
 [dependencies]

--- a/lib/wasi-web/webpack.config.mjs
+++ b/lib/wasi-web/webpack.config.mjs
@@ -17,6 +17,7 @@ export default {
         { from: resolve(__dirname, "public/wasmer.css") },
         { from: resolve(__dirname, "public/worker.js") },
         { from: resolve(__dirname, "public/favicon.png") },
+        { from: resolve(__dirname, "js/init.js") },
       ],
     }),
     new WasmPackPlugin({

--- a/lib/wasix/src/os/console/mod.rs
+++ b/lib/wasix/src/os/console/mod.rs
@@ -292,9 +292,10 @@ mod tests {
     #[cfg_attr(not(feature = "host-reqwest"), ignore = "Requires a HTTP client")]
     fn test_console_dash_tty_with_args_and_env() {
         let tokio_rt = tokio::runtime::Runtime::new().unwrap();
-        let _guard = tokio_rt.handle().enter();
+        let rt_handle = tokio_rt.handle().clone();
+        let _guard = rt_handle.enter();
 
-        let tm = TokioTaskManager::new(tokio_rt.handle().clone());
+        let tm = TokioTaskManager::new(tokio_rt);
         let mut rt = PluggableRuntime::new(Arc::new(tm));
         rt.set_engine(Some(wasmer::Engine::default()))
             .set_package_loader(BuiltinPackageLoader::from_env().unwrap());
@@ -316,7 +317,7 @@ mod tests {
             .run()
             .unwrap();
 
-        let code = tokio_rt
+        let code = rt_handle
             .block_on(async move {
                 virtual_fs::AsyncWriteExt::write_all(
                     &mut stdin_tx,

--- a/lib/wasix/src/runtime/task_manager/thread.rs
+++ b/lib/wasix/src/runtime/task_manager/thread.rs
@@ -18,6 +18,13 @@ pub struct ThreadTaskManager {
     pool: Arc<rayon::ThreadPool>,
 }
 
+impl Drop
+for ThreadTaskManager {
+    fn drop(&mut self) {
+        self.runtime.shutdown_timeout(Duration::from_secs(0));
+    }
+}
+
 impl Default for ThreadTaskManager {
     #[cfg(feature = "sys-thread")]
     fn default() -> Self {

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -1,5 +1,5 @@
-use std::{num::NonZeroUsize, pin::Pin, sync::Arc, time::Duration};
 use std::sync::Mutex;
+use std::{num::NonZeroUsize, pin::Pin, sync::Arc, time::Duration};
 
 use futures::{future::BoxFuture, Future};
 use tokio::runtime::{Handle, Runtime};
@@ -13,24 +13,25 @@ pub enum RuntimeOrHandle {
     Handle(Handle),
     Runtime(Handle, Arc<Mutex<Option<Runtime>>>),
 }
-impl From<Handle>
-for RuntimeOrHandle {
+impl From<Handle> for RuntimeOrHandle {
     fn from(value: Handle) -> Self {
         Self::Handle(value)
     }
 }
-impl From<Runtime>
-for RuntimeOrHandle {
+impl From<Runtime> for RuntimeOrHandle {
     fn from(value: Runtime) -> Self {
         Self::Runtime(value.handle().clone(), Arc::new(Mutex::new(Some(value))))
     }
 }
 
-impl Drop
-for RuntimeOrHandle {
+impl Drop for RuntimeOrHandle {
     fn drop(&mut self) {
         if let Self::Runtime(_, runtime) = self {
-            runtime.lock().unwrap().take().map(|h| h.shutdown_timeout(Duration::from_secs(0)));
+            runtime
+                .lock()
+                .unwrap()
+                .take()
+                .map(|h| h.shutdown_timeout(Duration::from_secs(0)));
         }
     }
 }
@@ -39,7 +40,7 @@ impl RuntimeOrHandle {
     pub fn handle(&self) -> &Handle {
         match self {
             Self::Handle(h) => h,
-            Self::Runtime(h, _) => h
+            Self::Runtime(h, _) => h,
         }
     }
 }
@@ -53,7 +54,9 @@ pub struct TokioTaskManager {
 
 impl TokioTaskManager {
     pub fn new<I>(rt: I) -> Self
-    where I: Into<RuntimeOrHandle> {
+    where
+        I: Into<RuntimeOrHandle>,
+    {
         let concurrency = std::thread::available_parallelism()
             .unwrap_or(NonZeroUsize::new(1).unwrap())
             .get();

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -27,11 +27,9 @@ impl From<Runtime> for RuntimeOrHandle {
 impl Drop for RuntimeOrHandle {
     fn drop(&mut self) {
         if let Self::Runtime(_, runtime) = self {
-            runtime
-                .lock()
-                .unwrap()
-                .take()
-                .map(|h| h.shutdown_timeout(Duration::from_secs(0)));
+            if let Some(h) = runtime.lock().unwrap().take() {
+                h.shutdown_timeout(Duration::from_secs(0))
+            }
         }
     }
 }
@@ -80,7 +78,7 @@ impl TokioTaskManager {
 
 impl Default for TokioTaskManager {
     fn default() -> Self {
-        Self::new(Handle::current().clone())
+        Self::new(Handle::current())
     }
 }
 

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -1,28 +1,66 @@
 use std::{num::NonZeroUsize, pin::Pin, sync::Arc, time::Duration};
+use std::sync::Mutex;
 
 use futures::{future::BoxFuture, Future};
-use tokio::runtime::Handle;
+use tokio::runtime::{Handle, Runtime};
 
 use crate::{os::task::thread::WasiThreadError, WasiFunctionEnv};
 
 use super::{TaskWasm, TaskWasmRunProperties, VirtualTaskManager};
 
+#[derive(Debug, Clone)]
+pub enum RuntimeOrHandle {
+    Handle(Handle),
+    Runtime(Handle, Arc<Mutex<Option<Runtime>>>),
+}
+impl From<Handle>
+for RuntimeOrHandle {
+    fn from(value: Handle) -> Self {
+        Self::Handle(value)
+    }
+}
+impl From<Runtime>
+for RuntimeOrHandle {
+    fn from(value: Runtime) -> Self {
+        Self::Runtime(value.handle().clone(), Arc::new(Mutex::new(Some(value))))
+    }
+}
+
+impl Drop
+for RuntimeOrHandle {
+    fn drop(&mut self) {
+        if let Self::Runtime(_, runtime) = self {
+            runtime.lock().unwrap().take().map(|h| h.shutdown_timeout(Duration::from_secs(0)));
+        }
+    }
+}
+
+impl RuntimeOrHandle {
+    pub fn handle(&self) -> &Handle {
+        match self {
+            Self::Handle(h) => h,
+            Self::Runtime(h, _) => h
+        }
+    }
+}
+
 /// A task manager that uses tokio to spawn tasks.
 #[derive(Clone, Debug)]
 pub struct TokioTaskManager {
-    handle: Handle,
+    rt: RuntimeOrHandle,
     pool: Arc<rayon::ThreadPool>,
 }
 
 impl TokioTaskManager {
-    pub fn new(rt: Handle) -> Self {
+    pub fn new<I>(rt: I) -> Self
+    where I: Into<RuntimeOrHandle> {
         let concurrency = std::thread::available_parallelism()
             .unwrap_or(NonZeroUsize::new(1).unwrap())
             .get();
         let max_threads = 200usize.max(concurrency * 100);
 
         Self {
-            handle: rt,
+            rt: rt.into(),
             pool: Arc::new(
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(max_threads)
@@ -33,13 +71,13 @@ impl TokioTaskManager {
     }
 
     pub fn runtime_handle(&self) -> tokio::runtime::Handle {
-        self.handle.clone()
+        self.rt.handle().clone()
     }
 }
 
 impl Default for TokioTaskManager {
     fn default() -> Self {
-        Self::new(Handle::current())
+        Self::new(Handle::current().clone())
     }
 }
 
@@ -55,7 +93,7 @@ impl VirtualTaskManager for TokioTaskManager {
     /// See [`VirtualTaskManager::sleep_now`].
     fn sleep_now(&self, time: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        self.handle.spawn(async move {
+        self.rt.handle().spawn(async move {
             if time == Duration::ZERO {
                 tokio::task::yield_now().await;
             } else {
@@ -73,7 +111,7 @@ impl VirtualTaskManager for TokioTaskManager {
         &self,
         task: Box<dyn FnOnce() -> BoxFuture<'static, ()> + Send + 'static>,
     ) -> Result<(), WasiThreadError> {
-        self.handle.spawn(async move {
+        self.rt.handle().spawn(async move {
             let fut = task();
             fut.await
         });
@@ -99,7 +137,7 @@ impl VirtualTaskManager for TokioTaskManager {
 
             let trigger = trigger();
             let pool = self.pool.clone();
-            self.handle.spawn(async move {
+            self.rt.handle().spawn(async move {
                 let result = trigger.await;
                 // Build the task that will go on the callback
                 pool.spawn(move || {

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -106,7 +106,7 @@ impl<'a> WasiTest<'a> {
         #[cfg(not(target_arch = "wasm32"))]
         let _guard = handle.enter();
         #[cfg(not(target_arch = "wasm32"))]
-        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(handle)));
+        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(runtime)));
         #[cfg(target_arch = "wasm32")]
         let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::default()));
         rt.set_engine(Some(store.engine().clone()));


### PR DESCRIPTION
- The initialization configuration is now stored in the init.js file
- The WASM binary has been reduced from 1.8MB  to 1.1MB
- When going to the site on HTTP it will redirect you to HTTPS