### PR TITLE
feat(api): Add SharedMemoryHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -2187,7 +2187,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/lib/api/src/errors.rs
+++ b/lib/api/src/errors.rs
@@ -265,7 +265,7 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for RuntimeError {
 
 /// Error that can occur during atomic operations. (notify/wait)
 // Non-exhaustive to allow for future variants without breaking changes!
-#[derive(Debug, Error)]
+#[derive(PartialEq, Eq, Debug, Error)]
 #[non_exhaustive]
 pub enum AtomicsError {
     /// Atomic operations are not supported by this memory.
@@ -279,9 +279,9 @@ pub enum AtomicsError {
 impl std::fmt::Display for AtomicsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AtomicsError::Unimplemented => write!(f, "Atomic operations are not supported"),
-            AtomicsError::TooManyWaiters => write!(f, "Too many waiters for address"),
-            AtomicsError::AtomicsDisabled => write!(f, "Atomic operations are disabled"),
+            Self::Unimplemented => write!(f, "Atomic operations are not supported"),
+            Self::TooManyWaiters => write!(f, "Too many waiters for address"),
+            Self::AtomicsDisabled => write!(f, "Atomic operations are disabled"),
         }
     }
 }

--- a/lib/api/src/errors.rs
+++ b/lib/api/src/errors.rs
@@ -262,3 +262,26 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for RuntimeError {
         }
     }
 }
+
+/// Error that can occur during atomic operations. (notify/wait)
+// Non-exhaustive to allow for future variants without breaking changes!
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum AtomicsError {
+    /// Atomic operations are not supported by this memory.
+    Unimplemented,
+    /// To many waiter for address.
+    TooManyWaiters,
+    /// Atomic operations are disabled.
+    AtomicsDisabled,
+}
+
+impl std::fmt::Display for AtomicsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AtomicsError::Unimplemented => write!(f, "Atomic operations are not supported"),
+            AtomicsError::TooManyWaiters => write!(f, "Too many waiters for address"),
+            AtomicsError::AtomicsDisabled => write!(f, "Atomic operations are disabled"),
+        }
+    }
+}

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -239,24 +239,24 @@ impl From<u32> for MemoryLocation {
     }
 }
 
