### PR TITLE
deps: use windows-sys instead of winapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6461,7 +6461,7 @@ dependencies = [
  "wasmer-vm",
  "wasmparser 0.121.2",
  "wat",
- "winapi 0.3.9",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6725,7 +6725,7 @@ dependencies = [
  "wasmer-types",
  "wasmer-vm",
  "wasmparser 0.121.2",
- "winapi 0.3.9",
+ "windows-sys 0.59.0",
  "xxhash-rust",
 ]
 
@@ -7096,7 +7096,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "wasmer-types",
- "winapi 0.3.9",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7181,7 +7181,7 @@ dependencies = [
  "web-sys",
  "webc",
  "weezl",
- "winapi 0.3.9",
+ "windows-sys 0.59.0",
  "xxhash-rust",
 ]
 
@@ -7548,6 +7548,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -56,7 +56,7 @@ wasmparser = { workspace = true, default-features = false, optional = true }
 
 # - Mandatory dependencies for `sys` on Windows.
 [target.'cfg(all(not(target_arch = "wasm32"), target_os = "windows"))'.dependencies]
-winapi = "0.3"
+windows-sys = "0.59"
 # - Development Dependencies for `sys`.
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 wat = "1.0"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -44,7 +44,7 @@ wasmer-vm = { path = "../vm", version = "=4.3.5" }
 region = { version = "3.0" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["winnt", "impl-default"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Diagnostics_Debug"] }
 
 [features]
 default = ["std"]

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -38,7 +38,7 @@ crossbeam-queue = "0.3.8"
 mach2 = "0.4.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["winbase", "memoryapi", "errhandlingapi"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Diagnostics_Debug", "Win32_System_Threading", "Win32_System_Kernel", "Win32_System_Memory"] }
 
 [build-dependencies]
 cc = "1.0"

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -192,8 +192,9 @@ impl Mmap {
         _backing_file: Option<std::path::PathBuf>,
         _memory_type: MmapType,
     ) -> Result<Self, String> {
-        use winapi::um::memoryapi::VirtualAlloc;
-        use winapi::um::winnt::{MEM_COMMIT, MEM_RESERVE, PAGE_NOACCESS, PAGE_READWRITE};
+        use windows_sys::Win32::System::Memory::{
+            VirtualAlloc, MEM_COMMIT, MEM_RESERVE, PAGE_NOACCESS, PAGE_READWRITE,
+        };
 
         let page_size = region::page::size();
         assert_le!(accessible_size, mapping_size);
@@ -272,9 +273,8 @@ impl Mmap {
     /// `self`'s reserved memory.
     #[cfg(target_os = "windows")]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
-        use winapi::ctypes::c_void;
-        use winapi::um::memoryapi::VirtualAlloc;
-        use winapi::um::winnt::{MEM_COMMIT, PAGE_READWRITE};
+        use std::ffi::c_void;
+        use windows_sys::Win32::System::Memory::{VirtualAlloc, MEM_COMMIT, PAGE_READWRITE};
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
@@ -396,9 +396,8 @@ impl Drop for Mmap {
     #[cfg(target_os = "windows")]
     fn drop(&mut self) {
         if self.len() != 0 {
-            use winapi::ctypes::c_void;
-            use winapi::um::memoryapi::VirtualFree;
-            use winapi::um::winnt::MEM_RELEASE;
+            use std::ffi::c_void;
+            use windows_sys::Win32::System::Memory::{VirtualFree, MEM_RELEASE};
             let r = unsafe { VirtualFree(self.ptr as *mut c_void, 0, MEM_RELEASE) };
             assert_ne!(r, 0);
         }

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -57,7 +57,7 @@ async-trait = { version = "^0.1" }
 urlencoding = { version = "^2" }
 serde_derive = { version = "^1" }
 serde_json = { version = "^1" }
-serde_yaml.workspace = true 
+serde_yaml.workspace = true
 weezl = { version = "^0.1" }
 hex = { version = "^0.4" }
 linked_hash_set = { version = "0.1" }
@@ -124,7 +124,7 @@ libc.workspace = true
 termios = { version = "0.3" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["sysinfoapi"] }
+windows-sys = { version = "0.59", features = ["Win32_System_SystemInformation"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 terminal_size = { version = "0.3.0" }

--- a/lib/wasix/src/syscalls/windows.rs
+++ b/lib/wasix/src/syscalls/windows.rs
@@ -30,7 +30,8 @@ pub fn platform_clock_time_get(
 ) -> Result<i64, wasi::Errno> {
     let nanos = match clock_id {
         wasi::Snapshot0Clockid::Monotonic => {
-            let tick_ms = unsafe { winapi::um::sysinfoapi::GetTickCount64() };
+            let tick_ms =
+                unsafe { windows_sys::Win32::System::SystemInformation::GetTickCount64() };
             tick_ms * 1_000_000
         }
         wasi::Snapshot0Clockid::Realtime => {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
winapi has no updates for more than 3 years, while windows-sys is bindings maintained by microsoft devs
