### PR TITLE
Fix WasiProcess::terminate()

### DIFF
--- a/lib/types/src/compilation/target.rs
+++ b/lib/types/src/compilation/target.rs
@@ -29,7 +29,7 @@ pub use target_lexicon::{
 ///
 /// [`cpuid` crate]: https://docs.rs/cpuid/0.1.1/cpuid/enum.CpuFeature.html
 /// [`cranelift-native`]: https://github.com/bytecodealliance/cranelift/blob/6988545fd20249b084c53f4761b8c861266f5d31/cranelift-native/src/lib.rs#L51-L92
-#[allow(missing_docs, clippy::derive_hash_xor_eq)]
+#[allow(missing_docs, clippy::derived_hash_with_manual_eq)]
 #[derive(EnumSetType, Debug, Hash)]
 pub enum CpuFeature {
     // X86 features

--- a/lib/vm/src/trap/trap.rs
+++ b/lib/vm/src/trap/trap.rs
@@ -91,7 +91,7 @@ impl Trap {
     pub fn downcast<T: Error + 'static>(self) -> Result<T, Self> {
         match self {
             // We only try to downcast user errors
-            Trap::User(err) if err.is::<T>() => Ok(*err.downcast::<T>().unwrap()),
+            Self::User(err) if err.is::<T>() => Ok(*err.downcast::<T>().unwrap()),
             _ => Err(self),
         }
     }
@@ -100,7 +100,7 @@ impl Trap {
     pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
         match &self {
             // We only try to downcast user errors
-            Trap::User(err) if err.is::<T>() => err.downcast_ref::<T>(),
+            Self::User(err) if err.is::<T>() => err.downcast_ref::<T>(),
             _ => None,
         }
     }
@@ -108,7 +108,7 @@ impl Trap {
     /// Returns true if the `Trap` is the same as T
     pub fn is<T: Error + 'static>(&self) -> bool {
         match self {
-            Trap::User(err) => err.is::<T>(),
+            Self::User(err) => err.is::<T>(),
             _ => false,
         }
     }
@@ -117,7 +117,7 @@ impl Trap {
 impl std::error::Error for Trap {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
-            Trap::User(err) => Some(&**err),
+            Self::User(err) => Some(&**err),
             _ => None,
         }
     }

--- a/lib/wasix/src/os/task/control_plane.rs
+++ b/lib/wasix/src/os/task/control_plane.rs
@@ -133,12 +133,11 @@ impl WasiControlPlane {
         }
 
         // Create the process first to do all the allocations before locking.
-        let mut proc = WasiProcess::new(WasiProcessId::from(0), module_hash, self.handle());
 
         let mut mutable = self.state.mutable.write().unwrap();
 
         let pid = mutable.next_process_id()?;
-        proc.set_pid(pid);
+        let proc = WasiProcess::new(pid, module_hash, self.handle());
         mutable.processes.insert(pid, proc.clone());
         Ok(proc)
     }

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -78,29 +78,36 @@ impl std::fmt::Debug for WasiProcessId {
     }
 }
 
-pub type LockableWasiProcessInner = Arc<(Mutex<WasiProcessInner>, Condvar)>;
-
 /// Represents a process running within the compute state
 /// TODO: fields should be private and only accessed via methods.
 #[derive(Debug, Clone)]
 pub struct WasiProcess {
+    state: Arc<State>,
+}
+
+#[derive(Debug)]
+struct State {
     /// Unique ID of this process
-    pub(crate) pid: WasiProcessId,
+    pid: WasiProcessId,
     /// Hash of the module that this process is using
-    pub(crate) module_hash: ModuleHash,
+    module_hash: ModuleHash,
     /// List of all the children spawned from this thread
-    pub(crate) parent: Option<Weak<RwLock<WasiProcessInner>>>,
-    /// The inner protected region of the process with a conditional
-    /// variable that is used for coordination such as checksums.
-    pub(crate) inner: LockableWasiProcessInner,
+    parent: Option<Weak<RwLock<WasiProcessInner>>>,
     /// Reference back to the compute engine
     // TODO: remove this reference, access should happen via separate state instead
     // (we don't want cyclical references)
-    pub(crate) compute: WasiControlPlaneHandle,
+    compute: WasiControlPlaneHandle,
+
     /// Reference to the exit code for the main thread
-    pub(crate) finished: Arc<OwnedTaskStatus>,
+    status: Arc<OwnedTaskStatus>,
+
     /// Number of threads waiting for children to exit
-    pub(crate) waiting: Arc<AtomicU32>,
+    waiting: Arc<AtomicU32>,
+
+    /// The inner protected region of the process with a conditional
+    /// variable that is used for coordination such as checksums.
+    lock_condvar: Condvar,
+    inner: Mutex<WasiProcessInner>,
 }
 
 /// Represents a freeze of all threads to perform some action
