### PR TITLE
Fix `path_open` sometimes ignoring trailing slash

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -205,6 +205,8 @@ pub(crate) fn path_open_internal(
 
     open_options.options(minimum_rights.clone());
 
+    let orig_path = path;
+
     let inode = if let Ok(inode) = maybe_inode {
         // Happy path, we found the file we're trying to open
         let processing_inode = inode.clone();
@@ -228,7 +230,7 @@ pub(crate) fn path_open_internal(
                     assert!(handle.is_some());
                     return Ok(Ok(*special_fd));
                 }
-                if o_flags.contains(Oflags::DIRECTORY) {
+                if o_flags.contains(Oflags::DIRECTORY) || orig_path.ends_with('/') {
                     return Ok(Err(Errno::Notdir));
                 }
 

--- a/tests/wasi-fyi/fs_open_trailing_slash.rs
+++ b/tests/wasi-fyi/fs_open_trailing_slash.rs
@@ -1,0 +1,57 @@
+#[link(wasm_import_module = "wasi_snapshot_preview1")]
+extern "C" {
+    pub fn path_open(
+        fd: i32,
+        dirflags: i32,
+        path: i32,
+        path_len: i32,
+        oflags: i32,
+        fs_rights_base: i64,
+        fs_rights_inheriting: i64,
+        fdflags: i32,
+        result_fd: i32,
+    ) -> i32;
+}
+
+const ERRNO_SUCCESS: i32 = 0;
+const ERRNO_NOTDIR: i32 = 54;
+const RIGHTS_FD_READ: i64 = 2;
+
+fn main() {
+    unsafe {
+        let fd = 5;
+        let path_ok = "fyi/fs_open_trailing_slash.dir/file";
+        let path_bad = "fyi/fs_open_trailing_slash.dir/file/";
+        let errno = path_open(
+            fd,
+            0,
+            path_ok.as_ptr() as i32,
+            path_ok.len() as i32,
+            0,
+            RIGHTS_FD_READ,
+            0,
+            0,
+            1024,
+        );
+        assert_eq!(
+            errno, ERRNO_SUCCESS,
+            "opening a file without a trailing slash works"
+        );
+
+        let errno = path_open(
+            fd,
+            0,
+            path_bad.as_ptr() as i32,
+            path_bad.len() as i32,
+            0,
+            RIGHTS_FD_READ,
+            0,
+            0,
+            1024,
+        );
+        assert_eq!(
+            errno, ERRNO_NOTDIR,
+            "opening a regular file with a trailing slash should fail"
+        );
+    }
+}


### PR DESCRIPTION
This commit fixes `path_open` sometimes ignoring the trailing slash.  On host Linux and other runtimes, opening an existing file with a path containing a trailing slash fails, but wasmer succeeds.

fixes #4820
