### PR TITLE
Migration to LLVM15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,14 +46,14 @@ jobs:
           - build: linux-x64
             os: ubuntu-20.04
             artifact_name: 'wasmer-linux-amd64'
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-linux-amd64.tar.xz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-linux-amd64.tar.xz'
             cross_compilation_artifact_name: 'cross_compiled_from_linux'
             use_sccache: true
             use_llvm: true
             build_wasm: true
           - build: macos-x64
             os: macos-11
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-darwin-amd64.tar.xz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-darwin-amd64.tar.xz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
             use_sccache: true
@@ -69,7 +69,7 @@ jobs:
           - build: windows-x64
             os: windows-2019
             artifact_name: 'wasmer-windows-amd64'
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-windows-amd64.tar.xz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
             cross_compilation_artifact_name: 'cross_compiled_from_win'
             use_sccache: true
             use_llvm: true
@@ -77,7 +77,7 @@ jobs:
           - build: linux-musl-x64
             os: ubuntu-latest
             artifact_name: 'wasmer-linux-musl-amd64'
-            #llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-linux-amd64.tar.xz'
+            #llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-linux-amd64.tar.xz'
             container: alpine:latest
             use_sccache: false
             use_llvm: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,11 +62,11 @@ jobs:
           sudo apt install -y libtinfo5
       - name: Install LLVM (Linux)
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz -L -o /opt/llvm.tar.xz
-          mkdir -p /opt/llvm-12
-          tar xf /opt/llvm.tar.xz --strip-components=1 -C /opt/llvm-12
-          echo '/opt/llvm-12/bin' >> $GITHUB_PATH
-          echo 'LLVM_SYS_120_PREFIX=/opt/llvm-12' >> $GITHUB_ENV
+          curl --proto '=https' --tlsv1.2 -sSf https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz -L -o /opt/llvm.tar.xz
+          mkdir -p /opt/llvm-15
+          tar xf /opt/llvm.tar.xz --strip-components=1 -C /opt/llvm-15
+          echo '/opt/llvm-15/bin' >> $GITHUB_PATH
+          echo 'LLVM_SYS_150_PREFIX=/opt/llvm-15' >> $GITHUB_ENV
       - name: Cache
         uses: whywaita/actions-cache-s3@v2
         with:
@@ -306,7 +306,7 @@ jobs:
             build: linux-x64,
             os: ubuntu-22.04,
             target: x86_64-unknown-linux-gnu,
