### PR TITLE
fix(cli): Respect WASMER_REGISTRY env var in all commands

### DIFF
--- a/lib/cli/src/opts.rs
+++ b/lib/cli/src/opts.rs
@@ -35,7 +35,7 @@ fn parse_registry_url(registry: &str) -> Result<url::Url, String> {
 pub struct ApiOpts {
     #[clap(long, env = "WASMER_TOKEN")]
     pub token: Option<String>,
-    #[clap(long, value_parser = parse_registry_url)]
+    #[clap(long, value_parser = parse_registry_url, env = "WASMER_REGISTRY")]
     pub registry: Option<url::Url>,
 }
 


### PR DESCRIPTION
The ApiOpts definition was missing the env declaration.

Closes #4843
