### PR TITLE
Add support for proper time in virtual-fs when targeting js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6239,6 +6239,7 @@ dependencies = [
  "tracing-test",
  "typetag",
  "wasmer-package",
+ "web-time",
  "webc",
 ]
 

--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -39,12 +39,8 @@ webc = { workspace = true, optional = true, features = ["v1"] }
 serde = { version = "1.0", default-features = false, features = [
 	"derive",
 ], optional = true }
-
-[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 getrandom = { version = "0.2" }
-
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+web-time = { version = "1.1", optional = true}
 
 [dev-dependencies]
 pretty_assertions.workspace = true
@@ -68,7 +64,10 @@ host-fs = [
 webc-fs = ["webc", "anyhow"]
 static-fs = ["webc", "anyhow"]
 enable-serde = ["typetag", "serde"]
-no-time = []
+js = [
+	"dep:web-time",
+	"getrandom/js",
+]
 # Enables memory tracking/limiting functionality for the in-memory filesystem.
 tracking = []
 futures = []

--- a/lib/virtual-fs/src/mem_fs/mod.rs
+++ b/lib/virtual-fs/src/mem_fs/mod.rs
@@ -7,7 +7,11 @@ mod stdio;
 use file::{File, FileHandle, ReadOnlyFile};
 pub use filesystem::FileSystem;
 pub use offloaded_file::OffloadBackingStore;
+#[cfg(not(feature = "js"))]
+use std::time::{SystemTime, UNIX_EPOCH};
 pub use stdio::{Stderr, Stdin, Stdout};
+#[cfg(feature = "js")]
+pub use web_time::{SystemTime, UNIX_EPOCH};
 
 use crate::Metadata;
 use std::{
@@ -155,18 +159,10 @@ impl Node {
 }
 
 fn time() -> u64 {
-    #[cfg(not(feature = "no-time"))]
-    {
-        // SAFETY: It's very unlikely that the system returns a time that
-        // is before `UNIX_EPOCH` :-).
-        std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64
-    }
-
-    #[cfg(feature = "no-time")]
-    {
-        0
-    }
+    // SAFETY: It's very unlikely that the system returns a time that
+    // is before `UNIX_EPOCH` :-).
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
 }

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -227,7 +227,7 @@ journal = ["tokio/fs", "wasmer-journal/log-file"]
 compiler = []
 
 js = [
-	"virtual-fs/no-time",
+	"virtual-fs/js",
 	"getrandom/js",
 	"chrono",
 	"js-sys",


### PR DESCRIPTION
This PR adds support for proper time responses in files/dirs when targeting JS environments (via the optional `web-time` crate and the new `virtual-fs/js` feature)