### PR TITLE
Remove `Send` bound from `FunctionEnv`

### DIFF
--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -140,7 +140,7 @@ impl Function {
     ///     Ok(vec![Value::I32(sum)])
     /// });
     /// ```
-    pub fn new_with_env<FT, F, T: Send + 'static>(
+    pub fn new_with_env<FT, F, T: 'static>(
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<T>,
         ty: FT,
@@ -184,7 +184,7 @@ impl Function {
     ///
     /// let f = Function::new_typed_with_env(&mut store, &env, sum);
     /// ```
-    pub fn new_typed_with_env<T: Send + 'static, F, Args, Rets>(
+    pub fn new_typed_with_env<T: 'static, F, Args, Rets>(
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<T>,
         func: F,

--- a/lib/api/src/function_env.rs
+++ b/lib/api/src/function_env.rs
@@ -13,12 +13,9 @@ pub struct FunctionEnv<T> {
     marker: PhantomData<T>,
 }
 
-impl<T> FunctionEnv<T> {
+impl<T: Any> FunctionEnv<T> {
     /// Make a new FunctionEnv
-    pub fn new(store: &mut impl AsStoreMut, value: T) -> Self
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn new(store: &mut impl AsStoreMut, value: T) -> Self {
         Self {
             handle: StoreHandle::new(
                 store.as_store_mut().objects_mut(),
@@ -29,10 +26,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Get the data as reference
-    pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef) -> &'a T
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef) -> &'a T {
         self.handle
             .get(store.as_store_ref().objects())
             .as_ref()
@@ -49,10 +43,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Get the data as mutable
-    pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut) -> &'a mut T
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut) -> &'a mut T {
         self.handle
             .get_mut(store.objects_mut())
             .as_mut()
@@ -61,10 +52,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Convert it into a `FunctionEnvMut`
-    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<T>
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<T> {
         FunctionEnvMut {
             store_mut: store.as_store_mut(),
             func_env: self,
@@ -102,16 +90,13 @@ pub struct FunctionEnvMut<'a, T: 'a> {
     pub(crate) func_env: FunctionEnv<T>,
 }
 
-impl<'a, T> Debug for FunctionEnvMut<'a, T>
-where
-    T: Send + Debug + 'static,
-{
+impl<'a, T: Debug + 'static> Debug for FunctionEnvMut<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.func_env.as_ref(&self.store_mut).fmt(f)
     }
 }
 
-impl<T: Send + 'static> FunctionEnvMut<'_, T> {
+impl<T: 'static> FunctionEnvMut<'_, T> {
     /// Returns a reference to the host state in this function environement.
     pub fn data(&self) -> &T {
         self.func_env.as_ref(&self.store_mut)

--- a/lib/api/src/js/externals/function.rs
+++ b/lib/api/src/js/externals/function.rs
@@ -60,7 +60,7 @@ impl Function {
     }
 
     #[allow(clippy::cast_ptr_alignment)]
-    pub fn new_with_env<FT, F, T: Send + 'static>(
+    pub fn new_with_env<FT, F, T: 'static>(
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<T>,
         ty: FT,
@@ -312,8 +312,6 @@ pub struct WasmFunction<Args = (), Rets = ()> {
     _phantom: PhantomData<(Args, Rets)>,
 }
 
-unsafe impl<Args, Rets> Send for WasmFunction<Args, Rets> {}
-
 impl<Args, Rets> WasmFunction<Args, Rets>
 where
     Args: WasmTypeList,
@@ -361,7 +359,7 @@ macro_rules! impl_host_function {
                 $( $x: FromToNativeWasmType, )*
                 Rets: WasmTypeList,
                 RetsAsResult: IntoResult<Rets>,
-                T: Send + 'static,
+                T: 'static,
                 Func: Fn(FunctionEnvMut<'_, T>, $( $x , )*) -> RetsAsResult + 'static,
             {
                 #[allow(non_snake_case)]
@@ -374,7 +372,7 @@ macro_rules! impl_host_function {
                         $( $x: FromToNativeWasmType, )*
                         Rets: WasmTypeList,
                         RetsAsResult: IntoResult<Rets>,
-                        T: Send + 'static,
+                        T: 'static,
                         Func: Fn(FunctionEnvMut<'_, T>, $( $x , )*) -> RetsAsResult + 'static,
                     {
                         let mut store = StoreMut::from_raw(store_ptr as *mut _);

--- a/lib/api/src/js/vm.rs
+++ b/lib/api/src/js/vm.rs
@@ -218,12 +218,12 @@ pub type VMInstance = WebAssembly::Instance;
 /// Underlying FunctionEnvironment used by a `VMFunction`.
 #[derive(Debug)]
 pub struct VMFunctionEnvironment {
-    contents: Box<dyn Any + Send + 'static>,
+    contents: Box<dyn Any>,
 }
 
 impl VMFunctionEnvironment {
     /// Wraps the given value to expose it to Wasm code as a function context.
-    pub fn new(val: impl Any + Send + 'static) -> Self {
+    pub fn new(val: impl Any) -> Self {
         Self {
             contents: Box::new(val),
         }
@@ -231,13 +231,13 @@ impl VMFunctionEnvironment {
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a reference to the underlying value.
-    pub fn as_ref(&self) -> &(dyn Any + Send + 'static) {
+    pub fn as_ref(&self) -> &dyn Any {
         &*self.contents
     }
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a mutable reference to the underlying value.
-    pub fn as_mut(&mut self) -> &mut (dyn Any + Send + 'static) {
+    pub fn as_mut(&mut self) -> &mut dyn Any {
         &mut *self.contents
     }
 }

--- a/lib/api/src/jsc/externals/function.rs
+++ b/lib/api/src/jsc/externals/function.rs
@@ -41,7 +41,7 @@ impl Function {
     }
 
     #[allow(clippy::cast_ptr_alignment)]
-    pub fn new_with_env<FT, F, T: Send + 'static>(
+    pub fn new_with_env<FT, F, T: 'static>(
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<T>,
         ty: FT,
@@ -333,7 +333,7 @@ macro_rules! impl_host_function {
                 $( $x: FromToNativeWasmType, )*
                 Rets: WasmTypeList,
                 RetsAsResult: IntoResult<Rets>,
-                T: Send + 'static,
+                T: 'static,
                 Func: Fn(FunctionEnvMut<'_, T>, $( $x , )*) -> RetsAsResult + 'static,
             {
                 #[allow(non_snake_case)]
@@ -350,7 +350,7 @@ macro_rules! impl_host_function {
                         Rets: WasmTypeList,
                         RetsAsResult: IntoResult<Rets>,
                         Func: Fn(FunctionEnvMut<'_, T>, $( $x , )*) -> RetsAsResult + 'static,
-                        T: Send + 'static,
+                        T: 'static,
                     {
                         use std::convert::TryInto;
 

--- a/lib/api/src/jsc/vm.rs
+++ b/lib/api/src/jsc/vm.rs
@@ -200,12 +200,12 @@ pub type VMInstance = JSObject;
 /// Underlying FunctionEnvironment used by a `VMFunction`.
 #[derive(Debug)]
 pub struct VMFunctionEnvironment {
-    contents: Box<dyn Any + Send + 'static>,
+    contents: Box<dyn Any>,
 }
 
 impl VMFunctionEnvironment {
     /// Wraps the given value to expose it to Wasm code as a function context.
-    pub fn new(val: impl Any + Send + 'static) -> Self {
+    pub fn new(val: impl Any) -> Self {
         Self {
             contents: Box::new(val),
         }
@@ -213,13 +213,13 @@ impl VMFunctionEnvironment {
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a reference to the underlying value.
-    pub fn as_ref(&self) -> &(dyn Any + Send + 'static) {
+    pub fn as_ref(&self) -> &dyn Any {
         &*self.contents
     }
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a mutable reference to the underlying value.
-    pub fn as_mut(&mut self) -> &mut (dyn Any + Send + 'static) {
+    pub fn as_mut(&mut self) -> &mut dyn Any {
         &mut *self.contents
     }
 }

--- a/lib/api/src/sys/externals/function.rs
+++ b/lib/api/src/sys/externals/function.rs
@@ -25,7 +25,7 @@ impl From<StoreHandle<VMFunction>> for Function {
 }
 
 impl Function {
-    pub fn new_with_env<FT, F, T: Send + 'static>(
+    pub fn new_with_env<FT, F, T: 'static>(
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<T>,
         ty: FT,
@@ -153,7 +153,7 @@ impl Function {
         }
     }
 
-    pub fn new_typed_with_env<T: Send + 'static, F, Args, Rets>(
+    pub fn new_typed_with_env<T: 'static, F, Args, Rets>(
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<T>,
         func: F,
@@ -469,7 +469,7 @@ macro_rules! impl_host_function {
             // Implement `HostFunction` for a function with a [`FunctionEnvMut`] that has the same
             // arity than the tuple.
             #[allow(unused_parens)]
-            impl< $( $x, )* Rets, RetsAsResult, T: Send + 'static, Func >
+            impl< $( $x, )* Rets, RetsAsResult, T: 'static, Func >
                 HostFunction<T, ( $( $x ),* ), Rets, WithEnv>
             for
                 Func
@@ -484,7 +484,7 @@ macro_rules! impl_host_function {
                     /// This is a function that wraps the real host
                     /// function. Its address will be used inside the
                     /// runtime.
-                    unsafe extern "C" fn func_wrapper<T: Send + 'static, $( $x, )* Rets, RetsAsResult, Func>( env: &StaticFunction<Func, T>, $( $x: <$x::Native as NativeWasmType>::Abi, )* ) -> Rets::CStruct
+                    unsafe extern "C" fn func_wrapper<T: 'static, $( $x, )* Rets, RetsAsResult, Func>( env: &StaticFunction<Func, T>, $( $x: <$x::Native as NativeWasmType>::Abi, )* ) -> Rets::CStruct
                     where
                         $( $x: FromToNativeWasmType, )*
                         Rets: WasmTypeList,

--- a/lib/vm/src/function_env.rs
+++ b/lib/vm/src/function_env.rs
@@ -6,12 +6,12 @@ use std::any::Any;
 #[derivative(Debug)]
 pub struct VMFunctionEnvironment {
     #[derivative(Debug = "ignore")]
-    contents: Box<dyn Any + Send + 'static>,
+    contents: Box<dyn Any>,
 }
 
 impl VMFunctionEnvironment {
     /// Wraps the given value to expose it to Wasm code as a function context.
-    pub fn new(val: impl Any + Send + 'static) -> Self {
+    pub fn new(val: impl Any) -> Self {
         Self {
             contents: Box::new(val),
         }
@@ -19,13 +19,13 @@ impl VMFunctionEnvironment {
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a reference to the underlying value.
-    pub fn as_ref(&self) -> &(dyn Any + Send + 'static) {
+    pub fn as_ref(&self) -> &dyn Any {
         &*self.contents
     }
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a mutable reference to the underlying value.
-    pub fn as_mut(&mut self) -> &mut (dyn Any + Send + 'static) {
+    pub fn as_mut(&mut self) -> &mut dyn Any {
         &mut *self.contents
     }
 }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/CONTRIBUTING.md#pull-requests

-->

# Description

Requiring that function environments be `Send` is quite onerous on the Web, in which many objects (including the Wasmer `Instance` itself, should we wish to pass around a reference to it) are not `Send`.  The function environment is not passed between threads in Wasmer, and in typed usage the user never sees the trait object, only concrete instances of it after casting — which means that all user-visible types will remain `Send` if the user should wish to pass them around. 

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
