### PR TITLE
Add `--wait` and `--timeout` flags to `wamer publish`

### DIFF
--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -27,11 +27,10 @@ pub struct Publish {
     /// Defaults to current working directory.
     #[clap(name = "PACKAGE_PATH")]
     pub package_path: Option<String>,
-    /// Wait for package to be available on the registry before exiting
+    /// Wait for package to be available on the registry before exiting.
     #[clap(long)]
     pub wait: bool,
-
-    /// Timeout (in seconds) for the publish query to the registry
+    /// Timeout (in seconds) for the publish query to the registry.
     #[clap(long, default_value = "30")]
     pub timeout: u64,
 }

--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -31,6 +31,10 @@ pub struct Publish {
     #[clap(long)]
     pub wait: bool,
     /// Timeout (in seconds) for the publish query to the registry.
+    ///
+    /// Note that this is not the timeout for the entire publish process, but
+    ///
+    /// for each individual query to the registry during the publish flow.
     #[clap(long, default_value = "30")]
     pub timeout: u64,
 }

--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -27,6 +27,13 @@ pub struct Publish {
     /// Defaults to current working directory.
     #[clap(name = "PACKAGE_PATH")]
     pub package_path: Option<String>,
+    /// Wait for package to be available on the registry before exiting
+    #[clap(long)]
+    pub wait: bool,
+
+    /// Timeout (in seconds) for the publish query to the registry
+    #[clap(long, default_value = "30")]
+    pub timeout: u64,
 }
 
 impl Publish {
@@ -46,6 +53,8 @@ impl Publish {
             token,
             no_validate: self.no_validate,
             package_path: self.package_path.clone(),
+            wait: self.wait,
+            timeout: std::time::Duration::from_secs(self.timeout),
         };
         publish.execute().map_err(on_error)?;
 

--- a/lib/registry/graphql/mutations/publish_package_chunked.graphql
+++ b/lib/registry/graphql/mutations/publish_package_chunked.graphql
@@ -12,6 +12,7 @@ mutation PublishPackageMutationChunked(
   $signature: InputSignature
   $signedUrl: String
   $private: Boolean
+  $wait: Boolean
 ) {
   publishPackage(
     input: {
@@ -29,6 +30,7 @@ mutation PublishPackageMutationChunked(
       signature: $signature
       clientMutationId: ""
       private: $private
+      wait: $wait
     }
   ) {
     success

--- a/lib/registry/src/package/builder.rs
+++ b/lib/registry/src/package/builder.rs
@@ -1,5 +1,6 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{fs, io::IsTerminal};
 
 use anyhow::{anyhow, bail, Context};
@@ -38,6 +39,10 @@ pub struct Publish {
     pub no_validate: bool,
     /// Directory containing the `wasmer.toml` (defaults to current root dir)
     pub package_path: Option<String>,
+    /// Wait for package to be available on the registry before exiting
+    pub wait: bool,
+    /// Timeout (in seconds) for the publish query to the registry
+    pub timeout: Duration,
 }
 
 #[derive(Debug, Error)]
@@ -186,6 +191,8 @@ impl Publish {
             &maybe_signature_data,
             archived_data_size,
             self.quiet,
+            self.wait,
+            self.timeout,
         )
     }
 

--- a/lib/registry/src/publish.rs
+++ b/lib/registry/src/publish.rs
@@ -122,6 +122,7 @@ pub fn try_chunked_uploading(
     let url = url::Url::parse(&signed_url).unwrap();
     let client = reqwest::blocking::Client::builder()
         .default_headers(reqwest::header::HeaderMap::default())
+        .timeout(timeout)
         .build()
         .unwrap();
 

--- a/lib/registry/src/publish.rs
+++ b/lib/registry/src/publish.rs
@@ -103,8 +103,12 @@ pub fn try_chunked_uploading(
         expires_after_seconds: Some(60 * 30),
     });
 
-    let _response: get_signed_url::ResponseData =
-        execute_query_modifier_inner(&registry, &token, &get_google_signed_url, None, |f| f)?;
+    let _response: get_signed_url::ResponseData = crate::graphql::execute_query_with_timeout(
+        &registry,
+        &token,
+        timeout,
+        &get_google_signed_url,
+    )?;
 
     let url = _response.url.ok_or_else(|| {
         anyhow::anyhow!(

--- a/lib/registry/src/publish.rs
+++ b/lib/registry/src/publish.rs
@@ -8,7 +8,6 @@ use graphql_client::GraphQLQuery;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 
 use crate::graphql::{
-    execute_query_modifier_inner,
     mutations::{publish_package_mutation_chunked, PublishPackageMutationChunked},
     queries::{get_signed_url, GetSignedUrl},
 };
@@ -39,7 +38,7 @@ pub fn try_chunked_uploading(
     maybe_signature_data: &SignArchiveResult,
     archived_data_size: u64,
     quiet: bool,
-    wait_for_webc_generation: bool,
+    wait: bool,
     timeout: Duration,
 ) -> Result<(), anyhow::Error> {
     let registry = match registry.as_ref() {
@@ -234,7 +233,7 @@ pub fn try_chunked_uploading(
             signature: maybe_signature_data,
             signed_url: Some(signed_url),
             private: Some(package.private),
-            wait: Some(wait_for_webc_generation),
+            wait: Some(wait),
         });
 
     let _response: publish_package_mutation_chunked::ResponseData =


### PR DESCRIPTION
## The `--wait` flag
Rasonale: When a large package is published, the user has to wait for a while to
be able to use it. This is because the webc of the package is not available on
the registry until the package is fully processed.

The registry now supports passing a wait flag to the publish command. This will
cause the command to wait until the webc of the package is available on the
registry before exiting. By default, this is set to false (for backwards
compatibility), and the `--wait` flag on the CLI enables it.


## The `--timeout` flag

Rasonale: When publishing a large package with the `--wait` flag - it may take a long
time.

The `--timeout` flag can be used to set the timeout for http requests made while
publishing the package. This is important because processing large webc files
may take a while. The default timeout is set to 30 seconds, but can be increased
if necessary (e.g. when publishing large packages).