### PR TITLE
fix(lib/vm): update `corosensei` to `0.2.2` to fix UB on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,9 +902,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corosensei"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad067b451c08956709f8762dba86e049c124ea52858e3ab8d076ba2892caa437"
+checksum = "5d1ea1c2a2f898d2a6ff149587b8a04f41ee708d248c723f01ac2f0f01edc0b3"
 dependencies = [
  "autocfg",
  "cfg-if",

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 enum-iterator = "0.7.0"
 scopeguard = "1.1.0"
 region = { version = "3.0.2" }
-corosensei = { version = "0.2.0" }
+corosensei = { version = "0.2.2" }
 fnv = "1.0.3"
 # - Optional shared dependencies.
 tracing = { version = "0.1", optional = true }


### PR DESCRIPTION
# Description

This PR fixes potential UB on Windows that we encountered here: gear-tech/gear#4341. This problem has been fixed in `corosensei`: Amanieu/corosensei#48 (actual fix).

It would be nice to have release ASAP.

# UB Case

We are using wasmer 4.3.5 in [gear-tech/gear](https://github.com/gear-tech/gear) and found UB related to corosensei and partially related to wasmer. We create protected memory pages for lazy loading from disk when wasm is executed. To do this, we use vector exception handler (VEH) that is triggered when JIT code wasmer attempts to access protected memory pages. However, we ran into the problem that our VEH was involved in some UB. For some reason, when calling VEH, vtable of object `core::fmt::Arguments as &dyn tracing_core::field::Value` was corrupted, leading to `call 0x00` and calling the VEH inside the VEH. We were confused by this situation and investigated this memory corruption. We used WinDbg Time Travel Debugging to find the cause and found that `__chkstk` had corrupted the vtable. For example, we had vtable address `DE AD BE EF` and it was changed to `00 AD BE EF`. I have given screenshot of the decompiled `__chkstk` function (in IDA Pro this is called `alloca_probe`). We found that `mov byte ptr [r11], 0` wrote `0x00` to the vtable. The only reason this is possible is that the value of the segment register `gs:[0x10]` (StackLimit) is incorrect. We found this strange and remembered that wasmer caches the stack: <https://github.com/wasmerio/wasmer/blob/v4.3.5/lib/vm/src/trap/traphandlers.rs#L920>. Then we tried removing caching and AddressSanitizer stopped finding errors and UB disappeared. Then my colleague figured out that corosensei does not update `gs:[0x10]` in some cases with wasm traps. And we just finished execution with wasm trap in our UB case. He made commit that fixes this problem: <https://github.com/gear-tech/corosensei/commit/de854ee1b6c8ddbab3d81a3bd31b0ed7d2ef84b7>.

![image1](https://github.com/user-attachments/assets/9c5d821f-3c18-4f72-a5ad-a67e8ebd9c02)
![image2](https://github.com/user-attachments/assets/579c9254-1c9f-4a99-a11a-8af9bdf943a4)
