### PR TITLE
Added the ability to print the addresses a running process is using

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "handlebars"
+version = "3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "harsh"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2277,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "interfaces"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6250a98af259a26fd5a4a6081fccea9ac116e4c3178acf4aeb86d32d2b7715"
+dependencies = [
+ "bitflags 2.4.0",
+ "cc",
+ "handlebars",
+ "lazy_static",
+ "libc",
+ "nix 0.26.2",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "inventory"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2565,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -2688,6 +2727,20 @@ dependencies = [
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3035,6 +3088,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest_derive"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3353,12 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -5102,6 +5195,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "hyper-tungstenite",
+ "interfaces",
  "libc",
  "mio",
  "pin-project-lite",

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -99,7 +99,12 @@ pub struct Wasi {
 
     /// Whenever a listening socket is opened it will be printed to the console
     ///
+    /// (deprecated: this should be done inside your WASM app instead however
+    ///              for a short time this will provide a stop-gap. DO NOT RELY
+    ///              on this being there in the future)
+    ///
     /// This is useful for determining what IP address and ports a process are listening on
+    #[deprecated = "this needs to be ported to a fork of `interfaces` rather than implemented in `Wasmer`"]
     #[clap(long = "print-listeners")]
     pub print_socket_listeners: bool,
 
@@ -267,6 +272,7 @@ impl Wasi {
     {
         let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(rt_or_handle.into())));
 
+        #[allow(deprecated)]
         if self.networking {
             let mut local_networking = virtual_net::host::LocalNetworking::default();
             local_networking.print_socket_listeners = self.print_socket_listeners;

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -97,6 +97,12 @@ pub struct Wasi {
     #[clap(long = "net")]
     pub networking: bool,
 
+    /// Whenever a listening socket is opened it will be printed to the console
+    ///
+    /// This is useful for determining what IP address and ports a process are listening on
+    #[clap(long = "print-listeners")]
+    pub print_socket_listeners: bool,
+
     /// Disables the TTY bridge
     #[clap(long = "no-tty")]
     pub no_tty: bool,
@@ -262,7 +268,9 @@ impl Wasi {
         let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(rt_or_handle.into())));
 
         if self.networking {
-            rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());
+            let mut local_networking = virtual_net::host::LocalNetworking::default();
+            local_networking.print_socket_listeners = self.print_socket_listeners;
+            rt.set_networking_implementation(local_networking);
         } else {
             rt.set_networking_implementation(virtual_net::UnsupportedVirtualNetworking::default());
         }

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -31,6 +31,7 @@ tokio-util = { version = "0.6", features = ["codec"], optional = true }
 hyper-tungstenite = { version = "0.10", optional = true }
 hyper = { version = "0.14", optional = true }
 tokio-tungstenite = { version = "0.19", optional = true }
+interfaces = { version = "0.0.9", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", default_features = false, features = [ "macros" ] }
@@ -38,7 +39,7 @@ tracing-test = { version = "0.2" }
 
 [features]
 default = [ "host-net", "remote", "json", "messagepack", "cbor", "hyper", "tokio-tungstenite" ]
-host-net = [ "tokio", "libc", "tokio/io-util", "virtual-mio/sys", "tokio/net", "tokio/rt", "socket2", "mio" ]
+host-net = [ "tokio", "libc", "tokio/io-util", "virtual-mio/sys", "tokio/net", "tokio/rt", "socket2", "mio", "interfaces" ]
 remote = [ "tokio", "libc", "tokio/io-util", "tokio/sync", "tokio-serde", "tokio-util" ]
 json = [ "tokio-serde/json" ]
 messagepack = [ "tokio-serde/messagepack" ]

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -153,6 +153,22 @@ impl VirtualNetworking for LocalNetworking {
             .map(|a| a.map(|a| a.ip()).collect::<Vec<_>>())
             .map_err(io_err_into_net_error)
     }
+
+    /// Lists all the IP addresses currently assigned to this interface
+    async fn ip_list(&self) -> Result<Vec<IpCidr>> {
+        let mut ret = Vec::new();
+        for interface in interfaces::Interface::get_all().map_err(|_| NetworkError::Unsupported)? {
+            for ip in interface.addresses.iter() {
+                if let Some(ip) = ip.addr {
+                    ret.push(IpCidr {
+                        ip: ip.ip(),
+                        prefix: 0,
+                    });
+                }
+            }
+        }
+        Ok(ret)
+    }
 }
 
 #[derive(Derivative)]

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -22,18 +22,26 @@ use virtual_mio::{InterestGuard, InterestHandler, Selector};
 pub struct LocalNetworking {
     selector: Arc<Selector>,
     handle: Handle,
+
+    #[deprecated = "this needs to be ported to a fork of `interfaces` rather than implemented in `Wasmer`"]
     pub print_socket_listeners: bool,
 }
 
 impl LocalNetworking {
     pub fn new() -> Self {
+        #[allow(deprecated)]
         Self {
             selector: Selector::new(),
             handle: Handle::current(),
             print_socket_listeners: false,
         }
     }
+
+    // TODO: this should be deleted when a fork of `interfaces` is implemented that allows
+    //       WASIX to print the current IP addresses
+    #[deprecated = "this needs to be ported to a fork of `interfaces` rather than implemented in `Wasmer`"]
     async fn print_listener(&self, addr: SocketAddr) {
+        #[allow(deprecated)]
         if !self.print_socket_listeners {
             return;
         }
@@ -71,7 +79,11 @@ impl VirtualNetworking for LocalNetworking {
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualTcpListener + Sync>> {
+        // TODO: this should be deleted when a fork of `interfaces` is implemented that allows
+        //       WASIX to print the current IP addresses
+        #[allow(deprecated)]
         self.print_listener(addr).await;
+
         let listener = std::net::TcpListener::bind(addr)
             .map(|sock| {
                 sock.set_nonblocking(true).ok();
@@ -91,7 +103,11 @@ impl VirtualNetworking for LocalNetworking {
         _reuse_port: bool,
         _reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
+        // TODO: this should be deleted when a fork of `interfaces` is implemented that allows
+        //       WASIX to print the current IP addresses
+        #[allow(deprecated)]
         self.print_listener(addr).await;
+
         let socket = mio::net::UdpSocket::bind(addr).map_err(io_err_into_net_error)?;
         socket2::SockRef::from(&socket).set_nonblocking(true).ok();
         Ok(Box::new(LocalUdpSocket {

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -36,7 +36,7 @@ impl LocalNetworking {
     async fn print_listener(&self, addr: SocketAddr) {
         if !self.print_socket_listeners {
             return;
-        }        
+        }
         if addr.ip().is_unspecified() {
             if let Ok(ip_list) = self.ip_list().await {
                 for ip in ip_list {

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -109,18 +109,7 @@ pub trait VirtualNetworking: fmt::Debug + Send + Sync + 'static {
 
     /// Lists all the IP addresses currently assigned to this interface
     async fn ip_list(&self) -> Result<Vec<IpCidr>> {
-        let mut ret = Vec::new();
-        for interface in interfaces::Interface::get_all().map_err(|_| NetworkError::Unsupported)? {
-            for ip in interface.addresses.iter() {
-                if let Some(ip) = ip.addr {
-                    ret.push(IpCidr {
-                        ip: ip.ip(),
-                        prefix: 0,
-                    });
-                }
-            }
-        }
-        Ok(ret)
+        Err(NetworkError::Unsupported)
     }
 
     /// Returns the hardware MAC address for this interface

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -109,7 +109,18 @@ pub trait VirtualNetworking: fmt::Debug + Send + Sync + 'static {
 
     /// Lists all the IP addresses currently assigned to this interface
     async fn ip_list(&self) -> Result<Vec<IpCidr>> {
-        Err(NetworkError::Unsupported)
+        let mut ret = Vec::new();
+        for interface in interfaces::Interface::get_all().map_err(|_| NetworkError::Unsupported)? {
+            for ip in interface.addresses.iter() {
+                if let Some(ip) = ip.addr {
+                    ret.push(IpCidr {
+                        ip: ip.ip(),
+                        prefix: 0,
+                    });
+                }
+            }
+        }
+        Ok(ret)
     }
 
     /// Returns the hardware MAC address for this interface


### PR DESCRIPTION
```
john@AlienWorld:/prog/wasmer/lib/cli$ sudo ../../target/debug/wasmer run --net --print-listeners wasmer/wasmer-sh
2023-08-25T01:47:08.285079Z  INFO static_web_server::logger: logging level: info
2023-08-25T01:47:08.336565Z  INFO static_web_server::server: config file: "./cfg/config.toml"
Listening on: 127.0.0.1:80
Listening on: [::1]:80
Listening on: [fe80::f860:efff:fec2:3d9b]:80
Listening on: 172.26.71.148:80
Listening on: [fe80::215:5dff:fea5:f276]:80
Listening on: [fdff::1]:80
Listening on: [fe80::a019:10ff:fe97:2bfe]:80
2023-08-25T01:47:08.337373Z  INFO static_web_server::server: server bound to tcp socket [::]:80
2023-08-25T01:47:08.338290Z  INFO static_web_server::server: runtime worker threads: 16
2023-08-25T01:47:08.338502Z  INFO static_web_server::server: runtime max blocking threads: 32
2023-08-25T01:47:08.338675Z  INFO static_web_server::server: security headers: enabled=false
2023-08-25T01:47:08.338843Z  INFO static_web_server::server: auto compression: enabled=true
2023-08-25T01:47:08.339009Z  INFO static_web_server::server: compression static: enabled=false
2023-08-25T01:47:08.339174Z  INFO static_web_server::server: directory listing: enabled=false
2023-08-25T01:47:08.339328Z  INFO static_web_server::server: directory listing order code: 6
2023-08-25T01:47:08.339494Z  INFO static_web_server::server: directory listing format: Html
2023-08-25T01:47:08.339659Z  INFO static_web_server::server: cache control headers: enabled=false
2023-08-25T01:47:08.339815Z  INFO static_web_server::server: basic authentication: enabled=false
2023-08-25T01:47:08.339966Z  INFO static_web_server::server: log remote address: enabled=false
2023-08-25T01:47:08.340116Z  INFO static_web_server::server: redirect trailing slash: enabled=true
2023-08-25T01:47:08.340270Z  INFO static_web_server::server: ignore hidden files: enabled=false
2023-08-25T01:47:08.340436Z  INFO static_web_server::server: grace period before graceful shutdown: 0s
2023-08-25T01:47:08.340973Z  INFO Server::start_server{addr_str="[::]:80" threads=16}: static_web_server::server: close time.busy=0.00ns time.idle=8.70µs
2023-08-25T01:47:08.341138Z  INFO static_web_server::server: listening on http://[::]:80
2023-08-25T01:47:08.341247Z  INFO static_web_server::server: press ctrl+c to shut down the server
```