### PR TITLE
Return 1 second past epoch even when an explicit zero timestamp exist…

### DIFF
--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -76,8 +76,6 @@ impl FileSystem for WebcVolumeFileSystem {
             });
         }
 
-        println!("{path:?} -> {entries:?}");
-
         Ok(ReadDir::new(entries))
     }
 


### PR DESCRIPTION
…s in webc

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
