### PR TITLE
chore: inline format args to improve readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -967,7 +967,7 @@ install-wasmer-headless-minimal:
 update-testsuite:
 	git subtree pull --prefix tests/wast/spec https://github.com/WebAssembly/testsuite.git master --squash
 
-lint-packages: RUSTFLAGS += -D dead-code -D nonstandard-style -D unused-imports -D unused-mut -D unused-variables -D unused-unsafe -D unreachable-patterns -D bad-style -D improper-ctypes -D unused-allocation -D unused-comparisons -D while-true -D unconditional-recursion -D bare-trait-objects -D function_item_references # TODO: add `-D missing-docs`
+lint-packages: RUSTFLAGS += -D dead-code -D nonstandard-style -D unused-imports -D unused-mut -D unused-variables -D unused-unsafe -D unreachable-patterns -D bad-style -D improper-ctypes -D unused-allocation -D unused-comparisons -D while-true -D unconditional-recursion -D bare-trait-objects -D function_item_references -D clippy::uninlined_format_args # TODO: add `-D missing-docs`
 lint-packages:
 	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --all --exclude wasmer-cli --exclude wasmer-swift --locked -- -D clippy::all
 	RUSTFLAGS="${RUSTFLAGS}" cargo clippy --manifest-path lib/cli/Cargo.toml --locked $(compiler_features) -- -D clippy::all

