### PR TITLE
Fd validity and basic bound checks on `fd_advise`

### DIFF
--- a/tests/wasi-fyi/fd_advise_validity.rs
+++ b/tests/wasi-fyi/fd_advise_validity.rs
@@ -1,0 +1,34 @@
+use std::os::fd::AsRawFd;
+
+#[link(wasm_import_module = "wasi_snapshot_preview1")]
+extern "C" {
+    pub fn fd_advise(arg0: i32, arg1: i64, arg2: i64, arg3: i32) -> i32;
+}
+
+const ERRNO_BADF: i32 = 8;
+const ERRNO_INVAL: i32 = 28;
+
+const ADVISE_WILLNEED: i32 = 3;
+
+fn main() {
+    unsafe {
+        let errno = fd_advise(9999, 0, 0, ADVISE_WILLNEED);
+        assert_eq!(
+            errno, ERRNO_BADF,
+            "fd_advise for invalid file descriptor should have failed with errno 8 (BADF)"
+        );
+
+        let f = std::fs::File::create("test.sh").unwrap();
+
+        let errno = fd_advise(
+            f.as_raw_fd(),
+            i64::MAX,
+            i64::MAX,
+            ADVISE_WILLNEED,
+        );
+        assert_eq!(
+            errno, ERRNO_INVAL,
+            "fd_advise with invalid overflowing offset + length should fail with errno 28 (INVAL)"
+        );
+    }
+}

--- a/tests/wasi-fyi/fd_advise_validity.rs
+++ b/tests/wasi-fyi/fd_advise_validity.rs
@@ -2,7 +2,7 @@ use std::os::fd::AsRawFd;
 
 #[link(wasm_import_module = "wasi_snapshot_preview1")]
 extern "C" {
-    pub fn fd_advise(arg0: i32, arg1: i64, arg2: i64, arg3: i32) -> i32;
+    pub fn fd_advise(arg0: i32, arg1: u64, arg2: u64, arg3: i32) -> i32;
 }
 
 const ERRNO_BADF: i32 = 8;
@@ -20,12 +20,7 @@ fn main() {
 
         let f = std::fs::File::create("test.sh").unwrap();
 
-        let errno = fd_advise(
-            f.as_raw_fd(),
-            i64::MAX,
-            i64::MAX,
-            ADVISE_WILLNEED,
-        );
+        let errno = fd_advise(f.as_raw_fd(), u64::MAX, u64::MAX, ADVISE_WILLNEED);
         assert_eq!(
             errno, ERRNO_INVAL,
             "fd_advise with invalid overflowing offset + length should fail with errno 28 (INVAL)"

--- a/tests/wasi-fyi/test.sh
+++ b/tests/wasi-fyi/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 bash build.sh


### PR DESCRIPTION
This commit fixes `fd_advise` unconditionally returning ok (0) on all inputs.  The details are discussed in issue #4554.


# Description
#4554 discusses the motivation. This is a behavior divergence between Wasmer and all other Wasm runtimes.

fixes [#4554][1]

[1]: https://github.com/wasmerio/wasmer/issues/4554
