### PR TITLE
add proxy support to the `package download` subcommand

### DIFF
--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -104,13 +104,13 @@ web-sys = { version = "0.3.64", features = [
 [target.'cfg(not(target_arch = "riscv64"))'.dependencies.reqwest]
 version = "0.11"
 default-features = false
-features = ["rustls-tls", "json", "stream", "socks"]
+features = ["rustls-tls", "json", "stream", "socks", "blocking"]
 optional = true
 
 [target.'cfg(target_arch = "riscv64")'.dependencies.reqwest]
 version = "0.11"
 default-features = false
-features = ["native-tls", "json", "stream", "socks"]
+features = ["native-tls", "json", "stream", "socks", "blocking"]
 optional = true
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
In continuation with #4624, this PR adds proxy support to the `wasmer package download` subcommand.