### PR TITLE
Handle local package resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "6.0.0-alpha5"
+version = "6.0.0-alpha6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10e8cca5fe3a8f85803e8cf67bb4f166c9fb326d4581c26a1a48e22f7922762"
+checksum = "f90e7ef808f844f15d1680a7cea4a0c5082ccaae0dc09621855a655f71989eb1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ wasmer-config = { path = "./lib/config" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates
-webc = { version = "6.0.0-alpha5", default-features = false, features = ["package"] }
+webc = { version = "6.0.0-alpha6", default-features = false, features = ["package"] }
 edge-schema = { version = "=0.1.0" }
 shared-buffer = "0.1.4"
 

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -673,15 +673,12 @@ impl ExecutableTarget {
         pb: &ProgressBar,
     ) -> Result<Self, Error> {
         pb.set_message(format!("Loading \"{}\" into memory", dir.display()));
-
-        let manifest_path = dir.join("wasmer.toml");
-        let webc = webc::wasmer_package::Package::from_manifest(manifest_path)?;
-        let container = Container::from(webc);
-
         pb.set_message("Resolving dependencies");
         let inner_runtime = runtime.clone();
-        let pkg = runtime.task_manager().spawn_and_block_on(async move {
-            BinaryPackage::from_webc(&container, inner_runtime.as_ref()).await
+        let pkg = runtime.task_manager().spawn_and_block_on({
+            let path = dir.to_path_buf();
+
+            async move { BinaryPackage::from_dir(&path, inner_runtime.as_ref()).await }
         })??;
 
         Ok(ExecutableTarget::Package(pkg))

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -1,4 +1,4 @@
-use std::{os::unix::ffi::OsStrExt, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use anyhow::Context;
 use derivative::*;
@@ -89,7 +89,7 @@ impl BinaryPackage {
 
         // since each package must be in its own directory, hash of the `dir` should provide a good enough
         // unique identifier for the package
-        let hash = sha2::Sha256::digest(dir.as_os_str().as_bytes()).into();
+        let hash = sha2::Sha256::digest(dir.display().to_string().as_bytes()).into();
         let id = PackageId::Hash(PackageHash::from_sha256_bytes(hash));
 
         let manifest_path = dir.join("wasmer.toml");

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -120,11 +120,13 @@ impl BinaryPackage {
         let source = rt.source();
 
         let manifest = container.manifest();
-        let id = PackageInfo::package_id_from_manifest(manifest)?.unwrap_or_else(|| {
-            PackageId::Hash(PackageHash::from_sha256_bytes(
-                container.webc_hash().unwrap(),
-            ))
-        });
+        let id = PackageInfo::package_id_from_manifest(manifest)?
+            .or_else(|| {
+                container
+                    .webc_hash()
+                    .map(|hash| PackageId::Hash(PackageHash::from_sha256_bytes(hash)))
+            })
+            .ok_or_else(|| anyhow::Error::msg("webc file did not provide its hash"))?;
 
         let root = PackageInfo::from_manifest(id, manifest, container.version())?;
         let root_id = root.id.clone();

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -237,9 +237,6 @@ mod tests {
         std::fs::create_dir_all(&out).unwrap();
         let file_txt = "Hello, World!";
         std::fs::write(out.join("file.txt"), file_txt).unwrap();
-        let webc: Container = webc::wasmer_package::Package::from_manifest(manifest)
-            .unwrap()
-            .into();
         let tasks = task_manager();
         let mut runtime = PluggableRuntime::new(tasks);
         runtime.set_package_loader(
@@ -247,7 +244,9 @@ mod tests {
                 .with_shared_http_client(runtime.http_client().unwrap().clone()),
         );
 
-        let pkg = BinaryPackage::from_webc(&webc, &runtime).await.unwrap();
+        let pkg = BinaryPackage::from_dir(&temp.path(), &runtime)
+            .await
+            .unwrap();
 
         // We should have mapped "./out/file.txt" on the host to
         // "/public/file.txt" on the guest.
@@ -290,7 +289,7 @@ mod tests {
         let atom_path = temp.path().join("foo.wasm");
         std::fs::write(&atom_path, b"").unwrap();
 
-        let webc: Container = webc::wasmer_package::Package::from_manifest(manifest)
+        let webc: Container = webc::wasmer_package::Package::from_manifest(&manifest)
             .unwrap()
             .into();
 
@@ -301,7 +300,9 @@ mod tests {
                 .with_shared_http_client(runtime.http_client().unwrap().clone()),
         );
 
-        let pkg = BinaryPackage::from_webc(&webc, &runtime).await.unwrap();
+        let pkg = BinaryPackage::from_dir(&temp.path(), &runtime)
+            .await
+            .unwrap();
 
         assert_eq!(pkg.commands.len(), 1);
         let command = pkg.get_command("cmd").unwrap();

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -121,7 +121,9 @@ impl BinaryPackage {
 
         let manifest = container.manifest();
         let id = PackageInfo::package_id_from_manifest(manifest)?.unwrap_or_else(|| {
-            PackageId::Hash(PackageHash::from_sha256_bytes(container.webc_hash()))
+            PackageId::Hash(PackageHash::from_sha256_bytes(
+                container.webc_hash().unwrap(),
+            ))
         });
 
         let root = PackageInfo::from_manifest(id, manifest, container.version())?;


### PR DESCRIPTION
Right now, the way for handling a local package is the same as a local webc file. This will cause the code to rely on webc hash as a unique identifier in the resolution graph. But the cost of computing the hash for a local package is much higher than a local webc file since for the package, we must serialize the package to get the hash.

This PR adds a new code path for running a local package and uses the hash of the package path as its unique identifier in the dependency graph.