### PR TITLE
Fix a couple of webc FS issues

### DIFF
--- a/lib/virtual-fs/src/buffer_file.rs
+++ b/lib/virtual-fs/src/buffer_file.rs
@@ -69,13 +69,13 @@ impl AsyncRead for BufferFile {
 
 impl VirtualFile for BufferFile {
     fn last_accessed(&self) -> u64 {
-        0
+        1_000_000_000 // 1 second after epoch, since zero times are bad!
     }
     fn last_modified(&self) -> u64 {
-        0
+        1_000_000_000
     }
     fn created_time(&self) -> u64 {
-        0
+        1_000_000_000
     }
     fn size(&self) -> u64 {
         self.data.get_ref().len() as u64

--- a/lib/virtual-fs/src/cow_file.rs
+++ b/lib/virtual-fs/src/cow_file.rs
@@ -1,12 +1,16 @@
 //! Used for /dev/zero - infinitely returns zero
 //! which is useful for commands like `dd if=/dev/zero of=bigfile.img size=1G`
 
+use derive_more::Debug;
 use replace_with::replace_with_or_abort;
-use std::io::{self, *};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    io::{self, *},
+};
 
-use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite};
 
 use crate::{BufferFile, VirtualFile};
 
@@ -14,24 +18,21 @@ use crate::{BufferFile, VirtualFile};
 enum CowState {
     ReadOnly(Box<dyn VirtualFile + Send + Sync>),
     Copying {
-        inner: Box<dyn VirtualFile + Send + Sync>,
-        just_started: bool,
+        #[debug(skip)]
+        future: Pin<Box<dyn Future<Output = io::Result<BufferFile>> + Send + Sync>>,
+        requested_size: Option<u64>,
+        requested_position: Option<SeekFrom>,
+        cached_size: u64,
     },
-    Copied,
+    Copied(BufferFile),
 }
+
 impl CowState {
-    fn as_ref(&self) -> Option<&(dyn VirtualFile + Send + Sync)> {
+    fn inner_mut(&mut self) -> &mut (dyn VirtualFile + Send + Sync) {
         match self {
-            Self::ReadOnly(inner) => Some(inner.as_ref()),
-            Self::Copying { inner, .. } => Some(inner.as_ref()),
-            _ => None,
-        }
-    }
-    fn as_mut(&mut self) -> Option<&mut Box<dyn VirtualFile + Send + Sync>> {
-        match self {
-            Self::ReadOnly(inner) => Some(inner),
-            Self::Copying { inner, .. } => Some(inner),
-            _ => None,
+            Self::ReadOnly(inner) => inner.as_mut(),
+            Self::Copying { .. } => panic!("Cannot access inner file while copying"),
+            Self::Copied(inner) => inner,
         }
     }
 }
@@ -42,7 +43,6 @@ pub struct CopyOnWriteFile {
     last_modified: u64,
     created_time: u64,
     state: CowState,
-    buf: BufferFile,
 }
 
 impl CopyOnWriteFile {
@@ -52,80 +52,94 @@ impl CopyOnWriteFile {
             last_modified: inner.last_modified(),
             created_time: inner.created_time(),
             state: CowState::ReadOnly(inner),
-            buf: BufferFile::default(),
         }
     }
+
+    async fn copy(mut inner: Box<dyn VirtualFile + Send + Sync>) -> io::Result<BufferFile> {
+        let initial_position = inner.seek(SeekFrom::Current(0)).await?;
+        inner.seek(SeekFrom::Start(0)).await?;
+
+        let mut buffer = [0u8; 8192];
+        let mut buffer_file = BufferFile::default();
+        loop {
+            let read_bytes = inner.read_buf(&mut &mut buffer[..]).await?;
+            if read_bytes == 0 {
+                break;
+            }
+            buffer_file.data.write_all(&buffer[0..read_bytes])?;
+        }
+
+        buffer_file.seek(SeekFrom::Start(initial_position)).await?;
+
+        Ok(buffer_file)
+    }
+
     fn poll_copy_progress(&mut self, cx: &mut Context) -> Poll<io::Result<()>> {
-        if let CowState::Copying {
-            ref mut inner,
-            ref mut just_started,
-        } = &mut self.state
-        {
-            if *just_started {
-                *just_started = false;
-                if let Err(err) = Pin::new(inner.as_mut()).start_seek(SeekFrom::Start(0)) {
-                    return Poll::Ready(Err(err));
+        match self.state {
+            CowState::Copying {
+                ref mut future,
+                requested_size,
+                requested_position,
+                ..
+            } => match future.as_mut().poll(cx) {
+                Poll::Ready(Ok(mut buf)) => {
+                    if let Some(requested_size) = requested_size {
+                        buf.set_len(requested_size)?;
+                    }
+                    if let Some(requested_position) = requested_position {
+                        Pin::new(&mut buf).start_seek(requested_position)?;
+                    }
+                    self.state = CowState::Copied(buf);
+                    Poll::Ready(Ok(()))
                 }
-            }
-
-            match Pin::new(inner.as_mut()).poll_complete(cx).map_ok(|_| ()) {
-                Poll::Ready(Ok(())) => {}
-                p => return p,
-            }
-
-            let mut temp = [0u8; 8192];
-
-            loop {
-                let mut read_temp = ReadBuf::new(&mut temp);
-
-                match Pin::new(inner.as_mut()).poll_read(cx, &mut read_temp) {
-                    Poll::Pending => return Poll::Pending,
-                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-                    Poll::Ready(Ok(())) => {}
-                }
-
-                if read_temp.filled().is_empty() {
-                    break;
-                }
-
-                self.buf.data.write_all(read_temp.filled()).unwrap();
-            }
-            self.state = CowState::Copied;
+                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                Poll::Pending => Poll::Pending,
+            },
+            _ => Poll::Ready(Ok(())),
         }
-        Poll::Ready(Ok(()))
     }
-    fn poll_copy_start_and_progress(&mut self, cx: &mut Context) -> Poll<io::Result<()>> {
+
+    fn start_copy(&mut self) {
         replace_with_or_abort(&mut self.state, |state| match state {
             CowState::ReadOnly(inner) => CowState::Copying {
-                inner,
-                just_started: false,
+                cached_size: inner.size(),
+                requested_size: None,
+                requested_position: None,
+                future: Box::pin(Self::copy(inner)),
             },
             state => state,
         });
+    }
+
+    fn poll_copy_start_and_progress(&mut self, cx: &mut Context) -> Poll<io::Result<()>> {
+        self.start_copy();
         self.poll_copy_progress(cx)
     }
 }
 
 impl AsyncSeek for CopyOnWriteFile {
     fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
-        let data = Pin::new(&mut self.buf);
-        data.start_seek(position)?;
+        match self.state {
+            CowState::Copying {
+                ref mut requested_position,
+                ..
+            } => {
+                *requested_position = Some(position);
+                Ok(())
+            }
 
-        if let Some(inner) = self.state.as_mut() {
-            Pin::new(inner.as_mut()).start_seek(position)?;
+            _ => Pin::new(self.state.inner_mut()).start_seek(position),
         }
-
-        Ok(())
     }
 
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        match self.state.as_mut() {
-            Some(inner) => Pin::new(inner.as_mut()).poll_complete(cx),
-            None => {
-                let data = Pin::new(&mut self.buf);
-                data.poll_complete(cx)
-            }
+        match self.poll_copy_progress(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
         }
+
+        Pin::new(self.state.inner_mut()).poll_complete(cx)
     }
 }
 
@@ -140,8 +154,7 @@ impl AsyncWrite for CopyOnWriteFile {
             Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
             Poll::Ready(Ok(())) => {}
         }
-        let data = Pin::new(&mut self.buf);
-        data.poll_write(cx, buf)
+        Pin::new(self.state.inner_mut()).poll_write(cx, buf)
     }
 
     fn poll_write_vectored(
@@ -154,8 +167,7 @@ impl AsyncWrite for CopyOnWriteFile {
             Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
             Poll::Ready(Ok(())) => {}
         }
-        let data = Pin::new(&mut self.buf);
-        data.poll_write_vectored(cx, bufs)
+        Pin::new(self.state.inner_mut()).poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -163,8 +175,7 @@ impl AsyncWrite for CopyOnWriteFile {
             Poll::Ready(Ok(())) => {}
             p => return p,
         }
-        let data = Pin::new(&mut self.buf);
-        data.poll_flush(cx)
+        Pin::new(self.state.inner_mut()).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -172,8 +183,7 @@ impl AsyncWrite for CopyOnWriteFile {
             Poll::Ready(Ok(())) => {}
             p => return p,
         }
-        let data = Pin::new(&mut self.buf);
-        data.poll_shutdown(cx)
+        Pin::new(self.state.inner_mut()).poll_shutdown(cx)
     }
 }
 
@@ -187,13 +197,7 @@ impl AsyncRead for CopyOnWriteFile {
             Poll::Ready(Ok(())) => {}
             p => return p,
         }
-        match self.state.as_mut() {
-            Some(inner) => Pin::new(inner.as_mut()).poll_read(cx, buf),
-            None => {
-                let data = Pin::new(&mut self.buf);
-                data.poll_read(cx, buf)
-            }
-        }
+        Pin::new(self.state.inner_mut()).poll_read(cx, buf)
     }
 }
 
