### PR TITLE
Use engine-specific default features

### DIFF
--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -264,11 +264,10 @@ impl RuntimeOptions {
 
     pub fn get_engine(&self, target: &Target) -> Result<Engine> {
         let backends = self.get_available_backends()?;
-        let required_features = Features::default();
-        backends
-            .first()
-            .unwrap()
-            .get_engine(target, &required_features)
+        let backend = backends.first().unwrap();
+        let backend_kind = wasmer::BackendKind::from(backend);
+        let required_features = wasmer::Engine::default_features_for_backend(&backend_kind, target);
+        backend.get_engine(target, &required_features)
     }
 
     pub fn get_engine_for_module(&self, module_contents: &[u8], target: &Target) -> Result<Engine> {

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -190,6 +190,9 @@ impl Run {
             }
         };
 
+        let engine_kind = engine.deterministic_id();
+        tracing::info!("Executing on backend {engine_kind:?}");
+
         #[cfg(feature = "sys")]
         if engine.is_sys() {
             if self.stack_size.is_some() {


### PR DESCRIPTION
Uses the engine's default features for backend instead of generic default features.