### PR TITLE
fix(wamr): Wamr zip folder not found

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -48,6 +48,8 @@ fn build_wamr() {
         zip.into_reader()
             .read_to_end(&mut zip_data)
             .expect("failed to download wamr");
+        std::fs::create_dir_all(&zip_dir)
+            .expect("Failed to create temporary zip extraction directory");
         zip::read::ZipArchive::new(std::io::Cursor::new(zip_data))
             .expect("failed to open wamr zip file")
             .extract(&zip_dir)


### PR DESCRIPTION
# Description
The error I was getting while building a project that utilizes wasmer v6.0.0-beta.1 to run some wasm:
```
   Compiling wasmer v6.0.0-beta.1 (https://github.com/wasmerio/wasmer?branch=main#4ef2417a)
error: failed to run custom build command for `wasmer v6.0.0-beta.1 (https://github.com/wasmerio/wasmer?branch=main#4ef2417a)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/home/myuser/myrepo/target/debug/build/wasmer-3315943f685e08fc/build-script-build` (exit status: 101)
  --- stderr

  thread 'main' panicked at /home/myuser/.cargo/git/checkouts/wasmer-3a90f166c3ea3f2f/4ef2417/lib/api/build.rs:54:14:
  failed to extract wamr zip file: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })
  stack backtrace:
     0: __rustc::rust_begin_unwind
               at /rustc/38c560ae681d5c0d3fd615eaedc537a282fb1086/library/std/src/panicking.rs:697:5
     1: core::panicking::panic_fmt
               at /rustc/38c560ae681d5c0d3fd615eaedc537a282fb1086/library/core/src/panicking.rs:75:14
     2: core::result::unwrap_failed
               at /rustc/38c560ae681d5c0d3fd615eaedc537a282fb1086/library/core/src/result.rs:1704:5
     3: core::result::Result<T,E>::expect
     4: build_script_build::build_wamr
     5: build_script_build::main
     6: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

# Solution
This PR ensures the temporary extraction directory is created using std::fs::create_dir_all(&zip_dir) before trying to extract the zip contents.