### PR TITLE
Allow packages to have commands that use a dependency's atom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6572,7 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.5.0"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b56acc943f6b80cc2842231f34f99a02cd406896a23f3c6dacd8130c24ab3d1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5723,7 +5723,7 @@ dependencies = [
  "wasmer-emscripten",
  "wasmer-object",
  "wasmer-registry 5.6.0",
- "wasmer-toml 0.6.0",
+ "wasmer-toml 0.8.0",
  "wasmer-types",
  "wasmer-vm",
  "wasmer-wasix",
@@ -6056,7 +6056,7 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "url",
- "wasmer-toml 0.6.0",
+ "wasmer-toml 0.8.0",
  "wasmer-wasm-interface 4.2.0",
  "wasmparser 0.51.4",
  "whoami",
@@ -6136,9 +6136,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-toml"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79d9e87af8aea672134da379ccef76e659b7bc316a10b7e51d30177515c0199"
+checksum = "e2d9ad139e1b613770613cf5952e95185e28b108120ddee14d88b4a004c7c94f"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -6572,9 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c35d27cb4c7898571b5f25036ead587736ffb371261f9e928a28edee7abf9d"
+version = "5.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -6599,7 +6597,7 @@ dependencies = [
  "toml 0.7.8",
  "url",
  "walkdir",
- "wasmer-toml 0.7.0",
+ "wasmer-toml 0.8.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ rust-version = "1.70"
 version = "4.2.0"
 
 [workspace.dependencies]
-webc = { version = "5.2.0", default-features = false, features = ["package"] }
-wasmer-toml = "0.6.0"
+webc = { version = "5.5.0", default-features = false, features = ["package"] }
+wasmer-toml = "0.8.0"
 
 [build-dependencies]
 test-generator = { path = "tests/lib/test-generator" }
@@ -311,3 +311,6 @@ required-features = ["backend"]
 name = "features"
 path = "examples/features.rs"
 required-features = ["cranelift"]
