### PR TITLE
Rephrase the docstring for `--forward-host-env` flag on `wasmer run`

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -66,7 +66,7 @@ pub struct Wasi {
     )]
     pub(crate) env_vars: Vec<(String, String)>,
 
-    /// Forward all host env variables to the wcgi task.
+    /// Forward all host env variables to guest
     #[clap(long, env)]
     pub(crate) forward_host_env: bool,
 


### PR DESCRIPTION
The doc in `wasmer run --help` for this flag says that it should only work for wcgi tasks, but it works for other packages as well.

This commit changes the doc to reflect that.