### PR TITLE
build: update setup-node to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,7 +112,7 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install wasm-pack
@@ -232,7 +232,7 @@ jobs:
           toolchain: ${{ env.MSRV }}
           target: x86_64-unknown-linux-gnu
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install libjavascriptcoregtk-4.0-dev


### PR DESCRIPTION
Bumps setup-node to v4 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/actions/setup-node/releases/tag/v4.0.0