### PR TITLE
Fix "error: GitHub API: more that one release selected" in `create-exe`

### DIFF
--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -1715,52 +1715,62 @@ pub(super) mod utils {
     }
 
     fn filter_tarball_internal(p: &Path, target: &Triple) -> Option<bool> {
-        if !p.file_name()?.to_str()?.ends_with(".tar.gz") {
+        // [todo]: Move this description to a better suited place.
+        //
+        // The filename scheme:
+        // FILENAME := "wasmer-" [ FEATURE ] OS  PLATFORM  .
+        // FEATURE  := "wamr-" | "v8-" | "wasmi-" .
+        // OS       := "darwin" | "linux" | "linux-musl" | "windows" .
+        // PLATFORM := "aarch64" | "amd64" | "gnu64" .
+        //
+        // In this function we want to select only those version where features don't appear.
+
+        let filename = p.file_name()?.to_str()?;
+
+        if !filename.ends_with(".tar.gz") {
             return None;
         }
 
-        if target.environment == Environment::Musl && !p.file_name()?.to_str()?.contains("musl")
-            || p.file_name()?.to_str()?.contains("musl") && target.environment != Environment::Musl
+        if filename.contains("wamr") || filename.contains("v8") || filename.contains("wasmi") {
+            return None;
+        }
+
+        if target.environment == Environment::Musl && !filename.contains("musl")
+            || filename.contains("musl") && target.environment != Environment::Musl
         {
             return None;
         }
 
         if let Architecture::Aarch64(_) = target.architecture {
-            if !(p.file_name()?.to_str()?.contains("aarch64")
-                || p.file_name()?.to_str()?.contains("arm64"))
-            {
+            if !(filename.contains("aarch64") || filename.contains("arm64")) {
                 return None;
             }
         }
 
         if let Architecture::X86_64 = target.architecture {
             if target.operating_system == OperatingSystem::Windows {
-                if !p.file_name()?.to_str()?.contains("gnu64") {
+                if !filename.contains("gnu64") {
                     return None;
                 }
-            } else if !(p.file_name()?.to_str()?.contains("x86_64")
-                || p.file_name()?.to_str()?.contains("amd64"))
-            {
+            } else if !(filename.contains("x86_64") || filename.contains("amd64")) {
                 return None;
             }
         }
 
         if let OperatingSystem::Windows = target.operating_system {
-            if !p.file_name()?.to_str()?.contains("windows") {
+            if !filename.contains("windows") {
                 return None;
             }
         }
 
         if let OperatingSystem::Darwin = target.operating_system {
-            if !(p.file_name()?.to_str()?.contains("apple")
-                || p.file_name()?.to_str()?.contains("darwin"))
-            {
+            if !(filename.contains("apple") || filename.contains("darwin")) {
                 return None;
             }
         }
 
         if let OperatingSystem::Linux = target.operating_system {
-            if !p.file_name()?.to_str()?.contains("linux") {
+            if !filename.contains("linux") {
                 return None;
             }
         }
@@ -2130,6 +2140,8 @@ mod http_fetch {
 
         let status = response.status();
 
+        log::info!("GitHub api response status: {status}");
+
         let body = response
             .bytes()
             .map_err(anyhow::Error::new)
@@ -2229,7 +2241,7 @@ mod http_fetch {
 
         if assets.len() != 1 {
             return Err(anyhow!(
-                "GitHub API: more that one release selected for target {target_triple}: {assets:?}"
+                "GitHub API: more than one release selected for target {target_triple}: {assets:#?}"
             ));
         }
 


### PR DESCRIPTION
Issue #5281 shows how, when running `wasmer create-exe`, an error occurs while downloading `libwasmer` from the latest release. It is due to the support of engines we recently introduced, which at the time did not allow their coexistence with "regular" engines (the `sys` ones), making separate releases (`-wasmi`, `-wamr`, `-v8`) necessary.  We plan, in the short term, to have a release that allows the simultaneous existence of said engines, so the separate release won't be mandatory anymore - we will have to figure out which engines to ship by default and/or a mechanism to install the necessary libraries (e.g. `libiwasm`, `libwee8`..) when needed. 

In the meantime, this patch fixes the current behaviour by filtering out the `-wasmi`,  `-wamr` and `-v8` releases upon download of `libwasmer`. 