### PR TITLE
Fixed some compilation errors introduced by #4204 that assume `tokio::task::block_in_place()` always exists

### DIFF
--- a/lib/wasix/src/lib.rs
+++ b/lib/wasix/src/lib.rs
@@ -786,3 +786,18 @@ fn mem_error_to_wasi(err: MemoryAccessError) -> Errno {
         _ => Errno::Unknown,
     }
 }
+
+/// Run a synchronous function that would normally be blocking.
+///
+/// When the `sys-thread` feature is enabled, this will call
+/// [`tokio::task::block_in_place()`]. Otherwise, it calls the function
+/// immediately.
+pub(crate) fn block_in_place<Ret>(thunk: impl FnOnce() -> Ret) -> Ret {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "sys-thread")] {
+            tokio::task::block_in_place(thunk)
+        } else {
+            thunk()
+        }
+    }
+}

--- a/lib/wasix/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasix/src/runtime/package_loader/builtin_loader.rs
@@ -271,10 +271,7 @@ impl FileSystemCache {
     async fn lookup(&self, hash: &WebcHash) -> Result<Option<Container>, Error> {
         let path = self.path(hash);
 
-        #[cfg(target_arch = "wasm32")]
-        let container = Container::from_disk(&path);
-        #[cfg(not(target_arch = "wasm32"))]
-        let container = tokio::task::block_in_place(|| Container::from_disk(&path));
+        let container = crate::block_in_place(|| Container::from_disk(&path));
         match container {
             Ok(c) => Ok(Some(c)),
             Err(ContainerError::Open { error, .. })

--- a/lib/wasix/src/runtime/resolver/filesystem_source.rs
+++ b/lib/wasix/src/runtime/resolver/filesystem_source.rs
@@ -23,17 +23,9 @@ impl Source for FileSystemSource {
             _ => return Err(QueryError::Unsupported),
         };
 
-        #[cfg(target_arch = "wasm32")]
-        let webc_sha256 = WebcHash::for_file(&path)
+        let webc_sha256 = crate::block_in_place(|| WebcHash::for_file(&path))
             .with_context(|| format!("Unable to hash \"{}\"", path.display()))?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let webc_sha256 = tokio::task::block_in_place(|| WebcHash::for_file(&path))
-            .with_context(|| format!("Unable to hash \"{}\"", path.display()))?;
-        #[cfg(target_arch = "wasm32")]
-        let container = Container::from_disk(&path)
-            .with_context(|| format!("Unable to parse \"{}\"", path.display()))?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let container = tokio::task::block_in_place(|| Container::from_disk(&path))
+        let container = crate::block_in_place(|| Container::from_disk(&path))
             .with_context(|| format!("Unable to parse \"{}\"", path.display()))?;
 
         let url = crate::runtime::resolver::utils::url_from_file_path(&path)

--- a/lib/wasix/src/runtime/resolver/web_source.rs
+++ b/lib/wasix/src/runtime/resolver/web_source.rs
@@ -240,20 +240,12 @@ impl Source for WebSource {
             .await
             .context("Unable to get the locally cached file")?;
 
-        #[cfg(target_arch = "wasm32")]
-        let webc_sha256 = WebcHash::for_file(&local_path)
-            .with_context(|| format!("Unable to hash \"{}\"", local_path.display()))?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let webc_sha256 = tokio::task::block_in_place(|| WebcHash::for_file(&local_path))
+        let webc_sha256 = crate::block_in_place(|| WebcHash::for_file(&local_path))
             .with_context(|| format!("Unable to hash \"{}\"", local_path.display()))?;
 
         // Note: We want to use Container::from_disk() rather than the bytes
         // our HTTP client gave us because then we can use memory-mapped files
-        #[cfg(target_arch = "wasm32")]
-        let container = Container::from_disk(&local_path)
-            .with_context(|| format!("Unable to load \"{}\"", local_path.display()))?;
-        #[cfg(not(target_arch = "wasm32"))]
-        let container = tokio::task::block_in_place(|| Container::from_disk(&local_path))
+        let container = crate::block_in_place(|| Container::from_disk(&local_path))
             .with_context(|| format!("Unable to load \"{}\"", local_path.display()))?;
         let pkg = PackageInfo::from_manifest(container.manifest())
             .context("Unable to determine the package's metadata")?;

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -13,8 +13,6 @@ use wasmer::{AsStoreMut, Instance, Module, Store};
 
 #[cfg(feature = "journal")]
 use crate::journal::{DynJournal, SnapshotTrigger};
-#[cfg(feature = "sys")]
-use crate::PluggableRuntime;
 use crate::{
     bin_factory::{BinFactory, BinaryPackage},
     capabilities::Capabilities,
@@ -800,7 +798,7 @@ impl WasiEnvBuilder {
             #[cfg(feature = "sys-thread")]
             {
                 #[allow(unused_mut)]
-                let mut runtime = PluggableRuntime::new(Arc::new(crate::runtime::task_manager::tokio::TokioTaskManager::default()));
+                let mut runtime = crate::runtime::PluggableRuntime::new(Arc::new(crate::runtime::task_manager::tokio::TokioTaskManager::default()));
                 #[cfg(feature = "journal")]
                 for journal in self.journals.clone() {
                     runtime.add_journal(journal);


### PR DESCRIPTION
I noticed that `cargo check --no-default-features --features=sys,wasmer/sys` no longer works because #4204 introduced some calls to `tokio::task::block_in_place()` when `#[cfg(feature = "sys")]`, but that function is only available when `tokio`'s `rt-multi-thread` feature flag is enabled (enabled by wasix's `sys-threads` feature).

I've updated all places that called `tokio::task::block_in_place()` so they go through a shim function that will defer to `tokio::task::block_in_place()` if it is available. This also helped hoist the conditional compilation out of our business logic.