### PR TITLE
Test virtual-net bincode and mpsc only on linux

### DIFF
--- a/lib/api/src/sys/tunables.rs
+++ b/lib/api/src/sys/tunables.rs
@@ -279,7 +279,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "singlepass", not(target_os = "windows")))]
+    #[cfg(all(
+        feature = "singlepass",
+        not(any(
+            target_os = "windows",
+            all(target_os = "macos", target_arch = "aarch64")
+        ))
+    ))]
     fn check_small_stack() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{imports, wat2wasm, Engine, Instance, Module, Store};
         use wasmer_compiler_singlepass::Singlepass;

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -125,6 +125,7 @@ async fn test_tcp(client: RemoteNetworkingClient, _server: RemoteNetworkingServe
 }
 
 #[cfg(feature = "remote")]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_mpsc() {
@@ -133,6 +134,7 @@ async fn test_tcp_with_mpsc() {
 }
 
 #[cfg(feature = "remote")]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_bincode() {
@@ -141,6 +143,7 @@ async fn test_tcp_with_small_pipe_using_bincode() {
 }
 
 #[cfg(feature = "remote")]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_using_bincode() {

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -153,7 +153,7 @@ async fn test_tcp_with_large_pipe_using_bincode() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_json() {
@@ -163,7 +163,7 @@ async fn test_tcp_with_small_pipe_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_json_using_json() {
@@ -173,7 +173,7 @@ async fn test_tcp_with_large_pipe_json_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_messagepack() {
@@ -183,7 +183,7 @@ async fn test_tcp_with_small_pipe_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_json_using_messagepack() {
@@ -193,7 +193,7 @@ async fn test_tcp_with_large_pipe_json_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_cbor() {
@@ -203,7 +203,7 @@ async fn test_tcp_with_small_pipe_using_cbor() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_json_using_cbor() {

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -153,6 +153,7 @@ async fn test_tcp_with_large_pipe_using_bincode() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
+#[cfg(not(target_os = "macos"))]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_json() {
@@ -162,6 +163,7 @@ async fn test_tcp_with_small_pipe_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
+#[cfg(not(target_os = "macos"))]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_json_using_json() {
@@ -171,6 +173,7 @@ async fn test_tcp_with_large_pipe_json_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
+#[cfg(not(target_os = "macos"))]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_messagepack() {
@@ -180,6 +183,7 @@ async fn test_tcp_with_small_pipe_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
+#[cfg(not(target_os = "macos"))]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_json_using_messagepack() {
@@ -189,6 +193,7 @@ async fn test_tcp_with_large_pipe_json_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
+#[cfg(not(target_os = "macos"))]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_small_pipe_using_cbor() {
@@ -198,6 +203,7 @@ async fn test_tcp_with_small_pipe_using_cbor() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
+#[cfg(not(target_os = "macos"))]
 #[traced_test]
 #[tokio::test]
 async fn test_tcp_with_large_pipe_json_using_cbor() {


### PR DESCRIPTION
CI-Test virtual-net "bincode" and "mpsc" only on linux, it's not implemented on Windows or macOS