### PR TITLE
Disallow `path_open` absolute path

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -128,6 +128,15 @@ pub(crate) fn path_open_internal(
     let (memory, mut state, mut inodes) =
         unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
 
+    if !wasi_try_ok_ok!(state.fs.get_fd_inode(dirfd))
+        .deref()
+        .name
+        .starts_with('/')
+        && path.starts_with('/')
+    {
+        return Ok(Err(Errno::Inval));
+    }
+
     let path_arg = std::path::PathBuf::from(&path);
     let maybe_inode = state.fs.get_inode_at_path(
         inodes,

--- a/tests/wasi-fyi/fs_open_root.rs
+++ b/tests/wasi-fyi/fs_open_root.rs
@@ -1,0 +1,44 @@
+use std::ffi::CString;
+use std::fs::File;
+
+#[link(wasm_import_module = "wasi_snapshot_preview1")]
+extern "C" {
+    pub fn path_open(
+        fd: i32,
+        dirflags: i32,
+        path: i32,
+        path_len: i32,
+        oflags: i32,
+        fs_rights_base: i64,
+        fs_rights_inheriting: i64,
+        fdflags: i32,
+        result_fd: i32,
+    ) -> i32;
+}
+
+const ERRNO_INVAL: i32 = 28;
+
+fn main() {
+    unsafe {
+        let fd = 5;
+        let path = CString::new("/fyi/should-fail").unwrap();
+
+        let errno = path_open(
+            fd,
+            0,
+            path.as_ptr() as i32,
+            path.as_bytes().len() as i32 + 1,
+            0,
+            0,
+            0,
+            0,
+            1024,
+        );
+        assert_eq!(
+            errno, ERRNO_INVAL,
+            "open absolute path at WASI level shall fail"
+        );
+
+        assert!(File::open("/hamlet/README.md").is_ok());
+    }
+}


### PR DESCRIPTION
This commit changes `path_open` to return `inval` when it is called with an absolute path.  This behavior is consistent with other runtimes (Wasmtime, WasmEdge, Wazero, WAMR, Node).  This does not break wasi-libc behavior.  WASI folks [have stated][1] absolute paths should not work at the raw WASI level.

fixes #4774

[1]: https://github.com/WebAssembly/WASI/issues/374

