### PR TITLE
chore: inline format args to improve readability (2)

### DIFF
--- a/benches/import_functions.rs
+++ b/benches/import_functions.rs
@@ -33,26 +33,23 @@ pub fn run_import_inner(store: &mut Store, n_fn: u32, compiler_name: &str, c: &m
     )
     .unwrap();
 
-    c.bench_function(
-        &format!("import in {} (size: {})", compiler_name, n_fn),
-        |b| {
-            let module = module.clone();
-            b.iter(|| {
-                let mut imports = imports! {};
-                for i in 0..n_fn {
-                    let name = format!("f{i}");
-                    imports.define(
-                        "env",
-                        &name,
-                        donor_instance.exports.get_function(&name).unwrap().clone(),
-                    );
-                }
+    c.bench_function(&format!("import in {compiler_name} (size: {n_fn})"), |b| {
+        let module = module.clone();
+        b.iter(|| {
+            let mut imports = imports! {};
+            for i in 0..n_fn {
+                let name = format!("f{i}");
+                imports.define(
+                    "env",
+                    &name,
+                    donor_instance.exports.get_function(&name).unwrap().clone(),
+                );
+            }
 
-                let instance = black_box(Instance::new(store, &module, &imports));
-                assert!(instance.is_ok());
-            })
-        },
-    );
+            let instance = black_box(Instance::new(store, &module, &imports));
+            assert!(instance.is_ok());
+        })
+    });
 }
 
 fn run_import_functions_benchmarks_small(_c: &mut Criterion) {

--- a/benches/static_and_dynamic_functions.rs
+++ b/benches/static_and_dynamic_functions.rs
@@ -42,7 +42,7 @@ pub fn run_basic_static_function(store: &mut Store, compiler_name: &str, c: &mut
     let dyn_f: &Function = instance.exports.get("add").unwrap();
     let f: TypedFunction<(i32, i32), i32> = dyn_f.typed(store).unwrap();
 
-    c.bench_function(&format!("basic static func {}", compiler_name), |b| {
+    c.bench_function(&format!("basic static func {compiler_name}"), |b| {
         b.iter(|| {
             let result = black_box(f.call(store, 4, 6).unwrap());
             assert_eq!(result, 10);
@@ -76,7 +76,7 @@ pub fn run_basic_static_function(store: &mut Store, compiler_name: &str, c: &mut
         i32,
     > = dyn_f_many.typed(store).unwrap();
     c.bench_function(
-        &format!("basic static func with many args {}", compiler_name),
+        &format!("basic static func with many args {compiler_name}"),
         |b| {
             b.iter(|| {
                 let result = black_box(
@@ -103,7 +103,7 @@ pub fn run_basic_dynamic_function(store: &mut Store, compiler_name: &str, c: &mu
     let instance = Instance::new(store, &module, &import_object).unwrap();
 
     let dyn_f: &Function = instance.exports.get("add").unwrap();
-    c.bench_function(&format!("basic dynfunc {}", compiler_name), |b| {
+    c.bench_function(&format!("basic dynfunc {compiler_name}"), |b| {
         b.iter(|| {
             let dyn_result = black_box(dyn_f.call(store, &[Value::I32(4), Value::I32(6)]).unwrap());
             assert_eq!(dyn_result[0], Value::I32(10));
@@ -112,7 +112,7 @@ pub fn run_basic_dynamic_function(store: &mut Store, compiler_name: &str, c: &mu
 
     let dyn_f_many: &Function = instance.exports.get("add20").unwrap();
     c.bench_function(
-        &format!("basic dynfunc with many args {}", compiler_name),
+        &format!("basic dynfunc with many args {compiler_name}"),
         |b| {
             b.iter(|| {
                 let dyn_result = black_box(

--- a/tests/compilers/artifact.rs
+++ b/tests/compilers/artifact.rs
@@ -32,7 +32,7 @@ fn artifact_serialization_build() {
     let chipset = "x86_64";
 
     for os in operating_systems {
-        let triple = Triple::from_str(&format!("{}-{}", chipset, os)).unwrap();
+        let triple = Triple::from_str(&format!("{chipset}-{os}")).unwrap();
         let mut cpu_feature = CpuFeature::set();
         cpu_feature.insert(CpuFeature::from_str("sse2").unwrap());
         let target = Target::new(triple, cpu_feature);
@@ -46,7 +46,7 @@ fn artifact_serialization_build() {
 
             let module = Module::new(&engine, wasm_module).unwrap();
             let serialized_bytes = module.serialize().unwrap();
-            let path = PathBuf::from(&format!("tests/compilers/wasmu/{}/{}u", os, file_name));
+            let path = PathBuf::from(&format!("tests/compilers/wasmu/{os}/{file_name}u"));
             std::fs::write(path, serialized_bytes).unwrap();
         }
     }

--- a/tests/compilers/config.rs
+++ b/tests/compilers/config.rs
@@ -93,10 +93,7 @@ impl Config {
             }
             #[allow(unreachable_patterns)]
             compiler => {
-                panic!(
-                    "The {:?} Compiler is not enabled. Enable it via the features",
-                    compiler
-                )
+                panic!("The {compiler:?} Compiler is not enabled. Enable it via the features",)
             }
         }
     }

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -114,7 +114,7 @@ fn test_trap_trace_cb(config: crate::Config) -> Result<()> {
         .expect_err("error calling function");
 
     let trace = e.trace();
-    println!("Trace {:?}", trace);
+    println!("Trace {trace:?}");
     // TODO: Reenable this (disabled as it was not working with llvm/singlepass)
     // assert_eq!(trace.len(), 2);
     // assert_eq!(trace[0].module_name(), "hello_mod");
@@ -430,7 +430,7 @@ fn call_signature_mismatch(config: crate::Config) -> Result<()> {
     let module = Module::new(&store, binary)?;
     let err = Instance::new(&mut store, &module, &imports! {}).expect_err("expected error");
     assert_eq!(
-        format!("{}", err),
+        format!("{err}"),
         "\
 RuntimeError: indirect call type mismatch
     at foo (a[0]:0x30)\
@@ -457,7 +457,7 @@ fn start_trap_pretty(config: crate::Config) -> Result<()> {
     let err = Instance::new(&mut store, &module, &imports! {}).expect_err("expected error");
 
     assert_eq!(
-        format!("{}", err),
+        format!("{err}"),
         "\
 RuntimeError: unreachable
     at die (m[0]:0x1d)
@@ -485,7 +485,7 @@ fn present_after_module_drop(config: crate::Config) -> Result<()> {
     return Ok(());
 
     fn assert_trap(t: RuntimeError) {
-        println!("{}", t);
+        println!("{t}");
         // assert_eq!(t.trace().len(), 1);
         // assert_eq!(t.trace()[0].func_index(), 0);
     }

--- a/tests/compilers/typed_functions.rs
+++ b/tests/compilers/typed_functions.rs
@@ -86,7 +86,7 @@ fn typed_host_function_closure_panics(config: crate::Config) {
     let mut store = config.store();
     let state = 3;
     Function::new_typed(&mut store, move |_: i32| {
-        println!("{}", state);
+        println!("{state}");
     });
 }
 
@@ -100,7 +100,7 @@ fn typed_with_env_host_function_closure_panics(config: crate::Config) {
         &mut store,
         &env,
         move |_env: FunctionEnvMut<i32>, _: i32| {
-            println!("{}", state);
+            println!("{state}");
         },
     );
 }

--- a/tests/compilers/wasi.rs
+++ b/tests/compilers/wasi.rs
@@ -22,7 +22,7 @@ pub fn run_wasi(
     base_dir: &str,
     filesystem_kind: WasiFileSystemKind,
 ) -> anyhow::Result<()> {
-    println!("Running wasi wast `{}`", wast_path);
+    println!("Running wasi wast `{wast_path}`");
     let mut store = config.store();
 
     let source = {

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -17,7 +17,7 @@ use wasmer_wast::Wast;
 include!(concat!(env!("OUT_DIR"), "/generated_spectests.rs"));
 
 pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()> {
-    println!("Running wast `{}`", wast_path);
+    println!("Running wast `{wast_path}`");
     let try_nan_canonicalization = wast_path.contains("nan-canonicalization");
     let mut features = Features::default();
     let is_bulkmemory = wast_path.contains("bulk-memory");

--- a/tests/integration/cli/src/assets.rs
+++ b/tests/integration/cli/src/assets.rs
@@ -67,7 +67,7 @@ pub fn get_libwasmer_path() -> PathBuf {
         ret = wasmer_target_path_2().join(LIBWASMER_FILENAME);
     }
     if !ret.exists() {
-        panic!("Could not find libwasmer path! {:?}", ret);
+        panic!("Could not find libwasmer path! {ret:?}");
     }
     ret
 }
@@ -93,7 +93,7 @@ pub fn get_wasmer_path() -> PathBuf {
                 }
             }
             None => {
-                panic!("Could not find wasmer executable path! {:?}", ret);
+                panic!("Could not find wasmer executable path! {ret:?}");
             }
         };
     }
@@ -112,7 +112,7 @@ pub fn get_wasmer_path() -> PathBuf {
                     .join(executable)
             }
             None => {
-                panic!("Could not find wasmer executable path! {:?}", ret);
+                panic!("Could not find wasmer executable path! {ret:?}");
             }
         };
     }

--- a/tests/integration/cli/tests/create.rs
+++ b/tests/integration/cli/tests/create.rs
@@ -17,9 +17,9 @@ fn wasmer_create_package() -> anyhow::Result<()> {
         .arg("--quiet")
         .arg(format!("--name={app_name}"))
         .arg(format!("--owner={username}"))
-        .arg(format!("--package=wasmer/hello"))
+        .arg("--package=wasmer/hello")
         .arg(format!("--dir={}", app_dir.display()))
-        .arg(format!("--non-interactive"))
+        .arg("--non-interactive")
         .arg("--registry=https://registry.wasmer.wtf/graphql");
 
     if let Some(token) = wapm_dev_token {
@@ -61,9 +61,9 @@ fn wasmer_create_template() -> anyhow::Result<()> {
         .arg("--quiet")
         .arg(format!("--name={app_name}"))
         .arg(format!("--owner={username}"))
-        .arg(format!("--template=static-website"))
+        .arg("--template=static-website")
         .arg(format!("--dir={}", app_dir.display()))
-        .arg(format!("--non-interactive"))
+        .arg("--non-interactive")
         .arg("--registry=https://registry.wasmer.wtf/graphql");
 
     if let Some(token) = wapm_dev_token {
@@ -86,8 +86,7 @@ owner: {username}
     let got = std::fs::read_to_string(app_dir.join("app.yaml"))?;
     assert_eq!(got, want);
 
-    let want = format!(
-        r#"[dependencies]
+    let want = r#"[dependencies]
 "wasmer/static-web-server" = "^1"
 
 [fs]
@@ -101,8 +100,7 @@ runner = "https://webc.org/runner/wasi"
 
 [command.annotations.wasi]
 main-args = ["-w", "/settings/config.toml"]
-"#
-    );
+"#;
     let got = std::fs::read_to_string(app_dir.join("wasmer.toml"))?;
     assert_eq!(got, want);
 

--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -65,7 +65,7 @@ impl WasmerCreateExe {
             output.arg("--tarball");
             output.arg(&tarball_path);
         }
-        let cmd = format!("{:?}", output);
+        let cmd = format!("{output:?}");
 
         println!("(integration-test) running create-exe: {cmd}");
 
@@ -135,7 +135,7 @@ impl WasmerCreateObj {
         output.arg("-o");
         output.arg(&self.output_object_path);
 
-        let cmd = format!("{:?}", output);
+        let cmd = format!("{output:?}");
 
         println!("(integration-test) running create-obj: {cmd}");
 
@@ -298,7 +298,7 @@ fn create_exe_works() -> anyhow::Result<()> {
     )
     .context("Failed to run generated executable")?;
     let result_lines = result.lines().collect::<Vec<&str>>();
-    assert_eq!(result_lines, vec!["\"Hello, World\""],);
+    assert_eq!(result_lines, vec!["\"Hello, World\""]);
 
     Ok(())
 }
@@ -398,7 +398,7 @@ fn create_exe_works_underscore_module_name() -> anyhow::Result<()> {
     let mut create_exe_flags = Vec::new();
 
     for a in atoms.iter() {
-        let object_path = operating_dir.as_path().join(&format!("{a}.o"));
+        let object_path = operating_dir.as_path().join(format!("{a}.o"));
         let _output: Vec<u8> = WasmerCreateObj {
             current_dir: operating_dir.clone(),
             wasm_path: wasm_path.clone(),
@@ -546,7 +546,7 @@ fn create_exe_works_with_file() -> anyhow::Result<()> {
     )
     .context("Failed to run generated executable")?;
     let result_lines = result.lines().collect::<Vec<&str>>();
-    assert_eq!(result_lines, vec!["\"Hello, World\""],);
+    assert_eq!(result_lines, vec!["\"Hello, World\""]);
 
     // test with `--mapdir`
     let result = run_code(
@@ -561,7 +561,7 @@ fn create_exe_works_with_file() -> anyhow::Result<()> {
     )
     .context("Failed to run generated executable")?;
     let result_lines = result.lines().collect::<Vec<&str>>();
-    assert_eq!(result_lines, vec!["\"Hello, World\""],);
+    assert_eq!(result_lines, vec!["\"Hello, World\""]);
 
     Ok(())
 }
@@ -675,7 +675,7 @@ fn create_exe_with_object_input(args: Vec<String>) -> anyhow::Result<()> {
     )
     .context("Failed to run generated executable")?;
     let result_lines = result.lines().collect::<Vec<&str>>();
-    assert_eq!(result_lines, vec!["\"Hello, World\""],);
+    assert_eq!(result_lines, vec!["\"Hello, World\""]);
 
     Ok(())
 }
@@ -830,7 +830,7 @@ fn test_cross_compile_python_windows() {
                     .filter_map(|e| Some(e.ok()?.path()))
                     .collect::<Vec<_>>();
                 let output = assert.get_output();
-                panic!("target {t} was not compiled correctly tempdir: {p:#?}, {output:?}",);
+                panic!("target {t} was not compiled correctly tempdir: {p:#?}, {output:?}");
             }
         }
     }

--- a/tests/integration/cli/tests/msrv.rs
+++ b/tests/integration/cli/tests/msrv.rs
@@ -96,7 +96,7 @@ fn ensure_file_contents(path: impl AsRef<Path>, contents: impl AsRef<str>) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    std::fs::write(&path, contents).unwrap();
+    std::fs::write(path, contents).unwrap();
     panic!(
         "\"{}\" was not up to date and has been updated. Please commit the changes and re-run the tests.",
         path.strip_prefix(project_root()).unwrap_or(path).display()

--- a/tests/integration/cli/tests/publish.rs
+++ b/tests/integration/cli/tests/publish.rs
@@ -180,7 +180,7 @@ fn wasmer_publish_and_run() {
     .unwrap();
 
     let package_name =
-        format!("{username}/largewasmfile@{random_major}.{random_minor}.{random_patch}",);
+        format!("{username}/largewasmfile@{random_major}.{random_minor}.{random_patch}");
 
     let mut cmd = std::process::Command::new(get_wasmer_path());
     cmd.arg("publish")

--- a/tests/integration/cli/tests/snapshot.rs
+++ b/tests/integration/cli/tests/snapshot.rs
@@ -644,7 +644,7 @@ fn test_run_http_request(
 
     let expected_size = match expected_size {
         None => {
-            let url = format!("http://localhost:{}/{}.size", port, what);
+            let url = format!("http://localhost:{port}/{what}.size");
             let expected_size = String::from_utf8_lossy(http_get(url, 50)?.as_ref())
                 .trim()
                 .parse()?;
@@ -655,9 +655,9 @@ fn test_run_http_request(
         }
         Some(s) => s,
     };
-    println!("expected_size: {}", expected_size);
+    println!("expected_size: {expected_size}");
 
-    let url = format!("http://localhost:{}/{}", port, what);
+    let url = format!("http://localhost:{port}/{what}");
     let reference_data = http_get(url.clone(), 50)?;
     for _ in 0..20 {
         let test_data = http_get(url.clone(), 2)?;
@@ -725,8 +725,7 @@ fn test_snapshot_web_server() {
 cat /public/main.js | wc -c > /public/main.js.size
 rm -r -f /cfg/
 cd /public
-/bin/webserver --log-level warn --root /public --port {}"#,
-        port
+/bin/webserver --log-level warn --root /public --port {port}"#,
     );
     let builder = TestBuilder::new()
         .with_name(name)
@@ -765,7 +764,7 @@ fn test_snapshot_web_server_epoll() {
         .arg("--log-level")
         .arg("warn")
         .arg("--port")
-        .arg(format!("{}", port));
+        .arg(format!("{port}"));
 
     let snapshot = builder.run_wasm_with(
         include_bytes!("./wasm/web-server-epoll.wasm"),
@@ -798,7 +797,7 @@ fn test_snapshot_web_server_poll() {
         .arg("--log-level")
         .arg("warn")
         .arg("--port")
-        .arg(&format!("{}", port));
+        .arg(format!("{port}"));
 
     let snapshot = builder.run_wasm_with(
         include_bytes!("./wasm/web-server-poll.wasm"),

--- a/tests/lib/compiler-test-derive/build.rs
+++ b/tests/lib/compiler-test-derive/build.rs
@@ -1,12 +1,12 @@
 fn main() {
     println!("cargo:rerun-if-changed=../../ignores.txt");
     if let Ok(os) = std::env::var("CARGO_CFG_TARGET_OS") {
-        println!("cargo:rustc-env=CFG_TARGET_OS={}", os);
+        println!("cargo:rustc-env=CFG_TARGET_OS={os}");
     }
     if let Ok(os) = std::env::var("CARGO_CFG_TARGET_ARCH") {
-        println!("cargo:rustc-env=CFG_TARGET_ARCH={}", os);
+        println!("cargo:rustc-env=CFG_TARGET_ARCH={os}");
     }
     if let Ok(os) = std::env::var("CARGO_CFG_TARGET_ENV") {
-        println!("cargo:rustc-env=CFG_TARGET_ENV={}", os);
+        println!("cargo:rustc-env=CFG_TARGET_ENV={os}");
     }
 }

--- a/tests/lib/test-generator/src/lib.rs
+++ b/tests/lib/test-generator/src/lib.rs
@@ -44,7 +44,7 @@ fn write_test(out: &mut Testsuite, testname: &str, body: &str) -> anyhow::Result
         "fn r#{}(config: crate::Config) -> anyhow::Result<()> {{",
         &testname
     )?;
-    writeln!(out.buffer, "{}", body)?;
+    writeln!(out.buffer, "{body}")?;
     writeln!(out.buffer, "}}")?;
     writeln!(out.buffer)?;
     Ok(())
@@ -58,7 +58,7 @@ pub fn test_directory(
     let path = path.as_ref();
     let mut dir_entries: Vec<_> = path
         .read_dir()
-        .context(format!("failed to read {:?}", path))?
+        .context(format!("failed to read {path:?}"))?
         .map(|r| r.expect("reading testsuite directory entry"))
         .filter_map(|dir_entry| processor(out, dir_entry.path()))
         .collect();

--- a/tests/lib/wast/src/spectest.rs
+++ b/tests/lib/wast/src/spectest.rs
@@ -5,17 +5,17 @@ use wasmer::*;
 #[allow(clippy::print_stdout)]
 pub fn spectest_importobject(store: &mut Store) -> Imports {
     let print = Function::new_typed(store, || {});
-    let print_i32 = Function::new_typed(store, |val: i32| println!("{}: i32", val));
-    let print_i64 = Function::new_typed(store, |val: i64| println!("{}: i64", val));
-    let print_f32 = Function::new_typed(store, |val: f32| println!("{}: f32", val));
-    let print_f64 = Function::new_typed(store, |val: f64| println!("{}: f64", val));
+    let print_i32 = Function::new_typed(store, |val: i32| println!("{val}: i32"));
+    let print_i64 = Function::new_typed(store, |val: i64| println!("{val}: i64"));
+    let print_f32 = Function::new_typed(store, |val: f32| println!("{val}: f32"));
+    let print_f64 = Function::new_typed(store, |val: f64| println!("{val}: f64"));
     let print_i32_f32 = Function::new_typed(store, |i: i32, f: f32| {
-        println!("{}: i32", i);
-        println!("{}: f32", f);
+        println!("{i}: i32");
+        println!("{f}: f32");
     });
     let print_f64_f64 = Function::new_typed(store, |f1: f64, f2: f64| {
-        println!("{}: f64", f1);
-        println!("{}: f64", f2);
+        println!("{f1}: f64");
+        println!("{f2}: f64");
     });
 
     let global_i32 = Global::new(store, Value::I32(666));

--- a/tests/lib/wast/src/wasi_wast.rs
+++ b/tests/lib/wast/src/wasi_wast.rs
@@ -155,9 +155,7 @@ impl<'a> WasiTest<'a> {
                 let stderr_str = get_stdio_output(&stderr_rx)?;
                 Err(e).with_context(|| {
                     format!(
-                        "failed to run WASI `_start` function: failed with stdout: \"{}\"\nstderr: \"{}\"",
-                        stdout_str,
-                        stderr_str,
+                        "failed to run WASI `_start` function: failed with stdout: \"{stdout_str}\"\nstderr: \"{stderr_str}\"",
                     )
                 })?;
             }
@@ -307,7 +305,7 @@ impl<'a> WasiTest<'a> {
 
                 for alias in &self.temp_dirs {
                     let temp_dir_name =
-                        PathBuf::from(format!("/.tmp_wasmer_wast_{}", temp_dir_index));
+                        PathBuf::from(format!("/.tmp_wasmer_wast_{temp_dir_index}"));
                     fs.create_dir(temp_dir_name.as_path())?;
                     builder.add_map_dir(alias, temp_dir_name)?;
                     temp_dir_index += 1;

--- a/tests/lib/wast/src/wast.rs
+++ b/tests/lib/wast/src/wast.rs
@@ -169,7 +169,7 @@ impl Wast {
     fn assert_trap(&self, result: Result<Vec<Value>>, expected: &str) -> Result<()> {
         let actual = match result {
             Ok(values) => bail!("expected trap, got {:?}", values),
-            Err(t) => format!("{}", t),
+            Err(t) => format!("{t}"),
         };
         if self.matches_message_assert_trap(expected, &actual) {
             return Ok(());
@@ -229,7 +229,7 @@ impl Wast {
                     Ok(()) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
-                let error_message = format!("{:?}", err);
+                let error_message = format!("{err:?}");
                 if !Self::matches_message_assert_invalid(message, &error_message) {
                     bail!(
                         "assert_invalid: expected \"{}\", got \"{}\"",
@@ -270,7 +270,7 @@ impl Wast {
                     Ok(()) => bail!("expected module to fail to link"),
                     Err(e) => e,
                 };
-                let error_message = format!("{:?}", err);
+                let error_message = format!("{err:?}");
                 if !Self::matches_message_assert_unlinkable(message, &error_message) {
                     bail!(
                         "assert_unlinkable: expected {}, got {}",
@@ -305,7 +305,7 @@ impl Wast {
         for directive in ast.directives {
             let sp = directive.span();
             if let Err(e) = self.run_directive(test, directive) {
-                let message = format!("{}", e);
+                let message = format!("{e}");
                 // If depends on an instance that doesn't exist
                 if message.contains("no previous instance found") {
                     continue;
@@ -376,7 +376,7 @@ impl Wast {
                 // We set the current to None to allow running other
                 // spectests when `fail_fast` is `false`.
                 self.current = None;
-                let error_message = format!("{}", e);
+                let error_message = format!("{e}");
                 self.current_is_allowed_failure = false;
                 for allowed_failure in self.allowed_instantiation_failures.iter() {
                     if error_message.contains(allowed_failure) {

--- a/tests/wasi-wast/src/set_up_toolchain.rs
+++ b/tests/wasi-wast/src/set_up_toolchain.rs
@@ -4,7 +4,7 @@ use super::wasi_version::*;
 use std::process::Command;
 
 fn install_toolchain(toolchain_name: &str) {
-    println!("Installing rustup toolchain: {}", toolchain_name);
+    println!("Installing rustup toolchain: {toolchain_name}");
     let rustup_out = Command::new("rustup")
         .arg("toolchain")
         .arg("install")

--- a/tests/wasi-wast/src/util.rs
+++ b/tests/wasi-wast/src/util.rs
@@ -1,6 +1,6 @@
 pub fn print_info_on_error(output: &std::process::Output, context: &str) {
     if !output.status.success() {
-        println!("{}", context);
+        println!("{context}");
         println!(
             "stdout:\n{}",
             std::str::from_utf8(&output.stdout[..]).unwrap()

--- a/tests/wasi-wast/src/wasitests.rs
+++ b/tests/wasi-wast/src/wasitests.rs
@@ -79,7 +79,7 @@ fn generate_native_output(
         .unwrap();
 
     if let Some(stdin_str) = &options.stdin {
-        write!(native_command.stdin.as_ref().unwrap(), "{}", stdin_str).unwrap();
+        write!(native_command.stdin.as_ref().unwrap(), "{stdin_str}").unwrap();
     }
 
     let result = native_command
@@ -100,8 +100,8 @@ fn generate_native_output(
     };
     if !result.success() {
         println!("NATIVE PROGRAM FAILED");
-        println!("stdout:\n{}", stdout_str);
-        eprintln!("stderr:\n{}", stderr_str);
+        println!("stdout:\n{stdout_str}");
+        eprintln!("stderr:\n{stderr_str}");
     }
 
     let result = result.code().unwrap() as i64;
@@ -131,7 +131,7 @@ fn compile_wasm_for_version(
         wasm_out_name.set_extension("wasm");
         wasm_out_name
     };
-    println!("Reading contents from file `{}`", file);
+    println!("Reading contents from file `{file}`");
     let file_contents: String = {
         let mut fc = String::new();
         let mut f = fs::OpenOptions::new().read(true).open(file)?;
@@ -139,7 +139,7 @@ fn compile_wasm_for_version(
         fc
     };
 
-    let temp_wasi_rs_file_name = temp_dir.join(format!("wasi_modified_version_{}.rs", rs_mod_name));
+    let temp_wasi_rs_file_name = temp_dir.join(format!("wasi_modified_version_{rs_mod_name}.rs"));
     {
         let mut actual_file = fs::OpenOptions::new()
             .write(true)
@@ -165,7 +165,7 @@ fn compile_wasm_for_version(
         .arg(&temp_wasi_rs_file_name)
         .arg("-o")
         .arg(&wasm_out_name);
-    println!("Command {:?}", command);
+    println!("Command {command:?}");
 
     let wasm_compilation_out = command.output().expect("Failed to compile program to wasm");
     util::print_info_on_error(&wasm_compilation_out, "WASM COMPILATION");
@@ -214,7 +214,7 @@ fn compile(temp_dir: &Path, file: &str, wasi_versions: &[WasiVersion]) {
         .expect("Generate native output");
 
     let test = WasiTest {
-        wasm_prog_name: format!("{}.wasm", rs_mod_name),
+        wasm_prog_name: format!("{rs_mod_name}.wasm"),
         stdout,
         stderr,
         result,
@@ -238,7 +238,7 @@ fn compile(temp_dir: &Path, file: &str, wasi_versions: &[WasiVersion]) {
             println!("Writing test output to {}", wasm_out_name.to_string_lossy());
             fs::write(&wasm_out_name, test_serialized.clone()).unwrap();
 
-            println!("Compiling wasm version {:?}", version);
+            println!("Compiling wasm version {version:?}");
             compile_wasm_for_version(temp_dir, file, &out_dir, &rs_mod_name, version)
                 .unwrap_or_else(|_| panic!("Could not compile Wasm to WASI version {:?}, perhaps you need to install the `{}` rust toolchain", version, version.get_compiler_toolchain()));
         }).for_each(drop); // Do nothing with it, but let the iterator be consumed/iterated.
@@ -261,7 +261,7 @@ pub fn build(wasi_versions: &[WasiVersion], specific_tests: &[&str]) {
                     compile(temp_dir.path(), test, wasi_versions);
                 }
             }
-            Err(e) => println!("{:?}", e),
+            Err(e) => println!("{e:?}"),
         }
     }
     println!("All modules generated.");
@@ -296,20 +296,20 @@ impl WasiTest {
                 .options
                 .env
                 .iter()
-                .map(|(name, value)| format!("\"{}={}\"", name, value))
+                .map(|(name, value)| format!("\"{name}={value}\""))
                 .collect::<Vec<String>>()
                 .join(" ");
-            let _ = write!(out, "\n  (envs {})", envs);
+            let _ = write!(out, "\n  (envs {envs})");
         }
         if !self.options.args.is_empty() {
             let args = self
                 .options
                 .args
                 .iter()
-                .map(|v| format!("\"{}\"", v))
+                .map(|v| format!("\"{v}\""))
                 .collect::<Vec<String>>()
                 .join(" ");
-            let _ = write!(out, "\n  (args {})", args);
+            let _ = write!(out, "\n  (args {args})");
         }
 
         if !self.options.dir.is_empty() {
@@ -317,35 +317,35 @@ impl WasiTest {
                 .options
                 .dir
                 .iter()
-                .map(|v| format!("\"{}\"", v))
+                .map(|v| format!("\"{v}\""))
                 .collect::<Vec<String>>()
                 .join(" ");
-            let _ = write!(out, "\n  (preopens {})", preopens);
+            let _ = write!(out, "\n  (preopens {preopens})");
         }
         if !self.options.mapdir.is_empty() {
             let map_dirs = self
                 .options
                 .mapdir
                 .iter()
-                .map(|(a, b)| format!("\"{}:{}\"", a, b))
+                .map(|(a, b)| format!("\"{a}:{b}\""))
                 .collect::<Vec<String>>()
                 .join(" ");
-            let _ = write!(out, "\n  (map_dirs {})", map_dirs);
+            let _ = write!(out, "\n  (map_dirs {map_dirs})");
         }
         if !self.options.tempdir.is_empty() {
             let temp_dirs = self
                 .options
                 .tempdir
                 .iter()
-                .map(|td| format!("\"{}\"", td))
+                .map(|td| format!("\"{td}\""))
                 .collect::<Vec<String>>()
                 .join(" ");
-            let _ = write!(out, "\n  (temp_dirs {})", temp_dirs);
+            let _ = write!(out, "\n  (temp_dirs {temp_dirs})");
         }
 
         let _ = write!(out, "\n  (assert_return (i64.const {}))", self.result);
         if let Some(stdin) = &self.options.stdin {
-            let _ = write!(out, "\n  (stdin {:?})", stdin);
+            let _ = write!(out, "\n  (stdin {stdin:?})");
         }
 
         if !self.stdout.is_empty() {
@@ -407,14 +407,14 @@ fn extract_args_from_source_file(source_code: &str) -> Option<WasiOptions> {
                         // And then we try splitting by `:` (for compatibility with previous API)
                         args.mapdir.push((alias.to_string(), real_dir.to_string()));
                     } else {
-                        eprintln!("Parse error in mapdir {} not parsed correctly", value);
+                        eprintln!("Parse error in mapdir {value} not parsed correctly");
                     }
                 }
                 "env" => {
                     if let [name, val] = value.split('=').collect::<Vec<&str>>()[..] {
                         args.env.push((name.to_string(), val.to_string()));
                     } else {
-                        eprintln!("Parse error in env {} not parsed correctly", value);
+                        eprintln!("Parse error in env {value} not parsed correctly");
                     }
                 }
                 "dir" => {
@@ -437,7 +437,7 @@ fn extract_args_from_source_file(source_code: &str) -> Option<WasiOptions> {
                     args.stdin = Some(s.to_string());
                 }
                 e => {
-                    eprintln!("WARN: comment arg: `{}` is not supported", e);
+                    eprintln!("WARN: comment arg: `{e}` is not supported");
                 }
             }
         }

--- a/tests/wasmer-argus/src/argus/mod.rs
+++ b/tests/wasmer-argus/src/argus/mod.rs
@@ -156,12 +156,11 @@ impl Argus {
             }
         };
 
-        p.set_message(format!("[{test_id}] testing package {package_name}",));
+        p.set_message(format!("[{test_id}] testing package {package_name}"));
 
         let path = Argus::get_path(config.clone(), package).await;
         p.set_message(format!(
-            "testing package {package_name} -- path to download to is: {:?}",
-            path
+            "testing package {package_name} -- path to download to is: {path:?}",
         ));
 
         #[cfg(not(feature = "wasmer_lib"))]

--- a/tests/wasmer-argus/src/argus/packages.rs
+++ b/tests/wasmer-argus/src/argus/packages.rs
@@ -101,7 +101,7 @@ impl Argus {
     ) -> anyhow::Result<()> {
         info!("downloading package from {} to file {:?}", url, path);
         static APP_USER_AGENT: &str =
-            concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+            concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
         let mut dir_path = path.clone();
         dir_path.pop();

--- a/tests/wasmer-argus/src/argus/tester/cli_tester.rs
+++ b/tests/wasmer-argus/src/argus/tester/cli_tester.rs
@@ -157,7 +157,7 @@ impl<'a> Tester for CLIRunner<'a> {
         let webc_v2_path = dir_path.join("package_v2.webc");
 
         self.p
-            .set_message(format!("unpacking webc at {:?}", webc_v2_path));
+            .set_message(format!("unpacking webc at {webc_v2_path:?}"));
 
         let v2_bytes = std::fs::read(&webc_v2_path)?;
 
@@ -182,7 +182,7 @@ impl<'a> Tester for CLIRunner<'a> {
         let webc_v3_path = dir_path.join("package_v3.webc");
 
         self.p
-            .set_message(format!("unpacking webc at {:?}", webc_v3_path));
+            .set_message(format!("unpacking webc at {webc_v3_path:?}"));
 
         let v3_bytes = std::fs::read(&webc_v3_path)?;
 


### PR DESCRIPTION
Using this command, fixed format argument inlining to improve readability, and fix a few minor related styling issues like trailing commas in a single line.   Only modifies the test dirs

```
cargo clippy --all-targets --workspace --exclude wasmer-cli --exclude wasmer-swift -- -D clippy::uninlined_format_args
```

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
