### PR TITLE
chore: Fix clippy lints for headless CLI build

### DIFF
--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -1,10 +1,13 @@
 //! Common module with common used structures across different
 //! commands.
 
-#[allow(unused_imports)]
+// NOTE: A lot of this code depends on feature flags.
+// To not go crazy with annotations, some lints are disablefor the whole
+// module.
+#![allow(dead_code, unused_imports, unused_variables)]
+
 use std::path::PathBuf;
 use std::string::ToString;
-#[allow(unused_imports)]
 use std::sync::Arc;
 
 use anyhow::{bail, Result};


### PR DESCRIPTION
Fix a CI build failure on the master CI that was introduced in a recent cleanup
PR.
