### PR TITLE
Remove `unwrap` in code that instantiates a WASI module

### DIFF
--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -138,7 +138,7 @@ pub fn spawn_exec_module(
             )
             .map_err(|err| {
                 error!("wasi[{}]::failed to launch module - {}", pid, err);
-                SpawnError::UnknownError
+                SpawnError::Other(Box::new(err))
             })?
     };
 

--- a/lib/wasix/src/os/task/thread.rs
+++ b/lib/wasix/src/os/task/thread.rs
@@ -618,7 +618,7 @@ pub enum WasiThreadError {
     MemoryCreateFailed(MemoryError),
     #[error("{0}")]
     ExportError(ExportError),
-    #[error("Failed to create the instance")]
+    #[error("Failed to create the instance - {0}")]
     // Note: Boxed so we can keep the error size down
     InstanceCreateFailed(Box<InstantiationError>),
     #[error("Initialization function failed - {0}")]


### PR DESCRIPTION
(fixes: https://github.com/wasmerio/wasmer/issues/5432)

This patch does two things: 
* fixes an `unwrap` introduced [here](https://github.com/wasmerio/wasmer/pull/5284/files#diff-869ef3b52ca7df003ad6395ca1448c280a51f1fe06345a6d4fe6fe7609c923c6R259)
* fixes an `#[error]` annotation to print the inner error

So that 
```
λ wasmer run new.wasm --llvm
thread 'TokioTaskManager Thread Pool_thread_2' panicked at lib/wasix/src/runtime/task_manager/tokio.rs:266:18:
called `Result::unwrap()` on an `Err` value: InstanceCreateFailed(Link(Import("env", "__wasm_longjmp", UnknownImport(Function(FunctionType { params: [I32, I32], results: [] })))))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

is now 

```
λ wasmer run new.wasm  --llvm
error: Spawn failed
╰─▶ 1: Failed to create the instance - Error while importing "env"."__wasm_longjmp": unknown import. Expected Function(FunctionType { params: [I32, I32], results: [] })
```