### PR TITLE
reuse atom signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5603,7 +5603,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -7145,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "6.0.0-alpha3"
+version = "6.0.0-alpha5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c544aa307af3ad0326ae962a1715400c6c456e91e45bb2c2d860fdccc128be3c"
+checksum = "c10e8cca5fe3a8f85803e8cf67bb4f166c9fb326d4581c26a1a48e22f7922762"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -7160,6 +7160,7 @@ dependencies = [
  "indexmap 1.9.3",
  "leb128",
  "lexical-sort",
+ "libc",
  "once_cell",
  "path-clean",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ wasmer-config = { path = "./lib/config" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates
-webc = { version = "6.0.0-alpha3", default-features = false, features = ["package"] }
+webc = { version = "6.0.0-alpha5", default-features = false, features = ["package"] }
 edge-schema = { version = "=0.1.0" }
 shared-buffer = "0.1.4"
 

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -705,9 +705,10 @@ impl ExecutableTarget {
                     .load_module_sync(&wasm)
                     .with_context(|| format!("Unable to compile \"{}\"", path.display()))?;
 
+                // FIXME: Amin
                 Ok(ExecutableTarget::WebAssembly {
                     module,
-                    module_hash: ModuleHash::hash(&wasm),
+                    module_hash: ModuleHash::xxhash(&wasm),
                     path: path.to_path_buf(),
                 })
             }
@@ -717,7 +718,8 @@ impl ExecutableTarget {
                 let module = unsafe { Module::deserialize_from_file(&engine, path)? };
                 let module_hash = {
                     let wasm = std::fs::read(path)?;
-                    ModuleHash::hash(wasm)
+                    // FIXME: Amin
+                    ModuleHash::xxhash(wasm)
                 };
 
                 Ok(ExecutableTarget::WebAssembly {

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -705,7 +705,6 @@ impl ExecutableTarget {
                     .load_module_sync(&wasm)
                     .with_context(|| format!("Unable to compile \"{}\"", path.display()))?;
 
-                // FIXME: Amin
                 Ok(ExecutableTarget::WebAssembly {
                     module,
                     module_hash: ModuleHash::xxhash(&wasm),
@@ -718,7 +717,6 @@ impl ExecutableTarget {
                 let module = unsafe { Module::deserialize_from_file(&engine, path)? };
                 let module_hash = {
                     let wasm = std::fs::read(path)?;
-                    // FIXME: Amin
                     ModuleHash::xxhash(wasm)
                 };
 

--- a/lib/journal/src/concrete/archived.rs
+++ b/lib/journal/src/concrete/archived.rs
@@ -950,7 +950,7 @@ pub enum ArchivedJournalEntry<'a> {
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
 #[archive_attr(derive(CheckBytes), repr(align(8)))]
 pub struct JournalEntryInitModuleV1 {
-    pub wasm_hash: [u8; 8],
+    pub wasm_hash: Vec<u8>,
 }
 
 #[repr(C)]

--- a/lib/journal/src/concrete/archived.rs
+++ b/lib/journal/src/concrete/archived.rs
@@ -950,7 +950,7 @@ pub enum ArchivedJournalEntry<'a> {
 #[derive(Debug, Clone, RkyvSerialize, RkyvDeserialize, Archive)]
 #[archive_attr(derive(CheckBytes), repr(align(8)))]
 pub struct JournalEntryInitModuleV1 {
-    pub wasm_hash: Vec<u8>,
+    pub wasm_hash: Box<[u8]>,
 }
 
 #[repr(C)]

--- a/lib/journal/src/concrete/archived_from.rs
+++ b/lib/journal/src/concrete/archived_from.rs
@@ -649,7 +649,7 @@ impl<'a> TryFrom<ArchivedJournalEntry<'a>> for JournalEntry<'a> {
         Ok(match value {
             ArchivedJournalEntry::InitModuleV1(ArchivedJournalEntryInitModuleV1 { wasm_hash }) => {
                 Self::InitModuleV1 {
-                    wasm_hash: *wasm_hash,
+                    wasm_hash: wasm_hash.to_vec(),
                 }
             }
             ArchivedJournalEntry::ClearEtherealV1(ArchivedJournalEntryClearEtherealV1 {

--- a/lib/journal/src/concrete/archived_from.rs
+++ b/lib/journal/src/concrete/archived_from.rs
@@ -649,7 +649,7 @@ impl<'a> TryFrom<ArchivedJournalEntry<'a>> for JournalEntry<'a> {
         Ok(match value {
             ArchivedJournalEntry::InitModuleV1(ArchivedJournalEntryInitModuleV1 { wasm_hash }) => {
                 Self::InitModuleV1 {
-                    wasm_hash: wasm_hash.to_vec(),
+                    wasm_hash: Box::from(wasm_hash.get()),
                 }
             }
             ArchivedJournalEntry::ClearEtherealV1(ArchivedJournalEntryClearEtherealV1 {

--- a/lib/journal/src/concrete/tests.rs
+++ b/lib/journal/src/concrete/tests.rs
@@ -49,7 +49,7 @@ pub fn run_test<'a>(record: JournalEntry<'a>) {
 #[test]
 pub fn test_record_init_module() {
     run_test(JournalEntry::InitModuleV1 {
-        wasm_hash: [13u8; 8],
+        wasm_hash: vec![13u8; 8],
     });
 }
 

--- a/lib/journal/src/concrete/tests.rs
+++ b/lib/journal/src/concrete/tests.rs
@@ -49,7 +49,7 @@ pub fn run_test<'a>(record: JournalEntry<'a>) {
 #[test]
 pub fn test_record_init_module() {
     run_test(JournalEntry::InitModuleV1 {
-        wasm_hash: vec![13u8; 8],
+        wasm_hash: Box::new([13u8; 8]),
     });
 }
 

--- a/lib/journal/src/entry.rs
+++ b/lib/journal/src/entry.rs
@@ -84,7 +84,7 @@ pub enum SocketOptTimeType {
 #[serde(rename_all = "snake_case")]
 pub enum JournalEntry<'a> {
     InitModuleV1 {
-        wasm_hash: [u8; 8],
+        wasm_hash: Vec<u8>,
     },
     ClearEtherealV1,
     UpdateMemoryRegionV1 {

--- a/lib/journal/src/entry.rs
+++ b/lib/journal/src/entry.rs
@@ -84,7 +84,7 @@ pub enum SocketOptTimeType {
 #[serde(rename_all = "snake_case")]
 pub enum JournalEntry<'a> {
     InitModuleV1 {
-        wasm_hash: Vec<u8>,
+        wasm_hash: Box<[u8]>,
     },
     ClearEtherealV1,
     UpdateMemoryRegionV1 {

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -23,16 +23,21 @@ pub struct BinaryPackageCommand {
     metadata: webc::metadata::Command,
     #[derivative(Debug = "ignore")]
     pub(crate) atom: SharedBytes,
-    hash: OnceCell<ModuleHash>,
+    hash: ModuleHash,
 }
 
 impl BinaryPackageCommand {
-    pub fn new(name: String, metadata: webc::metadata::Command, atom: SharedBytes) -> Self {
+    pub fn new(
+        name: String,
+        metadata: webc::metadata::Command,
+        atom: SharedBytes,
+        hash: ModuleHash,
+    ) -> Self {
         Self {
             name,
             metadata,
             atom,
-            hash: OnceCell::new(),
+            hash,
         }
     }
 
@@ -53,7 +58,7 @@ impl BinaryPackageCommand {
     }
 
     pub fn hash(&self) -> &ModuleHash {
-        self.hash.get_or_init(|| ModuleHash::xxhash(self.atom()))
+        &self.hash
     }
 }
 

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -15,6 +15,7 @@ use crate::{
     Runtime,
 };
 
+// FIXME: Amin
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct BinaryPackageCommand {
@@ -52,7 +53,7 @@ impl BinaryPackageCommand {
     }
 
     pub fn hash(&self) -> &ModuleHash {
-        self.hash.get_or_init(|| ModuleHash::hash(self.atom()))
+        self.hash.get_or_init(|| ModuleHash::xxhash(self.atom()))
     }
 }
 
@@ -146,9 +147,9 @@ impl BinaryPackage {
     pub fn hash(&self) -> ModuleHash {
         *self.hash.get_or_init(|| {
             if let Some(entry) = self.entrypoint_bytes() {
-                ModuleHash::hash(entry)
+                ModuleHash::xxhash(entry)
             } else {
-                ModuleHash::hash(self.id.to_string())
+                ModuleHash::xxhash(self.id.to_string())
             }
         })
     }

--- a/lib/wasix/src/os/task/control_plane.rs
+++ b/lib/wasix/src/os/task/control_plane.rs
@@ -225,7 +225,7 @@ mod tests {
             enable_exponential_cpu_backoff: None,
         });
 
-        let p1 = p.new_process(ModuleHash::random()).unwrap();
+        let p1 = p.new_process(ModuleHash::xxhash_random()).unwrap();
         let _t1 = p1
             .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
             .unwrap();
@@ -234,7 +234,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            p.new_process(ModuleHash::random()).unwrap_err(),
+            p.new_process(ModuleHash::xxhash_random()).unwrap_err(),
             ControlPlaneError::TaskLimitReached { max: 2 }
         );
     }
@@ -248,7 +248,7 @@ mod tests {
             enable_exponential_cpu_backoff: None,
         });
 
-        let p1 = p.new_process(ModuleHash::random()).unwrap();
+        let p1 = p.new_process(ModuleHash::xxhash_random()).unwrap();
 
         for _ in 0..10 {
             let _thread = p1
@@ -264,7 +264,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            p.new_process(ModuleHash::random()).unwrap_err(),
+            p.new_process(ModuleHash::xxhash_random()).unwrap_err(),
             ControlPlaneError::TaskLimitReached { max: 2 }
         );
     }

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -104,7 +104,8 @@ where
     fn load_module<'a>(&'a self, wasm: &'a [u8]) -> BoxFuture<'a, Result<Module, SpawnError>> {
         let engine = self.engine();
         let module_cache = self.module_cache();
-        let hash = ModuleHash::hash(wasm);
+        // FIXME: Amin
+        let hash = ModuleHash::xxhash(wasm);
 
         let task = async move { load_module(&engine, &module_cache, wasm, hash).await };
 
@@ -553,7 +554,8 @@ impl Runtime for OverriddenRuntime {
         if self.engine.is_some() || self.module_cache.is_some() {
             let engine = self.engine();
             let module_cache = self.module_cache();
-            let hash = ModuleHash::hash(wasm);
+            // FIXME: Amin
+            let hash = ModuleHash::xxhash(wasm);
 
             let task = async move { load_module(&engine, &module_cache, wasm, hash).await };
             Box::pin(task)

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -104,7 +104,6 @@ where
     fn load_module<'a>(&'a self, wasm: &'a [u8]) -> BoxFuture<'a, Result<Module, SpawnError>> {
         let engine = self.engine();
         let module_cache = self.module_cache();
-        // FIXME: Amin
         let hash = ModuleHash::xxhash(wasm);
 
         let task = async move { load_module(&engine, &module_cache, wasm, hash).await };
@@ -554,7 +553,6 @@ impl Runtime for OverriddenRuntime {
         if self.engine.is_some() || self.module_cache.is_some() {
             let engine = self.engine();
             let module_cache = self.module_cache();
-            // FIXME: Amin
             let hash = ModuleHash::xxhash(wasm);
 
             let task = async move { load_module(&engine, &module_cache, wasm, hash).await };

--- a/lib/wasix/src/runtime/module_cache/fallback.rs
+++ b/lib/wasix/src/runtime/module_cache/fallback.rs
@@ -179,7 +179,7 @@ mod tests {
     async fn load_from_primary() {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let primary = SharedCache::default();
         let fallback = SharedCache::default();
         primary.save(key, &engine, &module).await.unwrap();
@@ -204,7 +204,7 @@ mod tests {
     async fn loading_from_fallback_also_populates_primary() {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let primary = SharedCache::default();
         let fallback = SharedCache::default();
         fallback.save(key, &engine, &module).await.unwrap();
@@ -230,7 +230,7 @@ mod tests {
     async fn saving_will_update_both() {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let primary = SharedCache::default();
         let fallback = SharedCache::default();
         let cache = FallbackCache::new(&primary, &fallback);

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -220,7 +220,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let expected_path = cache.path(key, engine.deterministic_id());
 
         cache.save(key, &engine, &module).await.unwrap();
@@ -236,7 +236,7 @@ mod tests {
         let cache_dir = temp.path().join("this").join("doesn't").join("exist");
         assert!(!cache_dir.exists());
         let cache = FileSystemCache::new(&cache_dir, create_tokio_task_manager());
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
 
@@ -247,7 +247,7 @@ mod tests {
     async fn missing_file() {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
 
         let err = cache.load(key, &engine).await.unwrap_err();
@@ -260,7 +260,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let expected_path = cache.path(key, engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
@@ -283,7 +283,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let expected_path = cache.path(key, engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();

--- a/lib/wasix/src/runtime/module_cache/mod.rs
+++ b/lib/wasix/src/runtime/module_cache/mod.rs
@@ -45,6 +45,8 @@ pub use self::{
     types::{CacheError, ModuleCache, ModuleHash},
 };
 
+pub(crate) use self::types::hash_from_signature;
+
 #[cfg(feature = "sys-thread")]
 pub use self::filesystem::FileSystemCache;
 

--- a/lib/wasix/src/runtime/module_cache/mod.rs
+++ b/lib/wasix/src/runtime/module_cache/mod.rs
@@ -45,8 +45,6 @@ pub use self::{
     types::{CacheError, ModuleCache, ModuleHash},
 };
 
-pub(crate) use self::types::hash_from_signature;
-
 #[cfg(feature = "sys-thread")]
 pub use self::filesystem::FileSystemCache;
 

--- a/lib/wasix/src/runtime/module_cache/shared.rs
+++ b/lib/wasix/src/runtime/module_cache/shared.rs
@@ -64,7 +64,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = SharedCache::default();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
         let round_tripped = cache.load(key, &engine).await.unwrap();

--- a/lib/wasix/src/runtime/module_cache/thread_local.rs
+++ b/lib/wasix/src/runtime/module_cache/thread_local.rs
@@ -70,7 +70,7 @@ mod tests {
         let engine = Engine::default();
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = ThreadLocalCache::default();
-        let key = ModuleHash::from_bytes([0; 8]);
+        let key = ModuleHash::xxhash_from_bytes([0; 8]);
 
         cache.save(key, &engine, &module).await.unwrap();
         let round_tripped = cache.load(key, &engine).await.unwrap();

--- a/lib/wasix/src/runtime/module_cache/types.rs
+++ b/lib/wasix/src/runtime/module_cache/types.rs
@@ -5,8 +5,6 @@ use std::{
     path::PathBuf,
 };
 
-use anyhow::Context;
-use base64::Engine as Base64Engine;
 use rand::RngCore;
 use sha2::Digest;
 use wasmer::{Engine, Module};
@@ -205,35 +203,11 @@ impl ModuleHash {
     }
 }
 
-/// Loads the hash from an encoded string. This is not a public API since it relies on how we
-/// encode the atom signature in pirita.
-pub(crate) fn hash_from_signature(encoded: &str) -> Result<ModuleHash, anyhow::Error> {
-    if let Some(base64_encoded) = encoded.strip_prefix("xxhash:") {
-        let hash = base64::prelude::BASE64_STANDARD
-            .decode(base64_encoded)
-            .context("malformed base64 encoded hash")?;
-
-        let hash: [u8; 8] = hash
-            .as_slice()
-            .try_into()
-            .context("xxhash hash must be 8 bytes")?;
-
-        Ok(ModuleHash::xxhash_from_bytes(hash))
-    } else if let Some(base64_encoded) = encoded.strip_prefix("sha256:") {
-        let hash = base64::prelude::BASE64_STANDARD
-            .decode(base64_encoded)
-            .context("malformed base64 encoded hash")?;
-
-        let hash: [u8; 32] = hash
-            .as_slice()
-            .try_into()
-            .context("sha256 hash must be 32 bytes")?;
-
-        Ok(ModuleHash::sha256_from_bytes(hash))
-    } else {
-        return Err(anyhow::Error::msg(
-            "Only xxhash and sha256 encoded strings are accepted",
-        ));
+impl From<webc::metadata::AtomSignature> for ModuleHash {
+    fn from(value: webc::metadata::AtomSignature) -> Self {
+        match value {
+            webc::metadata::AtomSignature::Sha256(bytes) => ModuleHash::Sha256(bytes),
+        }
     }
 }
 

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Error};
+use base64::Engine;
 use futures::{future::BoxFuture, StreamExt, TryStreamExt};
 use once_cell::sync::OnceCell;
 use petgraph::visit::EdgeRef;
@@ -19,6 +20,7 @@ use webc::{
 use crate::{
     bin_factory::{BinaryPackage, BinaryPackageCommand},
     runtime::{
+        module_cache::ModuleHash,
         package_loader::PackageLoader,
         resolver::{
             DependencyGraph, ItemLocation, PackageSummary, Resolution, ResolvedFileSystemMapping,
@@ -148,13 +150,15 @@ fn load_binary_command(
         return Ok(legacy_atom_hack(webc, command_name, cmd));
     }
 
+    let hash = atom_hash(webc, &atom_name);
+
     let atom = atom.with_context(|| {
         format!(
             "The '{command_name}' command uses the '{atom_name}' atom, but it isn't present in the package {package_id}"
         )
     })?;
 
-    let cmd = BinaryPackageCommand::new(command_name.to_string(), cmd.clone(), atom);
+    let cmd = BinaryPackageCommand::new(command_name.to_string(), cmd.clone(), atom, hash);
 
     Ok(Some(cmd))
 }
@@ -213,11 +217,30 @@ fn legacy_atom_hack(
         "(hack) The command metadata is malformed. Falling back to the first atom in the WEBC file",
     );
 
+    let hash = atom_hash(webc, &name);
+
     Some(BinaryPackageCommand::new(
         command_name.to_string(),
         metadata.clone(),
         atom,
+        hash,
     ))
+}
+
+fn atom_hash(webc: &Container, atom_name: &str) -> ModuleHash {
+    let base64_encoded = webc.manifest().atoms[atom_name]
+        .signature
+        .strip_prefix("sha256")
+        .expect("malformed atom signature: does not have sha256 prefix");
+    let sha256 = base64::prelude::BASE64_STANDARD
+        .decode(base64_encoded)
+        .expect("malformed base64 encoded hash");
+    let hash: [u8; 32] = sha256
+        .as_slice()
+        .try_into()
+        .expect("sha256 hash is not 32 bytes");
+
+    ModuleHash::sha256_from_bytes(hash)
 }
 
 async fn fetch_dependencies(

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -230,7 +230,7 @@ fn legacy_atom_hack(
 fn atom_hash(webc: &Container, atom_name: &str) -> ModuleHash {
     let base64_encoded = webc.manifest().atoms[atom_name]
         .signature
-        .strip_prefix("sha256")
+        .strip_prefix("sha256:")
         .expect("malformed atom signature: does not have sha256 prefix");
     let sha256 = base64::prelude::BASE64_STANDARD
         .decode(base64_encoded)

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -910,7 +910,7 @@ impl WasiEnvBuilder {
 
     #[allow(clippy::result_large_err)]
     pub fn build(self) -> Result<WasiEnv, WasiRuntimeError> {
-        let module_hash = self.module_hash.unwrap_or_else(ModuleHash::random);
+        let module_hash = self.module_hash.unwrap_or_else(ModuleHash::xxhash_random);
         let init = self.build_init()?;
         WasiEnv::from_init(init, module_hash)
     }
@@ -925,7 +925,7 @@ impl WasiEnvBuilder {
         self,
         store: &mut impl AsStoreMut,
     ) -> Result<WasiFunctionEnv, WasiRuntimeError> {
-        let module_hash = self.module_hash.unwrap_or_else(ModuleHash::random);
+        let module_hash = self.module_hash.unwrap_or_else(ModuleHash::xxhash_random);
         let init = self.build_init()?;
         let env = WasiEnv::from_init(init, module_hash)?;
         let func_env = WasiFunctionEnv::new(store, env);
@@ -943,7 +943,7 @@ impl WasiEnvBuilder {
         module: Module,
         store: &mut impl AsStoreMut,
     ) -> Result<(Instance, WasiFunctionEnv), WasiRuntimeError> {
-        self.instantiate_ext(module, ModuleHash::random(), store)
+        self.instantiate_ext(module, ModuleHash::xxhash_random(), store)
     }
 
     #[allow(clippy::result_large_err)]
@@ -959,7 +959,7 @@ impl WasiEnvBuilder {
 
     #[allow(clippy::result_large_err)]
     pub fn run(self, module: Module) -> Result<(), WasiRuntimeError> {
-        self.run_ext(module, ModuleHash::random())
+        self.run_ext(module, ModuleHash::xxhash_random())
     }
 
     #[allow(clippy::result_large_err)]
@@ -971,7 +971,7 @@ impl WasiEnvBuilder {
     #[allow(clippy::result_large_err)]
     #[tracing::instrument(level = "debug", skip_all)]
     pub fn run_with_store(self, module: Module, store: &mut Store) -> Result<(), WasiRuntimeError> {
-        self.run_with_store_ext(module, ModuleHash::random(), store)
+        self.run_with_store_ext(module, ModuleHash::xxhash_random(), store)
     }
 
     #[allow(clippy::result_large_err)]

--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -285,7 +285,7 @@ impl WasiFunctionEnv {
                 // The first event we save is an event that records the module hash.
                 // Note: This is used to detect if an incorrect journal is used on the wrong
                 // process or if a process has been recompiled
-                let wasm_hash = self.data(&store).process.module_hash.as_bytes().to_vec();
+                let wasm_hash = Box::from(self.data(&store).process.module_hash.as_bytes());
                 let mut ctx = self.env.clone().into_mut(&mut store);
                 crate::journal::JournalEffector::save_event(
                     &mut ctx,

--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -285,7 +285,7 @@ impl WasiFunctionEnv {
                 // The first event we save is an event that records the module hash.
                 // Note: This is used to detect if an incorrect journal is used on the wrong
                 // process or if a process has been recompiled
-                let wasm_hash = self.data(&store).process.module_hash.as_bytes();
+                let wasm_hash = self.data(&store).process.module_hash.as_bytes().to_vec();
                 let mut ctx = self.env.clone().into_mut(&mut store);
                 crate::journal::JournalEffector::save_event(
                     &mut ctx,

--- a/lib/wasix/src/syscalls/journal/actions/init_module.rs
+++ b/lib/wasix/src/syscalls/journal/actions/init_module.rs
@@ -4,7 +4,7 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     #[allow(clippy::result_large_err)]
     pub(crate) unsafe fn action_init_module(
         &mut self,
-        wasm_hash: Vec<u8>,
+        wasm_hash: Box<[u8]>,
         differ_ethereal: Option<&mut Vec<JournalEntry<'a>>>,
     ) -> Result<(), WasiRuntimeError> {
         tracing::trace!("Replay journal - InitModule {:?}", wasm_hash);

--- a/lib/wasix/src/syscalls/journal/actions/init_module.rs
+++ b/lib/wasix/src/syscalls/journal/actions/init_module.rs
@@ -4,7 +4,7 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     #[allow(clippy::result_large_err)]
     pub(crate) unsafe fn action_init_module(
         &mut self,
-        wasm_hash: [u8; 8],
+        wasm_hash: Vec<u8>,
         differ_ethereal: Option<&mut Vec<JournalEntry<'a>>>,
     ) -> Result<(), WasiRuntimeError> {
         tracing::trace!("Replay journal - InitModule {:?}", wasm_hash);

--- a/lib/wasix/src/syscalls/journal/actions/set_thread.rs
+++ b/lib/wasix/src/syscalls/journal/actions/set_thread.rs
@@ -13,7 +13,7 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
         layout: WasiMemoryLayout,
         differ_ethereal: Option<&mut Vec<JournalEntry<'a>>>,
     ) -> Result<(), WasiRuntimeError> {
-        if Some(self.cur_module_hash) != self.journal_module_hash {
+        if Some(&self.cur_module_hash) != self.journal_module_hash.as_ref() {
             tracing::trace!(%id, "Skipping journal entry - SetThread call_stack={} bytes memory_stack={} bytes store_data={} bytes", call_stack.len(), memory_stack.len(), store_data.len());
             return Ok(());
         }

--- a/lib/wasix/src/syscalls/journal/actions/snapshot.rs
+++ b/lib/wasix/src/syscalls/journal/actions/snapshot.rs
@@ -13,11 +13,11 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
         // in a clean state)
         let mut clear_ethereal = false;
         if self.journal_module_hash.is_some()
-            && Some(self.cur_module_hash) != self.journal_module_hash
+            && Some(&self.cur_module_hash) != self.journal_module_hash.as_ref()
         {
             tracing::error!(
                 "The WASM module hash does not match the journal module hash (journal_hash={:x?} vs module_hash{:x?}) - forcing a restart",
-                self.journal_module_hash.unwrap(),
+                self.journal_module_hash.as_ref().unwrap(),
                 self.cur_module_hash
             );
             self.clear_ethereal(differ_ethereal);

--- a/lib/wasix/src/syscalls/journal/actions/update_memory.rs
+++ b/lib/wasix/src/syscalls/journal/actions/update_memory.rs
@@ -8,7 +8,7 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
         data: Cow<'a, [u8]>,
         differ_ethereal: Option<&mut Vec<JournalEntry<'a>>>,
     ) -> Result<(), WasiRuntimeError> {
-        if Some(self.cur_module_hash) != self.journal_module_hash {
+        if Some(&self.cur_module_hash) != self.journal_module_hash.as_ref() {
             tracing::trace!("Ignored journal - UpdateMemory");
             return Ok(());
         }

--- a/lib/wasix/src/syscalls/journal/mod.rs
+++ b/lib/wasix/src/syscalls/journal/mod.rs
@@ -52,7 +52,7 @@ pub struct JournalSyscallPlayer<'a, 'c> {
 
 impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     pub fn new(mut ctx: FunctionEnvMut<'c, WasiEnv>, bootstrapping: bool) -> Self {
-        let cur_module_hash: [u8; 8] = ctx.data().process.module_hash.as_bytes();
+        let cur_module_hash: &[u8] = ctx.data().process.module_hash.as_bytes();
         let mut ret = JournalSyscallPlayer {
             ctx,
             bootstrapping,

--- a/lib/wasix/src/syscalls/journal/mod.rs
+++ b/lib/wasix/src/syscalls/journal/mod.rs
@@ -31,9 +31,9 @@ pub struct JournalSyscallPlayer<'a, 'c> {
     pub ctx: FunctionEnvMut<'c, WasiEnv>,
     pub bootstrapping: bool,
 
-    pub journal_module_hash: Option<Vec<u8>>,
+    pub journal_module_hash: Option<Box<[u8]>>,
     pub rewind: Option<RewindState>,
-    pub cur_module_hash: Vec<u8>,
+    pub cur_module_hash: Box<[u8]>,
     pub real_fd: HashSet<WasiFd>,
 
     // We delay the spawning of threads until the end as its
@@ -52,7 +52,7 @@ pub struct JournalSyscallPlayer<'a, 'c> {
 
 impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     pub fn new(mut ctx: FunctionEnvMut<'c, WasiEnv>, bootstrapping: bool) -> Self {
-        let cur_module_hash = ctx.data().process.module_hash.as_bytes().to_vec();
+        let cur_module_hash: Box<[u8]> = Box::from(ctx.data().process.module_hash.as_bytes());
         let mut ret = JournalSyscallPlayer {
             ctx,
             bootstrapping,

--- a/lib/wasix/src/syscalls/journal/mod.rs
+++ b/lib/wasix/src/syscalls/journal/mod.rs
@@ -31,9 +31,9 @@ pub struct JournalSyscallPlayer<'a, 'c> {
     pub ctx: FunctionEnvMut<'c, WasiEnv>,
     pub bootstrapping: bool,
 
-    pub journal_module_hash: Option<[u8; 8]>,
+    pub journal_module_hash: Option<Vec<u8>>,
     pub rewind: Option<RewindState>,
-    pub cur_module_hash: [u8; 8],
+    pub cur_module_hash: Vec<u8>,
     pub real_fd: HashSet<WasiFd>,
 
     // We delay the spawning of threads until the end as its
@@ -52,7 +52,7 @@ pub struct JournalSyscallPlayer<'a, 'c> {
 
 impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     pub fn new(mut ctx: FunctionEnvMut<'c, WasiEnv>, bootstrapping: bool) -> Self {
-        let cur_module_hash: &[u8] = ctx.data().process.module_hash.as_bytes();
+        let cur_module_hash = ctx.data().process.module_hash.as_bytes().to_vec();
         let mut ret = JournalSyscallPlayer {
             ctx,
             bootstrapping,

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -121,7 +121,6 @@ impl<'a> WasiTest<'a> {
             wasm_module.read_to_end(&mut out)?;
             out
         };
-        // FIXME: Amin?
         let module_hash = ModuleHash::xxhash(&wasm_bytes);
 
         let module = Module::new(store, wasm_bytes)?;

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -121,7 +121,8 @@ impl<'a> WasiTest<'a> {
             wasm_module.read_to_end(&mut out)?;
             out
         };
-        let module_hash = ModuleHash::hash(&wasm_bytes);
+        // FIXME: Amin?
+        let module_hash = ModuleHash::xxhash(&wasm_bytes);
 
         let module = Module::new(store, wasm_bytes)?;
         let (builder, _tempdirs, mut stdin_tx, stdout_rx, stderr_rx) =


### PR DESCRIPTION
This PR tries to reuse the atom signature (sha256 hash of the atom) in the manifest to prevent recomputing the hash for that atom.
This will be done in two steps:
1. Add support for two hashing algorithms in `ModuleHash`, namely `xxhash` and `sha256`.
2. Use `sha256` for hashes of atoms in order to be able to reuse their signature.