### PR TITLE
path_create_directory shouldn't behave recursively

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_create_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_create_directory.rs
@@ -82,7 +82,7 @@ pub(crate) fn path_create_directory_internal(
 
     let mut cur_dir_inode = working_dir.inode;
     let mut created_directory = false;
-    for comp in &path_vec {
+    for (comp_idx, comp) in path_vec.iter().enumerate() {
         let processing_cur_dir_inode = cur_dir_inode.clone();
         let mut guard = processing_cur_dir_inode.write();
         match guard.deref_mut() {
@@ -122,6 +122,10 @@ pub(crate) fn path_create_directory_internal(
                             return Err(Errno::Notdir);
                         }
                     } else {
+                        if comp_idx != path_vec.len() - 1 {
+                            return Err(Errno::Noent);
+                        }
+
                         created_directory = true;
                         state.fs_create_dir(&adjusted_path)?;
                     }

--- a/tests/wasi-fyi/fs_create_dir-non_existent.rs
+++ b/tests/wasi-fyi/fs_create_dir-non_existent.rs
@@ -1,0 +1,5 @@
+use std::fs;
+
+fn main() {
+    assert!(fs::create_dir("/fyi/fs_create_dir-non_existent.dir/not-exist/new-directory").is_err());
+}


### PR DESCRIPTION
This commit fixes a non-compatible (with other runtimes, intention of WASI, and POSIX) behavior in `path_create_directory` WASI implementation. Instead of creating directories recursively, the function fails if any intermediate component does not exist.

fixes #5157

