### PR TITLE
Always use the download URL provided by the Wasmer registry instead of going through the frontend redirect

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,6 +98,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          log-level: error
 
   test_nodejs:
     name: Test on NodeJS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6949,18 +6949,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.23"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50cbb27c30666a6108abd6bc7577556265b44f243e2be89a8bc4e07a528c107"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.23"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25f293fe55f0a48e7010d65552bb63704f6ceb55a1a385da10d41d8f78e4a3d"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/wasix/src/runtime/resolver/wapm_source.rs
+++ b/lib/wasix/src/runtime/resolver/wapm_source.rs
@@ -548,7 +548,7 @@ mod tests {
                     }],
                 },
                 dist: DistributionInfo {
-                    webc: "https://wasmer.io/wasmer/wasmer-pack-cli@0.6.0"
+                    webc: "https://storage.googleapis.com/wapm-registry-prod/webc/wasmer/wasmer-pack-cli/0.6.0/wasmer-pack-cli-0.6.0.webc"
                         .parse()
                         .unwrap(),
                     webc_sha256: WebcHash::from_bytes([


### PR DESCRIPTION
Fixes SDK-62.