### PR TITLE
Fix progress bar tick chars

### DIFF
--- a/lib/cli/src/commands/package/common/macros.rs
+++ b/lib/cli/src/commands/package/common/macros.rs
@@ -9,7 +9,7 @@ macro_rules! make_spinner {
         pb.set_style(
             indicatif::ProgressStyle::with_template("{spinner:.magenta} {msg}")
                 .unwrap()
-                .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷"]),
+                .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷", "✶"]),
         );
 
         pb.set_message($msg);

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -121,7 +121,7 @@ pub(super) async fn upload(
     pb.set_style(ProgressStyle::with_template("{spinner:.yellow} [{elapsed_precise}] [{bar:.white}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
                  .unwrap()
                  .progress_chars("█▉▊▋▌▍▎▏  ")
-                 .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷"]));
+                 .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷", "✶"]));
     tracing::info!("webc is {total_bytes} bytes long");
 
     let chunk_size = (total_bytes / 20).min(10485760);

--- a/tests/wasmer-argus/src/argus/mod.rs
+++ b/tests/wasmer-argus/src/argus/mod.rs
@@ -89,7 +89,7 @@ impl Argus {
                 "[{test_id}] {{spinner:.blue}} {{msg}}"
             ))
             .unwrap()
-            .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷"]),
+            .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷", "✶"]),
         );
 
         p.enable_steady_tick(Duration::from_millis(100));
@@ -142,7 +142,7 @@ impl Argus {
                 "[{test_id}/{package_name}] {{spinner:.blue}} {{msg}}"
             ))
             .unwrap()
-            .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷"]),
+            .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷", "✶"]),
         );
 
         p.enable_steady_tick(Duration::from_millis(100));

--- a/tests/wasmer-argus/src/argus/packages.rs
+++ b/tests/wasmer-argus/src/argus/packages.rs
@@ -30,7 +30,7 @@ impl Argus {
         p.set_style(
             ProgressStyle::with_template("{spinner:.blue} {msg}")
                 .unwrap()
-                .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷"]),
+                .tick_strings(&["✶", "✸", "✹", "✺", "✹", "✷", "✶"]),
         );
         p.enable_steady_tick(Duration::from_millis(1000));
 


### PR DESCRIPTION
The TUI lib seems to miss the last progress bar tick char. I added an extra `✶` so it wouldn't miss the final `✸`, and if the implementation is fixed at some point, the `✶` will simply be displayed for a bit longer than the other chars.