### PR TITLE
V4.3.0 post release

### DIFF
--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -31,7 +31,7 @@ hex = { version = "^0.4" }
 # `rand` uses `getrandom` transitively, and to be able to
 # compile the project for `js`, we need to enable this feature
 [dependencies.getrandom]
-version = "*"
+version = "0.2.15"
 features = ["js"]
 
 [dev-dependencies]

--- a/tests/lib/wast/Cargo.toml
+++ b/tests/lib/wast/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-types = { path = "../../../lib/types" }
+wasmer-types = { path = "../../../lib/types", version="=4.3.0" }
 wasmer-wasix = { path = "../../../lib/wasix", version="=0.20.0" }
 wasmer = { path = "../../../lib/api", version = "=4.3.0", default-features = false }
 virtual-fs = { path = "../../../lib/virtual-fs", version = "0.11.4" }


### PR DESCRIPTION
This PR contains fixes that were necessary to do the publish.
- First fix is for a star dependency which crates.io does not allow.
- Second fix is already being tracked by #4657.