### PR TITLE
Fix sockets

### DIFF
--- a/lib/wasix/src/net/mod.rs
+++ b/lib/wasix/src/net/mod.rs
@@ -174,15 +174,9 @@ pub(crate) fn read_ip_port<M: MemorySize>(
             (IpAddr::V4(Ipv4Addr::new(o[2], o[3], o[4], o[5])), port)
         }
         Addressfamily::Inet6 => {
-            let [a, b, c, d, e, f, g, h] = {
-                let o = [
-                    o[2], o[3], o[4], o[5], o[6], o[7], o[8], o[9], o[10], o[11], o[12], o[13],
-                    o[14], o[15], o[16], o[17],
-                ];
-                unsafe { transmute::<_, [u16; 8]>(o) }
-            };
+            let octets: [u8; 16] = o[2..18].try_into().unwrap();
             (
-                IpAddr::V6(Ipv6Addr::new(a, b, c, d, e, f, g, h)),
+                IpAddr::V6(Ipv6Addr::from(octets)),
                 u16::from_ne_bytes([o[0], o[1]]),
             )
         }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -248,7 +248,7 @@ impl InodeSocket {
 
                     match *ty {
                         Socktype::Stream => {
-                            // we already set the socket address - next we need a bind or connect so nothing
+                            // we already set the socket address - next we need a listen or connect so nothing
                             // more to do at this time
                             return Ok(None);
                         }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -1096,7 +1096,10 @@ impl InodeSocket {
                                     Err(err) => Err(err),
                                 }
                             } else {
-                                Err(NetworkError::NotConnected)
+                                match socket.try_recv_from(self.data) {
+                                    Ok((amt, _)) => Ok(amt),
+                                    Err(err) => Err(err),
+                                }
                             }
                         }
                         InodeSocketKind::PreSocket { .. } => {


### PR DESCRIPTION
A couple of small fixes to sockets:

* Fixed endianness issue when deserializing IPv6 addresses that caused swapped bytes in each `u16`.
* Fixed receiving data from UDP sockets that have not been connected to a remote socket (i.e. server sockets).