### PR TITLE
fix(singlepass): Don't panic on `funcref` types

### DIFF
--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -309,7 +309,8 @@ impl ArgumentRegisterAllocator {
                 )))
             }
         };
-        return Ok(ret);
+
+        Ok(ret)
     }
 }
 

--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -7,7 +7,7 @@ use crate::{
 use std::collections::BTreeMap;
 use std::slice::Iter;
 use wasmer_compiler::types::target::CallingConvention;
-use wasmer_types::Type;
+use wasmer_types::{CompileError, Type};
 
 /// General-purpose registers.
 #[repr(u8)]
@@ -254,8 +254,8 @@ impl ArgumentRegisterAllocator {
         &mut self,
         ty: Type,
         calling_convention: CallingConvention,
-    ) -> Option<ARM64Register> {
-        match calling_convention {
+    ) -> Result<Option<ARM64Register>, CompileError> {
+        let ret = match calling_convention {
             CallingConvention::SystemV | CallingConvention::AppleAarch64 => {
                 static GPR_SEQ: &[GPR] = &[
                     GPR::X0,
@@ -296,14 +296,20 @@ impl ArgumentRegisterAllocator {
                             None
                         }
                     }
-                    _ => todo!(
-                        "ArgumentRegisterAllocator::next: Unsupported type: {:?}",
-                        ty
-                    ),
+                    _ => {
+                        return Err(CompileError::Codegen(format!(
+                            "No register available for {calling_convention:?} and type {ty}"
+                        )))
+                    }
                 }
             }
-            _ => unimplemented!(),
-        }
+            _ => {
+                return Err(CompileError::Codegen(format!(
+                    "No register available for {calling_convention:?} and type {ty}"
+                )))
+            }
+        };
+        return Ok(ret);
     }
 }
 

--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -3481,7 +3481,7 @@ pub fn gen_std_dynamic_import_trampoline_arm64(
         let mut stack_param_count: usize = 0;
 
         for (i, ty) in sig.params().iter().enumerate() {
-            let source_loc = match argalloc.next(*ty, calling_convention) {
+            let source_loc = match argalloc.next(*ty, calling_convention)? {
                 Some(ARM64Register::GPR(gpr)) => Location::GPR(gpr),
                 Some(ARM64Register::NEON(neon)) => Location::SIMD(neon),
                 None => {
@@ -3675,7 +3675,7 @@ pub fn gen_import_call_trampoline_arm64(
                 argalloc.next(Type::I64, calling_convention).unwrap(); // skip VMContext
                 for (i, ty) in sig.params().iter().enumerate() {
                     let prev_loc = param_locations[i];
-                    let targ = match argalloc.next(*ty, calling_convention) {
+                    let targ = match argalloc.next(*ty, calling_convention)? {
                         Some(ARM64Register::GPR(gpr)) => Location::GPR(gpr),
                         Some(ARM64Register::NEON(neon)) => Location::SIMD(neon),
                         None => {

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -7974,7 +7974,7 @@ impl Machine for MachineX86_64 {
             let mut stack_param_count: usize = 0;
 
             for (i, ty) in sig.params().iter().enumerate() {
-                let source_loc = match argalloc.next(*ty, calling_convention) {
+                let source_loc = match argalloc.next(*ty, calling_convention)? {
                     Some(X64Register::GPR(gpr)) => Location::GPR(gpr),
                     Some(X64Register::XMM(xmm)) => Location::SIMD(xmm),
                     None => {
@@ -8110,7 +8110,7 @@ impl Machine for MachineX86_64 {
                     let mut argalloc = ArgumentRegisterAllocator::default();
                     for (i, ty) in sig.params().iter().enumerate() {
                         let prev_loc = param_locations[i];
-                        match argalloc.next(*ty, calling_convention) {
+                        match argalloc.next(*ty, calling_convention)? {
                             Some(X64Register::GPR(_gpr)) => continue,
                             Some(X64Register::XMM(xmm)) => {
                                 a.emit_mov(Size::S64, prev_loc, Location::SIMD(xmm))?
@@ -8155,11 +8155,11 @@ impl Machine for MachineX86_64 {
 
                     // Copy arguments.
                     let mut argalloc = ArgumentRegisterAllocator::default();
-                    argalloc.next(Type::I64, calling_convention).unwrap(); // skip VMContext
+                    argalloc.next(Type::I64, calling_convention)?.unwrap(); // skip VMContext
                     let mut caller_stack_offset: i32 = 0;
                     for (i, ty) in sig.params().iter().enumerate() {
                         let prev_loc = param_locations[i];
-                        let targ = match argalloc.next(*ty, calling_convention) {
+                        let targ = match argalloc.next(*ty, calling_convention)? {
                             Some(X64Register::GPR(gpr)) => Location::GPR(gpr),
                             Some(X64Register::XMM(xmm)) => Location::SIMD(xmm),
                             None => {

--- a/tests/compilers/issues.rs
+++ b/tests/compilers/issues.rs
@@ -501,3 +501,29 @@ fn issue_4519_sdiv64(mut config: crate::Config) -> Result<()> {
 
     Ok(())
 }
+
+#[compiler_test(issues)]
+/// Singlepass panics when encountering ref types.
+///
+/// Note: this one is specific to Singlepass, but we want to test in all
+/// available compilers.
+///
+/// Note: for now, we don't want to implement reference types, we just don't want singlepass to
+/// panic.
+///
+/// https://github.com/wasmerio/wasmer/issues/5309
+fn issue_5309_reftype_panic(mut config: crate::Config) -> Result<()> {
+    let wat = format!(
+        r#"
+      (module
+        (type $x1 (func (param funcref)))
+        (import "env" "abort" (func $f (type $x1)))
+      )
+    "#,
+    );
+
+    let mut store = config.store();
+    let _ = Module::new(&store, wat);
+
+    Ok(())
+}


### PR DESCRIPTION
As shown in https://github.com/wasmerio/wasmer/issues/5309, as of now `singlepass` panics on 

```wasm
(module 
 (type $x1 (func (param funcref)))
  (import "env" "abort" (func $f (type $x1))))
```
with this error:
```
thread 'issues::issue_5309_reftype_panic::singlepass::universal' panicked at lib/compiler-singlepass/src/arm64_decl.rs:299:26:
not yet implemented: ArgumentRegisterAllocator::next: Unsupported type: FuncRef
```
It panics as well on `x64` targets with the same message. This patch changes the signature of the `ArgumentRegisterAllocator::next` function in singlepass' emitter to return an error instead.