### PR TITLE
CLI: Try to fetch owner from `app_id` if necessary while deploying

### DIFF
--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -180,6 +180,17 @@ impl CmdAppDeploy {
             return Ok((owner.clone(), r_ret));
         }
 
+        if let Some(app_id) = app.get("app_id") {
+            if let Some(app_id) = app_id.as_str() {
+                // Try to get the owner from the app_id. 
+                //
+                // In this case, don't edit the app config.
+                if let Ok(app) = wasmer_api::query::get_app_by_id(client, app_id.to_owned()).await {
+                    return Ok((app.owner.global_name, r_ret));
+                }
+            }
+        }
+
         if self.non_interactive {
             // if not interactive we can't prompt the user to choose the owner of the app.
             anyhow::bail!("No owner specified: use --owner XXX");

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -182,7 +182,7 @@ impl CmdAppDeploy {
 
         if let Some(app_id) = app.get("app_id") {
             if let Some(app_id) = app_id.as_str() {
-                // Try to get the owner from the app_id. 
+                // Try to get the owner from the app_id.
                 //
                 // In this case, don't edit the app config.
                 if let Ok(app) = wasmer_api::query::get_app_by_id(client, app_id.to_owned()).await {


### PR DESCRIPTION
(Closes #4957 , fixes RUN-372)

As per title: if no owner is supplied via CLI and there's no `owner` in the `app.yaml`, in the case that an `app_id` is present, the `deploy` command tries to fetch the app owner from the backend using the `app_id`. 