### PR TITLE
Fix build for 32bit targets (usize == u32)

### DIFF
--- a/lib/vm/src/threadconditions.rs
+++ b/lib/vm/src/threadconditions.rs
@@ -87,7 +87,7 @@ impl ThreadConditions {
         }
 
         // fetch the notifier
-        if self.inner.map.len() >= 1 << 32 {
+        if self.inner.map.len() as u64 >= 1u64 << 32 {
             return Err(WaiterError::TooManyWaiters);
         }
         self.inner.map.entry(dst).or_default().push(NotifyWaiter {


### PR DESCRIPTION
# Description
Fixes https://github.com/wasmerio/wasmer/issues/5303

As usize's size is platform dependent (usually the pointer size), the bit shift, which is inlined during compilation, leads to an overflow on 32bit platforms. 

By explicitly casting both sides to u64, we ensure that the constant (1<<32) will not overflow during compilation.
