### PR TITLE
Compile `wasmer-api` crate to `wasm32-unknown-unknown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6409,7 +6409,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "wasm-bindgen",
  "wasmer-config 0.4.0",
  "webc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge-streams"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f84f6452969abd246e7ac1fe4fe75906c76e8ec88d898df9aef37e0f3b6a7c2"
+dependencies = [
+ "futures-core",
+ "pin-project",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4499,17 @@ name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -6357,7 +6378,7 @@ dependencies = [
  "rustc-demangle",
  "rusty_jsc",
  "serde",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.4.5",
  "shared-buffer",
  "target-lexicon 0.12.14",
  "tempfile",
@@ -6386,10 +6407,13 @@ dependencies = [
  "cynic",
  "edge-schema 0.1.0",
  "futures 0.3.30",
+ "getrandom",
  "harsh",
+ "merge-streams",
  "pin-project-lite",
  "reqwest",
  "serde",
+ "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "serde_path_to_error",
  "time 0.3.36",
@@ -6397,6 +6421,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "wasm-bindgen",
  "wasmer-config 0.4.0",
  "webc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,17 +4506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6378,7 +6367,7 @@ dependencies = [
  "rustc-demangle",
  "rusty_jsc",
  "serde",
- "serde-wasm-bindgen 0.4.5",
+ "serde-wasm-bindgen",
  "shared-buffer",
  "target-lexicon 0.12.14",
  "tempfile",
@@ -6413,7 +6402,6 @@ dependencies = [
  "pin-project-lite",
  "reqwest",
  "serde",
- "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "serde_path_to_error",
  "time 0.3.36",

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -34,7 +34,6 @@ serde_path_to_error = "0.1.14"
 harsh = "0.2.2"
 reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
 merge-streams = "0.1.2"
-wasm-bindgen = "0.2.92"
 
 [target.'cfg(target_family = "wasm")'.dependencies.getrandom]
 version = "0.2.14"

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -13,9 +13,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-derive-wasm-bindgen = ["dep:serde-wasm-bindgen"]
-
 [dependencies]
 # Wasmer dependencies.
 edge-schema.workspace = true
@@ -38,7 +35,6 @@ harsh = "0.2.2"
 reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
 merge-streams = "0.1.2"
 wasm-bindgen = "0.2.92"
-serde-wasm-bindgen = { version = "0.6", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies.getrandom]
 version = "0.2.14"

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -13,6 +13,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+derive-wasm-bindgen = ["dep:serde-wasm-bindgen"]
 
 [dependencies]
 # Wasmer dependencies.
@@ -34,6 +36,13 @@ pin-project-lite = "0.2.10"
 serde_path_to_error = "0.1.14"
 harsh = "0.2.2"
 reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
+merge-streams = "0.1.2"
+wasm-bindgen = "0.2.92"
+serde-wasm-bindgen = { version = "0.6", optional = true }
+
+[target.'cfg(target_family = "wasm")'.dependencies.getrandom]
+version = "0.2.14"
+features = ["js"]
 
 [dev-dependencies]
 base64 = "0.13.1"

--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -193,7 +193,6 @@ type Namespace implements Node & PackageOwner & Owner {
   name: String!
   displayName: String
   description: String!
-  avatar: String!
   avatarUpdatedAt: DateTime
   twitterHandle: String
   githubHandle: String
@@ -205,6 +204,7 @@ type Namespace implements Node & PackageOwner & Owner {
   userSet(offset: Int, before: String, after: String, first: Int, last: Int): UserConnection!
   globalName: String!
   globalId: ID!
+  avatar: String!
   packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
   apps(sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
   packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
@@ -939,6 +939,8 @@ type BindingsGeneratorEdge {
 type BindingsGenerator implements Node {
   """The ID of the object"""
   id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
   packageVersion: PackageVersion!
   active: Boolean!
   commandName: String!
@@ -1235,11 +1237,13 @@ type AppTemplate implements Node {
   updatedAt: DateTime!
   readme: String!
   useCases: JSONString!
-  framework: String!
-  language: String!
   repoLicense: String!
   usingPackage: Package
   defaultImage: String
+  framework: String!
+  templateFramework: TemplateFramework
+  language: String!
+  templateLanguage: TemplateLanguage
 }
 
 type AppTemplateCategory implements Node {
@@ -1251,6 +1255,24 @@ type AppTemplateCategory implements Node {
   createdAt: DateTime!
   updatedAt: DateTime!
   appTemplates(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection!
+}
+
+type TemplateFramework implements Node {
+  """The ID of the object"""
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  name: String!
+  slug: String!
+}
+
+type TemplateLanguage implements Node {
+  """The ID of the object"""
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  name: String!
+  slug: String!
 }
 
 type Collection {
@@ -1540,14 +1562,14 @@ type DNSDomainEdge {
 }
 
 type DNSDomain implements Node {
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
   name: String!
 
   """This zone will be accessible at /dns/{slug}/."""
   slug: String!
   zoneFile: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
 
   """The ID of the object"""
   id: ID!
@@ -2258,7 +2280,9 @@ type Query {
   getAppByGlobalAlias(alias: String!): DeployApp
   getDeployApps(sortBy: DeployAppsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
   getAppVersions(sortBy: DeployAppVersionsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
-  getAppTemplates(categorySlug: String, sortBy: AppTemplatesSortBy, offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection
+  getTemplateFrameworks(offset: Int, before: String, after: String, first: Int, last: Int): TemplateFrameworkConnection
+  getTemplateLanguages(offset: Int, before: String, after: String, first: Int, last: Int): TemplateLanguageConnection
+  getAppTemplates(categorySlug: String, frameworkSlug: String, languageSlug: String, sortBy: AppTemplatesSortBy, offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection
   getAppTemplate(slug: String!): AppTemplate
   getAppTemplateCategories(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateCategoryConnection
   viewer: User
@@ -2355,6 +2379,46 @@ type DNSRecordEdge {
 enum DNSRecordsSortBy {
   NEWEST
   OLDEST
+}
+
+type TemplateFrameworkConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [TemplateFrameworkEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `TemplateFramework` and its cursor."""
+type TemplateFrameworkEdge {
+  """The item at the end of the edge"""
+  node: TemplateFramework
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+type TemplateLanguageConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [TemplateLanguageEdge]!
+
+  """Total number of items in the connection."""
+  totalCount: Int
+}
+
+"""A Relay edge containing a `TemplateLanguage` and its cursor."""
+type TemplateLanguageEdge {
+  """The item at the end of the edge"""
+  node: TemplateLanguage
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 enum AppTemplatesSortBy {

--- a/lib/backend-api/src/client.rs
+++ b/lib/backend-api/src/client.rs
@@ -53,12 +53,12 @@ impl WasmerClient {
     }
 
     pub fn new(graphql_endpoint: Url, user_agent: &str) -> Result<Self, anyhow::Error> {
-        #[cfg(all(target_family = "wasm", not(target = "wasm32-wasmer-wasi")))]
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         let client = reqwest::Client::builder()
             .build()
             .context("could not construct http client")?;
 
-        #[cfg(any(not(target_family = "wasm"), target = "wasm32-wasmer-wasi"))]
+        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(90))

--- a/lib/backend-api/src/client.rs
+++ b/lib/backend-api/src/client.rs
@@ -53,12 +53,12 @@ impl WasmerClient {
     }
 
     pub fn new(graphql_endpoint: Url, user_agent: &str) -> Result<Self, anyhow::Error> {
-        #[cfg(target_family = "wasm")]
+        #[cfg(all(target_family = "wasm", not(target = "wasm32-wasmer-wasi")))]
         let client = reqwest::Client::builder()
             .build()
             .context("could not construct http client")?;
 
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(any(not(target_family = "wasm"), target = "wasm32-wasmer-wasi"))]
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(90))

--- a/lib/backend-api/src/client.rs
+++ b/lib/backend-api/src/client.rs
@@ -1,10 +1,10 @@
+#[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
+use crate::GraphQLApiFailure;
 use anyhow::{bail, Context as _};
 use cynic::{http::CynicReqwestError, GraphQlResponse, Operation};
 use url::Url;
-
-use crate::GraphQLApiFailure;
 
 /// API client for the Wasmer API.
 ///
@@ -53,11 +53,18 @@ impl WasmerClient {
     }
 
     pub fn new(graphql_endpoint: Url, user_agent: &str) -> Result<Self, anyhow::Error> {
+        #[cfg(target_family = "wasm")]
+        let client = reqwest::Client::builder()
+            .build()
+            .context("could not construct http client")?;
+
+        #[cfg(not(target_family = "wasm"))]
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(90))
             .build()
             .context("could not construct http client")?;
+
         Self::new_with_client(client, graphql_endpoint, user_agent)
     }
 

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1346,12 +1346,12 @@ fn get_app_logs(
 
                 if page.is_empty() {
                     if watch {
-                        /* 
-                         * [TODO]: The resolution here should be configurable. 
+                        /*
+                         * [TODO]: The resolution here should be configurable.
                          */
 
-                        // No tokio::time::sleep on wasm32 as of now. 
-                        // Probably not ideal? 
+                        // No tokio::time::sleep on wasm32 as of now.
+                        // Probably not ideal?
                         #[cfg(target_family = "wasm32")]
                         std::thread::sleep(Duration::from_secs(1));
 

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1352,10 +1352,10 @@ fn get_app_logs(
 
                         // No tokio::time::sleep on wasm32 as of now.
                         // Probably not ideal?
-                        #[cfg(target_family = "wasm32")]
+                        #[cfg(target_family = "wasm")]
                         std::thread::sleep(Duration::from_secs(1));
 
-                        #[cfg(not(target_family = "wasm32"))]
+                        #[cfg(not(target_family = "wasm"))]
                         tokio::time::sleep(Duration::from_secs(1)).await;
 
                         continue;

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1350,9 +1350,10 @@ fn get_app_logs(
                          * [TODO]: The resolution here should be configurable.
                          */
 
-                        #[cfg(all(target_family = "wasm", not(target = "wasm32-wasmer-wasi")))]
+                        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                         std::thread::sleep(Duration::from_secs(1));
-                        #[cfg(any(not(target_family = "wasm"), target = "wasm32-wasmer-wasi"))]
+
+                        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                         tokio::time::sleep(Duration::from_secs(1)).await;
 
                         continue;

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1350,12 +1350,9 @@ fn get_app_logs(
                          * [TODO]: The resolution here should be configurable.
                          */
 
-                        // No tokio::time::sleep on wasm32 as of now.
-                        // Probably not ideal?
-                        #[cfg(target_family = "wasm")]
+                        #[cfg(all(target_family = "wasm", not(target = "wasm32-wasmer-wasi")))]
                         std::thread::sleep(Duration::from_secs(1));
-
-                        #[cfg(not(target_family = "wasm"))]
+                        #[cfg(any(not(target_family = "wasm"), target = "wasm32-wasmer-wasi"))]
                         tokio::time::sleep(Duration::from_secs(1)).await;
 
                         continue;

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -58,7 +58,7 @@ mod queries {
         pub viewer: Option<UserWithNamespaces>,
     }
 
-    #[derive(cynic::QueryFragment, Debug)]
+    #[derive(cynic::QueryFragment, Debug, serde::Serialize)]
     pub struct User {
         pub id: cynic::Id,
         pub username: String,


### PR DESCRIPTION
This patch resolves compiler errors arising when compiling the `wasmer-api` (a.k.a. `backend-api`) crate to `wasm32-unknown-unknown` targets. 

The main complication was the explicit use of a type (`Pin<Box<dyn Stream<Item = Result<Vec<DeployApp>, anyhow::Error>> + Send + Sync>>`) that required a `Sync` that was not available in `wasm32`. 