### PR TITLE
Remove owner and spurious informations from templates

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -455,15 +455,14 @@ impl CmdAppCreate {
         if app_yaml_path.exists() && app_yaml_path.is_file() {
             let contents = tokio::fs::read_to_string(&app_yaml_path).await?;
             let mut raw_yaml: serde_yaml::Value = serde_yaml::from_str(&contents)?;
-            match &mut raw_yaml {
-                serde_yaml::Value::Mapping(m) => {
-                    m.insert("name".into(), app_name.into());
-                    m.insert("owner".into(), owner.into());
-                    m.shift_remove("domains");
-                    m.shift_remove("app_id");
-                }
-                _ => {}
+
+            if let serde_yaml::Value::Mapping(m) = &mut raw_yaml {
+                m.insert("name".into(), app_name.into());
+                m.insert("owner".into(), owner.into());
+                m.shift_remove("domains");
+                m.shift_remove("app_id");
             };
+
             let raw_app = serde_yaml::to_string(&raw_yaml)?;
 
             // Validate..

--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -454,10 +454,21 @@ impl CmdAppCreate {
 
         if app_yaml_path.exists() && app_yaml_path.is_file() {
             let contents = tokio::fs::read_to_string(&app_yaml_path).await?;
-            let contents = format!("{contents}\nname: {app_name}");
-            let mut app_config = AppConfigV1::parse_yaml(&contents)?;
-            app_config.owner = Some(owner.to_string());
-            let raw_app = serde_yaml::to_string(&app_config)?;
+            let mut raw_yaml: serde_yaml::Value = serde_yaml::from_str(&contents)?;
+            match &mut raw_yaml {
+                serde_yaml::Value::Mapping(m) => {
+                    m.insert("name".into(), app_name.into());
+                    m.insert("owner".into(), owner.into());
+                    m.shift_remove("domains");
+                    m.shift_remove("app_id");
+                }
+                _ => {}
+            };
+            let raw_app = serde_yaml::to_string(&raw_yaml)?;
+
+            // Validate..
+            AppConfigV1::parse_yaml(&raw_app)?;
+
             tokio::fs::write(&app_yaml_path, raw_app).await?;
         }
 


### PR DESCRIPTION
If a template has an `app.yaml` that contains values for app name, owner, app_id and domain, remove them and substitute usable ones with user-provided values.