### PR TITLE
Disable auto-format of toml files in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 .idea
 .gdb_history
 /.cargo/
-**/.vscode
+**/.vscode/*
+!/.vscode/settings.json
 api-docs-repo/
 /.cargo_home/
 /package/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "[toml]": {
+        "editor.formatOnSave": false,
+        "editor.formatOnPaste": false,
+        "editor.formatOnType": false
+    }
+}


### PR DESCRIPTION
This PR disables auto-formatting of toml files in VS Code. This has been known to cause PRs to be difficult to review.