### PR TITLE
Module cache optimization round2

### DIFF
--- a/lib/api/src/sys/engine.rs
+++ b/lib/api/src/sys/engine.rs
@@ -128,8 +128,12 @@ impl NativeEngineExt for crate::engine::Engine {
         &self,
         file_ref: &Path,
     ) -> Result<crate::Module, DeserializeError> {
-        let bytes = std::fs::read(file_ref)?;
-        let artifact = Arc::new(Artifact::deserialize_unchecked(&self.0, bytes.into())?);
+        let file = std::fs::File::open(file_ref)?;
+        let artifact = Arc::new(Artifact::deserialize_unchecked(
+            &self.0,
+            OwnedBuffer::from_file(&file)
+                .map_err(|e| DeserializeError::Generic(format!("{e:?}")))?,
+        )?);
         Ok(crate::Module(super::module::Module::from_artifact(
             artifact,
         )))

--- a/lib/compiler/src/artifact_builders/artifact_builder.rs
+++ b/lib/compiler/src/artifact_builders/artifact_builder.rs
@@ -4,8 +4,10 @@
 #[cfg(feature = "compiler")]
 use super::trampoline::{libcall_trampoline_len, make_libcall_trampolines};
 use crate::ArtifactCreate;
+#[cfg(feature = "compiler")]
 use crate::EngineInner;
 use crate::Features;
+#[cfg(feature = "compiler")]
 use crate::{ModuleEnvironment, ModuleMiddlewareChain};
 use core::mem::MaybeUninit;
 use enumset::EnumSet;
@@ -18,7 +20,6 @@ use wasmer_types::entity::{ArchivedPrimaryMap, PrimaryMap};
 use wasmer_types::ArchivedOwnedDataInitializer;
 use wasmer_types::ArchivedSerializableCompilation;
 use wasmer_types::ArchivedSerializableModule;
-#[cfg(feature = "compiler")]
 use wasmer_types::CompileModuleInfo;
 use wasmer_types::DeserializeError;
 use wasmer_types::{
@@ -126,7 +127,7 @@ impl ArtifactBuild {
         };
         let serializable = SerializableModule {
             compilation: serializable_compilation,
-            compile_info: compile_info,
+            compile_info,
             data_initializers,
             cpu_features: cpu_features.as_u64(),
         };
@@ -134,19 +135,18 @@ impl ArtifactBuild {
     }
 
     /// Compile a data buffer into a `ArtifactBuild`, which may then be instantiated.
-    #[cfg(not(feature = "compiler"))]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn new(
-        _inner_engine: &mut EngineInner,
-        _data: &[u8],
-        _target: &Target,
-        _memory_styles: PrimaryMap<MemoryIndex, MemoryStyle>,
-        _table_styles: PrimaryMap<TableIndex, TableStyle>,
-    ) -> Result<Self, CompileError> {
-        Err(CompileError::Codegen(
-            "Compilation is not enabled in the engine".to_string(),
-        ))
-    }
+    // #[cfg(not(feature = "compiler"))]
+    // pub fn new(
+    //     _inner_engine: &mut EngineInner,
+    //     _data: &[u8],
+    //     _target: &Target,
+    //     _memory_styles: PrimaryMap<MemoryIndex, MemoryStyle>,
+    //     _table_styles: PrimaryMap<TableIndex, TableStyle>,
+    // ) -> Result<Self, CompileError> {
+    //     Err(CompileError::Codegen(
+    //         "Compilation is not enabled in the engine".to_string(),
+    //     ))
+    // }
 
     /// Create a new ArtifactBuild from a SerializableModule
     pub fn from_serializable(serializable: SerializableModule) -> Self {

--- a/lib/compiler/src/artifact_builders/artifact_builder.rs
+++ b/lib/compiler/src/artifact_builders/artifact_builder.rs
@@ -134,20 +134,6 @@ impl ArtifactBuild {
         Ok(Self { serializable })
     }
 
-    /// Compile a data buffer into a `ArtifactBuild`, which may then be instantiated.
-    // #[cfg(not(feature = "compiler"))]
-    // pub fn new(
-    //     _inner_engine: &mut EngineInner,
-    //     _data: &[u8],
-    //     _target: &Target,
-    //     _memory_styles: PrimaryMap<MemoryIndex, MemoryStyle>,
-    //     _table_styles: PrimaryMap<TableIndex, TableStyle>,
-    // ) -> Result<Self, CompileError> {
-    //     Err(CompileError::Codegen(
-    //         "Compilation is not enabled in the engine".to_string(),
-    //     ))
-    // }
-
     /// Create a new ArtifactBuild from a SerializableModule
     pub fn from_serializable(serializable: SerializableModule) -> Self {
         Self { serializable }

--- a/lib/compiler/src/artifact_builders/mod.rs
+++ b/lib/compiler/src/artifact_builders/mod.rs
@@ -1,7 +1,9 @@
 //! Generic Artifact abstraction for Wasmer Engines.
 
 mod artifact_builder;
+#[cfg(feature = "compiler")]
 mod trampoline;
 
 pub use self::artifact_builder::{ArtifactBuild, ArtifactBuildFromArchive, ModuleFromArchive};
+#[cfg(feature = "compiler")]
 pub use self::trampoline::*;

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -7,6 +7,7 @@ use crate::ArtifactBuild;
 use crate::ArtifactBuildFromArchive;
 use crate::ArtifactCreate;
 use crate::Features;
+use crate::FrameInfosVariant;
 use crate::ModuleEnvironment;
 use crate::{
     register_frame_info, resolve_imports, FunctionExtent, GlobalFrameInfoRegistration,
@@ -680,8 +681,10 @@ impl Artifact {
             self.artifact.create_module_info(),
             &finished_function_extents,
             match &self.artifact {
-                ArtifactBuildVariant::Plain(p) => p.get_frame_info_ref().clone(),
-                ArtifactBuildVariant::Archived(a) => a.deserialize_frame_info_ref()?,
+                ArtifactBuildVariant::Plain(p) => {
+                    FrameInfosVariant::Owned(p.get_frame_info_ref().clone())
+                }
+                ArtifactBuildVariant::Archived(a) => FrameInfosVariant::Archived(a.clone()),
             },
         );
 

--- a/lib/compiler/src/engine/trap/frame_info.rs
+++ b/lib/compiler/src/engine/trap/frame_info.rs
@@ -11,14 +11,23 @@
 //! let module: ModuleInfo = ...;
 //! FRAME_INFO.register(module, compiled_functions);
 //! ```
+use core::ops::Deref;
+use rkyv::vec::ArchivedVec;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
+use wasmer_types::compilation::address_map::{
+    ArchivedFunctionAddressMap, ArchivedInstructionAddressMap,
+};
+use wasmer_types::compilation::function::ArchivedCompiledFunctionFrameInfo;
 use wasmer_types::entity::{BoxedSlice, EntityRef, PrimaryMap};
 use wasmer_types::{
-    CompiledFunctionFrameInfo, FrameInfo, LocalFunctionIndex, ModuleInfo, TrapInformation,
+    CompiledFunctionFrameInfo, FrameInfo, FunctionAddressMap, InstructionAddressMap,
+    LocalFunctionIndex, ModuleInfo, SourceLoc, TrapInformation,
 };
 use wasmer_vm::FunctionBodyPtr;
+
+use crate::ArtifactBuildFromArchive;
 
 lazy_static::lazy_static! {
     /// This is a global cache of backtrace frame information for all active
@@ -56,11 +65,14 @@ struct ModuleInfoFrameInfo {
     start: usize,
     functions: BTreeMap<usize, FunctionInfo>,
     module: Arc<ModuleInfo>,
-    frame_infos: PrimaryMap<LocalFunctionIndex, CompiledFunctionFrameInfo>,
+    frame_infos: FrameInfosVariant,
 }
 
 impl ModuleInfoFrameInfo {
-    fn function_debug_info(&self, local_index: LocalFunctionIndex) -> &CompiledFunctionFrameInfo {
+    fn function_debug_info(
+        &self,
+        local_index: LocalFunctionIndex,
+    ) -> CompiledFunctionFrameInfoVariant {
         self.frame_infos.get(local_index).unwrap()
     }
 
@@ -94,11 +106,9 @@ impl GlobalFrameInfo {
         // machine instruction that corresponds to `pc`, which then allows us to
         // map that to a wasm original source location.
         let rel_pos = pc - func.start;
-        let instr_map = &module.function_debug_info(func.local_index).address_map;
-        let pos = match instr_map
-            .instructions
-            .binary_search_by_key(&rel_pos, |map| map.code_offset)
-        {
+        let debug_info = module.function_debug_info(func.local_index);
+        let instr_map = debug_info.address_map();
+        let pos = match instr_map.instructions().code_offset_by_key(rel_pos) {
             // Exact hit!
             Ok(pos) => Some(pos),
 
@@ -112,7 +122,7 @@ impl GlobalFrameInfo {
             // always get called with a `pc` that's an exact instruction
             // boundary.
             Err(n) => {
-                let instr = &instr_map.instructions[n - 1];
+                let instr = &instr_map.instructions().get(n - 1);
                 if instr.code_offset <= rel_pos && rel_pos < instr.code_offset + instr.code_len {
                     Some(n - 1)
                 } else {
@@ -122,32 +132,33 @@ impl GlobalFrameInfo {
         };
 
         let instr = match pos {
-            Some(pos) => instr_map.instructions[pos].srcloc,
+            Some(pos) => instr_map.instructions().get(pos).srcloc,
             // Some compilers don't emit yet the full trap information for each of
             // the instructions (such as LLVM).
             // In case no specific instruction is found, we return by default the
             // start offset of the function.
-            None => instr_map.start_srcloc,
+            None => instr_map.start_srcloc(),
         };
         let func_index = module.module.func_index(func.local_index);
         Some(FrameInfo::new(
             module.module.name(),
             func_index.index() as u32,
             module.module.function_names.get(&func_index).cloned(),
-            instr_map.start_srcloc,
+            instr_map.start_srcloc(),
             instr,
         ))
     }
 
     /// Fetches trap information about a program counter in a backtrace.
-    pub fn lookup_trap_info(&self, pc: usize) -> Option<&TrapInformation> {
+    pub fn lookup_trap_info(&self, pc: usize) -> Option<TrapInformation> {
         let module = self.module_info(pc)?;
         let func = module.function_info(pc)?;
-        let traps = &module.function_debug_info(func.local_index).traps;
+        let debug_info = module.function_debug_info(func.local_index);
+        let traps = debug_info.traps();
         let idx = traps
             .binary_search_by_key(&((pc - func.start) as u32), |info| info.code_offset)
             .ok()?;
-        Some(&traps[idx])
+        Some(traps[idx])
     }
 
     /// Gets a module given a pc
@@ -181,6 +192,164 @@ pub struct FunctionExtent {
     pub length: usize,
 }
 
+/// The variant of the frame information which can be an owned type
+/// or the explicit framed map
+#[derive(Debug)]
+pub enum FrameInfosVariant {
+    /// Owned frame infos
+    Owned(PrimaryMap<LocalFunctionIndex, CompiledFunctionFrameInfo>),
+    /// Archived frame infos
+    Archived(ArtifactBuildFromArchive),
+}
+
+impl FrameInfosVariant {
+    /// Gets the frame info for a given local function index
+    pub fn get(&self, index: LocalFunctionIndex) -> Option<CompiledFunctionFrameInfoVariant> {
+        match self {
+            FrameInfosVariant::Owned(map) => {
+                map.get(index).map(CompiledFunctionFrameInfoVariant::Ref)
+            }
+            FrameInfosVariant::Archived(archive) => archive
+                .get_frame_info_ref()
+                .get(index)
+                .map(CompiledFunctionFrameInfoVariant::Archived),
+        }
+    }
+}
+
+/// The variant of the compiled function frame info which can be an owned type
+#[derive(Debug)]
+pub enum CompiledFunctionFrameInfoVariant<'a> {
+    /// A reference to the frame info
+    Ref(&'a CompiledFunctionFrameInfo),
+    /// An archived frame info
+    Archived(&'a ArchivedCompiledFunctionFrameInfo),
+}
+
+impl CompiledFunctionFrameInfoVariant<'_> {
+    /// Gets the address map for the frame info
+    pub fn address_map(&self) -> FunctionAddressMapVariant<'_> {
+        match self {
+            CompiledFunctionFrameInfoVariant::Ref(info) => {
+                FunctionAddressMapVariant::Ref(&info.address_map)
+            }
+            CompiledFunctionFrameInfoVariant::Archived(info) => {
+                FunctionAddressMapVariant::Archived(&info.address_map)
+            }
+        }
+    }
+
+    /// Gets the traps for the frame info
+    pub fn traps(&self) -> VecTrapInformationVariant {
+        match self {
+            CompiledFunctionFrameInfoVariant::Ref(info) => {
+                VecTrapInformationVariant::Ref(&info.traps)
+            }
+            CompiledFunctionFrameInfoVariant::Archived(info) => {
+                VecTrapInformationVariant::Archived(&info.traps)
+            }
+        }
+    }
+}
+
+/// The variant of the trap information which can be an owned type
+#[derive(Debug)]
+pub enum VecTrapInformationVariant<'a> {
+    Ref(&'a Vec<TrapInformation>),
+    Archived(&'a ArchivedVec<TrapInformation>),
+}
+
+impl Deref for VecTrapInformationVariant<'_> {
+    type Target = [TrapInformation];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            VecTrapInformationVariant::Ref(traps) => traps,
+            VecTrapInformationVariant::Archived(traps) => traps,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FunctionAddressMapVariant<'a> {
+    Ref(&'a FunctionAddressMap),
+    Archived(&'a ArchivedFunctionAddressMap),
+}
+
+impl FunctionAddressMapVariant<'_> {
+    pub fn instructions(&self) -> FunctionAddressMapInstructionVariant {
+        match self {
+            FunctionAddressMapVariant::Ref(map) => {
+                FunctionAddressMapInstructionVariant::Owned(&map.instructions)
+            }
+            FunctionAddressMapVariant::Archived(map) => {
+                FunctionAddressMapInstructionVariant::Archived(&map.instructions)
+            }
+        }
+    }
+
+    pub fn start_srcloc(&self) -> SourceLoc {
+        match self {
+            FunctionAddressMapVariant::Ref(map) => map.start_srcloc,
+            FunctionAddressMapVariant::Archived(map) => map.start_srcloc,
+        }
+    }
+
+    pub fn end_srcloc(&self) -> SourceLoc {
+        match self {
+            FunctionAddressMapVariant::Ref(map) => map.end_srcloc,
+            FunctionAddressMapVariant::Archived(map) => map.end_srcloc,
+        }
+    }
+
+    pub fn body_offset(&self) -> usize {
+        match self {
+            FunctionAddressMapVariant::Ref(map) => map.body_offset,
+            FunctionAddressMapVariant::Archived(map) => map.body_offset as usize,
+        }
+    }
+
+    pub fn body_len(&self) -> usize {
+        match self {
+            FunctionAddressMapVariant::Ref(map) => map.body_len,
+            FunctionAddressMapVariant::Archived(map) => map.body_len as usize,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FunctionAddressMapInstructionVariant<'a> {
+    Owned(&'a Vec<InstructionAddressMap>),
+    Archived(&'a ArchivedVec<ArchivedInstructionAddressMap>),
+}
+
+impl FunctionAddressMapInstructionVariant<'_> {
+    pub fn code_offset_by_key(&self, key: usize) -> Result<usize, usize> {
+        match self {
+            FunctionAddressMapInstructionVariant::Owned(instructions) => {
+                instructions.binary_search_by_key(&key, |map| map.code_offset)
+            }
+            FunctionAddressMapInstructionVariant::Archived(instructions) => {
+                instructions.binary_search_by_key(&key, |map| map.code_offset as usize)
+            }
+        }
+    }
+
+    pub fn get(&self, index: usize) -> InstructionAddressMap {
+        match self {
+            FunctionAddressMapInstructionVariant::Owned(instructions) => instructions[index],
+            FunctionAddressMapInstructionVariant::Archived(instructions) => instructions
+                .get(index)
+                .map(|map| InstructionAddressMap {
+                    srcloc: map.srcloc,
+                    code_offset: map.code_offset as usize,
+                    code_len: map.code_len as usize,
+                })
+                .unwrap(),
+        }
+    }
+}
+
 /// Registers a new compiled module's frame information.
 ///
 /// This function will register the `names` information for all of the
@@ -190,7 +359,7 @@ pub struct FunctionExtent {
 pub fn register(
     module: Arc<ModuleInfo>,
     finished_functions: &BoxedSlice<LocalFunctionIndex, FunctionExtent>,
-    frame_infos: PrimaryMap<LocalFunctionIndex, CompiledFunctionFrameInfo>,
+    frame_infos: FrameInfosVariant,
 ) -> Option<GlobalFrameInfoRegistration> {
     let mut min = usize::max_value();
     let mut max = 0;

--- a/lib/compiler/src/engine/trap/mod.rs
+++ b/lib/compiler/src/engine/trap/mod.rs
@@ -1,6 +1,7 @@
 mod frame_info;
 mod stack;
 pub use frame_info::{
-    register as register_frame_info, FunctionExtent, GlobalFrameInfoRegistration, FRAME_INFO,
+    register as register_frame_info, CompiledFunctionFrameInfoVariant, FrameInfosVariant,
+    FunctionExtent, GlobalFrameInfoRegistration, FRAME_INFO,
 };
 pub use stack::get_trace_and_trapcode;

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -52,10 +52,8 @@ mod traits;
 pub use crate::engine::*;
 pub use crate::traits::*;
 
-#[cfg(feature = "translator")]
 mod artifact_builders;
 
-#[cfg(feature = "translator")]
 pub use self::artifact_builders::*;
 
 #[cfg(feature = "translator")]

--- a/lib/journal/src/concrete/archived.rs
+++ b/lib/journal/src/concrete/archived.rs
@@ -23,7 +23,7 @@ pub const JOURNAL_MAGIC_NUMBER_BYTES: [u8; 8] = JOURNAL_MAGIC_NUMBER.to_be_bytes
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalEntryRecordType {
     InitModuleV1 = 1,
     ProcessExitV1 = 2,
@@ -877,7 +877,7 @@ impl<'a> JournalEntry<'a> {
 /// changes to the journal entry types without having to
 /// worry about backward and forward compatibility
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub(crate) struct JournalEntryHeader {
     pub record_type: u16,
     pub record_size: u64,
@@ -1502,7 +1502,7 @@ pub struct JournalEntrySnapshotV1 {
 
 #[repr(C)]
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalSnapshot0ClockidV1 {
     Realtime,
     Monotonic,
@@ -1513,7 +1513,7 @@ pub enum JournalSnapshot0ClockidV1 {
 
 #[repr(C)]
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalWhenceV1 {
     Set,
     Cur,
@@ -1523,7 +1523,7 @@ pub enum JournalWhenceV1 {
 
 #[repr(C)]
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalAdviceV1 {
     Normal,
     Sequential,
@@ -1537,7 +1537,7 @@ pub enum JournalAdviceV1 {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct JournalIpCidrV1 {
     pub ip: IpAddr,
     pub prefix: u8,
@@ -1545,7 +1545,7 @@ pub struct JournalIpCidrV1 {
 
 #[repr(C)]
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalExitCodeV1 {
     Errno(u16),
     Other(i32),
@@ -1565,7 +1565,7 @@ pub enum JournalExitCodeV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalSnapshotTriggerV1 {
     Idle,
     Listen,
@@ -1593,7 +1593,7 @@ pub enum JournalSnapshotTriggerV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalEpollCtlV1 {
     Add,
     Mod,
@@ -1604,7 +1604,7 @@ pub enum JournalEpollCtlV1 {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct JournalEpollEventCtlV1 {
     pub events: u32,
     pub ptr: u64,
@@ -1627,7 +1627,7 @@ pub struct JournalEpollEventCtlV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalStreamSecurityV1 {
     Unencrypted,
     AnyEncryption,
@@ -1650,7 +1650,7 @@ pub enum JournalStreamSecurityV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalAddressfamilyV1 {
     Unspec,
     Inet4,
@@ -1672,7 +1672,7 @@ pub enum JournalAddressfamilyV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalSocktypeV1 {
     Unknown,
     Stream,
@@ -1695,7 +1695,7 @@ pub enum JournalSocktypeV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalSockoptionV1 {
     Noop,
     ReusePort,
@@ -1740,7 +1740,7 @@ pub enum JournalSockoptionV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalTimeTypeV1 {
     ReadTimeout,
     WriteTimeout,
@@ -1764,7 +1764,7 @@ pub enum JournalTimeTypeV1 {
     RkyvDeserialize,
     Archive,
 )]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub enum JournalSocketShutdownV1 {
     Read,
     Write,

--- a/lib/types/src/compilation/address_map.rs
+++ b/lib/types/src/compilation/address_map.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 
 /// Single source location to generated address mapping.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, Copy, PartialEq, Eq)]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct InstructionAddressMap {
     /// Original source location.
     pub srcloc: SourceLoc,
@@ -25,7 +25,7 @@ pub struct InstructionAddressMap {
 /// Function and its instructions addresses mappings.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq, Default)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct FunctionAddressMap {
     /// Instructions maps.
     /// The array is sorted by the InstructionAddressMap::code_offset field.

--- a/lib/types/src/compilation/function.rs
+++ b/lib/types/src/compilation/function.rs
@@ -24,7 +24,7 @@ use super::unwind::CompiledFunctionUnwindInfoLike;
 /// the frame information after a `Trap`.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq, Default)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct CompiledFunctionFrameInfo {
     /// The traps (in the function body).
     ///
@@ -38,7 +38,7 @@ pub struct CompiledFunctionFrameInfo {
 /// The function body.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct FunctionBody {
     /// The function body bytes.
     #[cfg_attr(feature = "enable-serde", serde(with = "serde_bytes"))]
@@ -91,7 +91,7 @@ impl<'a> FunctionBodyLike<'a> for ArchivedFunctionBody {
 /// and unwind information).
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct CompiledFunction {
     /// The function body.
     pub body: FunctionBody,

--- a/lib/types/src/compilation/module.rs
+++ b/lib/types/src/compilation/module.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 /// or the `MemoryStyle` and `TableStyle`).
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct CompileModuleInfo {
     /// The features used for compiling the module
     pub features: Features,

--- a/lib/types/src/compilation/relocation.rs
+++ b/lib/types/src/compilation/relocation.rs
@@ -93,7 +93,7 @@ impl fmt::Display for RelocationKind {
 /// A record of a relocation to perform.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct Relocation {
     /// The relocation kind.
     pub kind: RelocationKind,

--- a/lib/types/src/compilation/section.rs
+++ b/lib/types/src/compilation/section.rs
@@ -57,7 +57,7 @@ pub enum CustomSectionProtection {
 /// in the emitted module.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct CustomSection {
     /// Memory protection that applies to this section.
     pub protection: CustomSectionProtection,
@@ -119,7 +119,7 @@ impl<'a> CustomSectionLike<'a> for ArchivedCustomSection {
 /// The bytes in the section.
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq, Default)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct SectionBody(#[cfg_attr(feature = "enable-serde", serde(with = "serde_bytes"))] Vec<u8>);
 
 impl SectionBody {

--- a/lib/types/src/compilation/symbols.rs
+++ b/lib/types/src/compilation/symbols.rs
@@ -50,7 +50,7 @@ pub trait SymbolRegistry: Send + Sync {
 /// Serializable struct that represents the compiled metadata.
 #[derive(Debug, RkyvSerialize, RkyvDeserialize, Archive)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub struct ModuleMetadata {
     /// Compile info
     pub compile_info: CompileModuleInfo,

--- a/lib/types/src/compilation/unwind.rs
+++ b/lib/types/src/compilation/unwind.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// [unwind info]: https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=vs-2019
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive, Debug, Clone, PartialEq, Eq)]
-#[archive_attr(derive(rkyv::CheckBytes))]
+#[archive_attr(derive(rkyv::CheckBytes, Debug))]
 pub enum CompiledFunctionUnwindInfo {
     /// Windows UNWIND_INFO.
     WindowsX64(Vec<u8>),

--- a/lib/types/src/entity/primary_map.rs
+++ b/lib/types/src/entity/primary_map.rs
@@ -156,6 +156,28 @@ where
     }
 }
 
+impl<K, V> ArchivedPrimaryMap<K, V>
+where
+    K: EntityRef,
+    V: Archive,
+{
+    /// Get the element at `k` if it exists.
+    pub fn get(&self, k: K) -> Option<&V::Archived> {
+        self.elems.get(k.index())
+    }
+}
+
+impl<K, V> std::fmt::Debug for ArchivedPrimaryMap<K, V>
+where
+    K: EntityRef + std::fmt::Debug,
+    V: Archive,
+    V::Archived: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}
+
 impl<K, V> Default for PrimaryMap<K, V>
 where
     K: EntityRef,
@@ -243,6 +265,7 @@ impl<K, V> ArchivedPrimaryMap<K, V>
 where
     K: EntityRef,
     V: Archive,
+    V::Archived: std::fmt::Debug,
 {
     /// Iterator over all values in the `ArchivedPrimaryMap`
     pub fn values(&self) -> slice::Iter<Archived<V>> {
@@ -261,6 +284,7 @@ impl<K, V> Index<K> for ArchivedPrimaryMap<K, V>
 where
     K: EntityRef,
     V: Archive,
+    V::Archived: std::fmt::Debug,
 {
     type Output = Archived<V>;
 

--- a/lib/types/src/entity/secondary_map.rs
+++ b/lib/types/src/entity/secondary_map.rs
@@ -11,7 +11,7 @@ use crate::lib::std::marker::PhantomData;
 use crate::lib::std::ops::{Index, IndexMut};
 use crate::lib::std::slice;
 use crate::lib::std::vec::Vec;
-use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+use rkyv::{Archive, Archived, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{
     de::{Deserializer, SeqAccess, Visitor},
@@ -133,6 +133,38 @@ where
     /// Resize the map to have `n` entries by adding default entries as needed.
     pub fn resize(&mut self, n: usize) {
         self.elems.resize(n, self.default.clone());
+    }
+}
+
+impl<K, V> ArchivedSecondaryMap<K, V>
+where
+    K: EntityRef,
+    V: Archive + Clone,
+{
+    /// Get the element at `k` if it exists.
+    pub fn get(&self, k: K) -> Option<&V::Archived> {
+        self.elems.get(k.index())
+    }
+
+    /// Iterator over all values in the `ArchivedPrimaryMap`
+    pub fn values(&self) -> slice::Iter<Archived<V>> {
+        self.elems.iter()
+    }
+
+    /// Iterate over all the keys and values in this map.
+    pub fn iter(&self) -> Iter<K, Archived<V>> {
+        Iter::new(self.elems.iter())
+    }
+}
+
+impl<K, V> std::fmt::Debug for ArchivedSecondaryMap<K, V>
+where
+    K: EntityRef + std::fmt::Debug,
+    V: Archive + Clone,
+    V::Archived: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/lib/types/src/initializers.rs
+++ b/lib/types/src/initializers.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// A WebAssembly table initializer.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, RkyvSerialize, RkyvDeserialize, Archive)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct TableInitializer {
     /// The index of a table to initialize.
     pub table_index: TableIndex,
@@ -25,7 +25,7 @@ pub struct TableInitializer {
 /// should be performed.
 #[derive(Clone, Debug, PartialEq, Eq, RkyvSerialize, RkyvDeserialize, Archive)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct DataInitializerLocation {
     /// The index of the memory to initialize.
     pub memory_index: MemoryIndex,
@@ -91,7 +91,7 @@ pub struct DataInitializer<'data> {
 /// holding a reference to it
 #[derive(Debug, Clone, PartialEq, Eq, RkyvSerialize, RkyvDeserialize, Archive)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct OwnedDataInitializer {
     /// The location where the initialization is to be performed.
     pub location: DataInitializerLocation,

--- a/lib/types/src/module.rs
+++ b/lib/types/src/module.rs
@@ -26,7 +26,7 @@ use std::iter::ExactSizeIterator;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct ModuleId {
     id: usize,
 }
@@ -49,7 +49,7 @@ impl Default for ModuleId {
 /// Hash key of an import
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Default, RkyvSerialize, RkyvDeserialize, Archive)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-#[archive_attr(derive(CheckBytes, PartialEq, Eq, Hash))]
+#[archive_attr(derive(CheckBytes, PartialEq, Eq, Hash, Debug))]
 pub struct ImportKey {
     /// Module name
     pub module: String,
@@ -178,8 +178,8 @@ pub struct ModuleInfo {
 }
 
 /// Mirror version of ModuleInfo that can derive rkyv traits
-#[derive(RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[derive(Debug, RkyvSerialize, RkyvDeserialize, Archive)]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct ArchivableModuleInfo {
     name: Option<String>,
     imports: IndexMap<ImportKey, ImportIndex>,

--- a/lib/types/src/serialize.rs
+++ b/lib/types/src/serialize.rs
@@ -18,7 +18,7 @@ use std::mem;
 /// The compilation related data for a serialized modules
 #[derive(Archive, Default, RkyvDeserialize, RkyvSerialize)]
 #[allow(missing_docs)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct SerializableCompilation {
     pub function_bodies: PrimaryMap<LocalFunctionIndex, FunctionBody>,
     pub function_relocations: PrimaryMap<LocalFunctionIndex, Vec<Relocation>>,
@@ -53,7 +53,7 @@ impl SerializableCompilation {
 /// Serializable struct that is able to serialize from and to a `ArtifactInfo`.
 #[derive(Archive, RkyvDeserialize, RkyvSerialize)]
 #[allow(missing_docs)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct SerializableModule {
     /// The main serializable compilation object
     pub compilation: SerializableCompilation,

--- a/lib/types/src/stack/trap.rs
+++ b/lib/types/src/stack/trap.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// Information about trap.
 #[cfg_attr(feature = "enable-serde", derive(Deserialize, Serialize))]
 #[derive(
-    RkyvSerialize, RkyvDeserialize, Archive, rkyv::CheckBytes, Clone, Debug, PartialEq, Eq,
+    RkyvSerialize, RkyvDeserialize, Archive, rkyv::CheckBytes, Clone, Copy, Debug, PartialEq, Eq,
 )]
 #[archive(as = "Self")]
 pub struct TrapInformation {

--- a/lib/types/src/types.rs
+++ b/lib/types/src/types.rs
@@ -242,7 +242,7 @@ impl ExternType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct FunctionType {
     /// The parameters of the function
     params: Box<[Type]>,
@@ -447,7 +447,7 @@ pub enum GlobalInit {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct TableType {
     /// The type of data stored in elements of the table.
     pub ty: Type,
@@ -488,7 +488,7 @@ impl fmt::Display for TableType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive)]
-#[archive_attr(derive(CheckBytes))]
+#[archive_attr(derive(CheckBytes, Debug))]
 pub struct MemoryType {
     /// The minimum number of pages in the memory.
     pub minimum: Pages,

--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -90,7 +90,7 @@ pub async fn spawn_union_fs(env: &WasiEnv, binary: &BinaryPackage) -> Result<(),
     // If the file system has not already been union'ed then do so
     env.state
         .fs
-        .conditional_union(&binary)
+        .conditional_union(binary)
         .await
         .map_err(|err| {
             tracing::warn!("failed to union file system - {err}");

--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -30,6 +30,24 @@ pub async fn spawn_exec(
     env: WasiEnv,
     runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
 ) -> Result<TaskJoinHandle, SpawnError> {
+    // Load the WASM
+    let wasm = spawn_load_wasm(&env, &binary, name).await?;
+
+    // Load the module
+    let module = spawn_load_module(&env, name, wasm, runtime).await?;
+
+    // Spawn union the file system
+    spawn_union_fs(&env, &binary).await?;
+
+    // Now run the module
+    spawn_exec_module(module, env, runtime)
+}
+
+pub async fn spawn_load_wasm<'a>(
+    env: &WasiEnv,
+    binary: &'a BinaryPackage,
+    name: &str,
+) -> Result<&'a [u8], SpawnError> {
     let wasm = if let Some(cmd) = binary.get_command(name) {
         cmd.atom.as_ref()
     } else if let Some(wasm) = binary.entrypoint_bytes() {
@@ -44,7 +62,15 @@ pub async fn spawn_exec(
         env.on_exit(Some(Errno::Noexec.into())).await;
         return Err(SpawnError::CompileError);
     };
+    Ok(wasm)
+}
 
+pub async fn spawn_load_module(
+    env: &WasiEnv,
+    name: &str,
+    wasm: &[u8],
+    runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
+) -> Result<Module, SpawnError> {
     let module = match runtime.load_module(wasm).await {
         Ok(module) => module,
         Err(err) => {
@@ -57,7 +83,10 @@ pub async fn spawn_exec(
             return Err(SpawnError::CompileError);
         }
     };
+    Ok(module)
+}
 
+pub async fn spawn_union_fs(env: &WasiEnv, binary: &BinaryPackage) -> Result<(), SpawnError> {
     // If the file system has not already been union'ed then do so
     env.state
         .fs
@@ -68,9 +97,7 @@ pub async fn spawn_exec(
             SpawnError::FileSystemError
         })?;
     tracing::debug!("{:?}", env.state.fs);
-
-    // Now run the module
-    spawn_exec_module(module, env, runtime)
+    Ok(())
 }
 
 pub fn spawn_exec_module(

--- a/lib/wasix/src/bin_factory/mod.rs
+++ b/lib/wasix/src/bin_factory/mod.rs
@@ -14,7 +14,9 @@ mod exec;
 
 pub use self::{
     binary_package::*,
-    exec::{run_exec, spawn_exec, spawn_exec_module},
+    exec::{
+        run_exec, spawn_exec, spawn_exec_module, spawn_load_module, spawn_load_wasm, spawn_union_fs,
+    },
 };
 use crate::{os::command::Commands, Runtime};
 


### PR DESCRIPTION
Improvements as follows:
- Fixed the mmap accelerated module load which was not using mmap
- Removed a needless copy of the module code which the module is archived (i.e. it was not fully zero copy)
- Various other minor tweaks