### PR TITLE
New CLI integration tests

### DIFF
--- a/tests/integration/cli/tests/create.rs
+++ b/tests/integration/cli/tests/create.rs
@@ -1,30 +1,5 @@
 use assert_cmd::prelude::OutputAssertExt;
-use std::{
-    fs::OpenOptions,
-    path::{Path, PathBuf},
-};
 use wasmer_integration_tests_cli::get_wasmer_path;
-
-fn project_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(3)
-        .unwrap()
-}
-
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    std::fs::create_dir_all(&dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
-}
 
 #[test]
 fn wasmer_create_package() -> anyhow::Result<()> {
@@ -118,7 +93,7 @@ name: {app_name}
 owner: {username}
 "#
     );
-    let got = std::fs::read_to_string(app_dir.clone().join("app.yaml"))?;
+    let got = std::fs::read_to_string(app_dir.join("app.yaml"))?;
     assert_eq!(got, want);
 
     let want = format!(

--- a/tests/integration/cli/tests/create.rs
+++ b/tests/integration/cli/tests/create.rs
@@ -3,11 +3,6 @@ use wasmer_integration_tests_cli::get_wasmer_path;
 
 #[test]
 fn wasmer_create_package() -> anyhow::Result<()> {
-    // Only run this test in the CI
-    if std::env::var("GITHUB_TOKEN").is_err() {
-        return Ok(());
-    }
-
     let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
 
     let username = "ciuser";
@@ -52,11 +47,6 @@ package: wasmer/hello
 
 #[test]
 fn wasmer_create_template() -> anyhow::Result<()> {
-    // Only run this test in the CI
-    if std::env::var("GITHUB_TOKEN").is_err() {
-        return Ok(());
-    }
-
     let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
 
     let username = "ciuser";

--- a/tests/integration/cli/tests/create.rs
+++ b/tests/integration/cli/tests/create.rs
@@ -1,0 +1,145 @@
+use assert_cmd::prelude::OutputAssertExt;
+use std::{
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
+use wasmer_integration_tests_cli::get_wasmer_path;
+
+fn project_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap()
+}
+
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
+    std::fs::create_dir_all(&dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn wasmer_create_package() -> anyhow::Result<()> {
+    // Only run this test in the CI
+    if std::env::var("GITHUB_TOKEN").is_err() {
+        return Ok(());
+    }
+
+    let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
+
+    let username = "ciuser";
+    let app_name = format!("ci-create-replica-{}", rand::random::<u32>());
+
+    let tempdir = tempfile::tempdir()?;
+    let app_dir = tempdir.path();
+
+    let mut cmd = std::process::Command::new(get_wasmer_path());
+    cmd.arg("app")
+        .arg("create")
+        .arg("--quiet")
+        .arg(format!("--name={app_name}"))
+        .arg(format!("--owner={username}"))
+        .arg(format!("--package=wasmer/hello"))
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg(format!("--non-interactive"))
+        .arg("--registry=https://registry.wasmer.wtf/graphql");
+
+    if let Some(token) = wapm_dev_token {
+        // Special case: GitHub secrets aren't visible to outside collaborators
+        if token.is_empty() {
+            return Ok(());
+        }
+        cmd.arg("--token").arg(token);
+    }
+
+    cmd.assert().success();
+
+    let want = format!(
+        r#"kind: wasmer.io/App.v0
+name: {app_name}
+owner: {username}
+package: wasmer/hello
+"#
+    );
+    let got = std::fs::read_to_string(app_dir.join("app.yaml"))?;
+    assert_eq!(got, want);
+
+    Ok(())
+}
+
+#[test]
+fn wasmer_create_template() -> anyhow::Result<()> {
+    // Only run this test in the CI
+    if std::env::var("GITHUB_TOKEN").is_err() {
+        return Ok(());
+    }
+
+    let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
+
+    let username = "ciuser";
+    let app_name = format!("ci-create-replica-{}", rand::random::<u32>());
+
+    let tempdir = tempfile::tempdir()?;
+    let app_dir = tempdir.path();
+
+    let mut cmd = std::process::Command::new(get_wasmer_path());
+    cmd.arg("app")
+        .arg("create")
+        .arg("--quiet")
+        .arg(format!("--name={app_name}"))
+        .arg(format!("--owner={username}"))
+        .arg(format!("--template=static-website"))
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg(format!("--non-interactive"))
+        .arg("--registry=https://registry.wasmer.wtf/graphql");
+
+    if let Some(token) = wapm_dev_token {
+        // Special case: GitHub secrets aren't visible to outside collaborators
+        if token.is_empty() {
+            return Ok(());
+        }
+        cmd.arg("--token").arg(token);
+    }
+
+    cmd.assert().success();
+
+    let want = format!(
+        r#"kind: wasmer.io/App.v0
+package: .
+name: {app_name}
+owner: {username}
+"#
+    );
+    let got = std::fs::read_to_string(app_dir.clone().join("app.yaml"))?;
+    assert_eq!(got, want);
+
+    let want = format!(
+        r#"[dependencies]
+"wasmer/static-web-server" = "^1"
+
+[fs]
+"/public" = "public"
+"/settings" = "settings"
+
+[[command]]
+name = "script"
+module = "wasmer/static-web-server:webserver"
+runner = "https://webc.org/runner/wasi"
+
+[command.annotations.wasi]
+main-args = ["-w", "/settings/config.toml"]
+"#
+    );
+    let got = std::fs::read_to_string(app_dir.join("wasmer.toml"))?;
+    assert_eq!(got, want);
+
+    Ok(())
+}

--- a/tests/integration/cli/tests/deploy.rs
+++ b/tests/integration/cli/tests/deploy.rs
@@ -36,7 +36,7 @@ fn wasmer_deploy_php() -> anyhow::Result<()> {
     let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
 
     let username = "ciuser";
-    let app_name = format!("ci-php-replica-{}", rand::random::<u32>());
+    let app_name = format!("ci-{}", rand::random::<u32>());
     let random3 = format!("{}", rand::random::<u32>());
 
     let php_app_dir = project_root()
@@ -60,11 +60,12 @@ fn wasmer_deploy_php() -> anyhow::Result<()> {
 
     let mut cmd = std::process::Command::new(get_wasmer_path());
     cmd.arg("deploy")
-        .arg("--quiet")
+        .arg("--non-interactive")
+        .arg("-vvvvvv")
         .arg(format!("--app-name={app_name}"))
         .arg(format!("--owner={username}"))
-        .arg(format!("--path={}", app_dir.display()))
-        .arg("--registry=https://registry.wasmer.wtf/graphql");
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg("--registry=wasmer.wtf");
 
     if let Some(token) = wapm_dev_token {
         // Special case: GitHub secrets aren't visible to outside collaborators
@@ -78,10 +79,7 @@ fn wasmer_deploy_php() -> anyhow::Result<()> {
 
     cmd.assert()
         .success()
-        .stderr(predicates::boolean::AndPredicate::new(
-            predicates::str::contains("Deployment complete"),
-            predicates::str::contains(&app_url),
-        ));
+        .stderr(predicates::str::contains("Deployment complete"));
 
     let r = reqwest::blocking::Client::new();
     let r = r.get(app_url).query(&[("ci_rand", &random3)]).send()?;
@@ -102,7 +100,7 @@ fn wasmer_deploy_static_website() -> anyhow::Result<()> {
     let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
 
     let username = "ciuser";
-    let app_name = format!("ci-static-website-replica-{}", rand::random::<u32>());
+    let app_name = format!("ci-{}", rand::random::<u32>());
     let random3 = format!("{}", rand::random::<u32>());
 
     let src_app_dir = project_root()
@@ -124,12 +122,6 @@ fn wasmer_deploy_static_website() -> anyhow::Result<()> {
 
     let app_dir = app_dir.join("static_website");
 
-    let mut cmd = std::process::Command::new("sed");
-    cmd.arg("-r")
-        .arg(format!("{}", src_app_dir.display()))
-        .arg(format!("{}", app_dir.display()))
-        .output()?;
-
     let index_file_path = app_dir.join("public").join("index.html");
     let contents = std::fs::read_to_string(&index_file_path)?;
     let new = contents.replace("RANDOM_NUMBER", &random3);
@@ -144,11 +136,12 @@ fn wasmer_deploy_static_website() -> anyhow::Result<()> {
     let mut cmd = std::process::Command::new(get_wasmer_path());
     cmd.arg("deploy")
         // .arg("--quiet")
-        .arg("-vvvvv")
+        .arg("--non-interactive")
+        .arg("-vvvvvv")
         .arg(format!("--app-name={app_name}"))
         .arg(format!("--owner={username}"))
-        .arg(format!("--path={}", app_dir.display()))
-        .arg("--registry=https://registry.wasmer.wtf/graphql");
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg("--registry=wasmer.wtf");
 
     if let Some(token) = wapm_dev_token {
         // Special case: GitHub secrets aren't visible to outside collaborators
@@ -162,13 +155,145 @@ fn wasmer_deploy_static_website() -> anyhow::Result<()> {
 
     cmd.assert()
         .success()
-        .stderr(predicates::boolean::AndPredicate::new(
-            predicates::str::contains("Deployment complete"),
-            predicates::str::contains(&app_url),
-        ));
+        .stderr(predicates::str::contains("Deployment complete"));
 
     let r = reqwest::blocking::Client::new();
     let r = r.get(app_url).send()?;
+    let r = r.text()?;
+
+    assert!(r.contains(&random3));
+
+    Ok(())
+}
+
+#[test]
+fn wasmer_deploy_js() -> anyhow::Result<()> {
+    // Only run this test in the CI
+    if std::env::var("GITHUB_TOKEN").is_err() {
+        return Ok(());
+    }
+
+    let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
+
+    let username = "ciuser";
+    let app_name = format!("ci-{}", rand::random::<u32>());
+    let random3 = format!("{}", rand::random::<u32>());
+
+    let src_app_dir = project_root()
+        .join("tests")
+        .join("integration")
+        .join("cli")
+        .join("tests")
+        .join("packages")
+        .join("js");
+
+    let tempdir = tempfile::tempdir()?;
+    let app_dir = tempdir.path();
+
+    let mut cmd = std::process::Command::new("cp");
+    cmd.arg("-r")
+        .arg(format!("{}", src_app_dir.display()))
+        .arg(format!("{}", app_dir.display()))
+        .output()?;
+
+    let app_dir = app_dir.join("js");
+
+    let mut cmd = std::process::Command::new(get_wasmer_path());
+    cmd.arg("deploy")
+        // .arg("--quiet")
+        .arg("--non-interactive")
+        .arg("-vvvvvv")
+        .arg(format!("--app-name={app_name}"))
+        .arg(format!("--owner={username}"))
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg("--registry=wasmer.wtf");
+
+    if let Some(token) = wapm_dev_token {
+        // Special case: GitHub secrets aren't visible to outside collaborators
+        if token.is_empty() {
+            return Ok(());
+        }
+        cmd.arg("--token").arg(token);
+    }
+
+    let app_url = format!("https://{app_name}-{username}.wasmer.dev");
+
+    cmd.assert()
+        .success()
+        .stderr(predicates::str::contains("Deployment complete"));
+
+    let r = reqwest::blocking::Client::new();
+    let r = r.get(app_url).query(&[("ci_rand", &random3)]).send()?;
+    let r = r.text()?;
+
+    assert!(r.contains(&random3));
+
+    Ok(())
+}
+
+#[test]
+fn wasmer_deploy_axum() -> anyhow::Result<()> {
+    // Only run this test in the CI
+    if std::env::var("GITHUB_TOKEN").is_err() {
+        return Ok(());
+    }
+
+    let wapm_dev_token = std::env::var("WAPM_DEV_TOKEN").ok();
+
+    let username = "ciuser";
+    let app_name = format!("ci-{}", rand::random::<u32>());
+    let random3 = format!("{}", rand::random::<u32>());
+
+    let src_app_dir = project_root()
+        .join("tests")
+        .join("integration")
+        .join("cli")
+        .join("tests")
+        .join("packages")
+        .join("axum");
+
+    let tempdir = tempfile::tempdir()?;
+    let app_dir = tempdir.path();
+
+    let mut cmd = std::process::Command::new("cp");
+    cmd.arg("-r")
+        .arg(format!("{}", src_app_dir.display()))
+        .arg(format!("{}", app_dir.display()))
+        .output()?;
+
+    let app_dir = app_dir.join("axum");
+
+    std::env::set_current_dir(&app_dir)?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.arg("wasix").arg("build").output()?;
+
+    let mut cmd = std::process::Command::new(get_wasmer_path());
+    cmd.arg("deploy")
+        // .arg("--quiet")
+        .arg("--non-interactive")
+        .arg("-vvvvvv")
+        .arg(format!("--app-name={app_name}"))
+        .arg(format!("--owner={username}"))
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg("--registry=wasmer.wtf");
+
+    if let Some(token) = wapm_dev_token {
+        // Special case: GitHub secrets aren't visible to outside collaborators
+        if token.is_empty() {
+            return Ok(());
+        }
+        cmd.arg("--token").arg(token);
+    }
+
+    let app_url = format!("https://{app_name}-{username}.wasmer.dev");
+
+    cmd.assert()
+        .success()
+        .stderr(predicates::str::contains("Deployment complete"));
+
+    let r = reqwest::blocking::Client::new();
+    let r = r.get(app_url).query(&[("ci_rand", &random3)]).send()?;
     let r = r.text()?;
 
     assert!(r.contains(&random3));

--- a/tests/integration/cli/tests/deploy.rs
+++ b/tests/integration/cli/tests/deploy.rs
@@ -1,8 +1,5 @@
 use assert_cmd::prelude::OutputAssertExt;
-use std::{
-    fs::OpenOptions,
-    path::{Path, PathBuf},
-};
+use std::{fs::OpenOptions, path::Path};
 use wasmer_integration_tests_cli::get_wasmer_path;
 
 fn project_root() -> &'static Path {
@@ -10,20 +7,6 @@ fn project_root() -> &'static Path {
         .ancestors()
         .nth(3)
         .unwrap()
-}
-
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    std::fs::create_dir_all(&dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
 }
 
 #[test]

--- a/tests/integration/cli/tests/packages/axum/Cargo.toml
+++ b/tests/integration/cli/tests/packages/axum/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "wasix-axum"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = { version = "=0.6.9", features = ["tokio", "json"] }
+serde = { version = "1.0.160", features = ["derive"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["fmt"] }
+
+# NOTE: We need to pin and replace some dependencies to achieve wasix compatibility.
+tokio = { version = "=1.24.2", default-features = false, features = ["full"] }
+parking_lot = { version = "=0.12.1", features = ["nightly"] }
+
+[patch.crates-io]
+tokio = { git = "https://github.com/wasix-org/tokio.git", branch = "wasix-1.24.2" }
+socket2 = { git = "https://github.com/wasix-org/socket2.git", branch = "v0.4.9" }
+libc = { git = "https://github.com/wasix-org/libc.git", branch = "master" }
+parking_lot = { git = "https://github.com/wasix-org/parking_lot", branch = "master" }

--- a/tests/integration/cli/tests/packages/axum/app.yaml
+++ b/tests/integration/cli/tests/packages/axum/app.yaml
@@ -1,0 +1,2 @@
+kind: wasmer.io/App.v0
+package: .

--- a/tests/integration/cli/tests/packages/axum/src/main.rs
+++ b/tests/integration/cli/tests/packages/axum/src/main.rs
@@ -1,0 +1,25 @@
+use axum::{extract::Query, routing::get, Router};
+use std::{collections::HashMap, net::SocketAddr};
+
+#[tokio::main]
+async fn main() {
+    // Building our application with a single Route
+    let app = Router::new().route("/", get(handler));
+
+    let port = std::env::var("PORT").unwrap_or("80".to_string());
+    let port = port.parse::<u16>().unwrap_or_else(|_| {
+        eprintln!("Invalid port number: {}", port);
+        std::process::exit(1);
+    });
+    // Run the server with hyper on http://127.0.0.1:3000
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    eprintln!("Listening on http://{}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn handler(Query(params): Query<HashMap<String, String>>) -> String {
+    format!("{:?}", params)
+}

--- a/tests/integration/cli/tests/packages/axum/wasmer.toml
+++ b/tests/integration/cli/tests/packages/axum/wasmer.toml
@@ -1,0 +1,8 @@
+[[module]]
+name = "wasix-axum"
+source = "target/wasm32-wasmer-wasi/debug/wasix-axum.wasm"
+
+[[command]]
+name = "wasix-axum"
+module = "wasix-axum"
+runner = "wasi@unstable_"

--- a/tests/integration/cli/tests/packages/js/README.md
+++ b/tests/integration/cli/tests/packages/js/README.md
@@ -1,0 +1,26 @@
+This is a simple [Javascript Service Worker](https://python.org/) server template running with [WinterJS](https://github.com/wasmerio/winterjs).
+
+> This starter's full tutorial is available [here](https://docs.wasmer.io/edge/quickstart/js-wintercg).
+
+## Usage
+
+Modify the logic of your the Javascript worker in the `src/index.js` file.
+
+You can run the JS Service Worker locally with (check out the [Wasmer install guide](https://docs.wasmer.io/install)):
+
+```bash
+wasmer run . --net
+```
+
+Open [http://localhost:8080](http://localhost:8080) with your browser to see the worker working!
+
+
+## Deploy on Wasmer Edge
+
+The easiest way to deploy your Javascript Worker is to use the [Wasmer Edge](https://wasmer.io/products/edge).
+
+Live example: https://wasmer-js-worker-starter.wasmer.app/
+
+```bash
+wasmer deploy
+```

--- a/tests/integration/cli/tests/packages/js/app.yaml
+++ b/tests/integration/cli/tests/packages/js/app.yaml
@@ -1,0 +1,2 @@
+kind: wasmer.io/App.v0
+package: .

--- a/tests/integration/cli/tests/packages/js/src/index.js
+++ b/tests/integration/cli/tests/packages/js/src/index.js
@@ -1,0 +1,187 @@
+async function handleRequest(req) {
+  const accept = req.headers.get('accept') ?? '';
+  const url = new URL(req.url);
+  const queryFormat = url.searchParams.get('format');
+
+  let outputFormat = 'html';
+
+  if (queryFormat) {
+    switch (queryFormat) {
+      case 'json':
+        outputFormat = 'json';
+        break;
+      case 'html':
+        outputFormat = 'html';
+        break;
+      case 'echo':
+        outputFormat = 'echo';
+        break;
+    }
+  } else if (accept) {
+    if (accept.startsWith('application/json')) {
+      outputFormat = 'json';
+    } else if (accept.search('text/html') !== -1) {
+      outputFormat = 'html';
+    }
+  }
+
+  switch (outputFormat) {
+    case 'json':
+      return buildResponseJson(req);
+    case 'html':
+      return buildResponseHtml(req);
+    case 'echo':
+      return buildResponseEcho(req);
+  }
+}
+
+async function requestBodyToString(req) {
+  try {
+    const body = await req.text();
+    return !body ? '<no body>' : body;
+  } catch (e) {
+    console.warn("Could not decode request body", e);
+    return "<non-utf8 body>";
+  }
+}
+
+
+addEventListener("fetch", (ev) => {
+  ev.respondWith(handleRequest(ev.request));
+});
+
+async function buildResponseJson(req) {
+  const reqBody = await requestBodyToString(req);
+
+  const data = {
+    url: req.url,
+    method: req.method,
+    headers: Object.fromEntries(req.headers),
+    body: reqBody,
+  };
+  const body = JSON.stringify(data, null, 2);
+  return new Response(body, {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function buildResponseHtml(req) {
+
+  let headers = '';
+
+  for (const [key, value] of req.headers.entries()) {
+    headers += `
+      <tr>
+        <th>${key}</th>
+        <td>${value}</td>
+      </tr>`;
+  }
+
+  const url = new URL(req.url);
+  url.searchParams.set('format', 'json');
+  const jsonUrl = url.pathname + url.search;
+
+  const reqBody = await requestBodyToString(req);
+
+  let html = `
+  <!DOCTYPE html>
+  <html>
+
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+      <title>HTTP-Info - Analyze HTTP requests</title>
+    </head>
+
+    <body>
+      <section class="section">
+        <div class="container">
+          <h1 class="title">
+            HTTP-Info
+          </h1>
+
+          <div class="mb-4">
+            <a class="button" href="${jsonUrl}">JSON</a>
+          </div>
+
+          <table class="table">
+            <thead>
+            </thead>
+
+            <tbody>
+              <tr>
+                <th>URL</th>
+                <td>${req.url}</td>
+              </tr>
+              <tr>
+                <th>Method</th>
+                <td>${req.method}</td>
+              </tr>
+              <tr>
+                <th>Headers</th>
+                <td>
+                  <table>
+                    <tbody>
+                      ${headers}
+                    </tbody>
+                  </table>
+              </tr>
+              <tr>
+                <th>Body</th>
+                <td>${reqBody}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="message is-info">
+            <div class="message-header">
+              <p>Info</p>
+            </div>
+            <div class="message-body content">
+              <p>This service provides information about the incoming HTTP request.
+              It is useful for debugging and analyzing HTTP clients.</p>
+
+              <p>You can control the output format by:</p>
+
+              <ul>
+                <li>Setting the <code>Accept</code> header to <code>application/json</code> or <code>text/html</code></li>
+                <li>
+                  Setting the <code>?format=XXX</code> query parameter to
+                  <code>json</code>, <code>html</code> or <code>echo</code></li>.
+              </ul>
+
+              <p>
+                By default the output format is <code>html</code>.<br/>
+                If the format is <code>echo</code>, the response will contain
+                the request headers and body unchanged.
+              </p>
+
+            </div>
+          </div>
+
+          <article class="message is-link">
+            <div class="message-header">
+              <p>Wasmer Edge</p>
+            </div>
+            <div class="message-body">
+              This site is hosted on <a href="https://wasmer.io/products/edge">Wasmer Edge</a>.
+            </div>
+          </article>
+        </div>
+
+      </section>
+    </body>
+  </html>
+  `;
+
+  return new Response(html, {
+    headers: { "content-type": "text/html" },
+  });
+}
+
+function buildResponseEcho(req) {
+  return new Response(req.body, {
+    headers: req.headers,
+  });
+}

--- a/tests/integration/cli/tests/packages/js/wasmer.toml
+++ b/tests/integration/cli/tests/packages/js/wasmer.toml
@@ -1,0 +1,14 @@
+[dependencies]
+"wasmer/winterjs" = "*"
+
+[fs]
+"/src" = "./src"
+
+[[command]]
+name = "script"
+module = "wasmer/winterjs:winterjs"
+runner = "https://webc.org/runner/wasi"
+
+[command.annotations.wasi]
+env = ["JS_PATH=/src/index.js"]
+main-args = ["/src/index.js"]

--- a/tests/integration/cli/tests/packages/php/wasmer.toml
+++ b/tests/integration/cli/tests/packages/php/wasmer.toml
@@ -1,0 +1,12 @@
+[dependencies]
+"php/php" = "=8.3.4-beta.1"
+
+[fs]
+"/app" = "app"
+
+[[command]]
+name = "run"
+module = "php/php:php"
+runner = "wasi"
+[command.annotations.wasi]
+main-args = ["-t", "/app", "-S", "localhost:8080"]

--- a/tests/integration/cli/tests/packages/static_website/wasmer.toml
+++ b/tests/integration/cli/tests/packages/static_website/wasmer.toml
@@ -1,0 +1,10 @@
+[dependencies]
+"wasmer/static-web-server" = "^1"
+
+[fs]
+"/public" = "public"
+
+[[command]]
+name = "script"
+module = "wasmer/static-web-server:webserver"
+runner = "https://webc.org/runner/wasi"


### PR DESCRIPTION
Add integration tests for the *deploy* command
  - Deploy a PHP app, check w/ random query param
  - Deploy a JS app, check w/ random query param
  - Deploy an Axum server, check w/ random query param
  - Deploy a static website, check w/ random contents

..and *create* command
  - Create a new app from an existing package (wasmer/hello)
  - Create a new app from a template (static-website)
