### PR TITLE
fix(backend-api): Fix type of BigInt

### DIFF
--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1255,7 +1255,7 @@ mod queries {
     }
 
     #[derive(cynic::Scalar, Debug, Clone)]
-    pub struct BigInt(pub u64);
+    pub struct BigInt(pub i64);
 
     #[derive(cynic::InlineFragments, Debug)]
     pub enum Node {


### PR DESCRIPTION
Must be i64, not u64.
