### PR TITLE
Fix owner issues with app create

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -111,7 +111,6 @@ struct AppCreator {
 
 struct AppCreatorOutput {
     app: AppConfigV1,
-    pkg: StringWebcIdent,
     api_pkg: Option<Package>,
     local_package: Option<(PathBuf, wasmer_toml::Manifest)>,
 }
@@ -138,12 +137,6 @@ impl AppCreator {
         let outer_pkg_name =
             crate::utils::prompts::prompt_for_ident("Package name", Some(&default_name))?;
         let outer_pkg_full_name = format!("{}/{}", self.owner, outer_pkg_name);
-        let outer_pkg = StringWebcIdent(edge_schema::schema::WebcIdent {
-            repository: None,
-            namespace: self.owner.clone(),
-            name: outer_pkg_name.clone(),
-            tag: None,
-        });
 
         eprintln!("What should be the name of the app?");
 
@@ -219,7 +212,6 @@ impl AppCreator {
 
         Ok(AppCreatorOutput {
             app: app_cfg,
-            pkg: outer_pkg,
             api_pkg: None,
             local_package: Some((self.dir, manifest)),
         })
@@ -340,7 +332,7 @@ impl AppCreator {
         // TODO: check if name already exists.
         let cfg = AppConfigV1 {
             app_id: None,
-            owner: None,
+            owner: Some(self.owner.clone()),
             volumes: None,
             name,
             env: Default::default(),
@@ -360,7 +352,6 @@ impl AppCreator {
         Ok(AppCreatorOutput {
             app: cfg,
             api_pkg,
-            pkg,
             local_package,
         })
     }
@@ -490,7 +481,7 @@ impl AsyncCliCommand for CmdAppCreate {
             type_,
             interactive,
             dir: base_dir,
-            owner,
+            owner: owner.clone(),
             api,
             user,
             local_package,
@@ -507,8 +498,8 @@ impl AsyncCliCommand for CmdAppCreate {
         let AppCreatorOutput {
             app: cfg,
             api_pkg,
-            pkg,
             local_package,
+            ..
         } = output;
 
         let deploy_now = if self.offline {
@@ -559,7 +550,7 @@ impl AsyncCliCommand for CmdAppCreate {
                 original_config: None,
                 allow_create: true,
                 make_default: true,
-                owner: Some(pkg.0.namespace.clone()),
+                owner: Some(owner.clone()),
                 wait: wait_mode,
             };
             let (_app, app_version) = deploy_app_verbose(&api, opts).await?;


### PR DESCRIPTION
the owner field was being set to the same namespace as the package. This means
if the package is `wasmer/hello` then the owner becomes `wasmer`.

This PR also adds the owner field to app.yaml generated by `wasmer app create`