### PR TITLE
tests: Disable flaky network tests on MUSL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up base deps on musl
         if: matrix.build == 'linux-musl-x64'
-        run: |
-            apk add build-base bash musl-dev curl make libtool libffi-dev gcc automake autoconf git openssl-dev g++
+        run: ./scripts/alpine-linux-install-deps.sh
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,9 +371,7 @@ jobs:
           sudo apt-get install --reinstall g++
       - name: Set up base deps on musl
         if: matrix.metadata.build == 'linux-musl'
-        run: |
-            apk update
-            apk add build-base bash musl-dev curl tar make libtool libffi-dev gcc automake autoconf git openssl-dev g++
+        run: ./scripts/alpine-linux-install-deps.sh
       - name: Set up dependencies for Mac OS
         run: |
           brew install automake
@@ -603,9 +601,7 @@ jobs:
           sudo apt-get install --reinstall g++
       - name: Set up base deps on musl
         if: matrix.metadata.build == 'linux-musl'
-        run: |
-            apk update
-            apk add build-base bash musl-dev curl tar make libtool libffi-dev gcc automake autoconf git openssl-dev g++
+        run: ./scripts/alpine-linux-install-deps.sh
       - name: Set up dependencies for Mac OS
         run: |
           brew install automake
@@ -704,9 +700,7 @@ jobs:
           version: 0.10.0
       - name: Set up base deps on musl
         if: matrix.build == 'linux-musl'
-        run: |
-            apk update
-            apk add build-base bash musl-dev curl tar make libtool libffi-dev gcc automake autoconf git openssl-dev g++
+        run: ./scripts/alpine-linux-install-deps.sh
       - uses: actions/download-artifact@v3
         id: download
         with:

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -132,6 +132,9 @@ async fn test_tcp_with_mpsc() {
     test_tcp(client, server).await
 }
 
+// Disabled on musl due to flakiness.
+// See https://github.com/wasmerio/wasmer/issues/4425
+#[cfg(not(target_env = "musl"))]
 #[cfg(feature = "remote")]
 #[cfg_attr(windows, ignore)]
 #[traced_test]
@@ -152,6 +155,9 @@ async fn test_tcp_with_large_pipe_using_bincode() {
     test_tcp(client, server).await
 }
 
+// Disabled on musl due to flakiness.
+// See https://github.com/wasmerio/wasmer/issues/4425
+#[cfg(not(target_env = "musl"))]
 #[cfg(feature = "remote")]
 #[cfg(feature = "json")]
 #[cfg_attr(windows, ignore)]
@@ -174,6 +180,9 @@ async fn test_tcp_with_large_pipe_json_using_json() {
     test_tcp(client, server).await
 }
 
+// Disabled on musl due to flakiness.
+// See https://github.com/wasmerio/wasmer/issues/4425
+#[cfg(not(target_env = "musl"))]
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
 #[cfg_attr(windows, ignore)]
@@ -185,6 +194,9 @@ async fn test_tcp_with_small_pipe_using_messagepack() {
     test_tcp(client, server).await
 }
 
+// Disabled on musl due to flakiness.
+// See https://github.com/wasmerio/wasmer/issues/4425
+#[cfg(not(target_env = "musl"))]
 #[cfg(feature = "remote")]
 #[cfg(feature = "messagepack")]
 #[cfg_attr(windows, ignore)]
@@ -196,6 +208,9 @@ async fn test_tcp_with_large_pipe_json_using_messagepack() {
     test_tcp(client, server).await
 }
 
+// Disabled on musl due to flakiness.
+// See https://github.com/wasmerio/wasmer/issues/4425
+#[cfg(not(target_env = "musl"))]
 #[cfg(feature = "remote")]
 #[cfg(feature = "cbor")]
 #[cfg_attr(windows, ignore)]

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Install package dependencies on Alpine linux.
+#
+# This script is used by the CI!
+
+apk update
+apk add build-base bash musl-dev curl tar make libtool libffi-dev gcc automake autoconf git openssl-dev g++ pkgconfig

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -16,7 +16,7 @@ md5 = "0.7.0"
 hex = "0.4.3"
 pretty_assertions = "1.3.0"
 object = "0.30.0"
-reqwest = { version = "0.11.14", features = ["json", "blocking"] }
+reqwest = { version = "0.11.14", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 tokio = { version = "1", features = [ "rt", "rt-multi-thread", "macros" ] }
 assert_cmd = "2.0.8"
 predicates = "2.1.5"

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -178,7 +178,6 @@ fn test_wasmer_run_works_with_dir() {
 
 // FIXME: Re-enable. See https://github.com/wasmerio/wasmer/issues/3717
 #[ignore]
-#[cfg_attr(target_env = "musl", ignore)]
 #[test]
 fn test_wasmer_run_works() {
     let assert = Command::new(get_wasmer_path())


### PR DESCRIPTION
Disable some flaky tests on MUSL for now to not block the CI.
Needs a proper investigation in the future.

Part of #4425
