### PR TITLE
fix(create-exe): Misc fixes to make `create-exe` work on aarch64 targeting Mach-O object files

### DIFF
--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
+use object::ObjectSection;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -17,6 +18,7 @@ use std::{
     process::{Command, Stdio},
 };
 use tar::Archive;
+use target_lexicon::BinaryFormat;
 use wasmer::{
     sys::{engine::NativeEngineExt, *},
     *,
@@ -285,7 +287,13 @@ impl CliCommand for CreateExe {
 
         get_module_infos(&engine, &tempdir, &atoms)?;
         let mut entrypoint = get_entrypoint(&tempdir)?;
-        create_header_files_in_dir(&tempdir, &mut entrypoint, &atoms, &self.precompiled_atom)?;
+        create_header_files_in_dir(
+            &tempdir,
+            &mut entrypoint,
+            &atoms,
+            &self.precompiled_atom,
+            &target_triple.binary_format,
+        )?;
         link_exe_from_dir(
             &self.env,
             &tempdir,
@@ -1057,6 +1065,7 @@ pub(crate) fn create_header_files_in_dir(
     entrypoint: &mut Entrypoint,
     atoms: &[(String, Vec<u8>)],
     prefixes: &[String],
+    binary_fmt: &BinaryFormat,
 ) -> anyhow::Result<()> {
     use object::{Object, ObjectSymbol};
 
@@ -1080,10 +1089,36 @@ pub(crate) fn create_header_files_in_dir(
         let object_file = std::fs::read(&object_file_src)
             .map_err(|e| anyhow::anyhow!("could not read {}: {e}", object_file_src.display()))?;
         let obj_file = object::File::parse(&*object_file)?;
-        let metadata_length = obj_file
-            .symbol_by_name(&symbol_registry.symbol_to_name(Symbol::Metadata))
-            .unwrap()
-            .size() as usize;
+        let mut symbol_name = symbol_registry.symbol_to_name(Symbol::Metadata);
+        if matches!(binary_fmt, BinaryFormat::Macho) {
+            symbol_name = format!("_{symbol_name}");
+        }
+
+        let mut metadata_length = obj_file.symbol_by_name(&symbol_name).unwrap().size() as usize;
+        if metadata_length == 0 {
+            let metadata_obj = obj_file.symbol_by_name(&symbol_name).unwrap();
+            let sec = obj_file
+                .section_by_index(metadata_obj.section().index().unwrap())
+                .unwrap();
+            let mut syms_in_data_sec = obj_file
+                .symbols()
+                .filter(|v| v.section_index().is_some_and(|i| i == sec.index()))
+                .collect::<Vec<_>>();
+
+            syms_in_data_sec.sort_by_key(|v| v.address());
+
+            let metadata_obj_idx = syms_in_data_sec
+                .iter()
+                .position(|v| v.name().is_ok_and(|v| v == &symbol_name))
+                .unwrap();
+
+            metadata_length = if metadata_obj_idx == syms_in_data_sec.len() - 1 {
+                (sec.address() + sec.size()) - syms_in_data_sec[metadata_obj_idx].address()
+            } else {
+                syms_in_data_sec[metadata_obj_idx + 1].address()
+                    - syms_in_data_sec[metadata_obj_idx].address()
+            } as usize;
+        }
 
         let module_info = atom
             .module_info

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -1109,7 +1109,7 @@ pub(crate) fn create_header_files_in_dir(
 
             let metadata_obj_idx = syms_in_data_sec
                 .iter()
-                .position(|v| v.name().is_ok_and(|v| v == &symbol_name))
+                .position(|v| v.name().is_ok_and(|v| v == symbol_name))
                 .unwrap();
 
             metadata_length = if metadata_obj_idx == syms_in_data_sec.len() - 1 {

--- a/lib/cli/src/commands/wasmer_create_exe_main.c
+++ b/lib/cli/src/commands/wasmer_create_exe_main.c
@@ -14,7 +14,7 @@
 
 static void print_wasmer_error() {
   int error_len = wasmer_last_error_length();
-  printf("Error len: `%d`\n", error_len);
+  //printf("Error len: `%d`\n", error_len);
   char *error_str = (char *)malloc(error_len);
   wasmer_last_error_message(error_str, error_len);
   printf("%s\n", error_str);

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -153,9 +153,16 @@ pub fn emit_compilation(
     let debug_index = compilation.unwind_info.eh_frame;
 
     let default_align = match triple.architecture {
-        Architecture::X86_64 => 1,
-        // In Arm64 is recommended a 4-byte alignment
-        Architecture::Aarch64(_) => 4,
+        target_lexicon::Architecture::Aarch64(_) => {
+            if matches!(
+                triple.operating_system,
+                target_lexicon::OperatingSystem::Darwin
+            ) {
+                8
+            } else {
+                4
+            }
+        }
         _ => 1,
     };
 

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -323,9 +323,99 @@ pub fn emit_compilation(
                     RelocationEncoding::Generic,
                     32,
                 ),
+                Reloc::MachoArm64RelocBranch26 => (
+                    RelocationKind::MachO {
+                        value: macho::ARM64_RELOC_BRANCH26,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocUnsigned => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_UNSIGNED,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocSubtractor => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_SUBTRACTOR,
+                        relative: false,
+                    },
+                    RelocationEncoding::Generic,
+                    64,
+                ),
+                Reloc::MachoArm64RelocPage21 => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_PAGE21,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+
+                Reloc::MachoArm64RelocPageoff12 => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_PAGEOFF12,
+                        relative: false,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocGotLoadPage21 => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_GOT_LOAD_PAGE21,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocGotLoadPageoff12 => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_GOT_LOAD_PAGEOFF12,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocPointerToGot => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_POINTER_TO_GOT,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocTlvpLoadPage21 => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_TLVP_LOAD_PAGE21,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocTlvpLoadPageoff12 => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_TLVP_LOAD_PAGEOFF12,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+                Reloc::MachoArm64RelocAddend => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_ADDEND,
+                        relative: false,
+                    },
+                    RelocationEncoding::Generic,
+                    32,
+                ),
+
                 other => {
                     return Err(ObjectError::UnsupportedArchitecture(format!(
-                        "{} (relocation: {}",
+                        "{} (relocation: {})",
                         triple.architecture, other
                     )))
                 }
@@ -348,7 +438,13 @@ pub fn emit_compilation(
                     .map_err(ObjectError::Write)?;
                 }
                 RelocationTarget::LibCall(libcall) => {
-                    let libcall_fn_name = libcall.to_function_name().as_bytes();
+                    let mut libcall_fn_name = libcall.to_function_name().to_string();
+                    if matches!(triple.binary_format, BinaryFormat::Macho) {
+                        libcall_fn_name = format!("_{libcall_fn_name}");
+                    }
+
+                    let libcall_fn_name = libcall_fn_name.as_bytes();
+
                     // We add the symols lazily as we see them
                     let target_symbol = obj.symbol_id(libcall_fn_name).unwrap_or_else(|| {
                         obj.add_symbol(ObjSymbol {


### PR DESCRIPTION
As per description. Adds a check for the length of the header and changes the default alignment for aarch64-darwin platforms.