### PR TITLE
examples: funcref: memory_grow: resolve warnings

### DIFF
--- a/examples/funcref.rs
+++ b/examples/funcref.rs
@@ -1,8 +1,5 @@
 use std::error::Error;
-use wasmer::{
-    imports, ExternRef, FromToNativeWasmType, Function, FunctionType, Instance, Module,
-    RuntimeError, Store, Table, TableType, Type, Value,
-};
+use wasmer::{imports, Instance, Module, Store, Table, TableType, Type, Value};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // 1) Create a default Wasmer Store.

--- a/examples/memory_grow.rs
+++ b/examples/memory_grow.rs
@@ -6,7 +6,7 @@
 //! cargo run --example memory-grow --release --features "cranelift"
 //! ```
 
-use wasmer::{imports, wat2wasm, Instance, Module, Pages, Store};
+use wasmer::{imports, wat2wasm, Instance, Module, Store};
 
 fn main() -> anyhow::Result<()> {
     let wasm_bytes = wat2wasm(
@@ -30,10 +30,10 @@ fn main() -> anyhow::Result<()> {
     println!("Testing memory growth limits...");
     println!("Initial size: {:?}", memory.view(&store).size());
 
-    let result = memory.grow(&mut store, 65534)?;
+    let _ = memory.grow(&mut store, 65534)?;
     println!("After growing by 65534: {:?}", memory.view(&store).size());
 
-    let result = memory.grow(&mut store, 1)?;
+    let _ = memory.grow(&mut store, 1)?;
     println!(
         "After growing to max (65536): {:?}",
         memory.view(&store).size()


### PR DESCRIPTION
Resolves the following

examples:funcref.rs:
```
warning: unused imports: `ExternRef`, `FromToNativeWasmType`, `FunctionType`, `Function`, and `RuntimeError`
 --> examples/funcref.rs:3:14
  |
3 |     imports, ExternRef, FromToNativeWasmType, Function, FunctionType, Instance, Module,
  |              ^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^  ^^^^^^^^^^^^
4 |     RuntimeError, Store, Table, TableType, Type, Value,
  |     ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `wasmer-workspace` (example "funcref" test) generated 1 warning (run `cargo fix --example "funcref" --tests` to apply 1 suggestion)
```

examples/memory_grow.rs:
```
warning: unused import: `Pages`
 --> examples/memory_grow.rs:9:51
  |
9 | use wasmer::{imports, wat2wasm, Instance, Module, Pages, Store};
  |                                                   ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `result`
  --> examples/memory_grow.rs:33:9
   |
33 |     let result = memory.grow(&mut store, 65534)?;
   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_result`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `result`
  --> examples/memory_grow.rs:36:9
   |
36 |     let result = memory.grow(&mut store, 1)?;
   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_result`

warning: `wasmer-workspace` (example "memory-grow" test) generated 3 warnings (run `cargo fix --example "memory-grow" --tests` to apply 1 suggestion)
```