### PR TITLE
Fix invalid access to wasi instance handles in wasix proc_spawn

### DIFF
--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -851,6 +851,12 @@ impl WasiEnv {
         (memory, state, inodes)
     }
 
+    pub(crate) fn get_wasi_state_and_inodes(&self) -> (&WasiState, &WasiInodes) {
+        let state = self.state.deref();
+        let inodes = &state.inodes;
+        (state, inodes)
+    }
+
     /// Make all the commands in a [`BinaryPackage`] available to the WASI
     /// instance.
     ///

--- a/lib/wasix/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn.rs
@@ -145,8 +145,7 @@ pub fn proc_spawn_internal(
 
     // Replace the STDIO
     let (stdin, stdout, stderr) = {
-        let (_, child_state, child_inodes) =
-            unsafe { child_env.get_memory_and_wasi_state_and_inodes(&new_store, 0) };
+        let (child_state, child_inodes) = child_env.get_wasi_state_and_inodes();
         let mut conv_stdio_mode = |mode: WasiStdioMode, fd: WasiFd| -> Result<OptionFd, Errno> {
             match mode {
                 WasiStdioMode::Piped => {


### PR DESCRIPTION
# Description
Fixes `wasix` `proc_spawn` implementation by removing redundant attempt to retrieve memory from the uninitialized `inner` handle.
