### PR TITLE
Graceful Handling of OOM in `table.grow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,11 @@ path = "examples/table.rs"
 required-features = ["backend"]
 
 [[example]]
+name = "table-large-grow"
+path = "examples/table_large_grow.rs"
+required-features = ["backend"]
+
+[[example]]
 name = "memory"
 path = "examples/memory.rs"
 required-features = ["backend"]

--- a/examples/table_large_grow.rs
+++ b/examples/table_large_grow.rs
@@ -1,0 +1,48 @@
+//! Example demonstrating WebAssembly table growth limits
+//!
+//! Tests growing a table with a very large delta (0xff_ff_ff_ff) which should fail
+//! gracefully by returning -1 according to the WebAssembly specification.
+//!
+//! You can run the example directly by executing:
+//! ```shell
+//! cargo run --example table-large-grow --release --features backend
+//! ```
+
+use wasmer::{imports, Instance, Module, Store};
+
+fn main() -> anyhow::Result<()> {
+    let module_wat = r#"
+    (module
+      (table $t0 0 externref)
+      (table $t1 10 externref)
+      (func $init (export "init") (result i32)
+	(if (i32.ne (table.size $t1) (i32.const 10))
+	  (then (unreachable))
+	)
+	;; Store the result instead of dropping it
+	(table.grow $t0 (ref.null extern) (i32.const 0xff_ff_ff_ff))
+      )
+    )
+    "#;
+
+    let mut store = Store::default();
+    let module = Module::new(&store, &module_wat)?;
+    let import_object = imports! {};
+    let instance = Instance::new(&mut store, &module, &import_object)?;
+
+    let init = instance.exports.get_function("init")?;
+    let result = init.call(&mut store, &[])?;
+
+    assert_eq!(
+        result[0],
+        wasmer::Value::I32(-1),
+        "table.grow should return -1"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_memory_grow() -> anyhow::Result<()> {
+    main()
+}


### PR DESCRIPTION
Introduce `DEFAULT_MAX_TABLE_SIZE` set to 1,048,576 elements (~1
million, 2^20) as a default cap for tables lacking a specified
maximum (`self.maximum = None`). This prevents impractical growth
attempts, such as a delta of 0xff_ff_ff_ff (4,294,967,295 elements),
which could succeed misleadingly on overcommitting systems like macOS.

Replace panic-prone `Vec::resize` with `try_reserve_exact` to attempt
memory reservation before resizing. Returns `None` (mapping to
WebAssembly’s -1) on allocation failure, ensuring graceful handling of
out-of-memory (OOM) conditions rather than crashing, as seen
previously on Linux with large deltas.

Update growth logic to compute the effective
maximum (`self.maximum.unwrap_or(DEFAULT_MAX_TABLE_SIZE)`), failing
early if `new_len` exceeds this limit, followed by a safe reservation
and resize sequence.

These changes align with the WebAssembly 2.0 (Draft 2025-01-28) spec’s
allowance for implementation-defined resource limits (Section 7.2) and
`table.grow` semantics (returning -1 on exceeding limits or resource
constraints).