### PR TITLE
feat(llvm): Add ability to select how many threads LLVM should use during compilation.

### DIFF
--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -6,6 +6,7 @@
 // module.
 #![allow(dead_code, unused_imports, unused_variables)]
 
+use std::num::NonZero;
 use std::string::ToString;
 use std::sync::Arc;
 use std::{path::PathBuf, str::FromStr};
@@ -203,6 +204,11 @@ pub struct RuntimeOptions {
     /// global and the first (#0) memory passed between guest functions as explicit parameters.
     #[clap(long)]
     enable_pass_params_opt: bool,
+
+    /// Only available for the LLVM compiler. Sets the number of threads used to compile the
+    /// input module(s).
+    #[clap(long)]
+    llvm_num_threads: Option<NonZero<usize>>,
 
     #[clap(flatten)]
     features: WasmFeatures,
@@ -478,6 +484,10 @@ impl RuntimeOptions {
 
                 if self.enable_pass_params_opt {
                     config.enable_pass_params_opt();
+                }
+
+                if let Some(num_threads) = self.llvm_num_threads {
+                    config.num_threads(num_threads);
                 }
 
                 struct Callbacks {
@@ -791,6 +801,10 @@ impl BackendType {
 
                 if runtime_opts.enable_pass_params_opt {
                     config.enable_pass_params_opt();
+                }
+
+                if let Some(num_threads) = runtime_opts.llvm_num_threads {
+                    config.num_threads(num_threads);
                 }
 
                 if let Some(p) = &runtime_opts.profiler {

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -5,8 +5,8 @@ use inkwell::targets::{
 };
 pub use inkwell::OptimizationLevel as LLVMOptLevel;
 use itertools::Itertools;
-use std::fmt::Debug;
 use std::sync::Arc;
+use std::{fmt::Debug, num::NonZero};
 use target_lexicon::BinaryFormat;
 use wasmer_compiler::{Compiler, CompilerConfig, Engine, EngineBuilder, ModuleMiddleware};
 use wasmer_types::{
@@ -51,6 +51,8 @@ pub struct LLVM {
     pub(crate) callbacks: Option<Arc<dyn LLVMCallbacks>>,
     /// The middleware chain.
     pub(crate) middlewares: Vec<Arc<dyn ModuleMiddleware>>,
+    /// Number of threads to use when compiling a module.
+    pub(crate) num_threads: NonZero<usize>,
 }
 
 impl LLVM {
@@ -66,6 +68,7 @@ impl LLVM {
             callbacks: None,
             middlewares: vec![],
             enable_g0m0_opt: false,
+            num_threads: std::thread::available_parallelism().unwrap_or(NonZero::new(1).unwrap()),
         }
     }
 
@@ -80,6 +83,11 @@ impl LLVM {
     pub fn enable_pass_params_opt(&mut self) -> &mut Self {
         // internally, the "pass_params" opt is known as g0m0 opt.
         self.enable_g0m0_opt = true;
+        self
+    }
+
+    pub fn num_threads(&mut self, num_threads: NonZero<usize>) -> &mut Self {
+        self.num_threads = num_threads;
         self
     }
 


### PR DESCRIPTION
As per title. This PR also adds a `--llvm-num-threads` flag to the CLI. 

Note: if the requested number of threads is `1`, then rayon is not used during compilation, and modules are compiled instead on the calling thread. 