### PR TITLE
Optimize sleep_now for TokioTaskManager 

### DIFF
--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -123,7 +123,7 @@ impl VirtualTaskManager for TokioTaskManager {
                 .enter(handle, time)
                 .await
                 .ok()
-                .unwrap_or_else(|| ())
+                .unwrap_or(())
         })
     }
 
@@ -208,6 +208,7 @@ impl VirtualTaskManager for TokioTaskManager {
 }
 
 // Used by [`VirtualTaskManager::sleep_now`] to abort a sleep task when drop.
+#[derive(Default)]
 struct SleepNow {
     abort_handle: Option<tokio::task::AbortHandle>,
 }
@@ -230,14 +231,10 @@ impl SleepNow {
     }
 }
 
-impl Default for SleepNow {
-    fn default() -> Self {
-        Self { abort_handle: None }
-    }
-}
-
 impl Drop for SleepNow {
     fn drop(&mut self) {
-        self.abort_handle.as_ref().map(|h| h.abort());
+        if let Some(h) = self.abort_handle.as_ref() {
+            h.abort()
+        }
     }
 }

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -209,20 +209,20 @@ impl VirtualTaskManager for TokioTaskManager {
 
 // Used by [`VirtualTaskManager::sleep_now`] to abort a sleep task when drop.
 struct SleepNow {
-    abort_handle: Option<::tokio::task::AbortHandle>,
+    abort_handle: Option<tokio::task::AbortHandle>,
 }
 
 impl SleepNow {
     async fn enter(
         &mut self,
-        handle: ::tokio::runtime::Handle,
+        handle: tokio::runtime::Handle,
         time: Duration,
-    ) -> Result<(), ::tokio::task::JoinError> {
+    ) -> Result<(), tokio::task::JoinError> {
         let handle = handle.spawn(async move {
             if time == Duration::ZERO {
-                ::tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
             } else {
-                ::tokio::time::sleep(time).await;
+                tokio::time::sleep(time).await;
             }
         });
         self.abort_handle = Some(handle.abort_handle());

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -117,17 +117,13 @@ impl<'g> Drop for TokioRuntimeGuard<'g> {
 impl VirtualTaskManager for TokioTaskManager {
     /// See [`VirtualTaskManager::sleep_now`].
     fn sleep_now(&self, time: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        self.rt.handle().spawn(async move {
-            if time == Duration::ZERO {
-                tokio::task::yield_now().await;
-            } else {
-                tokio::time::sleep(time).await;
-            }
-            tx.send(()).ok();
-        });
+        let handle = self.runtime_handle();
         Box::pin(async move {
-            rx.recv().await;
+            SleepNow::default()
+                .enter(handle, time)
+                .await
+                .ok()
+                .unwrap_or_else(|| ())
         })
     }
 
@@ -208,5 +204,40 @@ impl VirtualTaskManager for TokioTaskManager {
         Ok(std::thread::available_parallelism()
             .map(usize::from)
             .unwrap_or(8))
+    }
+}
+
+// Used by [`VirtualTaskManager::sleep_now`] to abort a sleep task when drop.
+struct SleepNow {
+    abort_handle: Option<::tokio::task::AbortHandle>,
+}
+
+impl SleepNow {
+    async fn enter(
+        &mut self,
+        handle: ::tokio::runtime::Handle,
+        time: Duration,
+    ) -> Result<(), ::tokio::task::JoinError> {
+        let handle = handle.spawn(async move {
+            if time == Duration::ZERO {
+                ::tokio::task::yield_now().await;
+            } else {
+                ::tokio::time::sleep(time).await;
+            }
+        });
+        self.abort_handle = Some(handle.abort_handle());
+        handle.await
+    }
+}
+
+impl Default for SleepNow {
+    fn default() -> Self {
+        Self { abort_handle: None }
+    }
+}
+
+impl Drop for SleepNow {
+    fn drop(&mut self) {
+        self.abort_handle.as_ref().map(|h| h.abort());
     }
 }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
Currently, the `sleep_now` method in `VirtualTaskManager` is used in many places, such as socket. I found that according to the current `sleep_now`, after the task execution is completed, since the timeout task is just `recv` future, the sleep task that actually executes the timeout cannot be really canceling, this may cause tasks not being recycled immediately, so it will bring some potential resource issues.
This pr optimizes `sleep_now` and uses `AbortHandle` to abort the timeout task when dropping.