### PR TITLE
Fix wasi-fyi test.sh on darwin

### DIFF
--- a/tests/wasi-fyi/test.sh
+++ b/tests/wasi-fyi/test.sh
@@ -10,7 +10,7 @@ SKIP_LIST=()
 
 # List and process .foo files
 for file in *.wasm; do
-    if [[ " ${SKIP_LIST[@]} " =~ " ${file} " ]]; then
+    if [[ " ${SKIP_LIST[0]+${SKIP_LIST[@]}} " =~ " ${file} " ]]; then
         echo "Skipping $file"
     else
         echo "Testing $file"


### PR DESCRIPTION
The test script for wasi-fyi tests is broken on darwin which uses an older version of bash.  This fix uses a [workaround][1].

fixes #4775

[1]: https://stackoverflow.com/questions/48394251/why-are-empty-arrays-treated-as-unset-in-bash