### PR TITLE
fix(cli): Respect owner in app.yaml during app resolution

### DIFF
--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -41,14 +41,20 @@ mod queries {
         Viewer,
     }
 
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query")]
+    pub struct GetCurrentUser {
+        pub viewer: Option<User>,
+    }
+
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct GetCurrentUserVars {
+    pub struct GetCurrentUserWithNamespacesVars {
         pub namespace_role: Option<GrapheneRole>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(graphql_type = "Query", variables = "GetCurrentUserVars")]
-    pub struct GetCurrentUser {
+    #[cynic(graphql_type = "Query", variables = "GetCurrentUserWithNamespacesVars")]
+    pub struct GetCurrentUserWithNamespaces {
         pub viewer: Option<UserWithNamespaces>,
     }
 
@@ -447,7 +453,7 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
-    #[cynic(graphql_type = "User", variables = "GetCurrentUserVars")]
+    #[cynic(graphql_type = "User", variables = "GetCurrentUserWithNamespacesVars")]
     pub struct UserWithNamespaces {
         pub id: cynic::Id,
         pub username: String,


### PR DESCRIPTION
fix(cli): Fix app resolution - respect owner in config

The backend refactor that removed global aliases was not fully reflected
in the CLI, breaking "wasmer app get" and similar commands that all back
the reading the local app.yaml file.

This PR

* Removes the `Alias` variant of AppIdent, since there conceptually are no global
  aliases anymore, just domains

* Makes the resolution respect the `owner` in the config

* Falls back to trying to get the app by name with the current user as
  the owner

* Cleans up some related logic in the api crate

*Note*: we should add a way to retrieve apps by domain, but that requires additional backend support.

Closes #4818
