### PR TITLE
fix(CLI): Pass the `no_wait` flag to `Deploy`

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -47,7 +47,7 @@ pub struct CmdAppCreate {
     ///
     /// If selected, this might entail the step of publishing the package related to the
     /// application. By default, the application is not deployed and the package is not published.
-    #[clap(long)]
+    #[clap(long = "deploy")]
     pub deploy_app: bool,
 
     /// Skip local schema validation.
@@ -371,12 +371,12 @@ impl CmdAppCreate {
                 non_interactive: self.non_interactive,
                 publish_package: true,
                 path: self.app_dir_path.clone(),
-                no_wait: false,
+                no_wait: self.no_wait,
                 no_default: false,
                 no_persist_id: false,
                 owner: Some(String::from(owner)),
                 app_name: None,
-                autobump: false,
+                bump: false,
             };
             cmd_deploy.run_async().await?;
         }

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -77,9 +77,9 @@ pub struct CmdAppDeploy {
     #[clap(long)]
     pub app_name: Option<String>,
 
-    /// Whether or not to autobump the package version if publishing.
+    /// Whether or not to automatically bump the package version if publishing.
     #[clap(long)]
-    pub autobump: bool,
+    pub bump: bool,
 }
 
 impl CmdAppDeploy {
@@ -123,7 +123,7 @@ impl CmdAppDeploy {
                 None => Some(owner),
             },
             non_interactive: self.non_interactive,
-            autobump: self.autobump,
+            bump: self.bump,
         };
 
         match publish_cmd.run_async().await? {
@@ -186,7 +186,7 @@ impl CmdAppDeploy {
             offline: false,
             owner: None,
             app_name: None,
-            no_wait: false,
+            no_wait: self.no_wait,
             api: self.api.clone(),
             fmt: ItemFormatOpts {
                 format: self.fmt.format,

--- a/lib/cli/src/commands/publish.rs
+++ b/lib/cli/src/commands/publish.rs
@@ -55,7 +55,7 @@ pub struct Publish {
 
     /// Whether or not the patch field of the version of the package - if any - should be bumped.
     #[clap(long)]
-    pub autobump: bool,
+    pub bump: bool,
 
     /// Do not prompt for user input.
     #[clap(long, default_value_t = !std::io::stdin().is_terminal())]
@@ -139,7 +139,7 @@ impl AsyncCliCommand for Publish {
             };
 
             if pkg.version < latest_version {
-                if self.autobump {
+                if self.bump {
                     latest_version.patch += 1;
                     version = Some(latest_version);
                 } else if interactive {


### PR DESCRIPTION
A small change to pass the `no_wait` flag given when using the `create` command to the `deploy` command in case it is called. 

Also, rename: 
`autobump`  -> `bump`  in `deploy` and `publish`
`app_name` -> `name` in `create`
`deploy_app` -> `deploy` in `create`