### PR TITLE
Fix stack_low detection when data_end is above stack_pointer and stac…

### DIFF
--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -191,10 +191,17 @@ impl WasiFunctionEnv {
                     _ => 0,
                 }
             } else if let Some(data_end) = data_end {
-                match data_end.get(store) {
+                let data_end = match data_end.get(store) {
                     wasmer::Value::I32(a) => a as u64,
                     wasmer::Value::I64(a) => a as u64,
                     _ => 0,
+                };
+                // It's possible for the data section to be above the stack, we check for that here and
+                // if it is, we'll assume the stack starts at address 0
+                if data_end >= stack_base {
+                    0
+                } else {
+                    data_end
                 }
             } else {
                 // clang-16 and higher generate the `__stack_low` global, and it can be exported with


### PR DESCRIPTION
…k_lower is missing

This PR removes a false warning, but the behavior should otherwise be identical to what it was before, although accidentally.