@@ -201,12 +205,15 @@ impl VirtualFile for CopyOnWriteFile {
     fn last_accessed(&self) -> u64 {
         self.last_accessed
     }
+
     fn last_modified(&self) -> u64 {
         self.last_modified
     }
+
     fn created_time(&self) -> u64 {
         self.created_time
     }
+
     fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         if let Some(atime) = atime {
             self.last_accessed = atime;
@@ -217,34 +224,122 @@ impl VirtualFile for CopyOnWriteFile {
 
         Ok(())
     }
+
     fn size(&self) -> u64 {
-        match self.state.as_ref() {
-            Some(inner) => inner.size(),
-            None => self.buf.size(),
+        match &self.state {
+            CowState::ReadOnly(inner) => inner.size(),
+            CowState::Copying {
+                requested_size: Some(size),
+                ..
+            } => *size,
+            CowState::Copying { cached_size, .. } => *cached_size,
+            CowState::Copied(buffer_file) => buffer_file.size(),
         }
     }
+
     fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
-        self.buf.set_len(new_size)
+        match self.state {
+            CowState::ReadOnly(_) => {
+                self.start_copy();
+                let CowState::Copying {
+                    ref mut requested_size,
+                    ..
+                } = self.state
+                else {
+                    unreachable!()
+                };
+                *requested_size = Some(new_size);
+            }
+
+            CowState::Copying {
+                ref mut requested_size,
+                ..
+            } => {
+                *requested_size = Some(new_size);
+            }
+
+            CowState::Copied(ref mut buf) => {
+                buf.set_len(new_size)?;
+            }
+        }
+
+        Ok(())
     }
+
     fn unlink(&mut self) -> crate::Result<()> {
-        self.buf.set_len(0)
+        // TODO: one can imagine interrupting an in-progress copy here
+        self.set_len(0)
     }
+
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         match self.poll_copy_progress(cx) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
             Poll::Ready(Ok(())) => {}
         }
-        match self.state.as_mut() {
-            Some(inner) => Pin::new(inner.as_mut()).poll_read_ready(cx),
-            None => {
-                let data: Pin<&mut BufferFile> = Pin::new(&mut self.buf);
-                data.poll_read_ready(cx)
-            }
-        }
+        Pin::new(self.state.inner_mut()).poll_read_ready(cx)
     }
 
     fn poll_write_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         self.poll_copy_progress(cx).map_ok(|_| 8192)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This is as weird a test as it gets, yes, but I'm (unashamedly!) cramming
