### PR TITLE
Use nanoseconds in `filestat` for directories

### DIFF
--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -1520,11 +1520,13 @@ mod test_filesystem {
                     modified,
                     len: 0
                 }) if
-                    accessed == foo_metadata.accessed &&
-                    created == foo_metadata.created &&
+                    accessed <= foo_metadata.accessed &&
+                    created <= foo_metadata.created &&
                     modified > foo_metadata.modified
             ),
-            "the modified time of the parent is updated when file is renamed",
+            "the modified time of the parent is updated when file is renamed \n{:?}\n{:?}",
+            fs.metadata(path!("/")),
+            foo_metadata,
         );
     }
 

--- a/lib/virtual-fs/src/mem_fs/mod.rs
+++ b/lib/virtual-fs/src/mem_fs/mod.rs
@@ -142,7 +142,7 @@ fn time() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap()
-            .as_secs()
+            .as_nanos() as u64
     }
 
     #[cfg(feature = "no-time")]


### PR DESCRIPTION
This commit fixes the `filestat` type which contains three timestamps. Per [WASI spec], they should be in nanoseconds.  This is only a problem for directories.

[WASI spec]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-timestamp-u64

fixes https://github.com/wasmerio/wasmer/issues/4358
