### PR TITLE
Fix alignment and padding of the WASIX snapshot type to align with wasix-libc

### DIFF
--- a/lib/wasi-types/src/wasi/wasix_manual.rs
+++ b/lib/wasi-types/src/wasi/wasix_manual.rs
@@ -108,7 +108,24 @@ pub union EventUnion {
 #[repr(C)]
 pub struct StackSnapshot {
     pub user: u64,
-    pub hash: u128,
+    // The hash is defined as two u64s in wasix-libc, so we must do the same
+    // here to make sure the alignment and padding are the same.
+    pub hash_lower: u64,
+    pub hash_upper: u64,
+}
+
+impl StackSnapshot {
+    pub fn new(user: u64, hash: u128) -> Self {
+        Self {
+            user,
+            hash_lower: (hash & 0xffffffffffffffff) as u64,
+            hash_upper: (hash >> 64) as u64,
+        }
+    }
+
+    pub fn hash(&self) -> u128 {
+        ((self.hash_upper as u128) << 64) & (self.hash_lower as u128)
+    }
 }
 
 /// An event that occurred.

--- a/lib/wasix/src/syscalls/wasix/stack_checkpoint.rs
+++ b/lib/wasix/src/syscalls/wasix/stack_checkpoint.rs
@@ -36,7 +36,7 @@ pub fn stack_checkpoint<M: MemorySize>(
 
     // We clear the target memory location before we grab the stack so that
     // it correctly hashes
-    if let Err(err) = snapshot_ptr.write(&memory, StackSnapshot { hash: 0, user: 0 }) {
+    if let Err(err) = snapshot_ptr.write(&memory, StackSnapshot::new(0, 0)) {
         warn!(
             %err
         );
@@ -67,10 +67,7 @@ pub fn stack_checkpoint<M: MemorySize>(
         };
 
         // Build a stack snapshot
-        let snapshot = StackSnapshot {
-            hash,
-            user: ret_offset.into(),
-        };
+        let snapshot = StackSnapshot::new(ret_offset.into(), hash);
 
         // Get a reference directly to the bytes of snapshot
         let val_bytes = unsafe {
@@ -115,7 +112,7 @@ pub fn stack_checkpoint<M: MemorySize>(
             &rewind_stack[..],
             &store_data[..],
         );
-        trace!(hash = snapshot.hash, user = snapshot.user);
+        trace!(hash = snapshot.hash(), user = snapshot.user);
 
         // Save the stack snapshot
         let env = ctx.data();

--- a/lib/wasix/src/syscalls/wasix/stack_restore.rs
+++ b/lib/wasix/src/syscalls/wasix/stack_restore.rs
@@ -19,7 +19,7 @@ pub fn stack_restore<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
     let snapshot = match snapshot_ptr.read(&memory) {
         Ok(a) => {
-            trace!("with_ret={}, hash={}, user={}", val, a.hash, a.user);
+            trace!("with_ret={}, hash={}, user={}", val, a.hash(), a.user);
             a
         }
         Err(err) => {
@@ -33,7 +33,7 @@ pub fn stack_restore<M: MemorySize>(
         // Let the stack (or fail trying!)
         let env = ctx.data();
         if let Some((mut memory_stack, rewind_stack, store_data)) =
-            env.thread.get_snapshot(snapshot.hash)
+            env.thread.get_snapshot(snapshot.hash())
         {
             let env = ctx.data();
             let memory = unsafe { env.memory_view(&ctx) };
@@ -61,7 +61,7 @@ pub fn stack_restore<M: MemorySize>(
         } else {
             warn!(
                 "snapshot stack restore failed - the snapshot can not be found and hence restored (hash={})",
-                snapshot.hash
+                snapshot.hash()
             );
             OnCalledAction::Trap(Box::new(WasiError::Exit(Errno::Unknown.into())))
         }


### PR DESCRIPTION
This fixes the PHP crash when going through `zend_catch`.