### PR TITLE
feat(wasix): Improve module loading performance and API correctness

### DIFF
--- a/lib/package/src/utils.rs
+++ b/lib/package/src/utils.rs
@@ -62,6 +62,11 @@ pub fn from_disk(path: impl AsRef<Path>) -> Result<Container, WasmerPackageError
     }
 }
 
+/// Check if the data looks like a webc.
+pub fn is_container(bytes: &[u8]) -> bool {
+    is_tarball(std::io::Cursor::new(bytes)) || webc::detect(bytes).is_ok()
+}
+
 pub fn from_bytes(bytes: impl Into<Bytes>) -> Result<Container, WasmerPackageError> {
     let bytes: Bytes = bytes.into();
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -412,6 +412,16 @@ pub trait VirtualFile:
         })
     }
 
+    /// Get the full contents of this file as an [`OwnedBuffer`].
+    ///
+    /// **NOTE**: Only implement this if the file is already available in-memory
+    /// and can be cloned cheaply!
+    ///
+    /// Allows consumers to do zero-copy cloning of the underlying data.
+    fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
+        None
+    }
+
     /// Polls the file for when there is data to be read
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>>;
 

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -507,6 +507,17 @@ impl VirtualFile for FileHandle {
         self.cursor = cursor;
         Ok(())
     }
