### PR TITLE
chore(wasix): Reduce syscall instrumentation levels

### DIFF
--- a/lib/wasix/src/syscalls/legacy/snapshot0.rs
+++ b/lib/wasix/src/syscalls/legacy/snapshot0.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// Wrapper around `syscalls::fd_filestat_get` for old Snapshot0
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn fd_filestat_get(
     mut ctx: FunctionEnvMut<WasiEnv>,
     fd: Fd,
@@ -30,7 +30,7 @@ pub fn fd_filestat_get(
 }
 
 /// Wrapper around `syscalls::path_filestat_get` for old Snapshot0
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn path_filestat_get(
     mut ctx: FunctionEnvMut<WasiEnv>,
     fd: Fd,
@@ -50,7 +50,7 @@ pub fn path_filestat_get(
 
 /// Wrapper around `syscalls::fd_seek` with extra logic to remap the values
 /// of `Whence`
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn fd_seek(
     ctx: FunctionEnvMut<WasiEnv>,
     fd: Fd,

--- a/lib/wasix/src/syscalls/mod.rs
+++ b/lib/wasix/src/syscalls/mod.rs
@@ -1255,7 +1255,7 @@ where
     Ok(Errno::Success)
 }
 
-#[instrument(level = "debug", skip_all, fields(memory_stack_len = memory_stack.len(), rewind_stack_len = rewind_stack.len(), store_data_len = store_data.len()))]
+// NOTE: not tracing-instrumented because [`rewind_ext`] already is.
 #[must_use = "the action must be passed to the call loop"]
 pub fn rewind<M: MemorySize, T>(
     mut ctx: FunctionEnvMut<WasiEnv>,
@@ -1277,7 +1277,7 @@ where
     )
 }
 
-#[instrument(level = "debug", skip_all, fields(rewind_stack_len = rewind_stack.len(), store_data_len = store_data.len()))]
+#[instrument(level = "trace", skip_all, fields(rewind_stack_len = rewind_stack.len(), store_data_len = store_data.len()))]
 #[must_use = "the action must be passed to the call loop"]
 pub fn rewind_ext<M: MemorySize>(
     ctx: &mut FunctionEnvMut<WasiEnv>,

--- a/lib/wasix/src/syscalls/wasi/args_get.rs
+++ b/lib/wasix/src/syscalls/wasi/args_get.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// - `char *argv_buf`
 ///     A pointer to a buffer to write the argument string data.
 ///
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn args_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     argv: WasmPtr<WasmPtr<u8, M>, M>,

--- a/lib/wasix/src/syscalls/wasi/args_sizes_get.rs
+++ b/lib/wasix/src/syscalls/wasi/args_sizes_get.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 ///     The number of arguments.
 /// - `size_t *argv_buf_size`
 ///     The size of the argument string data.
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn args_sizes_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     argc: WasmPtr<M::Offset, M>,

--- a/lib/wasix/src/syscalls/wasi/environ_get.rs
+++ b/lib/wasix/src/syscalls/wasi/environ_get.rs
@@ -9,7 +9,7 @@ use crate::{journal::SnapshotTrigger, syscalls::*};
 ///     A pointer to a buffer to write the environment variable pointers.
 /// - `char *environ_buf`
 ///     A pointer to a buffer to write the environment variable string data.
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn environ_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     environ: WasmPtr<WasmPtr<u8, M>, M>,

--- a/lib/wasix/src/syscalls/wasi/fd_advise.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_advise.rs
@@ -12,7 +12,7 @@ use crate::syscalls::*;
 ///     The length from the offset to which the advice applies
 /// - `__wasi_advice_t advice`
 ///     The advice to give
-#[instrument(level = "debug", skip_all, fields(%fd, %offset, %len, ?advice), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, %offset, %len, ?advice), ret)]
 pub fn fd_advise(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_allocate.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_allocate.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 ///     The offset from the start marking the beginning of the allocation
 /// - `Filesize len`
 ///     The length from the offset marking the end of the allocation
-#[instrument(level = "debug", skip_all, fields(%fd, %offset, %len), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, %offset, %len), ret)]
 pub fn fd_allocate(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_close.rs
@@ -12,7 +12,7 @@ use crate::syscalls::*;
 ///     If `fd` is a directory
 /// - `Errno::Badf`
 ///     If `fd` is invalid or not open
-#[instrument(level = "debug", skip_all, fields(pid = ctx.data().process.pid().raw(), %fd), ret)]
+#[instrument(level = "trace", skip_all, fields(pid = ctx.data().process.pid().raw(), %fd), ret)]
 pub fn fd_close(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasi/fd_datasync.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_datasync.rs
@@ -6,7 +6,7 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `Fd fd`
 ///     The file descriptor to sync
-#[instrument(level = "debug", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd), ret)]
 pub fn fd_datasync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasi/fd_dup.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_dup.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// Outputs:
 /// - `Fd fd`
 ///   The new file handle that is a duplicate of the original
-#[instrument(level = "debug", skip_all, fields(%fd, ret_fd = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, ret_fd = field::Empty), ret)]
 pub fn fd_dup<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_event.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_event.rs
@@ -3,7 +3,7 @@ use crate::{fs::NotificationInner, syscalls::*};
 
 /// ### `fd_event()`
 /// Creates a file handle for event notifications
-#[instrument(level = "debug", skip_all, fields(%initial_val, ret_fd = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%initial_val, ret_fd = field::Empty), ret)]
 pub fn fd_event<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     initial_val: u64,

--- a/lib/wasix/src/syscalls/wasi/fd_fdstat_set_flags.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_fdstat_set_flags.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 ///     The file descriptor to apply the new flags to
 /// - `Fdflags flags`
 ///     The flags to apply to `fd`
-#[instrument(level = "debug", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd), ret)]
 pub fn fd_fdstat_set_flags(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_fdstat_set_rights.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_fdstat_set_rights.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 ///     The rights to apply to `fd`
 /// - `Rights fs_rights_inheriting`
 ///     The inheriting rights to apply to `fd`
-#[instrument(level = "debug", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd), ret)]
 pub fn fd_fdstat_set_rights(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
@@ -10,7 +10,7 @@ use crate::types::wasi::Snapshot0Filestat;
 /// Output:
 /// - `Filestat *buf`
 ///     Where the metadata from `fd` will be written
-#[instrument(level = "debug", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd), ret)]
 pub fn fd_filestat_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
@@ -56,7 +56,7 @@ pub(crate) fn fd_filestat_get_internal(
 /// Output:
 /// - `Snapshot0Filestat *buf`
 ///     Where the metadata from `fd` will be written
-#[instrument(level = "debug", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd), ret)]
 pub fn fd_filestat_get_old<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_size.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_size.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 ///     File descriptor to adjust
 /// - `Filesize st_size`
 ///     New size that `fd` will be set to
-#[instrument(level = "debug", skip_all, fields(%fd, %st_size), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, %st_size), ret)]
 pub fn fd_filestat_set_size(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
@@ -12,7 +12,7 @@ use crate::syscalls::*;
 ///     Last modified time
 /// - `Fstflags fst_flags`
 ///     Bit-vector for controlling which times get set
-#[instrument(level = "debug", skip_all, fields(%fd, %st_atim, %st_mtim), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, %st_atim, %st_mtim), ret)]
 pub fn fd_filestat_set_times(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_renumber.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_renumber.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 ///     File descriptor to copy
 /// - `Fd to`
 ///     Location to copy file descriptor to
-#[instrument(level = "debug", skip_all, fields(%from, %to), ret)]
+#[instrument(level = "trace", skip_all, fields(%from, %to), ret)]
 pub fn fd_renumber(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     from: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/fd_sync.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_sync.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// TODO: figure out which errors this should return
 /// - `Errno::Perm`
 /// - `Errno::Notcapable`
-#[instrument(level = "debug", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd), ret)]
 pub fn fd_sync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno, WasiError> {
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasi/fd_tell.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_tell.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// Output:
 /// - `Filesize *offset`
 ///     The offset of `fd` relative to the start of the file
-#[instrument(level = "debug", skip_all, fields(%fd, offset = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, offset = field::Empty), ret)]
 pub fn fd_tell<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_set_times.rs
@@ -18,7 +18,7 @@ use crate::syscalls::*;
 ///     The timestamp that the last modified time attribute is set to
 /// - `Fstflags fst_flags`
 ///     A bitmask controlling which attributes are set
-#[instrument(level = "debug", skip_all, fields(%fd, path = field::Empty, %st_atim, %st_mtim), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, path = field::Empty, %st_atim, %st_mtim), ret)]
 pub fn path_filestat_set_times<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_link.rs
+++ b/lib/wasix/src/syscalls/wasi/path_link.rs
@@ -18,7 +18,7 @@ use crate::syscalls::*;
 ///     String containing the new file path
 /// - `u32 old_path_len`
 ///     Length of the `new_path` string
-#[instrument(level = "debug", skip_all, fields(%old_fd, %new_fd, old_path = field::Empty, new_path = field::Empty, follow_symlinks = false), ret)]
+#[instrument(level = "trace", skip_all, fields(%old_fd, %new_fd, old_path = field::Empty, new_path = field::Empty, follow_symlinks = false), ret)]
 pub fn path_link<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     old_fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -25,7 +25,7 @@ use crate::syscalls::*;
 ///     The new file descriptor
 /// Possible Errors:
 /// - `Errno::Access`, `Errno::Badf`, `Errno::Fault`, `Errno::Fbig?`, `Errno::Inval`, `Errno::Io`, `Errno::Loop`, `Errno::Mfile`, `Errno::Nametoolong?`, `Errno::Nfile`, `Errno::Noent`, `Errno::Notdir`, `Errno::Rofs`, and `Errno::Notcapable`
-#[instrument(level = "debug", skip_all, fields(%dirfd, path = field::Empty, follow_symlinks = field::Empty, ret_fd = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%dirfd, path = field::Empty, follow_symlinks = field::Empty, ret_fd = field::Empty), ret)]
 pub fn path_open<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     dirfd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_readlink.rs
+++ b/lib/wasix/src/syscalls/wasi/path_readlink.rs
@@ -17,7 +17,7 @@ use crate::syscalls::*;
 ///     Pointer to characters containing the path that the symlink points to
 /// - `u32 buf_used`
 ///     The number of bytes written to `buf`
-#[instrument(level = "debug", skip_all, fields(%dir_fd, path = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%dir_fd, path = field::Empty), ret)]
 pub fn path_readlink<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     dir_fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::syscalls::*;
 
 /// Returns Errno::Notemtpy if directory is not empty
-#[instrument(level = "debug", skip_all, fields(%fd, path = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, path = field::Empty), ret)]
 pub fn path_remove_directory<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -16,7 +16,7 @@ use crate::syscalls::*;
 ///     Pointer to UTF8 bytes, the new file name
 /// - `u32 new_path_len`
 ///     The number of bytes to read from `new_path`
-#[instrument(level = "debug", skip_all, fields(%old_fd, %new_fd, old_path = field::Empty, new_path = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%old_fd, %new_fd, old_path = field::Empty, new_path = field::Empty), ret)]
 pub fn path_rename<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     old_fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/path_symlink.rs
+++ b/lib/wasix/src/syscalls/wasi/path_symlink.rs
@@ -14,7 +14,7 @@ use crate::syscalls::*;
 ///     Array of UTF-8 bytes representing the target path
 /// - `u32 new_path_len`
 ///     The number of bytes to read from `new_path`
-#[instrument(level = "debug", skip_all, fields(%fd, old_path = field::Empty, new_path = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, old_path = field::Empty, new_path = field::Empty), ret)]
 pub fn path_symlink<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     old_path: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 ///     Array of UTF-8 bytes representing the path
 /// - `u32 path_len`
 ///     The number of bytes in the `path` array
-#[instrument(level = "debug", skip_all, fields(%fd, path = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, path = field::Empty), ret)]
 pub fn path_unlink_file<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,

--- a/lib/wasix/src/syscalls/wasi/proc_exit.rs
+++ b/lib/wasix/src/syscalls/wasi/proc_exit.rs
@@ -8,7 +8,7 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `ExitCode`
 ///   Exit code to return to the operating system
-#[instrument(level = "debug", skip_all)]
+#[instrument(level = "trace", skip_all)]
 pub fn proc_exit<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     code: ExitCode,

--- a/lib/wasix/src/syscalls/wasi/proc_raise.rs
+++ b/lib/wasix/src/syscalls/wasi/proc_raise.rs
@@ -7,7 +7,7 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `Signal`
 ///   Signal to be raised for this process
-#[instrument(level = "debug", skip_all, fields(sig), ret)]
+#[instrument(level = "trace", skip_all, fields(sig), ret)]
 pub fn proc_raise(mut ctx: FunctionEnvMut<'_, WasiEnv>, sig: Signal) -> Result<Errno, WasiError> {
     let env = ctx.data();
     env.process.signal_process(sig);

--- a/lib/wasix/src/syscalls/wasi/thread_spawn.rs
+++ b/lib/wasix/src/syscalls/wasi/thread_spawn.rs
@@ -16,7 +16,7 @@ use wasmer_wasix_types::wasi::ThreadStart;
 ///
 /// Returns the thread index of the newly created thread
 /// (indices always start from the same value as `pid` and increments in steps)
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn thread_spawn<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     start_ptr: WasmPtr<ThreadStart<M>, M>,

--- a/lib/wasix/src/syscalls/wasix/chdir.rs
+++ b/lib/wasix/src/syscalls/wasix/chdir.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `chdir()`
 /// Sets the current working directory
-#[instrument(level = "debug", skip_all, fields(name = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(name = field::Empty), ret)]
 pub fn chdir<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     path: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/getcwd.rs
+++ b/lib/wasix/src/syscalls/wasix/getcwd.rs
@@ -5,7 +5,7 @@ use crate::syscalls::*;
 /// Returns the current working directory
 /// If the path exceeds the size of the buffer then this function
 /// will return ERANGE
-#[instrument(level = "debug", skip_all, fields(path = field::Empty, max_path_len = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(path = field::Empty, max_path_len = field::Empty), ret)]
 pub fn getcwd<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     path: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/port_addr_add.rs
+++ b/lib/wasix/src/syscalls/wasix/port_addr_add.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `addr` - Address to be added
-#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(ip = field::Empty), ret)]
 pub fn port_addr_add<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_cidr_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_addr_clear.rs
+++ b/lib/wasix/src/syscalls/wasix/port_addr_clear.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `port_addr_clear()`
 /// Clears all the addresses on the local port
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn port_addr_clear(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
     wasi_try_ok!(port_addr_clear_internal(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasix/port_addr_list.rs
+++ b/lib/wasix/src/syscalls/wasix/port_addr_list.rs
@@ -14,7 +14,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// The number of addresses returned.
-#[instrument(level = "debug", skip_all, fields(naddrs = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(naddrs = field::Empty), ret)]
 pub fn port_addr_list<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     addrs_ptr: WasmPtr<__wasi_cidr_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_addr_remove.rs
+++ b/lib/wasix/src/syscalls/wasix/port_addr_remove.rs
@@ -7,7 +7,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `addr` - Address to be removed
-#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(ip = field::Empty), ret)]
 pub fn port_addr_remove<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_addr_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_bridge.rs
+++ b/lib/wasix/src/syscalls/wasix/port_bridge.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// * `network` - Fully qualified identifier for the network
 /// * `token` - Access token used to authenticate with the network
 /// * `security` - Level of encryption to encapsulate the network connection with
-#[instrument(level = "debug", skip_all, fields(network = field::Empty, ?security), ret)]
+#[instrument(level = "trace", skip_all, fields(network = field::Empty, ?security), ret)]
 pub fn port_bridge<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     network: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/port_dhcp_acquire.rs
+++ b/lib/wasix/src/syscalls/wasix/port_dhcp_acquire.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `port_dhcp_acquire()`
 /// Acquires a set of IP addresses using DHCP
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn port_dhcp_acquire(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
     wasi_try_ok!(port_dhcp_acquire_internal(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasix/port_gateway_set.rs
+++ b/lib/wasix/src/syscalls/wasix/port_gateway_set.rs
@@ -7,7 +7,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `addr` - Address of the default gateway
-#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(ip = field::Empty), ret)]
 pub fn port_gateway_set<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_addr_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_mac.rs
+++ b/lib/wasix/src/syscalls/wasix/port_mac.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `port_mac()`
 /// Returns the MAC address of the local port
-#[instrument(level = "debug", skip_all, fields(max = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(max = field::Empty), ret)]
 pub fn port_mac<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ret_mac: WasmPtr<__wasi_hardwareaddress_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_route_add.rs
+++ b/lib/wasix/src/syscalls/wasix/port_route_add.rs
@@ -5,7 +5,7 @@ use crate::syscalls::*;
 
 /// ### `port_route_add()`
 /// Adds a new route to the local port
-#[instrument(level = "debug", skip_all, fields(cidr = field::Empty, via_router = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(cidr = field::Empty, via_router = field::Empty), ret)]
 pub fn port_route_add<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     cidr: WasmPtr<__wasi_cidr_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_route_clear.rs
+++ b/lib/wasix/src/syscalls/wasix/port_route_clear.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `port_route_clear()`
 /// Clears all the routes in the local port
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn port_route_clear(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
     wasi_try_ok!(port_route_clear_internal(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasix/port_route_list.rs
+++ b/lib/wasix/src/syscalls/wasix/port_route_list.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `routes` - The buffer where routes will be stored
-#[instrument(level = "debug", skip_all, fields(nroutes = field::Empty, max_routes = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(nroutes = field::Empty, max_routes = field::Empty), ret)]
 pub fn port_route_list<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     routes_ptr: WasmPtr<Route, M>,

--- a/lib/wasix/src/syscalls/wasix/port_route_remove.rs
+++ b/lib/wasix/src/syscalls/wasix/port_route_remove.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `port_route_remove()`
 /// Removes an existing route from the local port
-#[instrument(level = "debug", skip_all, fields(ip = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(ip = field::Empty), ret)]
 pub fn port_route_remove<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     ip: WasmPtr<__wasi_addr_t, M>,

--- a/lib/wasix/src/syscalls/wasix/port_unbridge.rs
+++ b/lib/wasix/src/syscalls/wasix/port_unbridge.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `port_unbridge()`
 /// Disconnects from a remote network
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn port_unbridge(mut ctx: FunctionEnvMut<'_, WasiEnv>) -> Result<Errno, WasiError> {
     wasi_try_ok!(port_unbridge_internal(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasix/proc_exec.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_exec.rs
@@ -17,7 +17,7 @@ use crate::{
 /// ## Return
 ///
 /// Returns a bus process id that can be used to invoke calls
-#[instrument(level = "debug", skip_all, fields(name = field::Empty, %args_len), ret)]
+#[instrument(level = "trace", skip_all, fields(name = field::Empty, %args_len), ret)]
 pub fn proc_exec<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     name: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/proc_exec2.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_exec2.rs
@@ -18,7 +18,7 @@ use crate::{
 /// ## Return
 ///
 /// Returns a bus process id that can be used to invoke calls
-#[instrument(level = "debug", skip_all, fields(name = field::Empty, %args_len), ret)]
+#[instrument(level = "trace", skip_all, fields(name = field::Empty, %args_len), ret)]
 pub fn proc_exec2<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     name: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/proc_fork.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork.rs
@@ -19,7 +19,7 @@ pub(crate) struct ForkResult {
 /// Forks the current process into a new subprocess. If the function
 /// returns a zero then its the new subprocess. If it returns a positive
 /// number then its the current process and the $pid represents the child.
-#[instrument(level = "debug", skip_all, fields(pid = ctx.data().process.pid().raw()), ret)]
+#[instrument(level = "trace", skip_all, fields(pid = ctx.data().process.pid().raw()), ret)]
 pub fn proc_fork<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     mut copy_memory: Bool,

--- a/lib/wasix/src/syscalls/wasix/proc_id.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_id.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `proc_id()`
 /// Returns the handle of the current process
-#[instrument(level = "debug", skip_all, fields(pid = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(pid = field::Empty), ret)]
 pub fn proc_id<M: MemorySize>(ctx: FunctionEnvMut<'_, WasiEnv>, ret_pid: WasmPtr<Pid, M>) -> Errno {
     let env = ctx.data();
     let memory = unsafe { env.memory_view(&ctx) };

--- a/lib/wasix/src/syscalls/wasix/proc_parent.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_parent.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `proc_parent()`
 /// Returns the parent handle of the supplied process
-#[instrument(level = "debug", skip_all, fields(%pid, parent = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%pid, parent = field::Empty), ret)]
 pub fn proc_parent<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     pid: Pid,

--- a/lib/wasix/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn.rs
@@ -23,7 +23,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// Returns a bus process id that can be used to invoke calls
-#[instrument(level = "debug", skip_all, fields(name = field::Empty, working_dir = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(name = field::Empty, working_dir = field::Empty), ret)]
 pub fn proc_spawn<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     name: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/resolve.rs
+++ b/lib/wasix/src/syscalls/wasix/resolve.rs
@@ -19,7 +19,7 @@ use crate::syscalls::*;
 /// ## Return
 ///
 /// The number of IP addresses returned during the DNS resolution.
-#[instrument(level = "debug", skip_all, fields(host = field::Empty, %port), ret)]
+#[instrument(level = "trace", skip_all, fields(host = field::Empty, %port), ret)]
 pub fn resolve<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     host: WasmPtr<u8, M>,

--- a/lib/wasix/src/syscalls/wasix/sock_accept.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_accept.rs
@@ -15,7 +15,7 @@ use crate::{net::socket::TimeType, syscalls::*};
 /// ## Return
 ///
 /// New socket connection
-#[instrument(level = "debug", skip_all, fields(%sock, fd = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, fd = field::Empty), ret)]
 pub fn sock_accept<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
@@ -57,7 +57,7 @@ pub fn sock_accept<M: MemorySize>(
 /// ## Return
 ///
 /// New socket connection
-#[instrument(level = "debug", skip_all, fields(%sock, fd = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, fd = field::Empty), ret)]
 pub fn sock_accept_v2<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_addr_local.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_addr_local.rs
@@ -12,7 +12,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `fd` - Socket that the address is bound to
-#[instrument(level = "debug", skip_all, fields(%sock, addr = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, addr = field::Empty), ret)]
 pub fn sock_addr_local<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_addr_peer.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_addr_peer.rs
@@ -12,7 +12,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `fd` - Socket that the address is bound to
-#[instrument(level = "debug", skip_all, fields(%sock, addr = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, addr = field::Empty), ret)]
 pub fn sock_addr_peer<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_bind.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_bind.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 ///
 /// * `fd` - File descriptor of the socket to be bind
 /// * `addr` - Address to bind the socket to
-#[instrument(level = "debug", skip_all, fields(%sock, addr = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, addr = field::Empty), ret)]
 pub fn sock_bind<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -13,7 +13,7 @@ use crate::syscalls::*;
 ///
 /// * `fd` - Socket descriptor
 /// * `addr` - Address of the socket to connect to
-#[instrument(level = "debug", skip_all, fields(%sock, addr = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, addr = field::Empty), ret)]
 pub fn sock_connect<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_get_opt_flag.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_get_opt_flag.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 ///
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be retrieved
-#[instrument(level = "debug", skip_all, fields(%sock, %opt), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %opt), ret)]
 pub fn sock_get_opt_flag<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_get_opt_size.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_get_opt_size.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 ///
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be retrieved
-#[instrument(level = "debug", skip_all, fields(%sock, %opt), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %opt), ret)]
 pub fn sock_get_opt_size<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_get_opt_time.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_get_opt_time.rs
@@ -8,7 +8,7 @@ use crate::{net::socket::TimeType, syscalls::*};
 ///
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be retrieved
-#[instrument(level = "debug", skip_all, fields(%sock, %opt), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %opt), ret)]
 pub fn sock_get_opt_time<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_join_multicast_v4.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_join_multicast_v4.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to joined
 /// * `interface` - Interface that will join
-#[instrument(level = "debug", skip_all, fields(%sock), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock), ret)]
 pub fn sock_join_multicast_v4<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_join_multicast_v6.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_join_multicast_v6.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to joined
 /// * `interface` - Interface that will join
-#[instrument(level = "debug", skip_all, fields(%sock, %iface), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %iface), ret)]
 pub fn sock_join_multicast_v6<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_leave_multicast_v4.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_leave_multicast_v4.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to leave
 /// * `interface` - Interface that will left
-#[instrument(level = "debug", skip_all, fields(%sock), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock), ret)]
 pub fn sock_leave_multicast_v4<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_leave_multicast_v6.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_leave_multicast_v6.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `multiaddr` - Multicast group to leave
 /// * `interface` - Interface that will left
-#[instrument(level = "debug", skip_all, fields(%sock, %iface), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %iface), ret)]
 pub fn sock_leave_multicast_v6<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_listen.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_listen.rs
@@ -13,7 +13,7 @@ use crate::{journal::SnapshotTrigger, syscalls::*};
 ///
 /// * `fd` - File descriptor of the socket to be bind
 /// * `backlog` - Maximum size of the queue for pending connections
-#[instrument(level = "debug", skip_all, fields(%sock, %backlog), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %backlog), ret)]
 pub fn sock_listen<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_open.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_open.rs
@@ -20,7 +20,7 @@ use crate::{net::socket::SocketProperties, syscalls::*};
 /// ## Return
 ///
 /// The file descriptor of the socket that has been opened.
-#[instrument(level = "debug", skip_all, fields(?af, ?ty, ?pt, sock = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(?af, ?ty, ?pt, sock = field::Empty), ret)]
 pub fn sock_open<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     af: Addressfamily,

--- a/lib/wasix/src/syscalls/wasix/sock_send_file.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_file.rs
@@ -15,7 +15,7 @@ use crate::{net::socket::TimeType, syscalls::*, WasiInodes};
 /// ## Return
 ///
 /// Number of bytes transmitted.
-#[instrument(level = "debug", skip_all, fields(%sock, %in_fd, %offset, %count, nsent = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %in_fd, %offset, %count, nsent = field::Empty), ret)]
 pub fn sock_send_file<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_set_opt_flag.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_set_opt_flag.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be set
 /// * `flag` - Value to set the option to
-#[instrument(level = "debug", skip_all, fields(%sock, %opt, %flag), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %opt, %flag), ret)]
 pub fn sock_set_opt_flag(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_set_opt_size.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_set_opt_size.rs
@@ -10,7 +10,7 @@ use crate::{net::socket::TimeType, syscalls::*};
 /// * `fd` - Socket descriptor
 /// * `opt` - Socket option to be set
 /// * `size` - Buffer size
-#[instrument(level = "debug", skip_all, fields(%sock, %opt, %size), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %opt, %size), ret)]
 pub fn sock_set_opt_size(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_set_opt_time.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_set_opt_time.rs
@@ -9,7 +9,7 @@ use crate::{net::socket::TimeType, syscalls::*};
 /// * `fd` - Socket descriptor
 /// * `sockopt` - Socket option to be set
 /// * `time` - Value to set the time to
-#[instrument(level = "debug", skip_all, fields(%sock, %opt, time = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, %opt, time = field::Empty), ret)]
 pub fn sock_set_opt_time<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_shutdown.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_shutdown.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `how` - Which channels on the socket to shut down.
-#[instrument(level = "debug", skip_all, fields(%sock), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock), ret)]
 pub fn sock_shutdown(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/sock_status.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_status.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `sock_status()`
 /// Returns the current status of a socket
-#[instrument(level = "debug", skip_all, fields(%sock, status = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(%sock, status = field::Empty), ret)]
 pub fn sock_status<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,

--- a/lib/wasix/src/syscalls/wasix/thread_exit.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_exit.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `rval` - The exit code returned by the process.
-#[instrument(level = "debug", skip_all, fields(%exitcode), ret)]
+#[instrument(level = "trace", skip_all, fields(%exitcode), ret)]
 pub fn thread_exit(ctx: FunctionEnvMut<'_, WasiEnv>, exitcode: ExitCode) -> Result<(), WasiError> {
     tracing::debug!(tid=%ctx.data().thread.id(), %exitcode);
     Err(WasiError::Exit(exitcode))

--- a/lib/wasix/src/syscalls/wasix/thread_join.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_join.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `tid` - Handle of the thread to wait on
-//#[instrument(level = "debug", skip_all, fields(%join_tid), ret)]
+//#[instrument(level = "trace", skip_all, fields(%join_tid), ret)]
 pub fn thread_join<M: MemorySize + 'static>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     join_tid: Tid,

--- a/lib/wasix/src/syscalls/wasix/thread_parallelism.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_parallelism.rs
@@ -4,7 +4,7 @@ use crate::syscalls::*;
 /// ### `thread_parallelism()`
 /// Returns the available parallelism which is normally the
 /// number of available cores that can run concurrently
-#[instrument(level = "debug", skip_all, fields(parallelism = field::Empty), ret)]
+#[instrument(level = "trace", skip_all, fields(parallelism = field::Empty), ret)]
 pub fn thread_parallelism<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     ret_parallelism: WasmPtr<M::Offset, M>,

--- a/lib/wasix/src/syscalls/wasix/thread_signal.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_signal.rs
@@ -7,7 +7,7 @@ use crate::syscalls::*;
 /// Inputs:
 /// - `Signal`
 ///   Signal to be raised for this process
-#[instrument(level = "debug", skip_all, fields(%tid, ?sig), ret)]
+#[instrument(level = "trace", skip_all, fields(%tid, ?sig), ret)]
 pub fn thread_signal(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     tid: Tid,

--- a/lib/wasix/src/syscalls/wasix/thread_sleep.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_sleep.rs
@@ -9,7 +9,7 @@ use crate::syscalls::*;
 /// ## Parameters
 ///
 /// * `duration` - Amount of time that the thread should sleep
-#[instrument(level = "debug", skip_all, fields(%duration), ret)]
+#[instrument(level = "trace", skip_all, fields(%duration), ret)]
 pub fn thread_sleep<M: MemorySize + 'static>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     duration: Timestamp,

--- a/lib/wasix/src/syscalls/wasix/thread_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_spawn.rs
@@ -30,7 +30,7 @@ use wasmer_wasix_types::wasi::ThreadStart;
 ///
 /// Returns the thread index of the newly created thread
 /// (indices always start from the same value as `pid` and increments in steps)
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn thread_spawn_v2<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     start_ptr: WasmPtr<ThreadStart<M>, M>,

--- a/lib/wasix/src/syscalls/wasix/tty_get.rs
+++ b/lib/wasix/src/syscalls/wasix/tty_get.rs
@@ -3,7 +3,7 @@ use crate::syscalls::*;
 
 /// ### `tty_get()`
 /// Retrieves the current state of the TTY
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn tty_get<M: MemorySize>(
     ctx: FunctionEnvMut<'_, WasiEnv>,
     tty_state: WasmPtr<Tty, M>,

--- a/lib/wasix/src/syscalls/wasix/tty_set.rs
+++ b/lib/wasix/src/syscalls/wasix/tty_set.rs
@@ -3,7 +3,7 @@ use crate::{syscalls::*, WasiTtyState};
 
 /// ### `tty_set()`
 /// Updates the properties of the rect
-#[instrument(level = "debug", skip_all, ret)]
+#[instrument(level = "trace", skip_all, ret)]
 pub fn tty_set<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     tty_state: WasmPtr<Tty, M>,


### PR DESCRIPTION
Improve tracing performance by reducing the syscall instrumentation
levels to "trace".

This allows compiling out all the instrumentation with a tracing feature
flag in release builds.

Closes #5101
Closes RUN-439