### PR TITLE
use faster hash algorithm when loading and saving a module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6295,6 +6295,7 @@ dependencies = [
  "webc",
  "weezl",
  "winapi",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -6931,6 +6932,12 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "yaml-rust"

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+xxhash-rust = { version = "0.8.8", features = ["xxh64"] }
 rusty_pool = { version = "0.7.0", optional = true }
 cfg-if = "1.0"
 thiserror = "1"

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -52,7 +52,7 @@ impl BinaryPackageCommand {
     }
 
     pub fn hash(&self) -> &ModuleHash {
-        self.hash.get_or_init(|| ModuleHash::sha256(self.atom()))
+        self.hash.get_or_init(|| ModuleHash::hash(self.atom()))
     }
 }
 
@@ -144,9 +144,9 @@ impl BinaryPackage {
     pub fn hash(&self) -> ModuleHash {
         *self.hash.get_or_init(|| {
             if let Some(entry) = self.entrypoint_bytes() {
-                ModuleHash::sha256(entry)
+                ModuleHash::hash(entry)
             } else {
-                ModuleHash::sha256(self.package_name.as_bytes())
+                ModuleHash::hash(self.package_name.as_bytes())
             }
         })
     }

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -116,7 +116,7 @@ pub async fn load_module(
     module_cache: &(dyn ModuleCache + Send + Sync),
     wasm: &[u8],
 ) -> Result<Module, anyhow::Error> {
-    let hash = ModuleHash::xxhash(wasm);
+    let hash = ModuleHash::hash(wasm);
     let result = module_cache.load(hash, engine).await;
 
     match result {

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -116,7 +116,7 @@ pub async fn load_module(
     module_cache: &(dyn ModuleCache + Send + Sync),
     wasm: &[u8],
 ) -> Result<Module, anyhow::Error> {
-    let hash = ModuleHash::sha256(wasm);
+    let hash = ModuleHash::xxhash(wasm);
     let result = module_cache.load(hash, engine).await;
 
     match result {

--- a/lib/wasix/src/runtime/module_cache/fallback.rs
+++ b/lib/wasix/src/runtime/module_cache/fallback.rs
@@ -179,7 +179,7 @@ mod tests {
     async fn load_from_primary() {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let primary = SharedCache::default();
         let fallback = SharedCache::default();
         primary.save(key, &engine, &module).await.unwrap();
@@ -204,7 +204,7 @@ mod tests {
     async fn loading_from_fallback_also_populates_primary() {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let primary = SharedCache::default();
         let fallback = SharedCache::default();
         fallback.save(key, &engine, &module).await.unwrap();
@@ -230,7 +230,7 @@ mod tests {
     async fn saving_will_update_both() {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let primary = SharedCache::default();
         let fallback = SharedCache::default();
         let cache = FallbackCache::new(&primary, &fallback);

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -182,7 +182,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = FileSystemCache::new(temp.path());
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let expected_path = cache.path(key, engine.deterministic_id());
 
         cache.save(key, &engine, &module).await.unwrap();
@@ -198,7 +198,7 @@ mod tests {
         let cache_dir = temp.path().join("this").join("doesn't").join("exist");
         assert!(!cache_dir.exists());
         let cache = FileSystemCache::new(&cache_dir);
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
 
@@ -209,7 +209,7 @@ mod tests {
     async fn missing_file() {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path());
 
         let err = cache.load(key, &engine).await.unwrap_err();
@@ -222,7 +222,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path());
         let expected_path = cache.path(key, engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
@@ -245,7 +245,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path());
         let expected_path = cache.path(key, engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();

--- a/lib/wasix/src/runtime/module_cache/shared.rs
+++ b/lib/wasix/src/runtime/module_cache/shared.rs
@@ -64,7 +64,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = SharedCache::default();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
         let round_tripped = cache.load(key, &engine).await.unwrap();

--- a/lib/wasix/src/runtime/module_cache/thread_local.rs
+++ b/lib/wasix/src/runtime/module_cache/thread_local.rs
@@ -70,7 +70,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = ThreadLocalCache::default();
-        let key = ModuleHash::from_bytes([0; 32]);
+        let key = ModuleHash::from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
         let round_tripped = cache.load(key, &engine).await.unwrap();

--- a/lib/wasix/src/runtime/module_cache/types.rs
+++ b/lib/wasix/src/runtime/module_cache/types.rs
@@ -5,7 +5,6 @@ use std::{
     path::PathBuf,
 };
 
-use sha2::{Digest, Sha256};
 use wasmer::{Engine, Module};
 
 use crate::runtime::module_cache::FallbackCache;
@@ -167,43 +166,32 @@ impl Display for ModuleHash {
         Ok(())
     }
 }
-//
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//
-//     #[test]
-//     fn is_object_safe() {
-//         let _: Option<Box<dyn ModuleCache>> = None;
-//     }
-//
-//     #[test]
-//     fn key_is_displayed_as_hex() {
-//         let key = ModuleHash::from_bytes([
-//             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
-//             0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
-//             0x1c, 0x1d, 0x1e, 0x1f,
-//         ]);
-//
-//         let repr = key.to_string();
-//
-//         assert_eq!(
-//             repr,
-//             "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
-//         );
-//     }
-//
-//     #[test]
-//     fn module_hash_is_just_sha_256() {
-//         let wasm = b"\0asm...";
-//         let raw = [
-//             0x5a, 0x39, 0xfe, 0xef, 0x52, 0xe5, 0x3b, 0x8f, 0xfe, 0xdf, 0xd7, 0x05, 0x15, 0x56,
-//             0xec, 0x10, 0x5e, 0xd8, 0x69, 0x82, 0xf1, 0x22, 0xa0, 0x5d, 0x27, 0x28, 0xd9, 0x67,
-//             0x78, 0xe4, 0xeb, 0x96,
-//         ];
-//
-//         let hash = ModuleHash::sha256(wasm);
-//
-//         assert_eq!(hash.as_bytes(), raw);
-//     }
-// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_object_safe() {
+        let _: Option<Box<dyn ModuleCache>> = None;
+    }
+
+    #[test]
+    fn key_is_displayed_as_hex() {
+        let key = ModuleHash::from_bytes([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
+
+        let repr = key.to_string();
+
+        assert_eq!(repr, "0001020304050607");
+    }
+
+    #[test]
+    fn module_hash_is_just_sha_256() {
+        let wasm = b"\0asm...";
+        let raw = [0x0c, 0xc7, 0x88, 0x60, 0xd4, 0x14, 0x71, 0x4c];
+
+        let hash = ModuleHash::sha256(wasm);
+
+        assert_eq!(hash.as_bytes(), raw);
+    }
+}

--- a/lib/wasix/src/runtime/module_cache/types.rs
+++ b/lib/wasix/src/runtime/module_cache/types.rs
@@ -121,29 +121,25 @@ impl CacheError {
     }
 }
 
-/// The SHA-256 hash of a WebAssembly module.
+/// The XXHash hash of a WebAssembly module.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ModuleHash([u8; 8]);
 
 impl ModuleHash {
-    /// Create a new [`ModuleHash`] from the raw SHA-256 hash.
+    /// Create a new [`ModuleHash`] from the raw XXHash hash.
     pub fn from_bytes(key: [u8; 8]) -> Self {
         ModuleHash(key)
     }
 
-    /// Parse a sha256 hash from a hex-encoded string.
+    /// Parse a XXHash hash from a hex-encoded string.
     pub fn parse_hex(hex_str: &str) -> Result<Self, hex::FromHexError> {
         let mut hash = [0_u8; 8];
         hex::decode_to_slice(hex_str, &mut hash)?;
         Ok(Self(hash))
     }
 
-    /// Generate a new [`ModuleCache`] based on the SHA-256 hash of some bytes.
-    pub fn sha256(wasm: impl AsRef<[u8]>) -> Self {
-        Self::xxhash(wasm)
-    }
-
-    pub fn xxhash(wasm: impl AsRef<[u8]>) -> Self {
+    /// Generate a new [`ModuleCache`] based on the XXHash hash of some bytes.
+    pub fn hash(wasm: impl AsRef<[u8]>) -> Self {
         let wasm = wasm.as_ref();
 
         let hash = xxhash_rust::xxh64::xxh64(wasm, 0);
@@ -151,7 +147,7 @@ impl ModuleHash {
         Self(hash.to_ne_bytes())
     }
 
-    /// Get the raw SHA-256 hash.
+    /// Get the raw XXHash hash.
     pub fn as_bytes(self) -> [u8; 8] {
         self.0
     }
@@ -190,7 +186,7 @@ mod tests {
         let wasm = b"\0asm...";
         let raw = [0x0c, 0xc7, 0x88, 0x60, 0xd4, 0x14, 0x71, 0x4c];
 
-        let hash = ModuleHash::sha256(wasm);
+        let hash = ModuleHash::hash(wasm);
 
         assert_eq!(hash.as_bytes(), raw);
     }

--- a/lib/wasix/src/runtime/module_cache/types.rs
+++ b/lib/wasix/src/runtime/module_cache/types.rs
@@ -124,31 +124,24 @@ impl CacheError {
 
 /// The SHA-256 hash of a WebAssembly module.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum ModuleHash {
-    Sha256([u8; 32]),
-    Xxhash([u8; 8]),
-}
+pub struct ModuleHash([u8; 8]);
 
 impl ModuleHash {
     /// Create a new [`ModuleHash`] from the raw SHA-256 hash.
-    pub fn from_bytes(key: [u8; 32]) -> Self {
-        ModuleHash::Sha256(key)
+    pub fn from_bytes(key: [u8; 8]) -> Self {
+        ModuleHash(key)
     }
 
     /// Parse a sha256 hash from a hex-encoded string.
     pub fn parse_hex(hex_str: &str) -> Result<Self, hex::FromHexError> {
-        let mut hash = [0_u8; 32];
+        let mut hash = [0_u8; 8];
         hex::decode_to_slice(hex_str, &mut hash)?;
-        Ok(Self::Sha256(hash))
+        Ok(Self(hash))
     }
 
     /// Generate a new [`ModuleCache`] based on the SHA-256 hash of some bytes.
     pub fn sha256(wasm: impl AsRef<[u8]>) -> Self {
-        let wasm = wasm.as_ref();
-
-        let mut hasher = Sha256::default();
-        hasher.update(wasm);
-        ModuleHash::from_bytes(hasher.finalize().into())
+        Self::xxhash(wasm)
     }
 
     pub fn xxhash(wasm: impl AsRef<[u8]>) -> Self {
@@ -156,70 +149,61 @@ impl ModuleHash {
 
         let hash = xxhash_rust::xxh64::xxh64(wasm, 0);
 
-        Self::Xxhash(hash.to_ne_bytes())
+        Self(hash.to_ne_bytes())
     }
 
     /// Get the raw SHA-256 hash.
-    pub fn as_bytes(self) -> [u8; 32] {
-        if let ModuleHash::Sha256(inner) = self {
-            inner
-        } else {
-            unreachable!("this should be unreachable")
-        }
+    pub fn as_bytes(self) -> [u8; 8] {
+        self.0
     }
 }
 
 impl Display for ModuleHash {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let bytes = match self {
-            ModuleHash::Sha256(bytes) => bytes.as_slice(),
-            ModuleHash::Xxhash(bytes) => bytes.as_slice(),
-        };
-
-        for byte in bytes {
+        for byte in self.0 {
             write!(f, "{byte:02X}")?;
         }
 
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn is_object_safe() {
-        let _: Option<Box<dyn ModuleCache>> = None;
-    }
-
-    #[test]
-    fn key_is_displayed_as_hex() {
-        let key = ModuleHash::from_bytes([
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
-            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
-            0x1c, 0x1d, 0x1e, 0x1f,
-        ]);
-
-        let repr = key.to_string();
-
-        assert_eq!(
-            repr,
-            "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
-        );
-    }
-
-    #[test]
-    fn module_hash_is_just_sha_256() {
-        let wasm = b"\0asm...";
-        let raw = [
-            0x5a, 0x39, 0xfe, 0xef, 0x52, 0xe5, 0x3b, 0x8f, 0xfe, 0xdf, 0xd7, 0x05, 0x15, 0x56,
-            0xec, 0x10, 0x5e, 0xd8, 0x69, 0x82, 0xf1, 0x22, 0xa0, 0x5d, 0x27, 0x28, 0xd9, 0x67,
-            0x78, 0xe4, 0xeb, 0x96,
-        ];
-
-        let hash = ModuleHash::sha256(wasm);
-
-        assert_eq!(hash.as_bytes(), raw);
-    }
-}
+//
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//
+//     #[test]
+//     fn is_object_safe() {
+//         let _: Option<Box<dyn ModuleCache>> = None;
+//     }
+//
+//     #[test]
+//     fn key_is_displayed_as_hex() {
+//         let key = ModuleHash::from_bytes([
+//             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+//             0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+//             0x1c, 0x1d, 0x1e, 0x1f,
+//         ]);
+//
+//         let repr = key.to_string();
+//
+//         assert_eq!(
+//             repr,
+//             "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
+//         );
+//     }
+//
+//     #[test]
+//     fn module_hash_is_just_sha_256() {
+//         let wasm = b"\0asm...";
+//         let raw = [
+//             0x5a, 0x39, 0xfe, 0xef, 0x52, 0xe5, 0x3b, 0x8f, 0xfe, 0xdf, 0xd7, 0x05, 0x15, 0x56,
+//             0xec, 0x10, 0x5e, 0xd8, 0x69, 0x82, 0xf1, 0x22, 0xa0, 0x5d, 0x27, 0x28, 0xd9, 0x67,
+//             0x78, 0xe4, 0xeb, 0x96,
+//         ];
+//
+//         let hash = ModuleHash::sha256(wasm);
+//
+//         assert_eq!(hash.as_bytes(), raw);
+//     }
+// }


### PR DESCRIPTION
Uses xxhash instead of sha256 to save and load a module from the local filesystem cache.
This should substantially improve the startup time of running a cached package.

before:
```
$ time wasmer run python -- --version

Python 3.12.0

real    0m2.749s
user    0m0.192s
sys     0m0.216s
```

after:
```
$ time wasmer run python -- --version

Python 3.12.0

real    0m0.284s
user    0m0.083s
sys     0m0.202s
```