### PR TITLE
Alias `.` to cwd in wasi env

### DIFF
--- a/lib/wasix/src/runners/wasi.rs
+++ b/lib/wasix/src/runners/wasi.rs
@@ -262,6 +262,18 @@ impl WasiRunner {
             None
         };
 
+        if self.wasi.is_home_mapped {
+            builder.set_current_dir(MAPPED_CURRENT_DIR_DEFAULT_PATH);
+        }
+
+        if let Some(current_dir) = &self.wasi.current_dir {
+            builder.set_current_dir(current_dir.clone());
+        }
+
+        if let Some(cwd) = &wasi.cwd {
+            builder.set_current_dir(cwd);
+        }
+
         self.wasi
             .prepare_webc_env(&mut builder, container_fs, wasi, root_fs)?;
 
@@ -273,13 +285,6 @@ impl WasiRunner {
         }
         if let Some(stderr) = &self.stderr {
             builder.set_stderr(Box::new(stderr.clone()));
-        }
-
-        if self.wasi.is_home_mapped {
-            builder.set_current_dir(MAPPED_CURRENT_DIR_DEFAULT_PATH);
-        }
-        if let Some(current_dir) = &self.wasi.current_dir {
-            builder.set_current_dir(current_dir.clone());
         }
 
         Ok(builder)
@@ -375,10 +380,6 @@ impl crate::runners::Runner for WasiRunner {
             for snapshot_trigger in self.wasi.snapshot_on.iter().cloned() {
                 env.add_snapshot_trigger(snapshot_trigger);
             }
-        }
-
-        if let Some(cwd) = &wasi.cwd {
-            env.set_current_dir(cwd);
         }
 
         let env = env.build()?;

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -73,7 +73,8 @@ impl CommonWasiOptions {
 
         if self.mounts.iter().all(|m| m.guest != ".") {
             // The user hasn't mounted "." to anything, so let's map it to "/"
-            builder.add_map_dir(".", "/")?;
+            let path = builder.get_current_dir().unwrap_or(PathBuf::from("/"));
+            builder.add_map_dir(".", path)?;
         }
 
         builder.set_fs(Box::new(fs));

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -579,6 +579,10 @@ impl WasiEnvBuilder {
         self.journals.push(journal);
     }
 
+    pub fn get_current_dir(&mut self) -> Option<PathBuf> {
+        self.current_dir.clone()
+    }
+
     pub fn set_current_dir(&mut self, dir: impl Into<PathBuf>) {
         self.current_dir = Some(dir.into());
     }

--- a/tests/wasix/create-dir-at-cwd-with-chdir/main.c
+++ b/tests/wasix/create-dir-at-cwd-with-chdir/main.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// the difference between this test and the one in create-dir-at-cwd is the
+// presence of chdir.
+
+// this will force chdir to be linked with this binary which in turn will change 
+// the behavior of rel_path logic the libc. 
+//
+// for more info see: libc-find-relpath.h in wasix-libc
+int (*dummy_chdir_ref)(const char *path) = chdir;
+
+int main() {
+    int status = EXIT_FAILURE;
+
+    const char *dirName1 = "test1";
+    if (mkdir(dirName1, 0755) != 0) {
+        goto end;
+    }
+
+    const char *dirName2 = "./test2";
+    if (mkdir(dirName2, 0755) != 0) {
+        goto end;
+    }
+
+    status = EXIT_SUCCESS;
+
+end:
+    printf("%d", status);
+    return 0;
+}

--- a/tests/wasix/create-dir-at-cwd-with-chdir/run.sh
+++ b/tests/wasix/create-dir-at-cwd-with-chdir/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --dir . > output
+
+rmdir test1 test2 2>/dev/null && printf "0" | diff -u output - 1>/dev/null

--- a/tests/wasix/create-dir-at-cwd/main.c
+++ b/tests/wasix/create-dir-at-cwd/main.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+int main() {
+    int status = EXIT_FAILURE;
+
+    const char *dirName1 = "test1";
+    if (mkdir(dirName1, 0755) != 0) {
+        goto end;
+    }
+
+    const char *dirName2 = "./test2";
+    if (mkdir(dirName2, 0755) != 0) {
+        goto end;
+    }
+
+    status = EXIT_SUCCESS;
+
+end:
+    printf("%d", status);
+    return 0;
+}

--- a/tests/wasix/create-dir-at-cwd/run.sh
+++ b/tests/wasix/create-dir-at-cwd/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --dir . > output
+
+rmdir test1 test2 2>/dev/null && printf "0" | diff -u output - 1>/dev/null


### PR DESCRIPTION
Partially resolves #5229. The full fix requires the sync added in wasix-libc in [(#45)](https://github.com/wasix-org/wasix-libc/pull/45).