### PR TITLE
Use `cargo nextest` when running tests in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,19 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Automatically mark a test as "slow" after 60 seconds, then kill it after 180s
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[[profile.default.overrides]]
+# Create-exe tests tend to be pretty flaky
+filter = "test(create_exe)"
+retries = 3
+
+[[profile.default.overrides]]
+# Snapshot tests tend to be flaky because they implicitly rely on how the OS will
+# schedule threads. Our pipe flushing is also pretty unreliable.
+filter = "test(snapshot)"
+retries = 3

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,14 +6,5 @@ failure-output = "immediate-final"
 fail-fast = false
 # Automatically mark a test as "slow" after 60 seconds, then kill it after 180s
 slow-timeout = { period = "60s", terminate-after = 3 }
-
-[[profile.default.overrides]]
-# Create-exe tests tend to be pretty flaky
-filter = "test(create_exe)"
-retries = 3
-
-[[profile.default.overrides]]
-# Snapshot tests tend to be flaky because they implicitly rely on how the OS will
-# schedule threads. Our pipe flushing is also pretty unreliable.
-filter = "test(snapshot)"
+# Retry a couple times in case there are flaky tests
 retries = 3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,7 @@ env:
   # can override that behaviour
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
   MSRV: "1.70"
+  NEXTEST_PROFILE: "ci"
 
 jobs:
 
@@ -371,6 +372,8 @@ jobs:
         with:
           toolchain: "nightly-2023-05-25"
           target: ${{ matrix.metadata.target }}
+      - name: Install Nextest
+        uses: taiki-e/install-action@nextest
       - name: Install Windows-GNU linker
         if: ${{ matrix.metadata.build == 'windows-gnu' }}
         shell: bash
@@ -595,6 +598,8 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
           target: ${{ matrix.metadata.target }}
+      - name: Install Nextest
+        uses: taiki-e/install-action@nextest
       - name: Install LLVM (macOS Apple Silicon)
         if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
         run: |
@@ -696,6 +701,8 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
           target: ${{ matrix.metadata.target }}
+      - name: Install Nextest
+        uses: taiki-e/install-action@nextest
       - name: Cache
         uses: whywaita/actions-cache-s3@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ build-capi-headless-ios:
 
 # test compilers
 test-stage-0-wast:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --tests $(compiler_features) --locked
+	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --release $(compiler_features) --locked
 
 # test packages
 test-stage-1-test-all:

--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,8 @@ test-stage-0-wast:
 
 # test packages
 test-stage-1-test-all:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --all --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --locked
+	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --locked
+	$(CARGO_BINARY) test --doc $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --locked
 test-stage-2-test-compiler-cranelift-nostd:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-cranelift/Cargo.toml --release --no-default-features --features=std --locked
 test-stage-3-test-compiler-singlepass-nostd:

