### PR TITLE
fix(compiler-test-derive): Don't use "Universal" as engine name/feature

### DIFF
--- a/tests/lib/compiler-test-derive/src/lib.rs
+++ b/tests/lib/compiler-test-derive/src/lib.rs
@@ -94,8 +94,12 @@ fn compiler_test_impl(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let construct_compiler_test =
         |func: &::syn::ItemFn, compiler_name: &str| -> ::proc_macro2::TokenStream {
             let mod_name = ::quote::format_ident!("{}", compiler_name.to_lowercase());
-            let universal_engine_test =
-                construct_engine_test(func, compiler_name, "Universal", "universal");
+            let universal_engine_test = construct_engine_test(
+                func,
+                compiler_name,
+                compiler_name,
+                &compiler_name.to_lowercase(),
+            );
             let compiler_name_lowercase = compiler_name.to_lowercase();
 
             quote! {

--- a/tests/lib/compiler-test-derive/src/tests.rs
+++ b/tests/lib/compiler-test-derive/src/tests.rs
@@ -56,8 +56,8 @@ gen_tests! {
                 use super:: * ;
                 #[test_log::test]
                 #[cold]
-                #[cfg(feature = "universal")]
-                fn universal() {
+                #[cfg(feature = "singlepass")]
+                fn singlepass() {
                     foo(crate::Config::new(
                         crate::Compiler::Singlepass
                     ))
@@ -69,8 +69,8 @@ gen_tests! {
                 use super:: * ;
                 #[test_log::test]
                 #[cold]
-                #[cfg(feature = "universal")]
-                fn universal() {
+                #[cfg(feature = "cranelift")]
+                fn cranelift() {
                     foo(crate::Config::new(
                         crate::Compiler::Cranelift
                     ))
@@ -82,8 +82,8 @@ gen_tests! {
                 use super:: * ;
                 #[test_log::test]
                 #[cold]
-                #[cfg(feature = "universal")]
-                fn universal() {
+                #[cfg(feature = "llvm")]
+                fn llvm() {
                     foo(crate::Config::new(
                         crate::Compiler::LLVM
                     ))


### PR DESCRIPTION
As per title.