### PR TITLE
CI: migrate workflows to cache v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,13 +196,13 @@ jobs:
           brew install gnu-tar
           echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
         if: startsWith(matrix.os, 'macos')
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ matrix.build }}-${{ matrix.target }}-cargo-${{ hashFiles('Cargo.lock') }}-v1
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: matrix.use_sccache
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache


### PR DESCRIPTION
GitHub runners now default to Node 20; actions/cache@v4 is the recommended version. Only workflow files changed—no functional impact.