### PR TITLE
Early check that a cached artifact is compatible with current CPU Features

### DIFF
--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -282,6 +282,16 @@ impl Artifact {
                 artifact,
                 allocated: None,
             });
+        } else {
+            // check if cpu features are compatible before anything else
+            let cpu_features = artifact.cpu_features();
+            for feature in cpu_features {
+                if !target.cpu_features().contains(feature) {
+                    return Err(DeserializeError::Incompatible(
+                        "Some CPU Features needed for the artifact are missing".to_owned(),
+                    ));
+                }
+            }
         }
         let module_info = artifact.module_info();
         let (

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -288,7 +288,7 @@ impl Artifact {
             if !target.cpu_features().is_superset(cpu_features) {
                 return Err(DeserializeError::Incompatible(format!(
                     "Some CPU Features needed for the artifact are missing: {:?}",
-                    cpu_features.difference(target.cpu_features().clone())
+                    cpu_features.difference(*target.cpu_features())
                 )));
             }
         }

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -285,12 +285,11 @@ impl Artifact {
         } else {
             // check if cpu features are compatible before anything else
             let cpu_features = artifact.cpu_features();
-            for feature in cpu_features {
-                if !target.cpu_features().contains(feature) {
-                    return Err(DeserializeError::Incompatible(
-                        "Some CPU Features needed for the artifact are missing".to_owned(),
-                    ));
-                }
+            if !target.cpu_features().is_superset(cpu_features) {
+                return Err(DeserializeError::Incompatible(format!(
+                    "Some CPU Features needed for the artifact are missing: {:?}",
+                    cpu_features.difference(target.cpu_features().clone())
+                )));
             }
         }
         let module_info = artifact.module_info();


### PR DESCRIPTION
Early check that a cached artifact is compatible with current CPU Features

This will fix https://github.com/wasmerio/wasmer/issues/4188

This has been tested localy by:
1. clearing cache
2. Forcing an CPUFeatures with more feature than the CPU currently support with
3. Generatic a cache (running will fail because of the super set of feature with this PR)
4. Relaunching the wasm program with the PR, it will silently discard the cache and re-create it

Code to force more Feature than the cpu have (in my case at least, as my CPU is pretty old and only have `EnumSet(SSE2 | SSE3 | SSSE3 | SSE41 | SSE42 | POPCNT | AVX)`):
```rust
impl StoreOptions {
    /// Gets the store for the host target, with the compiler name selected
    pub fn get_store(&self) -> Result<(Store, CompilerType)> {
        let target = Target::default();
        let cpu_features = target.cpu_features().clone();
        cpu_features.insert(CpuFeature::AVX2);
        cpu_features.insert(CpuFeature::AVX512DQ);
        cpu_features.insert(CpuFeature::AVX512VL);
        cpu_features.insert(CpuFeature::AVX512F);
        let target = Target::new(target.triple().clone(), cpu_features);
        self.get_store_for_target(target)
    }
```

in `lib/cli/src/store.rs`
