### PR TITLE
deps: Update to zip 2.4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,8 +2049,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -8112,9 +8114,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.3"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b280484c454e74e5fff658bbf7df8fdbe7a07c6b2de4a53def232c15ef138f3a"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
  "arbitrary",
@@ -8125,15 +8127,16 @@ dependencies = [
  "deflate64",
  "displaydoc",
  "flate2",
+ "getrandom 0.3.1",
  "hmac",
  "indexmap 2.7.1",
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "rand",
  "sha1",
  "thiserror 2.0.12",
  "time 0.3.39",
+ "xz2",
  "zeroize",
  "zopfli",
  "zstd",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -225,7 +225,7 @@ mac_address = { version = "1.1.5", optional = true }
 
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"
-zip = { version = "2.1.3", default-features = false, features = ["deflate"] }
+zip = { version = "2.4", default-features = false, features = ["deflate"] }
 console = "0.15.8"
 dotenvy = "0.15.7"
 lzma-rs = "0.3.0"


### PR DESCRIPTION
Due to https://github.com/zip-rs/zip2/security/advisories/GHSA-94vh-gphv-8pm8, the `zip` crate should be updated to 2.4.x immediately, to prevent specially-crafted templates from writing files outside the destination directory.