### PR TITLE
4309 add tty aware output to the wasmer package and wasmer container commands

### DIFF
--- a/lib/cli/src/commands/container/unpack.rs
+++ b/lib/cli/src/commands/container/unpack.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
-
 use anyhow::Context;
+use dialoguer::console::{style, Emoji};
+use std::path::PathBuf;
 
 /// Extract contents of a container to a directory.
 #[derive(clap::Parser, Debug)]
@@ -17,9 +17,16 @@ pub struct PackageUnpack {
     package_path: PathBuf,
 }
 
+static PACKAGE_EMOJI: Emoji<'_, '_> = Emoji("📦 ", "");
+static EXTRACTED_TO_EMOJI: Emoji<'_, '_> = Emoji("📂 ", "");
+
 impl PackageUnpack {
     pub(crate) fn execute(&self) -> Result<(), anyhow::Error> {
-        eprintln!("Unpacking...");
+        println!(
+            "{} {}Unpacking...",
+            style("[1/2]").bold().dim(),
+            PACKAGE_EMOJI
+        );
 
         let pkg = webc::compat::Container::from_disk(&self.package_path).with_context(|| {
             format!(
@@ -35,7 +42,12 @@ impl PackageUnpack {
         pkg.unpack(outdir, self.overwrite)
             .with_context(|| "could not extract package".to_string())?;
 
-        eprintln!("Extracted package contents to '{}'", self.out_dir.display());
+        println!(
+            "{} {}Extracted package contents to '{}'",
+            style("[2/2]").bold().dim(),
+            EXTRACTED_TO_EMOJI,
+            self.out_dir.display()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Adds:
- [x] Better messages with emojis for the commands implemented in #4287 
- [x] Adds a progress bar for the command `wasmer package download` 
