### PR TITLE
chore: fix all warnings

### DIFF
--- a/benches/run.rs
+++ b/benches/run.rs
@@ -30,7 +30,7 @@ pub fn run_fn(c: &mut Criterion, module: &[u8], name: &str, input: i64) {
             .unwrap();
 
         b.iter(|| {
-            func.call(&mut store, input);
+            let _ = func.call(&mut store, input);
         })
     });
 }

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -102,6 +102,7 @@ wasmer-artifact-create = ["wasmer-compiler/wasmer-artifact-create"]
 static-artifact-load = ["wasmer-compiler/static-artifact-load"]
 static-artifact-create = ["wasmer-compiler/static-artifact-create"]
 webc_runner = ["virtual-fs", "webc"]
+dylib = []
 # Deprecated features.
 jit = ["compiler"]
 

--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -71,6 +71,9 @@ macro_rules! map_feature_as_c_define {
 }
 
 fn main() {
+    // TODO: perhaps the "yes" value is not needed here?
+    println!(r#"cargo::rustc-check-cfg=cfg(__cbindgen_hack__, values("yes"))"#);
+
     if !running_self() {
         return;
     }

--- a/lib/cli-compiler/Cargo.toml
+++ b/lib/cli-compiler/Cargo.toml
@@ -75,6 +75,8 @@ cranelift = ["wasmer-compiler-cranelift", "compiler"]
 debug = ["fern", "log"]
 disable-all-logging = []
 jit = []
+llvm = []
+run = []
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -25,7 +25,7 @@ use wasmer_types::{
     entity::PrimaryMap, DeserializeError, FunctionIndex, FunctionType, LocalFunctionIndex,
     SignatureIndex,
 };
-use wasmer_types::{CompileError, Features, HashAlgorithm, ModuleInfo};
+use wasmer_types::{CompileError, Features, HashAlgorithm};
 
 #[cfg(not(target_arch = "wasm32"))]
 use wasmer_vm::{
@@ -350,7 +350,7 @@ impl EngineInner {
     #[allow(clippy::type_complexity)]
     pub(crate) fn allocate<'a, FunctionBody, CustomSection>(
         &'a mut self,
-        _module: &ModuleInfo,
+        _module: &wasmer_types::ModuleInfo,
         functions: impl ExactSizeIterator<Item = &'a FunctionBody> + 'a,
         function_call_trampolines: impl ExactSizeIterator<Item = &'a FunctionBody> + 'a,
         dynamic_function_trampolines: impl ExactSizeIterator<Item = &'a FunctionBody> + 'a,

--- a/lib/sys-utils/Cargo.toml
+++ b/lib/sys-utils/Cargo.toml
@@ -29,3 +29,7 @@ tracing = "0.1.37"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]
+
+[features]
+default = []
+tracing = []

--- a/tests/compilers/issues.rs
+++ b/tests/compilers/issues.rs
@@ -324,14 +324,20 @@ fn test_popcnt(mut config: crate::Config) -> Result<()> {
     let mut num = 1;
     for _ in 1..10000 {
         let result = popcnt_i32.call(&mut store, &[Value::I32(num)]).unwrap();
-        assert_eq!(&Value::I32(num.count_ones() as i32), result.get(0).unwrap());
+        assert_eq!(
+            &Value::I32(num.count_ones() as i32),
+            result.first().unwrap()
+        );
         num = get_next_number_i32(num);
     }
 
     let mut num = 1;
     for _ in 1..10000 {
         let result = popcnt_i64.call(&mut store, &[Value::I64(num)]).unwrap();
-        assert_eq!(&Value::I64(num.count_ones() as i64), result.get(0).unwrap());
+        assert_eq!(
+            &Value::I64(num.count_ones() as i64),
+            result.first().unwrap()
+        );
         num = get_next_number_i64(num);
     }
 
@@ -439,7 +445,7 @@ fn large_number_local(mut config: crate::Config) -> Result<()> {
         .get_function("large_local")?
         .call(&mut store, &[])
         .unwrap();
-    assert_eq!(&Value::I64(1_i64), result.get(0).unwrap());
+    assert_eq!(&Value::I64(1_i64), result.first().unwrap());
     Ok(())
 }
 

--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -41,7 +41,7 @@ impl Default for WasmerCreateExe {
         Self {
             current_dir: std::env::current_dir().unwrap(),
             wasmer_path: get_wasmer_path(),
-            wasm_path: PathBuf::from(fixtures::qjs()),
+            wasm_path: fixtures::qjs(),
             native_executable_path,
             compiler: Compiler::Cranelift,
             extra_cli_flags: vec![],
@@ -116,7 +116,7 @@ impl Default for WasmerCreateObj {
         Self {
             current_dir: std::env::current_dir().unwrap(),
             wasmer_path: get_wasmer_path(),
-            wasm_path: PathBuf::from(fixtures::qjs()),
+            wasm_path: fixtures::qjs(),
             output_object_path,
             compiler: Compiler::Cranelift,
             extra_cli_flags: vec![],


### PR DESCRIPTION
This fixes all compiler warnings. Note that `__cbindgen_hack__ = "yes"` is a bit weird - there is no need to make it support a value -- presence of a keyword is an indicator enough. Also, I couldn't figure out what actually sets that value.