### PR TITLE
Relax `wat` version requirement

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -38,7 +38,7 @@ derivative = { version = "^2" }
 bytes = "1"
 tracing = { version = "0.1" }
 # - Optional shared dependencies.
-wat = { version = "=1.216.0", optional = true }
+wat = { version = "1.216.0", optional = true }
 rustc-demangle = "0.1"
 shared-buffer = { workspace = true }
 wasmi_c_api = { version = "0.38.0", package = "wasmi_c_api_impl", optional = true }


### PR DESCRIPTION
I want to update the wasmer version to the latest release in https://github.com/containerd/runwasi, but cargo fails to resolve dependencies due to overly restrictive version requirements for the wat crate. For example

```
error: failed to select a version for `wat`.
    ... required by package `wasmtime v26.0.1`
    ... which satisfies dependency `wasmtime = "^26.0.1"` of package `containerd-shim-benchmarks v0.4.0
versions that meet the requirements `^1.218.0` are: 1.219.1, 1.220.0, 1.219.0, 1.218.0

all possible versions conflict with previously selected packages.

  previously selected package `wat v1.216.0`
    ... which satisfies dependency `wat = "=1.216.0"` of package `wasmer v5.0.1`
    ... which satisfies dependency `wasmer = "^5.0.1"` of package `containerd-shim-wasmer v0.5.0
```

Could we relax the strict version requirement?
