### PR TITLE
Add module-level middleware errors

### DIFF
--- a/lib/compiler/src/artifact_builders/artifact_builder.rs
+++ b/lib/compiler/src/artifact_builders/artifact_builder.rs
@@ -67,7 +67,9 @@ impl ArtifactBuild {
         // We try to apply the middleware first
         let mut module = translation.module;
         let middlewares = compiler.get_middlewares();
-        middlewares.apply_on_module_info(&mut module);
+        middlewares
+            .apply_on_module_info(&mut module)
+            .map_err(|err| CompileError::MiddlewareError(err.to_string()))?;
 
         if let Some(hash_algorithm) = hash_algorithm {
             let hash = match hash_algorithm {

--- a/lib/compiler/src/translator/middleware.rs
+++ b/lib/compiler/src/translator/middleware.rs
@@ -24,7 +24,9 @@ pub trait ModuleMiddleware: Debug + Send + Sync {
     ) -> Box<dyn FunctionMiddleware>;
 
     /// Transforms a `ModuleInfo` struct in-place. This is called before application on functions begins.
-    fn transform_module_info(&self, _: &mut ModuleInfo) {}
+    fn transform_module_info(&self, _: &mut ModuleInfo) -> Result<(), MiddlewareError> {
+        Ok(())
+    }
 }
 
 /// A function middleware specialized for a single function.
@@ -69,7 +71,7 @@ pub trait ModuleMiddlewareChain {
     ) -> Vec<Box<dyn FunctionMiddleware>>;
 
     /// Applies the chain on a `ModuleInfo` struct.
-    fn apply_on_module_info(&self, module_info: &mut ModuleInfo);
+    fn apply_on_module_info(&self, module_info: &mut ModuleInfo) -> Result<(), MiddlewareError>;
 }
 
 impl<T: Deref<Target = dyn ModuleMiddleware>> ModuleMiddlewareChain for [T] {
@@ -84,10 +86,11 @@ impl<T: Deref<Target = dyn ModuleMiddleware>> ModuleMiddlewareChain for [T] {
     }
 
     /// Applies the chain on a `ModuleInfo` struct.
-    fn apply_on_module_info(&self, module_info: &mut ModuleInfo) {
+    fn apply_on_module_info(&self, module_info: &mut ModuleInfo) -> Result<(), MiddlewareError> {
         for item in self {
-            item.transform_module_info(module_info);
+            item.transform_module_info(module_info)?;
         }
+        Ok(())
     }
 }
 

--- a/lib/middlewares/src/metering.rs
+++ b/lib/middlewares/src/metering.rs
@@ -154,7 +154,7 @@ impl<F: Fn(&Operator) -> u64 + Send + Sync + 'static> ModuleMiddleware for Meter
     }
 
     /// Transforms a `ModuleInfo` struct in-place. This is called before application on functions begins.
-    fn transform_module_info(&self, module_info: &mut ModuleInfo) {
+    fn transform_module_info(&self, module_info: &mut ModuleInfo) -> Result<(), MiddlewareError> {
         let mut global_indexes = self.global_indexes.lock().unwrap();
 
         if global_indexes.is_some() {
@@ -192,7 +192,9 @@ impl<F: Fn(&Operator) -> u64 + Send + Sync + 'static> ModuleMiddleware for Meter
         *global_indexes = Some(MeteringGlobalIndexes(
             remaining_points_global_index,
             points_exhausted_global_index,
-        ))
+        ));
+
+        Ok(())
     }
 }
 

--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -175,6 +175,10 @@ pub enum CompileError {
     /// Insufficient resources available for execution.
     #[cfg_attr(feature = "std", error("Insufficient resources: {0}"))]
     Resource(String),
+
+    /// Middleware error occurred.
+    #[cfg_attr(feature = "std", error("Middleware error: {0}"))]
+    MiddlewareError(String),
 }
 
 impl From<WasmError> for CompileError {


### PR DESCRIPTION
Adds the ability to return errors from module-level middleware. This allows a middleware to cancel compilation cleanly.

closes https://github.com/wasmerio/wasmer/issues/5010 

