### PR TITLE
Fix indirect call to dynamic imported function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 dependencies = [
  "serde",
 ]
@@ -2080,7 +2080,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2230,7 +2230,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "fnv",
  "itoa",
 ]
@@ -2241,7 +2241,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "http",
  "pin-project-lite",
 ]
@@ -2286,7 +2286,7 @@ version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2324,7 +2324,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "hyper",
  "native-tls",
  "tokio 1.37.0",
@@ -3969,7 +3969,7 @@ checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4033,7 +4033,7 @@ checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "hashbrown 0.12.3",
  "indexmap 1.9.3",
  "ptr_meta",
@@ -4675,7 +4675,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c99835bad52957e7aa241d3975ed17c1e5f8c92026377d117a606f36b84b16"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "memmap2 0.6.2",
 ]
 
@@ -5165,7 +5165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "libc",
  "mio 0.8.11",
  "num_cpus",
@@ -5305,7 +5305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
  "bincode",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "educe",
  "futures-core",
  "futures-sink",
@@ -5448,7 +5448,7 @@ version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -5547,7 +5547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "bitflags 2.5.0",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "futures-core",
  "futures-util",
  "http",
@@ -5721,7 +5721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "data-encoding",
  "http",
  "httparse",
@@ -5936,7 +5936,7 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "derivative",
  "dunce",
  "filetime",
@@ -5966,7 +5966,7 @@ name = "virtual-mio"
 version = "0.3.1"
 dependencies = [
  "async-trait",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "derivative",
  "futures 0.3.30",
  "mio 0.8.11",
@@ -5985,7 +5985,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "bytecheck",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "derivative",
  "futures-util",
  "hyper",
@@ -6356,7 +6356,7 @@ name = "wasmer"
 version = "4.3.4"
 dependencies = [
  "anyhow",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "cfg-if 1.0.0",
  "derivative",
  "hashbrown 0.11.2",
@@ -6530,7 +6530,7 @@ dependencies = [
  "anyhow",
  "assert_cmd 2.0.14",
  "async-trait",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "bytesize",
  "cargo_metadata",
  "cfg-if 1.0.0",
@@ -6623,7 +6623,7 @@ name = "wasmer-compiler"
 version = "4.3.4"
 dependencies = [
  "backtrace",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "cfg-if 1.0.0",
  "enum-iterator",
  "enumset",
@@ -6870,7 +6870,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "bytecheck",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "derivative",
  "lz4_flex",
  "num_enum",
@@ -7029,7 +7029,7 @@ dependencies = [
  "bincode",
  "blake3",
  "bytecheck",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "cfg-if 1.0.0",
  "chrono",
  "cooked-waker",
@@ -7307,7 +7307,7 @@ checksum = "c1fc686c7b43c9bc630a499f6ae1f0a4c4bd656576a53ae8a147b0cc9bc983ad"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
- "bytes 1.6.0",
+ "bytes 1.6.1",
  "cfg-if 1.0.0",
  "document-features",
  "flate2",

--- a/lib/compiler/src/engine/resolver.rs
+++ b/lib/compiler/src/engine/resolver.rs
@@ -113,6 +113,11 @@ pub fn resolve_imports(
                         let index = FunctionIndex::new(function_imports.len());
                         let ptr = finished_dynamic_function_trampolines[index].0
                             as *mut VMFunctionBody as _;
+                        // The logic is currently handling the "resolution" of dynamic imported functions at instantiation time.
+                        // However, ideally it should be done even before then, as you may have dynamic imported functions that
+                        // are linked at runtime and not instantiation time. And those will not work properly with the current logic.
+                        // Ideally, this logic should be done directly in the `wasmer-vm` crate.
+                        // TODO (@syrusakbary): Get rid of `VMFunctionKind`
                         unsafe { f.anyfunc.as_ptr().as_mut() }.func_ptr = ptr;
                         ptr
                     }

--- a/lib/compiler/src/engine/resolver.rs
+++ b/lib/compiler/src/engine/resolver.rs
@@ -64,7 +64,7 @@ fn get_runtime_size(context: &StoreObjects, extern_: &VMExtern) -> Option<u32> {
 pub fn resolve_imports(
     module: &ModuleInfo,
     imports: &[VMExtern],
-    context: &StoreObjects,
+    context: &mut StoreObjects,
     finished_dynamic_function_trampolines: &BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     memory_styles: &PrimaryMap<MemoryIndex, MemoryStyle>,
     _table_styles: &PrimaryMap<TableIndex, TableStyle>,
@@ -104,14 +104,17 @@ pub fn resolve_imports(
         }
         match *resolved {
             VMExtern::Function(handle) => {
-                let f = handle.get(context);
+                let f = handle.get_mut(context);
                 let address = match f.kind {
                     VMFunctionKind::Dynamic => {
                         // If this is a dynamic imported function,
                         // the address of the function is the address of the
                         // reverse trampoline.
                         let index = FunctionIndex::new(function_imports.len());
-                        finished_dynamic_function_trampolines[index].0 as *mut VMFunctionBody as _
+                        let ptr = finished_dynamic_function_trampolines[index].0
+                            as *mut VMFunctionBody as _;
+                        unsafe { f.anyfunc.as_ptr().as_mut() }.func_ptr = ptr;
+                        ptr
                     }
                     VMFunctionKind::Static => unsafe { f.anyfunc.as_ptr().as_ref().func_ptr },
                 };

--- a/tests/compilers/imports.rs
+++ b/tests/compilers/imports.rs
@@ -13,6 +13,8 @@ use wasmer::Type as ValueType;
 use wasmer::*;
 
 fn get_module(store: &Store) -> Result<Module> {
+    // Note: this module is also used to test indirect calls to imported
+    // functions, do not remove the call_indirect instruction
     let wat = r#"
         (type (func))
         (import "host" "0" (func $host_func_0 (type 0)))

--- a/tests/compilers/imports.rs
+++ b/tests/compilers/imports.rs
@@ -14,7 +14,8 @@ use wasmer::*;
 
 fn get_module(store: &Store) -> Result<Module> {
     let wat = r#"
-        (import "host" "0" (func))
+        (type (func))
+        (import "host" "0" (func $host_func_0 (type 0)))
         (import "host" "1" (func (param i32) (result i32)))
         (import "host" "2" (func (param i32) (param i64)))
         (import "host" "3" (func (param i32 i64 i32 f32 f64)))
@@ -22,7 +23,9 @@ fn get_module(store: &Store) -> Result<Module> {
         (export "memory" (memory $mem))
 
         (func $foo
-            call 0
+            i32.const 1
+            call_indirect (type 0)
+
             i32.const 0
             call 1
             i32.const 1
@@ -37,6 +40,8 @@ fn get_module(store: &Store) -> Result<Module> {
             f64.const 500
             call 3
         )
+        (table 2 2 funcref)
+        (elem (i32.const 1) func $host_func_0)
         (start $foo)
     "#;
 


### PR DESCRIPTION
Fixes #4565.

The solution is to update the func_ptr of the anyfunc with the generated trampoline address during the resolve step. I'm not sure this is the best place for this code though; careful review is required.