### PR TITLE
Revert "make path_create_directory return error if no dir was created"

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_create_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_create_directory.rs
@@ -84,7 +84,6 @@ pub(crate) fn path_create_directory_internal(
         return Err(Errno::Inval);
     }
 
-    let mut created_dir = false;
     let mut cur_dir_inode = working_dir.inode;
     for comp in &path_vec {
         let processing_cur_dir_inode = cur_dir_inode.clone();
@@ -126,7 +125,6 @@ pub(crate) fn path_create_directory_internal(
                             return Err(Errno::Notdir);
                         }
                     } else {
-                        created_dir = true;
                         state.fs_create_dir(&adjusted_path)?;
                     }
                     let kind = Kind::Dir {
@@ -162,9 +160,5 @@ pub(crate) fn path_create_directory_internal(
         }
     }
 
-    if created_dir {
-        Ok(())
-    } else {
-        Err(Errno::Exist)
-    }
+    Ok(())
 }

--- a/tests/wasi-fyi/test.sh
+++ b/tests/wasi-fyi/test.sh
@@ -6,7 +6,7 @@ bash build.sh
 status=0
 
 # Define skip list as an array
-SKIP_LIST=()
+SKIP_LIST=("fs_create_dir-existing-directory.wasm")
 
 # List and process .foo files
 for file in *.wasm; do


### PR DESCRIPTION
This reverts commit 1f44a86acd3a30c17b6fae4f5d7f2a1e9209434f.

The commit must be reverted as it breaks sqlite running under WASIX.