### PR TITLE
build: Make build dependency on `zip` and `xz` optional

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -130,7 +130,7 @@ llvm = ["compiler", "wasmer-compiler-llvm"]
 
 # - Engines.
 engine = ["sys"]
-wamr = ["wasm-c-api", "std", "wat"]
+wamr = ["wasm-c-api", "std", "wat", "dep:zip"]
 wasmi = ["wasm-c-api", "std", "wat", "dep:wasmi_c_api"]
 v8 = ["wasm-c-api", "std", "wat", "dep:seq-macro"]
 wasm-c-api = ["wasm-types-polyfill"]
@@ -165,7 +165,7 @@ cmake = "0.1.50"
 tar = "0.4.42"
 ureq = "2.10.1"
 xz = "0.1.0"
-zip = "2.2.0"
+zip = { version = "2.2.0", optional = true }
 
 [target.'cfg(target_env = "musl")'.build-dependencies]
 bindgen = { version = "0.70.1", default-features = false, features = [

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -132,7 +132,7 @@ llvm = ["compiler", "wasmer-compiler-llvm"]
 engine = ["sys"]
 wamr = ["wasm-c-api", "std", "wat", "dep:zip"]
 wasmi = ["wasm-c-api", "std", "wat", "dep:wasmi_c_api"]
-v8 = ["wasm-c-api", "std", "wat", "dep:seq-macro"]
+v8 = ["wasm-c-api", "std", "wat", "dep:seq-macro", "dep:xz"]
 wasm-c-api = ["wasm-types-polyfill"]
 
 # - Deprecated features.
@@ -164,7 +164,7 @@ static-artifact-create = ["wasmer-compiler/static-artifact-create"]
 cmake = "0.1.50"
 tar = "0.4.42"
 ureq = "2.10.1"
-xz = "0.1.0"
+xz = { version = "0.1.0", optional = true }
 zip = { version = "2.2.0", optional = true }
 
 [target.'cfg(target_env = "musl")'.build-dependencies]


### PR DESCRIPTION
# Description

The build script of `wasmer` only depends on `zip` if the feature `wamr` is enabled and only depends on `xz` if `v8` is enabled. So make the cargo feature follow it. I'm sending this PR because unnecessary dependency on `zip` => `zstd-sys` is blocking next.js builds. 

See: https://github.com/vercel/next.js/pull/74580
CI Run: https://github.com/vercel/next.js/actions/runs/12702533956/job/35408913334