### PR TITLE
remove memory footprint computation

### DIFF
--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -70,7 +70,6 @@ pub struct BinaryPackage {
     pub commands: Vec<BinaryPackageCommand>,
     pub uses: Vec<String>,
     pub version: Version,
-    pub module_memory_footprint: u64,
     pub file_system_memory_footprint: u64,
 }
 

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -45,10 +45,6 @@ pub async fn load_package_tree(
         commands(&resolution.package.commands, &containers, resolution)?;
 
     let file_system_memory_footprint = count_file_system(&fs, Path::new("/"));
-    let atoms_in_use: HashSet<_> = commands.iter().map(|cmd| cmd.atom()).collect();
-    let module_memory_footprint = atoms_in_use
-        .iter()
-        .fold(0, |footprint, atom| footprint + atom.len() as u64);
 
     let loaded = BinaryPackage {
         package_name: root.package_name.clone(),
@@ -64,7 +60,6 @@ pub async fn load_package_tree(
         webc_fs: Arc::new(fs),
         commands,
         uses: Vec::new(),
-        module_memory_footprint,
         file_system_memory_footprint,
     };
 


### PR DESCRIPTION
We calculate the `module_memory_footprint` in `load_package_tree` by collecting `atoms` in a set and adding their lengths together which is a costly operation. But, we don't use the calculated value anywhere in the code base. `load_package_tree` is in the critical path when running a package so removing these computation is beneficial.

before:
```
wasmer_wasix::runtime::package_loader::load_package_tree: close time.busy=60.9ms time.idle=2.12µs
```
after
```
wasmer_wasix::runtime::package_loader::load_package_tree: close time.busy=64.0µs time.idle=1.20µs
```