### PR TITLE
fix: Don't log the `FmtSpan::ENTER` event because it generates unnecessary logs

### DIFF
--- a/lib/cli/src/logging.rs
+++ b/lib/cli/src/logging.rs
@@ -31,7 +31,7 @@ impl Output {
     pub fn initialize_logging(&self) {
         let fmt_layer = fmt::layer()
             .with_target(true)
-            .with_span_events(fmt::format::FmtSpan::CLOSE | fmt::format::FmtSpan::ENTER)
+            .with_span_events(fmt::format::FmtSpan::CLOSE)
             .with_ansi(self.should_emit_colors())
             .with_thread_ids(true)
             .with_writer(std::io::stderr)


### PR DESCRIPTION
It looks like @john-sharratt added the `FmtSpan::ENTER` event while debugging `poll_oneoff` in a7f4460573d8c58562ac998993ec5627c03a93c1, but it was never removed afterwards so it ended up in the 4.2.4 release.

We don't want to be logging `FmtSpan::ENTER` because it means any async function annotated with `#[tracing::instrument]` will emit a log message every time the future is polled. Considering each read from a socket will poll the future again, that means you can easily end up with tens of thousands of unnecessary log entries printed to the screen when running with `RUST_LOG=wasmer_wasix=debug`.