### PR TITLE
Check if a user can deploy an app before deploying it

### DIFF
--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -43,6 +43,7 @@ type User implements Node & PackageOwner & Owner {
   id: ID!
   globalName: String!
   globalId: ID!
+  viewerCan(action: OwnerAction!): Boolean!
   avatar(size: Int = 80): String!
   isViewer: Boolean!
   hasUsablePassword: Boolean
@@ -76,12 +77,19 @@ type User implements Node & PackageOwner & Owner {
 interface PackageOwner {
   globalName: String!
   globalId: ID!
+  viewerCan(action: OwnerAction!): Boolean!
+}
+
+enum OwnerAction {
+  DEPLOY_APP
+  PUBLISH_PACKAGE
 }
 
 """An owner of a package."""
 interface Owner {
   globalName: String!
   globalId: ID!
+  viewerCan(action: OwnerAction!): Boolean!
 }
 
 """
@@ -204,6 +212,7 @@ type Namespace implements Node & PackageOwner & Owner {
   userSet(offset: Int, before: String, after: String, first: Int, last: Int): UserConnection!
   globalName: String!
   globalId: ID!
+  viewerCan(action: OwnerAction!): Boolean!
   avatar: String!
   packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
   apps(sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
@@ -372,6 +381,7 @@ type Package implements Likeable & Node & PackageOwner {
   viewerHasLiked: Boolean!
   globalName: String!
   globalId: ID!
+  viewerCan(action: OwnerAction!): Boolean!
   alias: String
   displayName: String!
 
@@ -926,6 +936,7 @@ type DeployApp implements Node & Owner {
   activeVersion: DeployAppVersion!
   globalName: String!
   globalId: ID!
+  viewerCan(action: OwnerAction!): Boolean!
   url: String!
   adminUrl: String!
   permalink: String!
@@ -2388,6 +2399,7 @@ type Query {
   getPackageRelease(hash: String!): PackageWebc
   getPackageInstanceByVersionOrHash(name: String!, version: String, hash: String): PackageInstance
   categories(offset: Int, before: String, after: String, first: Int, last: Int): CategoryConnection!
+  viewerCan(action: OwnerAction!, ownerName: String!): Boolean!
   blogposts(tags: [String!], before: String, after: String, first: Int, last: Int): BlogPostConnection!
   getBlogpost(slug: String, featured: Boolean): BlogPost
   allBlogpostTags(offset: Int, before: String, after: String, first: Int, last: Int): BlogPostTagConnection

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -15,6 +15,19 @@ use crate::{
     GraphQLApiFailure, WasmerClient,
 };
 
+pub async fn viewer_can_deploy_to_namespace(
+    client: &WasmerClient,
+    owner_name: &str,
+) -> Result<bool, anyhow::Error> {
+    client
+        .run_graphql_strict(types::ViewerCan::build(ViewerCanVariables {
+            action: OwnerAction::DeployApp,
+            owner_name,
+        }))
+        .await
+        .map(|v| v.viewer_can)
+}
+
 pub async fn redeploy_app_by_id(
     client: &WasmerClient,
     app_id: impl Into<String>,

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -42,6 +42,25 @@ mod queries {
     }
 
     #[derive(cynic::QueryVariables, Debug)]
+    pub struct ViewerCanVariables<'a> {
+        pub action: OwnerAction,
+        pub owner_name: &'a str,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", variables = "ViewerCanVariables")]
+    pub struct ViewerCan {
+        #[arguments(action: $action, ownerName: $owner_name)]
+        pub viewer_can: bool,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    pub enum OwnerAction {
+        DeployApp,
+        PublishPackage,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
     pub struct RevokeTokenVariables {
         pub token: String,
     }

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -284,12 +284,9 @@ impl AsyncCliCommand for CmdAppDeploy {
             .await?;
 
         if !wasmer_api::query::viewer_can_deploy_to_namespace(&client, &owner).await? {
-            eprintln!(
-                "Cannot deploy app to namespace {}, as the current user is not authorized.",
-                owner.bold()
-            );
+            eprintln!("It seems you don't have access to {}", owner.bold());
             if self.non_interactive {
-                anyhow::bail!("Please, check the app configuration or the current user with the `whoami` command!");
+                anyhow::bail!("Please, change the owner before deploying or check your current user with `{} whoami`.", std::env::args().next().unwrap_or("wasmer".into()));
             } else {
                 let user = wasmer_api::query::current_user_with_namespaces(&client, None).await?;
                 owner = crate::utils::prompts::prompt_for_namespace(

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -301,6 +301,14 @@ impl AsyncCliCommand for CmdAppDeploy {
                     .as_mapping_mut()
                     .unwrap()
                     .insert("owner".into(), owner.clone().into());
+
+                if app_yaml.get("app_id").is_some() {
+                    app_yaml.as_mapping_mut().unwrap().remove("app_id");
+                }
+
+                if app_yaml.get("name").is_some() {
+                    app_yaml.as_mapping_mut().unwrap().remove("name");
+                }
             }
         }
 

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -285,7 +285,8 @@ impl AsyncCliCommand for CmdAppDeploy {
 
         if !wasmer_api::query::viewer_can_deploy_to_namespace(&client, &owner).await? {
             eprintln!(
-                "Cannot deploy app to namespace {owner}, as the current user is not authorized."
+                "Cannot deploy app to namespace {}, as the current user is not authorized.",
+                owner.bold()
             );
             if self.non_interactive {
                 anyhow::bail!("Please, check the app configuration or the current user with the `whoami` command!");


### PR DESCRIPTION
(Closes #4961)

Currently, if a user `a` tries to deploy an app that in the config shows as owner the name `b` but `a` has no permissions to deploy on `b` the deploy fails. This PR adds a preventive check to make sure that the user has the correct permissions to deploy.  In case the user can't the CLI asks for a new owner and app name. 