### PR TITLE
Calculate the duration when timeout is absolute

### DIFF
--- a/lib/wasix/src/syscalls/wasi/clock_time_get.rs
+++ b/lib/wasix/src/syscalls/wasi/clock_time_get.rs
@@ -12,6 +12,7 @@ use crate::syscalls::*;
 /// - `Timestamp *time`
 ///     The value of the clock in nanoseconds
 //#[instrument(level = "trace", skip_all, fields(?clock_id, %precision), ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn clock_time_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     clock_id: Snapshot0Clockid,

--- a/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
+++ b/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use wasmer_wasix_types::wasi::{SubscriptionClock, Userdata};
+use wasmer_wasix_types::wasi::{Subclockflags, SubscriptionClock, Userdata};
 
 use super::*;
 use crate::{
@@ -299,7 +299,24 @@ where
                         time_to_sleep = Duration::ZERO;
                         clock_subs.push((clock_info, s.userdata));
                     } else {
-                        time_to_sleep = Duration::from_nanos(clock_info.timeout);
+                        // if the timeout is specified as an absolute time in the future,
+                        // we should calculate the duration we need to sleep
+                        time_to_sleep = if clock_info
+                            .flags
+                            .contains(Subclockflags::SUBSCRIPTION_CLOCK_ABSTIME)
+                        {
+                            let now = wasi_try_ok!(platform_clock_time_get(
+                                Snapshot0Clockid::Monotonic,
+                                1
+                            )) as u64;
+
+                            Duration::from_nanos(clock_info.timeout)
+                                - Duration::from_nanos(now as u64)
+                        } else {
+                            // if the timeout is not absolute, just use it as duration
+                            Duration::from_nanos(clock_info.timeout)
+                        };
+
                         clock_subs.push((clock_info, s.userdata));
                     }
                     continue;


### PR DESCRIPTION
This PR fixes the issue when calling `clock_nanosleep` with an absolute time via the `SUBSCRIPTION_CLOCK_ABSTIME` flag. Previously the flag was ignored and the timeout passed to this function was mistakenly treated as a duration where it was in fact an absolute time in the future.

Resolves #4671 and #4680.