### PR TITLE
feat(wasix): Add optional chunk timeout to ReqwestHttpClient

### DIFF
--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -75,13 +75,13 @@ web-sys = { version = "0.3.64", features = ["Request", "RequestInit", "Window", 
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies.reqwest]
 version = "0.11"
 default-features = false
-features = ["rustls-tls", "json"]
+features = ["rustls-tls", "json", "stream"]
 optional = true
 
 [target.'cfg(target_arch = "riscv64")'.dependencies.reqwest]
 version = "0.11"
 default-features = false
-features = ["native-tls", "json"]
+features = ["native-tls", "json", "stream"]
 optional = true
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Currenty executing a request can stall while retrieving the body.
This is especially problematic when downloading large items, like
packages.

This commit adds an optional per-chunk timeout, which makes sure
retrieval can not stall infinitely, but also doesn't prevent downloads
with some default timeout for the whole body retrieval.
