### PR TITLE
Fix for a panic in the sock_recv when a file handle is missing

### DIFF
--- a/lib/wasix/src/syscalls/wasix/sock_recv.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_recv.rs
@@ -27,7 +27,7 @@ pub fn sock_recv<M: MemorySize>(
     ro_flags: WasmPtr<RoFlags, M>,
 ) -> Result<Errno, WasiError> {
     let env = ctx.data();
-    let fd_entry = env.state.fs.get_fd(sock).unwrap();
+    let fd_entry = wasi_try_ok!(env.state.fs.get_fd(sock));
     let guard = fd_entry.inode.read();
     let use_read = matches!(guard.deref(), Kind::Pipe { .. });
     drop(guard);


### PR DESCRIPTION
This fixes this panic

```sh
thread 'rusty_pool_2_thread_2' panicked at /home/john/.cargo/git/checkouts/wasmer-f11f30e62739aa29/4adf375/lib/wasix/src/syscalls/wasix/sock_recv.rs:30:46:
called `Result::unwrap()` on an `Err` value: Errno::badf
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```