### PR TITLE
Added proper definition of ucontext for macos/aarch64 to avoid unaligned issue

### DIFF
--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -51,10 +51,7 @@ struct ucontext_t {
     uc_mcontext: libc::mcontext_t,
 }
 
-#[cfg(any(
-    target_os = "linux",
-    all(not(target_arch = "aarch64"), target_os = "macos")
-))]
+#[cfg(all(unix, not(all(target_arch = "aarch64", target_os = "macos"))))]
 use libc::ucontext_t;
 
 /// Default stack size is 1MB.

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -38,7 +38,7 @@ static MAGIC: u8 = 0xc0;
 
 static DEFAULT_STACK_SIZE: AtomicUsize = AtomicUsize::new(1024 * 1024);
 
-// Current definition of `ucontext_t` in the `libc` crate is incorrect 
+// Current definition of `ucontext_t` in the `libc` crate is incorrect
 // on aarch64-apple-drawin so it's defined here with a more accurate definition.
 #[repr(C)]
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -38,6 +38,22 @@ static MAGIC: u8 = 0xc0;
 
 static DEFAULT_STACK_SIZE: AtomicUsize = AtomicUsize::new(1024 * 1024);
 
+// Current definition of `ucontext_t` in the `libc` crate is incorrect 
+// on aarch64-apple-drawin so it's defined here with a more accurate definition.
+#[repr(C)]
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+struct ucontext_t {
+    uc_onstack: libc::c_int,
+    uc_sigmask: libc::sigset_t,
+    uc_stack: libc::stack_t,
+    uc_link: *mut libc::ucontext_t,
+    uc_mcsize: usize,
+    uc_mcontext: libc::mcontext_t,
+}
+
+#[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
+use libc::ucontext_t;
+
 /// Default stack size is 1MB.
 pub fn set_stack_size(size: usize) {
     DEFAULT_STACK_SIZE.store(size.max(8 * 1024).min(100 * 1024 * 1024), Ordering::Relaxed);
@@ -216,7 +232,7 @@ cfg_if::cfg_if! {
                 }
                 _ => None,
             };
-            let ucontext = &mut *(context as *mut libc::ucontext_t);
+            let ucontext = &mut *(context as *mut ucontext_t);
             let (pc, sp) = get_pc_sp(ucontext);
             let handled = TrapHandlerContext::handle_trap(
                 pc,
@@ -256,7 +272,7 @@ cfg_if::cfg_if! {
             }
         }
 
-        unsafe fn get_pc_sp(context: &libc::ucontext_t) -> (usize, usize) {
+        unsafe fn get_pc_sp(context: &ucontext_t) -> (usize, usize) {
             let (pc, sp);
             cfg_if::cfg_if! {
                 if #[cfg(all(
@@ -311,7 +327,7 @@ cfg_if::cfg_if! {
             (pc, sp)
         }
 
-        unsafe fn update_context(context: &mut libc::ucontext_t, regs: TrapHandlerRegs) {
+        unsafe fn update_context(context: &mut ucontext_t, regs: TrapHandlerRegs) {
             cfg_if::cfg_if! {
                 if #[cfg(all(
                         any(target_os = "linux", target_os = "android"),

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -51,7 +51,10 @@ struct ucontext_t {
     uc_mcontext: libc::mcontext_t,
 }
 
-#[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
+#[cfg(any(
+    target_os = "linux",
+    all(not(target_arch = "aarch64"), target_os = "macos")
+))]
 use libc::ucontext_t;
 
 /// Default stack size is 1MB.


### PR DESCRIPTION
Added proper definition of ucontext for macos/aarch64 to avoid unaligned issue

For https://github.com/wasmerio/wasmer/issues/4072