### PR TITLE
c-api/README.md: Fix double include in usage section

### DIFF
--- a/lib/c-api/README.md
+++ b/lib/c-api/README.md
@@ -14,7 +14,6 @@ $WASMER_DIR/
     wasm.h
     wasmer.h
     wasmer.hh
-    wasmer.h
 ```
 
 Wasmer binary also ships with [`wasmer-config`](#wasmer-config)


### PR DESCRIPTION

While reading the affected README, i saw, that the file "wasmer.h" was mentioned twice
in the list of installed include files. That's not correct.

Instead of creating an issue, i created this PR to change the README,
but I have never used or installed "wasmer", so i was not able to verify the result.

-- 
Regards ... Detlef

