### PR TITLE
Allow `WasiRunner` to mount `FileSystem` instances

### DIFF
--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -40,6 +40,8 @@ mod filesystems;
 pub(crate) mod ops;
 mod overlay_fs;
 pub mod pipe;
+#[cfg(feature = "host-fs")]
+mod scoped_directory_fs;
 mod static_file;
 #[cfg(feature = "static-fs")]
 pub mod static_fs;
@@ -65,6 +67,8 @@ pub use null_file::*;
 pub use overlay_fs::OverlayFileSystem;
 pub use passthru_fs::*;
 pub use pipe::*;
+#[cfg(feature = "host-fs")]
+pub use scoped_directory_fs::ScopedDirectoryFileSystem;
 pub use special_file::*;
 pub use static_file::StaticFile;
 pub use tmp_fs::*;

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -672,6 +672,13 @@ impl FileType {
         }
     }
 
+    pub fn new_file() -> Self {
+        Self {
+            file: true,
+            ..Default::default()
+        }
+    }
+
     pub fn is_dir(&self) -> bool {
         self.dir
     }

--- a/lib/virtual-fs/src/scoped_directory_fs.rs
+++ b/lib/virtual-fs/src/scoped_directory_fs.rs
@@ -1,0 +1,146 @@
+use std::path::{Component, Path, PathBuf};
+
+use futures::future::BoxFuture;
+
+use crate::{
+    DirEntry, FileOpener, FileSystem, FsError, Metadata, OpenOptions, OpenOptionsConfig, ReadDir,
+    VirtualFile,
+};
+
+/// A [`FileSystem`] implementation that is scoped to a specific directory on
+/// the host.
+#[derive(Debug, Clone)]
+pub struct ScopedDirectoryFileSystem {
+    root: PathBuf,
+    inner: crate::host_fs::FileSystem,
+}
+
+impl ScopedDirectoryFileSystem {
+    pub fn new(root: impl Into<PathBuf>, inner: crate::host_fs::FileSystem) -> Self {
+        ScopedDirectoryFileSystem {
+            root: root.into(),
+            inner,
+        }
+    }
+
+    /// Create a new [`ScopedDirectoryFileSystem`] using the current
+    /// [`tokio::runtime::Handle`].
+    ///
+    /// # Panics
+    ///
+    /// This will panic if called outside of a `tokio` context.
+    pub fn new_with_default_runtime(root: impl Into<PathBuf>) -> Self {
+        let handle = tokio::runtime::Handle::current();
+        let fs = crate::host_fs::FileSystem::new(handle);
+        ScopedDirectoryFileSystem::new(root, fs)
+    }
+
+    fn prepare_path(&self, path: &Path) -> PathBuf {
+        let path = normalize_path(path);
+        let path = path.strip_prefix("/").unwrap_or(&path);
+
+        let path = if !path.starts_with(&self.root) {
+            self.root.join(path)
+        } else {
+            path.to_owned()
+        };
+
+        debug_assert!(path.starts_with(&self.root));
+        path
+    }
+}
+
+impl FileSystem for ScopedDirectoryFileSystem {
+    fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
+        let path = self.prepare_path(path);
+
+        let mut entries = Vec::new();
+
+        for entry in self.inner.read_dir(&path)? {
+            let entry = entry?;
+            let path = entry
+                .path
+                .strip_prefix(&self.root)
+                .map_err(|_| FsError::InvalidData)?;
+            entries.push(DirEntry {
+                path: Path::new("/").join(path),
+                ..entry
+            });
+        }
+
+        Ok(ReadDir::new(entries))
+    }
+
+    fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+        let path = self.prepare_path(path);
+        self.inner.create_dir(&path)
+    }
+
+    fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
+        let path = self.prepare_path(path);
+        self.inner.remove_dir(&path)
+    }
+
+    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<(), FsError>> {
+        Box::pin(async move {
+            let from = self.prepare_path(from);
+            let to = self.prepare_path(to);
+            self.inner.rename(&from, &to).await
+        })
+    }
+
+    fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+        let path = self.prepare_path(path);
+        self.inner.metadata(&path)
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+        let path = self.prepare_path(path);
+        self.inner.remove_file(&path)
+    }
+
+    fn new_open_options(&self) -> OpenOptions {
+        OpenOptions::new(self)
+    }
+}
+
+impl FileOpener for ScopedDirectoryFileSystem {
+    fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>, FsError> {
+        let path = self.prepare_path(path);
+        self.inner
+            .new_open_options()
+            .options(conf.clone())
+            .open(&path)
+    }
+}
+
+// Copied from cargo
+// https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {}
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}

--- a/lib/wasix/src/runners/mod.rs
+++ b/lib/wasix/src/runners/mod.rs
@@ -9,15 +9,7 @@ mod wasi_common;
 #[cfg(feature = "webc_runner_rt_wcgi")]
 pub mod wcgi;
 
