### PR TITLE
enable socks support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,6 +3877,7 @@ dependencies = [
  "tokio 1.37.0",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -5174,6 +5175,18 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio 1.37.0",
 ]
 
 [[package]]

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -104,13 +104,13 @@ web-sys = { version = "0.3.64", features = [
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies.reqwest]
 version = "0.11"
 default-features = false
-features = ["rustls-tls", "json", "stream"]
+features = ["rustls-tls", "json", "stream", "socks"]
 optional = true
 
 [target.'cfg(target_arch = "riscv64")'.dependencies.reqwest]
 version = "0.11"
 default-features = false
-features = ["native-tls", "json", "stream"]
+features = ["native-tls", "json", "stream", "socks"]
 optional = true
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This PR simply enables the `socks5://` scheme in `reqwest`.