### PR TITLE
V4.2.8 leftover fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "virtual-net"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6610,7 +6610,7 @@ version = "4.2.8"
 
 [[package]]
 name = "wasmer-journal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -96,7 +96,7 @@ wasmer-object = { version = "=4.2.8", path = "../object", optional = true }
 virtual-fs = { version = "0.11.2", path = "../virtual-fs", default-features = false, features = [
   "host-fs",
 ] }
-virtual-net = { version = "0.6.3", path = "../virtual-net" }
+virtual-net = { version = "0.6.4", path = "../virtual-net" }
 virtual-mio = { version = "0.3.1", path = "../virtual-io" }
 
 # Wasmer-owned dependencies.

--- a/lib/journal/Cargo.toml
+++ b/lib/journal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-journal"
-version = "0.1.0"
+version = "0.1.1"
 description = "Journaling functionality used by Wasmer to save and restore WASM state"
 authors.workspace = true
 edition.workspace = true
@@ -16,8 +16,8 @@ log-file = [ "shared-buffer" ]
 [dependencies]
 wasmer = { default-features = false, path = "../api", version = "=4.2.8" }
 wasmer-wasix-types = { path = "../wasi-types", version = "0.18.3", features = [ "enable-serde" ] }
-virtual-net = { path = "../virtual-net", version = "0.6.3", default-features = false, features = ["rkyv"] }
-virtual-fs = { path = "../virtual-fs", default-features = false }
+virtual-net = { path = "../virtual-net", version = "0.6.4", default-features = false, features = ["rkyv"] }
+virtual-fs = { path = "../virtual-fs", version = "0.11.2", default-features = false }
 
 shared-buffer = { workspace = true, optional = true }
 thiserror = "1"

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtual-net"
-version = "0.6.3"
+version = "0.6.4"
 description = "Wasmer Virtual Networking"
 authors.workspace = true
 edition.workspace = true

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -24,7 +24,7 @@ wasmer-types = { path = "../types", version = "=4.2.8", default-features = false
 wasmer = { path = "../api", version = "=4.2.8", default-features = false, features = ["wat", "js-serializable-module"] }
 virtual-mio  = { path = "../virtual-io", version = "0.3.1", default-features = false }
 virtual-fs = { path = "../virtual-fs", version = "0.11.2", default-features = false, features = ["webc-fs"] }
-virtual-net = { path = "../virtual-net", version = "0.6.3", default-features = false, features = ["rkyv"] }
+virtual-net = { path = "../virtual-net", version = "0.6.4", default-features = false, features = ["rkyv"] }
 wasmer-journal = { path = "../journal", version = "0.1.0", default-features = false }
 wasmer-emscripten = { path = "../emscripten", version = "=4.2.8", optional = true }
 typetag = { version = "0.1", optional = true }

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -118,7 +118,7 @@ class Publisher:
             data = tomllib.load(file)
 
         if version is None:
-            version = data["package"]["version"]
+            version = data["workspace"]["package"]["version"]
         self.version: str = version
 
         if self.verbose and not self.dry_run:
@@ -203,7 +203,18 @@ class Publisher:
         if found_string is None:
             return False
 
-        return self.version == found_string
+        if self.version == found_string:
+            return True
+        
+        crate = self.crate_index[crate_name]
+        with open(crate.path + "/Cargo.toml", "rb") as file:
+            data = tomllib.load(file)
+        crate_version = data["package"]["version"]
+
+        if crate_version is None:
+            return False
+
+        return crate_version == found_string
 
     def publish_crate(self, crate_name: str):
         # pylint: disable=broad-except


### PR DESCRIPTION
Left-over changes from publishing the 4.2.8 version of all crates:

* Fixed the publish script to correctly detect already-published packages
* Had to bump `virtual-net` to 0.6.4, as the 0.6.3 on crates.io was missing some code for some reason
* Bumped `wasmer-journal` version and fixed its `Cargo.toml` to allow publishing to crates.io