### PR TITLE
CLI: Cache templates from different registries in diffferent directories

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -506,7 +506,7 @@ impl CmdAppCreate {
                 .registry_public_url()?
                 .host_str()
                 .unwrap_or("unknown_registry")
-                .replace(".", "_");
+                .replace('.', "_");
             let cache_dir = self.env.cache_dir().join("templates").join(registry);
 
             let languages = Self::fetch_template_languages_cached(client, &cache_dir).await?;

--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -501,8 +501,15 @@ impl CmdAppCreate {
             }
 
             let theme = ColorfulTheme::default();
-            let languages =
-                Self::fetch_template_languages_cached(client, &self.env.cache_dir).await?;
+            let registry = self
+                .env
+                .registry_public_url()?
+                .host_str()
+                .unwrap_or("unknown_registry")
+                .replace(".", "_");
+            let cache_dir = self.env.cache_dir().join("templates").join(registry);
+
+            let languages = Self::fetch_template_languages_cached(client, &cache_dir).await?;
 
             let items = languages.iter().map(|t| t.name.clone()).collect::<Vec<_>>();
 
@@ -523,8 +530,7 @@ impl CmdAppCreate {
                 .ok_or(anyhow::anyhow!("Invalid selection!"))?;
 
             let templates =
-                Self::fetch_templates_cached(client, &self.env.cache_dir, &selected_language.slug)
-                    .await?;
+                Self::fetch_templates_cached(client, &cache_dir, &selected_language.slug).await?;
 
             let items = templates
                 .iter()


### PR DESCRIPTION
(Closes #4969, fixes RUN-379)

As per title. For example, templates downloaded from `registry.wasmer.io` are cached in `$WASMER_CACHE_DIR/templates/wasmer_io/app_templates.json`. 