### PR TITLE
fix(wasix): Remove redundant module hash generation in BinaryPackage

### DIFF
--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -173,18 +173,25 @@ impl BinaryPackage {
         self.commands.iter().find(|cmd| cmd.name() == name)
     }
 
-    /// Get the bytes for the entrypoint command.
-    pub fn entrypoint_bytes(&self) -> Option<&[u8]> {
+    /// Resolve the entrypoint command name to a [`BinaryPackageCommand`].
+    fn get_entrypoint_cmd(&self) -> Option<&BinaryPackageCommand> {
         self.entrypoint_cmd
             .as_deref()
             .and_then(|name| self.get_command(name))
-            .map(|entry| entry.atom())
     }
 
+    /// Get the bytes for the entrypoint command.
+    pub fn entrypoint_bytes(&self) -> Option<&[u8]> {
+        self.get_entrypoint_cmd().map(|entry| entry.atom())
+    }
+
+    /// Get a hash for this binary package.
+    ///
+    /// Usually the hash of the entrypoint.
     pub fn hash(&self) -> ModuleHash {
         *self.hash.get_or_init(|| {
-            if let Some(entry) = self.entrypoint_bytes() {
-                ModuleHash::xxhash(entry)
+            if let Some(cmd) = self.get_entrypoint_cmd() {
+                cmd.hash.clone()
             } else {
                 ModuleHash::xxhash(self.id.to_string())
             }

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -174,15 +174,19 @@ impl BinaryPackage {
     }
 
     /// Resolve the entrypoint command name to a [`BinaryPackageCommand`].
-    fn get_entrypoint_cmd(&self) -> Option<&BinaryPackageCommand> {
+    pub fn get_entrypoint_command(&self) -> Option<&BinaryPackageCommand> {
         self.entrypoint_cmd
             .as_deref()
             .and_then(|name| self.get_command(name))
     }
 
     /// Get the bytes for the entrypoint command.
+    #[deprecated(
+        note = "Use BinaryPackage::get_entrypoint_cmd instead",
+        since = "0.22.0"
+    )]
     pub fn entrypoint_bytes(&self) -> Option<&[u8]> {
-        self.get_entrypoint_cmd().map(|entry| entry.atom())
+        self.get_entrypoint_command().map(|entry| entry.atom())
     }
 
     /// Get a hash for this binary package.
@@ -190,7 +194,7 @@ impl BinaryPackage {
     /// Usually the hash of the entrypoint.
     pub fn hash(&self) -> ModuleHash {
         *self.hash.get_or_init(|| {
-            if let Some(cmd) = self.get_entrypoint_cmd() {
+            if let Some(cmd) = self.get_entrypoint_command() {
                 cmd.hash
             } else {
                 ModuleHash::xxhash(self.id.to_string())

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -191,7 +191,7 @@ impl BinaryPackage {
     pub fn hash(&self) -> ModuleHash {
         *self.hash.get_or_init(|| {
             if let Some(cmd) = self.get_entrypoint_cmd() {
-                cmd.hash.clone()
+                cmd.hash
             } else {
                 ModuleHash::xxhash(self.id.to_string())
             }
@@ -251,7 +251,7 @@ mod tests {
                 .with_shared_http_client(runtime.http_client().unwrap().clone()),
         );
 
-        let pkg = BinaryPackage::from_dir(&temp.path(), &runtime)
+        let pkg = BinaryPackage::from_dir(temp.path(), &runtime)
             .await
             .unwrap();
 
@@ -307,7 +307,7 @@ mod tests {
                 .with_shared_http_client(runtime.http_client().unwrap().clone()),
         );
 
-        let pkg = BinaryPackage::from_dir(&temp.path(), &runtime)
+        let pkg = BinaryPackage::from_dir(temp.path(), &runtime)
             .await
             .unwrap();
 

--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -49,8 +49,8 @@ pub async fn spawn_load_wasm<'a>(
 ) -> Result<&'a [u8], SpawnError> {
     let wasm = if let Some(cmd) = binary.get_command(name) {
         cmd.atom.as_ref()
-    } else if let Some(wasm) = binary.entrypoint_bytes() {
-        wasm
+    } else if let Some(cmd) = binary.get_entrypoint_command() {
+        &cmd.atom
     } else {
         tracing::error!(
           command=name,

--- a/lib/wasix/tests/runners.rs
+++ b/lib/wasix/tests/runners.rs
@@ -44,16 +44,16 @@ mod wasi {
         let container = Container::from_bytes(webc).unwrap();
         let (rt, tasks) = runtime();
         let pkg = BinaryPackage::from_webc(&container, &rt).await.unwrap();
-        let mut stdout = virtual_fs::ArcFile::new(Box::new(virtual_fs::BufferFile::default()));
+        let mut stdout = virtual_fs::ArcFile::new(Box::<virtual_fs::BufferFile>::default());
 
         let stdout_2 = stdout.clone();
         let handle = std::thread::spawn(move || {
             let _guard = tasks.runtime_handle().enter();
             WasiRunner::new()
                 .with_args(["--version"])
-                .with_stdin(Box::new(virtual_fs::NullFile::default()))
+                .with_stdin(Box::<virtual_fs::NullFile>::default())
                 .with_stdout(Box::new(stdout_2) as Box<_>)
-                .with_stderr(Box::new(virtual_fs::NullFile::default()))
+                .with_stderr(Box::<virtual_fs::NullFile>::default())
                 .run_command("wat2wasm", &pkg, Arc::new(rt))
         });
 
@@ -79,9 +79,9 @@ mod wasi {
             let _guard = tasks.runtime_handle().enter();
             WasiRunner::new()
                 .with_args(["-c", "import sys; sys.exit(42)"])
-                .with_stdin(Box::new(virtual_fs::NullFile::default()))
-                .with_stdout(Box::new(virtual_fs::NullFile::default()))
-                .with_stderr(Box::new(virtual_fs::NullFile::default()))
+                .with_stdin(Box::<virtual_fs::NullFile>::default())
+                .with_stdout(Box::<virtual_fs::NullFile>::default())
+                .with_stderr(Box::<virtual_fs::NullFile>::default())
                 .run_command("python", &pkg, Arc::new(rt))
         });
 


### PR DESCRIPTION
The hash is already available, no need to re-compute.

Closes #4785 