### PR TITLE
Use write instead of send for pipe, to accomodate socketpair

### DIFF
--- a/lib/wasix/src/syscalls/wasix/fd_pipe.rs
+++ b/lib/wasix/src/syscalls/wasix/fd_pipe.rs
@@ -39,6 +39,7 @@ pub fn fd_pipe<M: MemorySize>(
         | Rights::FD_SYNC
         | Rights::FD_DATASYNC
         | Rights::POLL_FD_READWRITE
+        | Rights::SOCK_SEND
         | Rights::FD_FDSTAT_SET_FLAGS;
     let fd1 = wasi_try!(state
         .fs

--- a/lib/wasix/src/syscalls/wasix/sock_recv.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_recv.rs
@@ -28,12 +28,8 @@ pub fn sock_recv<M: MemorySize>(
 ) -> Result<Errno, WasiError> {
     let env = ctx.data();
     let fd_entry = env.state.fs.get_fd(sock).unwrap();
-    let inode = fd_entry.inode.clone();
-    let guard = inode.read();
-    let use_read = match guard.deref() {
-        Kind::Pipe { .. } => true,
-        _ => false,
-    };
+    let guard = fd_entry.inode.read();
+    let use_read = matches!(guard.deref(), Kind::Pipe { .. });
     drop(guard);
     if use_read {
         fd_read(ctx, sock, ri_data, ri_data_len, ro_data_len)

--- a/lib/wasix/src/syscalls/wasix/sock_send.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send.rs
@@ -27,12 +27,8 @@ pub fn sock_send<M: MemorySize>(
 ) -> Result<Errno, WasiError> {
     let env = ctx.data();
     let fd_entry = env.state.fs.get_fd(sock).unwrap();
-    let inode = fd_entry.inode.clone();
-    let guard = inode.read();
-    let use_write = match guard.deref() {
-        Kind::Pipe { .. } => true,
-        _ => false,
-    };
+    let guard = fd_entry.inode.read();
+    let use_write = matches!(guard.deref(), Kind::Pipe { .. });
     drop(guard);
     if use_write {
         fd_write(ctx, sock, si_data, si_data_len, ret_data_len)

--- a/lib/wasix/src/syscalls/wasix/sock_send.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send.rs
@@ -25,7 +25,20 @@ pub fn sock_send<M: MemorySize>(
     si_flags: SiFlags,
     ret_data_len: WasmPtr<M::Offset, M>,
 ) -> Result<Errno, WasiError> {
-    sock_send_internal(ctx, sock, si_data, si_data_len, si_flags, ret_data_len)
+    let env = ctx.data();
+    let fd_entry = env.state.fs.get_fd(sock).unwrap();
+    let inode = fd_entry.inode.clone();
+    let guard = inode.read();
+    let use_write = match guard.deref() {
+        Kind::Pipe { .. } => true,
+        _ => false,
+    };
+    drop(guard);
+    if use_write {
+        fd_write(ctx, sock, si_data, si_data_len, ret_data_len)
+    } else {
+        sock_send_internal(ctx, sock, si_data, si_data_len, si_flags, ret_data_len)
+    }
 }
 
 pub(super) fn sock_send_internal<M: MemorySize>(


### PR DESCRIPTION
Use write instead of send for pipe, to accomodate socketpair.

Because C socketpair use fd_pipe to create the pair, waist pipe will need to handle `sock_send`