### PR TITLE
deps: Upgrade h2 due to RUSTSEC advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -2207,7 +2207,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio 1.36.0",
  "tower-service",
  "tracing",
@@ -5538,7 +5538,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 


### PR DESCRIPTION
The advisory is not relevant for us, it's a denial of service vector for
servers.

The advisory fails the cargo-deny checks though, so the upgrade is
needed.

Details:  https://rustsec.org/advisories/RUSTSEC-2024-0332
