### PR TITLE
CLI: Manually exit upon SIGINT reception

### DIFF
--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -84,6 +84,12 @@ pub(crate) trait AsyncCliCommand: Send + Sync {
                     _ = tokio::signal::ctrl_c() => {
                         let term = console::Term::stdout();
                         let _ = term.show_cursor();
+                        // https://learn.microsoft.com/en-us/cpp/c-runtime-library/signal-constants
+                        #[cfg(target_os = "windows")]
+                        std::process::exit(3);
+
+                        // POSIX compliant OSs: 128 + SIGINT (2)
+                        #[cfg(not(target_os = "windows"))]
                         std::process::exit(130);
                     }
                 }

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -84,6 +84,7 @@ pub(crate) trait AsyncCliCommand: Send + Sync {
                     _ = tokio::signal::ctrl_c() => {
                         let term = console::Term::stdout();
                         let _ = term.show_cursor();
+                        std::process::exit(130);
                     }
                 }
 


### PR DESCRIPTION
As per title. The CLI returns with a `130` (128 + SIGINT) exit code upon receiving a SIGINT (CTRL+C) signal. 