### PR TITLE
Fix impossible relocation error in emit sdiv64 for singlepass compiler

### DIFF
--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -2631,7 +2631,7 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::GPR(reg)) => {
                 let reg = reg.into_index() as u32;
-                dynasm!(self ; cbz W(reg), => label);
+                dynasm!(self ; cbz X(reg), => near_label);
                 dynasm!(self ; b => continue_label);
             }
             _ => codegen_error!("singlepass can't emit CBZ {:?} {:?} {:?}", sz, reg, label),

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -4981,7 +4981,7 @@ impl Machine for MachineARM64 {
         let dest = self.location_to_reg(Size::S64, ret, &mut temps, ImmType::None, false, None)?;
 
         self.assembler
-            .emit_cbz_label(Size::S64, src2, integer_division_by_zero)?;
+            .emit_cbz_label_far(Size::S64, src2, integer_division_by_zero)?;
         let label_nooverflow = self.assembler.get_label();
         let tmp = self.location_to_reg(
             Size::S64,


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Fixes reoccurring error `ImpossibleRelocation(Dynamic(DynamicLabel(0)))` with singlepass compiler  for aarch64 targets
when generating sdiv64 binop.

Program which reproduce the bug [bug.wat.zip](https://github.com/user-attachments/files/16366458/bug.wat.zip).

See #4519 and [comment](https://github.com/wasmerio/wasmer/issues/4519#issuecomment-2248709808) for more info.

# What's done

- Use `emit_cbz_label_far` when emitting `sdiv64` binop
- Fix seemingly typos in S64 `emit_cbz_label_far` method
