### PR TITLE
Remove `clock_time_get` instrumentation

### DIFF
--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -165,6 +165,7 @@ sys-default = [
     "ctrlc"
 ]
 sys-poll = []
+extra-logging = []
 sys-thread = ["tokio/rt", "tokio/time", "tokio/rt-multi-thread", "rusty_pool"]
 journal = ["tokio/fs", "wasmer-journal/log-file"]
 

--- a/lib/wasix/src/syscalls/wasi/clock_time_get.rs
+++ b/lib/wasix/src/syscalls/wasi/clock_time_get.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::syscalls::*;
 
+// NOTE: This syscall is not instrumented since it will be logged too much,
+// hence introducing too much noise to the logs.
+
 /// ### `clock_time_get()`
 /// Get the time of the specified clock
 /// Inputs:
@@ -11,8 +14,6 @@ use crate::syscalls::*;
 /// Output:
 /// - `Timestamp *time`
 ///     The value of the clock in nanoseconds
-//#[instrument(level = "trace", skip_all, fields(?clock_id, %precision), ret)]
-#[instrument(level = "trace", skip_all, ret)]
 pub fn clock_time_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     clock_id: Snapshot0Clockid,

--- a/lib/wasix/src/syscalls/wasi/clock_time_get.rs
+++ b/lib/wasix/src/syscalls/wasi/clock_time_get.rs
@@ -14,6 +14,10 @@ use crate::syscalls::*;
 /// Output:
 /// - `Timestamp *time`
 ///     The value of the clock in nanoseconds
+#[cfg_attr(
+    feature = "extra-logging",
+    tracing::instrument(level = "trace", skip_all, ret)
+)]
 pub fn clock_time_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     clock_id: Snapshot0Clockid,


### PR DESCRIPTION
This PR reverts the instrumentation added to `clock_time_get` since it proved to add too much noise to the logs. Also, it adds an explanation as to why this syscall does not have an instrumentation.

Although it may help debugging some scenarios, especially in case of clock related bugs (see #4682), it makes debugging other scenarios more difficult since it clutters the logs.