### PR TITLE
Replace stack pool mutex with lock-free queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6166,6 +6176,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "corosensei",
+ "crossbeam-queue",
  "dashmap",
  "derivative",
  "enum-iterator",
@@ -6342,6 +6353,7 @@ dependencies = [
  "cfg-if",
  "compiler-test-derive",
  "criterion",
+ "crossbeam-queue",
  "glob",
  "lazy_static",
  "rustc_version 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1", features = [
     "rt-multi-thread",
     "macros",
 ], optional = true }
+crossbeam-queue = "0.3.8"
 
 [workspace]
 members = [
@@ -116,15 +117,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 [features]
 # Don't add the compiler features in default, please add them on the Makefile
 # since we might want to autoconfigure them depending on the availability on the host.
-default = [
-    "wat",
-    "wast",
-    "cache",
-    "wasi",
-    "engine",
-    "emscripten",
-    "middlewares",
-]
+default = ["wat", "wast", "cache", "wasi", "engine", "emscripten", "middlewares"]
 # backend means that the `wasmer` crate will be compiled with the `wasmer-compiler` or the `jsc`.
 # That means: that is able to execute modules
 backend = []

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -32,6 +32,7 @@ dashmap = { version = "5.4" }
 fnv = "1.0.3"
 # - Optional shared dependencies.
 tracing = { version = "0.1", optional = true }
+crossbeam-queue = "0.3.8"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 mach = "0.3.2"

--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -309,6 +309,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2539,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "corosensei",
+ "crossbeam-queue",
  "dashmap",
  "derivative",
  "enum-iterator",


### PR DESCRIPTION
Alternate implementation of #3922 using a lock-free queue instead of thread locals. I benchmarked this by creating 100 threads and running a simple WASM function in a loop 30,000 times in each thread. This PR reduces the total time by ~75% on my 10-core CPU, and does not create meaningful impact on single-threaded performance. Also, since the queue is shared among threads, there is no risk of high memory consumption in highly concurrent scenarios.