@@ -117,7 +124,7 @@ pub enum WasiProcessCheckpoint {
     Snapshot { trigger: SnapshotTrigger },
 }
 
-// TODO: fields should be private and only accessed via methods.
+// TODO(theduke): this struct should be private!
 #[derive(Debug)]
 pub struct WasiProcessInner {
     /// Unique ID of this process
@@ -128,7 +135,7 @@ pub struct WasiProcessInner {
     pub thread_count: u32,
     /// Signals that will be triggered at specific intervals
     pub signal_intervals: HashMap<Signal, WasiSignalInterval>,
-    /// List of all the children spawned from this thread
+    /// Child processes.
     pub children: Vec<WasiProcess>,
     /// Represents a checkpoint which blocks all the threads
     /// and then executes some maintenance action
@@ -140,29 +147,313 @@ pub enum MaybeCheckpointResult<'a> {
     Unwinding,
 }
 
+impl WasiProcess {
+    pub fn new(pid: WasiProcessId, module_hash: ModuleHash, plane: WasiControlPlaneHandle) -> Self {
+        WasiProcess {
+            state: Arc::new(State {
+                pid,
+                module_hash,
+                parent: None,
+                compute: plane,
+                lock_condvar: Condvar::new(),
+                inner: Mutex::new(WasiProcessInner {
+                    pid,
+                    threads: Default::default(),
+                    thread_count: Default::default(),
+                    signal_intervals: Default::default(),
+                    children: Default::default(),
+                    checkpoint: WasiProcessCheckpoint::Execute,
+                }),
+                status: Arc::new(OwnedTaskStatus::default()),
+                waiting: Arc::new(AtomicU32::new(0)),
+            }),
+        }
+    }
+
+    pub fn handle(&self) -> WasiProcessHandle {
+        WasiProcessHandle::new(&self.state)
+    }
+
+    #[inline]
+    pub fn module_hash(&self) -> &ModuleHash {
+        &self.state.module_hash
+    }
+
+    #[inline]
+    pub fn status(&self) -> &Arc<OwnedTaskStatus> {
+        &self.state.status
+    }
+
+    #[inline]
+    pub fn control_plane(&self) -> &WasiControlPlaneHandle {
+        &self.state.compute
+    }
+
+    /// Gets the process ID of this process
+    #[inline]
+    pub fn pid(&self) -> WasiProcessId {
+        self.state.pid
+    }
+
+    /// Notify the shared lock condvar to trigger waiters.
+    pub fn lock_notify_all(&self) {
+        self.state.lock_condvar.notify_all();
+    }
+
+    pub fn lock_wait<'a>(
+        &self,
+        guard: MutexGuard<'a, WasiProcessInner>,
+    ) -> MutexGuard<'a, WasiProcessInner> {
+        self.state.lock_condvar.wait(guard).unwrap()
+    }
+
+    /// Gets the process ID of the parent process
+    pub fn ppid(&self) -> WasiProcessId {
+        self.state
+            .parent
+            .iter()
+            .filter_map(|parent| parent.upgrade())
+            .map(|parent| parent.read().unwrap().pid)
+            .next()
+            .unwrap_or(WasiProcessId(0))
+    }
+
+    /// Gains access to the process internals
+    // TODO: Make this private, all inner access should be exposed with methods.
+    pub fn lock(&self) -> MutexGuard<'_, WasiProcessInner> {
+        self.state.inner.lock().unwrap()
+    }
+
+    /// Creates a a thread and returns it
+    pub fn new_thread(
+        &self,
+        layout: WasiMemoryLayout,
+    ) -> Result<WasiThreadHandle, ControlPlaneError> {
+        let control_plane = self.state.compute.must_upgrade();
+        let task_count_guard = control_plane.register_task()?;
+
+        // Determine if its the main thread or not
+        let is_main = {
+            let inner = self.lock();
+            inner.thread_count == 0
+        };
+
+        // Generate a new process ID (this is because the process ID and thread ID
+        // address space must not overlap in libc). For the main proecess the TID=PID
+        let tid: WasiThreadId = if is_main {
+            self.pid().raw().into()
+        } else {
+            let tid: u32 = control_plane.generate_id()?.into();
+            tid.into()
+        };
+
+        // The wait finished should be the process version if its the main thread
+        let mut inner = self.lock();
+        let finished = if is_main {
+            self.state.status.clone()
+        } else {
+            Arc::new(OwnedTaskStatus::default())
+        };
+
+        // Insert the thread into the pool
+        let ctrl = WasiThread::new(self.pid(), tid, is_main, finished, task_count_guard, layout);
+        inner.threads.insert(tid, ctrl.clone());
+        inner.thread_count += 1;
+
+        Ok(WasiThreadHandle::new(ctrl, self.handle()))
+    }
+
+    /// Gets a reference to a particular thread
+    pub fn get_thread(&self, tid: &WasiThreadId) -> Option<WasiThread> {
+        self.lock().threads.get(tid).cloned()
+    }
+
+    /// Signals a particular thread in the process
+    pub fn signal_thread(&self, tid: &WasiThreadId, signal: Signal) {
+        // Sometimes we will signal the process rather than the thread hence this libc hardcoded value
+        let mut tid = tid.raw();
+        if tid == 1073741823 {
+            tid = self.pid().raw();
+        }
+        let tid: WasiThreadId = tid.into();
+
+        let pid = self.pid();
+        tracing::trace!(%pid, %tid, "signal-thread({:?})", signal);
+
+        let inner = self.lock();
+        if let Some(thread) = inner.threads.get(&tid) {
+            thread.signal(signal);
+        } else {
+            trace!(
+                "wasi[{}]::lost-signal(tid={}, sig={:?})",
+                self.pid(),
+                tid,
+                signal
+            );
+        }
+    }
+
+    /// Signals all the threads in this process
+    pub fn signal_process(&self, signal: Signal) {
+        let pid = self.pid();
+        tracing::trace!(%pid, "signal-process({:?})", signal);
+
+        {
+            let inner = self.lock();
+            if self.state.waiting.load(Ordering::Acquire) > 0 {
+                let mut triggered = false;
+                for child in inner.children.iter() {
+                    child.signal_process(signal);
+                    triggered = true;
+                }
+                if triggered {
+                    return;
+                }
+            }
+        }
+        let inner = self.lock();
+        for thread in inner.threads.values() {
+            thread.signal(signal);
+        }
+    }
+
+    /// Signals one of the threads every interval
+    pub fn signal_interval(&self, signal: Signal, interval: Option<Duration>, repeat: bool) {
+        let mut inner = self.lock();
+
+        let interval = match interval {
+            None => {
+                inner.signal_intervals.remove(&signal);
+                return;
+            }
+            Some(a) => a,
+        };
+
+        let now = platform_clock_time_get(Snapshot0Clockid::Monotonic, 1_000_000).unwrap() as u128;
+        inner.signal_intervals.insert(
+            signal,
+            WasiSignalInterval {
+                signal,
+                interval,
+                last_signal: now,
+                repeat,
+            },
+        );
+    }
+
+    /// Returns the number of active threads for this process
+    pub fn active_threads(&self) -> u32 {
+        let inner = self.lock();
+        inner.thread_count
+    }
+
+    /// Waits until the process is finished.
+    pub async fn join(&self) -> Result<ExitCode, Arc<WasiRuntimeError>> {
+        let _guard = WasiProcessWait::new(self);
+        self.state.status.await_termination().await
+    }
+
+    /// Attempts to join on the process
+    pub fn try_join(&self) -> Option<Result<ExitCode, Arc<WasiRuntimeError>>> {
+        self.state.status.status().into_finished()
+    }
+
+    /// Waits for all the children to be finished
+    pub async fn join_children(&self) -> Option<Result<ExitCode, Arc<WasiRuntimeError>>> {
+        let _guard = WasiProcessWait::new(self);
+        let children: Vec<_> = {
+            let inner = self.lock();
+            inner.children.clone()
+        };
+        if children.is_empty() {
+            return None;
+        }
+        let mut waits = Vec::new();
+        for child in children {
+            if let Some(process) = self.state.compute.must_upgrade().get_process(child.pid()) {
+                let self_ = self.clone();
+                waits.push(async move {
+                    let join = process.join().await;
+                    let mut inner = self_.lock();
+                    inner.children.retain(|a| a.pid() != child.pid());
+                    join
+                })
+            }
+        }
+        futures::future::join_all(waits.into_iter())
+            .await
+            .into_iter()
+            .next()
+    }
+
+    /// Waits for any of the children to finished
+    pub async fn join_any_child(&self) -> Result<Option<(WasiProcessId, ExitCode)>, Errno> {
+        let _guard = WasiProcessWait::new(self);
+        let children: Vec<_> = {
+            let inner = self.lock();
+            inner.children.clone()
+        };
+        if children.is_empty() {
+            return Err(Errno::Child);
+        }
+
+        let mut waits = Vec::new();
+        for child in children {
+            if let Some(process) = self.state.compute.must_upgrade().get_process(child.pid()) {
+                let self_ = self.clone();
+                waits.push(async move {
+                    let join = process.join().await;
+                    let mut inner = self_.lock();
+                    inner.children.retain(|a| a.pid() != child.pid());
+                    (child, join)
+                })
+            }
+        }
+        let (child, res) = futures::future::select_all(waits.into_iter().map(|a| Box::pin(a)))
+            .await
+            .0;
+
+        let code =
+            res.unwrap_or_else(|e| e.as_exit_code().unwrap_or_else(|| Errno::Canceled.into()));
+
+        Ok(Some((child.pid(), code)))
+    }
+
+    /// Terminate the process and all its threads
+    pub fn terminate(&self, exit_code: ExitCode) {
+        // FIXME: this is wrong, threads might still be running!
+        // Need special logic for the main thread.
+        let guard = self.lock();
+        for thread in guard.threads.values() {
+            thread.set_status_finished(Ok(exit_code))
+        }
+    }
+}
+
 impl WasiProcessInner {
     /// Checkpoints the process which will cause all other threads to
     /// pause and for the thread and memory state to be saved
     #[cfg(feature = "journal")]
     pub fn checkpoint<M: wasmer_types::MemorySize>(
-        inner: LockableWasiProcessInner,
+        process: WasiProcess,
         ctx: FunctionEnvMut<'_, WasiEnv>,
-        for_what: WasiProcessCheckpoint,
+        for_what: ProcessCheckpoint,
     ) -> WasiResult<MaybeCheckpointResult<'_>> {
         // Set the checkpoint flag and then enter the normal processing loop
         {
-            let mut inner = inner.0.lock().unwrap();
+            // TODO: add set_checkpoint method
+            let mut inner = process.lock();
             inner.checkpoint = for_what;
         }
 
-        Self::maybe_checkpoint::<M>(inner, ctx)
+        Self::maybe_checkpoint::<M>(process, ctx)
     }
 
     /// If a checkpoint has been started this will block the current process
     /// until the checkpoint operation has completed
     #[cfg(feature = "journal")]
     pub fn maybe_checkpoint<M: wasmer_types::MemorySize>(
-        inner: LockableWasiProcessInner,
+        process: WasiProcess,
         ctx: FunctionEnvMut<'_, WasiEnv>,
     ) -> WasiResult<MaybeCheckpointResult<'_>> {
         // Enter the lock which will determine if we are in a checkpoint or not