--- a/build.rs
+++ b/build.rs
@@ -86,7 +86,7 @@ fn main() -> anyhow::Result<()> {
                         with_test_module(wasitests, wasi_filesystem_test_name, |wasitests| {
                             test_directory(
                                 wasitests,
-                                format!("tests/wasi-wast/wasi/{}", wasi_version),
+                                format!("tests/wasi-wast/wasi/{wasi_version}"),
                                 |out, path| wasi_processor(out, path, wasi_filesystem_kind),
                             )
                         })?;

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -18,7 +18,7 @@ fn main() {
             "freebsd" => "freebsd",
             "android" => "android",
             "ios" => "ios",
-            other => panic!("Unsupported CARGO_CFG_TARGET_OS: {}", other),
+            other => panic!("Unsupported CARGO_CFG_TARGET_OS: {other}"),
         };
 
         // Read target arch from cargo env
@@ -31,7 +31,7 @@ fn main() {
             "mips" => "MIPS",
             "powerpc" => "POWERPC",
             "powerpc64" => "POWERPC64",
-            other => panic!("Unsupported CARGO_CFG_TARGET_ARCH: {}", other),
+            other => panic!("Unsupported CARGO_CFG_TARGET_ARCH: {other}"),
         };
 
         // Cleanup tmp data from prior builds
@@ -220,7 +220,7 @@ fn main() {
         println!("cargo:rustc-link-lib=v8_snapshot");
         println!("cargo:rustc-link-lib=v8_torque_generated");
 
-        if cfg!(any(target_os = "linux",)) {
+        if cfg!(any(target_os = "linux")) {
             println!("cargo:rustc-link-lib=stdc++");
         } else if cfg!(target_os = "windows") {
             /* do nothing */

--- a/lib/api/src/c_api/as_c.rs
+++ b/lib/api/src/c_api/as_c.rs
@@ -217,10 +217,7 @@ pub fn valtype_to_type(type_: *const wasm_valtype_t) -> Type {
         crate::bindings::wasm_valkind_enum_WASM_V128 => Type::V128,
         crate::bindings::wasm_valkind_enum_WASM_EXTERNREF => Type::ExternRef,
         crate::bindings::wasm_valkind_enum_WASM_FUNCREF => Type::FuncRef,
-        _ => unreachable!(
-            "valtype {:?} has no matching valkind and therefore no matching wasmer_types::Type",
-            type_
-        ),
+        _ => unreachable!("valtype {type_:?} has no matching valkind and therefore no matching wasmer_types::Type"),
     }
     #[cfg(feature = "wasmi")]
     match type_ as _ {
@@ -231,8 +228,7 @@ pub fn valtype_to_type(type_: *const wasm_valtype_t) -> Type {
         crate::bindings::wasm_valkind_enum_WASM_EXTERNREF => Type::ExternRef,
         crate::bindings::wasm_valkind_enum_WASM_FUNCREF => Type::FuncRef,
         _ => unreachable!(
-            "valtype {:?} has no matching valkind and therefore no matching wasmer_types::Type",
-            type_
+            "valtype {type_:?} has no matching valkind and therefore no matching wasmer_types::Type",
         ),
     }
     #[cfg(feature = "v8")]
@@ -244,8 +240,7 @@ pub fn valtype_to_type(type_: *const wasm_valtype_t) -> Type {
         crate::bindings::wasm_valkind_enum_WASM_ANYREF => Type::ExternRef,
         crate::bindings::wasm_valkind_enum_WASM_FUNCREF => Type::FuncRef,
         _ => unreachable!(
-            "valtype {:?} has no matching valkind and therefore no matching wasmer_types::Type",
-            type_
+            "valtype {type_:?} has no matching valkind and therefore no matching wasmer_types::Type",
         ),
     }
 }

--- a/lib/api/src/c_api/trap.rs
+++ b/lib/api/src/c_api/trap.rs
@@ -63,7 +63,7 @@ impl Trap {
                 let err_ptr = Box::leak(Box::new(err));
                 let mut data = std::mem::zeroed();
                 // let x = format!("")
-                let s1 = format!("🐛{:p}", err_ptr);
+                let s1 = format!("🐛{err_ptr:p}");
                 let _s = s1.into_bytes().into_boxed_slice();
                 wasm_byte_vec_new(&mut data, _s.len(), _s.as_ptr() as _);
                 std::mem::forget(_s);
@@ -76,7 +76,7 @@ impl Trap {
     // pub unsafe fn deserialize_from_wasm_trap(trap: *mut wasm_trap_t) -> Self {
     //     let mut data = std::mem::zeroed();
     //     wasm_trap_message(trap, data);
-    //     println!("data: {:p}", data);
+    //     println!("data: {data:p}");
 
     //     std::ptr::read(data as *const _)
     // }
@@ -126,7 +126,7 @@ impl std::error::Error for Trap {
 impl fmt::Display for Trap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.inner {
-            InnerTrap::User(e) => write!(f, "{}", e),
+            InnerTrap::User(e) => write!(f, "{e}"),
             InnerTrap::CApi(value) => {
                 // let message: wasm_message_t;
                 // wasm_trap_message(value, &mut message);

--- a/lib/api/src/errors.rs
+++ b/lib/api/src/errors.rs
@@ -232,8 +232,8 @@ impl fmt::Display for RuntimeError {
             write!(f, "    at ")?;
             match frame.function_name() {
                 Some(name) => match rustc_demangle::try_demangle(name) {
-                    Ok(name) => write!(f, "{}", name)?,
-                    Err(_) => write!(f, "{}", name)?,
+                    Ok(name) => write!(f, "{name}")?,
+                    Err(_) => write!(f, "{name}")?,
                 },
                 None => write!(f, "<unnamed>")?,
             }

--- a/lib/api/src/externals/function.rs
+++ b/lib/api/src/externals/function.rs
@@ -421,9 +421,7 @@ impl Function {
 
             if expected != given {
                 return Err(RuntimeError::new(format!(
-                    "given types (`{:?}`) for the function arguments don't match the actual types (`{:?}`)",
-                    given,
-                    expected,
+                    "given types (`{given:?}`) for the function arguments don't match the actual types (`{expected:?}`)",
                 )));
             }
         }
@@ -435,9 +433,7 @@ impl Function {
             if expected != given {
                 // todo: error result types don't match
                 return Err(RuntimeError::new(format!(
-                    "given types (`{:?}`) for the function results don't match the actual types (`{:?}`)",
-                    given,
-                    expected,
+                    "given types (`{given:?}`) for the function results don't match the actual types (`{expected:?}`)",
                 )));
             }
         }

--- a/lib/api/src/imports.rs
+++ b/lib/api/src/imports.rs
@@ -225,7 +225,7 @@ impl fmt::Debug for Imports {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 match self {
                     Self::Empty => write!(f, "(empty)"),
-                    Self::Some(len) => write!(f, "(... {} item(s) ...)", len),
+                    Self::Some(len) => write!(f, "(... {len} item(s) ...)"),
                 }
             }
         }

--- a/lib/api/src/module.rs
+++ b/lib/api/src/module.rs
@@ -120,8 +120,7 @@ impl Module {
         #[cfg(feature = "wat")]
         let bytes = wat::parse_bytes(bytes.as_ref()).map_err(|e| {
             CompileError::Wasm(WasmError::Generic(format!(
-                "Error when converting wat: {}",
-                e
+                "Error when converting wat: {e}",
             )))
         })?;
         Self::from_binary(engine, bytes.as_ref())

--- a/lib/api/src/sys/externals/table.rs
+++ b/lib/api/src/sys/externals/table.rs
@@ -105,7 +105,7 @@ impl Table {
         self.handle
             .get_mut(store.objects_mut())
             .grow(delta, item)
-            .ok_or_else(|| RuntimeError::new(format!("failed to grow table by `{}`", delta)))
+            .ok_or_else(|| RuntimeError::new(format!("failed to grow table by `{delta}`")))
     }
 
     pub fn copy(

--- a/lib/api/src/sys/tunables.rs
+++ b/lib/api/src/sys/tunables.rs
@@ -31,7 +31,7 @@ mod tests {
         let style = tunables.memory_style(&requested);
         match style {
             MemoryStyle::Dynamic { offset_guard_size } => assert_eq!(offset_guard_size, 256),
-            s => panic!("Unexpected memory style: {:?}", s),
+            s => panic!("Unexpected memory style: {s:?}"),
         }
 
         // Large maximum
@@ -39,7 +39,7 @@ mod tests {
         let style = tunables.memory_style(&requested);
         match style {
             MemoryStyle::Dynamic { offset_guard_size } => assert_eq!(offset_guard_size, 256),
-            s => panic!("Unexpected memory style: {:?}", s),
+            s => panic!("Unexpected memory style: {s:?}"),
         }
 
         // Small maximum
@@ -53,7 +53,7 @@ mod tests {
                 assert_eq!(bound, Pages(2048));
                 assert_eq!(offset_guard_size, 128);
             }
-            s => panic!("Unexpected memory style: {:?}", s),
+            s => panic!("Unexpected memory style: {s:?}"),
         }
     }
 
@@ -471,7 +471,7 @@ mod tests {
             .get_function("large_local")?
             .call(&mut store, &[]);
 
-        println!("result = {:?}", result);
+        println!("result = {result:?}");
         assert!(result.is_err());
 
         Ok(())

--- a/lib/api/src/value.rs
+++ b/lib/api/src/value.rs
@@ -157,15 +157,15 @@ impl Value {
 impl fmt::Debug for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::I32(v) => write!(f, "I32({:?})", v),
-            Self::I64(v) => write!(f, "I64({:?})", v),
-            Self::F32(v) => write!(f, "F32({:?})", v),
-            Self::F64(v) => write!(f, "F64({:?})", v),
+            Self::I32(v) => write!(f, "I32({v:?})"),
+            Self::I64(v) => write!(f, "I64({v:?})"),
+            Self::F32(v) => write!(f, "F32({v:?})"),
+            Self::F64(v) => write!(f, "F64({v:?})"),
             Self::ExternRef(None) => write!(f, "Null ExternRef"),
-            Self::ExternRef(Some(v)) => write!(f, "ExternRef({:?})", v),
+            Self::ExternRef(Some(v)) => write!(f, "ExternRef({v:?})"),
             Self::FuncRef(None) => write!(f, "Null FuncRef"),
-            Self::FuncRef(Some(v)) => write!(f, "FuncRef({:?})", v),
-            Self::V128(v) => write!(f, "V128({:?})", v),
+            Self::FuncRef(Some(v)) => write!(f, "FuncRef({v:?})"),
+            Self::V128(v) => write!(f, "V128({v:?})"),
         }
     }
 }

--- a/lib/api/tests/import_function.rs
+++ b/lib/api/tests/import_function.rs
@@ -140,7 +140,7 @@ fn back_and_forth_with_imports() -> Result<()> {
     )?;
 
     fn sum(a: i32, b: i32) -> i32 {
-        println!("Summing: {}+{}", a, b);
+        println!("Summing: {a}+{b}");
         a + b
     }
 

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -194,35 +194,35 @@ fn calling_host_functions_with_negative_values_works() -> Result<(), String> {
     let imports = imports! {
         "host" => {
             "host_func1" => Function::new_typed(&mut store, |p: u64| {
-                println!("host_func1: Found number {}", p);
+                println!("host_func1: Found number {p}");
                 assert_eq!(p, u64::max_value());
             }),
             "host_func2" => Function::new_typed(&mut store, |p: u32| {
-                println!("host_func2: Found number {}", p);
+                println!("host_func2: Found number {p}");
                 assert_eq!(p, u32::max_value());
             }),
             "host_func3" => Function::new_typed(&mut store, |p: i64| {
-                println!("host_func3: Found number {}", p);
+                println!("host_func3: Found number {p}");
                 assert_eq!(p, -1);
             }),
             "host_func4" => Function::new_typed(&mut store, |p: i32| {
-                println!("host_func4: Found number {}", p);
+                println!("host_func4: Found number {p}");
                 assert_eq!(p, -1);
             }),
             "host_func5" => Function::new_typed(&mut store, |p: i16| {
-                println!("host_func5: Found number {}", p);
+                println!("host_func5: Found number {p}");
                 assert_eq!(p, -1);
             }),
             "host_func6" => Function::new_typed(&mut store, |p: u16| {
-                println!("host_func6: Found number {}", p);
+                println!("host_func6: Found number {p}");
                 assert_eq!(p, u16::max_value());
             }),
             "host_func7" => Function::new_typed(&mut store, |p: i8| {
-                println!("host_func7: Found number {}", p);
+                println!("host_func7: Found number {p}");
                 assert_eq!(p, -1);
             }),
             "host_func8" => Function::new_typed(&mut store, |p: u8| {
-                println!("host_func8: Found number {}", p);
+                println!("host_func8: Found number {p}");
                 assert_eq!(p, u8::max_value());
             }),
         }

--- a/lib/api/tests/typed_functions.rs
+++ b/lib/api/tests/typed_functions.rs
@@ -14,7 +14,7 @@ fn typed_host_function_closure_panics() -> Result<(), String> {
     let state = 3;
 
     Function::new_typed(&mut store, move |_: i32| {
-        println!("{}", state);
+        println!("{state}");
     });
 
     Ok(())
@@ -34,7 +34,7 @@ fn typed_with_env_host_function_closure_panics() -> Result<(), String> {
         &mut store,
         &env,
         move |_env: FunctionEnvMut<i32>, _: i32| {
-            println!("{}", state);
+            println!("{state}");
         },
     );
 

--- a/lib/backend-api/src/client.rs
+++ b/lib/backend-api/src/client.rs
@@ -45,7 +45,7 @@ impl WasmerClient {
         }
         user_agent
             .parse()
-            .with_context(|| format!("invalid user agent: '{}'", user_agent))
+            .with_context(|| format!("invalid user agent: '{user_agent}'"))
     }
 
     pub fn new_with_client(

--- a/lib/backend-api/src/error.rs
+++ b/lib/backend-api/src/error.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for GraphQLApiFailure {
             .map(|err| err.to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "GraphQL API failure: {}", errs)
+        write!(f, "GraphQL API failure: {errs}")
     }
 }
 

--- a/lib/backend-api/src/global_id.rs
+++ b/lib/backend-api/src/global_id.rs
@@ -371,25 +371,25 @@ impl std::fmt::Display for GlobalIdParseError {
 
         match &self.kind {
             ErrorKind::UnknownPrefix(p) => {
-                write!(f, "unknown type prefix '{}'", p)
+                write!(f, "unknown type prefix '{p}'")
             }
             ErrorKind::Decode(s) => {
-                write!(f, "decode error: {}", s)
+                write!(f, "decode error: {s}")
             }
             ErrorKind::MissingScope => {
                 write!(f, "missing scope value")
             }
             ErrorKind::UnknownScope(x) => {
-                write!(f, "unknown scope value {}", x)
+                write!(f, "unknown scope value {x}")
             }
             ErrorKind::MissingVersion => {
                 write!(f, "missing version value")
             }
             ErrorKind::UnknownVersion(v) => {
-                write!(f, "unknown version value {}", v)
+                write!(f, "unknown version value {v}")
             }
             ErrorKind::UnknownNodeType(t) => {
-                write!(f, "unknown node type '{}'", t)
+                write!(f, "unknown node type '{t}'")
             }
             ErrorKind::MissingPrefix => write!(f, "missing prefix"),
             ErrorKind::PrefixTypeMismatch => write!(f, "prefix type mismatch"),
@@ -412,7 +412,7 @@ mod tests {
             kind: NodeKind::DeployApp,
             database_id: 123,
         };
-        assert_eq!(Ok(x1), GlobalId::parse_prefixed(&x1.encode_prefixed()),);
+        assert_eq!(Ok(x1), GlobalId::parse_prefixed(&x1.encode_prefixed()));
         assert_eq!(Ok(x1), GlobalId::parse_url(&x1.encode_url()));
 
         assert_eq!(
@@ -450,12 +450,12 @@ mod tests {
 
     #[test]
     fn test_global_id_parse_values() {
-        assert_eq!(GlobalId::parse_values(&[]), Err(ErrorKind::MissingScope),);
+        assert_eq!(GlobalId::parse_values(&[]), Err(ErrorKind::MissingScope));
         assert_eq!(
             GlobalId::parse_values(&[2]),
             Err(ErrorKind::UnknownScope(2)),
         );
-        assert_eq!(GlobalId::parse_values(&[1]), Err(ErrorKind::MissingVersion),);
+        assert_eq!(GlobalId::parse_values(&[1]), Err(ErrorKind::MissingVersion));
         assert_eq!(
             GlobalId::parse_values(&[1, 999]),
             Err(ErrorKind::UnknownVersion(999)),

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1075,7 +1075,7 @@ pub async fn app_deployment(
 ) -> Result<types::AutobuildRepository, anyhow::Error> {
     let node = get_node(client, id.clone())
         .await?
-        .with_context(|| format!("app deployment with id '{}' not found", id))?;
+        .with_context(|| format!("app deployment with id '{id}' not found"))?;
     match node {
         types::Node::AutobuildRepository(x) => Ok(*x),
         _ => anyhow::bail!("invalid node type returned"),
@@ -1429,7 +1429,7 @@ pub async fn namespace_apps(
 
         let ns = res
             .get_namespace
-            .with_context(|| format!("failed to get namespace '{}'", namespace))?;
+            .with_context(|| format!("failed to get namespace '{namespace}'"))?;
 
         let apps: Vec<_> = ns
             .apps

--- a/lib/backend-api/src/subscription.rs
+++ b/lib/backend-api/src/subscription.rs
@@ -38,7 +38,7 @@ pub async fn package_version_ready(
     if let Some(token) = client.auth_token() {
         req.headers_mut().insert(
             reqwest::header::AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", token))?,
+            HeaderValue::from_str(&format!("Bearer {token}"))?,
         );
     }
 

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -138,8 +138,7 @@ fn build_wasm_c_api_headers(crate_dir: &str, out_dir: &str) {
 #if !defined(WASMER_H_PRELUDE)
 
 #define WASMER_H_PRELUDE
-{pre_header}"#,
-        pre_header = PRE_HEADER
+{PRE_HEADER}"#,
     );
 
     map_feature_as_c_define!("jsc", JSC_FEATURE_AS_C_DEFINE, pre_header);
@@ -245,10 +244,7 @@ fn build_inline_c_env_vars() {
     );
 
     if let Ok(compiler_engine) = env::var("TEST") {
-        println!(
-            "cargo:rustc-env=INLINE_C_RS_TEST={test}",
-            test = compiler_engine
-        );
+        println!("cargo:rustc-env=INLINE_C_RS_TEST={compiler_engine}");
     }
 
     println!(
@@ -294,6 +290,7 @@ fn build_cdylib_link_arg() {
         }
 
         ("macos", _) | ("ios", _) => {
+            #[allow(clippy::uninlined_format_args)]
             lines.push(format!(
                 "-Wl,-install_name,@rpath/libwasmer.dylib,-current_version,{x}.{y}.{z},-compatibility_version,{x}",
                 x = version_major,
@@ -318,7 +315,7 @@ fn build_cdylib_link_arg() {
     }
 
     for line in lines {
-        println!("cargo:rustc-cdylib-link-arg={}", line);
+        println!("cargo:rustc-cdylib-link-arg={line}");
     }
 }
 

--- a/lib/c-api/examples/wasmer-capi-examples-runner/src/lib.rs
+++ b/lib/c-api/examples/wasmer-capi-examples-runner/src/lib.rs
@@ -172,7 +172,7 @@ pub const TESTS: &[&str] = &[
 fn test_run() {
     let _drop = RemoveTestsOnDrop::default();
     let config = Config::get();
-    println!("config: {:#?}", config);
+    println!("config: {config:#?}");
 
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let host = target_lexicon::HOST.to_string();
@@ -453,7 +453,7 @@ fn fixup_symlinks_inner(include_paths: &[String], log: &mut String) -> Result<()
             _ => continue,
         };
         let lines_3 = file.lines().take(3).collect::<Vec<_>>();
-        log.push_str(&format!("first 3 lines of {path:?}: {:#?}\n", lines_3));
+        log.push_str(&format!("first 3 lines of {path:?}: {lines_3:#?}\n"));
 
         let parent = std::path::Path::new(&path).parent().unwrap();
         if let Ok(symlink) = std::fs::read_to_string(parent.join(&file)) {
@@ -466,7 +466,7 @@ fn fixup_symlinks_inner(include_paths: &[String], log: &mut String) -> Result<()
             .captures_iter(&file)
             .map(|c| c[1].to_string())
             .collect::<Vec<_>>();
-        log.push_str(&format!("regex captures: ({path:?}): {:#?}\n", filepaths));
+        log.push_str(&format!("regex captures: ({path:?}): {filepaths:#?}\n"));
         let joined_filepaths = filepaths
             .iter()
             .map(|s| {

--- a/lib/c-api/src/wasm_c_api/types/frame.rs
+++ b/lib/c-api/src/wasm_c_api/types/frame.rs
@@ -123,5 +123,5 @@ fn test_frame_name() {
         wasm_name_delete(Some(&mut wasm_frame_module_name));
     }
 
-    println!("{:#?}", info);
+    println!("{info:#?}");
 }

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -450,7 +450,7 @@ fn read_inner(
         match wasi_file.read(inner_buffer).await {
             Ok(a) => a as isize,
             Err(err) => {
-                update_last_error(format!("failed to read wasi_file: {}", err));
+                update_last_error(format!("failed to read wasi_file: {err}"));
                 -1
             }
         }

--- a/lib/c-api/tests/wasmer-c-api-test-runner/src/lib.rs
+++ b/lib/c-api/tests/wasmer-c-api-test-runner/src/lib.rs
@@ -115,7 +115,7 @@ pub const CAPI_BASE_TESTS_NOT_WORKING: &[&str] = &[
 fn test_ok() {
     let _drop = RemoveTestsOnDrop::default();
     let config = Config::get();
-    println!("config: {:#?}", config);
+    println!("config: {config:#?}");
 
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let host = target_lexicon::HOST.to_string();
@@ -143,7 +143,7 @@ fn test_ok() {
 
             let compiler = build.try_get_compiler().unwrap();
 
-            println!("compiler {:#?}", compiler);
+            println!("compiler {compiler:#?}");
 
             // run vcvars
             let vcvars_bat_path = find_vcvars64(&compiler).expect("no vcvars64.bat");
@@ -202,7 +202,7 @@ fn test_ok() {
             if !output.status.success() {
                 println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
                 println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-                println!("output: {:#?}", output);
+                println!("output: {output:#?}");
                 // print_wasmer_root_to_stdout(&config);
                 panic!("failed to compile {test}");
             }
@@ -224,7 +224,7 @@ fn test_ok() {
             if !output.status.success() {
                 println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
                 println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-                println!("output: {:#?}", output);
+                println!("output: {output:#?}");
                 // print_wasmer_root_to_stdout(&config);
                 panic!("failed to execute {test}");
             }
@@ -411,7 +411,7 @@ fn fixup_symlinks_inner(include_paths: &[String], log: &mut String) -> Result<()
             _ => continue,
         };
         let lines_3 = file.lines().take(3).collect::<Vec<_>>();
-        log.push_str(&format!("first 3 lines of {path:?}: {:#?}\n", lines_3));
+        log.push_str(&format!("first 3 lines of {path:?}: {lines_3:#?}\n"));
 
         let parent = std::path::Path::new(&path).parent().unwrap();
         if let Ok(symlink) = std::fs::read_to_string(parent.join(&file)) {
@@ -424,7 +424,7 @@ fn fixup_symlinks_inner(include_paths: &[String], log: &mut String) -> Result<()
             .captures_iter(&file)
             .map(|c| c[1].to_string())
             .collect::<Vec<_>>();
-        log.push_str(&format!("regex captures: ({path:?}): {:#?}\n", filepaths));
+        log.push_str(&format!("regex captures: ({path:?}): {filepaths:#?}\n"));
         let joined_filepaths = filepaths
             .iter()
             .map(|s| {

--- a/lib/cache/src/filesystem.rs
+++ b/lib/cache/src/filesystem.rs
@@ -98,7 +98,7 @@ impl Cache for FileSystemCache {
         key: Hash,
     ) -> Result<Module, Self::DeserializeError> {
         let filename = if let Some(ref ext) = self.ext {
-            format!("{}.{}", key, ext)
+            format!("{key}.{ext}")
         } else {
             key.to_string()
         };
@@ -114,7 +114,7 @@ impl Cache for FileSystemCache {
 
     fn store(&mut self, key: Hash, module: &Module) -> Result<(), Self::SerializeError> {
         let filename = if let Some(ref ext) = self.ext {
-            format!("{}.{}", key, ext)
+            format!("{key}.{ext}")
         } else {
             key.to_string()
         };

--- a/lib/cache/src/hash.rs
+++ b/lib/cache/src/hash.rs
@@ -46,8 +46,7 @@ impl FromStr for Hash {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s).map_err(|e| {
             DeserializeError::Generic(format!(
-                "Could not decode prehashed key as hexadecimal: {}",
-                e
+                "Could not decode prehashed key as hexadecimal: {e}",
             ))
         })?;
         if bytes.len() != 32 {
@@ -56,7 +55,7 @@ impl FromStr for Hash {
             ));
         }
         Ok(Self(bytes[0..32].try_into().map_err(|e| {
-            DeserializeError::Generic(format!("Could not get first 32 bytes: {}", e))
+            DeserializeError::Generic(format!("Could not get first 32 bytes: {e}"))
         })?))
     }
 }

--- a/lib/cli-compiler/src/commands/compile.rs
+++ b/lib/cli-compiler/src/commands/compile.rs
@@ -82,7 +82,7 @@ impl Compile {
         }
         let tunables = self.store.get_tunables_for_target(&target)?;
 
-        println!("Compiler: {}", compiler_type);
+        println!("Compiler: {compiler_type}");
         println!("Target: {}", target.triple());
 
         // compile and save the artifact (without using module from api)

--- a/lib/cli-compiler/src/commands/config.rs
+++ b/lib/cli-compiler/src/commands/config.rs
@@ -57,8 +57,7 @@ impl Config {
                 Some(dir)
             })
             .context(format!(
-                "failed to retrieve the {} environment variables",
-                key
+                "failed to retrieve the {key} environment variables",
             ))?;
 
         let prefix = PathBuf::from(wasmer_dir);
@@ -67,40 +66,40 @@ impl Config {
         let bindir = prefix.join("bin").display().to_string();
         let includedir = prefix.join("include").display().to_string();
         let libdir = prefix.join("lib").display().to_string();
-        let cflags = format!("-I{}", includedir);
-        let libs = format!("-L{} -lwasmer", libdir);
+        let cflags = format!("-I{includedir}");
+        let libs = format!("-L{libdir} -lwasmer");
 
         if self.pkg_config {
-            println!("prefix={}", prefixdir);
-            println!("exec_prefix={}", bindir);
-            println!("includedir={}", includedir);
-            println!("libdir={}", libdir);
+            println!("prefix={prefixdir}");
+            println!("exec_prefix={bindir}");
+            println!("includedir={includedir}");
+            println!("libdir={libdir}");
             println!();
             println!("Name: wasmer");
             println!("Description: The Wasmer library for running WebAssembly");
-            println!("Version: {}", VERSION);
-            println!("Cflags: {}", cflags);
-            println!("Libs: {}", libs);
+            println!("Version: {VERSION}");
+            println!("Cflags: {cflags}");
+            println!("Libs: {libs}");
             return Ok(());
         }
 
         if self.prefix {
-            println!("{}", prefixdir);
+            println!("{prefixdir}");
         }
         if self.bindir {
-            println!("{}", bindir);
+            println!("{bindir}");
         }
         if self.includedir {
-            println!("{}", includedir);
+            println!("{includedir}");
         }
         if self.libdir {
-            println!("{}", libdir);
+            println!("{libdir}");
         }
         if self.libs {
-            println!("{}", libs);
+            println!("{libs}");
         }
         if self.cflags {
-            println!("{}", cflags);
+            println!("{cflags}");
         }
         Ok(())
     }

--- a/lib/cli-compiler/src/error.rs
+++ b/lib/cli-compiler/src/error.rs
@@ -55,7 +55,7 @@ impl Debug for PrettyError {
                     is_last: n == total_errors - 1,
                     started: false,
                 };
-                write!(indented, "{}", error)?;
+                write!(indented, "{error}")?;
             }
         }
         Ok(())
@@ -84,14 +84,14 @@ where
                                 self.inner,
                                 "{} {: >4} ",
                                 "│".bold().blue(),
-                                format!("{}:", number).dimmed()
+                                format!("{number}:").dimmed()
                             )?
                         } else {
                             write!(
                                 self.inner,
                                 "{}{: >2}: ",
                                 "╰─▶".bold().blue(),
-                                format!("{}", number).bold().blue()
+                                format!("{number}").bold().blue()
                             )?
                         }
                     }

--- a/lib/cli-compiler/src/store.rs
+++ b/lib/cli-compiler/src/store.rs
@@ -308,7 +308,7 @@ impl CompilerOptions {
                 }
                 Box::new(config)
             }
-            #[cfg(not(all(feature = "singlepass", feature = "cranelift", feature = "llvm",)))]
+            #[cfg(not(all(feature = "singlepass", feature = "cranelift", feature = "llvm")))]
             compiler => {
                 bail!(
                     "The `{}` compiler is not included in this binary.",

--- a/lib/cli/build.rs
+++ b/lib/cli/build.rs
@@ -10,7 +10,7 @@ pub fn main() {
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .unwrap_or_default();
-    println!("cargo:rustc-env=WASMER_BUILD_GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=WASMER_BUILD_GIT_HASH={git_hash}");
 
     if git_hash.len() > 5 {
         println!(
@@ -23,5 +23,5 @@ pub fn main() {
 
     let utc: DateTime<Utc> = Utc::now();
     let date = utc.format("%Y-%m-%d").to_string();
-    println!("cargo:rustc-env=WASMER_BUILD_DATE={}", date);
+    println!("cargo:rustc-env=WASMER_BUILD_DATE={date}");
 }

--- a/lib/cli/src/c_gen/mod.rs
+++ b/lib/cli/src/c_gen/mod.rs
@@ -326,7 +326,7 @@ impl CStatement {
                 w.push_str("typedef ");
                 // leaky abstraction / hack, doesn't fully solve the problem
                 if let CType::Function { .. } = source_type {
-                    source_type.generate_c_with_name(&format!("(*{})", new_name), w);
+                    source_type.generate_c_with_name(&format!("(*{new_name})"), w);
                 } else {
                     source_type.generate_c(w);
                     w.push(' ');

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -423,14 +423,14 @@ impl AsyncCliCommand for CmdAppDeploy {
                                         "Found local package (manifest path: {}).",
                                         manifest_path.display()
                                     );
-                                    eprintln!("The `package` field in `app.yaml` specified the same named package ({}).", name);
+                                    eprintln!("The `package` field in `app.yaml` specified the same named package ({name}).");
                                     eprintln!("This behaviour is deprecated.");
                                 }
 
                                 let theme = dialoguer::theme::ColorfulTheme::default();
                                 if self.non_interactive {
                                     if !self.quiet {
-                                        eprintln!("Hint: replace `package: {}` with `package: .` to replicate the intended behaviour.", n);
+                                        eprintln!("Hint: replace `package: {n}` with `package: .` to replicate the intended behaviour.");
                                     }
                                     anyhow::bail!("deprecated deploy behaviour")
                                 } else if Confirm::with_theme(&theme)
@@ -565,7 +565,7 @@ impl AsyncCliCommand for CmdAppDeploy {
         };
 
         if !self.quiet {
-            eprintln!("\nDeploying app {} to Wasmer Edge...\n", pretty_name);
+            eprintln!("\nDeploying app {pretty_name} to Wasmer Edge...\n");
         }
 
         let app_version = deploy_app(&client, opts.clone()).await?;

--- a/lib/cli/src/commands/app/util.rs
+++ b/lib/cli/src/commands/app/util.rs
@@ -35,13 +35,13 @@ impl AppIdent {
             AppIdent::AppId(app_id) => {
                 wasmer_backend_api::query::get_app_by_id(client, app_id.clone())
                     .await
-                    .with_context(|| format!("Could not find app with id '{}'", app_id))
+                    .with_context(|| format!("Could not find app with id '{app_id}'"))
             }
             AppIdent::AppVersionId(id) => {
                 let (app, _version) =
                     wasmer_backend_api::query::get_app_version_by_id_with_app(client, id.clone())
                         .await
-                        .with_context(|| format!("Could not query for app version id '{}'", id))?;
+                        .with_context(|| format!("Could not query for app version id '{id}'"))?;
                 Ok(app)
             }
             AppIdent::Name(name) => {

--- a/lib/cli/src/commands/auth/login/auth_server.rs
+++ b/lib/cli/src/commands/auth/login/auth_server.rs
@@ -27,7 +27,7 @@ pub(super) async fn setup_listener() -> Result<(TcpListener, String), anyhow::Er
     let addr = listener.local_addr()?;
     let port = addr.port();
 
-    let server_url = format!("http://localhost:{}", port);
+    let server_url = format!("http://localhost:{port}");
 
     Ok((listener, server_url))
 }

--- a/lib/cli/src/commands/auth/login/mod.rs
+++ b/lib/cli/src/commands/auth/login/mod.rs
@@ -130,7 +130,7 @@ impl Login {
                     let fut = graceful.watch(conn);
                     futs.push(async move {
                         if let Err(e) = fut.await {
-                            eprintln!("Error serving connection: {:?}", e);
+                            eprintln!("Error serving connection: {e:?}");
                         }
                     });
                 },

--- a/lib/cli/src/commands/compile.rs
+++ b/lib/cli/src/commands/compile.rs
@@ -80,7 +80,7 @@ impl Compile {
                 warning!("the output file has no extension. We recommend using `{}.{}` for the chosen target", &output_filename, &recommended_extension)
             }
         }
-        println!("Compiler: {}", compiler_type);
+        println!("Compiler: {compiler_type}");
         println!("Target: {}", target.triple());
 
         let module = Module::from_file(&store, &self.path)?;

--- a/lib/cli/src/commands/config.rs
+++ b/lib/cli/src/commands/config.rs
@@ -190,40 +190,40 @@ impl Config {
         let bindir = prefix.join("bin").display().to_string();
         let includedir = prefix.join("include").display().to_string();
         let libdir = prefix.join("lib").display().to_string();
-        let cflags = format!("-I{}", includedir);
-        let libs = format!("-L{} -lwasmer", libdir);
+        let cflags = format!("-I{includedir}");
+        let libs = format!("-L{libdir} -lwasmer");
 
         if flags.pkg_config {
-            println!("prefix={}", prefixdir);
-            println!("exec_prefix={}", bindir);
-            println!("includedir={}", includedir);
-            println!("libdir={}", libdir);
+            println!("prefix={prefixdir}");
+            println!("exec_prefix={bindir}");
+            println!("includedir={includedir}");
+            println!("libdir={libdir}");
             println!();
             println!("Name: wasmer");
             println!("Description: The Wasmer library for running WebAssembly");
-            println!("Version: {}", VERSION);
-            println!("Cflags: {}", cflags);
-            println!("Libs: {}", libs);
+            println!("Version: {VERSION}");
+            println!("Cflags: {cflags}");
+            println!("Libs: {libs}");
             return Ok(());
         }
 
         if flags.prefix {
-            println!("{}", prefixdir);
+            println!("{prefixdir}");
         }
         if flags.bindir {
-            println!("{}", bindir);
+            println!("{bindir}");
         }
         if flags.includedir {
-            println!("{}", includedir);
+            println!("{includedir}");
         }
         if flags.libdir {
-            println!("{}", libdir);
+            println!("{libdir}");
         }
         if flags.libs {
-            println!("{}", libs);
+            println!("{libs}");
         }
         if flags.cflags {
-            println!("{}", cflags);
+            println!("{cflags}");
         }
 
         if flags.config_path {

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -237,7 +237,7 @@ impl CliCommand for CreateExe {
         let hash_algorithm = self.hash_algorithm.unwrap_or_default().into();
         engine.set_hash_algorithm(Some(hash_algorithm));
 
-        println!("Compiler: {}", compiler_type);
+        println!("Compiler: {compiler_type}");
         println!("Target: {}", target.triple());
         println!(
             "Using path `{}` as libwasmer path.",
@@ -376,7 +376,7 @@ pub(super) fn compile_pirita_into_directory(
         AllowMultiWasm::Reject(Some(s)) => {
             let atom = pirita
                 .get_atom(s)
-                .with_context(|| format!("could not find atom \"{s}\"",))?;
+                .with_context(|| format!("could not find atom \"{s}\""))?;
             vec![(s.to_string(), atom)]
         }
     };
@@ -885,7 +885,7 @@ fn run_c_compile(
 
     // On some compiler -target isn't implemented
     if *target != Triple::host() {
-        command = command.arg("-target").arg(format!("{}", target));
+        command = command.arg("-target").arg(format!("{target}"));
     }
 
     let command = command.arg("-o").arg(output_name);
@@ -1410,7 +1410,7 @@ fn link_objects_system_linker(
 
     if *target != Triple::host() {
         command = command.arg("-target");
-        command = command.arg(format!("{}", target));
+        command = command.arg(format!("{target}"));
     }
 
     for include_dir in include_dirs {
@@ -1436,11 +1436,11 @@ fn link_objects_system_linker(
     } else {
         additional_libraries.extend(LINK_SYSTEM_LIBRARIES_UNIX.iter().map(|s| s.to_string()));
     }
-    let link_against_extra_libs = additional_libraries.iter().map(|lib| format!("-l{}", lib));
+    let link_against_extra_libs = additional_libraries.iter().map(|lib| format!("-l{lib}"));
     let command = command.args(link_against_extra_libs);
     let command = command.arg("-o").arg(output_path);
     if debug {
-        println!("{:#?}", command);
+        println!("{command:#?}");
     }
     let output = command.output()?;
 
@@ -1556,8 +1556,7 @@ fn generate_wasmer_main_c(
                 })?;
             writeln!(
                 c_code_to_instantiate,
-                "if (strcmp(selected_atom, \"{a}\") == 0) {{ module = atom_{}; }}",
-                prefix
+                "if (strcmp(selected_atom, \"{a}\") == 0) {{ module = atom_{prefix}; }}",
             )?;
         }
     }
@@ -1861,7 +1860,7 @@ pub(super) mod utils {
             Environment::Msvc => "msvc",
             _ => "none",
         };
-        format!("{}-{}-{}", arch, os, env)
+        format!("{arch}-{os}-{env}")
     }
 
     pub(super) fn get_wasmer_include_directory(env: &WasmerEnv) -> anyhow::Result<PathBuf> {
@@ -2311,10 +2310,7 @@ mod http_fetch {
                 }
             }
             Err(err) => {
-                eprintln!(
-                    "Could not determine cache path for downloaded binaries.: {}",
-                    err
-                );
+                eprintln!("Could not determine cache path for downloaded binaries.: {err}");
                 Err(anyhow!("Could not determine libwasmer cache path"))
             }
         }

--- a/lib/cli/src/commands/create_obj.rs
+++ b/lib/cli/src/commands/create_obj.rs
@@ -81,7 +81,7 @@ impl CreateObj {
             &self.cpu_features,
         );
         let (_, compiler_type) = self.compiler.get_store_for_target(target.clone())?;
-        println!("Compiler: {}", compiler_type);
+        println!("Compiler: {compiler_type}");
         println!("Target: {}", target.triple());
 
         let atoms = if let Ok(webc) = from_disk(&input_path) {

--- a/lib/cli/src/commands/domain/zonefile.rs
+++ b/lib/cli/src/commands/domain/zonefile.rs
@@ -46,7 +46,7 @@ impl AsyncCliCommand for CmdZoneFileGet {
                 std::fs::write(zone_file_path, zone_file_contents)
                     .context("Unable to write file")?;
             } else {
-                println!("{}", zone_file_contents);
+                println!("{zone_file_contents}");
             }
         } else {
             anyhow::bail!("Domain not found");

--- a/lib/cli/src/commands/journal/filter.rs
+++ b/lib/cli/src/commands/journal/filter.rs
@@ -35,7 +35,7 @@ impl FromStr for FilterOut {
             "core" => Self::Core,
             "snap" | "snapshot" | "snapshots" => Self::Snapshots,
             "net" | "network" | "networking" => Self::Networking,
-            t => return Err(format!("unknown filter type - {}", t)),
+            t => return Err(format!("unknown filter type - {t}")),
         })
     }
 }

--- a/lib/cli/src/commands/journal/import.rs
+++ b/lib/cli/src/commands/journal/import.rs
@@ -46,7 +46,7 @@ impl CliCommand for CmdJournalImport {
             }
 
             let record = serde_json::from_str::<JournalEntry<'static>>(&lines)?;
-            println!("{}", record);
+            println!("{record}");
             journal.write(record)?;
             lines.clear();
         }

--- a/lib/cli/src/commands/package/build.rs
+++ b/lib/cli/src/commands/package/build.rs
@@ -70,10 +70,10 @@ impl PackageBuild {
                     format!("{}-{}.webc", name.replace('/', "-"), pkg_hash)
                 }
             } else {
-                format!("{}.webc", pkg_hash)
+                format!("{pkg_hash}.webc")
             }
         } else {
-            format!("{}.webc", pkg_hash)
+            format!("{pkg_hash}.webc")
         };
 
         // Setup the progress bar

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -162,13 +162,13 @@ pub(super) async fn upload(
     let res = client
         .put(&session_uri)
         .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
-        .header(reqwest::header::CONTENT_LENGTH, format!("{}", total_bytes))
+        .header(reqwest::header::CONTENT_LENGTH, format!("{total_bytes}"))
         .body(Body::wrap_stream(stream));
 
     res.send()
         .await
         .map(|response| response.error_for_status())
-        .map_err(|e| anyhow::anyhow!("error uploading package to {session_uri}: {e}",))??;
+        .map_err(|e| anyhow::anyhow!("error uploading package to {session_uri}: {e}"))??;
 
     Ok(session_uri)
 }

--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -56,9 +56,7 @@ impl PackageDownload {
 
         pb.println(format!(
             "{} {}Creating output directory...",
-            style(format!("[{}/{}]", step_num, total_steps))
-                .bold()
-                .dim(),
+            style(format!("[{step_num}/{total_steps}]")).bold().dim(),
             CREATING_OUTPUT_DIRECTORY_EMOJI,
         ));
 
@@ -84,9 +82,7 @@ impl PackageDownload {
 
         pb.println(format!(
             "{} {}Retrieving package information...",
-            style(format!("[{}/{}]", step_num, total_steps))
-                .bold()
-                .dim(),
+            style(format!("[{step_num}/{total_steps}]")).bold().dim(),
             RETRIEVING_PACKAGE_INFORMATION_EMOJI
         ));
 
@@ -151,7 +147,7 @@ impl PackageDownload {
                     .with_context(|| format!("Package with {hash} does not exist in the registry, or is not accessible"))?;
 
                 let ident = hash.to_string();
-                let filename = format!("{}.webc", hash);
+                let filename = format!("{hash}.webc");
 
                 (pkg.webc_url, ident, filename)
             }
@@ -173,12 +169,8 @@ impl PackageDownload {
             .header(http::header::ACCEPT, "application/webc");
 
         pb.println(format!(
-            "{} {}Downloading package {} ...",
-            style(format!("[{}/{}]", step_num, total_steps))
-                .bold()
-                .dim(),
-            DOWNLOADING_PACKAGE_EMOJI,
-            ident,
+            "{} {DOWNLOADING_PACKAGE_EMOJI}Downloading package {ident} ...",
+            style(format!("[{step_num}/{total_steps}]")).bold().dim(),
         ));
 
         step_num += 1;
@@ -221,8 +213,7 @@ impl PackageDownload {
         if !(accepted_contenttypes.contains(&ty)) {
             eprintln!(
                 "Warning: response has invalid content type - expected \
-                 one of {:?}, got {ty}",
-                accepted_contenttypes
+                 one of {accepted_contenttypes:?}, got {ty}",
             );
         }
 
@@ -234,11 +225,8 @@ impl PackageDownload {
         if self.validate {
             if !self.quiet {
                 println!(
-                    "{} {}Validating package...",
-                    style(format!("[{}/{}]", step_num, total_steps))
-                        .bold()
-                        .dim(),
-                    VALIDATING_PACKAGE_EMOJI
+                    "{} {VALIDATING_PACKAGE_EMOJI}Validating package...",
+                    style(format!("[{step_num}/{total_steps}]")).bold().dim(),
                 );
             }
 
@@ -262,11 +250,8 @@ impl PackageDownload {
         })?;
 
         pb.println(format!(
-            "{} {}Package downloaded to '{}'",
-            style(format!("[{}/{}]", step_num, total_steps))
-                .bold()
-                .dim(),
-            WRITING_PACKAGE_EMOJI,
+            "{} {WRITING_PACKAGE_EMOJI}Package downloaded to '{}'",
+            style(format!("[{step_num}/{total_steps}]")).bold().dim(),
             out_path.display()
         ));
 

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -231,7 +231,7 @@ impl PackageTag {
         match r.await? {
             Some(r) => {
                 if r.success {
-                    spinner_ok!(pb, format!("Successfully tagged package {id}",));
+                    spinner_ok!(pb, format!("Successfully tagged package {id}"));
                     if let Some(package_version) = r.package_version {
                         wait_package(client, self.wait, package_version.id, self.timeout).await?;
                     }

--- a/lib/cli/src/commands/run/capabilities/mod.rs
+++ b/lib/cli/src/commands/run/capabilities/mod.rs
@@ -90,7 +90,7 @@ pub(crate) fn get_capability_cache_path(
                     n.name
                 ),
                 wasmer_config::package::PackageIdent::Hash(h) => {
-                    format!("hash_{}", h)
+                    format!("hash_{h}")
                 }
             },
             PackageSpecifier::Path(f) => {

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -639,7 +639,7 @@ impl TargetOnDisk {
         let mut buffer = [0_u8; 512];
 
         let mut f = File::open(path)
-            .with_context(|| format!("Unable to open \"{}\" for reading", path.display(),))?;
+            .with_context(|| format!("Unable to open \"{}\" for reading", path.display()))?;
         let bytes_read = f.read(&mut buffer)?;
 
         let leading_bytes = &buffer[..bytes_read];

--- a/lib/cli/src/commands/ssh.rs
+++ b/lib/cli/src/commands/ssh.rs
@@ -75,10 +75,7 @@ impl AsyncCliCommand for CmdSsh {
             ])
             .args(["-p", format!("{port}").as_str()]);
         for map_port in self.map_port {
-            cmd = cmd.args([
-                "-L",
-                format!("{}:localhost:{}", map_port, map_port).as_str(),
-            ]);
+            cmd = cmd.args(["-L", format!("{map_port}:localhost:{map_port}").as_str()]);
         }
 
         cmd = cmd.arg(format!("{token}@{host}")).arg(self.run.as_str());

--- a/lib/cli/src/error.rs
+++ b/lib/cli/src/error.rs
@@ -94,7 +94,7 @@ impl Debug for PrettyError {
                     is_last: n == total_errors - 1,
                     started: false,
                 };
-                write!(indented, "{}", error)?;
+                write!(indented, "{error}")?;
             }
         }
         Ok(())
@@ -123,14 +123,14 @@ where
                                 self.inner,
                                 "{} {: >4} ",
                                 "│".bold().blue(),
-                                format!("{}:", number).dimmed()
+                                format!("{number}:").dimmed()
                             )?
                         } else {
                             write!(
                                 self.inner,
                                 "{}{: >2}: ",
                                 "╰─▶".bold().blue(),
-                                format!("{}", number).bold().blue()
+                                format!("{number}").bold().blue()
                             )?
                         }
                     }

--- a/lib/cli/src/store.rs
+++ b/lib/cli/src/store.rs
@@ -296,7 +296,7 @@ impl CompilerOptions {
                 }
                 Box::new(config)
             }
-            #[cfg(not(all(feature = "singlepass", feature = "cranelift", feature = "llvm",)))]
+            #[cfg(not(all(feature = "singlepass", feature = "cranelift", feature = "llvm")))]
             compiler => {
                 bail!(
                     "The `{}` compiler is not included in this binary.",

--- a/lib/compiler-cranelift/build.rs
+++ b/lib/compiler-cranelift/build.rs
@@ -11,5 +11,5 @@ fn main() {
         Ok(output) => str::from_utf8(&output.stdout).unwrap().trim().to_string(),
         Err(_) => env!("CARGO_PKG_VERSION").to_string(),
     };
-    println!("cargo:rustc-env=GIT_REV={}", git_rev);
+    println!("cargo:rustc-env=GIT_REV={git_rev}");
 }

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -2722,7 +2722,7 @@ fn mem_op_size(opcode: ir::Opcode, ty: Type) -> u8 {
         ir::Opcode::Istore16 | ir::Opcode::Sload16 | ir::Opcode::Uload16 => 2,
         ir::Opcode::Istore32 | ir::Opcode::Sload32 | ir::Opcode::Uload32 => 4,
         ir::Opcode::Store | ir::Opcode::Load => u8::try_from(ty.bytes()).unwrap(),
-        _ => panic!("unknown size of mem op for {:?}", opcode),
+        _ => panic!("unknown size of mem op for {opcode:?}"),
     }
 }
 

--- a/lib/compiler-cranelift/src/translator/translation_utils.rs
+++ b/lib/compiler-cranelift/src/translator/translation_utils.rs
@@ -86,7 +86,7 @@ pub fn irreloc_to_relocationkind(reloc: Reloc) -> RelocationKind {
         Reloc::X86GOTPCRel4 => RelocationKind::X86GOTPCRel4,
         Reloc::Arm64Call => RelocationKind::Arm64Call,
         Reloc::RiscvCallPlt => RelocationKind::RiscvCall,
-        _ => panic!("The relocation {} is not yet supported.", reloc),
+        _ => panic!("The relocation {reloc} is not yet supported."),
     }
 }
 
@@ -116,8 +116,7 @@ pub fn block_with_params<'a, PE: TargetEnvironment + ?Sized>(
                     builder.append_block_param(block, environ.reference_type());
                 } else {
                     return Err(WasmError::Unsupported(format!(
-                        "unsupported reference type: {:?}",
-                        ty
+                        "unsupported reference type: {ty:?}"
                     )));
                 }
             }

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -200,7 +200,7 @@ impl LLVM {
         // are compliant with the same string representations as gcc.
         let llvm_cpu_features = cpu_features
             .iter()
-            .map(|feature| format!("+{}", feature))
+            .map(|feature| format!("+{feature}"))
             .join(",");
 
         let target_triple = self.target_triple(target);

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -16,11 +16,11 @@ use wasmer_compiler::types::{
 use wasmer_vm::libcalls::LibCall;
 
 fn map_tryfromint_err(error: TryFromIntError) -> CompileError {
-    CompileError::Codegen(format!("int doesn't fit: {}", error))
+    CompileError::Codegen(format!("int doesn't fit: {error}"))
 }
 
 fn map_object_err(error: object::read::Error) -> CompileError {
-    CompileError::Codegen(format!("error parsing object file: {}", error))
+    CompileError::Codegen(format!("error parsing object file: {error}"))
 }
 
 pub struct CompiledFunction {
@@ -132,7 +132,7 @@ where
 
     let root_section_index = elf
         .section_by_name(root_section)
-        .ok_or_else(|| CompileError::Codegen(format!("no section named {}", root_section)))?
+        .ok_or_else(|| CompileError::Codegen(format!("no section named {root_section}")))?
         .index();
 
     let mut section_to_custom_section = HashMap::new();
@@ -310,8 +310,7 @@ where
 
                 _ => {
                     return Err(CompileError::Codegen(format!(
-                        "unknown relocation {:?}",
-                        reloc
+                        "unknown relocation {reloc:?}",
                     )));
                 }
             };
@@ -334,8 +333,7 @@ where
                             }
                             _ => {
                                 return Err(CompileError::Codegen(format!(
-                                    "relocation targets unknown section {:?}",
-                                    reloc
+                                    "relocation targets unknown section {reloc:?}",
                                 )));
                             }
                         }
@@ -361,8 +359,7 @@ where
                         }
                     } else {
                         return Err(CompileError::Codegen(format!(
-                            "relocation targets unknown symbol {:?}",
-                            reloc
+                            "relocation targets unknown symbol {reloc:?}",
                         )));
                     }
                 }
@@ -383,8 +380,7 @@ where
                     // addresses in them because none of the parts of the Wasm
                     // VM, nor the generated code are loaded at fixed addresses.
                     return Err(CompileError::Codegen(format!(
-                        "relocation targets absolute address {:?}",
-                        reloc
+                        "relocation targets absolute address {reloc:?}",
                     )));
                 }
 
@@ -396,8 +392,7 @@ where
                 // be added to account for any future variants.
                 t => {
                     return Err(CompileError::Codegen(format!(
-                        "relocation target is unknown `{:?}`",
-                        t
+                        "relocation target is unknown `{t:?}`",
                     )));
                 }
             };
@@ -419,8 +414,7 @@ where
             section_to_custom_section.get(index).map_or_else(
                 || {
                     Err(CompileError::Codegen(format!(
-                        ".eh_frame section with index={:?} was never loaded",
-                        index
+                        ".eh_frame section with index={index:?} was never loaded",
                     )))
                 },
                 |idx| Ok(*idx),

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -139,8 +139,7 @@ impl FuncTrampoline {
             RelocationTarget::LocalFunc(LocalFunctionIndex::from_u32(0)),
             |name: &str| {
                 Err(CompileError::Codegen(format!(
-                    "trampoline generation produced reference to unknown function {}",
-                    name
+                    "trampoline generation produced reference to unknown function {name}",
                 )))
             },
         )?;
@@ -264,8 +263,7 @@ impl FuncTrampoline {
             RelocationTarget::LocalFunc(LocalFunctionIndex::from_u32(0)),
             |name: &str| {
                 Err(CompileError::Codegen(format!(
-                    "trampoline generation produced reference to unknown function {}",
-                    name
+                    "trampoline generation produced reference to unknown function {name}",
                 )))
             },
         )?;

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -83,8 +83,8 @@ impl FuncTranslator {
         let function_name =
             symbol_registry.symbol_to_name(Symbol::LocalFunction(*local_func_index));
         let module_name = match wasm_module.name.as_ref() {
-            None => format!("<anonymous module> function {}", function_name),
-            Some(module_name) => format!("module {} function {}", module_name, function_name),
+            None => format!("<anonymous module> function {function_name}"),
+            Some(module_name) => format!("module {module_name} function {function_name}"),
         };
         let module = self.ctx.create_module(module_name.as_str());
 
@@ -2119,7 +2119,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 tbaa_label(
                     self.module,
                     self.intrinsics,
-                    format!("local {}", local_index),
+                    format!("local {local_index}"),
                     v.as_instruction_value().unwrap(),
                 );
                 self.state.push1(v);
@@ -2132,7 +2132,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 tbaa_label(
                     self.module,
                     self.intrinsics,
-                    format!("local {}", local_index),
+                    format!("local {local_index}"),
                     store,
                 );
             }
@@ -2144,7 +2144,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 tbaa_label(
                     self.module,
                     self.intrinsics,
-                    format!("local {}", local_index),
+                    format!("local {local_index}"),
                     store,
                 );
             }
@@ -11968,8 +11968,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             }
             _ => {
                 return Err(CompileError::Codegen(format!(
-                    "Operator {:?} unimplemented",
-                    op
+                    "Operator {op:?} unimplemented",
                 )));
             }
         }

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -1332,7 +1332,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                         ))
                     };
                     let ptr_to_base_ptr =
-                        err!(cache_builder.build_bit_cast(ptr_to_base_ptr, intrinsics.ptr_ty, "",))
+                        err!(cache_builder.build_bit_cast(ptr_to_base_ptr, intrinsics.ptr_ty, ""))
                             .into_pointer_value();
                     let offset = intrinsics.i64_ty.const_int(
                         offsets
@@ -1393,7 +1393,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                         ))
                     };
                     let ptr_to_base_ptr =
-                        err!(cache_builder.build_bit_cast(ptr_to_base_ptr, intrinsics.ptr_ty, "",))
+                        err!(cache_builder.build_bit_cast(ptr_to_base_ptr, intrinsics.ptr_ty, ""))
                             .into_pointer_value();
                     let offset = intrinsics
                         .i64_ty
@@ -1544,7 +1544,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                         ))
                     };
                     let global_ptr_ptr =
-                        err!(cache_builder.build_bit_cast(global_ptr_ptr, intrinsics.ptr_ty, "",))
+                        err!(cache_builder.build_bit_cast(global_ptr_ptr, intrinsics.ptr_ty, ""))
                             .into_pointer_value();
                     let global_ptr =
                         err!(cache_builder.build_load(intrinsics.ptr_ty, global_ptr_ptr, ""))
@@ -1689,7 +1689,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                     "",
                 ));
                 let body_ptr = err!(cache_builder.build_load(intrinsics.ptr_ty, body_ptr_ptr, ""));
-                let body_ptr = err!(cache_builder.build_bit_cast(body_ptr, intrinsics.ptr_ty, "",))
+                let body_ptr = err!(cache_builder.build_bit_cast(body_ptr, intrinsics.ptr_ty, ""))
                     .into_pointer_value();
                 let vmctx_ptr_ptr = err!(cache_builder.build_struct_gep(
                     intrinsics.vmfunction_import_ty,
@@ -1744,7 +1744,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 };
 
                 let grow_fn_ptr_ptr =
-                    err!(cache_builder.build_bit_cast(grow_fn_ptr_ptr, intrinsics.ptr_ty, "",))
+                    err!(cache_builder.build_bit_cast(grow_fn_ptr_ptr, intrinsics.ptr_ty, ""))
                         .into_pointer_value();
                 let val = err!(cache_builder.build_load(grow_fn_ty, grow_fn_ptr_ptr, ""))
                     .into_pointer_value();
@@ -1790,7 +1790,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 };
 
                 let size_fn_ptr_ptr =
-                    err!(cache_builder.build_bit_cast(size_fn_ptr_ptr, intrinsics.ptr_ty, "",))
+                    err!(cache_builder.build_bit_cast(size_fn_ptr_ptr, intrinsics.ptr_ty, ""))
                         .into_pointer_value();
 
                 let val = err!(cache_builder.build_load(size_fn_ty, size_fn_ptr_ptr, ""))
@@ -1835,7 +1835,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 };
 
                 let size_fn_ptr_ptr =
-                    err!(cache_builder.build_bit_cast(size_fn_ptr_ptr, intrinsics.ptr_ty, "",))
+                    err!(cache_builder.build_bit_cast(size_fn_ptr_ptr, intrinsics.ptr_ty, ""))
                         .into_pointer_value();
 
                 let val = err!(cache_builder.build_load(size_fn_ty, size_fn_ptr_ptr, ""))
@@ -1927,7 +1927,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
                 };
 
                 let size_fn_ptr_ptr =
-                    err!(cache_builder.build_bit_cast(size_fn_ptr_ptr, intrinsics.ptr_ty, "",))
+                    err!(cache_builder.build_bit_cast(size_fn_ptr_ptr, intrinsics.ptr_ty, ""))
                         .into_pointer_value();
 
                 let val = err!(cache_builder.build_load(size_fn_ty, size_fn_ptr_ptr, ""))

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -4091,7 +4091,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 let targets = targets
                     .targets()
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| CompileError::Codegen(format!("BrTable read_table: {:?}", e)))?;
+                    .map_err(|e| CompileError::Codegen(format!("BrTable read_table: {e:?}")))?;
                 let cond = self.pop_value_released()?;
                 let table_label = self.machine.get_label();
                 let mut table: Vec<Label> = vec![];
@@ -4114,8 +4114,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     if !frame.loop_like && !frame.returns.is_empty() {
                         if frame.returns.len() != 1 {
                             return Err(CompileError::Codegen(format!(
-                                "BrTable: incorrect frame.returns for {:?}",
-                                target
+                                "BrTable: incorrect frame.returns for {target:?}",
                             )));
                         }
 
@@ -6619,8 +6618,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             }
             _ => {
                 return Err(CompileError::Codegen(format!(
-                    "not yet implemented: {:?}",
-                    op
+                    "not yet implemented: {op:?}"
                 )));
             }
         }

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -326,7 +326,7 @@ mod tests {
         let result = compiler.compile_module(&linux32, &info, &translation, inputs);
         match result.unwrap_err() {
             CompileError::UnsupportedTarget(name) => assert_eq!(name, "i686"),
-            error => panic!("Unexpected error: {:?}", error),
+            error => panic!("Unexpected error: {error:?}"),
         };
 
         // Compile for win32
@@ -335,7 +335,7 @@ mod tests {
         let result = compiler.compile_module(&win32, &info, &translation, inputs);
         match result.unwrap_err() {
             CompileError::UnsupportedTarget(name) => assert_eq!(name, "i686"), // Windows should be checked before architecture
-            error => panic!("Unexpected error: {:?}", error),
+            error => panic!("Unexpected error: {error:?}"),
         };
     }
 

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -102,7 +102,7 @@ fn dwarf_index(reg: u16) -> gimli::Register {
     match reg {
         0..=31 => DWARF_GPR[reg as usize],
         64..=95 => DWARF_NEON[reg as usize - 64],
-        _ => panic!("Unknown register index {}", reg),
+        _ => panic!("Unknown register index {reg}"),
     }
 }
 
@@ -2309,7 +2309,7 @@ impl Machine for MachineARM64 {
     // assembler finalize
     fn assembler_finalize(self) -> Result<Vec<u8>, CompileError> {
         self.assembler.finalize().map_err(|e| {
-            CompileError::Codegen(format!("Assembler failed finalization with: {:?}", e))
+            CompileError::Codegen(format!("Assembler failed finalization with: {e:?}"))
         })
     }
 

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -126,7 +126,7 @@ fn dwarf_index(reg: u16) -> gimli::Register {
     match reg {
         0..=15 => DWARF_GPR[reg as usize],
         17..=24 => DWARF_XMM[reg as usize - 17],
-        _ => panic!("Unknown register index {}", reg),
+        _ => panic!("Unknown register index {reg}"),
     }
 }
 
@@ -2433,10 +2433,7 @@ impl Machine for MachineX86_64 {
                     }
                 }
             },
-            _ => panic!(
-                "unimplemented move_location_extend({:?}, {}, {:?}, {:?}, {:?}",
-                size_val, signed, source, size_op, dest
-            ),
+            _ => panic!(                "unimplemented move_location_extend({size_val:?}, {signed}, {source:?}, {size_op:?}, {dest:?}"            ),
         }?;
         if dst != dest {
             self.assembler.emit_mov(size_op, dst, dest)?;
@@ -2508,7 +2505,7 @@ impl Machine for MachineX86_64 {
     // assembler finalize
     fn assembler_finalize(self) -> Result<Vec<u8>, CompileError> {
         self.assembler.finalize().map_err(|e| {
-            CompileError::Codegen(format!("Assembler failed finalization with: {:?}", e))
+            CompileError::Codegen(format!("Assembler failed finalization with: {e:?}"))
         })
     }
 

--- a/lib/compiler/src/artifact_builders/artifact_builder.rs
+++ b/lib/compiler/src/artifact_builders/artifact_builder.rs
@@ -324,7 +324,7 @@ impl ArtifactBuildFromArchive {
             let module = module_builder(buffer)?;
             compile_info = MaybeUninit::new(
                 rkyv::deserialize::<_, RkyvError>(&module.compile_info)
-                    .map_err(|e| DeserializeError::CorruptedBinary(format!("{:?}", e)))?,
+                    .map_err(|e| DeserializeError::CorruptedBinary(format!("{e:?}")))?,
             );
             ModuleFromArchive::from_serializable_module(module)
         })?;
@@ -437,7 +437,7 @@ impl ArtifactBuildFromArchive {
         rkyv::deserialize::<_, RkyvError>(
             &self.cell.borrow_dependent().compilation.function_frame_info,
         )
-        .map_err(|e| DeserializeError::CorruptedBinary(format!("{:?}", e)))
+        .map_err(|e| DeserializeError::CorruptedBinary(format!("{e:?}")))
     }
 }
 

--- a/lib/compiler/src/artifact_builders/trampoline.rs
+++ b/lib/compiler/src/artifact_builders/trampoline.rs
@@ -92,7 +92,7 @@ fn make_trampoline(
                 addend: 0,
             });
         }
-        arch => panic!("Unsupported architecture: {}", arch),
+        arch => panic!("Unsupported architecture: {arch}"),
     };
 }
 
@@ -103,7 +103,7 @@ pub fn libcall_trampoline_len(target: &Target) -> usize {
         Architecture::X86_64 => X86_64_TRAMPOLINE.len(),
         Architecture::Riscv64(_) => RISCV64_TRAMPOLINE.len(),
         Architecture::LoongArch64 => LOONGARCH64_TRAMPOLINE.len(),
-        arch => panic!("Unsupported architecture: {}", arch),
+        arch => panic!("Unsupported architecture: {arch}"),
     }
 }
 

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -103,7 +103,7 @@ pub trait Compiler: Send {
         let mut validator = Validator::new_with_features(wasm_features);
         validator
             .validate_all(data)
-            .map_err(|e| CompileError::Validate(format!("{}", e)))?;
+            .map_err(|e| CompileError::Validate(format!("{e}")))?;
         Ok(())
     }
 

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -423,7 +423,7 @@ impl Artifact {
 
         artifact
             .internal_register_frame_info()
-            .map_err(|e| DeserializeError::CorruptedBinary(format!("{:?}", e)))?;
+            .map_err(|e| DeserializeError::CorruptedBinary(format!("{e:?}")))?;
         if let Some(frame_info) = artifact.internal_take_frame_info_registration() {
             engine_inner.register_frame_info(frame_info);
         }
@@ -981,7 +981,7 @@ impl Artifact {
         use crate::types::symbols::{ModuleMetadataSymbolRegistry, SymbolRegistry};
 
         fn to_compile_error(err: impl std::error::Error) -> CompileError {
-            CompileError::Codegen(format!("{}", err))
+            CompileError::Codegen(format!("{err}"))
         }
 
         let target_triple = target.triple();

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -391,8 +391,7 @@ impl EngineInner {
                 )
                 .map_err(|message| {
                     CompileError::Resource(format!(
-                        "failed to allocate memory for functions: {}",
-                        message
+                        "failed to allocate memory for functions: {message}",
                     ))
                 })?;
 
@@ -459,7 +458,7 @@ impl EngineInner {
             .unwind_registry_mut()
             .publish(eh_frame)
             .map_err(|e| {
-                CompileError::Resource(format!("Error while publishing the unwind code: {}", e))
+                CompileError::Resource(format!("Error while publishing the unwind code: {e}"))
             })?;
         Ok(())
     }

--- a/lib/compiler/src/engine/link.rs
+++ b/lib/compiler/src/engine/link.rs
@@ -218,10 +218,7 @@ fn apply_relocation(
                 | (read_unaligned(reloc_address as *mut u32) & 0xFFC003FF);
             write_unaligned(reloc_address as *mut u32, reloc_delta);
         },
-        kind => panic!(
-            "Relocation kind unsupported in the current architecture {}",
-            kind
-        ),
+        kind => panic!("Relocation kind unsupported in the current architecture {kind}"),
     }
 }
 

--- a/lib/compiler/src/engine/tunables.rs
+++ b/lib/compiler/src/engine/tunables.rs
@@ -84,7 +84,7 @@ pub trait Tunables {
             memories.push(InternalStoreHandle::new(
                 context,
                 self.create_vm_memory(ty, style, *mdl)
-                    .map_err(|e| LinkError::Resource(format!("Failed to create memory: {}", e)))?,
+                    .map_err(|e| LinkError::Resource(format!("Failed to create memory: {e}")))?,
             ));
         }
         Ok(memories)

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -40,8 +40,7 @@ pub fn get_object_for_target(triple: &Triple) -> Result<Object, ObjectError> {
         BinaryFormat::Coff => object::BinaryFormat::Coff,
         binary_format => {
             return Err(ObjectError::UnsupportedBinaryFormat(format!(
-                "{}",
-                binary_format
+                "{binary_format}"
             )));
         }
     };
@@ -52,8 +51,7 @@ pub fn get_object_for_target(triple: &Triple) -> Result<Object, ObjectError> {
         Architecture::LoongArch64 => object::Architecture::LoongArch64,
         architecture => {
             return Err(ObjectError::UnsupportedArchitecture(format!(
-                "{}",
-                architecture
+                "{architecture}"
             )));
         }
     };
@@ -314,7 +312,7 @@ pub fn emit_compilation(
                             value: macho::ARM64_RELOC_BRANCH26,
                             relative: true,
                         },
-                        fmt => panic!("unsupported binary format {:?}", fmt),
+                        fmt => panic!("unsupported binary format {fmt:?}"),
                     },
                     RelocationEncoding::Generic,
                     32,
@@ -425,8 +423,8 @@ pub fn emit_serialized(
 ) -> Result<(), ObjectError> {
     obj.set_mangling(object::write::Mangling::None);
     //let module_name = module.compile_info.module.name.clone();
-    let len_name = format!("{}_LENGTH", object_name);
-    let data_name = format!("{}_DATA", object_name);
+    let len_name = format!("{object_name}_LENGTH");
+    let data_name = format!("{object_name}_DATA");
     //let metadata_name = "WASMER_MODULE_METADATA";
 
     let align = match triple.architecture {

--- a/lib/compiler/src/translator/error.rs
+++ b/lib/compiler/src/translator/error.rs
@@ -37,7 +37,7 @@ mod tests {
                 assert_eq!(message, "unexpected end-of-file");
                 assert_eq!(offset, 0);
             }
-            err => panic!("Unexpected error: {:?}", err),
+            err => panic!("Unexpected error: {err:?}"),
         }
     }
 
@@ -50,7 +50,7 @@ mod tests {
                 assert_eq!(message, "unexpected end-of-file");
                 assert_eq!(offset, 0);
             }
-            err => panic!("Unexpected error: {:?}", err),
+            err => panic!("Unexpected error: {err:?}"),
         }
     }
 }

--- a/lib/compiler/src/types/symbols.rs
+++ b/lib/compiler/src/types/symbols.rs
@@ -149,7 +149,7 @@ impl ModuleMetadata {
         archived: &ArchivedModuleMetadata,
     ) -> Result<Self, DeserializeError> {
         rkyv::deserialize::<_, rkyv::rancor::Error>(archived)
-            .map_err(|e| DeserializeError::CorruptedBinary(format!("{:?}", e)))
+            .map_err(|e| DeserializeError::CorruptedBinary(format!("{e:?}")))
     }
 }
 

