### PR TITLE
`wasmer app logs`: support app IDs, improve output format

### DIFF
--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -884,7 +884,7 @@ fn get_app_logs(
                     .run_graphql(types::GetDeployAppLogs::build(variables.clone()))
                     .await?
                     .get_deploy_app_version
-                    .context("unknown package version")?;
+                    .context("app version not found")?;
 
                 let page: Vec<_> = deploy_app_version
                     .logs

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -817,7 +817,7 @@ mod queries {
         pub token: String,
     }
 
-    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    #[derive(cynic::Enum, Clone, Copy, Debug, PartialEq)]
     pub enum LogStream {
         Stdout,
         Stderr,
@@ -871,6 +871,7 @@ mod queries {
         pub message: String,
         /// When the message was recorded, in nanoseconds since the Unix epoch.
         pub timestamp: f64,
+        pub stream: Option<LogStream>,
     }
 
     #[derive(cynic::QueryVariables, Debug)]

--- a/lib/cli/src/commands/app/logs.rs
+++ b/lib/cli/src/commands/app/logs.rs
@@ -1,6 +1,7 @@
 //! Show logs for an Edge app.
 
-use comfy_table::Table;
+use colored::Colorize;
+use comfy_table::{Cell, Table};
 use edge_schema::pretty_duration::parse_timestamp_or_relative_time;
 use futures::StreamExt;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -8,8 +9,10 @@ use wasmer_api::types::{Log, LogStream};
 
 use crate::{
     opts::{ApiOpts, ListFormatOpts},
-    utils::{render::CliRender, Identifier},
+    utils::render::CliRender,
 };
+
+use super::util::AppIdentOpts;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, clap::ValueEnum)]
 pub enum LogStreamArg {
@@ -58,17 +61,13 @@ pub struct CmdAppLogs {
     #[clap(long, default_value = "false")]
     watch: bool,
 
-    /// The name of the app.
-    ///
-    /// Eg:
-    /// - name (assumes current user)
-    /// - namespace/name
-    /// - namespace/name@version
-    ident: Identifier,
-
     /// Streams of logs to display
     #[clap(long, value_delimiter = ',', value_enum)]
     streams: Option<Vec<LogStreamArg>>,
+
+    #[clap(flatten)]
+    #[allow(missing_docs)]
+    pub ident: AppIdentOpts,
 }
 
 #[async_trait::async_trait]
@@ -78,28 +77,16 @@ impl crate::commands::AsyncCliCommand for CmdAppLogs {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.api.client()?;
 
-        let Identifier {
-            name,
-            owner,
-            version,
-        } = &self.ident;
-
-        let owner = match owner {
-            Some(owner) => owner.to_string(),
-            None => {
-                let user = wasmer_api::query::current_user_with_namespaces(&client, None).await?;
-                user.username
-            }
-        };
+        let (_ident, app) = self.ident.load_app(&client).await?;
 
         let from = self
             .from
             .unwrap_or_else(|| OffsetDateTime::now_utc() - time::Duration::minutes(10));
 
         tracing::info!(
-            package.name=%self.ident.name,
-            package.owner=%owner,
-            package.version=self.ident.version.as_deref(),
+            app.name=%app.name,
+            app.owner=%app.owner.global_name,
+            app.version=app.active_version.version,
             range.start=%from,
             range.end=self.until.map(|ts| ts.to_string()),
             "Fetching logs",
@@ -131,9 +118,9 @@ impl crate::commands::AsyncCliCommand for CmdAppLogs {
 
         let logs_stream = wasmer_api::query::get_app_logs_paginated(
             &client,
-            name.clone(),
-            owner.to_string(),
-            version.clone(),
+            app.name.clone(),
+            app.owner.global_name.to_string(),
+            None, // keep version None since we want logs from all versions atm
             from,
             self.until,
             self.watch,
@@ -171,8 +158,10 @@ impl crate::commands::AsyncCliCommand for CmdAppLogs {
 impl CliRender for Log {
     fn render_item_table(&self) -> String {
         let mut table = Table::new();
-
-        let Log { message, timestamp } = self;
+        // remove all borders from the table
+        let Log {
+            message, timestamp, ..
+        }: &Log = self;
 
         table.add_rows([
             vec![
@@ -186,12 +175,26 @@ impl CliRender for Log {
 
     fn render_list_table(items: &[Self]) -> String {
         let mut table = Table::new();
-        table.set_header(vec!["Timestamp".to_string(), "Message".to_string()]);
+        // table.set_header(vec!["Timestamp".to_string(), "Message".to_string()]);
+        table.load_preset(comfy_table::presets::NOTHING);
+        table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
 
         for item in items {
+            let mut message = item.message.clone().bold();
+            if let Some(stream) = item.stream {
+                message = match stream {
+                    LogStream::Stdout => message,
+                    LogStream::Stderr => message.yellow(),
+                    LogStream::Runtime => message.cyan(),
+                };
+            }
             table.add_row([
-                datetime_from_unix(item.timestamp).format(&Rfc3339).unwrap(),
-                item.message.clone(),
+                Cell::new(format!(
+                    "[{}]",
+                    datetime_from_unix(item.timestamp).format(&Rfc3339).unwrap()
+                ))
+                .set_alignment(comfy_table::CellAlignment::Right),
+                Cell::new(message),
             ]);
         }
         table.to_string()


### PR DESCRIPTION
Using the `AppIdentOpts` instead of `Identifier`, the `logs`
subcommand can now fetch get a `DeployApp` instance from an ID, or a
name or an alias.

Misc: this commit also cleans up the formatting a little bit.