### PR TITLE
make `AppConfig.name` optional in wasmer-config

### DIFF
--- a/docs/schema/generated/jsonschema/types/AppConfigV1.schema.json
+++ b/docs/schema/generated/jsonschema/types/AppConfigV1.schema.json
@@ -4,7 +4,6 @@
   "description": "User-facing app.yaml config file for apps.\n\nNOTE: only used by the backend, Edge itself does not use this format, and uses [`super::AppVersionV1Spec`] instead.",
   "type": "object",
   "required": [
-    "name",
     "package"
   ],
   "properties": {
@@ -81,7 +80,10 @@
     },
     "name": {
       "description": "Name of the app.",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "owner": {
       "description": "Owner of the app.\n\nThis is either a username or a namespace.",

--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -132,7 +132,7 @@ impl CmdAppCreate {
     #[inline]
     fn get_app_config(&self, owner: &str, name: &str, package: &str) -> AppConfigV1 {
         AppConfigV1 {
-            name: String::from(name),
+            name: Some(String::from(name)),
             owner: Some(String::from(owner)),
             package: PackageSource::from_str(package).unwrap(),
             app_id: None,

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -548,9 +548,20 @@ impl AsyncCliCommand for CmdAppDeploy {
         let app = &opts.app;
 
         let pretty_name = if let Some(owner) = &owner {
-            format!("{} ({})", app.name.as_ref().context("App name has to be specified")?.bold(), owner.bold())
+            format!(
+                "{} ({})",
+                app.name
+                    .as_ref()
+                    .context("App name has to be specified")?
+                    .bold(),
+                owner.bold()
+            )
         } else {
-            app.name.as_ref().context("App name has to be specified")?.bold().to_string()
+            app.name
+                .as_ref()
+                .context("App name has to be specified")?
+                .bold()
+                .to_string()
         };
 
         if !self.quiet {

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -548,9 +548,9 @@ impl AsyncCliCommand for CmdAppDeploy {
         let app = &opts.app;
 
         let pretty_name = if let Some(owner) = &owner {
-            format!("{} ({})", app.name.bold(), owner.bold())
+            format!("{} ({})", app.name.as_ref().context("App name has to be specified")?.bold(), owner.bold())
         } else {
-            app.name.bold().to_string()
+            app.name.as_ref().context("App name has to be specified")?.bold().to_string()
         };
 
         if !self.quiet {
@@ -629,7 +629,7 @@ pub async fn deploy_app(
         client,
         wasmer_backend_api::types::PublishDeployAppVars {
             config: raw_config,
-            name: app.name.clone().into(),
+            name: app.name.clone().context("Expected an app name")?.into(),
             owner: opts.owner.map(|o| o.into()),
             make_default: Some(opts.make_default),
         },

--- a/lib/cli/src/commands/app/secrets/utils/mod.rs
+++ b/lib/cli/src/commands/app/secrets/utils/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod render;
-
+use anyhow::Context;
 use colored::Colorize;
 use std::{
     env::current_dir,
@@ -112,9 +112,9 @@ pub(super) async fn get_app_id(
         let (app, _) = r;
 
         let app_name = if let Some(owner) = &app.owner {
-            format!("{owner}/{}", app.name)
+            format!("{owner}/{}", &app.name.clone().context("App name has to be specified")?)
         } else {
-            app.name.to_string()
+            app.name.clone().context("App name has to be specified")?.to_string()
         };
 
         let id = if let Some(id) = &app.app_id {
@@ -140,10 +140,10 @@ pub(super) async fn get_app_id(
                 if let Some(owner) = &app.owner {
                     eprintln!(
                         "Managing secrets related to app {} ({owner}).",
-                        app.name.bold()
+                        app.name.context("App name has to be specified")?.bold()
                     );
                 } else {
-                    eprintln!("Managing secrets related to app {}.", app.name.bold());
+                    eprintln!("Managing secrets related to app {}.", app.name.context("App name has to be specified")?.bold());
                 }
             }
             return Ok(id);

--- a/lib/cli/src/commands/app/secrets/utils/mod.rs
+++ b/lib/cli/src/commands/app/secrets/utils/mod.rs
@@ -112,9 +112,15 @@ pub(super) async fn get_app_id(
         let (app, _) = r;
 
         let app_name = if let Some(owner) = &app.owner {
-            format!("{owner}/{}", &app.name.clone().context("App name has to be specified")?)
+            format!(
+                "{owner}/{}",
+                &app.name.clone().context("App name has to be specified")?
+            )
         } else {
-            app.name.clone().context("App name has to be specified")?.to_string()
+            app.name
+                .clone()
+                .context("App name has to be specified")?
+                .to_string()
         };
 
         let id = if let Some(id) = &app.app_id {
@@ -143,7 +149,10 @@ pub(super) async fn get_app_id(
                         app.name.context("App name has to be specified")?.bold()
                     );
                 } else {
-                    eprintln!("Managing secrets related to app {}.", app.name.context("App name has to be specified")?.bold());
+                    eprintln!(
+                        "Managing secrets related to app {}.",
+                        app.name.context("App name has to be specified")?.bold()
+                    );
                 }
             }
             return Ok(id);

--- a/lib/cli/src/commands/app/util.rs
+++ b/lib/cli/src/commands/app/util.rs
@@ -152,7 +152,10 @@ impl AppIdentOpts {
         let ident = if let Some(id) = &config.app_id {
             AppIdent::AppId(id.clone())
         } else if let Some(owner) = &config.owner {
-            AppIdent::NamespacedName(owner.clone(), config.name.clone().context("App name was not specified")?)
+            AppIdent::NamespacedName(
+                owner.clone(),
+                config.name.clone().context("App name was not specified")?,
+            )
         } else {
             AppIdent::Name(config.name.clone().context("App name was not specified")?)
         };

--- a/lib/cli/src/commands/app/util.rs
+++ b/lib/cli/src/commands/app/util.rs
@@ -152,9 +152,9 @@ impl AppIdentOpts {
         let ident = if let Some(id) = &config.app_id {
             AppIdent::AppId(id.clone())
         } else if let Some(owner) = &config.owner {
-            AppIdent::NamespacedName(owner.clone(), config.name.clone())
+            AppIdent::NamespacedName(owner.clone(), config.name.clone().context("App name was not specified")?)
         } else {
-            AppIdent::Name(config.name.clone())
+            AppIdent::Name(config.name.clone().context("App name was not specified")?)
         };
 
         Ok(ResolvedAppIdent::Config {

--- a/lib/config/src/app/mod.rs
+++ b/lib/config/src/app/mod.rs
@@ -310,7 +310,7 @@ scheduled_tasks:
         assert_eq!(
             parsed,
             AppConfigV1 {
-                name: "test".to_string(),
+                name: Some("test".to_string()),
                 app_id: None,
                 package: "ns/name@0.1.0".parse().unwrap(),
                 owner: None,

--- a/lib/config/src/app/mod.rs
+++ b/lib/config/src/app/mod.rs
@@ -32,7 +32,7 @@ pub const HEADER_APP_VERSION_ID: &str = "x-edge-app-version-id";
 )]
 pub struct AppConfigV1 {
     /// Name of the app.
-    pub name: String,
+    pub name: Option<String>,
 
     /// App id assigned by the backend.
     ///


### PR DESCRIPTION
The wasmer-cli treats `AppConfig` objects without names as valid, but
this behavior is not reflected in the `AppConfig` schema.

This discrepancy caused issues when attempting to parse a "valid"
`AppConfig` as per the wasmer cli. Wasmer CLI injects a name
if it does not exist, so this issue is not seen. But as the name field was
marked as required, other clients using wasmer-config would fail.

#### Example app.yaml config that works with wasmer-cli but not with other clients:

```yaml
kind: wasmer.io/App.v0
package: wasmer/hello
```

This commit makes the `AppConfig.name` field optional, thereby allowing
programs to successfully parse configurations without a name field.