### PR TITLE
Make bundling webcs fail if there are major errors

### DIFF
--- a/lib/package/src/package/strictness.rs
+++ b/lib/package/src/package/strictness.rs
@@ -1,7 +1,5 @@
 use std::{fmt::Debug, path::Path};
 
-use anyhow::Error;
-
 use super::ManifestError;
 
 /// The strictness to use when working with a
@@ -22,13 +20,6 @@ pub enum Strictness {
 impl Strictness {
     pub(crate) fn is_strict(self) -> bool {
         matches!(self, Strictness::Strict)
-    }
-
-    pub(crate) fn on_error(&self, _path: &Path, error: Error) -> Result<(), Error> {
-        match self {
-            Strictness::Lossy => Ok(()),
-            Strictness::Strict => Err(error),
-        }
     }
 
     pub(crate) fn outside_base_directory(

--- a/lib/package/src/package/volume/fs.rs
+++ b/lib/package/src/package/volume/fs.rs
@@ -501,4 +501,32 @@ mod tests {
             "man page"
         );
     }
+
+    #[test]
+    fn directory_tree_propagates_errors() {
+        let temp = TempDir::new().unwrap();
+
+        // Create a directory that will be used as the base directory
+        let base_dir = temp.path().to_path_buf();
+
+        // Create a non-existent path that will cause `from_path_with_ignore` to fail
+        let non_existent_path = base_dir.join("non_existent_dir");
+
+        // Try to create a directory tree with a non-existent path
+        let result = directory_tree(std::iter::once(non_existent_path.clone()), &base_dir);
+
+        // Verify that the error is propagated
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("Unable to add"),
+            "Error message should indicate failure to add path: {}",
+            error
+        );
+        assert!(
+            error.to_string().contains("non_existent_dir"),
+            "Error message should include the problematic path: {}",
+            error
+        );
+    }
 }


### PR DESCRIPTION
The current behaviour silently omits fs entries from a webc if there is a problem reading that directory and strictness is set to loose. However, an I/O error when reading a directory is a critical error and should be reported to the user. This PR changes the behaviour to abort and report that error to the user. That behaviour mirrors the behaviour when including a single file.