### PR TITLE
Journal fixes to enable PHP+proc_snapshot

### DIFF
--- a/docs/schema/generated/jsonschema/types/AppConfigV1.schema.json
+++ b/docs/schema/generated/jsonschema/types/AppConfigV1.schema.json
@@ -161,6 +161,18 @@
             }
           ]
         },
+        "mode": {
+          "description": "The method to use to generate the instaboot snapshot for the instance.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InstabootSnapshotModeV1"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "requests": {
           "description": "HTTP requests to perform during startup snapshot creation. Apps can perform all the appropriate warmup logic in these requests.\n\nNOTE: if no requests are configured, then a single HTTP request to '/' will be performed instead.",
           "type": "array",
@@ -195,6 +207,17 @@
               "type": "null"
             }
           ]
+        },
+        "runtime": {
+          "description": "Runtime settings.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AppConfigCapabilityRuntimeV1"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": true
@@ -205,6 +228,26 @@
       "properties": {
         "limit": {
           "description": "Memory limit for an instance.\n\nFormat: [digit][unit], where unit is Mb/Gb/MiB/GiB,...",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "AppConfigCapabilityRuntimeV1": {
+      "description": "Runtime capability settings.",
+      "type": "object",
+      "properties": {
+        "async_threads": {
+          "description": "Whether to enable asynchronous threads/deep sleeping.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "engine": {
+          "description": "Engine to use for an instance, e.g. wasmer_cranelift, wasmer_llvm, etc.",
           "type": [
             "string",
             "null"
@@ -542,6 +585,34 @@
           }
         }
       }
+    },
+    "InstabootSnapshotModeV1": {
+      "description": "How will an instance be bootstrapped?",
+      "oneOf": [
+        {
+          "description": "Start the instance without any snapshot triggers. Once the requests are done, use [`snapshot_and_stop`](wasmer_wasix::WasiProcess::snapshot_and_stop) to capture a snapshot and shut the instance down.",
+          "type": "string",
+          "enum": [
+            "bootstrap"
+          ]
+        },
+        {
+          "description": "Explicitly enable the given snapshot triggers before starting the instance. The instance's process will have its stop_running_after_checkpoint flag set, so the first snapshot will cause the instance to shut down.",
+          "type": "object",
+          "required": [
+            "triggers"
+          ],
+          "properties": {
+            "triggers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "Job": {
       "description": "Job configuration.",

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -450,6 +450,7 @@ impl Run {
             for journal in w {
                 runner.with_writable_journal(journal);
             }
+            runner.with_skip_stdio_during_bootstrap(self.wasi.skip_stdio_during_bootstrap);
         }
 
         Ok(runner)

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -324,6 +324,9 @@ impl Run {
                 }
                 config.with_snapshot_interval(Duration::from_millis(period));
             }
+            if self.wasi.stop_after_snapshot {
+                config.with_stop_running_after_snapshot(true);
+            }
             for journal in self.wasi.build_journals()? {
                 config.add_journal(journal);
             }
@@ -433,6 +436,9 @@ impl Run {
                 }
                 runner.with_snapshot_interval(Duration::from_millis(period));
             }
+            if self.wasi.stop_after_snapshot {
+                runner.with_stop_running_after_snapshot(true);
+            }
             for journal in self.wasi.build_journals()? {
                 runner.with_journal(journal);
             }
@@ -452,7 +458,7 @@ impl Run {
         let program_name = wasm_path.display().to_string();
 
         let runner = self.build_wasi_runner(&runtime)?;
-        runner.run_wasm(runtime, &program_name, module)
+        runner.run_wasm(runtime, &program_name, module, module_hash)
     }
 
     #[allow(unused_variables)]

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -434,6 +434,7 @@ impl Wasi {
     }
 
     #[cfg(feature = "journal")]
+    #[allow(clippy::type_complexity)]
     pub fn build_journals(
         &self,
     ) -> anyhow::Result<(Vec<Arc<DynReadableJournal>>, Vec<Arc<DynJournal>>)> {

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -204,6 +204,11 @@ pub struct Wasi {
     #[clap(long = "stop-after-snapshot")]
     pub stop_after_snapshot: bool,
 
+    /// Skip writes to stdout and stderr when replying journal events to bootstrap a module.
+    #[cfg(feature = "journal")]
+    #[clap(long = "skip-journal-stdio")]
+    pub skip_stdio_during_bootstrap: bool,
+
     /// Allow instances to send http requests.
     ///
     /// Access to domains is granted by default.
@@ -422,6 +427,7 @@ impl Wasi {
             for journal in w {
                 builder.add_writable_journal(journal);
             }
+            builder.with_skip_stdio_during_bootstrap(self.skip_stdio_during_bootstrap);
         }
 
         Ok(builder)

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -23,7 +23,7 @@ use wasmer_wasix::{
     capabilities::Capabilities,
     default_fs_backing, get_wasi_versions,
     http::HttpClient,
-    journal::{CompactingLogFileJournal, DynJournal},
+    journal::{CompactingLogFileJournal, DynJournal, DynReadableJournal},
     os::{tty_sys::SysTty, TtyBridge},
     rewind_ext,
     runners::MAPPED_CURRENT_DIR_DEFAULT_PATH,
@@ -136,6 +136,15 @@ pub struct Wasi {
     pub enable_cpu_backoff: Option<u64>,
 
     /// Specifies one or more journal files that Wasmer will use to restore
+    /// the state of the WASM process as it executes.
+    ///
+    /// The state of the WASM process and its sandbox will be reapplied using
+    /// the journals in the order that you specify here.
+    #[cfg(feature = "journal")]
+    #[clap(long = "journal")]
+    pub read_only_journals: Vec<PathBuf>,
+
+    /// Specifies one or more journal files that Wasmer will use to restore
     /// and save the state of the WASM process as it executes.
     ///
     /// The state of the WASM process and its sandbox will be reapplied using
@@ -145,8 +154,8 @@ pub struct Wasi {
     /// and opened for read and write. New journal events will be written to this
     /// file
     #[cfg(feature = "journal")]
-    #[clap(long = "journal")]
-    pub journals: Vec<PathBuf>,
+    #[clap(long = "journal-writable")]
+    pub writable_journals: Vec<PathBuf>,
 
     /// Flag that indicates if the journal will be automatically compacted
     /// as it fills up and when the process exits
@@ -406,8 +415,12 @@ impl Wasi {
             if self.stop_after_snapshot {
                 builder.with_stop_running_after_snapshot(true);
             }
-            for journal in self.build_journals()? {
-                builder.add_journal(journal);
+            let (r, w) = self.build_journals()?;
+            for journal in r {
+                builder.add_read_only_journal(journal);
+            }
+            for journal in w {
+                builder.add_writable_journal(journal);
             }
         }
 
@@ -415,9 +428,22 @@ impl Wasi {
     }
 
     #[cfg(feature = "journal")]
-    pub fn build_journals(&self) -> anyhow::Result<Vec<Arc<DynJournal>>> {
-        let mut ret = Vec::new();
-        for journal in self.journals.clone() {
+    pub fn build_journals(
+        &self,
+    ) -> anyhow::Result<(Vec<Arc<DynReadableJournal>>, Vec<Arc<DynJournal>>)> {
+        let mut readable = Vec::new();
+        for journal in self.read_only_journals.clone() {
+            if matches!(std::fs::metadata(&journal), Err(e) if e.kind() == std::io::ErrorKind::NotFound)
+            {
+                bail!("Read-only journal file does not exist: {journal:?}");
+            }
+
+            readable
+                .push(Arc::new(LogFileJournal::new_readonly(journal)?) as Arc<DynReadableJournal>);
+        }
+
+        let mut writable = Vec::new();
+        for journal in self.writable_journals.clone() {
             if self.enable_compaction {
                 let mut journal = CompactingLogFileJournal::new(journal)?;
                 if !self.without_compact_on_drop {
@@ -426,12 +452,12 @@ impl Wasi {
                 if self.with_compact_on_growth.is_normal() && self.with_compact_on_growth != 0f32 {
                     journal = journal.with_compact_on_factor_size(self.with_compact_on_growth);
                 }
-                ret.push(Arc::new(journal) as Arc<DynJournal>);
+                writable.push(Arc::new(journal) as Arc<DynJournal>);
             } else {
-                ret.push(Arc::new(LogFileJournal::new(journal)?));
+                writable.push(Arc::new(LogFileJournal::new(journal)?));
             }
         }
-        Ok(ret)
+        Ok((readable, writable))
     }
 
     #[cfg(not(feature = "journal"))]
@@ -614,8 +640,14 @@ impl Wasi {
         }
 
         #[cfg(feature = "journal")]
-        for journal in self.build_journals()? {
-            rt.add_journal(journal);
+        {
+            let (r, w) = self.build_journals()?;
+            for journal in r {
+                rt.add_read_only_journal(journal);
+            }
+            for journal in w {
+                rt.add_writable_journal(journal);
+            }
         }
 
         if !self.no_tty {

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -189,6 +189,12 @@ pub struct Wasi {
     #[clap(long = "snapshot-period")]
     pub snapshot_interval: Option<u64>,
 
+    /// If specified, the runtime will stop executing the WASM module after the first snapshot
+    /// is taken.
+    #[cfg(feature = "journal")]
+    #[clap(long = "stop-after-snapshot")]
+    pub stop_after_snapshot: bool,
+
     /// Allow instances to send http requests.
     ///
     /// Access to domains is granted by default.
@@ -396,6 +402,9 @@ impl Wasi {
             }
             if let Some(interval) = self.snapshot_interval {
                 builder.with_snapshot_interval(std::time::Duration::from_millis(interval));
+            }
+            if self.stop_after_snapshot {
+                builder.with_stop_running_after_snapshot(true);
             }
             for journal in self.build_journals()? {
                 builder.add_journal(journal);

--- a/lib/journal/src/concrete/compacting.rs
+++ b/lib/journal/src/concrete/compacting.rs
@@ -61,7 +61,7 @@ impl From<Range<u64>> for MemoryRange {
 /// on the final deterministic outcome of the entire log.
 ///
 /// By grouping events into subevents it makes it possible to ignore an
-/// entire subgroup of events which are superseeded by a later event. For
+/// entire subgroup of events which are superceded by a later event. For
 /// example, all the events involved in creating a file are irrelevant if
 /// that file is later deleted.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/lib/journal/src/concrete/compacting.rs
+++ b/lib/journal/src/concrete/compacting.rs
@@ -230,6 +230,15 @@ impl State {
         filter.build_split(writer, reader)
     }
 
+    fn insert_new_sub_events_empty(&mut self) -> SubGroupIndex {
+        let lookup = SubGroupIndex(self.descriptor_seed);
+        self.descriptor_seed += 1;
+
+        self.sub_events.entry(lookup).or_default();
+
+        lookup
+    }
+
     fn insert_new_sub_events(&mut self, event_index: usize) -> SubGroupIndex {
         let lookup = SubGroupIndex(self.descriptor_seed);
         self.descriptor_seed += 1;
@@ -299,6 +308,10 @@ impl State {
         self.stdio_descriptors.clear();
         self.suspect_descriptors.clear();
         self.thread_map.clear();
+        for i in 0..=2 {
+            let lookup = self.insert_new_sub_events_empty();
+            self.stdio_descriptors.insert(i, lookup);
+        }
     }
 }
 
@@ -335,7 +348,7 @@ impl CompactingJournal {
         J: Journal,
     {
         let (tx, rx) = inner.split();
-        let state = State {
+        let mut state = State {
             inner_tx: tx,
             inner_rx: rx.as_restarted()?,
             tty: None,
@@ -364,6 +377,11 @@ impl CompactingJournal {
             delta_list: None,
             event_index: 0,
         };
+        // stdio FDs are always created for a process initially, fill them out here
+        for i in 0..=2 {
+            let lookup = state.insert_new_sub_events_empty();
+            state.stdio_descriptors.insert(i, lookup);
+        }
         Ok(Self {
             tx: CompactingJournalTx {
                 state: Arc::new(Mutex::new(state)),
@@ -584,12 +602,6 @@ impl WritableJournal for CompactingJournalTx {
                     state.keep_descriptors.insert(*fd, lookup);
                 }
 
-                // If its stdio then we need to create the descriptor if its not there already
-                if *fd <= 3 && !state.stdio_descriptors.contains_key(fd) {
-                    let lookup = state.insert_new_sub_events(event_index);
-                    state.stdio_descriptors.insert(*fd, lookup);
-                }
-
                 // Update the state
                 if let Some(state) = state
                     .find_sub_events(fd)
@@ -608,19 +620,11 @@ impl WritableJournal for CompactingJournalTx {
                     }
                 }
             }
-            // Seeks to a particular position within
+            // We keep non-mutable events for file descriptors that are suspect
             JournalEntry::FileDescriptorSeekV1 { fd, .. }
             | JournalEntry::FileDescriptorSetFdFlagsV1 { fd, .. }
-            | JournalEntry::FileDescriptorSetFlagsV1 { fd, .. } => {
-                // If its stdio then we need to create the descriptor if its not there already
-                if *fd <= 3 && !state.stdio_descriptors.contains_key(fd) {
-                    let lookup = state.insert_new_sub_events(event_index);
-                    state.stdio_descriptors.insert(*fd, lookup);
-                }
-                state.find_sub_events_and_append(fd, event_index);
-            }
-            // We keep non-mutable events for file descriptors that are suspect
-            JournalEntry::SocketBindV1 { fd, .. }
+            | JournalEntry::FileDescriptorSetFlagsV1 { fd, .. }
+            | JournalEntry::SocketBindV1 { fd, .. }
             | JournalEntry::SocketSendFileV1 { socket_fd: fd, .. }
             | JournalEntry::SocketSendToV1 { fd, .. }
             | JournalEntry::SocketSendV1 { fd, .. }
@@ -669,36 +673,50 @@ impl WritableJournal for CompactingJournalTx {
             } => {
                 if let Some(lookup) = state.suspect_descriptors.get(original_fd).cloned() {
                     state.suspect_descriptors.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.keep_descriptors.get(original_fd).cloned() {
                     state.keep_descriptors.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.stdio_descriptors.get(original_fd).cloned() {
                     state.stdio_descriptors.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.open_pipes.get(original_fd).cloned() {
                     state.open_pipes.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.open_sockets.get(original_fd).cloned() {
                     state.open_sockets.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.accepted_sockets.get(original_fd).cloned() {
                     state.accepted_sockets.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.event_descriptors.get(original_fd).cloned() {
                     state.event_descriptors.insert(*copied_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 }
             }
             // Renumbered file descriptors will retain their suspect status
             JournalEntry::RenumberFileDescriptorV1 { old_fd, new_fd } => {
                 if let Some(lookup) = state.suspect_descriptors.remove(old_fd) {
                     state.suspect_descriptors.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.keep_descriptors.remove(old_fd) {
                     state.keep_descriptors.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.stdio_descriptors.remove(old_fd) {
                     state.stdio_descriptors.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.open_pipes.remove(old_fd) {
                     state.open_pipes.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.open_sockets.remove(old_fd) {
                     state.open_sockets.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.open_sockets.remove(old_fd) {
                     state.accepted_sockets.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 } else if let Some(lookup) = state.event_descriptors.remove(old_fd) {
                     state.event_descriptors.insert(*new_fd, lookup);
+                    state.append_to_sub_events(&lookup, event_index);
                 }
             }
             // Creating a new directory only needs to be done once

--- a/lib/journal/src/concrete/printing.rs
+++ b/lib/journal/src/concrete/printing.rs
@@ -100,7 +100,7 @@ impl<'a> fmt::Display for JournalEntry<'a> {
                 ..
             } => write!(
                 f,
-                "thread-update (id={}, call-stack.len={}, mem-stack.len={}, store-size={}",
+                "thread-update (id={}, call-stack.len={}, mem-stack.len={}, store-size={})",
                 id,
                 call_stack.len(),
                 memory_stack.len(),
@@ -287,7 +287,7 @@ impl<'a> fmt::Display for JournalEntry<'a> {
                 write!(f, "sock-send-to (fd={}, data.len={}, addr={})", fd, data.len(), addr)
             }
             JournalEntry::SocketSendV1 { fd, data, .. } => {
-                write!(f, "sock-send (fd={}, data.len={}", fd, data.len())
+                write!(f, "sock-send (fd={}, data.len={})", fd, data.len())
             }
             JournalEntry::SocketSetOptFlagV1 { fd, opt, flag } => {
                 write!(f, "sock-set-opt (fd={fd}, opt={opt:?}, flag={flag})")

--- a/lib/journal/src/lib.rs
+++ b/lib/journal/src/lib.rs
@@ -95,7 +95,9 @@ pub trait ReadableJournal: std::fmt::Debug {
 /// a WASM process at a point in time and saves it so that it can be restored.
 /// It also allows for the restoration of that state at a later moment
 #[allow(unused_variables)]
-pub trait Journal: WritableJournal + ReadableJournal + std::fmt::Debug {
+pub trait Journal:
+    WritableJournal + ReadableJournal + AsDynReadableJournal + std::fmt::Debug
+{
     /// Splits the journal into a read and write side
     fn split(self) -> (Box<DynWritableJournal>, Box<DynReadableJournal>);
 }
@@ -103,3 +105,14 @@ pub trait Journal: WritableJournal + ReadableJournal + std::fmt::Debug {
 pub type DynJournal = dyn Journal + Send + Sync;
 pub type DynWritableJournal = dyn WritableJournal + Send + Sync;
 pub type DynReadableJournal = dyn ReadableJournal + Send + Sync;
+
+/// A bit of manual up-casting support
+pub trait AsDynReadableJournal {
+    fn as_dyn_readable_journal(&self) -> &DynReadableJournal;
+}
+
+impl<T: Journal + Send + Sync + 'static> AsDynReadableJournal for T {
+    fn as_dyn_readable_journal(&self) -> &DynReadableJournal {
+        self
+    }
+}

--- a/lib/journal/src/snapshot.rs
+++ b/lib/journal/src/snapshot.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::*;
 
 /// Various triggers that will cause the runtime to take snapshot
@@ -79,5 +81,30 @@ impl FromStr for SnapshotTrigger {
             "explicit" => Self::Explicit,
             a => return Err(anyhow::format_err!("invalid or unknown trigger ({a})")),
         })
+    }
+}
+
+impl Display for SnapshotTrigger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Bootstrap => "bootstrap",
+                Self::Explicit => "explicit",
+                Self::FirstEnviron => "first-environ",
+                Self::FirstListen => "first-listen",
+                Self::FirstSigint => "first-sigint",
+                Self::FirstStdin => "first-stdin",
+                Self::Idle => "idle",
+                Self::NonDeterministicCall => "non-deterministic-call",
+                Self::PeriodicInterval => "periodic-interval",
+                Self::Sigalrm => "sigalrm",
+                Self::Sigint => "sigint",
+                Self::Sigtstp => "sigtstp",
+                Self::Sigstop => "sigstop",
+                Self::Transaction => "transaction",
+            }
+        )
     }
 }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -83,6 +83,7 @@ const STDIN_DEFAULT_RIGHTS: Rights = {
             | Rights::FD_SYNC.bits()
             | Rights::FD_ADVISE.bits()
             | Rights::FD_FILESTAT_GET.bits()
+            | Rights::FD_FDSTAT_SET_FLAGS.bits()
             | Rights::POLL_FD_READWRITE.bits(),
     )
 };
@@ -95,6 +96,7 @@ const STDOUT_DEFAULT_RIGHTS: Rights = {
             | Rights::FD_WRITE.bits()
             | Rights::FD_ADVISE.bits()
             | Rights::FD_FILESTAT_GET.bits()
+            | Rights::FD_FDSTAT_SET_FLAGS.bits()
             | Rights::POLL_FD_READWRITE.bits(),
     )
 };

--- a/lib/wasix/src/journal/effector/syscalls/fd_duplicate.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_duplicate.rs
@@ -33,14 +33,16 @@ impl JournalEffector {
                 )
             })?;
 
-        let ret = crate::syscalls::fd_renumber_internal(ctx, ret_fd, copied_fd);
-        if !matches!(ret, Ok(Errno::Success)) {
-            bail!(
-                "journal restore error: failed renumber file descriptor after duplicate (from={}, to={}) - {}",
-                ret_fd,
-                copied_fd,
-                ret.unwrap_or(Errno::Unknown)
-            );
+        if ret_fd != copied_fd {
+            let ret = crate::syscalls::fd_renumber_internal(ctx, ret_fd, copied_fd);
+            if !matches!(ret, Ok(Errno::Success)) {
+                bail!(
+                    "journal restore error: failed renumber file descriptor after duplicate (from={}, to={}) - {}",
+                    ret_fd,
+                    copied_fd,
+                    ret.unwrap_or(Errno::Unknown)
+                );
+            }
         }
 
         let ret = crate::syscalls::fd_fdflags_set_internal(
@@ -54,8 +56,7 @@ impl JournalEffector {
         );
         if !matches!(ret, Ok(Errno::Success)) {
             bail!(
-                "journal restore error: failed renumber file descriptor after duplicate (from={}, to={}) - {}",
-                ret_fd,
+                "journal restore error: failed to update fdflags after duplicate (fd={}) - {}",
                 copied_fd,
                 ret.unwrap_or(Errno::Unknown)
             );

--- a/lib/wasix/src/journal/effector/syscalls/fd_duplicate.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_duplicate.rs
@@ -45,23 +45,6 @@ impl JournalEffector {
             }
         }
 
-        let ret = crate::syscalls::fd_fdflags_set_internal(
-            ctx,
-            copied_fd,
-            if cloexec {
-                Fdflagsext::CLOEXEC
-            } else {
-                Fdflagsext::empty()
-            },
-        );
-        if !matches!(ret, Ok(Errno::Success)) {
-            bail!(
-                "journal restore error: failed to update fdflags after duplicate (fd={}) - {}",
-                copied_fd,
-                ret.unwrap_or(Errno::Unknown)
-            );
-        }
-
         Ok(())
     }
 }

--- a/lib/wasix/src/os/console/mod.rs
+++ b/lib/wasix/src/os/console/mod.rs
@@ -12,6 +12,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc, Mutex},
 };
 
+use futures::future::Either;
 use linked_hash_set::LinkedHashSet;
 use tokio::sync::{mpsc, RwLock};
 #[allow(unused_imports, dead_code)]
@@ -229,7 +230,7 @@ impl Console {
             .prepare_webc_env(
                 prog,
                 &wasi_opts,
-                Some(&pkg),
+                Either::Left(&pkg),
                 self.runtime.clone(),
                 Some(root_fs),
             )

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -607,6 +607,21 @@ impl WasiProcess {
         self.wait_for_checkpoint_finish()
     }
 
+    /// Takes a snapshot of the process and shuts it down after the snapshot
+    /// is taken.
+    ///
+    /// Note: If you ignore the returned future the checkpoint will still
+    /// occur but it will execute asynchronously
+    pub fn snapshot_and_stop(
+        &self,
+        trigger: SnapshotTrigger,
+    ) -> std::pin::Pin<Box<dyn futures::Future<Output = ()> + Send + Sync>> {
+        let mut guard = self.inner.0.lock().unwrap();
+        guard.stop_running_after_checkpoint = true;
+        guard.checkpoint = WasiProcessCheckpoint::Snapshot { trigger };
+        self.wait_for_checkpoint_finish()
+    }
+
     /// Takes a snapshot of the process
     ///
     /// Note: If you ignore the returned future the checkpoint will still

--- a/lib/wasix/src/runners/dcgi/runner.rs
+++ b/lib/wasix/src/runners/dcgi/runner.rs
@@ -75,7 +75,6 @@ impl crate::runners::Runner for DcgiRunner {
         // once due to limitations in the runtime
         let journals = runtime
             .writable_journals()
-            .into_iter()
             .map(|journal| {
                 let journal = FilteredJournalBuilder::new()
                     .with_ignore_memory(true)

--- a/lib/wasix/src/runners/dcgi/runner.rs
+++ b/lib/wasix/src/runners/dcgi/runner.rs
@@ -74,8 +74,7 @@ impl crate::runners::Runner for DcgiRunner {
         // file system changes as it is unable to run the main function more than
         // once due to limitations in the runtime
         let journals = runtime
-            .journals()
-            .clone()
+            .writable_journals()
             .into_iter()
             .map(|journal| {
                 let journal = FilteredJournalBuilder::new()
@@ -89,7 +88,7 @@ impl crate::runners::Runner for DcgiRunner {
                 Arc::new(journal) as Arc<DynJournal>
             })
             .collect::<Vec<_>>();
-        let runtime = OverriddenRuntime::new(runtime).with_journals(journals);
+        let runtime = OverriddenRuntime::new(runtime).with_writable_journals(journals);
         let runtime = Arc::new(runtime) as Arc<DynRuntime>;
 
         //We now pass the runtime to the handlers
@@ -191,19 +190,23 @@ impl Config {
         self.inner.capabilities()
     }
 
+    #[cfg(feature = "journal")]
     pub fn add_snapshot_trigger(&mut self, on: crate::journal::SnapshotTrigger) {
         self.inner.add_snapshot_trigger(on);
     }
 
+    #[cfg(feature = "journal")]
     pub fn add_default_snapshot_triggers(&mut self) -> &mut Self {
         self.inner.add_default_snapshot_triggers();
         self
     }
 
+    #[cfg(feature = "journal")]
     pub fn has_snapshot_trigger(&self, on: crate::journal::SnapshotTrigger) -> bool {
         self.inner.has_snapshot_trigger(on)
     }
 
+    #[cfg(feature = "journal")]
     pub fn with_snapshot_interval(&mut self, period: std::time::Duration) -> &mut Self {
         self.inner.with_snapshot_interval(period);
         self
@@ -214,8 +217,18 @@ impl Config {
         self.inner.with_stop_running_after_snapshot(stop_running);
     }
 
-    pub fn add_journal(&mut self, journal: Arc<crate::journal::DynJournal>) -> &mut Self {
-        self.inner.add_journal(journal);
+    #[cfg(feature = "journal")]
+    pub fn add_read_only_journal(
+        &mut self,
+        journal: Arc<crate::journal::DynReadableJournal>,
+    ) -> &mut Self {
+        self.inner.add_read_only_journal(journal);
+        self
+    }
+
+    #[cfg(feature = "journal")]
+    pub fn add_writable_journal(&mut self, journal: Arc<crate::journal::DynJournal>) -> &mut Self {
+        self.inner.add_writable_journal(journal);
         self
     }
 }

--- a/lib/wasix/src/runners/dcgi/runner.rs
+++ b/lib/wasix/src/runners/dcgi/runner.rs
@@ -209,6 +209,11 @@ impl Config {
         self
     }
 
+    #[cfg(feature = "journal")]
+    pub fn with_stop_running_after_snapshot(&mut self, stop_running: bool) {
+        self.inner.with_stop_running_after_snapshot(stop_running);
+    }
+
     pub fn add_journal(&mut self, journal: Arc<crate::journal::DynJournal>) -> &mut Self {
         self.inner.add_journal(journal);
         self

--- a/lib/wasix/src/runners/dproxy/factory.rs
+++ b/lib/wasix/src/runners/dproxy/factory.rs
@@ -58,17 +58,14 @@ impl DProxyInstanceFactory {
         // DProxy is able to resume execution of the stateful workload using memory
         // snapshots hence the journals it stores are complete journals
         let journals = runtime
-            .journals()
-            .clone()
-            .into_iter()
+            .writable_journals()
             .map(|journal| {
-                let tx = journal.clone();
                 let rx = journal.as_restarted()?;
-                let combined = RecombinedJournal::new(tx, rx);
+                let combined = RecombinedJournal::new(journal, rx);
                 anyhow::Result::Ok(Arc::new(combined) as Arc<DynJournal>)
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let mut runtime = OverriddenRuntime::new(runtime).with_journals(journals);
+        let mut runtime = OverriddenRuntime::new(runtime).with_writable_journals(journals);
 
         // We attach a composite networking to the runtime which includes a loopback
         // networking implementation connected to a socket manager

--- a/lib/wasix/src/runners/wasi.rs
+++ b/lib/wasix/src/runners/wasi.rs
@@ -218,6 +218,11 @@ impl WasiRunner {
         self
     }
 
+    pub fn with_skip_stdio_during_bootstrap(&mut self, skip: bool) -> &mut Self {
+        self.wasi.skip_stdio_during_bootstrap = skip;
+        self
+    }
+
     pub fn with_stdin(&mut self, stdin: Box<dyn VirtualFile + Send + Sync>) -> &mut Self {
         self.stdin = Some(ArcBoxFile::new(stdin));
         self
@@ -363,6 +368,7 @@ impl WasiRunner {
             }
 
             builder.with_stop_running_after_snapshot(self.wasi.stop_running_after_snapshot);
+            builder.with_skip_stdio_during_bootstrap(self.wasi.skip_stdio_during_bootstrap);
         }
 
         let env = builder.build()?;

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -43,6 +43,7 @@ pub(crate) struct CommonWasiOptions {
     pub(crate) journals: Vec<Arc<DynJournal>>,
     pub(crate) snapshot_on: Vec<SnapshotTrigger>,
     pub(crate) snapshot_interval: Option<std::time::Duration>,
+    pub(crate) stop_running_after_snapshot: bool,
     pub(crate) current_dir: Option<PathBuf>,
     pub(crate) additional_imports: Imports,
 }

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -14,7 +14,7 @@ use webc::metadata::annotations::Wasi as WasiAnnotation;
 use crate::{
     bin_factory::BinaryPackage,
     capabilities::Capabilities,
-    journal::{DynJournal, SnapshotTrigger},
+    journal::{DynJournal, DynReadableJournal, SnapshotTrigger},
     WasiEnvBuilder,
 };
 
@@ -40,7 +40,8 @@ pub(crate) struct CommonWasiOptions {
     pub(crate) is_tmp_mapped: bool,
     pub(crate) injected_packages: Vec<BinaryPackage>,
     pub(crate) capabilities: Capabilities,
-    pub(crate) journals: Vec<Arc<DynJournal>>,
+    pub(crate) read_only_journals: Vec<Arc<DynReadableJournal>>,
+    pub(crate) writable_journals: Vec<Arc<DynJournal>>,
     pub(crate) snapshot_on: Vec<SnapshotTrigger>,
     pub(crate) snapshot_interval: Option<std::time::Duration>,
     pub(crate) stop_running_after_snapshot: bool,

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -106,7 +106,7 @@ impl CommonWasiOptions {
                 builder.add_writable_journal(journal.clone());
             }
             for trigger in &self.snapshot_on {
-                builder.add_snapshot_trigger(trigger.clone());
+                builder.add_snapshot_trigger(*trigger);
             }
             if let Some(interval) = self.snapshot_interval {
                 builder.with_snapshot_interval(interval);

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -14,7 +14,7 @@ use webc::metadata::annotations::Wasi as WasiAnnotation;
 use crate::{
     bin_factory::BinaryPackage,
     capabilities::Capabilities,
-    journal::{self, DynJournal, DynReadableJournal, SnapshotTrigger},
+    journal::{DynJournal, DynReadableJournal, SnapshotTrigger},
     WasiEnvBuilder,
 };
 

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -45,6 +45,7 @@ pub(crate) struct CommonWasiOptions {
     pub(crate) snapshot_on: Vec<SnapshotTrigger>,
     pub(crate) snapshot_interval: Option<std::time::Duration>,
     pub(crate) stop_running_after_snapshot: bool,
+    pub(crate) skip_stdio_during_bootstrap: bool,
     pub(crate) current_dir: Option<PathBuf>,
     pub(crate) additional_imports: Imports,
 }

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -14,7 +14,7 @@ use webc::metadata::annotations::Wasi as WasiAnnotation;
 use crate::{
     bin_factory::BinaryPackage,
     capabilities::Capabilities,
-    journal::{DynJournal, DynReadableJournal, SnapshotTrigger},
+    journal::{self, DynJournal, DynReadableJournal, SnapshotTrigger},
     WasiEnvBuilder,
 };
 
@@ -96,6 +96,23 @@ impl CommonWasiOptions {
         *builder.capabilities_mut() = self.capabilities.clone();
 
         builder.add_imports(&self.additional_imports);
+
+        #[cfg(feature = "journal")]
+        {
+            for journal in &self.read_only_journals {
+                builder.add_read_only_journal(journal.clone());
+            }
+            for journal in &self.writable_journals {
+                builder.add_writable_journal(journal.clone());
+            }
+            for trigger in &self.snapshot_on {
+                builder.add_snapshot_trigger(trigger.clone());
+            }
+            if let Some(interval) = self.snapshot_interval {
+                builder.with_snapshot_interval(interval);
+            }
+            builder.with_stop_running_after_snapshot(self.stop_running_after_snapshot);
+        }
 
         Ok(())
     }

--- a/lib/wasix/src/runners/wcgi/runner.rs
+++ b/lib/wasix/src/runners/wcgi/runner.rs
@@ -330,8 +330,17 @@ impl Config {
     }
 
     #[cfg(feature = "journal")]
-    pub fn add_journal(&mut self, journal: Arc<crate::journal::DynJournal>) -> &mut Self {
-        self.wasi.journals.push(journal);
+    pub fn add_read_only_journal(
+        &mut self,
+        journal: Arc<crate::journal::DynReadableJournal>,
+    ) -> &mut Self {
+        self.wasi.read_only_journals.push(journal);
+        self
+    }
+
+    #[cfg(feature = "journal")]
+    pub fn add_writable_journal(&mut self, journal: Arc<crate::journal::DynJournal>) -> &mut Self {
+        self.wasi.writable_journals.push(journal);
         self
     }
 }

--- a/lib/wasix/src/runners/wcgi/runner.rs
+++ b/lib/wasix/src/runners/wcgi/runner.rs
@@ -325,6 +325,11 @@ impl Config {
     }
 
     #[cfg(feature = "journal")]
+    pub fn with_stop_running_after_snapshot(&mut self, stop_running: bool) {
+        self.wasi.stop_running_after_snapshot = stop_running;
+    }
+
+    #[cfg(feature = "journal")]
     pub fn add_journal(&mut self, journal: Arc<crate::journal::DynJournal>) -> &mut Self {
         self.wasi.journals.push(journal);
         self

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -1022,6 +1022,7 @@ impl WasiEnvBuilder {
             extra_tracing: true,
             #[cfg(feature = "journal")]
             snapshot_on: self.snapshot_on,
+            #[cfg(feature = "journal")]
             stop_running_after_snapshot: self.stop_running_after_snapshot,
             skip_stdio_during_bootstrap: self.skip_stdio_during_bootstrap,
             additional_imports: self.additional_imports,

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -92,6 +92,9 @@ pub struct WasiEnvBuilder {
     pub(super) snapshot_interval: Option<std::time::Duration>,
 
     #[cfg(feature = "journal")]
+    pub(super) stop_running_after_snapshot: bool,
+
+    #[cfg(feature = "journal")]
     pub(super) journals: Vec<Arc<DynJournal>>,
 
     #[cfg(feature = "ctrlc")]
@@ -740,6 +743,11 @@ impl WasiEnvBuilder {
         self.snapshot_interval.replace(interval);
     }
 
+    #[cfg(feature = "journal")]
+    pub fn with_stop_running_after_snapshot(&mut self, stop_running: bool) {
+        self.stop_running_after_snapshot = stop_running;
+    }
+
     /// Add an item to the list of importable items provided to the instance.
     pub fn import(
         mut self,
@@ -990,6 +998,7 @@ impl WasiEnvBuilder {
             extra_tracing: true,
             #[cfg(feature = "journal")]
             snapshot_on: self.snapshot_on,
+            stop_running_after_snapshot: self.stop_running_after_snapshot,
             additional_imports: self.additional_imports,
         };
 

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -100,6 +100,8 @@ pub struct WasiEnvBuilder {
     #[cfg(feature = "journal")]
     pub(super) writable_journals: Vec<Arc<DynJournal>>,
 
+    pub(super) skip_stdio_during_bootstrap: bool,
+
     #[cfg(feature = "ctrlc")]
     pub(super) attach_ctrl_c: bool,
 }
@@ -761,6 +763,10 @@ impl WasiEnvBuilder {
         self.stop_running_after_snapshot = stop_running;
     }
 
+    pub fn with_skip_stdio_during_bootstrap(&mut self, skip: bool) {
+        self.skip_stdio_during_bootstrap = skip;
+    }
+
     /// Add an item to the list of importable items provided to the instance.
     pub fn import(
         mut self,
@@ -1017,6 +1023,7 @@ impl WasiEnvBuilder {
             #[cfg(feature = "journal")]
             snapshot_on: self.snapshot_on,
             stop_running_after_snapshot: self.stop_running_after_snapshot,
+            skip_stdio_during_bootstrap: self.skip_stdio_during_bootstrap,
             additional_imports: self.additional_imports,
         };
 

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -253,6 +253,9 @@ pub struct WasiEnvInit {
     /// Stop running after the first snapshot is taken
     #[cfg(feature = "journal")]
     pub stop_running_after_snapshot: bool,
+
+    /// Skip writes to stdout and stderr when bootstrapping from a journal
+    pub skip_stdio_during_bootstrap: bool,
 }
 
 impl WasiEnvInit {
@@ -293,6 +296,7 @@ impl WasiEnvInit {
             #[cfg(feature = "journal")]
             snapshot_on: self.snapshot_on.clone(),
             stop_running_after_snapshot: self.stop_running_after_snapshot,
+            skip_stdio_during_bootstrap: self.skip_stdio_during_bootstrap,
             additional_imports: self.additional_imports.clone(),
         }
     }
@@ -339,6 +343,9 @@ pub struct WasiEnv {
     /// (and hence it should not record new events)
     pub replaying_journal: bool,
 
+    /// Should stdio be skipped when bootstrapping this module from an existing journal?
+    pub skip_stdio_during_bootstrap: bool,
+
     /// Flag that indicates the cleanup of the environment is to be disabled
     /// (this is normally used so that the instance can be reused later on)
     pub(crate) disable_fs_cleanup: bool,
@@ -375,6 +382,7 @@ impl Clone for WasiEnv {
             enable_journal: self.enable_journal,
             enable_exponential_cpu_backoff: self.enable_exponential_cpu_backoff,
             replaying_journal: self.replaying_journal,
+            skip_stdio_during_bootstrap: self.skip_stdio_during_bootstrap,
             disable_fs_cleanup: self.disable_fs_cleanup,
         }
     }
@@ -415,6 +423,7 @@ impl WasiEnv {
             enable_journal: self.enable_journal,
             enable_exponential_cpu_backoff: self.enable_exponential_cpu_backoff,
             replaying_journal: false,
+            skip_stdio_during_bootstrap: self.skip_stdio_during_bootstrap,
             disable_fs_cleanup: self.disable_fs_cleanup,
         };
         Ok((new_env, handle))
@@ -543,6 +552,7 @@ impl WasiEnv {
             #[cfg(not(feature = "journal"))]
             enable_journal: false,
             replaying_journal: false,
+            skip_stdio_during_bootstrap: init.skip_stdio_during_bootstrap,
             enable_deep_sleep: init.capabilities.threading.enable_asynchronous_threading,
             enable_exponential_cpu_backoff: init
                 .capabilities

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -295,6 +295,7 @@ impl WasiEnvInit {
             extra_tracing: false,
             #[cfg(feature = "journal")]
             snapshot_on: self.snapshot_on.clone(),
+            #[cfg(feature = "journal")]
             stop_running_after_snapshot: self.stop_running_after_snapshot,
             skip_stdio_during_bootstrap: self.skip_stdio_during_bootstrap,
             additional_imports: self.additional_imports.clone(),

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -249,6 +249,10 @@ pub struct WasiEnvInit {
     /// Indicates triggers that will cause a snapshot to be taken
     #[cfg(feature = "journal")]
     pub snapshot_on: Vec<SnapshotTrigger>,
+
+    /// Stop running after the first snapshot is taken
+    #[cfg(feature = "journal")]
+    pub stop_running_after_snapshot: bool,
 }
 
 impl WasiEnvInit {
@@ -288,6 +292,7 @@ impl WasiEnvInit {
             extra_tracing: false,
             #[cfg(feature = "journal")]
             snapshot_on: self.snapshot_on.clone(),
+            stop_running_after_snapshot: self.stop_running_after_snapshot,
             additional_imports: self.additional_imports.clone(),
         }
     }
@@ -511,7 +516,9 @@ impl WasiEnv {
 
         #[cfg(feature = "journal")]
         {
-            process.inner.0.lock().unwrap().snapshot_on = init.snapshot_on.into_iter().collect();
+            let mut guard = process.inner.0.lock().unwrap();
+            guard.snapshot_on = init.snapshot_on.into_iter().collect();
+            guard.stop_running_after_checkpoint = init.stop_running_after_snapshot;
         }
 
         let layout = WasiMemoryLayout::default();

--- a/lib/wasix/src/syscalls/journal/actions/fd_write.rs
+++ b/lib/wasix/src/syscalls/journal/actions/fd_write.rs
@@ -11,15 +11,23 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     ) -> Result<(), WasiRuntimeError> {
         tracing::trace!(%fd, %offset, "Replay journal - FdWrite");
         if self.stdout_fds.contains(&fd) {
-            self.stdout
-                .as_mut()
-                .map(|x| x.push((offset, data, is_64bit)));
+            if let Some(x) = self.stdout.as_mut() {
+                x.push(JournalStdIoWrite {
+                    offset,
+                    data,
+                    is_64bit,
+                });
+            }
             return Ok(());
         }
         if self.stderr_fds.contains(&fd) {
-            self.stderr
-                .as_mut()
-                .map(|x| x.push((offset, data, is_64bit)));
+            if let Some(x) = self.stdout.as_mut() {
+                x.push(JournalStdIoWrite {
+                    offset,
+                    data,
+                    is_64bit,
+                });
+            }
             return Ok(());
         }
 

--- a/lib/wasix/src/syscalls/journal/actions/fd_write.rs
+++ b/lib/wasix/src/syscalls/journal/actions/fd_write.rs
@@ -11,11 +11,15 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     ) -> Result<(), WasiRuntimeError> {
         tracing::trace!(%fd, %offset, "Replay journal - FdWrite");
         if self.stdout_fds.contains(&fd) {
-            self.stdout.push((offset, data, is_64bit));
+            self.stdout
+                .as_mut()
+                .map(|x| x.push((offset, data, is_64bit)));
             return Ok(());
         }
         if self.stderr_fds.contains(&fd) {
-            self.stderr.push((offset, data, is_64bit));
+            self.stderr
+                .as_mut()
+                .map(|x| x.push((offset, data, is_64bit)));
             return Ok(());
         }
 

--- a/lib/wasix/src/syscalls/journal/actions/mod.rs
+++ b/lib/wasix/src/syscalls/journal/actions/mod.rs
@@ -22,7 +22,7 @@ mod update_memory;
 
 use crate::journal::JournalEffector;
 use crate::syscalls::anyhow_err_to_runtime_err;
-use crate::syscalls::JournalSyscallPlayer;
+use crate::syscalls::{JournalStdIoWrite, JournalSyscallPlayer};
 use crate::RewindState;
 use crate::WasiRuntimeError;
 use crate::WasiThreadId;

--- a/lib/wasix/src/syscalls/journal/clear_ethereal.rs
+++ b/lib/wasix/src/syscalls/journal/clear_ethereal.rs
@@ -7,12 +7,15 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
     ) {
         tracing::trace!("Replay journal - ClearEthereal");
         self.spawn_threads.clear();
-        self.stdout.clear();
-        self.stderr.clear();
+
+        self.stdout.as_mut().map(|x| x.clear());
         self.stdout_fds.clear();
-        self.stderr_fds.clear();
         self.stdout_fds.insert(1 as WasiFd);
+
+        self.stderr.as_mut().map(|x| x.clear());
+        self.stderr_fds.clear();
         self.stderr_fds.insert(2 as WasiFd);
+
         differ_ethereal.iter_mut().for_each(|e| e.clear());
         self.staged_differ_memory.clear();
     }

--- a/lib/wasix/src/syscalls/journal/clear_ethereal.rs
+++ b/lib/wasix/src/syscalls/journal/clear_ethereal.rs
@@ -8,11 +8,15 @@ impl<'a, 'c> JournalSyscallPlayer<'a, 'c> {
         tracing::trace!("Replay journal - ClearEthereal");
         self.spawn_threads.clear();
 
-        self.stdout.as_mut().map(|x| x.clear());
+        if let Some(x) = self.stdout.as_mut() {
+            x.clear();
+        }
         self.stdout_fds.clear();
         self.stdout_fds.insert(1 as WasiFd);
 
-        self.stderr.as_mut().map(|x| x.clear());
+        if let Some(x) = self.stderr.as_mut() {
+            x.clear();
+        }
         self.stderr_fds.clear();
         self.stderr_fds.insert(2 as WasiFd);
 

--- a/lib/wasix/src/syscalls/journal/mod.rs
+++ b/lib/wasix/src/syscalls/journal/mod.rs
@@ -27,6 +27,12 @@ use std::{collections::BTreeMap, ops::Range};
 
 use super::*;
 
+pub struct JournalStdIoWrite<'a> {
+    pub offset: u64,
+    pub data: Cow<'a, [u8]>,
+    pub is_64bit: bool,
+}
+
 pub struct JournalSyscallPlayer<'a, 'c> {
     pub ctx: FunctionEnvMut<'c, WasiEnv>,
     pub bootstrapping: bool,
@@ -45,8 +51,8 @@ pub struct JournalSyscallPlayer<'a, 'c> {
     pub differ_memory: Vec<(Range<u64>, Cow<'a, [u8]>)>,
 
     // We capture the stdout and stderr while we replay
-    pub stdout: Option<Vec<(u64, Cow<'a, [u8]>, bool)>>,
-    pub stderr: Option<Vec<(u64, Cow<'a, [u8]>, bool)>>,
+    pub stdout: Option<Vec<JournalStdIoWrite<'a>>>,
+    pub stderr: Option<Vec<JournalStdIoWrite<'a>>>,
     pub stdout_fds: HashSet<u32>,
     pub stderr_fds: HashSet<u32>,
 }

--- a/lib/wasix/src/syscalls/journal/restore_snapshot.rs
+++ b/lib/wasix/src/syscalls/journal/restore_snapshot.rs
@@ -22,7 +22,7 @@ pub unsafe fn restore_snapshot(
     let mut ethereal_events = Vec::new();
     while let Some(next) = journal.read().map_err(anyhow_err_to_runtime_err)? {
         tracing::trace!(event=?next, "restoring event");
-        runner.play_event(next.into_inner(), Some(&mut ethereal_events));
+        runner.play_event(next.into_inner(), Some(&mut ethereal_events))?;
     }
 
     // Check for events that are orphaned
@@ -30,25 +30,32 @@ pub unsafe fn restore_snapshot(
         tracing::trace!("Orphaned ethereal events - {:?}", evt);
     }
 
+    // FIXME: if the stdout/stderr FDs were closed as a result of replaying the journal,
+    // this breaks. A potential fix would be to only close those two FDs afterwards; so
+    // a `JournalSyscallPlayer::should_close_stdout: bool` or similar.
     // Now output the stdout and stderr
-    tracing::trace!("replaying stdout");
-    for (offset, data, is_64bit) in runner.stdout {
-        if is_64bit {
-            JournalEffector::apply_fd_write::<Memory64>(&mut runner.ctx, 1, offset, data)
-        } else {
-            JournalEffector::apply_fd_write::<Memory32>(&mut runner.ctx, 1, offset, data)
+    if let Some(stdout) = runner.stdout {
+        tracing::trace!("replaying stdout");
+        for (offset, data, is_64bit) in stdout {
+            if is_64bit {
+                JournalEffector::apply_fd_write::<Memory64>(&mut runner.ctx, 1, offset, data)
+            } else {
+                JournalEffector::apply_fd_write::<Memory32>(&mut runner.ctx, 1, offset, data)
+            }
+            .map_err(anyhow_err_to_runtime_err)?;
         }
-        .map_err(anyhow_err_to_runtime_err)?;
     }
 
-    tracing::trace!("replaying stdout");
-    for (offset, data, is_64bit) in runner.stderr {
-        if is_64bit {
-            JournalEffector::apply_fd_write::<Memory64>(&mut runner.ctx, 2, offset, data)
-        } else {
-            JournalEffector::apply_fd_write::<Memory32>(&mut runner.ctx, 2, offset, data)
+    if let Some(stderr) = runner.stderr {
+        tracing::trace!("replaying stderr");
+        for (offset, data, is_64bit) in stderr {
+            if is_64bit {
+                JournalEffector::apply_fd_write::<Memory64>(&mut runner.ctx, 2, offset, data)
+            } else {
+                JournalEffector::apply_fd_write::<Memory32>(&mut runner.ctx, 2, offset, data)
+            }
+            .map_err(anyhow_err_to_runtime_err)?;
         }
-        .map_err(anyhow_err_to_runtime_err)?;
     }
 
     // Apply the memory changes (if this is in bootstrapping mode we differed them)

--- a/lib/wasix/src/syscalls/journal/restore_snapshot.rs
+++ b/lib/wasix/src/syscalls/journal/restore_snapshot.rs
@@ -36,7 +36,12 @@ pub unsafe fn restore_snapshot(
     // Now output the stdout and stderr
     if let Some(stdout) = runner.stdout {
         tracing::trace!("replaying stdout");
-        for (offset, data, is_64bit) in stdout {
+        for JournalStdIoWrite {
+            offset,
+            data,
+            is_64bit,
+        } in stdout
+        {
             if is_64bit {
                 JournalEffector::apply_fd_write::<Memory64>(&mut runner.ctx, 1, offset, data)
             } else {
@@ -48,7 +53,12 @@ pub unsafe fn restore_snapshot(
 
     if let Some(stderr) = runner.stderr {
         tracing::trace!("replaying stderr");
-        for (offset, data, is_64bit) in stderr {
+        for JournalStdIoWrite {
+            offset,
+            data,
+            is_64bit,
+        } in stderr
+        {
             if is_64bit {
                 JournalEffector::apply_fd_write::<Memory64>(&mut runner.ctx, 2, offset, data)
             } else {

--- a/lib/wasix/src/syscalls/journal/restore_snapshot.rs
+++ b/lib/wasix/src/syscalls/journal/restore_snapshot.rs
@@ -8,7 +8,7 @@ use super::*;
 #[tracing::instrument(skip_all)]
 pub unsafe fn restore_snapshot(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
-    journal: Arc<DynJournal>,
+    journal: &DynReadableJournal,
     bootstrapping: bool,
 ) -> Result<Option<RewindState>, WasiRuntimeError> {
     use std::{collections::BTreeMap, ops::Range};

--- a/lib/wasix/src/syscalls/mod.rs
+++ b/lib/wasix/src/syscalls/mod.rs
@@ -124,7 +124,7 @@ use crate::{
         fs_error_into_wasi_err, virtual_file_type_to_wasi_file_type, Fd, FdInner, InodeVal, Kind,
         MAX_SYMLINKS,
     },
-    journal::{DynJournal, JournalEffector},
+    journal::{DynJournal, DynReadableJournal, DynWritableJournal, JournalEffector},
     os::task::{
         process::{MaybeCheckpointResult, WasiProcessCheckpoint},
         thread::{RewindResult, RewindResultType},

--- a/lib/wasix/src/syscalls/wasix/proc_snapshot.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_snapshot.rs
@@ -6,6 +6,9 @@ use crate::syscalls::*;
 pub fn proc_snapshot<M: MemorySize>(
     mut ctx: FunctionEnvMut<'_, WasiEnv>,
 ) -> Result<Errno, WasiError> {
-    wasi_try_ok!(maybe_snapshot_once::<M>(ctx, SnapshotTrigger::Explicit)?);
+    // If we have an Explicit trigger, process that...
+    ctx = wasi_try_ok!(maybe_snapshot_once::<M>(ctx, SnapshotTrigger::Explicit)?);
+    // ... if not, we may still have an external request for a snapshot, so do that as well
+    ctx = wasi_try_ok!(maybe_snapshot::<M>(ctx)?);
     Ok(Errno::Success)
 }


### PR DESCRIPTION
This PR introduces a number of new CLI flags to `wasmer run`:

* `--journal` now adds a read-only journal. Adding writable journals happens via `--journal-writable`. This is a breaking change, so this PR must be merged before releasing 6.0.0 (cc @xdoardo)
* `--stop-after-snapshot` causes Wasmer to stop recording journal events and shut the module down immediately after the first snapshot is created. This also prevents appending thread exit and process exit events to the journal.
* `--skip-journal-stdio` causes writes to stdout and stderr to be skipped when replaying a journal. I feel there's more that can be done in this area; for example, if an app appends its output to a log file, we don't want to re-add all the logs if the app is resuming from a snapshot. However, for now, only stdio is supported by this flag.
