### PR TITLE
Update README: new zig bindings for wasmer with WASI Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ languages** with the Wasmer SDK:
 | ![C++ logo]      | [**C++**][C integration]             | [`wasm.hh` header]                    | [Learn][c docs]        |
 | ![C# logo]       | [**C#**][C# integration]             | [`WasmerSharp` NuGet package]         | [Learn][c# docs]       |
 | ![D logo]        | [**D**][D integration]               | [`wasmer` Dub package]                | [Learn][d docs]        |
+| ![Zig logo]      | [**Zig**][Zig integration]           | [`wasmer` Zig package]                | [Learn][zig docs]      |
 | ![Python logo]   | [**Python**][Python integration]     | [`wasmer` PyPI package]               | [Learn][python docs]   |
 | ![JS logo]       | [**Javascript**][JS integration]     | [`@wasmerio` NPM packages]            | [Learn][js docs]       |
 | ![Go logo]       | [**Go**][Go integration]             | [`wasmer` Go package]                 | [Learn][go docs]       |
@@ -137,7 +138,6 @@ languages** with the Wasmer SDK:
 | ![R logo]        | [**R**][R integration]               | _no published package_                | [Learn][r docs]        |
 | ![Postgres logo] | [**Postgres**][Postgres integration] | _no published package_                | [Learn][postgres docs] |
 | ![Swift logo]    | [**Swift**][Swift integration]       | _no published package_                |                        |
-| ![Zig logo]      | [**Zig**][Zig integration]           | _no published package_                |                        |
 | ![Dart logo]     | [**Dart**][Dart integration]         | [`wasm` pub package]                  |                        |
 | ![Crystal logo]  | [**Crystal**][Crystal integration]   | _no published package_                | [Learn][crystal docs]  |
 | ![Lisp logo]     | [**Lisp**][Lisp integration]         | _no published package_                |                        |
@@ -201,8 +201,10 @@ languages** with the Wasmer SDK:
 [postgres docs]: https://github.com/wasmerio/wasmer-postgres#usage--documentation
 [swift logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/swift.svg
 [swift integration]: https://github.com/AlwaysRightInstitute/SwiftyWasmer
-[zig logo]: https://raw.githubusercontent.com/ziglang/logo/master/zig-favicon.png
-[zig integration]: https://github.com/zigwasm/wasmer-zig
+[zig logo]: https://raw.githubusercontent.com/ziglang/logo/master/zig-mark.svg
+[zig integration]: https://github.com/Afirium/wasmer-zig-api
+[`wasmer` Zig package]: https://github.com/Afirium/wasmer-zig-api/releases/
+[zig docs]: https://wasmer-zig-api.crappy.systems/
 [dart logo]: https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/languages/dart.svg
 [dart integration]: https://github.com/dart-lang/wasm
 [`wasm` pub package]: https://pub.dev/packages/wasm


### PR DESCRIPTION
Thanks to the whole wasmer community for a great wasm runtime!

# Description
## Motivation
The current Zig bindings for Wasmer are outdated and incompatible with recent Zig versions. They lack documentation, do not support WASI, and have minimal testing.

To address these issues, we introduce the wasmer-zig-api package. This new package ensures full backward compatibility while introducing several enhancements:
- Comprehensive documentation
- WASI support
- Extensive testing

You can easily add the wasmer-zig-api package via the official Zig package manager. For more details, visit:
- [Release v0.1.0](https://github.com/Afirium/wasmer-zig-api/releases/tag/v0.1.0)
- [Project documentation](https://wasmer-zig-api.crappy.systems/)

This package supports all Zig versions from 0.12.0 onwards.

My team and I have successfully deployed these bindings in production environments, and we are committed to maintaining compatibility with future releases of Zig and Wasmer.

