### PR TITLE
Fix mac runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             use_llvm: true
             build_wasm: true
           - build: macos-x64
-            os: macos-11
+            os: macos-latest
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-darwin-amd64.tar.xz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
@@ -100,7 +100,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: matrix.use_sccache != true
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.os == 'macos-11.0' && !matrix.llvm_url
+        if: matrix.os == 'macos-latest' && !matrix.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -129,7 +129,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-11.0'
+        if: matrix.os == 'macos-latest'
       - uses: actions/cache@v2
         with:
           path: |
@@ -314,7 +314,7 @@ jobs:
 
   darwin_aarch64_jsc:
     name: macOS aarch64 (JSC)
-    runs-on: macos-11.0
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -347,7 +347,7 @@ jobs:
 
   darwin_x86_64_jsc:
     name: macOS x86_64 (JSC)
-    runs-on: macos-11.0
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             use_llvm: true
             build_wasm: true
           - build: macos-x64
-            os: macos-latest
+            os: macos-12
             llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/15.x/llvm-darwin-amd64.tar.xz'
             artifact_name: 'wasmer-darwin-amd64'
             cross_compilation_artifact_name: 'cross_compiled_from_mac'
@@ -100,7 +100,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: matrix.use_sccache != true
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.os == 'macos-latest' && !matrix.llvm_url
+        if: matrix.os == 'macos-12' && !matrix.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -129,7 +129,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
       - uses: actions/cache@v2
         with:
           path: |
@@ -314,7 +314,7 @@ jobs:
 
   darwin_aarch64_jsc:
     name: macOS aarch64 (JSC)
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -347,7 +347,7 @@ jobs:
 
   darwin_x86_64_jsc:
     name: macOS x86_64 (JSC)
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,13 +371,13 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-11,
+            os: macos-latest,
             target: x86_64-apple-darwin,
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           },
           {
             build: macos-arm,
-            os: macos-11,
+            os: macos-latest,
             target: aarch64-apple-darwin,
           },
           {
@@ -413,7 +413,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-11.0'
+        if: matrix.metadata.os == 'macos-latest'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -454,7 +454,7 @@ jobs:
           mkdir -p package/winsdk
           cp -r /tmp/winsdk/* package/winsdk
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-latest' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -596,7 +596,7 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-11,
+            os: macos-latest,
             target: x86_64-apple-darwin,
             exe: '',
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
@@ -643,7 +643,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest' || matrix.metadata.os == 'macos-11.0'
+        if: matrix.metadata.os == 'macos-latest'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -652,7 +652,7 @@ jobs:
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-11.0' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-latest' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -710,12 +710,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           - build: macos-x64
-            os: macos-11
+            os: macos-latest
             target: x86_64-apple-darwin
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           # we only build the integration-test CLI, we don't run tests
           - build: macos-arm
-            os: macos-11
+            os: macos-latest
             target: aarch64-apple-darwin,
           - build: linux-musl
             target: x86_64-unknown-linux-musl

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -371,13 +371,13 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-latest,
+            os: macos-12,
             target: x86_64-apple-darwin,
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           },
           {
             build: macos-arm,
-            os: macos-latest,
+            os: macos-12,
             target: aarch64-apple-darwin,
           },
           {
@@ -413,7 +413,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest'
+        if: matrix.metadata.os == 'macos-12'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -454,7 +454,7 @@ jobs:
           mkdir -p package/winsdk
           cp -r /tmp/winsdk/* package/winsdk
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-latest' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-12' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -596,7 +596,7 @@ jobs:
           },
           {
             build: macos-x64,
-            os: macos-latest,
+            os: macos-12,
             target: x86_64-apple-darwin,
             exe: '',
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
@@ -643,7 +643,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-latest'
+        if: matrix.metadata.os == 'macos-12'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -652,7 +652,7 @@ jobs:
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
       - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.metadata.os == 'macos-latest' && !matrix.metadata.llvm_url
+        if: matrix.metadata.os == 'macos-12' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
       - name: Install LLVM
@@ -710,12 +710,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz'
           - build: macos-x64
-            os: macos-latest
+            os: macos-12
             target: x86_64-apple-darwin
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.7/clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz'
           # we only build the integration-test CLI, we don't run tests
           - build: macos-arm
-            os: macos-latest
+            os: macos-12
             target: aarch64-apple-darwin,
           - build: linux-musl
             target: x86_64-unknown-linux-musl


### PR DESCRIPTION
since macos-11 is deprecated, the CIs were not able to find suitable
runners.

This fixes the issue by having CIs run using `macos-latest` instead.