### PR TITLE
NativeEngineExt::deserialize now returns Module

### DIFF
--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -120,7 +120,7 @@ impl Module {
         Ok(Self::from_artifact(artifact))
     }
 
-    fn from_artifact(artifact: Arc<Artifact>) -> Self {
+    pub(super) fn from_artifact(artifact: Arc<Artifact>) -> Self {
         Self { artifact }
     }
 


### PR DESCRIPTION
This is done to make the result actually usable, because there is no
public constructor that allows going from Artifact to Module.

Followup to #4139 