### PR TITLE
deps: Bump edge-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-edge-cli"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a4fd3142520febcdaa8771517de6b4a87546472dd92e273323146827d61e17"
+checksum = "2d6efa3ced01dd6f1f7b2cab243e323136412bb186fea31c3b751081cc883403"
 dependencies = [
  "anyhow",
  "clap",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -64,7 +64,7 @@ virtual-net = { version = "0.6.1", path = "../virtual-net" }
 
 # Wasmer-owned dependencies.
 webc = { workspace = true }
-wasmer-edge-cli = { version = "=0.1.0", default-features = false }
+wasmer-edge-cli = { version = "=0.1.1", default-features = false }
 
 # Third-party dependencies.
 


### PR DESCRIPTION
Contains a bug fix for `wasmer app create`, which would
previously fail due to not appending `wasmer.toml` to the manifest path,
and trying to use a directory path instead.

Closes #4330
