### PR TITLE
Update C API examples link in README to current documentation

### DIFF
--- a/lib/c-api/README.md
+++ b/lib/c-api/README.md
@@ -127,7 +127,7 @@ If you want to generate the library and headers in a friendly format as shown in
 make package-capi
 ```
 
-This command will generate a `package` directory, that you can then use easily in the [Wasmer C API examples](https://docs.wasmer.io/integrations/examples).
+This command will generate a `package` directory, that you can then use easily in the [Wasmer C API examples](https://wasmerio.github.io/wasmer/crates/doc/wasmer_c_api/).
 
 
 ## Testing


### PR DESCRIPTION
# Description

This PR replaces the outdated link to the Wasmer C API examples (https://docs.wasmer.io/integrations/examples) in lib/c-api/README.md with the current and correct documentation URL: https://wasmerio.github.io/wasmer/crates/doc/wasmer_c_api/. This ensures users can easily find up-to-date examples and API references.
