### PR TITLE
Fix feature flags to build packages when publishing crates

### DIFF
--- a/lib/package/Cargo.toml
+++ b/lib/package/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 webc.workspace = true
 wasmer-config = { version = "0.14.0", path = "../config" }
-wasmer-types = { path = "../types", features = ["detect-wasm-features"] }
+wasmer-types = { version = "6.0.0-beta.1", path = "../types", features = ["detect-wasm-features"] }
 toml = { workspace = true }
 bytes = "1.8.0"
 sha2 = "0.10.8"

--- a/lib/wai-bindgen-wasmer/Cargo.toml
+++ b/lib/wai-bindgen-wasmer/Cargo.toml
@@ -34,7 +34,7 @@ async = ["async-trait", "wai-bindgen-wasmer-impl/async"]
 
 # Wasmer features
 js = ["wasmer/js-default"]
-sys = ["wasmer/sys"]
+sys = ["wasmer/sys-default"]
 
 # Wasmer compiler (with `sys` feature only)
 cranelift = ["wasmer/cranelift"]

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -46,11 +46,11 @@ SETTINGS = {
     # compiler by default otherwise it won't work standalone
     "publish_features": {
         "wasmer-cli": "default,cranelift",
-        "wasmer-wasix": "sys,wasmer/sys",
-        "wasmer-wasix-types": "wasmer/sys",
-        "wasmer-wast": "wasmer/sys",
+        "wasmer-wasix": "sys,wasmer/sys-default",
+        "wasmer-wasix-types": "wasmer/sys-default",
+        "wasmer-wast": "wasmer/sys-default",
         "wai-bindgen-wasmer": "sys",
-        "wasmer-cache": "wasmer/sys",
+        "wasmer-cache": "wasmer/sys-default",
     },
     # workspace members we want to publish but whose path doesn't start by
     # "./lib/"


### PR DESCRIPTION
As per title. This mostly entails changing `sys` to `sys-default` where needed and explicitly declare the version of the `wasmer-types` dependency in `wasmer-package`.