### PR TITLE
Transfer the file size when renamed

### DIFF
--- a/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
@@ -10,13 +10,17 @@ use crate::types::wasi::Snapshot0Filestat;
 /// Output:
 /// - `Filestat *buf`
 ///     Where the metadata from `fd` will be written
-#[instrument(level = "trace", skip_all, fields(%fd), ret)]
+#[instrument(level = "trace", skip_all, fields(%fd, size = field::Empty, mtime = field::Empty), ret)]
 pub fn fd_filestat_get<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
     fd: WasiFd,
     buf: WasmPtr<Filestat, M>,
 ) -> Errno {
     let stat = wasi_try!(fd_filestat_get_internal(&mut ctx, fd));
+
+    // These two values have proved to be helpful in multiple investigations
+    Span::current().record("size", stat.st_size);
+    Span::current().record("mtime", stat.st_mtim);
 
     let env = ctx.data();
     let (memory, _) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -77,10 +77,9 @@ pub fn path_rename_internal(
         .fs
         .get_inode_at_path(inodes, source_fd, source_path, true));
     // Create the destination inode if the file exists.
-    let target_inode =
-        wasi_try_ok!(state
-            .fs
-            .get_inode_at_path(inodes, target_fd, target_path, true));
+    let _ = state
+        .fs
+        .get_inode_at_path(inodes, target_fd, target_path, true);
     let (source_parent_inode, source_entry_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
         inodes,
         source_fd,
@@ -216,6 +215,10 @@ pub fn path_rename_internal(
     }
 
     // The target entry is created, one way or the other
+    let target_inode =
+        wasi_try_ok!(state
+            .fs
+            .get_inode_at_path(inodes, target_fd, target_path, true));
     target_inode.stat.write().unwrap().st_size = source_size;
 
     Ok(Errno::Success)


### PR DESCRIPTION
Previously, when a file was renamed, the new file (target file) had zero as its size since stats were not properly transferred from the old file to the new one. This PR fixes the issue with the size.

Resolves #5103.