### PR TITLE
chore: Fix clippy lints in API crate

### DIFF
--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -16,13 +16,15 @@ pub struct Instance {
 mod send_test {
     use super::*;
 
-    fn is_send<T: Send>() -> bool {
-        true
-    }
+    // Only here to statically ensure that `Instance` is `Send`.
+    // Will fail to compile otherwise.
+    #[allow(dead_code)]
+    fn instance_is_send(inst: Instance) {
+        fn is_send(t: impl Send) {
+            let _ = t;
+        }
 
-    #[test]
-    fn instance_is_send() {
-        assert!(is_send::<Instance>());
+        is_send(inst);
     }
 }
 

--- a/lib/api/tests/function_env.rs
+++ b/lib/api/tests/function_env.rs
@@ -24,7 +24,7 @@ fn data_and_store_mut() -> Result<(), String> {
     let (mut data, mut storemut) = envmut.data_and_store_mut();
 
     assert_eq!(
-        data.global.ty(&mut storemut),
+        data.global.ty(&storemut),
         GlobalType {
             ty: Type::I32,
             mutability: Mutability::Var

--- a/lib/api/tests/import_function.rs
+++ b/lib/api/tests/import_function.rs
@@ -109,8 +109,7 @@ fn calling_function_exports() -> Result<()> {
     };
     let instance = Instance::new(&mut store, &module, &imports)?;
 
-    let add: TypedFunction<(i32, i32), i32> =
-        instance.exports.get_typed_function(&mut store, "add")?;
+    let add: TypedFunction<(i32, i32), i32> = instance.exports.get_typed_function(&store, "add")?;
 
     let result = add.call(&mut store, 10, 20)?;
     assert_eq!(result, 30);
@@ -145,7 +144,7 @@ fn back_and_forth_with_imports() -> Result<()> {
     let instance = Instance::new(&mut store, &module, &import_object)?;
 
     let add_one: TypedFunction<i32, i32> =
-        instance.exports.get_typed_function(&mut store, "add_one")?;
+        instance.exports.get_typed_function(&store, "add_one")?;
     add_one.call(&mut store, 1)?;
 
     Ok(())

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -233,35 +233,35 @@ fn calling_host_functions_with_negative_values_works() -> Result<(), String> {
 
     let f1: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func1")
+        .get_typed_function(&store, "call_host_func1")
         .map_err(|e| format!("{e:?}"))?;
     let f2: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func2")
+        .get_typed_function(&store, "call_host_func2")
         .map_err(|e| format!("{e:?}"))?;
     let f3: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func3")
+        .get_typed_function(&store, "call_host_func3")
         .map_err(|e| format!("{e:?}"))?;
     let f4: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func4")
+        .get_typed_function(&store, "call_host_func4")
         .map_err(|e| format!("{e:?}"))?;
     let f5: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func5")
+        .get_typed_function(&store, "call_host_func5")
         .map_err(|e| format!("{e:?}"))?;
     let f6: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func6")
+        .get_typed_function(&store, "call_host_func6")
         .map_err(|e| format!("{e:?}"))?;
     let f7: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func7")
+        .get_typed_function(&store, "call_host_func7")
         .map_err(|e| format!("{e:?}"))?;
     let f8: TypedFunction<(), ()> = instance
         .exports
-        .get_typed_function(&mut store, "call_host_func8")
+        .get_typed_function(&store, "call_host_func8")
         .map_err(|e| format!("{e:?}"))?;
 
     f1.call(&mut store).map_err(|e| format!("{e:?}"))?;


### PR DESCRIPTION
Fix clippy lints in the API crate.

The fixes are in test code, which is ingored on CI, but the warnings are
annoying when developing.
