### PR TITLE
feat(cli): Amend `app` command description

### DIFF
--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -415,7 +415,7 @@ enum Cmd {
     /// Deploy apps to Wasmer Edge [alias: app deploy]
     Deploy(crate::commands::app::deploy::CmdAppDeploy),
 
-    /// Create and manage Wasmer Edge apps 
+    /// Create and manage Wasmer Edge apps
     #[clap(subcommand, alias = "apps")]
     App(crate::commands::app::CmdApp),
 

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -415,7 +415,7 @@ enum Cmd {
     /// Deploy apps to Wasmer Edge [alias: app deploy]
     Deploy(crate::commands::app::deploy::CmdAppDeploy),
 
-    /// Manage deployed Edge apps
+    /// Create and manage Wasmer Edge apps 
     #[clap(subcommand, alias = "apps")]
     App(crate::commands::app::CmdApp),
 


### PR DESCRIPTION
A bit of context:
> Improve description of wasmer apps from "manage apps" to "create and manage apps"

This patch changes the doc comment of the `App` subcommand from  `Manage deployed Edge apps` to `Create and manage Wasmer Edge apps`. 