### PR TITLE
Fix offset in append mode

### DIFF
--- a/lib/wasix/src/syscalls/wasi/fd_seek.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_seek.rs
@@ -62,6 +62,9 @@ pub(crate) fn fd_seek_internal(
     if !fd_entry.rights.contains(Rights::FD_SEEK) {
         return Ok(Err(Errno::Access));
     }
+    if fd_entry.flags.contains(Fdflags::APPEND) {
+        return Ok(Ok(fd_entry.offset.load(Ordering::Acquire)));
+    }
 
     // TODO: handle case if fd is a dir?
     let new_offset = match whence {

--- a/tests/wasi-fyi/fs_seek_append_mode.rs
+++ b/tests/wasi-fyi/fs_seek_append_mode.rs
@@ -1,0 +1,24 @@
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::io::SeekFrom;
+
+fn main() {
+    let mut file = OpenOptions::new()
+        .append(true)
+        .read(true)
+        .create(true)
+        .open("file")
+        .unwrap();
+
+    // file offset must be 1 now
+    write!(file, "{}", "a").unwrap();
+
+    // rewind should not work on file in append mode
+    // since the offset must always be at the end of the file
+    let _ = file.rewind();
+
+    // file offset must be 2 now
+    write!(file, "{}", "b").unwrap();
+
+    assert_eq!(file.seek(SeekFrom::Current(0)).unwrap(), 2);
+}


### PR DESCRIPTION
This PR prevents a seek from changing the offset on a file when opened in append mode since the file offset must always point to the end of the file.

Resolves #4469 and #4681.