### PR TITLE
Change intrinsics::transmute to mem::transmute

### DIFF
--- a/lib/wasix/src/net/mod.rs
+++ b/lib/wasix/src/net/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    intrinsics::transmute,
+    mem::transmute,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     time::Duration,
 };


### PR DESCRIPTION
`std::intrinsics::transmute` has been deprected because it was moved to `std::mem::transmute`

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