--- a/lib/config/src/app/mod.rs
+++ b/lib/config/src/app/mod.rs
@@ -377,10 +377,7 @@ volumes:
         if let Some(actual_volumes) = parsed.volumes {
             assert_eq!(actual_volumes, expected_volumes);
         } else {
-            panic!(
-                "Parsed volumes are None, expected Some({:?})",
-                expected_volumes
-            );
+            panic!("Parsed volumes are None, expected Some({expected_volumes:?})");
         }
     }
 }

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -385,7 +385,7 @@ fn toml_to_cbor_value(val: &toml::Value) -> ciborium::Value {
         toml::Value::Integer(i) => ciborium::Value::Integer(ciborium::value::Integer::from(*i)),
         toml::Value::Float(f) => ciborium::Value::Float(*f),
         toml::Value::Boolean(b) => ciborium::Value::Bool(*b),
-        toml::Value::Datetime(d) => ciborium::Value::Text(format!("{}", d)),
+        toml::Value::Datetime(d) => ciborium::Value::Text(format!("{d}")),
         toml::Value::Array(sq) => {
             ciborium::Value::Array(sq.iter().map(toml_to_cbor_value).collect())
         }

--- a/lib/config/src/package/named_package_ident.rs
+++ b/lib/config/src/package/named_package_ident.rs
@@ -121,7 +121,7 @@ impl NamedPackageIdent {
         };
 
         let reg = if !reg.starts_with("http://") && !reg.starts_with("https://") {
-            format!("https://{}", reg)
+            format!("https://{reg}")
         } else {
             reg.clone()
         };
@@ -144,7 +144,7 @@ impl NamedPackageIdent {
         if let Some(tag) = &self.tag {
             ident.push('@');
             // Writing to a string only fails on memory allocation errors.
-            write!(&mut ident, "{}", tag).unwrap();
+            write!(&mut ident, "{tag}").unwrap();
         }
         ident
     }
@@ -153,7 +153,7 @@ impl NamedPackageIdent {
         let mut out = String::new();
         if let Some(url) = &self.registry {
             // NOTE: writing to a String can only fail on allocation errors.
-            write!(&mut out, "{}", url).unwrap();
+            write!(&mut out, "{url}").unwrap();
 
             if !out.ends_with('/') {
                 out.push(':');
@@ -167,7 +167,7 @@ impl NamedPackageIdent {
         if let Some(tag) = &self.tag {
             out.push('@');
             // Writing to a string only fails on memory allocation errors.
-            write!(&mut out, "{}", tag).unwrap();
+            write!(&mut out, "{tag}").unwrap();
         }
 
         out

--- a/lib/config/src/package/package_hash.rs
+++ b/lib/config/src/package/package_hash.rs
@@ -32,7 +32,7 @@ impl From<Sha256Hash> for PackageHash {
 impl std::fmt::Display for PackageHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Sha256(hash) => write!(f, "sha256:{}", hash),
+            Self::Sha256(hash) => write!(f, "sha256:{hash}"),
         }
     }
 }

--- a/lib/derive/tests/compiletest.rs
+++ b/lib/derive/tests/compiletest.rs
@@ -20,7 +20,7 @@ fn run_mode(src: &'static str, mode: &'static str) {
     let mut config = ct::Config {
         mode: mode.parse().expect("invalid mode"),
         target_rustcflags: Some("-L ../../target/debug/deps".to_owned()),
-        src_base: format!("tests/{}", src).into(),
+        src_base: format!("tests/{src}").into(),
         ..Default::default()
     };
 

--- a/lib/journal/src/concrete/printing.rs
+++ b/lib/journal/src/concrete/printing.rs
@@ -42,7 +42,7 @@ impl ReadableJournal for PrintingJournal {
 impl WritableJournal for PrintingJournal {
     fn write<'a>(&'a self, entry: JournalEntry<'a>) -> anyhow::Result<LogWriteResult> {
         match self.mode {
-            JournalPrintingMode::Text => println!("{}", entry),
+            JournalPrintingMode::Text => println!("{entry}"),
             JournalPrintingMode::Json => {
                 println!("{}", serde_json::to_string_pretty(&entry)?)
             }
@@ -71,7 +71,7 @@ impl<'a> fmt::Display for JournalEntry<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             JournalEntry::InitModuleV1 { wasm_hash } => {
-                write!(f, "init-module (hash={:x?})", wasm_hash)
+                write!(f, "init-module (hash={wasm_hash:x?})")
             }
             JournalEntry::ClearEtherealV1 => {
                 write!(f, "clear-ethereal")
@@ -90,7 +90,7 @@ impl<'a> fmt::Display for JournalEntry<'a> {
                 compressed_data.len()
             ),
             JournalEntry::ProcessExitV1 { exit_code } => {
-                write!(f, "process-exit (code={:?})", exit_code)
+                write!(f, "process-exit (code={exit_code:?})")
             }
             JournalEntry::SetThreadV1 {
                 id,
@@ -107,142 +107,110 @@ impl<'a> fmt::Display for JournalEntry<'a> {
                 store_data.len(),
             ),
             JournalEntry::CloseThreadV1 { id, exit_code } => {
-                write!(f, "thread-close (id={}, code={:?})", id, exit_code)
+                write!(f, "thread-close (id={id}, code={exit_code:?})")
             }
-            JournalEntry::FileDescriptorSeekV1 { fd, offset, whence } => write!(
-                f,
-                "fd-seek (fd={}, offset={}, whence={:?})",
-                fd, offset, whence
-            ),
+            JournalEntry::FileDescriptorSeekV1 { fd, offset, whence } => {
+                write!(f, "fd-seek (fd={fd}, offset={offset}, whence={whence:?})")
+            },
             JournalEntry::FileDescriptorWriteV1 {
                 fd, offset, data, ..
-            } => write!(
-                f,
-                "fd-write (fd={}, offset={}, data.len={})",
-                fd,
-                offset,
-                data.len()
-            ),
+            } => write!(f, "fd-write (fd={fd}, offset={offset}, data.len={})", data.len()),
             JournalEntry::SetClockTimeV1 { clock_id, time } => {
-                write!(f, "set-clock-time (id={:?}, time={})", clock_id, time)
+                write!(f, "set-clock-time (id={clock_id:?}, time={time})")
             }
-            JournalEntry::CloseFileDescriptorV1 { fd } => write!(f, "fd-close (fd={})", fd),
+            JournalEntry::CloseFileDescriptorV1 { fd } => write!(f, "fd-close (fd={fd})"),
             JournalEntry::OpenFileDescriptorV1 {
                 fd, path, o_flags, ..
             } => {
                 if o_flags.contains(wasi::Oflags::CREATE) {
                     if o_flags.contains(wasi::Oflags::TRUNC) {
-                        write!(f, "fd-create-new (fd={}, path={})", fd, path)
+                        write!(f, "fd-create-new (fd={fd}, path={path})")
                     } else if o_flags.contains(wasi::Oflags::EXCL) {
-                        write!(f, "fd-create-excl (fd={}, path={})", fd, path)
+                        write!(f, "fd-create-excl (fd={fd}, path={path})")
                     } else {
-                        write!(f, "fd-create (fd={}, path={})", fd, path)
+                        write!(f, "fd-create (fd={fd}, path={path})")
                     }
                 } else if o_flags.contains(wasi::Oflags::TRUNC) {
-                    write!(f, "fd-open-new (fd={}, path={})", fd, path)
+                    write!(f, "fd-open-new (fd={fd}, path={path})")
                 } else {
-                    write!(f, "fd-open (fd={}, path={})", fd, path)
+                    write!(f, "fd-open (fd={fd}, path={path})")
                 }
             }
             JournalEntry::RenumberFileDescriptorV1 { old_fd, new_fd } => {
-                write!(f, "fd-renumber (old={}, new={})", old_fd, new_fd)
+                write!(f, "fd-renumber (old={old_fd}, new={new_fd})")
             }
             JournalEntry::DuplicateFileDescriptorV1 {
                 original_fd,
                 copied_fd,
-            } => write!(
-                f,
-                "fd-duplicate (original={}, copied={})",
-                original_fd, copied_fd
-            ),
+            } => write!(f, "fd-duplicate (original={original_fd}, copied={copied_fd})"),
             JournalEntry::CreateDirectoryV1 { fd, path } => {
-                write!(f, "path-create-dir (fd={}, path={})", fd, path)
+                write!(f, "path-create-dir (fd={fd}, path={path})")
             }
             JournalEntry::RemoveDirectoryV1 { fd, path } => {
-                write!(f, "path-remove-dir (fd={}, path={})", fd, path)
+                write!(f, "path-remove-dir (fd={fd}, path={path})")
             }
             JournalEntry::PathSetTimesV1 {
                 path,
                 st_atim,
                 st_mtim,
                 ..
-            } => write!(
-                f,
-                "path-set-times (path={}, atime={}, mtime={}))",
-                path, st_atim, st_mtim
-            ),
+            } => write!(f, "path-set-times (path={path}, atime={st_atim}, mtime={st_mtim}))"),
             JournalEntry::FileDescriptorSetTimesV1 {
                 fd,
                 st_atim,
                 st_mtim,
                 ..
-            } => write!(
-                f,
-                "fd-set-times (fd={}, atime={}, mtime={})",
-                fd, st_atim, st_mtim
-            ),
+            } => write!(f, "fd-set-times (fd={fd}, atime={st_atim}, mtime={st_mtim})"),
             JournalEntry::FileDescriptorSetFlagsV1 { fd, flags } => {
-                write!(f, "fd-set-flags (fd={}, flags={:?})", fd, flags)
+                write!(f, "fd-set-flags (fd={fd}, flags={flags:?})")
             }
             JournalEntry::FileDescriptorSetRightsV1 {
                 fd,
                 fs_rights_base,
                 fs_rights_inheriting,
-            } => write!(
-                f,
-                "fd-set-rights (fd={}, base={:?}, inherited={:?})",
-                fd, fs_rights_base, fs_rights_inheriting
-            ),
+            } => write!(f, "fd-set-rights (fd={fd}, base={fs_rights_base:?}, inherited={fs_rights_inheriting:?})"),
             JournalEntry::FileDescriptorSetSizeV1 { fd, st_size } => {
-                write!(f, "fd-set-size (fd={}, size={})", fd, st_size)
+                write!(f, "fd-set-size (fd={fd}, size={st_size})")
             }
             JournalEntry::FileDescriptorAdviseV1 {
                 fd, offset, len, ..
-            } => write!(f, "fd-advise (fd={}, offset={}, len={})", fd, offset, len),
+            } => write!(f, "fd-advise (fd={fd}, offset={offset}, len={len})"),
             JournalEntry::FileDescriptorAllocateV1 { fd, offset, len } => {
-                write!(f, "fd-allocate (fd={}, offset={}, len={})", fd, offset, len)
+                write!(f, "fd-allocate (fd={fd}, offset={offset}, len={len})")
             }
             JournalEntry::CreateHardLinkV1 {
                 old_path, new_path, ..
-            } => write!(f, "path-link (from={}, to={})", old_path, new_path),
+            } => write!(f, "path-link (from={old_path}, to={new_path})"),
             JournalEntry::CreateSymbolicLinkV1 {
                 old_path, new_path, ..
-            } => write!(f, "path-symlink (from={}, to={})", old_path, new_path),
-            JournalEntry::UnlinkFileV1 { path, .. } => write!(f, "path-unlink (path={})", path),
+            } => write!(f, "path-symlink (from={old_path}, to={new_path})"),
+            JournalEntry::UnlinkFileV1 { path, .. } => write!(f, "path-unlink (path={path})"),
             JournalEntry::PathRenameV1 {
                 old_path, new_path, ..
-            } => write!(
-                f,
-                "path-rename (old-path={}, new-path={})",
-                old_path, new_path
-            ),
-            JournalEntry::ChangeDirectoryV1 { path } => write!(f, "chdir (path={})", path),
-            JournalEntry::EpollCreateV1 { fd } => write!(f, "epoll-create (fd={})", fd),
+            } => write!(f, "path-rename (old-path={old_path}, new-path={new_path})"),
+            JournalEntry::ChangeDirectoryV1 { path } => write!(f, "chdir (path={path})"),
+            JournalEntry::EpollCreateV1 { fd } => write!(f, "epoll-create (fd={fd})"),
             JournalEntry::EpollCtlV1 { epfd, op, fd, .. } => {
-                write!(f, "epoll-ctl (epfd={}, op={:?}, fd={})", epfd, op, fd)
+                write!(f, "epoll-ctl (epfd={epfd}, op={op:?}, fd={fd})")
             }
