### PR TITLE
Support partial manifest fields

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -559,31 +559,36 @@ impl AppCreator {
                 ),
             };
 
-            let full = format!("{}@{}", pkg.name, pkg.version);
-            let mut pkg_ident = NamedPackageIdent::from_str(&pkg.name)
-                .with_context(|| format!("local package manifest has invalid name: '{full}'"))?;
+            if let (Some(name), Some(version)) = (pkg.name, pkg.version) {
+                let full = format!("{}@{}", name, version);
+                let mut pkg_ident = NamedPackageIdent::from_str(&name).with_context(|| {
+                    format!("local package manifest has invalid name: '{full}'")
+                })?;
 
-            // Pin the version.
-            pkg_ident.tag = Some(Tag::from_str(&pkg.version.to_string()).unwrap());
+                // Pin the version.
+                pkg_ident.tag = Some(Tag::from_str(&version.to_string()).unwrap());
 
-            if self.interactive {
-                eprintln!("Found local package: '{}'", full.green());
+                if self.interactive {
+                    eprintln!("Found local package: '{}'", full.green());
 
-                let msg = format!("Use package '{pkg_ident}'");
+                    let msg = format!("Use package '{pkg_ident}'");
 
-                let theme = dialoguer::theme::ColorfulTheme::default();
-                let should_use = Confirm::with_theme(&theme)
-                    .with_prompt(&msg)
-                    .interact_opt()?
-                    .unwrap_or_default();
+                    let theme = dialoguer::theme::ColorfulTheme::default();
+                    let should_use = Confirm::with_theme(&theme)
+                        .with_prompt(&msg)
+                        .interact_opt()?
+                        .unwrap_or_default();
 
-                if should_use {
-                    Some(pkg_ident)
+                    if should_use {
+                        Some(pkg_ident)
+                    } else {
+                        None
+                    }
                 } else {
-                    None
+                    Some(pkg_ident)
                 }
             } else {
-                Some(pkg_ident)
+                None
             }
         } else {
             None

--- a/lib/cli/src/commands/package/build.rs
+++ b/lib/cli/src/commands/package/build.rs
@@ -55,11 +55,15 @@ impl PackageBuild {
         let pkg = webc::wasmer_package::Package::from_manifest(manifest_path)?;
         let pkg_hash = PackageHash::from_sha256_bytes(pkg.webc_hash());
         let name = if let Some(manifest_pkg) = manifest.package {
-            format!(
-                "{}-{}.webc",
-                manifest_pkg.name.replace('/', "-"),
-                manifest_pkg.version
-            )
+            if let Some(name) = manifest_pkg.name {
+                if let Some(version) = manifest_pkg.version {
+                    format!("{}-{}.webc", name.replace('/', "-"), version)
+                } else {
+                    format!("{}-{}.webc", name.replace('/', "-"), pkg_hash)
+                }
+            } else {
+                format!("{}.webc", pkg_hash)
+            }
         } else {
             format!("{}.webc", pkg_hash)
         };

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -113,13 +113,14 @@ const LICENSE_PATHS: &[&str; 3] = &["LICENSE", "LICENSE.md", "COPYING"];
 #[non_exhaustive]
 pub struct Package {
     /// The package's name in the form `namespace/name`.
-    #[builder(setter(into))]
-    pub name: String,
+    #[builder(setter(into, strip_option), default)]
+    pub name: Option<String>,
     /// The package's version number.
-    pub version: Version,
+    #[builder(setter(into, strip_option), default)]
+    pub version: Option<Version>,
     /// A brief description of the package.
-    #[builder(setter(into))]
-    pub description: String,
+    #[builder(setter(into, strip_option), default)]
+    pub description: Option<String>,
     /// A SPDX license specifier for this package.
     #[builder(setter(into, strip_option), default)]
     pub license: Option<String>,

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -976,9 +976,9 @@ mod tests {
     fn test_to_string() {
         Manifest {
             package: Some(Package {
-                name: "package/name".to_string(),
-                version: Version::parse("1.0.0").unwrap(),
-                description: "test".to_string(),
+                name: Some("package/name".to_string()),
+                version: Some(Version::parse("1.0.0").unwrap()),
+                description: Some("test".to_string()),
                 license: None,
                 license_file: None,
                 readme: None,


### PR DESCRIPTION
This PR makes the `name`, `version` and `description` fields of the `Package` type in `wasmer_config` optional and deals with the cascading changes. This PR tackles #4626 and  opens the way for #4621 and #4612.