### PR TITLE
Disallow empty path on path_open

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -50,6 +50,10 @@ pub fn path_open<M: MemorySize>(
         return Ok(Errno::Nametoolong);
     }
 
+    if path_len64 == 0 {
+        return Ok(Errno::Noent);
+    }
+
     // o_flags:
     // - __WASI_O_CREAT (create if it does not exist)
     // - __WASI_O_DIRECTORY (fail if not dir)

--- a/tests/wasi-fyi/fs_empty_path.rs
+++ b/tests/wasi-fyi/fs_empty_path.rs
@@ -1,0 +1,26 @@
+#[link(wasm_import_module = "wasi_snapshot_preview1")]
+extern "C" {
+    pub fn path_open(
+        fd: i32,
+        dirflags: i32,
+        path: i32,
+        path_len: i32,
+        oflags: i32,
+        fs_rights_base: i64,
+        fs_rights_inheriting: i64,
+        fdflags: i32,
+        result_fd: i32,
+    ) -> i32;
+}
+
+const ERRNO_NOENT: i32 = 44;
+
+fn main() {
+    unsafe {
+        let errno = path_open(5, 0, 0, 0, 0, 0, 0, 0, 1024);
+        assert_eq!(
+            errno, ERRNO_NOENT,
+            "empty path should not resolve successfully"
+        );
+    }
+}


### PR DESCRIPTION
This commit changes `path_open` to return errno `noent` when the input path is empty.  This is consistent with other runtimes as well as Linux host. POSIX also specifies this behavior.

fixes #4755

