### PR TITLE
deps: bump tun-tap version for wasmer-cli

### DIFF
--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -226,7 +226,7 @@ tokio-tungstenite = { version = "0.21.0", features = [
 	"stream",
 ], optional = true }
 mac_address = { version = "1.1.5", optional = true }
-tun-tap = { version = "0.1.3", features = ["tokio"], optional = true }
+tun-tap = { version = "0.1.4", features = ["tokio"], optional = true }
 
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/CONTRIBUTING.md#pull-requests

-->

# Description
bump tun-tap version to match with one from Cargo.lock
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
