### PR TITLE
fix: prevent potential UB by deriving repr C for union

### DIFF
--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -23,6 +23,7 @@ use wasmer_types::RawValue;
 /// It may either be a pointer to the [`VMContext`] if it's a Wasm function
 /// or a pointer to arbitrary data controlled by the host if it's a host function.
 #[derive(Copy, Clone, Eq)]
+#[repr(C)]
 pub union VMFunctionContext {
     /// Wasm functions take a pointer to [`VMContext`].
     pub vmctx: *mut VMContext,


### PR DESCRIPTION
# Description
Use repr C for `VMFunctionContext` to prevent undefined behavior. I believe this union may exhibit UB since it [crosses an FFI boundary](https://github.com/wasmerio/wasmer/blob/d18aa794978e6b951e36632e29e58f4ef7e0da03/lib/vm/src/trap/traphandlers.rs#L642-L670). Also, I think `eq` and `is_null` may be called on both instances of the union despite the layout not being guaranteed. This is explained further [this](https://rust-lang.github.io/rust-clippy/master/index.html#/default_union_representation) by this clippy lint so perhaps it's worth configuring it to be `deny`.