### PR TITLE
utils: prompts: add prompt_for_app_ident

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -174,7 +174,7 @@ impl CmdAppCreate {
             }),
         };
 
-        crate::utils::prompts::prompt_for_ident(
+        crate::utils::prompts::prompt_for_app_ident(
             "What should be the name of the app?",
             default_name.as_deref(),
         )

--- a/lib/cli/src/utils/prompts.rs
+++ b/lib/cli/src/utils/prompts.rs
@@ -23,6 +23,31 @@ pub fn prompt_for_ident(message: &str, default: Option<&str>) -> Result<String, 
     }
 }
 
+/// Ask a user for an application name.
+///
+/// Will continue looping until the user provides a valid name that contains
+/// neither dots nor spaces. Returns an error if there are issues with
+/// the input interaction.
+pub fn prompt_for_app_ident(message: &str, default: Option<&str>) -> Result<String, anyhow::Error> {
+    loop {
+        let theme = ColorfulTheme::default();
+        let diag = dialoguer::Input::with_theme(&theme)
+            .with_prompt(message)
+            .with_initial_text(default.unwrap_or_default());
+
+        let raw: String = diag.interact_text()?;
+        let val = raw.trim();
+        if val.is_empty() {
+            continue;
+        }
+        if val.contains('.') || val.contains(' ') {
+            eprintln!("The name must not contain dots or spaces. Please try again.");
+            continue;
+        }
+        return Ok(val.to_string());
+    }
+}
+
 /// Ask a user for a package name.
 ///
 /// Will continue looping until the user provides a valid name.


### PR DESCRIPTION
Trying to deploy an app with a dot(.) or spaces( ) cause GraphQL API failures, as in,
```
  error: could not create app in the backend
  │   1: could not publish app
  ╰─▶ 2: GraphQL API failure: App name `tmp .cWmMN5keRo` provided is invalid
```
And,
```
  error: could not create app in the backend
  │   1: could not publish app
  ╰─▶ 2: GraphQL API failure: App name `tmp dadRZuK0CqK4` provided is invalid
```
Fixes #5341