### PR TITLE
Add ModuleCache::contains() + make compilation opts hashable

### DIFF
--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -515,7 +515,7 @@ pub struct UserAnnotations {
 }
 
 /// Suggested optimization that might be operated on the module when (and if) compiled.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, Default)]
 pub struct SuggestedCompilerOptimizations {
     pub pass_params: Option<bool>,
 }

--- a/lib/types/src/features.rs
+++ b/lib/types/src/features.rs
@@ -8,7 +8,7 @@ use wasmparser::{Parser, Payload, Validator, WasmFeatures};
 /// Features usually have a corresponding [WebAssembly proposal].
 ///
 /// [WebAssembly proposal]: https://github.com/WebAssembly/proposals
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
 #[derive(RkyvSerialize, RkyvDeserialize, Archive)]

--- a/lib/types/src/target.rs
+++ b/lib/types/src/target.rs
@@ -234,7 +234,7 @@ impl Default for Target {
 ///
 // Note: This type is a copy of `wasmer_config::package::SuggestedCompilerOptimizations`, so to
 // avoid dependencies on `wasmer_config` for crates that already depend on `wasmer_types`.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct UserCompilerOptimizations {
     /// Suggest the `pass_params` (also known as g0m0) optimization pass.
     pub pass_params: Option<bool>,

--- a/lib/wasix/src/runtime/module_cache/fallback.rs
+++ b/lib/wasix/src/runtime/module_cache/fallback.rs
@@ -85,6 +85,14 @@ where
         Err(primary_error)
     }
 
+    async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
+        if self.primary.contains(key, engine).await? {
+            return Ok(true);
+        }
+
+        self.fallback.contains(key, engine).await
+    }
+
     async fn save(
         &self,
         key: ModuleHash,
@@ -154,6 +162,10 @@ mod tests {
                     Err(e)
                 }
             }
+        }
+
+        async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
+            self.inner.contains(key, engine).await
         }
 
         async fn save(

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -90,6 +90,16 @@ impl ModuleCache for FileSystemCache {
             .unwrap()
     }
 
+    async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
+        let path = self.path(key, &engine.deterministic_id());
+        tokio::fs::try_exists(&path)
+            .await
+            .map_err(|e| CacheError::FileRead {
+                path: path.clone(),
+                error: e,
+            })
+    }
+
     #[tracing::instrument(level = "debug", skip_all, fields(% key))]
     async fn save(
         &self,

--- a/lib/wasix/src/runtime/module_cache/shared.rs
+++ b/lib/wasix/src/runtime/module_cache/shared.rs
@@ -32,6 +32,11 @@ impl ModuleCache for SharedCache {
         }
     }
 
+    async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
+        let key = (key, engine.deterministic_id().to_string());
+        Ok(self.modules.contains_key(&key))
+    }
+
     #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn save(
         &self,

--- a/lib/wasix/src/runtime/module_cache/thread_local.rs
+++ b/lib/wasix/src/runtime/module_cache/thread_local.rs
@@ -40,6 +40,11 @@ impl ModuleCache for ThreadLocalCache {
         }
     }
 
+    async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
+        let exists = self.lookup(key, &engine.deterministic_id()).is_some();
+        Ok(exists)
+    }
+
     #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn save(
         &self,

--- a/lib/wasix/src/runtime/module_cache/types.rs
+++ b/lib/wasix/src/runtime/module_cache/types.rs
@@ -26,6 +26,9 @@ pub trait ModuleCache: Debug {
     /// Load a module based on its hash.
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError>;
 
+    /// Check if a module is present in the cache.
+    async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError>;
+
     /// Save a module so it can be retrieved with [`ModuleCache::load()`] at a
     /// later time.
     ///
@@ -77,6 +80,10 @@ where
 {
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
         (**self).load(key, engine).await
+    }
+
+    async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
+        (**self).contains(key, engine).await
     }
 
     async fn save(


### PR DESCRIPTION
- **feat(wasix): Add ModuleCache::contains()**

Allows for checking if a module is already cached without loading it.

Also implement std::hash::Hash  for optimisation flag types, which is needed
downstream for module caching changes.


