### PR TITLE
fix(cli): publish: Fix panic + Make waiting for build results more modular

### DIFF
--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
 use clap::Parser;
-use wasmer_registry::wasmer_env::WasmerEnv;
+use wasmer_registry::{publish::PublishWait, wasmer_env::WasmerEnv};
 
 /// Publish a package to the package registry.
 #[derive(Debug, Parser)]
@@ -30,6 +30,12 @@ pub struct Publish {
     /// Wait for package to be available on the registry before exiting.
     #[clap(long)]
     pub wait: bool,
+    /// Wait for the package and all dependencies to be available on the registry
+    /// before exiting.
+    ///
+    /// This includes the container, native executables and bindings.
+    #[clap(long)]
+    pub wait_all: bool,
     /// Timeout (in seconds) for the publish query to the registry.
     ///
     /// Note that this is not the timeout for the entire publish process, but
@@ -40,12 +46,19 @@ pub struct Publish {
 
 impl Publish {
     /// Executes `wasmer publish`
-    #[tokio::main]
-    pub async fn execute(&self) -> Result<(), anyhow::Error> {
+    pub fn execute(&self) -> Result<(), anyhow::Error> {
         let token = self
             .env
             .token()
             .context("could not determine auth token for registry - run 'wasmer login'")?;
+
+        let wait = if self.wait_all {
+            PublishWait::new_all()
+        } else if self.wait {
+            PublishWait::new_container()
+        } else {
+            PublishWait::new_none()
+        };
 
         let publish = wasmer_registry::package::builder::Publish {
             registry: self.env.registry_endpoint().map(|u| u.to_string()).ok(),
@@ -56,10 +69,10 @@ impl Publish {
             token,
             no_validate: self.no_validate,
             package_path: self.package_path.clone(),
-            wait: self.wait,
+            wait,
             timeout: self.timeout.into(),
         };
-        publish.execute().await.map_err(on_error)?;
+        publish.execute().map_err(on_error)?;
 
         if let Err(e) = invalidate_graphql_query_cache(&self.env) {
             tracing::warn!(

--- a/lib/cli/src/utils/mod.rs
+++ b/lib/cli/src/utils/mod.rs
@@ -238,7 +238,7 @@ pub async fn republish_package_with_bumped_version(
         quiet: false,
         package_name: None,
         version: None,
-        wait: false,
+        wait: wasmer_registry::publish::PublishWait::new_none(),
         token,
         no_validate: true,
         package_path: Some(dir.to_str().unwrap().to_string()),
@@ -246,7 +246,7 @@ pub async fn republish_package_with_bumped_version(
         // large packages.
         timeout: std::time::Duration::from_secs(60 * 60 * 12),
     };
-    publish.execute().await?;
+    publish.execute()?;
 
     Ok(manifest)
 }

--- a/lib/registry/src/package/builder.rs
+++ b/lib/registry/src/package/builder.rs
@@ -10,6 +10,7 @@ use tar::Builder;
 use thiserror::Error;
 use time::{self, OffsetDateTime};
 
+use crate::publish::PublishWait;
 use crate::{package::builder::validate::ValidationPolicy, publish::SignArchiveResult};
 use crate::{WasmerConfig, PACKAGE_TOML_FALLBACK_NAME};
 
@@ -40,7 +41,7 @@ pub struct Publish {
     /// Directory containing the `wasmer.toml` (defaults to current root dir)
     pub package_path: Option<String>,
     /// Wait for package to be available on the registry before exiting
-    pub wait: bool,
+    pub wait: PublishWait,
     /// Timeout (in seconds) for the publish query to the registry
     pub timeout: Duration,
 }
@@ -63,7 +64,7 @@ enum PackageBuildError {
 
 impl Publish {
     /// Executes `wasmer publish`
-    pub async fn execute(&self) -> Result<(), anyhow::Error> {
+    pub fn execute(&self) -> Result<(), anyhow::Error> {
         let input_path = match self.package_path.as_ref() {
             Some(s) => std::env::current_dir()?.join(s),
             None => std::env::current_dir()?,
@@ -194,7 +195,6 @@ impl Publish {
             self.wait,
             self.timeout,
         )
-        .await
     }
 
     fn validation_policy(&self) -> Box<dyn ValidationPolicy> {


### PR DESCRIPTION
* Fixes a panic due to nested tokio runtimes

* Exposes a --wait flag, which only waits for the container, and a
--wait-all flag, which also waits for bindings and native executables.

Also adds a timeout for waiting.