### PR TITLE
table: Add table.fill and table.init

### DIFF
--- a/lib/api/src/backend/js/entities/table.rs
+++ b/lib/api/src/backend/js/entities/table.rs
@@ -101,6 +101,27 @@ impl Table {
         unimplemented!();
     }
 
+    pub fn fill(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _index: u32,
+        _len: u32,
+        _value: Value,
+    ) -> Result<(), RuntimeError> {
+        unimplemented!();
+    }
+
+    pub fn init(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _dst_index: u32,
+        _src_index: u32,
+        _len: u32,
+        _values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        unimplemented!();
+    }
+
     pub fn copy(
         _store: &mut impl AsStoreMut,
         _dst_table: &Self,

--- a/lib/api/src/backend/jsc/entities/table.rs
+++ b/lib/api/src/backend/jsc/entities/table.rs
@@ -124,6 +124,27 @@ impl Table {
         }
     }
 
+    pub fn fill(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _index: u32,
+        _len: u32,
+        _value: Value,
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Table.fill is not natively supported in Javascript");
+    }
+
+    pub fn init(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _dst_index: u32,
+        _src_index: u32,
+        _len: u32,
+        _values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Table.init is not natively supported in Javascript");
+    }
+
     pub fn copy(
         _store: &mut impl AsStoreMut,
         _dst_table: &Self,

--- a/lib/api/src/backend/v8/entities/table.rs
+++ b/lib/api/src/backend/v8/entities/table.rs
@@ -173,6 +173,27 @@ impl Table {
         }
     }
 
+    pub fn fill(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _index: u32,
+        _len: u32,
+        _value: Value,
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Table.fill is not currently not implemented");
+    }
+
+    pub fn init(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _dst_index: u32,
+        _src_index: u32,
+        _len: u32,
+        _values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Table.init is not currently not implemented");
+    }
+
     pub fn copy(
         _store: &mut impl AsStoreMut,
         _dst_table: &Self,

--- a/lib/api/src/backend/wamr/entities/table.rs
+++ b/lib/api/src/backend/wamr/entities/table.rs
@@ -159,6 +159,27 @@ impl Table {
         }
     }
 
+    pub fn fill(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _index: u32,
+        _len: u32,
+        _value: Value,
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Filling tables is currently not implemented!")
+    }
+
+    pub fn init(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _dst_index: u32,
+        _src_index: u32,
+        _len: u32,
+        _values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("init table is currently not implemented!")
+    }
+
     pub fn copy(
         _store: &mut impl AsStoreMut,
         _dst_table: &Self,

--- a/lib/api/src/backend/wasmi/entities/table.rs
+++ b/lib/api/src/backend/wasmi/entities/table.rs
@@ -158,6 +158,27 @@ impl Table {
         }
     }
 
+    pub fn fill(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _index: u32,
+        _len: u32,
+        _value: Value,
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Table.fill is not currently not implemented");
+    }
+
+    pub fn init(
+        &self,
+        _store: &mut impl AsStoreMut,
+        _dst_index: u32,
+        _src_index: u32,
+        _len: u32,
+        _values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        unimplemented!("Table.init is not currently not implemented");
+    }
+
     pub fn copy(
         _store: &mut impl AsStoreMut,
         _dst_table: &Self,

--- a/lib/api/src/entities/table/inner.rs
+++ b/lib/api/src/entities/table/inner.rs
@@ -119,6 +119,43 @@ impl BackendTable {
         })
     }
 
+    /// Fills `len` elements starting at `index` with the provided `value`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is out of bounds for the table.
+    #[inline]
+    pub fn fill(
+        &self,
+        store: &mut impl AsStoreMut,
+        index: u32,
+        len: u32,
+        value: Value,
+    ) -> Result<(), RuntimeError> {
+        match_rt!(on self => s {
+            s.fill(store, index, len, value)
+        })
+    }
+
+    /// Initializes `len` elements at `dst_index` with values from `values[src_index..]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is out of bounds for the table or values.
+    #[inline]
+    pub fn init(
+        &self,
+        store: &mut impl AsStoreMut,
+        dst_index: u32,
+        src_index: u32,
+        len: u32,
+        values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        match_rt!(on self => s {
+            s.init(store, dst_index, src_index, len, values)
+        })
+    }
+
     /// Copies the `len` elements of `src_table` starting at `src_index`
     /// to the destination table `dst_table` at index `dst_index`.
     ///

--- a/lib/api/src/entities/table/mod.rs
+++ b/lib/api/src/entities/table/mod.rs
@@ -98,6 +98,37 @@ impl Table {
         BackendTable::copy(store, &dst_table.0, dst_index, &src_table.0, src_index, len)
     }
 
+    /// Fills `len` elements in the table starting at `index` with `value`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is out of bounds or `value` mismatches the table type.
+    pub fn fill(
+        &self,
+        store: &mut impl AsStoreMut,
+        index: u32,
+        len: u32,
+        value: Value,
+    ) -> Result<(), RuntimeError> {
+        self.0.fill(store, index, len, value)
+    }
+
+    /// Initializes `len` elements in the table at `dst_index` from `values[src_index..]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table or segment range is out of bounds or values mismatch the table type.
+    pub fn init(
+        &self,
+        store: &mut impl AsStoreMut,
+        dst_index: u32,
+        src_index: u32,
+        len: u32,
+        values: &[Value],
+    ) -> Result<(), RuntimeError> {
+        self.0.init(store, dst_index, src_index, len, values)
+    }
+
     pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, ext: VMExternTable) -> Self {
         Self(BackendTable::from_vm_extern(store, ext))
     }


### PR DESCRIPTION
This commit introduces support for WebAssembly 2.0 (Draft 2025-01-28)[1] bulk table operations, specifically `table.fill` and `table.init`.

These methods allow for efficient filling and initialization of table ranges.

The implementation includes bounds-checked `fill` and `init` operations in `VMTable` for low-level functionality, with these methods exposed through the `Table` abstraction and system backend for consistent API access. These additions align with [WebAssembly 2.0's bulk memory and table instructions (Section 7.6)](https://webassembly.github.io/spec/core/bikeshed/#bulk-memory-and-table-instructions%E2%91%A0).

[1]: https://webassembly.github.io/spec/core/bikeshed/#bulk-memory-and-table-instructions%E2%91%A0