### PR TITLE
Fix missing dependency in `wasmer-package` for `wasm` targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7107,6 +7107,7 @@ dependencies = [
  "hexdump",
  "ignore",
  "insta",
+ "libc",
  "pretty_assertions",
  "regex",
  "semver 1.0.26",

--- a/lib/package/Cargo.toml
+++ b/lib/package/Cargo.toml
@@ -34,6 +34,9 @@ tar.workspace = true
 tempfile.workspace = true
 ignore = "0.4"
 
+[target.'cfg(all(target_family = "wasm", target_os = "wasi"))'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 pretty_assertions.workspace = true
 tempfile.workspace = true


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

The following error occurred while building `wasmer-wasix` for the `wasm32-wasip1` target:
```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> lib/package/src/package/package.rs:652:9
    |
652 |         libc::open(
    |         ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> lib/package/src/package/package.rs:654:13
    |
654 |             libc::O_RDONLY,
    |             ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> lib/package/src/package/package.rs:665:30
    |
665 |             tv_sec: unsafe { libc::time(std::ptr::null_mut()) }, // now
    |                              ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> lib/package/src/package/package.rs:675:24
    |
675 |     let res = unsafe { libc::futimens(fd, timespec.as_ptr() as _) };
    |                        ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> lib/package/src/package/package.rs:664:9
    |
664 |         libc::timespec {
    |         ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> lib/package/src/package/package.rs:669:9
    |
669 |         libc::timespec {
    |         ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`
```

It appears that `wasmer-package` conditionally depends on `libc` when targeting `wasm32-wasip1`, which is not declared in `Cargo.toml`.

This PR addresses the issue by explicitly adding `libc` to the dependencies.