### PR TITLE
propagate timestamps to virtual file handles

### DIFF
--- a/lib/virtual-fs/src/arc_box_file.rs
+++ b/lib/virtual-fs/src/arc_box_file.rs
@@ -102,6 +102,10 @@ impl VirtualFile for ArcBoxFile {
         let inner = self.inner.lock().unwrap();
         inner.created_time()
     }
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.set_times(atime, mtime);
+    }
     fn size(&self) -> u64 {
         let inner = self.inner.lock().unwrap();
         inner.size()

--- a/lib/virtual-fs/src/arc_box_file.rs
+++ b/lib/virtual-fs/src/arc_box_file.rs
@@ -102,9 +102,9 @@ impl VirtualFile for ArcBoxFile {
         let inner = self.inner.lock().unwrap();
         inner.created_time()
     }
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         let mut inner = self.inner.lock().unwrap();
-        inner.set_times(atime, mtime);
+        inner.set_times(atime, mtime)
     }
     fn size(&self) -> u64 {
         let inner = self.inner.lock().unwrap();

--- a/lib/virtual-fs/src/arc_file.rs
+++ b/lib/virtual-fs/src/arc_file.rs
@@ -118,9 +118,9 @@ where
         let inner = self.inner.lock().unwrap();
         inner.created_time()
     }
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         let mut inner = self.inner.lock().unwrap();
-        inner.set_times(atime, mtime);
+        inner.set_times(atime, mtime)
     }
     fn size(&self) -> u64 {
         let inner = self.inner.lock().unwrap();

--- a/lib/virtual-fs/src/arc_file.rs
+++ b/lib/virtual-fs/src/arc_file.rs
@@ -118,6 +118,10 @@ where
         let inner = self.inner.lock().unwrap();
         inner.created_time()
     }
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.set_times(atime, mtime);
+    }
     fn size(&self) -> u64 {
         let inner = self.inner.lock().unwrap();
         inner.size()

--- a/lib/virtual-fs/src/combine_file.rs
+++ b/lib/virtual-fs/src/combine_file.rs
@@ -33,6 +33,10 @@ impl VirtualFile for CombineFile {
         self.tx.created_time()
     }
 
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        self.tx.set_times(atime, mtime)
+    }
+
     fn size(&self) -> u64 {
         self.rx.size()
     }

--- a/lib/virtual-fs/src/combine_file.rs
+++ b/lib/virtual-fs/src/combine_file.rs
@@ -33,7 +33,7 @@ impl VirtualFile for CombineFile {
         self.tx.created_time()
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         self.tx.set_times(atime, mtime)
     }
 

