### PR TITLE
fix(cli): Fix auto-package version bumping in 'wasmer deploy'

### DIFF
--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -1958,7 +1958,7 @@ pub(super) mod utils {
     #[test]
     fn test_filter_tarball() {
         use std::str::FromStr;
-        let test_paths = vec![
+        let test_paths = [
             "/test/wasmer-darwin-amd64.tar.gz",
             "/test/wasmer-darwin-arm64.tar.gz",
             "/test/wasmer-linux-aarch64.tar.gz",


### PR DESCRIPTION
THe backend does not return reliable version information, so we have to
introduce a loop that checks for the next available version.

Closes #4464
Closes RUN-100