### PR TITLE
Change the default directory the manual pages are generated to

### DIFF
--- a/lib/cli/src/commands/gen_manpage.rs
+++ b/lib/cli/src/commands/gen_manpage.rs
@@ -5,7 +5,7 @@ use clap_mangen::generate_to;
 use std::path::PathBuf;
 
 lazy_static::lazy_static! {
-    static ref DEFAULT_MAN_DIR_PATH: PathBuf = dirs::data_dir().unwrap_or_default().join("man");
+    static ref DEFAULT_MAN_DIR_PATH: PathBuf = dirs::data_dir().unwrap_or_default().join("man").join("man1");
 }
 
 #[derive(Debug, Clone, clap::Parser)]


### PR DESCRIPTION
Small PR: instead of generating by default to `./local/share/man`, generate to `./local/share/man/man1`. 