### PR TITLE
deps: Remove usage of unmaintained derivative crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,17 +1372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1424,27 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4374,7 +4384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "derive_more",
+ "derive_more 0.99.18",
  "twox-hash",
 ]
 
@@ -5877,7 +5887,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "dashmap 6.1.0",
- "derivative",
+ "derive_more 1.0.0",
  "dunce",
  "filetime",
  "fs_extra",
@@ -5908,7 +5918,6 @@ version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
- "derivative",
  "futures",
  "mio",
  "serde",
@@ -5927,7 +5936,7 @@ dependencies = [
  "bincode",
  "bytecheck 0.6.12",
  "bytes",
- "derivative",
+ "derive_more 1.0.0",
  "futures-util",
  "hyper",
  "hyper-tungstenite",
@@ -6292,7 +6301,6 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
- "derivative",
  "hashbrown 0.11.2",
  "indexmap 1.9.3",
  "js-sys",
@@ -6336,7 +6344,7 @@ dependencies = [
  "async-trait",
  "clap",
  "cynic",
- "derive_more",
+ "derive_more 0.99.18",
  "futures",
  "indicatif",
  "log",
@@ -6743,7 +6751,6 @@ version = "5.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd 2.0.16",
- "derivative",
  "dirs",
  "flate2",
  "futures",
@@ -6779,7 +6786,7 @@ dependencies = [
  "bincode",
  "bytecheck 0.6.12",
  "bytes",
- "derivative",
+ "derive_more 1.0.0",
  "lz4_flex",
  "num_enum",
  "rkyv",
@@ -6893,7 +6900,6 @@ dependencies = [
  "corosensei",
  "crossbeam-queue",
  "dashmap 6.1.0",
- "derivative",
  "enum-iterator",
  "fnv",
  "indexmap 2.6.0",
@@ -6928,7 +6934,7 @@ dependencies = [
  "chrono",
  "cooked-waker",
  "dashmap 6.1.0",
- "derivative",
+ "derive_more 1.0.0",
  "env_logger",
  "futures",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ base64 = "0.22.0"
 time = "0.3.36"
 target-lexicon = { version = "0.12.2", default-features = false }
 object = "0.32.0"
+derive_more = { version = "1", features = ["debug"] }
 
 [build-dependencies]
 test-generator = { path = "tests/lib/test-generator" }

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -34,7 +34,6 @@ indexmap = { version = "1.6" }
 cfg-if = "1.0"
 thiserror = "1.0"
 more-asserts = "0.2"
-derivative = { version = "^2" }
 bytes = "1"
 tracing = { version = "0.1" }
 # - Optional shared dependencies.

--- a/lib/api/src/c_api/store.rs
+++ b/lib/api/src/c_api/store.rs
@@ -6,6 +6,7 @@ use crate::{
 pub(crate) use objects::{InternalStoreHandle, StoreObject};
 pub use objects::{StoreHandle, StoreObjects};
 
+#[derive(Debug)]
 pub(crate) struct Store {
     pub(crate) engine: Engine,
     pub(crate) inner: *mut wasm_store_t,

--- a/lib/api/src/js/store.rs
+++ b/lib/api/src/js/store.rs
@@ -3,6 +3,7 @@ use crate::engine::{AsEngineRef, Engine, EngineRef};
 pub(crate) use objects::{InternalStoreHandle, StoreObject};
 pub use objects::{StoreHandle, StoreObjects};
 
+#[derive(Debug)]
 pub(crate) struct Store {
     pub(crate) engine: Engine,
 }

--- a/lib/api/src/jsc/store.rs
+++ b/lib/api/src/jsc/store.rs
@@ -3,6 +3,7 @@ use crate::engine::{AsEngineRef, Engine, EngineRef};
 pub(crate) use objects::{InternalStoreHandle, StoreObject};
 pub use objects::{StoreHandle, StoreObjects};
 
+#[derive(Debug)]
 pub(crate) struct Store {
     pub(crate) engine: Engine,
 }

--- a/lib/api/src/store.rs
+++ b/lib/api/src/store.rs
@@ -1,7 +1,6 @@
 use crate::engine::{AsEngineRef, Engine, EngineRef};
 #[cfg(feature = "sys")]
 use crate::sys::NativeStoreExt;
-use derivative::Derivative;
 use std::{
     fmt,
     ops::{Deref, DerefMut},
@@ -45,14 +44,20 @@ pub type OnCalledHandler = Box<
 /// We require the context to have a fixed memory address for its lifetime since
 /// various bits of the VM have raw pointers that point back to it. Hence we
 /// wrap the actual context in a box.
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub(crate) struct StoreInner {
     pub(crate) objects: StoreObjects,
-    #[derivative(Debug = "ignore")]
     pub(crate) store: store_imp::Store,
-    #[derivative(Debug = "ignore")]
     pub(crate) on_called: Option<OnCalledHandler>,
+}
+
+impl std::fmt::Debug for StoreInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("StoreInner")
+            .field("objects", &self.objects)
+            .field("store", &self.store)
+            .field("on_called", &"<...>")
+            .finish()
+    }
 }
 
 /// The store represents all global state that can be manipulated by

--- a/lib/api/src/sys/store.rs
+++ b/lib/api/src/sys/store.rs
@@ -4,8 +4,15 @@ use wasmer_vm::TrapHandlerFn;
 
 pub(crate) struct Store {
     pub(crate) engine: Engine,
-
     pub(crate) trap_handler: Option<Box<TrapHandlerFn<'static>>>,
+}
+
+impl std::fmt::Debug for Store {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Store")
+            .field("engine", &self.engine)
+            .finish()
+    }
 }
 
 impl Store {

--- a/lib/api/src/typed_function.rs
+++ b/lib/api/src/typed_function.rs
@@ -14,7 +14,7 @@ use crate::store::AsStoreRef;
 
 /// A WebAssembly function that can be called natively
 /// (using the Native ABI).
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TypedFunction<Args, Rets> {
     pub(crate) func: Function,
     _phantom: PhantomData<fn(Args) -> Rets>,

--- a/lib/journal/Cargo.toml
+++ b/lib/journal/Cargo.toml
@@ -22,15 +22,16 @@ virtual-net = { path = "../virtual-net", version = "0.11.0", default-features = 
 	"rkyv",
 ] }
 virtual-fs = { path = "../virtual-fs", version = "0.19.0", default-features = false }
+
 shared-buffer = { workspace = true, optional = true }
 base64.workspace = true
+derive_more.workspace = true
 rkyv = { workspace = true }
 
 thiserror = "1"
 bytes = "1.1"
 async-trait = { version = "^0.1" }
 tracing = "0.1"
-derivative = { version = "^2" }
 bincode = { version = "1.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 anyhow = "1.0"

--- a/lib/journal/src/entry.rs
+++ b/lib/journal/src/entry.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::net::{Shutdown, SocketAddr};
@@ -79,8 +78,7 @@ pub enum SocketOptTimeType {
 /// Represents a log entry in a snapshot log stream that represents the total
 /// state of a WASM process at a point in time.
 #[allow(clippy::large_enum_variant)]
-#[derive(Derivative, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum JournalEntry<'a> {
     InitModuleV1 {
@@ -89,7 +87,7 @@ pub enum JournalEntry<'a> {
     ClearEtherealV1,
     UpdateMemoryRegionV1 {
         region: Range<u64>,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         compressed_data: Cow<'a, [u8]>,
     },
@@ -98,13 +96,13 @@ pub enum JournalEntry<'a> {
     },
     SetThreadV1 {
         id: u32,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         call_stack: Cow<'a, [u8]>,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         memory_stack: Cow<'a, [u8]>,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         store_data: Cow<'a, [u8]>,
         start: ThreadStartType,
@@ -123,7 +121,7 @@ pub enum JournalEntry<'a> {
     FileDescriptorWriteV1 {
         fd: Fd,
         offset: u64,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         data: Cow<'a, [u8]>,
         is_64bit: bool,
@@ -141,9 +139,9 @@ pub enum JournalEntry<'a> {
         dirflags: LookupFlags,
         path: Cow<'a, str>,
         o_flags: Oflags,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         fs_rights_base: Rights,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         fs_rights_inheriting: Rights,
         fs_flags: Fdflags,
     },
@@ -330,7 +328,7 @@ pub enum JournalEntry<'a> {
     },
     SocketSendToV1 {
         fd: Fd,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         data: Cow<'a, [u8]>,
         flags: SiFlags,
@@ -339,7 +337,7 @@ pub enum JournalEntry<'a> {
     },
     SocketSendV1 {
         fd: Fd,
-        #[derivative(Debug = "ignore")]
+        #[debug(ignore)]
         #[serde(with = "base64")]
         data: Cow<'a, [u8]>,
         flags: SiFlags,

--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -12,11 +12,11 @@ rust-version.workspace = true
 [dependencies]
 wasmer-package.workspace = true
 dashmap.workspace = true
+derive_more.workspace = true
 dunce = "1.0.4"
 anyhow = { version = "1.0.66", optional = true }
 async-trait = { version = "^0.1" }
 bytes = "1"
-derivative = "2.2.0"
 filetime = { version = "0.2.18", optional = true }
 fs_extra = { version = "1.2.0", optional = true }
 futures = { version = "0.3" }

--- a/lib/virtual-fs/src/arc_box_file.rs
+++ b/lib/virtual-fs/src/arc_box_file.rs
@@ -8,15 +8,12 @@ use std::{
     task::{Context, Poll},
 };
 
-use derivative::Derivative;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
 use crate::VirtualFile;
 
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct ArcBoxFile {
-    #[derivative(Debug = "ignore")]
     inner: Arc<Mutex<Box<dyn VirtualFile + Send + Sync + 'static>>>,
 }
 

--- a/lib/virtual-fs/src/arc_file.rs
+++ b/lib/virtual-fs/src/arc_file.rs
@@ -2,7 +2,6 @@
 //! effectively this is a symbolic link without all the complex path redirection
 
 use crate::{ClonableVirtualFile, VirtualFile};
-use derivative::Derivative;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{
@@ -11,13 +10,11 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct ArcFile<T>
 where
     T: VirtualFile + Send + Sync + 'static,
 {
-    #[derivative(Debug = "ignore")]
     inner: Arc<Mutex<Box<T>>>,
 }
 

--- a/lib/virtual-fs/src/combine_file.rs
+++ b/lib/virtual-fs/src/combine_file.rs
@@ -1,11 +1,8 @@
-use derivative::Derivative;
-
 use super::*;
 
 use crate::VirtualFile;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct CombineFile {
     tx: Box<dyn VirtualFile + Send + Sync + 'static>,
     rx: Box<dyn VirtualFile + Send + Sync + 'static>,

--- a/lib/virtual-fs/src/dual_write_file.rs
+++ b/lib/virtual-fs/src/dual_write_file.rs
@@ -1,5 +1,3 @@
-use derivative::Derivative;
-
 use super::*;
 
 use crate::VirtualFile;
@@ -7,12 +5,11 @@ use crate::VirtualFile;
 /// Wraps a [`VirtualFile`], and also invokes a provided function for each write.
 ///
 /// Useful for debugging.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug)]
 pub struct DualWriteFile {
     inner: Box<dyn VirtualFile + Send + Sync + 'static>,
-    #[derivative(Debug = "ignore")]
     #[allow(clippy::type_complexity)]
+    #[debug(ignore)]
     extra_write: Box<dyn FnMut(&[u8]) + Send + Sync + 'static>,
 }
 

--- a/lib/virtual-io/Cargo.toml
+++ b/lib/virtual-io/Cargo.toml
@@ -17,7 +17,6 @@ tracing = "0.1"
 
 mio = { workspace = true, features = ["os-poll"], optional = true }
 socket2 = { workspace = true, optional = true }
-derivative = { version = "^2" }
 futures = { version = "0.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/lib/virtual-io/src/arc.rs
+++ b/lib/virtual-io/src/arc.rs
@@ -1,14 +1,10 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use derivative::Derivative;
-
 use crate::{InterestHandler, InterestType};
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 struct ArcInterestHandlerState {
-    #[derivative(Debug = "ignore")]
     handler: Box<dyn InterestHandler + Send + Sync>,
 }
 

--- a/lib/virtual-io/src/interest.rs
+++ b/lib/virtual-io/src/interest.rs
@@ -5,8 +5,6 @@ use std::{
     task::{Context, RawWaker, RawWakerVTable, Waker},
 };
 
-use derivative::Derivative;
-
 #[derive(Debug, Clone, Serialize, Deserialize, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum InterestType {
     Readable,
@@ -71,7 +69,7 @@ impl InterestHandler for SharedWakerInterestHandler {
     }
 }
 
-pub trait InterestHandler: Send + Sync {
+pub trait InterestHandler: Send + Sync + std::fmt::Debug {
     fn push_interest(&mut self, interest: InterestType);
 
     fn pop_interest(&mut self, interest: InterestType) -> bool;
@@ -101,10 +99,8 @@ pub fn handler_into_waker(
     })
 }
 
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct InterestHandlerWaker {
-    #[derivative(Debug = "ignore")]
     handler: Arc<Mutex<Box<dyn InterestHandler + Send + Sync>>>,
     interest: InterestType,
 }

--- a/lib/virtual-io/src/selector.rs
+++ b/lib/virtual-io/src/selector.rs
@@ -4,22 +4,18 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use derivative::Derivative;
 use mio::{Registry, Token};
 
 use crate::{InterestHandler, InterestType};
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub(crate) struct EngineInner {
     seed: usize,
     registry: Registry,
-    #[derivative(Debug = "ignore")]
     lookup: HashMap<Token, Box<dyn InterestHandler + Send + Sync>>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Selector {
     token_close: Token,
     inner: Mutex<EngineInner>,

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, default-features = false, features = ["io-util"] }
 libc = { workspace = true, optional = true }
 mio = { workspace = true, optional = true }
 socket2 = { workspace = true, optional = true }
-derivative = { version = "^2" }
+derive_more.workspace = true
 virtual-mio = { path = "../virtual-io", version = "0.5.0", default-features = false }
 bincode = { version = "1.3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 
 use bytes::Buf;
 use bytes::BytesMut;
-use derivative::Derivative;
 use futures_util::future::BoxFuture;
 use futures_util::stream::FuturesOrdered;
 use futures_util::Sink;
@@ -530,12 +529,11 @@ struct SocketWithAddr {
 }
 type SocketMap<T> = HashMap<SocketId, T>;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug)]
 struct RemoteCommon {
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     tx: RemoteTx<MessageRequest>,
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     rx: Mutex<RemoteRx<MessageResponse>>,
     request_seed: AtomicU64,
     requests: Mutex<HashMap<u64, RequestTx>>,
@@ -544,7 +542,7 @@ struct RemoteCommon {
     recv_with_addr_tx: Mutex<SocketMap<mpsc::Sender<DataWithAddr>>>,
     accept_tx: Mutex<SocketMap<mpsc::Sender<SocketWithAddr>>>,
     sent_tx: Mutex<SocketMap<mpsc::Sender<u64>>>,
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     handlers: Mutex<SocketMap<Box<dyn virtual_mio::InterestHandler + Send + Sync>>>,
 
     // The stall guard will prevent reads while its held and there are background tasks running

--- a/lib/virtual-net/src/composite.rs
+++ b/lib/virtual-net/src/composite.rs
@@ -2,13 +2,10 @@ use std::net::SocketAddr;
 use std::task::{Context, Poll};
 
 use crate::{Ipv4Addr, Ipv6Addr, NetworkError, VirtualIoSource, VirtualTcpListener};
-use derivative::Derivative;
 use virtual_mio::ArcInterestHandler;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct CompositeTcpListener {
-    #[derivative(Debug = "ignore")]
     ports: Vec<Box<dyn VirtualTcpListener + Sync>>,
 }
 

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -7,7 +7,6 @@ use crate::{
     VirtualSocket, VirtualTcpListener, VirtualTcpSocket, VirtualUdpSocket,
 };
 use bytes::{Buf, BytesMut};
-use derivative::Derivative;
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::mem::MaybeUninit;
@@ -29,8 +28,7 @@ use virtual_mio::{
     state_as_waker_map, HandlerGuardState, InterestGuard, InterestHandler, InterestType, Selector,
 };
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct LocalNetworking {
     selector: Arc<Selector>,
     handle: Handle,
@@ -148,8 +146,7 @@ impl VirtualNetworking for LocalNetworking {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct LocalTcpListener {
     stream: mio::net::TcpListener,
     selector: Arc<Selector>,

--- a/lib/virtual-net/src/loopback.rs
+++ b/lib/virtual-net/src/loopback.rs
@@ -9,7 +9,6 @@ use crate::{
     InterestHandler, IpAddr, IpCidr, Ipv4Addr, Ipv6Addr, NetworkError, VirtualIoSource,
     VirtualNetworking, VirtualTcpListener, VirtualTcpSocket,
 };
-use derivative::Derivative;
 use virtual_mio::InterestType;
 
 const DEFAULT_MAX_BUFFER_SIZE: usize = 1_048_576;
@@ -136,10 +135,8 @@ impl VirtualNetworking for LoopbackNetworking {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 struct LoopbackTcpListenerState {
-    #[derivative(Debug = "ignore")]
     handler: Option<Box<dyn InterestHandler + Send + Sync>>,
     addr_local: SocketAddr,
     backlog: VecDeque<TcpSocketHalf>,

--- a/lib/virtual-net/src/rx_tx.rs
+++ b/lib/virtual-net/src/rx_tx.rs
@@ -62,6 +62,7 @@ impl AsyncWrite for FailOnWrite {
 
 pub(crate) type StreamSink<T> = Pin<Box<dyn Sink<T, Error = std::io::Error> + Send + 'static>>;
 
+#[derive(derive_more::Debug)]
 pub(crate) enum RemoteTx<T>
 where
     T: Serialize,
@@ -72,6 +73,7 @@ where
         wakers: RemoteTxWakers,
     },
     Stream {
+        #[debug(ignore)]
         tx: Arc<tokio::sync::Mutex<StreamSink<T>>>,
         work: mpsc::UnboundedSender<BoxFuture<'static, ()>>,
         wakers: RemoteTxWakers,
@@ -504,6 +506,7 @@ where
     }
 }
 
+#[derive(derive_more::Debug)]
 pub(crate) enum RemoteRx<T>
 where
     T: serde::de::DeserializeOwned,
@@ -513,6 +516,7 @@ where
         wakers: RemoteTxWakers,
     },
     Stream {
+        #[debug(ignore)]
         rx: Pin<Box<dyn Stream<Item = std::io::Result<T>> + Send + 'static>>,
     },
     #[cfg(feature = "hyper")]

--- a/lib/virtual-net/src/server.rs
+++ b/lib/virtual-net/src/server.rs
@@ -5,7 +5,6 @@ use crate::{
     VirtualNetworking, VirtualRawSocket, VirtualTcpListener, VirtualTcpSocket, VirtualUdpSocket,
 };
 use crate::{IpCidr, IpRoute, NetworkError, StreamSecurity, VirtualIcmpSocket};
-use derivative::Derivative;
 use futures_util::stream::FuturesOrdered;
 #[cfg(any(feature = "hyper", feature = "tokio-tungstenite"))]
 use futures_util::stream::{SplitSink, SplitStream};
@@ -1223,6 +1222,7 @@ impl RemoteNetworkingServerDriver {
     }
 }
 
+#[derive(Debug)]
 enum RemoteAdapterSocket {
     TcpListener {
         socket: Box<dyn VirtualTcpListener + Sync + 'static>,
@@ -1616,14 +1616,10 @@ impl InterestHandler for RemoteAdapterHandler {
 
 type SocketMap<T> = HashMap<SocketId, T>;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 struct RemoteAdapterCommon {
-    #[derivative(Debug = "ignore")]
     tx: RemoteTx<MessageResponse>,
-    #[derivative(Debug = "ignore")]
     rx: Mutex<RemoteRx<MessageRequest>>,
-    #[derivative(Debug = "ignore")]
     sockets: Mutex<SocketMap<RemoteAdapterSocket>>,
     socket_accept: Mutex<SocketMap<SocketId>>,
     handler: RemoteAdapterHandler,

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -28,7 +28,6 @@ scopeguard = "1.1.0"
 lazy_static = "1.4.0"
 region = { version = "3.0.2" }
 corosensei = { version = "0.2.0" }
-derivative = { version = "^2" }
 fnv = "1.0.3"
 # - Optional shared dependencies.
 tracing = { version = "0.1", optional = true }

--- a/lib/vm/src/export.rs
+++ b/lib/vm/src/export.rs
@@ -7,7 +7,6 @@ use crate::store::InternalStoreHandle;
 use crate::table::VMTable;
 use crate::vmcontext::VMFunctionKind;
 use crate::{MaybeInstanceOwned, VMCallerCheckedAnyfunc};
-use derivative::Derivative;
 use std::any::Any;
 use wasmer_types::FunctionType;
 
@@ -28,12 +27,10 @@ pub enum VMExtern {
 }
 
 /// A function export value.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct VMFunction {
     /// Pointer to the `VMCallerCheckedAnyfunc` which contains data needed to
     /// call the function and check its signature.
-    #[derivative(Debug = "ignore")]
     pub anyfunc: MaybeInstanceOwned<VMCallerCheckedAnyfunc>,
 
     /// The function type, used for compatibility checking.
@@ -44,6 +41,5 @@ pub struct VMFunction {
     pub kind: VMFunctionKind,
 
     /// Associated data owned by a host function.
-    #[derivative(Debug = "ignore")]
     pub host_data: Box<dyn Any>,
 }

--- a/lib/vm/src/extern_ref.rs
+++ b/lib/vm/src/extern_ref.rs
@@ -1,14 +1,11 @@
-use derivative::Derivative;
 use std::any::Any;
 use wasmer_types::RawValue;
 
 use crate::store::InternalStoreHandle;
 
 /// Underlying object referenced by a `VMExternRef`.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct VMExternObj {
-    #[derivative(Debug = "ignore")]
     contents: Box<dyn Any + Send + Sync + 'static>,
 }
 

--- a/lib/vm/src/function_env.rs
+++ b/lib/vm/src/function_env.rs
@@ -1,12 +1,16 @@
-use derivative::Derivative;
 use std::any::Any;
 
 /// Underlying FunctionEnvironment used by a `VMFunction`.
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct VMFunctionEnvironment {
-    #[derivative(Debug = "ignore")]
     contents: Box<dyn Any + Send + 'static>,
+}
+
+impl std::fmt::Debug for VMFunctionEnvironment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VMFunctionEnvironment")
+            .field("contents", &(&*self.contents as *const _))
+            .finish()
+    }
 }
 
 impl VMFunctionEnvironment {

--- a/lib/vm/src/global.rs
+++ b/lib/vm/src/global.rs
@@ -1,14 +1,11 @@
 use crate::{store::MaybeInstanceOwned, vmcontext::VMGlobalDefinition};
-use derivative::Derivative;
 use std::{cell::UnsafeCell, ptr::NonNull};
 use wasmer_types::GlobalType;
 
 /// A Global instance
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct VMGlobal {
     ty: GlobalType,
-    #[derivative(Debug = "ignore")]
     vm_global_definition: MaybeInstanceOwned<VMGlobalDefinition>,
 }
 

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -10,7 +10,6 @@ use crate::vmcontext::VMTableDefinition;
 use crate::Trap;
 use crate::VMExternRef;
 use crate::VMFuncRef;
-use derivative::Derivative;
 use std::cell::UnsafeCell;
 use std::convert::TryFrom;
 use std::fmt;
@@ -70,17 +69,14 @@ impl Default for TableElement {
 }
 
 /// A table instance.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct VMTable {
-    #[derivative(Debug = "ignore")]
     vec: Vec<RawTableElement>,
     maximum: Option<u32>,
     /// The WebAssembly table description.
     table: TableType,
     /// Our chosen implementation style.
     style: TableStyle,
-    #[derivative(Debug = "ignore")]
     vm_table_definition: MaybeInstanceOwned<VMTableDefinition>,
 }
 

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -40,6 +40,7 @@ serde_yaml.workspace = true
 rkyv.workspace = true
 shared-buffer.workspace = true
 hyper = { workspace = true, features = ["server"], optional = true }
+derive_more.workspace = true
 
 xxhash-rust = { version = "0.8.8", features = ["xxh64"] }
 rusty_pool = { version = "0.7.0", optional = true }
@@ -55,7 +56,6 @@ chrono = { version = "^0.4.38", default-features = false, features = [
 	"std",
 	"clock",
 ], optional = true }
-derivative = { version = "^2" }
 bytes = "1"
 anyhow = { version = "1.0.66" }
 lazy_static = "1.4"

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -1,7 +1,6 @@
 use std::{path::Path, sync::Arc};
 
 use anyhow::Context;
-use derivative::*;
 use once_cell::sync::OnceCell;
 use sha2::Digest;
 use virtual_fs::FileSystem;
@@ -17,12 +16,11 @@ use crate::{
 };
 use wasmer_types::ModuleHash;
 
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug, Clone)]
 pub struct BinaryPackageCommand {
     name: String,
     metadata: webc::metadata::Command,
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     pub(crate) atom: SharedBytes,
     hash: ModuleHash,
 }
@@ -64,8 +62,7 @@ impl BinaryPackageCommand {
 }
 
 /// A WebAssembly package that has been loaded into memory.
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct BinaryPackage {
     pub id: PackageId,
     /// Includes the ids of all the packages in the tree

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -9,7 +9,6 @@ use std::{
     time::Duration,
 };
 
-use derivative::Derivative;
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
 use virtual_mio::InterestHandler;
@@ -33,8 +32,7 @@ pub enum InodeHttpSocketType {
     Headers,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct SocketProperties {
     pub family: Addressfamily,
     pub ty: Socktype,
@@ -51,7 +49,6 @@ pub struct SocketProperties {
     pub read_timeout: Option<Duration>,
     pub accept_timeout: Option<Duration>,
     pub connect_timeout: Option<Duration>,
-    #[derivative(Debug = "ignore")]
     pub handler: Option<Box<dyn InterestHandler + Send + Sync>>,
 }
 

--- a/lib/wasix/src/os/console/mod.rs
+++ b/lib/wasix/src/os/console/mod.rs
@@ -12,7 +12,6 @@ use std::{
     sync::{atomic::AtomicBool, Arc, Mutex},
 };
 
-use derivative::*;
 use linked_hash_set::LinkedHashSet;
 use tokio::sync::{mpsc, RwLock};
 #[allow(unused_imports, dead_code)]
@@ -35,8 +34,7 @@ use crate::{
     Runtime, SpawnError, WasiEnv, WasiEnvBuilder, WasiRuntimeError,
 };
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Console {
     user_agent: Option<String>,
     boot_cmd: String,

--- a/lib/wasix/src/os/tty/mod.rs
+++ b/lib/wasix/src/os/tty/mod.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use derivative::*;
 use futures::future::BoxFuture;
 use virtual_fs::{AsyncWriteExt, NullFile, VirtualFile};
 use wasmer_wasix_types::wasi::{Signal, Snapshot0Clockid};
@@ -113,8 +112,7 @@ impl TtyOptions {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Tty {
     stdin: Box<dyn VirtualFile + Send + Sync + 'static>,
     stdout: Box<dyn VirtualFile + Send + Sync + 'static>,
@@ -444,7 +442,7 @@ impl Default for WasiTtyState {
 }
 
 /// Provides access to a TTY.
-pub trait TtyBridge {
+pub trait TtyBridge: std::fmt::Debug {
     /// Resets the values
     fn reset(&self);
 

--- a/lib/wasix/src/runners/dcgi/callbacks.rs
+++ b/lib/wasix/src/runners/dcgi/callbacks.rs
@@ -1,16 +1,12 @@
 use std::sync::Arc;
 
-use derivative::Derivative;
-
 use super::*;
 use crate::runners::wcgi::{self, CreateEnvConfig, CreateEnvResult, RecycleEnvConfig};
 use virtual_fs::NullFile;
 use wasmer_wasix_types::types::{__WASI_STDERR_FILENO, __WASI_STDIN_FILENO, __WASI_STDOUT_FILENO};
 
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct DcgiCallbacks {
-    #[derivative(Debug = "ignore")]
     inner: Arc<dyn wcgi::Callbacks>,
     factory: DcgiInstanceFactory,
 }

--- a/lib/wasix/src/runners/dcgi/factory.rs
+++ b/lib/wasix/src/runners/dcgi/factory.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-use derivative::Derivative;
 use virtual_fs::Pipe;
 use wasmer_wasix_types::types::{__WASI_STDERR_FILENO, __WASI_STDIN_FILENO, __WASI_STDOUT_FILENO};
 
@@ -20,8 +19,7 @@ struct State {
 
 /// This factory will store and reuse instances between invocations thus
 /// allowing for the instances to be stateful.
-#[derive(Derivative, Clone, Default)]
-#[derivative(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct DcgiInstanceFactory {
     state: Arc<Mutex<State>>,
 }

--- a/lib/wasix/src/runners/dcgi/handler.rs
+++ b/lib/wasix/src/runners/dcgi/handler.rs
@@ -53,9 +53,10 @@ impl Deref for Handler {
     }
 }
 
-#[derive(derivative::Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub(crate) struct SharedState {
+    #[allow(dead_code)]
     pub(crate) inner: Arc<wcgi::SharedState>,
     factory: DcgiInstanceFactory,
     master_lock: Arc<tokio::sync::Mutex<()>>,

--- a/lib/wasix/src/runners/dproxy/factory.rs
+++ b/lib/wasix/src/runners/dproxy/factory.rs
@@ -5,7 +5,6 @@ use std::{
     time::Instant,
 };
 
-use derivative::Derivative;
 use hyper_util::rt::TokioExecutor;
 use wasmer_journal::{DynJournal, RecombinedJournal};
 
@@ -26,8 +25,7 @@ struct State {
 
 /// This factory will store and reuse instances between invocations thus
 /// allowing for the instances to be stateful.
-#[derive(Derivative, Clone, Default)]
-#[derivative(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct DProxyInstanceFactory {
     state: Arc<Mutex<State>>,
 }

--- a/lib/wasix/src/runners/dproxy/handler.rs
+++ b/lib/wasix/src/runners/dproxy/handler.rs
@@ -14,12 +14,10 @@ use crate::Runtime;
 use super::factory::DProxyInstanceFactory;
 use super::Config;
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct SharedState {
     pub(crate) config: Config,
     pub(crate) command_name: String,
-    #[derivative(Debug = "ignore")]
     pub(crate) runtime: Arc<dyn Runtime + Send + Sync>,
     pub(crate) factory: DProxyInstanceFactory,
 }

--- a/lib/wasix/src/runners/dproxy/socket_manager.rs
+++ b/lib/wasix/src/runners/dproxy/socket_manager.rs
@@ -9,17 +9,15 @@ use std::{
     time::Duration,
 };
 
-use derivative::Derivative;
 use tokio::sync::broadcast;
 use virtual_net::{tcp_pair::TcpSocketHalf, LoopbackNetworking};
 
 pub type PollListeningFn =
     Arc<dyn Fn(&mut Context<'_>) -> Poll<SocketAddr> + Send + Sync + 'static>;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug)]
 pub struct SocketManager {
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     poll_listening: PollListeningFn,
     loopback_networking: LoopbackNetworking,
     proxy_connect_init_timeout: Duration,

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use anyhow::{Context, Error};
-use derivative::Derivative;
 use futures::future::BoxFuture;
 use tokio::runtime::Handle;
 use virtual_fs::{FileSystem, FsError, OverlayFileSystem, RootFileSystemBuilder, TmpFileSystem};
@@ -29,8 +28,7 @@ pub struct MappedCommand {
     pub target: String,
 }
 
-#[derive(Derivative, Default, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct CommonWasiOptions {
     pub(crate) entry_function: Option<String>,
     pub(crate) args: Vec<String>,
@@ -42,7 +40,6 @@ pub(crate) struct CommonWasiOptions {
     pub(crate) is_tmp_mapped: bool,
     pub(crate) injected_packages: Vec<BinaryPackage>,
     pub(crate) capabilities: Capabilities,
-    #[derivative(Debug = "ignore")]
     pub(crate) journals: Vec<Arc<DynJournal>>,
     pub(crate) snapshot_on: Vec<SnapshotTrigger>,
     pub(crate) snapshot_interval: Option<std::time::Duration>,

--- a/lib/wasix/src/runners/wcgi/callbacks.rs
+++ b/lib/wasix/src/runners/wcgi/callbacks.rs
@@ -36,7 +36,7 @@ pub struct RecycleEnvConfig {
 /// Callbacks that are triggered at various points in the lifecycle of a runner
 /// and any WebAssembly instances it may start.
 #[async_trait::async_trait]
-pub trait Callbacks: Send + Sync + 'static {
+pub trait Callbacks: std::fmt::Debug + Send + Sync + 'static {
     /// A callback that is called whenever the server starts.
     fn started(&self, _abort: AbortHandle) {}
 
@@ -57,6 +57,7 @@ pub trait Callbacks: Send + Sync + 'static {
     }
 }
 
+#[derive(Debug)]
 pub struct NoOpWcgiCallbacks;
 
 impl Callbacks for NoOpWcgiCallbacks {}

--- a/lib/wasix/src/runners/wcgi/handler.rs
+++ b/lib/wasix/src/runners/wcgi/handler.rs
@@ -318,19 +318,16 @@ async fn consume_stderr(
 
 pub type SetupBuilder = Arc<dyn Fn(&mut WasiEnvBuilder) -> Result<(), anyhow::Error> + Send + Sync>;
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug)]
 pub(crate) struct SharedState {
     pub(crate) module: Module,
     pub(crate) module_hash: ModuleHash,
     pub(crate) dialect: CgiDialect,
     pub(crate) program_name: String,
     pub(crate) propagate_stderr: bool,
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     pub(crate) setup_builder: SetupBuilder,
-    #[derivative(Debug = "ignore")]
     pub(crate) callbacks: Arc<dyn Callbacks>,
-    #[derivative(Debug = "ignore")]
     pub(crate) runtime: Arc<dyn Runtime + Send + Sync>,
 }
 

--- a/lib/wasix/src/runners/wcgi/runner.rs
+++ b/lib/wasix/src/runners/wcgi/runner.rs
@@ -200,12 +200,10 @@ impl crate::runners::Runner for WcgiRunner {
     }
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Config {
     pub(crate) wasi: CommonWasiOptions,
     pub(crate) addr: SocketAddr,
-    #[derivative(Debug = "ignore")]
     pub(crate) callbacks: Arc<dyn Callbacks>,
 }
 

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -13,7 +13,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use derivative::Derivative;
 use futures::future::BoxFuture;
 use virtual_net::{DynVirtualNetworking, VirtualNetworking};
 use wasmer::{Module, RuntimeError};
@@ -205,8 +204,7 @@ impl TtyBridge for DefaultTty {
     }
 }
 
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct PluggableRuntime {
     pub rt: Arc<dyn VirtualTaskManager>,
     pub networking: DynVirtualNetworking,
@@ -215,10 +213,8 @@ pub struct PluggableRuntime {
     pub source: Arc<dyn Source + Send + Sync>,
     pub engine: Option<wasmer::Engine>,
     pub module_cache: Arc<dyn ModuleCache + Send + Sync>,
-    #[derivative(Debug = "ignore")]
     pub tty: Option<Arc<dyn TtyBridge + Send + Sync>>,
     #[cfg(feature = "journal")]
-    #[derivative(Debug = "ignore")]
     pub journals: Vec<Arc<DynJournal>>,
 }
 
@@ -366,8 +362,7 @@ impl Runtime for PluggableRuntime {
 
 /// Runtime that allows for certain things to be overridden
 /// such as the active journals
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Debug)]
 pub struct OverriddenRuntime {
     inner: Arc<DynRuntime>,
     task_manager: Option<Arc<dyn VirtualTaskManager>>,
@@ -377,10 +372,8 @@ pub struct OverriddenRuntime {
     source: Option<Arc<dyn Source + Send + Sync>>,
     engine: Option<wasmer::Engine>,
     module_cache: Option<Arc<dyn ModuleCache + Send + Sync>>,
-    #[derivative(Debug = "ignore")]
     tty: Option<Arc<dyn TtyBridge + Send + Sync>>,
     #[cfg(feature = "journal")]
-    #[derivative(Debug = "ignore")]
     journals: Option<Vec<Arc<DynJournal>>>,
 }
 

--- a/lib/wasix/src/runtime/task_manager/mod.rs
+++ b/lib/wasix/src/runtime/task_manager/mod.rs
@@ -7,7 +7,6 @@ use std::task::{Context, Poll};
 use std::{pin::Pin, time::Duration};
 
 use bytes::Bytes;
-use derivative::Derivative;
 use futures::future::BoxFuture;
 use futures::{Future, TryFutureExt};
 use wasmer::{AsStoreMut, AsStoreRef, Memory, MemoryType, Module, Store, StoreMut, StoreRef};
@@ -39,8 +38,7 @@ pub type WasmResumeTrigger = dyn FnOnce() -> Pin<Box<dyn Future<Output = Result<
     + Sync;
 
 /// The properties passed to the task
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(derive_more::Debug)]
 pub struct TaskWasmRunProperties {
     pub ctx: WasiFunctionEnv,
     pub store: Store,
@@ -49,7 +47,7 @@ pub struct TaskWasmRunProperties {
     /// (if the trigger returns an ExitCode then the WASM process will be terminated without resuming)
     pub trigger_result: Option<Result<Bytes, ExitCode>>,
     /// The instance will be recycled back to this function when the WASM run has finished
-    #[derivative(Debug = "ignore")]
+    #[debug(ignore)]
     pub recycle: Option<Box<TaskWasmRecycle>>,
 }
 

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -6,7 +6,6 @@ use std::{
     time::Duration,
 };
 
-use derivative::Derivative;
 use futures::future::BoxFuture;
 use rand::Rng;
 use virtual_fs::{FileSystem, FsError, StaticFile, VirtualFile};
@@ -49,8 +48,7 @@ use super::{conv_env_vars, WasiState};
 ///
 /// Used to access and modify runtime state.
 // TODO: make fields private
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Debug, Clone)]
 pub struct WasiInstanceHandles {
     // TODO: the two fields below are instance specific, while all others are module specific.
     // Should be split up.
@@ -71,11 +69,9 @@ pub struct WasiInstanceHandles {
     pub(crate) stack_high: Option<Global>,
 
     /// Main function that will be invoked (name = "_start")
-    #[derivative(Debug = "ignore")]
     pub(crate) start: Option<TypedFunction<(), ()>>,
 
     /// Function thats invoked to initialize the WASM module (name = "_initialize")
-    #[derivative(Debug = "ignore")]
     // TODO: review allow...
     #[allow(dead_code)]
     pub(crate) initialize: Option<TypedFunction<(), ()>>,
@@ -83,12 +79,10 @@ pub struct WasiInstanceHandles {
     /// Represents the callback for spawning a thread (name = "wasi_thread_start")
     /// (due to limitations with i64 in browsers the parameters are broken into i32 pairs)
     /// [this takes a user_data field]
-    #[derivative(Debug = "ignore")]
     pub(crate) thread_spawn: Option<TypedFunction<(i32, i32), ()>>,
 
     /// Represents the callback for signals (name = "__wasm_signal")
     /// Signals are triggered asynchronously at idle times of the process
-    #[derivative(Debug = "ignore")]
     pub(crate) signal: Option<TypedFunction<i32, ()>>,
 
     /// Flag that indicates if the signal callback has been set by the WASM
@@ -103,7 +97,6 @@ pub struct WasiInstanceHandles {
     /// asyncify_start_unwind(data : i32): call this to start unwinding the
     /// stack from the current location. "data" must point to a data
     /// structure as described above (with fields containing valid data).
-    #[derivative(Debug = "ignore")]
     // TODO: review allow...
     #[allow(dead_code)]
     pub(crate) asyncify_start_unwind: Option<TypedFunction<i32, ()>>,
@@ -115,7 +108,6 @@ pub struct WasiInstanceHandles {
     /// "sleep", then you must call this at the proper time. Otherwise,
     /// the code will think it is still unwinding when it should not be,
     /// which means it will keep unwinding in a meaningless way.
-    #[derivative(Debug = "ignore")]
     // TODO: review allow...
     #[allow(dead_code)]
     pub(crate) asyncify_stop_unwind: Option<TypedFunction<(), ()>>,
@@ -124,14 +116,12 @@ pub struct WasiInstanceHandles {
     /// stack vack up to the location stored in the provided data. This prepares
     /// for the rewind; to start it, you must call the first function in the
     /// call stack to be unwound.
-    #[derivative(Debug = "ignore")]
     // TODO: review allow...
     #[allow(dead_code)]
     pub(crate) asyncify_start_rewind: Option<TypedFunction<i32, ()>>,
 
     /// asyncify_stop_rewind(): call this to note that rewinding has
     /// concluded, and normal execution can resume.
-    #[derivative(Debug = "ignore")]
     // TODO: review allow...
     #[allow(dead_code)]
     pub(crate) asyncify_stop_rewind: Option<TypedFunction<(), ()>>,
@@ -142,7 +132,6 @@ pub struct WasiInstanceHandles {
     /// calls, so that you know when to start an asynchronous operation and
     /// when to propagate results back.
     #[allow(dead_code)]
-    #[derivative(Debug = "ignore")]
     pub(crate) asyncify_get_state: Option<TypedFunction<(), i32>>,
 }
 

--- a/lib/wasix/src/syscalls/wasix/epoll_ctl.rs
+++ b/lib/wasix/src/syscalls/wasix/epoll_ctl.rs
@@ -164,6 +164,8 @@ impl EpollJoinWaker {
         unsafe { Waker::from_raw(raw_waker) }
     }
 }
+
+#[derive(Debug)]
 pub struct EpollHandler {
     fd: WasiFd,
     tx: Arc<watch::Sender<EpollInterest>>,

--- a/tests/integration/cli/Cargo.toml
+++ b/tests/integration/cli/Cargo.toml
@@ -32,7 +32,6 @@ target-lexicon = "0.12.5"
 tar = "0.4.38"
 flate2 = "1.0.24"
 dirs = "4.0.0"
-derivative = { version = "^2" }
 
 [features]
 default = ["webc_runner"]

--- a/tests/integration/cli/tests/snapshot.rs
+++ b/tests/integration/cli/tests/snapshot.rs
@@ -7,20 +7,23 @@ use std::{
 };
 
 use anyhow::Error;
-use derivative::Derivative;
 use futures::TryFutureExt;
 use insta::assert_json_snapshot;
 
 use tempfile::NamedTempFile;
 use wasmer_integration_tests_cli::get_wasmer_path;
 
-#[derive(Derivative, serde::Serialize, serde::Deserialize, Clone)]
-#[derivative(Debug, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct TestIncludeWeb {
     pub name: String,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
     #[serde(skip, default = "default_include_webc")]
     pub webc: Arc<NamedTempFile>,
+}
+
+impl PartialEq for TestIncludeWeb {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
 }
 
 fn default_include_webc() -> Arc<NamedTempFile> {


### PR DESCRIPTION
The crate is unmaintained and shows up in cargo-deny lints.

Do a manual std::fmt::Debug impl where appropriate

use derive_more instead
