### PR TITLE
Fix note about unaligned references in `WasmRef` docs

### DIFF
--- a/lib/api/src/mem_access.rs
+++ b/lib/api/src/mem_access.rs
@@ -44,8 +44,7 @@ impl From<FromUtf8Error> for MemoryAccessError {
 /// trait which guarantees that reading and writing such a value to untrusted
 /// memory is safe.
 ///
-/// The address is not required to be aligned: unaligned accesses are fully
-/// supported.
+/// The address is required to be aligned: unaligned accesses cause undefined behavior.
 ///
 /// This wrapper safely handles concurrent modifications of the data by another
 /// thread.
@@ -86,7 +85,7 @@ impl<'a, T: ValueType> WasmRef<'a, T> {
         WasmPtr::new(self.offset)
     }
 
-    /// Get a `WasmPtr` fror this `WasmRef`.
+    /// Get a `WasmPtr` for this `WasmRef`.
     #[inline]
     pub fn as_ptr<M: MemorySize>(self) -> WasmPtr<T, M> {
         let offset: M::Offset = self


### PR DESCRIPTION
Contrary to the current docs, `WasmRef` is not safe for unaligned references. This PR adjusts the docs.
Here's an example that shows the problem:

```rust
use wasmer::{Memory, MemoryType, Store, WasmPtr};

fn main() -> anyhow::Result<()> {
    let mut store = Store::default();
    let memory = Memory::new(&mut store, MemoryType::new(1, None, false))?;
    let memory = memory.view(&store);
    // write unaligned value into memory
    WasmPtr::<u32>::new(1).deref(&memory).write(42u32)?; // <- this panics with `misaligned pointer dereference`

    Ok(())
}
```

It would be possible to support this using `write_unaligned`, but that would require some refactoring, since it needs to be kept a pointer and not converted to a reference, as is currently done in [`WasmRefAccess::new`](https://github.com/chipshort/wasmer/blob/ebfd642b2eb3a7bd103e780fac45a5b0877190bd/lib/api/src/jsc/mem_access.rs#L61).