### PR TITLE
Relax fd_advise spec

### DIFF
--- a/lib/wasix/src/syscalls/wasi/fd_advise.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_advise.rs
@@ -53,7 +53,5 @@ pub(crate) fn fd_advise_internal(
         return Err(Errno::Access);
     }
 
-    let _end = offset.checked_add(len).ok_or(Errno::Inval)?;
-
     Ok(())
 }

--- a/tests/wasi-fyi/fd_advise_validity.rs
+++ b/tests/wasi-fyi/fd_advise_validity.rs
@@ -5,8 +5,8 @@ extern "C" {
     pub fn fd_advise(arg0: i32, arg1: u64, arg2: u64, arg3: i32) -> i32;
 }
 
+const ERRNO_SUCCESS: i32 = 0;
 const ERRNO_BADF: i32 = 8;
-const ERRNO_INVAL: i32 = 28;
 
 const ADVISE_WILLNEED: i32 = 3;
 
@@ -22,8 +22,8 @@ fn main() {
 
         let errno = fd_advise(f.as_raw_fd(), u64::MAX, u64::MAX, ADVISE_WILLNEED);
         assert_eq!(
-            errno, ERRNO_INVAL,
-            "fd_advise with invalid overflowing offset + length should fail with errno 28 (INVAL)"
+            errno, ERRNO_SUCCESS,
+            "fd_advise with valid fd should succeed"
         );
     }
 }


### PR DESCRIPTION
`fd_advise` is spec'd so that the sum of offset and len cannot overflow. This is unnecessary.  None of the other runtimes exhibit this behavior. In addition, on Linux host, `posix_advise()` returns OK with `INT64_MAX` as both offset and len.  This commit removes this part of the test.

fixes #4586 