### PR TITLE
Add support for `exec-name` and transfer args and envs after execve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7377,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "6.0.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48441419be082f8d2537c84d8b1f502624d77bc08fbbd09ab17cadfe7f0ac53"
+checksum = "cdea84cf234555864ca9b7a5084c1a99dbdf2d148035f62a09b19ce5606532c1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ wasmer-config = { path = "./lib/config" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates
-webc = { version = "6.0.1", default-features = false, features = ["package"] }
+webc = { version = "6.1.0", default-features = false, features = ["package"] }
 shared-buffer = "0.1.4"
 
 # Third-party crates

--- a/lib/wasix/src/os/command/builtins/cmd_wasmer.rs
+++ b/lib/wasix/src/os/command/builtins/cmd_wasmer.rs
@@ -69,7 +69,7 @@ impl CmdWasmer {
             // Set the arguments of the environment by replacing the state
             let mut state = env.state.fork();
             args.insert(0, what.clone());
-            state.args = args;
+            state.args = std::sync::Mutex::new(args);
             env.state = Arc::new(state);
 
             if let Ok(binary) = self.get_package(&what).await {
@@ -130,7 +130,7 @@ impl VirtualCommand for CmdWasmer {
     ) -> Result<TaskJoinHandle, SpawnError> {
         // Read the command we want to run
         let env_inner = env.as_ref().ok_or(SpawnError::UnknownError)?;
-        let args = env_inner.state.args.clone();
+        let args = env_inner.state.args.lock().unwrap().clone();
         let mut args = args.iter().map(|s| s.as_str());
         let _alias = args.next();
         let cmd = args.next();

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -867,7 +867,7 @@ impl WasiEnvBuilder {
             fs: wasi_fs,
             secret: rand::thread_rng().gen::<[u8; 32]>(),
             inodes,
-            args: self.args.clone(),
+            args: std::sync::Mutex::new(self.args.clone()),
             preopen: self.vfs_preopens.clone(),
             futexs: Default::default(),
             clock_offset: Default::default(),

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -295,7 +295,7 @@ impl WasiEnvInit {
                 clock_offset: std::sync::Mutex::new(
                     self.state.clock_offset.lock().unwrap().clone(),
                 ),
-                args: self.state.args.clone(),
+                args: std::sync::Mutex::new(self.state.args.lock().unwrap().clone()),
                 envs: std::sync::Mutex::new(self.state.envs.lock().unwrap().deref().clone()),
                 preopen: self.state.preopen.clone(),
             },

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -133,7 +133,7 @@ pub(crate) struct WasiState {
     pub inodes: WasiInodes,
     pub futexs: Mutex<WasiFutexState>,
     pub clock_offset: Mutex<HashMap<Snapshot0Clockid, i64>>,
-    pub args: Vec<String>,
+    pub args: Mutex<Vec<String>>,
     pub envs: Mutex<Vec<Vec<u8>>>,
 
     // TODO: should not be here, since this requires active work to resolve.
@@ -255,7 +255,7 @@ impl WasiState {
             inodes: self.inodes.clone(),
             futexs: Default::default(),
             clock_offset: Mutex::new(self.clock_offset.lock().unwrap().clone()),
-            args: self.args.clone(),
+            args: Mutex::new(self.args.lock().unwrap().clone()),
             envs: Mutex::new(self.envs.lock().unwrap().clone()),
             preopen: self.preopen.clone(),
         }

--- a/lib/wasix/src/syscalls/mod.rs
+++ b/lib/wasix/src/syscalls/mod.rs
@@ -1495,7 +1495,7 @@ pub(crate) fn _prepare_wasi(
     // Swap out the arguments with the new ones
     if let Some(args) = args {
         let mut wasi_state = wasi_env.state.fork();
-        wasi_state.args = args;
+        *wasi_state.args.lock().unwrap() = args;
         wasi_env.state = Arc::new(wasi_state);
     }
 

--- a/lib/wasix/src/syscalls/wasi/args_get.rs
+++ b/lib/wasix/src/syscalls/wasi/args_get.rs
@@ -21,6 +21,8 @@ pub fn args_get<M: MemorySize>(
 
     let args = state
         .args
+        .lock()
+        .unwrap()
         .iter()
         .map(|a| a.as_bytes().to_vec())
         .collect::<Vec<_>>();
@@ -30,6 +32,8 @@ pub fn args_get<M: MemorySize>(
         "args:\n{}",
         state
             .args
+            .lock()
+            .unwrap()
             .iter()
             .enumerate()
             .map(|(i, v)| format!("{:>20}: {}", i, v))

--- a/lib/wasix/src/syscalls/wasi/args_sizes_get.rs
+++ b/lib/wasix/src/syscalls/wasi/args_sizes_get.rs
@@ -20,8 +20,14 @@ pub fn args_sizes_get<M: MemorySize>(
     let argc = argc.deref(&memory);
     let argv_buf_size = argv_buf_size.deref(&memory);
 
-    let argc_val: M::Offset = wasi_try!(state.args.len().try_into().map_err(|_| Errno::Overflow));
-    let argv_buf_size_val: usize = state.args.iter().map(|v| v.len() + 1).sum();
+    let argc_val: M::Offset = wasi_try!(state
+        .args
+        .lock()
+        .unwrap()
+        .len()
+        .try_into()
+        .map_err(|_| Errno::Overflow));
+    let argv_buf_size_val: usize = state.args.lock().unwrap().iter().map(|v| v.len() + 1).sum();
     let argv_buf_size_val: M::Offset =
         wasi_try!(argv_buf_size_val.try_into().map_err(|_| Errno::Overflow));
     wasi_try_mem!(argc.write(argc_val));

--- a/lib/wasix/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn.rs
@@ -117,7 +117,7 @@ pub fn proc_spawn_internal(
     let child_process = child_env.process.clone();
     if let Some(args) = args {
         let mut child_state = env.state.fork();
-        child_state.args = args;
+        child_state.args = std::sync::Mutex::new(args);
         child_env.state = Arc::new(child_state);
     }
 


### PR DESCRIPTION
This PR adds support for `exec-name` annotation for overriding the name that is passed to an executable as arg0. Also, previously when spawning a command using `execve`, the args and env vars specified in the manifest for that command, were not passed along properly when spawning the package. This would break some command that expect a specific env vars or args to function properly.

This PR is marked as draft since using `exec-name` in the code path used by `wasmer run` is still not done.