### PR TITLE
Fix documentation comments in examples

### DIFF
--- a/examples/engine.rs
+++ b/examples/engine.rs
@@ -13,7 +13,7 @@
 //! You can run the example directly by executing in Wasmer root:
 //!
 //! ```shell
-//! cargo run --example engine-universal --release --features "cranelift"
+//! cargo run --example engine --release --features "cranelift"
 //! ```
 //!
 //! Ready?

--- a/examples/wasi_manual_setup.rs
+++ b/examples/wasi_manual_setup.rs
@@ -10,7 +10,7 @@
 //! You can run the example directly by executing in Wasmer root:
 //!
 //! ```shell
-//! cargo run --example wasi-manual-setup --release --features "cranelift,wasi"
+//! cargo run --example wasi-manual-setup --release --features "cranelift,tokio,wasi"
 //! ```
 //!
 //! Ready?

--- a/examples/wasi_pipes.rs
+++ b/examples/wasi_pipes.rs
@@ -6,7 +6,7 @@
 //! You can run the example directly by executing in Wasmer root:
 //!
 //! ```shell
-//! cargo run --example wasi-pipes --release --features "cranelift,wasi"
+//! cargo run --example wasi-pipes --release --features "cranelift,tokio,backend,wasi"
 //! ```
 //!
 //! Ready?


### PR DESCRIPTION
Updated documentation comments for several examples to prevent errors caused by missing features or incorrect target names.