### PR TITLE
feat: add `enable_email` field to app.yaml configuration

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -147,8 +147,9 @@ impl CmdAppCreate {
             scaling: None,
             locality: None,
             redirect: None,
-            extra: IndexMap::new(),
             jobs: None,
+            enable_email: None,
+            extra: IndexMap::new(),
         }
     }
 

--- a/lib/config/src/app/mod.rs
+++ b/lib/config/src/app/mod.rs
@@ -97,6 +97,10 @@ pub struct AppConfigV1 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jobs: Option<Vec<Job>>,
 
+    /// Associate an email account with the app
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enable_email: Option<bool>,
+
     /// Capture extra fields for forwards compatibility.
     #[serde(flatten)]
     pub extra: IndexMap<String, serde_json::Value>,


### PR DESCRIPTION
this allows users to specify if they want an email address associated
with their app. When enabled, the following happens:

- a randomly generated email address is associated with the app
- env vars are set to allow the app to access the email credentials