### PR TITLE
feat: Rename `wasmer-api` to `wasmer-backend-api`

### DIFF
--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "wasmer-api"
+name = "wasmer-backend-api"
 version = "0.1.0"
 description = "Client library for the Wasmer GraphQL API"
 readme = "README.md"
-documentation = "https://docs.rs/wasmer-api"
+documentation = "https://docs.rs/wasmer-backend-api"
 
 authors.workspace = true
 edition.workspace = true

--- a/lib/backend-api/README.md
+++ b/lib/backend-api/README.md
@@ -1,4 +1,4 @@
-# wasmer-api
+# wasmer-backend-api
 
 GraphQL API client for the [Wasmer](https://wasmer.io) backend.
 

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -144,7 +144,7 @@ virtual-mio = { version = "0.5.0", path = "../virtual-io" }
 # Wasmer-owned dependencies.
 
 webc = { workspace = true }
-wasmer-api = { version = "=0.1.0", path = "../backend-api" }
+wasmer-backend-api = { version = "=0.1.0", path = "../backend-api" }
 lazy_static = "1.4.0"
 
 # Used by the mount command

--- a/lib/cli/src/commands/add.rs
+++ b/lib/cli/src/commands/add.rs
@@ -3,7 +3,7 @@ use crate::config::WasmerEnv;
 use anyhow::{Context, Error};
 use clap::Parser;
 use std::process::{Command, Stdio};
-use wasmer_api::{
+use wasmer_backend_api::{
     types::{Bindings, ProgrammingLanguage},
     WasmerClient,
 };
@@ -102,7 +102,7 @@ async fn lookup_bindings_for_package(
     pkg: &NamedPackageIdent,
     language: &ProgrammingLanguage,
 ) -> Result<Bindings, Error> {
-    let all_bindings = wasmer_api::query::list_bindings(
+    let all_bindings = wasmer_backend_api::query::list_bindings(
         client,
         &pkg.name,
         pkg.version_opt().map(|v| v.to_string()).as_deref(),

--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -14,7 +14,7 @@ use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
 use futures::stream::TryStreamExt;
 use is_terminal::IsTerminal;
-use wasmer_api::{
+use wasmer_backend_api::{
     types::{AppTemplate, TemplateLanguage},
     WasmerClient,
 };
@@ -190,7 +190,7 @@ impl CmdAppCreate {
         }
 
         let user = if let Some(client) = client {
-            Some(wasmer_api::query::current_user_with_namespaces(client, None).await?)
+            Some(wasmer_backend_api::query::current_user_with_namespaces(client, None).await?)
         } else {
             None
         };
@@ -359,10 +359,10 @@ impl CmdAppCreate {
         // Fetch the first page.
         // If first item matches, then no need to re-fetch.
         //
-        let stream = wasmer_api::query::fetch_all_app_templates_from_language(
+        let stream = wasmer_backend_api::query::fetch_all_app_templates_from_language(
             client,
             10,
-            Some(wasmer_api::types::AppTemplatesSortBy::Newest),
+            Some(wasmer_backend_api::types::AppTemplatesSortBy::Newest),
             language.to_string(),
         );
 
@@ -446,7 +446,7 @@ impl CmdAppCreate {
         // Either no cache present, or cache has exceeded max age.
         // Fetch the first page.
         // If first item matches, then no need to re-fetch.
-        let mut stream = Box::pin(wasmer_api::query::fetch_all_app_template_languages(
+        let mut stream = Box::pin(wasmer_backend_api::query::fetch_all_app_template_languages(
             client, None,
         ));
 
@@ -489,7 +489,8 @@ impl CmdAppCreate {
             if let Ok(url) = url::Url::parse(template) {
                 url
             } else if let Some(template) =
-                wasmer_api::query::fetch_app_template_from_slug(client, template.clone()).await?
+                wasmer_backend_api::query::fetch_app_template_from_slug(client, template.clone())
+                    .await?
             {
                 url::Url::parse(&template.repo_url)?
             } else {

--- a/lib/cli/src/commands/app/delete.rs
+++ b/lib/cli/src/commands/app/delete.rs
@@ -53,7 +53,7 @@ impl AsyncCliCommand for CmdAppDelete {
             app.name,
             app.id.inner(),
         );
-        wasmer_api::query::delete_app(&client, app.id.into_inner()).await?;
+        wasmer_backend_api::query::delete_app(&client, app.id.into_inner()).await?;
 
         eprintln!("App '{}/{}' was deleted!", app.owner.global_name, app.name);
 

--- a/lib/cli/src/commands/app/deployments/get.rs
+++ b/lib/cli/src/commands/app/deployments/get.rs
@@ -21,7 +21,7 @@ impl AsyncCliCommand for CmdAppDeploymentGet {
 
     async fn run_async(mut self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
-        let item = wasmer_api::query::app_deployment(&client, self.id).await?;
+        let item = wasmer_backend_api::query::app_deployment(&client, self.id).await?;
 
         println!("{}", self.fmt.get().render(&item));
         Ok(())

--- a/lib/cli/src/commands/app/deployments/list.rs
+++ b/lib/cli/src/commands/app/deployments/list.rs
@@ -30,14 +30,14 @@ impl AsyncCliCommand for CmdAppDeploymentList {
         let client = self.env.client()?;
 
         let (_ident, app) = self.ident.load_app(&client).await?;
-        let vars = wasmer_api::types::GetAppDeploymentsVariables {
+        let vars = wasmer_backend_api::types::GetAppDeploymentsVariables {
             after: None,
             first: self.limit.map(|x| x as i32),
             name: app.name.clone(),
             offset: self.offset.map(|x| x as i32),
             owner: app.owner.global_name,
         };
-        let items = wasmer_api::query::app_deployments(&client, vars).await?;
+        let items = wasmer_backend_api::query::app_deployments(&client, vars).await?;
 
         if items.is_empty() {
             eprintln!("App {} has no deployments!", app.name);

--- a/lib/cli/src/commands/app/deployments/logs.rs
+++ b/lib/cli/src/commands/app/deployments/logs.rs
@@ -26,7 +26,7 @@ impl AsyncCliCommand for CmdAppDeploymentLogs {
 
     async fn run_async(mut self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
-        let item = wasmer_api::query::app_deployment(&client, self.id).await?;
+        let item = wasmer_backend_api::query::app_deployment(&client, self.id).await?;
 
         let url = item
             .log_url

--- a/lib/cli/src/commands/app/get.rs
+++ b/lib/cli/src/commands/app/get.rs
@@ -1,6 +1,6 @@
 //! Get information about an edge app.
 
-use wasmer_api::types::DeployApp;
+use wasmer_backend_api::types::DeployApp;
 
 use super::util::AppIdentOpts;
 

--- a/lib/cli/src/commands/app/list.rs
+++ b/lib/cli/src/commands/app/list.rs
@@ -3,7 +3,7 @@
 use std::pin::Pin;
 
 use futures::{Stream, StreamExt};
-use wasmer_api::types::{DeployApp, DeployAppsSortBy};
+use wasmer_backend_api::types::{DeployApp, DeployAppsSortBy};
 
 use crate::{commands::AsyncCliCommand, config::WasmerEnv, opts::ListFormatOpts};
 
@@ -65,11 +65,11 @@ impl AsyncCliCommand for CmdAppList {
         let apps_stream: Pin<
             Box<dyn Stream<Item = Result<Vec<DeployApp>, anyhow::Error>> + Send + Sync>,
         > = if let Some(ns) = self.namespace.clone() {
-            Box::pin(wasmer_api::query::namespace_apps(&client, ns, sort).await)
+            Box::pin(wasmer_backend_api::query::namespace_apps(&client, ns, sort).await)
         } else if self.all {
-            Box::pin(wasmer_api::query::user_accessible_apps(&client, sort).await?)
+            Box::pin(wasmer_backend_api::query::user_accessible_apps(&client, sort).await?)
         } else {
-            Box::pin(wasmer_api::query::user_apps(&client, sort).await)
+            Box::pin(wasmer_backend_api::query::user_apps(&client, sort).await)
         };
 
         let mut apps_stream = std::pin::pin!(apps_stream);

--- a/lib/cli/src/commands/app/logs.rs
+++ b/lib/cli/src/commands/app/logs.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 use comfy_table::{Cell, Table};
 use futures::StreamExt;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
-use wasmer_api::types::{Log, LogStream};
+use wasmer_backend_api::types::{Log, LogStream};
 
 use crate::{config::WasmerEnv, opts::ListFormatOpts, utils::render::CliRender};
 
@@ -127,7 +127,7 @@ impl crate::commands::AsyncCliCommand for CmdAppLogs {
 
         // Code duplication to avoid a dependency to `OR` streams.
         if let Some(instance_id) = &self.instance_id {
-            let logs_stream = wasmer_api::query::get_app_logs_paginated_filter_instance(
+            let logs_stream = wasmer_backend_api::query::get_app_logs_paginated_filter_instance(
                 &client,
                 app.name.clone(),
                 app.owner.global_name.to_string(),
@@ -162,7 +162,7 @@ impl crate::commands::AsyncCliCommand for CmdAppLogs {
                 }
             }
         } else if let Some(request_id) = &self.request_id {
-            let logs_stream = wasmer_api::query::get_app_logs_paginated_filter_request(
+            let logs_stream = wasmer_backend_api::query::get_app_logs_paginated_filter_request(
                 &client,
                 app.name.clone(),
                 app.owner.global_name.to_string(),
@@ -197,7 +197,7 @@ impl crate::commands::AsyncCliCommand for CmdAppLogs {
                 }
             }
         } else {
-            let logs_stream = wasmer_api::query::get_app_logs_paginated(
+            let logs_stream = wasmer_backend_api::query::get_app_logs_paginated(
                 &client,
                 app.name.clone(),
                 app.owner.global_name.to_string(),

--- a/lib/cli/src/commands/app/purge_cache.rs
+++ b/lib/cli/src/commands/app/purge_cache.rs
@@ -46,8 +46,8 @@ impl AsyncCliCommand for CmdAppPurgeCache {
             version_id.inner()
         );
 
-        let vars = wasmer_api::types::PurgeCacheForAppVersionVars { id: version_id };
-        wasmer_api::query::purge_cache_for_app_version(&client, vars).await?;
+        let vars = wasmer_backend_api::types::PurgeCacheForAppVersionVars { id: version_id };
+        wasmer_backend_api::query::purge_cache_for_app_version(&client, vars).await?;
 
         println!("🚽 swirl! All caches have been purged!");
 

--- a/lib/cli/src/commands/app/regions/list.rs
+++ b/lib/cli/src/commands/app/regions/list.rs
@@ -26,7 +26,7 @@ impl AsyncCliCommand for CmdAppRegionsList {
 
     async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
         let client = self.env.client()?;
-        let regions = wasmer_api::query::get_all_app_regions(&client).await?;
+        let regions = wasmer_backend_api::query::get_all_app_regions(&client).await?;
 
         println!("{}", self.fmt.format.render(regions.as_slice()));
 

--- a/lib/cli/src/commands/app/regions/utils/render.rs
+++ b/lib/cli/src/commands/app/regions/utils/render.rs
@@ -1,6 +1,6 @@
 use crate::utils::render::CliRender;
 use comfy_table::{Cell, Table};
-use wasmer_api::types::AppRegion;
+use wasmer_backend_api::types::AppRegion;
 
 impl CliRender for AppRegion {
     fn render_item_table(&self) -> String {

--- a/lib/cli/src/commands/app/secrets/create.rs
+++ b/lib/cli/src/commands/app/secrets/create.rs
@@ -11,7 +11,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 
 /// Create a new app secret.
 #[derive(clap::Parser, Debug)]
@@ -95,7 +95,7 @@ impl CmdAppSecretsCreate {
     ) -> anyhow::Result<Vec<Secret>> {
         let names = secrets.iter().map(|s| &s.name);
         let app_secrets =
-            wasmer_api::query::get_all_app_secrets_filtered(client, app_id, names).await?;
+            wasmer_backend_api::query::get_all_app_secrets_filtered(client, app_id, names).await?;
         let mut sset = HashSet::<String>::from_iter(app_secrets.iter().map(|s| s.name.clone()));
         let mut ret = HashMap::new();
 
@@ -142,7 +142,7 @@ impl CmdAppSecretsCreate {
         app_id: &str,
         secrets: Vec<Secret>,
     ) -> Result<(), anyhow::Error> {
-        let res = wasmer_api::query::upsert_app_secrets(
+        let res = wasmer_backend_api::query::upsert_app_secrets(
             client,
             app_id,
             secrets.iter().map(|s| (s.name.as_str(), s.value.as_str())),
@@ -173,7 +173,7 @@ impl CmdAppSecretsCreate {
                 };
 
                 if should_redeploy {
-                    wasmer_api::query::redeploy_app_by_id(client, app_id).await?;
+                    wasmer_backend_api::query::redeploy_app_by_id(client, app_id).await?;
                     eprintln!("{} Deployment complete", "𖥔".yellow().bold());
                 } else {
                     eprintln!(

--- a/lib/cli/src/commands/app/secrets/delete.rs
+++ b/lib/cli/src/commands/app/secrets/delete.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use dialoguer::theme::ColorfulTheme;
 use is_terminal::IsTerminal;
 use std::path::{Path, PathBuf};
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 
 use super::utils::{self, get_secrets};
 
@@ -91,7 +91,8 @@ impl CmdAppSecretsDelete {
                 }
             }
 
-            let res = wasmer_api::query::delete_app_secret(client, secret.id.into_inner()).await?;
+            let res = wasmer_backend_api::query::delete_app_secret(client, secret.id.into_inner())
+                .await?;
 
             match res {
                 Some(res) if !res.success => {

--- a/lib/cli/src/commands/app/secrets/update.rs
+++ b/lib/cli/src/commands/app/secrets/update.rs
@@ -11,7 +11,7 @@ use std::{
     collections::HashSet,
     path::{Path, PathBuf},
 };
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 
 /// Update an existing app secret.
 #[derive(clap::Parser, Debug)]
@@ -100,7 +100,7 @@ impl CmdAppSecretsUpdate {
     ) -> anyhow::Result<Vec<Secret>> {
         let names = secrets.iter().map(|s| &s.name);
         let app_secrets =
-            wasmer_api::query::get_all_app_secrets_filtered(client, app_id, names).await?;
+            wasmer_backend_api::query::get_all_app_secrets_filtered(client, app_id, names).await?;
         let sset = HashSet::<&str>::from_iter(app_secrets.iter().map(|s| s.name.as_str()));
 
         let mut ret = vec![];
@@ -136,7 +136,7 @@ impl CmdAppSecretsUpdate {
         app_id: &str,
         secrets: Vec<Secret>,
     ) -> Result<(), anyhow::Error> {
-        let res = wasmer_api::query::upsert_app_secrets(
+        let res = wasmer_backend_api::query::upsert_app_secrets(
             client,
             app_id,
             secrets.iter().map(|s| (s.name.as_str(), s.value.as_str())),
@@ -167,7 +167,7 @@ impl CmdAppSecretsUpdate {
                 };
 
                 if should_redeploy {
-                    wasmer_api::query::redeploy_app_by_id(client, app_id).await?;
+                    wasmer_backend_api::query::redeploy_app_by_id(client, app_id).await?;
                     eprintln!("{} Deployment complete", "𖥔".yellow().bold());
                 } else {
                     eprintln!(

--- a/lib/cli/src/commands/app/secrets/utils/mod.rs
+++ b/lib/cli/src/commands/app/secrets/utils/mod.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use wasmer_api::{types::Secret as BackendSecret, WasmerClient};
+use wasmer_backend_api::{types::Secret as BackendSecret, WasmerClient};
 
 use crate::commands::app::util::{get_app_config_from_dir, prompt_app_ident, AppIdent};
 
@@ -30,20 +30,20 @@ pub(super) async fn get_secret_by_name(
     app_id: &str,
     secret_name: &str,
 ) -> anyhow::Result<Option<BackendSecret>> {
-    wasmer_api::query::get_app_secret_by_name(client, app_id, secret_name).await
+    wasmer_backend_api::query::get_app_secret_by_name(client, app_id, secret_name).await
 }
 pub(crate) async fn get_secrets(
     client: &WasmerClient,
     app_id: &str,
-) -> anyhow::Result<Vec<wasmer_api::types::Secret>> {
-    wasmer_api::query::get_all_app_secrets(client, app_id).await
+) -> anyhow::Result<Vec<wasmer_backend_api::types::Secret>> {
+    wasmer_backend_api::query::get_all_app_secrets(client, app_id).await
 }
 
 pub(crate) async fn get_secret_value(
     client: &WasmerClient,
-    secret: &wasmer_api::types::Secret,
+    secret: &wasmer_backend_api::types::Secret,
 ) -> anyhow::Result<String> {
-    wasmer_api::query::get_app_secret_value_by_id(client, secret.id.clone().into_inner())
+    wasmer_backend_api::query::get_app_secret_value_by_id(client, secret.id.clone().into_inner())
         .await?
         .ok_or_else(|| {
             anyhow::anyhow!(
@@ -68,7 +68,7 @@ pub(crate) async fn reveal_secrets(
     client: &WasmerClient,
     app_id: &str,
 ) -> anyhow::Result<Vec<Secret>> {
-    let secrets = wasmer_api::query::get_all_app_secrets(client, app_id).await?;
+    let secrets = wasmer_backend_api::query::get_all_app_secrets(client, app_id).await?;
     let mut ret = vec![];
     for secret in secrets {
         let name = secret.name.clone();

--- a/lib/cli/src/commands/app/secrets/utils/render.rs
+++ b/lib/cli/src/commands/app/secrets/utils/render.rs
@@ -3,7 +3,7 @@ use crate::utils::render::CliRender;
 use colored::Colorize;
 use comfy_table::{Cell, Table};
 use time::OffsetDateTime;
-use wasmer_api::types::{DateTime, Secret as BackendSecret};
+use wasmer_backend_api::types::{DateTime, Secret as BackendSecret};
 
 impl CliRender for Secret {
     fn render_item_table(&self) -> String {

--- a/lib/cli/src/commands/app/util.rs
+++ b/lib/cli/src/commands/app/util.rs
@@ -3,7 +3,7 @@ use std::{path::Path, str::FromStr};
 use anyhow::{bail, Context};
 use colored::Colorize;
 use dialoguer::{theme::ColorfulTheme, Confirm};
-use wasmer_api::{
+use wasmer_backend_api::{
     global_id::{GlobalId, NodeKind},
     types::DeployApp,
     WasmerClient,
@@ -32,12 +32,14 @@ impl AppIdent {
     /// Resolve an app identifier through the API.
     pub async fn resolve(&self, client: &WasmerClient) -> Result<DeployApp, anyhow::Error> {
         match self {
-            AppIdent::AppId(app_id) => wasmer_api::query::get_app_by_id(client, app_id.clone())
-                .await
-                .with_context(|| format!("Could not find app with id '{}'", app_id)),
+            AppIdent::AppId(app_id) => {
+                wasmer_backend_api::query::get_app_by_id(client, app_id.clone())
+                    .await
+                    .with_context(|| format!("Could not find app with id '{}'", app_id))
+            }
             AppIdent::AppVersionId(id) => {
                 let (app, _version) =
-                    wasmer_api::query::get_app_version_by_id_with_app(client, id.clone())
+                    wasmer_backend_api::query::get_app_version_by_id_with_app(client, id.clone())
                         .await
                         .with_context(|| format!("Could not query for app version id '{}'", id))?;
                 Ok(app)
@@ -46,16 +48,16 @@ impl AppIdent {
                 // The API only allows to query by owner + name,
                 // so default to the current user as the owner.
                 // To to so the username must first be retrieved.
-                let user = wasmer_api::query::current_user(client)
+                let user = wasmer_backend_api::query::current_user(client)
                     .await?
                     .context("not logged in")?;
 
-                wasmer_api::query::get_app(client, user.username, name.clone())
+                wasmer_backend_api::query::get_app(client, user.username, name.clone())
                     .await?
                     .with_context(|| format!("Could not find app with name '{name}'"))
             }
             AppIdent::NamespacedName(owner, name) => {
-                wasmer_api::query::get_app(client, owner.clone(), name.clone())
+                wasmer_backend_api::query::get_app(client, owner.clone(), name.clone())
                     .await?
                     .with_context(|| format!("Could not find app '{owner}/{name}'"))
             }

--- a/lib/cli/src/commands/app/version/activate.rs
+++ b/lib/cli/src/commands/app/version/activate.rs
@@ -23,7 +23,7 @@ impl AsyncCliCommand for CmdAppVersionActivate {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
 
-        let app = wasmer_api::query::app_version_activate(&client, self.version).await?;
+        let app = wasmer_backend_api::query::app_version_activate(&client, self.version).await?;
 
         let Some(version) = &app.active_version else {
             anyhow::bail!("Failed to activate version: backend did not update version!");

--- a/lib/cli/src/commands/app/version/get.rs
+++ b/lib/cli/src/commands/app/version/get.rs
@@ -33,7 +33,7 @@ impl AsyncCliCommand for CmdAppVersionGet {
         let client = self.env.client()?;
         let (_ident, app) = self.ident.load_app(&client).await?;
 
-        let version = wasmer_api::query::get_app_version(
+        let version = wasmer_backend_api::query::get_app_version(
             &client,
             app.owner.global_name,
             app.name,

--- a/lib/cli/src/commands/app/version/list.rs
+++ b/lib/cli/src/commands/app/version/list.rs
@@ -1,4 +1,4 @@
-use wasmer_api::types::{DeployAppVersionsSortBy, GetDeployAppVersionsVars};
+use wasmer_backend_api::types::{DeployAppVersionsSortBy, GetDeployAppVersionsVars};
 
 use crate::{
     commands::{app::util::AppIdentOpts, AsyncCliCommand},
@@ -77,7 +77,8 @@ impl AsyncCliCommand for CmdAppVersionList {
         let (_ident, app) = self.ident.load_app(&client).await?;
 
         let versions = if self.all {
-            wasmer_api::query::all_app_versions(&client, app.owner.global_name, app.name).await?
+            wasmer_backend_api::query::all_app_versions(&client, app.owner.global_name, app.name)
+                .await?
         } else {
             let vars = GetDeployAppVersionsVars {
                 owner: app.owner.global_name,
@@ -91,7 +92,7 @@ impl AsyncCliCommand for CmdAppVersionList {
             };
 
             let versions =
-                wasmer_api::query::get_deploy_app_versions(&client, vars.clone()).await?;
+                wasmer_backend_api::query::get_deploy_app_versions(&client, vars.clone()).await?;
 
             versions
                 .edges

--- a/lib/cli/src/commands/app/volumes/credentials/mod.rs
+++ b/lib/cli/src/commands/app/volumes/credentials/mod.rs
@@ -30,7 +30,8 @@ impl AsyncCliCommand for CmdAppVolumesCredentials {
         let (_ident, app) = self.ident.load_app(&client).await?;
 
         let creds =
-            wasmer_api::query::get_app_s3_credentials(&client, app.id.clone().into_inner()).await?;
+            wasmer_backend_api::query::get_app_s3_credentials(&client, app.id.clone().into_inner())
+                .await?;
 
         match self.fmt.format {
             CredsItemFormat::Rclone => {

--- a/lib/cli/src/commands/app/volumes/credentials/rotate_secrets.rs
+++ b/lib/cli/src/commands/app/volumes/credentials/rotate_secrets.rs
@@ -28,7 +28,7 @@ impl AsyncCliCommand for CmdAppVolumesRotateSecrets {
         let client = self.env.client()?;
         let (_ident, app) = self.ident.load_app(&client).await?;
 
-        wasmer_api::query::rotate_s3_secrets(&client, app.id).await?;
+        wasmer_backend_api::query::rotate_s3_secrets(&client, app.id).await?;
 
         // Don't print it here and leave it implied, so users can append the output
         // of `wasmer app volumes credentials` without worrying about this message.

--- a/lib/cli/src/commands/app/volumes/list.rs
+++ b/lib/cli/src/commands/app/volumes/list.rs
@@ -25,7 +25,8 @@ impl AsyncCliCommand for CmdAppVolumesList {
 
         let (_ident, app) = self.ident.load_app(&client).await?;
         let volumes =
-            wasmer_api::query::get_app_volumes(&client, &app.owner.global_name, &app.name).await?;
+            wasmer_backend_api::query::get_app_volumes(&client, &app.owner.global_name, &app.name)
+                .await?;
 
         if volumes.is_empty() {
             eprintln!("App {} has no volumes!", app.name);

--- a/lib/cli/src/commands/auth/logout.rs
+++ b/lib/cli/src/commands/auth/logout.rs
@@ -39,7 +39,7 @@ impl AsyncCliCommand for Logout {
             .client()
             .map_err(|_| anyhow::anyhow!("Not logged into registry {host_str}"))?;
 
-        let user = wasmer_api::query::current_user(&client)
+        let user = wasmer_backend_api::query::current_user(&client)
             .await
             .map_err(|e| anyhow::anyhow!("Not logged into registry {host_str}: {e}"))?
             .ok_or_else(|| anyhow::anyhow!("Not logged into registry {host_str}"))?;
@@ -92,7 +92,7 @@ impl AsyncCliCommand for Logout {
                 };
 
                 if should_revoke {
-                    wasmer_api::query::revoke_token(&client, token).await?;
+                    wasmer_backend_api::query::revoke_token(&client, token).await?;
                     println!(
                         "Token for user {} in registry {host_str} correctly revoked",
                         user.username.bold()

--- a/lib/cli/src/commands/auth/whoami.rs
+++ b/lib/cli/src/commands/auth/whoami.rs
@@ -20,7 +20,7 @@ impl AsyncCliCommand for Whoami {
     async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
         let client = self.env.client_unauthennticated()?;
         let host_str = self.env.registry_public_url()?.host_str().unwrap().bold();
-        let user = wasmer_api::query::current_user(&client)
+        let user = wasmer_backend_api::query::current_user(&client)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Not logged in registry {host_str}"))?;
         println!(

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -273,7 +273,9 @@ impl GetOrSet {
                         config.registry.set_current_registry(&s.url).await;
                         let current_registry = config.registry.get_current_registry();
                         if let Ok(client) = env.client() {
-                            if let Some(u) = wasmer_api::query::current_user(&client).await? {
+                            if let Some(u) =
+                                wasmer_backend_api::query::current_user(&client).await?
+                            {
                                 println!(
                                 "Successfully logged into registry {current_registry:?} as user {u:?}"
                             );

--- a/lib/cli/src/commands/domain/get.rs
+++ b/lib/cli/src/commands/domain/get.rs
@@ -19,7 +19,8 @@ impl AsyncCliCommand for CmdDomainGet {
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
-        if let Some(domain) = wasmer_api::query::get_domain_with_records(&client, self.name).await?
+        if let Some(domain) =
+            wasmer_backend_api::query::get_domain_with_records(&client, self.name).await?
         {
             println!("{}", self.fmt.format.render(&domain));
         } else {

--- a/lib/cli/src/commands/domain/list.rs
+++ b/lib/cli/src/commands/domain/list.rs
@@ -1,4 +1,4 @@
-use wasmer_api::types::GetAllDomainsVariables;
+use wasmer_backend_api::types::GetAllDomainsVariables;
 
 use crate::{commands::AsyncCliCommand, config::WasmerEnv, opts::ListFormatOpts};
 
@@ -21,7 +21,7 @@ impl AsyncCliCommand for CmdDomainList {
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
-        let domains = wasmer_api::query::get_all_domains(
+        let domains = wasmer_backend_api::query::get_all_domains(
             &client,
             GetAllDomainsVariables {
                 first: None,

--- a/lib/cli/src/commands/domain/register.rs
+++ b/lib/cli/src/commands/domain/register.rs
@@ -27,7 +27,7 @@ impl AsyncCliCommand for CmdDomainRegister {
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
-        let domain = wasmer_api::query::register_domain(
+        let domain = wasmer_backend_api::query::register_domain(
             &client,
             self.name,
             self.namespace,

--- a/lib/cli/src/commands/domain/zonefile.rs
+++ b/lib/cli/src/commands/domain/zonefile.rs
@@ -39,7 +39,7 @@ impl AsyncCliCommand for CmdZoneFileGet {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
         if let Some(domain) =
-            wasmer_api::query::get_domain_zone_file(&client, self.domain_name).await?
+            wasmer_backend_api::query::get_domain_zone_file(&client, self.domain_name).await?
         {
             let zone_file_contents = domain.zone_file;
             if let Some(zone_file_path) = self.zone_file_path {
@@ -62,7 +62,7 @@ impl AsyncCliCommand for CmdZoneFileSync {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let data = std::fs::read(&self.zone_file_path).context("Unable to read file")?;
         let zone_file_contents = String::from_utf8(data).context("Not a valid UTF-8 sequence")?;
-        let domain = wasmer_api::query::upsert_domain_from_zone_file(
+        let domain = wasmer_backend_api::query::upsert_domain_from_zone_file(
             &self.env.client()?,
             zone_file_contents,
             !self.no_delete_missing_records,

--- a/lib/cli/src/commands/init.rs
+++ b/lib/cli/src/commands/init.rs
@@ -396,7 +396,7 @@ async fn construct_manifest(
         Some(n) => Some(n),
         None => {
             if let Ok(client) = env.client() {
-                if let Ok(Some(u)) = wasmer_api::query::current_user(&client).await {
+                if let Ok(Some(u)) = wasmer_backend_api::query::current_user(&client).await {
                     Some(u.username)
                 } else {
                     None

--- a/lib/cli/src/commands/namespace/create.rs
+++ b/lib/cli/src/commands/namespace/create.rs
@@ -24,11 +24,11 @@ impl AsyncCliCommand for CmdNamespaceCreate {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
 
-        let vars = wasmer_api::types::CreateNamespaceVars {
+        let vars = wasmer_backend_api::types::CreateNamespaceVars {
             name: self.name.clone(),
             description: self.description.clone(),
         };
-        let namespace = wasmer_api::query::create_namespace(&client, vars).await?;
+        let namespace = wasmer_backend_api::query::create_namespace(&client, vars).await?;
 
         println!("{}", self.fmt.get().render(&namespace));
 

--- a/lib/cli/src/commands/namespace/get.rs
+++ b/lib/cli/src/commands/namespace/get.rs
@@ -22,7 +22,7 @@ impl AsyncCliCommand for CmdNamespaceGet {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
 
-        let namespace = wasmer_api::query::get_namespace(&client, self.name)
+        let namespace = wasmer_backend_api::query::get_namespace(&client, self.name)
             .await?
             .context("namespace not found")?;
 

--- a/lib/cli/src/commands/namespace/list.rs
+++ b/lib/cli/src/commands/namespace/list.rs
@@ -16,7 +16,7 @@ impl AsyncCliCommand for CmdNamespaceList {
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
 
-        let namespaces = wasmer_api::query::user_namespaces(&client).await?;
+        let namespaces = wasmer_backend_api::query::user_namespaces(&client).await?;
 
         println!("{}", self.fmt.format.render(&namespaces));
 

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -11,7 +11,7 @@ use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 use wasmer_config::package::{Manifest, NamedPackageIdent, PackageHash};
 use wasmer_package::package::Package;
 
@@ -51,7 +51,7 @@ pub(super) async fn upload(
 
     let session_uri = {
         let default_timeout_secs = Some(60 * 30);
-        let q = wasmer_api::query::get_signed_url_for_package_upload(
+        let q = wasmer_backend_api::query::get_signed_url_for_package_upload(
             client,
             default_timeout_secs,
             Some(hash_str),

--- a/lib/cli/src/commands/package/common/wait.rs
+++ b/lib/cli/src/commands/package/common/wait.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use wasmer_api::{types::PackageVersionState, WasmerClient};
+use wasmer_backend_api::{types::PackageVersionState, WasmerClient};
 
 /// Different conditions that can be "awaited" when publishing a package.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -79,7 +79,7 @@ impl From<PublishWait> for WaitPackageState {
 pub async fn wait_package(
     client: &WasmerClient,
     to_wait: PublishWait,
-    package_version_id: wasmer_api::types::Id,
+    package_version_id: wasmer_backend_api::types::Id,
     timeout: humantime::Duration,
 ) -> anyhow::Result<()> {
     if let PublishWait::None = to_wait {
@@ -89,7 +89,8 @@ pub async fn wait_package(
     let package_version_id = package_version_id.into_inner();
 
     let mut stream =
-        wasmer_api::subscription::package_version_ready(client, &package_version_id).await?;
+        wasmer_backend_api::subscription::package_version_ready(client, &package_version_id)
+            .await?;
 
     let mut state: WaitPackageState = to_wait.into();
 

--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -109,7 +109,7 @@ impl PackageDownload {
 
                 let rt = tokio::runtime::Runtime::new()?;
                 let package = rt
-                    .block_on(wasmer_api::query::get_package_version(
+                    .block_on(wasmer_backend_api::query::get_package_version(
                         &client,
                         full_name.clone(),
                         version.clone(),
@@ -147,7 +147,7 @@ impl PackageDownload {
                 let client = self.env.client_unauthennticated()?;
 
                 let rt = tokio::runtime::Runtime::new()?;
-                let pkg = rt.block_on(wasmer_api::query::get_package_release(&client, &hash.to_string()))?
+                let pkg = rt.block_on(wasmer_backend_api::query::get_package_release(&client, &hash.to_string()))?
                     .with_context(|| format!("Package with {hash} does not exist in the registry, or is not accessible"))?;
 
                 let ident = hash.to_string();

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -12,7 +12,7 @@ use crate::{
 use colored::Colorize;
 use is_terminal::IsTerminal;
 use std::path::{Path, PathBuf};
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 use wasmer_config::package::{Manifest, PackageIdent};
 
 /// Publish (push and tag) a package to the registry.

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use colored::Colorize;
 use is_terminal::IsTerminal;
 use std::path::{Path, PathBuf};
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 use wasmer_config::package::{Manifest, PackageHash};
 use wasmer_package::package::Package;
 
@@ -78,7 +78,7 @@ impl PackagePush {
             anyhow::bail!("No package namespace specified: use --namespace XXX");
         }
 
-        let user = wasmer_api::query::current_user_with_namespaces(client, None).await?;
+        let user = wasmer_backend_api::query::current_user_with_namespaces(client, None).await?;
         let owner = crate::utils::prompts::prompt_for_namespace(
             "Choose a namespace to push the package to",
             None,
@@ -112,7 +112,7 @@ impl PackagePush {
     }
 
     async fn should_push(&self, client: &WasmerClient, hash: &PackageHash) -> anyhow::Result<bool> {
-        let res = wasmer_api::query::get_package_release(client, &hash.to_string()).await;
+        let res = wasmer_backend_api::query::get_package_release(client, &hash.to_string()).await;
         tracing::info!("{:?}", res);
         res.map(|p| p.is_none())
     }
@@ -140,7 +140,7 @@ impl PackagePush {
         spinner_ok!(pb, "Package correctly uploaded");
 
         let pb = make_spinner!(self.quiet, "Waiting for package to become available...");
-        match wasmer_api::query::push_package_release(
+        match wasmer_backend_api::query::push_package_release(
             client,
             name.as_deref(),
             namespace,

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -13,7 +13,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 use wasmer_config::package::{
     Manifest, NamedPackageId, NamedPackageIdent, PackageBuilder, PackageHash, PackageIdent,
 };
@@ -154,7 +154,7 @@ impl PackageTag {
         client: &WasmerClient,
         id: &NamedPackageId,
         manifest: Option<&Manifest>,
-        package_release_id: &wasmer_api::types::Id,
+        package_release_id: &wasmer_backend_api::types::Id,
     ) -> anyhow::Result<()> {
         tracing::info!(
             "Tagging package with registry id {:?} and specifier {:?}",
@@ -200,7 +200,7 @@ impl PackageTag {
             None
         };
 
-        let r = wasmer_api::query::tag_package_release(
+        let r = wasmer_backend_api::query::tag_package_release(
             client,
             maybe_description.as_deref(),
             maybe_homepage.as_deref(),
@@ -241,7 +241,7 @@ impl PackageTag {
         client: &WasmerClient,
         hash: &PackageHash,
         check_package_exists: bool,
-    ) -> anyhow::Result<wasmer_api::types::Id> {
+    ) -> anyhow::Result<wasmer_backend_api::types::Id> {
         let pb = make_spinner!(
             self.quiet || check_package_exists,
             "Checking if the package exists.."
@@ -249,7 +249,9 @@ impl PackageTag {
 
         tracing::debug!("Searching for package with hash: {hash}");
 
-        let pkg = match wasmer_api::query::get_package_release(client, &hash.to_string()).await? {
+        let pkg = match wasmer_backend_api::query::get_package_release(client, &hash.to_string())
+            .await?
+        {
             Some(p) => p,
             None => {
                 spinner_err!(pb, "The package is not in the registry!");
@@ -366,7 +368,7 @@ impl PackageTag {
             anyhow::bail!("No package namespace specified: use --namespace <package_namespace>");
         }
 
-        let user = wasmer_api::query::current_user_with_namespaces(client, None).await?;
+        let user = wasmer_backend_api::query::current_user_with_namespaces(client, None).await?;
         crate::utils::prompts::prompt_for_namespace("Choose a namespace", None, Some(&user))
     }
 
@@ -403,7 +405,7 @@ impl PackageTag {
             format!("Checking if a version of {full_pkg_name} already exists..")
         );
 
-        if let Some(registry_version) = wasmer_api::query::get_package_version(
+        if let Some(registry_version) = wasmer_backend_api::query::get_package_version(
             client,
             full_pkg_name.to_string(),
             String::from("latest"),
@@ -425,7 +427,7 @@ impl PackageTag {
 
             // Must necessarily bump if there's a package with the chosen version with a different hash.
             let must_bump = {
-                let maybe_pkg = wasmer_api::query::get_package_version(
+                let maybe_pkg = wasmer_backend_api::query::get_package_version(
                     client,
                     full_pkg_name.to_string(),
                     user_version.to_string(),
@@ -590,7 +592,7 @@ impl PackageTag {
             return Ok(false);
         }
 
-        let pkg = wasmer_api::query::get_package_version(
+        let pkg = wasmer_backend_api::query::get_package_version(
             client,
             id.full_name.clone(),
             id.version.to_string(),

--- a/lib/cli/src/commands/ssh.rs
+++ b/lib/cli/src/commands/ssh.rs
@@ -1,7 +1,7 @@
 //! Edge SSH command.
 
 use anyhow::Context;
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 
 use super::AsyncCliCommand;
 use crate::{config::WasmerEnv, edge_config::EdgeConfig};
@@ -122,7 +122,10 @@ async fn acquire_ssh_token(
 
 /// Create a new token for SSH access through the backend API.
 async fn create_ssh_token(client: &WasmerClient) -> Result<RawToken, anyhow::Error> {
-    wasmer_api::query::generate_deploy_config_token_raw(client, wasmer_api::query::TokenKind::SSH)
-        .await
-        .context("Could not create token for ssh access")
+    wasmer_backend_api::query::generate_deploy_config_token_raw(
+        client,
+        wasmer_backend_api::query::TokenKind::SSH,
+    )
+    .await
+    .context("Could not create token for ssh access")
 }

--- a/lib/cli/src/config/env.rs
+++ b/lib/cli/src/config/env.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Error};
 use lazy_static::lazy_static;
 use std::path::{Path, PathBuf};
 use url::Url;
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 
 lazy_static! {
     pub static ref DEFAULT_WASMER_CLI_USER_AGENT: String =
@@ -141,7 +141,7 @@ impl WasmerEnv {
 
         let proxy = self.proxy()?;
 
-        let client = wasmer_api::WasmerClient::new_with_proxy(
+        let client = wasmer_backend_api::WasmerClient::new_with_proxy(
             registry_url,
             &DEFAULT_WASMER_CLI_USER_AGENT,
             proxy,

--- a/lib/cli/src/config/mod.rs
+++ b/lib/cli/src/config/mod.rs
@@ -4,7 +4,7 @@ pub use env::*;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use url::Url;
-use wasmer_api::WasmerClient;
+use wasmer_backend_api::WasmerClient;
 
 pub static GLOBAL_CONFIG_FILE_NAME: &str = "wasmer.toml";
 pub static DEFAULT_PROD_REGISTRY: &str = "https://registry.wasmer.io/graphql";
@@ -123,7 +123,9 @@ fn endpoint_from_domain_name(domain_name: &str) -> String {
 async fn test_if_registry_present(registry: &str) -> anyhow::Result<()> {
     let client = WasmerClient::new(url::Url::parse(registry)?, &DEFAULT_WASMER_CLI_USER_AGENT)?;
 
-    wasmer_api::query::current_user(&client).await.map(|_| ())
+    wasmer_backend_api::query::current_user(&client)
+        .await
+        .map(|_| ())
 }
 
 #[derive(PartialEq, Eq, Copy, Clone)]

--- a/lib/cli/src/types.rs
+++ b/lib/cli/src/types.rs
@@ -1,5 +1,5 @@
 use comfy_table::Table;
-use wasmer_api::types::{
+use wasmer_backend_api::types::{
     DeployApp, DeployAppVersion, Deployment, DnsDomain, DnsDomainWithRecords, Namespace,
 };
 
@@ -163,7 +163,7 @@ impl CliRender for DeployAppVersion {
     }
 }
 
-impl CliRender for wasmer_api::types::AppVersionVolume {
+impl CliRender for wasmer_backend_api::types::AppVersionVolume {
     fn render_item_table(&self) -> String {
         let mut table = Table::new();
         table.add_rows([
@@ -189,7 +189,7 @@ impl CliRender for wasmer_api::types::AppVersionVolume {
     }
 }
 
-fn format_disk_size_opt(value: Option<wasmer_api::types::BigInt>) -> String {
+fn format_disk_size_opt(value: Option<wasmer_backend_api::types::BigInt>) -> String {
     let value = value.and_then(|x| {
         let y: Option<u64> = x.0.try_into().ok();
         y
@@ -259,7 +259,7 @@ impl CliRender for Deployment {
     }
 }
 
-impl CliRender for wasmer_api::types::NakedDeployment {
+impl CliRender for wasmer_backend_api::types::NakedDeployment {
     fn render_item_table(&self) -> String {
         let mut table = Table::new();
         table.add_rows([
@@ -295,7 +295,7 @@ impl CliRender for wasmer_api::types::NakedDeployment {
     }
 }
 
-impl CliRender for wasmer_api::types::AutobuildRepository {
+impl CliRender for wasmer_backend_api::types::AutobuildRepository {
     fn render_item_table(&self) -> String {
         let mut table = Table::new();
         table.add_rows([

--- a/lib/cli/src/utils/package_wizard/mod.rs
+++ b/lib/cli/src/utils/package_wizard/mod.rs
@@ -2,7 +2,7 @@
 //
 // use anyhow::Context;
 // use dialoguer::{theme::ColorfulTheme, Select};
-// use wasmer_api::{types::UserWithNamespaces, WasmerClient};
+// use wasmer_backend_api::{types::UserWithNamespaces, WasmerClient};
 //
 // use super::prompts::PackageCheckMode;
 //
@@ -77,7 +77,7 @@
 // }
 //
 // pub struct PackageWizardOutput {
-//     pub api: Option<wasmer_api::types::Package>,
+//     pub api: Option<wasmer_backend_api::types::Package>,
 //     pub local_path: Option<PathBuf>,
 //     pub local_manifest: Option<wasmer_config::package::Manifest>,
 // }


### PR DESCRIPTION
The crate `wasmer-api` is named in a way that might misdirect users. This small patch renames it to `wasmer-backend-api`. 