### PR TITLE
Bump min enumset version to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ rust-version = "1.70"
 version = "4.2.3"
 
 [workspace.dependencies]
+enumset = "1.1.0"
 memoffset = "0.9.0"
 wasmer-toml = "0.9.2"
 webc = { version = "5.8.0", default-features = false, features = ["package"] }

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -35,7 +35,7 @@ wasmer-types = { version = "=4.2.3", path = "../types" }
 wasmer-wasix = { version = "0.16.0", path = "../wasix", features = ["host-fs", "host-vnet"], optional = true }
 webc = { version = "5.0", optional = true }
 virtual-fs = { version = "0.9.0", path = "../virtual-fs", optional = true, default-features = false, features = ["static-fs"] }
-enumset = "1.0.2"
+enumset = "1.1.0"
 cfg-if = "1.0"
 lazy_static = "1.4"
 libc = { version = "^0.2", default-features = false }

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -35,7 +35,7 @@ wasmer-types = { version = "=4.2.3", path = "../types" }
 wasmer-wasix = { version = "0.16.0", path = "../wasix", features = ["host-fs", "host-vnet"], optional = true }
 webc = { version = "5.0", optional = true }
 virtual-fs = { version = "0.9.0", path = "../virtual-fs", optional = true, default-features = false, features = ["static-fs"] }
-enumset = "1.1.0"
+enumset.workspace = true
 cfg-if = "1.0"
 lazy_static = "1.4"
 libc = { version = "^0.2", default-features = false }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -18,7 +18,7 @@ wasmer-compiler = { path = "../compiler", version = "=4.2.3", features = ["trans
 wasmer-types = { path = "../types", version = "=4.2.3", default-features = false, features = ["std"] }
 hashbrown = { version = "0.11", optional = true }
 gimli = { version = "0.26", optional = true }
-enumset = "1.1.0"
+enumset.workspace = true
 more-asserts = "0.2"
 dynasm = "1.2.3"
 dynasmrt = "1.2.3"

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -18,7 +18,7 @@ wasmer-compiler = { path = "../compiler", version = "=4.2.3", features = ["trans
 wasmer-types = { path = "../types", version = "=4.2.3", default-features = false, features = ["std"] }
 hashbrown = { version = "0.11", optional = true }
 gimli = { version = "0.26", optional = true }
-enumset = "1.0.2"
+enumset = "1.1.0"
 more-asserts = "0.2"
 dynasm = "1.2.3"
 dynasmrt = "1.2.3"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -16,7 +16,7 @@ version.workspace = true
 wasmer-types = { path = "../types", version = "=4.2.3", default-features = false }
 wasmer-object = { path = "../object", version = "=4.2.3", optional = true }
 wasmparser = { version = "0.95", optional = true, default-features = false }
-enumset = "1.1.0"
+enumset.workspace = true
 hashbrown = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -16,7 +16,7 @@ version.workspace = true
 wasmer-types = { path = "../types", version = "=4.2.3", default-features = false }
 wasmer-object = { path = "../object", version = "=4.2.3", optional = true }
 wasmparser = { version = "0.95", optional = true, default-features = false }
-enumset = "1.0.2"
+enumset = "1.1.0"
 hashbrown = { version = "0.11", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = { version = "1.6" }
 rkyv = { version = "0.7.40", features = ["indexmap", "validation", "strict"] }
 enum-iterator = "0.7.0"
 target-lexicon = { version = "0.12.2", default-features = false }
-enumset = "1.0"
+enumset = "1.1.0"
 bytecheck = "0.6.8"
 
 [dev-dependencies]

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -21,7 +21,7 @@ indexmap = { version = "1.6" }
 rkyv = { version = "0.7.40", features = ["indexmap", "validation", "strict"] }
 enum-iterator = "0.7.0"
 target-lexicon = { version = "0.12.2", default-features = false }
-enumset = "1.1.0"
+enumset.workspace = true
 bytecheck = "0.6.8"
 
 [dev-dependencies]


### PR DESCRIPTION
# Description

The symbol `enumset::__internal::EnumSetTypeRepr` used in wasmer-types was only made public in 1.1.0:
https://github.com/Lymia/enumset/compare/v1.0.13...v1.1.0

In order to ensure a project embedding Wasmer does not use incompatible enumset versions ^1.0.0, < 1.1.0 we should bump the version here to the actual min required version.