### PR TITLE
CLI(package/tag): Don't cache previously fetched user package

### DIFF
--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -115,7 +115,6 @@ impl PackagePublish {
             package_path: self.package_path.clone(),
             package_hash,
             package_id: None,
-            maybe_user_package: None,
         }
         .tag(
             client,


### PR DESCRIPTION
Recently it was brought up that tagging would fail in the case that the users selects to bump the package but its hash is the same. This was due to the fact that the implementation, in order to avoid making two calls, cached a response from the backend that potentially had the wrong (pre-bump) version but the same hash, which gated the tagging itself. 