-            JournalEntry::TtySetV1 { tty, line_feeds } => write!(
-                f,
-                "tty-set (echo={}, buffering={}, feeds={})",
-                tty.echo, tty.line_buffered, line_feeds
-            ),
+            JournalEntry::TtySetV1 { tty, line_feeds } => write!(f, "tty-set (echo={}, buffering={}, feeds={})", tty.echo, tty.line_buffered, line_feeds),
             JournalEntry::CreatePipeV1 { fd1, fd2 } => {
-                write!(f, "fd-pipe (fd1={}, fd2={})", fd1, fd2)
+                write!(f, "fd-pipe (fd1={fd1}, fd2={fd2})")
             }
             JournalEntry::CreateEventV1 {
                 initial_val, fd, ..
-            } => write!(f, "fd-event (fd={}, initial={})", fd, initial_val),
+            } => write!(f, "fd-event (fd={fd}, initial={initial_val})"),
             JournalEntry::PortAddAddrV1 { cidr } => {
                 write!(f, "port-addr-add (ip={}, prefix={})", cidr.ip, cidr.prefix)
             }
-            JournalEntry::PortDelAddrV1 { addr } => write!(f, "port-addr-del (addr={})", addr),
+            JournalEntry::PortDelAddrV1 { addr } => write!(f, "port-addr-del (addr={addr})"),
             JournalEntry::PortAddrClearV1 => write!(f, "port-addr-clear"),
             JournalEntry::PortBridgeV1 { network, .. } => {
-                write!(f, "port-bridge (network={})", network)
+                write!(f, "port-bridge (network={network})")
             }
             JournalEntry::PortUnbridgeV1 => write!(f, "port-unbridge"),
             JournalEntry::PortDhcpAcquireV1 => write!(f, "port-dhcp-acquire"),
