### PR TITLE
Add help-docs for the `--watch` flag in `wasmer app logs`

### DIFF
--- a/lib/cli/src/commands/app/logs.rs
+++ b/lib/cli/src/commands/app/logs.rs
@@ -56,6 +56,7 @@ pub struct CmdAppLogs {
     #[clap(long, default_value = "1000")]
     max: usize,
 
+    /// Continuously watch for new logs and display them in real-time.
     #[clap(long, default_value = "false")]
     watch: bool,
 


### PR DESCRIPTION
the docs were missing so I added it.