### PR TITLE
 Forward reuse_port and reuse_addr when it's possible to

### DIFF
--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -106,7 +106,7 @@ impl VirtualNetworking for LocalNetworking {
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
-        use socket2::{Socket, Domain, Type};        
+        use socket2::{Domain, Socket, Type};
 
         if let Some(ruleset) = self.ruleset.as_ref() {
             if !ruleset.allows_socket(addr, Direction::Inbound) {
@@ -115,11 +115,16 @@ impl VirtualNetworking for LocalNetworking {
             }
         }
 
-        let std_sock = Socket::new(Domain::IPV4, Type::DGRAM, None).map_err(io_err_into_net_error)?;
         #[cfg(not(windows))]
         let socket = {
-            std_sock.set_reuse_address(reuse_addr).map_err(io_err_into_net_error)?;
-            std_sock.set_reuse_port(reuse_port).map_err(io_err_into_net_error)?;
+            let std_sock =
+                Socket::new(Domain::IPV4, Type::DGRAM, None).map_err(io_err_into_net_error)?;
+            std_sock
+                .set_reuse_address(reuse_addr)
+                .map_err(io_err_into_net_error)?;
+            std_sock
+                .set_reuse_port(reuse_port)
+                .map_err(io_err_into_net_error)?;
             std_sock.bind(&addr.into()).map_err(io_err_into_net_error)?;
             mio::net::UdpSocket::from_std(std_sock.into())
         };

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -115,6 +115,7 @@ impl VirtualNetworking for LocalNetworking {
             }
         }
 
+        #[cfg(not(windows))]
         let socket = {
             let std_sock =
                 Socket::new(Domain::IPV4, Type::DGRAM, None).map_err(io_err_into_net_error)?;
@@ -127,6 +128,8 @@ impl VirtualNetworking for LocalNetworking {
             std_sock.bind(&addr.into()).map_err(io_err_into_net_error)?;
             mio::net::UdpSocket::from_std(std_sock.into())
         };
+        #[cfg(windows)]
+        let socket = mio::net::UdpSocket::bind(addr).map_err(io_err_into_net_error)?;
 
         #[allow(unused_mut)]
         let mut ret = LocalUdpSocket {

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -115,7 +115,6 @@ impl VirtualNetworking for LocalNetworking {
             }
         }
 
-        #[cfg(not(windows))]
         let socket = {
             let std_sock =
                 Socket::new(Domain::IPV4, Type::DGRAM, None).map_err(io_err_into_net_error)?;
@@ -128,8 +127,6 @@ impl VirtualNetworking for LocalNetworking {
             std_sock.bind(&addr.into()).map_err(io_err_into_net_error)?;
             mio::net::UdpSocket::from_std(std_sock.into())
         };
-        #[cfg(windows)]
-        let socket = mio::net::UdpSocket::bind(addr).map_err(io_err_into_net_error)?;
 
         #[allow(unused_mut)]
         let mut ret = LocalUdpSocket {

--- a/tests/wasix/udp-addr-reuse/main.c
+++ b/tests/wasix/udp-addr-reuse/main.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+/*
+this is an exemple of address reuse using UDP sockets
+it set address reuse option to 1 and then bind to the same address
+it set port reuse option to 1 and then bind to the same port
+*/
+//#ifndef SO_REUSEPORT
+//#define SO_REUSEPORT 15
+//#endif
+
+
+int main(int argc, char *argv[])
+{
+    int sock1, sock2;
+    int reuse = 1;
+    struct sockaddr_in addr;
+
+    sock1 = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock1 < 0)
+    {
+        perror("socket");
+        return EXIT_FAILURE;
+    }
+
+    if (setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+    {
+        perror("setsockopt first socket SO_REUSEADDR failed");
+        return EXIT_FAILURE;
+    }
+
+    if (setsockopt(sock1, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
+    {
+        perror("setsockopt first socket SO_REUSEPORT failed");
+        return EXIT_FAILURE;
+    }
+
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(12345);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(sock1, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
+        perror("first socket bind failed");
+        return EXIT_FAILURE;
+    }
+
+    sock2 = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock2 < 0)
+    {
+        perror("socket");
+        return EXIT_FAILURE;
+    }
+
+    if (setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+    {
+        perror("setsockopt second socket SO_REUSEADDR failed");
+        return EXIT_FAILURE;
+    }
+
+    if (setsockopt(sock2, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
+    {
+        perror("setsockopt second socket SO_REUSEPORT failed");
+        return EXIT_FAILURE;
+    }
+
+    if (bind(sock2, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
+        perror("second socket bind failed");
+        return EXIT_FAILURE;
+    }
+
+    close(sock1);
+    close(sock2);
+
+    return EXIT_SUCCESS;
+    
+}

--- a/tests/wasix/udp-addr-reuse/main.c
+++ b/tests/wasix/udp-addr-reuse/main.c
@@ -24,19 +24,19 @@ int main(int argc, char *argv[])
     sock1 = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock1 < 0)
     {
-        perror("socket");
+        puts("failed to create the first socket");
         return EXIT_FAILURE;
     }
 
     if (setsockopt(sock1, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
     {
-        perror("setsockopt first socket SO_REUSEADDR failed");
+        puts("setsockopt first socket SO_REUSEADDR failed");
         return EXIT_FAILURE;
     }
 
     if (setsockopt(sock1, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
     {
-        perror("setsockopt first socket SO_REUSEPORT failed");
+        puts("setsockopt first socket SO_REUSEPORT failed");
         return EXIT_FAILURE;
     }
 
@@ -46,38 +46,39 @@ int main(int argc, char *argv[])
 
     if (bind(sock1, (struct sockaddr *)&addr, sizeof(addr)) < 0)
     {
-        perror("first socket bind failed");
+        puts("first socket bind failed");
         return EXIT_FAILURE;
     }
 
     sock2 = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock2 < 0)
     {
-        perror("socket");
+        puts("failed to create the second socket");
         return EXIT_FAILURE;
     }
 
     if (setsockopt(sock2, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
     {
-        perror("setsockopt second socket SO_REUSEADDR failed");
+        puts("setsockopt second socket SO_REUSEADDR failed");
         return EXIT_FAILURE;
     }
 
     if (setsockopt(sock2, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
     {
-        perror("setsockopt second socket SO_REUSEPORT failed");
+        puts("setsockopt second socket SO_REUSEPORT failed");
         return EXIT_FAILURE;
     }
 
     if (bind(sock2, (struct sockaddr *)&addr, sizeof(addr)) < 0)
     {
-        perror("second socket bind failed");
+        puts("second socket bind failed");
         return EXIT_FAILURE;
     }
 
     close(sock1);
     close(sock2);
 
+    printf("%d", EXIT_SUCCESS);
     return EXIT_SUCCESS;
     
 }

--- a/tests/wasix/udp-addr-reuse/run.sh
+++ b/tests/wasix/udp-addr-reuse/run.sh
@@ -1,0 +1,3 @@
+$WASMER -q run main.wasm > output
+
+printf "0" | diff -u output - 1>/dev/null

--- a/tests/wasix/udp-addr-reuse/run.sh
+++ b/tests/wasix/udp-addr-reuse/run.sh
@@ -1,3 +1,2 @@
-$WASMER -q run main.wasm > output
-
+$WASMER -q run --net main.wasm > output
 printf "0" | diff -u output - 1>/dev/null


### PR DESCRIPTION

The runtime exposes functions to allow us to set SO_REUSEADDR and SO_REUSEPORT, however it's not working:
```sh
wasmer run --net examples/rust_udp/target/wasm32-wasmer-wasi/debug/udp_example.rustc.wasm
Starting UDP server
Binding to 0.0.0.0:8080
Error: Os { code: 3, kind: AddrInUse, message: "Address in use" }
```


The example code:
```rust
use tokio::net::UdpSocket;
use std::io;
use std::net::{SocketAddr};
use socket2::{Socket, Domain, Type};


#[tokio::main]
async fn main() -> io::Result<()> {
    println!("Starting UDP server");
    let std_sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
    std_sock.set_reuse_address(true)?;

    println!("Binding to 0.0.0.0:8080");

    let address: SocketAddr = "0.0.0.0:8080".parse().unwrap();
    let address = address.into();
    std_sock.bind(&address)?;
   
    let sock = UdpSocket::from_std(std_sock.into())?;

    let mut buf = [0; 1024];
    loop {
        let (len, addr) = sock.recv_from(&mut buf).await?;
        println!("{:?} bytes received from {:?}", len, addr);

        let len = sock.send_to(&buf[..len], addr).await?;
        println!("{:?} bytes sent", len);
    }
}
```

This pull request intend to solve [issue-5247](https://github.com/wasmerio/wasmer/issues/5247)

**I need help to understand the impact of the changes on other platforms, I tested it in my use case and I was able to reuse the address when I ran Wasmer on Ubuntu.**