### PR TITLE
allow owner field in app.yaml

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -199,11 +199,11 @@ impl AppCreator {
         let app_cfg = AppConfigV1 {
             app_id: None,
             name: app_name,
+            owner: Some(self.owner.clone()),
             cli_args: None,
             env: Default::default(),
             volumes: None,
             domains: None,
-            owner: None,
             scaling: None,
             package: edge_schema::schema::StringWebcIdent(edge_schema::schema::WebcIdent {
                 repository: None,

--- a/lib/cli/src/commands/app/mod.rs
+++ b/lib/cli/src/commands/app/mod.rs
@@ -117,7 +117,7 @@ pub async fn deploy_app_verbose(
     client: &WasmerClient,
     opts: DeployAppOpts<'_>,
 ) -> Result<(DeployApp, DeployAppVersion), anyhow::Error> {
-    let owner = &opts.owner.or_else(|| opts.app.owner.clone());
+    let owner = &opts.owner.clone().or_else(|| opts.app.owner.clone());
     let app = &opts.app;
 
     let pretty_name = if let Some(owner) = &owner {

--- a/lib/cli/src/commands/app/mod.rs
+++ b/lib/cli/src/commands/app/mod.rs
@@ -117,7 +117,7 @@ pub async fn deploy_app_verbose(
     client: &WasmerClient,
     opts: DeployAppOpts<'_>,
 ) -> Result<(DeployApp, DeployAppVersion), anyhow::Error> {
-    let owner = &opts.owner;
+    let owner = &opts.owner.or_else(|| opts.app.owner.clone());
     let app = &opts.app;
 
     let pretty_name = if let Some(owner) = &owner {


### PR DESCRIPTION
- [x] support `owner` field in app.yaml
- [x] add `owner` field to app.yaml generated by `wasmer app create`

makes it so app.yaml can process owner field in two ways,

In descending order of priority:
- via the `--owner` flag passed to the CLI
- via the `owner` field in the app.yaml

sample config:

```yaml
kind: wasmer.io/App.v0
name: my-fun-little-app
owner: <user or namespace> # new owner field
package: wasmer/hello
```

