### PR TITLE
Safely handle offset in fd_seek

### DIFF
--- a/lib/wasix/src/syscalls/wasi/fd_seek.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_seek.rs
@@ -134,8 +134,10 @@ pub(crate) fn fd_seek_internal(
         Whence::Set => {
             let mut fd_map = state.fs.fd_map.write().unwrap();
             let fd_entry = wasi_try_ok_ok!(fd_map.get_mut(&fd).ok_or(Errno::Badf));
-            fd_entry.offset.store(offset as u64, Ordering::Release);
-            offset as u64
+            let offset: u64 = wasi_try_ok_ok!(u64::try_from(offset).map_err(|_| Errno::Inval));
+
+            fd_entry.offset.store(offset, Ordering::Release);
+            offset
         }
         _ => return Ok(Err(Errno::Inval)),
     };


### PR DESCRIPTION
# Description

This PR fixes [#4556][1].  Passing in a negative offset along with `whence::set` causes wasmer to erroneously seek to a very large offset.

[1]: https://github.com/wasmerio/wasmer/issues/4556