### PR TITLE
Add subcommands to generate shell completions and manual pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +634,16 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "cloudabi"
@@ -4034,6 +4053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
+
+[[package]]
 name = "rpassword"
 version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6470,6 +6495,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "colored 2.1.0",
  "comfy-table",
  "dialoguer",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -169,7 +169,7 @@ bytesize = "1.0"
 cfg-if = "1.0"
 tempfile = "3.6.0"
 serde = { version = "1.0.147", features = ["derive"] }
-dirs = { version = "4.0" }
+dirs = "4.0"
 serde_json = { version = "1.0" }
 target-lexicon = { version = "0.12", features = ["std"] }
 wasmer-config = { version = "0.2.0", path = "../config" }

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -227,6 +227,9 @@ tokio-tungstenite = { version = "0.20.1", features = [
 mac_address = { version = "1.1.5", optional = true }
 tun-tap = { version = "0.1.3", features = ["tokio"], optional = true }
 
+clap_complete = "4.5.2"
+clap_mangen = "0.2.20"
+
 # NOTE: Must use different features for clap because the "color" feature does not
 # work on wasi due to the anstream dependency not compiling.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/lib/cli/src/commands/app/delete.rs
+++ b/lib/cli/src/commands/app/delete.rs
@@ -6,7 +6,7 @@ use is_terminal::IsTerminal;
 use super::util::AppIdentOpts;
 use crate::{commands::AsyncCliCommand, opts::ApiOpts};
 
-/// Show an app.
+/// Delete an existing Edge app
 #[derive(clap::Parser, Debug)]
 pub struct CmdAppDelete {
     #[clap(flatten)]

--- a/lib/cli/src/commands/app/get.rs
+++ b/lib/cli/src/commands/app/get.rs
@@ -8,7 +8,7 @@ use crate::{
     opts::{ApiOpts, ItemFormatOpts},
 };
 
-/// Show an app.
+/// Retrieve detailed informations about an app
 #[derive(clap::Parser, Debug)]
 pub struct CmdAppGet {
     #[clap(flatten)]

--- a/lib/cli/src/commands/app/list.rs
+++ b/lib/cli/src/commands/app/list.rs
@@ -10,7 +10,7 @@ use crate::{
     opts::{ApiOpts, ListFormatOpts},
 };
 
-/// List apps.
+/// List apps belonging to a namespace
 #[derive(clap::Parser, Debug)]
 pub struct CmdAppList {
     #[clap(flatten)]

--- a/lib/cli/src/commands/app/logs.rs
+++ b/lib/cli/src/commands/app/logs.rs
@@ -17,7 +17,7 @@ pub enum LogStreamArg {
     Stderr,
 }
 
-/// Show an app.
+/// Retrieve the logs of an app
 #[derive(clap::Parser, Debug)]
 pub struct CmdAppLogs {
     #[clap(flatten)]

--- a/lib/cli/src/commands/gen_completions.rs
+++ b/lib/cli/src/commands/gen_completions.rs
@@ -1,0 +1,34 @@
+use super::WasmerCmd;
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+use std::fs::OpenOptions;
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct CmdGenCompletions {
+    /// The shell to generate the autocompletions script for.
+    pub shell: Shell,
+
+    /// Where to store the generated file(s) to. Defaults to stdout.
+    #[clap(long)]
+    pub out: Option<String>,
+}
+
+impl CmdGenCompletions {
+    pub fn execute(&self) -> anyhow::Result<()> {
+        let mut cmd = WasmerCmd::command();
+
+        let name = cmd.get_name().to_string();
+        if let Some(out) = &self.out {
+            let mut f = OpenOptions::new()
+                .truncate(true)
+                .create(true)
+                .write(true)
+                .open(out)?;
+            generate(self.shell, &mut cmd, name, &mut f);
+            Ok(())
+        } else {
+            generate(self.shell, &mut cmd, name, &mut std::io::stdout());
+            Ok(())
+        }
+    }
+}

--- a/lib/cli/src/commands/gen_manpage.rs
+++ b/lib/cli/src/commands/gen_manpage.rs
@@ -2,22 +2,25 @@ use super::WasmerCmd;
 use anyhow::Context;
 use clap::CommandFactory;
 use clap_mangen::generate_to;
+use std::path::PathBuf;
+
+lazy_static::lazy_static! {
+    static ref DEFAULT_MAN_DIR_PATH: PathBuf = dirs::data_dir().unwrap_or_default().join("man");
+}
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct CmdGenManPage {
     /// Where to store the generated file(s) to.
-    #[clap(long)]
-    pub out: Option<String>,
+    #[clap(long, default_value = DEFAULT_MAN_DIR_PATH.as_os_str())]
+    pub out: PathBuf,
 }
 
 impl CmdGenManPage {
     pub fn execute(&self) -> anyhow::Result<()> {
         let cmd = WasmerCmd::command();
-        let outpath = if let Some(out) = &self.out {
-            out.clone()
-        } else {
-            "~/.local/share/man".to_string()
-        };
-        generate_to(cmd, &outpath).context(format!("While generating the man page(s) to {outpath}"))
+        generate_to(cmd, &self.out).context(format!(
+            "While generating the man page(s) to {}",
+            self.out.display()
+        ))
     }
 }

--- a/lib/cli/src/commands/gen_manpage.rs
+++ b/lib/cli/src/commands/gen_manpage.rs
@@ -1,0 +1,23 @@
+use super::WasmerCmd;
+use anyhow::Context;
+use clap::CommandFactory;
+use clap_mangen::generate_to;
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct CmdGenManPage {
+    /// Where to store the generated file(s) to.
+    #[clap(long)]
+    pub out: Option<String>,
+}
+
+impl CmdGenManPage {
+    pub fn execute(&self) -> anyhow::Result<()> {
+        let cmd = WasmerCmd::command();
+        let outpath = if let Some(out) = &self.out {
+            out.clone()
+        } else {
+            "~/.local/share/man".to_string()
+        };
+        generate_to(cmd, &outpath).context(format!("While generating the man page(s) to {outpath}"))
+    }
+}

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -16,6 +16,8 @@ mod create_obj;
 pub(crate) mod domain;
 #[cfg(feature = "static-artifact-create")]
 mod gen_c_header;
+mod gen_completions;
+mod gen_manpage;
 mod init;
 mod inspect;
 #[cfg(feature = "journal")]
@@ -115,6 +117,8 @@ impl WasmerCmd {
         }
 
         match cmd {
+            Some(Cmd::GenManPage(cmd)) => cmd.execute(),
+            Some(Cmd::GenCompletions(cmd)) => cmd.execute(),
             Some(Cmd::Run(options)) => options.execute(output),
             Some(Cmd::SelfUpdate(options)) => options.execute(),
             Some(Cmd::Cache(cache)) => cache.execute(),
@@ -220,7 +224,7 @@ enum Cmd {
     #[clap(name = "publish")]
     Publish(crate::commands::package::publish::PackagePublish),
 
-    /// Wasmer cache
+    /// Manage the local Wasmer cache
     Cache(Cache),
 
     /// Validate a WebAssembly binary
@@ -363,6 +367,14 @@ enum Cmd {
     /// Manage DNS records
     #[clap(subcommand, alias = "domains")]
     Domain(crate::commands::domain::CmdDomain),
+
+    /// Generate autocompletion for different shells
+    #[clap(name = "gen-completions")]
+    GenCompletions(crate::commands::gen_completions::CmdGenCompletions),
+
+    /// Generate man pages
+    #[clap(name = "gen-man")]
+    GenManPage(crate::commands::gen_manpage::CmdGenManPage),
 }
 
 fn is_binfmt_interpreter() -> bool {

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -373,7 +373,7 @@ enum Cmd {
     GenCompletions(crate::commands::gen_completions::CmdGenCompletions),
 
     /// Generate man pages
-    #[clap(name = "gen-man")]
+    #[clap(name = "gen-man", hide = true)]
     GenManPage(crate::commands::gen_manpage::CmdGenManPage),
 }
 

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -97,7 +97,6 @@ impl PackagePublish {
                 quiet: self.quiet,
                 package_namespace: self.package_namespace.clone(),
                 timeout: self.timeout,
-                bump: self.bump,
                 non_interactive: self.non_interactive,
                 wait: self.wait,
                 package_path: self.package_path.clone(),

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -41,10 +41,6 @@ pub struct PackagePush {
     #[clap(long, default_value = "5m")]
     pub timeout: humantime::Duration,
 
-    /// Whether or not the patch field of the version of the package - if any - should be bumped.
-    #[clap(long, conflicts_with = "version")]
-    pub bump: bool,
-
     /// Do not prompt for user input.
     #[clap(long, default_value_t = !std::io::stdin().is_terminal())]
     pub non_interactive: bool,

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -79,7 +79,7 @@ pub struct Run {
     #[clap(short, long, aliases = &["command", "invoke", "command-name"])]
     entrypoint: Option<String>,
     /// Generate a coredump at this path if a WebAssembly trap occurs
-    #[clap(name = "COREDUMP PATH", long)]
+    #[clap(name = "COREDUMP_PATH", long)]
     coredump_on_trap: Option<PathBuf>,
     /// The file, URL, or package to run.
     #[clap(value_parser = PackageSource::infer)]


### PR DESCRIPTION
This PR adds two new subcommands: `gen-completions` and `gen-man`. The former takes an argument that specifies the shell to generate completions for, while the latter takes an optional argument to specify the directory to generate the man pages to. Resolves #4678 and #4677.

<img width="1438" alt="image" src="https://github.com/wasmerio/wasmer/assets/48774736/ff5b4224-6aba-4d60-af0e-ac6231e5fda4">
<img width="1018" alt="image" src="https://github.com/wasmerio/wasmer/assets/48774736/a77aecbe-0745-4b18-a105-bffbcf59cf8a">

As part of this effort, it also changes some doc comments and removes an unused flag in the `push` subcommand.
