### PR TITLE
Fix the swift build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,6 +6844,7 @@ dependencies = [
  "uniffi",
  "virtual-fs",
  "wasmer",
+ "wasmer-package",
  "wasmer-wasix",
  "webc",
 ]

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -24,6 +24,7 @@ wasmer = { version = "=5.0.0", path = "../api", default-features = false, featur
 ] }
 wasmer-wasix = { version = "=0.30.0", path = "../wasix" }
 webc.workspace = true
+wasmer-package.workspace = true
 
 
 [build-dependencies]

--- a/lib/swift/src/lib.rs
+++ b/lib/swift/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use virtual_fs::{AsyncReadExt, AsyncSeekExt};
+use wasmer_package::utils::from_bytes;
 use wasmer_wasix::{
     bin_factory::BinaryPackage,
     runners::{wasi::WasiRunner, Runner},
@@ -32,7 +33,7 @@ pub enum WasmerError {
 pub fn run_package(webc_bytes: Vec<u8>, args: Vec<String>) -> Result<String, WasmerError> {
     let tokio_rt = Runtime::new().unwrap();
     let _enter = tokio_rt.enter();
-    let container = err!(webc::Container::from_bytes(webc_bytes));
+    let container = err!(from_bytes(webc_bytes));
     let tasks = TokioTaskManager::new(tokio_rt.handle().clone());
     let tasks = Arc::new(tasks);
     let mut rt = PluggableRuntime::new(Arc::clone(&tasks) as Arc<_>);


### PR DESCRIPTION
Fixes the swift crate by migrating to the new `wasmer-package` API.