### PR TITLE
fix(cli): Actively wait for packages only after tag

### DIFF
--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -280,6 +280,7 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug)]
     pub struct TagPackageReleasePayload {
         pub success: bool,
+        pub package_version: Option<PackageVersion>,
     }
 
     #[derive(cynic::InputObject, Debug)]

--- a/lib/cli/src/commands/package/common/wait.rs
+++ b/lib/cli/src/commands/package/common/wait.rs
@@ -134,7 +134,7 @@ pub async fn wait_package(
                     state.bindings = false
                 }
                 wasmer_registry::subscriptions::PackageVersionState::NATIVE_EXES_GENERATED => {
-                    state.native_executables = true
+                    state.native_executables = false
                 }
                 wasmer_registry::subscriptions::PackageVersionState::Other(_) => {}
             }

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -98,7 +98,6 @@ impl PackagePublish {
                 package_namespace: self.package_namespace.clone(),
                 timeout: self.timeout,
                 non_interactive: self.non_interactive,
-                wait: self.wait,
                 package_path: self.package_path.clone(),
             };
 
@@ -106,6 +105,7 @@ impl PackagePublish {
         };
 
         PackageTag {
+            wait: self.wait,
             api: self.api.clone(),
             env: self.env.clone(),
             dry_run: self.dry_run,

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -1,4 +1,4 @@
-use super::common::{macros::*, wait::*, *};
+use super::common::{macros::*, *};
 use crate::{
     commands::{AsyncCliCommand, PackageBuild},
     opts::{ApiOpts, WasmerEnv},
@@ -45,17 +45,6 @@ pub struct PackagePush {
     /// Do not prompt for user input.
     #[clap(long, default_value_t = !std::io::stdin().is_terminal())]
     pub non_interactive: bool,
-
-    /// Wait for package to be available on the registry before exiting.
-    #[clap(
-            long,
-            require_equals = true,
-            num_args = 0..=1,
-            default_value_t = PublishWait::None,
-            default_missing_value = "container",
-            value_enum
-        )]
-    pub wait: PublishWait,
 
     /// Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
     ///
@@ -124,7 +113,7 @@ impl PackagePush {
         spinner_ok!(pb, "Package correctly uploaded");
 
         let pb = make_spinner!(self.quiet, "Waiting for package to become available...");
-        let id = match wasmer_api::query::push_package_release(
+        match wasmer_api::query::push_package_release(
             client,
             None,
             namespace,
@@ -143,7 +132,6 @@ impl PackagePush {
             None => anyhow::bail!("An unidentified error occurred while publishing the package."), // <- This is extremely bad..
         };
 
-        wait_package(client, self.wait, id, self.timeout).await?;
         let msg = format!("Succesfully pushed release to namespace {namespace} on the registry");
         spinner_ok!(pb, msg);
 


### PR DESCRIPTION
Before we waited for native executables, bindings and so forth after pushing a package. This patch moves this wait after tagging it - that is, when a package version is actually available.
