### PR TITLE
Simply object initialization path with relocations

### DIFF
--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -29,7 +29,9 @@ use shared_buffer::OwnedBuffer;
 use std::mem;
 
 #[cfg(feature = "static-artifact-create")]
-use crate::object::{emit_compilation, emit_data, get_object_for_target, Object};
+use crate::object::{
+    emit_compilation, emit_data, get_object_for_target, Object, ObjectMetadataBuilder,
+};
 
 #[cfg(feature = "compiler")]
 use wasmer_types::HashAlgorithm;
@@ -1073,10 +1075,8 @@ impl Artifact {
         - SignatureIndex -> VMSharedSignatureindextureIndex // signatures
          */
 
-        let serialized_data = metadata.serialize().map_err(to_compile_error)?;
-        let mut metadata_binary = vec![];
-        metadata_binary.extend(MetadataHeader::new(serialized_data.len()).into_bytes());
-        metadata_binary.extend(serialized_data);
+        let mut metadata_builder =
+            ObjectMetadataBuilder::new(&metadata, target_triple).map_err(to_compile_error)?;
 
         let (_compile_info, symbol_registry) = metadata.split();
 
@@ -1093,15 +1093,21 @@ impl Artifact {
         }
         .symbol_to_name(crate::types::symbols::Symbol::Metadata);
 
-        emit_data(&mut obj, object_name.as_bytes(), &metadata_binary, 1)
+        emit_data(&mut obj, object_name.as_bytes(), 1, &mut metadata_builder)
             .map_err(to_compile_error)?;
 
-        emit_compilation(&mut obj, compilation, &symbol_registry, target_triple)
-            .map_err(to_compile_error)?;
+        emit_compilation(
+            &mut obj,
+            compilation,
+            &symbol_registry,
+            target_triple,
+            &metadata_builder,
+        )
+        .map_err(to_compile_error)?;
         Ok((
             Arc::try_unwrap(metadata.compile_info.module).unwrap(),
             obj,
-            metadata_binary.len(),
+            metadata_builder.placeholder_data().len(),
             Box::new(symbol_registry),
         ))
     }

--- a/lib/compiler/src/object/mod.rs
+++ b/lib/compiler/src/object/mod.rs
@@ -21,5 +21,7 @@ mod error;
 mod module;
 
 pub use self::error::ObjectError;
-pub use self::module::{emit_compilation, emit_data, emit_serialized, get_object_for_target};
+pub use self::module::{
+    emit_compilation, emit_data, emit_serialized, get_object_for_target, ObjectMetadataBuilder,
+};
 pub use object::{self, write::Object};

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -1,20 +1,24 @@
 use super::error::ObjectError;
-use crate::types::{
-    function::Compilation,
-    relocation::{RelocationKind as Reloc, RelocationTarget},
-    section::{CustomSectionProtection, SectionIndex},
-    symbols::{Symbol, SymbolRegistry},
+use crate::{
+    serialize::MetadataHeader,
+    types::{
+        function::Compilation,
+        relocation::{RelocationKind as Reloc, RelocationTarget},
+        section::{CustomSectionProtection, SectionIndex},
+        symbols::{ModuleMetadata, Symbol, SymbolRegistry},
+    },
 };
 use object::{
     elf, macho,
     write::{
-        Object, Relocation, StandardSection, StandardSegment, Symbol as ObjSymbol, SymbolSection,
+        Object, Relocation, StandardSection, StandardSegment, Symbol as ObjSymbol, SymbolId,
+        SymbolSection,
     },
     FileFlags, RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind,
     SymbolScope,
 };
-use wasmer_types::entity::PrimaryMap;
-use wasmer_types::target::{Architecture, BinaryFormat, Endianness, Triple};
+use wasmer_types::entity::{EntityRef, PrimaryMap};
+use wasmer_types::target::{Architecture, BinaryFormat, Endianness, PointerWidth, Triple};
 use wasmer_types::LocalFunctionIndex;
 
 const DWARF_SECTION_NAME: &[u8] = b".eh_frame";
@@ -94,8 +98,8 @@ pub fn get_object_for_target(triple: &Triple) -> Result<Object, ObjectError> {
 pub fn emit_data(
     obj: &mut Object,
     name: &[u8],
-    data: &[u8],
     align: u64,
+    relocs_builder: &mut ObjectMetadataBuilder,
 ) -> Result<(), ObjectError> {
     let symbol_id = obj.add_symbol(ObjSymbol {
         name: name.to_vec(),
@@ -108,7 +112,13 @@ pub fn emit_data(
         flags: SymbolFlags::None,
     });
     let section_id = obj.section_id(StandardSection::Data);
-    obj.add_symbol_data(symbol_id, section_id, data, align);
+    let offset = obj.add_symbol_data(
+        symbol_id,
+        section_id,
+        relocs_builder.placeholder_data(),
+        align,
+    );
+    relocs_builder.set_section_offset(offset);
 
     Ok(())
 }
@@ -137,6 +147,7 @@ pub fn emit_compilation(
     compilation: Compilation,
     symbol_registry: &impl SymbolRegistry,
     triple: &Triple,
+    relocs_builder: &ObjectMetadataBuilder,
 ) -> Result<(), ObjectError> {
     let mut function_bodies = PrimaryMap::with_capacity(compilation.functions.len());
     let mut function_relocations = PrimaryMap::with_capacity(compilation.functions.len());
@@ -233,6 +244,9 @@ pub fn emit_compilation(
             (section_id, symbol_id)
         })
         .collect::<PrimaryMap<LocalFunctionIndex, _>>();
+    for (i, (_, symbol_id)) in function_symbol_ids.iter() {
+        relocs_builder.setup_function_pointer(obj, i.index(), *symbol_id)?;
+    }
 
     // Add function call trampolines
     for (signature_index, function) in compilation.function_call_trampolines.into_iter() {
@@ -250,6 +264,8 @@ pub fn emit_compilation(
             flags: SymbolFlags::None,
         });
         obj.add_symbol_data(symbol_id, section_id, &function.body, align);
+
+        relocs_builder.setup_trampoline(obj, signature_index.index(), symbol_id)?;
     }
 
     // Add dynamic function trampolines
@@ -268,6 +284,12 @@ pub fn emit_compilation(
             flags: SymbolFlags::None,
         });
         obj.add_symbol_data(symbol_id, section_id, &function.body, align);
+
+        relocs_builder.setup_dynamic_function_trampoline_pointer(
+            obj,
+            func_index.index(),
+            symbol_id,
+        )?;
     }
 
     let mut all_relocations = Vec::new();
