### PR TITLE
CLI: app create - Template handling improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6380,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-api"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-api"
-version = "0.0.28"
+version = "0.0.29"
 description = "Client library for the Wasmer GraphQL API"
 readme = "README.md"
 documentation = "https://docs.rs/wasmer-api"

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -149,16 +149,31 @@ mod queries {
         #[arguments(slug: $slug)]
         pub get_app_template: Option<AppTemplate>,
     }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    pub enum AppTemplatesSortBy {
+        Newest,
+        Oldest,
+        Popular,
+    }
+
     #[derive(cynic::QueryVariables, Debug)]
     pub struct GetAppTemplatesQueryVariables {
         pub category_slug: String,
         pub first: i32,
+        pub after: Option<String>,
+        pub sort_by: Option<AppTemplatesSortBy>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Query", variables = "GetAppTemplatesQueryVariables")]
     pub struct GetAppTemplatesQuery {
-        #[arguments(categorySlug: $category_slug, first: $first)]
+        #[arguments(
+            categorySlug: $category_slug,
+            first: $first,
+            after: $after,
+            sortBy: $sort_by
+        )]
         pub get_app_templates: Option<AppTemplateConnection>,
     }
 
@@ -174,21 +189,28 @@ mod queries {
         pub cursor: String,
     }
 