--- a/Makefile
+++ b/Makefile
@@ -637,9 +637,9 @@ test-integration-cli: build-wasmer build-capi package-capi-headless package dist
 	WASMER_DIR=`pwd`/package $(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner --no-fail-fast -p wasmer-integration-tests-cli --locked
 
 # Before running this in the CI, we need to set up link.tar.gz and /cache/wasmer-[target].tar.gz
-test-integration-cli-ci:
+test-integration-cli-ci: require-nextest
 	rustup target add wasm32-wasi
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner -p wasmer-integration-tests-cli --locked
+	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --features webc_runner -p wasmer-integration-tests-cli --locked
 
 test-integration-ios:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --features webc_runner -p wasmer-integration-tests-ios --locked
@@ -940,3 +940,6 @@ test-minimal-versions:
 
 update-graphql-schema:
 	curl -sSfL https://registry.wapm.io/graphql/schema.graphql > lib/registry/graphql/schema.graphql
+
+require-nextest:
+	cargo nextest --version > /dev/null || cargo binstall cargo-nextest --secure || cargo install cargo-nextest

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -33,7 +33,7 @@ hyper = { version = "0.14", optional = true }
 tokio-tungstenite = { version = "0.20", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", default_features = false, features = [ "macros" ] }
+tokio = { version = "1", default_features = false, features = [ "macros", "rt-multi-thread" ] }
 tracing-test = { version = "0.2" }
 
 [features]

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -71,19 +71,20 @@ async fn setup_pipe(
 
 #[cfg(feature = "remote")]
 async fn test_tcp(client: RemoteNetworkingClient, _server: RemoteNetworkingServer) {
-    static PORT: AtomicU16 = AtomicU16::new(8000);
-    let addr = SocketAddr::V4(SocketAddrV4::new(
-        Ipv4Addr::LOCALHOST,
-        PORT.fetch_add(1, Ordering::SeqCst),
-    ));
-    tracing::info!("listening on {addr}");
     let mut listener = client
-        .listen_tcp(addr.clone(), false, false, false)
+        .listen_tcp(
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            false,
+            false,
+            false,
+        )
         .await
         .unwrap();
+    let addr = listener.addr_local().unwrap();
+    tracing::info!("listening on {addr}");
 
-    const TEST1: &'static str = "the cat ran up the wall!";
-    const TEST2: &'static str = "...and fell off the roof! raise the roof! oop oop";
+    const TEST1: &str = "the cat ran up the wall!";
+    const TEST2: &str = "...and fell off the roof! raise the roof! oop oop";
 
     tracing::info!("spawning acceptor worker thread");
     tokio::task::spawn(async move {
@@ -104,10 +105,7 @@ async fn test_tcp(client: RemoteNetworkingClient, _server: RemoteNetworkingServe
 
     tracing::info!("connecting to listening socket");
     let mut socket = client
-        .connect_tcp(
-            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
-            addr,
-        )
+        .connect_tcp(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)), addr)
         .await
         .unwrap();
 

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -123,6 +123,7 @@ async fn test_tcp(client: RemoteNetworkingClient, _server: RemoteNetworkingServe
 }
 
 #[cfg(feature = "remote")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_mpsc() {
@@ -131,6 +132,7 @@ async fn test_tcp_with_mpsc() {
 }
 
 #[cfg(feature = "remote")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_bincode() {
@@ -139,6 +141,7 @@ async fn test_tcp_with_small_pipe_using_bincode() {
 }
 
 #[cfg(feature = "remote")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_using_bincode() {
@@ -148,6 +151,7 @@ async fn test_tcp_with_large_pipe_using_bincode() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_json() {
@@ -157,6 +161,7 @@ async fn test_tcp_with_small_pipe_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_json_using_json() {
@@ -166,6 +171,7 @@ async fn test_tcp_with_large_pipe_json_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_messagepack() {
@@ -175,6 +181,7 @@ async fn test_tcp_with_small_pipe_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_json_using_messagepack() {
@@ -184,6 +191,7 @@ async fn test_tcp_with_large_pipe_json_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_cbor() {
@@ -193,6 +201,7 @@ async fn test_tcp_with_small_pipe_using_cbor() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_json_using_cbor() {
@@ -200,6 +209,7 @@ async fn test_tcp_with_large_pipe_json_using_cbor() {
     test_tcp(client, server).await
 }
 
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test]
 async fn test_google_poll() {
@@ -290,6 +300,7 @@ async fn test_google_poll() {
     tracing::info!("done");
 }
 
+#[cfg_attr(windows, ignore)]
 #[traced_test]
 #[tokio::test]
 async fn test_google_epoll() {

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -123,27 +123,24 @@ async fn test_tcp(client: RemoteNetworkingClient, _server: RemoteNetworkingServe
 }
 
 #[cfg(feature = "remote")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_mpsc() {
     let (client, server) = setup_mpsc().await;
     test_tcp(client, server).await
 }
 
 #[cfg(feature = "remote")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_bincode() {
     let (client, server) = setup_pipe(10, FrameSerializationFormat::Bincode).await;
     test_tcp(client, server).await
 }
 
 #[cfg(feature = "remote")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_using_bincode() {
     let (client, server) = setup_pipe(1024000, FrameSerializationFormat::Bincode).await;
     test_tcp(client, server).await
@@ -151,9 +148,8 @@ async fn test_tcp_with_large_pipe_using_bincode() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_json() {
     let (client, server) = setup_pipe(10, FrameSerializationFormat::Json).await;
     test_tcp(client, server).await
@@ -161,9 +157,8 @@ async fn test_tcp_with_small_pipe_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_json_using_json() {
     let (client, server) = setup_pipe(1024000, FrameSerializationFormat::Json).await;
     test_tcp(client, server).await
@@ -171,9 +166,8 @@ async fn test_tcp_with_large_pipe_json_using_json() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_messagepack() {
     let (client, server) = setup_pipe(10, FrameSerializationFormat::MessagePack).await;
     test_tcp(client, server).await
@@ -181,9 +175,8 @@ async fn test_tcp_with_small_pipe_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_json_using_messagepack() {
     let (client, server) = setup_pipe(1024000, FrameSerializationFormat::MessagePack).await;
     test_tcp(client, server).await
@@ -191,9 +184,8 @@ async fn test_tcp_with_large_pipe_json_using_messagepack() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_small_pipe_using_cbor() {
     let (client, server) = setup_pipe(10, FrameSerializationFormat::Cbor).await;
     test_tcp(client, server).await
@@ -201,15 +193,13 @@ async fn test_tcp_with_small_pipe_using_cbor() {
 
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
-#[cfg(target_os = "linux")]
 #[traced_test]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tcp_with_large_pipe_json_using_cbor() {
     let (client, server) = setup_pipe(1024000, FrameSerializationFormat::Cbor).await;
     test_tcp(client, server).await
 }
 
-#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_google_poll() {
@@ -300,7 +290,6 @@ async fn test_google_poll() {
     tracing::info!("done");
 }
 
-#[cfg(target_os = "linux")]
 #[traced_test]
 #[tokio::test]
 async fn test_google_epoll() {


### PR DESCRIPTION
It's a well-known problem that Wasmer contains many flaky tests, and it's not uncommon to need to restart a CI run 2 or 3 times before tests will pass. For example, [this CI run](https://github.com/wasmerio/wasmer/actions/runs/6264613048/attempts/4) from #4224 took 5 restarts before all the `create-exe` tests would pass. 

This PR switches from `cargo test` to `cargo nextest` and enables automatic retries for some known flaky tests. I've deliberately not added a blanket `retries = 3` because this lets us track roughly which tests are flaky. The intention is that if you are working on a PR and notice a flaky test, you'll explicitly add it to the set of overrides in `.config/nextest.toml`.

This won't fix issues like `note: /usr/bin/ld: final link failed: No space left on device` when our cache grows so big it fills up the disk, but hopefully it'll help mask the flakiness a bit better.