### PR TITLE
increase pagination size for app logs

### DIFF
--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -690,9 +690,6 @@ fn get_app_logs(
             name: name.clone(),
             owner: owner.clone(),
             version: tag.clone(),
-            // TODO: increase pagination size
-            // See https://github.com/wasmerio/edge/issues/460
-            // first: Some(500),
             first: Some(100),
             starting_from: unix_timestamp(start),
             until: end.map(unix_timestamp),

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -693,7 +693,7 @@ fn get_app_logs(
             // TODO: increase pagination size
             // See https://github.com/wasmerio/edge/issues/460
             // first: Some(500),
-            first: Some(10),
+            first: Some(100),
             starting_from: unix_timestamp(start),
             until: end.map(unix_timestamp),
         };


### PR DESCRIPTION
I remember talking with @ayys and he mentioned the pagination size was increased for app logs on the backend. If not, feel free to close this PR.