### PR TITLE
chore: Make wasmer_wasix::os::console submodule public (again)

### DIFF
--- a/lib/wasix/src/os/mod.rs
+++ b/lib/wasix/src/os/mod.rs
@@ -1,5 +1,5 @@
 pub mod common;
-mod console;
+pub mod console;
 pub mod tty;
 
 pub mod command;


### PR DESCRIPTION
This used to be public, and is used by Edge.

This is the last remaining difference between the Wasmer master branch and the 
`edge` branch, and thus simplifies the workflow for Edge.
