### PR TITLE
Feat: Add support for `perfmap`-based profiler data generation

### DIFF
--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -260,9 +260,11 @@ impl Run {
                                 let engine_id = filtered_backends[0].to_string();
 
                                 // Get a new engine that's compatible with the required features
-                                if let Ok(new_engine) =
-                                    filtered_backends[0].get_engine(&Target::default(), &features)
-                                {
+                                if let Ok(new_engine) = filtered_backends[0].get_engine(
+                                    &Target::default(),
+                                    &features,
+                                    &self.rt,
+                                ) {
                                     tracing::info!(
                                         "The command '{}' requires to run the Wasm module with the features {:?}. The backends available are {}. Choosing {}.",
                                         cmd.name(),

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -70,6 +70,10 @@ impl Compiler for CraneliftCompiler {
         "cranelift"
     }
 
+    fn get_perfmap_enabled(&self) -> bool {
+        self.config.enable_perfmap
+    }
+
     /// Get the middlewares for this compiler
     fn get_middlewares(&self) -> &[Arc<dyn ModuleMiddleware>] {
         &self.config.middlewares

--- a/lib/compiler-cranelift/src/config.rs
+++ b/lib/compiler-cranelift/src/config.rs
@@ -33,6 +33,7 @@ pub enum CraneliftOptLevel {
 pub struct Cranelift {
     enable_nan_canonicalization: bool,
     enable_verifier: bool,
+    pub(crate) enable_perfmap: bool,
     enable_pic: bool,
     opt_level: CraneliftOptLevel,
     /// The middleware chain.
@@ -49,6 +50,7 @@ impl Cranelift {
             opt_level: CraneliftOptLevel::Speed,
             enable_pic: false,
             middlewares: vec![],
+            enable_perfmap: false,
         }
     }
 
@@ -192,6 +194,10 @@ impl CompilerConfig for Cranelift {
 
     fn enable_verifier(&mut self) {
         self.enable_verifier = true;
+    }
+
+    fn enable_perfmap(&mut self) {
+        self.enable_perfmap = true;
     }
 
     fn canonicalize_nans(&mut self, enable: bool) {

--- a/lib/compiler-llvm/src/abi/aarch64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/aarch64_systemv.rs
@@ -15,13 +15,15 @@ use wasmer_vm::VMOffsets;
 
 use std::convert::TryInto;
 
+use super::{FunctionKind, LocalFunctionG0M0params};
+
 /// Implementation of the [`Abi`] trait for the Aarch64 ABI on Linux.
 pub struct Aarch64SystemV {}
 
 impl Abi for Aarch64SystemV {
     // Given a function definition, retrieve the parameter that is the vmctx pointer.
     fn get_vmctx_ptr_param<'ctx>(&self, func_value: &FunctionValue<'ctx>) -> PointerValue<'ctx> {
-        func_value
+        let param = func_value
             .get_nth_param(u32::from(
                 func_value
                     .get_enum_attribute(
@@ -30,8 +32,48 @@ impl Abi for Aarch64SystemV {
                     )
                     .is_some(),
             ))
-            .unwrap()
-            .into_pointer_value()
+            .unwrap();
+        //param.set_name("vmctx");
+
+        param.into_pointer_value()
+    }
+
+    /// Given a function definition, retrieve the parameter that is the pointer to the first --
+    /// number 0 -- local global.
+    fn get_g0_ptr_param<'ctx>(&self, func_value: &FunctionValue<'ctx>) -> IntValue<'ctx> {
+        // g0 is always after the vmctx.
+        let vmctx_idx = u32::from(
+            func_value
+                .get_enum_attribute(
+                    AttributeLoc::Param(0),
+                    Attribute::get_named_enum_kind_id("sret"),
+                )
+                .is_some(),
+        );
+
+        let param = func_value.get_nth_param(vmctx_idx + 1).unwrap();
+        param.set_name("g0");
+
+        param.into_int_value()
+    }
+
+    /// Given a function definition, retrieve the parameter that is the pointer to the first --
+    /// number 0 -- local memory.
+    fn get_m0_ptr_param<'ctx>(&self, func_value: &FunctionValue<'ctx>) -> PointerValue<'ctx> {
+        // m0 is always after g0.
+        let vmctx_idx = u32::from(
+            func_value
+                .get_enum_attribute(
+                    AttributeLoc::Param(0),
+                    Attribute::get_named_enum_kind_id("sret"),
+                )
+                .is_some(),
+        );
+
+        let param = func_value.get_nth_param(vmctx_idx + 2).unwrap();
+        param.set_name("m0_base_ptr");
+
+        param.into_pointer_value()
     }
 
     // Given a wasm function type, produce an llvm function declaration.
@@ -41,11 +83,19 @@ impl Abi for Aarch64SystemV {
         intrinsics: &Intrinsics<'ctx>,
         offsets: Option<&VMOffsets>,
         sig: &FuncSig,
+        function_kind: Option<FunctionKind>,
     ) -> Result<(FunctionType<'ctx>, Vec<(Attribute, AttributeLoc)>), CompileError> {
         let user_param_types = sig.params().iter().map(|&ty| type_to_llvm(intrinsics, ty));
 
-        let param_types =
-            std::iter::once(Ok(intrinsics.ptr_ty.as_basic_type_enum())).chain(user_param_types);
+        let mut param_types = vec![Ok(intrinsics.ptr_ty.as_basic_type_enum())];
+        if function_kind.is_some_and(|v| v.is_local()) {
+            // The value of g0
+            param_types.push(Ok(intrinsics.i32_ty.as_basic_type_enum()));
+            // The base pointer to m0
+            param_types.push(Ok(intrinsics.ptr_ty.as_basic_type_enum()));
+        }
+
+        let param_types = param_types.into_iter().chain(user_param_types);
 
         let vmctx_attributes = |i: u32| {
             vec![
@@ -261,6 +311,7 @@ impl Abi for Aarch64SystemV {
         ctx_ptr: PointerValue<'ctx>,
         values: &[BasicValueEnum<'ctx>],
         intrinsics: &Intrinsics<'ctx>,
+        g0m0: LocalFunctionG0M0params<'ctx>,
     ) -> Result<Vec<BasicValueEnum<'ctx>>, CompileError> {
         // If it's an sret, allocate the return space.
         let sret = if llvm_fn_ty.get_return_type().is_none() && func_sig.results().len() > 1 {
@@ -277,14 +328,21 @@ impl Abi for Aarch64SystemV {
             None
         };
 
-        let values = std::iter::once(ctx_ptr.as_basic_value_enum()).chain(values.iter().copied());
+        let mut args = vec![ctx_ptr.as_basic_value_enum()];
+
+        if let Some((g0, m0)) = g0m0 {
+            args.push(g0.into());
+            args.push(m0.into());
+        }
+
+        let args = args.into_iter().chain(values.iter().copied());
 
         let ret = if let Some(sret) = sret {
             std::iter::once(sret.as_basic_value_enum())
-                .chain(values)
+                .chain(args)
                 .collect()
         } else {
-            values.collect()
+            args.collect()
         };
 
         Ok(ret)

--- a/lib/compiler-llvm/src/abi/mod.rs
+++ b/lib/compiler-llvm/src/abi/mod.rs
@@ -90,6 +90,7 @@ pub trait Abi {
     ) -> Result<(FunctionType<'ctx>, Vec<(Attribute, AttributeLoc)>), CompileError>;
 
     /// Marshall wasm stack values into function parameters.
+    #[allow(clippy::too_many_arguments)]
     fn args_to_call<'ctx>(
         &self,
         alloca_builder: &Builder<'ctx>,

--- a/lib/compiler-llvm/src/abi/x86_64_systemv.rs
+++ b/lib/compiler-llvm/src/abi/x86_64_systemv.rs
@@ -17,13 +17,15 @@ use wasmer_vm::VMOffsets;
 
 use std::convert::TryInto;
 
+use super::{FunctionKind, LocalFunctionG0M0params};
+
 /// Implementation of the [`Abi`] trait for the AMD64 SystemV ABI.
 pub struct X86_64SystemV {}
 
 impl Abi for X86_64SystemV {
-    // Given a function definition, retrieve the parameter that is the vmctx pointer.
+    /// Given a function definition, retrieve the parameter that is the vmctx pointer.
     fn get_vmctx_ptr_param<'ctx>(&self, func_value: &FunctionValue<'ctx>) -> PointerValue<'ctx> {
-        func_value
+        let param = func_value
             .get_nth_param(u32::from(
                 func_value
                     .get_enum_attribute(
@@ -32,8 +34,48 @@ impl Abi for X86_64SystemV {
                     )
                     .is_some(),
             ))
-            .unwrap()
-            .into_pointer_value()
+            .unwrap();
+        //param.set_name("vmctx");
+
+        param.into_pointer_value()
+    }
+
+    /// Given a function definition, retrieve the parameter that is the pointer to the first --
+    /// number 0 -- local global.
+    fn get_g0_ptr_param<'ctx>(&self, func_value: &FunctionValue<'ctx>) -> IntValue<'ctx> {
+        // g0 is always after the vmctx.
+        let vmctx_idx = u32::from(
+            func_value
+                .get_enum_attribute(
+                    AttributeLoc::Param(0),
+                    Attribute::get_named_enum_kind_id("sret"),
+                )
+                .is_some(),
+        );
+
+        let param = func_value.get_nth_param(vmctx_idx + 1).unwrap();
+        param.set_name("g0");
+
+        param.into_int_value()
+    }
+
+    /// Given a function definition, retrieve the parameter that is the pointer to the first --
+    /// number 0 -- local memory.
+    fn get_m0_ptr_param<'ctx>(&self, func_value: &FunctionValue<'ctx>) -> PointerValue<'ctx> {
+        // m0 is always after g0.
+        let vmctx_idx = u32::from(
+            func_value
+                .get_enum_attribute(
+                    AttributeLoc::Param(0),
+                    Attribute::get_named_enum_kind_id("sret"),
+                )
+                .is_some(),
+        );
+
+        let param = func_value.get_nth_param(vmctx_idx + 2).unwrap();
+        param.set_name("m0_base_ptr");
+
+        param.into_pointer_value()
     }
 
     // Given a wasm function type, produce an llvm function declaration.
@@ -43,11 +85,19 @@ impl Abi for X86_64SystemV {
         intrinsics: &Intrinsics<'ctx>,
         offsets: Option<&VMOffsets>,
         sig: &FuncSig,
+        function_kind: Option<FunctionKind>,
     ) -> Result<(FunctionType<'ctx>, Vec<(Attribute, AttributeLoc)>), CompileError> {
         let user_param_types = sig.params().iter().map(|&ty| type_to_llvm(intrinsics, ty));
 
-        let param_types =
-            std::iter::once(Ok(intrinsics.ptr_ty.as_basic_type_enum())).chain(user_param_types);
+        let mut param_types = vec![Ok(intrinsics.ptr_ty.as_basic_type_enum())];
+        if function_kind.is_some_and(|v| v.is_local()) {
+            // The value of g0
+            param_types.push(Ok(intrinsics.i32_ty.as_basic_type_enum()));
+            // The base pointer to m0
+            param_types.push(Ok(intrinsics.ptr_ty.as_basic_type_enum()));
+        }
+
+        let param_types = param_types.into_iter().chain(user_param_types);
 
         // TODO: figure out how many bytes long vmctx is, and mark it dereferenceable. (no need to mark it nonnull once we do this.)
         let vmctx_attributes = |i: u32| {
@@ -296,6 +346,7 @@ impl Abi for X86_64SystemV {
         ctx_ptr: PointerValue<'ctx>,
         values: &[BasicValueEnum<'ctx>],
         intrinsics: &Intrinsics<'ctx>,
+        g0m0: LocalFunctionG0M0params<'ctx>,
     ) -> Result<Vec<BasicValueEnum<'ctx>>, CompileError> {
         // If it's an sret, allocate the return space.
         let sret = if llvm_fn_ty.get_return_type().is_none() && func_sig.results().len() > 1 {
@@ -312,14 +363,21 @@ impl Abi for X86_64SystemV {
             None
         };
 
-        let values = std::iter::once(ctx_ptr.as_basic_value_enum()).chain(values.iter().copied());
+        let mut args = vec![ctx_ptr.as_basic_value_enum()];
+
+        if let Some((g0, m0)) = g0m0 {
+            args.push(g0.into());
+            args.push(m0.into());
+        }
+
+        let args = args.into_iter().chain(values.iter().copied());
 
         let ret = if let Some(sret) = sret {
             std::iter::once(sret.as_basic_value_enum())
-                .chain(values)
+                .chain(args)
                 .collect()
         } else {
-            values.collect()
+            args.collect()
         };
 
         Ok(ret)

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -261,6 +261,10 @@ impl Compiler for LLVMCompiler {
         "llvm"
     }
 
+    fn get_perfmap_enabled(&self) -> bool {
+        self.config.enable_perfmap
+    }
+
     /// Get the middlewares for this compiler
     fn get_middlewares(&self) -> &[Arc<dyn ModuleMiddleware>] {
         &self.config.middlewares

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -94,7 +94,7 @@ impl ModuleBasedSymbolRegistry {
             wasm_module
                 .function_names
                 .iter()
-                .map(|(f, v)| (wasm_module.local_func_index(f.clone()), v))
+                .map(|(f, v)| (wasm_module.local_func_index(*f), v))
                 .filter(|(f, _)| f.is_some())
                 .map(|(f, v)| (v.clone(), f.unwrap())),
         );
@@ -113,7 +113,7 @@ impl SymbolRegistry for ModuleBasedSymbolRegistry {
                 .wasm_module
                 .function_names
                 .get(&self.wasm_module.func_index(index))
-                .map(|v| v.clone())
+                .cloned()
                 .unwrap_or(self.short_names.symbol_to_name(symbol)),
             _ => self.short_names.symbol_to_name(symbol),
         }

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -173,7 +173,12 @@ impl LLVMCompiler {
             },
             |func_trampoline, (i, sig)| {
                 let name = symbol_registry.symbol_to_name(Symbol::FunctionCallTrampoline(i));
-                let module = func_trampoline.trampoline_to_module(sig, self.config(), &name)?;
+                let module = func_trampoline.trampoline_to_module(
+                    sig,
+                    self.config(),
+                    &name,
+                    compile_info,
+                )?;
                 Ok(module.write_bitcode_to_memory().as_slice().to_vec())
             },
         );
@@ -452,7 +457,9 @@ impl Compiler for LLVMCompiler {
                     let target_machine = self.config().target_machine(target);
                     FuncTrampoline::new(target_machine, binary_format).unwrap()
                 },
-                |func_trampoline, sig| func_trampoline.trampoline(sig, self.config(), ""),
+                |func_trampoline, sig| {
+                    func_trampoline.trampoline(sig, self.config(), "", compile_info)
+                },
             )
             .collect::<Vec<_>>()
             .into_iter()

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -43,6 +43,7 @@ pub trait LLVMCallbacks: Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub struct LLVM {
     pub(crate) enable_nan_canonicalization: bool,
+    pub(crate) enable_g0m0_opt: bool,
     pub(crate) enable_verifier: bool,
     pub(crate) opt_level: LLVMOptLevel,
     is_pic: bool,
@@ -62,12 +63,21 @@ impl LLVM {
             is_pic: false,
             callbacks: None,
             middlewares: vec![],
+            enable_g0m0_opt: false,
         }
     }
 
     /// The optimization levels when optimizing the IR.
     pub fn opt_level(&mut self, opt_level: LLVMOptLevel) -> &mut Self {
         self.opt_level = opt_level;
+        self
+    }
+
+    /// (warning: experimental) Pass the value of the first (#0) global and the base pointer of the
+    /// first (#0) memory as parameter between guest functions.
+    pub fn enable_pass_params_opt(&mut self) -> &mut Self {
+        // internally, the "pass_params" opt is known as g0m0 opt.
+        self.enable_g0m0_opt = true;
         self
     }
 

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -45,6 +45,7 @@ pub struct LLVM {
     pub(crate) enable_nan_canonicalization: bool,
     pub(crate) enable_g0m0_opt: bool,
     pub(crate) enable_verifier: bool,
+    pub(crate) enable_perfmap: bool,
     pub(crate) opt_level: LLVMOptLevel,
     is_pic: bool,
     pub(crate) callbacks: Option<Arc<dyn LLVMCallbacks>>,
@@ -59,6 +60,7 @@ impl LLVM {
         Self {
             enable_nan_canonicalization: false,
             enable_verifier: false,
+            enable_perfmap: false,
             opt_level: LLVMOptLevel::Aggressive,
             is_pic: false,
             callbacks: None,
@@ -298,6 +300,10 @@ impl CompilerConfig for LLVM {
         // TODO: although we can emit PIC, the object file parser does not yet
         // support all the relocations.
         self.is_pic = true;
+    }
+
+    fn enable_perfmap(&mut self) {
+        self.enable_perfmap = true
     }
 
     /// Whether to verify compiler IR.

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -346,6 +346,7 @@ impl FuncTrampoline {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn generate_trampoline<'ctx>(
         &self,
         config: &LLVM,
@@ -375,11 +376,12 @@ impl FuncTrampoline {
                 }
             };
 
-        let mut args_vec: Vec<BasicMetadataValueEnum> = Vec::with_capacity(if config.enable_g0m0_opt {
-            func_sig.params().len() + 3
-        } else {
-            func_sig.params().len() + 1
-        });
+        let mut args_vec: Vec<BasicMetadataValueEnum> =
+            Vec::with_capacity(if config.enable_g0m0_opt {
+                func_sig.params().len() + 3
+            } else {
+                func_sig.params().len() + 1
+            });
 
         if self.abi.is_sret(func_sig)? {
             let basic_types: Vec<_> = func_sig
@@ -436,12 +438,11 @@ impl FuncTrampoline {
 
             let global_value = match global_mutability {
                 wasmer_types::Mutability::Const => {
-                    let value = err!(builder.build_load(
+                    err!(builder.build_load(
                         type_to_llvm(intrinsics, global_value_type)?,
                         global_ptr,
                         "g0",
-                    ));
-                    value
+                    ))
                 }
                 wasmer_types::Mutability::Var => {
                     err!(builder.build_load(

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -1,5 +1,5 @@
 use crate::{
-    abi::{get_abi, Abi},
+    abi::{get_abi, Abi, FunctionKind},
     config::{CompiledKind, LLVM},
     error::{err, err_nt},
     object_file::{load_object_file, CompiledFunction},
@@ -17,8 +17,11 @@ use inkwell::{
 };
 use std::{cmp, convert::TryInto};
 use target_lexicon::BinaryFormat;
-use wasmer_compiler::types::{function::FunctionBody, relocation::RelocationTarget};
+use wasmer_compiler::types::{
+    function::FunctionBody, module::CompileModuleInfo, relocation::RelocationTarget,
+};
 use wasmer_types::{CompileError, FunctionType as FuncType, LocalFunctionIndex};
+use wasmer_vm::MemoryStyle;
 
 pub struct FuncTrampoline {
     ctx: Context,
@@ -59,6 +62,7 @@ impl FuncTrampoline {
         ty: &FuncType,
         config: &LLVM,
         name: &str,
+        compile_info: &CompileModuleInfo,
     ) -> Result<Module, CompileError> {
         // The function type, used for the callbacks.
         let function = CompiledKind::FunctionCallTrampoline(ty.clone());
@@ -70,9 +74,15 @@ impl FuncTrampoline {
         module.set_data_layout(&target_data.get_data_layout());
         let intrinsics = Intrinsics::declare(&module, &self.ctx, &target_data, &self.binary_fmt);
 
+        let func_kind = if config.enable_g0m0_opt {
+            Some(FunctionKind::Local)
+        } else {
+            None
+        };
+
         let (callee_ty, callee_attrs) =
             self.abi
-                .func_type_to_llvm(&self.ctx, &intrinsics, None, ty)?;
+                .func_type_to_llvm(&self.ctx, &intrinsics, None, ty, func_kind)?;
         let trampoline_ty = intrinsics.void_ty.fn_type(
             &[
                 intrinsics.ptr_ty.into(), // vmctx ptr
@@ -95,6 +105,8 @@ impl FuncTrampoline {
         trampoline_func.add_attribute(AttributeLoc::Function, intrinsics.uwtable);
         trampoline_func.add_attribute(AttributeLoc::Function, intrinsics.frame_pointer);
         self.generate_trampoline(
+            config,
+            compile_info,
             trampoline_func,
             ty,
             callee_ty,
@@ -141,8 +153,9 @@ impl FuncTrampoline {
         ty: &FuncType,
         config: &LLVM,
         name: &str,
+        compile_info: &CompileModuleInfo,
     ) -> Result<FunctionBody, CompileError> {
-        let module = self.trampoline_to_module(ty, config, name)?;
+        let module = self.trampoline_to_module(ty, config, name, compile_info)?;
         let function = CompiledKind::FunctionCallTrampoline(ty.clone());
         let target_machine = &self.target_machine;
 
@@ -222,7 +235,7 @@ impl FuncTrampoline {
 
         let (trampoline_ty, trampoline_attrs) =
             self.abi
-                .func_type_to_llvm(&self.ctx, &intrinsics, None, ty)?;
+                .func_type_to_llvm(&self.ctx, &intrinsics, None, ty, None)?;
         let trampoline_func = module.add_function(name, trampoline_ty, Some(Linkage::External));
         for (attr, attr_loc) in trampoline_attrs {
             trampoline_func.add_attribute(attr_loc, attr);
@@ -335,6 +348,8 @@ impl FuncTrampoline {
 
     fn generate_trampoline<'ctx>(
         &self,
+        config: &LLVM,
+        compile_info: &CompileModuleInfo,
         trampoline_func: FunctionValue,
         func_sig: &FuncType,
         llvm_func_type: FunctionType,
@@ -360,8 +375,11 @@ impl FuncTrampoline {
                 }
             };
 
-        let mut args_vec: Vec<BasicMetadataValueEnum> =
-            Vec::with_capacity(func_sig.params().len() + 1);
+        let mut args_vec: Vec<BasicMetadataValueEnum> = Vec::with_capacity(if config.enable_g0m0_opt {
+            func_sig.params().len() + 3
+        } else {
+            func_sig.params().len() + 1
+        });
 
         if self.abi.is_sret(func_sig)? {
             let basic_types: Vec<_> = func_sig
@@ -375,6 +393,117 @@ impl FuncTrampoline {
         }
 
         args_vec.push(callee_vmctx_ptr.into());
+
+        if config.enable_g0m0_opt {
+            let wasm_module = &compile_info.module;
+            let memory_styles = &compile_info.memory_styles;
+            let callee_vmctx_ptr_value = callee_vmctx_ptr.into_pointer_value();
+            // get value of G0, get a pointer to M0's base
+
+            let offsets = wasmer_vm::VMOffsets::new(8, wasm_module);
+
+            let global_index = wasmer_types::GlobalIndex::from_u32(0);
+            let global_type = wasm_module.globals[global_index];
+            let global_value_type = global_type.ty;
+            let global_mutability = global_type.mutability;
+
+            let offset =
+                if let Some(local_global_index) = wasm_module.local_global_index(global_index) {
+                    offsets.vmctx_vmglobal_definition(local_global_index)
+                } else {
+                    offsets.vmctx_vmglobal_import(global_index)
+                };
+            let offset = intrinsics.i32_ty.const_int(offset.into(), false);
+            let global_ptr = {
+                let global_ptr_ptr = unsafe {
+                    err!(builder.build_gep(intrinsics.i8_ty, callee_vmctx_ptr_value, &[offset], ""))
+                };
+                let global_ptr_ptr =
+                    err!(builder.build_bit_cast(global_ptr_ptr, intrinsics.ptr_ty, ""))
+                        .into_pointer_value();
+                let global_ptr = err!(builder.build_load(intrinsics.ptr_ty, global_ptr_ptr, ""))
+                    .into_pointer_value();
+
+                global_ptr
+            };
+
+            let global_ptr = err!(builder.build_bit_cast(
+                global_ptr,
+                type_to_llvm_ptr(intrinsics, global_value_type)?,
+                "",
+            ))
+            .into_pointer_value();
+
+            let global_value = match global_mutability {
+                wasmer_types::Mutability::Const => {
+                    let value = err!(builder.build_load(
+                        type_to_llvm(intrinsics, global_value_type)?,
+                        global_ptr,
+                        "g0",
+                    ));
+                    value
+                }
+                wasmer_types::Mutability::Var => {
+                    err!(builder.build_load(
+                        type_to_llvm(intrinsics, global_value_type)?,
+                        global_ptr,
+                        ""
+                    ))
+                }
+            };
+
+            global_value.set_name("trmpl_g0");
+            args_vec.push(global_value.into());
+
+            // load mem
+            let memory_index = wasmer_types::MemoryIndex::from_u32(0);
+            let memory_definition_ptr = if let Some(local_memory_index) =
+                wasm_module.local_memory_index(memory_index)
+            {
+                let offset = offsets.vmctx_vmmemory_definition(local_memory_index);
+                let offset = intrinsics.i32_ty.const_int(offset.into(), false);
+                unsafe {
+                    err!(builder.build_gep(intrinsics.i8_ty, callee_vmctx_ptr_value, &[offset], ""))
+                }
+            } else {
+                let offset = offsets.vmctx_vmmemory_import(memory_index);
+                let offset = intrinsics.i32_ty.const_int(offset.into(), false);
+                let memory_definition_ptr_ptr = unsafe {
+                    err!(builder.build_gep(intrinsics.i8_ty, callee_vmctx_ptr_value, &[offset], ""))
+                };
+                let memory_definition_ptr_ptr =
+                    err!(builder.build_bit_cast(memory_definition_ptr_ptr, intrinsics.ptr_ty, "",))
+                        .into_pointer_value();
+                let memory_definition_ptr =
+                    err!(builder.build_load(intrinsics.ptr_ty, memory_definition_ptr_ptr, ""))
+                        .into_pointer_value();
+
+                memory_definition_ptr
+            };
+            let memory_definition_ptr =
+                err!(builder.build_bit_cast(memory_definition_ptr, intrinsics.ptr_ty, "",))
+                    .into_pointer_value();
+            let base_ptr = err!(builder.build_struct_gep(
+                intrinsics.vmmemory_definition_ty,
+                memory_definition_ptr,
+                intrinsics.vmmemory_definition_base_element,
+                "",
+            ));
+
+            let memory_style = &memory_styles[memory_index];
+            let base_ptr = if let MemoryStyle::Dynamic { .. } = memory_style {
+                base_ptr
+            } else {
+                let base_ptr =
+                    err!(builder.build_load(intrinsics.ptr_ty, base_ptr, "")).into_pointer_value();
+
+                base_ptr
+            };
+
+            base_ptr.set_name("trmpl_m0_base_ptr");
+
+            args_vec.push(base_ptr.into());
+        }
 
         for (i, param_ty) in func_sig.params().iter().enumerate() {
             let index = intrinsics.i32_ty.const_int(i as _, false);

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -16,8 +16,9 @@ use inkwell::{
     targets::{FileType, TargetMachine},
     types::{BasicType, BasicTypeEnum, FloatMathType, IntType, PointerType, VectorType},
     values::{
-        AnyValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, FloatValue, FunctionValue,
-        InstructionOpcode, InstructionValue, IntValue, PhiValue, PointerValue, VectorValue,
+        AnyValue, BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallSiteValue, FloatValue,
+        FunctionValue, InstructionOpcode, InstructionValue, IntValue, PhiValue, PointerValue,
+        VectorValue,
     },
     AddressSpace, AtomicOrdering, AtomicRMWBinOp, DLLStorageClass, FloatPredicate, IntPredicate,
 };
@@ -26,7 +27,7 @@ use smallvec::SmallVec;
 use target_lexicon::BinaryFormat;
 
 use crate::{
-    abi::{get_abi, Abi},
+    abi::{get_abi, Abi, FunctionKind, LocalFunctionG0M0params},
     config::{CompiledKind, LLVM},
     error::{err, err_nt},
     object_file::{load_object_file, CompiledFunction},
@@ -100,6 +101,14 @@ impl FuncTranslator {
         let func_index = wasm_module.func_index(*local_func_index);
         let function_name =
             symbol_registry.symbol_to_name(Symbol::LocalFunction(*local_func_index));
+
+        let g0m0_is_enabled = config.enable_g0m0_opt;
+        let func_kind = if g0m0_is_enabled {
+            Some(FunctionKind::Local)
+        } else {
+            None
+        };
+
         let module_name = match wasm_module.name.as_ref() {
             None => format!("<anonymous module> function {function_name}"),
             Some(module_name) => format!("module {module_name} function {function_name}"),
@@ -119,9 +128,13 @@ impl FuncTranslator {
         // TODO: pointer width
         let offsets = VMOffsets::new(8, wasm_module);
         let intrinsics = Intrinsics::declare(&module, &self.ctx, &target_data, &self.binary_fmt);
-        let (func_type, func_attrs) =
-            self.abi
-                .func_type_to_llvm(&self.ctx, &intrinsics, Some(&offsets), wasm_fn_type)?;
+        let (func_type, func_attrs) = self.abi.func_type_to_llvm(
+            &self.ctx,
+            &intrinsics,
+            Some(&offsets),
+            wasm_fn_type,
+            func_kind,
+        )?;
 
         let func = module.add_function(&function_name, func_type, Some(Linkage::External));
         for (attr, attr_loc) in &func_attrs {
@@ -189,9 +202,17 @@ impl FuncTranslator {
         let mut params = vec![];
         let first_param =
             if func_type.get_return_type().is_none() && wasm_fn_type.results().len() > 1 {
-                2
+                if g0m0_is_enabled {
+                    4
+                } else {
+                    2
+                }
             } else {
-                1
+                if g0m0_is_enabled {
+                    3
+                } else {
+                    1
+                }
             };
         let mut is_first_alloca = true;
         let mut insert_alloca = |ty, name| -> Result<PointerValue, CompileError> {
@@ -230,7 +251,21 @@ impl FuncTranslator {
         let mut params_locals = params.clone();
         params_locals.extend(locals.iter().cloned());
 
+        let mut g0m0_params = None;
+
+        if g0m0_is_enabled {
+            let value = self.abi.get_g0_ptr_param(&func);
+            let g0 = insert_alloca(intrinsics.i32_ty.as_basic_type_enum(), "g0")?;
+            err!(cache_builder.build_store(g0, value));
+            g0.set_name("g0");
+            let m0 = self.abi.get_m0_ptr_param(&func);
+            m0.set_name("m0_base_ptr");
+
+            g0m0_params = Some((g0, m0));
+        }
+
         let mut fcg = LLVMFunctionCodeGenerator {
+            g0m0: g0m0_params,
             context: &self.ctx,
             builder,
             alloca_builder,
@@ -310,6 +345,16 @@ impl FuncTranslator {
         passes.push("simplifycfg");
         passes.push("mem2reg");
 
+        let llvm_dump_path = std::env::var("WASMER_LLVM_DUMP_DIR");
+        if let Ok(ref llvm_dump_path) = llvm_dump_path {
+            let path = std::path::Path::new(llvm_dump_path);
+            if !path.exists() {
+                std::fs::create_dir_all(path).unwrap()
+            }
+            let path = path.join(format!("{function_name}.ll"));
+            _ = module.print_to_file(path).unwrap();
+        }
+
         module
             .run_passes(
                 passes.join(",").as_str(),
@@ -317,6 +362,14 @@ impl FuncTranslator {
                 PassBuilderOptions::create(),
             )
             .unwrap();
+
+        if let Ok(ref llvm_dump_path) = llvm_dump_path {
+            if !passes.is_empty() {
+                let path =
+                    std::path::Path::new(llvm_dump_path).join(format!("{function_name}_opt.ll"));
+                _ = module.print_to_file(path).unwrap();
+            }
+        }
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.postopt_ir(&function, &module);
@@ -358,6 +411,7 @@ impl FuncTranslator {
         }
 
         let mem_buf_slice = memory_buffer.as_slice();
+
         load_object_file(
             mem_buf_slice,
             &self.func_section,
@@ -1171,7 +1225,9 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
         let offset = err!(builder.build_int_add(var_offset, imm_offset, ""));
 
         // Look up the memory base (as pointer) and bounds (as unsigned integer).
-        let base_ptr =
+        let base_ptr = if let Some((_, ref m0)) = self.g0m0 {
+            m0.clone()
+        } else {
             match self
                 .ctx
                 .memory(memory_index, intrinsics, self.module, self.memory_styles)?
@@ -1284,7 +1340,8 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     ptr_to_base
                 }
                 MemoryCache::Static { base_ptr } => base_ptr,
-            };
+            }
+        };
         let value_ptr =
             unsafe { err!(builder.build_gep(self.intrinsics.i8_ty, base_ptr, &[offset], "")) };
         err_nt!(builder
@@ -1485,6 +1542,262 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             panic!()
         }
     }
+
+    fn build_g0m0_indirect_call(
+        &mut self,
+        table_index: u32,
+        ctx_ptr: PointerValue<'ctx>,
+        func_type: &FunctionType,
+        func_ptr: PointerValue<'ctx>,
+        func_index: IntValue<'ctx>,
+    ) -> Result<(), CompileError> {
+        let Some((g0, m0)) = self.g0m0 else {
+            return Err(CompileError::Codegen(format!(
+                "Call to build_g0m0_indirect_call without g0m0 parameters!"
+            )));
+        };
+
+        let mut local_func_indices = vec![];
+        let mut foreign_func_indices = vec![];
+
+        for t in &self.wasm_module.table_initializers {
+            if t.table_index.as_u32() == table_index {
+                for (func_in_table_idx, func_idx) in t.elements.iter().enumerate() {
+                    if self.wasm_module.local_func_index(*func_idx).is_some() {
+                        local_func_indices.push(func_in_table_idx)
+                    } else {
+                        foreign_func_indices.push(func_in_table_idx)
+                    }
+                }
+                break;
+            }
+        }
+
+        // removed with mem2reg.
+        //
+        let g0_value = err!(self.builder.build_load(self.intrinsics.i32_ty, g0, "g0"));
+
+        let needs_switch = self.g0m0.is_some()
+            && !local_func_indices.is_empty()
+            && !foreign_func_indices.is_empty();
+
+        if needs_switch {
+            let foreign_idx_block = self
+                .context
+                .append_basic_block(self.function, "foreign_call_block");
+            let local_idx_block = self
+                .context
+                .append_basic_block(self.function, "local_call_block");
+            let unreachable_indirect_call_branch_block = self
+                .context
+                .append_basic_block(self.function, "unreachable_indirect_call_branch");
+
+            let cont = self.context.append_basic_block(self.function, "cont");
+
+            err!(self.builder.build_switch(
+                func_index,
+                unreachable_indirect_call_branch_block,
+                &local_func_indices
+                    .into_iter()
+                    .map(|v| (
+                        self.intrinsics.i32_ty.const_int(v as _, false),
+                        local_idx_block.clone()
+                    ))
+                    .chain(foreign_func_indices.into_iter().map(|v| (
+                        self.intrinsics.i32_ty.const_int(v as _, false),
+                        foreign_idx_block.clone()
+                    )))
+                    .collect::<Vec<_>>()
+            ));
+
+            self.builder
+                .position_at_end(unreachable_indirect_call_branch_block);
+            err!(self.builder.build_unreachable());
+
+            //let current_block = self.builder.get_insert_block().unwrap();
+            self.builder.position_at_end(local_idx_block);
+            let local_call_site = self.build_indirect_call(
+                ctx_ptr,
+                func_type,
+                func_ptr,
+                Some(FunctionKind::Local),
+                Some((g0_value.into_int_value(), m0)),
+            )?;
+
+            let local_rets = self.abi.rets_from_call(
+                &self.builder,
+                self.intrinsics,
+                local_call_site,
+                func_type,
+            )?;
+
+            err!(self.builder.build_unconditional_branch(cont));
+
+            self.builder.position_at_end(foreign_idx_block);
+            let foreign_call_site = self.build_indirect_call(
+                ctx_ptr,
+                func_type,
+                func_ptr,
+                Some(FunctionKind::Imported),
+                None,
+            )?;
+
+            let foreign_rets = self.abi.rets_from_call(
+                &self.builder,
+                self.intrinsics,
+                foreign_call_site,
+                func_type,
+            )?;
+
+            err!(self.builder.build_unconditional_branch(cont));
+
+            self.builder.position_at_end(cont);
+
+            for i in 0..foreign_rets.len() {
+                let f_i = foreign_rets[i];
+                let l_i = local_rets[i];
+                let ty = f_i.get_type();
+                let v = err!(self.builder.build_phi(ty, ""));
+                v.add_incoming(&[(&f_i, foreign_idx_block), (&l_i, local_idx_block)]);
+                self.state.push1(v.as_basic_value());
+            }
+        } else if foreign_func_indices.is_empty() {
+            let call_site = self.build_indirect_call(
+                ctx_ptr,
+                func_type,
+                func_ptr,
+                Some(FunctionKind::Local),
+                Some((g0_value.into_int_value(), m0)),
+            )?;
+
+            self.abi
+                .rets_from_call(&self.builder, self.intrinsics, call_site, func_type)?
+                .iter()
+                .for_each(|ret| self.state.push1(*ret));
+        } else {
+            let call_site = self.build_indirect_call(
+                ctx_ptr,
+                func_type,
+                func_ptr,
+                Some(FunctionKind::Imported),
+                Some((g0_value.into_int_value(), m0)),
+            )?;
+            self.abi
+                .rets_from_call(&self.builder, self.intrinsics, call_site, func_type)?
+                .iter()
+                .for_each(|ret| self.state.push1(*ret));
+        }
+
+        Ok(())
+    }
+
+    fn build_indirect_call(
+        &mut self,
+        ctx_ptr: PointerValue<'ctx>,
+        func_type: &FunctionType,
+        func_ptr: PointerValue<'ctx>,
+        func_kind: Option<FunctionKind>,
+        g0m0_params: LocalFunctionG0M0params<'ctx>,
+    ) -> Result<CallSiteValue<'ctx>, CompileError> {
+        let (llvm_func_type, llvm_func_attrs) = self.abi.func_type_to_llvm(
+            self.context,
+            self.intrinsics,
+            Some(self.ctx.get_offsets()),
+            func_type,
+            func_kind,
+        )?;
+
+        let params = self.state.popn_save_extra(func_type.params().len())?;
+
+        // Apply pending canonicalizations.
+        let params = params
+            .iter()
+            .zip(func_type.params().iter())
+            .map(|((v, info), wasm_ty)| match wasm_ty {
+                Type::F32 => err_nt!(self.builder.build_bit_cast(
+                    self.apply_pending_canonicalization(*v, *info)?,
+                    self.intrinsics.f32_ty,
+                    "",
+                )),
+                Type::F64 => err_nt!(self.builder.build_bit_cast(
+                    self.apply_pending_canonicalization(*v, *info)?,
+                    self.intrinsics.f64_ty,
+                    "",
+                )),
+                Type::V128 => self.apply_pending_canonicalization(*v, *info),
+                _ => Ok(*v),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let params = self.abi.args_to_call(
+            &self.alloca_builder,
+            func_type,
+            &llvm_func_type,
+            ctx_ptr,
+            params.as_slice(),
+            self.intrinsics,
+            g0m0_params,
+        )?;
+
+        let typed_func_ptr = err!(self.builder.build_pointer_cast(
+            func_ptr,
+            self.context.ptr_type(AddressSpace::default()),
+            "typed_func_ptr",
+        ));
+
+        /*
+        if self.track_state {
+            if let Some(offset) = opcode_offset {
+                let mut stackmaps = self.stackmaps.borrow_mut();
+                emit_stack_map(
+                    &info,
+                    self.intrinsics,
+                    self.builder,
+                    self.index,
+                    &mut *stackmaps,
+                    StackmapEntryKind::Call,
+                    &self.locals,
+                    state,
+                    ctx,
+                    offset,
+                )
+            }
+        }
+        */
+
+        let call_site_local = if let Some(lpad) = self.state.get_landingpad() {
+            let then_block = self.context.append_basic_block(self.function, "then_block");
+
+            let ret = err!(self.builder.build_indirect_invoke(
+                llvm_func_type,
+                typed_func_ptr,
+                params.as_slice(),
+                then_block,
+                lpad,
+                "",
+            ));
+
+            self.builder.position_at_end(then_block);
+            ret
+        } else {
+            err!(self.builder.build_indirect_call(
+                llvm_func_type,
+                typed_func_ptr,
+                params
+                    .iter()
+                    .copied()
+                    .map(Into::into)
+                    .collect::<Vec<BasicMetadataValueEnum>>()
+                    .as_slice(),
+                "indirect_call",
+            ))
+        };
+        for (attr, attr_loc) in llvm_func_attrs {
+            call_site_local.add_attribute(attr_loc, attr);
+        }
+
+        Ok(call_site_local)
+    }
 }
 
 /*
@@ -1573,6 +1886,7 @@ fn finalize_opcode_stack_map<'ctx>(
  */
 
 pub struct LLVMFunctionCodeGenerator<'ctx, 'a> {
+    g0m0: Option<(PointerValue<'ctx>, PointerValue<'ctx>)>,
     context: &'ctx Context,
     builder: Builder<'ctx>,
     alloca_builder: Builder<'ctx>,
@@ -2306,52 +2620,78 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
             }
 
             Operator::GlobalGet { global_index } => {
-                let global_index = GlobalIndex::from_u32(global_index);
-                match self
-                    .ctx
-                    .global(global_index, self.intrinsics, self.module)?
-                {
-                    GlobalCache::Const { value } => {
-                        self.state.push1(*value);
-                    }
-                    GlobalCache::Mut {
-                        ptr_to_value,
-                        value_type,
-                    } => {
-                        let value = err!(self.builder.build_load(*value_type, *ptr_to_value, ""));
-                        tbaa_label(
-                            self.module,
-                            self.intrinsics,
-                            format!("global {}", global_index.as_u32()),
-                            value.as_instruction_value().unwrap(),
-                        );
-                        self.state.push1(value);
+                if self.g0m0.is_some() && global_index == 0 {
+                    let Some((g0, _)) = self.g0m0 else {
+                        unreachable!()
+                    };
+
+                    // Removed with mem2reg.
+                    let value =
+                        err!(self
+                            .builder
+                            .build_load(self.intrinsics.i32_ty, g0.clone(), ""));
+
+                    self.state.push1(value);
+                } else {
+                    let global_index = GlobalIndex::from_u32(global_index);
+                    match self
+                        .ctx
+                        .global(global_index, self.intrinsics, self.module)?
+                    {
+                        GlobalCache::Const { value } => {
+                            self.state.push1(*value);
+                        }
+                        GlobalCache::Mut {
+                            ptr_to_value,
+                            value_type,
+                        } => {
+                            let value =
+                                err!(self.builder.build_load(*value_type, *ptr_to_value, ""));
+                            tbaa_label(
+                                self.module,
+                                self.intrinsics,
+                                format!("global {}", global_index.as_u32()),
+                                value.as_instruction_value().unwrap(),
+                            );
+                            self.state.push1(value);
+                        }
                     }
                 }
             }
             Operator::GlobalSet { global_index } => {
-                let global_index = GlobalIndex::from_u32(global_index);
-                match self
-                    .ctx
-                    .global(global_index, self.intrinsics, self.module)?
-                {
-                    GlobalCache::Const { value: _ } => {
-                        return Err(CompileError::Codegen(format!(
-                            "global.set on immutable global index {}",
-                            global_index.as_u32()
-                        )))
-                    }
-                    GlobalCache::Mut { ptr_to_value, .. } => {
-                        let ptr_to_value = *ptr_to_value;
-                        let (value, info) = self.state.pop1_extra()?;
-                        let value = self.apply_pending_canonicalization(value, info)?;
-                        let store = err!(self.builder.build_store(ptr_to_value, value));
-                        tbaa_label(
-                            self.module,
-                            self.intrinsics,
-                            format!("global {}", global_index.as_u32()),
-                            store,
-                        );
+                if self.g0m0.is_some() && global_index == 0 {
+                    let Some((g0, _)) = self.g0m0 else {
+                        unreachable!()
+                    };
+                    let ptr_to_value = g0.clone();
+                    let (value, info) = self.state.pop1_extra()?;
+                    let value = self.apply_pending_canonicalization(value, info)?;
+                    let store = err!(self.builder.build_store(ptr_to_value, value));
+                    tbaa_label(self.module, self.intrinsics, format!("global 0",), store);
+                } else {
+                    let global_index = GlobalIndex::from_u32(global_index);
+                    match self
+                        .ctx
+                        .global(global_index, self.intrinsics, self.module)?
+                    {
+                        GlobalCache::Const { value: _ } => {
+                            return Err(CompileError::Codegen(format!(
+                                "global.set on immutable global index {}",
+                                global_index.as_u32()
+                            )))
+                        }
+                        GlobalCache::Mut { ptr_to_value, .. } => {
+                            let ptr_to_value = *ptr_to_value;
+                            let (value, info) = self.state.pop1_extra()?;
+                            let value = self.apply_pending_canonicalization(value, info)?;
+                            let store = err!(self.builder.build_store(ptr_to_value, value));
+                            tbaa_label(
+                                self.module,
+                                self.intrinsics,
+                                format!("global {}", global_index.as_u32()),
+                                store,
+                            );
+                        }
                     }
                 }
             }
@@ -2405,15 +2745,28 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 let sigindex = &self.wasm_module.functions[func_index];
                 let func_type = &self.wasm_module.signatures[*sigindex];
 
+                let mut g0m0_params = None;
+
                 let FunctionCache {
                     func,
                     llvm_func_type,
                     vmctx: callee_vmctx,
                     attrs,
                 } = if let Some(local_func_index) = self.wasm_module.local_func_index(func_index) {
+                    if let Some((g0, m0)) = &self.g0m0 {
+                        // removed with mem2reg.
+                        let value =
+                            err!(self
+                                .builder
+                                .build_load(self.intrinsics.i32_ty, g0.clone(), ""));
+
+                        g0m0_params = Some((value.into_int_value(), m0.clone()));
+                    }
+
                     let function_name = self
                         .symbol_registry
                         .symbol_to_name(Symbol::LocalFunction(local_func_index));
+
                     self.ctx.local_func(
                         local_func_index,
                         func_index,
@@ -2466,6 +2819,7 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                     callee_vmctx.into_pointer_value(),
                     params.as_slice(),
                     self.intrinsics,
+                    g0m0_params,
                 )?;
 
                 /*
@@ -2756,120 +3110,28 @@ impl<'ctx, 'a> LLVMFunctionCodeGenerator<'ctx, 'a> {
                 err!(self.builder.build_unreachable());
                 self.builder.position_at_end(continue_block);
 
-                let (llvm_func_type, llvm_func_attrs) = self.abi.func_type_to_llvm(
-                    self.context,
-                    self.intrinsics,
-                    Some(self.ctx.get_offsets()),
-                    func_type,
-                )?;
-
-                let params = self.state.popn_save_extra(func_type.params().len())?;
-
-                // Apply pending canonicalizations.
-                let params = params
-                    .iter()
-                    .zip(func_type.params().iter())
-                    .map(|((v, info), wasm_ty)| match wasm_ty {
-                        Type::F32 => err_nt!(self.builder.build_bit_cast(
-                            self.apply_pending_canonicalization(*v, *info)?,
-                            self.intrinsics.f32_ty,
-                            "",
-                        )),
-                        Type::F64 => err_nt!(self.builder.build_bit_cast(
-                            self.apply_pending_canonicalization(*v, *info)?,
-                            self.intrinsics.f64_ty,
-                            "",
-                        )),
-                        Type::V128 => self.apply_pending_canonicalization(*v, *info),
-                        _ => Ok(*v),
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                let params = self.abi.args_to_call(
-                    &self.alloca_builder,
-                    func_type,
-                    &llvm_func_type,
-                    ctx_ptr.into_pointer_value(),
-                    params.as_slice(),
-                    self.intrinsics,
-                )?;
-
-                let typed_func_ptr = err!(self.builder.build_pointer_cast(
-                    func_ptr,
-                    self.context.ptr_type(AddressSpace::default()),
-                    "typed_func_ptr",
-                ));
-
-                /*
-                if self.track_state {
-                    if let Some(offset) = opcode_offset {
-                        let mut stackmaps = self.stackmaps.borrow_mut();
-                        emit_stack_map(
-                            &info,
-                            self.intrinsics,
-                            self.builder,
-                            self.index,
-                            &mut *stackmaps,
-                            StackmapEntryKind::Call,
-                            &self.locals,
-                            state,
-                            ctx,
-                            offset,
-                        )
-                    }
-                }
-                */
-
-                let call_site = if let Some(lpad) = self.state.get_landingpad() {
-                    let then_block = self.context.append_basic_block(self.function, "then_block");
-
-                    let ret = err!(self.builder.build_indirect_invoke(
-                        llvm_func_type,
-                        typed_func_ptr,
-                        params.as_slice(),
-                        then_block,
-                        lpad,
-                        "",
-                    ));
-
-                    self.builder.position_at_end(then_block);
-                    ret
+                if self.g0m0.is_some() {
+                    self.build_g0m0_indirect_call(
+                        table_index,
+                        ctx_ptr.into_pointer_value(),
+                        func_type,
+                        func_ptr,
+                        func_index,
+                    )?;
                 } else {
-                    err!(self.builder.build_indirect_call(
-                        llvm_func_type,
-                        typed_func_ptr,
-                        params
-                            .iter()
-                            .copied()
-                            .map(Into::into)
-                            .collect::<Vec<BasicMetadataValueEnum>>()
-                            .as_slice(),
-                        "indirect_call",
-                    ))
-                };
-                for (attr, attr_loc) in llvm_func_attrs {
-                    call_site.add_attribute(attr_loc, attr);
-                }
-                /*
-                if self.track_state {
-                    if let Some(offset) = opcode_offset {
-                        let mut stackmaps = self.stackmaps.borrow_mut();
-                        finalize_opcode_stack_map(
-                            self.intrinsics,
-                            self.builder,
-                            self.index,
-                            &mut *stackmaps,
-                            StackmapEntryKind::Call,
-                            offset,
-                        )
-                    }
-                }
-                */
+                    let call_site = self.build_indirect_call(
+                        ctx_ptr.into_pointer_value(),
+                        func_type,
+                        func_ptr,
+                        None,
+                        None,
+                    )?;
 
-                self.abi
-                    .rets_from_call(&self.builder, self.intrinsics, call_site, func_type)?
-                    .iter()
-                    .for_each(|ret| self.state.push1(*ret));
+                    self.abi
+                        .rets_from_call(&self.builder, self.intrinsics, call_site, func_type)?
+                        .iter()
+                        .for_each(|ret| self.state.push1(*ret));
+                }
             }
 
             /***************************

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -1695,9 +1695,13 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
                 debug_assert!(module.get_function(function_name).is_none());
-                let (llvm_func_type, llvm_func_attrs) =
-                    self.abi
-                        .func_type_to_llvm(context, intrinsics, Some(offsets), func_type)?;
+                let (llvm_func_type, llvm_func_attrs) = self.abi.func_type_to_llvm(
+                    context,
+                    intrinsics,
+                    Some(offsets),
+                    func_type,
+                    Some(crate::abi::FunctionKind::Local),
+                )?;
                 let func =
                     module.add_function(function_name, llvm_func_type, Some(Linkage::External));
                 for (attr, attr_loc) in &llvm_func_attrs {
@@ -1730,9 +1734,13 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
         match cached_functions.entry(function_index) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
             Entry::Vacant(entry) => {
-                let (llvm_func_type, llvm_func_attrs) =
-                    self.abi
-                        .func_type_to_llvm(context, intrinsics, Some(offsets), func_type)?;
+                let (llvm_func_type, llvm_func_attrs) = self.abi.func_type_to_llvm(
+                    context,
+                    intrinsics,
+                    Some(offsets),
+                    func_type,
+                    None,
+                )?;
                 debug_assert!(wasm_module.local_func_index(function_index).is_none());
                 let offset = offsets.vmctx_vmfunction_import(function_index);
                 let offset = intrinsics.i32_ty.const_int(offset.into(), false);

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -39,6 +39,12 @@ pub trait CompilerConfig {
         // in case they create an IR that they can verify.
     }
 
+    /// Enable generation of perfmaps to sample the JIT compiled frames.
+    fn enable_perfmap(&mut self) {
+        // By default we do nothing, each backend will need to customize this
+        // in case they create an IR that they can verify.
+    }
+
     /// Enable NaN canonicalization.
     ///
     /// NaN canonicalization is useful when trying to run WebAssembly
@@ -154,5 +160,10 @@ pub trait Compiler: Send {
     /// Get the CpuFeatues used by the compiler
     fn get_cpu_features_used(&self, cpu_features: &EnumSet<CpuFeature>) -> EnumSet<CpuFeature> {
         *cpu_features
+    }
+
+    /// Get whether `perfmap` is enabled or not.
+    fn get_perfmap_enabled(&self) -> bool {
+        false
     }
 }

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -446,6 +446,8 @@ impl Artifact {
             get_got_address(RelocationTarget::LibCall(wasmer_vm::LibCall::EHPersonality)),
         )?;
 
+        engine_inner.register_perfmap(&finished_functions, module_info)?;
+
         // Make all code compiled thus far executable.
         engine_inner.publish_compiled_code();
 

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -373,7 +373,7 @@ impl Instance {
 
         let sig = self.module.functions[start_index];
         let trampoline = self.function_call_trampolines[sig];
-        let values_vec = vec![].as_mut_ptr() as *mut u8;
+        let values_vec = vec![].as_mut_ptr();
 
         unsafe {
             // Even though we already know the type of the function we need to call, in certain


### PR DESCRIPTION
This PR adds a CLI command (`--profiler=perfmap`) and compiler options (`.enable_`) to enable the generation of `perfmap`-based (see [here](https://github.com/torvalds/linux/blob/master/tools/perf/Documentation/jit-interface.txt)) info for the frame generated by Wasmer's compiler backends.