### PR TITLE
fix: rephrase the description for `--no-persist-id`

### DIFF
--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -65,7 +65,7 @@ pub struct CmdAppDeploy {
     #[clap(long)]
     pub no_default: bool,
 
-    /// Do not persist the app version ID in the app.yaml.
+    /// Do not persist the app ID under `app_id` field in app.yaml.
     #[clap(long)]
     pub no_persist_id: bool,
 


### PR DESCRIPTION
The flag description currently says app-version ID but actually the app-id is stored. So the description is misleading.