### PR TITLE
fix(cli/package/tag): Better messages when tagging an existing package

### DIFF
--- a/lib/cli/src/commands/package/mod.rs
+++ b/lib/cli/src/commands/package/mod.rs
@@ -13,6 +13,7 @@ pub use common::wait::PublishWait;
 // Allowing missing_docs because the comment would override the doc comment on
 // the command struct.
 #[allow(missing_docs)]
+#[allow(clippy::large_enum_variant)]
 pub enum Package {
     Download(download::PackageDownload),
     Build(build::PackageBuild),

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -120,6 +120,7 @@ impl PackagePublish {
             package_path: self.package_path.clone(),
             package_hash,
             package_id: None,
+            maybe_user_package: None,
         }
         .tag(
             client,

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -466,16 +466,16 @@ impl PackageTag {
                             "Warn".bold().yellow()
                         );
                         let res = Confirm::with_theme(&theme)
-                            .with_prompt(format!("Continue ({user_version} -> {new_version})?"))
+                            .with_prompt(format!(
+                                "Update the version from {user_version} to {new_version}?"
+                            ))
                             .interact()?;
                         if res {
                             user_version = new_version.clone();
                             self.update_manifest_version(manifest_path, manifest, &user_version)
                                 .await?;
                         } else {
-                            anyhow::bail!(
-                                "Refusing to map two different releases of {full_pkg_name} to the same version."
-                            )
+                            anyhow::bail!("Aborted by the user")
                         }
                     } else {
                         let res = Confirm::with_theme(&theme)

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -461,7 +461,10 @@ impl PackageTag {
                     new_version.patch += 1;
                     if must_bump {
                         eprintln!("{}: Registry already has version {user_version} of {full_pkg_name}, but with different contents.", "Warn".bold().yellow());
-                        eprintln!("{}: Not bumping the version will make this action fail.", "Warn".bold().yellow());
+                        eprintln!(
+                            "{}: Not bumping the version will make this action fail.",
+                            "Warn".bold().yellow()
+                        );
                         let res = Confirm::with_theme(&theme)
                             .with_prompt(format!("Continue ({user_version} -> {new_version})?"))
                             .interact()?;


### PR DESCRIPTION
(Closes #4801, closes #4707, fixes RUN-276)

This PR adds a better message shown to users in the case they try to tag two different releases of the same package with the same version: 

<img width="838" alt="Screenshot 2024-07-17 at 13 48 22" src="https://github.com/user-attachments/assets/2d334d42-ee30-4632-8fd5-dfa774861c6b">
