### PR TITLE
Allow memory growing to exactly 65536 pages, as per the specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,6 +341,11 @@ path = "examples/memory.rs"
 required-features = ["backend"]
 
 [[example]]
+name = "memory-grow"
+path = "examples/memory_grow.rs"
+required-features = ["backend"]
+
+[[example]]
 name = "instance"
 path = "examples/instance.rs"
 required-features = ["backend"]

--- a/examples/memory_grow.rs
+++ b/examples/memory_grow.rs
@@ -1,0 +1,51 @@
+//! Example demonstrating WebAssembly memory growth limits
+//!
+//! Tests growing memory to maximum allowed size according to the spec
+//! You can run the example directly by executing:
+//! ```shell
+//! cargo run --example memory-grow --release --features "cranelift"
+//! ```
+
+use wasmer::{imports, wat2wasm, Instance, Module, Pages, Store};
+
+fn main() -> anyhow::Result<()> {
+    let wasm_bytes = wat2wasm(
+        r#"
+(module
+   (memory (export "memory") 1 65536)
+   (func (export "mem_size") (result i32)
+       memory.size)
+   (func (export "grow") (param i32) (result i32)
+       local.get 0
+       memory.grow))
+"#
+        .as_bytes(),
+    )?;
+
+    let mut store = Store::default();
+    let module = Module::new(&store, wasm_bytes)?;
+    let instance = Instance::new(&mut store, &module, &imports! {})?;
+    let memory = instance.exports.get_memory("memory")?;
+
+    println!("Testing memory growth limits...");
+    println!("Initial size: {:?}", memory.view(&store).size());
+
+    let result = memory.grow(&mut store, 65534)?;
+    println!("After growing by 65534: {:?}", memory.view(&store).size());
+
+    let result = memory.grow(&mut store, 1)?;
+    println!(
+        "After growing to max (65536): {:?}",
+        memory.view(&store).size()
+    );
+
+    let result = memory.grow(&mut store, 1);
+    println!("Attempt to exceed max: {:?}", result);
+
+    Ok(())
+}
+
+#[test]
+fn test_memory_grow() -> anyhow::Result<()> {
+    main()
+}

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -71,7 +71,7 @@ impl WasmMmap {
         // Wasm linear memories are never allowed to grow beyond what is
         // indexable. If the memory has no maximum, enforce the greatest
         // limit here.
-        if new_pages >= Pages::max_value() {
+        if new_pages > Pages::max_value() {
             // Linear memory size would exceed the index range.
             return Err(MemoryError::CouldNotGrow {
                 current: self.size,


### PR DESCRIPTION
The Wasm spec allows memory to grow up to 2^16 pages[1]. We were a bit more restrictive, failing at `>= 65536` instead of `> 65536`. This fixes the check to allow valid 65536-page allocations.

Added test verifying correct memory growth behavior through `example/memory_grow.rs`.

[1]: https://webassembly.github.io/spec/core/bikeshed/index.html#growing-memories%E2%91%A0
1: https://webassembly.github.io/spec/core/bikeshed/index.html#growing-memories%E2%91%A0

```
If len is larger than 2^16, then fail
```