### PR TITLE
fix: have wasmer-wasix (lib/wasix) compile with `cargo build`

### DIFF
--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -213,8 +213,9 @@ sys-default = [
 	"sys-thread",
 	"host-vnet",
 	"host-threads",
-	"host-reqwest",
-	"ctrlc",
+        "host-reqwest",
+        "wasmer/sys",
+	"ctrlc"
 ]
 sys-poll = []
 extra-logging = []


### PR DESCRIPTION
When trying to compile wasmer-wasix with a simple `cargo build`, I noticed that it needed the sys flag from lib/api crate to be enabled. So I am adding the flag to `sys-default` which is enabled by default.