### PR TITLE
Try to build the package before publishing it

### DIFF
--- a/lib/cli/src/commands/package/build.rs
+++ b/lib/cli/src/commands/package/build.rs
@@ -20,6 +20,10 @@ pub struct PackageBuild {
     ///
     /// Defaults to current directory.
     package: Option<PathBuf>,
+
+    /// Only checks whether the package could be built successfully
+    #[clap(long)]
+    check: bool,
 }
 
 static READING_MANIFEST_EMOJI: Emoji<'_, '_> = Emoji("📖 ", "");
@@ -28,6 +32,15 @@ static WRITING_PACKAGE_EMOJI: Emoji<'_, '_> = Emoji("📦 ", "");
 static SPARKLE: Emoji<'_, '_> = Emoji("✨ ", ":-)");
 
 impl PackageBuild {
+    pub(crate) fn check(package_path: PathBuf) -> Self {
+        PackageBuild {
+            out: None,
+            quiet: true,
+            package: Some(package_path),
+            check: true,
+        }
+    }
+
     pub(crate) fn execute(&self) -> Result<(), anyhow::Error> {
         let manifest_path = self.manifest_path()?;
         let pkg = webc::wasmer_package::Package::from_manifest(manifest_path)?;
@@ -50,6 +63,12 @@ impl PackageBuild {
             .wapm()
             .context("could not load package manifest")?
             .context("package does not contain a Wasmer manifest")?;
+
+        // rest of the code writes the package to disk and is irrelevant
+        // to checking.
+        if self.check {
+            return Ok(());
+        }
 
         let pkgname = manifest.name.replace('/', "-");
         let name = format!("{}-{}.webc", pkgname, manifest.version,);
@@ -169,6 +188,7 @@ description = "hello"
             package: Some(path.to_owned()),
             out: Some(path.to_owned()),
             quiet: true,
+            check: false,
         };
 
         cmd.execute().unwrap();

--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -2,6 +2,8 @@ use anyhow::Context as _;
 use clap::Parser;
 use wasmer_registry::{publish::PublishWait, wasmer_env::WasmerEnv};
 
+use super::PackageBuild;
+
 /// Publish a package to the package registry.
 #[derive(Debug, Parser)]
 pub struct Publish {
@@ -47,6 +49,13 @@ pub struct Publish {
 impl Publish {
     /// Executes `wasmer publish`
     pub fn execute(&self) -> Result<(), anyhow::Error> {
+        // first check if the package could be built successfuly
+        let package_path = match self.package_path.as_ref() {
+            Some(s) => std::env::current_dir()?.join(s),
+            None => std::env::current_dir()?,
+        };
+        PackageBuild::check(package_path).execute()?;
+
         let token = self
             .env
             .token()


### PR DESCRIPTION
This PR adds a preliminary step to `wasmer run` that tries to build the package before publishing it. As a bonus, `wasmer package build` now has the `--check` flag which only checks whether the package could be built or not.

Related to #4288 and this [comment](https://github.com/wasmerio/wasmer/issues/4288#issuecomment-1919086857).
