### PR TITLE
feat(llvm): Add `asm_memory_buffer` to `LLVMCallbacks`

### DIFF
--- a/lib/cli-compiler/src/store.rs
+++ b/lib/cli-compiler/src/store.rs
@@ -294,6 +294,22 @@ impl CompilerOptions {
                             pos += file.write(&mem_buf_slice[pos..]).unwrap();
                         }
                     }
+
+                    fn asm_memory_buffer(
+                        &self,
+                        kind: &CompiledKind,
+                        asm_memory_buffer: &InkwellMemoryBuffer,
+                    ) {
+                        let mut path = self.debug_dir.clone();
+                        path.push(format!("{}.s", function_kind_to_filename(kind)));
+                        let mem_buf_slice = asm_memory_buffer.as_slice();
+                        let mut file = File::create(path)
+                            .expect("Error while creating debug object file from LLVM IR");
+                        let mut pos = 0;
+                        while pos < mem_buf_slice.len() {
+                            pos += file.write(&mem_buf_slice[pos..]).unwrap();
+                        }
+                    }
                 }
 
                 impl fmt::Debug for Callbacks {

--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -568,6 +568,21 @@ impl RuntimeOptions {
                             pos += file.write(&mem_buf_slice[pos..]).unwrap();
                         }
                     }
+                    fn asm_memory_buffer(
+                        &self,
+                        kind: &CompiledKind,
+                        asm_memory_buffer: &InkwellMemoryBuffer,
+                    ) {
+                        let mut path = self.debug_dir.clone();
+                        path.push(format!("{}.s", function_kind_to_filename(kind)));
+                        let mem_buf_slice = asm_memory_buffer.as_slice();
+                        let mut file = File::create(path)
+                            .expect("Error while creating debug object file from LLVM IR");
+                        let mut pos = 0;
+                        while pos < mem_buf_slice.len() {
+                            pos += file.write(&mem_buf_slice[pos..]).unwrap();
+                        }
+                    }
                 }
 
                 impl fmt::Debug for Callbacks {
@@ -777,6 +792,21 @@ impl BackendType {
                         let mut path = self.debug_dir.clone();
                         path.push(format!("{}.o", function_kind_to_filename(kind)));
                         let mem_buf_slice = memory_buffer.as_slice();
+                        let mut file = File::create(path)
+                            .expect("Error while creating debug object file from LLVM IR");
+                        let mut pos = 0;
+                        while pos < mem_buf_slice.len() {
+                            pos += file.write(&mem_buf_slice[pos..]).unwrap();
+                        }
+                    }
+                    fn asm_memory_buffer(
+                        &self,
+                        kind: &CompiledKind,
+                        asm_memory_buffer: &InkwellMemoryBuffer,
+                    ) {
+                        let mut path = self.debug_dir.clone();
+                        path.push(format!("{}.s", function_kind_to_filename(kind)));
+                        let mem_buf_slice = asm_memory_buffer.as_slice();
                         let mut file = File::create(path)
                             .expect("Error while creating debug object file from LLVM IR");
                         let mut pos = 0;

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -38,6 +38,7 @@ pub trait LLVMCallbacks: Debug + Send + Sync {
     fn preopt_ir(&self, function: &CompiledKind, module: &InkwellModule);
     fn postopt_ir(&self, function: &CompiledKind, module: &InkwellModule);
     fn obj_memory_buffer(&self, function: &CompiledKind, memory_buffer: &InkwellMemoryBuffer);
+    fn asm_memory_buffer(&self, function: &CompiledKind, memory_buffer: &InkwellMemoryBuffer);
 }
 
 #[derive(Debug, Clone)]

--- a/lib/compiler-llvm/src/trampoline/wasm.rs
+++ b/lib/compiler-llvm/src/trampoline/wasm.rs
@@ -165,6 +165,10 @@ impl FuncTrampoline {
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.obj_memory_buffer(&function, &memory_buffer);
+            let asm_buffer = target_machine
+                .write_to_memory_buffer(&module, FileType::Assembly)
+                .unwrap();
+            callbacks.asm_memory_buffer(&function, &asm_buffer);
         }
 
         let mem_buf_slice = memory_buffer.as_slice();
@@ -293,6 +297,10 @@ impl FuncTrampoline {
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.obj_memory_buffer(&function, &memory_buffer);
+            let asm_buffer = target_machine
+                .write_to_memory_buffer(&module, FileType::Assembly)
+                .unwrap();
+            callbacks.asm_memory_buffer(&function, &asm_buffer)
         }
 
         let mem_buf_slice = memory_buffer.as_slice();

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -406,6 +406,10 @@ impl FuncTranslator {
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.obj_memory_buffer(&function, &memory_buffer);
+            let asm_buffer = target_machine
+                .write_to_memory_buffer(&module, FileType::Assembly)
+                .unwrap();
+            callbacks.asm_memory_buffer(&function, &asm_buffer)
         }
 
         let mem_buf_slice = memory_buffer.as_slice();


### PR DESCRIPTION
Which is used by `LLVMCallbacks` implementers to be able to serialize the assembly of the generated functions.
