### PR TITLE
Stop requiring __stack_pointer import for dynamic wasi main modules

### DIFF
--- a/lib/wasix/src/state/linker.rs
+++ b/lib/wasix/src/state/linker.rs
@@ -961,12 +961,11 @@ impl Linker {
             "Memory layout"
         );
 
-        let stack_pointer_import = main_module
-            .imports()
-            .find(|i| i.module() == "env" && i.name() == "__stack_pointer")
-            .ok_or(LinkError::MissingMainModuleImport(
-                "__stack_pointer".to_string(),
-            ))?;
+        let stack_pointer_import = ImportType::new(
+            "env".into(),
+            "__stack_pointer".into(),
+            ExternType::Global(GlobalType::new(Type::I32, Mutability::Var)),
+        );
 
         let stack_pointer = define_integer_global_import(store, &stack_pointer_import, stack_high)?;
 


### PR DESCRIPTION
This PR allows for dynamically linked wasix main modules that don't export a `__stack_pointer`. This is primarily useful for testing modules that don't do anything. 

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->



<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
