### PR TITLE
build: Add Wasmer CLI package definition to Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686089707,
-        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "lastModified": 1712168706,
+        "narHash": "sha256-XP24tOobf6GGElMd0ux90FEBalUtw6NkBSVh/RlA6ik=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "rev": "1487bdea619e4a7a53a4590c475deabb5a9d1bfb",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
-  description = "wasmer Webassembly runtime";
+  description = "Wasmer Webassembly runtime";
 
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     flakeutils.url = "github:numtide/flake-utils";
   };
 
@@ -9,54 +10,68 @@
     flakeutils.lib.eachDefaultSystem (system:
       let
         NAME = "wasmer";
-        VERSION = "0.1";
 
         pkgs = import nixpkgs {
           inherit system;
         };
-
       in
       rec {
+        packages.${NAME} = import ./scripts/nix/pkg.nix pkgs;
+        defaultPackage = pkgs.callPackage packages.${NAME} pkgs;
 
-        # packages.${NAME} = pkgs.stdenv.mkDerivation {
-        #   pname = NAME;
-        #   version = VERSION;
+        # For `nix run`.
+        apps.${NAME} = flakeutils.lib.mkApp {
+          drv = packages.${NAME};
+        };
+        defaultApp = apps.${NAME};
 
-        #   buildPhase = "echo 'no-build'";
-        # };
-
-        # defaultPackage = packages.${NAME};
-
-        # # For `nix run`.
-        # apps.${NAME} = flakeutils.lib.mkApp {
-        #   drv = packages.${NAME};
-        # };
-        # defaultApp = apps.${NAME};
-
-        devShell = pkgs.stdenv.mkDerivation {
+        # Development shell.
+        # Run "nix develop" to activate.
+        devShell = pkgs.mkShell {
           name = NAME;
           src = self;
-          buildInputs = with pkgs; [
-            pkgconfig
+          packages = with pkgs; [
+            pkg-config
             openssl
-            llvmPackages_15.libllvm
-            # Snapshot testing
-            cargo-insta
-            wabt
-            binaryen
 
             # LLVM and related dependencies
+            llvmPackages_15.libllvm
             llvmPackages_15.llvm
             libxml2
             libffi
 
-            # Test runner
-            cargo-nextest
-          ];
-          runtimeDependencies = with pkgs; [ ];
+            # Rust tooling
 
-          LD_LIBRARY_PATH = "${pkgs.openssl.out}/lib";
-          LLVM_SYS_150_PREFIX = "${pkgs.llvmPackages_15.llvm.dev}";
+            # Snapshot testing
+            # https://github.com/mitsuhiko/insta
+            cargo-insta
+            # Test runner
+            # https://github.com/nextest-rs/nextest
+            cargo-nextest
+            # Rust dependency vulnerability checker
+            # https://github.com/EmbarkStudios/cargo-deny
+            cargo-deny
+
+            # Webassembly tooling
+
+            # "Official" WASM CLI tools
+            # (wasm2wat, wat2wasm, wasm-objdump, ...)
+            # https://github.com/WebAssembly/wabt
+            wabt
+            # Provides `wasm-opt` (WASM optimizer) and some other tools
+            # https://github.com/WebAssembly/binaryen
+            binaryen
+            # Various WASM debugging and conversion tools
+            # (partial overlap with "wabt")
+            # https://github.com/bytecodealliance/wasm-tools
+            wasm-tools
+          ];
+
+          env.LLVM_SYS_150_PREFIX = pkgs.llvmPackages_15.llvm.dev;
+          env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.stdenv.cc.cc
+            pkgs.openssl.out
+          ];
         };
       }
     );

--- a/scripts/nix/pkg.nix
+++ b/scripts/nix/pkg.nix
@@ -1,0 +1,74 @@
+# Nix derivation for the Wasmer CLI binary
+#
+# NOTE: mostly copied from upstrean nixpkgs
+# See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/wasmer/default.nix
+pkgs@{ stdenv
+, lib
+, rustPlatform
+, fetchFromGitHub
+, llvmPackages
+, libffi
+, libxml2
+, withLLVM ? !stdenv.isDarwin
+, withSinglepass ? !(stdenv.isDarwin && stdenv.isx86_64)
+, ...
+}:
+
+let
+  # Get the release version from Cargo.toml
+  cargoToml = builtins.fromTOML (builtins.readFile ../../lib/cli/Cargo.toml);
+  version = cargoToml.package.version;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "wasmer";
+  version = "4.2.5";
+
+  src = ../..;
+
+  cargoLock = {
+    lockFile = ../../Cargo.lock;
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = lib.optionals withLLVM [
+    llvmPackages.llvm
+    libffi
+    libxml2
+  ] ++ lib.optionals stdenv.isDarwin [
+    pkgs.CoreFoundation
+    pkgs.SystemConfiguration
+    pkgs.Security
+  ];
+
+  # check references to `compiler_features` in Makefile on update
+  buildFeatures = [
+    "cranelift"
+    "wasmer-artifact-create"
+    "static-artifact-create"
+    "wasmer-artifact-load"
+    "static-artifact-load"
+  ]
+  ++ lib.optional withLLVM "llvm"
+  ++ lib.optional withSinglepass "singlepass";
+
+  cargoBuildFlags = [ "--manifest-path" "lib/cli/Cargo.toml" "--bin" "wasmer" ];
+
+  env.LLVM_SYS_150_PREFIX = lib.optionalString withLLVM llvmPackages.llvm.dev;
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "The Universal WebAssembly Runtime";
+    longDescription = ''
+      Wasmer is a standalone WebAssembly runtime for running WebAssembly outside
+      of the browser, supporting WASI and Emscripten. Wasmer can be used
+      standalone (via the CLI) and embedded in different languages, running in
+      x86 and ARM devices.
+    '';
+    homepage = "https://wasmer.io/";
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
Allows `nix run github:wasmerio/wasmer` to run the CLI.

Also:

* switches the nixpkgs channel used to 23.11-stable to avoid churn
* Adds wasm-tools and cargo-deny into the devshell