@@ -464,4 +486,200 @@ pub fn emit_serialized(
     obj.add_symbol_data(symbol_id, section_id, sercomp, align);
 
     Ok(())
+}
+
+/// FunctionRelocsBuilder uses information from a ModuleInfo to build
+/// a table of functions, trampolines and dynamic function trampoline
+/// pointers. A linker can then rely on this information to fill in actual
+/// addresses of functions automatically. There is no need for serialized
+/// data generation in C header file.
+
+/// ObjectMetadataBuilder builds serialized module metadata include in
+/// an object. In addition, it also relies on information from ModuleInfo
+/// to build a table of function pointers, trmampolines and dynamic function
+/// trampoline pointers. ObjectMetadataBuilder takes care of setting up
+/// relocations, so a linker can automatically fill in actuall addesses of
+/// all relavant functions. There is no need to piece the information together
+/// in the glue C file.
+pub struct ObjectMetadataBuilder {
+    placeholder_data: Vec<u8>,
+    metadata_length: u64,
+    section_offset: u64,
+    num_function_pointers: u64,
+    num_trampolines: u64,
+    num_dynamic_function_trampoline_pointers: u64,
+    endianness: Endianness,
+    pointer_width: PointerWidth,
+}
+
+impl ObjectMetadataBuilder {
+    /// Creates a new FunctionRelocsBuilder
+    pub fn new(metadata: &ModuleMetadata, triple: &Triple) -> Result<Self, ObjectError> {
+        let serialized_data = metadata.serialize()?;
+        let mut metadata_binary = vec![];
+        metadata_binary.extend(MetadataHeader::new(serialized_data.len()).into_bytes());
+        metadata_binary.extend(serialized_data);
+        let metadata_length = metadata_binary.len() as u64;
+
+        let pointer_width = triple.pointer_width().unwrap();
+        let endianness = triple
+            .endianness()
+            .map_err(|_| ObjectError::UnknownEndianness)?;
+
+        let module = &metadata.compile_info.module;
+        let num_function_pointers = module
+            .functions
+            .iter()
+            .filter(|(f_index, _)| module.local_func_index(*f_index).is_some())
+            .count() as u64;
+        let num_trampolines = module.signatures.len() as u64;
+        let num_dynamic_function_trampoline_pointers = module.num_imported_functions as u64;
+
+        let mut aself = Self {
+            placeholder_data: metadata_binary,
+            metadata_length,
+            section_offset: 0,
+            num_function_pointers,
+            num_trampolines,
+            num_dynamic_function_trampoline_pointers,
+            endianness,
+            pointer_width,
+        };
+
+        aself
+            .placeholder_data
+            .extend_from_slice(&aself.serialize_value(aself.num_function_pointers));
+        aself.placeholder_data.extend_from_slice(&vec![
+            0u8;
+            (aself.pointer_bytes() * aself.num_function_pointers)
+                as usize
+        ]);
+        aself
+            .placeholder_data
+            .extend_from_slice(&aself.serialize_value(aself.num_trampolines));
+        aself.placeholder_data.extend_from_slice(&vec![
+            0u8;
+            (aself.pointer_bytes() * aself.num_trampolines)
+                as usize
+        ]);
+        aself.placeholder_data.extend_from_slice(
+            &aself.serialize_value(aself.num_dynamic_function_trampoline_pointers),
+        );
+        aself.placeholder_data.extend_from_slice(&vec![
+            0u8;
+            (aself.pointer_bytes() * aself.num_dynamic_function_trampoline_pointers)
+                as usize
+        ]);
+
+        Ok(aself)
+    }
+
+    fn set_section_offset(&mut self, offset: u64) {
+        self.section_offset = offset;
+    }
+
+    /// Placeholder data for emit_data call
+    pub fn placeholder_data(&self) -> &[u8] {
+        &self.placeholder_data
+    }
+
+    /// Bytes of a pointer for target architecture
+    pub fn pointer_bytes(&self) -> u64 {
+        self.pointer_width.bytes() as u64
+    }
+
+    /// Sets up relocation for a function pointer
+    pub fn setup_function_pointer(
+        &self,
+        obj: &mut Object,
+        index: usize,
+        symbol_id: SymbolId,
+    ) -> Result<(), ObjectError> {
+        let section_id = obj.section_id(StandardSection::Data);
+        obj.add_relocation(
+            section_id,
+            Relocation {
+                offset: self.function_pointers_start_offset()
+                    + self.pointer_bytes() * (index as u64),
+                size: self.pointer_width.bits(),
+                kind: RelocationKind::Absolute,
+                encoding: RelocationEncoding::Generic,
+                symbol: symbol_id,
+                addend: 0,
+            },
+        )
+        .map_err(ObjectError::Write)
+    }
+
+    /// Sets up relocation for a trampoline
+    pub fn setup_trampoline(
+        &self,
+        obj: &mut Object,
+        index: usize,
+        symbol_id: SymbolId,
+    ) -> Result<(), ObjectError> {
+        let section_id = obj.section_id(StandardSection::Data);
+        obj.add_relocation(
+            section_id,
+            Relocation {
+                offset: self.trampolines_start_offset() + self.pointer_bytes() * (index as u64),
+                size: self.pointer_width.bits(),
+                kind: RelocationKind::Absolute,
+                encoding: RelocationEncoding::Generic,
+                symbol: symbol_id,
+                addend: 0,
+            },
+        )
+        .map_err(ObjectError::Write)
+    }
+
+    /// Sets up relocation for a dynamic function trampoline pointer
+    pub fn setup_dynamic_function_trampoline_pointer(
+        &self,
+        obj: &mut Object,
+        index: usize,
+        symbol_id: SymbolId,
+    ) -> Result<(), ObjectError> {
+        let section_id = obj.section_id(StandardSection::Data);
+        obj.add_relocation(
+            section_id,
+            Relocation {
+                offset: self.dynamic_function_trampoline_pointers_start_offset()
+                    + self.pointer_bytes() * (index as u64),
+                size: self.pointer_width.bits(),
+                kind: RelocationKind::Absolute,
+                encoding: RelocationEncoding::Generic,
+                symbol: symbol_id,
+                addend: 0,
+            },
+        )
+        .map_err(ObjectError::Write)
+    }
+
+    fn function_pointers_start_offset(&self) -> u64 {
+        self.section_offset + self.metadata_length + self.pointer_bytes()
+    }
+
+    fn trampolines_start_offset(&self) -> u64 {
+        self.function_pointers_start_offset()
+            + self.pointer_bytes() * self.num_function_pointers
+            + self.pointer_bytes()
+    }
+
+    fn dynamic_function_trampoline_pointers_start_offset(&self) -> u64 {
+        self.trampolines_start_offset()
+            + self.pointer_bytes() * self.num_trampolines
+            + self.pointer_bytes()
+    }
+
+    fn serialize_value(&self, value: u64) -> Vec<u8> {
+        match (self.endianness, self.pointer_width) {
+            (Endianness::Little, PointerWidth::U16) => (value as u16).to_le_bytes().to_vec(),
+            (Endianness::Big, PointerWidth::U16) => (value as u16).to_be_bytes().to_vec(),
+            (Endianness::Little, PointerWidth::U32) => (value as u32).to_le_bytes().to_vec(),
+            (Endianness::Big, PointerWidth::U32) => (value as u32).to_be_bytes().to_vec(),
+            (Endianness::Little, PointerWidth::U64) => value.to_le_bytes().to_vec(),
+            (Endianness::Big, PointerWidth::U64) => value.to_be_bytes().to_vec(),
+        }
+    }
 }


### PR DESCRIPTION
Previous code relies on C glue code to piece metadata and actual function addresses after linking together. This change refines the process, so proper relocations are generated for each function / trampoline when building the object. This way a linker should be able to fulfill the task of filling in actual function addresses in the final binary, there is no need to use glue code to do the memcpy work anymore.