### PR TITLE
fix(jsc): Export engine as `JSC`

### DIFF
--- a/lib/api/src/backend/jsc/mod.rs
+++ b/lib/api/src/backend/jsc/mod.rs
@@ -5,4 +5,4 @@ pub(crate) mod error;
 pub(crate) mod utils;
 pub(crate) mod vm;
 
-pub use entities::*;
+pub use entities::{engine::Engine as JSC, *};

--- a/lib/c-api/src/wasm_c_api/engine/config/jsc.rs
+++ b/lib/c-api/src/wasm_c_api/engine/config/jsc.rs
@@ -23,7 +23,7 @@ pub(crate) fn wasm_jsc_engine_new_with_config(config: wasm_config_t) -> Option<B
     }
 
     Some(Box::new(wasm_engine_t {
-        inner: wasmer_api::jsc::Engine::default().into(),
+        inner: wasmer_api::jsc::JSC::default().into(),
     }))
 }
 


### PR DESCRIPTION
As per title. Fixes build errors in the c-api implementation backed by jsc. 