### PR TITLE
Miscellaneous nitpicks for publish (and deploy)

### DIFF
--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -121,7 +121,7 @@ impl CmdAppDeploy {
             api: self.api.clone(),
         };
 
-        publish_cmd.publish(client, &manifest_path, &manifest).await
+        publish_cmd.publish(client, &manifest_path, &manifest, true).await
     }
 
     async fn get_owner(

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -452,7 +452,18 @@ impl AsyncCliCommand for CmdAppDeploy {
             }
         };
 
-        let (_app, app_version) = deploy_app_verbose(&client, opts).await?;
+        let owner = &opts.owner.clone().or_else(|| opts.app.owner.clone());
+        let app = &opts.app;
+
+        let pretty_name = if let Some(owner) = &owner {
+            format!("{} ({})", app.name.bold(), owner.bold())
+        } else {
+            app.name.bold().to_string()
+        };
+
+        eprintln!("\nDeploying app {} to Wasmer Edge...\n", pretty_name);
+
+        let app_version = deploy_app(&client, opts.clone()).await?;
 
         let mut new_app_config = app_config_from_api(&app_version)?;
 
@@ -470,7 +481,7 @@ impl AsyncCliCommand for CmdAppDeploy {
             // settings without requring new CLI versions, so instead of just
             // serializing the new config, we merge it with the old one.
             let new_merged = crate::utils::merge_yaml_values(
-                &app_config.to_yaml_value()?,
+                &app_config.clone().to_yaml_value()?,
                 &new_app_config.to_yaml_value()?,
             );
             let new_config_raw = serde_yaml::to_string(&new_merged)?;
@@ -478,6 +489,8 @@ impl AsyncCliCommand for CmdAppDeploy {
                 format!("Could not write file: '{}'", app_config_path.display())
             })?;
         }
