### PR TITLE
CLI: Use a channel to signal that the main fn is done

### DIFF
--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -103,14 +103,11 @@ impl<O: Send + Sync, C: AsyncCliCommand<Output = O>> CliCommand for C {
             let (snd, rcv) = tokio::sync::oneshot::channel();
             let handle = self.setup(rcv);
 
-            match AsyncCliCommand::run_async(self).await {
-                Ok(k) => return Ok(k),
-                Err(e) => {
-                    if let Some(handle) = handle {
-                        handle.abort();
-                    }
-                    return Err(e);
+            if let Err(e) = AsyncCliCommand::run_async(self).await {
+                if let Some(handle) = handle {
+                    handle.abort();
                 }
+                return Err(e);
             }
 
             if let Some(handle) = handle {


### PR DESCRIPTION
Tries to solve #4859. Use a channel to notify the `setup` thread that the main CLI function (`deploy`, `tag`, `push`..) is done and, in this case, should not wait for SIGINT to be received. Another approach could be that of simply calling `.abort()` on the `JoinHandle`.
