### PR TITLE
Upgrade wasmer-wasix to the newest version of wasm-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5049,16 +5049,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -5099,9 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5109,22 +5109,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-bindgen-test"

--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -2200,9 +2200,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2212,16 +2212,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2272,22 +2272,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -2482,7 +2482,6 @@ dependencies = [
  "virtual-net",
  "wai-bindgen-wasmer",
  "waker-fn",
- "wasm-bindgen",
  "wasmer",
  "wasmer-types",
  "wasmer-wasix-types",

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -67,6 +67,7 @@ tower = { version = "0.4.13", features = ["make", "util"], optional = true }
 url = "2.3.1"
 petgraph = "0.6.3"
 rayon = { version = "1.7.0", optional = true }
+wasm-bindgen = { version = "0.2.87", optional = true }
 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies.reqwest]
 version = "0.11"
@@ -88,11 +89,6 @@ termios = { version = "0.3" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-# NOTE: Currently the wasm-bindgen version is pinned to < 0.2.85 because 0.2.85
-# causes a build failure.
-wasm-bindgen = ">= 0.2.74, < 0.2.85"
 
 [dev-dependencies]
 wasmer = { path = "../api", version = "=4.1.1", default-features = false, features = ["wat", "js-serializable-module"] }


### PR DESCRIPTION
This fixes a bunch of nasty version conflict issues downstream.

```console
$ cargo check
    Updating crates.io index
error: failed to select a version for `wasm-bindgen`.
    ... required by package `wasmer-wasix v0.10.0`
    ... which satisfies dependency `wasmer-wasix = "^0.10"` of package `wasmer-wasix-js v0.0.1-alpha.1 (/Users/work/Documents/wasmer/wasmer-js)`
versions that meet the requirements `>=0.2.74, <0.2.85` are: 0.2.84, 0.2.83, 0.2.82, 0.2.81, 0.2.80, 0.2.79, 0.2.78, 0.2.77, 0.2.76, 0.2.75, 0.2.74

all possible versions conflict with previously selected packages.

  previously selected package `wasm-bindgen v0.2.87`
    ... which satisfies dependency `wasm-bindgen = "^0.2.87"` of package `js-sys v0.3.64`
    ... which satisfies dependency `js-sys = "^0.3.60"` of package `wasm-bindgen-downcast v0.1.1`
    ... which satisfies dependency `wasm-bindgen-downcast = "^0.1.1"` of package `wasmer v4.1.0`
    ... which satisfies dependency `wasmer = "=4.1.0"` of package `wasmer-wasix v0.10.0`
    ... which satisfies dependency `wasmer-wasix = "^0.10"` of package `wasmer-wasix-js v0.0.1-alpha.1 (/Users/work/Documents/wasmer/wasmer-js)`

failed to select a version for `wasm-bindgen` which could resolve this conflict
```