### PR TITLE
Allow loading the main module via dlopen

### DIFF
--- a/lib/wasix/src/state/linker.rs
+++ b/lib/wasix/src/state/linker.rs
@@ -289,8 +289,8 @@ use crate::{
 
 use super::{WasiModuleInstanceHandles, WasiState};
 
-// Module handle 0 is always the main module. Side modules get handles starting from 1.
-pub static MAIN_MODULE_HANDLE: ModuleHandle = ModuleHandle(0);
+// Module handle 1 is always the main module. Side modules get handles starting from the next one after the main module.
+pub static MAIN_MODULE_HANDLE: ModuleHandle = ModuleHandle(1);
 static INVALID_MODULE_HANDLE: ModuleHandle = ModuleHandle(u32::MAX);
 
 static MAIN_MODULE_MEMORY_BASE: u64 = 0;
@@ -1013,7 +1013,7 @@ impl Linker {
             main_module_dylink_info: dylink_section,
             side_modules: BTreeMap::new(),
             side_modules_by_name: HashMap::new(),
-            next_module_handle: 1,
+            next_module_handle: MAIN_MODULE_HANDLE.0 + 1,
             memory_allocator: MemoryAllocator::new(),
             heap_base: stack_high,
             symbol_resolution_records: HashMap::new(),


### PR DESCRIPTION
Calling dl_open with a `NULL` path now returns the handle of the main module. The PR also changes the dlopen handle of the main module to 1, because 0 means `search everywhere`.

<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
