### PR TITLE
fix(types): Bump `CURRENT_VERSION`

### DIFF
--- a/lib/types/src/serialize.rs
+++ b/lib/types/src/serialize.rs
@@ -13,7 +13,7 @@ pub struct MetadataHeader {
 impl MetadataHeader {
     /// Current ABI version. Increment this any time breaking changes are made
     /// to the format of the serialized data.
-    pub const CURRENT_VERSION: u32 = 9;
+    pub const CURRENT_VERSION: u32 = 10;
 
     /// Magic number to identify wasmer metadata.
     const MAGIC: [u8; 8] = *b"WASMER\0\0";


### PR DESCRIPTION
We merged [this](https://github.com/wakabat/official-wasmer/blame/4b3a98b1ba522c314aaa2319b9274503fff30f46/lib/compiler/src/types/section.rs#L73) PR that changed the format of custom sections but forgot to bump the artefacts version. 
No updates to the .wasmu images because this bump was wrongly forgotten when they were last updated.