-/// See [`SharedMemoryHandle`].
+/// See [`SharedMemory`].
 pub(crate) trait SharedMemoryOps {
-    /// See [`SharedMemoryHandle::disable_atomics`].
+    /// See [`SharedMemory::disable_atomics`].
     fn disable_atomics(&self) -> Result<(), MemoryError> {
         Err(MemoryError::AtomicsNotSupported)
     }
 
-    /// See [`SharedMemoryHandle::wake_all_atomic_waiters`].
+    /// See [`SharedMemory::wake_all_atomic_waiters`].
     fn wake_all_atomic_waiters(&self) -> Result<(), MemoryError> {
         Err(MemoryError::AtomicsNotSupported)
     }
 
-    /// See [`SharedMemoryHandle::notify`].
+    /// See [`SharedMemory::notify`].
     fn notify(&self, _dst: MemoryLocation, _count: u32) -> Result<u32, AtomicsError> {
         Err(AtomicsError::Unimplemented)
     }
 
-    /// See [`SharedMemoryHandle::wait`].
+    /// See [`SharedMemory::wait`].
     fn wait(
         &self,
         _dst: MemoryLocation,
@@ -280,7 +280,7 @@ pub struct SharedMemory {
 
 impl std::fmt::Debug for SharedMemory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedMemoryHandle").finish()
+        f.debug_struct("SharedMemory").finish()
     }
 }
 
@@ -291,6 +291,7 @@ impl SharedMemory {
     }
 
     /// Create a new handle from ops.
+    #[allow(unused)]
     pub(crate) fn new(memory: Memory, ops: impl SharedMemoryOps + Send + Sync + 'static) -> Self {
         Self {
             memory,

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -268,7 +268,7 @@ pub(crate) trait SharedMemoryOps {
 
 /// A handle that exposes operations only relevant for shared memories.
 ///
-/// Enables interaction independent from the [`Store`], and thus allows calling
+/// Enables interaction independent from the [`crate::Store`], and thus allows calling
 /// some methods an instane is running.
 ///
 /// **NOTE**: Not all methods are supported by all backends.

--- a/lib/api/src/externals/memory.rs
+++ b/lib/api/src/externals/memory.rs
@@ -193,8 +193,11 @@ impl Memory {
     /// backend supports shared memory operations.
     ///
     /// See [`SharedMemory`] and its methods for more information.
-    pub fn to_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
-        self.0.to_shared(store)
+    pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
+        if !self.ty(store).shared {
+            return None;
+        }
+        self.0.as_shared(store)
     }
 
     /// To `VMExtern`.

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -6,7 +6,7 @@ mod table;
 
 pub use self::function::{Function, HostFunction};
 pub use self::global::Global;
-pub use self::memory::Memory;
+pub use self::memory::{Memory, SharedMemoryHandle};
 pub use self::memory_view::MemoryView;
 pub use self::table::Table;
 

--- a/lib/api/src/externals/mod.rs
+++ b/lib/api/src/externals/mod.rs
@@ -6,7 +6,7 @@ mod table;
 
 pub use self::function::{Function, HostFunction};
 pub use self::global::Global;
-pub use self::memory::{Memory, SharedMemoryHandle};
+pub use self::memory::{Memory, MemoryLocation, SharedMemory};
 pub use self::memory_view::MemoryView;
 pub use self::table::Table;
 

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -184,7 +184,7 @@ impl Memory {
         true
     }
 
-    pub fn as_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+    pub fn as_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemory> {
         // Not supported.
         None
     }

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -183,6 +183,11 @@ impl Memory {
     pub fn is_from_store(&self, _store: &impl AsStoreRef) -> bool {
         true
     }
+
+    pub fn shared_handle(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+        // Not supported.
+        None
+    }
 }
 
 impl std::cmp::PartialEq for Memory {

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -184,7 +184,7 @@ impl Memory {
         true
     }
 
-    pub fn shared_handle(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+    pub fn to_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
         // Not supported.
         None
     }

--- a/lib/api/src/js/externals/memory.rs
+++ b/lib/api/src/js/externals/memory.rs
@@ -184,7 +184,7 @@ impl Memory {
         true
     }
 
-    pub fn to_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+    pub fn as_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
         // Not supported.
         None
     }

--- a/lib/api/src/jsc/externals/memory.rs
+++ b/lib/api/src/jsc/externals/memory.rs
@@ -211,7 +211,7 @@ impl Memory {
         self.handle.duplicate(store)
     }
 
-    pub fn to_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+    pub fn as_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
         // Not supported.
         None
     }

--- a/lib/api/src/jsc/externals/memory.rs
+++ b/lib/api/src/jsc/externals/memory.rs
@@ -211,7 +211,7 @@ impl Memory {
         self.handle.duplicate(store)
     }
 
-    pub fn as_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+    pub fn as_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemory> {
         // Not supported.
         None
     }

--- a/lib/api/src/jsc/externals/memory.rs
+++ b/lib/api/src/jsc/externals/memory.rs
@@ -210,6 +210,11 @@ impl Memory {
     pub fn duplicate(&mut self, store: &impl AsStoreRef) -> Result<VMMemory, MemoryError> {
         self.handle.duplicate(store)
     }
+
+    pub fn shared_handle(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+        // Not supported.
+        None
+    }
 }
 
 impl std::cmp::PartialEq for Memory {

--- a/lib/api/src/jsc/externals/memory.rs
+++ b/lib/api/src/jsc/externals/memory.rs
@@ -211,7 +211,7 @@ impl Memory {
         self.handle.duplicate(store)
     }
 
-    pub fn shared_handle(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+    pub fn to_shared(&self, _store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
         // Not supported.
         None
     }

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -468,7 +468,7 @@ pub use crate::externals::{
 };
 pub use access::WasmSliceAccess;
 pub use engine::{AsEngineRef, Engine, EngineRef};
-pub use errors::{InstantiationError, LinkError, RuntimeError};
+pub use errors::{AtomicsError, InstantiationError, LinkError, RuntimeError};
 pub use exports::{ExportError, Exportable, Exports, ExportsIterator};
 pub use extern_ref::ExternRef;
 pub use function_env::{FunctionEnv, FunctionEnvMut};

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -464,7 +464,7 @@ mod jsc;
 pub use jsc::*;
 
 pub use crate::externals::{
-    Extern, Function, Global, HostFunction, Memory, MemoryView, SharedMemoryHandle, Table,
+    Extern, Function, Global, HostFunction, Memory, MemoryLocation, MemoryView, SharedMemory, Table,
 };
 pub use access::WasmSliceAccess;
 pub use engine::{AsEngineRef, Engine, EngineRef};

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -463,7 +463,9 @@ mod jsc;
 #[cfg(feature = "jsc")]
 pub use jsc::*;
 
-pub use crate::externals::{Extern, Function, Global, HostFunction, Memory, MemoryView, Table};
+pub use crate::externals::{
+    Extern, Function, Global, HostFunction, Memory, MemoryView, SharedMemoryHandle, Table,
+};
 pub use access::WasmSliceAccess;
 pub use engine::{AsEngineRef, Engine, EngineRef};
 pub use errors::{InstantiationError, LinkError, RuntimeError};

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -99,9 +99,28 @@ impl Memory {
         mem.copy()
     }
 
+    pub fn shared_handle(&self, store: &impl AsStoreRef) -> Option<crate::SharedMemoryHandle> {
+        let mem = self.handle.get(store.as_store_ref().objects());
+        let conds = mem.thread_conditions()?.clone();
+
+        Some(crate::SharedMemoryHandle::new(conds))
+    }
+
     /// To `VMExtern`.
     pub(crate) fn to_vm_extern(&self) -> VMExtern {
         VMExtern::Memory(self.handle.internal_handle())
+    }
+}
+
+impl crate::externals::memory::SharedMemoryOps for wasmer_vm::ThreadConditions {
+    fn disable_atomics(&self) -> Result<(), MemoryError> {
+        self.disable_atomics();
+        Ok(())
+    }
+
+    fn wake_all_atomic_waiters(&self) -> Result<(), MemoryError> {
+        self.wake_all_atomic_waiters();
+        Ok(())
     }
 }
 

--- a/lib/api/src/sys/externals/memory.rs
+++ b/lib/api/src/sys/externals/memory.rs
@@ -101,7 +101,7 @@ impl Memory {
         mem.copy()
     }
 
-    pub fn to_shared(&self, store: &impl AsStoreRef) -> Option<crate::SharedMemory> {
+    pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<crate::SharedMemory> {
         let mem = self.handle.get(store.as_store_ref().objects());
         let conds = mem.thread_conditions()?.downgrade();
 

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -1,0 +1,78 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use wasmer::{imports, Instance, Memory, MemoryLocation, MemoryType, Module, Store};
+
+#[test]
+fn test_shared_memory_atomics_notify_send() {
+    let mut store = Store::default();
+    let wat = r#"(module
+(import "host" "memory" (memory 10 65536 shared))
+)"#;
+    let module = Module::new(&store, wat)
+        .map_err(|e| format!("{e:?}"))
+        .unwrap();
+
+    let mem = Memory::new(&mut store, MemoryType::new(10, Some(65536), true)).unwrap();
+
+    let imports = imports! {
+        "host" => {
+            "memory" => mem.clone(),
+        },
+    };
+
+    let _inst = Instance::new(&mut store, &module, &imports).unwrap();
+
+    let mem = if let Some(m) = mem.to_shared(&store) {
+        m
+    } else {
+        #[cfg(feature = "sys")]
+        panic!("Memory is not shared");
+        #[cfg(not(feature = "sys"))]
+        return Ok(());
+    };
+
+    // Test basic notify.
+    let mem2 = mem.clone();
+    std::thread::spawn(move || loop {
+        if mem2.notify(MemoryLocation::new_32(10), 1).unwrap() > 0 {
+            break;
+        }
+    });
+
+    mem.wait(MemoryLocation::new_32(10), None).unwrap();
+
+    // Test wake_all
+
+    let done = Arc::new(AtomicBool::new(false));
+
+    std::thread::spawn({
+        let mem = mem.clone();
+        let done = done.clone();
+        move || {
+            while !done.load(Ordering::SeqCst) {
+                mem.wake_all_atomic_waiters().ok();
+            }
+        }
+    });
+
+    mem.wait(MemoryLocation::new_32(10), None).unwrap();
+    done.store(true, Ordering::SeqCst);
+}
+
+#[cfg(feature = "sys")]
+#[test]
+fn test_shared_memory_disable_atomics() {
+    use wasmer::AtomicsError;
+
+    let mut store = Store::default();
+    let mem = Memory::new(&mut store, MemoryType::new(10, Some(65536), true)).unwrap();
+
+    let mem = mem.to_shared(&store).unwrap();
+    mem.disable_atomics().unwrap();
+
+    let err = mem.wait(MemoryLocation::new_32(1), None).unwrap_err();
+    assert_eq!(err, AtomicsError::AtomicsDisabled);
+}

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -25,7 +25,7 @@ fn test_shared_memory_atomics_notify_send() {
 
     let _inst = Instance::new(&mut store, &module, &imports).unwrap();
 
-    let mem = if let Some(m) = mem.to_shared(&store) {
+    let mem = if let Some(m) = mem.as_shared(&store) {
         m
     } else {
         #[cfg(feature = "sys")]
@@ -70,7 +70,7 @@ fn test_shared_memory_disable_atomics() {
     let mut store = Store::default();
     let mem = Memory::new(&mut store, MemoryType::new(10, Some(65536), true)).unwrap();
 
-    let mem = mem.to_shared(&store).unwrap();
+    let mem = mem.as_shared(&store).unwrap();
     mem.disable_atomics().unwrap();
 
     let err = mem.wait(MemoryLocation::new_32(1), None).unwrap_err();

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -31,7 +31,7 @@ fn test_shared_memory_atomics_notify_send() {
         #[cfg(feature = "sys")]
         panic!("Memory is not shared");
         #[cfg(not(feature = "sys"))]
-        return Ok(());
+        return;
     };
 
     // Test basic notify.

--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -93,6 +93,9 @@ pub enum MemoryError {
         /// Message describing the unsupported operation.
         message: String,
     },
+    /// The memory does not support atomic operations.
+    #[error("The memory does not support atomic operations")]
+    AtomicsNotSupported,
     /// A user defined error value, used for error cases not listed above.
     #[error("A user-defined error occurred: {0}")]
     Generic(String),

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -812,12 +812,13 @@ impl Instance {
         } else {
             Some(std::time::Duration::from_nanos(timeout as u64))
         };
-        let waiter = memory.do_wait(location, timeout);
-        if waiter.is_err() {
-            // ret is None if there is more than 2^32 waiter in queue or some other error
-            return Err(Trap::lib(TrapCode::TableAccessOutOfBounds));
+        match memory.do_wait(location, timeout) {
+            Ok(count) => Ok(count),
+            Err(_err) => {
+                // ret is None if there is more than 2^32 waiter in queue or some other error
+                Err(Trap::lib(TrapCode::TableAccessOutOfBounds))
+            }
         }
-        Ok(waiter.unwrap())
     }
 
     /// Perform an Atomic.Wait32

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -57,8 +57,7 @@ pub use crate::sig_registry::SignatureRegistry;
 pub use crate::store::{InternalStoreHandle, MaybeInstanceOwned, StoreHandle, StoreObjects};
 pub use crate::table::{TableElement, VMTable};
 #[doc(hidden)]
-pub use crate::threadconditions::ThreadConditions;
-pub use crate::threadconditions::WaiterError;
+pub use crate::threadconditions::{ThreadConditions, ThreadConditionsHandle, WaiterError};
 pub use crate::trap::*;
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMDynamicFunctionContext, VMFunctionContext,

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -497,6 +497,10 @@ impl LinearMemory for VMSharedMemory {
     fn do_notify(&mut self, dst: NotifyLocation, count: u32) -> u32 {
         self.conditions.do_notify(dst, count)
     }
+
+    fn thread_conditions(&self) -> Option<&ThreadConditions> {
+        Some(&self.conditions)
+    }
 }
 
 impl From<VMOwnedMemory> for VMMemory {
@@ -589,6 +593,10 @@ impl LinearMemory for VMMemory {
     /// Notify waiters from the wait list. Return the number of waiters notified
     fn do_notify(&mut self, dst: NotifyLocation, count: u32) -> u32 {
         self.0.do_notify(dst, count)
+    }
+
+    fn thread_conditions(&self) -> Option<&ThreadConditions> {
+        self.0.thread_conditions()
     }
 }
 
@@ -737,5 +745,12 @@ where
     /// Notify waiters from the wait list. Return the number of waiters notified
     fn do_notify(&mut self, _dst: NotifyLocation, _count: u32) -> u32 {
         0
+    }
+
+    /// Access the internal atomics handler.
+    ///
+    /// Will be [`None`] if the memory does not support atomics.
+    fn thread_conditions(&self) -> Option<&ThreadConditions> {
+        None
     }
 }

--- a/lib/vm/src/threadconditions.rs
+++ b/lib/vm/src/threadconditions.rs
@@ -159,6 +159,32 @@ impl ThreadConditions {
             .store(true, std::sync::atomic::Ordering::Release);
         self.wake_all_atomic_waiters();
     }
+
+    /// Get a weak handle to this `ThreadConditions` instance.
+    ///
+    /// See [`ThreadConditionsHandle`] for more information.
+    pub fn downgrade(&self) -> ThreadConditionsHandle {
+        ThreadConditionsHandle {
+            inner: Arc::downgrade(&self.inner),
+        }
+    }
+}
+
+/// A weak handle to a `ThreadConditions` instance, which does not prolong its
+/// lifetime.
+///
+/// Internally holds a [`std::sync::Weak`] pointer.
+pub struct ThreadConditionsHandle {
+    inner: std::sync::Weak<NotifyMap>,
+}
+
+impl ThreadConditionsHandle {
+    /// Attempt to upgrade this handle to a strong reference.
+    ///
+    /// Returns `None` if the original `ThreadConditions` instance has been dropped.
+    pub fn upgrade(&self) -> Option<ThreadConditions> {
+        self.inner.upgrade().map(|inner| ThreadConditions { inner })
+    }
 }
 
 #[cfg(test)]

--- a/lib/vm/src/threadconditions.rs
+++ b/lib/vm/src/threadconditions.rs
@@ -1,19 +1,22 @@
 use dashmap::DashMap;
 use fnv::FnvBuildHasher;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::thread::{current, park, park_timeout, Thread};
 use std::time::Duration;
 use thiserror::Error;
 
 /// Error that can occur during wait/notify calls.
-#[derive(Debug, Error)]
 // Non-exhaustive to allow for future variants without breaking changes!
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum WaiterError {
     /// Wait/Notify is not implemented for this memory
     Unimplemented,
     /// To many waiter for an address
     TooManyWaiters,
+    /// Atomic operations are disabled.
+    AtomicsDisabled,
 }
 
 impl std::fmt::Display for WaiterError {
@@ -31,18 +34,29 @@ pub struct NotifyLocation {
 
 #[derive(Debug)]
 struct NotifyWaiter {
-    pub thread: Thread,
-    pub notified: bool,
+    thread: Thread,
+    notified: bool,
 }
+
 #[derive(Debug, Default)]
 struct NotifyMap {
-    pub map: DashMap<NotifyLocation, Vec<NotifyWaiter>, FnvBuildHasher>,
+    /// If set to true, all waits will fail with an error.
+    closed: AtomicBool,
+    map: DashMap<NotifyLocation, Vec<NotifyWaiter>, FnvBuildHasher>,
 }
 
 /// HashMap of Waiters for the Thread/Notify opcodes
 #[derive(Debug)]
 pub struct ThreadConditions {
     inner: Arc<NotifyMap>, // The Hasmap with the Notify for the Notify/wait opcodes
+}
+
+impl Clone for ThreadConditions {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl ThreadConditions {
@@ -68,6 +82,10 @@ impl ThreadConditions {
         dst: NotifyLocation,
         timeout: Option<Duration>,
     ) -> Result<u32, WaiterError> {
+        if self.inner.closed.load(std::sync::atomic::Ordering::Acquire) {
+            return Err(WaiterError::AtomicsDisabled);
+        }
+
         // fetch the notifier
         if self.inner.map.len() >= 1 << 32 {
             return Err(WaiterError::TooManyWaiters);
@@ -111,7 +129,7 @@ impl ThreadConditions {
         if let Some(mut v) = self.inner.map.get_mut(&dst) {
             for waiter in v.value_mut() {
                 if count_token < count && !waiter.notified {
-                    waiter.notified = true; // mark as was waiked up
+                    waiter.notified = true; // waiter was notified, not just an elapsed timeout
                     waiter.thread.unpark(); // wakeup!
                     count_token += 1;
                 }
@@ -119,13 +137,27 @@ impl ThreadConditions {
         }
         count_token
     }
-}
 
-impl Clone for ThreadConditions {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
+    /// Wake all the waiters, *without* marking them as notified.
+    ///
+    /// Useful on shutdown to resume execution in all waiters.
+    pub fn wake_all_atomic_waiters(&self) {
+        for mut item in self.inner.map.iter_mut() {
+            for waiter in item.value_mut() {
+                waiter.thread.unpark();
+            }
         }
+    }
+
+    /// Disable the use of atomics, leading to all atomic waits failing with
+    /// an error, which leads to a Webassembly trap.
+    ///
+    /// Useful for force-closing instances that keep waiting on atomics.
+    pub fn disable_atomics(&self) {
+        self.inner
+            .closed
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.wake_all_atomic_waiters();
     }
 }
 


### PR DESCRIPTION
Allows to trigger atomics related operations on a memory that supports
interacting with the atomics layer though a shared handle.

Note that this needs to be a separate handle that is not a store reference, because it needs to be accessible while an instance is executing.

Right now only final operations are exposed that wake up all atomic
waiters, and that allow disabling atomics.

This is required for forceful shutdown of instances that keep
hot-looping on atomics, and will be used from WASIX.

Part of #4383
