### PR TITLE
feat: Add `SuggestedCompilerOptimization` type(s) to automatically infer when to enable g0m0 optimization

### DIFF
--- a/lib/api/src/backend/js/entities/engine.rs
+++ b/lib/api/src/backend/js/entities/engine.rs
@@ -5,9 +5,9 @@ use wasmer_types::{target::Target, Features};
 pub struct Engine;
 
 impl Engine {
-    pub(crate) fn deterministic_id(&self) -> &str {
+    pub(crate) fn deterministic_id(&self) -> String {
         // All js engines have the same id
-        "js-generic"
+        String::from("js-generic")
     }
 
     /// Returns the WebAssembly features supported by the JS engine.

--- a/lib/api/src/backend/jsc/entities/engine.rs
+++ b/lib/api/src/backend/jsc/entities/engine.rs
@@ -166,9 +166,9 @@ impl JSCEngine {
 }
 
 impl Engine {
-    pub(crate) fn deterministic_id(&self) -> &str {
+    pub(crate) fn deterministic_id(&self) -> String {
         // All js engines have the same id
-        "javascriptcore"
+        String::from("javascriptcore")
     }
 
     /// Returns the WebAssembly features supported by the JSC engine for the given target.

--- a/lib/api/src/backend/v8/entities/engine.rs
+++ b/lib/api/src/backend/v8/entities/engine.rs
@@ -50,8 +50,8 @@ impl Engine {
         Self::default()
     }
 
-    pub(crate) fn deterministic_id(&self) -> &str {
-        "v8"
+    pub(crate) fn deterministic_id(&self) -> String {
+        String::from("v8")
     }
 
     /// Returns the WebAssembly features supported by the V8 engine.

--- a/lib/api/src/backend/wamr/entities/engine.rs
+++ b/lib/api/src/backend/wamr/entities/engine.rs
@@ -36,8 +36,8 @@ impl Engine {
         Self::default()
     }
 
-    pub(crate) fn deterministic_id(&self) -> &str {
-        "wamr"
+    pub(crate) fn deterministic_id(&self) -> String {
+        String::from("wamr")
     }
 
     /// Returns the WebAssembly features supported by the WAMR engine.

--- a/lib/api/src/backend/wasmi/entities/engine.rs
+++ b/lib/api/src/backend/wasmi/entities/engine.rs
@@ -36,8 +36,8 @@ impl Engine {
         Self::default()
     }
 
-    pub(crate) fn deterministic_id(&self) -> &str {
-        "wasmi"
+    pub(crate) fn deterministic_id(&self) -> String {
+        String::from("wasmi")
     }
 
     /// Returns the WebAssembly features supported by the WASMI engine.

--- a/lib/api/src/entities/engine/inner.rs
+++ b/lib/api/src/entities/engine/inner.rs
@@ -17,7 +17,7 @@ gen_rt_ty!(Engine @derives Debug, Clone);
 impl BackendEngine {
     /// Returns the deterministic id of this engine.
     #[inline]
-    pub fn deterministic_id(&self) -> &str {
+    pub fn deterministic_id(&self) -> String {
         match_rt!(on self  => s {
             s.deterministic_id()
         })

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 use std::{path::Path, sync::Arc};
 use wasmer_types::{
-    target::{UserCompilerOptimizations, Target},
+    target::{Target, UserCompilerOptimizations},
     CompileError, DeserializeError, Features,
 };
 

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 use std::{path::Path, sync::Arc};
 use wasmer_types::{
-    target::{SuggestedCompilerOptimizations, Target},
+    target::{UserCompilerOptimizations, Target},
     CompileError, DeserializeError, Features,
 };
 
@@ -236,7 +236,7 @@ impl Engine {
     /// more optimizations.
     pub fn with_opts(
         &mut self,
-        suggested_opts: &SuggestedCompilerOptimizations,
+        suggested_opts: &UserCompilerOptimizations,
     ) -> Result<(), CompileError> {
         match self.be {
             #[cfg(feature = "sys")]

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -2,7 +2,10 @@
 
 use bytes::Bytes;
 use std::{path::Path, sync::Arc};
-use wasmer_types::{target::Target, DeserializeError, Features};
+use wasmer_types::{
+    target::{SuggestedCompilerOptimizations, Target},
+    CompileError, DeserializeError, Features,
+};
 
 #[cfg(feature = "sys")]
 use wasmer_compiler::Artifact;
@@ -222,5 +225,23 @@ impl Engine {
         file_ref: &Path,
     ) -> Result<Arc<Artifact>, DeserializeError> {
         self.be.deserialize_from_file_unchecked(file_ref)
+    }
+
+    /// Add suggested optimizations to this engine.
+    ///
+    /// # Note
+    ///
+    /// Not every backend supports every optimization. This function may fail (i.e. not set the
+    /// suggested optimizations) silently if the underlying engine backend does not support one or
+    /// more optimizations.
+    pub fn with_opts(
+        &mut self,
+        suggested_opts: &SuggestedCompilerOptimizations,
+    ) -> Result<(), CompileError> {
+        match self.be {
+            #[cfg(feature = "sys")]
+            BackendEngine::Sys(ref mut e) => e.with_opts(suggested_opts),
+            _ => Ok(()),
+        }
     }
 }

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -51,7 +51,7 @@ impl Engine {
     }
 
     /// Returns the deterministic id of this engine.
-    pub fn deterministic_id(&self) -> &str {
+    pub fn deterministic_id(&self) -> String {
         self.be.deterministic_id()
     }
 

--- a/lib/cli/src/commands/init.rs
+++ b/lib/cli/src/commands/init.rs
@@ -491,6 +491,7 @@ async fn construct_manifest(
             map.insert("wasi".to_string(), "0.1.0-unstable".to_string());
             map
         }),
+        annotations: None,
     }];
 
     let mut pkg = wasmer_config::package::Package::builder(

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -49,6 +49,7 @@ use wasmer_types::{
 
 /// A compiler that compiles a WebAssembly module with Cranelift, translating the Wasm to Cranelift IR,
 /// optimizing it and then translating to assembly.
+#[derive(Debug)]
 pub struct CraneliftCompiler {
     config: Cranelift,
 }
@@ -68,6 +69,10 @@ impl CraneliftCompiler {
 impl Compiler for CraneliftCompiler {
     fn name(&self) -> &str {
         "cranelift"
+    }
+
+    fn deterministic_id(&self) -> String {
+        String::from("cranelift")
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -29,6 +29,7 @@ use wasmer_vm::LibCall;
 
 /// A compiler that compiles a WebAssembly module with LLVM, translating the Wasm to LLVM IR,
 /// optimizing it and then translating to assembly.
+#[derive(Debug)]
 pub struct LLVMCompiler {
     config: LLVM,
 }
@@ -259,6 +260,24 @@ impl LLVMCompiler {
 impl Compiler for LLVMCompiler {
     fn name(&self) -> &str {
         "llvm"
+    }
+
+    fn deterministic_id(&self) -> String {
+        let mut ret = format!(
+            "llvm-{}",
+            match self.config.opt_level {
+                inkwell::OptimizationLevel::None => "opt0",
+                inkwell::OptimizationLevel::Less => "optl",
+                inkwell::OptimizationLevel::Default => "optd",
+                inkwell::OptimizationLevel::Aggressive => "opta",
+            }
+        );
+
+        if self.config.enable_g0m0_opt {
+            ret.push_str("-g0m0");
+        }
+
+        ret
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -557,4 +557,14 @@ impl Compiler for LLVMCompiler {
             got,
         })
     }
+
+    fn with_opts(
+        &mut self,
+        suggested_compiler_opts: &wasmer_types::target::SuggestedCompilerOptimizations,
+    ) -> Result<(), CompileError> {
+        if suggested_compiler_opts.pass_params.is_some_and(|v| v) {
+            self.config.enable_g0m0_opt = true;
+        }
+        Ok(())
+    }
 }

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -560,7 +560,7 @@ impl Compiler for LLVMCompiler {
 
     fn with_opts(
         &mut self,
-        suggested_compiler_opts: &wasmer_types::target::SuggestedCompilerOptimizations,
+        suggested_compiler_opts: &wasmer_types::target::UserCompilerOptimizations,
     ) -> Result<(), CompileError> {
         if suggested_compiler_opts.pass_params.is_some_and(|v| v) {
             self.config.enable_g0m0_opt = true;

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -38,6 +38,7 @@ use wasmer_types::{
 
 /// A compiler that compiles a WebAssembly module with Singlepass.
 /// It does the compilation in one pass
+#[derive(Debug)]
 pub struct SinglepassCompiler {
     config: Singlepass,
 }
@@ -57,6 +58,10 @@ impl SinglepassCompiler {
 impl Compiler for SinglepassCompiler {
     fn name(&self) -> &str {
         "singlepass"
+    }
+
+    fn deterministic_id(&self) -> String {
+        String::from("singlepass")
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -12,7 +12,7 @@ use enumset::EnumSet;
 use wasmer_types::{
     entity::PrimaryMap,
     error::CompileError,
-    target::{CpuFeature, UserCompilerOptimizations, Target},
+    target::{CpuFeature, Target, UserCompilerOptimizations},
     Features, LocalFunctionIndex,
 };
 #[cfg(feature = "translator")]

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -9,6 +9,7 @@ use crate::{
     FunctionBodyData, ModuleTranslationState,
 };
 use enumset::EnumSet;
+use wasmer_types::target::SuggestedCompilerOptimizations;
 use wasmer_types::{
     entity::PrimaryMap,
     error::CompileError,
@@ -84,6 +85,22 @@ pub trait Compiler: Send + std::fmt::Debug {
     /// Returns the deterministic id of this compiler. Same compilers with different
     /// optimizations map to different deterministic IDs.
     fn deterministic_id(&self) -> String;
+
+    /// Add suggested optimizations to this compiler.
+    ///
+    /// # Note
+    ///
+    /// Not every compiler supports every optimization. This function may fail (i.e. not set the
+    /// suggested optimizations) silently if the underlying compiler does not support one or
+    /// more optimizations.
+    fn with_opts(
+        &mut self,
+        suggested_compiler_opts: &SuggestedCompilerOptimizations,
+    ) -> Result<(), CompileError> {
+        _ = suggested_compiler_opts;
+        Ok(())
+    }
+
     /// Validates a module.
     ///
     /// It returns the a succesful Result in case is valid, `CompileError` in case is not.

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -12,7 +12,7 @@ use enumset::EnumSet;
 use wasmer_types::{
     entity::PrimaryMap,
     error::CompileError,
-    target::{CpuFeature, SuggestedCompilerOptimizations, Target},
+    target::{CpuFeature, UserCompilerOptimizations, Target},
     Features, LocalFunctionIndex,
 };
 #[cfg(feature = "translator")]
@@ -94,7 +94,7 @@ pub trait Compiler: Send + std::fmt::Debug {
     /// more optimizations.
     fn with_opts(
         &mut self,
-        suggested_compiler_opts: &SuggestedCompilerOptimizations,
+        suggested_compiler_opts: &UserCompilerOptimizations,
     ) -> Result<(), CompileError> {
         _ = suggested_compiler_opts;
         Ok(())

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -75,12 +75,15 @@ where
 }
 
 /// An implementation of a Compiler from parsed WebAssembly module to Compiled native code.
-pub trait Compiler: Send {
+pub trait Compiler: Send + std::fmt::Debug {
     /// Returns a descriptive name for this compiler.
     ///
     /// Note that this is an API breaking change since 3.0
     fn name(&self) -> &str;
 
+    /// Returns the deterministic id of this compiler. Same compilers with different
+    /// optimizations map to different deterministic IDs.
+    fn deterministic_id(&self) -> String;
     /// Validates a module.
     ///
     /// It returns the a succesful Result in case is valid, `CompileError` in case is not.

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -9,11 +9,10 @@ use crate::{
     FunctionBodyData, ModuleTranslationState,
 };
 use enumset::EnumSet;
-use wasmer_types::target::SuggestedCompilerOptimizations;
 use wasmer_types::{
     entity::PrimaryMap,
     error::CompileError,
-    target::{CpuFeature, Target},
+    target::{CpuFeature, SuggestedCompilerOptimizations, Target},
     Features, LocalFunctionIndex,
 };
 #[cfg(feature = "translator")]

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -94,12 +94,13 @@ impl Engine {
     }
 
     /// Returns the deterministic id of this engine
-    pub fn deterministic_id(&self) -> &str {
-        // TODO: add a `deterministic_id` to the Compiler, so two
-        // compilers can actually serialize into a different deterministic_id
-        // if their configuration is different (eg. LLVM with optimizations vs LLVM
-        // without optimizations)
-        self.name.as_str()
+    pub fn deterministic_id(&self) -> String {
+        let i = self.inner();
+        if let Some(ref c) = i.compiler {
+            c.deterministic_id()
+        } else {
+            self.name.clone()
+        }
     }
 
     /// Create a headless `Engine`

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -107,7 +107,7 @@ impl Engine {
 
         #[allow(unreachable_code)]
         {
-            return self.name.to_string();
+            self.name.to_string()
         }
     }
 

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -284,11 +284,31 @@ impl Engine {
     pub fn tunables(&self) -> &dyn Tunables {
         self.tunables.as_ref()
     }
+
+    /// Add suggested optimizations to this engine.
+    ///
+    /// # Note
+    ///
+    /// Not every backend supports every optimization. This function may fail (i.e. not set the
+    /// suggested optimizations) silently if the underlying engine backend does not support one or
+    /// more optimizations.
+    pub fn with_opts(
+        &mut self,
+        suggested_opts: &wasmer_types::target::SuggestedCompilerOptimizations,
+    ) -> Result<(), CompileError> {
+        let mut i = self.inner_mut();
+        if let Some(ref mut c) = i.compiler {
+            c.with_opts(suggested_opts)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for Engine {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Engine")
+            .field("inner", &self.inner)
             .field("target", &self.target)
             .field("engine_id", &self.engine_id)
             .field("name", &self.name)
@@ -312,6 +332,16 @@ pub struct EngineInner {
     /// performantly.
     #[cfg(not(target_arch = "wasm32"))]
     signatures: SignatureRegistry,
+}
+
+impl std::fmt::Debug for EngineInner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EngineInner")
+            .field("compiler", &self.compiler)
+            .field("features", &self.features)
+            .field("signatures", &self.signatures)
+            .finish()
+    }
 }
 
 impl EngineInner {

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -302,7 +302,7 @@ impl Engine {
     /// more optimizations.
     pub fn with_opts(
         &mut self,
-        suggested_opts: &wasmer_types::target::SuggestedCompilerOptimizations,
+        suggested_opts: &wasmer_types::target::UserCompilerOptimizations,
     ) -> Result<(), CompileError> {
         #[cfg(feature = "compiler")]
         {

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -503,6 +503,26 @@ pub struct Module {
     /// Interface definitions that can be used to generate bindings to this
     /// module.
     pub bindings: Option<Bindings>,
+    /// Miscellaneous annotations from the user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<UserAnnotations>,
+}
+
+/// Miscellaneous annotations specified by the user.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct UserAnnotations {
+    pub suggested_compiler_optimizations: SuggestedCompilerOptimizations,
+}
+
+/// Suggested optimization that might be operated on the module when (and if) compiled.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+pub struct SuggestedCompilerOptimizations {
+    pub pass_params: Option<bool>,
+}
+
+impl SuggestedCompilerOptimizations {
+    pub const KEY: &'static str = "suggested_compiler_optimizations";
+    pub const PASS_PARAMS_KEY: &'static str = "pass_params";
 }
 
 /// The interface exposed by a [`Module`].
@@ -1007,6 +1027,7 @@ mod tests {
                 interfaces: None,
                 kind: Some("https://webc.org/kind/wasi".to_string()),
                 source: Path::new("test.wasm").to_path_buf(),
+                annotations: None,
             }],
             commands: Vec::new(),
             fs: vec![
@@ -1062,6 +1083,7 @@ module = "mod"
                     wit_exports: PathBuf::from("exports.wit"),
                     wit_bindgen: "0.0.0".parse().unwrap()
                 })),
+                annotations: None
             },
         );
     }

--- a/lib/package/src/convert/webc_to_package.rs
+++ b/lib/package/src/convert/webc_to_package.rs
@@ -1,8 +1,6 @@
 use std::path::Path;
 
-use wasmer_config::package::{
-    UserAnnotations, ModuleReference, SuggestedCompilerOptimizations,
-};
+use wasmer_config::package::{ModuleReference, SuggestedCompilerOptimizations, UserAnnotations};
 
 use webc::Container;
 
@@ -160,8 +158,11 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
                     .get(SuggestedCompilerOptimizations::KEY)
                 {
                     if let Some((_, v)) = sco.as_map().and_then(|v| {
-                        v.iter()
-                            .find(|(k, _)| k.as_text().is_some_and(|v| v == SuggestedCompilerOptimizations::PASS_PARAMS_KEY))
+                        v.iter().find(|(k, _)| {
+                            k.as_text().is_some_and(|v| {
+                                v == SuggestedCompilerOptimizations::PASS_PARAMS_KEY
+                            })
+                        })
                     }) {
                         annotations = Some(UserAnnotations {
                             suggested_compiler_optimizations: SuggestedCompilerOptimizations {

--- a/lib/package/src/convert/webc_to_package.rs
+++ b/lib/package/src/convert/webc_to_package.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use wasmer_config::package::ModuleReference;
+use wasmer_config::package::{
+    UserAnnotations, ModuleReference, SuggestedCompilerOptimizations,
+};
 
 use webc::Container;
 
@@ -150,6 +152,26 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
 
             let relative_path = format!("./{module_dir_name}/{atom_name}");
 
+            let mut annotations = None;
+
+            if let Some(manifest_atom) = manifest.atoms.get(&atom_name) {
+                if let Some(sco) = manifest_atom
+                    .annotations
+                    .get(SuggestedCompilerOptimizations::KEY)
+                {
+                    if let Some((_, v)) = sco.as_map().and_then(|v| {
+                        v.iter()
+                            .find(|(k, _)| k.as_text().is_some_and(|v| v == SuggestedCompilerOptimizations::PASS_PARAMS_KEY))
+                    }) {
+                        annotations = Some(UserAnnotations {
+                            suggested_compiler_optimizations: SuggestedCompilerOptimizations {
+                                pass_params: Some(v.as_bool().unwrap_or_default()),
+                            },
+                        });
+                    }
+                }
+            }
+
             pkg_manifest.modules.push(wasmer_config::package::Module {
                 name: atom_name,
                 source: relative_path.into(),
@@ -157,6 +179,7 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
                 kind: None,
                 interfaces: None,
                 bindings: None,
+                annotations,
             });
         }
     }

--- a/lib/package/src/package/manifest.rs
+++ b/lib/package/src/package/manifest.rs
@@ -3,13 +3,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ciborium::Value;
+use ciborium::{cbor, Value};
 use semver::VersionReq;
 use sha2::Digest;
 use shared_buffer::{MmapError, OwnedBuffer};
 use url::Url;
 #[allow(deprecated)]
 use wasmer_config::package::{CommandV1, CommandV2, Manifest as WasmerManifest, Package};
+use wasmer_config::package::{UserAnnotations, SuggestedCompilerOptimizations};
 use webc::{
     indexmap::{self, IndexMap},
     metadata::AtomSignature,
@@ -160,7 +161,14 @@ pub(crate) fn wasmer_manifest_to_webc(
 /// take a `wasmer.toml` manifest and convert it to the `*.webc` equivalent.
 pub(crate) fn in_memory_wasmer_manifest_to_webc(
     manifest: &WasmerManifest,
-    atoms: &BTreeMap<String, (Option<String>, OwnedBuffer)>,
+    atoms: &BTreeMap<
+        String,
+        (
+            Option<String>,
+            OwnedBuffer,
+            Option<&UserAnnotations>,
+        ),
+    >,
 ) -> Result<(WebcManifest, BTreeMap<String, OwnedBuffer>), ManifestError> {
     let use_map = transform_dependencies(&manifest.dependencies)?;
 
@@ -279,27 +287,55 @@ fn transform_atoms(
             error,
         })?;
 
-        atom_entries.insert(name.clone(), (module.kind.clone(), file));
+        atom_entries.insert(
+            name.clone(),
+            (module.kind.clone(), file, module.annotations.as_ref()),
+        );
     }
 
     transform_atoms_shared(&atom_entries)
 }
 
 fn transform_in_memory_atoms(
-    atoms: &BTreeMap<String, (Option<String>, OwnedBuffer)>,
+    atoms: &BTreeMap<
+        String,
+        (
+            Option<String>,
+            OwnedBuffer,
+            Option<&UserAnnotations>,
+        ),
+    >,
 ) -> Result<(IndexMap<String, Atom>, Atoms), ManifestError> {
     transform_atoms_shared(atoms)
 }
 
 fn transform_atoms_shared(
-    atoms: &BTreeMap<String, (Option<String>, OwnedBuffer)>,
+    atoms: &BTreeMap<
+        String,
+        (
+            Option<String>,
+            OwnedBuffer,
+            Option<&UserAnnotations>,
+        ),
+    >,
 ) -> Result<(IndexMap<String, Atom>, Atoms), ManifestError> {
     let mut atom_files = BTreeMap::new();
     let mut metadata = IndexMap::new();
 
-    for (name, (kind, content)) in atoms.iter() {
+    for (name, (kind, content, misc_annotations)) in atoms.iter() {
         // Create atom with annotations including Wasm features if available
         let mut annotations = IndexMap::new();
+        if let Some(misc_annotations) = misc_annotations {
+            if let Some(pass_params) = misc_annotations
+                .suggested_compiler_optimizations
+                .pass_params
+            {
+                annotations.insert(
+                    SuggestedCompilerOptimizations::KEY.to_string(),
+                    cbor!({"pass_params" => pass_params}).unwrap(),
+                );
+            }
+        }
 
         // Detect required WebAssembly features by analyzing the module binary
         let features_result = wasmer_types::Features::detect_from_wasm(content);

--- a/lib/package/src/package/manifest.rs
+++ b/lib/package/src/package/manifest.rs
@@ -10,7 +10,7 @@ use shared_buffer::{MmapError, OwnedBuffer};
 use url::Url;
 #[allow(deprecated)]
 use wasmer_config::package::{CommandV1, CommandV2, Manifest as WasmerManifest, Package};
-use wasmer_config::package::{UserAnnotations, SuggestedCompilerOptimizations};
+use wasmer_config::package::{SuggestedCompilerOptimizations, UserAnnotations};
 use webc::{
     indexmap::{self, IndexMap},
     metadata::AtomSignature,
@@ -161,14 +161,7 @@ pub(crate) fn wasmer_manifest_to_webc(
 /// take a `wasmer.toml` manifest and convert it to the `*.webc` equivalent.
 pub(crate) fn in_memory_wasmer_manifest_to_webc(
     manifest: &WasmerManifest,
-    atoms: &BTreeMap<
-        String,
-        (
-            Option<String>,
-            OwnedBuffer,
-            Option<&UserAnnotations>,
-        ),
-    >,
+    atoms: &BTreeMap<String, (Option<String>, OwnedBuffer, Option<&UserAnnotations>)>,
 ) -> Result<(WebcManifest, BTreeMap<String, OwnedBuffer>), ManifestError> {
     let use_map = transform_dependencies(&manifest.dependencies)?;
 
@@ -297,27 +290,13 @@ fn transform_atoms(
 }
 
 fn transform_in_memory_atoms(
-    atoms: &BTreeMap<
-        String,
-        (
-            Option<String>,
-            OwnedBuffer,
-            Option<&UserAnnotations>,
-        ),
-    >,
+    atoms: &BTreeMap<String, (Option<String>, OwnedBuffer, Option<&UserAnnotations>)>,
 ) -> Result<(IndexMap<String, Atom>, Atoms), ManifestError> {
     transform_atoms_shared(atoms)
 }
 
 fn transform_atoms_shared(
-    atoms: &BTreeMap<
-        String,
-        (
-            Option<String>,
-            OwnedBuffer,
-            Option<&UserAnnotations>,
-        ),
-    >,
+    atoms: &BTreeMap<String, (Option<String>, OwnedBuffer, Option<&UserAnnotations>)>,
 ) -> Result<(IndexMap<String, Atom>, Atoms), ManifestError> {
     let mut atom_files = BTreeMap::new();
     let mut metadata = IndexMap::new();

--- a/lib/package/src/package/package.rs
+++ b/lib/package/src/package/package.rs
@@ -355,8 +355,21 @@ impl Package {
 
         let volumes = new_volumes;
 
+        let mut annotated_atoms = BTreeMap::new();
+
+        for (atom_name, (a, b)) in atoms {
+            let annotations =
+                if let Some(module) = manifest.modules.iter().find(|v| v.name == atom_name) {
+                    module.annotations.as_ref()
+                } else {
+                    None
+                };
+
+            annotated_atoms.insert(atom_name, (a, b, annotations));
+        }
+
         let (mut manifest, atoms) =
-            super::manifest::in_memory_wasmer_manifest_to_webc(&manifest, &atoms)?;
+            super::manifest::in_memory_wasmer_manifest_to_webc(&manifest, &annotated_atoms)?;
 
         if let Some(entry) = manifest.package.get_mut(Wapm::KEY) {
             let mut wapm: Wapm = entry.deserialized()?;

--- a/lib/types/src/target.rs
+++ b/lib/types/src/target.rs
@@ -230,12 +230,12 @@ impl Default for Target {
     }
 }
 
-/// Suggested optimization that might be operated on the module when (and if) compiled.
+/// User-suggested optimization that might be operated on the module when (and if) compiled.
 ///
 // Note: This type is a copy of `wasmer_config::package::SuggestedCompilerOptimizations`, so to
 // avoid dependencies on `wasmer_config` for crates that already depend on `wasmer_types`.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct SuggestedCompilerOptimizations {
+pub struct UserCompilerOptimizations {
     /// Suggest the `pass_params` (also known as g0m0) optimization pass.
     pub pass_params: Option<bool>,
 }

--- a/lib/types/src/target.rs
+++ b/lib/types/src/target.rs
@@ -230,10 +230,12 @@ impl Default for Target {
     }
 }
 
-/// A set of suggested optimizations, which will be passed on to backends in the chain of
-/// execution.
-#[derive(Debug, Clone, Default)]
+/// Suggested optimization that might be operated on the module when (and if) compiled.
+///
+// Note: This type is a copy of `wasmer_config::package::SuggestedCompilerOptimizations`, so to
+// avoid dependencies on `wasmer_config` for crates that already depend on `wasmer_types`.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct SuggestedCompilerOptimizations {
-    /// Suggest the "pass_params" (also known as `g0m0`) optimiation to be enabled.
+    /// Suggest the `pass_params` (also known as g0m0) optimization pass.
     pub pass_params: Option<bool>,
 }

--- a/lib/types/src/target.rs
+++ b/lib/types/src/target.rs
@@ -229,3 +229,11 @@ impl Default for Target {
         }
     }
 }
+
+/// A set of suggested optimizations, which will be passed on to backends in the chain of
+/// execution.
+#[derive(Debug, Clone, Default)]
+pub struct SuggestedCompilerOptimizations {
+    /// Suggest the "pass_params" (also known as `g0m0`) optimiation to be enabled.
+    pub pass_params: Option<bool>,
+}

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -4,7 +4,9 @@ use anyhow::Context;
 use once_cell::sync::OnceCell;
 use sha2::Digest;
 use virtual_fs::FileSystem;
-use wasmer_config::package::{PackageHash, PackageId, PackageSource};
+use wasmer_config::package::{
+    PackageHash, PackageId, PackageSource, SuggestedCompilerOptimizations,
+};
 use wasmer_package::package::Package;
 use webc::compat::SharedBytes;
 use webc::Container;
@@ -24,6 +26,7 @@ pub struct BinaryPackageCommand {
     pub(crate) atom: SharedBytes,
     hash: ModuleHash,
     features: Option<wasmer_types::Features>,
+    pub suggested_compiler_optimizations: SuggestedCompilerOptimizations,
 }
 
 impl BinaryPackageCommand {
@@ -33,6 +36,7 @@ impl BinaryPackageCommand {
         atom: SharedBytes,
         hash: ModuleHash,
         features: Option<wasmer_types::Features>,
+        suggested_compiler_optimizations: SuggestedCompilerOptimizations,
     ) -> Self {
         Self {
             name,
@@ -40,6 +44,7 @@ impl BinaryPackageCommand {
             atom,
             hash,
             features,
+            suggested_compiler_optimizations,
         }
     }
 

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -7,7 +7,7 @@ pub use self::task_manager::{SpawnMemoryType, VirtualTaskManager};
 use self::{module_cache::CacheError, task_manager::InlineWaker};
 use wasmer_config::package::SuggestedCompilerOptimizations;
 use wasmer_types::{
-    target::SuggestedCompilerOptimizations as WasmerSuggestedCompilerOptimizations, ModuleHash,
+    target::UserCompilerOptimizations as WasmerSuggestedCompilerOptimizations, ModuleHash,
 };
 
 use std::{

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -5,7 +5,10 @@ pub mod task_manager;
 
 pub use self::task_manager::{SpawnMemoryType, VirtualTaskManager};
 use self::{module_cache::CacheError, task_manager::InlineWaker};
-use wasmer_types::ModuleHash;
+use wasmer_config::package::SuggestedCompilerOptimizations;
+use wasmer_types::{
+    target::SuggestedCompilerOptimizations as WasmerSuggestedCompilerOptimizations, ModuleHash,
+};
 
 use std::{
     fmt,
@@ -15,7 +18,7 @@ use std::{
 
 use futures::future::BoxFuture;
 use virtual_net::{DynVirtualNetworking, VirtualNetworking};
-use wasmer::{Module, RuntimeError};
+use wasmer::{CompileError, Module, RuntimeError};
 use wasmer_wasix_types::wasi::ExitCode;
 
 #[cfg(feature = "journal")]
@@ -77,6 +80,17 @@ where
         wasmer::Engine::default()
     }
 
+    fn engine_with_suggested_opts(
+        &self,
+        suggested_opts: &SuggestedCompilerOptimizations,
+    ) -> Result<wasmer::Engine, CompileError> {
+        let mut engine = self.engine();
+        engine.with_opts(&WasmerSuggestedCompilerOptimizations {
+            pass_params: suggested_opts.pass_params,
+        })?;
+        Ok(engine)
+    }
+
     /// Create a new [`wasmer::Store`].
     fn new_store(&self) -> wasmer::Store {
         cfg_if::cfg_if! {
@@ -106,10 +120,21 @@ where
         &self,
         cmd: &BinaryPackageCommand,
     ) -> BoxFuture<'_, Result<Module, SpawnError>> {
-        let engine = self.engine();
         let hash = *cmd.hash();
         let wasm = cmd.atom();
         let module_cache = self.module_cache();
+
+        let engine = match self.engine_with_suggested_opts(&cmd.suggested_compiler_optimizations) {
+            Ok(engine) => engine,
+            Err(error) => {
+                return Box::pin(async move {
+                    Err(SpawnError::CompileError {
+                        module_hash: hash,
+                        error,
+                    })
+                })
+            }
+        };
 
         let task = async move { load_module(&engine, &module_cache, &wasm, hash).await };
 

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -42,7 +42,7 @@ impl FileSystemCache {
 impl ModuleCache for FileSystemCache {
     #[tracing::instrument(level = "debug", skip_all, fields(% key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        let path = self.path(key, engine.deterministic_id());
+        let path = self.path(key, &engine.deterministic_id());
 
         self.task_manager
             .runtime_handle()
@@ -97,7 +97,7 @@ impl ModuleCache for FileSystemCache {
         engine: &Engine,
         module: &Module,
     ) -> Result<(), CacheError> {
-        let path = self.path(key, engine.deterministic_id());
+        let path = self.path(key, &engine.deterministic_id());
 
         self.task_manager
             .runtime_handle()
@@ -221,7 +221,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let key = ModuleHash::xxhash_from_bytes([0; 8]);
-        let expected_path = cache.path(key, engine.deterministic_id());
+        let expected_path = cache.path(key, &engine.deterministic_id());
 
         cache.save(key, &engine, &module).await.unwrap();
 
@@ -262,7 +262,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
-        let expected_path = cache.path(key, engine.deterministic_id());
+        let expected_path = cache.path(key, &engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
         let serialized = module.serialize().unwrap();
         std::fs::write(&expected_path, &serialized).unwrap();
@@ -285,7 +285,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let key = ModuleHash::xxhash_from_bytes([0; 8]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
-        let expected_path = cache.path(key, engine.deterministic_id());
+        let expected_path = cache.path(key, &engine.deterministic_id());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
         let serialized = module.serialize().unwrap();
         let mut encoder = weezl::encode::Encoder::new(weezl::BitOrder::Msb, 8);

--- a/lib/wasix/src/runtime/module_cache/shared.rs
+++ b/lib/wasix/src/runtime/module_cache/shared.rs
@@ -20,7 +20,7 @@ impl SharedCache {
 impl ModuleCache for SharedCache {
     #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        let key = (key, engine.deterministic_id().to_string());
+        let key = (key, engine.deterministic_id());
 
         match self.modules.get(&key) {
             Some(m) => {

--- a/lib/wasix/src/runtime/module_cache/thread_local.rs
+++ b/lib/wasix/src/runtime/module_cache/thread_local.rs
@@ -31,7 +31,7 @@ impl ThreadLocalCache {
 impl ModuleCache for ThreadLocalCache {
     #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        match self.lookup(key, engine.deterministic_id()) {
+        match self.lookup(key, &engine.deterministic_id()) {
             Some(m) => {
                 tracing::debug!("Cache hit!");
                 Ok(m)
@@ -47,7 +47,7 @@ impl ModuleCache for ThreadLocalCache {
         engine: &Engine,
         module: &Module,
     ) -> Result<(), CacheError> {
-        self.insert(key, module, engine.deterministic_id());
+        self.insert(key, module, &engine.deterministic_id());
         Ok(())
     }
 }


### PR DESCRIPTION
As per title. This PR introduces two (equally-shaped) types in `wasmer_config` (to refer to the annotation observed from a Wasmer manifest) and in `wasmer_types::target` (for the actual types to pass to engines) that represent annotations from users, which can be used to specify suggested compiler optimizations. For example: 
```toml
# ....
[[module]]
name = "php"
source = "sapi/cli/php.wasm"
abi = "wasi"
annotations.suggested_compiler_optimizations = { pass_params = true }
# ...
```

This PR also adds the code necessary to serialize and deserialize this metadata in the manifest (and keep it in the related webc). 