### PR TITLE
Refactor path_create_directory and path_remove_directory to…

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_create_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_create_directory.rs
@@ -83,14 +83,16 @@ pub(crate) fn path_create_directory_internal(
 
             // TODO: This condition should already have been checked by the entries.get check
             // above, but it was in the code before my refactor and I'm keeping it just in case.
-            if let Ok(_) = path_filestat_get_internal(
+            if path_filestat_get_internal(
                 &memory,
                 state,
                 inodes,
                 fd,
                 0,
                 &new_dir_path.to_string_lossy(),
-            ) {
+            )
+            .is_ok()
+            {
                 return Err(Errno::Exist);
             }
 

--- a/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
@@ -47,7 +47,7 @@ pub(crate) fn path_remove_directory_internal(
     let (parent_inode, dir_name) =
         state
             .fs
-            .get_parent_inode_at_path(inodes, fd, &Path::new(path), true)?;
+            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)?;
 
     let mut guard = parent_inode.write();
     match guard.deref_mut() {

--- a/tests/wasix/create-and-remove-dirs/main.c
+++ b/tests/wasix/create-and-remove-dirs/main.c
@@ -1,0 +1,99 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int ensure_dir_accessible(const char *dir_name)
+{
+    struct stat st;
+    char buf[256];
+
+    if (stat(dir_name, &st) != 0 || !S_ISDIR(st.st_mode))
+    {
+        return -1;
+    }
+
+    sprintf(buf, "./%s", dir_name);
+    if (stat(buf, &st) != 0 || !S_ISDIR(st.st_mode))
+    {
+        return -1;
+    }
+
+    sprintf(buf, "/home/%s", dir_name);
+    if (stat(buf, &st) != 0 || !S_ISDIR(st.st_mode))
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+int ensure_dir_removed(const char *dir_name)
+{
+    struct stat st;
+
+    if (stat(dir_name, &st) == 0 || errno != ENOENT)
+    {
+        return -1;
+    }
+
+    errno = 0;
+    return 0;
+}
+
+void error(const char *message)
+{
+    perror(message);
+    exit(-1);
+}
+
+int main()
+{
+    if (mkdir("test1/test2", S_IRWXU | S_IRWXG | S_IRWXO) == 0)
+    {
+        printf("Expected recursive directory creation to fail\n");
+        return -1;
+    }
+
+    if (mkdir("test1", S_IRWXU | S_IRWXG | S_IRWXO) != 0 || ensure_dir_accessible("test1") != 0)
+    {
+        error("mkdir test1");
+    }
+
+    if (mkdir("test1/test2", S_IRWXU | S_IRWXG | S_IRWXO) != 0 || ensure_dir_accessible("test1/test2") != 0)
+    {
+        error("mkdir test2");
+    }
+
+    if (rmdir("test1") == 0)
+    {
+        printf("Expected removing non-empty directory to fail\n");
+        return -1;
+    }
+
+    if (rmdir("test1/test2") != 0 || ensure_dir_removed("test1/test2") != 0)
+    {
+        error("rmdir test2");
+    }
+
+    if (rmdir("test1") != 0 || ensure_dir_removed("test1") != 0)
+    {
+        error("rmdir test1");
+    }
+
+    if (mkdir("test1", S_IRWXU | S_IRWXG | S_IRWXO) != 0 || ensure_dir_accessible("test1") != 0)
+    {
+        error("re-create test1");
+    }
+
+    if (rmdir("test1") != 0 || ensure_dir_removed("test1") != 0)
+    {
+        error("re-remove test1");
+    }
+
+    printf("0");
+    return 0;
+}

--- a/tests/wasix/create-and-remove-dirs/run.sh
+++ b/tests/wasix/create-and-remove-dirs/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+$WASMER -q run main.wasm --dir . > output
+
+rm -rf test1 2>/dev/null && printf "0" | diff -u output - 1>/dev/null


### PR DESCRIPTION
… fix bad EEXIST when re-creating directory

Note: both `path_create_directory` and `path_remove_directory` are supposed to only create/remove one directory. The previous recursive behavior was wrong and it has been removed.