@@ -172,13 +463,15 @@ impl WasiProcessInner {
         use wasmer_types::OnCalledAction;
 
         use crate::{rewind_ext, WasiError};
-        let guard = inner.0.lock().unwrap();
-        if guard.checkpoint == WasiProcessCheckpoint::Execute {
-            // No checkpoint so just carry on
-            return Ok(Ok(MaybeCheckpointResult::NotThisTime(ctx)));
+        {
+            let guard = process.lock();
+            if guard.checkpoint == WasiProcessCheckpoint::Execute {
+                // No checkpoint so just carry on
+                return Ok(Ok(MaybeCheckpointResult::NotThisTime(ctx)));
+            }
+            trace!("checkpoint capture");
+            drop(guard);
         }
-        trace!("checkpoint capture");
-        drop(guard);
 
         // Perform the unwind action
         unwind::<M, _>(ctx, move |mut ctx, memory_stack, rewind_stack| {
@@ -210,7 +503,7 @@ impl WasiProcessInner {
                 return wasmer_types::OnCalledAction::Trap(err.into());
             }
 
-            let mut guard = inner.0.lock().unwrap();
+            let mut guard = process.lock();
 
             // Wait for the checkpoint to finish (or if we are the last thread
             // to freeze then we have to execute the checksum operation)
@@ -224,7 +517,7 @@ impl WasiProcessInner {
                         if let Err(err) =
                             JournalEffector::save_memory_and_snapshot(&mut ctx, &mut guard, trigger)
                         {
-                            inner.1.notify_all();
+                            process.lock_notify_all();
                             return wasmer_types::OnCalledAction::Trap(err.into());
                         }
 
@@ -232,9 +525,9 @@ impl WasiProcessInner {
                         ctx.data().thread.set_check_pointing(false);
                         guard.checkpoint = WasiProcessCheckpoint::Execute;
                         trace!("checkpoint complete");
-                        inner.1.notify_all();
+                        process.lock_notify_all();
                     } else {
-                        guard = inner.1.wait(guard).unwrap();
+                        guard = process.lock_wait(guard);
                     }
                     continue;
                 }
@@ -261,6 +554,24 @@ impl WasiProcessInner {
     }
 }
 
+/// Weak handle to a process.
+#[derive(Debug, Clone)]
+pub struct WasiProcessHandle {
+    process: Weak<State>,
+}
+
+impl WasiProcessHandle {
+    fn new(process: &Arc<State>) -> Self {
+        Self {
+            process: Arc::downgrade(process),
+        }
+    }
+
+    pub fn upgrade(&self) -> Option<WasiProcess> {
+        self.process.upgrade().map(|state| WasiProcess { state })
+    }
+}
+
 // TODO: why do we need this, how is it used?
 pub(crate) struct WasiProcessWait {
     waiting: Arc<AtomicU32>,
@@ -268,9 +579,9 @@ pub(crate) struct WasiProcessWait {
 
 impl WasiProcessWait {
     pub fn new(process: &WasiProcess) -> Self {
-        process.waiting.fetch_add(1, Ordering::AcqRel);
+        process.state.waiting.fetch_add(1, Ordering::AcqRel);
         Self {
-            waiting: process.waiting.clone(),
+            waiting: process.state.waiting.clone(),
         }
     }
 }
@@ -278,261 +589,6 @@ impl WasiProcessWait {
 impl Drop for WasiProcessWait {
     fn drop(&mut self) {
         self.waiting.fetch_sub(1, Ordering::AcqRel);
-    }
-}
-
-impl WasiProcess {
-    pub fn new(pid: WasiProcessId, module_hash: ModuleHash, plane: WasiControlPlaneHandle) -> Self {
-        WasiProcess {
-            pid,
-            module_hash,
-            parent: None,
-            compute: plane,
-            inner: Arc::new((
-                Mutex::new(WasiProcessInner {
-                    pid,
-                    threads: Default::default(),
-                    thread_count: Default::default(),
-                    signal_intervals: Default::default(),
-                    children: Default::default(),
-                    checkpoint: WasiProcessCheckpoint::Execute,
-                }),
-                Condvar::new(),
-            )),
-            finished: Arc::new(OwnedTaskStatus::default()),
-            waiting: Arc::new(AtomicU32::new(0)),
-        }
-    }
-
-    pub(super) fn set_pid(&mut self, pid: WasiProcessId) {
-        self.pid = pid;
-    }
-
-    /// Gets the process ID of this process
-    pub fn pid(&self) -> WasiProcessId {
-        self.pid
-    }
-
-    /// Gets the process ID of the parent process
-    pub fn ppid(&self) -> WasiProcessId {
-        self.parent
-            .iter()
-            .filter_map(|parent| parent.upgrade())
-            .map(|parent| parent.read().unwrap().pid)
-            .next()
-            .unwrap_or(WasiProcessId(0))
-    }
-
-    /// Gains access to the process internals
-    // TODO: Make this private, all inner access should be exposed with methods.
-    pub fn lock(&self) -> MutexGuard<'_, WasiProcessInner> {
-        self.inner.0.lock().unwrap()
-    }
-
-    /// Creates a a thread and returns it
-    pub fn new_thread(
-        &self,
-        layout: WasiMemoryLayout,
-    ) -> Result<WasiThreadHandle, ControlPlaneError> {
-        let control_plane = self.compute.must_upgrade();
-        let task_count_guard = control_plane.register_task()?;
-
-        // Determine if its the main thread or not
-        let is_main = {
-            let inner = self.inner.0.lock().unwrap();
-            inner.thread_count == 0
-        };
-
-        // Generate a new process ID (this is because the process ID and thread ID
-        // address space must not overlap in libc). For the main proecess the TID=PID
-        let tid: WasiThreadId = if is_main {
-            self.pid().raw().into()
-        } else {
-            let tid: u32 = control_plane.generate_id()?.into();
-            tid.into()
-        };
-
-        // The wait finished should be the process version if its the main thread
-        let mut inner = self.inner.0.lock().unwrap();
-        let finished = if is_main {
-            self.finished.clone()
-        } else {
-            Arc::new(OwnedTaskStatus::default())
-        };
-
-        // Insert the thread into the pool
-        let ctrl = WasiThread::new(self.pid(), tid, is_main, finished, task_count_guard, layout);
-        inner.threads.insert(tid, ctrl.clone());
-        inner.thread_count += 1;
-
-        Ok(WasiThreadHandle::new(ctrl, &self.inner))
-    }
-
-    /// Gets a reference to a particular thread
-    pub fn get_thread(&self, tid: &WasiThreadId) -> Option<WasiThread> {
-        let inner = self.inner.0.lock().unwrap();
-        inner.threads.get(tid).cloned()
-    }
-
-    /// Signals a particular thread in the process
-    pub fn signal_thread(&self, tid: &WasiThreadId, signal: Signal) {
-        // Sometimes we will signal the process rather than the thread hence this libc hardcoded value
-        let mut tid = tid.raw();
-        if tid == 1073741823 {
-            tid = self.pid().raw();
-        }
-        let tid: WasiThreadId = tid.into();
-
-        let pid = self.pid();
-        tracing::trace!(%pid, %tid, "signal-thread({:?})", signal);
-
-        let inner = self.inner.0.lock().unwrap();
-        if let Some(thread) = inner.threads.get(&tid) {
-            thread.signal(signal);
-        } else {
-            trace!(
-                "wasi[{}]::lost-signal(tid={}, sig={:?})",
-                self.pid(),
-                tid,
-                signal
-            );
-        }
-    }
-
-    /// Signals all the threads in this process
-    pub fn signal_process(&self, signal: Signal) {
-        let pid = self.pid();
-        tracing::trace!(%pid, "signal-process({:?})", signal);
-
-        {
-            let inner = self.inner.0.lock().unwrap();
-            if self.waiting.load(Ordering::Acquire) > 0 {
-                let mut triggered = false;
-                for child in inner.children.iter() {
-                    child.signal_process(signal);
-                    triggered = true;
-                }
-                if triggered {
-                    return;
-                }
-            }
-        }
-        let inner = self.inner.0.lock().unwrap();
-        for thread in inner.threads.values() {
-            thread.signal(signal);
-        }
-    }
-
-    /// Signals one of the threads every interval
-    pub fn signal_interval(&self, signal: Signal, interval: Option<Duration>, repeat: bool) {
-        let mut inner = self.inner.0.lock().unwrap();
-
-        let interval = match interval {
-            None => {
-                inner.signal_intervals.remove(&signal);
-                return;
-            }
-            Some(a) => a,
-        };
-
-        let now = platform_clock_time_get(Snapshot0Clockid::Monotonic, 1_000_000).unwrap() as u128;
-        inner.signal_intervals.insert(
-            signal,
-            WasiSignalInterval {
-                signal,
-                interval,
-                last_signal: now,
-                repeat,
-            },
-        );
-    }
-
-    /// Returns the number of active threads for this process
-    pub fn active_threads(&self) -> u32 {
-        let inner = self.inner.0.lock().unwrap();
-        inner.thread_count
-    }
-
-    /// Waits until the process is finished.
-    pub async fn join(&self) -> Result<ExitCode, Arc<WasiRuntimeError>> {
-        let _guard = WasiProcessWait::new(self);
-        self.finished.await_termination().await
-    }
-
-    /// Attempts to join on the process
-    pub fn try_join(&self) -> Option<Result<ExitCode, Arc<WasiRuntimeError>>> {
-        self.finished.status().into_finished()
-    }
-
-    /// Waits for all the children to be finished
-    pub async fn join_children(&mut self) -> Option<Result<ExitCode, Arc<WasiRuntimeError>>> {
-        let _guard = WasiProcessWait::new(self);
-        let children: Vec<_> = {
-            let inner = self.inner.0.lock().unwrap();
-            inner.children.clone()
-        };
-        if children.is_empty() {
-            return None;
-        }
-        let mut waits = Vec::new();
-        for child in children {
-            if let Some(process) = self.compute.must_upgrade().get_process(child.pid) {
-                let inner = self.inner.clone();
-                waits.push(async move {
-                    let join = process.join().await;
-                    let mut inner = inner.0.lock().unwrap();
-                    inner.children.retain(|a| a.pid != child.pid);
-                    join
-                })
-            }
-        }
-        futures::future::join_all(waits.into_iter())
-            .await
-            .into_iter()
-            .next()
-    }
-
-    /// Waits for any of the children to finished
-    pub async fn join_any_child(&mut self) -> Result<Option<(WasiProcessId, ExitCode)>, Errno> {
-        let _guard = WasiProcessWait::new(self);
-        let children: Vec<_> = {
-            let inner = self.inner.0.lock().unwrap();
-            inner.children.clone()
-        };
-        if children.is_empty() {
-            return Err(Errno::Child);
-        }
-
-        let mut waits = Vec::new();
-        for child in children {
-            if let Some(process) = self.compute.must_upgrade().get_process(child.pid) {
-                let inner = self.inner.clone();
-                waits.push(async move {
-                    let join = process.join().await;
-                    let mut inner = inner.0.lock().unwrap();
-                    inner.children.retain(|a| a.pid != child.pid);
-                    (child, join)
-                })
-            }
-        }
-        let (child, res) = futures::future::select_all(waits.into_iter().map(|a| Box::pin(a)))
-            .await
-            .0;
-
-        let code =
-            res.unwrap_or_else(|e| e.as_exit_code().unwrap_or_else(|| Errno::Canceled.into()));
-
-        Ok(Some((child.pid, code)))
-    }
-
-    /// Terminate the process and all its threads
-    pub fn terminate(&self, exit_code: ExitCode) {
-        // FIXME: this is wrong, threads might still be running!
-        // Need special logic for the main thread.
-        let guard = self.inner.0.lock().unwrap();
-        for thread in guard.threads.values() {
-            thread.set_status_finished(Ok(exit_code))
-        }
     }
 }
 

--- a/lib/wasix/src/os/task/thread.rs
+++ b/lib/wasix/src/os/task/thread.rs
@@ -275,21 +275,6 @@ impl WasiThread {
         self.state.status.set_running();
     }
 
-    /// Gets or sets the exit code based of a signal that was received
-    /// Note: if the exit code was already set earlier this method will
-    /// just return that earlier set exit code
-    pub fn set_or_get_exit_code_for_signal(&self, sig: Signal) -> ExitCode {
-        let default_exitcode: ExitCode = match sig {
-            Signal::Sigquit | Signal::Sigabrt => Errno::Success.into(),
-            _ => Errno::Intr.into(),
-        };
-        // This will only set the status code if its not already set
-        self.set_status_finished(Ok(default_exitcode));
-        self.try_join()
-            .map(|r| r.unwrap_or(default_exitcode))
-            .unwrap_or(default_exitcode)
-    }
-
     /// Marks the thread as finished (which will cause anyone that
     /// joined on it to wake up)
     pub fn set_status_finished(&self, res: Result<ExitCode, WasiRuntimeError>) {

--- a/lib/wasix/src/runners/wcgi/handler.rs
+++ b/lib/wasix/src/runners/wcgi/handler.rs
@@ -98,7 +98,7 @@ impl Handler {
                 drop(token);
             }
         };
-        let finished = env.process.finished.clone();
+        let finished = env.process.status().clone();
 
         /*
          * TODO: Reusing memory for DCGI calls and not just the file system

--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -278,7 +278,7 @@ impl WasiFunctionEnv {
             // The first event we save is an event that records the module hash.
             // Note: This is used to detect if an incorrect journal is used on the wrong
             // process or if a process has been recompiled
-            let wasm_hash = self.data(&store).process.module_hash.as_bytes();
+            let wasm_hash = self.data(&store).process.module_hash().as_bytes();
             let mut ctx = self.env.clone().into_mut(&mut store);
             crate::journal::JournalEffector::save_event(
                 &mut ctx,

--- a/lib/wasix/src/syscalls/journal.rs
+++ b/lib/wasix/src/syscalls/journal.rs
@@ -14,7 +14,7 @@ pub fn maybe_snapshot_once<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     trigger: crate::journal::SnapshotTrigger,
 ) -> WasiResult<FunctionEnvMut<'_, WasiEnv>> {
-    use crate::os::task::process::{WasiProcessCheckpoint, WasiProcessInner};
+    use crate::os::task::process::{ProcessCheckpoint, WasiProcessInner};
 
     unsafe { handle_rewind_ext::<M, ()>(&mut ctx, HandleRewindType::Resultless) };
 
@@ -27,7 +27,7 @@ pub fn maybe_snapshot_once<M: MemorySize>(
         let res = wasi_try_ok_ok!(WasiProcessInner::checkpoint::<M>(
             process,
             ctx,
-            WasiProcessCheckpoint::Snapshot { trigger },
+            ProcessCheckpoint::Snapshot { trigger },
         )?);
         match res {
             MaybeCheckpointResult::Unwinding => return Ok(Err(Errno::Success)),
@@ -51,7 +51,7 @@ pub fn maybe_snapshot<M: MemorySize>(
 pub fn maybe_snapshot<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
 ) -> WasiResult<FunctionEnvMut<'_, WasiEnv>> {
-    use crate::os::task::process::{WasiProcessCheckpoint, WasiProcessInner};
+    use crate::os::task::process::{ProcessCheckpoint, WasiProcessInner};
 
     if !ctx.data().enable_journal {
         return Ok(Ok(ctx));

--- a/lib/wasix/src/syscalls/wasi/fd_read.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_read.rs
@@ -7,7 +7,7 @@ use crate::{
     fs::NotificationInner,
     journal::SnapshotTrigger,
     net::socket::TimeType,
-    os::task::process::{MaybeCheckpointResult, WasiProcessCheckpoint, WasiProcessInner},
+    os::task::process::{MaybeCheckpointResult, ProcessCheckpoint, WasiProcessInner},
     syscalls::*,
 };
 

--- a/lib/wasix/src/syscalls/wasix/proc_exec.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_exec.rs
@@ -82,7 +82,7 @@ pub fn proc_exec<M: MemorySize>(
         // We will need the child pid later
         let child_process = ctx.data().process.clone();
         let child_pid = child_process.pid();
-        let child_finished = child_process.finished;
+        let child_finished = child_process.status();
 
         // Restore the WasiEnv to the point when we vforked
         vfork.env.swap_inner(ctx.data_mut());

--- a/lib/wasix/src/syscalls/wasix/proc_fork.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork.rs
@@ -57,7 +57,7 @@ pub fn proc_fork<M: MemorySize>(
         }
     };
     let child_pid = child_env.process.pid();
-    let child_finished = child_env.process.finished.clone();
+    let child_finished = child_env.process.status().clone();
 
     // We write a zero to the PID before we capture the stack
     // so that this is what will be returned to the child

--- a/lib/wasix/src/syscalls/wasix/proc_join.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_join.rs
@@ -161,10 +161,10 @@ pub(super) fn proc_join_internal<M: MemorySize + 'static>(
         let process = inner
             .children
             .iter()
-            .filter(|c| c.pid == pid)
+            .filter(|c| c.pid() == pid)
             .map(Clone::clone)
             .next();
-        inner.children.retain(|c| c.pid != pid);
+        inner.children.retain(|c| c.pid() != pid);
         process
     };
 


### PR DESCRIPTION
fix(wasix): Fix WasiProcess::terminate()

Previously the code would mix up the output status of a thread/process with
an instruction to exit with a specific code.

The Process::terminate() method would just set the output status,
leaving no way to check if a thread had actually terminated.

This commit adds an additonal atomic flag that records if the process
should exit, and changes the relevant code (signal processing etc) to
check that flag.

The terminate method now just sets this code and then sends a kill
signal.

**NOTE**: The PR also contains some cleanup of the WasiProcess internal state.
Best to review commit by commit.

- chore(wasix): Clean up WasiProcess state
- refactor(wasix): Rename WasiProcessCheckpoint to ProcessCheckpoint
- chore(vm): Fix clippy lints
- fix(wasix): Fix WasiProcess::terminate()
