### PR TITLE
make: cli-compiler: resolve build-doc errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6860,6 +6860,7 @@ dependencies = [
  "unix_mode",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
+ "wasmer-compiler-llvm",
  "wasmer-compiler-singlepass",
  "wasmer-types",
 ]

--- a/lib/cli-compiler/Cargo.toml
+++ b/lib/cli-compiler/Cargo.toml
@@ -40,6 +40,7 @@ target-lexicon = { version = "0.12", features = ["std"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmer-compiler-singlepass = { version = "=5.0.5-rc1", path = "../compiler-singlepass", optional = true }
 wasmer-compiler-cranelift = { version = "=5.0.5-rc1", path = "../compiler-cranelift", optional = true }
+wasmer-compiler-llvm = { version = "=5.0.5-rc1", path = "../compiler-llvm", optional = true }
 clap = { version = "4.4.0", features = ["derive", "env"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -49,6 +50,7 @@ wasmer-compiler-singlepass = { version = "=5.0.5-rc1", path = "../compiler-singl
 wasmer-compiler-cranelift = { version = "=5.0.5-rc1", path = "../compiler-cranelift", optional = true, default-features = false, features = [
 	"wasm",
 ] }
+wasmer-compiler-llvm = { version = "=5.0.5-rc1", path = "../compiler-llvm",  optional = true, default-features = false, features = [] }
 # NOTE: Must use different features for clap because the "color" feature does not
 # work on wasi, due to the anstream dependency not compiling.
 clap = { version = "4.4.0", default-features = false, features = [
@@ -75,7 +77,7 @@ cranelift = ["wasmer-compiler-cranelift", "compiler"]
 debug = ["fern", "log"]
 disable-all-logging = []
 jit = []
-llvm = []
+llvm = ["wasmer-compiler-llvm"]
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/lib/cli-compiler/src/store.rs
+++ b/lib/cli-compiler/src/store.rs
@@ -4,6 +4,8 @@
 use crate::common::WasmFeatures;
 use anyhow::Result;
 use clap::Parser;
+#[cfg(doc)]
+use std::path::PathBuf;
 use std::string::ToString;
 #[allow(unused_imports)]
 use std::sync::Arc;
@@ -11,6 +13,8 @@ use wasmer_compiler::{
     types::target::{PointerWidth, Target},
     CompilerConfig, EngineBuilder, Features,
 };
+#[cfg(doc)]
+use wasmer_types::Type;
 use wasmer_types::{MemoryStyle, MemoryType, Pages, TableStyle, TableType};
 
 /// Minimul Subset of Tunable parameters for WebAssembly compilation.
@@ -211,7 +215,7 @@ impl CompilerOptions {
                 use std::fs::File;
                 use std::io::Write;
                 use wasmer_compiler_llvm::{
-                    CompiledKind, InkwellMemoryBuffer, InkwellModule, LLVMCallbacks, LLVM,
+                    CompiledKind, InkwellMemoryBuffer, InkwellModule, LLVMCallbacks,
                 };
                 use wasmer_types::entity::EntityRef;
                 let mut config = LLVM::new();


### PR DESCRIPTION
Fix compilation errors in documentation build by:
- Adding missing LLVM compiler dependency
- Correcting imports in store.rs
- Updating feature flags in cli-compiler