+    // everything we know was wrong with the impl into this one test to save time.
+    #[tokio::test]
+    async fn cow_file_works() {
+        let mut data = Vec::with_capacity(16385);
+        for i in 0..16385 {
+            data.push(i as u8);
+        }
+        let inner = BufferFile {
+            data: Cursor::new(data),
+        };
+        let mut file = CopyOnWriteFile::new(Box::new(inner));
+
+        assert!(matches!(file.state, CowState::ReadOnly(_)));
+        assert_eq!(file.size(), 16385);
+        assert_ne!(file.created_time(), 0);
+        assert_ne!(file.last_accessed(), 0);
+        assert_ne!(file.last_modified(), 0);
+
+        let mut buf = [0u8; 4];
+        let read = file.read_exact(buf.as_mut()).await.unwrap();
+        assert_eq!(read, 4);
+        assert_eq!(buf, [0, 1, 2, 3]);
+        assert_eq!(file.seek(SeekFrom::Current(0)).await.unwrap(), 4);
+        assert!(matches!(file.state, CowState::ReadOnly { .. }));
+
+        // After this call, the file will "start" copying, but the actual
+        // future won't be polled until we try to read or write.
+        file.start_copy();
+        assert!(matches!(file.state, CowState::Copying { .. }));
+        assert_eq!(file.size(), 16385);
+
+        // The cached length should be returned while copying
+        file.set_len(16400).unwrap();
+        assert!(matches!(file.state, CowState::Copying { .. }));
+        assert_eq!(file.size(), 16400);
+
+        // Now try to read from the file, which will trigger the copy
+        let read = file.read_exact(buf.as_mut()).await.unwrap();
+        assert!(matches!(file.state, CowState::Copied { .. }));
+        assert_eq!(read, 4);
+        assert_eq!(buf, [4, 5, 6, 7]);
+        assert_eq!(file.seek(SeekFrom::Current(0)).await.unwrap(), 8);
+        assert_eq!(file.size(), 16400);
+
+        file.seek(SeekFrom::Start(16383)).await.unwrap();
+        let read = file.read_exact(buf.as_mut()).await.unwrap();
+        assert_eq!(read, 4);
+        // set_len should have filled the rest with zeroes
+        assert_eq!(buf, [(16383 % 256) as u8, (16384 % 256) as u8, 0, 0]);
+        assert_eq!(file.seek(SeekFrom::Current(0)).await.unwrap(), 16387);
+        assert!(matches!(file.state, CowState::Copied { .. }));
     }
 }

--- a/lib/wasix/src/journal/effector/syscalls/fd_close.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_close.rs
@@ -8,6 +8,8 @@ impl JournalEffector {
     pub fn apply_fd_close(ctx: &mut FunctionEnvMut<'_, WasiEnv>, fd: Fd) -> anyhow::Result<()> {
         let env = ctx.data();
         let (_, state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
+        // FIXME: the journal should use the same logic as the fd_close syscall,
+        // NOT invent its own!!
         if let Err(err) = state.fs.close_fd(fd) {
             bail!(
                 "journal restore error: failed to close descriptor (fd={}) - {}",


### PR DESCRIPTION
* Fix using CopyOnWriteFile with files larger than 8KiB
* Fix error when an OverlayFS::CopyOnWriteFile receives a flush/shutdown request while in read-only state

Note we have two things named CopyOnWriteFile, and this PR references both.