### PR TITLE
Asyncify filesystem cache

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -451,7 +451,8 @@ impl Wasi {
     where
         I: Into<RuntimeOrHandle>,
     {
-        let mut rt = PluggableRuntime::new(Arc::new(TokioTaskManager::new(rt_or_handle.into())));
+        let tokio_task_manager = Arc::new(TokioTaskManager::new(rt_or_handle.into()));
+        let mut rt = PluggableRuntime::new(tokio_task_manager.clone());
 
         if self.networking {
             rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());
@@ -477,7 +478,7 @@ impl Wasi {
 
         let cache_dir = env.cache_dir().join("compiled");
         let module_cache = wasmer_wasix::runtime::module_cache::in_memory()
-            .with_fallback(FileSystemCache::new(cache_dir, rt.task_manager().clone()));
+            .with_fallback(FileSystemCache::new(cache_dir, tokio_task_manager));
 
         rt.set_package_loader(package_loader)
             .set_module_cache(module_cache)

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -477,7 +477,7 @@ impl Wasi {
 
         let cache_dir = env.cache_dir().join("compiled");
         let module_cache = wasmer_wasix::runtime::module_cache::in_memory()
-            .with_fallback(FileSystemCache::new(cache_dir));
+            .with_fallback(FileSystemCache::new(cache_dir, rt.task_manager().clone()));
 
         rt.set_package_loader(package_loader)
             .set_module_cache(module_cache)

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -127,7 +127,7 @@ impl ModuleCache for FileSystemCache {
                     let mut file = tokio::fs::File::from_std(file);
 
                     let serialized = task_manager
-                        .spawn_await({ move || module.serialize() })
+                        .spawn_await(move || module.serialize())
                         .await
                         .unwrap()?;
 
@@ -219,7 +219,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let expected_path = cache.path(key, engine.deterministic_id());
 
         cache.save(key, &engine, &module).await.unwrap();
@@ -235,7 +235,7 @@ mod tests {
         let cache_dir = temp.path().join("this").join("doesn't").join("exist");
         assert!(!cache_dir.exists());
         let cache = FileSystemCache::new(&cache_dir, create_tokio_task_manager());
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
 
@@ -246,7 +246,7 @@ mod tests {
     async fn missing_file() {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
 
         let err = cache.load(key, &engine).await.unwrap_err();
@@ -259,7 +259,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let expected_path = cache.path(key, engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
@@ -282,7 +282,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let expected_path = cache.path(key, engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();

--- a/lib/wasix/src/runtime/module_cache/mod.rs
+++ b/lib/wasix/src/runtime/module_cache/mod.rs
@@ -32,6 +32,7 @@
 //! chain a fast in-memory cache with a slower file-based cache as a fallback.
 
 mod fallback;
+#[cfg(feature = "sys-thread")]
 mod filesystem;
 mod shared;
 mod thread_local;
@@ -39,11 +40,13 @@ mod types;
 
 pub use self::{
     fallback::FallbackCache,
-    filesystem::FileSystemCache,
     shared::SharedCache,
     thread_local::ThreadLocalCache,
     types::{CacheError, ModuleCache, ModuleHash},
 };
+
+#[cfg(feature = "sys-thread")]
+pub use self::filesystem::FileSystemCache;
 
 /// Get a [`ModuleCache`] which should be good enough for most in-memory use
 /// cases.

--- a/lib/wasix/src/runtime/module_cache/types.rs
+++ b/lib/wasix/src/runtime/module_cache/types.rs
@@ -55,9 +55,14 @@ pub trait ModuleCache: Debug {
     /// use wasmer_wasix::runtime::module_cache::{
     ///     ModuleCache, ThreadLocalCache, FileSystemCache, SharedCache,
     /// };
+    /// use wasmer_wasix::runtime::task_manager::tokio::{RuntimeOrHandle, TokioTaskManager};
+    ///
+    /// let runtime = tokio::runtime::Runtime::new().unwrap();
+    /// let rt_handle = RuntimeOrHandle::from(runtime);
+    /// let task_manager = std::sync::Arc::new(TokioTaskManager::new(rt_handle));
     ///
     /// let cache = SharedCache::default()
-    ///     .with_fallback(FileSystemCache::new("~/.local/cache"));
+    ///     .with_fallback(FileSystemCache::new("~/.local/cache", task_manager));
     /// ```
     fn with_fallback<C>(self, other: C) -> FallbackCache<Self, C>
     where

--- a/lib/wasix/src/runtime/task_manager/mod.rs
+++ b/lib/wasix/src/runtime/task_manager/mod.rs
@@ -8,7 +8,7 @@ use std::{pin::Pin, time::Duration};
 
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::Future;
+use futures::{Future, TryFutureExt};
 use wasmer::{AsStoreMut, AsStoreRef, Memory, MemoryType, Module, Store, StoreMut, StoreRef};
 use wasmer_wasix_types::wasi::{Errno, ExitCode};
 
@@ -64,6 +64,7 @@ pub struct TaskWasm<'a, 'b> {
     pub trigger: Option<Box<WasmResumeTrigger>>,
     pub update_layout: bool,
 }
+
 impl<'a, 'b> TaskWasm<'a, 'b> {
     pub fn new(run: Box<TaskWasmRun>, env: WasiEnv, module: Module, update_layout: bool) -> Self {
         Self {
@@ -370,6 +371,14 @@ pub trait VirtualTaskManagerExt {
     fn spawn_and_block_on<A>(&self, task: impl Future<Output = A> + Send + 'static) -> A
     where
         A: Send + 'static;
+
+    fn spawn_await<O, F>(
+        &self,
+        f: F,
+    ) -> Box<dyn Future<Output = Result<O, Box<dyn std::error::Error>>> + Unpin + Send + 'static>
+    where
+        O: Send + 'static,
+        F: FnOnce() -> O + Send + 'static;
 }
 
 impl<D, T> VirtualTaskManagerExt for D
@@ -390,5 +399,24 @@ where
         });
         self.task_shared(Box::new(move || work)).unwrap();
         InlineWaker::block_on(work_rx.recv()).unwrap()
+    }
+
+    fn spawn_await<O, F>(
+        &self,
+        f: F,
+    ) -> Box<dyn Future<Output = Result<O, Box<dyn std::error::Error>>> + Unpin + Send + 'static>
+    where
+        O: Send + 'static,
+        F: FnOnce() -> O + Send + 'static,
+    {
+        let (sender, receiver) = ::tokio::sync::oneshot::channel();
+
+        self.task_dedicated(Box::new(move || {
+            let result = f();
+            let _ = sender.send(result);
+        }))
+        .unwrap();
+
+        Box::new(receiver.map_err(|e| Box::new(e).into()))
     }
 }

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -98,6 +98,10 @@ impl TokioTaskManager {
     pub fn runtime_handle(&self) -> tokio::runtime::Handle {
         self.rt.handle().clone()
     }
+
+    pub fn pool_handle(&self) -> Arc<ThreadPool> {
+        self.pool.clone()
+    }
 }
 
 impl Default for TokioTaskManager {

--- a/lib/wasix/tests/runners.rs
+++ b/lib/wasix/tests/runners.rs
@@ -246,8 +246,10 @@ fn runtime() -> (impl Runtime + Send + Sync, Arc<TokioTaskManager>) {
     let tasks = Arc::new(tasks);
     let mut rt = PluggableRuntime::new(Arc::clone(&tasks) as Arc<_>);
 
-    let cache =
-        SharedCache::default().with_fallback(FileSystemCache::new(tmp_dir().join("compiled")));
+    let cache = SharedCache::default().with_fallback(FileSystemCache::new(
+        tmp_dir().join("compiled"),
+        tasks.clone(),
+    ));
 
     let cache_dir = Path::new(env!("CARGO_TARGET_TMPDIR"))
         .join(env!("CARGO_PKG_NAME"))


### PR DESCRIPTION
In the middle of my investigations for improving startup time, I encountered issue #3851 in one of the comments.
This fix isn't ideal since it uses the `tokio` thread pool instead of the pool in `TokioTaskManager`. I couldn't figure out how to design a trait that is both object-safe, and is able to model the `spawn_await` function that I had in mind properly. This is the best that I came up with:
```rust
pub trait AsyncTaskManager {
    type Future<T>: Future<Output = T>;
    
    fn spawn_await<T>(&self, f: impl Future<Output = T>) -> Self::Future<T>;
}
```
which isn't object-safe.

I could clone the `TokioTaskManager` directly into `FileSystemCache`, but I was not sure about it.