### PR TITLE
Enable the api sys feature which is required to build

### DIFF
--- a/lib/emscripten/Cargo.toml
+++ b/lib/emscripten/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.4"
 libc = "^0.2"
 log = "0.4"
 time = { version = "0.2", features = ["std"] }
-wasmer = { path = "../api", version = "=4.1.1", default-features = false }
+wasmer = { path = "../api", version = "=4.1.1", default-features = false, features = ["sys"] }
 wasmer-types = { path = "../types", version = "=4.1.1" }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
# Description

The motivation is to fix build `wasmer-emscripten`. `api`'s `sys` feature seems to be required to build `wasmer-emscripten`.