### PR TITLE
Fix bug with `app deploy`: app URL is stale

### DIFF
--- a/lib/cli/src/commands/app/mod.rs
+++ b/lib/cli/src/commands/app/mod.rs
@@ -115,7 +115,7 @@ pub enum WaitMode {
 /// Same as [Self::deploy], but also prints verbose information.
 pub async fn deploy_app_verbose(
     client: &WasmerClient,
-    mut opts: DeployAppOpts<'_>,
+    opts: DeployAppOpts<'_>,
 ) -> Result<(DeployApp, DeployAppVersion), anyhow::Error> {
     let owner = &opts.owner;
     let app = &opts.app;
@@ -130,20 +130,6 @@ pub async fn deploy_app_verbose(
 
     eprintln!("Deploying app {pretty_name}...\n");
 
-    let (owner, app_opt) = if let Some(owner) = owner {
-        (Some(owner.clone()), None)
-    } else if let Some(id) = &app.app_id {
-        let app = wasmer_api::query::get_app_by_id(client, id.clone())
-            .await
-            .context("could not fetch app from backend")?;
-
-        (Some(app.owner.global_name.clone()), Some(app))
-    } else {
-        (None, None)
-    };
-
-    opts.owner = owner;
-
     let wait = opts.wait;
     let version = deploy_app(client, opts).await?;
 
@@ -155,13 +141,9 @@ pub async fn deploy_app_verbose(
         .inner()
         .to_string();
 
-    let app = if let Some(app) = app_opt {
-        app
-    } else {
-        wasmer_api::query::get_app_by_id(client, app_id.clone())
-            .await
-            .context("could not fetch app from backend")?
-    };
+    let app = wasmer_api::query::get_app_by_id(client, app_id.clone())
+        .await
+        .context("could not fetch app from backend")?;
 
     let full_name = format!("{}/{}", app.owner.global_name, app.name);
 


### PR DESCRIPTION
The app was being fetched before the new version was published. Now that aliases are properly changed on the backend, this resulted in stale URL being pinged.

This fixes by querying the backend after the app has been deployed.