### PR TITLE
Hide host-fs and only expose scoped fs

### DIFF
--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -39,11 +39,16 @@ pub struct wasi_config_t {
 #[no_mangle]
 pub unsafe extern "C" fn wasi_config_new(
     program_name: *const c_char,
+    mount_dir: *const c_char,
 ) -> Option<Box<wasi_config_t>> {
     debug_assert!(!program_name.is_null());
+    debug_assert!(!mount_dir.is_null());
 
     let name_c_str = CStr::from_ptr(program_name);
     let prog_name = c_try!(name_c_str.to_str());
+
+    let mount_dir = CStr::from_ptr(mount_dir);
+    let mount_dir = c_try!(mount_dir.to_str());
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -55,7 +60,7 @@ pub unsafe extern "C" fn wasi_config_new(
         inherit_stdout: true,
         inherit_stderr: true,
         inherit_stdin: true,
-        builder: WasiEnv::builder(prog_name).fs(default_fs_backing()),
+        builder: WasiEnv::builder(prog_name).fs(default_fs_backing(mount_dir)),
         runtime: Some(runtime),
     }))
 }

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -334,9 +334,10 @@ impl Wasi {
             }
 
             if !mapped_dirs.is_empty() {
-                let fs_backing: Arc<dyn FileSystem + Send + Sync> =
-                    Arc::new(PassthruFileSystem::new(default_fs_backing()));
                 for MappedDirectory { host, guest } in self.mapped_dirs.clone() {
+                    let fs_backing: Arc<dyn FileSystem + Send + Sync> =
+                        Arc::new(PassthruFileSystem::new(default_fs_backing(&guest)));
+
                     let host = if !host.is_absolute() {
                         Path::new("/").join(host)
                     } else {

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -25,8 +25,6 @@ pub mod combine_file;
 pub mod cow_file;
 pub mod dual_write_file;
 pub mod empty_fs;
-#[cfg(feature = "host-fs")]
-pub mod host_fs;
 pub mod mem_fs;
 pub mod null_file;
 pub mod passthru_fs;
@@ -41,7 +39,7 @@ pub(crate) mod ops;
 mod overlay_fs;
 pub mod pipe;
 #[cfg(feature = "host-fs")]
-mod scoped_directory_fs;
+pub mod scoped_directory_fs;
 mod static_file;
 #[cfg(feature = "static-fs")]
 pub mod static_fs;

--- a/lib/virtual-fs/src/scoped_directory_fs.rs
+++ b/lib/virtual-fs/src/scoped_directory_fs.rs
@@ -1,3 +1,5 @@
+mod host_fs;
+
 use std::path::{Component, Path, PathBuf};
 
 use futures::future::BoxFuture;
@@ -7,16 +9,18 @@ use crate::{
     VirtualFile,
 };
 
+pub use host_fs::{Stderr, Stdin, Stdout};
+
 /// A [`FileSystem`] implementation that is scoped to a specific directory on
 /// the host.
 #[derive(Debug, Clone)]
 pub struct ScopedDirectoryFileSystem {
     root: PathBuf,
-    inner: crate::host_fs::FileSystem,
+    inner: host_fs::FileSystem,
 }
 
 impl ScopedDirectoryFileSystem {
-    pub fn new(root: impl Into<PathBuf>, inner: crate::host_fs::FileSystem) -> Self {
+    pub fn new(root: impl Into<PathBuf>, inner: host_fs::FileSystem) -> Self {
         ScopedDirectoryFileSystem {
             root: root.into(),
             inner,
@@ -31,7 +35,7 @@ impl ScopedDirectoryFileSystem {
     /// This will panic if called outside of a `tokio` context.
     pub fn new_with_default_runtime(root: impl Into<PathBuf>) -> Self {
         let handle = tokio::runtime::Handle::current();
-        let fs = crate::host_fs::FileSystem::new(handle);
+        let fs = host_fs::FileSystem::new(handle);
         ScopedDirectoryFileSystem::new(root, fs)
     }
 

--- a/lib/virtual-fs/src/scoped_directory_fs/host_fs.rs
+++ b/lib/virtual-fs/src/scoped_directory_fs/host_fs.rs
@@ -976,7 +976,7 @@ impl VirtualFile for Stdin {
 mod tests {
     use tempfile::TempDir;
 
-    use crate::host_fs::FileSystem;
+    use super::FileSystem;
     use crate::FileSystem as FileSystemTrait;
     use crate::FsError;
     use std::path::Path;

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -2012,16 +2012,19 @@ impl std::fmt::Debug for WasiFs {
 }
 
 /// Returns the default filesystem backing
+#[cfg(feature = "host-fs")]
+pub fn default_fs_backing(
+    path: impl Into<PathBuf>,
+) -> Box<dyn virtual_fs::FileSystem + Send + Sync> {
+    Box::new(
+        virtual_fs::scoped_directory_fs::ScopedDirectoryFileSystem::new_with_default_runtime(path),
+    )
+}
+
+/// Returns the default filesystem backing
+#[cfg(not(feature = "host-fs"))]
 pub fn default_fs_backing() -> Box<dyn virtual_fs::FileSystem + Send + Sync> {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "host-fs")] {
-            Box::<virtual_fs::host_fs::FileSystem>::default()
-        } else if #[cfg(not(feature = "host-fs"))] {
-            Box::<virtual_fs::mem_fs::FileSystem>::default()
-        } else {
-            Box::<FallbackFileSystem>::default()
-        }
-    }
+    Box::<virtual_fs::mem_fs::FileSystem>::default()
 }
 
 #[derive(Debug, Default)]

--- a/lib/wasix/src/state/types.rs
+++ b/lib/wasix/src/state/types.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 cfg_if! {
     if #[cfg(feature = "host-fs")] {
-        pub use virtual_fs::host_fs::{Stderr, Stdin, Stdout};
+        pub use virtual_fs::scoped_directory_fs::{Stderr, Stdin, Stdout};
     } else {
         pub use virtual_fs::mem_fs::{Stderr, Stdin, Stdout};
     }

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use virtual_fs::{
-    host_fs, mem_fs, passthru_fs, tmp_fs, union_fs, AsyncRead, AsyncSeek, AsyncWrite,
+    mem_fs, passthru_fs, scoped_directory_fs, tmp_fs, union_fs, AsyncRead, AsyncSeek, AsyncWrite,
     AsyncWriteExt, FileSystem, Pipe, ReadBuf, RootFileSystemBuilder,
 };
 use wasmer::{FunctionEnv, Imports, Module, Store};
@@ -201,7 +201,9 @@ impl<'a> WasiTest<'a> {
 
         match filesystem_kind {
             WasiFileSystemKind::Host => {
-                let fs = host_fs::FileSystem::default();
+                let fs = scoped_directory_fs::ScopedDirectoryFileSystem::new_with_default_runtime(
+                    BASE_TEST_DIR,
+                );
 
                 for (alias, real_dir) in &self.mapped_dirs {
                     let mut dir = PathBuf::from(BASE_TEST_DIR);


### PR DESCRIPTION
This PR hides the `host-fs` from the public API and makes it accessible via the `ScopedDirectoryFileSystem`.

Resolves #4723.