### PR TITLE
Better network sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,6 +2656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "iprange"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37209be0ad225457e63814401415e748e2453a5297f9b637338f5fb8afa4ec00"
+dependencies = [
+ "ipnet",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,7 +2777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5940,6 +5949,8 @@ dependencies = [
  "hyper",
  "hyper-tungstenite",
  "hyper-util",
+ "ipnet",
+ "iprange",
  "libc",
  "mio",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heapless"
@@ -2515,7 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
  "serde",
 ]
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use tokio::runtime::Handle;
 use url::Url;
 use virtual_fs::{DeviceFile, FileSystem, PassthruFileSystem, RootFileSystemBuilder};
-use virtual_net::ruleset::RuleSet;
+use virtual_net::ruleset::Ruleset;
 use wasmer::{Engine, Function, Instance, Memory32, Memory64, Module, RuntimeError, Store, Value};
 use wasmer_config::package::PackageSource as PackageSpecifier;
 use wasmer_types::ModuleHash;
@@ -566,7 +566,7 @@ impl Wasi {
             .networking
             .clone()
             .flatten()
-            .map(|ruleset| RuleSet::from_str(&ruleset))
+            .map(|ruleset| Ruleset::from_str(&ruleset))
             .transpose()?;
 
         let network = if let Some(ruleset) = ruleset {

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -9,7 +9,6 @@ use std::{
 use anyhow::{bail, Context, Result};
 use bytes::Bytes;
 use clap::Parser;
-use futures::future::FlattenSink;
 use tokio::runtime::Handle;
 use url::Url;
 use virtual_fs::{DeviceFile, FileSystem, PassthruFileSystem, RootFileSystemBuilder};

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -103,7 +103,21 @@ pub struct Wasi {
     #[clap(long = "net")]
     pub networking: bool,
 
-    /// Define a set of filters to control the network sandbox
+    /// Define a set of network filters
+    ///
+    /// Allows fine-grained control over the network sandbox.
+    ///
+    /// Syntax:
+    ///
+    /// <rule-type>:<allow|deny>=<rule-expression>
+    ///
+    /// Examples:
+    ///
+    ///  - Allow a specific domain and port: dns:allow=example.com:80
+    ///
+    ///  - Deny a domain and all its subdomains on all ports: dns:deny=*danger.xyz:*
+    ///
+    ///  - Allow opening ipv4 sockets only on a specific IP and port: ipv4:allow=127.0.0.1:80/in.
     #[clap(long, requires = "networking")]
     pub net_filter: Option<String>,
 

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -14,6 +14,8 @@ base64.workspace = true
 hyper = { workspace = true, optional = true }
 rkyv = { workspace = true, optional = true }
 
+ipnet = "2.10.1"
+iprange = "0.6.7"
 thiserror = "1"
 bytes = "1.1"
 async-trait = { version = "^0.1" }

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -7,6 +7,7 @@ pub mod composite;
 pub mod host;
 pub mod loopback;
 pub mod meta;
+pub mod ruleset;
 #[cfg(feature = "remote")]
 pub mod rx_tx;
 #[cfg(feature = "remote")]

--- a/lib/virtual-net/src/ruleset.rs
+++ b/lib/virtual-net/src/ruleset.rs
@@ -1,0 +1,480 @@
+use std::net::{IpAddr, SocketAddr};
+use std::ops::RangeInclusive;
+use std::str::FromStr;
+
+use ipnet::{Ipv4Net, Ipv6Net};
+use iprange::IpRange;
+
+#[derive(Debug, Clone)]
+pub enum IPRange {
+    IPV4Range(IpRange<Ipv4Net>),
+    IPV6Range(IpRange<Ipv6Net>),
+}
+
+impl IPRange {
+    pub fn matches(&self, ip: IpAddr) -> bool {
+        match (self, ip) {
+            (IPRange::IPV4Range(v4_range), IpAddr::V4(v4)) => v4_range.contains(&v4),
+            (IPRange::IPV6Range(v6_range), IpAddr::V6(v6)) => v6_range.contains(&v6),
+            _ => false,
+        }
+    }
+}
+
+impl FromStr for IPRange {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let ip_range = if s.contains(':') {
+            let ip = Ipv6Net::from_str(s)?;
+            let mut ip_range = IpRange::<Ipv6Net>::new();
+            ip_range.add(ip);
+
+            IPRange::IPV6Range(ip_range)
+        } else {
+            let ip = Ipv4Net::from_str(s)?;
+            let mut ip_range = IpRange::<Ipv4Net>::new();
+            ip_range.add(ip);
+
+            IPRange::IPV4Range(ip_range)
+        };
+
+        Ok(ip_range)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum IPRule {
+    All,
+    IP(IpAddr),
+    IPRange(IPRange),
+}
+
+impl IPRule {
+    pub fn matches(&self, ip: IpAddr) -> bool {
+        match (self, ip) {
+            (IPRule::All, _) => true,
+            (IPRule::IP(allowed_ip), IpAddr::V4(v4)) => *allowed_ip == v4,
+            (IPRule::IP(allowed_ip), IpAddr::V6(v6)) => *allowed_ip == v6,
+            (IPRule::IPRange(ip_range), _) => ip_range.matches(ip),
+        }
+    }
+}
+
+impl FromStr for IPRule {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let ip_rule = if s == "*" {
+            IPRule::All
+        } else if s.contains('/') {
+            IPRule::IPRange(IPRange::from_str(s)?)
+        } else {
+            IPRule::IP(IpAddr::from_str(s)?)
+        };
+
+        Ok(ip_rule)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum PortRule {
+    All,
+    Port(u16),
+    PortRange(RangeInclusive<u16>),
+}
+
+impl PortRule {
+    pub fn matches(&self, port: u16) -> bool {
+        match self {
+            PortRule::All => true,
+            PortRule::Port(allowed_port) => *allowed_port == port,
+            PortRule::PortRange(port_range) => port_range.contains(&port),
+        }
+    }
+}
+
+impl FromStr for PortRule {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let port_rule = if s == "*" {
+            PortRule::All
+        } else if s.contains('-') {
+            let (start, end) = s.split_once('-').unwrap();
+
+            let (start, end) = (start.parse()?, end.parse()?);
+
+            PortRule::PortRange(start..=end)
+        } else {
+            PortRule::Port(s.parse()?)
+        };
+
+        Ok(port_rule)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DomainRule {
+    Domain(String),
+    DomainGlob(String),
+}
+
+impl DomainRule {
+    pub fn matches(&self, domain: impl AsRef<str>) -> bool {
+        let domain = domain.as_ref();
+
+        match self {
+            DomainRule::Domain(allowed_domain) => allowed_domain == domain,
+            DomainRule::DomainGlob(allowed_glob) => domain.ends_with(allowed_glob),
+        }
+    }
+}
+
+impl FromStr for DomainRule {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let domain_rule = if let Some(domain) = s.strip_prefix('*') {
+            DomainRule::DomainGlob(domain.to_string())
+        } else {
+            DomainRule::Domain(s.to_string())
+        };
+
+        Ok(domain_rule)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Rule {
+    All,
+    IPAndPort {
+        ip_rule: IPRule,
+        port_rule: PortRule,
+    },
+    Domain(DomainRule),
+}
+
+impl Rule {
+    pub fn matches_ip(&self, ip: IpAddr) -> bool {
+        match self {
+            Rule::IPAndPort { ip_rule, .. } => ip_rule.matches(ip),
+            _ => true,
+        }
+    }
+
+    pub fn matches_port(&self, port: u16) -> bool {
+        match self {
+            Rule::All => true,
+            Rule::IPAndPort { port_rule, .. } => port_rule.matches(port),
+            _ => false,
+        }
+    }
+
+    pub fn matches_domain(&self, domain: impl AsRef<str>) -> bool {
+        match self {
+            Rule::All => true,
+            Rule::Domain(domain_rule) => domain_rule.matches(domain),
+            _ => false,
+        }
+    }
+}
+
+impl FromStr for Rule {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == ":" {
+            return Ok(Rule::All);
+        }
+
+        let rule = if s.starts_with('[') {
+            // ipv6 address and port
+            let (ip, port) = s.rsplit_once(':').unwrap();
+
+            let start = ip.find('[').unwrap();
+            let end = ip.find(']').unwrap();
+
+            Rule::IPAndPort {
+                ip_rule: IPRule::from_str(&s[start + 1..end])?,
+                port_rule: PortRule::from_str(port)?,
+            }
+        } else if s.matches(':').count() > 1 {
+            // ipv6
+            Rule::IPAndPort {
+                ip_rule: IPRule::from_str(s)?,
+                port_rule: PortRule::All,
+            }
+        } else if s.contains(':') {
+            // ipv4 and port
+            let (ip, port) = s.rsplit_once(':').unwrap();
+
+            Rule::IPAndPort {
+                ip_rule: IPRule::from_str(ip)?,
+                port_rule: PortRule::from_str(port)?,
+            }
+        } else {
+            // either an ipv4 or a domain
+            if let Ok(ip_rule) = IPRule::from_str(s) {
+                Rule::IPAndPort {
+                    ip_rule,
+                    port_rule: PortRule::All,
+                }
+            } else if let Ok(domain_rule) = DomainRule::from_str(s) {
+                Rule::Domain(domain_rule)
+            } else {
+                anyhow::bail!("failed to parse rule: {}", s);
+            }
+        };
+
+        Ok(rule)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuleSet {
+    rules: Vec<Rule>,
+}
+
+impl RuleSet {
+    pub fn matches_ip(&self, ip: IpAddr) -> bool {
+        self.rules.iter().any(|rule| rule.matches_ip(ip))
+    }
+
+    pub fn matches_port(&self, port: u16) -> bool {
+        self.rules.iter().any(|rule| rule.matches_port(port))
+    }
+
+    pub fn matches_socket_addr(&self, socket_addr: SocketAddr) -> bool {
+        self.matches_ip(socket_addr.ip()) && self.matches_port(socket_addr.port())
+    }
+
+    pub fn matches_domain(&self, domain: impl AsRef<str>) -> bool {
+        let domain = domain.as_ref();
+
+        self.rules.iter().any(|rule| rule.matches_domain(domain))
+    }
+}
+
+impl FromStr for RuleSet {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rules = s
+            .split(',')
+            .map(|s| Rule::from_str(s.trim()))
+            .collect::<Result<Vec<_>, anyhow::Error>>()?;
+
+        Ok(Self { rules })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    #[test]
+    fn ip_rule_all() {
+        let rule = IPRule::from_str("*").unwrap();
+
+        assert!(rule.matches("192.168.1.0".parse().unwrap()));
+        assert!(rule.matches("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ip_rule_ipv4() {
+        let rule = IPRule::from_str("192.168.1.0").unwrap();
+
+        let ip_addr: IpAddr = "192.168.1.0".parse().unwrap();
+        assert!(rule.matches(ip_addr));
+
+        let ip_addr: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(!rule.matches(ip_addr));
+    }
+
+    #[test]
+    fn ip_rule_ipv4_range() {
+        let rule = IPRule::from_str("192.168.1.0/24").unwrap();
+
+        let matches = vec![
+            "192.168.1.1",
+            "192.168.1.0",
+            "192.168.1.255",
+            "192.168.1.100",
+            "192.168.1.50",
+        ];
+
+        let non_matches = vec![
+            "192.168.2.0",
+            "192.167.1.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.0.255",
+        ];
+
+        for ip in matches {
+            let ip_addr: IpAddr = ip.parse().unwrap();
+            assert!(rule.matches(ip_addr));
+        }
+
+        for ip in non_matches {
+            let ip_addr: IpAddr = ip.parse().unwrap();
+            assert!(!rule.matches(ip_addr));
+        }
+    }
+
+    #[test]
+    fn ip_rule_ipv6() {
+        let rule = IPRule::from_str("2001:db8::1").unwrap();
+
+        assert!(rule.matches("2001:db8::1".parse().unwrap()));
+        assert!(!rule.matches("2001:db7::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ip_rule_ipv6_range() {
+        let rule = IPRule::from_str("2001:db8::/32").unwrap();
+
+        let matches = vec![
+            "2001:db8::1",
+            "2001:db8::",
+            "2001:db8:0:0:0:0:0:1234",
+            "2001:db8::abcd",
+            "2001:db8::ffff",
+        ];
+
+        let non_matches = vec![
+            "2001:db9::",
+            "2001:db7::1",
+            "2001:dead::1",
+            "fe80::1",
+            "::1",
+        ];
+
+        for ip in matches {
+            let ip_addr: IpAddr = ip.parse().unwrap();
+            assert!(rule.matches(ip_addr));
+        }
+
+        for ip in non_matches {
+            let ip_addr: IpAddr = ip.parse().unwrap();
+            assert!(!rule.matches(ip_addr));
+        }
+    }
+
+    #[test]
+    fn port_rule_all() {
+        let rule = PortRule::from_str("*").unwrap();
+
+        assert!(rule.matches(80));
+    }
+
+    #[test]
+    fn port_rule_single_port() {
+        let rule = PortRule::from_str("80").unwrap();
+
+        assert!(!rule.matches(79));
+        assert!(rule.matches(80));
+        assert!(!rule.matches(81));
+    }
+
+    #[test]
+    fn port_rule_port_range() {
+        let rule = PortRule::from_str("80-100").unwrap();
+
+        assert!(!rule.matches(79));
+        for port in 80..=100 {
+            assert!(rule.matches(port));
+        }
+        assert!(!rule.matches(101));
+    }
+
+    #[test]
+    fn domain_rule_single_domain() {
+        let rule = DomainRule::from_str("a.b.c").unwrap();
+
+        assert!(rule.matches("a.b.c"));
+        assert!(!rule.matches("b.c"));
+    }
+
+    #[test]
+    fn domain_rule_domain_glob() {
+        let rule = DomainRule::from_str("*.b.c").unwrap();
+
+        assert!(rule.matches("a.b.c"));
+        assert!(!rule.matches("b.c"));
+        assert!(!rule.matches("d.c"));
+    }
+
+    #[test]
+    fn rule_all_matches_everything() {
+        let rule = Rule::from_str(":").unwrap();
+        assert!(rule.matches_ip("192.168.1.1".parse().unwrap()));
+        assert!(rule.matches_ip("2001:db8::1".parse().unwrap()));
+        assert!(rule.matches_port(80));
+        assert!(rule.matches_domain("example.com"));
+    }
+
+    #[test]
+    fn rule_ipv4_and_port() {
+        let rule = Rule::from_str("192.168.1.1:80").unwrap();
+        assert!(rule.matches_ip("192.168.1.1".parse().unwrap()));
+        assert!(!rule.matches_ip("192.168.1.2".parse().unwrap()));
+        assert!(rule.matches_port(80));
+        assert!(!rule.matches_port(443));
+        assert!(!rule.matches_domain("example.com"));
+    }
+
+    #[test]
+    fn rule_ipv6_and_port() {
+        let rule = Rule::from_str("[2001:db8::1]:443").unwrap();
+        assert!(rule.matches_ip(IpAddr::V6("2001:db8::1".parse().unwrap())));
+        assert!(!rule.matches_ip(IpAddr::V6("2001:db8::2".parse().unwrap())));
+        assert!(rule.matches_port(443));
+        assert!(!rule.matches_port(80));
+        assert!(!rule.matches_domain("example.com"));
+    }
+
+    #[test]
+    fn rule_ipv4_range() {
+        let rule = Rule::from_str("192.168.1.0/24").unwrap();
+        assert!(rule.matches_ip("192.168.1.1".parse().unwrap()));
+        assert!(rule.matches_ip("192.168.1.255".parse().unwrap()));
+        assert!(!rule.matches_ip("192.168.2.1".parse().unwrap()));
+        assert!(rule.matches_port(80));
+        assert!(!rule.matches_domain("example.com"));
+    }
+
+    #[test]
+    fn rule_ipv6_range() {
+        let rule = Rule::from_str("2001:db8::1/32").unwrap();
+        assert!(rule.matches_ip("2001:db8::1".parse().unwrap()));
+        assert!(rule.matches_ip("2001:db8:0:0:0:0:0:1234".parse().unwrap()));
+        assert!(!rule.matches_ip("2001:db7::1".parse().unwrap()));
+        assert!(rule.matches_port(80));
+        assert!(!rule.matches_domain("example.com"));
+    }
+
+    #[test]
+    fn rule_domain_with_subdomains() {
+        let rule = Rule::from_str("*.example.com").unwrap();
+        assert!(rule.matches_domain("sub.example.com"));
+        assert!(rule.matches_domain("another.sub.example.com"));
+        assert!(!rule.matches_domain("example.com"));
+        assert!(!rule.matches_domain("other.com"));
+    }
+
+    #[test]
+    fn rule_any_ip_specific_port() {
+        let rule = Rule::from_str("*:80-100").unwrap();
+        assert!(rule.matches_ip("192.168.1.1".parse().unwrap()));
+        assert!(rule.matches_ip("2001:db8::1".parse().unwrap()));
+        assert!(rule.matches_port(80));
+        assert!(!rule.matches_port(79));
+        for port in 80..=100 {
+            assert!(rule.matches_port(port));
+        }
+        assert!(!rule.matches_port(101));
+    }
+}

--- a/lib/virtual-net/src/ruleset.rs
+++ b/lib/virtual-net/src/ruleset.rs
@@ -1,351 +1,771 @@
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use iprange::IpRange;
 
-#[derive(Debug, Clone)]
-pub enum IPRange {
-    IPV4Range(IpRange<Ipv4Net>),
-    IPV6Range(IpRange<Ipv6Net>),
+// <rule_kind>:<rule_action>=<rule_expr>
+//
+// <rule_kind>: dns, ipv4, ipv6
+//
+// <rule_action>: allow | deny
+//
+// dns:
+// <rule_expr>:
+// {<domain_spec>}:{<port_spec>} (this will be expanded to an outbound IP rule)
+// <domain_spec>: domain | domain glob | *
+//
+// ipv4:
+// <rule_expr>:
+// {<ipv4_spec>}:{<port_spec>}/<in|out>
+// <ipv4_spec>: ipv4 | ipv4_range | *
+//
+// ipv6:
+// <rule_expr>:
+// {<ipv6_spec>}:{<port_spec>}/<in|out>
+// <ipv4_spec>: ipv6 | ipv6_range | *
+//
+// <port_spec>: port | start_port-end_port | *
+
+#[derive(Debug, thiserror::Error)]
+pub enum RulesetError {
+    #[error("invalid connection direction: {0}")]
+    DirectionParsingError(String),
+    #[error("failed to parse int: {0}")]
+    IntParsingError(#[from] std::num::ParseIntError),
+    #[error("failed to parse IP address: {0}")]
+    IpNetParsingError(#[from] ipnet::AddrParseError),
+    #[error("failed to parse IP address: {0}")]
+    IpParsingError(#[from] std::net::AddrParseError),
+    #[error("missing colon in rule: {0}")]
+    MissingColon(String),
+    #[error("Single IPV6 entry is not enclosed in brackets: {0}")]
+    IPV6ParsingError(String),
+    #[error("Invalid rule type: {0}. Rule type must be either dns, ipv4, or ipv6")]
+    InvalidRuleType(String),
+    #[error("Invalid rule action: {0}. Rule action must be either allow or deny")]
+    InvalidRuleAction(String),
+    #[error("Domain rule not found for: {0}")]
+    DomainRuleNotFound(String),
+    #[error("Domain rule already expanded: {0}")]
+    DomainAlreadyExpanded(String),
 }
 
-impl IPRange {
-    pub fn matches(&self, ip: IpAddr) -> bool {
-        match (self, ip) {
-            (IPRange::IPV4Range(v4_range), IpAddr::V4(v4)) => v4_range.contains(&v4),
-            (IPRange::IPV6Range(v6_range), IpAddr::V6(v6)) => v6_range.contains(&v6),
-            _ => false,
-        }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Inbound,
+    Outbound,
+    Bidirectional,
+}
+
+impl Direction {
+    pub fn matches(&self, direction: Direction) -> bool {
+        *self == Direction::Bidirectional || *self == direction
     }
 }
 
-impl FromStr for IPRange {
-    type Err = anyhow::Error;
+impl FromStr for Direction {
+    type Err = RulesetError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let ip_range = if s.contains(':') {
-            let ip = Ipv6Net::from_str(s)?;
-            let mut ip_range = IpRange::<Ipv6Net>::new();
-            ip_range.add(ip);
-
-            IPRange::IPV6Range(ip_range)
+        let direction = if s == "in" {
+            Direction::Inbound
+        } else if s == "out" {
+            Direction::Outbound
         } else {
-            let ip = Ipv4Net::from_str(s)?;
-            let mut ip_range = IpRange::<Ipv4Net>::new();
-            ip_range.add(ip);
-
-            IPRange::IPV4Range(ip_range)
+            return Err(RulesetError::DirectionParsingError(s.to_string()));
         };
 
-        Ok(ip_range)
+        Ok(direction)
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum IPRule {
-    All,
-    IP(IpAddr),
-    IPRange(IPRange),
-}
-
-impl IPRule {
-    pub fn matches(&self, ip: IpAddr) -> bool {
-        match (self, ip) {
-            (IPRule::All, _) => true,
-            (IPRule::IP(allowed_ip), IpAddr::V4(v4)) => *allowed_ip == v4,
-            (IPRule::IP(allowed_ip), IpAddr::V6(v6)) => *allowed_ip == v6,
-            (IPRule::IPRange(ip_range), _) => ip_range.matches(ip),
-        }
-    }
-}
-
-impl FromStr for IPRule {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let ip_rule = if s == "*" {
-            IPRule::All
-        } else if s.contains('/') {
-            IPRule::IPRange(IPRange::from_str(s)?)
-        } else {
-            IPRule::IP(IpAddr::from_str(s)?)
-        };
-
-        Ok(ip_rule)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum PortRule {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PortSpec {
     All,
     Port(u16),
     PortRange(RangeInclusive<u16>),
 }
 
-impl PortRule {
+impl PortSpec {
     pub fn matches(&self, port: u16) -> bool {
         match self {
-            PortRule::All => true,
-            PortRule::Port(allowed_port) => *allowed_port == port,
-            PortRule::PortRange(port_range) => port_range.contains(&port),
+            PortSpec::All => true,
+            PortSpec::Port(allowed_port) => *allowed_port == port,
+            PortSpec::PortRange(allowed_port_range) => allowed_port_range.contains(&port),
         }
     }
 }
 
-impl FromStr for PortRule {
-    type Err = anyhow::Error;
+impl FromStr for PortSpec {
+    type Err = RulesetError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let port_rule = if s == "*" {
-            PortRule::All
+        let rule = if s == "*" {
+            PortSpec::All
         } else if s.contains('-') {
             let (start, end) = s.split_once('-').unwrap();
 
             let (start, end) = (start.parse()?, end.parse()?);
 
-            PortRule::PortRange(start..=end)
+            PortSpec::PortRange(start..=end)
         } else {
-            PortRule::Port(s.parse()?)
-        };
-
-        Ok(port_rule)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum DomainRule {
-    Domain(String),
-    DomainGlob(String),
-}
-
-impl DomainRule {
-    pub fn matches(&self, domain: impl AsRef<str>) -> bool {
-        let domain = domain.as_ref();
-
-        match self {
-            DomainRule::Domain(allowed_domain) => allowed_domain == domain,
-            DomainRule::DomainGlob(allowed_glob) => domain.ends_with(allowed_glob),
-        }
-    }
-}
-
-impl FromStr for DomainRule {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "*.*" {
-            // this will match every domain
-            return Ok(DomainRule::DomainGlob("".to_string()));
-        }
-
-        let domain_rule = if let Some(domain) = s.strip_prefix('*') {
-            DomainRule::DomainGlob(domain.to_string())
-        } else {
-            DomainRule::Domain(s.to_string())
-        };
-
-        Ok(domain_rule)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum Rule {
-    IPAndPort {
-        ip_rule: IPRule,
-        port_rule: PortRule,
-    },
-    Domain {
-        domain_rule: DomainRule,
-
-        // this port is used during rule expansion
-        port_rule: PortRule,
-    },
-    Negative(Arc<Rule>),
-}
-
-impl Rule {
-    pub fn allows_ip(&self, ip: IpAddr) -> bool {
-        match self {
-            Rule::IPAndPort { ip_rule, .. } => ip_rule.matches(ip),
-            _ => false,
-        }
-    }
-
-    pub fn allows_port(&self, port: u16) -> bool {
-        match self {
-            Rule::IPAndPort { port_rule, .. } => port_rule.matches(port),
-            _ => false,
-        }
-    }
-
-    pub fn allows_domain(&self, domain: impl AsRef<str>) -> bool {
-        match self {
-            Rule::Domain { domain_rule, .. } => domain_rule.matches(domain),
-            _ => false,
-        }
-    }
-
-    pub fn blocks_ip(&self, ip: IpAddr) -> bool {
-        match self {
-            Rule::Negative(rule) => rule.allows_ip(ip),
-            _ => false,
-        }
-    }
-
-    pub fn blocks_port(&self, port: u16) -> bool {
-        match self {
-            Rule::Negative(rule) => rule.allows_port(port),
-            _ => false,
-        }
-    }
-
-    pub fn blocks_domain(&self, domain: impl AsRef<str>) -> bool {
-        match self {
-            Rule::Negative(rule) => rule.allows_domain(domain),
-            _ => false,
-        }
-    }
-}
-
-impl FromStr for Rule {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // !rule
-        // TODO(amin): handle negative rules
-        let mut negative = false;
-        let s = s
-            .strip_prefix('!')
-            .inspect(|_| {
-                negative = true;
-            })
-            .unwrap_or(s);
-
-        let rule = if s.starts_with('[') {
-            // ipv6 address and port
-            let (ip, port) = s.rsplit_once(':').unwrap();
-
-            let start = ip.find('[').unwrap();
-            let end = ip.find(']').unwrap();
-
-            Rule::IPAndPort {
-                ip_rule: IPRule::from_str(&s[start + 1..end])?,
-                port_rule: PortRule::from_str(port)?,
-            }
-        } else if s.matches(':').count() > 1 {
-            // ipv6
-            Rule::IPAndPort {
-                ip_rule: IPRule::from_str(s)?,
-                port_rule: PortRule::All,
-            }
-        } else if s.contains(':') {
-            // ipv4 or domain and port
-            let (ip_or_domain, port) = s.rsplit_once(':').unwrap();
-
-            let port_rule = PortRule::from_str(port)?;
-            if let Ok(ip_rule) = IPRule::from_str(ip_or_domain) {
-                Rule::IPAndPort { ip_rule, port_rule }
-            } else {
-                Rule::Domain {
-                    domain_rule: DomainRule::from_str(ip_or_domain)?,
-                    port_rule,
-                }
-            }
-        } else {
-            // either an ipv4 or a domain
-            if let Ok(ip_rule) = IPRule::from_str(s) {
-                Rule::IPAndPort {
-                    ip_rule,
-                    port_rule: PortRule::All,
-                }
-            } else if let Ok(domain_rule) = DomainRule::from_str(s) {
-                Rule::Domain {
-                    domain_rule,
-                    port_rule: PortRule::All,
-                }
-            } else {
-                anyhow::bail!("failed to parse rule: {}", s);
-            }
-        };
-
-        let rule = if negative {
-            Rule::Negative(Arc::new(rule))
-        } else {
-            rule
+            PortSpec::Port(s.parse()?)
         };
 
         Ok(rule)
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct RuleSet {
-    rules: Vec<Rule>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DomainSpec {
+    All,
+    Domain(String),
+    DomainGlob(String),
 }
 
-impl RuleSet {
-    pub fn matches_ip(&self, ip: IpAddr) -> bool {
-        self.rules.iter().any(|rule| rule.allows_ip(ip))
-    }
-
-    pub fn matches_port(&self, port: u16) -> bool {
-        self.rules.iter().any(|rule| rule.allows_port(port))
-    }
-
-    pub fn matches_socket_addr(&self, socket_addr: SocketAddr) -> bool {
-        self.matches_ip(socket_addr.ip()) && self.matches_port(socket_addr.port())
-    }
-
-    pub fn matches_domain(&self, domain: impl AsRef<str>) -> bool {
+impl DomainSpec {
+    pub fn matches(&self, domain: impl AsRef<str>) -> bool {
         let domain = domain.as_ref();
 
-        self.rules.iter().any(|rule| rule.allows_domain(domain))
+        match self {
+            DomainSpec::All => true,
+            DomainSpec::Domain(allowed_domain) => allowed_domain == domain,
+            DomainSpec::DomainGlob(domain_glob) => domain.ends_with(domain_glob),
+        }
     }
 }
 
-impl FromStr for RuleSet {
-    type Err = anyhow::Error;
+impl FromStr for DomainSpec {
+    type Err = RulesetError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let rules = s
-            .split(',')
-            .map(|s| Rule::from_str(s.trim()))
-            .collect::<Result<Vec<_>, anyhow::Error>>()?;
+        let spec = if s == "*" {
+            DomainSpec::All
+        } else if let Some(glob) = s.strip_prefix('*') {
+            DomainSpec::DomainGlob(glob.to_string())
+        } else {
+            DomainSpec::Domain(s.to_string())
+        };
 
-        Ok(Self { rules })
+        Ok(spec)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DNSRule {
+    domain: DomainSpec,
+    port: PortSpec,
+    expanded: bool,
+}
+
+impl DNSRule {
+    pub fn is_allowed(&self, domain: impl AsRef<str>) -> bool {
+        self.domain.matches(domain)
+    }
+
+    pub fn allowed_ports(&self) -> PortSpec {
+        self.port.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IPV4Spec {
+    All,
+    IP(Ipv4Addr),
+    IPRange(IpRange<Ipv4Net>),
+}
+
+impl IPV4Spec {
+    pub fn matches(&self, ip: impl Into<Ipv4Addr>) -> bool {
+        let ip = ip.into();
+
+        match self {
+            IPV4Spec::All => true,
+            IPV4Spec::IP(allowed_ip) => *allowed_ip == ip,
+            IPV4Spec::IPRange(allowed_ip_range) => allowed_ip_range.contains(&ip),
+        }
+    }
+}
+
+impl FromStr for IPV4Spec {
+    type Err = RulesetError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let spec = if s == "*" {
+            IPV4Spec::All
+        } else if s.contains('/') {
+            let ip = Ipv4Net::from_str(s)?;
+            let mut ip_range = IpRange::<Ipv4Net>::new();
+            ip_range.add(ip);
+
+            IPV4Spec::IPRange(ip_range)
+        } else {
+            IPV4Spec::IP(s.parse()?)
+        };
+
+        Ok(spec)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IPV4Rule {
+    ip_spec: IPV4Spec,
+    port_spec: PortSpec,
+    direction: Direction,
+}
+
+impl IPV4Rule {
+    pub fn is_allowed(&self, ip: impl Into<Ipv4Addr>, port: u16, dir: Direction) -> bool {
+        let ip = ip.into();
+
+        self.ip_spec.matches(ip) && self.port_spec.matches(port) && self.direction.matches(dir)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IPV6Spec {
+    All,
+    IP(Ipv6Addr),
+    IPRange(IpRange<Ipv6Net>),
+}
+
+impl IPV6Spec {
+    pub fn matches(&self, ip: Ipv6Addr) -> bool {
+        match self {
+            IPV6Spec::All => true,
+            IPV6Spec::IP(allowed_ip) => *allowed_ip == ip,
+            IPV6Spec::IPRange(allowed_ip_range) => allowed_ip_range.contains(&ip),
+        }
+    }
+}
+
+impl FromStr for IPV6Spec {
+    type Err = RulesetError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let spec = if s == "*" {
+            IPV6Spec::All
+        } else if s.contains('/') {
+            let ip = Ipv6Net::from_str(s)?;
+            let mut ip_range = IpRange::<Ipv6Net>::new();
+            ip_range.add(ip);
+
+            IPV6Spec::IPRange(ip_range)
+        } else {
+            IPV6Spec::IP(s.parse()?)
+        };
+
+        Ok(spec)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IPV6Rule {
+    ip_spec: IPV6Spec,
+    port_spec: PortSpec,
+    direction: Direction,
+}
+
+impl IPV6Rule {
+    pub fn is_allowed(&self, ip: impl Into<Ipv6Addr>, port: u16, dir: Direction) -> bool {
+        let ip = ip.into();
+
+        self.ip_spec.matches(ip) && self.port_spec.matches(port) && self.direction.matches(dir)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Rule {
+    IPV4(IPV4Rule),
+    IPV6(IPV6Rule),
+    DNS(DNSRule),
+    Neg(Arc<Rule>),
+}
+
+impl Rule {
+    pub fn is_socket_allowed(&self, socket_addr: SocketAddr, direction: Direction) -> bool {
+        let ip = socket_addr.ip();
+        let port = socket_addr.port();
+
+        match (self, ip) {
+            (Rule::IPV4(rule), IpAddr::V4(ip)) => rule.is_allowed(ip, port, direction),
+            (Rule::IPV6(rule), IpAddr::V6(ip)) => rule.is_allowed(ip, port, direction),
+            _ => false,
+        }
+    }
+
+    pub fn is_domain_allowed(&self, domain: impl AsRef<str>) -> bool {
+        if let Rule::DNS(rule) = self {
+            rule.is_allowed(domain)
+        } else {
+            false
+        }
+    }
+
+    pub fn is_socket_blocked(&self, socket_addr: SocketAddr, direction: Direction) -> bool {
+        if let Rule::Neg(rule) = self {
+            rule.is_socket_allowed(socket_addr, direction)
+        } else {
+            false
+        }
+    }
+
+    pub fn is_domain_blocked(&self, domain: impl AsRef<str>) -> bool {
+        if let Rule::Neg(rule) = self {
+            rule.is_domain_allowed(domain)
+        } else {
+            false
+        }
+    }
+
+    pub fn port_spec_of_domain(&mut self, domain: impl AsRef<str>) -> Option<PortSpec> {
+        if let Rule::DNS(rule) = self {
+            if rule.is_allowed(domain) {
+                return Some(rule.allowed_ports());
+            }
+        }
+
+        None
+    }
+
+    pub fn is_expandable(&self) -> bool {
+        if let Rule::DNS(rule) = self {
+            !rule.expanded
+        } else {
+            false
+        }
+    }
+
+    pub fn set_expanded(&mut self, expanded: bool) {
+        if let Rule::DNS(rule) = self {
+            rule.expanded = expanded;
+        }
+    }
+}
+
+fn parse_enclosed(s: &str, left: char, right: char) -> Option<&str> {
+    match (s.find(left), s.rfind(right)) {
+        (Some(left_idx), Some(right_idx)) if left_idx < right_idx => {
+            Some(&s[left_idx + 1..right_idx])
+        }
+        _ => None,
+    }
+}
+
+fn parse_as_list<T: FromStr<Err = RulesetError>>(s: &str) -> Result<Vec<T>, RulesetError> {
+    let entries = if let Some(entries) = parse_enclosed(s, '{', '}') {
+        entries
+            .split(',')
+            .map(|s| s.trim().parse())
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        let entry = T::from_str(s)?;
+
+        vec![entry]
+    };
+
+    Ok(entries)
+}
+
+fn parse_ipv4_rule(s: &str) -> Result<Vec<IPV4Rule>, RulesetError> {
+    let (ips, ports_and_direction) = s
+        .split_once(':')
+        .ok_or_else(|| RulesetError::MissingColon(s.to_string()))?;
+
+    let mut direction = Direction::Bidirectional;
+    let ports = if let Some((ports, dir)) = ports_and_direction.split_once('/') {
+        direction = dir.parse()?;
+
+        ports
+    } else {
+        ports_and_direction
+    };
+
+    let mut rules = Vec::new();
+    let ips = parse_as_list::<IPV4Spec>(ips)?;
+    let ports = parse_as_list::<PortSpec>(ports)?;
+
+    for ip in &ips {
+        for port in &ports {
+            rules.push(IPV4Rule {
+                ip_spec: ip.clone(),
+                port_spec: port.clone(),
+                direction,
+            });
+        }
+    }
+
+    Ok(rules)
+}
+
+fn parse_ipv6_rule(s: &str) -> Result<Vec<IPV6Rule>, RulesetError> {
+    let (ips, ports_and_direction) = s
+        .rsplit_once(':')
+        .ok_or_else(|| RulesetError::MissingColon(s.to_string()))?;
+
+    let mut direction = Direction::Bidirectional;
+    let ports = if let Some((ports, dir)) = ports_and_direction.split_once('/') {
+        direction = dir.parse()?;
+
+        ports
+    } else {
+        ports_and_direction
+    };
+
+    let mut rules = Vec::new();
+
+    let ips = if ips.contains('[') {
+        let ip = parse_enclosed(ips, '[', ']')
+            .ok_or_else(|| RulesetError::IPV6ParsingError(ips.to_string()))?;
+
+        vec![ip.parse::<IPV6Spec>()?]
+    } else {
+        parse_as_list::<IPV6Spec>(ips)?
+    };
+    let ports = parse_as_list::<PortSpec>(ports)?;
+
+    for ip in &ips {
+        for port in &ports {
+            rules.push(IPV6Rule {
+                ip_spec: ip.clone(),
+                port_spec: port.clone(),
+                direction,
+            });
+        }
+    }
+
+    Ok(rules)
+}
+
+fn parse_dns_rule(s: &str) -> Result<Vec<DNSRule>, RulesetError> {
+    let (domains, ports) = s
+        .split_once(':')
+        .ok_or_else(|| RulesetError::MissingColon(s.to_string()))?;
+
+    let mut rules = Vec::new();
+    let domains = parse_as_list::<DomainSpec>(domains)?;
+    let ports = parse_as_list::<PortSpec>(ports)?;
+
+    for domain in &domains {
+        for port in &ports {
+            rules.push(DNSRule {
+                domain: domain.clone(),
+                port: port.clone(),
+                expanded: false,
+            });
+        }
+    }
+
+    Ok(rules)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuleType {
+    Dns,
+    IPV4,
+    IPV6,
+}
+
+impl RuleType {
+    pub fn consume_input(input: &str) -> Result<(Self, &str), RulesetError> {
+        let pair = if let Some(rem) = input.strip_prefix("dns:") {
+            (RuleType::Dns, rem)
+        } else if let Some(rem) = input.strip_prefix("ipv4:") {
+            (RuleType::IPV4, rem)
+        } else if let Some(rem) = input.strip_prefix("ipv6:") {
+            (RuleType::IPV6, rem)
+        } else {
+            return Err(RulesetError::InvalidRuleType(input.to_string()));
+        };
+
+        Ok(pair)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuleAction {
+    Allow,
+    Deny,
+}
+
+impl RuleAction {
+    pub fn consume_input(input: &str) -> Result<(Self, &str), RulesetError> {
+        let pair = if let Some(rem) = input.strip_prefix("allow=") {
+            (RuleAction::Allow, rem)
+        } else if let Some(rem) = input.strip_prefix("deny=") {
+            (RuleAction::Deny, rem)
+        } else {
+            return Err(RulesetError::InvalidRuleAction(input.to_string()));
+        };
+
+        Ok(pair)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuleExpr(String);
+
+impl RuleExpr {
+    pub fn consume_input(input: &str) -> Result<(Self, &str), RulesetError> {
+        let mut next_dns_entry = usize::MAX;
+        let mut next_ipv4_entry = usize::MAX;
+        let mut next_ipv6_entry = usize::MAX;
+
+        if let Some(idx) = input.find(",dns:") {
+            next_dns_entry = idx;
+        }
+
+        if let Some(idx) = input.find(",ipv4:") {
+            next_ipv4_entry = idx;
+        }
+
+        if let Some(idx) = input.find(",ipv6:") {
+            next_ipv6_entry = idx;
+        }
+
+        let next_entry = next_dns_entry
+            .min(next_ipv4_entry)
+            .min(next_ipv6_entry)
+            .min(input.len());
+
+        let (expr, rem) = input.split_at(next_entry);
+
+        let rem = rem.strip_prefix(',').unwrap_or(rem);
+
+        Ok((RuleExpr(expr.to_string()), rem))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RulesetSegment {
+    ty: RuleType,
+    action: RuleAction,
+    expr: RuleExpr,
+}
+
+fn ruleset_segments(s: impl AsRef<str>) -> Result<Vec<RulesetSegment>, RulesetError> {
+    let mut input = s.as_ref();
+    let mut segments = Vec::new();
+
+    while !input.is_empty() {
+        let (ty, remaining) = RuleType::consume_input(input)?;
+        let (action, remaining) = RuleAction::consume_input(remaining)?;
+        let (expr, remaining) = RuleExpr::consume_input(remaining)?;
+
+        segments.push(RulesetSegment { ty, action, expr });
+
+        input = remaining;
+    }
+
+    Ok(segments)
+}
+
+#[derive(Debug, Clone)]
+pub struct Ruleset {
+    rules: Arc<RwLock<Vec<Rule>>>,
+}
+
+impl Ruleset {
+    pub fn is_socket_allowed(&self, addr: impl Into<SocketAddr>, dir: Direction) -> bool {
+        let addr = addr.into();
+
+        let ruleset = self.rules.read().unwrap();
+        let is_whitelisted = ruleset.iter().any(|r| r.is_socket_allowed(addr, dir));
+        let is_blacklisted = ruleset.iter().any(|r| r.is_socket_blocked(addr, dir));
+        drop(ruleset);
+
+        is_whitelisted && !is_blacklisted
+    }
+
+    pub fn is_domain_allowed(&self, domain: impl AsRef<str>) -> bool {
+        let domain = domain.as_ref();
+
+        let ruleset = self.rules.read().unwrap();
+        let is_whitelisted = ruleset.iter().any(|r| r.is_domain_allowed(domain));
+        let is_blacklisted = ruleset.iter().any(|r| r.is_domain_blocked(domain));
+        drop(ruleset);
+
+        is_whitelisted && !is_blacklisted
+    }
+
+    pub fn expand_domain(
+        &self,
+        domain: impl AsRef<str>,
+        addrs: impl AsRef<[IpAddr]>,
+    ) -> Result<(), RulesetError> {
+        let mut ruleset = self.rules.write().unwrap();
+        let domain = domain.as_ref();
+
+        let mut already_expanded = false;
+        let port_spec = ruleset
+            .iter_mut()
+            .find_map(|rule| {
+                let port_spec = rule.port_spec_of_domain(domain);
+
+                if port_spec.is_some() {
+                    if rule.is_expandable() {
+                        rule.set_expanded(true);
+
+                        return port_spec;
+                    } else {
+                        already_expanded = true;
+                    }
+                }
+
+                None
+            })
+            .ok_or_else(|| {
+                if already_expanded {
+                    RulesetError::DomainAlreadyExpanded(domain.to_string())
+                } else {
+                    RulesetError::DomainRuleNotFound(domain.to_string())
+                }
+            })?;
+
+        for addr in addrs.as_ref() {
+            let rule = match addr {
+                IpAddr::V4(ip) => Rule::IPV4(IPV4Rule {
+                    ip_spec: IPV4Spec::IP(*ip),
+                    port_spec: port_spec.clone(),
+                    direction: Direction::Outbound,
+                }),
+                IpAddr::V6(ip) => Rule::IPV6(IPV6Rule {
+                    ip_spec: IPV6Spec::IP(*ip),
+                    port_spec: port_spec.clone(),
+                    direction: Direction::Outbound,
+                }),
+            };
+
+            ruleset.push(rule);
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for Ruleset {
+    type Err = RulesetError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s: String = s.chars().filter(|c| !c.is_whitespace()).collect();
+        let mut rules = vec![];
+        for seg in ruleset_segments(s)? {
+            let rule_type = &seg.ty;
+            let rule_action = &seg.action;
+            let rule_expr = &seg.expr;
+
+            let parsed_rules: Vec<Rule> = match rule_type {
+                RuleType::Dns => parse_dns_rule(&rule_expr.0)?
+                    .into_iter()
+                    .map(Rule::DNS)
+                    .collect(),
+                RuleType::IPV4 => parse_ipv4_rule(&rule_expr.0)?
+                    .into_iter()
+                    .map(Rule::IPV4)
+                    .collect(),
+                RuleType::IPV6 => parse_ipv6_rule(&rule_expr.0)?
+                    .into_iter()
+                    .map(Rule::IPV6)
+                    .collect(),
+            };
+
+            let parsed_rules = match rule_action {
+                RuleAction::Allow => parsed_rules,
+                RuleAction::Deny => parsed_rules
+                    .into_iter()
+                    .map(|rule| Rule::Neg(Arc::new(rule)))
+                    .collect(),
+            };
+
+            rules.extend(parsed_rules);
+        }
+
+        Ok(Self {
+            rules: Arc::new(RwLock::new(rules)),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::IpAddr;
 
     #[test]
-    fn all_ips() {
-        let rule = IPRule::from_str("*").unwrap();
+    fn all_ports_spec() {
+        let spec = PortSpec::from_str("*").unwrap();
 
-        assert!(rule.matches("192.168.1.0".parse().unwrap()));
-        assert!(rule.matches("2001:db8::1".parse().unwrap()));
+        assert!(spec.matches(80));
     }
 
     #[test]
-    fn single_ipv4() {
-        let rule = IPRule::from_str("192.168.1.0").unwrap();
+    fn port_spec() {
+        let spec = PortSpec::from_str("80").unwrap();
 
-        let ip_addr: IpAddr = "192.168.1.0".parse().unwrap();
-        assert!(rule.matches(ip_addr));
-
-        let ip_addr: IpAddr = "127.0.0.1".parse().unwrap();
-        assert!(!rule.matches(ip_addr));
+        assert!(spec.matches(80));
+        assert!(!spec.matches(443));
     }
 
     #[test]
-    fn ipv4_range() {
-        let rule = IPRule::from_str("192.168.1.0/24").unwrap();
+    fn port_range_spec() {
+        let spec = PortSpec::from_str("80-85").unwrap();
+
+        assert!(!spec.matches(79));
+        assert!(spec.matches(80));
+        assert!(spec.matches(81));
+        assert!(spec.matches(82));
+        assert!(spec.matches(83));
+        assert!(spec.matches(84));
+        assert!(spec.matches(85));
+        assert!(!spec.matches(86));
+    }
+
+    #[test]
+    fn all_domains_spec() {
+        let spec = DomainSpec::from_str("*").unwrap();
+
+        assert!(spec.matches("example.com"));
+    }
+
+    #[test]
+    fn domain_spec() {
+        let spec = DomainSpec::from_str("example.com").unwrap();
+
+        assert!(spec.matches("example.com"));
+        assert!(!spec.matches("sub.example.com"));
+        assert!(!spec.matches("test.com"));
+    }
+
+    #[test]
+    fn domain_glob_spec() {
+        let spec = DomainSpec::from_str("*.example.com").unwrap();
+
+        assert!(!spec.matches("example.com"));
+        assert!(spec.matches("sub.example.com"));
+        assert!(spec.matches("another.sub.example.com"));
+        assert!(!spec.matches("test.com"));
+    }
+
+    #[test]
+    fn all_ipv4s_spec() {
+        let spec = IPV4Spec::from_str("*").unwrap();
+
+        assert!(spec.matches([127, 0, 0, 1]));
+    }
+
+    #[test]
+    fn ipv4_spec() {
+        let spec = IPV4Spec::from_str("127.0.0.1").unwrap();
+
+        assert!(spec.matches([127, 0, 0, 1]));
+        assert!(!spec.matches([192, 168, 1, 1]));
+    }
+
+    #[test]
+    fn ipv4_range_spec() {
+        let rule = IPV4Spec::from_str("192.168.1.0/24").unwrap();
 
         let matches = vec![
             "192.168.1.1",
@@ -364,27 +784,34 @@ mod tests {
         ];
 
         for ip in matches {
-            let ip_addr: IpAddr = ip.parse().unwrap();
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
             assert!(rule.matches(ip_addr));
         }
 
         for ip in non_matches {
-            let ip_addr: IpAddr = ip.parse().unwrap();
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
             assert!(!rule.matches(ip_addr));
         }
     }
 
     #[test]
-    fn single_ipv6() {
-        let rule = IPRule::from_str("2001:db8::1").unwrap();
+    fn all_ipv6s_spec() {
+        let spec = IPV6Spec::from_str("*").unwrap();
 
-        assert!(rule.matches("2001:db8::1".parse().unwrap()));
-        assert!(!rule.matches("2001:db7::1".parse().unwrap()));
+        assert!(spec.matches("2001:db8::1".parse().unwrap()));
     }
 
     #[test]
-    fn ipv6_range() {
-        let rule = IPRule::from_str("2001:db8::/32").unwrap();
+    fn ipv6_spec() {
+        let spec = IPV6Spec::from_str("2001:db8::1").unwrap();
+
+        assert!(spec.matches("2001:db8::1".parse().unwrap()));
+        assert!(!spec.matches("2001:db7::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv6_range_spec() {
+        let spec = IPV6Spec::from_str("2001:db8::/32").unwrap();
 
         let matches = vec![
             "2001:db8::1",
@@ -403,257 +830,559 @@ mod tests {
         ];
 
         for ip in matches {
-            let ip_addr: IpAddr = ip.parse().unwrap();
-            assert!(rule.matches(ip_addr));
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(spec.matches(ip_addr));
         }
 
         for ip in non_matches {
-            let ip_addr: IpAddr = ip.parse().unwrap();
-            assert!(!rule.matches(ip_addr));
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!spec.matches(ip_addr));
         }
     }
 
     #[test]
-    fn all_ports() {
-        let rule = PortRule::from_str("*").unwrap();
+    fn dns_rule_all() {
+        let rules = parse_dns_rule("*:*").unwrap();
 
-        assert!(rule.matches(80));
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed("example.com"));
+        assert_eq!(rules[0].allowed_ports(), PortSpec::All);
     }
 
     #[test]
-    fn single_port() {
-        let rule = PortRule::from_str("80").unwrap();
+    fn dns_rule_single_domain_and_port() {
+        let rules = parse_dns_rule("example.com:80").unwrap();
 
-        assert!(!rule.matches(79));
-        assert!(rule.matches(80));
-        assert!(!rule.matches(81));
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed("example.com"));
+        assert_eq!(rules[0].allowed_ports(), PortSpec::Port(80));
     }
 
     #[test]
-    fn port_range() {
-        let rule = PortRule::from_str("80-100").unwrap();
+    fn dns_rule_multiple_domain_and_ports() {
+        let mut rules = parse_dns_rule("{a.com, *.b.com}:{80, 100-200}").unwrap();
 
-        assert!(!rule.matches(79));
-        for port in 80..=100 {
-            assert!(rule.matches(port));
+        let rule1 = rules.pop().unwrap(); // *.b.com:100-200
+        let rule2 = rules.pop().unwrap(); // *.b.com:80
+        let rule3 = rules.pop().unwrap(); // a.com:100-200
+        let rule4 = rules.pop().unwrap(); // a.com:80
+
+        assert!(rules.is_empty());
+
+        assert!(rule1.is_allowed("sub.b.com"));
+        assert!(!rule1.is_allowed("b.com"));
+        assert!(!rule1.is_allowed("a.com"));
+        assert_eq!(rule1.allowed_ports(), PortSpec::PortRange(100..=200));
+
+        assert!(rule2.is_allowed("sub.b.com"));
+        assert!(!rule2.is_allowed("b.com"));
+        assert!(!rule2.is_allowed("a.com"));
+        assert_eq!(rule2.allowed_ports(), PortSpec::Port(80));
+
+        assert!(rule3.is_allowed("a.com"));
+        assert!(!rule3.is_allowed("sub.a.com"));
+        assert!(!rule3.is_allowed("b.com"));
+        assert_eq!(rule3.allowed_ports(), PortSpec::PortRange(100..=200));
+
+        assert!(rule4.is_allowed("a.com"));
+        assert!(!rule4.is_allowed("sub.a.com"));
+        assert!(!rule4.is_allowed("b.com"));
+        assert_eq!(rule4.allowed_ports(), PortSpec::Port(80));
+    }
+
+    #[test]
+    fn ipv4_rule_all() {
+        let rules = parse_ipv4_rule("*:*").unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed([127, 0, 0, 1], 80, Direction::Inbound));
+        assert!(rules[0].is_allowed([127, 0, 0, 1], 80, Direction::Outbound));
+    }
+
+    #[test]
+    fn ipv4_rule_single_ip_all_ports_inbound() {
+        let rules = parse_ipv4_rule("127.0.0.1:*/in").unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed([127, 0, 0, 1], 80, Direction::Inbound));
+        assert!(!rules[0].is_allowed([127, 0, 0, 1], 80, Direction::Outbound));
+        assert!(!rules[0].is_allowed([192, 168, 1, 2], 80, Direction::Inbound));
+        assert!(!rules[0].is_allowed([192, 168, 1, 2], 80, Direction::Outbound));
+    }
+
+    #[test]
+    fn ipv4_rule_ip_range_all_ports_outbound() {
+        let mut rules = parse_ipv4_rule("192.168.1.0/24:*/out").unwrap();
+
+        let ip_matches = vec![
+            "192.168.1.1",
+            "192.168.1.0",
+            "192.168.1.255",
+            "192.168.1.100",
+            "192.168.1.50",
+        ];
+
+        let ip_non_matches = vec![
+            "192.168.2.0",
+            "192.167.1.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.0.255",
+        ];
+
+        assert_eq!(rules.len(), 1);
+        let rule = rules.pop().unwrap();
+
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(rule.is_allowed(ip_addr, 8080, Direction::Outbound));
         }
-        assert!(!rule.matches(101));
-    }
-
-    #[test]
-    fn all_domain() {
-        let rule = DomainRule::from_str("*.*").unwrap();
-
-        assert!(rule.matches("a.b.c"));
-        assert!(rule.matches("b.c"));
-    }
-
-    #[test]
-    fn single_domain() {
-        let rule = DomainRule::from_str("a.b.c").unwrap();
-
-        assert!(rule.matches("a.b.c"));
-        assert!(!rule.matches("b.c"));
-    }
-
-    #[test]
-    fn domain_glob() {
-        let rule = DomainRule::from_str("*.b.c").unwrap();
-
-        assert!(rule.matches("a.b.c"));
-        assert!(!rule.matches("b.c"));
-        assert!(!rule.matches("d.c"));
-    }
-
-    #[test]
-    fn rule_ipv4_and_port() {
-        let rule = Rule::from_str("192.168.1.1:80").unwrap();
-        assert!(rule.allows_ip("192.168.1.1".parse().unwrap()));
-        assert!(!rule.allows_ip("192.168.1.2".parse().unwrap()));
-        assert!(rule.allows_port(80));
-        assert!(!rule.allows_port(443));
-        assert!(!rule.allows_domain("example.com"));
-    }
-
-    #[test]
-    fn rule_ipv6_and_port() {
-        let rule = Rule::from_str("[2001:db8::1]:443").unwrap();
-        assert!(rule.allows_ip(IpAddr::V6("2001:db8::1".parse().unwrap())));
-        assert!(!rule.allows_ip(IpAddr::V6("2001:db8::2".parse().unwrap())));
-        assert!(rule.allows_port(443));
-        assert!(!rule.allows_port(80));
-        assert!(!rule.allows_domain("example.com"));
-    }
-
-    #[test]
-    fn rule_ipv4_range() {
-        let rule = Rule::from_str("192.168.1.0/24").unwrap();
-        assert!(rule.allows_ip("192.168.1.1".parse().unwrap()));
-        assert!(rule.allows_ip("192.168.1.255".parse().unwrap()));
-        assert!(!rule.allows_ip("192.168.2.1".parse().unwrap()));
-        assert!(rule.allows_port(80));
-        assert!(!rule.allows_domain("example.com"));
-    }
-
-    #[test]
-    fn rule_ipv6_range() {
-        let rule = Rule::from_str("2001:db8::1/32").unwrap();
-        assert!(rule.allows_ip("2001:db8::1".parse().unwrap()));
-        assert!(rule.allows_ip("2001:db8:0:0:0:0:0:1234".parse().unwrap()));
-        assert!(!rule.allows_ip("2001:db7::1".parse().unwrap()));
-        assert!(rule.allows_port(80));
-        assert!(!rule.allows_domain("example.com"));
-    }
-
-    #[test]
-    fn rule_domain_with_subdomains() {
-        let rule = Rule::from_str("*.example.com").unwrap();
-        assert!(rule.allows_domain("sub.example.com"));
-        assert!(rule.allows_domain("another.sub.example.com"));
-        assert!(!rule.allows_domain("example.com"));
-        assert!(!rule.allows_domain("other.com"));
-    }
-
-    #[test]
-    fn rule_all_domains_specific_port() {
-        let rule = Rule::from_str("*.*:80").unwrap();
-        assert!(rule.allows_domain("sub.example.com"));
-        assert!(rule.allows_domain("another.sub.example.com"));
-        assert!(rule.allows_domain("example.com"));
-        assert!(rule.allows_domain("other.com"));
-    }
-
-    #[test]
-    fn rule_all_ip_specific_port() {
-        let rule = Rule::from_str("*:80-100").unwrap();
-        assert!(rule.allows_ip("192.168.1.1".parse().unwrap()));
-        assert!(rule.allows_ip("2001:db8::1".parse().unwrap()));
-        assert!(rule.allows_port(80));
-        assert!(!rule.allows_port(79));
-        for port in 80..=100 {
-            assert!(rule.allows_port(port));
+        // direction is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule.is_allowed(ip_addr, 8080, Direction::Inbound));
         }
-        assert!(!rule.allows_port(101));
-    }
-
-    #[test]
-    fn negative_rule_ipv4_and_port() {
-        let rule = Rule::from_str("!192.168.1.1:80").unwrap();
-
-        assert!(!rule.allows_ip("192.168.1.1".parse().unwrap()));
-        assert!(!rule.allows_ip("192.168.1.2".parse().unwrap()));
-        assert!(!rule.allows_port(80));
-        assert!(!rule.allows_port(443));
-        assert!(!rule.allows_domain("example.com"));
-
-        assert!(rule.blocks_ip("192.168.1.1".parse().unwrap()));
-        assert!(!rule.blocks_ip("192.168.1.2".parse().unwrap()));
-        assert!(rule.blocks_port(80));
-        assert!(!rule.blocks_port(443));
-        assert!(!rule.blocks_domain("example.com"));
-    }
-
-    #[test]
-    fn negative_rule_ipv6_and_port() {
-        let rule = Rule::from_str("![2001:db8::1]:443").unwrap();
-
-        assert!(!rule.allows_ip(IpAddr::V6("2001:db8::1".parse().unwrap())));
-        assert!(!rule.allows_ip(IpAddr::V6("2001:db8::2".parse().unwrap())));
-        assert!(!rule.allows_port(443));
-        assert!(!rule.allows_port(80));
-        assert!(!rule.allows_domain("example.com"));
-
-        assert!(rule.blocks_ip(IpAddr::V6("2001:db8::1".parse().unwrap())));
-        assert!(!rule.blocks_ip(IpAddr::V6("2001:db8::2".parse().unwrap())));
-        assert!(rule.blocks_port(443));
-        assert!(!rule.blocks_port(80));
-        assert!(!rule.blocks_domain("example.com"));
-    }
-
-    #[test]
-    fn negative_rule_ipv4_range() {
-        let rule = Rule::from_str("!192.168.1.0/24").unwrap();
-
-        assert!(!rule.allows_ip("192.168.1.1".parse().unwrap()));
-        assert!(!rule.allows_ip("192.168.1.255".parse().unwrap()));
-        assert!(!rule.allows_ip("192.168.2.1".parse().unwrap()));
-        assert!(!rule.allows_port(80));
-        assert!(!rule.allows_domain("example.com"));
-
-        assert!(rule.blocks_ip("192.168.1.1".parse().unwrap()));
-        assert!(rule.blocks_ip("192.168.1.255".parse().unwrap()));
-        assert!(!rule.blocks_ip("192.168.2.1".parse().unwrap()));
-        assert!(rule.blocks_port(80));
-        assert!(!rule.blocks_domain("example.com"));
-    }
-
-    #[test]
-    fn negative_rule_ipv6_range() {
-        let rule = Rule::from_str("!2001:db8::1/32").unwrap();
-
-        assert!(!rule.allows_ip("2001:db8::1".parse().unwrap()));
-        assert!(!rule.allows_ip("2001:db8:0:0:0:0:0:1234".parse().unwrap()));
-        assert!(!rule.allows_ip("2001:db7::1".parse().unwrap()));
-        assert!(!rule.allows_port(80));
-        assert!(!rule.allows_domain("example.com"));
-
-        assert!(rule.blocks_ip("2001:db8::1".parse().unwrap()));
-        assert!(rule.blocks_ip("2001:db8:0:0:0:0:0:1234".parse().unwrap()));
-        assert!(!rule.blocks_ip("2001:db7::1".parse().unwrap()));
-        assert!(rule.blocks_port(80));
-        assert!(!rule.blocks_domain("example.com"));
-    }
-
-    #[test]
-    fn negative_rule_domain_with_subdomains() {
-        let rule = Rule::from_str("!*.example.com").unwrap();
-
-        assert!(!rule.allows_domain("sub.example.com"));
-        assert!(!rule.allows_domain("another.sub.example.com"));
-        assert!(!rule.allows_domain("example.com"));
-        assert!(!rule.allows_domain("other.com"));
-
-        assert!(rule.blocks_domain("sub.example.com"));
-        assert!(rule.blocks_domain("another.sub.example.com"));
-        assert!(!rule.blocks_domain("example.com"));
-        assert!(!rule.blocks_domain("other.com"));
-    }
-
-    #[test]
-    fn negative_rule_all_domains_specific_port() {
-        let rule = Rule::from_str("!*.*:80").unwrap();
-
-        assert!(!rule.allows_domain("sub.example.com"));
-        assert!(!rule.allows_domain("another.sub.example.com"));
-        assert!(!rule.allows_domain("example.com"));
-        assert!(!rule.allows_domain("other.com"));
-
-        assert!(rule.blocks_domain("sub.example.com"));
-        assert!(rule.blocks_domain("another.sub.example.com"));
-        assert!(rule.blocks_domain("example.com"));
-        assert!(rule.blocks_domain("other.com"));
-    }
-
-    #[test]
-    fn negative_rule_all_ip_specific_port() {
-        let rule = Rule::from_str("!*:80-100").unwrap();
-
-        assert!(!rule.allows_ip("192.168.1.1".parse().unwrap()));
-        assert!(!rule.allows_ip("2001:db8::1".parse().unwrap()));
-        assert!(!rule.allows_port(80));
-        assert!(!rule.allows_port(79));
-        for port in 80..=100 {
-            assert!(!rule.allows_port(port));
+        // ip is wrong
+        for ip in &ip_non_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule.is_allowed(ip_addr, 8080, Direction::Inbound));
         }
-        assert!(!rule.allows_port(101));
+    }
 
-        assert!(rule.blocks_ip("192.168.1.1".parse().unwrap()));
-        assert!(rule.blocks_ip("2001:db8::1".parse().unwrap()));
-        assert!(rule.blocks_port(80));
-        assert!(!rule.blocks_port(79));
-        for port in 80..=100 {
-            assert!(rule.blocks_port(port));
+    #[test]
+    fn ipv4_rule_all_ip_port_range_outbound() {
+        let rules = parse_ipv4_rule("*:80-90/out").unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert!(!rules[0].is_allowed([127, 0, 0, 1], 80, Direction::Inbound));
+        assert!(rules[0].is_allowed([127, 0, 0, 1], 80, Direction::Outbound));
+        assert!(rules[0].is_allowed([127, 0, 0, 1], 85, Direction::Outbound));
+        assert!(rules[0].is_allowed([127, 0, 0, 1], 90, Direction::Outbound));
+        assert!(!rules[0].is_allowed([127, 0, 0, 1], 443, Direction::Outbound));
+        assert!(!rules[0].is_allowed([192, 168, 1, 2], 80, Direction::Inbound));
+        assert!(rules[0].is_allowed([192, 168, 1, 2], 80, Direction::Outbound));
+    }
+
+    #[test]
+    fn multiple_ipv4_rules() {
+        let mut rules = parse_ipv4_rule("{127.0.0.1, 192.168.1.0/24}:{80, 8080}/in").unwrap();
+
+        let rule1 = rules.pop().unwrap(); // 192.168.1.0/24:8080/in
+        let rule2 = rules.pop().unwrap(); // 192.168.1.0/24:80/in
+        let rule3 = rules.pop().unwrap(); // 127.0.0.1:8080/in
+        let rule4 = rules.pop().unwrap(); // 127.0.0.1:80/in
+
+        assert!(rules.is_empty());
+
+        let ip_matches = vec![
+            "192.168.1.1",
+            "192.168.1.0",
+            "192.168.1.255",
+            "192.168.1.100",
+            "192.168.1.50",
+        ];
+
+        let ip_non_matches = vec![
+            "192.168.2.0",
+            "192.167.1.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.0.255",
+        ];
+
+        // rule1
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(rule1.is_allowed(ip_addr, 8080, Direction::Inbound));
         }
-        assert!(!rule.blocks_port(101));
+        // direction is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule1.is_allowed(ip_addr, 8080, Direction::Outbound));
+        }
+        // port is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule1.is_allowed(ip_addr, 80, Direction::Inbound));
+        }
+        // ip is wrong
+        for ip in &ip_non_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule1.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+
+        // rule2
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(rule2.is_allowed(ip_addr, 80, Direction::Inbound));
+        }
+        // direction is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule2.is_allowed(ip_addr, 80, Direction::Outbound));
+        }
+        // port is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule2.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+        // ip is wrong
+        for ip in &ip_non_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!rule2.is_allowed(ip_addr, 80, Direction::Inbound));
+        }
+
+        // rule3
+        assert!(rule3.is_allowed([127, 0, 0, 1], 8080, Direction::Inbound));
+        assert!(!rule3.is_allowed([192, 168, 1, 2], 8080, Direction::Inbound));
+        assert!(!rule3.is_allowed([127, 0, 0, 1], 80, Direction::Inbound));
+        assert!(!rule3.is_allowed([127, 0, 0, 1], 8080, Direction::Outbound));
+
+        // rule4
+        assert!(rule4.is_allowed([127, 0, 0, 1], 80, Direction::Inbound));
+        assert!(!rule4.is_allowed([192, 168, 1, 2], 80, Direction::Inbound));
+        assert!(!rule4.is_allowed([127, 0, 0, 1], 8080, Direction::Inbound));
+        assert!(!rule4.is_allowed([127, 0, 0, 1], 80, Direction::Outbound));
+    }
+
+    #[test]
+    fn ipv6_rule_all() {
+        let rules = parse_ipv6_rule("*:*").unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed(
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(rules[0].is_allowed(
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Outbound
+        ));
+    }
+
+    #[test]
+    fn ipv6_rule_single_ip_and_port() {
+        let rules = parse_ipv6_rule("[2001:db8::1]:80").unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed(
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(rules[0].is_allowed(
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Outbound
+        ));
+    }
+
+    #[test]
+    fn ipv6_rule_single_ip_all_ports_inbound() {
+        let rules = parse_ipv6_rule("[2001:db8::1]:*/in").unwrap();
+
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].is_allowed(
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(!rules[0].is_allowed(
+            "2002:db8::1".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(!rules[0].is_allowed(
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            8080,
+            Direction::Outbound
+        ));
+    }
+
+    #[test]
+    fn ipv6_rule_ip_range_all_ports_outbound() {
+        let mut rules = parse_ipv6_rule("[2001:db8::/32]:*/out").unwrap();
+
+        let ip_matches = vec![
+            "2001:db8::1",
+            "2001:db8::",
+            "2001:db8:0:0:0:0:0:1234",
+            "2001:db8::abcd",
+            "2001:db8::ffff",
+        ];
+
+        let ip_non_matches = vec![
+            "2001:db9::",
+            "2001:db7::1",
+            "2001:dead::1",
+            "fe80::1",
+            "::1",
+        ];
+
+        assert_eq!(rules.len(), 1);
+        let rule = rules.pop().unwrap();
+
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(rule.is_allowed(ip_addr, 8080, Direction::Outbound));
+        }
+        // direction is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+        // ip is wrong
+        for ip in &ip_non_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+    }
+
+    #[test]
+    fn multiple_ipv6_rules() {
+        let mut rules = parse_ipv6_rule("{3001:db8::, 2001:db8::/32}:{80, 8080}/in").unwrap();
+
+        let rule1 = rules.pop().unwrap(); // [2001:db8::/32]:8080/in
+        let rule2 = rules.pop().unwrap(); // [2001:db8::/32]:80/in
+        let rule3 = rules.pop().unwrap(); // [3001:db8::]:8080/in
+        let rule4 = rules.pop().unwrap(); // [3001:db8::]:80/in
+
+        assert!(rules.is_empty());
+
+        let ip_matches = vec![
+            "2001:db8::1",
+            "2001:db8::",
+            "2001:db8:0:0:0:0:0:1234",
+            "2001:db8::abcd",
+            "2001:db8::ffff",
+        ];
+
+        let ip_non_matches = vec![
+            "2001:db9::",
+            "2001:db7::1",
+            "2001:dead::1",
+            "fe80::1",
+            "::1",
+        ];
+
+        // rule1
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(rule1.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+        // direction is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule1.is_allowed(ip_addr, 8080, Direction::Outbound));
+        }
+        // port is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule1.is_allowed(ip_addr, 80, Direction::Inbound));
+        }
+        // ip is wrong
+        for ip in &ip_non_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule1.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+
+        // rule2
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(rule2.is_allowed(ip_addr, 80, Direction::Inbound));
+        }
+        // direction is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule2.is_allowed(ip_addr, 80, Direction::Outbound));
+        }
+        // port is wrong
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule2.is_allowed(ip_addr, 8080, Direction::Inbound));
+        }
+        // ip is wrong
+        for ip in &ip_non_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(!rule2.is_allowed(ip_addr, 80, Direction::Inbound));
+        }
+
+        // rule3
+        assert!(rule3.is_allowed(
+            "3001:db8::".parse::<Ipv6Addr>().unwrap(),
+            8080,
+            Direction::Inbound
+        ));
+        assert!(!rule3.is_allowed(
+            "4001:db8::".parse::<Ipv6Addr>().unwrap(),
+            8080,
+            Direction::Inbound
+        ));
+        assert!(!rule3.is_allowed(
+            "3001:db8::".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(!rule3.is_allowed(
+            "3001:db8::".parse::<Ipv6Addr>().unwrap(),
+            8080,
+            Direction::Outbound
+        ));
+
+        // rule4
+        assert!(rule4.is_allowed(
+            "3001:db8::".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(!rule4.is_allowed(
+            "4001:db8::".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Inbound
+        ));
+        assert!(!rule4.is_allowed(
+            "3001:db8::".parse::<Ipv6Addr>().unwrap(),
+            8080,
+            Direction::Inbound
+        ));
+        assert!(!rule4.is_allowed(
+            "3001:db8::".parse::<Ipv6Addr>().unwrap(),
+            80,
+            Direction::Outbound
+        ));
+    }
+
+    #[test]
+    fn ruleset_dns() {
+        let ruleset = Ruleset::from_str("dns:allow={a.com, *.b.com}:{80, 8080}").unwrap();
+
+        assert!(ruleset.is_domain_allowed("a.com"));
+        assert!(!ruleset.is_domain_allowed("sub.a.com"));
+        assert!(!ruleset.is_domain_allowed("b.com"));
+        assert!(ruleset.is_domain_allowed("sub.b.com"));
+        assert!(ruleset.is_domain_allowed("another.sub.b.com"));
+    }
+
+    #[test]
+    fn ruleset_ipv4() {
+        let ruleset =
+            Ruleset::from_str("ipv4:deny={127.0.0.1, 192.168.1.0/24}:{80, 8080}/in").unwrap();
+
+        let ip_matches = vec![
+            "192.168.1.1",
+            "192.168.1.0",
+            "192.168.1.255",
+            "192.168.1.100",
+            "192.168.1.50",
+        ];
+
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!ruleset.is_socket_allowed((ip_addr, 8080), Direction::Inbound));
+        }
+
+        assert!(!ruleset.is_socket_allowed(([127, 0, 0, 1], 8080), Direction::Inbound));
+        assert!(!ruleset.is_socket_allowed(([127, 0, 0, 1], 80), Direction::Inbound));
+    }
+
+    #[test]
+    fn ruleset_ipv6() {
+        let ruleset =
+            Ruleset::from_str("ipv6:allow={3001:db8::, 2001:db8::/32}:{80, 8080}/in").unwrap();
+
+        let ip_matches = vec![
+            "2001:db8::1",
+            "2001:db8::",
+            "2001:db8:0:0:0:0:0:1234",
+            "2001:db8::abcd",
+            "2001:db8::ffff",
+        ];
+
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(ruleset.is_socket_allowed((ip_addr, 8080), Direction::Inbound));
+        }
+
+        assert!(ruleset.is_socket_allowed(
+            ("3001:db8::".parse::<Ipv6Addr>().unwrap(), 8080),
+            Direction::Inbound
+        ));
+        assert!(ruleset.is_socket_allowed(
+            ("3001:db8::".parse::<Ipv6Addr>().unwrap(), 8080),
+            Direction::Inbound
+        ));
+    }
+
+    #[test]
+    fn ruleset_full() {
+        let ruleset = Ruleset::from_str(
+            "dns:allow={a.com, *.b.com}:{80, 8080},
+            ipv4:deny={127.0.0.1, 192.168.1.0/24}:{80, 8080}/in,
+            ipv6:allow={3001:db8::, 2001:db8::/32}:{80, 8080}/in",
+        )
+        .unwrap();
+
+        // dns rules
+        assert!(ruleset.is_domain_allowed("a.com"));
+        assert!(!ruleset.is_domain_allowed("sub.a.com"));
+        assert!(!ruleset.is_domain_allowed("b.com"));
+        assert!(ruleset.is_domain_allowed("sub.b.com"));
+        assert!(ruleset.is_domain_allowed("another.sub.b.com"));
+
+        // ipv4 rules
+        let ip_matches = vec![
+            "192.168.1.1",
+            "192.168.1.0",
+            "192.168.1.255",
+            "192.168.1.100",
+            "192.168.1.50",
+        ];
+
+        for ip in &ip_matches {
+            let ip_addr: Ipv4Addr = ip.parse().unwrap();
+            assert!(!ruleset.is_socket_allowed((ip_addr, 8080), Direction::Inbound));
+        }
+
+        assert!(!ruleset.is_socket_allowed(([127, 0, 0, 1], 8080), Direction::Inbound));
+        assert!(!ruleset.is_socket_allowed(([127, 0, 0, 1], 80), Direction::Inbound));
+
+        // ipv6 rules
+        let ip_matches = vec![
+            "2001:db8::1",
+            "2001:db8::",
+            "2001:db8:0:0:0:0:0:1234",
+            "2001:db8::abcd",
+            "2001:db8::ffff",
+        ];
+
+        for ip in &ip_matches {
+            let ip_addr: Ipv6Addr = ip.parse().unwrap();
+            assert!(ruleset.is_socket_allowed((ip_addr, 8080), Direction::Inbound));
+        }
+
+        assert!(ruleset.is_socket_allowed(
+            ("3001:db8::".parse::<Ipv6Addr>().unwrap(), 8080),
+            Direction::Inbound
+        ));
+        assert!(ruleset.is_socket_allowed(
+            ("3001:db8::".parse::<Ipv6Addr>().unwrap(), 8080),
+            Direction::Inbound
+        ));
+    }
+
+    #[test]
+    fn ruleset_temp() {
+        let _ruleset = Ruleset::from_str(
+            "
+            dns:allow=localhost:8080,
+            ipv4:allow=*:8080/in,
+            ipv6:allow=*:8080/in,
+            ipv4:allow=*:*/out,
+            ipv6:allow=*:*/out
+        ",
+        )
+        .unwrap();
     }
 }

--- a/lib/virtual-net/src/ruleset.rs
+++ b/lib/virtual-net/src/ruleset.rs
@@ -3,7 +3,7 @@
 ///
 /// ## Rule Specification
 /// Each rule can be expressed like:
-/// ```
+/// ```text
 /// <rule_kind>:<rule_action>=<rule_expr>
 ///
 /// <rule_kind>: dns, ipv4, ipv6
@@ -44,11 +44,11 @@
 /// ### Rule Combination
 /// In order to prevent repetition, the parts before and after the `:` could hold multiple values.
 /// For example:
-/// ```
+/// ```text
 /// ipv4:deny={127.0.0.1/24, 192.168.1.1/24}:{80, 443}
 /// ```
 /// This is equivalent to:
-/// ```
+/// ```text
 /// ipv4:deny=127.0.0.1/24:80,
 /// ipv4:deny=127.0.0.1/24:443,
 /// ipv4:deny=192.168.1.1/24:80,


### PR DESCRIPTION
## Overview
This PR adds a more fine-grained sandbox for the network layer. Previously, the wasm module did not have access to any networking functionality by default and the user could give this access by providing the `--net` flag to the wasmer client. But this would expose all of host's network stack to the wasm module. Now users can provide a list of  of patterns that will act as a whitelist or blacklist. This is done by adding the new `--net-filter` flag:
```
wasmer run --net-filter=<comma_separated_list_of_rules>
```

## Rule Specification
Each member of the `<comma_separated_list_of_rules>` can be expressed like:
```
<rule_kind>:<rule_action>=<rule_expr>

<rule_kind>: dns, ipv4, ipv6

<rule_action>: allow | deny

dns:
<rule_expr>:
{<domain_spec>}:{<port_spec>} (this will be expanded to an outbound IP rule)
<domain_spec>: domain | domain glob | *

ipv4:
<rule_expr>:
<ipv4_specs>:<port_specs>/<in|out>
<ipv4_specs>: <ipv4_spec> | {<ipv4_spec>,}
<ipv4_spec>: ipv4 | ipv4_range | *

ipv6:
<rule_expr>:
<ipv6_specs>:<port_specs>/<in|out>
<ipv6_specs>: <ipv6_spec> | {<ipv6_spec>,}
<ipv6_spec>: ipv6 | ipv6_range | *

<port_specs>: <port_spec> | {<port_specs>,}
<port_spec>: port | start_port-end_port | *
```
Some examples:
- Allow a specific domain and port: `dns:allow=example.com:80`
- Deny a domain and all its subdomains on all ports: `dns:deny=*danger.xyz:*`
- Allow opening ipv4 sockets only on a specific IP and port: `ipv4:allow=127.0.0.1:80/in`.

## Features

### Whitelisting and Blacklisting
Each rule can be expressed as an `allow` (whitelist) or `deny` (blacklist). A socket or domain is only accessible if at least one rule whitelists it and no rule blacklists it.

### Directional Filtering
IP based rules can be either directional by specifying `/in` or `/out` postfixes to the rule, or bidirectional which is the default setting for these rules.

### Rule Combination
In order to prevent repetition, the parts before and after the `:` could hold multiple values. For example:
```
ipv4:deny={127.0.0.1/24, 192.168.1.1/24}:{80, 443}
```
This is equivalent to:
```
ipv4:deny=127.0.0.1/24:80,
ipv4:deny=127.0.0.1/24:443,
ipv4:deny=192.168.1.1/24:80,
ipv4:deny=192.168.1.1/24:443
```

Resolves #5280.