+
+    fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
+        let fs = self.filesystem.inner.read().ok()?;
+
+        let inode = fs.storage.get(self.inode)?;
+        match inode {
+            Node::ReadOnlyFile(f) => Some(f.file.buffer.clone()),
+            Node::CustomFile(f) => f.file.lock().ok()?.as_owned_buffer(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -251,6 +251,10 @@ impl VirtualFile for File {
     ) -> Poll<std::io::Result<usize>> {
         Poll::Ready(Err(std::io::ErrorKind::PermissionDenied.into()))
     }
+
+    fn as_owned_buffer(&self) -> Option<SharedBytes> {
+        Some(self.content.get_ref().clone())
+    }
 }
 
 impl AsyncRead for File {

--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -6,6 +6,7 @@ use crate::{
         TaskJoinHandle,
     },
     runtime::{
+        module_cache::HashedModuleData,
         task_manager::{
             TaskWasm, TaskWasmRecycle, TaskWasmRecycleProperties, TaskWasmRunProperties,
         },
@@ -43,7 +44,7 @@ pub async fn spawn_exec(
 
 #[tracing::instrument(level = "trace", skip_all, fields(%name))]
 pub async fn spawn_exec_wasm(
-    wasm: &[u8],
+    wasm: HashedModuleData,
     name: &str,
     env: WasiEnv,
     runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
@@ -85,7 +86,7 @@ pub fn package_command_by_name<'a>(
 
 pub async fn spawn_load_module(
     name: &str,
-    wasm: &[u8],
+    wasm: HashedModuleData,
     runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
 ) -> Result<Module, SpawnError> {
     match runtime.load_module(wasm).await {

--- a/lib/wasix/src/os/command/builtins/cmd_wasmer.rs
+++ b/lib/wasix/src/os/command/builtins/cmd_wasmer.rs
@@ -3,9 +3,10 @@ use std::{any::Any, path::PathBuf, sync::Arc};
 use crate::{
     bin_factory::spawn_exec_wasm,
     os::task::{OwnedTaskStatus, TaskJoinHandle},
-    runtime::task_manager::InlineWaker,
+    runtime::{module_cache::HashedModuleData, task_manager::InlineWaker},
     SpawnError,
 };
+use shared_buffer::OwnedBuffer;
 use virtual_fs::{AsyncReadExt, FileSystem};
 use wasmer::FunctionEnvMut;
 use wasmer_package::utils::from_bytes;
@@ -50,6 +51,12 @@ impl CmdWasmer {
     }
 }
 
+#[derive(Debug, Clone)]
+enum Executable {
+    Wasm(OwnedBuffer),
+    BinaryPackage(BinaryPackage),
+}
+
 impl CmdWasmer {
     async fn run<'a>(
         &self,
@@ -59,11 +66,6 @@ impl CmdWasmer {
         what: Option<String>,
         mut args: Vec<String>,
     ) -> Result<TaskJoinHandle, SpawnError> {
-        pub enum Executable {
-            Wasm(bytes::Bytes),
-            BinaryPackage(BinaryPackage),
-        }
-
         // If the first argument is a '--' then skip it
         if args.first().map(|a| a.as_str()) == Some("--") {
             args = args.into_iter().skip(1).collect();
@@ -102,7 +104,7 @@ impl CmdWasmer {
 
                     Executable::BinaryPackage(pkg)
                 } else {
-                    Executable::Wasm(bytes)
+                    Executable::Wasm(OwnedBuffer::from_bytes(bytes))
                 }
             } else if let Ok(pkg) = self.get_package(&what).await {
                 Executable::BinaryPackage(pkg)
@@ -136,7 +138,10 @@ impl CmdWasmer {
                     // Now run the module
                     spawn_exec(binary, name, env, &self.runtime).await
                 }
-                Executable::Wasm(bytes) => spawn_exec_wasm(&bytes, name, env, &self.runtime).await,
+                Executable::Wasm(bytes) => {
+                    let data = HashedModuleData::new_xxhash(bytes);
+                    spawn_exec_wasm(data, name, env, &self.runtime).await
+                }
             }
         } else {
             let _ = unsafe { stderr_write(parent_ctx, HELP_RUN.as_bytes()) }.await;

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -5,7 +5,7 @@ pub mod task_manager;
 
 pub use self::task_manager::{SpawnMemoryType, VirtualTaskManager};
 use self::{module_cache::CacheError, task_manager::InlineWaker};
-use wasmer_types::ModuleHash;
+use module_cache::HashedModuleData;
 
 use std::{
     fmt,
@@ -106,14 +106,7 @@ where
         &self,
         cmd: &BinaryPackageCommand,
     ) -> BoxFuture<'_, Result<Module, SpawnError>> {
-        let engine = self.engine();
-        let hash = *cmd.hash();
-        let wasm = cmd.atom();
-        let module_cache = self.module_cache();
-
-        let task = async move { load_module(&engine, &module_cache, &wasm, hash).await };
-
-        Box::pin(task)
+        self.load_module(HashedModuleData::from_command(cmd))
     }
 
     /// Sync version of [`Self::load_command_module`].
@@ -121,13 +114,21 @@ where
         InlineWaker::block_on(self.load_command_module(cmd))
     }
 
-    /// Load a a Webassembly module, trying to use a pre-compiled version if possible.
-    fn load_module<'a>(&'a self, wasm: &'a [u8]) -> BoxFuture<'a, Result<Module, SpawnError>> {
+    /// Load a a Webassembly module.
+    ///
+    /// Should try to use a cached version of the module, if possible.
+    /// Otherwise compiles the module.
+    ///
+    /// Receives a [`HashedModule`] to allow fast cache retrieval through the
+    /// hash.
+    fn load_module<'a>(
+        &'a self,
+        module: HashedModuleData,
+    ) -> BoxFuture<'a, Result<Module, SpawnError>> {
         let engine = self.engine();
         let module_cache = self.module_cache();
-        let hash = ModuleHash::xxhash(wasm);
 
-        let task = async move { load_module(&engine, &module_cache, wasm, hash).await };
+        let task = async move { load_module(&engine, &module_cache, &module).await };
 
         Box::pin(task)
     }
@@ -135,7 +136,7 @@ where
     /// Load a a Webassembly module, trying to use a pre-compiled version if possible.
     ///
     /// Non-async version of [`Self::load_module`].
-    fn load_module_sync(&self, wasm: &[u8]) -> Result<Module, SpawnError> {
+    fn load_module_sync(&self, wasm: HashedModuleData) -> Result<Module, SpawnError> {
         InlineWaker::block_on(self.load_module(wasm))
     }
 
@@ -174,9 +175,9 @@ pub type DynRuntime = dyn Runtime + Send + Sync;
 pub async fn load_module(
     engine: &wasmer::Engine,
     module_cache: &(dyn ModuleCache + Send + Sync),
-    wasm: &[u8],
-    wasm_hash: ModuleHash,
+    module: &HashedModuleData,
 ) -> Result<Module, crate::SpawnError> {
+    let wasm_hash = module.hash().clone();
     let result = module_cache.load(wasm_hash, engine).await;
 
     match result {
@@ -191,11 +192,13 @@ pub async fn load_module(
         }
     }
 
-    let module = Module::new(&engine, wasm).map_err(|err| crate::SpawnError::CompileError {
-        module_hash: wasm_hash,
-        error: err,
-    })?;
+    let module =
+        Module::new(&engine, module.wasm()).map_err(|err| crate::SpawnError::CompileError {
+            module_hash: wasm_hash,
+            error: err,
+        })?;
 
+    // TODO: pass a [`HashedModule`] struct that is safe by construction.
     if let Err(e) = module_cache.save(wasm_hash, engine, &module).await {
         tracing::warn!(
             %wasm_hash,
@@ -596,20 +599,22 @@ impl Runtime for OverriddenRuntime {
         }
     }
 
-    fn load_module<'a>(&'a self, wasm: &'a [u8]) -> BoxFuture<'a, Result<Module, SpawnError>> {
+    fn load_module<'a>(
+        &'a self,
+        data: HashedModuleData,
+    ) -> BoxFuture<'a, Result<Module, SpawnError>> {
         if self.engine.is_some() || self.module_cache.is_some() {
             let engine = self.engine();
             let module_cache = self.module_cache();
-            let hash = ModuleHash::xxhash(wasm);
 
-            let task = async move { load_module(&engine, &module_cache, wasm, hash).await };
+            let task = async move { load_module(&engine, &module_cache, &data).await };
             Box::pin(task)
         } else {
-            self.inner.load_module(wasm)
+            self.inner.load_module(data)
         }
     }
 
-    fn load_module_sync(&self, wasm: &[u8]) -> Result<Module, SpawnError> {
+    fn load_module_sync(&self, wasm: HashedModuleData) -> Result<Module, SpawnError> {
         if self.engine.is_some() || self.module_cache.is_some() {
             InlineWaker::block_on(self.load_module(wasm))
         } else {

--- a/lib/wasix/src/runtime/module_cache/hashed_module.rs
+++ b/lib/wasix/src/runtime/module_cache/hashed_module.rs
@@ -1,0 +1,50 @@
+use shared_buffer::OwnedBuffer;
+use wasmer_types::ModuleHash;
+
+use crate::bin_factory::BinaryPackageCommand;
+
+/// A wrapper around Webassembly code and its hash.
+///
+/// Allows passing around WASM code and it's hash without the danger of
+/// using a wrong hash.
+///
+/// Safe by construction: can only be created from a [`BinaryCommand`], which
+/// already has the hash embedded, or from bytes that will be hashed in the
+/// constructor.
+///
+/// Can be cloned cheaply.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HashedModuleData {
+    hash: ModuleHash,
+    wasm: OwnedBuffer,
+}
+
+impl HashedModuleData {
+    /// Create new [`HashedModuleData`] from the given bytes, hashing the
+    /// the bytes into a [`ModuleHash`] with xxhash.
+    pub fn new_xxhash(bytes: impl Into<OwnedBuffer>) -> Self {
+        let wasm = bytes.into();
+        let hash = ModuleHash::xxhash(&wasm);
+        Self { hash, wasm }
+    }
+
+    /// Create new [`HashedModuleData`] from the given [`BinaryPackageCommand`].
+    ///
+    /// This is very cheap, as the hash is already available in the command.
+    pub fn from_command(command: &BinaryPackageCommand) -> Self {
+        Self {
+            hash: command.hash().clone(),
+            wasm: command.atom(),
+        }
+    }
+
+    /// Get the module hash.
+    pub fn hash(&self) -> &ModuleHash {
+        &self.hash
+    }
+
+    /// Get the WASM code.
+    pub fn wasm(&self) -> &OwnedBuffer {
+        &self.wasm
+    }
+}

--- a/lib/wasix/src/runtime/module_cache/mod.rs
+++ b/lib/wasix/src/runtime/module_cache/mod.rs
@@ -31,6 +31,8 @@
 //! caching strategies. For example, you could use the [`FallbackCache`] to
 //! chain a fast in-memory cache with a slower file-based cache as a fallback.
 
+mod hashed_module;
+
 mod fallback;
 #[cfg(feature = "sys-thread")]
 mod filesystem;
@@ -40,6 +42,7 @@ mod types;
 
 pub use self::{
     fallback::FallbackCache,
+    hashed_module::HashedModuleData,
     shared::SharedCache,
     thread_local::ThreadLocalCache,
     types::{CacheError, ModuleCache},


### PR DESCRIPTION
This commit contains two notable changes:

* The VirtualFile trait is extended with a new as_owned_buffer() method.
  This allows cheap copying of file data if the file is already fully in
  memory, and enables optimisations for code that is aware of this
  functionality by allowing zero-copy cloning.
  This is especially useful for data that is already mmaped.

  The new method has an empty default impl, but is implemented for
  appropriate files (ReadOnlyFile, webc volume files).

* Modifies the Runtime::load_module method to take a new
  `HashedModuleData` struct

  This has multiple benefits:
  - HashedModuleData is safe by construction, thanks to private fields,
    so the hash it contains will always be valid for the module data.
    This removes a source of bugs due to passing a wrong hash for module
    data to module loaders etc.
  - HashedModuleData can be cheaply creating from a
    BinaryPackageCommand, preventing redundant cloning of data
  - The load_module method now receives owned data that is cheaply
    clonable.
    Previously it received a slice, which introduces the neccessity of
    cloning the data if it needs to be passed on to a different thread.

In combination this PR can significantly reduce memory usage for
high-concurrency scenarios.
