### PR TITLE
feat: Add `check-api-features` Makefile target

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -498,6 +498,11 @@ jobs:
               build-cmd: "make build-wasmer && make package-wasmer && make tar-wasmer",
               name: "Build wasmer-cli",
             },
+            {
+              key: "api-feats",
+              build-cmd: "make check-api-features",
+              name: "Check wasmer API with all sys features enabled"
+            },
           ]
         metadata: [
             {

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -692,6 +692,10 @@ jobs:
           TARGET: ${{ matrix.metadata.target }}
           TARGET_DIR: target/${{ matrix.metadata.target }}/release
           CARGO_TARGET: ${{ matrix.metadata.target }}
+      - name: Check `wasmer` crate with all the `sys` features enabled
+        shell: bash
+        if: ${{ matrix.build-what.key == 'api-feats' && matrix.metadata.build != 'windows-gnu' }}
+        run: ${{ matrix.build-what.build-cmd }}
       - name: Test C-API
         shell: bash
         if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl'  || matrix.metadata.build == 'windows-gnu') }}

--- a/Makefile
+++ b/Makefile
@@ -1051,3 +1051,7 @@ update-graphql-schema:
 
 require-nextest:
 	cargo nextest --version > /dev/null || cargo binstall cargo-nextest --secure || cargo install cargo-nextest
+
+# Check all the features compatible with the `sys` backend.
+check-api-features:
+	cargo check --package wasmer --features=$(subst $(space),$(comma),$(compilers)),default,artifact-size,core,enable-serde,wasmer-artifact-load,wasmer-artifact-create,static-artifact-load,static-artifact-create


### PR DESCRIPTION
(fixes https://github.com/wasmerio/wasmer/issues/5434)

This small PR adds a make target `check-api-features` which has the purpose of being run in CI to check if all the features relevant for the `sys` target are built without failure. 

A couple notes: 
* We might want to add a similar make target for the CLI and other relevant packages
* We might want to add a similar make target for the non-sys backends in the `wasmer` crate
* This patch does not add the `artifact-size` to the any of the make targets we already have (as the feature relevant in the issue linked above is present only in the `wasmer` crate, among the "top-level" user facing ones)