### PR TITLE
feat(wasix): Expose the builtin package loder module

### DIFF
--- a/lib/wasix/src/runtime/package_loader/mod.rs
+++ b/lib/wasix/src/runtime/package_loader/mod.rs
@@ -1,4 +1,4 @@
-mod builtin_loader;
+pub mod builtin_loader;
 mod load_package_tree;
 mod types;
 mod unsupported;


### PR DESCRIPTION
Required for upstream use.
