### PR TITLE
fix(api): Provide stub impls for new LinearMemory methods

### DIFF
--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -86,6 +86,13 @@ pub enum MemoryError {
     /// Returned when a shared memory is required, but the given memory is not shared.
     #[error("The memory is not shared")]
     MemoryNotShared,
+    /// Returned when trying to call a memory operation that is not supported by
+    /// the particular memory implementation.
+    #[error("tried to call an unsupported memory operation: {message}")]
+    UnsupportedOperation {
+        /// Message describing the unsupported operation.
+        message: String,
+    },
     /// A user defined error value, used for error cases not listed above.
     #[error("A user-defined error occurred: {0}")]
     Generic(String),

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -692,10 +692,18 @@ where
 
     /// Grows the memory to at least a minimum size. If the memory is already big enough
     /// for the min size then this function does nothing
-    fn grow_at_least(&mut self, min_size: u64) -> Result<(), MemoryError>;
+    fn grow_at_least(&mut self, _min_size: u64) -> Result<(), MemoryError> {
+        Err(MemoryError::UnsupportedOperation {
+            message: "grow_at_least() is not supported".to_string(),
+        })
+    }
 
     /// Resets the memory back to zero length
-    fn reset(&mut self) -> Result<(), MemoryError>;
+    fn reset(&mut self) -> Result<(), MemoryError> {
+        Err(MemoryError::UnsupportedOperation {
+            message: "reset() is not supported".to_string(),
+        })
+    }
 
     /// Return a `VMMemoryDefinition` for exposing the memory to compiled wasm code.
     fn vmmemory(&self) -> NonNull<VMMemoryDefinition>;


### PR DESCRIPTION
This reverts a breaking API change by providing stub implementations for
two new methods on LinearMemory (grow_at_least, reset).

The implementations return a new MemoryError::UnsupportedOperation.
Note: Since MemoryError is non-exhaustive, adding a new variant is
allowed.

We can make these methods required in a future major release if desired.

Closes #4392
