### PR TITLE
Disable windows in Unit-test packages job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -657,7 +657,7 @@ jobs:
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
-        if: "! (matrix.metadata.build == 'windows-x64' && matrix.stage.description == 'Run wast test suite for all compilers')"
+        if: ${{ ! (matrix.metadata.build == 'windows-x64' && matrix.stage.description == 'Run wast test suite for all compilers') }}
         run: make ${{ matrix.stage.make }}
         env:
           TARGET: ${{ matrix.metadata.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -657,7 +657,7 @@ jobs:
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
-        if: ${{ ! matrix.metadata.build == 'windows-x64' || ! matrix.stage.description == 'Run wast test suite for all compilers' }}
+        if: ${{ !((matrix.metadata.build == 'windows-x64') && (matrix.stage.description == 'Run wast test suite for all compilers')) }}
         run: make ${{ matrix.stage.make }}
         env:
           TARGET: ${{ matrix.metadata.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -572,13 +572,14 @@ jobs:
             target: aarch64-apple-darwin,
             exe: '',
           },
-          {
-            build: windows-x64,
-            os: windows-2019,
-            target: x86_64-pc-windows-msvc,
-            exe: '.exe',
-            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
-          },
+          # FIXME: This fails for now
+          # {
+          #   build: windows-x64,
+          #   os: windows-2019,
+          #   target: x86_64-pc-windows-msvc,
+          #   exe: '.exe',
+          #   llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
+          # },
           {
             build: linux-musl,
             target: x86_64-unknown-linux-musl,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -657,7 +657,7 @@ jobs:
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
-        if: !(matrix.metadata.build == 'windows-x64' && matrix.stage.description == 'Run wast test suite for all compilers')
+        if: "! (matrix.metadata.build == 'windows-x64' && matrix.stage.description == 'Run wast test suite for all compilers')"
         run: make ${{ matrix.stage.make }}
         env:
           TARGET: ${{ matrix.metadata.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -572,14 +572,14 @@ jobs:
             target: aarch64-apple-darwin,
             exe: '',
           },
-          # FIXME: This fails for now
-          # {
-          #   build: windows-x64,
-          #   os: windows-2019,
-          #   target: x86_64-pc-windows-msvc,
-          #   exe: '.exe',
-          #   llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
-          # },
+          FIXME: This fails for now
+          {
+            build: windows-x64,
+            os: windows-2019,
+            target: x86_64-pc-windows-msvc,
+            exe: '.exe',
+            llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-windows-amd64.tar.xz'
+          },
           {
             build: linux-musl,
             target: x86_64-unknown-linux-musl,
@@ -657,6 +657,7 @@ jobs:
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
+        if: !(matrix.metadata.build == 'windows-x64' && matrix.stage.description == 'Run wast test suite for all compilers')
         run: make ${{ matrix.stage.make }}
         env:
           TARGET: ${{ matrix.metadata.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -572,7 +572,6 @@ jobs:
             target: aarch64-apple-darwin,
             exe: '',
           },
-          FIXME: This fails for now
           {
             build: windows-x64,
             os: windows-2019,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -656,7 +656,7 @@ jobs:
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
-        if: ${{ !((matrix.metadata.build == 'windows-x64') && (matrix.stage.description == 'Run wast test suite for all compilers')) }}
+        if: ${{ !((matrix.metadata.build == 'windows-x64') && (matrix.stage.description == 'Unit-test packages on std')) }}
         run: make ${{ matrix.stage.make }}
         env:
           TARGET: ${{ matrix.metadata.target }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -657,7 +657,7 @@ jobs:
           aws-s3-bucket-endpoint: false
           aws-s3-force-path-style: true
       - name: ${{ matrix.stage.description }}
-        if: ${{ ! (matrix.metadata.build == 'windows-x64' && matrix.stage.description == 'Run wast test suite for all compilers') }}
+        if: ${{ ! matrix.metadata.build == 'windows-x64' || ! matrix.stage.description == 'Run wast test suite for all compilers' }}
         run: make ${{ matrix.stage.make }}
         env:
           TARGET: ${{ matrix.metadata.target }}


### PR DESCRIPTION
This PR temporarily disables Windows for the `Unit-test packages` CI job since it has been failing with an unrelated error.