### PR TITLE
fix: Make the "wasmer cache" command use the same cache directory as the rest of the CLI 

### DIFF
--- a/lib/cli/src/cli.rs
+++ b/lib/cli/src/cli.rs
@@ -145,7 +145,6 @@ enum Cmd {
     Publish(Publish),
 
     /// Wasmer cache
-    #[clap(subcommand)]
     Cache(Cache),
 
     /// Validate a WebAssembly binary

--- a/lib/cli/src/commands/cache.rs
+++ b/lib/cli/src/commands/cache.rs
@@ -42,9 +42,9 @@ enum Cmd {
 
 fn clean(cache_dir: &Path) -> Result<()> {
     if cache_dir.exists() {
-        fs::remove_dir_all(&cache_dir)?;
+        fs::remove_dir_all(cache_dir)?;
     }
-    fs::create_dir_all(&cache_dir)?;
+    fs::create_dir_all(cache_dir)?;
     eprintln!("Wasmer cache cleaned successfully.");
 
     Ok(())

--- a/lib/cli/src/commands/cache.rs
+++ b/lib/cli/src/commands/cache.rs
@@ -1,44 +1,51 @@
-use crate::common::get_cache_dir;
-use anyhow::{Context, Result};
+use std::{fs, path::Path};
+
+use anyhow::Result;
 use clap::Parser;
-use std::fs;
+use wasmer_registry::wasmer_env::WasmerEnv;
 
 #[derive(Debug, Parser)]
 /// The options for the `wasmer cache` subcommand
-pub enum Cache {
-    /// Clear the cache
-    #[clap(name = "clean")]
-    Clean,
-
-    /// Display the location of the cache
-    #[clap(name = "dir")]
-    Dir,
+pub struct Cache {
+    #[clap(flatten)]
+    env: WasmerEnv,
+    /// The operation to perform.
+    #[clap(subcommand)]
+    cmd: Cmd,
 }
 
 impl Cache {
     /// Execute the cache command
     pub fn execute(&self) -> Result<()> {
-        match &self {
-            Cache::Clean => {
-                self.clean().context("failed to clean wasmer cache.")?;
+        let cache_dir = self.env.cache_dir();
+
+        match self.cmd {
+            Cmd::Clean => {
+                clean(&cache_dir)?;
             }
-            Cache::Dir => {
-                self.dir()?;
+            Cmd::Dir => {
+                println!("{}", self.env.cache_dir().display());
             }
         }
+
         Ok(())
     }
-    fn clean(&self) -> Result<()> {
-        let cache_dir = get_cache_dir();
-        if cache_dir.exists() {
-            fs::remove_dir_all(cache_dir.clone())?;
-        }
-        fs::create_dir_all(cache_dir)?;
-        eprintln!("Wasmer cache cleaned successfully.");
-        Ok(())
+}
+
+#[derive(Debug, Copy, Clone, Parser)]
+enum Cmd {
+    /// Clear the cache
+    Clean,
+    /// Display the location of the cache
+    Dir,
+}
+
+fn clean(cache_dir: &Path) -> Result<()> {
+    if cache_dir.exists() {
+        fs::remove_dir_all(&cache_dir)?;
     }
-    fn dir(&self) -> Result<()> {
-        println!("{}", get_cache_dir().to_string_lossy());
-        Ok(())
-    }
+    fs::create_dir_all(&cache_dir)?;
+    eprintln!("Wasmer cache cleaned successfully.");
+
+    Ok(())
 }

--- a/lib/cli/src/common.rs
+++ b/lib/cli/src/common.rs
@@ -1,9 +1,7 @@
 //! Common module with common used structures across different
 //! commands.
-use crate::VERSION;
+
 use clap::Parser;
-use std::env;
-use std::path::PathBuf;
 
 #[derive(Debug, Parser, Clone, Default)]
 /// The WebAssembly features that can be passed through the
@@ -36,24 +34,6 @@ pub struct WasmFeatures {
     /// Enable support for all pre-standard proposals.
     #[clap(long = "enable-all")]
     pub all: bool,
-}
-
-/// Get the cache dir
-pub fn get_cache_dir() -> PathBuf {
-    match env::var("WASMER_CACHE_DIR") {
-        Ok(dir) => {
-            let mut path = PathBuf::from(dir);
-            path.push(VERSION);
-            path
-        }
-        Err(_) => {
-            // We use a temporal directory for saving cache files
-            let mut temp_dir = env::temp_dir();
-            temp_dir.push("wasmer");
-            temp_dir.push(VERSION);
-            temp_dir
-        }
-    }
 }
 
 pub(crate) fn normalize_path(s: &str) -> String {


### PR DESCRIPTION
It turns out the `wasmer cache` command was using a `crate::common::get_cache_dir()` helper to get the cache directory, but that helper isn't actually used by anything else (they all use `wasmer_registry::wasmer_env::WasmerEnv`) and automatically appends the current version number to `$WASMER_DIR/cache`.

That means `wasmer cache clean` would try to delete `~/.wasmer/cache/4.1.1` while the rest of the runtime was saving things to `~/.wasmer/cache/compiled`, `~/.wasmer/cache/downloads`, and so on.


Fixes #4093.