### PR TITLE
chore(wasix): Avoid redundant hashing when spawning commands

### DIFF
--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -19,7 +19,7 @@ use virtual_mio::InlineWaker;
 use wasmer::{Function, Memory32, Memory64, Module, RuntimeError, Store, Value};
 use wasmer_wasix_types::wasi::Errno;
 
-use super::BinaryPackage;
+use super::{BinaryPackage, BinaryPackageCommand};
 use crate::{Runtime, WasiEnv, WasiFunctionEnv};
 
 #[tracing::instrument(level = "trace", skip_all, fields(%name, package_id=%binary.id))]
@@ -31,9 +31,8 @@ pub async fn spawn_exec(
 ) -> Result<TaskJoinHandle, SpawnError> {
     spawn_union_fs(&env, &binary).await?;
 
-    let wasm = spawn_load_wasm(&binary, name).await?;
-
-    let module = spawn_load_module(name, wasm, runtime).await?;
+    let cmd = package_command_by_name(&binary, name)?;
+    let module = runtime.load_command_module(cmd).await?;
 
     // Free the space used by the binary, since we don't need it
     // any longer
@@ -54,25 +53,34 @@ pub async fn spawn_exec_wasm(
     spawn_exec_module(module, env, runtime)
 }
 
-pub async fn spawn_load_wasm<'a>(
-    binary: &'a BinaryPackage,
+pub fn package_command_by_name<'a>(
+    pkg: &'a BinaryPackage,
     name: &str,
-) -> Result<&'a [u8], SpawnError> {
-    let wasm = if let Some(cmd) = binary.get_command(name) {
-        cmd.atom.as_ref()
-    } else if let Some(cmd) = binary.get_entrypoint_command() {
-        &cmd.atom
+) -> Result<&'a BinaryPackageCommand, SpawnError> {
+    // If an explicit command is provided, use it.
+    // Otherwise, use the entrypoint.
+    // If no entrypoint exists, and the package has a single
+    // command, then use it. This is done for backwards
+    // compatibility.
+    let cmd = if let Some(cmd) = pkg.get_command(name) {
+        cmd
+    } else if let Some(cmd) = pkg.get_entrypoint_command() {
+        cmd
     } else {
-        tracing::error!(
-          command=name,
-          pkg=%binary.id,
-          "Unable to spawn a command because its package has no entrypoint",
-        );
-        return Err(SpawnError::MissingEntrypoint {
-            package_id: binary.id.clone(),
-        });
+        match pkg.commands.as_slice() {
+            // Package only has a single command, so use it.
+            [first] => first,
+            // Package either has no command, or has multiple commands, which
+            // would make the choice ambiguous, so fail.
+            _ => {
+                return Err(SpawnError::MissingEntrypoint {
+                    package_id: pkg.id.clone(),
+                });
+            }
+        }
     };
-    Ok(wasm)
+
+    Ok(cmd)
 }
 
 pub async fn spawn_load_module(

--- a/lib/wasix/src/bin_factory/mod.rs
+++ b/lib/wasix/src/bin_factory/mod.rs
@@ -18,8 +18,8 @@ mod exec;
 pub use self::{
     binary_package::*,
     exec::{
-        run_exec, spawn_exec, spawn_exec_module, spawn_exec_wasm, spawn_load_module,
-        spawn_load_wasm, spawn_union_fs,
+        package_command_by_name, run_exec, spawn_exec, spawn_exec_module, spawn_exec_wasm,
+        spawn_load_module, spawn_union_fs,
     },
 };
 use crate::{
@@ -88,20 +88,7 @@ impl BinFactory {
                 }
                 Executable::BinaryPackage(pkg) => {
                     // Get the command that is going to be executed
-                    let cmd = if let Some(cmd) = pkg.get_command(name.as_str()) {
-                        cmd
-                    } else if let Some(cmd) = pkg.get_entrypoint_command() {
-                        cmd
-                    } else {
-                        tracing::error!(
-                          command=name,
-                          pkg=%pkg.id,
-                          "Unable to spawn a command because its package has no entrypoint",
-                        );
-                        return Err(SpawnError::MissingEntrypoint {
-                            package_id: pkg.id.clone(),
-                        });
-                    };
+                    let cmd = package_command_by_name(&pkg, name.as_str())?;
 
                     env.prepare_spawn(cmd);
 

--- a/lib/wasix/src/runners/wcgi/runner.rs
+++ b/lib/wasix/src/runners/wcgi/runner.rs
@@ -62,7 +62,7 @@ impl WcgiRunner {
             .annotation("wasi")?
             .unwrap_or_else(|| Wasi::new(command_name));
 
-        let module = runtime.load_module_sync(&cmd.atom())?;
+        let module = runtime.load_command_module_sync(cmd)?;
 
         let Wcgi { dialect, .. } = metadata.annotation("wcgi")?.unwrap_or_default();
         let dialect = match dialect {


### PR DESCRIPTION
When loading modules for package commands, re-use the hash from the
command to avoid redundant re-hashing, which can be quite expensive.
