### PR TITLE
use rusty_pool instead of rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +3804,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusty_pool"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed36cdb20de66d89a17ea04b8883fc7a386f2cf877aaedca5005583ce4876ff"
+dependencies = [
+ "crossbeam-channel",
+ "futures",
+ "futures-channel",
+ "futures-executor",
+ "num_cpus",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6240,8 +6263,8 @@ dependencies = [
  "pin-project",
  "pretty_assertions",
  "rand",
- "rayon",
  "reqwest",
+ "rusty_pool",
  "semver 1.0.20",
  "serde",
  "serde_cbor",

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+rusty_pool = { version = "0.7.0", optional = true }
 cfg-if = "1.0"
 thiserror = "1"
 tracing = { version = "0.1.37" }
@@ -66,7 +67,6 @@ tower-http = { version = "0.4.0", features = ["trace", "util", "catch-panic", "c
 tower = { version = "0.4.13", features = ["make", "util"], optional = true }
 url = "2.3.1"
 petgraph = "0.6.3"
-rayon = { version = "1.7.0", optional = true }
 wasm-bindgen = { version = "0.2.87", optional = true }
 js-sys = { version = "0.3.64", optional = true }
 wasm-bindgen-futures = { version = "0.4.37", optional = true }
@@ -118,7 +118,7 @@ webc_runner_rt_emscripten = ["wasmer-emscripten"]
 sys = ["webc/mmap", "time", "virtual-mio/sys"]
 sys-default = ["sys", "logging", "host-fs", "sys-poll", "sys-thread", "host-vnet", "host-threads", "host-reqwest"]
 sys-poll = []
-sys-thread = ["tokio/rt", "tokio/time", "tokio/rt-multi-thread", "rayon"]
+sys-thread = ["tokio/rt", "tokio/time", "tokio/rt-multi-thread", "rusty_pool"]
 
 # Deprecated. Kept it for compatibility
 compiler = []


### PR DESCRIPTION
Uses `rusty_pool` instead of `rayon` as the thread pool implementation.

Resolves #4311, #4320, #4201.

Most likely resolves #4094.
