### PR TITLE
chore(compiler): Print only the `deterministic_id()` of the engine in `Debug` impl

### DIFF
--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -321,12 +321,7 @@ impl Engine {
 
 impl std::fmt::Debug for Engine {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Engine")
-            .field("inner", &self.inner)
-            .field("target", &self.target)
-            .field("engine_id", &self.engine_id)
-            .field("name", &self.name)
-            .finish()
+       write!(f, "{}", self.deterministic_id())
     }
 }
 

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -321,7 +321,7 @@ impl Engine {
 
 impl std::fmt::Debug for Engine {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-       write!(f, "{}", self.deterministic_id())
+        write!(f, "{}", self.deterministic_id())
     }
 }
 


### PR DESCRIPTION
As per title.