### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,10 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
           components: rustfmt, clippy
+      - name: Install rust version
+        shell: bash
+        run: |
+          rustup install ${{ env.MSRV }}
       - name: Install libtinfo
         shell: bash
         run: |


### PR DESCRIPTION
We've recently seen some failures due to the rust-toolchain not being installed. We fix these failures in this PR. 