### PR TITLE
Ignore `fd_close(3)` to avoid breaking POSIX programs that blindly close all file descriptors

### DIFF
--- a/lib/wasix/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_close.rs
@@ -16,6 +16,18 @@ use crate::syscalls::*;
 pub fn fd_close(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 
+    // HACK: As a special case, we don't want to close fd 3 because it can break
+    // some programs...
+    // - On Wasix, we have some default fd, 0:stdin, 1:stdout, 2:stderr, 3:root
+    // - On Posix, we have some default fd: 0:stdin, 1:stdout, 2:stderr
+    // - A POSIX program might want to closed all open fd (e.g. when Python
+    //   spawns subprocesses), so it blindly does fd_close() for fd=3..255
+    // - Wasix doesn't work well when 3:root is closed, because it's the root
+    if fd == 3 {
+        tracing::debug!("Skipping fd_close(3)");
+        return Ok(Errno::Success);
+    }
+
     let env = ctx.data();
     let (_, mut state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
     wasi_try_ok!(state.fs.close_fd(fd));


### PR DESCRIPTION
This adds a hack that ignores `fd_close(3)` so POSIX programs that blindly close all file descriptors other than stdin/stdout/stderr don't lock themselves out of the filesystem.

See @ptitSeb's troubleshooting [on Slack](https://wasmerio.slack.com/archives/C02CK7101PG/p1694591219376609) for more context.

It's pretty difficult to write tests for WASIX syscalls at the moment, so I'm just going to test manually.