-pub use self::{runner::Runner, wasi_common::MappedCommand};
-
-/// A directory that should be mapped from the host filesystem into a WASI
-/// instance (the "guest").
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct MappedDirectory {
-    /// The absolute path for a directory on the host filesystem.
-    pub host: std::path::PathBuf,
-    /// The absolute path specifying where the host directory should be mounted
-    /// inside the guest.
-    pub guest: String,
-}
+pub use self::{
+    runner::Runner,
+    wasi_common::{MappedCommand, MappedDirectory, MountedDirectory},
+};

--- a/lib/wasix/src/runners/wasi.rs
+++ b/lib/wasix/src/runners/wasi.rs
@@ -4,7 +4,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Error};
 use tracing::Instrument;
-use virtual_fs::{ArcBoxFile, TmpFileSystem, VirtualFile};
+use virtual_fs::{ArcBoxFile, FileSystem, TmpFileSystem, VirtualFile};
 use wasmer::Module;
 use webc::metadata::{annotations::Wasi, Command};
 
@@ -12,7 +12,7 @@ use crate::{
     bin_factory::BinaryPackage,
     capabilities::Capabilities,
     journal::{DynJournal, SnapshotTrigger},
-    runners::{wasi_common::CommonWasiOptions, MappedDirectory},
+    runners::{wasi_common::CommonWasiOptions, MappedDirectory, MountedDirectory},
     runtime::{module_cache::ModuleHash, task_manager::VirtualTaskManagerExt},
     Runtime, WasiEnvBuilder, WasiError, WasiRuntimeError,
 };
@@ -98,14 +98,25 @@ impl WasiRunner {
         self.wasi.forward_host_env = forward;
     }
 
-    pub fn with_mapped_directories<I, D>(mut self, dirs: I) -> Self
+    pub fn with_mapped_directories<I, D>(self, dirs: I) -> Self
     where
         I: IntoIterator<Item = D>,
         D: Into<MappedDirectory>,
     {
-        self.wasi
-            .mapped_dirs
-            .extend(dirs.into_iter().map(|d| d.into()));
+        self.with_mounted_directories(dirs.into_iter().map(Into::into).map(MountedDirectory::from))
+    }
+
+    pub fn with_mounted_directories<I, D>(mut self, dirs: I) -> Self
+    where
+        I: IntoIterator<Item = D>,
+        D: Into<MountedDirectory>,
+    {
+        self.wasi.mounts.extend(dirs.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn mount(&mut self, dest: String, fs: Arc<dyn FileSystem + Send + Sync>) -> &mut Self {
+        self.wasi.mounts.push(MountedDirectory { guest: dest, fs });
         self
     }
 

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -9,7 +9,7 @@ use derivative::Derivative;
 use futures::future::BoxFuture;
 use virtual_fs::{
     DirEntry, FileOpener, FileSystem, FsError, OverlayFileSystem, RootFileSystemBuilder,
-    TmpFileSystem, ScopedDirectoryFileSystem,
+    ScopedDirectoryFileSystem, TmpFileSystem,
 };
 use webc::metadata::annotations::Wasi as WasiAnnotation;
 
@@ -265,7 +265,6 @@ impl From<MappedDirectory> for MountedDirectory {
         MountedDirectory { guest, fs }
     }
 }
-
 
 #[derive(Debug)]
 struct RelativeOrAbsolutePathHack<F>(F);

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -265,7 +265,7 @@ impl From<MappedDirectory> for MountedDirectory {
             if #[cfg(feature = "host-fs")] {
                 let MappedDirectory { host, guest } = value;
                 let fs: Arc<dyn FileSystem + Send + Sync> =
-                    Arc::new(ScopedDirectoryFileSystem::new_with_default_runtime(host));
+                    Arc::new(virtual_fs::ScopedDirectoryFileSystem::new_with_default_runtime(host));
 
                 MountedDirectory { guest, fs }
             } else {

--- a/lib/wasix/src/runners/wcgi/runner.rs
+++ b/lib/wasix/src/runners/wcgi/runner.rs
@@ -237,7 +237,7 @@ impl Config {
     }
 
     pub fn map_directory(&mut self, dir: MappedDirectory) -> &mut Self {
-        self.wasi.mapped_dirs.push(dir);
+        self.wasi.mounts.push(dir.into());
         self
     }
 
@@ -245,7 +245,9 @@ impl Config {
         &mut self,
         mappings: impl IntoIterator<Item = MappedDirectory>,
     ) -> &mut Self {
-        self.wasi.mapped_dirs.extend(mappings.into_iter());
+        for mapping in mappings {
+            self.map_directory(mapping);
+        }
         self
     }
 


### PR DESCRIPTION
As part of https://github.com/wasmerio/wasmer-js/pull/334 we need the ability to mount entire `FileSystem` instances at a particular point in the WASIX instance's filesystem. 

I've added an adaptor so the existing `map_directory()` methods for mapping a directory on the host filesystem goes through this new `mount()` mechanism.