### PR TITLE
feat(cli/push): Push with name if available (+ CLI flag)

### DIFF
--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -95,6 +95,7 @@ impl PackagePublish {
                 env: self.env.clone(),
                 dry_run: self.dry_run,
                 quiet: self.quiet,
+                package_name: self.package_name.clone(),
                 package_namespace: self.package_namespace.clone(),
                 timeout: self.timeout,
                 non_interactive: self.non_interactive,


### PR DESCRIPTION
As of now, while users can push a package to a namespace without a version, they can't attach to it a name as well. This patch introduces the necessary infrastructure for the CLI to be able to push *unversioned* (as in, named, but without a version) packages to the registry. 

For example, if a manifest such as the following 
```
[package]
name = "my-namespace/my-package"
<no version> 
...
```
is found in the directory of the package to push, then the result of `wasmer package push` is to push to the registry a package bound to the identifier `my-namespace/my-package` but without a version. This can behaviour can also be enforced with the corresponding `--name` flag in the `push` subcommand. 

This does not allow users to *run* unversioned packages, as no consensus on naming was reached yet - this means that, as of now, executing  `wasmer run my-namespace/my-package:<hash>` will fail. Instead, users can run their package with `wasmer run <hash>`. 