### PR TITLE
Protect preopened inodes from being closed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          targets: "wasm32-wasi"
+          targets: "wasm32-wasip1"
       - name: Install wasm-pack
         run: |
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/tests/wasi-fyi/build.sh
+++ b/tests/wasi-fyi/build.sh
@@ -5,5 +5,5 @@ for input in *.rs; do
   output="$(basename $input .rs).wasm"
 
   echo "Compiling $input"
-  rustc +nightly --target=wasm32-wasi -o "$output" "$input"
+  rustc +nightly --target=wasm32-wasip1 -o "$output" "$input"
 done

--- a/tests/wasi-fyi/ported_close_preopen_fd.stdout
+++ b/tests/wasi-fyi/ported_close_preopen_fd.stdout
@@ -1,3 +1,3 @@
 accessing preopen fd was a success
 Closing preopen fd was a success
-accessing closed preopen fd was an EBADF error: true
+accessing closed preopen fd was an EBADF error: false

--- a/tests/wasi-fyi/ported_fd_close.stdout
+++ b/tests/wasi-fyi/ported_fd_close.stdout
@@ -1,3 +1,4 @@
 Successfully closed file!
 Successfully closed stderr!
 Successfully closed stdin!
+Successfully closed stdout!

--- a/tests/wasi-wast/wasi/nightly_2022_10_18/close_preopen_fd.wast
+++ b/tests/wasi-wast/wasi/nightly_2022_10_18/close_preopen_fd.wast
@@ -3,5 +3,5 @@
 (wasi_test "close_preopen_fd.wasm"
   (map_dirs "hamlet:test_fs/hamlet")
   (assert_return (i64.const 0))
-  (assert_stdout "accessing preopen fd was a success\nClosing preopen fd was a success\naccessing closed preopen fd was an EBADF error: true\n")
+  (assert_stdout "accessing preopen fd was a success\nClosing preopen fd was a success\naccessing closed preopen fd was an EBADF error: false\n")
 )

--- a/tests/wasi-wast/wasi/snapshot1/close_preopen_fd.wast
+++ b/tests/wasi-wast/wasi/snapshot1/close_preopen_fd.wast
@@ -3,5 +3,5 @@
 (wasi_test "close_preopen_fd.wasm"
   (map_dirs "hamlet:test_fs/hamlet")
   (assert_return (i64.const 0))
-  (assert_stdout "accessing preopen fd was a success\nClosing preopen fd was a success\naccessing closed preopen fd was an EBADF error: true\n")
+  (assert_stdout "accessing preopen fd was a success\nClosing preopen fd was a success\naccessing closed preopen fd was an EBADF error: false\n")
 )

--- a/tests/wasi-wast/wasi/unstable/close_preopen_fd.wast
+++ b/tests/wasi-wast/wasi/unstable/close_preopen_fd.wast
@@ -3,5 +3,5 @@
 (wasi_test "close_preopen_fd.wasm"
   (map_dirs "hamlet:test_fs/hamlet")
   (assert_return (i64.const 0))
-  (assert_stdout "accessing preopen fd was a success\nClosing preopen fd was a success\naccessing closed preopen fd was an EBADF error: true\n")
+  (assert_stdout "accessing preopen fd was a success\nClosing preopen fd was a success\naccessing closed preopen fd was an EBADF error: false\n")
 )

--- a/tests/wasix/closing-pre-opened-dirs/main.c
+++ b/tests/wasix/closing-pre-opened-dirs/main.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+
+int main() {
+    const char *expected_entries[] = {".", "..", "main.c", "main.wasm", "output", "run.sh", NULL};
+
+    for (int fd = 0; fd <= 5; fd++) {
+        close(fd);
+    }
+
+    DIR *dir = opendir(".");
+    if (!dir) {
+        printf("opendir");
+        exit(EXIT_FAILURE);
+    }
+
+    struct dirent *entry;
+    int i = 0;
+    while ((entry = readdir(dir)) != NULL) {
+        if (expected_entries[i] == NULL) {
+            fprintf(stdout, "Unexpected extra entry: %s\n", entry->d_name);
+            closedir(dir);
+            exit(EXIT_FAILURE);
+        }
+
+        int cmp_result = strcmp(entry->d_name, expected_entries[i]);
+        if (cmp_result != 0) {
+            printf("1");
+            return 1;
+        }
+
+        i++;
+    }
+
+    if (expected_entries[i] != NULL) {
+      printf("1");
+      return 1;
+    }
+
+    closedir(dir);
+
+    printf("0");
+    return 0;
+}
+

--- a/tests/wasix/closing-pre-opened-dirs/run.sh
+++ b/tests/wasix/closing-pre-opened-dirs/run.sh
@@ -1,0 +1,5 @@
+rm output
+
+$WASMER -q run main.wasm --dir . > output
+
+printf "0" | diff -u output - 1>/dev/null


### PR DESCRIPTION
This PR adds protection for pre-opened inodes from being closed by the wasm code.