-            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           },
           {
             build: linux-musl,
@@ -318,7 +318,7 @@ jobs:
             build: macos-x64,
             os: macos-11,
             target: x86_64-apple-darwin,
-            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           },
           {
             build: macos-arm,
@@ -329,7 +329,7 @@ jobs:
             build: windows-x64,
             os: windows-2019,
             target: x86_64-pc-windows-msvc,
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-windows-amd64.tar.xz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
           },
           {
             build: windows-gnu,
@@ -542,21 +542,21 @@ jobs:
             os: ubuntu-22.04,
             target: x86_64-unknown-linux-gnu,
             exe: '',
-            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           },
           {
             build: macos-x64,
             os: macos-11,
             target: x86_64-apple-darwin,
             exe: '',
-            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           },
           {
             build: windows-x64,
             os: windows-2019,
             target: x86_64-pc-windows-msvc,
             exe: '.exe',
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/14.x/llvm-windows-amd64.tar.xz'
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
           },
           {
             build: linux-musl,
@@ -652,11 +652,11 @@ jobs:
           - build: linux-x64
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           - build: macos-x64
             os: macos-11
             target: x86_64-apple-darwin
-            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz'
+            llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           # we only build the integration-test CLI, we don't run tests
           - build: macos-arm
             os: macos-11

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -418,7 +418,7 @@ jobs:
           echo "ENABLE_LLVM=1" >> $GITHUB_ENV
           echo "${LLVM_DIR}/bin" >> $GITHUB_PATH
           echo "${LLVM_DIR}/usr/bin" >> $GITHUB_PATH
-          echo "LLVM_SYS_140_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
+          echo "LLVM_SYS_150_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
       - name: Setup Rust target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,9 +2427,9 @@ checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "llvm-sys"
-version = "140.1.2"
+version = "150.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b285f8682531b9b394dd9891977a2a28c47006e491bda944e1ca62ebab2664"
+checksum = "417dbaef2fece3b186fe15704e010849279de5f7eea1caa8845558130867bdd2"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Makefile
+++ b/Makefile
@@ -146,24 +146,19 @@ else ifeq ($(ENABLE_LLVM), 1)
 	LLVM_VERSION := $(shell llvm-config --version)
 	compilers += llvm
 	# … or try to autodetect LLVM from `llvm-config-<version>`.
-else ifneq (, $(shell which llvm-config-14 2>/dev/null))
-	LLVM_VERSION := $(shell llvm-config-14 --version)
-	compilers += llvm
-	# need force LLVM_SYS_140_PREFIX, or llvm_sys will not build in the case
-	export LLVM_SYS_140_PREFIX = $(shell llvm-config-14 --prefix)
 else ifneq (, $(shell which llvm-config-15 2>/dev/null))
 	LLVM_VERSION := $(shell llvm-config-15 --version)
 	compilers += llvm
-	# need force LLVM_SYS_140_PREFIX, or llvm_sys will not build in the case
-	export LLVM_SYS_140_PREFIX = $(shell llvm-config-15 --prefix)
+	# need force LLVM_SYS_150_PREFIX, or llvm_sys will not build in the case
+	export LLVM_SYS_150_PREFIX = $(shell llvm-config-15 --prefix)
 else ifneq (, $(shell which llvm-config 2>/dev/null))
 	LLVM_VERSION := $(shell llvm-config --version)
 	ifneq (, $(findstring 15,$(LLVM_VERSION)))
 		compilers += llvm
-		export LLVM_SYS_140_PREFIX = $(shell llvm-config --prefix)
+		export LLVM_SYS_150_PREFIX = $(shell llvm-config --prefix)
 	else ifneq (, $(findstring 14,$(LLVM_VERSION)))
 		compilers += llvm
-		export LLVM_SYS_140_PREFIX = $(shell llvm-config --prefix)
+		export LLVM_SYS_150_PREFIX = $(shell llvm-config --prefix)
 	endif
 endif
 

--- a/lib/compiler-llvm/Cargo.toml
+++ b/lib/compiler-llvm/Cargo.toml
@@ -31,7 +31,7 @@ rayon = "1.5"
 package = "inkwell"
 version = "0.1.1"
 default-features = false
-features = ["llvm14-0", "target-x86", "target-aarch64", "target-riscv"]
+features = ["llvm15-0", "target-x86", "target-aarch64", "target-riscv"]
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/compiler-llvm/README.md
+++ b/lib/compiler-llvm/README.md
@@ -23,7 +23,7 @@ to native speeds.
 ## Requirements
 
 The LLVM compiler requires a valid installation of LLVM in your system.
-It currently requires **LLVM 14**.
+It currently requires **LLVM 15**.
 
 
 You can install LLVM easily on your Debian-like system via this command:

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -246,13 +246,12 @@ impl Abi for Aarch64SystemV {
         let sret = if llvm_fn_ty.get_return_type().is_none() && func_sig.results().len() > 1 {
             let llvm_params: Vec<_> = func_sig
                 .results()
-                .to_vec()
-                .into_iter()
-                .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                .iter()
+                .map(|x| type_to_llvm(intrinsics, *x).unwrap())
                 .collect();
             let llvm_params = llvm_fn_ty
                 .get_context()
-                .struct_type(&llvm_params.as_slice(), false);
+                .struct_type(llvm_params.as_slice(), false);
             Some(alloca_builder.build_alloca(llvm_params, "sret"))
         } else {
             None
@@ -439,13 +438,13 @@ impl Abi for Aarch64SystemV {
                 // re-build the llvm-type struct holding the return values
                 let llvm_results: Vec<_> = func_sig
                     .results()
-                    .into_iter()
-                    .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                    .iter()
+                    .map(|x| type_to_llvm(intrinsics, *x).unwrap())
                     .collect();
                 let struct_type = intrinsics
                     .i32_ty
                     .get_context()
-                    .struct_type(&llvm_results.as_slice(), false);
+                    .struct_type(llvm_results.as_slice(), false);
 
                 let struct_value = builder
                     .build_load(struct_type, sret, "")

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -237,21 +237,23 @@ impl Abi for Aarch64SystemV {
         &self,
         alloca_builder: &Builder<'ctx>,
         func_sig: &FuncSig,
-        ctx_ptr: PointerValue<'ctx>,
         llvm_fn_ty: &FunctionType<'ctx>,
+        ctx_ptr: PointerValue<'ctx>,
         values: &[BasicValueEnum<'ctx>],
+        intrinsics: &Intrinsics<'ctx>,
     ) -> Vec<BasicValueEnum<'ctx>> {
         // If it's an sret, allocate the return space.
         let sret = if llvm_fn_ty.get_return_type().is_none() && func_sig.results().len() > 1 {
-            Some(
-                alloca_builder.build_alloca(
-                    llvm_fn_ty.get_param_types()[0]
-                        .into_pointer_type()
-                        .get_element_type()
-                        .into_struct_type(),
-                    "sret",
-                ),
-            )
+            let llvm_params: Vec<_> = func_sig
+                .results()
+                .to_vec()
+                .into_iter()
+                .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                .collect();
+            let llvm_params = llvm_fn_ty
+                .get_context()
+                .struct_type(&llvm_params.as_slice(), false);
+            Some(alloca_builder.build_alloca(llvm_params, "sret"))
         } else {
             None
         };
@@ -425,16 +427,29 @@ impl Abi for Aarch64SystemV {
                 )
                 .is_some()
             {
-                let sret = call_site
+                let sret_ty = call_site
                     .try_as_basic_value()
                     .right()
                     .unwrap()
                     .get_operand(0)
                     .unwrap()
                     .left()
-                    .unwrap()
-                    .into_pointer_value();
-                let struct_value = builder.build_load(sret, "").into_struct_value();
+                    .unwrap();
+                let sret = sret_ty.into_pointer_value();
+                // re-build the llvm-type struct holding the return values
+                let llvm_results: Vec<_> = func_sig
+                    .results()
+                    .into_iter()
+                    .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                    .collect();
+                let struct_type = intrinsics
+                    .i32_ty
+                    .get_context()
+                    .struct_type(&llvm_results.as_slice(), false);
+
+                let struct_value = builder
+                    .build_load(struct_type, sret, "")
+                    .into_struct_value();
                 let mut rets: Vec<_> = Vec::new();
                 for i in 0..struct_value.get_type().count_fields() {
                     let value = builder.build_extract_value(struct_value, i, "").unwrap();

--- a/lib/compiler-llvm/src/abi/mod.rs
+++ b/lib/compiler-llvm/src/abi/mod.rs
@@ -59,9 +59,10 @@ pub trait Abi {
         &self,
         alloca_builder: &Builder<'ctx>,
         func_sig: &FuncSig,
-        ctx_ptr: PointerValue<'ctx>,
         llvm_fn_ty: &FunctionType<'ctx>,
+        ctx_ptr: PointerValue<'ctx>,
         values: &[BasicValueEnum<'ctx>],
+        intrinsics: &Intrinsics<'ctx>,
     ) -> Vec<BasicValueEnum<'ctx>>;
 
     /// Given a CallSite, extract the returned values and return them in a Vec.

--- a/lib/compiler-llvm/src/abi/x86_64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/x86_64_systemv.rs
@@ -291,21 +291,23 @@ impl Abi for X86_64SystemV {
         &self,
         alloca_builder: &Builder<'ctx>,
         func_sig: &FuncSig,
-        ctx_ptr: PointerValue<'ctx>,
         llvm_fn_ty: &FunctionType<'ctx>,
+        ctx_ptr: PointerValue<'ctx>,
         values: &[BasicValueEnum<'ctx>],
+        intrinsics: &Intrinsics<'ctx>,
     ) -> Vec<BasicValueEnum<'ctx>> {
         // If it's an sret, allocate the return space.
         let sret = if llvm_fn_ty.get_return_type().is_none() && func_sig.results().len() > 1 {
-            Some(
-                alloca_builder.build_alloca(
-                    llvm_fn_ty.get_param_types()[0]
-                        .into_pointer_type()
-                        .get_element_type()
-                        .into_struct_type(),
-                    "sret",
-                ),
-            )
+            let llvm_params: Vec<_> = func_sig
+                .results()
+                .to_vec()
+                .into_iter()
+                .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                .collect();
+            let llvm_params = llvm_fn_ty
+                .get_context()
+                .struct_type(&llvm_params.as_slice(), false);
+            Some(alloca_builder.build_alloca(llvm_params, "sret"))
         } else {
             None
         };
@@ -476,16 +478,29 @@ impl Abi for X86_64SystemV {
                 )
                 .is_some()
             {
-                let sret = call_site
+                let sret_ty = call_site
                     .try_as_basic_value()
                     .right()
                     .unwrap()
                     .get_operand(0)
                     .unwrap()
                     .left()
-                    .unwrap()
-                    .into_pointer_value();
-                let struct_value = builder.build_load(sret, "").into_struct_value();
+                    .unwrap();
+                let sret = sret_ty.into_pointer_value();
+                // re-build the llvm-type struct holding the return values
+                let llvm_results: Vec<_> = func_sig
+                    .results()
+                    .into_iter()
+                    .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                    .collect();
+                let struct_type = intrinsics
+                    .i32_ty
+                    .get_context()
+                    .struct_type(&llvm_results.as_slice(), false);
+
+                let struct_value = builder
+                    .build_load(struct_type, sret, "")
+                    .into_struct_value();
                 let mut rets: Vec<_> = Vec::new();
                 for i in 0..struct_value.get_type().count_fields() {
                     let value = builder.build_extract_value(struct_value, i, "").unwrap();

--- a/lib/compiler-llvm/src/abi/x86_64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/x86_64_systemv.rs
@@ -300,13 +300,12 @@ impl Abi for X86_64SystemV {
         let sret = if llvm_fn_ty.get_return_type().is_none() && func_sig.results().len() > 1 {
             let llvm_params: Vec<_> = func_sig
                 .results()
-                .to_vec()
-                .into_iter()
-                .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                .iter()
+                .map(|x| type_to_llvm(intrinsics, *x).unwrap())
                 .collect();
             let llvm_params = llvm_fn_ty
                 .get_context()
-                .struct_type(&llvm_params.as_slice(), false);
+                .struct_type(llvm_params.as_slice(), false);
             Some(alloca_builder.build_alloca(llvm_params, "sret"))
         } else {
             None
@@ -490,13 +489,13 @@ impl Abi for X86_64SystemV {
                 // re-build the llvm-type struct holding the return values
                 let llvm_results: Vec<_> = func_sig
                     .results()
-                    .into_iter()
-                    .map(|x| type_to_llvm(intrinsics, x.clone()).unwrap())
+                    .iter()
+                    .map(|x| type_to_llvm(intrinsics, *x).unwrap())
                     .collect();
                 let struct_type = intrinsics
                     .i32_ty
                     .get_context()
-                    .struct_type(&llvm_results.as_slice(), false);
+                    .struct_type(llvm_results.as_slice(), false);
 
                 let struct_value = builder
                     .build_load(struct_type, sret, "")

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -456,7 +456,7 @@ impl FuncTrampoline {
                 .map(|(idx, ty)| {
                     let ptr = unsafe {
                         builder.build_gep(
-                            intrinsics.i32_ty,
+                            intrinsics.i128_ty,
                             values,
                             &[intrinsics.i32_ty.const_int(idx.try_into().unwrap(), false)],
                             "",
@@ -464,7 +464,7 @@ impl FuncTrampoline {
                     };
                     let ptr =
                         builder.build_pointer_cast(ptr, type_to_llvm_ptr(intrinsics, *ty)?, "");
-                    Ok(builder.build_load(intrinsics.i32_ptr_ty, ptr, ""))
+                    Ok(builder.build_load(type_to_llvm(intrinsics, *ty)?, ptr, ""))
                 })
                 .collect::<Result<Vec<_>, CompileError>>()?;
 

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -9,15 +9,14 @@ use inkwell::{
     module::{Linkage, Module},
     passes::PassManager,
     targets::{FileType, TargetMachine},
-    types::BasicType,
+    types::{BasicType, FunctionType},
     values::FunctionValue,
     AddressSpace, DLLStorageClass,
 };
 use std::cmp;
-use std::convert::TryFrom;
 use std::convert::TryInto;
 use wasmer_types::{
-    CompileError, FunctionBody, FunctionType, LocalFunctionIndex, RelocationTarget,
+    CompileError, FunctionBody, FunctionType as FuncType, LocalFunctionIndex, RelocationTarget,
 };
 
 pub struct FuncTrampoline {
@@ -40,7 +39,7 @@ impl FuncTrampoline {
 
     pub fn trampoline_to_module(
         &self,
-        ty: &FunctionType,
+        ty: &FuncType,
         config: &LLVM,
         name: &str,
     ) -> Result<Module, CompileError> {
@@ -76,7 +75,14 @@ impl FuncTrampoline {
         trampoline_func
             .as_global_value()
             .set_dll_storage_class(DLLStorageClass::Export);
-        self.generate_trampoline(trampoline_func, ty, &callee_attrs, &self.ctx, &intrinsics)?;
+        self.generate_trampoline(
+            trampoline_func,
+            ty,
+            callee_ty,
+            &callee_attrs,
+            &self.ctx,
+            &intrinsics,
+        )?;
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.preopt_ir(&function, &module);
@@ -101,7 +107,7 @@ impl FuncTrampoline {
 
     pub fn trampoline(
         &self,
-        ty: &FunctionType,
+        ty: &FuncType,
         config: &LLVM,
         name: &str,
     ) -> Result<FunctionBody, CompileError> {
@@ -166,7 +172,7 @@ impl FuncTrampoline {
 
     pub fn dynamic_trampoline_to_module(
         &self,
-        ty: &FunctionType,
+        ty: &FuncType,
         config: &LLVM,
         name: &str,
     ) -> Result<Module, CompileError> {
@@ -220,7 +226,7 @@ impl FuncTrampoline {
     }
     pub fn dynamic_trampoline(
         &self,
-        ty: &FunctionType,
+        ty: &FuncType,
         config: &LLVM,
         name: &str,
     ) -> Result<FunctionBody, CompileError> {
@@ -287,7 +293,8 @@ impl FuncTrampoline {
     fn generate_trampoline<'ctx>(
         &self,
         trampoline_func: FunctionValue,
-        func_sig: &FunctionType,
+        func_sig: &FuncType,
+        llvm_func_type: FunctionType,
         func_attrs: &[(Attribute, AttributeLoc)],
         context: &'ctx Context,
         intrinsics: &Intrinsics<'ctx>,
@@ -328,20 +335,22 @@ impl FuncTrampoline {
 
         for (i, param_ty) in func_sig.params().iter().enumerate() {
             let index = intrinsics.i32_ty.const_int(i as _, false);
-            let item_pointer =
-                unsafe { builder.build_in_bounds_gep(args_rets_ptr, &[index], "arg_ptr") };
+            let item_pointer = unsafe {
+                builder.build_in_bounds_gep(intrinsics.i128_ty, args_rets_ptr, &[index], "arg_ptr")
+            };
 
+            let casted_type = type_to_llvm(intrinsics, *param_ty)?;
             let casted_pointer_type = type_to_llvm_ptr(intrinsics, *param_ty)?;
 
             let typed_item_pointer =
                 builder.build_pointer_cast(item_pointer, casted_pointer_type, "typed_arg_pointer");
 
-            let arg = builder.build_load(typed_item_pointer, "arg");
+            let arg = builder.build_load(casted_type, typed_item_pointer, "arg");
             args_vec.push(arg.into());
         }
 
-        let callable_func = inkwell::values::CallableValue::try_from(func_ptr).unwrap();
-        let call_site = builder.build_call(callable_func, args_vec.as_slice(), "call");
+        let call_site =
+            builder.build_indirect_call(llvm_func_type, func_ptr, args_vec.as_slice(), "call");
         for (attr, attr_loc) in func_attrs {
             call_site.add_attribute(*attr_loc, *attr);
         }
@@ -353,6 +362,7 @@ impl FuncTrampoline {
         rets.iter().for_each(|v| {
             let ptr = unsafe {
                 builder.build_gep(
+                    intrinsics.i64_ty,
                     args_rets_ptr,
                     &[intrinsics.i32_ty.const_int(idx, false)],
                     "",
@@ -374,7 +384,7 @@ impl FuncTrampoline {
     fn generate_dynamic_trampoline<'ctx>(
         &self,
         trampoline_func: FunctionValue,
-        func_sig: &FunctionType,
+        func_sig: &FuncType,
         context: &'ctx Context,
         intrinsics: &Intrinsics<'ctx>,
     ) -> Result<(), CompileError> {
@@ -396,12 +406,10 @@ impl FuncTrampoline {
         for i in 0..func_sig.params().len() {
             let ptr = unsafe {
                 builder.build_in_bounds_gep(
+                    intrinsics.i128_ty,
                     values,
-                    &[
-                        intrinsics.i32_zero,
-                        intrinsics.i32_ty.const_int(i.try_into().unwrap(), false),
-                    ],
-                    "",
+                    &[intrinsics.i32_ty.const_int(i.try_into().unwrap(), false)],
+                    "args",
                 )
             };
             let ptr = builder
@@ -415,29 +423,28 @@ impl FuncTrampoline {
             );
         }
 
-        let callee_ty = intrinsics
-            .void_ty
-            .fn_type(
-                &[
-                    intrinsics.ctx_ptr_ty.into(),  // vmctx ptr
-                    intrinsics.i128_ptr_ty.into(), // in/out values ptr
-                ],
-                false,
-            )
-            .ptr_type(AddressSpace::default());
+        let callee_ptr_ty = intrinsics.void_ty.fn_type(
+            &[
+                intrinsics.ctx_ptr_ty.into(),  // vmctx ptr
+                intrinsics.i128_ptr_ty.into(), // in/out values ptr
+            ],
+            false,
+        );
+        let callee_ty = callee_ptr_ty.ptr_type(AddressSpace::default());
         let vmctx = self.abi.get_vmctx_ptr_param(&trampoline_func);
+        let callee_ty =
+            builder.build_bitcast(vmctx, callee_ty.ptr_type(AddressSpace::default()), "");
         let callee = builder
-            .build_load(
-                builder
-                    .build_bitcast(vmctx, callee_ty.ptr_type(AddressSpace::default()), "")
-                    .into_pointer_value(),
-                "",
-            )
+            .build_load(intrinsics.ctx_ptr_ty, callee_ty.into_pointer_value(), "")
             .into_pointer_value();
 
         let values_ptr = builder.build_pointer_cast(values, intrinsics.i128_ptr_ty, "");
-        let callable_func = inkwell::values::CallableValue::try_from(callee).unwrap();
-        builder.build_call(callable_func, &[vmctx.into(), values_ptr.into()], "");
+        builder.build_indirect_call(
+            callee_ptr_ty,
+            callee,
+            &[vmctx.into(), values_ptr.into()],
+            "",
+        );
 
         if func_sig.results().is_empty() {
             builder.build_return(None);
@@ -449,17 +456,15 @@ impl FuncTrampoline {
                 .map(|(idx, ty)| {
                     let ptr = unsafe {
                         builder.build_gep(
+                            intrinsics.i32_ty,
                             values,
-                            &[
-                                intrinsics.i32_ty.const_zero(),
-                                intrinsics.i32_ty.const_int(idx.try_into().unwrap(), false),
-                            ],
+                            &[intrinsics.i32_ty.const_int(idx.try_into().unwrap(), false)],
                             "",
                         )
                     };
                     let ptr =
                         builder.build_pointer_cast(ptr, type_to_llvm_ptr(intrinsics, *ty)?, "");
-                    Ok(builder.build_load(ptr, ""))
+                    Ok(builder.build_load(intrinsics.i32_ptr_ty, ptr, ""))
                 })
                 .collect::<Result<Vec<_>, CompileError>>()?;
 
@@ -468,11 +473,14 @@ impl FuncTrampoline {
                     .get_first_param()
                     .unwrap()
                     .into_pointer_value();
-                let mut struct_value = sret
-                    .get_type()
-                    .get_element_type()
-                    .into_struct_type()
-                    .get_undef();
+
+                let basic_types: Vec<_> = func_sig
+                    .results()
+                    .iter()
+                    .map(|&ty| type_to_llvm(intrinsics, ty))
+                    .collect::<Result<_, _>>()?;
+                let mut struct_value = context.struct_type(&basic_types, false).get_undef();
+
                 for (idx, value) in results.iter().enumerate() {
                     let value = builder.build_bitcast(
                         *value,

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -362,7 +362,7 @@ impl FuncTrampoline {
         rets.iter().for_each(|v| {
             let ptr = unsafe {
                 builder.build_gep(
-                    intrinsics.i64_ty,
+                    intrinsics.i128_ty,
                     args_rets_ptr,
                     &[intrinsics.i32_ty.const_int(idx, false)],
                     "",
@@ -371,9 +371,6 @@ impl FuncTrampoline {
             let ptr =
                 builder.build_pointer_cast(ptr, v.get_type().ptr_type(AddressSpace::default()), "");
             builder.build_store(ptr, *v);
-            if v.get_type() == intrinsics.i128_ty.as_basic_type_enum() {
-                idx += 1;
-            }
             idx += 1;
         });
 

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -12,7 +12,7 @@ use inkwell::{
     module::{Linkage, Module},
     passes::PassManager,
     targets::{FileType, TargetMachine},
-    types::{BasicType, FloatMathType, IntType, PointerType, VectorType},
+    types::{BasicType, BasicTypeEnum, FloatMathType, IntType, PointerType, VectorType},
     values::{
         BasicMetadataValueEnum, BasicValue, BasicValueEnum, FloatValue, FunctionValue,
         InstructionOpcode, InstructionValue, IntValue, PhiValue, PointerValue, VectorValue,
@@ -24,7 +24,6 @@ use smallvec::SmallVec;
 use crate::abi::{get_abi, Abi};
 use crate::config::{CompiledKind, LLVM};
 use crate::object_file::{load_object_file, CompiledFunction};
-use std::convert::TryFrom;
 use wasmer_compiler::wasmparser::{MemArg, Operator};
 use wasmer_compiler::{
     from_binaryreadererror_wasmerror, wptype_to_type, FunctionBinaryReader, FunctionBodyData,
@@ -168,7 +167,7 @@ impl FuncTranslator {
                 .unwrap();
             let alloca = insert_alloca(ty, "param");
             cache_builder.build_store(alloca, value);
-            params.push(alloca);
+            params.push((ty, alloca));
         }
 
         let mut locals = vec![];
@@ -180,7 +179,7 @@ impl FuncTranslator {
             for _ in 0..count {
                 let alloca = insert_alloca(ty, "local");
                 cache_builder.build_store(alloca, ty.const_zero());
-                locals.push(alloca);
+                locals.push((ty, alloca));
             }
         }
 
@@ -209,6 +208,7 @@ impl FuncTranslator {
         fcg.ctx.add_func(
             func_index,
             func.as_global_value().as_pointer_value(),
+            func_type,
             fcg.ctx.basic(),
             &func_attrs,
         );
@@ -243,7 +243,6 @@ impl FuncTranslator {
         pass_manager.add_cfg_simplification_pass();
         pass_manager.add_reassociate_pass();
         pass_manager.add_loop_rotate_pass();
-        pass_manager.add_loop_unswitch_pass();
         pass_manager.add_ind_var_simplify_pass();
         pass_manager.add_licm_pass();
         pass_manager.add_loop_vectorize_pass();
@@ -1099,7 +1098,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                         let load_offset_end = builder.build_int_add(offset, value_size_v, "");
 
                         let current_length = builder
-                            .build_load(ptr_to_current_length, "")
+                            .build_load(self.intrinsics.i32_ty, ptr_to_current_length, "")
                             .into_int_value();
                         tbaa_label(
                             self.module,
@@ -1157,7 +1156,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                         builder.build_unreachable();
                         builder.position_at_end(in_bounds_continue_block);
                     }
-                    let ptr_to_base = builder.build_load(ptr_to_base_ptr, "").into_pointer_value();
+                    let ptr_to_base = builder
+                        .build_load(intrinsics.i8_ptr_ty, ptr_to_base_ptr, "")
+                        .into_pointer_value();
                     tbaa_label(
                         self.module,
                         self.intrinsics,
@@ -1168,7 +1169,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 }
                 MemoryCache::Static { base_ptr } => base_ptr,
             };
-        let value_ptr = unsafe { builder.build_gep(base_ptr, &[offset], "") };
+        let value_ptr =
+            unsafe { builder.build_gep(self.intrinsics.i8_ty, base_ptr, &[offset], "") };
         Ok(builder
             .build_bitcast(value_ptr, ptr_ty, "")
             .into_pointer_value())
@@ -1239,10 +1241,14 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 .get_first_param()
                 .unwrap()
                 .into_pointer_value();
-            let mut struct_value = sret
-                .get_type()
-                .get_element_type()
-                .into_struct_type()
+            let llvm_params: Vec<_> = wasm_fn_type
+                .results()
+                .into_iter()
+                .map(|x| type_to_llvm(self.intrinsics, x.clone()).unwrap())
+                .collect();
+            let mut struct_value = self
+                .context
+                .struct_type(&llvm_params.as_slice(), false)
                 .get_undef();
             for (idx, value) in results.enumerate() {
                 let value = self.builder.build_bitcast(
@@ -1363,7 +1369,7 @@ pub struct LLVMFunctionCodeGenerator<'ctx, 'a> {
     intrinsics: &'a Intrinsics<'ctx>,
     state: State<'ctx>,
     function: FunctionValue<'ctx>,
-    locals: Vec<PointerValue<'ctx>>, // Contains params and locals
+    locals: Vec<(BasicTypeEnum<'ctx>, PointerValue<'ctx>)>, // Contains params and locals
     ctx: CtxType<'ctx, 'a>,
     unreachable_depth: usize,
     memory_styles: &'a PrimaryMap<MemoryIndex, MemoryStyle>,
@@ -2023,8 +2029,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
             // Operate on self.locals.
             Operator::LocalGet { local_index } => {
-                let pointer_value = self.locals[local_index as usize];
-                let v = self.builder.build_load(pointer_value, "");
+                let (type_value, pointer_value) = self.locals[local_index as usize];
+                let v = self.builder.build_load(type_value, pointer_value, "");
                 tbaa_label(
                     self.module,
                     self.intrinsics,
@@ -2034,7 +2040,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.state.push1(v);
             }
             Operator::LocalSet { local_index } => {
-                let pointer_value = self.locals[local_index as usize];
+                let pointer_value = self.locals[local_index as usize].1;
                 let (v, i) = self.state.pop1_extra()?;
                 let v = self.apply_pending_canonicalization(v, i);
                 let store = self.builder.build_store(pointer_value, v);
@@ -2046,7 +2052,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 );
             }
             Operator::LocalTee { local_index } => {
-                let pointer_value = self.locals[local_index as usize];
+                let pointer_value = self.locals[local_index as usize].1;
                 let (v, i) = self.state.peek1_extra()?;
                 let v = self.apply_pending_canonicalization(v, i);
                 let store = self.builder.build_store(pointer_value, v);
@@ -2067,8 +2073,11 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     GlobalCache::Const { value } => {
                         self.state.push1(*value);
                     }
-                    GlobalCache::Mut { ptr_to_value } => {
-                        let value = self.builder.build_load(*ptr_to_value, "");
+                    GlobalCache::Mut {
+                        ptr_to_value,
+                        value_type,
+                    } => {
+                        let value = self.builder.build_load(*value_type, *ptr_to_value, "");
                         tbaa_label(
                             self.module,
                             self.intrinsics,
@@ -2091,7 +2100,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                             global_index.as_u32()
                         )))
                     }
-                    GlobalCache::Mut { ptr_to_value } => {
+                    GlobalCache::Mut { ptr_to_value, .. } => {
                         let ptr_to_value = *ptr_to_value;
                         let (value, info) = self.state.pop1_extra()?;
                         let value = self.apply_pending_canonicalization(value, info);
@@ -2157,6 +2166,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let FunctionCache {
                     func,
+                    llvm_func_type,
                     vmctx: callee_vmctx,
                     attrs,
                 } = if let Some(local_func_index) = self.wasm_module.local_func_index(func_index) {
@@ -2176,6 +2186,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     self.ctx
                         .func(func_index, self.intrinsics, self.context, func_type)?
                 };
+                let llvm_func_type = llvm_func_type.clone();
                 let func = *func;
                 let callee_vmctx = *callee_vmctx;
                 let attrs = attrs.clone();
@@ -2188,31 +2199,32 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let params = self.state.popn_save_extra(func_type.params().len())?;
 
                 // Apply pending canonicalizations.
-                let params =
-                    params
-                        .iter()
-                        .zip(func_type.params().iter())
-                        .map(|((v, info), wasm_ty)| match wasm_ty {
-                            Type::F32 => self.builder.build_bitcast(
-                                self.apply_pending_canonicalization(*v, *info),
-                                self.intrinsics.f32_ty,
-                                "",
-                            ),
-                            Type::F64 => self.builder.build_bitcast(
-                                self.apply_pending_canonicalization(*v, *info),
-                                self.intrinsics.f64_ty,
-                                "",
-                            ),
-                            Type::V128 => self.apply_pending_canonicalization(*v, *info),
-                            _ => *v,
-                        });
+                let params = params
+                    .iter()
+                    .zip(func_type.params().iter())
+                    .map(|((v, info), wasm_ty)| match wasm_ty {
+                        Type::F32 => self.builder.build_bitcast(
+                            self.apply_pending_canonicalization(*v, *info),
+                            self.intrinsics.f32_ty,
+                            "",
+                        ),
+                        Type::F64 => self.builder.build_bitcast(
+                            self.apply_pending_canonicalization(*v, *info),
+                            self.intrinsics.f64_ty,
+                            "",
+                        ),
+                        Type::V128 => self.apply_pending_canonicalization(*v, *info),
+                        _ => *v,
+                    })
+                    .collect::<Vec<_>>();
 
                 let params = self.abi.args_to_call(
                     &self.alloca_builder,
                     func_type,
+                    &llvm_func_type,
                     callee_vmctx.into_pointer_value(),
-                    &func.get_type().get_element_type().into_function_type(),
-                    params.collect::<Vec<_>>().as_slice(),
+                    params.as_slice(),
+                    self.intrinsics,
                 );
 
                 /*
@@ -2234,10 +2246,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     }
                 }
                 */
-
-                let callable_func = inkwell::values::CallableValue::try_from(func).unwrap();
-                let call_site = self.builder.build_call(
-                    callable_func,
+                let call_site = self.builder.build_indirect_call(
+                    llvm_func_type,
+                    func,
                     params
                         .iter()
                         .copied()
@@ -2346,6 +2357,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
 
                 let funcref_ptr = unsafe {
                     self.builder.build_in_bounds_gep(
+                        self.intrinsics.funcref_ty,
                         casted_table_base,
                         &[func_index],
                         "funcref_ptr",
@@ -2355,7 +2367,11 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 // a funcref (pointer to `anyfunc`)
                 let anyfunc_struct_ptr = self
                     .builder
-                    .build_load(funcref_ptr, "anyfunc_struct_ptr")
+                    .build_load(
+                        self.intrinsics.funcref_ty,
+                        funcref_ptr,
+                        "anyfunc_struct_ptr",
+                    )
                     .into_pointer_value();
 
                 // trap if we're trying to call a null funcref
@@ -2387,29 +2403,42 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 }
 
                 // Load things from the anyfunc data structure.
+                let func_ptr_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        self.intrinsics.anyfunc_ty,
+                        anyfunc_struct_ptr,
+                        0,
+                        "func_ptr_ptr",
+                    )
+                    .unwrap();
+                let sigindex_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        self.intrinsics.anyfunc_ty,
+                        anyfunc_struct_ptr,
+                        1,
+                        "sigindex_ptr",
+                    )
+                    .unwrap();
+                let ctx_ptr_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        self.intrinsics.anyfunc_ty,
+                        anyfunc_struct_ptr,
+                        2,
+                        "ctx_ptr_ptr",
+                    )
+                    .unwrap();
                 let (func_ptr, found_dynamic_sigindex, ctx_ptr) = (
                     self.builder
-                        .build_load(
-                            self.builder
-                                .build_struct_gep(anyfunc_struct_ptr, 0, "func_ptr_ptr")
-                                .unwrap(),
-                            "func_ptr",
-                        )
+                        .build_load(self.intrinsics.i8_ptr_ty, func_ptr_ptr, "func_ptr")
                         .into_pointer_value(),
                     self.builder
-                        .build_load(
-                            self.builder
-                                .build_struct_gep(anyfunc_struct_ptr, 1, "sigindex_ptr")
-                                .unwrap(),
-                            "sigindex",
-                        )
+                        .build_load(self.intrinsics.i32_ty, sigindex_ptr, "sigindex")
                         .into_int_value(),
-                    self.builder.build_load(
-                        self.builder
-                            .build_struct_gep(anyfunc_struct_ptr, 2, "ctx_ptr_ptr")
-                            .unwrap(),
-                        "ctx_ptr",
-                    ),
+                    self.builder
+                        .build_load(self.intrinsics.ctx_ptr_ty, ctx_ptr_ptr, "ctx_ptr"),
                 );
 
                 // Next, check if the table element is initialized.
@@ -2502,9 +2531,10 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let params = self.abi.args_to_call(
                     &self.alloca_builder,
                     func_type,
-                    ctx_ptr.into_pointer_value(),
                     &llvm_func_type,
+                    ctx_ptr.into_pointer_value(),
                     params.collect::<Vec<_>>().as_slice(),
+                    self.intrinsics,
                 );
 
                 let typed_func_ptr = self.builder.build_pointer_cast(
@@ -2532,10 +2562,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     }
                 }
                 */
-                let callable_func =
-                    inkwell::values::CallableValue::try_from(typed_func_ptr).unwrap();
-                let call_site = self.builder.build_call(
-                    callable_func,
+                let call_site = self.builder.build_indirect_call(
+                    llvm_func_type,
+                    typed_func_ptr,
                     params
                         .iter()
                         .copied()
@@ -7628,7 +7657,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let result = self.builder.build_load(effective_address, "");
+                let result = self
+                    .builder
+                    .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7647,7 +7678,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let result = self.builder.build_load(effective_address, "");
+                let result = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7666,7 +7699,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let result = self.builder.build_load(effective_address, "");
+                let result = self
+                    .builder
+                    .build_load(self.intrinsics.f32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7685,7 +7720,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let result = self.builder.build_load(effective_address, "");
+                let result = self
+                    .builder
+                    .build_load(self.intrinsics.f64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7704,7 +7741,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     16,
                 )?;
-                let result = self.builder.build_load(effective_address, "");
+                let result =
+                    self.builder
+                        .build_load(self.intrinsics.i128_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7725,7 +7764,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let element = self.builder.build_load(effective_address, "");
+                let element = self
+                    .builder
+                    .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7749,7 +7790,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let element = self.builder.build_load(effective_address, "");
+                let element =
+                    self.builder
+                        .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7773,7 +7816,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let element = self.builder.build_load(effective_address, "");
+                let element =
+                    self.builder
+                        .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7797,7 +7842,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let element = self.builder.build_load(effective_address, "");
+                let element =
+                    self.builder
+                        .build_load(self.intrinsics.i64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7821,7 +7868,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7842,7 +7891,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7864,7 +7915,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.f32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7886,7 +7939,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.f64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7908,7 +7963,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     16,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i128_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7931,7 +7988,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7956,7 +8015,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -7981,7 +8042,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8006,7 +8069,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8028,7 +8093,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8052,7 +8119,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8078,7 +8147,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 )?;
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i8_ty, effective_address, "")
                     .into_int_value();
                 self.annotate_user_memaccess(
                     memory_index,
@@ -8103,7 +8172,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 )?;
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i16_ty, effective_address, "")
                     .into_int_value();
                 self.annotate_user_memaccess(
                     memory_index,
@@ -8126,7 +8195,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8151,7 +8222,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8175,7 +8248,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8199,7 +8274,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8223,7 +8300,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8247,7 +8326,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let narrow_result = self.builder.build_load(effective_address, "");
+                let narrow_result =
+                    self.builder
+                        .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8273,7 +8354,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8297,7 +8380,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8321,7 +8406,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let dead_load = self.builder.build_load(effective_address, "");
+                let dead_load =
+                    self.builder
+                        .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8703,7 +8790,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let v = self.builder.build_load(effective_address, "");
+                let v = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let v = self
                     .builder
                     .build_bitcast(v, self.intrinsics.i8_ty.vec_type(8), "")
@@ -8724,7 +8813,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let v = self.builder.build_load(effective_address, "");
+                let v = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let v = self
                     .builder
                     .build_bitcast(v, self.intrinsics.i8_ty.vec_type(8), "")
@@ -8745,7 +8836,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let v = self.builder.build_load(effective_address, "");
+                let v = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let v = self
                     .builder
                     .build_bitcast(v, self.intrinsics.i16_ty.vec_type(4), "")
@@ -8766,7 +8859,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let v = self.builder.build_load(effective_address, "");
+                let v = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let v = self
                     .builder
                     .build_bitcast(v, self.intrinsics.i16_ty.vec_type(4), "")
@@ -8787,7 +8882,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let v = self.builder.build_load(effective_address, "");
+                let v = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let v = self
                     .builder
                     .build_bitcast(v, self.intrinsics.i32_ty.vec_type(2), "")
@@ -8808,7 +8905,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let v = self.builder.build_load(effective_address, "");
+                let v = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let v = self
                     .builder
                     .build_bitcast(v, self.intrinsics.i32_ty.vec_type(2), "")
@@ -8829,7 +8928,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let elem = self.builder.build_load(effective_address, "");
+                let elem = self
+                    .builder
+                    .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8853,7 +8954,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let elem = self.builder.build_load(effective_address, "");
+                let elem = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8877,7 +8980,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     1,
                 )?;
-                let elem = self.builder.build_load(effective_address, "");
+                let elem = self
+                    .builder
+                    .build_load(self.intrinsics.i8_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8898,7 +9003,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     2,
                 )?;
-                let elem = self.builder.build_load(effective_address, "");
+                let elem = self
+                    .builder
+                    .build_load(self.intrinsics.i16_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8919,7 +9026,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     4,
                 )?;
-                let elem = self.builder.build_load(effective_address, "");
+                let elem = self
+                    .builder
+                    .build_load(self.intrinsics.i32_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8940,7 +9049,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     offset,
                     8,
                 )?;
-                let elem = self.builder.build_load(effective_address, "");
+                let elem = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 self.annotate_user_memaccess(
                     memory_index,
                     memarg,
@@ -8971,7 +9082,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     4,
                 )?;
                 self.trap_if_misaligned(memarg, effective_address, 4);
-                let result = self.builder.build_load(effective_address, "");
+                let result = self
+                    .builder
+                    .build_load(self.intrinsics.i32_ty, effective_address, "");
                 let load = result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 4, load)?;
                 load.set_atomic_ordering(AtomicOrdering::SequentiallyConsistent)
@@ -8989,7 +9102,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     8,
                 )?;
                 self.trap_if_misaligned(memarg, effective_address, 8);
-                let result = self.builder.build_load(effective_address, "");
+                let result = self
+                    .builder
+                    .build_load(self.intrinsics.i64_ty, effective_address, "");
                 let load = result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 8, load)?;
                 load.set_atomic_ordering(AtomicOrdering::SequentiallyConsistent)
@@ -9009,7 +9124,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.trap_if_misaligned(memarg, effective_address, 1);
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i8_ty, effective_address, "")
                     .into_int_value();
                 let load = narrow_result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 1, load)?;
@@ -9033,7 +9148,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.trap_if_misaligned(memarg, effective_address, 2);
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i16_ty, effective_address, "")
                     .into_int_value();
                 let load = narrow_result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 2, load)?;
@@ -9057,7 +9172,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.trap_if_misaligned(memarg, effective_address, 1);
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i8_ty, effective_address, "")
                     .into_int_value();
                 let load = narrow_result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 1, load)?;
@@ -9081,7 +9196,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.trap_if_misaligned(memarg, effective_address, 2);
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i16_ty, effective_address, "")
                     .into_int_value();
                 let load = narrow_result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 2, load)?;
@@ -9105,7 +9220,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 self.trap_if_misaligned(memarg, effective_address, 4);
                 let narrow_result = self
                     .builder
-                    .build_load(effective_address, "")
+                    .build_load(self.intrinsics.i32_ty, effective_address, "")
                     .into_int_value();
                 let load = narrow_result.as_instruction_value().unwrap();
                 self.annotate_user_memaccess(memory_index, memarg, 4, load)?;
@@ -10925,9 +11040,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let memory_index = MemoryIndex::from_u32(mem);
                 let delta = self.state.pop1()?;
                 let grow_fn_ptr = self.ctx.memory_grow(memory_index, self.intrinsics);
-                let callable_func = inkwell::values::CallableValue::try_from(grow_fn_ptr).unwrap();
-                let grow = self.builder.build_call(
-                    callable_func,
+                let grow = self.builder.build_indirect_call(
+                    self.intrinsics.memory_grow_ty,
+                    grow_fn_ptr,
                     &[
                         vmctx.as_basic_value_enum().into(),
                         delta.into(),
@@ -10940,9 +11055,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             Operator::MemorySize { mem, mem_byte: _ } => {
                 let memory_index = MemoryIndex::from_u32(mem);
                 let size_fn_ptr = self.ctx.memory_size(memory_index, self.intrinsics);
-                let callable_func = inkwell::values::CallableValue::try_from(size_fn_ptr).unwrap();
-                let size = self.builder.build_call(
-                    callable_func,
+                let size = self.builder.build_indirect_call(
+                    self.intrinsics.memory_size_ty,
+                    size_fn_ptr,
                     &[
                         vmctx.as_basic_value_enum().into(),
                         self.intrinsics.i32_ty.const_int(mem.into(), false).into(),
@@ -11243,10 +11358,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let memory_index = MemoryIndex::from_u32(memarg.memory);
                 let (dst, val, timeout) = self.state.pop3()?;
                 let wait32_fn_ptr = self.ctx.memory_wait32(memory_index, self.intrinsics);
-                let callable_func =
-                    inkwell::values::CallableValue::try_from(wait32_fn_ptr).unwrap();
-                let ret = self.builder.build_call(
-                    callable_func,
+                let ret = self.builder.build_indirect_call(
+                    self.intrinsics.memory_wait32_ty,
+                    wait32_fn_ptr,
                     &[
                         vmctx.as_basic_value_enum().into(),
                         self.intrinsics
@@ -11265,10 +11379,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let memory_index = MemoryIndex::from_u32(memarg.memory);
                 let (dst, val, timeout) = self.state.pop3()?;
                 let wait64_fn_ptr = self.ctx.memory_wait64(memory_index, self.intrinsics);
-                let callable_func =
-                    inkwell::values::CallableValue::try_from(wait64_fn_ptr).unwrap();
-                let ret = self.builder.build_call(
-                    callable_func,
+                let ret = self.builder.build_indirect_call(
+                    self.intrinsics.memory_wait64_ty,
+                    wait64_fn_ptr,
                     &[
                         vmctx.as_basic_value_enum().into(),
                         self.intrinsics
@@ -11287,10 +11400,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let memory_index = MemoryIndex::from_u32(memarg.memory);
                 let (dst, count) = self.state.pop2()?;
                 let notify_fn_ptr = self.ctx.memory_notify(memory_index, self.intrinsics);
-                let callable_func =
-                    inkwell::values::CallableValue::try_from(notify_fn_ptr).unwrap();
-                let cnt = self.builder.build_call(
-                    callable_func,
+                let cnt = self.builder.build_indirect_call(
+                    self.intrinsics.memory_notify_ty,
+                    notify_fn_ptr,
                     &[
                         vmctx.as_basic_value_enum().into(),
                         self.intrinsics

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1243,12 +1243,12 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 .into_pointer_value();
             let llvm_params: Vec<_> = wasm_fn_type
                 .results()
-                .into_iter()
-                .map(|x| type_to_llvm(self.intrinsics, x.clone()).unwrap())
+                .iter()
+                .map(|x| type_to_llvm(self.intrinsics, *x).unwrap())
                 .collect();
             let mut struct_value = self
                 .context
-                .struct_type(&llvm_params.as_slice(), false)
+                .struct_type(llvm_params.as_slice(), false)
                 .get_undef();
             for (idx, value) in results.enumerate() {
                 let value = self.builder.build_bitcast(
@@ -2186,7 +2186,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     self.ctx
                         .func(func_index, self.intrinsics, self.context, func_type)?
                 };
-                let llvm_func_type = llvm_func_type.clone();
+                let llvm_func_type = *llvm_func_type;
                 let func = *func;
                 let callee_vmctx = *callee_vmctx;
                 let attrs = attrs.clone();

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -13,8 +13,8 @@ use inkwell::{
     module::{Linkage, Module},
     targets::TargetData,
     types::{
-        BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FloatType, IntType, PointerType,
-        StructType, VectorType, VoidType,
+        BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FloatType, FunctionType, IntType,
+        PointerType, StructType, VectorType, VoidType,
     },
     values::{
         BasicValue, BasicValueEnum, FloatValue, FunctionValue, InstructionValue, IntValue,
@@ -240,21 +240,28 @@ pub struct Intrinsics<'ctx> {
     pub imported_memory_copy: FunctionValue<'ctx>,
     pub memory_fill: FunctionValue<'ctx>,
     pub imported_memory_fill: FunctionValue<'ctx>,
+    pub memory_size_ty: FunctionType<'ctx>,
+    pub memory_grow_ty: FunctionType<'ctx>,
     pub memory_wait32: FunctionValue<'ctx>,
+    pub memory_wait32_ty: FunctionType<'ctx>,
     pub imported_memory_wait32: FunctionValue<'ctx>,
     pub memory_wait64: FunctionValue<'ctx>,
+    pub memory_wait64_ty: FunctionType<'ctx>,
     pub imported_memory_wait64: FunctionValue<'ctx>,
     pub memory_notify: FunctionValue<'ctx>,
+    pub memory_notify_ty: FunctionType<'ctx>,
     pub imported_memory_notify: FunctionValue<'ctx>,
 
     pub throw_trap: FunctionValue<'ctx>,
 
     // VM builtins.
     pub vmfunction_import_ptr_ty: PointerType<'ctx>,
+    pub vmfunction_import_ty: StructType<'ctx>,
     pub vmfunction_import_body_element: u32,
     pub vmfunction_import_vmctx_element: u32,
 
     pub vmmemory_definition_ptr_ty: PointerType<'ctx>,
+    pub vmmemory_definition_ty: StructType<'ctx>,
     pub vmmemory_definition_base_element: u32,
     pub vmmemory_definition_current_length_element: u32,
 
@@ -999,6 +1006,11 @@ impl<'ctx> Intrinsics<'ctx> {
                 ),
                 None,
             ),
+            memory_size_ty: i32_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
+            memory_grow_ty: i32_ty.fn_type(
+                &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                false,
+            ),
             data_drop: module.add_function(
                 "wasmer_vm_data_drop",
                 void_ty.fn_type(&[ctx_ptr_ty_basic_md, i32_ty_basic_md], false),
@@ -1033,6 +1045,16 @@ impl<'ctx> Intrinsics<'ctx> {
                 ),
                 None,
             ),
+            memory_wait32_ty: i32_ty.fn_type(
+                &[
+                    ctx_ptr_ty_basic_md,
+                    i32_ty_basic_md,
+                    i32_ty_basic_md,
+                    i32_ty_basic_md,
+                    i64_ty_basic_md,
+                ],
+                false,
+            ),
             imported_memory_wait32: module.add_function(
                 "wasmer_vm_imported_memory32_atomic_wait32",
                 i32_ty.fn_type(
@@ -1061,6 +1083,16 @@ impl<'ctx> Intrinsics<'ctx> {
                 ),
                 None,
             ),
+            memory_wait64_ty: i32_ty.fn_type(
+                &[
+                    ctx_ptr_ty_basic_md,
+                    i32_ty_basic_md,
+                    i32_ty_basic_md,
+                    i64_ty_basic_md,
+                    i64_ty_basic_md,
+                ],
+                false,
+            ),
             imported_memory_wait64: module.add_function(
                 "wasmer_vm_imported_memory32_atomic_wait64",
                 i32_ty.fn_type(
@@ -1083,6 +1115,10 @@ impl<'ctx> Intrinsics<'ctx> {
                 ),
                 None,
             ),
+            memory_notify_ty: i32_ty.fn_type(
+                &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                false,
+            ),
             imported_memory_notify: module.add_function(
                 "wasmer_vm_imported_memory32_atomic_notify",
                 i32_ty.fn_type(
@@ -1095,12 +1131,14 @@ impl<'ctx> Intrinsics<'ctx> {
             vmfunction_import_ptr_ty: context
                 .struct_type(&[i8_ptr_ty_basic, i8_ptr_ty_basic], false)
                 .ptr_type(AddressSpace::default()),
+            vmfunction_import_ty: context.struct_type(&[i8_ptr_ty_basic, i8_ptr_ty_basic], false),
             vmfunction_import_body_element: 0,
             vmfunction_import_vmctx_element: 1,
 
             vmmemory_definition_ptr_ty: context
                 .struct_type(&[i8_ptr_ty_basic, isize_ty.into()], false)
                 .ptr_type(AddressSpace::default()),
+            vmmemory_definition_ty: context.struct_type(&[i8_ptr_ty_basic, isize_ty.into()], false),
             vmmemory_definition_base_element: 0,
             vmmemory_definition_current_length_element: 1,
 
@@ -1227,13 +1265,19 @@ struct TableCache<'ctx> {
 
 #[derive(Clone, Copy)]
 pub enum GlobalCache<'ctx> {
-    Mut { ptr_to_value: PointerValue<'ctx> },
-    Const { value: BasicValueEnum<'ctx> },
+    Mut {
+        ptr_to_value: PointerValue<'ctx>,
+        value_type: BasicTypeEnum<'ctx>,
+    },
+    Const {
+        value: BasicValueEnum<'ctx>,
+    },
 }
 
 #[derive(Clone)]
 pub struct FunctionCache<'ctx> {
     pub func: PointerValue<'ctx>,
+    pub llvm_func_type: FunctionType<'ctx>,
     pub vmctx: BasicValueEnum<'ctx>,
     pub attrs: Vec<(Attribute, AttributeLoc)>,
 }
@@ -1303,34 +1347,36 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
         );
         let memory_style = &memory_styles[index];
         *cached_memories.entry(index).or_insert_with(|| {
-            let memory_definition_ptr =
-                if let Some(local_memory_index) = wasm_module.local_memory_index(index) {
-                    let offset = offsets.vmctx_vmmemory_definition(local_memory_index);
-                    let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-                    unsafe { cache_builder.build_gep(ctx_ptr_value, &[offset], "") }
-                } else {
-                    let offset = offsets.vmctx_vmmemory_import(index);
-                    let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-                    let memory_definition_ptr_ptr =
-                        unsafe { cache_builder.build_gep(ctx_ptr_value, &[offset], "") };
-                    let memory_definition_ptr_ptr = cache_builder
-                        .build_bitcast(
-                            memory_definition_ptr_ptr,
-                            intrinsics.i8_ptr_ty.ptr_type(AddressSpace::default()),
-                            "",
-                        )
-                        .into_pointer_value();
-                    let memory_definition_ptr = cache_builder
-                        .build_load(memory_definition_ptr_ptr, "")
-                        .into_pointer_value();
-                    tbaa_label(
-                        module,
-                        intrinsics,
-                        format!("memory {} definition", index.as_u32()),
-                        memory_definition_ptr.as_instruction_value().unwrap(),
-                    );
-                    memory_definition_ptr
+            let memory_definition_ptr = if let Some(local_memory_index) =
+                wasm_module.local_memory_index(index)
+            {
+                let offset = offsets.vmctx_vmmemory_definition(local_memory_index);
+                let offset = intrinsics.i32_ty.const_int(offset.into(), false);
+                unsafe { cache_builder.build_gep(intrinsics.i8_ty, ctx_ptr_value, &[offset], "") }
+            } else {
+                let offset = offsets.vmctx_vmmemory_import(index);
+                let offset = intrinsics.i32_ty.const_int(offset.into(), false);
+                let memory_definition_ptr_ptr = unsafe {
+                    cache_builder.build_gep(intrinsics.i8_ty, ctx_ptr_value, &[offset], "")
                 };
+                let memory_definition_ptr_ptr = cache_builder
+                    .build_bitcast(
+                        memory_definition_ptr_ptr,
+                        intrinsics.i8_ptr_ty.ptr_type(AddressSpace::default()),
+                        "",
+                    )
+                    .into_pointer_value();
+                let memory_definition_ptr = cache_builder
+                    .build_load(intrinsics.i8_ptr_ty, memory_definition_ptr_ptr, "")
+                    .into_pointer_value();
+                tbaa_label(
+                    module,
+                    intrinsics,
+                    format!("memory {} definition", index.as_u32()),
+                    memory_definition_ptr.as_instruction_value().unwrap(),
+                );
+                memory_definition_ptr
+            };
             let memory_definition_ptr = cache_builder
                 .build_bitcast(
                     memory_definition_ptr,
@@ -1340,6 +1386,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 .into_pointer_value();
             let base_ptr = cache_builder
                 .build_struct_gep(
+                    intrinsics.vmmemory_definition_ty,
                     memory_definition_ptr,
                     intrinsics.vmmemory_definition_base_element,
                     "",
@@ -1348,6 +1395,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             if let MemoryStyle::Dynamic { .. } = memory_style {
                 let current_length_ptr = cache_builder
                     .build_struct_gep(
+                        intrinsics.vmmemory_definition_ty,
                         memory_definition_ptr,
                         intrinsics.vmmemory_definition_current_length_element,
                         "",
@@ -1358,7 +1406,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     ptr_to_current_length: current_length_ptr,
                 }
             } else {
-                let base_ptr = cache_builder.build_load(base_ptr, "").into_pointer_value();
+                let base_ptr = cache_builder
+                    .build_load(intrinsics.i8_ptr_ty, base_ptr, "")
+                    .into_pointer_value();
                 tbaa_label(
                     module,
                     intrinsics,
@@ -1395,8 +1445,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                             .into(),
                         false,
                     );
-                    let ptr_to_base_ptr =
-                        unsafe { cache_builder.build_gep(ctx_ptr_value, &[offset], "") };
+                    let ptr_to_base_ptr = unsafe {
+                        cache_builder.build_gep(intrinsics.i8_ty, ctx_ptr_value, &[offset], "")
+                    };
                     let ptr_to_base_ptr = cache_builder
                         .build_bitcast(
                             ptr_to_base_ptr,
@@ -1410,8 +1461,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                             .into(),
                         false,
                     );
-                    let ptr_to_bounds =
-                        unsafe { cache_builder.build_gep(ctx_ptr_value, &[offset], "") };
+                    let ptr_to_bounds = unsafe {
+                        cache_builder.build_gep(intrinsics.i8_ty, ctx_ptr_value, &[offset], "")
+                    };
                     let ptr_to_bounds = cache_builder
                         .build_bitcast(ptr_to_bounds, intrinsics.i32_ptr_ty, "")
                         .into_pointer_value();
@@ -1421,8 +1473,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                         offsets.vmctx_vmtable_import_definition(table_index).into(),
                         false,
                     );
-                    let definition_ptr_ptr =
-                        unsafe { cache_builder.build_gep(ctx_ptr_value, &[offset], "") };
+                    let definition_ptr_ptr = unsafe {
+                        cache_builder.build_gep(intrinsics.i8_ty, ctx_ptr_value, &[offset], "")
+                    };
                     let definition_ptr_ptr = cache_builder
                         .build_bitcast(
                             definition_ptr_ptr,
@@ -1431,7 +1484,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                         )
                         .into_pointer_value();
                     let definition_ptr = cache_builder
-                        .build_load(definition_ptr_ptr, "")
+                        .build_load(intrinsics.i8_ptr_ty, definition_ptr_ptr, "")
                         .into_pointer_value();
                     tbaa_label(
                         module,
@@ -1443,8 +1496,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let offset = intrinsics
                         .i64_ty
                         .const_int(offsets.vmtable_definition_base().into(), false);
-                    let ptr_to_base_ptr =
-                        unsafe { cache_builder.build_gep(definition_ptr, &[offset], "") };
+                    let ptr_to_base_ptr = unsafe {
+                        cache_builder.build_gep(intrinsics.i8_ty, definition_ptr, &[offset], "")
+                    };
                     let ptr_to_base_ptr = cache_builder
                         .build_bitcast(
                             ptr_to_base_ptr,
@@ -1455,8 +1509,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     let offset = intrinsics
                         .i64_ty
                         .const_int(offsets.vmtable_definition_current_elements().into(), false);
-                    let ptr_to_bounds =
-                        unsafe { cache_builder.build_gep(definition_ptr, &[offset], "") };
+                    let ptr_to_bounds = unsafe {
+                        cache_builder.build_gep(intrinsics.i8_ty, definition_ptr, &[offset], "")
+                    };
                     let ptr_to_bounds = cache_builder
                         .build_bitcast(ptr_to_bounds, intrinsics.i32_ptr_ty, "")
                         .into_pointer_value();
@@ -1480,11 +1535,11 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
         let (ptr_to_base_ptr, ptr_to_bounds) = self.table_prepare(index, intrinsics, module);
         let base_ptr = self
             .cache_builder
-            .build_load(ptr_to_base_ptr, "base_ptr")
+            .build_load(intrinsics.i8_ptr_ty, ptr_to_base_ptr, "base_ptr")
             .into_pointer_value();
         let bounds = self
             .cache_builder
-            .build_load(ptr_to_bounds, "bounds")
+            .build_load(intrinsics.isize_ty, ptr_to_bounds, "bounds")
             .into_int_value();
         tbaa_label(
             module,
@@ -1518,14 +1573,19 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 .i64_ty
                 .const_int(offsets.vmctx_vmshared_signature_id(index).into(), false);
             let sigindex_ptr = unsafe {
-                cache_builder.build_gep(ctx_ptr_value, &[byte_offset], "dynamic_sigindex")
+                cache_builder.build_gep(
+                    intrinsics.i8_ty,
+                    ctx_ptr_value,
+                    &[byte_offset],
+                    "dynamic_sigindex",
+                )
             };
             let sigindex_ptr = cache_builder
                 .build_bitcast(sigindex_ptr, intrinsics.i32_ptr_ty, "")
                 .into_pointer_value();
 
             let sigindex = cache_builder
-                .build_load(sigindex_ptr, "sigindex")
+                .build_load(intrinsics.i32_ty, sigindex_ptr, "sigindex")
                 .into_int_value();
             tbaa_label(
                 module,
@@ -1565,8 +1625,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 };
                 let offset = intrinsics.i32_ty.const_int(offset.into(), false);
                 let global_ptr = {
-                    let global_ptr_ptr =
-                        unsafe { cache_builder.build_gep(ctx_ptr_value, &[offset], "") };
+                    let global_ptr_ptr = unsafe {
+                        cache_builder.build_gep(intrinsics.i8_ty, ctx_ptr_value, &[offset], "")
+                    };
                     let global_ptr_ptr = cache_builder
                         .build_bitcast(
                             global_ptr_ptr,
@@ -1575,7 +1636,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                         )
                         .into_pointer_value();
                     let global_ptr = cache_builder
-                        .build_load(global_ptr_ptr, "")
+                        .build_load(intrinsics.i32_ptr_ty, global_ptr_ptr, "")
                         .into_pointer_value();
                     tbaa_label(
                         module,
@@ -1595,7 +1656,11 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
 
                 entry.insert(match global_mutability {
                     Mutability::Const => {
-                        let value = cache_builder.build_load(global_ptr, "");
+                        let value = cache_builder.build_load(
+                            type_to_llvm(intrinsics, global_value_type)?,
+                            global_ptr,
+                            "",
+                        );
                         tbaa_label(
                             module,
                             intrinsics,
@@ -1606,6 +1671,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     }
                     Mutability::Var => GlobalCache::Mut {
                         ptr_to_value: global_ptr,
+                        value_type: type_to_llvm(intrinsics, global_value_type)?,
                     },
                 })
             }
@@ -1616,6 +1682,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
         &mut self,
         function_index: FunctionIndex,
         func: PointerValue<'ctx>,
+        llvm_func_type: FunctionType<'ctx>,
         vmctx: BasicValueEnum<'ctx>,
         attrs: &[(Attribute, AttributeLoc)],
     ) {
@@ -1624,6 +1691,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             Entry::Vacant(entry) => {
                 entry.insert(FunctionCache {
                     func,
+                    llvm_func_type,
                     vmctx,
                     attrs: attrs.to_vec(),
                 });
@@ -1661,6 +1729,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 }
                 entry.insert(FunctionCache {
                     func: func.as_global_value().as_pointer_value(),
+                    llvm_func_type,
                     vmctx: ctx_ptr_value.as_basic_value_enum(),
                     attrs: llvm_func_attrs,
                 })
@@ -1691,8 +1760,9 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 debug_assert!(wasm_module.local_func_index(function_index).is_none());
                 let offset = offsets.vmctx_vmfunction_import(function_index);
                 let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-                let vmfunction_import_ptr =
-                    unsafe { cache_builder.build_gep(*ctx_ptr_value, &[offset], "") };
+                let vmfunction_import_ptr = unsafe {
+                    cache_builder.build_gep(intrinsics.i8_ty, *ctx_ptr_value, &[offset], "")
+                };
                 let vmfunction_import_ptr = cache_builder
                     .build_bitcast(
                         vmfunction_import_ptr,
@@ -1703,12 +1773,13 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
 
                 let body_ptr_ptr = cache_builder
                     .build_struct_gep(
+                        intrinsics.vmfunction_import_ty,
                         vmfunction_import_ptr,
                         intrinsics.vmfunction_import_body_element,
                         "",
                     )
                     .unwrap();
-                let body_ptr = cache_builder.build_load(body_ptr_ptr, "");
+                let body_ptr = cache_builder.build_load(intrinsics.i8_ptr_ty, body_ptr_ptr, "");
                 let body_ptr = cache_builder
                     .build_bitcast(
                         body_ptr,
@@ -1718,14 +1789,16 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     .into_pointer_value();
                 let vmctx_ptr_ptr = cache_builder
                     .build_struct_gep(
+                        intrinsics.vmfunction_import_ty,
                         vmfunction_import_ptr,
                         intrinsics.vmfunction_import_vmctx_element,
                         "",
                     )
                     .unwrap();
-                let vmctx_ptr = cache_builder.build_load(vmctx_ptr_ptr, "");
+                let vmctx_ptr = cache_builder.build_load(intrinsics.ctx_ptr_ty, vmctx_ptr_ptr, "");
                 entry.insert(FunctionCache {
                     func: body_ptr,
+                    llvm_func_type,
                     vmctx: vmctx_ptr,
                     attrs: llvm_func_attrs,
                 })
@@ -1759,7 +1832,8 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             };
             let offset = offsets.vmctx_builtin_function(grow_fn);
             let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-            let grow_fn_ptr_ptr = unsafe { cache_builder.build_gep(*ctx_ptr_value, &[offset], "") };
+            let grow_fn_ptr_ptr =
+                unsafe { cache_builder.build_gep(intrinsics.i8_ty, *ctx_ptr_value, &[offset], "") };
 
             let grow_fn_ptr_ptr = cache_builder
                 .build_bitcast(
@@ -1769,7 +1843,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 )
                 .into_pointer_value();
             cache_builder
-                .build_load(grow_fn_ptr_ptr, "")
+                .build_load(grow_fn_ty, grow_fn_ptr_ptr, "")
                 .into_pointer_value()
         })
     }
@@ -1800,7 +1874,8 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             };
             let offset = offsets.vmctx_builtin_function(size_fn);
             let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-            let size_fn_ptr_ptr = unsafe { cache_builder.build_gep(*ctx_ptr_value, &[offset], "") };
+            let size_fn_ptr_ptr =
+                unsafe { cache_builder.build_gep(intrinsics.i8_ty, *ctx_ptr_value, &[offset], "") };
 
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
@@ -1811,7 +1886,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 .into_pointer_value();
 
             cache_builder
-                .build_load(size_fn_ptr_ptr, "")
+                .build_load(size_fn_ty, size_fn_ptr_ptr, "")
                 .into_pointer_value()
         })
     }
@@ -1842,7 +1917,8 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             };
             let offset = offsets.vmctx_builtin_function(size_fn);
             let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-            let size_fn_ptr_ptr = unsafe { cache_builder.build_gep(*ctx_ptr_value, &[offset], "") };
+            let size_fn_ptr_ptr =
+                unsafe { cache_builder.build_gep(intrinsics.i8_ty, *ctx_ptr_value, &[offset], "") };
 
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
@@ -1853,7 +1929,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 .into_pointer_value();
 
             cache_builder
-                .build_load(size_fn_ptr_ptr, "")
+                .build_load(size_fn_ty, size_fn_ptr_ptr, "")
                 .into_pointer_value()
         })
     }
@@ -1884,7 +1960,8 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             };
             let offset = offsets.vmctx_builtin_function(size_fn);
             let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-            let size_fn_ptr_ptr = unsafe { cache_builder.build_gep(*ctx_ptr_value, &[offset], "") };
+            let size_fn_ptr_ptr =
+                unsafe { cache_builder.build_gep(intrinsics.i8_ty, *ctx_ptr_value, &[offset], "") };
 
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
@@ -1895,7 +1972,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 .into_pointer_value();
 
             cache_builder
-                .build_load(size_fn_ptr_ptr, "")
+                .build_load(size_fn_ty, size_fn_ptr_ptr, "")
                 .into_pointer_value()
         })
     }
@@ -1926,7 +2003,8 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             };
             let offset = offsets.vmctx_builtin_function(size_fn);
             let offset = intrinsics.i32_ty.const_int(offset.into(), false);
-            let size_fn_ptr_ptr = unsafe { cache_builder.build_gep(*ctx_ptr_value, &[offset], "") };
+            let size_fn_ptr_ptr =
+                unsafe { cache_builder.build_gep(intrinsics.i8_ty, *ctx_ptr_value, &[offset], "") };
 
             let size_fn_ptr_ptr = cache_builder
                 .build_bitcast(
@@ -1937,7 +2015,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 .into_pointer_value();
 
             cache_builder
-                .build_load(size_fn_ptr_ptr, "")
+                .build_load(size_fn_ty, size_fn_ptr_ptr, "")
                 .into_pointer_value()
         })
     }

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -1110,19 +1110,34 @@ impl<'ctx> Intrinsics<'ctx> {
             memory_notify: module.add_function(
                 "wasmer_vm_memory32_atomic_notify",
                 i32_ty.fn_type(
-                    &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                    &[
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                    ],
                     false,
                 ),
                 None,
             ),
             memory_notify_ty: i32_ty.fn_type(
-                &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                &[
+                    ctx_ptr_ty_basic_md,
+                    i32_ty_basic_md,
+                    i32_ty_basic_md,
+                    i32_ty_basic_md,
+                ],
                 false,
             ),
             imported_memory_notify: module.add_function(
                 "wasmer_vm_imported_memory32_atomic_notify",
                 i32_ty.fn_type(
-                    &[ctx_ptr_ty_basic_md, i32_ty_basic_md, i32_ty_basic_md],
+                    &[
+                        ctx_ptr_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                        i32_ty_basic_md,
+                    ],
                     false,
                 ),
                 None,


### PR DESCRIPTION
Migration to LLVM 15.

This update removed of LLVM the tracking of the pointee-type for pointers, making the tracking the responsability of the user program.
