### PR TITLE
fix(api): Check if `WasmSliceAccess` ptr is aligned before reading

### DIFF
--- a/lib/api/src/utils/mem/access.rs
+++ b/lib/api/src/utils/mem/access.rs
@@ -246,6 +246,9 @@ where
         let buf = unsafe {
             let buf_ptr: *mut u8 = slice.buffer.base().add(slice.offset as usize);
             let buf_ptr: *mut T = std::mem::transmute(buf_ptr);
+            if !buf_ptr.is_aligned() {
+                return Err(MemoryAccessError::UnalignedPointerRead);
+            }
             std::slice::from_raw_parts_mut(buf_ptr, slice.len as usize)
         };
         Ok(Self {

--- a/lib/api/src/utils/mem/mod.rs
+++ b/lib/api/src/utils/mem/mod.rs
@@ -28,6 +28,9 @@ pub enum MemoryAccessError {
     /// String is not valid UTF-8.
     #[error("string is not valid utf-8")]
     NonUtf8String,
+    /// Pointer to memory is unaligned.
+    #[error("unaligned pointer read")]
+    UnalignedPointerRead,
 }
 
 impl From<MemoryAccessError> for RuntimeError {

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -2,7 +2,10 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use wasmer::{imports, Instance, Memory, MemoryLocation, MemoryType, Module, Store};
+use wasmer::{
+    imports, Instance, Memory, MemoryAccessError, MemoryLocation, MemoryType, Module, Store,
+    WasmSlice,
+};
 
 #[test]
 #[cfg_attr(feature = "wamr", ignore = "wamr ignores import memories")]
@@ -80,4 +83,32 @@ fn test_shared_memory_disable_atomics() {
 
     let err = mem.wait(MemoryLocation::new_32(1), None).unwrap_err();
     assert_eq!(err, AtomicsError::AtomicsDisabled);
+}
+
+/// See https://github.com/wasmerio/wasmer/issues/5444
+#[test]
+fn test_wasm_slice_issue_5444() {
+    let mut store = Store::default();
+    let wat = r#"(module
+(import "host" "memory" (memory 10 65536))
+)"#;
+    let module = Module::new(&store, wat)
+        .map_err(|e| format!("{e:?}"))
+        .unwrap();
+
+    let mem = Memory::new(&mut store, MemoryType::new(10, Some(65536), false)).unwrap();
+
+    let imports = imports! {
+        "host" => {
+            "memory" => mem.clone(),
+        },
+    };
+
+    let _inst = Instance::new(&mut store, &module, &imports).unwrap();
+
+    let view = mem.view(&store);
+    let slice = WasmSlice::<u64>::new(&view, 1, 10).unwrap();
+    let access = slice.access();
+
+    assert!(matches!(access.err(), Some(MemoryAccessError::UnalignedPointerRead)))
 }

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -110,5 +110,8 @@ fn test_wasm_slice_issue_5444() {
     let slice = WasmSlice::<u64>::new(&view, 1, 10).unwrap();
     let access = slice.access();
 
-    assert!(matches!(access.err(), Some(MemoryAccessError::UnalignedPointerRead)))
+    assert!(matches!(
+        access.err(),
+        Some(MemoryAccessError::UnalignedPointerRead)
+    ))
 }

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -87,6 +87,7 @@ fn test_shared_memory_disable_atomics() {
 
 /// See https://github.com/wasmerio/wasmer/issues/5444
 #[test]
+#[cfg(feature = "sys")]
 fn test_wasm_slice_issue_5444() {
     let mut store = Store::default();
     let wat = r#"(module


### PR DESCRIPTION
As per title. Fixes https://github.com/wasmerio/wasmer/issues/5444