### PR TITLE
Add support for publishing private packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e1373abdaa212b704512ec2bd8b26bd0b7d5c3f70117411a5d9a451383c859"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -275,9 +275,9 @@ checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c12265665aebaa236af9bbe266681bcc9c5666192119e3d8335cf083aca26f"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
 dependencies = [
  "serde",
 ]
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1322,9 +1322,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "dynasm"
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba330b70a5341d3bc730b8e205aaee97ddab5d9c448c4f51a7c2d924266fa8f9"
+checksum = "ef81e7cedce6ab54cd5dc7b3400c442c8d132fe03200a1be0637db7ef308ff17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2138,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -2310,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2877,9 +2877,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
 dependencies = [
  "cc",
  "libc",
@@ -3028,7 +3028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -3071,9 +3071,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "portable-atomic"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b559898e0b4931ed2d3b959ab0c2da4d99cc644c4b0b1a35b4d344027f474023"
+checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "powerfmt"
@@ -3666,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -3984,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -4042,7 +4042,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -4340,13 +4340,13 @@ checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -4655,14 +4655,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef75d881185fd2df4a040793927c153d863651108a93c7e17a9e591baa95cc6"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.4",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -4680,7 +4680,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4689,11 +4689,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.4"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f9e8120405471f7c9ad1860a713ef5ece6a670c7eae39225e477340f32fc4"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5348,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5358,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -5373,9 +5373,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5385,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5395,9 +5395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5408,15 +5408,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
+checksum = "c6433b7c56db97397842c46b67e11873eda263170afeb3a2dc74a7cb370fee0d"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -5428,12 +5428,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
+checksum = "493fcbab756bb764fa37e6bee8cec2dd709eb4273d06d0c282a5e74275ded735"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -5717,7 +5718,7 @@ dependencies = [
  "wasmer-emscripten",
  "wasmer-object",
  "wasmer-registry 5.9.0",
- "wasmer-toml 0.8.1",
+ "wasmer-toml 0.9.2",
  "wasmer-types",
  "wasmer-vm",
  "wasmer-wasix",
@@ -5870,7 +5871,7 @@ dependencies = [
  "wasmer-api",
  "wasmer-deploy-schema",
  "wasmer-deploy-util",
- "wasmer-registry 5.8.0",
+ "wasmer-registry 5.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-toml 0.9.2",
  "webc",
 ]
@@ -6017,47 +6018,6 @@ dependencies = [
 
 [[package]]
 name = "wasmer-registry"
-version = "5.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d8adaefc30f6dfb78c9b4262578dd1d3d86f7f2b18a7a5d3f7e1fee1cf11cf"
-dependencies = [
- "anyhow",
- "console",
- "dirs",
- "filetime",
- "flate2",
- "futures-util",
- "graphql_client",
- "hex",
- "indexmap 1.9.3",
- "indicatif",
- "lazy_static",
- "log",
- "lzma-rs",
- "minisign",
- "regex",
- "reqwest",
- "rpassword",
- "rusqlite",
- "semver 1.0.20",
- "serde",
- "serde_json",
- "tar",
- "tempfile",
- "thiserror",
- "time",
- "tldextract",
- "tokio",
- "toml 0.5.11",
- "url",
- "wasmer-toml 0.8.1",
- "wasmer-wasm-interface 4.2.2",
- "wasmparser 0.51.4",
- "whoami",
-]
-
-[[package]]
-name = "wasmer-registry"
 version = "5.9.0"
 dependencies = [
  "anyhow",
@@ -6091,8 +6051,49 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "url",
- "wasmer-toml 0.8.1",
+ "wasmer-toml 0.9.2",
  "wasmer-wasm-interface 4.2.3",
+ "wasmparser 0.51.4",
+ "whoami",
+]
+
+[[package]]
+name = "wasmer-registry"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2ecfb16d793bfe1e2b98af07e6f344bd00ba0efea8e1b24737701d823a3ee"
+dependencies = [
+ "anyhow",
+ "console",
+ "dirs",
+ "filetime",
+ "flate2",
+ "futures-util",
+ "graphql_client",
+ "hex",
+ "indexmap 1.9.3",
+ "indicatif",
+ "lazy_static",
+ "log",
+ "lzma-rs",
+ "minisign",
+ "regex",
+ "reqwest",
+ "rpassword",
+ "rusqlite",
+ "semver 1.0.20",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "time",
+ "tldextract",
+ "tokio",
+ "toml 0.5.11",
+ "url",
+ "wasmer-toml 0.8.1",
+ "wasmer-wasm-interface 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.51.4",
  "whoami",
 ]
@@ -6137,14 +6138,14 @@ checksum = "d21472954ee9443235ca32522b17fc8f0fe58e2174556266a0d9766db055cc52"
 dependencies = [
  "anyhow",
  "derive_builder",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "semver 1.0.20",
  "serde",
  "serde_cbor",
  "serde_json",
  "serde_yaml 0.9.27",
  "thiserror",
- "toml 0.8.4",
+ "toml 0.8.6",
 ]
 
 [[package]]
@@ -6302,18 +6303,6 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasm-interface"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba32201b5ca948e76353eb324b00ef8b2c1c7b019f765cb5418a53d898db723"
-dependencies = [
- "either",
- "nom 5.1.3",
- "serde",
- "wasmparser 0.51.4",
-]
-
-[[package]]
-name = "wasmer-wasm-interface"
 version = "4.2.3"
 dependencies = [
  "bincode",
@@ -6322,6 +6311,18 @@ dependencies = [
  "serde",
  "wasmparser 0.51.4",
  "wat",
+]
+
+[[package]]
+name = "wasmer-wasm-interface"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70759b128088ce07ab6f31b97d83ceb8642285c650677fc84f554d68dc534ac4"
+dependencies = [
+ "either",
+ "nom 5.1.3",
+ "serde",
+ "wasmparser 0.51.4",
 ]
 
 [[package]]
@@ -6398,22 +6399,22 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.115.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
+checksum = "53290b1276c5c2d47d694fb1a920538c01f51690e7e261acbe1d10c5fc306ea1"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "semver 1.0.20",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74458a9bc5cc9c7108abfa0fe4dc88d5abf1f3baf194df3264985f17d559b5e"
+checksum = "8f98260aa20f939518bcec1fac32c78898d5c68872e7363a4651f21f791b6c7e"
 dependencies = [
  "anyhow",
- "wasmparser 0.115.0",
+ "wasmparser 0.116.0",
 ]
 
 [[package]]
@@ -6557,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6567,9 +6568,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.7.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fc974157e8532c5c31fa44c38046264227e580cd2a0d939543891d23f43779"
+checksum = "ac815d472f09ed064ef70a3046843972646727cbe55db795dd8a9925b76ed0c4"
 dependencies = [
  "anyhow",
  "base64",
@@ -6836,9 +6837,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
 dependencies = [
  "memchr",
 ]
@@ -6914,18 +6915,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.15"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
+checksum = "e50cbb27c30666a6108abd6bc7577556265b44f243e2be89a8bc4e07a528c107"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.15"
+version = "0.7.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
+checksum = "a25f293fe55f0a48e7010d65552bb63704f6ceb55a1a385da10d41d8f78e4a3d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5668,7 +5681,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored 2.0.4",
- "dialoguer",
+ "dialoguer 0.10.4",
  "dirs",
  "distance",
  "flate2",
@@ -5848,7 +5861,7 @@ dependencies = [
  "clap-verbosity-flag",
  "colored 2.0.4",
  "comfy-table",
- "dialoguer",
+ "dialoguer 0.10.4",
  "futures",
  "is-terminal",
  "log",
@@ -6023,6 +6036,7 @@ dependencies = [
  "anyhow",
  "clap",
  "console",
+ "dialoguer 0.11.0",
  "dirs",
  "filetime",
  "flate2",
@@ -6050,6 +6064,7 @@ dependencies = [
  "tldextract",
  "tokio",
  "toml 0.5.11",
+ "tracing",
  "url",
  "wasmer-toml 0.9.2",
  "wasmer-wasm-interface 4.2.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ version = "4.2.3"
 
 [workspace.dependencies]
 memoffset = "0.9.0"
-wasmer-toml = "0.9.1"
+wasmer-toml = "0.9.2"
 webc = { version = "5.6.0", default-features = false, features = ["package"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,9 @@ rust-version = "1.70"
 version = "4.2.3"
 
 [workspace.dependencies]
-webc = { version = "5.5.1", default-features = false, features = ["package"] }
-wasmer-toml = "0.8.0"
 memoffset = "0.9.0"
+wasmer-toml = "0.9.1"
+webc = { version = "5.6.0", default-features = false, features = ["package"] }
 
 [build-dependencies]
 test-generator = { path = "tests/lib/test-generator" }

--- a/lib/cli/src/commands/init.rs
+++ b/lib/cli/src/commands/init.rs
@@ -6,7 +6,6 @@ use std::{
 use anyhow::Context;
 use cargo_metadata::{CargoOpt, MetadataCommand};
 use clap::Parser;
-use indexmap::IndexMap;
 use semver::VersionReq;
 use wasmer_registry::wasmer_env::WasmerEnv;
 
@@ -230,24 +229,17 @@ impl Init {
         }
     }
 
-    fn get_filesystem_mapping(include: &[String]) -> IndexMap<String, PathBuf> {
-        if include.is_empty() {
-            return IndexMap::new();
-        }
+    fn get_filesystem_mapping(include: &[String]) -> impl Iterator<Item = (String, PathBuf)> + '_ {
+        include.iter().map(|path| {
+            if path == "." || path == "/" {
+                return ("/".to_string(), Path::new("/").to_path_buf());
+            }
 
-        include
-            .iter()
-            .map(|path| {
-                if path == "." || path == "/" {
-                    return ("/".to_string(), Path::new("/").to_path_buf());
-                }
+            let key = format!("./{path}");
+            let value = PathBuf::from(format!("/{path}"));
 
-                let key = format!("./{path}");
-                let value = PathBuf::from(format!("/{path}"));
-
-                (key, value)
-            })
-            .collect()
+            (key, value)
+        })
     }
 
     fn get_command(
@@ -515,7 +507,7 @@ fn construct_manifest(
     manifest
         .dependencies(Init::get_dependencies(template))
         .commands(Init::get_command(&modules, bin_or_lib))
-        .fs(Init::get_filesystem_mapping(include_fs));
+        .fs(Init::get_filesystem_mapping(include_fs).collect());
     match bin_or_lib {
         BinOrLib::Bin | BinOrLib::Lib => {
             manifest.modules(modules);

--- a/lib/cli/src/commands/init.rs
+++ b/lib/cli/src/commands/init.rs
@@ -250,13 +250,13 @@ impl Init {
             BinOrLib::Bin => modules
                 .iter()
                 .map(|m| {
-                    wasmer_toml::Command::V1(wasmer_toml::CommandV1 {
+                    wasmer_toml::Command::V2(wasmer_toml::CommandV2 {
                         name: m.name.clone(),
                         module: wasmer_toml::ModuleReference::CurrentPackage {
                             module: m.name.clone(),
                         },
-                        main_args: None,
-                        package: None,
+                        runner: "wasi".to_string(),
+                        annotations: None,
                     })
                 })
                 .collect(),

--- a/lib/registry/Cargo.toml
+++ b/lib/registry/Cargo.toml
@@ -16,6 +16,7 @@ build-package  = ["rusqlite", "indexmap", "wasmer-wasm-interface", "wasmparser",
 anyhow = "1.0.65"
 clap = { version = "4.3.5", default-features = false, features = ["derive", "env"], optional = true }
 console = "0.15.2"
+dialoguer = "0.11.0"
 dirs = "4.0.0"
 filetime = "0.2.19"
 flate2 = "1.0.24"
@@ -42,6 +43,7 @@ time = { version = "0.3.17", default-features = false, features = ["parsing", "s
 tldextract = "0.6.0"
 tokio = "1.24.0"
 toml = "0.5.9"
+tracing = "0.1.40"
 url = "2.3.1"
 wasmer-toml = { workspace = true }
 wasmer-wasm-interface = { version = "4.2.3", path = "../wasm-interface", optional = true }

--- a/lib/registry/graphql/mutations/publish_package_chunked.graphql
+++ b/lib/registry/graphql/mutations/publish_package_chunked.graphql
@@ -11,6 +11,7 @@ mutation PublishPackageMutationChunked(
   $homepage: String
   $signature: InputSignature
   $signedUrl: String
+  $private: Boolean
 ) {
   publishPackage(
     input: {
@@ -27,6 +28,7 @@ mutation PublishPackageMutationChunked(
       homepage: $homepage
       signature: $signature
       clientMutationId: ""
+      private: $private
     }
   ) {
     success

--- a/lib/registry/graphql/queries/get_package_by_command.graphql
+++ b/lib/registry/graphql/queries/get_package_by_command.graphql
@@ -11,6 +11,7 @@ query GetPackageByCommandQuery($commandName: String!) {
       }
       package {
         displayName
+        private
       }
     }
   }

--- a/lib/registry/graphql/queries/get_package_version.graphql
+++ b/lib/registry/graphql/queries/get_package_version.graphql
@@ -2,6 +2,7 @@ query GetPackageVersionQuery($name: String!, $version: String) {
   packageVersion: getPackageVersion(name: $name, version: $version) {
     package {
       name
+      private
     }
     version
     isLastVersion

--- a/lib/registry/graphql/schema.graphql
+++ b/lib/registry/graphql/schema.graphql
@@ -1,14 +1,10 @@
 interface Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
 }
 
 type PublicKey implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   owner: User!
   keyId: String!
@@ -25,106 +21,53 @@ type User implements Node & PackageOwner & Owner {
   email: String!
   dateJoined: DateTime!
 
-  """
-  Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
-  """
+  """Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."""
   username: String!
   isEmailValidated: Boolean!
   bio: String
   location: String
   websiteUrl: String
 
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   globalName: String!
+  globalId: ID!
   avatar(size: Int = 80): String!
   isViewer: Boolean!
   hasUsablePassword: Boolean
   fullName: String!
   githubUrl: String
   twitterUrl: String
-  publicActivity(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): ActivityEventConnection!
+  companyRole: String
+  companyDescription: String
+  publicActivity(before: String, after: String, first: Int, last: Int): ActivityEventConnection!
   billing: Billing
   waitlist(name: String!): WaitlistMember
-  namespaces(
-    role: GrapheneRole
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NamespaceConnection!
-  packages(
-    collaborating: Boolean = false
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageConnection!
-  apps(
-    collaborating: Boolean = false
-    sortBy: DeployAppsSortBy
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): DeployAppConnection!
+  namespaces(role: GrapheneRole, offset: Int, before: String, after: String, first: Int, last: Int): NamespaceConnection!
+  packages(collaborating: Boolean = false, offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+  apps(collaborating: Boolean = false, sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
   usageMetrics(forRange: MetricRange!, variant: MetricType!): [UsageMetric]!
   isStaff: Boolean
-  packageVersions(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionConnection!
-  packageTransfersIncoming(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageTransferRequestConnection!
-  packageInvitesIncoming(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageCollaboratorInviteConnection!
-  namespaceInvitesIncoming(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NamespaceCollaboratorInviteConnection!
-  apiTokens(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): APITokenConnection!
-  notifications(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): UserNotificationConnection!
+  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  packageTransfersIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
+  packageInvitesIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
+  namespaceInvitesIncoming(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+  apiTokens(before: String, after: String, first: Int, last: Int): APITokenConnection!
+  notifications(before: String, after: String, first: Int, last: Int): UserNotificationConnection!
+  dashboardActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+  loginMethods: [LoginMethod!]!
 }
 
-"""
-Setup for backwards compatibility with existing frontends.
-"""
+"""Setup for backwards compatibility with existing frontends."""
 interface PackageOwner {
   globalName: String!
+  globalId: ID!
 }
 
+"""An owner of a package."""
 interface Owner {
   globalName: String!
+  globalId: ID!
 }
 
 """
@@ -135,14 +78,10 @@ value as specified by
 scalar DateTime
 
 type ActivityEventConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [ActivityEventEdge]!
 }
 
@@ -150,46 +89,30 @@ type ActivityEventConnection {
 The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
 """
 type PageInfo {
-  """
-  When paginating forwards, are there more items?
-  """
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  """
-  When paginating backwards, are there more items?
-  """
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  """
-  When paginating backwards, the cursor to continue.
-  """
+  """When paginating backwards, the cursor to continue."""
   startCursor: String
 
-  """
-  When paginating forwards, the cursor to continue.
-  """
+  """When paginating forwards, the cursor to continue."""
   endCursor: String
 }
 
-"""
-A Relay edge containing a `ActivityEvent` and its cursor.
-"""
+"""A Relay edge containing a `ActivityEvent` and its cursor."""
 type ActivityEventEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: ActivityEvent
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type ActivityEvent implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   body: ActivityEventBody!
   actorIcon: String!
@@ -212,9 +135,7 @@ type WaitlistMember implements Node {
   joinedAt: DateTime!
   approvedAt: DateTime
 
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   member: Owner!
   approved: Boolean!
@@ -225,43 +146,32 @@ type Waitlist implements Node {
   createdAt: DateTime!
   updatedAt: DateTime!
 
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
 }
 
 type NamespaceConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [NamespaceEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
-"""
-A Relay edge containing a `Namespace` and its cursor.
-"""
+"""A Relay edge containing a `Namespace` and its cursor."""
 type NamespaceEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Namespace
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type Namespace implements Node & PackageOwner & Owner {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   name: String!
   displayName: String
@@ -270,100 +180,45 @@ type Namespace implements Node & PackageOwner & Owner {
   avatarUpdatedAt: DateTime
   createdAt: DateTime!
   updatedAt: DateTime!
-  maintainerInvites(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NamespaceCollaboratorInviteConnection!
-  userSet(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): UserConnection!
+  maintainerInvites(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+  userSet(offset: Int, before: String, after: String, first: Int, last: Int): UserConnection!
   globalName: String!
-  packages(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageConnection!
-  apps(
-    sortBy: DeployAppsSortBy
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): DeployAppConnection!
-  packageVersions(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionConnection!
-  collaborators(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NamespaceCollaboratorConnection!
-  publicActivity(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): ActivityEventConnection!
-  pendingInvites(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NamespaceCollaboratorInviteConnection!
+  globalId: ID!
+  packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+  apps(sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
+  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  collaborators(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorConnection!
+  publicActivity(before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+  pendingInvites(before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
   viewerHasRole(role: GrapheneRole!): Boolean!
-  packageTransfersIncoming(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageTransferRequestConnection!
+  packageTransfersIncoming(before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
   usageMetrics(forRange: MetricRange!, variant: MetricType!): [UsageMetric]!
 }
 
 type NamespaceCollaboratorInviteConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [NamespaceCollaboratorInviteEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
 """
 A Relay edge containing a `NamespaceCollaboratorInvite` and its cursor.
 """
 type NamespaceCollaboratorInviteEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: NamespaceCollaboratorInvite
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type NamespaceCollaboratorInvite implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   requestedBy: User!
   user: User
@@ -379,26 +234,18 @@ type NamespaceCollaboratorInvite implements Node {
 }
 
 enum RegistryNamespaceMaintainerInviteRoleChoices {
-  """
-  Admin
-  """
+  """Admin"""
   ADMIN
 
-  """
-  Editor
-  """
+  """Editor"""
   EDITOR
 
-  """
-  Viewer
-  """
+  """Viewer"""
   VIEWER
 }
 
 type NamespaceCollaborator implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   user: User!
   role: RegistryNamespaceMaintainerRoleChoices!
@@ -409,88 +256,60 @@ type NamespaceCollaborator implements Node {
 }
 
 enum RegistryNamespaceMaintainerRoleChoices {
-  """
-  Admin
-  """
+  """Admin"""
   ADMIN
 
-  """
-  Editor
-  """
+  """Editor"""
   EDITOR
 
-  """
-  Viewer
-  """
+  """Viewer"""
   VIEWER
 }
 
 type UserConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [UserEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `User` and its cursor.
-"""
+"""A Relay edge containing a `User` and its cursor."""
 type UserEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: User
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type PackageConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [PackageEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
-"""
-A Relay edge containing a `Package` and its cursor.
-"""
+"""A Relay edge containing a `Package` and its cursor."""
 type PackageEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Package
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type Package implements Likeable & Node & PackageOwner {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   name: String!
-  namespace: String
   private: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -499,58 +318,43 @@ type Package implements Likeable & Node & PackageOwner {
   ownerObjectId: Int!
   lastVersion: PackageVersion
 
-  """
-  The app icon. It should be formatted in the same way as Apple icons
-  """
+  """The app icon. It should be formatted in the same way as Apple icons"""
   icon: String!
   totalDownloads: Int!
   iconUpdatedAt: DateTime
   watchersCount: Int!
   versions: [PackageVersion]!
   collectionSet: [Collection!]!
+  keywords(offset: Int, before: String, after: String, first: Int, last: Int): PackageKeywordConnection!
   likersCount: Int!
   viewerHasLiked: Boolean!
   globalName: String!
+  globalId: ID!
   alias: String
+  namespace: String!
   displayName: String!
 
-  """
-  The name of the package without the owner
-  """
+  """The name of the package without the owner"""
   packageName: String!
 
-  """
-  The app icon. It should be formatted in the same way as Apple icons
-  """
+  """The app icon. It should be formatted in the same way as Apple icons"""
   appIcon: String! @deprecated(reason: "Please use icon instead")
 
-  """
-  The total number of downloads of the package
-  """
+  """The total number of downloads of the package"""
   downloadsCount: Int
 
-  """
-  The public keys for all the published versions
-  """
+  """The public keys for all the published versions"""
   publicKeys: [PublicKey!]!
-  collaborators(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageCollaboratorConnection!
-  pendingInvites(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageCollaboratorInviteConnection!
+  collaborators(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorConnection!
+  pendingInvites(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
   viewerHasRole(role: GrapheneRole!): Boolean!
   owner: PackageOwner!
   isTransferring: Boolean!
   activeTransferRequest: PackageTransferRequest
   isArchived: Boolean!
   viewerIsWatching: Boolean!
+  showDeployButton: Boolean!
+  similarPackageVersions(before: String, after: String, first: Int, last: Int): PackageSearchConnection!
 }
 
 interface Likeable {
@@ -560,9 +364,7 @@ interface Likeable {
 }
 
 type PackageVersion implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   package: Package!
   version: String!
@@ -583,57 +385,28 @@ type PackageVersion implements Node {
   isArchived: Boolean!
   file: String!
 
-  """
-  """
+  """"""
   fileSize: BigInt!
   piritaFile: String
 
-  """
-  """
+  """"""
   piritaFileSize: BigInt!
   piritaManifest: JSONString
   piritaVolumes: JSONString
   totalDownloads: Int!
-  pirita256hash: String
-    @deprecated(reason: "Please use distribution.piritaSha256Hash instead.")
+  pirita256hash: String @deprecated(reason: "Please use distribution.piritaSha256Hash instead.")
   bindingsState: RegistryPackageVersionBindingsStateChoices!
   nativeExecutablesState: RegistryPackageVersionNativeExecutablesStateChoices!
-  lastversionPackage(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageConnection!
+
+  """List of direct dependencies of this package version"""
+  dependencies(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  deployappversionSet(offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
+  lastversionPackage(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
   commands: [Command!]!
-  nativeexecutableSet(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NativeExecutableConnection!
-  bindingsgeneratorSet(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): BindingsGeneratorConnection!
-  javascriptlanguagebindingSet(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionNPMBindingConnection!
-  pythonlanguagebindingSet(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionPythonBindingConnection!
+  nativeexecutableSet(offset: Int, before: String, after: String, first: Int, last: Int): NativeExecutableConnection!
+  bindingsgeneratorSet(offset: Int, before: String, after: String, first: Int, last: Int): BindingsGeneratorConnection!
+  javascriptlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
+  pythonlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
   distribution: PackageDistribution!
   filesystem: [PackageVersionFilesystem]!
   isLastVersion: Boolean!
@@ -641,19 +414,15 @@ type PackageVersion implements Node {
   isSigned: Boolean!
   moduleInterfaces: [InterfaceVersion!]!
   modules: [PackageVersionModule!]!
-  getPiritaContents(
-    volume: String! = "atom"
-    root: String! = ""
-  ): [PiritaFilesystemItem!]!
-  nativeExecutables(
-    triple: String
-    wasmerCompilerVersion: String
-  ): [NativeExecutable]
+  getPiritaContents(volume: String! = "atom", base: String! = ""): [PiritaFilesystemItem!]!
+  getWebcContents(volume: String! = "atom", base: String! = "/"): [WEBCFilesystemItem!]!
+  nativeExecutables(triple: String, wasmerCompilerVersion: String): [NativeExecutable]
   bindings: [PackageVersionLanguageBinding]!
   npmBindings: PackageVersionNPMBinding
   pythonBindings: PackageVersionPythonBinding
   hasBindings: Boolean!
   hasCommands: Boolean!
+  showDeployButton: Boolean!
 }
 
 """
@@ -672,47 +441,232 @@ schema (one of the key benefits of GraphQL).
 scalar JSONString
 
 enum RegistryPackageVersionBindingsStateChoices {
-  """
-  Bindings are not detected
-  """
+  """Bindings are not detected"""
   NOT_PRESENT
 
-  """
-  Bindings are being built
-  """
+  """Bindings are being built"""
   GENERATING
 
-  """
-  Bindings generation has failed
-  """
+  """Bindings generation has failed"""
   ERROR
 
-  """
-  Bindings are built and present
-  """
+  """Bindings are built and present"""
   GENERATED_AND_PRESENT
 }
 
 enum RegistryPackageVersionNativeExecutablesStateChoices {
-  """
-  Native Executables are not detected
-  """
+  """Native Executables are not detected"""
   NOT_PRESENT
 
-  """
-  Native Executables are being built
-  """
+  """Native Executables are being built"""
   GENERATING
 
-  """
-  Native Executables generation has failed
-  """
+  """Native Executables generation has failed"""
   ERROR
 
-  """
-  Native Executables are built and present
-  """
+  """Native Executables are built and present"""
   GENERATED_AND_PRESENT
+}
+
+type PackageVersionConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageVersionEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `PackageVersion` and its cursor."""
+type PackageVersionEdge {
+  """The item at the end of the edge"""
+  node: PackageVersion
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type DeployAppVersionConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [DeployAppVersionEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `DeployAppVersion` and its cursor."""
+type DeployAppVersionEdge {
+  """The item at the end of the edge"""
+  node: DeployAppVersion
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type DeployAppVersion implements Node {
+  """The ID of the object"""
+  id: ID!
+  app: DeployApp!
+  yamlConfig: String!
+  userYamlConfig: String!
+  signature: String
+  description: String
+  publishedBy: User!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  configWebc: String @deprecated(reason: "webc support has been deprecated for apps")
+  config: String! @deprecated(reason: "Please use jsonConfig instead")
+  jsonConfig: String!
+  url: String!
+  permalink: String!
+  urls: [String]!
+  version: String!
+  isActive: Boolean!
+  manifest: String!
+  logs(
+    """
+    Get logs starting from this timestamp. Takes EPOCH timestamp in seconds.
+    """
+    startingFrom: Float!
+
+    """Fetch logs until this timestamp. Takes EPOCH timestamp in seconds."""
+    until: Float
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): LogConnection!
+  usageMetrics(forRange: MetricRange!, variant: MetricType!): [UsageMetric]!
+  sourcePackageVersion: PackageVersion!
+  aggregateMetrics: AggregateMetrics!
+}
+
+type DeployApp implements Node & Owner {
+  """The ID of the object"""
+  id: ID!
+  createdBy: User!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  activeVersion: DeployAppVersion!
+  globalName: String!
+  globalId: ID!
+  url: String!
+  adminUrl: String!
+  permalink: String!
+  urls: [String]!
+  description: String
+  name: String!
+  owner: Owner!
+  versions(sortBy: DeployAppVersionsSortBy, createdAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
+  aggregateMetrics: AggregateMetrics!
+  aliases(offset: Int, before: String, after: String, first: Int, last: Int): AppAliasConnection!
+  usageMetrics(forRange: MetricRange!, variant: MetricType!): [UsageMetric]!
+  deleted: Boolean!
+}
+
+enum DeployAppVersionsSortBy {
+  NEWEST
+  OLDEST
+}
+
+type AggregateMetrics {
+  cpuTime: String!
+  memoryTime: String!
+  ingress: String!
+  egress: String!
+  noRequests: String!
+  monthlyCost: String!
+}
+
+type AppAliasConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [AppAliasEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `AppAlias` and its cursor."""
+type AppAliasEdge {
+  """The item at the end of the edge"""
+  node: AppAlias
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type AppAlias implements Node {
+  name: String!
+  app: DeployApp!
+  isDefault: Boolean!
+
+  """The ID of the object"""
+  id: ID!
+  url: String!
+}
+
+type UsageMetric {
+  variant: MetricType!
+  value: Float!
+  unit: MetricUnit!
+  timestamp: DateTime!
+}
+
+enum MetricType {
+  cpu_time
+  memory_time
+  network_egress
+  network_ingress
+  no_of_requests
+  cost
+}
+
+"""Units for metrics"""
+enum MetricUnit {
+  """represents the unit of "seconds"."""
+  SEC
+
+  """represents the unit of "kilobytes"."""
+  KB
+
+  """represents the unit of "kilobytes per second"."""
+  KBS
+
+  """represents the unit of "number of requests"."""
+  NO_REQUESTS
+
+  """represents the unit of "cost" in USD."""
+  DOLLARS
+}
+
+enum MetricRange {
+  LAST_24_HOURS
+  LAST_30_DAYS
+}
+
+type LogConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [LogEdge]!
+}
+
+"""A Relay edge containing a `Log` and its cursor."""
+type LogEdge {
+  """The item at the end of the edge"""
+  node: Log
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 type Command {
@@ -729,213 +683,125 @@ type PackageVersionModule {
 }
 
 type NativeExecutableConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [NativeExecutableEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `NativeExecutable` and its cursor.
-"""
+"""A Relay edge containing a `NativeExecutable` and its cursor."""
 type NativeExecutableEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: NativeExecutable
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type NativeExecutable implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   module: String! @deprecated(reason: "Use filename instead")
   filename: String!
+  filesize: Int!
   targetTriple: String!
   downloadUrl: String!
 }
 
 type BindingsGeneratorConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [BindingsGeneratorEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `BindingsGenerator` and its cursor.
-"""
+"""A Relay edge containing a `BindingsGenerator` and its cursor."""
 type BindingsGeneratorEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: BindingsGenerator
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type BindingsGenerator implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   packageVersion: PackageVersion!
   active: Boolean!
   commandName: String!
-  registryJavascriptlanguagebindings(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionNPMBindingConnection!
-  registryPythonlanguagebindings(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionPythonBindingConnection!
+  registryJavascriptlanguagebindings(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
+  registryPythonlanguagebindings(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
 }
 
 type PackageVersionNPMBindingConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [PackageVersionNPMBindingEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `PackageVersionNPMBinding` and its cursor.
-"""
+"""A Relay edge containing a `PackageVersionNPMBinding` and its cursor."""
 type PackageVersionNPMBindingEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PackageVersionNPMBinding
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type PackageVersionNPMBinding implements PackageVersionLanguageBinding & Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   language: ProgrammingLanguage!
 
-  """
-  The URL of the generated artifacts on Wasmer CDN.
-  """
+  """The URL of the generated artifacts on Wasmer CDN."""
   url: String!
 
-  """
-  When the binding was generated
-  """
+  """When the binding was generated"""
   createdAt: DateTime!
 
-  """
-  Package version used to generate this binding
-  """
+  """Package version used to generate this binding"""
   generator: BindingsGenerator!
-  name: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
-  kind: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
+  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
 
-  """
-  Name of package source
-  """
+  """Name of package source"""
   packageName: String!
-  module: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
-  npmDefaultInstallPackageName(url: String): String!
-    @deprecated(reason: "Please use packageName instead")
+  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  npmDefaultInstallPackageName(url: String): String! @deprecated(reason: "Please use packageName instead")
 }
 
 interface PackageVersionLanguageBinding {
   id: ID!
   language: ProgrammingLanguage!
 
-  """
-  The URL of the generated artifacts on Wasmer CDN.
-  """
+  """The URL of the generated artifacts on Wasmer CDN."""
   url: String!
 
-  """
-  When the binding was generated
-  """
+  """When the binding was generated"""
   createdAt: DateTime!
 
-  """
-  Package version used to generate this binding
-  """
+  """Package version used to generate this binding"""
   generator: BindingsGenerator!
-  name: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
-  kind: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
+  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
 
-  """
-  Name of package source
-  """
+  """Name of package source"""
   packageName: String!
-  module: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
+  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
 }
 
 enum ProgrammingLanguage {
@@ -944,19 +810,13 @@ enum ProgrammingLanguage {
 }
 
 type PackageVersionPythonBindingConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [PackageVersionPythonBindingEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
@@ -964,55 +824,32 @@ type PackageVersionPythonBindingConnection {
 A Relay edge containing a `PackageVersionPythonBinding` and its cursor.
 """
 type PackageVersionPythonBindingEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PackageVersionPythonBinding
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type PackageVersionPythonBinding implements PackageVersionLanguageBinding & Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   language: ProgrammingLanguage!
 
-  """
-  The URL of the generated artifacts on Wasmer CDN.
-  """
+  """The URL of the generated artifacts on Wasmer CDN."""
   url: String!
 
-  """
-  When the binding was generated
-  """
+  """When the binding was generated"""
   createdAt: DateTime!
 
-  """
-  Package version used to generate this binding
-  """
+  """Package version used to generate this binding"""
   generator: BindingsGenerator!
-  name: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
-  kind: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
+  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
 
-  """
-  Name of package source
-  """
+  """Name of package source"""
   packageName: String!
-  module: String!
-    @deprecated(
-      reason: "Do not use this field, since bindings for all modules are generated at once now."
-    )
+  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
   pythonDefaultInstallPackageName(url: String): String!
 }
 
@@ -1030,9 +867,7 @@ type PackageVersionFilesystem {
 }
 
 type InterfaceVersion implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   interface: Interface!
   version: String!
@@ -1040,19 +875,11 @@ type InterfaceVersion implements Node {
   createdAt: DateTime!
   updatedAt: DateTime!
   publishedBy: User!
-  packageVersions(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionConnection!
+  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
 }
 
 type Interface implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   name: String!
   displayName: String!
@@ -1061,72 +888,27 @@ type Interface implements Node {
   icon: String
   createdAt: DateTime!
   updatedAt: DateTime!
-  versions(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): InterfaceVersionConnection!
+  versions(offset: Int, before: String, after: String, first: Int, last: Int): InterfaceVersionConnection!
   lastVersion: InterfaceVersion
 }
 
 type InterfaceVersionConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [InterfaceVersionEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `InterfaceVersion` and its cursor.
-"""
+"""A Relay edge containing a `InterfaceVersion` and its cursor."""
 type InterfaceVersionEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: InterfaceVersion
 
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-type PackageVersionConnection {
-  """
-  Pagination data for this connection.
-  """
-  pageInfo: PageInfo!
-
-  """
-  Contains the nodes in this connection.
-  """
-  edges: [PackageVersionEdge]!
-}
-
-"""
-A Relay edge containing a `PackageVersion` and its cursor.
-"""
-type PackageVersionEdge {
-  """
-  The item at the end of the edge
-  """
-  node: PackageVersion
-
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
@@ -1147,51 +929,70 @@ type PiritaFilesystemDir {
   name(display: PiritaFilesystemNameDisplay): String!
 }
 
+type WEBCFilesystemItem {
+  name: String!
+  checksum: String!
+  size: Int!
+  offset: Int!
+}
+
 type Collection {
   slug: String!
   displayName: String!
   description: String!
   createdAt: DateTime!
   banner: String!
-  packages(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageConnection!
+  packages(before: String, after: String, first: Int, last: Int): PackageConnection!
+}
+
+type PackageKeywordConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [PackageKeywordEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `PackageKeyword` and its cursor."""
+type PackageKeywordEdge {
+  """The item at the end of the edge"""
+  node: PackageKeyword
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type PackageKeyword implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String!
 }
 
 type PackageCollaboratorConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [PackageCollaboratorEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
-"""
-A Relay edge containing a `PackageCollaborator` and its cursor.
-"""
+"""A Relay edge containing a `PackageCollaborator` and its cursor."""
 type PackageCollaboratorEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PackageCollaborator
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type PackageCollaborator implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   user: User!
   role: RegistryPackageMaintainerRoleChoices!
@@ -1202,26 +1003,18 @@ type PackageCollaborator implements Node {
 }
 
 enum RegistryPackageMaintainerRoleChoices {
-  """
-  Admin
-  """
+  """Admin"""
   ADMIN
 
-  """
-  Editor
-  """
+  """Editor"""
   EDITOR
 
-  """
-  Viewer
-  """
+  """Viewer"""
   VIEWER
 }
 
 type PackageCollaboratorInvite implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   requestedBy: User!
   user: User
@@ -1237,46 +1030,33 @@ type PackageCollaboratorInvite implements Node {
 }
 
 enum RegistryPackageMaintainerInviteRoleChoices {
-  """
-  Admin
-  """
+  """Admin"""
   ADMIN
 
-  """
-  Editor
-  """
+  """Editor"""
   EDITOR
 
-  """
-  Viewer
-  """
+  """Viewer"""
   VIEWER
 }
 
 type PackageCollaboratorInviteConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [PackageCollaboratorInviteEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
-"""
-A Relay edge containing a `PackageCollaboratorInvite` and its cursor.
-"""
+"""A Relay edge containing a `PackageCollaboratorInvite` and its cursor."""
 type PackageCollaboratorInviteEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PackageCollaboratorInvite
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
@@ -1287,9 +1067,7 @@ enum GrapheneRole {
 }
 
 type PackageTransferRequest implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   requestedBy: User!
   previousOwnerObjectId: Int!
@@ -1304,330 +1082,42 @@ type PackageTransferRequest implements Node {
   newOwner: PackageOwner!
 }
 
-type DeployAppConnection {
-  """
-  Pagination data for this connection.
-  """
+type PackageSearchConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
+  edges: [PackageSearchEdge]!
+  totalCount: Int
+}
+
+"""A Relay edge containing a `PackageSearch` and its cursor."""
+type PackageSearchEdge {
+  """The item at the end of the edge"""
+  node: PackageVersion
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type DeployAppConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
   edges: [DeployAppEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `DeployApp` and its cursor.
-"""
+"""A Relay edge containing a `DeployApp` and its cursor."""
 type DeployAppEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: DeployApp
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
-}
-
-type DeployApp implements Node & Owner {
-  """
-  The ID of the object
-  """
-  id: ID!
-  createdBy: User!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  activeVersion: DeployAppVersion!
-  globalName: String!
-  url: String!
-  adminUrl: String!
-  permalink: String!
-  urls: [String]!
-  description: String
-  name: String!
-  owner: Owner!
-  versions(
-    sortBy: DeployAppVersionsSortBy
-    createdAfter: DateTime
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): DeployAppVersionConnection!
-  aggregateMetrics: AggregateMetrics!
-  aliases(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): AppAliasConnection!
-  usageMetrics(forRange: MetricRange!, variant: MetricType!): [UsageMetric]!
-}
-
-type DeployAppVersion implements Node {
-  """
-  The ID of the object
-  """
-  id: ID!
-  app: DeployApp!
-  yamlConfig: String!
-  userYamlConfig: String!
-  signature: String
-  description: String
-  publishedBy: User!
-  createdAt: DateTime!
-  configWebc: String
-    @deprecated(reason: "webc support has been deprecated for apps")
-  config: String! @deprecated(reason: "Please use jsonConfig instead")
-  jsonConfig: String!
-  url: String!
-  permalink: String!
-  urls: [String]!
-  version: String!
-  isActive: Boolean!
-  manifest: String!
-  logs(
-    """
-    Get logs starting from this timestamp. Takes EPOCH timestamp in seconds.
-    """
-    startingFrom: Float!
-
-    """
-    Fetch logs until this timestamp. Takes EPOCH timestamp in seconds.
-    """
-    until: Float
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): LogConnection!
-  usageMetrics(forRange: MetricRange!, variant: MetricType!): [UsageMetric]!
-  sourcePackageVersion: PackageVersion!
-  aggregateMetrics: AggregateMetrics!
-}
-
-type LogConnection {
-  """
-  Pagination data for this connection.
-  """
-  pageInfo: PageInfo!
-
-  """
-  Contains the nodes in this connection.
-  """
-  edges: [LogEdge]!
-}
-
-"""
-A Relay edge containing a `Log` and its cursor.
-"""
-type LogEdge {
-  """
-  The item at the end of the edge
-  """
-  node: Log
-
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-type UsageMetric {
-  variant: MetricType!
-  value: Float!
-  unit: MetricUnit!
-  timestamp: DateTime!
-}
-
-enum MetricType {
-  cpu_time
-  memory_time
-  network_egress
-  network_ingress
-  no_of_requests
-  cost
-}
-
-"""
-Units for metrics
-"""
-enum MetricUnit {
-  """
-  represents the unit of "seconds".
-  """
-  SEC
-
-  """
-  represents the unit of "kilobytes".
-  """
-  KB
-
-  """
-  represents the unit of "kilobytes per second".
-  """
-  KBS
-
-  """
-  represents the unit of "number of requests".
-  """
-  NO_REQUESTS
-
-  """
-  represents the unit of "cost" in USD.
-  """
-  DOLLARS
-}
-
-enum MetricRange {
-  LAST_24_HOURS
-  LAST_30_DAYS
-}
-
-type AggregateMetrics {
-  cpuTime: String!
-  memoryTime: String!
-  ingress: String!
-  egress: String!
-  noRequests: String!
-  monthlyCost: String!
-}
-
-type DeployAppVersionConnection {
-  """
-  Pagination data for this connection.
-  """
-  pageInfo: PageInfo!
-
-  """
-  Contains the nodes in this connection.
-  """
-  edges: [DeployAppVersionEdge]!
-
-  """
-  Total number of items in the connection.
-  """
-  totalCount: Int
-}
-
-"""
-A Relay edge containing a `DeployAppVersion` and its cursor.
-"""
-type DeployAppVersionEdge {
-  """
-  The item at the end of the edge
-  """
-  node: DeployAppVersion
-
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-enum DeployAppVersionsSortBy {
-  NEWEST
-  OLDEST
-}
-
-type AppAliasConnection {
-  """
-  Pagination data for this connection.
-  """
-  pageInfo: PageInfo!
-
-  """
-  Contains the nodes in this connection.
-  """
-  edges: [AppAliasEdge]!
-
-  """
-  Total number of items in the connection.
-  """
-  totalCount: Int
-}
-
-"""
-A Relay edge containing a `AppAlias` and its cursor.
-"""
-type AppAliasEdge {
-  """
-  The item at the end of the edge
-  """
-  node: AppAlias
-
-  """
-  A cursor for use in pagination
-  """
-  cursor: String!
-}
-
-type AppAlias implements Node {
-  name: String!
-  app: DeployConfigInfo!
-  isDefault: Boolean!
-
-  """
-  The ID of the object
-  """
-  id: ID!
-  url: String!
-}
-
-type DeployConfigInfo implements Node {
-  """
-  The ID of the object
-  """
-  id: ID!
-  createdBy: User!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  versions: [DeployConfigVersion]
-  publishedBy: User
-  namespace: String!
-  name: String!
-}
-
-type DeployConfigVersion implements Node {
-  """
-  The ID of the object
-  """
-  id: ID!
-  signature: String
-  description: String
-  createdAt: DateTime!
-
-  """
-  """
-  versionNumber: BigInt!
-  updatedAt: DateTime!
-  webcUrl: String!
-    @deprecated(
-      reason: "webc support for apps has been deprecated. Use DeployAppVersion.yamlConfig directly."
-    )
-  fileSize: BigInt!
-    @deprecated(
-      reason: "webc support for apps has been deprecated. Use DeployAppVersion.yamlConfig directly."
-    )
-  fileOffset: BigInt!
-    @deprecated(
-      reason: "webc support for apps has been deprecated. Use DeployAppVersion.yamlConfig directly."
-    )
-  config: String!
-  manifest: String
-    @deprecated(
-      reason: "webc support for apps as been deprecated. use DeployAppVersion.yamlConfig directly."
-    )
-  info: DeployConfigInfo
 }
 
 enum DeployAppsSortBy {
@@ -1637,83 +1127,59 @@ enum DeployAppsSortBy {
 }
 
 type NamespaceCollaboratorConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [NamespaceCollaboratorEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
-"""
-A Relay edge containing a `NamespaceCollaborator` and its cursor.
-"""
+"""A Relay edge containing a `NamespaceCollaborator` and its cursor."""
 type NamespaceCollaboratorEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: NamespaceCollaborator
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type PackageTransferRequestConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [PackageTransferRequestEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
 }
 
-"""
-A Relay edge containing a `PackageTransferRequest` and its cursor.
-"""
+"""A Relay edge containing a `PackageTransferRequest` and its cursor."""
 type PackageTransferRequestEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: PackageTransferRequest
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type APITokenConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [APITokenEdge]!
 }
 
-"""
-A Relay edge containing a `APIToken` and its cursor.
-"""
+"""A Relay edge containing a `APIToken` and its cursor."""
 type APITokenEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: APIToken
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
@@ -1724,51 +1190,31 @@ type APIToken {
   createdAt: DateTime!
   revokedAt: DateTime
   lastUsedAt: DateTime
-  nonceSet(
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): NonceConnection!
+  nonceSet(offset: Int, before: String, after: String, first: Int, last: Int): NonceConnection!
 }
 
 type NonceConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [NonceEdge]!
 
-  """
-  Total number of items in the connection.
-  """
+  """Total number of items in the connection."""
   totalCount: Int
 }
 
-"""
-A Relay edge containing a `Nonce` and its cursor.
-"""
+"""A Relay edge containing a `Nonce` and its cursor."""
 type NonceEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Nonce
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type Nonce implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   name: String!
   callbackUrl: String!
@@ -1781,37 +1227,25 @@ type Nonce implements Node {
 }
 
 type UserNotificationConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [UserNotificationEdge]!
   hasPendingNotifications: Boolean!
 }
 
-"""
-A Relay edge containing a `UserNotification` and its cursor.
-"""
+"""A Relay edge containing a `UserNotification` and its cursor."""
 type UserNotificationEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: UserNotification
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type UserNotification implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   icon: String
   body: UserNotificationBody!
@@ -1831,11 +1265,7 @@ enum UserNotificationSeenState {
   SEEN_AND_READ
 }
 
-union UserNotificationKind =
-    UserNotificationKindPublishedPackageVersion
-  | UserNotificationKindIncomingPackageTransfer
-  | UserNotificationKindIncomingPackageInvite
-  | UserNotificationKindIncomingNamespaceInvite
+union UserNotificationKind = UserNotificationKindPublishedPackageVersion | UserNotificationKindIncomingPackageTransfer | UserNotificationKindIncomingPackageInvite | UserNotificationKindIncomingNamespaceInvite
 
 type UserNotificationKindPublishedPackageVersion {
   packageVersion: PackageVersion!
@@ -1843,6 +1273,18 @@ type UserNotificationKindPublishedPackageVersion {
 
 type UserNotificationKindIncomingNamespaceInvite {
   namespaceInvite: NamespaceCollaboratorInvite!
+}
+
+"""
+
+    Enum of ways a user can login. One user can have many login methods
+    associated with their account.
+    
+"""
+enum LoginMethod {
+  GOOGLE
+  GITHUB
+  PASSWORD
 }
 
 type Signature {
@@ -1966,9 +1408,7 @@ input WorkloadRunnerV1 {
   wcgi: RunnerWCGIV1
 }
 
-"""
-Run a webassembly file.
-"""
+"""Run a webassembly file."""
 input RunnerWCGIV1 {
   source: WorkloadRunnerWasmSourceV1!
   dialect: String
@@ -1993,9 +1433,10 @@ type Billing {
 }
 
 type PaymentIntent implements Node {
-  """
-  Three-letter ISO currency code
-  """
+  """The datetime this object was created in stripe."""
+  created: DateTime
+
+  """Three-letter ISO currency code"""
   currency: String!
 
   """
@@ -2003,9 +1444,7 @@ type PaymentIntent implements Node {
   """
   status: DjstripePaymentIntentStatusChoices!
 
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   amount: String!
 }
@@ -2016,43 +1455,29 @@ enum DjstripePaymentIntentStatusChoices {
   """
   CANCELED
 
-  """
-  Required actions have been handled.
-  """
+  """Required actions have been handled."""
   PROCESSING
 
-  """
-  Payment Method require additional action, such as 3D secure.
-  """
+  """Payment Method require additional action, such as 3D secure."""
   REQUIRES_ACTION
 
-  """
-  Capture the funds on the cards which have been put on holds.
-  """
+  """Capture the funds on the cards which have been put on holds."""
   REQUIRES_CAPTURE
 
-  """
-  Intent is ready to be confirmed.
-  """
+  """Intent is ready to be confirmed."""
   REQUIRES_CONFIRMATION
 
-  """
-  Intent created and requires a Payment Method to be attached.
-  """
+  """Intent created and requires a Payment Method to be attached."""
   REQUIRES_PAYMENT_METHOD
 
-  """
-  The funds are in your account.
-  """
+  """The funds are in your account."""
   SUCCEEDED
 }
 
 union PaymentMethod = CardPaymentMethod
 
 type CardPaymentMethod implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   brand: CardBrand!
   country: String!
@@ -2097,76 +1522,26 @@ type Payment {
   paidOn: DateTime
 }
 
-"""
-Log entry for deploy app.
-"""
+"""Log entry for deploy app."""
 type Log {
   timestamp: Float!
   message: String!
 }
 
 type Query {
-  getDeployConfigVersion(name: String!, signature: String): DeployConfigVersion
-    @deprecated(reason: "Please use getDeployAppVersion instead")
-  getDeployConfigVersions(
-    name: String
-    signature: String
-  ): [DeployConfigVersion]
-    @deprecated(reason: "Please use getDeployAppVersions instead")
-  getAnyDeployConfigVersion(
-    namespace: String!
-    name: String!
-    version: Int
-  ): DeployConfigVersion
-    @deprecated(reason: "Please use getAnyDeployAppVersion instead")
-  getAnyDeployConfigVersions(
-    namespace: String!
-    name: String!
-    version: Int
-  ): [DeployConfigVersion]
-    @deprecated(reason: "Please use getAnyDeployAppVersions instead")
-  getDeployConfigs(name: String, signature: String): [DeployConfigInfo]
-    @deprecated(reason: "Please use getDeployApps instead")
-  getAnyDeployConfig(namespace: String!, name: String!): DeployConfigInfo
-    @deprecated(reason: "Please use getAnyDeployApp instead")
-  getAnyDeployConfigs(namespace: String, name: String): [DeployConfigInfo]
-    @deprecated(reason: "Please use getAnyDeployApps instead")
-  getDeployConfig(name: String!, namespace: String): DeployConfigInfo
-    @deprecated(reason: "Please use getDeployApp instead")
-  getDeployAppVersion(
-    name: String!
-    owner: String!
-    version: String
-  ): DeployAppVersion
-  getDeployApp(name: String!, owner: String!): DeployApp
+  latestTOS: TermsOfService!
+  getDeployAppVersion(name: String!, owner: String, version: String): DeployAppVersion
+  getDeployApp(name: String!, owner: String): DeployApp
   getAppByGlobalAlias(alias: String!): DeployApp
-  getDeployApps(
-    sortBy: DeployAppsSortBy
-    updatedAfter: DateTime
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): DeployAppConnection!
+  getDeployApps(sortBy: DeployAppsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
+  getAppVersions(sortBy: DeployAppVersionsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
   viewer: User
   getUser(username: String!): User
   getPasswordResetToken(token: String!): GetPasswordResetToken
   getAuthNonce(name: String!): Nonce
-  packages(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageConnection
-  recentPackageVersions(
-    curated: Boolean
-    offset: Int
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): PackageVersionConnection!
+  packages(before: String, after: String, first: Int, last: Int): PackageConnection
+  recentPackageVersions(curated: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+  allPackageVersions(sortBy: PackageVersionSortBy, createdAfter: DateTime, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
   getNamespace(name: String!): Namespace
   getPackage(name: String!): Package
   getPackages(names: [String!]!): [Package]!
@@ -2174,61 +1549,34 @@ type Query {
   getPackageVersions(names: [String!]!): [PackageVersion]
   getInterface(name: String!): Interface
   getInterfaces(names: [String!]!): [Interface]!
-  getInterfaceVersion(
-    name: String!
-    version: String = "latest"
-  ): InterfaceVersion
-  getContract(name: String!): Interface
-    @deprecated(reason: "Please use getInterface instead")
-  getContracts(names: [String!]!): [Interface]!
-    @deprecated(reason: "Please use getInterfaces instead")
-  getContractVersion(name: String!, version: String): InterfaceVersion
-    @deprecated(reason: "Please use getInterfaceVersion instead")
+  getInterfaceVersion(name: String!, version: String = "latest"): InterfaceVersion
+  getContract(name: String!): Interface @deprecated(reason: "Please use getInterface instead")
+  getContracts(names: [String!]!): [Interface]! @deprecated(reason: "Please use getInterfaces instead")
+  getContractVersion(name: String!, version: String): InterfaceVersion @deprecated(reason: "Please use getInterfaceVersion instead")
   getCommand(name: String!): Command
   getCommands(names: [String!]!): [Command]
-  getCollections(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): CollectionConnection
-  getSignedUrlForPackageUpload(
-    name: String!
-    version: String = "latest"
-    expiresAfterSeconds: Int = 60
-  ): SignedUrl
-  search(
-    query: String!
-    curated: Boolean
-    orderBy: SearchOrderBy
-    sort: SearchOrderSort
-    kind: [SearchKind!]
-    publishDate: SearchPublishDate
-    hasBindings: Boolean
-    hasCommands: Boolean
-    isStandalone: Boolean
-    withInterfaces: [String!]
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): SearchConnection!
-  searchAutocomplete(
-    kind: [SearchKind!]
-    query: String!
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): SearchConnection!
+  getCollections(before: String, after: String, first: Int, last: Int): CollectionConnection
+  getSignedUrlForPackageUpload(name: String!, version: String = "latest", expiresAfterSeconds: Int = 60): SignedUrl
+  blogposts(tags: [String!], before: String, after: String, first: Int, last: Int): BlogPostConnection!
+  getBlogpost(slug: String, featured: Boolean): BlogPost
+  allBlogpostTags(offset: Int, before: String, after: String, first: Int, last: Int): BlogPostTagConnection
+  search(query: String!, packages: PackagesFilter, namespaces: NamespacesFilter, users: UsersFilter, apps: AppFilter, blogposts: BlogPostsFilter, before: String, after: String, first: Int, last: Int): SearchConnection!
+  searchAutocomplete(kind: [SearchKind!], query: String!, before: String, after: String, first: Int, last: Int): SearchConnection!
   getGlobalObject(slug: String!): GlobalObject
   node(
-    """
-    The ID of the object
-    """
+    """The ID of the object"""
     id: ID!
   ): Node
+  nodes(ids: [ID!]!): [Node]
   info: RegistryInfo
+}
+
+type TermsOfService implements Node {
+  """The ID of the object"""
+  id: ID!
+  content: String!
+  createdAt: DateTime!
+  viewerHasAccepted: Boolean!
 }
 
 type GetPasswordResetToken {
@@ -2236,30 +1584,25 @@ type GetPasswordResetToken {
   user: User
 }
 
+enum PackageVersionSortBy {
+  NEWEST
+  OLDEST
+}
+
 type CollectionConnection {
-  """
-  Pagination data for this connection.
-  """
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
+  """Contains the nodes in this connection."""
   edges: [CollectionEdge]!
 }
 
-"""
-A Relay edge containing a `Collection` and its cursor.
-"""
+"""A Relay edge containing a `Collection` and its cursor."""
 type CollectionEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Collection
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
@@ -2267,51 +1610,116 @@ type SignedUrl {
   url: String!
 }
 
-type SearchConnection {
-  """
-  Pagination data for this connection.
-  """
+type BlogPostConnection {
+  """Pagination data for this connection."""
   pageInfo: PageInfo!
 
-  """
-  Contains the nodes in this connection.
-  """
-  edges: [SearchEdge]!
+  """Contains the nodes in this connection."""
+  edges: [BlogPostEdge]!
 }
 
-"""
-A Relay edge containing a `Search` and its cursor.
-"""
-type SearchEdge {
-  """
-  The item at the end of the edge
-  """
-  node: SearchResult
+"""A Relay edge containing a `BlogPost` and its cursor."""
+type BlogPostEdge {
+  """The item at the end of the edge"""
+  node: BlogPost
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
-union SearchResult = PackageVersion | User | Namespace
+type BlogPost implements Node {
+  """The ID of the object"""
+  id: ID!
+  live: Boolean!
 
-enum SearchOrderBy {
-  ALPHABETICALLY
-  SIZE
-  TOTAL_DOWNLOADS
-  PUBLISHED_DATE
+  """The page title as you'd like it to be seen by the public"""
+  title: String!
+
+  """
+  The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/
+  """
+  slug: String!
+  owner: User
+  body: String!
+  publishDate: DateTime
+  url: String!
+  coverImageUrl: String
+  tagline: String!
+  relatedArticles: [BlogPost!]
+  updatedAt: DateTime!
+  tags: [BlogPostTag!]
+  editUrl: String
+}
+
+type BlogPostTag implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String!
+  slug: String!
+}
+
+type BlogPostTagConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [BlogPostTagEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `BlogPostTag` and its cursor."""
+type BlogPostTagEdge {
+  """The item at the end of the edge"""
+  node: BlogPostTag
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type SearchConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [SearchEdge]!
+  totalCount: Int
+}
+
+"""A Relay edge containing a `Search` and its cursor."""
+type SearchEdge {
+  """The item at the end of the edge"""
+  node: SearchResult
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+union SearchResult = PackageVersion | User | Namespace | DeployApp | BlogPost
+
+input PackagesFilter {
+  count: Int = 1000
+  sortBy: SearchOrderSort = ASC
+  curated: Boolean
+  publishDate: SearchPublishDate
+  hasBindings: Boolean = false
+  isStandalone: Boolean = false
+  hasCommands: Boolean = false
+  withInterfaces: [String]
+  deployable: Boolean
+  license: String
+  size: CountFilter
+  downloads: CountFilter
+  likes: CountFilter
+  owner: String
+  publishedBy: String
+  orderBy: PackageOrderBy = PUBLISHED_DATE
 }
 
 enum SearchOrderSort {
   ASC
   DESC
-}
-
-enum SearchKind {
-  PACKAGE
-  NAMESPACE
-  USER
 }
 
 enum SearchPublishDate {
@@ -2321,141 +1729,169 @@ enum SearchPublishDate {
   LAST_YEAR
 }
 
+input CountFilter {
+  count: Int = 0
+  comparison: CountComparison = GREATER_THAN_OR_EQUAL
+}
+
+enum CountComparison {
+  EQUAL
+  GREATER_THAN
+  LESS_THAN
+  GREATER_THAN_OR_EQUAL
+  LESS_THAN_OR_EQUAL
+}
+
+enum PackageOrderBy {
+  ALPHABETICALLY
+  SIZE
+  TOTAL_DOWNLOADS
+  PUBLISHED_DATE
+}
+
+input NamespacesFilter {
+  count: Int = 1000
+  sortBy: SearchOrderSort = ASC
+  packageCount: CountFilter
+  userCount: CountFilter
+  collaborator: String
+  orderBy: NamespaceOrderBy = CREATED_DATE
+}
+
+enum NamespaceOrderBy {
+  PACKAGE_COUNT
+  COLLABORATOR_COUNT
+  APP_COUNT
+  CREATED_DATE
+}
+
+input UsersFilter {
+  count: Int = 1000
+  sortBy: SearchOrderSort = ASC
+  packageCount: CountFilter
+  namespaceCount: CountFilter
+  orderBy: UserOrderBy = CREATED_DATE
+}
+
+enum UserOrderBy {
+  PACKAGE_COUNT
+  APP_COUNT
+  CREATED_DATE
+}
+
+input AppFilter {
+  count: Int = 1000
+  sortBy: SearchOrderSort = ASC
+  deployedBy: String
+  owner: String
+}
+
+input BlogPostsFilter {
+  count: Int = 1000
+  sortBy: SearchOrderSort = ASC
+  tags: [String]
+}
+
+enum SearchKind {
+  PACKAGE
+  NAMESPACE
+  USER
+}
+
 union GlobalObject = User | Namespace
 
 type RegistryInfo {
-  """
-  Base URL for this registry
-  """
+  """Base URL for this registry"""
   baseUrl: String!
 
-  """
-  Base URL for the default frontend
-  """
+  """Base URL for the default frontend"""
   defaultFrontend: String!
 
-  """
-  URL to the graphql endpoint
-  """
+  """URL to the graphql endpoint"""
   graphqlUrl: String!
 
-  """
-  Public metadata about packages
-  """
+  """URL to the graphql endpoint"""
+  createBlogpostUrl: String
+
+  """Public metadata about packages"""
   packages: PackageInfo!
 
-  """
-  Public metadata about the graphql schema
-  """
+  """Public metadata about the graphql schema"""
   schema: SchemaInfo!
 }
 
 type PackageInfo {
-  """
-  Number of package versions published this month
-  """
+  """Number of package versions published this month"""
   versionsPublishedThisMonth: Int!
 
-  """
-  Number of new packages published this month
-  """
+  """Number of new packages published this month"""
   newPackagesThisMonth: Int!
 
-  """
-  Number of package downloads this month
-  """
+  """Number of package downloads this month"""
   packageDownloadsThisMonth: Int!
 }
 
 type SchemaInfo {
-  """
-  Download link for graphql schema
-  """
+  """Download link for graphql schema"""
   downloadUrl: String!
 
-  """
-  SHA256 hash of the schema data
-  """
+  """SHA256 hash of the schema data"""
   SHA256Hash: String!
 
-  """
-  Timestamp when the schema was last updated
-  """
+  """Timestamp when the schema was last updated"""
   lastUpdated: DateTime!
 }
 
 type Mutation {
-  publishDeployConfig(
-    input: PublishDeployConfigInput!
-  ): PublishDeployConfigPayload
-    @deprecated(reason: "Please use publishDeployApp instead.")
+  """Viewer accepts the latest ToS."""
+  acceptTOS(input: AcceptTOSInput!): AcceptTOSPayload
   publishDeployApp(input: PublishDeployAppInput!): PublishDeployAppPayload
+  deleteApp(input: DeleteAppInput!): DeleteAppPayload
 
-  """
-  Add current user to the waitlist.
-  """
+  """Add current user to the waitlist."""
   joinWaitlist(input: JoinWaitlistInput!): JoinWaitlistPayload
 
-  """
-  Add stripe payment to the user
-  """
+  """Add stripe payment to the user"""
   addPayment(input: AddPaymentInput!): AddPaymentPayload
 
   """
   Mutation to change the active version of a DeployApp to another DeployAppVersion.
   """
-  markAppVersionAsActive(
-    input: MarkAppVersionAsActiveInput!
-  ): MarkAppVersionAsActivePayload
+  markAppVersionAsActive(input: MarkAppVersionAsActiveInput!): MarkAppVersionAsActivePayload
 
-  """
-  Set a payment method as default for the user.
-  """
-  makePaymentDefault(
-    input: SetDefaultPaymentMethodInput!
-  ): SetDefaultPaymentMethodPayload
+  """Set a payment method as default for the user."""
+  makePaymentDefault(input: SetDefaultPaymentMethodInput!): SetDefaultPaymentMethodPayload
 
   """
   Try to detach a payment method from customer.
   Fails if trying to detach a default method,
   or if it's the only payment method.
   """
-  detachPaymentMethod(
-    input: DetachPaymentMethodInput!
-  ): DetachPaymentMethodPayload
-  generateDeployConfigToken(
-    input: GenerateDeployConfigTokenInput!
-  ): GenerateDeployConfigTokenPayload
+  detachPaymentMethod(input: DetachPaymentMethodInput!): DetachPaymentMethodPayload
+  generateDeployConfigToken(input: GenerateDeployConfigTokenInput!): GenerateDeployConfigTokenPayload
+  requestAppTransfer(input: RequestAppTransferInput!): RequestAppTransferPayload
+  acceptAppTransferRequest(input: AcceptAppTransferRequestInput!): AcceptAppTransferRequestPayload
+  removeAppTransferRequest(input: RemoveAppTransferRequestInput!): RemoveAppTransferRequestPayload
   tokenAuth(input: ObtainJSONWebTokenInput!): ObtainJSONWebTokenPayload
-  generateDeployToken(
-    input: GenerateDeployTokenInput!
-  ): GenerateDeployTokenPayload
+  generateDeployToken(input: GenerateDeployTokenInput!): GenerateDeployTokenPayload
   verifyAccessToken(token: String): Verify
   refreshAccessToken(refreshToken: String): Refresh
   revokeAccessToken(refreshToken: String): Revoke
   registerUser(input: RegisterUserInput!): RegisterUserPayload
   socialAuth(input: SocialAuthJWTInput!): SocialAuthJWTPayload
   validateUserEmail(input: ValidateUserEmailInput!): ValidateUserEmailPayload
-  requestPasswordReset(
-    input: RequestPasswordResetInput!
-  ): RequestPasswordResetPayload
-  requestValidationEmail(
-    input: RequestValidationEmailInput!
-  ): RequestValidationEmailPayload
+  requestPasswordReset(input: RequestPasswordResetInput!): RequestPasswordResetPayload
+  requestValidationEmail(input: RequestValidationEmailInput!): RequestValidationEmailPayload
   changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordPayload
   changeUserUsername(input: ChangeUserUsernameInput!): ChangeUserUsernamePayload
   changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload
   updateUserInfo(input: UpdateUserInfoInput!): UpdateUserInfoPayload
-  validateUserPassword(
-    input: ValidateUserPasswordInput!
-  ): ValidateUserPasswordPayload
+  validateUserPassword(input: ValidateUserPasswordInput!): ValidateUserPasswordPayload
   generateApiToken(input: GenerateAPITokenInput!): GenerateAPITokenPayload
   revokeApiToken(input: RevokeAPITokenInput!): RevokeAPITokenPayload
   checkUserExists(input: CheckUserExistsInput!): CheckUserExistsPayload
   readNotification(input: ReadNotificationInput!): ReadNotificationPayload
-  seePendingNotifications(
-    input: SeePendingNotificationsInput!
-  ): SeePendingNotificationsPayload
+  seePendingNotifications(input: SeePendingNotificationsInput!): SeePendingNotificationsPayload
   newNonce(input: NewNonceInput!): NewNoncePayload
   validateNonce(input: ValidateNonceInput!): ValidateNoncePayload
   publishPublicKey(input: PublishPublicKeyInput!): PublishPublicKeyPayload
@@ -2466,71 +1902,36 @@ type Mutation {
   watchPackage(input: WatchPackageInput!): WatchPackagePayload
   unwatchPackage(input: UnwatchPackageInput!): UnwatchPackagePayload
   archivePackage(input: ArchivePackageInput!): ArchivePackagePayload
-  changePackageVersionArchivedStatus(
-    input: ChangePackageVersionArchivedStatusInput!
-  ): ChangePackageVersionArchivedStatusPayload
+  changePackageVersionArchivedStatus(input: ChangePackageVersionArchivedStatusInput!): ChangePackageVersionArchivedStatusPayload
   createNamespace(input: CreateNamespaceInput!): CreateNamespacePayload
   updateNamespace(input: UpdateNamespaceInput!): UpdateNamespacePayload
   deleteNamespace(input: DeleteNamespaceInput!): DeleteNamespacePayload
-  inviteNamespaceCollaborator(
-    input: InviteNamespaceCollaboratorInput!
-  ): InviteNamespaceCollaboratorPayload
-  acceptNamespaceCollaboratorInvite(
-    input: AcceptNamespaceCollaboratorInviteInput!
-  ): AcceptNamespaceCollaboratorInvitePayload
-  removeNamespaceCollaboratorInvite(
-    input: RemoveNamespaceCollaboratorInviteInput!
-  ): RemoveNamespaceCollaboratorInvitePayload
-  removeNamespaceCollaborator(
-    input: RemoveNamespaceCollaboratorInput!
-  ): RemoveNamespaceCollaboratorPayload
-  updateNamespaceCollaboratorRole(
-    input: UpdateNamespaceCollaboratorRoleInput!
-  ): UpdateNamespaceCollaboratorRolePayload
-  updateNamespaceCollaboratorInviteRole(
-    input: UpdateNamespaceCollaboratorInviteRoleInput!
-  ): UpdateNamespaceCollaboratorInviteRolePayload
-  invitePackageCollaborator(
-    input: InvitePackageCollaboratorInput!
-  ): InvitePackageCollaboratorPayload
-  acceptPackageCollaboratorInvite(
-    input: AcceptPackageCollaboratorInviteInput!
-  ): AcceptPackageCollaboratorInvitePayload
-  removePackageCollaboratorInvite(
-    input: RemovePackageCollaboratorInviteInput!
-  ): RemovePackageCollaboratorInvitePayload
-  updatePackageCollaboratorRole(
-    input: UpdatePackageCollaboratorRoleInput!
-  ): UpdatePackageCollaboratorRolePayload
-  updatePackageCollaboratorInviteRole(
-    input: UpdatePackageCollaboratorInviteRoleInput!
-  ): UpdatePackageCollaboratorInviteRolePayload
-  removePackageCollaborator(
-    input: RemovePackageCollaboratorInput!
-  ): RemovePackageCollaboratorPayload
-  requestPackageTransfer(
-    input: RequestPackageTransferInput!
-  ): RequestPackageTransferPayload
-  acceptPackageTransferRequest(
-    input: AcceptPackageTransferRequestInput!
-  ): AcceptPackageTransferRequestPayload
-  removePackageTransferRequest(
-    input: RemovePackageTransferRequestInput!
-  ): RemovePackageTransferRequestPayload
-  generateBindingsForAllPackages(
-    input: GenerateBindingsForAllPackagesInput!
-  ): GenerateBindingsForAllPackagesPayload
+  inviteNamespaceCollaborator(input: InviteNamespaceCollaboratorInput!): InviteNamespaceCollaboratorPayload
+  acceptNamespaceCollaboratorInvite(input: AcceptNamespaceCollaboratorInviteInput!): AcceptNamespaceCollaboratorInvitePayload
+  removeNamespaceCollaboratorInvite(input: RemoveNamespaceCollaboratorInviteInput!): RemoveNamespaceCollaboratorInvitePayload
+  removeNamespaceCollaborator(input: RemoveNamespaceCollaboratorInput!): RemoveNamespaceCollaboratorPayload
+  updateNamespaceCollaboratorRole(input: UpdateNamespaceCollaboratorRoleInput!): UpdateNamespaceCollaboratorRolePayload
+  updateNamespaceCollaboratorInviteRole(input: UpdateNamespaceCollaboratorInviteRoleInput!): UpdateNamespaceCollaboratorInviteRolePayload
+  invitePackageCollaborator(input: InvitePackageCollaboratorInput!): InvitePackageCollaboratorPayload
+  acceptPackageCollaboratorInvite(input: AcceptPackageCollaboratorInviteInput!): AcceptPackageCollaboratorInvitePayload
+  removePackageCollaboratorInvite(input: RemovePackageCollaboratorInviteInput!): RemovePackageCollaboratorInvitePayload
+  updatePackageCollaboratorRole(input: UpdatePackageCollaboratorRoleInput!): UpdatePackageCollaboratorRolePayload
+  updatePackageCollaboratorInviteRole(input: UpdatePackageCollaboratorInviteRoleInput!): UpdatePackageCollaboratorInviteRolePayload
+  removePackageCollaborator(input: RemovePackageCollaboratorInput!): RemovePackageCollaboratorPayload
+  requestPackageTransfer(input: RequestPackageTransferInput!): RequestPackageTransferPayload
+  acceptPackageTransferRequest(input: AcceptPackageTransferRequestInput!): AcceptPackageTransferRequestPayload
+  removePackageTransferRequest(input: RemovePackageTransferRequestInput!): RemovePackageTransferRequestPayload
+  generateBindingsForAllPackages(input: GenerateBindingsForAllPackagesInput!): GenerateBindingsForAllPackagesPayload
+  makePackagePublic(input: MakePackagePublicInput!): MakePackagePublicPayload
 }
 
-type PublishDeployConfigPayload {
-  deployConfigVersion: DeployConfigVersion!
+"""Viewer accepts the latest ToS."""
+type AcceptTOSPayload {
+  TOS: TermsOfService!
   clientMutationId: String
 }
 
-input PublishDeployConfigInput {
-  content: String!
-  name: ID
-  description: String
+input AcceptTOSInput {
   clientMutationId: String
 }
 
@@ -2540,11 +1941,25 @@ type PublishDeployAppPayload {
 }
 
 input PublishDeployAppInput {
+  """The configuration of the app."""
   config: Configuration!
+
+  """The name of the app."""
   name: ID
+
+  """The owner of the app."""
   owner: ID
+
+  """The description of the app."""
   description: String
+
+  """If true, the new version will be set as the default version."""
   makeDefault: Boolean = true
+
+  """
+  If true, Publishing will fail if the source package does not have a valid webc.
+  """
+  strict: Boolean = false
   clientMutationId: String
 }
 
@@ -2561,9 +1976,18 @@ input AppV0 {
   package: String!
 }
 
-"""
-Add current user to the waitlist.
-"""
+type DeleteAppPayload {
+  success: Boolean!
+  clientMutationId: String
+}
+
+input DeleteAppInput {
+  """App ID to delete."""
+  id: ID!
+  clientMutationId: String
+}
+
+"""Add current user to the waitlist."""
 type JoinWaitlistPayload {
   waitlistMember: WaitlistMember!
   clientMutationId: String
@@ -2574,9 +1998,7 @@ input JoinWaitlistInput {
   clientMutationId: String
 }
 
-"""
-Add stripe payment to the user
-"""
+"""Add stripe payment to the user"""
 type AddPaymentPayload {
   customerSecret: String!
   clientMutationId: String
@@ -2595,16 +2017,12 @@ type MarkAppVersionAsActivePayload {
 }
 
 input MarkAppVersionAsActiveInput {
-  """
-  The ID of the DeployAppVersion to set as the new active version.
-  """
+  """The ID of the DeployAppVersion to set as the new active version."""
   appVersion: ID!
   clientMutationId: String
 }
 
-"""
-Set a payment method as default for the user.
-"""
+"""Set a payment method as default for the user."""
 type SetDefaultPaymentMethodPayload {
   success: Boolean!
   billing: Billing!
@@ -2643,6 +2061,54 @@ input GenerateDeployConfigTokenInput {
   clientMutationId: String
 }
 
+type RequestAppTransferPayload {
+  appTransferRequest: AppTransferRequest!
+  clientMutationId: String
+}
+
+type AppTransferRequest implements Node {
+  """The ID of the object"""
+  id: ID!
+  requestedBy: User!
+  previousOwnerObjectId: Int!
+  newOwnerObjectId: Int!
+  app: DeployApp!
+  approvedBy: User
+  declinedBy: User
+  createdAt: DateTime!
+  expiresAt: DateTime!
+  closedAt: DateTime
+  previousOwner: Owner!
+  newOwner: Owner!
+}
+
+input RequestAppTransferInput {
+  appId: ID!
+  newOwnerId: ID!
+  clientMutationId: String
+}
+
+type AcceptAppTransferRequestPayload {
+  app: DeployApp!
+  appTransferRequest: AppTransferRequest!
+  clientMutationId: String
+}
+
+input AcceptAppTransferRequestInput {
+  appTransferRequestId: ID!
+  clientMutationId: String
+}
+
+type RemoveAppTransferRequestPayload {
+  app: DeployApp!
+  clientMutationId: String
+}
+
+input RemoveAppTransferRequestInput {
+  appTransferRequestId: ID!
+  clientMutationId: String
+}
+
 type ObtainJSONWebTokenPayload {
   payload: GenericScalar!
   refreshExpiresIn: Int!
@@ -2674,7 +2140,7 @@ input ObtainJSONWebTokenInput {
 
 type GenerateDeployTokenPayload {
   token: String!
-  deployConfigVersion: DeployConfigVersion!
+  deployConfigVersion: DeployAppVersion!
   clientMutationId: String
 }
 
@@ -2718,9 +2184,7 @@ type SocialAuthJWTPayload {
 }
 
 type SocialAuth implements Node {
-  """
-  The ID of the object
-  """
+  """The ID of the object"""
   id: ID!
   user: User!
   provider: String!
@@ -2733,6 +2197,7 @@ type SocialAuth implements Node {
 input SocialAuthJWTInput {
   provider: String!
   accessToken: String!
+  register: Boolean = false
   clientMutationId: String
 }
 
@@ -2742,9 +2207,7 @@ type ValidateUserEmailPayload {
 }
 
 input ValidateUserEmailInput {
-  """
-  The user id
-  """
+  """The user id"""
   userId: ID
   challenge: String!
   clientMutationId: String
@@ -2773,9 +2236,7 @@ type RequestValidationEmailPayload {
 }
 
 input RequestValidationEmailInput {
-  """
-  The user id
-  """
+  """The user id"""
   userId: ID
   clientMutationId: String
 }
@@ -2802,9 +2263,7 @@ type ChangeUserUsernamePayload {
 }
 
 input ChangeUserUsernameInput {
-  """
-  The new user username
-  """
+  """The new user username"""
   username: CaseInsensitiveString!
   clientMutationId: String
 }
@@ -2825,24 +2284,16 @@ type UpdateUserInfoPayload {
 }
 
 input UpdateUserInfoInput {
-  """
-  The user id
-  """
+  """The user id"""
   userId: ID
 
-  """
-  The user full name
-  """
+  """The user full name"""
   fullName: String
 
-  """
-  The user bio
-  """
+  """The user bio"""
   bio: String
 
-  """
-  The user avatar
-  """
+  """The user avatar"""
   avatar: String
 
   """
@@ -2855,14 +2306,10 @@ input UpdateUserInfoInput {
   """
   github: String
 
-  """
-  The user website (it must be a valid url)
-  """
+  """The user website (it must be a valid url)"""
   websiteUrl: String
 
-  """
-  The user location
-  """
+  """The user location"""
   location: String
   clientMutationId: String
 }
@@ -2896,9 +2343,7 @@ type RevokeAPITokenPayload {
 }
 
 input RevokeAPITokenInput {
-  """
-  The API token ID
-  """
+  """The API token ID"""
   tokenId: ID!
   clientMutationId: String
 }
@@ -2906,17 +2351,13 @@ input RevokeAPITokenInput {
 type CheckUserExistsPayload {
   exists: Boolean!
 
-  """
-  The user is only returned if the user input was the username
-  """
+  """The user is only returned if the user input was the username"""
   user: User
   clientMutationId: String
 }
 
 input CheckUserExistsInput {
-  """
-  The user
-  """
+  """The user"""
   user: String!
   clientMutationId: String
 }
@@ -2995,10 +2436,11 @@ input PublishPackageInput {
   signedUrl: String
   signature: InputSignature
 
-  """
-  The package icon
-  """
+  """The package icon"""
   icon: String
+
+  """Whether the package is private"""
+  private: Boolean = false
   clientMutationId: String
 }
 
@@ -3015,9 +2457,7 @@ type UpdatePackagePayload {
 input UpdatePackageInput {
   packageId: ID!
 
-  """
-  The package icon
-  """
+  """The package icon"""
   icon: String
   clientMutationId: String
 }
@@ -3092,19 +2532,13 @@ type CreateNamespacePayload {
 input CreateNamespaceInput {
   name: String!
 
-  """
-  The namespace display name
-  """
+  """The namespace display name"""
   displayName: String
 
-  """
-  The namespace description
-  """
+  """The namespace description"""
   description: String
 
-  """
-  The namespace avatar
-  """
+  """The namespace avatar"""
   avatar: String
   clientMutationId: String
 }
@@ -3117,24 +2551,16 @@ type UpdateNamespacePayload {
 input UpdateNamespaceInput {
   namespaceId: ID!
 
-  """
-  The namespace slug name
-  """
+  """The namespace slug name"""
   name: String
 
-  """
-  The namespace display name
-  """
+  """The namespace display name"""
   displayName: String
 
-  """
-  The namespace description
-  """
+  """The namespace description"""
   description: String
 
-  """
-  The namespace avatar
-  """
+  """The namespace avatar"""
   avatar: String
   clientMutationId: String
 }
@@ -3321,6 +2747,17 @@ type GenerateBindingsForAllPackagesPayload {
 input GenerateBindingsForAllPackagesInput {
   bindingsGeneratorId: ID
   bindingsGeneratorCommand: String
+  clientMutationId: String
+}
+
+type MakePackagePublicPayload {
+  package: Package!
+  clientMutationId: String
+}
+
+input MakePackagePublicInput {
+  """The ID of the package to make public"""
+  id: ID!
   clientMutationId: String
 }
 

--- a/lib/registry/src/lib.rs
+++ b/lib/registry/src/lib.rs
@@ -45,11 +45,14 @@ pub static PACKAGE_TOML_FALLBACK_NAME: &str = "wapm.toml";
 pub static GLOBAL_CONFIG_FILE_NAME: &str = "wasmer.toml";
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[non_exhaustive]
 pub struct PackageDownloadInfo {
     pub registry: String,
     pub package: String,
     pub version: String,
     pub is_latest_version: bool,
+    /// Is the package private?
+    pub is_private: bool,
     pub commands: String,
     pub manifest: String,
     pub url: String,
@@ -90,6 +93,7 @@ pub fn query_command_from_registry(
         commands: command_name.to_string(),
         url,
         pirita_url,
+        is_private: command.package_version.package.private,
     })
 }
 
@@ -112,6 +116,8 @@ impl fmt::Display for QueryPackageError {
         }
     }
 }
+
+impl std::error::Error for QueryPackageError {}
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum GetIfPackageHasNewVersionResult {
@@ -177,6 +183,7 @@ pub fn query_package_from_registry(
 
         version: v.version.clone(),
         is_latest_version: v.is_last_version,
+        is_private: v.package.private,
         manifest: v.manifest.clone(),
 
         commands: manifest

--- a/lib/registry/src/publish.rs
+++ b/lib/registry/src/publish.rs
@@ -231,6 +231,7 @@ pub fn try_chunked_uploading(
             file_name: Some(archive_name.to_string()),
             signature: maybe_signature_data,
             signed_url: Some(signed_url),
+            private: Some(package.private),
         });
 
     let _response: publish_package_mutation_chunked::ResponseData =

--- a/lib/wasi-web/Cargo.lock
+++ b/lib/wasi-web/Cargo.lock
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbc60abd742b35f2492f808e1abbb83d45f72db402e14c55057edc9c7b1e9e4"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -643,9 +643,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -668,15 +668,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -685,15 +685,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -702,21 +702,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -921,9 +921,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1194,7 +1194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1627,7 +1627,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -1766,13 +1766,13 @@ checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1936,14 +1936,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef75d881185fd2df4a040793927c153d863651108a93c7e17a9e591baa95cc6"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.4",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -1961,7 +1961,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1970,11 +1970,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.4"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f9e8120405471f7c9ad1860a713ef5ece6a670c7eae39225e477340f32fc4"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2338,9 +2338,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2350,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -2365,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2387,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2400,15 +2400,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
+checksum = "c6433b7c56db97397842c46b67e11873eda263170afeb3a2dc74a7cb370fee0d"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -2420,12 +2420,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
+checksum = "493fcbab756bb764fa37e6bee8cec2dd709eb4273d06d0c282a5e74275ded735"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2506,14 +2507,14 @@ checksum = "d21472954ee9443235ca32522b17fc8f0fe58e2174556266a0d9766db055cc52"
 dependencies = [
  "anyhow",
  "derive_builder",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "semver",
  "serde",
  "serde_cbor",
  "serde_json",
  "serde_yaml 0.9.27",
  "thiserror",
- "toml 0.8.4",
+ "toml 0.8.6",
 ]
 
 [[package]]
@@ -2717,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2727,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "5.7.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fc974157e8532c5c31fa44c38046264227e580cd2a0d939543891d23f43779"
+checksum = "ac815d472f09ed064ef70a3046843972646727cbe55db795dd8a9925b76ed0c4"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -2914,9 +2915,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
 dependencies = [
  "memchr",
 ]

--- a/tests/integration/cli/tests/fixtures/init1.toml
+++ b/tests/integration/cli/tests/fixtures/init1.toml
@@ -16,3 +16,4 @@ wasi = '0.1.0-unstable'
 [[command]]
 name = 'testfirstproject'
 module = 'testfirstproject'
+runner = 'wasi'

--- a/tests/integration/cli/tests/fixtures/init4.toml
+++ b/tests/integration/cli/tests/fixtures/init4.toml
@@ -16,3 +16,4 @@ wasi = '0.1.0-unstable'
 [[command]]
 name = 'wasmer'
 module = 'wasmer'
+runner = 'wasi'


### PR DESCRIPTION
This updates the `wasmer publish` command to allow users to publish private packages. When a package is private, you will only be able to access it if you have contributor access (e.g. because you are the owner, have been added as a contributor, or are part of a namespace that owns the package).