### PR TITLE
5.0.0-rc.1 post release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
 	"lib/wasm-interface",
 	"lib/journal",
 	"lib/swift",
+	"lib/package",
 	"tests/integration/cli",
 	"tests/integration/ios",
 	"tests/lib/compiler-test-derive",

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -2,6 +2,8 @@
 name = "wasmer-swift"
 version = "0.1.0"
 edition = "2021"
+description = "Experimental wasmer bindings for swift"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -13,15 +13,15 @@ name = "wasmer_swift"
 thiserror = "1"
 tokio = { version = "1.28.1", features = [ "rt" ], default-features = false }
 uniffi = "0.27"
-virtual-fs = { path = "../virtual-fs", version = "0.18.0", default-features = false, features = [
+virtual-fs = { version = "=0.18.0", default-features = false, features = [
 	"webc-fs",
 ] }
-wasmer = { version = "5.0.0-rc.1", path = "../api", default-features = false, features = [
+wasmer = { version = "=5.0.0-rc.1", path = "../api", default-features = false, features = [
 	"wamr",
 	"std",
 ] }
-wasmer-wasix.workspace = true
-webc.workspace = true
+wasmer-wasix = "=0.29.0"
+webc = { version = "6.1.0", default-features = false, features = ["package"] }
 
 
 [build-dependencies]

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -15,15 +15,15 @@ name = "wasmer_swift"
 thiserror = "1"
 tokio = { version = "1.28.1", features = [ "rt" ], default-features = false }
 uniffi = "0.27"
-virtual-fs = { version = "=0.18.0", default-features = false, features = [
+virtual-fs = { path = "../virtual-fs", version = "=0.18.0", default-features = false, features = [
 	"webc-fs",
 ] }
 wasmer = { version = "=5.0.0-rc.1", path = "../api", default-features = false, features = [
 	"wamr",
 	"std",
 ] }
-wasmer-wasix = "=0.29.0"
-webc = { version = "6.1.0", default-features = false, features = ["package"] }
+wasmer-wasix = { version = "=0.29.0", path = "../wasix" }
+webc.workspace = true
 
 
 [build-dependencies]


### PR DESCRIPTION
This PR fixes packaging for `wasmer-package` and `wasmer-swift`