### PR TITLE
Fix preopened current directory not working 

### DIFF
--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -187,7 +187,7 @@ impl FileSystem {
                             let time = time();
                             Metadata {
                                 ft: FileType {
-                                    file: true,
+                                    dir: true,
                                     ..Default::default()
                                 },
                                 accessed: time,

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -705,7 +705,7 @@ impl WasiFs {
             if path.contains("//") {
                 path = path.replace("//", "/");
             }
-        } else if !path.starts_with("/") {
+        } else if !path.starts_with('/') {
             // Path is relative but does not start with `./`
 
             let current_dir = self.current_dir.lock().unwrap();

--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -70,7 +70,7 @@ pub fn path_open<M: MemorySize>(
     Span::current().record("path", path_string.as_str());
 
     // Convert relative paths into absolute paths
-    if path_string.starts_with("./") {
+    if !path_string.starts_with("/") {
         path_string = ctx.data().state.fs.relative_path_to_absolute(path_string);
         trace!(
             %path_string

--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -70,7 +70,7 @@ pub fn path_open<M: MemorySize>(
     Span::current().record("path", path_string.as_str());
 
     // Convert relative paths into absolute paths
-    if !path_string.starts_with("/") {
+    if !path_string.starts_with('/') {
         path_string = ctx.data().state.fs.relative_path_to_absolute(path_string);
         trace!(
             %path_string


### PR DESCRIPTION
This commit fixes a bug where creating a file with an implicit relative
path returns `0` indicating success, but no file is created on the host.
Here, implicit relative means a relative path that does not begin with
`./`. For example, calling `open("somefile", O_CREAT | O_WRONLY)` will
try to create a file called `somefile` in the current working directory.

The fix is to change the current directory if the user has explicitly
mounted any host directory to `.` in guest.  In this case, the user's
intention is clear: the current directory *is* the mounted host
directory.

fixes https://github.com/wasmerio/wasmer/issues/4361
