### PR TITLE
chore: Remove `isle-in-source-tree` feature from `cranelift-codegen`

### DIFF
--- a/lib/compiler-cranelift/Cargo.toml
+++ b/lib/compiler-cranelift/Cargo.toml
@@ -26,7 +26,6 @@ cranelift-codegen = { version = "=0.110.2", default-features = false, features =
 	"x86",
 	"arm64",
 	"riscv64",
-	"isle-in-source-tree",
 ] }
 cranelift-frontend = { version = "=0.110.2", default-features = false }
 itertools = "0.12.0"


### PR DESCRIPTION
As per title. Probably, this feature was the source of the issues we've seen in CI related to `cranelift-codegen`. 
