### PR TITLE
Make try_memory public

### DIFF
--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -905,7 +905,7 @@ impl WasiEnv {
 
     /// Providers safe access to the memory
     /// (it must be initialized before it can be used)
-    pub(crate) fn try_memory(&self) -> Option<WasiInstanceGuardMemory<'_>> {
+    pub fn try_memory(&self) -> Option<WasiInstanceGuardMemory<'_>> {
         self.try_inner().map(|i| i.memory())
     }
 


### PR DESCRIPTION
I found no way to access the memory of a rust wasm file compiled with cargo wasix build

i just locally made this public and it did work without any issues


this was the setup i was not able to access the memory


```
let mut store = Store::default();
let caps = Capabilities {
    insecure_allow_all: true,
    http_client: HttpClientCapabilityV1::new_allow_all(),
    threading: CapabilityThreadingV1::default(),
};
let mut builder = WasiEnvBuilder::new("Crust").fs(Box::new(fs::default_fs_backing()));
builder.set_capabilities(caps);
let module = Module::from_file(&store, path)?;

let (instance, wasi_env) = builder.instantiate(module, &mut store)?;
```