### PR TITLE
fix(ci): Move addition of `brew` libs to other step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,11 +271,6 @@ jobs:
           echo "${LLVM_DIR}/bin" >> $GITHUB_PATH
         env:
           LLVM_DIR: .llvm
-      - name: Add `brew` libs to `RUSTFLAGS`
-        if: matrix.metadata.os == 'macos-14'
-        shell: bash
-        run: |
-          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
       - name: Configure LLVM (Windows)
         # The Custom Windows build does not contains llvm-config.exe, so need to setup manualy here
         if: startsWith(matrix.build, 'windows-x64') && matrix.llvm_url
@@ -292,6 +287,7 @@ jobs:
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
         if: startsWith(matrix.os, 'macos')
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,13 +281,16 @@ jobs:
           echo LLVM_ENABLE=1 >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
+      - name: Add `brew` libraries (Apple Silicon)
+        run: |
+          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
+        if: matrix.os == 'macos-14'
       - name: Set up dependencies for Mac OS
         run: |
           brew install automake
           # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
         if: startsWith(matrix.os, 'macos')
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
A small patch that moves the addition of `brew` libs to another step. 
(Reference issue: https://github.com/wasmerio/wasmer/issues/5217)