### PR TITLE
[WIP] Make VirtualTaskManager non WASI Dependant

### DIFF
--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -217,7 +217,12 @@ fn call_module(
 
                     // Spawns the WASM process after a trigger
                     if let Err(err) = unsafe {
-                        tasks.resume_wasm_after_poller(Box::new(respawn), ctx, store, deep.trigger)
+                        tasks.resume_wasm_after_poller(
+                            Box::new(respawn),
+                            ctx.data(&store).clone(),
+                            store,
+                            deep.trigger,
+                        )
                     } {
                         debug!("failed to go into deep sleep - {}", err);
                     }

--- a/lib/wasix/src/runtime/task_manager/mod.rs
+++ b/lib/wasix/src/runtime/task_manager/mod.rs
@@ -285,7 +285,7 @@ impl dyn VirtualTaskManager {
     pub unsafe fn resume_wasm_after_poller(
         &self,
         task: Box<WasmResumeTask>,
-        ctx: WasiFunctionEnv,
+        env: WasiEnv,
         mut store: Store,
         trigger: Pin<Box<AsyncifyFuture>>,
     ) -> Result<(), WasiThreadError> {
@@ -312,7 +312,6 @@ impl dyn VirtualTaskManager {
         }
 
         let snapshot = capture_snapshot(&mut store.as_store_mut());
-        let env = ctx.data(&store);
         let module = env.inner().module_clone();
         let memory = env.inner().memory_clone();
         let thread = env.thread.clone();

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -1058,7 +1058,12 @@ fn handle_result(
             // Spawns the WASM process after a trigger
             unsafe {
                 tasks
-                    .resume_wasm_after_poller(Box::new(respawn), env, store, work.trigger)
+                    .resume_wasm_after_poller(
+                        Box::new(respawn),
+                        env.data(&store).clone(),
+                        store,
+                        work.trigger,
+                    )
                     .unwrap();
             }
 

--- a/lib/wasix/src/syscalls/wasix/proc_fork.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork.rs
@@ -295,7 +295,12 @@ fn run<M: MemorySize>(
 
                 /// Spawns the WASM process after a trigger
                 unsafe {
-                    tasks.resume_wasm_after_poller(Box::new(respawn), ctx, store, deep.trigger)
+                    tasks.resume_wasm_after_poller(
+                        Box::new(respawn),
+                        ctx.data(&store).clone(),
+                        store,
+                        deep.trigger,
+                    )
                 };
                 return Errno::Success.into();
             }

--- a/lib/wasix/src/syscalls/wasix/thread_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_spawn.rs
@@ -244,7 +244,12 @@ fn call_module<M: MemorySize>(
 
             /// Spawns the WASM process after a trigger
             unsafe {
-                tasks.resume_wasm_after_poller(Box::new(respawn), ctx, store, deep.trigger)
+                tasks.resume_wasm_after_poller(
+                    Box::new(respawn),
+                    ctx.data(&store).clone(),
+                    store,
+                    deep.trigger,
+                )
             };
             Err(Errno::Unknown)
         }


### PR DESCRIPTION
VirtualTaskManager right now depends on WASI functionality, we should remove that so we can untie refactoring the runner out
