### PR TITLE
lib/api/src/js/store.rs: fix typo

### DIFF
--- a/lib/api/src/js/store.rs
+++ b/lib/api/src/js/store.rs
@@ -96,7 +96,7 @@ mod objects {
         }
 
         /// Set a global, at index idx. Will panic if idx is out of range
-        /// Safety: the caller should check taht the raw value is compatible
+        /// Safety: the caller should check that the raw value is compatible
         /// with destination VMGlobal type
         pub fn set_global_unchecked(&self, idx: usize, new_val: u128) {
             assert!(idx < self.globals.len());


### PR DESCRIPTION
Fixes a small typo in lib/api/src/js/store.rs (taht -> that)