-            JournalEntry::PortGatewaySetV1 { ip } => write!(f, "port-gateway-set (ip={})", ip),
+            JournalEntry::PortGatewaySetV1 { ip } => write!(f, "port-gateway-set (ip={ip})"),
             JournalEntry::PortRouteAddV1 {
                 cidr, via_router, ..
             } => write!(
@@ -251,30 +219,22 @@ impl<'a> fmt::Display for JournalEntry<'a> {
                 cidr.ip, cidr.prefix, via_router
             ),
             JournalEntry::PortRouteClearV1 => write!(f, "port-route-clear"),
-            JournalEntry::PortRouteDelV1 { ip } => write!(f, "port-route-del (ip={})", ip),
+            JournalEntry::PortRouteDelV1 { ip } => write!(f, "port-route-del (ip={ip})"),
             JournalEntry::SocketOpenV1 { af, ty, pt, fd } => {
-                write!(
-                    f,
-                    "sock-open (fd={}, af={:?}, ty={:?}, pt={:?})",
-                    fd, af, ty, pt
-                )
+                write!(f, "sock-open (fd={fd}, af={af:?}, ty={ty:?}, pt={pt:?})")
             }
             JournalEntry::SocketListenV1 { fd, backlog } => {
-                write!(f, "sock-listen (fd={}, backlog={})", fd, backlog)
+                write!(f, "sock-listen (fd={fd}, backlog={backlog})")
             }
             JournalEntry::SocketBindV1 { fd, addr } => {
-                write!(f, "sock-bind (fd={}, addr={})", fd, addr)
+                write!(f, "sock-bind (fd={fd}, addr={addr})")
             }
             JournalEntry::SocketConnectedV1 {
                 fd,
                 local_addr,
                 peer_addr,
             } => {
-                write!(
-                    f,
-                    "sock-connect (fd={}, addr={}, peer={})",
-                    fd, local_addr, peer_addr
-                )
+                write!(f, "sock-connect (fd={fd}, addr={local_addr}, peer={peer_addr})")
             }
             JournalEntry::SocketAcceptedV1 {
                 listen_fd,
@@ -282,81 +242,53 @@ impl<'a> fmt::Display for JournalEntry<'a> {
                 local_addr,
                 peer_addr,
                 ..
-            } => write!(
-                f,
-                "sock-accept (listen-fd={}, sock_fd={}, addr={}, peer={})",
-                listen_fd, fd, local_addr, peer_addr
-            ),
+            } => write!(f, "sock-accept (listen-fd={listen_fd}, sock_fd={fd}, addr={local_addr}, peer={peer_addr})"),
             JournalEntry::SocketJoinIpv4MulticastV1 {
                 fd,
                 multiaddr,
                 iface,
-            } => write!(
-                f,
-                "sock-join-mcast-ipv4 (fd={}, addr={}, iface={})",
-                fd, multiaddr, iface
-            ),
+            } => write!(f, "sock-join-mcast-ipv4 (fd={fd}, addr={multiaddr}, iface={iface})"),
             JournalEntry::SocketJoinIpv6MulticastV1 {
                 fd,
                 multi_addr: multiaddr,
                 iface,
-            } => write!(
-                f,
-                "sock-join-mcast-ipv6 (fd={}, addr={}, iface={})",
-                fd, multiaddr, iface
-            ),
+            } => write!(f, "sock-join-mcast-ipv6 (fd={fd}, addr={multiaddr}, iface={iface})"),
             JournalEntry::SocketLeaveIpv4MulticastV1 {
                 fd,
                 multi_addr: multiaddr,
                 iface,
-            } => write!(
-                f,
-                "sock-leave-mcast-ipv4 (fd={}, addr={}, iface={})",
-                fd, multiaddr, iface
-            ),
+            } => write!(f, "sock-leave-mcast-ipv4 (fd={fd}, addr={multiaddr}, iface={iface})"),
             JournalEntry::SocketLeaveIpv6MulticastV1 {
                 fd,
                 multi_addr: multiaddr,
                 iface,
-            } => write!(
-                f,
-                "sock-leave-mcast-ipv6 (fd={}, addr={}, iface={})",
-                fd, multiaddr, iface
-            ),
+            } => write!(f, "sock-leave-mcast-ipv6 (fd={fd}, addr={multiaddr}, iface={iface})"),
             JournalEntry::SocketSendFileV1 {
                 socket_fd,
                 file_fd,
                 offset,
                 count,
-            } => write!(
-                f,
-                "sock-send-file (sock-fd={}, file-fd={}, offset={}, count={})",
-                socket_fd, file_fd, offset, count
-            ),
-            JournalEntry::SocketSendToV1 { fd, data, addr, .. } => write!(
-                f,
-                "sock-send-to (fd={}, data.len={}, addr={})",
-                fd,
-                data.len(),
-                addr
-            ),
+            } => write!(f, "sock-send-file (sock-fd={socket_fd}, file-fd={file_fd}, offset={offset}, count={count})"),
+            JournalEntry::SocketSendToV1 { fd, data, addr, .. } => {
+                write!(f, "sock-send-to (fd={}, data.len={}, addr={})", fd, data.len(), addr)
+            }
             JournalEntry::SocketSendV1 { fd, data, .. } => {
                 write!(f, "sock-send (fd={}, data.len={}", fd, data.len())
             }
             JournalEntry::SocketSetOptFlagV1 { fd, opt, flag } => {
-                write!(f, "sock-set-opt (fd={}, opt={:?}, flag={})", fd, opt, flag)
+                write!(f, "sock-set-opt (fd={fd}, opt={opt:?}, flag={flag})")
             }
             JournalEntry::SocketSetOptSizeV1 { fd, opt, size } => {
-                write!(f, "sock-set-opt (fd={}, opt={:?}, size={})", fd, opt, size)
+                write!(f, "sock-set-opt (fd={fd}, opt={opt:?}, size={size})")
             }
             JournalEntry::SocketSetOptTimeV1 { fd, ty, time } => {
-                write!(f, "sock-set-opt (fd={}, opt={:?}, time={:?})", fd, ty, time)
+                write!(f, "sock-set-opt (fd={fd}, opt={ty:?}, time={time:?})")
             }
             JournalEntry::SocketShutdownV1 { fd, how } => {
-                write!(f, "sock-shutdown (fd={}, how={:?})", fd, how)
+                write!(f, "sock-shutdown (fd={fd}, how={how:?})")
             }
             JournalEntry::SnapshotV1 { when, trigger } => {
-                write!(f, "snapshot (when={:?}, trigger={:?})", when, trigger)
+                write!(f, "snapshot (when={when:?}, trigger={trigger:?})")
             }
         }
     }

