### PR TITLE
chore: inline format args to improve readability (3)

### DIFF
--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -309,7 +309,7 @@ fn call_module(
                     return;
                 }
                 Ok(WasiError::UnknownWasiVersion) => {
-                    debug!("failed as wasi version is unknown",);
+                    debug!("failed as wasi version is unknown");
                     runtime.on_taint(TaintReason::UnknownWasiVersion);
                     Ok(Errno::Noexec)
                 }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -1781,7 +1781,7 @@ impl WasiFs {
                 Fd::READ,
                 self.root_inode.clone(),
             )
-            .map_err(|e| format!("Could not create root fd: {}", e))?;
+            .map_err(|e| format!("Could not create root fd: {e}"))?;
         self.preopen_fds.write().unwrap().push(fd);
         Ok(())
     }
@@ -1814,23 +1814,19 @@ impl WasiFs {
                 .create_inode(inodes, kind, true, preopen_name.clone())
                 .map_err(|e| {
                     format!(
-                        "Failed to create inode for preopened dir (name `{}`): WASI error code: {}",
-                        preopen_name, e
+                        "Failed to create inode for preopened dir (name `{preopen_name}`): WASI error code: {e}",
                     )
                 })?;
             let fd_flags = Fd::READ;
             let fd = self
                 .create_fd(rights, rights, Fdflags::empty(), fd_flags, inode.clone())
-                .map_err(|e| format!("Could not open fd for file {:?}: {}", preopen_name, e))?;
+                .map_err(|e| format!("Could not open fd for file {preopen_name:?}: {e}"))?;
             {
                 let mut guard = self.root_inode.write();
                 if let Kind::Root { entries } = guard.deref_mut() {
                     let existing_entry = entries.insert(preopen_name.clone(), inode);
                     if existing_entry.is_some() && !ignore_duplicates {
-                        return Err(format!(
-                            "Found duplicate entry for alias `{}`",
-                            preopen_name
-                        ));
+                        return Err(format!("Found duplicate entry for alias `{preopen_name}`"));
                     }
                 }
             }
@@ -1853,7 +1849,7 @@ impl WasiFs {
             let cur_dir_metadata = self
                 .root_fs
                 .metadata(path)
-                .map_err(|e| format!("Could not get metadata for file {:?}: {}", path, e))?;
+                .map_err(|e| format!("Could not get metadata for file {path:?}: {e}"))?;
 
             let kind = if cur_dir_metadata.is_dir() {
                 Kind::Dir {
@@ -1917,10 +1913,7 @@ impl WasiFs {
                 self.create_inode(inodes, kind, true, path.to_string_lossy().into_owned())
             }
             .map_err(|e| {
-                format!(
-                    "Failed to create inode for preopened dir: WASI error code: {}",
-                    e
-                )
+                format!("Failed to create inode for preopened dir: WASI error code: {e}")
             })?;
             let fd_flags = {
                 let mut fd_flags = 0;
@@ -1938,7 +1931,7 @@ impl WasiFs {
             };
             let fd = self
                 .create_fd(rights, rights, Fdflags::empty(), fd_flags, inode.clone())
-                .map_err(|e| format!("Could not open fd for file {:?}: {}", path, e))?;
+                .map_err(|e| format!("Could not open fd for file {path:?}: {e}"))?;
             {
                 let mut guard = self.root_inode.write();
                 if let Kind::Root { entries } = guard.deref_mut() {
@@ -1949,7 +1942,7 @@ impl WasiFs {
                     };
                     let existing_entry = entries.insert(key.clone(), inode);
                     if existing_entry.is_some() && !ignore_duplicates {
-                        return Err(format!("Found duplicate entry for alias `{}`", key));
+                        return Err(format!("Found duplicate entry for alias `{key}`"));
                     }
                 }
             }

--- a/lib/wasix/src/http/client.rs
+++ b/lib/wasix/src/http/client.rs
@@ -95,7 +95,7 @@ impl std::fmt::Debug for HttpRequest {
         } = self;
 
         f.debug_struct("HttpRequest")
-            .field("url", &format_args!("{}", url))
+            .field("url", &format_args!("{url}"))
             .field("method", method)
             .field("headers", headers)
             .field("body", &body.as_deref().map(String::from_utf8_lossy))

--- a/lib/wasix/src/lib.rs
+++ b/lib/wasix/src/lib.rs
@@ -223,7 +223,7 @@ impl std::fmt::Display for ExtendedFsError {
         write!(f, "fs error: {}", self.error)?;
 
         if let Some(msg) = &self.message {
-            write!(f, " | {}", msg)?;
+            write!(f, " | {msg}")?;
         }
 
         Ok(())

--- a/lib/wasix/src/os/command/mod.rs
+++ b/lib/wasix/src/os/command/mod.rs
@@ -96,7 +96,7 @@ impl Commands {
             unsafe {
                 InlineWaker::block_on(stderr_write(
                     parent_ctx,
-                    format!("wasm command unknown - {}\r\n", path).as_bytes(),
+                    format!("wasm command unknown - {path}\r\n").as_bytes(),
                 ))
             }
             .ok();

--- a/lib/wasix/src/os/console/mod.rs
+++ b/lib/wasix/src/os/console/mod.rs
@@ -248,12 +248,9 @@ impl Console {
         if let Err(err) = env.uses(self.uses.clone()) {
             let mut stderr = self.stderr.clone();
             InlineWaker::block_on(async {
-                virtual_fs::AsyncWriteExt::write_all(
-                    &mut stderr,
-                    format!("{}\r\n", err).as_bytes(),
-                )
-                .await
-                .ok();
+                virtual_fs::AsyncWriteExt::write_all(&mut stderr, format!("{err}\r\n").as_bytes())
+                    .await
+                    .ok();
             });
             tracing::debug!("failed to load used dependency - {}", err);
             return Err(SpawnError::BadRequest);

--- a/lib/wasix/src/runtime/resolver/backend_source.rs
+++ b/lib/wasix/src/runtime/resolver/backend_source.rs
@@ -422,7 +422,7 @@ fn decode_summary(
         };
 
     let id = PackageId::Named(NamedPackageId {
-        full_name: format!("{}/{}", namespace, package_name),
+        full_name: format!("{namespace}/{package_name}"),
         version: pkg_version
             .version
             .parse()

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -59,7 +59,7 @@ fn registry_error_message(specifier: &PackageSource) -> String {
         }
         PackageSource::Url(url) => format!("Unable to resolve \"{url}\""),
         PackageSource::Path(path) => {
-            format!("Unable to load \"{}\" from disk", path)
+            format!("Unable to load \"{path}\" from disk")
         }
     }
 }

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -143,7 +143,7 @@ pub enum WasiStateCreationError {
 fn validate_mapped_dir_alias(alias: &str) -> Result<(), WasiStateCreationError> {
     if !alias.bytes().all(|b| b != b'\0') {
         return Err(WasiStateCreationError::MappedDirAliasFormattingError(
-            format!("Alias \"{}\" contains a nul byte", alias),
+            format!("Alias \"{alias}\" contains a nul byte"),
         ));
     }
 
@@ -774,16 +774,13 @@ impl WasiEnvBuilder {
             }) {
                 Some(InvalidCharacter::Nul) => {
                     return Err(WasiStateCreationError::EnvironmentVariableFormatError(
-                        format!("found nul byte in env var key \"{}\" (key=value)", env_key),
+                        format!("found nul byte in env var key \"{env_key}\" (key=value)"),
                     ))
                 }
 
                 Some(InvalidCharacter::Equal) => {
                     return Err(WasiStateCreationError::EnvironmentVariableFormatError(
-                        format!(
-                            "found equal sign in env var key \"{}\" (key=value)",
-                            env_key
-                        ),
+                        format!("found equal sign in env var key \"{env_key}\" (key=value)"),
                     ))
                 }
 

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1164,15 +1164,13 @@ impl WasiEnv {
         for package_name in uses {
             let specifier = package_name.parse::<PackageSource>().map_err(|e| {
                 WasiStateCreationError::WasiIncludePackageError(format!(
-                    "package_name={package_name}, {}",
-                    e
+                    "package_name={package_name}, {e}",
                 ))
             })?;
             let pkg = InlineWaker::block_on(BinaryPackage::from_registry(&specifier, rt)).map_err(
                 |e| {
                     WasiStateCreationError::WasiIncludePackageError(format!(
-                        "package_name={package_name}, {}",
-                        e
+                        "package_name={package_name}, {e}",
                     ))
                 },
             )?;
@@ -1209,7 +1207,7 @@ impl WasiEnv {
             if let WasiFsRoot::Sandbox(root_fs) = &self.state.fs.root_fs {
                 let _ = root_fs.create_dir(Path::new("/bin"));
 
-                let path = format!("/bin/{}", command);
+                let path = format!("/bin/{command}");
                 let path = Path::new(path.as_str());
                 if let Err(err) = root_fs.new_open_options_ext().insert_ro_file(path, file) {
                     tracing::debug!("failed to add atom command [{}] - {}", command, err);

--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -358,8 +358,7 @@ impl WasiFunctionEnv {
                 )
                 .map_err(|err| {
                     WasiRuntimeError::Runtime(wasmer::RuntimeError::new(format!(
-                        "journal failed to save the module initialization event - {}",
-                        err
+                        "journal failed to save the module initialization event - {err}"
                     )))
                 })?;
             } else {
@@ -371,8 +370,7 @@ impl WasiFunctionEnv {
                 )
                 .map_err(|err| {
                     WasiRuntimeError::Runtime(wasmer::RuntimeError::new(format!(
-                        "journal failed to save clear ethereal event - {}",
-                        err
+                        "journal failed to save clear ethereal event - {err}",
                     )))
                 })?;
             }

--- a/lib/wasix/src/syscalls/mod.rs
+++ b/lib/wasix/src/syscalls/mod.rs
@@ -988,7 +988,7 @@ pub(crate) fn get_memory_stack<M: MemorySize>(
                 .map_err(|err| format!("failed to save stack: stack pointer overflow (stack_pointer={}, stack_lower={}, stack_upper={})", stack_offset, env.layout.stack_lower, env.layout.stack_upper))?,
         )
         .and_then(|memory_stack| memory_stack.read_to_bytes())
-        .map_err(|err| format!("failed to read stack: {}", err))
+        .map_err(|err| format!("failed to read stack: {err}"))
 }
 
 #[allow(dead_code)]
@@ -1018,7 +1018,7 @@ pub(crate) fn set_memory_stack<M: MemorySize>(
                 .map_err(|_| "failed to restore stack: stack pointer overflow".to_string())?,
         )
         .and_then(|memory_stack| memory_stack.write_slice(&stack[..]))
-        .map_err(|err| format!("failed to write stack: {}", err))?;
+        .map_err(|err| format!("failed to write stack: {err}"))?;
 
     // Set the stack pointer itself and return
     set_memory_stack_offset(env, store, stack_offset)?;
@@ -1233,7 +1233,7 @@ where
                     .map_err(|_| "failed to save stack: stack pointer overflow".to_string())?,
             )
             .and_then(|memory_stack| memory_stack.read_to_bytes())
-            .map_err(|err| format!("failed to read stack: {}", err))?;
+            .map_err(|err| format!("failed to read stack: {err}"))?;
 
         // Notify asyncify that we are no longer unwinding
         if let Some(asyncify_stop_unwind) = env

--- a/lib/wasix/src/syscalls/wasi/args_get.rs
+++ b/lib/wasix/src/syscalls/wasi/args_get.rs
@@ -36,7 +36,7 @@ pub fn args_get<M: MemorySize>(
             .unwrap()
             .iter()
             .enumerate()
-            .map(|(i, v)| format!("{:>20}: {}", i, v))
+            .map(|(i, v)| format!("{i:>20}: {v}"))
             .collect::<Vec<String>>()
             .join("\n")
     );

--- a/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
+++ b/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
@@ -357,9 +357,9 @@ where
 
             if fd_guards.len() > 10 {
                 let small_list: Vec<_> = fd_guards.iter().take(10).collect();
-                tracing::Span::current().record("fd_guards", format!("{:?}...", small_list));
+                tracing::Span::current().record("fd_guards", format!("{small_list:?}..."));
             } else {
-                tracing::Span::current().record("fd_guards", format!("{:?}", fd_guards));
+                tracing::Span::current().record("fd_guards", format!("{fd_guards:?}"));
             }
 
             fd_guards
@@ -391,7 +391,7 @@ where
         |ctx: &FunctionEnvMut<'a, WasiEnv>| {
             // The timeout has triggered so lets add that event
             if clock_subs.is_empty() {
-                tracing::warn!("triggered_timeout (without any clock subscriptions)",);
+                tracing::warn!("triggered_timeout (without any clock subscriptions)");
             }
             let mut evts = Vec::new();
             for (clock_info, userdata) in clock_subs {

--- a/lib/wasix/src/syscalls/wasix/chdir.rs
+++ b/lib/wasix/src/syscalls/wasix/chdir.rs
@@ -14,7 +14,7 @@ pub fn chdir<M: MemorySize>(
     let path = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path.as_str());
 
-    wasi_try_ok!(chdir_internal(&mut ctx, &path,));
+    wasi_try_ok!(chdir_internal(&mut ctx, &path));
     let env = ctx.data();
 
     #[cfg(feature = "journal")]

--- a/lib/wasix/src/syscalls/wasix/futex_wait.rs
+++ b/lib/wasix/src/syscalls/wasix/futex_wait.rs
@@ -113,7 +113,7 @@ pub(super) fn futex_wait_internal<M: MemorySize + 'static>(
         OptionTag::Some => Some(Duration::from_nanos(timeout.u)),
         _ => None,
     };
-    Span::current().record("timeout", format!("{:?}", timeout));
+    Span::current().record("timeout", format!("{timeout:?}"));
 
     let state = env.state.clone();
     let futex_idx: u64 = futex_ptr.offset().into();

--- a/lib/wasix/src/syscalls/wasix/getcwd.rs
+++ b/lib/wasix/src/syscalls/wasix/getcwd.rs
@@ -14,7 +14,7 @@ pub fn getcwd<M: MemorySize>(
     let env = ctx.data();
     let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
 
-    let (_, cur_dir) = wasi_try!(state.fs.get_current_dir(inodes, crate::VIRTUAL_ROOT_FD,));
+    let (_, cur_dir) = wasi_try!(state.fs.get_current_dir(inodes, crate::VIRTUAL_ROOT_FD));
     Span::current().record("path", cur_dir.as_str());
 
     let max_path_len = wasi_try_mem!(path_len.read(&memory));

--- a/lib/wasix/src/syscalls/wasix/port_addr_add.rs
+++ b/lib/wasix/src/syscalls/wasix/port_addr_add.rs
@@ -18,7 +18,7 @@ pub fn port_addr_add<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
 
     let cidr = wasi_try_ok!(crate::net::read_cidr(&memory, ip));
-    Span::current().record("ip", format!("{:?}", cidr));
+    Span::current().record("ip", format!("{cidr:?}"));
 
     wasi_try_ok!(port_addr_add_internal(&mut ctx, cidr)?);
 

--- a/lib/wasix/src/syscalls/wasix/port_addr_remove.rs
+++ b/lib/wasix/src/syscalls/wasix/port_addr_remove.rs
@@ -16,7 +16,7 @@ pub fn port_addr_remove<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
 
     let ip = wasi_try_ok!(crate::net::read_ip(&memory, ip));
-    Span::current().record("ip", format!("{:?}", ip));
+    Span::current().record("ip", format!("{ip:?}"));
 
     wasi_try_ok!(port_addr_remove_internal(&mut ctx, ip)?);
 

--- a/lib/wasix/src/syscalls/wasix/port_gateway_set.rs
+++ b/lib/wasix/src/syscalls/wasix/port_gateway_set.rs
@@ -16,7 +16,7 @@ pub fn port_gateway_set<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
 
     let ip = wasi_try_ok!(crate::net::read_ip(&memory, ip));
-    Span::current().record("ip", format!("{:?}", ip));
+    Span::current().record("ip", format!("{ip:?}"));
 
     wasi_try_ok!(port_gateway_set_internal(&mut ctx, ip)?);
 

--- a/lib/wasix/src/syscalls/wasix/port_route_add.rs
+++ b/lib/wasix/src/syscalls/wasix/port_route_add.rs
@@ -17,10 +17,10 @@ pub fn port_route_add<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
 
     let cidr = wasi_try_ok!(crate::net::read_cidr(&memory, cidr));
-    Span::current().record("cidr", format!("{:?}", cidr));
+    Span::current().record("cidr", format!("{cidr:?}"));
 
     let via_router = wasi_try_ok!(crate::net::read_ip(&memory, via_router));
-    Span::current().record("via_router", format!("{:?}", via_router));
+    Span::current().record("via_router", format!("{via_router:?}"));
 
     let preferred_until = wasi_try_mem_ok!(preferred_until.read(&memory));
     let preferred_until = match preferred_until.tag {

--- a/lib/wasix/src/syscalls/wasix/port_route_remove.rs
+++ b/lib/wasix/src/syscalls/wasix/port_route_remove.rs
@@ -12,7 +12,7 @@ pub fn port_route_remove<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
 
     let ip = wasi_try_ok!(crate::net::read_ip(&memory, ip));
-    Span::current().record("ip", format!("{:?}", ip));
+    Span::current().record("ip", format!("{ip:?}"));
 
     wasi_try_ok!(port_route_remove_internal(&mut ctx, ip)?);
 

--- a/lib/wasix/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn.rs
@@ -53,7 +53,7 @@ pub fn proc_spawn<M: MemorySize>(
         .record("working_dir", working_dir.as_str());
 
     if chroot == Bool::True {
-        warn!("chroot is not currently supported",);
+        warn!("chroot is not currently supported");
         return Ok(Errno::Notsup);
     }
 

--- a/lib/wasix/src/syscalls/wasix/sock_addr_local.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_addr_local.rs
@@ -25,7 +25,7 @@ pub fn sock_addr_local<M: MemorySize>(
         |socket, _| socket.addr_local()
     ));
 
-    Span::current().record("addr", format!("{:?}", addr));
+    Span::current().record("addr", format!("{addr:?}"));
 
     let memory = unsafe { ctx.data().memory_view(&ctx) };
     wasi_try!(crate::net::write_ip_port(

--- a/lib/wasix/src/syscalls/wasix/sock_addr_peer.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_addr_peer.rs
@@ -24,7 +24,7 @@ pub fn sock_addr_peer<M: MemorySize>(
         Rights::empty(),
         |socket, _| socket.addr_peer()
     ));
-    Span::current().record("addr", format!("{:?}", addr));
+    Span::current().record("addr", format!("{addr:?}"));
 
     let env = ctx.data();
     let memory = unsafe { env.memory_view(&ctx) };

--- a/lib/wasix/src/syscalls/wasix/sock_bind.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_bind.rs
@@ -20,7 +20,7 @@ pub fn sock_bind<M: MemorySize>(
 
     let addr = wasi_try_ok!(crate::net::read_ip_port(&memory, addr));
     let addr = SocketAddr::new(addr.0, addr.1);
-    Span::current().record("addr", format!("{:?}", addr));
+    Span::current().record("addr", format!("{addr:?}"));
 
     wasi_try_ok!(sock_bind_internal(&mut ctx, sock, addr)?);
 

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -23,7 +23,7 @@ pub fn sock_connect<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
     let addr = wasi_try_ok!(crate::net::read_ip_port(&memory, addr));
     let peer_addr = SocketAddr::new(addr.0, addr.1);
-    Span::current().record("addr", format!("{:?}", peer_addr));
+    Span::current().record("addr", format!("{peer_addr:?}"));
 
     wasi_try_ok!(sock_connect_internal(&mut ctx, sock, peer_addr)?);
 

--- a/lib/wasix/src/syscalls/wasix/sock_recv_from.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_recv_from.rs
@@ -134,7 +134,7 @@ pub(super) fn sock_recv_from_internal<M: MemorySize>(
     };
     Span::current()
         .record("nread", bytes_read)
-        .record("peer", format!("{:?}", peer));
+        .record("peer", format!("{peer:?}"));
 
     wasi_try_ok!(write_ip_port(&memory, ro_addr, peer.ip(), peer.port()));
 

--- a/lib/wasix/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_to.rs
@@ -36,7 +36,7 @@ pub fn sock_send_to<M: MemorySize>(
         wasi_try_ok!(read_ip_port(&memory, addr))
     };
     let addr = SocketAddr::new(addr_ip, addr_port);
-    Span::current().record("addr", format!("{:?}", addr));
+    Span::current().record("addr", format!("{addr:?}"));
 
     let bytes_written = wasi_try_ok!(sock_send_to_internal(
         &ctx,

--- a/lib/wasix/src/syscalls/wasix/sock_set_opt_time.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_set_opt_time.rs
@@ -24,7 +24,7 @@ pub fn sock_set_opt_time<M: MemorySize>(
         OptionTag::Some => Some(Duration::from_nanos(time.u)),
         _ => return Ok(Errno::Inval),
     };
-    Span::current().record("time", format!("{:?}", time));
+    Span::current().record("time", format!("{time:?}"));
 
     let ty = match opt {
         Sockoption::RecvTimeout => TimeType::ReadTimeout,

--- a/lib/wasix/src/syscalls/wasix/sock_status.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_status.rs
@@ -23,7 +23,7 @@ pub fn sock_status<M: MemorySize>(
         WasiSocketStatus::Closed => Sockstatus::Closed,
         WasiSocketStatus::Failed => Sockstatus::Failed,
     };
-    Span::current().record("status", format!("{:?}", status));
+    Span::current().record("status", format!("{status:?}"));
 
     let env = ctx.data();
     let memory = unsafe { env.memory_view(&ctx) };

--- a/lib/wasix/src/syscalls/wasix/stack_checkpoint.rs
+++ b/lib/wasix/src/syscalls/wasix/stack_checkpoint.rs
@@ -18,7 +18,7 @@ pub fn stack_checkpoint<M: MemorySize>(
         trace!("restored - (ret={})", val);
         return Ok(Errno::Success);
     }
-    trace!("capturing",);
+    trace!("capturing");
 
     wasi_try_ok!(WasiEnv::process_signals_and_exit(&mut ctx)?);
 

--- a/lib/wasix/src/syscalls/wasix/thread_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_spawn.rs
@@ -230,7 +230,7 @@ fn call_module<M: MemorySize>(
                     return Err(deep);
                 }
                 Ok(WasiError::UnknownWasiVersion) => {
-                    debug!("failed as wasi version is unknown",);
+                    debug!("failed as wasi version is unknown");
                     env.data(&store)
                         .runtime
                         .on_taint(TaintReason::UnknownWasiVersion);

--- a/lib/wasix/src/utils/owned_mutex_guard.rs
+++ b/lib/wasix/src/utils/owned_mutex_guard.rs
@@ -115,7 +115,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(guard) = self.guard.as_ref() {
-            write!(f, "{:?}", guard)
+            write!(f, "{guard:?}")
         } else {
             write!(f, "none")
         }
@@ -128,7 +128,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(guard) = self.guard.as_ref() {
-            write!(f, "{}", guard)
+            write!(f, "{guard}")
         } else {
             write!(f, "none")
         }
@@ -193,7 +193,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(guard) = self.guard.as_ref() {
-            write!(f, "{:?}", guard)
+            write!(f, "{guard:?}")
         } else {
             write!(f, "none")
         }
@@ -206,7 +206,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(guard) = self.guard.as_ref() {
-            write!(f, "{}", guard)
+            write!(f, "{guard}")
         } else {
             write!(f, "none")
         }

--- a/lib/wasix/tests/envvar.rs
+++ b/lib/wasix/tests/envvar.rs
@@ -10,14 +10,14 @@ fn get_env_var(var_name: &str) -> Result<String, env::VarError> {
 
 fn main() {
     let mut env_vars = env::vars()
-        .map(|(key, value)| format!("{}={}", key, value))
+        .map(|(key, value)| format!("{key}={value}"))
         .collect::<Vec<String>>();
 
     env_vars.sort();
 
     println!("Env vars:");
     for e in env_vars {
-        println!("{}", e);
+        println!("{e}");
     }
 
     env::set_var("WASI_ENVVAR_TEST", "HELLO");

--- a/lib/wasix/tests/runners.rs
+++ b/lib/wasix/tests/runners.rs
@@ -130,8 +130,8 @@ mod wasi {
         let runtime_error = err.chain().find_map(|e| e.downcast_ref::<WasiError>());
         let exit_code = match runtime_error {
             Some(WasiError::Exit(code)) => *code,
-            Some(other) => panic!("Something else went wrong: {:?}", other),
-            None => panic!("Not a WasiError: {:?}", err),
+            Some(other) => panic!("Something else went wrong: {other:?}"),
+            None => panic!("Not a WasiError: {err:?}"),
         };
         assert_eq!(exit_code.raw(), 42);
     }


### PR DESCRIPTION
Using this command, fixed format argument inlining to improve readability, and fix a few minor related styling issues like trailing commas in a single line.  Only `lib/wasix` dir.

```
cargo clippy --all-targets --workspace --exclude wasmer-cli --exclude wasmer-swift -- -D clippy::uninlined_format_args
```
