### PR TITLE
Fix experimental attribute and support keyword in tests, update example comment

### DIFF
--- a/tests/wasi-wast/wasi/tests/inode.rs
+++ b/tests/wasi-wast/wasi/tests/inode.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::os::wasi::fs::MetadataExt;
 
 // `test_fs` will be implicit.
-// this need experimentat MetadataExt
+// this need experimental MetadataExt
 // this program does nothing in native
 // it only tests things in wasi
 fn main() {

--- a/tests/wasi-wast/wasi/tests/path_rename.rs
+++ b/tests/wasi-wast/wasi/tests/path_rename.rs
@@ -48,7 +48,7 @@ fn run_with_toplevel_dir() {
         return;
     }
 
-    // TODO: add temp directory suport for native execution...
+    // TODO: add temp directory support for native execution...
     // until then, don't actually inspect the directory when running native code.
     #[cfg(target_os = "wasi")]
     for item in fs::read_dir(&base).unwrap() {
@@ -128,7 +128,7 @@ fn run_with_toplevel_dir_overwrite() {
         return;
     }
 
-    // TODO: add temp directory suport for native execution...
+    // TODO: add temp directory support for native execution...
     // until then, don't actually inspect the directory when running native code.
     #[cfg(target_os = "wasi")]
     for item in fs::read_dir(&base).unwrap() {

--- a/tests/wasix/udp-addr-reuse/main.c
+++ b/tests/wasix/udp-addr-reuse/main.c
@@ -6,7 +6,7 @@
 #include <arpa/inet.h>
 
 /*
-this is an exemple of address reuse using UDP sockets
+this is an example of address reuse using UDP sockets
 it set address reuse option to 1 and then bind to the same address
 it set port reuse option to 1 and then bind to the same port
 */


### PR DESCRIPTION
This PR includes the following changes:

1. Fixed the spelling of "experimental" attribute in tests/wasi-wast/wasi/tests/inode.rs
2. Changed "suport" to "support" in TODO comments in tests/wasi-wast/wasi/tests/path_rename.rs
3. Updated comment style in tests/wasix/udp-addr-reuse/main.c to use proper example keyword

These changes improve code consistency and fix minor typos in the codebase.