### PR TITLE
epoll_wait timeout is in milliseconds

### DIFF
--- a/lib/wasix/src/syscalls/wasix/epoll_wait.rs
+++ b/lib/wasix/src/syscalls/wasix/epoll_wait.rs
@@ -126,7 +126,7 @@ pub fn epoll_wait<'a, M: MemorySize + 'static>(
         let timeout = if timeout == TIMEOUT_FOREVER {
             None
         } else {
-            Some(ctx.data().tasks().sleep_now(Duration::from_nanos(timeout)))
+            Some(ctx.data().tasks().sleep_now(Duration::from_millis(timeout)))
         };
         async move {
             if let Some(timeout) = timeout {


### PR DESCRIPTION
Expecting that timeout must be in milliseconds.
Currently it is in nanoseconds so we max can allocate 2.1 seconds timeout in int32 function argument.

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
Porting nodejs to wasm having libuv and other epoll_(p)wait function expect that duration of timeout is in milliseconds.
Currently nanoseconds is used so we can use maximum 2.1second timeout on int32 wasm parameter.
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
