### PR TITLE
Add tests for `msync`

### DIFF
--- a/tests/wasix/msync-end-of-file/main.c
+++ b/tests/wasix/msync-end-of-file/main.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("/data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abcdef", 6);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, 3, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 3);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "hij", 3);
+
+    msync(data, 3, MS_SYNC);
+
+    munmap(data, 3);
+
+    fd = open("/data/my_file.txt", O_RDONLY);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "abchij", filesize) != 0)
+    {
+        printf("Error: Expected content 'abchij', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/msync-end-of-file/run.sh
+++ b/tests/wasix/msync-end-of-file/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt

--- a/tests/wasix/msync-middle-of-file/main.c
+++ b/tests/wasix/msync-middle-of-file/main.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abcdef", 6);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, 2, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 2);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "hi", 2);
+
+    msync(data, 2, MS_SYNC);
+
+    munmap(data, 2);
+
+    fd = open("data/my_file.txt", O_RDONLY);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "abhief", filesize) != 0)
+    {
+        printf("Error: Expected content 'abhief', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/msync-middle-of-file/run.sh
+++ b/tests/wasix/msync-middle-of-file/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt

--- a/tests/wasix/msync-start-of-file/main.c
+++ b/tests/wasix/msync-start-of-file/main.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("/data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abc", 3);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, filesize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "def", 3);
+
+    msync(data, filesize, MS_SYNC);
+
+    munmap(data, filesize);
+
+    fd = open("/data/my_file.txt", O_RDONLY);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "def", filesize) != 0)
+    {
+        printf("Error: Expected content 'def', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/msync-start-of-file/run.sh
+++ b/tests/wasix/msync-start-of-file/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt

--- a/tests/wasix/munmap-sync-end-of-file/main.c
+++ b/tests/wasix/munmap-sync-end-of-file/main.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("/data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abcdef", 6);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, 3, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 3);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "hij", 3);
+
+    munmap(data, 3);
+
+    fd = open("/data/my_file.txt", O_RDONLY);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "abchij", filesize) != 0)
+    {
+        printf("Error: Expected content 'abchij', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/munmap-sync-end-of-file/run.sh
+++ b/tests/wasix/munmap-sync-end-of-file/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt

--- a/tests/wasix/munmap-sync-middle-of-file/main.c
+++ b/tests/wasix/munmap-sync-middle-of-file/main.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abcdef", 6);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, 2, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 2);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "hi", 2);
+
+    munmap(data, 2);
+
+    fd = open("data/my_file.txt", O_RDONLY);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "abhief", filesize) != 0)
+    {
+        printf("Error: Expected content 'abhief', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/munmap-sync-middle-of-file/run.sh
+++ b/tests/wasix/munmap-sync-middle-of-file/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt

--- a/tests/wasix/munmap-sync-start-of-file/main.c
+++ b/tests/wasix/munmap-sync-start-of-file/main.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("/data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abc", 3);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, filesize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "def", 3);
+
+    munmap(data, filesize);
+
+    fd = open("/data/my_file.txt", O_RDONLY);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "def", filesize) != 0)
+    {
+        printf("Error: Expected content 'def', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/munmap-sync-start-of-file/run.sh
+++ b/tests/wasix/munmap-sync-start-of-file/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt

--- a/tests/wasix/read-after-munmap/main.c
+++ b/tests/wasix/read-after-munmap/main.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    int fd;
+    char *data;
+
+    fd = open("data/my_file.txt", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+    if (fd == -1)
+    {
+        printf("open");
+        exit(1);
+    }
+
+    write(fd, "abcdef", 6);
+
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t filesize = statbuf.st_size;
+
+    data = mmap(NULL, 2, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 2);
+    if (data == MAP_FAILED)
+    {
+        printf("mmap");
+        exit(1);
+    }
+
+    memcpy(data, "hi", 2);
+
+    munmap(data, 2);
+
+    off_t offset = lseek(fd, 0, SEEK_SET);
+    if (offset == -1)
+    {
+        printf("lseek");
+    }
+
+    char buffer[filesize];
+    ssize_t bytes_read = read(fd, buffer, filesize);
+    if (bytes_read == -1)
+    {
+        printf("read");
+        exit(1);
+    }
+
+    if (strncmp(buffer, "abhief", filesize) != 0)
+    {
+        printf("Error: Expected content 'abhief', got '%s'\n", buffer);
+        exit(1);
+    }
+
+    printf("0");
+    close(fd);
+    return 0;
+}

--- a/tests/wasix/read-after-munmap/run.sh
+++ b/tests/wasix/read-after-munmap/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --mapdir=/data:. > output
+
+printf "0" | diff -u output - 1>/dev/null
+
+rm my_file.txt


### PR DESCRIPTION
This PR adds tests for the `msync` syscall added in this [PR](https://github.com/wasix-org/wasix-libc/pull/42) in the wasix-libc repo.