### PR TITLE
fix(api): Add missing loupe::MemoryUsage impls

### DIFF
--- a/lib/api/src/backend/sys/entities/exception.rs
+++ b/lib/api/src/backend/sys/entities/exception.rs
@@ -83,3 +83,10 @@ impl ExceptionRef {
         self.handle.store_id() == store.as_store_ref().objects().id()
     }
 }
+
+#[cfg(feature = "artifact-size")]
+impl loupe::MemoryUsage for Exception {
+    fn size_of_val(&self, tracker: &mut dyn loupe::MemoryUsageTracker) -> usize {
+        std::mem::size_of::<Self>()
+    }
+}

--- a/lib/api/src/backend/sys/entities/tag.rs
+++ b/lib/api/src/backend/sys/entities/tag.rs
@@ -64,3 +64,10 @@ impl Tag {
         VMExtern::Sys(wasmer_vm::VMExtern::Tag(self.handle.internal_handle()))
     }
 }
+
+#[cfg(feature = "artifact-size")]
+impl loupe::MemoryUsage for Tag {
+    fn size_of_val(&self, tracker: &mut dyn loupe::MemoryUsageTracker) -> usize {
+        std::mem::size_of::<Self>()
+    }
+}


### PR DESCRIPTION
These were forgotten in a recent refactor.