+
+[patch.crates-io]
+webc = { path = "../pirita/crates/webc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust-version = "1.70"
 version = "4.2.0"
 
 [workspace.dependencies]
-webc = { version = "5.5.0", default-features = false, features = ["package"] }
+webc = { version = "5.5.1", default-features = false, features = ["package"] }
 wasmer-toml = "0.8.0"
 
 [build-dependencies]
@@ -311,6 +311,3 @@ required-features = ["backend"]
 name = "features"
 path = "examples/features.rs"
 required-features = ["cranelift"]
-
-[patch.crates-io]
-webc = { path = "../pirita/crates/webc" }

--- a/lib/registry/Cargo.toml
+++ b/lib/registry/Cargo.toml
@@ -43,7 +43,7 @@ tldextract = "0.6.0"
 tokio = "1.24.0"
 toml = "0.5.9"
 url = "2.3.1"
-wasmer-toml = "0.6.0"
+wasmer-toml = { workspace = true }
 wasmer-wasm-interface = { version = "4.2.0", path = "../wasm-interface", optional = true }
 wasmparser = { version = "0.51.4", optional = true }
 whoami = "1.2.3"

--- a/lib/registry/src/lib.rs
+++ b/lib/registry/src/lib.rs
@@ -180,8 +180,7 @@ pub fn query_package_from_registry(
         manifest: v.manifest.clone(),
 
         commands: manifest
-            .command
-            .unwrap_or_default()
+            .commands
             .iter()
             .map(|s| s.get_name())
             .collect::<Vec<_>>()

--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -2500,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-toml"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79d9e87af8aea672134da379ccef76e659b7bc316a10b7e51d30177515c0199"
+checksum = "e2d9ad139e1b613770613cf5952e95185e28b108120ddee14d88b4a004c7c94f"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.3.0"
+version = "5.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c35d27cb4c7898571b5f25036ead587736ffb371261f9e928a28edee7abf9d"
+checksum = "4b56acc943f6b80cc2842231f34f99a02cd406896a23f3c6dacd8130c24ab3d1"
 dependencies = [
  "anyhow",
  "base64 0.21.4",

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -113,7 +113,7 @@ fn load_binary_command(
         name: atom_name,
         dependency,
         ..
-    } = match dbg!(atom_name_for_command(command_name, cmd)?) {
+    } = match atom_name_for_command(command_name, cmd)? {
         Some(name) => name,
         None => {
             tracing::warn!(
@@ -147,12 +147,10 @@ fn load_binary_command(
         None => package,
     };
 
-    dbg!(package_id, command_name, cmd);
-
     let atom = webc.get_atom(&atom_name);
 
     if atom.is_none() && cmd.annotations.is_empty() {
-        return Ok(legacy_atom_hack(webc, &command_name, cmd));
+        return Ok(legacy_atom_hack(webc, command_name, cmd));
     }
 
     let atom = atom.with_context(|| {

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -8,8 +8,12 @@ use std::{
 use anyhow::{Context, Error};
 use futures::{future::BoxFuture, StreamExt, TryStreamExt};
 use once_cell::sync::OnceCell;
+use petgraph::visit::EdgeRef;
 use virtual_fs::{FileSystem, OverlayFileSystem, WebcVolumeFileSystem};
-use webc::compat::{Container, Volume};
+use webc::{
+    compat::{Container, Volume},
+    metadata::annotations::Atom as AtomAnnotation,
+};
 
 use crate::{
     bin_factory::{BinaryPackage, BinaryPackageCommand},
@@ -37,7 +41,8 @@ pub async fn load_package_tree(
     let fs = filesystem(&containers, &resolution.package)?;
 
     let root = &resolution.package.root_package;
-    let commands: Vec<BinaryPackageCommand> = commands(&resolution.package.commands, &containers)?;
+    let commands: Vec<BinaryPackageCommand> =
+        commands(&resolution.package.commands, &containers, resolution)?;
 
     let file_system_memory_footprint = count_file_system(&fs, Path::new("/"));
     let atoms_in_use: HashSet<_> = commands.iter().map(|cmd| cmd.atom()).collect();
@@ -69,6 +74,7 @@ pub async fn load_package_tree(
 fn commands(
     commands: &BTreeMap<String, ItemLocation>,
     containers: &HashMap<PackageId, Container>,
+    resolution: &Resolution,
 ) -> Result<Vec<BinaryPackageCommand>, Error> {
     let mut pkg_commands = Vec::new();
 
@@ -84,7 +90,9 @@ fn commands(
         let manifest = webc.manifest();
         let command_metadata = &manifest.commands[original_name];
 
-        if let Some(cmd) = load_binary_command(webc, name, command_metadata)? {
+        if let Some(cmd) =
+            load_binary_command(package, name, command_metadata, containers, resolution)?
+        {
             pkg_commands.push(cmd);
         }
     }
@@ -92,16 +100,24 @@ fn commands(
     Ok(pkg_commands)
 }
 
+/// Given a [`webc::metadata::Command`], figure out which atom it uses and load
+/// that atom into a [`BinaryPackageCommand`].
 fn load_binary_command(
-    webc: &Container,
-    name: &str,
+    package_id: &PackageId,
+    command_name: &str,
     cmd: &webc::metadata::Command,
+    containers: &HashMap<PackageId, Container>,
+    resolution: &Resolution,
 ) -> Result<Option<BinaryPackageCommand>, anyhow::Error> {
-    let atom_name = match atom_name_for_command(name, cmd)? {
+    let AtomAnnotation {
+        name: atom_name,
+        dependency,
+        ..
+    } = match dbg!(atom_name_for_command(command_name, cmd)?) {
         Some(name) => name,
         None => {
             tracing::warn!(
-                cmd.name=name,
+                cmd.name=command_name,
                 cmd.runner=%cmd.runner,
                 "Skipping unsupported command",
             );
@@ -109,16 +125,43 @@ fn load_binary_command(
         }
     };
 
+    let package = &containers[package_id];
+
+    let webc = match dependency {
+        Some(dep) => {
+            let ix = resolution
+                .graph
+                .packages()
+                .get(package_id)
+                .copied()
+                .unwrap();
+            let graph = resolution.graph.graph();
+            let edge_reference = graph
+                .edges_directed(ix, petgraph::Direction::Outgoing)
+                .find(|edge| edge.weight().alias == dep)
+                .with_context(|| format!("Unable to find the \"{dep}\" dependency for the \"{command_name}\" command in \"{package_id}\""))?;
+
+            let other_package = graph.node_weight(edge_reference.target()).unwrap();
+            &containers[&other_package.id]
+        }
+        None => package,
+    };
+
+    dbg!(package_id, command_name, cmd);
+
     let atom = webc.get_atom(&atom_name);
 
     if atom.is_none() && cmd.annotations.is_empty() {
-        return Ok(legacy_atom_hack(webc, name, cmd));
+        return Ok(legacy_atom_hack(webc, &command_name, cmd));
     }
 
-    let atom = atom
-        .with_context(|| format!("The '{name}' command uses the '{atom_name}' atom, but it isn't present in the WEBC file"))?;
+    let atom = atom.with_context(|| {
+        format!(
+            "The '{command_name}' command uses the '{atom_name}' atom, but it isn't present in the WEBC file"
+        )
+    })?;
 
-    let cmd = BinaryPackageCommand::new(name.to_string(), cmd.clone(), atom);
+    let cmd = BinaryPackageCommand::new(command_name.to_string(), cmd.clone(), atom);
 
     Ok(Some(cmd))
 }
@@ -126,28 +169,12 @@ fn load_binary_command(
 fn atom_name_for_command(
     command_name: &str,
     cmd: &webc::metadata::Command,
-) -> Result<Option<String>, anyhow::Error> {
-    use webc::metadata::annotations::{
-        Emscripten, Wasi, EMSCRIPTEN_RUNNER_URI, WASI_RUNNER_URI, WCGI_RUNNER_URI,
-    };
+) -> Result<Option<AtomAnnotation>, anyhow::Error> {
+    use webc::metadata::annotations::{EMSCRIPTEN_RUNNER_URI, WASI_RUNNER_URI, WCGI_RUNNER_URI};
 
-    // FIXME: command metadata should include an "atom: Option<String>" field
-    // because it's so common, rather than relying on each runner to include
-    // annotations where "atom" just so happens to contain the atom's name
-    // (like in Wasi and Emscripten)
-
-    if let Some(Wasi { atom, .. }) = cmd
-        .annotation("wasi")
-        .context("Unable to deserialize 'wasi' annotations")?
-    {
-        return Ok(Some(atom));
-    }
-
-    if let Some(Emscripten {
-        atom: Some(atom), ..
-    }) = cmd
-        .annotation("emscripten")
-        .context("Unable to deserialize 'emscripten' annotations")?
+    if let Some(atom) = cmd
+        .atom()
+        .context("Unable to deserialize atom annotations")?
     {
         return Ok(Some(atom));
     }
@@ -163,7 +190,7 @@ fn atom_name_for_command(
             command = command_name,
             "No annotations specifying the atom name found. Falling back to the command name"
         );
-        return Ok(Some(command_name.to_string()));
+        return Ok(Some(AtomAnnotation::new(command_name, None)));
     }
 
     Ok(None)

--- a/tests/integration/cli/tests/fixtures/init1.toml
+++ b/tests/integration/cli/tests/fixtures/init1.toml
@@ -5,8 +5,6 @@ description = 'Description for package testfirstproject'
 
 # See more keys and definitions at https://docs.wasmer.io/registry/manifest
 
-[dependencies]
-
 [[module]]
 name = 'testfirstproject'
 source = 'testfirstproject.wasm'

--- a/tests/integration/cli/tests/fixtures/init4.toml
+++ b/tests/integration/cli/tests/fixtures/init4.toml
@@ -5,8 +5,6 @@ description = 'Description for package wasmer'
 
 # See more keys and definitions at https://docs.wasmer.io/registry/manifest
 
-[dependencies]
-
 [[module]]
 name = 'wasmer'
 source = 'target/wasm32-wasi/release/wasmer.wasm'

--- a/tests/integration/cli/tests/init.rs
+++ b/tests/integration/cli/tests/init.rs
@@ -9,37 +9,15 @@ use wasmer_integration_tests_cli::get_wasmer_path;
 
 // Test that wasmer init without arguments works
 #[test]
-fn wasmer_init_works_1() -> anyhow::Result<()> {
-    let wasmer_dir = TempDir::new()?;
-    let tempdir = tempfile::tempdir()?;
+fn wasmer_init_works_1() {
+    let wasmer_dir = TempDir::new().unwrap();
+    let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path().join("testfirstproject");
-    std::fs::create_dir_all(&path)?;
-
-    if std::env::var("GITHUB_TOKEN").is_err() {
-        return Ok(());
-    }
-
-    let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
-    println!("wapm dev token ok...");
-
-    if let Some(token) = wapm_dev_token {
-        // Special case: GitHub secrets aren't visible to outside collaborators
-        if token.is_empty() {
-            return Ok(());
-        }
-        Command::new(get_wasmer_path())
-            .arg("login")
-            .arg("--registry=wapm.dev")
-            .arg(token)
-            .env("WASMER_DIR", wasmer_dir.path())
-            .assert()
-            .success();
-    }
-
-    println!("wasmer login ok!");
+    std::fs::create_dir_all(&path).unwrap();
 
     Command::new(get_wasmer_path())
         .arg("init")
+        .arg("--namespace=ciuser")
         .current_dir(&path)
         .env("WASMER_DIR", wasmer_dir.path())
         .assert()
@@ -49,47 +27,25 @@ fn wasmer_init_works_1() -> anyhow::Result<()> {
         std::fs::read_to_string(path.join("wasmer.toml")).unwrap(),
         include_str!("./fixtures/init1.toml"),
     );
-
-    Ok(())
 }
 
 #[test]
-fn wasmer_init_works_2() -> anyhow::Result<()> {
-    let tempdir = tempfile::tempdir()?;
+fn wasmer_init_works_2() {
+    let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path();
     let path = path.join("testfirstproject");
-    std::fs::create_dir_all(&path)?;
+    std::fs::create_dir_all(&path).unwrap();
     std::fs::write(
         path.join("Cargo.toml"),
         include_bytes!("./fixtures/init2.toml"),
-    )?;
-    std::fs::create_dir_all(path.join("src"))?;
-    std::fs::write(path.join("src").join("main.rs"), b"fn main() { }")?;
-
-    if std::env::var("GITHUB_TOKEN").is_err() {
-        return Ok(());
-    }
-
-    let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
-    println!("wapm dev token ok...");
-
-    if let Some(token) = wapm_dev_token.as_ref() {
-        // Special case: GitHub secrets aren't visible to outside collaborators
-        if token.is_empty() {
-            return Ok(());
-        }
-        Command::new(get_wasmer_path())
-            .arg("login")
-            .arg("--registry=wapm.dev")
-            .arg(token)
-            .assert()
-            .success();
-    }
-
-    println!("wasmer login ok!");
+    )
+    .unwrap();
+    std::fs::create_dir_all(path.join("src")).unwrap();
+    std::fs::write(path.join("src").join("main.rs"), b"fn main() { }").unwrap();
 
     Command::new(get_wasmer_path())
         .arg("init")
+        .arg("--namespace=ciuser")
         .current_dir(&path)
         .assert()
         .success();
@@ -98,13 +54,8 @@ fn wasmer_init_works_2() -> anyhow::Result<()> {
         std::fs::read_to_string(path.join("Cargo.toml")).unwrap(),
         include_str!("./fixtures/init2.toml")
     );
-
-    println!("ok 1");
-
     assert_eq!(
         std::fs::read_to_string(path.join("wasmer.toml")).unwrap(),
         include_str!("./fixtures/init4.toml")
     );
-
-    Ok(())
 }

--- a/tests/integration/cli/tests/packages/js-script/src/index.js
+++ b/tests/integration/cli/tests/packages/js-script/src/index.js
@@ -1,0 +1,1 @@
+console.log("Hello, World!");

--- a/tests/integration/cli/tests/packages/js-script/wasmer.toml
+++ b/tests/integration/cli/tests/packages/js-script/wasmer.toml
@@ -1,0 +1,18 @@
+[package]
+name = "wasmer/js-script"
+version = "0.0.0"
+description = "A package which uses quickjs to run a JavaScript program"
+
+[dependencies]
+"saghul/quickjs" = "0.0.3"
+
+[[command]]
+name = "main"
+module = "saghul/quickjs:quickjs"
+runner = "wasi"
+
+[command.annotations.wasi]
+main_args = ["/src/index.js"]
+
+[fs]
+"/src" = "./src"

--- a/tests/integration/cli/tests/packages/js-script/wasmer.toml
+++ b/tests/integration/cli/tests/packages/js-script/wasmer.toml
@@ -12,7 +12,7 @@ module = "saghul/quickjs:quickjs"
 runner = "wasi"
 
 [command.annotations.wasi]
-main_args = ["/src/index.js"]
+main-args = ["/src/index.js"]
 
 [fs]
 "/src" = "./src"

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -908,7 +908,7 @@ fn run_a_package_that_uses_an_atom_from_a_dependency() {
 fn project_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
-        .find(|path| path.join(".git").exists())
+        .nth(3)
         .unwrap()
 }
 

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -885,6 +885,33 @@ fn run_bash_using_coreutils() {
     assert.success().stdout(contains(some_expected_binaries));
 }
 
+#[test]
+fn run_a_package_that_uses_an_atom_from_a_dependency() {
+    let js_script_dir = project_root()
+        .join("tests")
+        .join("integration")
+        .join("cli")
+        .join("tests")
+        .join("packages")
+        .join("js-script");
+
+    let assert = Command::new(get_wasmer_path())
+        .arg("run")
+        .arg(&js_script_dir)
+        .arg("--registry=wasmer.io")
+        .env("RUST_LOG", &*RUST_LOG)
+        .assert();
+
+    assert.success().stdout(contains("Hello, World!"));
+}
+
+fn project_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .find(|path| path.join(".git").exists())
+        .unwrap()
+}
+
 /// A helper that wraps [`Child`] to make sure it gets terminated
 /// when it is no longer needed.
 struct JoinableChild {


### PR DESCRIPTION
This is the `wasmer` counterpart to https://github.com/wasmerio/pirita/issues/172 and https://github.com/wasmerio/wasmer-toml/pull/22, adding support for commands that can use atoms from a dependency.