### PR TITLE
Revert `wasmer-wasix` dependency to per project instead of workspace

### DIFF
--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -32,7 +32,7 @@ wasmer-compiler-singlepass = { version = "=4.3.0-beta.1", path = "../compiler-si
 wasmer-emscripten = { version = "=4.3.0-beta.1", path = "../emscripten", optional = true }
 wasmer-middlewares = { version = "=4.3.0-beta.1", path = "../middlewares", optional = true }
 wasmer-types = { version = "=4.3.0-beta.1", path = "../types" }
-wasmer-wasix = { workspace = true, features = ["host-fs", "host-vnet"], optional = true }
+wasmer-wasix = { path = "../wasix", version="=0.19.0", features = ["host-fs", "host-vnet"], optional = true }
 webc = { workspace = true, optional = true }
 virtual-fs = { version = "0.11.4", path = "../virtual-fs", optional = true, default-features = false, features = ["static-fs"] }
 enumset.workspace = true

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -118,7 +118,7 @@ wasmer-compiler-singlepass = { version = "=4.3.0-beta.1", path = "../compiler-si
 wasmer-compiler-llvm = { version = "=4.3.0-beta.1", path = "../compiler-llvm", optional = true }
 wasmer-emscripten = { version = "=4.3.0-beta.1", path = "../emscripten" }
 wasmer-vm = { version = "=4.3.0-beta.1", path = "../vm", optional = true }
-wasmer-wasix = { workspace = true, features = [
+wasmer-wasix = { path = "../wasix", version="=0.19.0" , features = [
 	"logging",
 	"webc_runner_rt_wcgi",
 	"webc_runner_rt_dcgi",

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-wasix.workspace = true
+wasmer-wasix = { path = "../../../lib/wasix", version="=0.19.0" }
 wasmer = { path = "../../../lib/api", version = "=4.3.0-beta.1", default-features = false }
 virtual-fs = { path = "../../../lib/virtual-fs", version = "0.11.4" }
 


### PR DESCRIPTION
Using `wasmer-wasix` as a workspace dependency causes trouble for the release script. So for now, this PR reverts the dependency back to a per project style.