### PR TITLE
Dynamically detect libgcc-vs-libunwind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6618,6 +6618,7 @@ dependencies = [
  "hashbrown 0.11.2",
  "lazy_static",
  "leb128",
+ "libc",
  "memmap2 0.5.10",
  "more-asserts",
  "region",

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -37,6 +37,7 @@ bytes = "1.0"
 self_cell = "1.0"
 rkyv = { workspace = true }
 shared-buffer = { workspace = true }
+libc.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmer-vm = { path = "../vm", version = "=4.3.2" }


### PR DESCRIPTION
An (in progress) fix for #4488
