### PR TITLE
Prevent unnecessary panics when compiling on x86_64 CPUs that dont support AVX or SSE4.2

### DIFF
--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -211,8 +211,8 @@ impl Compiler for SinglepassCompiler {
             .values()
             .collect::<Vec<_>>()
             .into_par_iter_if_rayon()
-            .map(|func_type| gen_std_trampoline(func_type, target, calling_convention).unwrap())
-            .collect::<Vec<_>>()
+            .map(|func_type| gen_std_trampoline(func_type, target, calling_convention))
+            .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .collect::<PrimaryMap<_, _>>();
 
@@ -227,9 +227,8 @@ impl Compiler for SinglepassCompiler {
                     target,
                     calling_convention,
                 )
-                .unwrap()
             })
-            .collect::<Vec<_>>()
+            .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .collect::<PrimaryMap<FunctionIndex, FunctionBody>>();
 

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -129,9 +129,8 @@ impl Compiler for SinglepassCompiler {
                     target,
                     calling_convention,
                 )
-                .unwrap()
             })
-            .collect::<Vec<_>>()
+            .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .collect();
         let (functions, fdes): (Vec<CompiledFunction>, Vec<_>) = function_body_inputs


### PR DESCRIPTION
# Description
My company, Bitping, operates a distributed network of user devices to perform network tests and other types of work using WASM binaries. We use wasmer as the interpreter for these binaries and recently after an update one of our node operators with an AMD Turion II processor reported the following error at start up, which caused our application to fail to start.

![image](https://github.com/user-attachments/assets/fb750a45-8556-4c77-a632-c55c61d73b64)

This PR attempts to solve the panic by returning a Result instead if compilation fails on older x86_64 CPUs that dont support AVX or SSE4.2.

I've successfully compiled the package locally as well as run the compiler_singlepass tests, which all pass.
