### PR TITLE
Update pre-release crate versions automatically

### DIFF
--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -3,6 +3,18 @@
 PREVIOUS_VERSION='6.0.0-alpha.2'
 NEXT_VERSION='6.0.0-beta.1'
 
+def make_prerelease_version(version: str) -> str:
+    parts = version.split('.', 2)
+    if len(parts) != 3:
+        raise ValueError(f"Invalid version format: {version} - {parts}")
+    major, minor, patch = parts
+    new_minor = str(int(major) * 100 + int(minor))
+    # patch may potentially contain a pre-release identifier, and that's OK
+    return f"0.{new_minor}.{patch}"
+
+PREVIOUS_PRERELEASE_VERSION = make_prerelease_version(PREVIOUS_VERSION)
+NEXT_PRERELEASE_VERSION = make_prerelease_version(NEXT_VERSION)
+
 import os
 import re
 
@@ -25,18 +37,23 @@ def replace_version(path):
     print(PREVIOUS_VERSION + " -> " + NEXT_VERSION + " (" + path + ")")
     replace(path, "version = \"" + PREVIOUS_VERSION +"\"", "version = \"" + NEXT_VERSION +"\"")
     replace(path, "version = \"=" + PREVIOUS_VERSION +"\"", "version = \"=" + NEXT_VERSION +"\"")
+    replace(path, "version = \"" + PREVIOUS_PRERELEASE_VERSION +"\"", "version = \"" + NEXT_PRERELEASE_VERSION +"\"")
+    replace(path, "version = \"=" + PREVIOUS_PRERELEASE_VERSION +"\"", "version = \"=" + NEXT_PRERELEASE_VERSION +"\"")
     pass
 
 def replace_version_py(path):
     print(PREVIOUS_VERSION + " -> " + NEXT_VERSION + " (" + path + ")")
     replace(path, "target_version = \"" + PREVIOUS_VERSION +"\"", "target_version = \"" + NEXT_VERSION +"\"")
+    replace(path, "target_version = \"" + PREVIOUS_PRERELEASE_VERSION +"\"", "target_version = \"" + NEXT_PRERELEASE_VERSION +"\"")
     pass
 
 def replace_version_iss(path):
     print(PREVIOUS_VERSION + " -> " + NEXT_VERSION + " (" + path + ")")
     replace(path, "AppVersion=" + PREVIOUS_VERSION, "AppVersion=" + NEXT_VERSION)
+    replace(path, "AppVersion=" + PREVIOUS_PRERELEASE_VERSION, "AppVersion=" + NEXT_PRERELEASE_VERSION)
     pass
 
+print ("Updating crate versions from " + PREVIOUS_VERSION + " to " + NEXT_VERSION + " (and prerelease versions from " + PREVIOUS_PRERELEASE_VERSION + " to " + NEXT_PRERELEASE_VERSION + ")")
 for root, dirs, files in os.walk("."):
     path = root.split(os.sep)
     # print((len(path) - 1) * '---', os.path.basename(root))


### PR DESCRIPTION
Pre-release crate versions are now automatically updated to 0.<major>0<minor>.patch (for example, 6.1.2 -> 0.601.2). This scheme works as long as we don't publish more than 100 minors for the same major version.