### PR TITLE
feat(cli): Better final messages for `push`, `tag` and `publish`

### DIFF
--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use wasmer_api::WasmerClient;
-use wasmer_config::package::{Manifest, PackageHash};
+use wasmer_config::package::{Manifest, NamedPackageIdent, PackageHash};
 use webc::wasmer_package::Package;
 
 pub mod macros;
@@ -206,4 +206,21 @@ pub(super) async fn login_user(
     }
 
     api.client()
+}
+
+pub(super) fn make_package_url(client: &WasmerClient, pkg: &NamedPackageIdent) -> String {
+    let host = client.graphql_endpoint().domain().unwrap_or("wasmer.io");
+
+    // Our special cases..
+    let host = match host {
+        _ if host.contains("wasmer.wtf") => "wasmer.wtf",
+        _ if host.contains("wasmer.io") => "wasmer.io",
+        _ => host,
+    };
+
+    format!(
+        "https://{host}/{}@{}",
+        pkg.full_name(),
+        pkg.version_or_default().to_string().replace('=', "")
+    )
 }

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -150,10 +150,7 @@ impl AsyncCliCommand for PackagePublish {
         match ident {
             PackageIdent::Named(ref n) => {
                 let url = make_package_url(&client, n);
-                eprintln!(
-                    "{} Package URL: {url}",
-                    "𖥔".yellow().bold()
-                );
+                eprintln!("{} Package URL: {url}", "𖥔".yellow().bold());
             }
             PackageIdent::Hash(ref h) => {
                 eprintln!("{} Succesfully published package ({h})", "✔".green().bold());

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -149,23 +149,14 @@ impl AsyncCliCommand for PackagePublish {
 
         match ident {
             PackageIdent::Named(ref n) => {
-                let host = client.graphql_endpoint().domain().unwrap_or("wasmer.io");
-
-                // Our special cases..
-                let host = match host {
-                    _ if host.contains("wasmer.wtf") => "wasmer.wtf",
-                    _ if host.contains("wasmer.io") => "wasmer.io",
-                    _ => host,
-                };
-
+                let url = make_package_url(&client, n);
                 eprintln!(
-                    "{} Check out the package's page at {}",
-                    "𖥔".green().bold(),
-                    format!("https://{host}/{}", n.build_identifier()).bold()
+                    "{} Check out the package's page at {url}",
+                    "𖥔".yellow().bold()
                 );
             }
             PackageIdent::Hash(ref h) => {
-                eprintln!("{} Succesfully published package {h}", "𖥔".green().bold(),);
+                eprintln!("{} Succesfully published package ({h})", "✔".green().bold());
             }
         }
 

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -1,7 +1,7 @@
 use crate::{
     commands::{
         package::{
-            common::{macros::*, wait::*, *},
+            common::{wait::*, *},
             push::PackagePush,
             tag::PackageTag,
         },
@@ -147,12 +147,26 @@ impl AsyncCliCommand for PackagePublish {
             .publish(&client, &manifest_path, &manifest, false)
             .await?;
 
-        if !self.quiet && !self.non_interactive {
-            eprintln!(
-                "{} You can now run your package with {}",
-                "𖥔".green().bold(),
-                format!("`{} run {ident}`", bin_name!()).bold()
-            );
+        match ident {
+            PackageIdent::Named(ref n) => {
+                let host = client.graphql_endpoint().domain().unwrap_or("wasmer.io");
+
+                // Our special cases..
+                let host = match host {
+                    _ if host.contains("wasmer.wtf") => "wasmer.wtf",
+                    _ if host.contains("wasmer.io") => "wasmer.io",
+                    _ => host,
+                };
+
+                eprintln!(
+                    "{} Check out the package's page at {}",
+                    "𖥔".green().bold(),
+                    format!("https://{host}/{}", n.build_identifier()).bold()
+                );
+            }
+            PackageIdent::Hash(ref h) => {
+                eprintln!("{} Succesfully published package {h}", "𖥔".green().bold(),);
+            }
         }
 
         Ok(ident)

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -151,7 +151,7 @@ impl AsyncCliCommand for PackagePublish {
             PackageIdent::Named(ref n) => {
                 let url = make_package_url(&client, n);
                 eprintln!(
-                    "{} Check out the package's page at {url}",
+                    "{} Package URL: {url}",
                     "𖥔".yellow().bold()
                 );
             }

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -234,7 +234,7 @@ impl AsyncCliCommand for PackagePush {
 
                 eprintln!(
                     "{} You can now tag your package with `{}`",
-                    "✔".green().bold(),
+                    "𖥔".yellow().bold(),
                     format!(
                         "{bin_name} package tag {}{}",
                         hash,
@@ -247,10 +247,10 @@ impl AsyncCliCommand for PackagePush {
                     .bold()
                 )
             } else {
-                eprintln!("{} Succesfully pushed package {hash}", "✔".green().bold(),);
+                eprintln!("{} Succesfully pushed package ({hash})", "✔".green().bold());
             }
         } else {
-            eprintln!("{} Succesfully pushed package {hash}", "✔".green().bold(),);
+            eprintln!("{} Succesfully pushed package ({hash})", "✔".green().bold());
         }
 
         Ok(())

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -226,38 +226,31 @@ impl AsyncCliCommand for PackagePush {
 
         let (_, hash) = self.push(&client, &manifest, &manifest_path).await?;
 
-        if !self.quiet {
-            let bin_name = bin_name!();
-            if let Some(package) = &manifest.package {
-                if package.name.is_some() {
-                    let mut manifest_path_dir = manifest_path.clone();
-                    manifest_path_dir.pop();
+        let bin_name = bin_name!();
+        if let Some(package) = &manifest.package {
+            if package.name.is_some() {
+                let mut manifest_path_dir = manifest_path.clone();
+                manifest_path_dir.pop();
 
-                    eprintln!(
-                        "You can now tag your package with `{}`",
-                        format!(
-                            "{bin_name} package tag {}{}",
-                            hash,
-                            if manifest_path_dir.canonicalize()? == std::env::current_dir()? {
-                                String::new()
-                            } else {
-                                format!(" {}", manifest_path_dir.display())
-                            }
-                        )
-                        .bold()
-                    )
-                } else {
-                    eprintln!(
-                        "You can now run your package with `{}`",
-                        format!("{bin_name} run {}", hash).bold()
-                    );
-                }
-            } else {
                 eprintln!(
-                    "You can now run your package with `{}`",
-                    format!("{bin_name} run {}", hash).bold()
-                );
+                    "{} You can now tag your package with `{}`",
+                    "✔".green().bold(),
+                    format!(
+                        "{bin_name} package tag {}{}",
+                        hash,
+                        if manifest_path_dir.canonicalize()? == std::env::current_dir()? {
+                            String::new()
+                        } else {
+                            format!(" {}", manifest_path_dir.display())
+                        }
+                    )
+                    .bold()
+                )
+            } else {
+                eprintln!("{} Succesfully pushed package {hash}", "✔".green().bold(),);
             }
+        } else {
+            eprintln!("{} Succesfully pushed package {hash}", "✔".green().bold(),);
         }
 
         Ok(())

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -490,11 +490,17 @@ impl AsyncCliCommand for PackageTag {
             .tag(&client, &manifest, &manifest_path, false, false)
             .await?;
 
-        if !self.quiet {
-            eprintln!(
-                "You can now run your package with `{}`",
-                format!("{} run {id}", bin_name!()).bold()
-            );
+        match id {
+            PackageIdent::Named(ref n) => {
+                eprintln!(
+                    "{} Check out the package's page at {}",
+                    "✔".green().bold(),
+                    format!("https://wasmer.io/{}", n.build_identifier()).bold()
+                );
+            }
+            PackageIdent::Hash(ref h) => {
+                eprintln!("{} Succesfully tagget package {h}", "✔".green().bold(),);
+            }
         }
 
         Ok(())

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -492,14 +492,11 @@ impl AsyncCliCommand for PackageTag {
 
         match id {
             PackageIdent::Named(ref n) => {
-                eprintln!(
-                    "{} Check out the package's page at {}",
-                    "✔".green().bold(),
-                    format!("https://wasmer.io/{}", n.build_identifier()).bold()
-                );
+                let url = make_package_url(&client, n);
+                eprintln!("{} Package URL: {url}", "𖥔".yellow().bold());
             }
             PackageIdent::Hash(ref h) => {
-                eprintln!("{} Succesfully tagget package {h}", "✔".green().bold(),);
+                eprintln!("{} Succesfully tagged package ({h})", "✔".green().bold());
             }
         }
 


### PR DESCRIPTION
This small PR edits the final messages shown to the user for the above-mentioned commands.
Resolves #4663.