### PR TITLE
Return Notsup for absolute symlinks instead of panicking

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -930,7 +930,8 @@ impl WasiFs {
                                 let (pre_open_dir_fd, relative_path) = if link_value.is_relative() {
                                     self.path_into_pre_open_and_relative_path(&file)?
                                 } else {
-                                    unimplemented!("Absolute symlinks are not yet supported");
+                                    tracing::error!("Absolute symlinks are not yet supported");
+                                    return Err(Errno::Notsup);
                                 };
                                 loop_for_symlink = true;
                                 symlink_count += 1;


### PR DESCRIPTION
Generally when userspace tries to do something the environment can't do (even if it might be able to do it in the future), the usual response is the return a "Not Supported" error, rather than crashing the entire environment.

This addresses, but doesn't quite solve #2243.