### PR TITLE
redirect to child node in a different fs

### DIFF
--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -739,7 +739,11 @@ impl FileSystemInner {
                             Some(Err(FsError::DirectoryNotEmpty))
                         }
                     }
-
+                    Node::ArcDirectory(ArcDirectoryNode { name, fs, path, .. })
+                        if name.as_os_str() == name_of_directory =>
+                    {
+                        Some(Ok((0, InodeResolution::Redirect(fs.clone(), path.clone()))))
+                    }
                     _ => None,
                 })
                 .ok_or(FsError::InvalidInput)

--- a/tests/wasi-fyi/fs_remove_dir_all.rs
+++ b/tests/wasi-fyi/fs_remove_dir_all.rs
@@ -2,5 +2,14 @@ use std::fs;
 
 fn main() {
     assert!(fs::create_dir_all("/fyi/foo/bar").is_ok());
+    assert!(fs::create_dir_all("/fyi/foo/baz").is_ok());
+    assert_eq!(
+        fs::read_dir("/fyi/foo")
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect::<Vec<_>>(),
+        vec!["bar", "baz"]
+    );
     assert!(fs::remove_dir_all("/fyi/foo").is_ok());
+    assert!(fs::read_dir("/fyi/foo").is_err());
 }

--- a/tests/wasi-fyi/fs_remove_dir_all.rs
+++ b/tests/wasi-fyi/fs_remove_dir_all.rs
@@ -1,0 +1,6 @@
+use std::fs;
+
+fn main() {
+    assert!(fs::create_dir_all("/fyi/foo/bar").is_ok());
+    assert!(fs::remove_dir_all("/fyi/foo").is_ok());
+}


### PR DESCRIPTION
This PR adds the missing logic in `mem_fs` for redirecting when resolving a child node that resides in a different fs.

Resolves #3575.