-    #[derive(cynic::QueryFragment, Debug)]
+    #[derive(serde::Serialize, cynic::QueryFragment, Debug)]
     pub struct AppTemplate {
+        #[serde(rename = "demoUrl")]
         pub demo_url: String,
         pub language: String,
         pub name: String,
         pub framework: String,
+        #[serde(rename = "createdAt")]
         pub created_at: DateTime,
         pub description: String,
         pub id: cynic::Id,
+        #[serde(rename = "isPublic")]
         pub is_public: bool,
+        #[serde(rename = "repoLicense")]
         pub repo_license: String,
         pub readme: String,
+        #[serde(rename = "repoUrl")]
         pub repo_url: String,
         pub slug: String,
+        #[serde(rename = "updatedAt")]
         pub updated_at: DateTime,
+        #[serde(rename = "useCases")]
         pub use_cases: Jsonstring,
     }
 

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -9,7 +9,7 @@ mod queries {
 
     use super::schema;
 
-    #[derive(cynic::Scalar, Debug, Clone)]
+    #[derive(cynic::Scalar, Debug, Clone, PartialEq, Eq)]
     pub struct DateTime(pub String);
 
     impl TryFrom<OffsetDateTime> for DateTime {
@@ -157,8 +157,8 @@ mod queries {
         Popular,
     }
 
-    #[derive(cynic::QueryVariables, Debug)]
-    pub struct GetAppTemplatesQueryVariables {
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetAppTemplatesVars {
         pub category_slug: String,
         pub first: i32,
         pub after: Option<String>,
@@ -166,8 +166,8 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", variables = "GetAppTemplatesQueryVariables")]
-    pub struct GetAppTemplatesQuery {
+    #[cynic(graphql_type = "Query", variables = "GetAppTemplatesVars")]
+    pub struct GetAppTemplates {
         #[arguments(
             categorySlug: $category_slug,
             first: $first,
@@ -189,7 +189,7 @@ mod queries {
         pub cursor: String,
     }
 
-    #[derive(serde::Serialize, cynic::QueryFragment, Debug)]
+    #[derive(serde::Serialize, cynic::QueryFragment, PartialEq, Eq, Debug)]
     pub struct AppTemplate {
         #[serde(rename = "demoUrl")]
         pub demo_url: String,
@@ -214,7 +214,7 @@ mod queries {
         pub use_cases: Jsonstring,
     }
 
-    #[derive(cynic::Scalar, Debug, Clone)]
+    #[derive(cynic::Scalar, Debug, Clone, PartialEq, Eq)]
     #[cynic(graphql_type = "JSONString")]
     pub struct Jsonstring(pub String);
 

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -145,7 +145,7 @@ virtual-mio = { version = "0.3.1", path = "../virtual-io" }
 # Wasmer-owned dependencies.
 
 webc = { workspace = true }
-wasmer-api = { version = "=0.0.28", path = "../backend-api" }
+wasmer-api = { version = "=0.0.29", path = "../backend-api" }
 edge-schema.workspace = true
 edge-util = { version = "=0.1.0" }
 lazy_static = "1.4.0"

--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -1,14 +1,5 @@
 //! Create a new Edge app.
 
-use crate::{
-    commands::AsyncCliCommand,
-    opts::{ApiOpts, ItemFormatOpts, WasmerEnv},
-    utils::{load_package_manifest, prompts::PackageCheckMode},
-};
-use anyhow::Context;
-use colored::Colorize;
-use dialoguer::{theme::ColorfulTheme, Confirm, Select};
-use is_terminal::IsTerminal;
 use std::{
     collections::HashMap,
     env,
@@ -17,10 +8,21 @@ use std::{
     str::FromStr,
     time::Duration,
 };
+
+use anyhow::Context;
+use colored::Colorize;
+use dialoguer::{theme::ColorfulTheme, Confirm, Select};
+use futures::stream::TryStreamExt;
+use is_terminal::IsTerminal;
 use wasmer_api::{types::AppTemplate, WasmerClient};
 use wasmer_config::{app::AppConfigV1, package::PackageSource};
 
 use super::{deploy::CmdAppDeploy, util::login_user};
+use crate::{
+    commands::AsyncCliCommand,
+    opts::{ApiOpts, ItemFormatOpts, WasmerEnv},
+    utils::{load_package_manifest, prompts::PackageCheckMode},
+};
 
 async fn write_app_config(app_config: &AppConfigV1, dir: Option<PathBuf>) -> anyhow::Result<()> {
     let raw_app_config = app_config.clone().to_yaml()?;
@@ -282,18 +284,13 @@ impl CmdAppCreate {
     /// Returns an error if the cache file is older than the max age.
     fn load_cached_templates(
         path: &Path,
-        max_cache_age: std::time::Duration,
-    ) -> Result<Vec<AppTemplate>, anyhow::Error> {
+    ) -> Result<(Vec<AppTemplate>, std::time::Duration), anyhow::Error> {
         let modified = path.metadata()?.modified()?;
         let age = modified.elapsed()?;
 
-        if age > max_cache_age {
-            anyhow::bail!("cache has expired");
-        }
-
         let data = std::fs::read_to_string(path)?;
         match serde_json::from_str::<Vec<AppTemplate>>(&data) {
-            Ok(v) => Ok(v),
+            Ok(v) => Ok((v, age)),
             Err(err) => {
                 std::fs::remove_file(path).ok();
                 Err(err).context("could not deserialize cached file")
@@ -321,35 +318,65 @@ impl CmdAppCreate {
         client: &WasmerClient,
         cache_dir: &Path,
     ) -> Result<Vec<AppTemplate>, anyhow::Error> {
-        const MAX_CACHE_AGE: Duration = Duration::from_secs(60 * 15);
+        const MAX_CACHE_AGE: Duration = Duration::from_secs(60 * 60);
         const MAX_COUNT: usize = 100;
-        const CACHE_FILENAME: &'static str = "app_templates.json";
+        const CACHE_FILENAME: &str = "app_templates.json";
 
         let cache_path = cache_dir.join(CACHE_FILENAME);
 
-        match Self::load_cached_templates(&cache_path, MAX_CACHE_AGE) {
-            Ok(v) => {
-                return Ok(v);
+        let cached_items = match Self::load_cached_templates(&cache_path) {
+            Ok((items, age)) => {
+                if age <= MAX_CACHE_AGE {
+                    return Ok(items);
+                }
+                items
             }
             Err(e) => {
                 tracing::trace!(error = &*e, "could not load templates from local cache");
+                Vec::new()
+            }
+        };
+
+        // Either no cache present, or cache has exceeded max age.
+        // Fetch the first page.
+        // If first item matches, then no need to re-fetch.
+        let mut stream = Box::pin(wasmer_api::query::fetch_all_app_templates(
+            client,
+            10,
+            Some(wasmer_api::types::AppTemplatesSortBy::Newest),
+        ));
+
+        let first_page = match stream.try_next().await? {
+            Some(items) => items,
+            None => return Ok(Vec::new()),
+        };
+
+        if let (Some(a), Some(b)) = (cached_items.first(), first_page.first()) {
+            if a == b {
+                // Cached items are up to date, no need to query more.
+                return Ok(cached_items);
             }
         }
 
-        let templates = wasmer_api::query::fetch_all_app_templates(
-            client,
-            10,
-            MAX_COUNT,
-            Some(wasmer_api::types::AppTemplatesSortBy::Popular),
-        )
-        .await?;
+        let mut items = first_page;
+        while let Some(next) = stream.try_next().await? {
+            items.extend(next);
+
+            if items.len() >= MAX_COUNT {
+                break;
+            }
+        }
 
         // Persist to cache.
-        if let Err(err) = Self::persist_template_cache(&cache_path, &templates) {
+        if let Err(err) = Self::persist_template_cache(&cache_path, &items) {
             tracing::trace!(error = &*err, "could not persist template cache");
         }
 
-        Ok(templates)
+        // TODO: sort items by popularity!
+        // Since we can't rely on backend sorting because of the cache
+        // preservation logic, the backend needs to add a popluarity field.
+
+        Ok(items)
     }
 
     // A utility function used to fetch the URL of the template to use.
@@ -395,6 +422,7 @@ impl CmdAppCreate {
             let dialog = dialoguer::Select::with_theme(&theme)
                 .with_prompt(format!("Select a template ({} available)", items.len()))
                 .items(&items)
+                .max_length(10)
                 .clear(true)
                 .report(false)
                 .default(0);


### PR DESCRIPTION
Adds a local template cache (currently 15 minutes), and fetches more templates
from the backend, currently up to 100.

Also sorts the templates by popularity now.

NOTE: we should really use dialoger::FuzzySelect to give users a search prompt,
but that currently conflicts with the custom stylings of the select items and
messes up the formatting.
(See https://github.com/console-rs/dialoguer/issues/312)

Closes #4804
