### PR TITLE
Consume unused result in `lib/compiler/src/engine/artifact.rs`

### DIFF
--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -890,7 +890,9 @@ impl Artifact {
         use crate::translator::ModuleMiddlewareChain;
         let mut module = translation.module;
         let middlewares = compiler.get_middlewares();
-        middlewares.apply_on_module_info(&mut module);
+        middlewares
+            .apply_on_module_info(&mut module)
+            .map_err(|e| CompileError::MiddlewareError(e.to_string()))?;
 
         let memory_styles: PrimaryMap<MemoryIndex, MemoryStyle> = module
             .memories


### PR DESCRIPTION
As per title.