### PR TITLE
deps: Bump Edge CLI version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -161,8 +161,8 @@ jobs:
           toolchain: "nightly-2023-05-25"
           target: x86_64-unknown-linux-gnu
       - run: cargo install toml-cli # toml-cli is required to run `make test-build-docs-rs`
-      - name: make test-build-docs-rs
-        run: make test-build-docs-rs
+      - name: make test-build-docs-rs-ci
+        run: make test-build-docs-rs-ci
 
   build_linux_aarch64:
     name: ${{ matrix.build-what.name }} on linux-aarch64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
+          toolchain: "nightly-2023-05-25"
           target: x86_64-unknown-linux-gnu
       - run: cargo install toml-cli # toml-cli is required to run `make test-build-docs-rs`
       - name: make test-build-docs-rs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "nightly-2023-05-25"
           target: x86_64-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,20 +1870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "handlebars"
-version = "3.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
-dependencies = [
- "log",
- "pest",
- "pest_derive",
- "quick-error",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "harsh"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,22 +2263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interfaces"
-version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6250a98af259a26fd5a4a6081fccea9ac116e4c3178acf4aeb86d32d2b7715"
-dependencies = [
- "bitflags 2.4.0",
- "cc",
- "handlebars",
- "lazy_static",
- "libc",
- "nix 0.26.2",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "inventory"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,15 +2535,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -2727,20 +2688,6 @@ dependencies = [
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
- "static_assertions",
 ]
 
 [[package]]
@@ -3088,40 +3035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,12 +3266,6 @@ dependencies = [
  "memchr",
  "unicase",
 ]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -5915,9 +5822,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-deploy-cli"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8390b4117c361b17ab27620a1bbd00bf031aae984b0199d47a9d6e4d8d79199f"
+checksum = "9fd8eabd19ea7799654bd5ad30af7220e34b02458a0a5627fafe6c5780f4335c"
 dependencies = [
  "anyhow",
  "clap",
@@ -5926,7 +5833,6 @@ dependencies = [
  "comfy-table",
  "dialoguer",
  "futures",
- "interfaces",
  "is-terminal",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.3"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",

--- a/Makefile
+++ b/Makefile
@@ -472,10 +472,10 @@ test-build-docs-rs-ci:
 			fi; \
 			printf "*** Building doc for package with manifest $$manifest_path ***\n\n"; \
 			if [ -z "$$features" ]; then \
-				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" || exit 1; \
+				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) +nightly-2023-05-25 doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" || exit 1; \
 			else \
 				printf "Following features are inferred from Cargo.toml: $$features\n\n\n"; \
-				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" --features "$$features" || exit 1; \
+				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) +nightly-2023-05-25 doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" --features "$$features" || exit 1; \
 			fi; \
 		fi; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -460,6 +460,26 @@ test-build-docs-rs:
 		fi; \
 	done
 
+test-build-docs-rs-ci:
+	@manifest_docs_rs_features_path="package.metadata.docs.rs.features"; \
+	for manifest_path in lib/*/Cargo.toml; do \
+		if [ "$$manifest_path" !=  "lib/wasi-web/Cargo.toml" ]; then \
+			toml get "$$manifest_path" "$$manifest_docs_rs_features_path" >/dev/null 2>&1; \
+			if [ $$? -ne 0 ]; then \
+				features=""; \
+			else \
+				features=$$(toml get "$$manifest_path" "$$manifest_docs_rs_features_path" | sed 's/\[//; s/\]//; s/"\([^"]*\)"/\1/g'); \
+			fi; \
+			printf "*** Building doc for package with manifest $$manifest_path ***\n\n"; \
+			if [ -z "$$features" ]; then \
+				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" || exit 1; \
+			else \
+				printf "Following features are inferred from Cargo.toml: $$features\n\n\n"; \
+				RUSTDOCFLAGS="--cfg=docsrs" $(CARGO_BINARY) doc $(CARGO_TARGET_FLAG) --manifest-path "$$manifest_path" --features "$$features" || exit 1; \
+			fi; \
+		fi; \
+	done
+
 build-docs-capi:
 	# `wasmer-c-api` lib's name is `wasmer`. To avoid a conflict
 	# when generating the documentation, we rename it to its

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -64,7 +64,7 @@ virtual-net = { version = "0.5.0", path = "../virtual-net" }
 
 # Wasmer-owned dependencies.
 webc = { workspace = true }
-wasmer-deploy-cli = { version = "=0.1.23", default-features = false }
+wasmer-deploy-cli = { version = "=0.1.24", default-features = false }
 
 # Third-party dependencies.
 


### PR DESCRIPTION
Prevents usage of the `interfaces` dependency if the tuntap feature is
not enabled in the wasmer-deploy-cli crate.
