### PR TITLE
Add make target for building `wasmer-api` with `js` feature as `cdylib`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,9 @@ build-wasmer-wasmi:
 build-wasmer-jsc:
 	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --release --manifest-path lib/cli/Cargo.toml --no-default-features --features="jsc,wat" --bin wasmer --locked
 
+build-wasmer-api-js:
+	$(CARGO_BINARY) rustc --target wasm32-unknown-unknown --release --manifest-path lib/api/Cargo.toml --no-default-features --features "js, js-default, wasm-types-polyfill, enable-serde" --crate-type=cdylib --locked
+
 build-wasmer-debug:
 	$(CARGO_BINARY) build $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --bin wasmer --locked
 

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -19,8 +19,6 @@
     clippy::unicode_not_nfc,
     clippy::use_self
 )]
-#![allow(deprecated_cfg_attr_crate_type_name)]
-#![cfg_attr(feature = "js", crate_type = "cdylib")]
 
 //! [`Wasmer`](https://wasmer.io/) is the most popular
 //! [WebAssembly](https://webassembly.org/) runtime for Rust. It supports


### PR DESCRIPTION
Since Rust `1.59.0`, using:
```rust
#![cfg_attr(feature = "js", crate_type = "cdylib")]
```
has been deprecated. Seems like in Rust `1.84.0`, this is going to be a hard error, so building the `wasmer` crate  with the `js` feature enabled, will result in an error (and does result an error now if you try to build with the latest `nightly`).

I've tried multiple ways to solve this issue, namely:
- Setting a conditional `cfg` in `lib/api/Cargo.toml` to set the `crate-type` to `cdylib` when the `js` feature is enabled. This did not work. Cargo will emit a warning that such a config is just ignored. You can also confirm that by seeing that `wasmer.wasm` was not generated.
- I tried to pass flags to `rustc` via `lib/api/build.rs` and `RUSTFLAGS`, but neither  worked.

Finally I've settled on the solution proposed by this PR. For convenience, I added a make target for this specific kind of build. I can confirm that running this target with the latest nightly, correctly produces the desired `wasmer.wasm` file.

Resolves #5214.