--- a/lib/package/src/convert/error.rs
+++ b/lib/package/src/convert/error.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for ConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "could not convert manifest: {}", self.message)?;
         if let Some(cause) = &self.cause {
-            write!(f, " (cause: {})", cause)?;
+            write!(f, " (cause: {cause})")?;
         }
 
         Ok(())

--- a/lib/package/src/convert/webc_to_package.rs
+++ b/lib/package/src/convert/webc_to_package.rs
@@ -56,7 +56,7 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
                 let (name, version) = if let Some((name, version_raw)) = raw.split_once('@') {
                     let version = version_raw.parse().map_err(|err| {
                         ConversionError::with_cause(
-                            format!("Could not parse version of dependency: '{}'", raw),
+                            format!("Could not parse version of dependency: '{raw}'"),
                             err,
                         )
                     })?;
@@ -134,7 +134,7 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
     if !atoms.is_empty() {
         std::fs::create_dir_all(&module_dir).map_err(|err| {
             ConversionError::with_cause(
-                format!("Could not create directory '{}'", module_dir.display(),),
+                format!("Could not create directory '{}'", module_dir.display()),
                 err,
             )
         })?;
@@ -178,7 +178,7 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
             .annotation::<webc::metadata::annotations::Atom>(webc::metadata::annotations::Atom::KEY)
             .map_err(|err| {
                 ConversionError::with_cause(
-                    format!("could not read atom annotation for command '{}'", name),
+                    format!("could not read atom annotation for command '{name}'"),
                     err,
                 )
             })?

--- a/lib/package/src/package/manifest.rs
+++ b/lib/package/src/package/manifest.rs
@@ -663,7 +663,7 @@ fn toml_to_cbor_value(val: &toml::value::Value) -> ciborium::Value {
         toml::Value::Integer(i) => ciborium::Value::Integer(ciborium::value::Integer::from(*i)),
         toml::Value::Float(f) => ciborium::Value::Float(*f),
         toml::Value::Boolean(b) => ciborium::Value::Bool(*b),
-        toml::Value::Datetime(d) => ciborium::Value::Text(format!("{}", d)),
+        toml::Value::Datetime(d) => ciborium::Value::Text(format!("{d}")),
         toml::Value::Array(sq) => {
             ciborium::Value::Array(sq.iter().map(toml_to_cbor_value).collect())
         }

--- a/lib/package/src/package/package.rs
+++ b/lib/package/src/package/package.rs
@@ -1534,8 +1534,8 @@ mod tests {
             meta_volume.read_file("README.md").unwrap(),
             (b"readme".as_slice().into(), Some(readme_hash)),
         );
-        assert!(dir1_volume.read_dir("/").unwrap().is_empty(),);
-        assert!(dir2_volume.read_dir("/").unwrap().is_empty(),);
+        assert!(dir1_volume.read_dir("/").unwrap().is_empty());
+        assert!(dir2_volume.read_dir("/").unwrap().is_empty());
     }
 
     #[test]

--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -288,7 +288,7 @@ mod tests {
                 assert_eq!(name, "manipulator3000");
                 assert_eq!(message, "foo");
             }
-            err => panic!("Unexpected error: {:?}", err),
+            err => panic!("Unexpected error: {err:?}"),
         }
     }
 }

