### PR TITLE
Expose `store::StoreObjects`

### DIFF
--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -501,7 +501,9 @@ pub use mem_access::{MemoryAccessError, WasmRef, WasmSlice, WasmSliceIter};
 pub use module::{IoCompileError, Module};
 pub use native_type::{FromToNativeWasmType, NativeWasmTypeInto, WasmTypeList};
 pub use ptr::{Memory32, Memory64, MemorySize, WasmPtr, WasmPtr64};
-pub use store::{AsStoreMut, AsStoreRef, OnCalledHandler, Store, StoreId, StoreMut, StoreRef};
+pub use store::{
+    AsStoreMut, AsStoreRef, OnCalledHandler, Store, StoreId, StoreMut, StoreObjects, StoreRef,
+};
 #[cfg(feature = "sys")]
 pub use store::{TrapHandlerFn, Tunables};
 #[cfg(any(feature = "sys", feature = "jsc"))]


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/master/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Currently `store::AsStoreMut` is exposed, including its function `objects_mut`.  This function returns a `StoreObjects` type that is not exported.  If we're native, it can be imported from `wasmer_vm`, but under `js` `StoreObjects` is not visible and therefore the trait can't be implemented.

This PR exports `StoreObjects` so that JS and native code alike can implement `AsStoreMut`.