### PR TITLE
chore(deps): Upgrade some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3417,23 +3417,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3692,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ wasmer-cache = { version = "=6.0.1", path = "lib/cache", optional = true }
 wasmer-types = { version = "=6.0.1", path = "lib/types" }
 wasmer-middlewares = { version = "=6.0.1", path = "lib/middlewares", optional = true }
 
-# Third party dependencies
-cfg-if = "1.0"
 
+# Third party dependencies
+
+cfg-if = "1.0"
 tokio = { version = "1.39", features = [
 	"rt",
 	"rt-multi-thread",
@@ -97,6 +98,7 @@ shared-buffer = "0.1.4"
 loupe = "0.2.0"
 
 # Third-party crates
+num_enum = "0.7.3"
 dashmap = "6.0.1"
 http = "1.0.0"
 hyper = "1"

--- a/lib/journal/Cargo.toml
+++ b/lib/journal/Cargo.toml
@@ -38,7 +38,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 anyhow = "1.0"
 bytecheck = { version = "0.6.8" }
 lz4_flex = { version = "0.11" }
-num_enum = "0.5.7"
+num_enum.workspace = true
 serde_json = { version = "^1" }
 
 [dev-dependencies]

--- a/lib/wasi-types/Cargo.toml
+++ b/lib/wasi-types/Cargo.toml
@@ -26,7 +26,7 @@ wai-bindgen-gen-rust-wasm = "0.2.1"
 wai-bindgen-gen-core = "0.2.1"
 wai-parser = "0.2.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
-num_enum = "0.5.7"
+num_enum.workspace = true
 bitflags = "1.3.0"
 cfg-if = "1.0.0"
 anyhow = "1.0.66"

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -83,7 +83,7 @@ once_cell = "1.17.0"
 pin-project = "1.0.12"
 semver = "1.0.17"
 tempfile = "3.6.0"
-num_enum = "0.5.7"
+num_enum.workspace = true
 # Used by the WCGI runner
 wcgi = { version = "0.3.0", optional = true }
 wcgi-host = { version = "0.3.0", optional = true }
@@ -97,7 +97,7 @@ tower = { version = "0.4.13", features = ["make", "util"], optional = true }
 url = "2.3.1"
 bytecheck = "0.6.8"
 blake3 = "1.0"
-petgraph = "0.6.3"
+petgraph = "0.7.0"
 lz4_flex = { version = "0.11" }
 rayon = { version = "1.7.0", optional = true }
 wasm-bindgen = { version = "0.2.87", optional = true }


### PR DESCRIPTION
This helps reduce dependency duplication in other projects.

Also lifts num_enum to a workspace dependency.