--- a/lib/types/src/types.rs
+++ b/lib/types/src/types.rs
@@ -56,7 +56,7 @@ impl Type {
 
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -287,16 +287,16 @@ impl fmt::Display for FunctionType {
         let params = self
             .params
             .iter()
-            .map(|p| format!("{:?}", p))
+            .map(|p| format!("{p:?}"))
             .collect::<Vec<_>>()
             .join(", ");
         let results = self
             .results
             .iter()
-            .map(|p| format!("{:?}", p))
+            .map(|p| format!("{p:?}"))
             .collect::<Vec<_>>()
             .join(", ");
-        write!(f, "[{}] -> [{}]", params, results)
+        write!(f, "[{params}] -> [{results}]")
     }
 }
 

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -1115,7 +1115,7 @@ mod tests {
         let cur_dir = read_dir_names(&fs, "/");
 
         if !cur_dir.contains(&"foo".to_string()) {
-            panic!("cur_dir does not contain foo: {:#?}", cur_dir);
+            panic!("cur_dir does not contain foo: {cur_dir:#?}");
         }
 
         assert!(
@@ -1276,7 +1276,7 @@ mod tests {
         let bar_dir = read_dir_names(&fs, bar);
 
         if !bar_dir.contains(&"qux".to_string()) {
-            println!("qux does not exist: {:?}", bar_dir)
+            println!("qux does not exist: {bar_dir:?}")
         }
 
         let qux_dir = read_dir_names(&fs, bar.join("qux"));
@@ -1293,7 +1293,7 @@ mod tests {
             "the /bar/hello2.txt file exists"
         );
 
-        assert_eq!(fs.create_dir(foo), Ok(()), "create ./foo again",);
+        assert_eq!(fs.create_dir(foo), Ok(()), "create ./foo again");
 
         assert_eq!(
             fs.rename(&bar.join("hello2.txt"), &foo.join("world2.txt"))
@@ -1487,7 +1487,7 @@ mod tests {
         assert!(next.metadata().unwrap().is_dir(), "checking entry #5");
 
         if let Some(s) = readdir.next() {
-            panic!("next: {:?}", s);
+            panic!("next: {s:?}");
         }
     }
 }

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -393,7 +393,7 @@ pub trait VirtualFile:
     ) -> BoxFuture<'_, std::io::Result<()>> {
         Box::pin(async move {
             let bytes_written = tokio::io::copy(&mut src, self).await?;
-            tracing::trace!(bytes_written, "Copying file into host filesystem",);
+            tracing::trace!(bytes_written, "Copying file into host filesystem");
             Ok(())
         })
     }

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -1197,7 +1197,7 @@ mod test_filesystem {
             "creating the root which already exists",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating a directory",);
+        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating a directory");
 
         {
             let fs_inner = fs.inner.read().unwrap();
@@ -1300,7 +1300,7 @@ mod test_filesystem {
             "cannot remove a directory that doesn't exist",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating a directory",);
+        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating a directory");
 
         assert_eq!(
             fs.create_dir(path!("/foo/bar")),
@@ -1329,7 +1329,7 @@ mod test_filesystem {
             "removing a sub-directory",
         );
 
-        assert_eq!(fs.remove_dir(path!("/foo")), Ok(()), "removing a directory",);
+        assert_eq!(fs.remove_dir(path!("/foo")), Ok(()), "removing a directory");
 
         {
             let fs_inner = fs.inner.read().unwrap();

--- a/lib/virtual-fs/src/mem_fs/stdio.rs
+++ b/lib/virtual-fs/src/mem_fs/stdio.rs
@@ -261,7 +261,7 @@ mod test_read_write_seek {
             matches!(stdout.write(b"qux").await, Ok(3)),
             "writing again into `stdout`",
         );
-        assert_eq!(stdout.buf, b"bazqux", "checking the content of `stdout`",);
+        assert_eq!(stdout.buf, b"bazqux", "checking the content of `stdout`");
     }
 
     #[tokio::test]
@@ -301,7 +301,7 @@ mod test_read_write_seek {
             matches!(stderr.write(b"qux").await, Ok(3)),
             "writing again into `stderr`",
         );
-        assert_eq!(stderr.buf, b"bazqux", "checking the content of `stderr`",);
+        assert_eq!(stderr.buf, b"bazqux", "checking the content of `stderr`");
     }
 
     #[tokio::test]

--- a/lib/virtual-fs/src/overlay_fs.rs
+++ b/lib/virtual-fs/src/overlay_fs.rs
@@ -823,7 +823,7 @@ where
         fn poll_copy_start_and_progress(&mut self, cx: &mut Context) -> Poll<io::Result<()>> {
             replace_with_or_abort(&mut self.state, |state| match state {
                 CowState::ReadOnly(inner) => {
-                    tracing::trace!("COW file touched, starting file clone",);
+                    tracing::trace!("COW file touched, starting file clone");
                     CowState::SeekingGet(inner)
                 }
                 state => state,
@@ -1285,7 +1285,7 @@ mod tests {
         f.set_len(0).unwrap();
         assert_eq!(f.write(b"Hi").await.unwrap(), 2);
         // Same with flushing
-        assert_eq!(f.flush().await.unwrap(), (),);
+        assert_eq!(f.flush().await.unwrap(), ());
 
         // if we now read it then the data should be different
         buf = String::new();

--- a/lib/virtual-fs/src/union_fs.rs
+++ b/lib/virtual-fs/src/union_fs.rs
@@ -520,7 +520,7 @@ mod tests {
     async fn test_create_dir() {
         let fs = gen_filesystem();
 
-        assert_eq!(fs.create_dir(Path::new("/")), Ok(()),);
+        assert_eq!(fs.create_dir(Path::new("/")), Ok(()));
 
         assert_eq!(fs.create_dir(Path::new("/test_create_dir")), Ok(()));
 
@@ -533,7 +533,7 @@ mod tests {
         let cur_dir = read_dir_names(&fs, "/test_create_dir");
 
         if !cur_dir.contains(&"foo".to_string()) {
-            panic!("cur_dir does not contain foo: {:#?}", cur_dir);
+            panic!("cur_dir does not contain foo: {cur_dir:#?}");
         }
 
         assert!(
@@ -644,7 +644,7 @@ mod tests {
             "renaming to a directory that has no parent",
         );
 
-        assert_eq!(fs.create_dir(Path::new("/test_rename")), Ok(()),);
+        assert_eq!(fs.create_dir(Path::new("/test_rename")), Ok(()));
         assert_eq!(fs.create_dir(Path::new("/test_rename/foo")), Ok(()));
         assert_eq!(fs.create_dir(Path::new("/test_rename/foo/qux")), Ok(()));
 
@@ -699,7 +699,7 @@ mod tests {
         let bar_dir = read_dir_names(&fs, "/test_rename/bar");
 
         if !bar_dir.contains(&"qux".to_string()) {
-            println!("qux does not exist: {:?}", bar_dir)
+            println!("qux does not exist: {bar_dir:?}")
         }
 
         let qux_dir = read_dir_names(&fs, "/test_rename/bar/qux");
@@ -913,7 +913,7 @@ mod tests {
             "creating `b.txt`",
         );
 
-        println!("fs: {:?}", fs);
+        println!("fs: {fs:?}");
 
         let readdir = fs.read_dir(Path::new("/test_readdir"));
 
@@ -923,7 +923,7 @@ mod tests {
 
         let next = readdir.next().unwrap().unwrap();
         assert!(next.path.ends_with("foo"), "checking entry #1");
-        println!("entry 1: {:#?}", next);
+        println!("entry 1: {next:#?}");
         assert!(next.file_type().unwrap().is_dir(), "checking entry #1");
 
         let next = readdir.next().unwrap().unwrap();
@@ -943,7 +943,7 @@ mod tests {
         assert!(next.file_type().unwrap().is_file(), "checking entry #5");
 
         if let Some(s) = readdir.next() {
-            panic!("next: {:?}", s);
+            panic!("next: {s:?}");
         }
 
         let _ = fs_extra::remove_items(&["./test_readdir"]);

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -98,7 +98,7 @@ impl Mmap {
 
             let len = file.metadata().map_err(|e| e.to_string())?.len() as usize;
             if len < mapping_size {
-                std::fs::write(&backing_file_accessible, format!("{}", len).as_bytes()).ok();
+                std::fs::write(&backing_file_accessible, format!("{len}").as_bytes()).ok();
 
                 file.set_len(mapping_size as u64)
                     .map_err(|e| e.to_string())?;

--- a/lib/vm/src/table.rs
+++ b/lib/vm/src/table.rs
@@ -119,8 +119,7 @@ impl VMTable {
             ValType::FuncRef | ValType::ExternRef => (),
             ty => {
                 return Err(format!(
-                    "tables of types other than funcref or externref ({})",
-                    ty
+                    "tables of types other than funcref or externref ({ty})",
                 ))
             }
         };
@@ -243,10 +242,7 @@ impl VMTable {
                     // This path should never be hit by the generated code due to Wasm
                     // validation.
                     (ty, v) => {
-                        panic!(
-                            "Attempted to set a table of type {} with the value {:?}",
-                            ty, v
-                        )
+                        panic!("Attempted to set a table of type {ty} with the value {v:?}")
                     }
                 };
 
@@ -311,7 +307,7 @@ impl VMTable {
     pub fn copy_on_write(&self) -> Result<Self, String> {
         let mut ret = Self::new(&self.table, &self.style)?;
         ret.copy(self, 0, 0, self.size())
-            .map_err(|trap| format!("failed to copy the table - {:?}", trap))?;
+            .map_err(|trap| format!("failed to copy the table - {trap:?}"))?;
         Ok(ret)
     }
 

--- a/lib/vm/src/trap/trap.rs
+++ b/lib/vm/src/trap/trap.rs
@@ -126,7 +126,7 @@ impl std::error::Error for Trap {
 impl fmt::Display for Trap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::User(e) => write!(f, "{}", e),
+            Self::User(e) => write!(f, "{e}"),
             Self::Lib { .. } => write!(f, "lib"),
             Self::Wasm { .. } => write!(f, "wasm"),
             Self::OOM { .. } => write!(f, "Wasmer VM out of memory"),

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -236,7 +236,7 @@ cfg_if::cfg_if! {
                 libc::SIGBUS => &PREV_SIGBUS,
                 libc::SIGFPE => &PREV_SIGFPE,
                 libc::SIGILL => &PREV_SIGILL,
-                _ => panic!("unknown signal: {}", signum),
+                _ => panic!("unknown signal: {signum}"),
             };
             // We try to get the fault address associated to this signal
             let maybe_fault_address = match signum {

--- a/lib/wai-bindgen-wasmer/src/lib.rs
+++ b/lib/wai-bindgen-wasmer/src/lib.rs
@@ -82,7 +82,7 @@ pub mod rt {
     }
 
     pub fn invalid_variant(name: &str) -> RuntimeError {
-        let msg = format!("invalid discriminant for `{}`", name);
+        let msg = format!("invalid discriminant for `{name}`");
         RuntimeError::new(msg)
     }
 
@@ -96,7 +96,7 @@ pub mod rt {
         T: std::ops::Not<Output = T> + std::ops::BitAnd<Output = T> + From<u8> + PartialEq + Copy,
     {
         if bits & !all != 0u8.into() {
-            let msg = format!("invalid flags specified for `{}`", name);
+            let msg = format!("invalid flags specified for `{name}`");
             Err(RuntimeError::new(msg))
         } else {
             Ok(mk(bits))

--- a/lib/wasi-types/src/types.rs
+++ b/lib/wasi-types/src/types.rs
@@ -41,7 +41,7 @@ pub mod file {
                 right_set.insert(cur_right.to_str().unwrap_or("INVALID RIGHT"));
             }
         }
-        println!("{:#?}", right_set);
+        println!("{right_set:#?}");
     }
 }
 

--- a/lib/wasi-types/src/wasi/bindings_manual.rs
+++ b/lib/wasi-types/src/wasi/bindings_manual.rs
@@ -155,7 +155,7 @@ impl std::fmt::Display for Sockoption {
             Self::Type => "Sockoption::Type",
             Self::Proto => "Sockoption::Proto",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/lib/wasix/src/runners/dproxy/runner.rs
+++ b/lib/wasix/src/runners/dproxy/runner.rs
@@ -101,7 +101,7 @@ impl crate::runners::Runner for DProxyRunner {
                             let fut = graceful.watch(conn);
                             futs.push(async move {
                                 if let Err(e) = fut.await {
-                                    eprintln!("Error serving connection: {:?}", e);
+                                    eprintln!("Error serving connection: {e:?}");
                                 }
                             });
                         },

--- a/lib/wasix/src/runners/wcgi/runner.rs
+++ b/lib/wasix/src/runners/wcgi/runner.rs
@@ -154,7 +154,7 @@ impl WcgiRunner {
                         let fut = graceful.watch(conn);
                         futs.push(async move {
                             if let Err(e) = fut.await {
-                                eprintln!("Error serving connection: {:?}", e);
+                                eprintln!("Error serving connection: {e:?}");
                             }
                         });
                     },

--- a/tests/compilers/config.rs
+++ b/tests/compilers/config.rs
@@ -93,7 +93,7 @@ impl Config {
             }
             #[allow(unreachable_patterns)]
             compiler => {
-                panic!("The {compiler:?} Compiler is not enabled. Enable it via the features",)
+                panic!("The {compiler:?} Compiler is not enabled. Enable it via the features")
             }
         }
     }


### PR DESCRIPTION
Using this command, fixed format argument inlining to improve readability, and fix a few minor related styling issues like trailing commas in a single line.

```
cargo clippy --all-targets --workspace --exclude wasmer-cli --exclude wasmer-swift -- -D clippy::uninlined_format_args
```

P.S.  Make sure to hide whitespace changes when reviewing