### PR TITLE
Remove `Send` and `Sync` from `wasmer` types backed by JavaScript objects

### DIFF
--- a/lib/api/src/js/externals/function.rs
+++ b/lib/api/src/js/externals/function.rs
@@ -43,9 +43,7 @@ pub struct Function {
     pub(crate) handle: VMFunction,
 }
 
-// Function can't be Send in js because it dosen't support `structuredClone`
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-// unsafe impl Send for Function {}
+assert_not_implemented!(Function: !Send + !Sync);
 
 impl From<VMFunction> for Function {
     fn from(handle: VMFunction) -> Self {

--- a/lib/api/src/js/externals/global.rs
+++ b/lib/api/src/js/externals/global.rs
@@ -13,9 +13,7 @@ pub struct Global {
     pub(crate) handle: VMGlobal,
 }
 
-// Global can't be Send in js because it dosen't support `structuredClone`
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-// unsafe impl Send for Global {}
+assert_not_implemented!(Global: !Send + !Sync);
 
 impl Global {
     pub(crate) fn to_vm_extern(&self) -> VMExtern {

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -53,20 +53,7 @@ pub struct Memory {
     pub(crate) handle: VMMemory,
 }
 
-// Only SharedMemories can be Send in js, becuase they support `structuredClone`.
-// Normal memories will fail while doing structuredClone.
-// In this case, we implement Send just in case as it can be a shared memory.
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-// ```js
-// const memory = new WebAssembly.Memory({
-//   initial: 10,
-//   maximum: 100,
-//   shared: true // <--- It must be shared, otherwise structuredClone will fail
-// });
-// structuredClone(memory)
-// ```
-unsafe impl Send for Memory {}
-unsafe impl Sync for Memory {}
+assert_not_implemented!(Memory: !Send + !Sync);
 
 impl Memory {
     pub fn new(store: &mut impl AsStoreMut, ty: MemoryType) -> Result<Self, MemoryError> {

--- a/lib/api/src/js/externals/table.rs
+++ b/lib/api/src/js/externals/table.rs
@@ -11,9 +11,7 @@ pub struct Table {
     pub(crate) handle: VMTable,
 }
 
-// Table can't be Send in js because it dosen't support `structuredClone`
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-// unsafe impl Send for Table {}
+assert_not_implemented!(Table: !Send + !Sync);
 
 fn set_table_item(table: &VMTable, item_index: u32, item: &Function) -> Result<(), RuntimeError> {
     table.table.set(item_index, item).map_err(|e| e.into())

--- a/lib/api/src/js/instance.rs
+++ b/lib/api/src/js/instance.rs
@@ -13,9 +13,7 @@ pub struct Instance {
     pub(crate) _handle: VMInstance,
 }
 
-// Instance can't be Send in js because it dosen't support `structuredClone`
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-// unsafe impl Send for Instance {}
+assert_not_implemented!(Instance: !Send + !Sync);
 
 impl Instance {
     pub(crate) fn new(

--- a/lib/api/src/js/macros.rs
+++ b/lib/api/src/js/macros.rs
@@ -1,0 +1,32 @@
+/// Assert that a type does **not** implement a set of traits.
+macro_rules! assert_not_implemented {
+    ($t:ty : !$first:ident $(+ !$rest:ident)*) => {
+        const _: fn() = || {
+            // Generic trait with a blanket impl over `()` for all types.
+            trait AmbiguousIfImpl<A> {
+                // Required for actually being able to reference the trait.
+                fn some_item() {}
+            }
+
+            impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+
+            // Creates multiple scoped `Invalid` types for each trait,
+            // over which a specialized `AmbiguousIfImpl<Invalid>` is
+            // implemented for every type that implements the trait.
+            #[allow(dead_code)]
+            struct InvalidFirst;
+            impl<T: ?Sized + $first> AmbiguousIfImpl<InvalidFirst> for T {}
+
+            $({
+                #[allow(dead_code)]
+                struct Invalid;
+            impl<T: ?Sized + $rest> AmbiguousIfImpl<Invalid> for T {}
+            })*
+
+            // If there is only one specialized trait impl, type inference
+            // with `_` can be resolved and this can compile. Fails to
+            // compile if `$t` implements any `AmbiguousIfImpl<Invalid>`.
+            let _ = <$t as AmbiguousIfImpl<_>>::some_item;
+        };
+    }
+}

--- a/lib/api/src/js/mod.rs
+++ b/lib/api/src/js/mod.rs
@@ -23,6 +23,9 @@ mod lib {
     }
 }
 
+#[macro_use]
+mod macros;
+
 mod as_js;
 pub(crate) mod engine;
 pub(crate) mod errors;

--- a/lib/api/src/js/module.rs
+++ b/lib/api/src/js/module.rs
@@ -45,16 +45,7 @@ pub struct Module {
     raw_bytes: Option<Bytes>,
 }
 
-// Module implements `structuredClone` in js, so it's safe it to make it Send.
-// https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
-// ```js
-// const module = new WebAssembly.Module(new Uint8Array([
-//   0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00
-// ]));
-// structuredClone(module)
-// ```
-unsafe impl Send for Module {}
-unsafe impl Sync for Module {}
+assert_not_implemented!(Module: !Send + !Sync);
 
 impl From<Module> for JsValue {
     fn from(val: Module) -> Self {
@@ -81,12 +72,13 @@ impl Module {
     }
 
     /// Creates a new WebAssembly module skipping any kind of validation from a javascript module
-    ///
     pub(crate) unsafe fn from_js_module(
         module: WebAssembly::Module,
         binary: impl IntoBytes,
     ) -> Self {
+        #[allow(unused_variables)]
         let binary = binary.into_bytes();
+
         // The module is now validated, so we can safely parse it's types
         #[cfg(feature = "wasm-types-polyfill")]
         let (type_hints, name) = {

--- a/lib/api/src/js/trap.rs
+++ b/lib/api/src/js/trap.rs
@@ -18,8 +18,7 @@ pub struct Trap {
     inner: InnerTrap,
 }
 
-unsafe impl Send for Trap {}
-unsafe impl Sync for Trap {}
+assert_not_implemented!(Trap: !Send + !Sync);
 
 impl Trap {
     pub fn user(error: Box<dyn Error + Send + Sync>) -> Self {

--- a/lib/api/src/js/vm.rs
+++ b/lib/api/src/js/vm.rs
@@ -26,8 +26,7 @@ pub struct VMMemory {
     pub(crate) ty: MemoryType,
 }
 
-unsafe impl Send for VMMemory {}
-unsafe impl Sync for VMMemory {}
+assert_not_implemented!(VMMemory: !Send + !Sync);
 
 #[derive(Serialize, Deserialize)]
 struct DummyBuffer {
@@ -140,8 +139,7 @@ impl VMGlobal {
     }
 }
 
-unsafe impl Send for VMGlobal {}
-unsafe impl Sync for VMGlobal {}
+assert_not_implemented!(VMGlobal: !Send + !Sync);
 
 /// The VM Table type
 #[derive(Clone, Debug, PartialEq)]
@@ -150,8 +148,7 @@ pub struct VMTable {
     pub(crate) ty: TableType,
 }
 
-unsafe impl Send for VMTable {}
-unsafe impl Sync for VMTable {}
+assert_not_implemented!(VMTable: !Send + !Sync);
 
 impl VMTable {
     pub(crate) fn new(table: JsTable, ty: TableType) -> Self {
@@ -171,8 +168,7 @@ pub struct VMFunction {
     pub(crate) ty: FunctionType,
 }
 
-unsafe impl Send for VMFunction {}
-unsafe impl Sync for VMFunction {}
+assert_not_implemented!(VMFunction: !Send + !Sync);
 
 impl VMFunction {
     pub(crate) fn new(function: JsFunction, ty: FunctionType) -> Self {


### PR DESCRIPTION
This fixes a soundness bug introduced in #3556 which added `Send+Sync` bounds to things like `wasmer::js::Module` and `wasmer::js::Memory`.

Here's one example:

https://github.com/wasmerio/wasmer/blob/d53b9e26d3275483e6af9dfbddb69d57c825fc2b/lib/api/src/js/module.rs#L48-L57

The underlying assumption is that because a type implements `structuredClone` it's fine to implement `Send` and `Sync`.

However, `structuredClone` **only** applies when sending values to a worker using `postMessage`.

If you use any other method to transfer a value to another thread (e.g. channels) then the underlying `JsValue` will point to the wrong object on that thread's wasm-bindgen "heap" and you'll have a bad time.

Fixes #4158.