### PR TITLE
fix: Explicitly allow "paste - no longer maintained" advisory in `cargo-deny`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ ignore = [
 
 	"proc-macro-error@1.0.4",
 	"RUSTSEC-2024-0370",
+	"RUSTSEC-2024-0436"
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
...since there's no maintained candidate crate to replace `paste`, currently.