+
+        wait_app(&client, opts.clone(), app_version.clone()).await?;
 
         if self.fmt.format == crate::utils::render::ItemFormat::Json {
             println!("{}", serde_json::to_string_pretty(&app_version)?);
@@ -487,7 +500,7 @@ impl AsyncCliCommand for CmdAppDeploy {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeployAppOpts<'a> {
     pub app: &'a AppConfigV1,
     // Original raw yaml config.
@@ -541,25 +554,13 @@ pub enum WaitMode {
 }
 
 /// Same as [Self::deploy], but also prints verbose information.
-pub async fn deploy_app_verbose(
+pub async fn wait_app(
     client: &WasmerClient,
     opts: DeployAppOpts<'_>,
+    version: DeployAppVersion,
 ) -> Result<(DeployApp, DeployAppVersion), anyhow::Error> {
-    let owner = &opts.owner.clone().or_else(|| opts.app.owner.clone());
-    let app = &opts.app;
-
-    let pretty_name = if let Some(owner) = &owner {
-        format!("{} ({})", app.name.bold(), owner.bold())
-    } else {
-        app.name.bold().to_string()
-    };
-
-    let make_default = opts.make_default;
-
-    eprintln!("\nDeploying app {} to Wasmer Edge...\n", pretty_name);
-
     let wait = opts.wait;
-    let version = deploy_app(client, opts).await?;
+    let make_default = opts.make_default;
 
     let app_id = version
         .app
@@ -625,7 +626,7 @@ pub async fn deploy_app_verbose(
 
                         if header == version.id.inner() {
                             eprintln!("\nNew version is now reachable at {check_url}");
-                            eprintln!("✅ Deployment complete");
+                            eprintln!("{} Deployment complete", "✔".green().bold());
                             break;
                         }
 

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -121,7 +121,9 @@ impl CmdAppDeploy {
             api: self.api.clone(),
         };
 
-        publish_cmd.publish(client, &manifest_path, &manifest, true).await
+        publish_cmd
+            .publish(client, &manifest_path, &manifest, true)
+            .await
     }
 
     async fn get_owner(

--- a/lib/cli/src/commands/package/common/wait.rs
+++ b/lib/cli/src/commands/package/common/wait.rs
@@ -1,3 +1,5 @@
+use super::macros::spinner_ok;
+use colored::Colorize;
 use futures_util::StreamExt;
 use indicatif::ProgressBar;
 use wasmer_api::WasmerClient;
@@ -144,6 +146,6 @@ pub async fn wait_package(
         }
     }
 
-    pb.finish_and_clear();
+    spinner_ok!(pb, "Package is available in the registry");
     Ok(())
 }

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -87,6 +87,7 @@ impl PackagePublish {
         client: &WasmerClient,
         manifest_path: &Path,
         manifest: &Manifest,
+        allow_unnamed: bool,
     ) -> anyhow::Result<PackageIdent> {
         let (package_namespace, package_hash) = {
             let push_cmd = PackagePush {
@@ -119,7 +120,7 @@ impl PackagePublish {
             package_path: self.package_path.clone(),
             package_hash,
         }
-        .tag(client, manifest)
+        .tag(client, manifest, manifest_path, true, allow_unnamed)
         .await
     }
 }
@@ -142,7 +143,9 @@ impl AsyncCliCommand for PackagePublish {
         let (manifest_path, manifest) = get_manifest(&self.package_path)?;
         tracing::info!("Got manifest at path {}", manifest_path.display());
 
-        let ident = self.publish(&client, &manifest_path, &manifest).await?;
+        let ident = self
+            .publish(&client, &manifest_path, &manifest, false)
+            .await?;
 
         if !self.quiet && !self.non_interactive {
             eprintln!(

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -92,7 +92,7 @@ impl PackagePush {
 
         let user = wasmer_api::query::current_user_with_namespaces(client, None).await?;
         let owner =
-            crate::utils::prompts::prompt_for_namespace("Choose a namespace", None, Some(&user))?;
+            crate::utils::prompts::prompt_for_namespace("Choose a namespace to push the package to", None, Some(&user))?;
 
         Ok(owner.clone())
     }

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -91,8 +91,11 @@ impl PackagePush {
         }
 
         let user = wasmer_api::query::current_user_with_namespaces(client, None).await?;
-        let owner =
-            crate::utils::prompts::prompt_for_namespace("Choose a namespace to push the package to", None, Some(&user))?;
+        let owner = crate::utils::prompts::prompt_for_namespace(
+            "Choose a namespace to push the package to",
+            None,
+            Some(&user),
+        )?;
 
         Ok(owner.clone())
     }

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -1,18 +1,20 @@
-use super::common::PackageSpecifier;
 use crate::{
     commands::{
         package::common::{macros::*, *},
         AsyncCliCommand,
     },
     opts::{ApiOpts, WasmerEnv},
-    utils::prompt_for_package_version,
 };
+use anyhow::Context;
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
 use is_terminal::IsTerminal;
-use std::path::PathBuf;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use wasmer_api::WasmerClient;
-use wasmer_config::package::{Manifest, PackageHash, PackageIdent};
+use wasmer_config::package::{Manifest, NamedPackageId, PackageBuilder, PackageHash, PackageIdent};
 
 /// Tag an existing package.
 #[derive(Debug, clap::Parser)]
@@ -71,190 +73,45 @@ pub struct PackageTag {
 }
 
 impl PackageTag {
-    async fn get_namespace(
+    async fn update_manifest_version(
         &self,
-        client: &WasmerClient,
+        manifest_path: &Path,
         manifest: &Manifest,
-    ) -> anyhow::Result<String> {
-        if let Some(owner) = &self.package_namespace {
-            return Ok(owner.clone());
+        user_version: &semver::Version,
+    ) -> anyhow::Result<()> {
+        let mut new_manifest = manifest.clone();
+        if let Some(pkg) = &mut new_manifest.package {
+            pkg.version = Some(user_version.clone());
+        } else {
+            let package = PackageBuilder::default()
+                .version(user_version.clone())
+                .build()?;
+            new_manifest.package = Some(package);
         }
 
-        if let Some(pkg) = &manifest.package {
-            if let Some(ns) = &pkg.name {
-                if let Some(first) = ns.split('/').next() {
-                    return Ok(first.to_string());
-                }
-            }
-        }
+        let manifest_raw = toml::to_string(&new_manifest)?;
 
-        if self.non_interactive {
-            // if not interactive we can't prompt the user to choose the owner of the app.
-            anyhow::bail!("No package namespace specified: use --namespace XXX");
-        }
-
-        let user = wasmer_api::query::current_user_with_namespaces(client, None).await?;
-        let owner =
-            crate::utils::prompts::prompt_for_namespace("Choose a namespace", None, Some(&user))?;
-
-        Ok(owner.clone())
-    }
-
-    async fn synthesize_tagger(
-        &self,
-        client: &WasmerClient,
-        ident: &PackageSpecifier,
-        package_release_id: &wasmer_api::types::Id,
-    ) -> anyhow::Result<PackageSpecifier> {
-        let mut new_ident = ident.clone();
-
-        if let Some(user_version) = &self.package_version {
-            match &mut new_ident {
-                PackageSpecifier::Hash { .. } => {
-                    match (&self.package_name, &self.package_namespace) {
-                        (Some(name), Some(namespace)) => {
-                            new_ident = PackageSpecifier::Named {
-                                namespace: namespace.clone(),
-                                name: name.clone(),
-                                tag: Tag::Version(user_version.clone()),
-                            }
-                        }
-                        _ => anyhow::bail!(
-                            "The flag `--version` was specified, but no namespace and name were given."
-                        ),
-                    }
-                }
-                PackageSpecifier::Named { tag, .. } => *tag = Tag::Version(user_version.clone()),
-            }
-        } else if let Some(user_namespace) = &self.package_namespace {
-            match &mut new_ident {
-                PackageSpecifier::Hash { hash, namespace } => match &self.package_name {
-                    Some(name) => {
-                        new_ident = PackageSpecifier::Named {
-                            namespace: user_namespace.clone(),
-                            name: name.clone(),
-                            tag: Tag::Hash(hash.clone()),
-                        }
-                    }
-                    _ => *namespace = user_namespace.clone(),
-                },
-                PackageSpecifier::Named { namespace, .. } => *namespace = user_namespace.clone(),
-            }
-        } else if let Some(user_name) = &self.package_name {
-            match &mut new_ident {
-                PackageSpecifier::Hash { .. } => {
-                    anyhow::bail!("The flag `--name` was specified, but no namespace was given.")
-                }
-                PackageSpecifier::Named { name, .. } => *name = user_name.clone(),
-            }
-        }
-
-        // At this point, we can resolve the version from the registry if any and if necessary bump
-        // the version.
-        if let PackageSpecifier::Named {
-            name,
-            namespace,
-            tag,
-        } = &mut new_ident
-        {
-            let full_pkg_name = format!("{namespace}/{name}");
-            let pb = make_spinner!(
-                self.quiet,
-                format!("Checking if a version of {full_pkg_name} already exists..")
-            );
-
-            if let Some(p) = wasmer_api::query::get_package_version(
-                client,
-                full_pkg_name.clone(),
-                String::from("latest"),
-            )
-            .await?
-            {
-                let registry_version = semver::Version::parse(&p.version)?;
-                spinner_ok!(
-                    pb,
-                    format!("Found version {registry_version} of package {full_pkg_name}")
-                );
-
-                tracing::info!(
-                    "Package to tag has id = {}, while latest version has id = {}",
-                    package_release_id.inner(),
-                    p.id.inner()
-                );
-
-                if let Tag::Hash(_) = &tag {
-                    *tag = Tag::Version(registry_version.clone());
-                }
-
-                let user_version: &mut semver::Version = match tag {
-                    Tag::Version(v) => v,
-                    Tag::Hash(_) => unreachable!(),
-                };
-
-                if user_version.clone() <= registry_version && (&p.id != package_release_id) {
-                    if self.bump {
-                        *user_version = registry_version.clone();
-                        user_version.patch = registry_version.patch + 1;
-                    } else if !self.non_interactive {
-                        let theme = ColorfulTheme::default();
-                        let mut new_version = registry_version.clone();
-                        new_version.patch += 1;
-                        if Confirm::with_theme(&theme).with_prompt(format!("Do you want to bump the package's version ({user_version} -> {new_version})?")).interact()? {
-                            *user_version = new_version.clone();
-                            // TODO: serialize new version?
-                       }
-                    }
-                }
-            } else {
-                spinner_ok!(pb, format!("No version of {full_pkg_name} in registry!"));
-                let version =
-                    prompt_for_package_version("Enter the package version", Some("0.1.0"))?;
-                *tag = Tag::Version(version);
-            }
-        }
-
-        Ok(new_ident)
+        tokio::fs::write(manifest_path, manifest_raw)
+            .await
+            .context("while trying to serialize the manifest")
     }
 
     async fn do_tag(
         &self,
         client: &WasmerClient,
-        ident: &PackageSpecifier,
+        id: &NamedPackageId,
         manifest: &Manifest,
         package_release_id: &wasmer_api::types::Id,
-    ) -> anyhow::Result<PackageSpecifier> {
+    ) -> anyhow::Result<()> {
         tracing::info!(
             "Tagging package with registry id {:?} and specifier {:?}",
             package_release_id,
-            ident
+            id
         );
-
-        let tagger = self
-            .synthesize_tagger(client, ident, package_release_id)
-            .await?;
 
         let pb = make_spinner!(self.quiet, "Tagging package...");
 
-        if let PackageSpecifier::Hash { .. } = &tagger {
-            spinner_ok!(pb, "Package is unnamed, no need to tag it");
-            return Ok(tagger);
-        }
-
-        let PackageSpecifier::Named {
-            namespace,
-            name,
-            tag,
-        } = tagger.clone()
-        else {
-            unreachable!()
-        };
-
-        if self.dry_run {
-            tracing::info!("No tagging to do here, dry-run is set");
-            spinner_ok!(pb, "Skipping tag (dry-run)");
-            return Ok(tagger);
-        }
-
+        let NamedPackageId { full_name, version } = id;
         let maybe_description = manifest
             .package
             .as_ref()
@@ -272,19 +129,14 @@ impl PackageTag {
             .and_then(|p| p.readme.clone())
             .map(|f| f.to_string_lossy().to_string());
         let maybe_repository = manifest.package.as_ref().and_then(|p| p.repository.clone());
-        let (version, full_name) = (
-            match &tag {
-                Tag::Version(v) => v.to_string(),
-                Tag::Hash(h) => h.to_string(),
-            },
-            format!("{namespace}/{name}"),
-        );
 
         let private = if let Some(pkg) = &manifest.package {
             Some(pkg.private)
         } else {
             Some(false)
         };
+
+        let version = version.to_string();
 
         let manifest_raw = toml::to_string(&manifest)?;
 
@@ -307,14 +159,8 @@ impl PackageTag {
         match r.await? {
             Some(r) => {
                 if r.success {
-                    spinner_ok!(
-                        pb,
-                        format!(
-                            "Successfully tagged package {}",
-                            Into::<PackageIdent>::into(tagger.clone())
-                        )
-                    );
-                    Ok(tagger)
+                    spinner_ok!(pb, format!("Successfully tagged package {id}",));
+                    Ok(())
                 } else {
                     spinner_err!(pb, "Could not tag package!");
                     anyhow::bail!("An unknown error occurred and the tagging failed.")
@@ -331,8 +177,12 @@ impl PackageTag {
         &self,
         client: &WasmerClient,
         hash: &PackageHash,
+        check_package_exists: bool,
     ) -> anyhow::Result<wasmer_api::types::Id> {
-        let pb = make_spinner!(self.quiet, "Checking if the package exists..");
+        let pb = make_spinner!(
+            self.quiet || check_package_exists,
+            "Checking if the package exists.."
+        );
 
         tracing::debug!("Searching for package with hash: {hash}");
 
@@ -385,28 +235,201 @@ impl PackageTag {
         Ok(pkg.id)
     }
 
+    fn get_name(&self, manifest: &Manifest, allow_unnamed: bool) -> anyhow::Result<Option<String>> {
+        if let Some(name) = &self.package_name {
+            return Ok(Some(name.clone()));
+        }
+
+        if let Some(pkg) = &manifest.package {
+            if let Some(ns) = &pkg.name {
+                if let Some(name) = ns.split('/').nth(1) {
+                    return Ok(Some(name.to_string()));
+                }
+            }
+        }
+
+        if allow_unnamed {
+            return Ok(None);
+        }
+
+        if self.non_interactive {
+            // if not interactive we can't prompt the user to choose the owner of the app.
+            anyhow::bail!("No package name specified: use --name <package_name>");
+        }
+
+        let default_name = std::env::current_dir().ok().and_then(|dir| {
+            dir.file_name()
+                .and_then(|f| f.to_str())
+                .map(|s| s.to_owned())
+        });
+
+        crate::utils::prompts::prompt_for_ident("Choose a package name", default_name.as_deref())
+            .map(|n| Some(n))
+    }
+
+    async fn get_namespace(
+        &self,
+        client: &WasmerClient,
+        manifest: &Manifest,
+    ) -> anyhow::Result<String> {
+        if let Some(namespace) = &self.package_namespace {
+            return Ok(namespace.clone());
+        }
+
+        if let Some(pkg) = &manifest.package {
+            if let Some(name) = &pkg.name {
+                if let Some(ns) = name.split('/').next() {
+                    return Ok(ns.to_string());
+                }
+            }
+        }
+
+        if self.non_interactive {
+            // if not interactive we can't prompt the user to choose the owner of the app.
+            anyhow::bail!("No package namespace specified: use --namespace <package_namespace>");
+        }
+
+        let user = wasmer_api::query::current_user_with_namespaces(client, None).await?;
+        crate::utils::prompts::prompt_for_namespace("Choose a namespace", None, Some(&user))
+    }
+
+    async fn get_version(
+        &self,
+        client: &WasmerClient,
+        manifest: &Manifest,
+        manifest_path: &Path,
+        full_pkg_name: &str,
+    ) -> anyhow::Result<semver::Version> {
+        if let Some(version) = &self.package_version {
+            // If a user specified a version, then they meant it.
+            return Ok(version.clone());
+        }
+
+        let user_version = if let Some(pkg) = &manifest.package {
+            pkg.version.clone()
+        } else {
+            None
+        };
+
+        let pb = make_spinner!(
+            self.quiet,
+            format!("Checking if a version of {full_pkg_name} already exists..")
+        );
+
+        if let Some(registry_version) = wasmer_api::query::get_package_version(
+            client,
+            full_pkg_name.to_string(),
+            String::from("latest"),
+        )
+        .await?
+        .map(|p| p.version)
+        .and_then(|v| semver::Version::from_str(&v).ok())
+        {
+            spinner_ok!(
+                pb,
+                format!("Found version {registry_version} of {full_pkg_name}")
+            );
+
+            let mut user_version = if let Some(v) = user_version {
+                v
+            } else {
+                registry_version.clone()
+            };
+
+            if user_version <= registry_version {
+                if self.bump {
+                    user_version = registry_version.clone();
+                    user_version.patch = registry_version.patch + 1;
+                } else if !self.non_interactive {
+                    let theme = ColorfulTheme::default();
+                    let mut new_version = registry_version.clone();
+                    new_version.patch += 1;
+                    if Confirm::with_theme(&theme)
+                        .with_prompt(format!("Do you want to bump the package's version ({user_version} -> {new_version})?"))
+                            .interact()? {
+                            user_version = new_version.clone();
+                            self.update_manifest_version(manifest_path, manifest, &user_version).await?;
+                       } else {
+                           eprintln!("{}: if version {user_version} of {full_pkg_name} already exists tagging will fail.", "WARN".bold().yellow());
+                       }
+                }
+            }
+
+            Ok(user_version)
+        } else {
+            pb.finish_and_clear();
+
+            match user_version {
+                Some(v) => Ok(v),
+                None => {
+                    if self.non_interactive {
+                        anyhow::bail!("No package name specified: use --version <package_version>")
+                    } else {
+                        let version = crate::utils::prompts::prompt_for_package_version(
+                            "Enter the package version",
+                            Some("0.1.0"),
+                        )?;
+
+                        self.update_manifest_version(manifest_path, manifest, &version)
+                            .await?;
+
+                        Ok(version)
+                    }
+                }
+            }
+        }
+    }
+
+    async fn synthesize_id(
+        &self,
+        client: &WasmerClient,
+        manifest: &Manifest,
+        manifest_path: &Path,
+        allow_unnamed: bool,
+    ) -> anyhow::Result<Option<NamedPackageId>> {
+        let name = match self.get_name(manifest, allow_unnamed)? {
+            Some(name) => name,
+            None => return Ok(None),
+        };
+
+        let namespace = self.get_namespace(client, manifest).await?;
+        let full_name = format!("{namespace}/{name}");
+        let version = self
+            .get_version(client, manifest, manifest_path, &full_name)
+            .await?;
+
+        Ok(Some(NamedPackageId { full_name, version }))
+    }
+
     pub async fn tag(
         &self,
         client: &WasmerClient,
         manifest: &Manifest,
+        manifest_path: &Path,
+        after_push: bool,
+        allow_unnamed: bool,
     ) -> anyhow::Result<PackageIdent> {
-        let namespace = self.get_namespace(client, manifest).await?;
-
-        let ident = into_specifier(manifest, &self.package_hash, namespace)?;
-        tracing::info!("PackageIdent extracted from manifest is {:?}", ident);
-
-        let package_id = self.get_package_id(client, &self.package_hash).await?;
+        let package_id = self
+            .get_package_id(client, &self.package_hash, after_push)
+            .await?;
         tracing::info!(
             "The package identifier returned from the registry is {:?}",
             package_id
         );
 
-        let ident = self
-            .do_tag(client, &ident, manifest, &package_id)
+        let id = match self
+            .synthesize_id(client, manifest, manifest_path, allow_unnamed)
+            .await?
+        {
+            Some(id) => id,
+            None => return Ok(PackageIdent::Hash(self.package_hash.clone())),
+        };
+
+        self.do_tag(client, &id, manifest, &package_id)
             .await
             .map_err(on_error)?;
 
-        Ok(ident.into())
+        Ok(PackageIdent::Named(id.into()))
     }
 }
 
@@ -423,7 +446,16 @@ impl AsyncCliCommand for PackageTag {
         let (manifest_path, manifest) = get_manifest(&self.package_path)?;
         tracing::info!("Got manifest at path {}", manifest_path.display());
 
-        self.tag(&client, &manifest).await?;
+        let id = self
+            .tag(&client, &manifest, &manifest_path, false, false)
+            .await?;
+
+        if !self.quiet {
+            eprintln!(
+                "You can now run your package with `{}`",
+                format!("{} run {id}", bin_name!()).bold()
+            );
+        }
 
         Ok(())
     }

--- a/lib/cli/src/utils/mod.rs
+++ b/lib/cli/src/utils/mod.rs
@@ -135,29 +135,7 @@ pub fn prompt_for_package_name(
     }
 }
 
-/// Ask a user for a package name.
-///
-/// Will continue looping until the user provides a valid name.
-pub fn prompt_for_package_version(
-    message: &str,
-    default: Option<&str>,
-) -> Result<semver::Version, anyhow::Error> {
-    loop {
-        let theme = ColorfulTheme::default();
-        let raw: String = dialoguer::Input::with_theme(&theme)
-            .with_prompt(message)
-            .with_initial_text(default.unwrap_or_default())
-            .interact_text()
-            .context("could not read user input")?;
 
-        match raw.parse::<semver::Version>() {
-            Ok(p) => break Ok(p),
-            Err(err) => {
-                eprintln!("invalid package version: {err}");
-            }
-        }
-    }
-}
 
 /// Defines how to check for a package.
 pub enum PackageCheckMode {

--- a/lib/cli/src/utils/mod.rs
+++ b/lib/cli/src/utils/mod.rs
@@ -135,8 +135,6 @@ pub fn prompt_for_package_name(
     }
 }
 
-
-
 /// Defines how to check for a package.
 pub enum PackageCheckMode {
     /// The package must exist in the registry.

--- a/lib/cli/src/utils/prompts.rs
+++ b/lib/cli/src/utils/prompts.rs
@@ -56,6 +56,30 @@ pub enum PackageCheckMode {
     MustNotExist,
 }
 
+/// Ask a user for a package version.
+///
+/// Will continue looping until the user provides a valid version.
+pub fn prompt_for_package_version(
+    message: &str,
+    default: Option<&str>,
+) -> Result<semver::Version, anyhow::Error> {
+    loop {
+        let theme = ColorfulTheme::default();
+        let raw: String = dialoguer::Input::with_theme(&theme)
+            .with_prompt(message)
+            .with_initial_text(default.unwrap_or_default())
+            .interact_text()
+            .context("could not read user input")?;
+
+        match raw.parse::<semver::Version>() {
+            Ok(p) => break Ok(p),
+            Err(err) => {
+                eprintln!("invalid package version: {err}");
+            }
+        }
+    }
+}
+
 /// Ask for a package name.
 ///
 /// Will continue looping until the user provides a valid name.


### PR DESCRIPTION
This PR solves the issues pointed out in #4656. Mainly, it cleaned up some of the code, fixed a couple edge cases regarding deployment, and fixed the behaviour concerning the serialisation of `version`, `name` and `namespace` when tagging a package and `app_id` when deploying an app. 