### PR TITLE
Moved tmp as tmpdirectory outside of RootFileSystemBuilder

### DIFF
--- a/lib/virtual-fs/src/builder.rs
+++ b/lib/virtual-fs/src/builder.rs
@@ -64,7 +64,7 @@ impl RootFileSystemBuilder {
     pub fn build(self) -> TmpFileSystem {
         let tmp = TmpFileSystem::new();
         if self.default_root_dirs {
-            for root_dir in &["/.app", "/.private", "/bin", "/dev", "/etc", "/tmp"] {
+            for root_dir in &["/.app", "/.private", "/bin", "/dev", "/etc"] {
                 if let Err(err) = tmp.create_dir(Path::new(root_dir)) {
                     debug!("failed to create dir [{}] - {}", root_dir, err);
                 }

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -159,9 +159,7 @@ fn prepare_filesystem(
     }
 
     let temp_fs: Arc<dyn FileSystem + Send + Sync> = Arc::new(TmpFileSystem::new());
-    root_fs
-        .mount("/tmp".into(), &temp_fs, "/".into())
-        .unwrap();
+    root_fs.mount("/tmp".into(), &temp_fs, "/".into()).unwrap();
 
     // HACK(Michael-F-Bryan): The WebcVolumeFileSystem only accepts relative
     // paths, but our Python executable will try to access its standard library

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -158,6 +158,11 @@ fn prepare_filesystem(
         }
     }
 
+    let temp_fs: Arc<dyn FileSystem + Send + Sync> = Arc::new(TmpFileSystem::new());
+    root_fs
+        .mount("/tmp".into(), &temp_fs, "/".into())
+        .unwrap();
+
     // HACK(Michael-F-Bryan): The WebcVolumeFileSystem only accepts relative
     // paths, but our Python executable will try to access its standard library
     // with relative paths assuming that it is being run from the root


### PR DESCRIPTION
This fixes an issue with the tmpfilesystem being reused across spawning processes (aka clang)