### PR TITLE
Fix usage of exit code

### DIFF
--- a/lib/wasix/src/syscalls/wasix/thread_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_spawn.rs
@@ -235,7 +235,7 @@ fn call_module<M: MemorySize>(
                         .runtime
                         .on_taint(TaintReason::UnknownWasiVersion);
                     ret = Errno::Noexec;
-                    exit_code = Some(ExitCode::Other(128 + ret as i32));
+                    exit_code = Some(ExitCode::from(128 + ret as i32));
                 }
                 Err(err) => {
                     debug!("failed with runtime error: {}", err);
@@ -243,7 +243,7 @@ fn call_module<M: MemorySize>(
                         .runtime
                         .on_taint(TaintReason::RuntimeError(err));
                     ret = Errno::Noexec;
-                    exit_code = Some(ExitCode::Other(128 + ret as i32));
+                    exit_code = Some(ExitCode::from(128 + ret as i32));
                 }
             }
         } else {


### PR DESCRIPTION
The CI on main is failing due to some usage of the old API of `ExitCode`. Although the [PR](https://github.com/wasmerio/wasmer/pull/5151) that changed the API passed all the tests, things failed on main.