### PR TITLE
fix(c_api): Feature gate compiler-related types and functions behind …

### DIFF
--- a/lib/c-api/src/wasm_c_api/engine.rs
+++ b/lib/c-api/src/wasm_c_api/engine.rs
@@ -1,18 +1,23 @@
-#[cfg(feature = "compiler")]
-pub use super::unstable::engine::wasmer_is_compiler_available;
-pub use super::unstable::engine::{wasm_config_set_features, wasm_config_set_target};
+pub use super::unstable::engine::wasm_config_set_features;
 use super::unstable::features::wasmer_features_t;
+use crate::error::update_last_error;
+use cfg_if::cfg_if;
+
+#[cfg(feature = "compiler")]
+pub use super::unstable::engine::{wasm_config_set_target, wasmer_is_compiler_available};
+#[cfg(feature = "compiler")]
+use super::unstable::target_lexicon::wasmer_target_t;
+
 #[cfg(feature = "middlewares")]
 pub use super::unstable::middlewares::wasm_config_push_middleware;
 #[cfg(feature = "middlewares")]
 use super::unstable::middlewares::wasmer_middleware_t;
-use super::unstable::target_lexicon::wasmer_target_t;
-use crate::error::update_last_error;
-use cfg_if::cfg_if;
-#[cfg(not(any(feature = "compiler", feature = "compiler-headless")))]
-use wasmer_api::Engine;
+
 #[cfg(any(feature = "compiler", feature = "compiler-headless"))]
 use wasmer_compiler::{Engine, EngineBuilder};
+
+#[cfg(not(any(feature = "compiler", feature = "compiler-headless")))]
+use wasmer_api::Engine;
 
 /// Kind of compilers that can be used by the engines.
 ///
@@ -84,6 +89,7 @@ pub struct wasm_config_t {
     pub(super) middlewares: Vec<wasmer_middleware_t>,
     pub(super) nan_canonicalization: bool,
     pub(super) features: Option<Box<wasmer_features_t>>,
+    #[cfg(feature = "compiler")]
     pub(super) target: Option<Box<wasmer_target_t>>,
 }
 
@@ -376,8 +382,10 @@ pub extern "C" fn wasm_engine_new_with_config(
 
     #[allow(unused)]
     let config = config?;
-    #[cfg(not(any(feature = "compiler", feature = "compiler-headless")))]
-    return return_with_error("Wasmer has not been compiled with the `compiler` feature.");
+    //#[cfg(not(any(feature = "compiler", feature = "compiler-headless")))]
+    //return return_with_error("Wasmer has not been compiled with the `compiler` feature.");
+
+
     cfg_if! {
         if #[cfg(feature = "compiler")] {
             #[allow(unused_mut)]

--- a/lib/c-api/src/wasm_c_api/store.rs
+++ b/lib/c-api/src/wasm_c_api/store.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn wasm_store_new(
     engine: Option<&wasm_engine_t>,
 ) -> Option<Box<wasm_store_t>> {
     let engine = engine?;
-    let store = Store::new(&engine.inner);
+    let store = Store::new(engine.inner.clone());
 
     Some(Box::new(wasm_store_t {
         inner: StoreRef {

--- a/lib/c-api/src/wasm_c_api/unstable/engine.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/engine.rs
@@ -1,12 +1,13 @@
 //! Unstable non-standard Wasmer-specific types for the
 //! `wasm_engine_t` and siblings.
 
-#[cfg(feature = "compiler")]
-use super::super::engine::wasmer_compiler_t;
-use super::super::engine::{wasm_config_t, wasmer_engine_t};
+use super::{
+    super::engine::{wasm_config_t, wasmer_engine_t},
+    features::wasmer_features_t,
+};
 
-use super::features::wasmer_features_t;
-use super::target_lexicon::wasmer_target_t;
+#[cfg(feature = "compiler")]
+use super::{super::engine::wasmer_compiler_t, target_lexicon::wasmer_target_t};
 
 /// Unstable non-standard Wasmer-specific API to update the
 /// configuration to specify a particular target for the engine.
@@ -48,6 +49,7 @@ use super::target_lexicon::wasmer_target_t;
 /// # }
 /// ```
 #[no_mangle]
+#[cfg(feature = "compiler")]
 pub extern "C" fn wasm_config_set_target(config: &mut wasm_config_t, target: Box<wasmer_target_t>) {
     config.target = Some(target);
 }

--- a/lib/c-api/src/wasm_c_api/unstable/mod.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/mod.rs
@@ -5,6 +5,7 @@ pub mod middlewares;
 pub mod module;
 #[cfg(feature = "compiler")]
 pub mod parser;
+#[cfg(feature = "compiler")]
 pub mod target_lexicon;
 #[cfg(feature = "wasi")]
 pub mod wasi;


### PR DESCRIPTION
This small patch feature-gates some of the `wasmer_c_api` types and functions behind the already-used `"compiler"` feature. Affected are the `wasmer_target_t` type and the `wasm_config_set_target` function. Also, the `target` field of the `wasm_config_type` is behind the same feature-gate -- note that the `compiler` field was already behind the same feature gate. 