--- a/lib/virtual-fs/src/cow_file.rs
+++ b/lib/virtual-fs/src/cow_file.rs
@@ -195,13 +195,15 @@ impl VirtualFile for CopyOnWriteFile {
     fn created_time(&self) -> u64 {
         self.created_time
     }
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         if let Some(atime) = atime {
             self.last_accessed = atime;
         }
         if let Some(mtime) = mtime {
             self.last_modified = mtime;
         }
+
+        Ok(())
     }
     fn size(&self) -> u64 {
         match self.state.as_ref() {

--- a/lib/virtual-fs/src/cow_file.rs
+++ b/lib/virtual-fs/src/cow_file.rs
@@ -195,6 +195,14 @@ impl VirtualFile for CopyOnWriteFile {
     fn created_time(&self) -> u64 {
         self.created_time
     }
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        if let Some(atime) = atime {
+            self.last_accessed = atime;
+        }
+        if let Some(mtime) = mtime {
+            self.last_modified = mtime;
+        }
+    }
     fn size(&self) -> u64 {
         match self.state.as_ref() {
             Some(inner) => inner.size(),

--- a/lib/virtual-fs/src/dual_write_file.rs
+++ b/lib/virtual-fs/src/dual_write_file.rs
@@ -41,7 +41,7 @@ impl VirtualFile for DualWriteFile {
         self.inner.created_time()
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         self.inner.set_times(atime, mtime)
     }
 

--- a/lib/virtual-fs/src/dual_write_file.rs
+++ b/lib/virtual-fs/src/dual_write_file.rs
@@ -41,6 +41,10 @@ impl VirtualFile for DualWriteFile {
         self.inner.created_time()
     }
 
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        self.inner.set_times(atime, mtime)
+    }
+
     fn size(&self) -> u64 {
         self.inner.size()
     }

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -434,6 +434,11 @@ impl VirtualFile for File {
             .unwrap_or(0)
     }
 
+    // FIXME: Need to think about this
+    fn set_times(&mut self, _atime: Option<u64>, _mtime: Option<u64>) {
+        todo!()
+    }
+
     fn size(&self) -> u64 {
         self.metadata().len()
     }

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -434,9 +434,12 @@ impl VirtualFile for File {
             .unwrap_or(0)
     }
 
-    // FIXME: Need to think about this
-    fn set_times(&mut self, _atime: Option<u64>, _mtime: Option<u64>) {
-        todo!()
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        let atime = atime.map(|t| filetime::FileTime::from_unix_time(t as i64, 0));
+        let mtime = mtime.map(|t| filetime::FileTime::from_unix_time(t as i64, 0));
+
+        filetime::set_file_handle_times(&self.inner_std, atime, mtime)
+            .map_err(|_| crate::FsError::IOError)
     }
 
     fn size(&self) -> u64 {

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -336,6 +336,12 @@ pub trait VirtualFile:
     /// the time at which the file was created in nanoseconds as a UNIX timestamp
     fn created_time(&self) -> u64;
 
+    /// sets accessed time
+    fn set_accessed(&mut self, _atime: u64) {}
+
+    /// sets modification time
+    fn set_modified(&mut self, _mtime: u64) {}
+
     /// the size of the file in bytes
     fn size(&self) -> u64;
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -336,11 +336,8 @@ pub trait VirtualFile:
     /// the time at which the file was created in nanoseconds as a UNIX timestamp
     fn created_time(&self) -> u64;
 
-    /// sets accessed time
-    fn set_accessed(&mut self, _atime: u64) {}
-
-    /// sets modification time
-    fn set_modified(&mut self, _mtime: u64) {}
+    /// sets accessed and modified time
+    fn set_times(&mut self, _atime: Option<u64>, _mtime: Option<u64>) {}
 
     /// the size of the file in bytes
     fn size(&self) -> u64;

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -338,7 +338,9 @@ pub trait VirtualFile:
 
     #[allow(unused_variables)]
     /// sets accessed and modified time
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {}
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        Ok(())
+    }
 
     /// the size of the file in bytes
     fn size(&self) -> u64;

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -336,8 +336,9 @@ pub trait VirtualFile:
     /// the time at which the file was created in nanoseconds as a UNIX timestamp
     fn created_time(&self) -> u64;
 
+    #[allow(unused_variables)]
     /// sets accessed and modified time
-    fn set_times(&mut self, _atime: Option<u64>, _mtime: Option<u64>) {}
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {}
 
     /// the size of the file in bytes
     fn size(&self) -> u64;

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -144,7 +144,7 @@ impl VirtualFile for FileHandle {
         node.metadata().created
     }
 
-    fn set_accessed(&mut self, atime: u64) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
         let mut fs = match self.filesystem.inner.write() {
             Ok(fs) => fs,
             _ => return,
@@ -152,19 +152,12 @@ impl VirtualFile for FileHandle {
 
         let inode = fs.storage.get_mut(self.inode);
         if let Some(node) = inode {
-            node.metadata_mut().accessed = atime;
-        }
-    }
-
-    fn set_modified(&mut self, mtime: u64) {
-        let mut fs = match self.filesystem.inner.write() {
-            Ok(fs) => fs,
-            _ => return,
-        };
-
-        let inode = fs.storage.get_mut(self.inode);
-        if let Some(node) = inode {
-            node.metadata_mut().modified = mtime;
+            if let Some(atime) = atime {
+                node.metadata_mut().accessed = atime;
+            }
+            if let Some(mtime) = mtime {
+                node.metadata_mut().modified = mtime;
+            }
         }
     }
 

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -162,7 +162,7 @@ impl VirtualFile for FileHandle {
             return Ok(());
         }
 
-        return Err(crate::FsError::UnknownError);
+        Err(crate::FsError::UnknownError)
     }
 
     fn size(&self) -> u64 {

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -144,6 +144,30 @@ impl VirtualFile for FileHandle {
         node.metadata().created
     }
 
+    fn set_accessed(&mut self, atime: u64) {
+        let mut fs = match self.filesystem.inner.write() {
+            Ok(fs) => fs,
+            _ => return,
+        };
+
+        let inode = fs.storage.get_mut(self.inode);
+        if let Some(node) = inode {
+            node.metadata_mut().accessed = atime;
+        }
+    }
+
+    fn set_modified(&mut self, mtime: u64) {
+        let mut fs = match self.filesystem.inner.write() {
+            Ok(fs) => fs,
+            _ => return,
+        };
+
+        let inode = fs.storage.get_mut(self.inode);
+        if let Some(node) = inode {
+            node.metadata_mut().modified = mtime;
+        }
+    }
+
     fn size(&self) -> u64 {
         let fs = match self.filesystem.inner.read() {
             Ok(fs) => fs,

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -144,10 +144,10 @@ impl VirtualFile for FileHandle {
         node.metadata().created
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         let mut fs = match self.filesystem.inner.write() {
             Ok(fs) => fs,
-            _ => return,
+            _ => return Err(crate::FsError::Lock),
         };
 
         let inode = fs.storage.get_mut(self.inode);
@@ -158,7 +158,11 @@ impl VirtualFile for FileHandle {
             if let Some(mtime) = mtime {
                 node.metadata_mut().modified = mtime;
             }
+
+            return Ok(());
         }
+
+        return Err(crate::FsError::UnknownError);
     }
 
     fn size(&self) -> u64 {

--- a/lib/virtual-fs/src/trace_fs.rs
+++ b/lib/virtual-fs/src/trace_fs.rs
@@ -120,7 +120,7 @@ impl VirtualFile for TraceFile {
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         self.file.set_times(atime, mtime)
     }
 

--- a/lib/virtual-fs/src/trace_fs.rs
+++ b/lib/virtual-fs/src/trace_fs.rs
@@ -120,6 +120,11 @@ impl VirtualFile for TraceFile {
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        self.file.set_times(atime, mtime)
+    }
+
+    #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
     fn size(&self) -> u64 {
         self.file.size()
     }

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -510,6 +510,13 @@ impl VirtualFile for WasiStateFileGuard {
         }
     }
 
+    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+        let mut guard = self.lock_write();
+        if let Some(file) = guard.as_mut() {
+            file.set_times(atime, mtime)
+        }
+    }
+
     fn size(&self) -> u64 {
         let guard = self.lock_read();
         if let Some(file) = guard.as_ref() {

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -510,10 +510,16 @@ impl VirtualFile for WasiStateFileGuard {
         }
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) {
+    fn set_times(
+        &mut self,
+        atime: Option<u64>,
+        mtime: Option<u64>,
+    ) -> Result<(), virtual_fs::FsError> {
         let mut guard = self.lock_write();
         if let Some(file) = guard.as_mut() {
             file.set_times(atime, mtime)
+        } else {
+            Err(crate::FsError::Lock)
         }
     }
 

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
@@ -1,3 +1,5 @@
+use std::borrow::BorrowMut;
+
 use super::*;
 use crate::syscalls::*;
 
@@ -59,6 +61,9 @@ pub(crate) fn fd_filestat_set_times_internal(
 
     let inode = fd_entry.inode;
 
+    let mut atime = None;
+    let mut mtime = None;
+
     if fst_flags.contains(Fstflags::SET_ATIM) || fst_flags.contains(Fstflags::SET_ATIM_NOW) {
         let time_to_set = if fst_flags.contains(Fstflags::SET_ATIM) {
             st_atim
@@ -66,6 +71,7 @@ pub(crate) fn fd_filestat_set_times_internal(
             get_current_time_in_nanos()?
         };
         inode.stat.write().unwrap().st_atim = time_to_set;
+        atime = Some(time_to_set);
     }
 
     if fst_flags.contains(Fstflags::SET_MTIM) || fst_flags.contains(Fstflags::SET_MTIM_NOW) {
@@ -75,6 +81,23 @@ pub(crate) fn fd_filestat_set_times_internal(
             get_current_time_in_nanos()?
         };
         inode.stat.write().unwrap().st_mtim = time_to_set;
+        mtime = Some(time_to_set);
+    }
+
+    if let Kind::File {
+        handle: Some(handle),
+        ..
+    } = inode.kind.write().unwrap().deref()
+    {
+        let mut handle = handle.write().unwrap();
+
+        if let Some(time) = atime {
+            handle.set_accessed(time);
+        }
+
+        if let Some(time) = mtime {
+            handle.set_modified(time);
+        }
     }
 
     Ok(())

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
@@ -91,13 +91,7 @@ pub(crate) fn fd_filestat_set_times_internal(
     {
         let mut handle = handle.write().unwrap();
 
-        if let Some(time) = atime {
-            handle.set_accessed(time);
-        }
-
-        if let Some(time) = mtime {
-            handle.set_modified(time);
-        }
+        handle.set_times(atime, mtime);
     }
 
     Ok(())


### PR DESCRIPTION
This PR propagates the timestamps to the virtual file whenever `fd_filestat_set_times` is called.