### PR TITLE
fix(cli/WasmerEnv): strip `registry.` only if hostname starts with it

### DIFF
--- a/lib/cli/src/commands/auth/login/mod.rs
+++ b/lib/cli/src/commands/auth/login/mod.rs
@@ -181,6 +181,7 @@ impl Login {
             }
             #[cfg(test)]
             {
+                _ = user;
                 false
             }
         } else {

--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -279,8 +279,6 @@ impl PackageDownload {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::UserRegistry;
-
     use super::*;
 
     /// Download a package from the dev registry.

--- a/lib/cli/src/config/env.rs
+++ b/lib/cli/src/config/env.rs
@@ -323,7 +323,10 @@ mod tests {
             ("https://wasmer.io/", "https://registry.wasmer.io/graphql"),
             ("https://wasmer.wtf/", "https://registry.wasmer.wtf/graphql"),
             ("https://wasmer.wtf/", "https://registry.wasmer.wtf/graphql"),
-            ("https://wasmer.wtf/", "https://registry.wasmer.wtf/something/else"),
+            (
+                "https://wasmer.wtf/",
+                "https://registry.wasmer.wtf/something/else",
+            ),
             ("https://wasmer.wtf/", "https://wasmer.wtf/graphql"),
             ("https://wasmer.wtf/", "https://wasmer.wtf/graphql"),
             ("http://localhost:8000/", "http://localhost:8000/graphql"),

--- a/lib/cli/src/config/env.rs
+++ b/lib/cli/src/config/env.rs
@@ -56,12 +56,11 @@ impl WasmerEnv {
         let mut url = self.registry_endpoint()?;
         url.set_path("");
 
-        let domain = url
-            .host_str()
-            .context("url has no host")?
-            .strip_prefix("registry.")
-            .context("could not derive registry public url")?
-            .to_string();
+        let mut domain = url.host_str().context("url has no host")?.to_string();
+        if domain.starts_with("registry.") {
+            domain = domain.strip_prefix("registry.").unwrap().to_string();
+        }
+
         url.set_host(Some(&domain))
             .context("could not derive registry public url")?;
 

--- a/lib/registry/src/wasmer_env.rs
+++ b/lib/registry/src/wasmer_env.rs
@@ -46,12 +46,10 @@ impl WasmerEnv {
         let mut url = self.registry_endpoint()?;
         url.set_path("");
 
-        let domain = url
-            .host_str()
-            .context("url has no host")?
-            .strip_prefix("registry.")
-            .context("could not derive registry public url")?
-            .to_string();
+        let mut domain = url.host_str().context("url has no host")?.to_string();
+        if domain.starts_with("registry.") {
+            domain = domain.strip_prefix("registry.").unwrap().to_string();
+        }
         url.set_host(Some(&domain))
             .context("could not derive registry public url")?;
 


### PR DESCRIPTION
Currently, if a user has a non-canonical registry URL set as default url - for example, `http://localhost:11/graphql` - the CLI will fail as it tries to strip the `registry.` part of the URL, which might not be there. This small patch applies that change only in the case that the hostname actually starts with `registry.`. 