### PR TITLE
CLI: Ask users to allow networking capabilities if not set

### DIFF
--- a/lib/cli/src/commands/run/capabilities/mod.rs
+++ b/lib/cli/src/commands/run/capabilities/mod.rs
@@ -1,0 +1,3 @@
+/// A custom implementation of the [`virtual_net::VirtualNetwork`] that asks users if they want to
+/// use networking features at runtime.
+pub(crate) mod net;

--- a/lib/cli/src/commands/run/capabilities/mod.rs
+++ b/lib/cli/src/commands/run/capabilities/mod.rs
@@ -1,3 +1,12 @@
 /// A custom implementation of the [`virtual_net::VirtualNetwork`] that asks users if they want to
 /// use networking features at runtime.
 pub(crate) mod net;
+
+/// The default name of the directory to store cached capabilities for packages.
+pub(crate) const DEFAULT_WASMER_PKG_CAPABILITY_CACHE_DIR: &str = "pkg_capabilities";
+
+/// A struct representing cached capabilities for a specific package.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct PkgCapabilityCache {
+    pub enable_networking: bool,
+}

--- a/lib/cli/src/commands/run/capabilities/net.rs
+++ b/lib/cli/src/commands/run/capabilities/net.rs
@@ -1,0 +1,222 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::OnceLock,
+    time::Duration,
+};
+
+use colored::Colorize;
+use dialoguer::theme::ColorfulTheme;
+use virtual_net::{
+    DynVirtualNetworking, IpCidr, IpRoute, NetworkError, Result, StreamSecurity,
+    UnsupportedVirtualNetworking, VirtualIcmpSocket, VirtualNetworking, VirtualRawSocket,
+    VirtualTcpListener, VirtualTcpSocket, VirtualUdpSocket,
+};
+
+/// A custom implementation of the [`virtual_net::VirtualNetwork`] that asks users if they want to
+/// use networking features at runtime.
+#[derive(Debug, Clone)]
+pub(crate) struct AskingNetworking {
+    enable: OnceLock<Result<bool>>,
+    capable: DynVirtualNetworking,
+    unsupported: DynVirtualNetworking,
+}
+
+fn ask_user(fn_name: &str) -> Result<bool> {
+    let theme = ColorfulTheme::default();
+
+    println!("Networking needs to be enabled to call function '{fn_name}'.");
+    if dialoguer::Confirm::with_theme(&theme)
+        .with_prompt("Enable networking?")
+        .interact()
+        .map_err(|_| NetworkError::UnknownError)?
+    {
+        eprintln!(
+            "{}: to enable networking by default, use the `--net` flag",
+            "Info".bold()
+        );
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+macro_rules! call {
+    ($self: expr, $fn_name: ident, $( $arg: expr ),* ) => {
+
+        let enable_networking = $self.enable.get_or_init(|| ask_user(stringify!($fn_name))).map_err(|_| NetworkError::UnknownError)?;
+
+        if enable_networking {
+            return $self.capable.$fn_name( $( $arg ),* ).await;
+        } else {
+            return $self.unsupported.$fn_name( $( $arg ),* ).await;
+        }
+    };
+
+    ($self: expr, $fn_name: ident) => {
+
+        let enable_networking = $self.enable.get_or_init(|| ask_user(stringify!($fn_name))).map_err(|_| NetworkError::UnknownError)?;
+
+        if enable_networking {
+            return $self.capable.$fn_name().await;
+        } else {
+            return $self.unsupported.$fn_name().await;
+        }
+    };
+}
+
+impl AskingNetworking {
+    pub(crate) fn new(capable_networking: DynVirtualNetworking) -> Self {
+        let enable_networking = OnceLock::new();
+
+        Self {
+            enable: enable_networking,
+            capable: capable_networking,
+            unsupported: std::sync::Arc::new(UnsupportedVirtualNetworking::default()),
+        }
+    }
+}
+
+/// An implementation of virtual networking
+#[async_trait::async_trait]
+#[allow(unused_variables)]
+impl VirtualNetworking for AskingNetworking {
+    /// Bridges this local network with a remote network, which is required in
+    /// order to make lower level networking calls (such as UDP/TCP)
+    async fn bridge(
+        &self,
+        network: &str,
+        access_token: &str,
+        security: StreamSecurity,
+    ) -> Result<()> {
+        call!(self, bridge, network, access_token, security);
+    }
+
+    /// Disconnects from the remote network essentially unbridging it
+    async fn unbridge(&self) -> Result<()> {
+        call!(self, unbridge);
+    }
+
+    /// Acquires an IP address on the network and configures the routing tables
+    async fn dhcp_acquire(&self) -> Result<Vec<IpAddr>> {
+        call!(self, dhcp_acquire);
+    }
+
+    /// Adds a static IP address to the interface with a netmask prefix
+    async fn ip_add(&self, ip: IpAddr, prefix: u8) -> Result<()> {
+        call!(self, ip_add, ip, prefix);
+    }
+
+    /// Removes a static (or dynamic) IP address from the interface
+    async fn ip_remove(&self, ip: IpAddr) -> Result<()> {
+        call!(self, ip_remove, ip);
+    }
+
+    /// Clears all the assigned IP addresses for this interface
+    async fn ip_clear(&self) -> Result<()> {
+        call!(self, ip_clear);
+    }
+
+    /// Lists all the IP addresses currently assigned to this interface
+    async fn ip_list(&self) -> Result<Vec<IpCidr>> {
+        call!(self, ip_list);
+    }
+
+    /// Returns the hardware MAC address for this interface
+    async fn mac(&self) -> Result<[u8; 6]> {
+        call!(self, mac);
+    }
+
+    /// Adds a default gateway to the routing table
+    async fn gateway_set(&self, ip: IpAddr) -> Result<()> {
+        call!(self, gateway_set, ip);
+    }
+
+    /// Adds a specific route to the routing table
+    async fn route_add(
+        &self,
+        cidr: IpCidr,
+        via_router: IpAddr,
+        preferred_until: Option<Duration>,
+        expires_at: Option<Duration>,
+    ) -> Result<()> {
+        call!(
+            self,
+            route_add,
+            cidr,
+            via_router,
+            preferred_until,
+            expires_at
+        );
+    }
+
+    /// Removes a routing rule from the routing table
+    async fn route_remove(&self, cidr: IpAddr) -> Result<()> {
+        call!(self, route_remove, cidr);
+    }
+
+    /// Clears the routing table for this interface
+    async fn route_clear(&self) -> Result<()> {
+        call!(self, route_clear);
+    }
+
+    /// Lists all the routes defined in the routing table for this interface
+    async fn route_list(&self) -> Result<Vec<IpRoute>> {
+        call!(self, route_list);
+    }
+
+    /// Creates a low level socket that can read and write Ethernet packets
+    /// directly to the interface
+    async fn bind_raw(&self) -> Result<Box<dyn VirtualRawSocket + Sync>> {
+        call!(self, bind_raw);
+    }
+
+    /// Lists for TCP connections on a specific IP and Port combination
+    /// Multiple servers (processes or threads) can bind to the same port if they each set
+    /// the reuse-port and-or reuse-addr flags
+    async fn listen_tcp(
+        &self,
+        addr: SocketAddr,
+        only_v6: bool,
+        reuse_port: bool,
+        reuse_addr: bool,
+    ) -> Result<Box<dyn VirtualTcpListener + Sync>> {
+        call!(self, listen_tcp, addr, only_v6, reuse_port, reuse_addr);
+    }
+
+    /// Opens a UDP socket that listens on a specific IP and Port combination
+    /// Multiple servers (processes or threads) can bind to the same port if they each set
+    /// the reuse-port and-or reuse-addr flags
+    async fn bind_udp(
+        &self,
+        addr: SocketAddr,
+        reuse_port: bool,
+        reuse_addr: bool,
+    ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
+        call!(self, bind_udp, addr, reuse_port, reuse_addr);
+    }
+
+    /// Creates a socket that can be used to send and receive ICMP packets
+    /// from a paritcular IP address
+    async fn bind_icmp(&self, addr: IpAddr) -> Result<Box<dyn VirtualIcmpSocket + Sync>> {
+        call!(self, bind_icmp, addr);
+    }
+
+    /// Opens a TCP connection to a particular destination IP address and port
+    async fn connect_tcp(
+        &self,
+        addr: SocketAddr,
+        peer: SocketAddr,
+    ) -> Result<Box<dyn VirtualTcpSocket + Sync>> {
+        call!(self, connect_tcp, addr, peer);
+    }
+
+    /// Performs DNS resolution for a specific hostname
+    async fn resolve(
+        &self,
+        host: &str,
+        port: Option<u16>,
+        dns_server: Option<IpAddr>,
+    ) -> Result<Vec<IpAddr>> {
+        call!(self, resolve, host, port, dns_server);
+    }
+}

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -175,7 +175,7 @@ impl Run {
             }
             PackageSource::Package(p) => match p {
                 PackageSpecifier::Ident(id) => {
-                    format!("id_{}.json", id.to_string())
+                    format!("id_{id}.json")
                 }
                 PackageSpecifier::Path(f) => {
                     let full_path = PathBuf::from(f).canonicalize()?.to_path_buf();

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs, unused)]
 
 mod wasi;
+mod capabilities;
 
 use std::{
     collections::BTreeMap,

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -47,6 +47,8 @@ use wasmer_wasix::{
 
 use crate::utils::{parse_envvar, parse_mapdir};
 
+use super::{capabilities::PkgCapabilityCache, ExecutableTarget, PackageSource};
+
 const WAPM_SOURCE_CACHE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Debug, Parser, Clone, Default)]
@@ -539,6 +541,7 @@ impl Wasi {
         &self,
         engine: Engine,
         env: &WasmerEnv,
+        pkg_cache_path: &Path,
         rt_or_handle: I,
         preferred_webc_version: webc::Version,
     ) -> Result<impl Runtime + Send + Sync>
@@ -548,12 +551,26 @@ impl Wasi {
         let tokio_task_manager = Arc::new(TokioTaskManager::new(rt_or_handle.into()));
         let mut rt = PluggableRuntime::new(tokio_task_manager.clone());
 
-        if self.networking {
+        let has_networking = self.networking || {
+            if pkg_cache_path.is_file() {
+                let raw = std::fs::read_to_string(pkg_cache_path)?;
+                if let Ok(pkg_capability_cache) = serde_json::from_str::<PkgCapabilityCache>(&raw) {
+                    pkg_capability_cache.enable_networking
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        if has_networking {
             rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());
         } else {
-            let net = super::capabilities::net::AskingNetworking::new(Arc::new(
-                virtual_net::host::LocalNetworking::default(),
-            ));
+            let net = super::capabilities::net::AskingNetworking::new(
+                pkg_cache_path.to_path_buf(),
+                Arc::new(virtual_net::host::LocalNetworking::default()),
+            );
 
             rt.set_networking_implementation(net);
         }

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -551,7 +551,11 @@ impl Wasi {
         if self.networking {
             rt.set_networking_implementation(virtual_net::host::LocalNetworking::default());
         } else {
-            rt.set_networking_implementation(virtual_net::UnsupportedVirtualNetworking::default());
+            let net = super::capabilities::net::AskingNetworking::new(Arc::new(
+                virtual_net::host::LocalNetworking::default(),
+            ));
+
+            rt.set_networking_implementation(net);
         }
 
         #[cfg(feature = "journal")]


### PR DESCRIPTION
(Closes #4953, fixes RUN-371)

As per title. This patch introduces a mechanism that allows users to recover from not permitted networking accesses with a prompt: 

<img width="631" alt="Screenshot 2024-07-30 at 14 18 47" src="https://github.com/user-attachments/assets/e702611e-fc87-4103-a39a-7d3e7f308c50">

In addition, as implied by the prompt, this patch adds a mechanism to cache the users' choice in response to the prompt above. 