### PR TITLE
Use upload/download artifact v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,7 +238,7 @@ jobs:
         run: |
           make distribution
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: dist
@@ -305,7 +305,7 @@ jobs:
           CARGO_TARGET: x86_64-pc-windows-gnu
           TARGET_DIR: target/x86_64-pc-windows-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'wasmer-windows-gnu64'
           path: dist
@@ -338,7 +338,7 @@ jobs:
           CARGO_TARGET: aarch64-apple-darwin
           TARGET_DIR: target/aarch64-apple-darwin/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'aarch64-apple-darwin-jsc'
           path: dist
@@ -367,7 +367,7 @@ jobs:
           CARGO_TARGET: x86_64-apple-darwin
           TARGET_DIR: target/x86_64-apple-darwin/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'x86_64-apple-darwin-jsc'
           path: dist
@@ -432,7 +432,7 @@ jobs:
           TARGET: aarch64-unknown-linux-gnu
           TARGET_DIR: target/aarch64-unknown-linux-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasmer-linux-aarch64
           path: dist
@@ -497,7 +497,7 @@ jobs:
           TARGET: riscv64gc-unknown-linux-gnu
           TARGET_DIR: target/riscv64gc-unknown-linux-gnu/release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasmer-linux-riscv64
           path: dist
@@ -510,7 +510,7 @@ jobs:
     if: needs.setup.outputs.DOING_RELEASE == '1' || github.event.inputs.release != ''
     steps:
       - name: Download the Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Create Release

--- a/.github/workflows/check-public-api.yaml
+++ b/.github/workflows/check-public-api.yaml
@@ -38,7 +38,7 @@ jobs:
           cargo public-api --manifest-path=lib/api/Cargo.toml --diff-git-checkouts $LATEST_VERSION main > diff.txt
       
       - name: Archive change report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api-diff-report
           path: |

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -17,7 +17,7 @@ jobs:
        language: rust
        fuzz-seconds: 300
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -272,7 +272,7 @@ jobs:
           TARGET_DIR: target/aarch64-unknown-linux-gnu/release
       - name: Upload Artifacts
         if: ${{ matrix.build-what.key == 'capi' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: capi-linux-aarch64
           path: dist
@@ -330,7 +330,7 @@ jobs:
           TARGET_DIR: target/riscv64gc-unknown-linux-gnu/release
       - name: Upload Artifacts
         if: ${{ matrix.build-what.key == 'capi' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: capi-linux-riscv64
           path: dist
@@ -538,14 +538,14 @@ jobs:
           TARGET_DIR: target/${{ matrix.metadata.target }}/release
           CARGO_TARGET: ${{ matrix.metadata.target }}
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wasmer-cli-${{ matrix.metadata.build }}
           path: build-wasmer.tar.gz
           if-no-files-found: ignore
           retention-days: 2
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: capi-${{ matrix.metadata.build }}
           path: build-capi.tar.gz


### PR DESCRIPTION
Versions `v1` and `v2` for `actions/download-artifact` and `actions/upload-artifact`  are deprecated based on this [blog post ](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/) by GitHub. This causes a breakage in our release pipeline. This PR migrates all of these actions to `v4` which according to GitHub:
>This version improves upload/download speeds by up to 98%, addresses long-standing customer feedback requests, and represents the future of artifacts in GitHub Actions.