### PR TITLE
feat(cli/package-tag): Manifest is not mandatory anymore while tagging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,13 +371,13 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-11,
+            os: macos-latest,
             target: x86_64-apple-darwin,
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           },
           {
             build: macos-arm,
-            os: macos-11,
+            os: macos-latest,
             target: aarch64-apple-darwin,
           },
           {
@@ -413,7 +413,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-11.0'
+        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-latest.0'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -454,7 +454,7 @@ jobs:
           mkdir -p package/winsdk
           cp -r /tmp/winsdk/* package/winsdk
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-latest.0' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -596,7 +596,7 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-11,
+            os: macos-latest,
             target: x86_64-apple-darwin,
             exe: '',
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
@@ -643,7 +643,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-11.0'
+        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-latest.0'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -652,7 +652,7 @@ jobs:
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-latest.0' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -710,12 +710,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           - build: macos-x64
-            os: macos-11
+            os: macos-latest
             target: x86_64-apple-darwin
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           # we only build the integration-test CLI, we don't run tests
           - build: macos-arm
-            os: macos-11
+            os: macos-latest
             target: aarch64-apple-darwin,
           - build: linux-musl
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,13 +371,13 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-latest,
+            os: macos-11,
             target: x86_64-apple-darwin,
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           },
           {
             build: macos-arm,
-            os: macos-latest,
+            os: macos-11,
             target: aarch64-apple-darwin,
           },
           {
@@ -413,7 +413,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-latest.0'
+        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-11.0'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -454,7 +454,7 @@ jobs:
           mkdir -p package/winsdk
           cp -r /tmp/winsdk/* package/winsdk
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-latest.0' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -596,7 +596,7 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-latest,
+            os: macos-11,
             target: x86_64-apple-darwin,
             exe: '',
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
@@ -643,7 +643,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-latest.0'
+        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-11.0'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -652,7 +652,7 @@ jobs:
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-latest.0' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -710,12 +710,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           - build: macos-x64
-            os: macos-latest
+            os: macos-11
             target: x86_64-apple-darwin
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           # we only build the integration-test CLI, we don't run tests
           - build: macos-arm
-            os: macos-latest
+            os: macos-11
             target: aarch64-apple-darwin,
           - build: linux-musl
             target: x86_64-unknown-linux-musl

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -193,7 +193,7 @@ pub async fn tag_package_release(
     homepage: Option<&str>,
     license: Option<&str>,
     license_file: Option<&str>,
-    manifest: &str,
+    manifest: Option<&str>,
     name: &str,
     namespace: Option<&str>,
     package_release_id: &cynic::Id,

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -288,7 +288,7 @@ mod queries {
         pub homepage: Option<&'a str>,
         pub license: Option<&'a str>,
         pub license_file: Option<&'a str>,
-        pub manifest: &'a str,
+        pub manifest: Option<&'a str>,
         pub name: &'a str,
         pub namespace: Option<&'a str>,
         pub package_release_id: &'a cynic::Id,

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -118,8 +118,15 @@ impl PackagePublish {
             non_interactive: self.non_interactive,
             package_path: self.package_path.clone(),
             package_hash,
+            package_id: None,
         }
-        .tag(client, manifest, manifest_path, true, allow_unnamed)
+        .tag(
+            client,
+            Some(manifest),
+            Some(manifest_path),
+            true,
+            allow_unnamed,
+        )
         .await
     }
 }

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -75,7 +75,7 @@ pub struct PackageTag {
     /// Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
     ///
     /// Defaults to current working directory.
-    #[clap(long = "manifest-path", default_value = ".")]
+    #[clap(long = "path", default_value = ".")]
     pub package_path: PathBuf,
 
     /// Wait for package to be available on the registry before exiting.

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -14,7 +14,9 @@ use std::{
     str::FromStr,
 };
 use wasmer_api::WasmerClient;
-use wasmer_config::package::{Manifest, NamedPackageId, PackageBuilder, PackageHash, PackageIdent};
+use wasmer_config::package::{
+    Manifest, NamedPackageId, NamedPackageIdent, PackageBuilder, PackageHash, PackageIdent,
+};
 
 use super::PublishWait;
 
@@ -66,11 +68,14 @@ pub struct PackageTag {
     #[clap(name = "hash")]
     pub package_hash: PackageHash,
 
-    ///
+    /// The package to tag.
+    #[clap(name = "package_ident")]
+    pub package_id: Option<NamedPackageIdent>,
+
     /// Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
     ///
     /// Defaults to current working directory.
-    #[clap(name = "path", default_value = ".")]
+    #[clap(long, name = "manifest-path", default_value = ".")]
     pub package_path: PathBuf,
 
     /// Wait for package to be available on the registry before exiting.
@@ -88,11 +93,17 @@ pub struct PackageTag {
 impl PackageTag {
     async fn update_manifest_name(
         &self,
-        manifest_path: &Path,
-        manifest: &Manifest,
+        manifest_path: Option<&Path>,
+        manifest: Option<&Manifest>,
         full_name: &str,
-    ) -> anyhow::Result<Manifest> {
-        let mut new_manifest = manifest.clone();
+    ) -> anyhow::Result<Option<Manifest>> {
+        if manifest_path.is_none() && manifest.is_none() {
+            return Ok(None);
+        }
+
+        let mut new_manifest = manifest.cloned().unwrap();
+        let manifest_path = manifest_path.clone().unwrap();
+
         if let Some(pkg) = &mut new_manifest.package {
             pkg.name = Some(full_name.to_string());
         } else {
@@ -106,16 +117,22 @@ impl PackageTag {
             .await
             .context("while trying to serialize the manifest")?;
 
-        Ok(new_manifest)
+        Ok(Some(new_manifest))
     }
 
     async fn update_manifest_version(
         &self,
-        manifest_path: &Path,
-        manifest: &Manifest,
+        manifest_path: Option<&Path>,
+        manifest: Option<&Manifest>,
         user_version: &semver::Version,
-    ) -> anyhow::Result<Manifest> {
-        let mut new_manifest = manifest.clone();
+    ) -> anyhow::Result<Option<Manifest>> {
+        if manifest_path.is_none() && manifest.is_none() {
+            return Ok(None);
+        }
+
+        let mut new_manifest = manifest.cloned().unwrap();
+        let manifest_path = manifest_path.clone().unwrap();
+
         if let Some(pkg) = &mut new_manifest.package {
             pkg.version = Some(user_version.clone());
         } else {
@@ -131,14 +148,14 @@ impl PackageTag {
             .await
             .context("while trying to serialize the manifest")?;
 
-        Ok(new_manifest)
+        Ok(Some(new_manifest))
     }
 
     async fn do_tag(
         &self,
         client: &WasmerClient,
         id: &NamedPackageId,
-        manifest: &Manifest,
+        manifest: Option<&Manifest>,
         package_release_id: &wasmer_api::types::Id,
     ) -> anyhow::Result<()> {
         tracing::info!(
@@ -151,24 +168,27 @@ impl PackageTag {
 
         let NamedPackageId { full_name, version } = id;
         let maybe_description = manifest
-            .package
-            .as_ref()
+            .and_then(|m| m.package.as_ref())
             .and_then(|p| p.description.clone());
-        let maybe_homepage = manifest.package.as_ref().and_then(|p| p.homepage.clone());
-        let maybe_license = manifest.package.as_ref().and_then(|p| p.license.clone());
+        let maybe_homepage = manifest
+            .and_then(|m| m.package.as_ref())
+            .and_then(|p| p.homepage.clone());
+        let maybe_license = manifest
+            .and_then(|m| m.package.as_ref())
+            .and_then(|p| p.license.clone());
         let maybe_license_file = manifest
-            .package
-            .as_ref()
+            .and_then(|m| m.package.as_ref())
             .and_then(|p| p.license_file.clone())
             .map(|f| f.to_string_lossy().to_string());
         let maybe_readme = manifest
-            .package
-            .as_ref()
+            .and_then(|m| m.package.as_ref())
             .and_then(|p| p.readme.clone())
             .map(|f| f.to_string_lossy().to_string());
-        let maybe_repository = manifest.package.as_ref().and_then(|p| p.repository.clone());
+        let maybe_repository = manifest
+            .and_then(|m| m.package.as_ref())
+            .and_then(|p| p.repository.clone());
 
-        let private = if let Some(pkg) = &manifest.package {
+        let private = if let Some(pkg) = &manifest.and_then(|m| m.package.as_ref()) {
             Some(pkg.private)
         } else {
             Some(false)
@@ -176,7 +196,11 @@ impl PackageTag {
 
         let version = version.to_string();
 
-        let manifest_raw = toml::to_string(&manifest)?;
+        let manifest_raw = if let Some(manifest) = manifest {
+            Some(toml::to_string(&manifest)?)
+        } else {
+            None
+        };
 
         let r = wasmer_api::query::tag_package_release(
             client,
@@ -184,7 +208,7 @@ impl PackageTag {
             maybe_homepage.as_deref(),
             maybe_license.as_deref(),
             maybe_license_file.as_deref(),
-            &manifest_raw,
+            manifest_raw.as_deref(),
             full_name,
             None,
             package_release_id,
@@ -276,12 +300,25 @@ impl PackageTag {
         Ok(pkg.id)
     }
 
-    fn get_name(&self, manifest: &Manifest, allow_unnamed: bool) -> anyhow::Result<Option<String>> {
+    fn get_name(
+        &self,
+        manifest: Option<&Manifest>,
+        allow_unnamed: bool,
+    ) -> anyhow::Result<Option<String>> {
+        if let Some(name) = &self
+            .package_id
+            .as_ref()
+            .and_then(|id| Some(id.name.clone()))
+        {
+            return Ok(Some(name.clone()));
+        }
+
+        // REMOVE ME: This is here for backwards compatibility, but we should remove the flag.
         if let Some(name) = &self.package_name {
             return Ok(Some(name.clone()));
         }
 
-        if let Some(pkg) = &manifest.package {
+        if let Some(pkg) = &manifest.and_then(|m| m.package.as_ref()) {
             if let Some(ns) = &pkg.name {
                 if let Some(name) = ns.split('/').nth(1) {
                     return Ok(Some(name.to_string()));
@@ -311,13 +348,18 @@ impl PackageTag {
     async fn get_namespace(
         &self,
         client: &WasmerClient,
-        manifest: &Manifest,
+        manifest: Option<&Manifest>,
     ) -> anyhow::Result<String> {
+        if let Some(namespace) = self.package_id.as_ref().and_then(|id| id.namespace.clone()) {
+            return Ok(namespace);
+        }
+
+        // REMOVE ME: This is here for backwards compatibility, but we should remove the flag.
         if let Some(namespace) = &self.package_namespace {
             return Ok(namespace.clone());
         }
 
-        if let Some(pkg) = &manifest.package {
+        if let Some(pkg) = manifest.and_then(|m| m.package.clone()) {
             if let Some(name) = &pkg.name {
                 if let Some(ns) = name.split('/').next() {
                     return Ok(ns.to_string());
@@ -337,16 +379,26 @@ impl PackageTag {
     async fn get_version(
         &self,
         client: &WasmerClient,
-        manifest: &Manifest,
-        manifest_path: &Path,
+        manifest: Option<&Manifest>,
+        manifest_path: Option<&Path>,
         full_pkg_name: &str,
     ) -> anyhow::Result<semver::Version> {
+        if let Some(tag) = self.package_id.as_ref().and_then(|id| id.tag.clone()) {
+            if let wasmer_config::package::Tag::VersionReq(r) = tag {
+                let mut version = r.to_string();
+                version.remove(0);
+                let version = semver::Version::parse(&version)?;
+                return Ok(version);
+            }
+        }
+
+        // REMOVE ME: This is here for backwards compatibility, but we should remove the flag.
         if let Some(version) = &self.package_version {
             // If a user specified a version, then they meant it.
             return Ok(version.clone());
         }
 
-        let user_version = if let Some(pkg) = &manifest.package {
+        let user_version = if let Some(pkg) = manifest.and_then(|m| m.package.as_ref()) {
             pkg.version.clone()
         } else {
             None
@@ -422,8 +474,8 @@ impl PackageTag {
     async fn synthesize_id(
         &self,
         client: &WasmerClient,
-        manifest: &Manifest,
-        manifest_path: &Path,
+        manifest: Option<&Manifest>,
+        manifest_path: Option<&Path>,
         allow_unnamed: bool,
     ) -> anyhow::Result<Option<NamedPackageId>> {
         let name = match self.get_name(manifest, allow_unnamed)? {
@@ -433,7 +485,7 @@ impl PackageTag {
 
         let namespace = self.get_namespace(client, manifest).await?;
         let full_name = format!("{namespace}/{name}");
-        let should_update_name = match &manifest.package {
+        let should_update_name = match &manifest.and_then(|m| m.package.as_ref()) {
             Some(pkg) => match &pkg.name {
                 Some(n) => n.as_str() != full_name.as_str(),
                 None => true,
@@ -445,11 +497,11 @@ impl PackageTag {
             self.update_manifest_name(manifest_path, manifest, &full_name)
                 .await?
         } else {
-            manifest.clone()
+            manifest.cloned()
         };
 
         let version = self
-            .get_version(client, &manifest, manifest_path, &full_name)
+            .get_version(client, manifest.as_ref(), manifest_path, &full_name)
             .await?;
 
         Ok(Some(NamedPackageId { full_name, version }))
@@ -458,11 +510,12 @@ impl PackageTag {
     pub async fn tag(
         &self,
         client: &WasmerClient,
-        manifest: &Manifest,
-        manifest_path: &Path,
+        manifest: Option<&Manifest>,
+        manifest_path: Option<&Path>,
         after_push: bool,
         allow_unnamed: bool,
     ) -> anyhow::Result<PackageIdent> {
+        tracing::debug!("{:?}", self);
         let package_id = self
             .get_package_id(client, &self.package_hash, after_push)
             .await?;
@@ -491,6 +544,13 @@ impl PackageTag {
     // Check if a package with the same hash, namespace, name and version already exists. In such a
     // case, don't tag the package again.
     async fn should_tag(&self, client: &WasmerClient, id: &NamedPackageId) -> anyhow::Result<bool> {
+        if self.dry_run {
+            if !self.quiet {
+                eprintln!("Skipping tagging {id} as `--dry-run` was set");
+            }
+            return Ok(false);
+        }
+
         if let Some(pkg) = wasmer_api::query::get_package_version(
             client,
             id.full_name.clone(),
@@ -518,12 +578,22 @@ impl AsyncCliCommand for PackageTag {
         let client =
             login_user(&self.api, &self.env, !self.non_interactive, "tag a package").await?;
 
-        tracing::info!("Loading manifest");
-        let (manifest_path, manifest) = get_manifest(&self.package_path)?;
-        tracing::info!("Got manifest at path {}", manifest_path.display());
+        let (manifest_path, manifest) = match get_manifest(&self.package_path) {
+            Ok((manifest_path, manifest)) => {
+                tracing::info!("Got manifest at path {}", manifest_path.display());
+                (Some(manifest_path), Some(manifest))
+            }
+            Err(_) => (None, None),
+        };
 
         let id = self
-            .tag(&client, &manifest, &manifest_path, false, false)
+            .tag(
+                &client,
+                manifest.as_ref(),
+                manifest_path.as_deref(),
+                false,
+                false,
+            )
             .await?;
 
         match id {

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -75,7 +75,7 @@ pub struct PackageTag {
     /// Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
     ///
     /// Defaults to current working directory.
-    #[clap(long, name = "manifest-path", default_value = ".")]
+    #[clap(long = "manifest-path", default_value = ".")]
     pub package_path: PathBuf,
 
     /// Wait for package to be available on the registry before exiting.
@@ -102,7 +102,7 @@ impl PackageTag {
         }
 
         let mut new_manifest = manifest.cloned().unwrap();
-        let manifest_path = manifest_path.clone().unwrap();
+        let manifest_path = manifest_path.unwrap();
 
         if let Some(pkg) = &mut new_manifest.package {
             pkg.name = Some(full_name.to_string());
@@ -131,7 +131,7 @@ impl PackageTag {
         }
 
         let mut new_manifest = manifest.cloned().unwrap();
-        let manifest_path = manifest_path.clone().unwrap();
+        let manifest_path = manifest_path.unwrap();
 
         if let Some(pkg) = &mut new_manifest.package {
             pkg.version = Some(user_version.clone());
@@ -305,11 +305,7 @@ impl PackageTag {
         manifest: Option<&Manifest>,
         allow_unnamed: bool,
     ) -> anyhow::Result<Option<String>> {
-        if let Some(name) = &self
-            .package_id
-            .as_ref()
-            .and_then(|id| Some(id.name.clone()))
-        {
+        if let Some(name) = &self.package_id.as_ref().map(|id| id.name.clone()) {
             return Ok(Some(name.clone()));
         }
 
@@ -383,13 +379,13 @@ impl PackageTag {
         manifest_path: Option<&Path>,
         full_pkg_name: &str,
     ) -> anyhow::Result<semver::Version> {
-        if let Some(tag) = self.package_id.as_ref().and_then(|id| id.tag.clone()) {
-            if let wasmer_config::package::Tag::VersionReq(r) = tag {
-                let mut version = r.to_string();
-                version.remove(0);
-                let version = semver::Version::parse(&version)?;
-                return Ok(version);
-            }
+        if let Some(wasmer_config::package::Tag::VersionReq(r)) =
+            self.package_id.as_ref().and_then(|id| id.tag.clone())
+        {
+            let mut version = r.to_string();
+            version.remove(0);
+            let version = semver::Version::parse(&version)?;
+            return Ok(version);
         }
 
         // REMOVE ME: This is here for backwards compatibility, but we should remove the flag.

--- a/lib/cli/src/opts.rs
+++ b/lib/cli/src/opts.rs
@@ -37,7 +37,7 @@ pub struct ApiOpts {
     #[clap(long, env = "WASMER_TOKEN")]
     pub token: Option<String>,
 
-    /// The registry to interact with
+    /// Change the current registry 
     #[clap(long, value_parser = parse_registry_url, env = "WASMER_REGISTRY")]
     pub registry: Option<url::Url>,
 }

--- a/lib/cli/src/opts.rs
+++ b/lib/cli/src/opts.rs
@@ -37,7 +37,7 @@ pub struct ApiOpts {
     #[clap(long, env = "WASMER_TOKEN")]
     pub token: Option<String>,
 
-    /// Change the current registry 
+    /// Change the current registry
     #[clap(long, value_parser = parse_registry_url, env = "WASMER_REGISTRY")]
     pub registry: Option<url::Url>,
 }

--- a/lib/cli/src/opts.rs
+++ b/lib/cli/src/opts.rs
@@ -33,8 +33,11 @@ fn parse_registry_url(registry: &str) -> Result<url::Url, String> {
 
 #[derive(clap::Parser, Debug, Clone, Default)]
 pub struct ApiOpts {
+    /// The (optional) authorization token to pass to the registry
     #[clap(long, env = "WASMER_TOKEN")]
     pub token: Option<String>,
+
+    /// The registry to interact with
     #[clap(long, value_parser = parse_registry_url, env = "WASMER_REGISTRY")]
     pub registry: Option<url::Url>,
 }


### PR DESCRIPTION
This PR tries to solve #4672 and #4788. 
This involves necessary breaking changes to the `tag` command which we introduced in 4.3.0, as before we had
```
wasmer package tag sha256:abc....    ./path/to/manifest_dir
```
and, in this PR, it should now be 
```
wasmer package tag sha256:abc.... namespace/name[version] 
```
So, keeping both args (path and namespace) to maintain backwards compatibility would make this PR nonsensical - as it would still need a manifest. Users can still specify a manifest to draw the info regarding the package to tag from with the `--package-path` flag. 

In general, this PR still keeps the concept of manifest in the tagging logic. This, of course, is to keep a minimum of backwards compatibility, but also because some package values - such as description, readme and so forth -  are better read off of the manifest, rather than passed via flag from the user. 