### PR TITLE
Support `?Send` function environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6583,6 +6594,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cmake",
+ "derive-where",
  "derive_more 2.0.1",
  "hashbrown 0.11.2",
  "indexmap 2.9.0",
@@ -7186,6 +7198,7 @@ dependencies = [
  "corosensei",
  "crossbeam-queue",
  "dashmap 6.1.0",
+ "derive-where",
  "enum-iterator",
  "fnv",
  "indexmap 2.9.0",
@@ -7348,6 +7361,7 @@ dependencies = [
  "compiler-test-derive",
  "criterion",
  "crossbeam-queue",
+ "derive-where",
  "glob",
  "reqwest",
  "rustc_version 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7195,7 +7195,6 @@ dependencies = [
  "mach2",
  "memoffset 0.9.1",
  "more-asserts",
- "paste",
  "region",
  "scopeguard",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7195,6 +7195,7 @@ dependencies = [
  "mach2",
  "memoffset 0.9.1",
  "more-asserts",
+ "paste",
  "region",
  "scopeguard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ version = "6.0.1"
 [workspace.dependencies]
 # Repo-local crates
 wasmer-package = { version = "0.600.1", path = "lib/package" }
-wasmer-config = { path = "./lib/config" }
 wasmer-wasix = { path = "./lib/wasix" }
 
 # Wasmer-owned crates
@@ -250,8 +249,6 @@ coverage = []
 # slow without optimizations.
 [profile.dev.package.cranelift-codegen]
 opt-level = 3
-[profile.dev.package.regalloc2]
-opt-level = 3
 [profile.dev.package.wasmparser]
 opt-level = 3
 [profile.dev.package.rkyv]
@@ -263,8 +260,6 @@ opt-level = 3
 [profile.dev.package.sha2]
 opt-level = 3
 [profile.dev.package.xxhash-rust]
-opt-level = 3
-[profile.dev.package.digest]
 opt-level = 3
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.39", features = [
 	"macros",
 ], optional = true }
 crossbeam-queue = "0.3.8"
+derive-where = "1.5.0"
 
 [workspace]
 members = [

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -51,6 +51,7 @@ loupe = { workspace = true, optional = true, features = [
 ] }
 paste = "1.0.15"
 derive_more = { workspace = true, features = ["from", "debug"] }
+derive-where = "1.5.0"
 
 # Dependencies and Development Dependencies for `sys`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/lib/api/src/backend/sys/entities/function/env.rs
+++ b/lib/api/src/backend/sys/entities/function/env.rs
@@ -64,7 +64,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Convert it into a `FunctionEnvMut`
-    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<T>
+    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<'_, T>
     where
         T: Any + Send + 'static + Sized,
     {
@@ -165,7 +165,7 @@ impl<T: Send + 'static> FunctionEnvMut<'_, T> {
     }
 
     /// Borrows a new mutable reference of both the attached Store and host state
-    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut) {
+    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut<'_>) {
         let data = self.func_env.as_mut(&mut self.store_mut) as *mut T;
         // telling the borrow check to close his eyes here
         // this is still relatively safe to do as func_env are

--- a/lib/api/src/backend/sys/entities/function/mod.rs
+++ b/lib/api/src/backend/sys/entities/function/mod.rs
@@ -545,7 +545,7 @@ macro_rules! impl_host_function {
                 }
             }
 
-            func_wrapper::< $( $x, )* Rets, Object, RetsAsResult, Func > as _
+            func_wrapper::< $( $x, )* Rets, RetsAsResult, Object, Func > as _
 
         }
 
@@ -582,7 +582,7 @@ macro_rules! impl_host_function {
             /// This is a function that wraps the real host
             /// function. Its address will be used inside the
             /// runtime.
-            unsafe extern "C" fn func_wrapper<T: Send + 'static, Object, $( $x, )* Rets, RetsAsResult, Func>( env: &StaticFunction<Func, T>, $( $x: <$x::Native as NativeWasmType>::Abi, )* ) -> Rets::CStruct
+            unsafe extern "C" fn func_wrapper<T: Send + 'static, $( $x, )* Rets, RetsAsResult, Object, Func>( env: &StaticFunction<Func, T>, $( $x: <$x::Native as NativeWasmType>::Abi, )* ) -> Rets::CStruct
                 where
                 $( $x: FromToNativeWasmType, )*
                 Rets: WasmTypeList,
@@ -611,7 +611,7 @@ macro_rules! impl_host_function {
   	                Err(panic) => wasmer_vm::resume_panic(panic),
   	            }
             }
-            func_wrapper::< T, $( $x, )* Rets, RetsAsResult, Func > as _
+            func_wrapper::< T, $( $x, )* Rets, RetsAsResult, Object, Func > as _
         }
 
         #[allow(non_snake_case)]

--- a/lib/api/src/backend/sys/entities/function/mod.rs
+++ b/lib/api/src/backend/sys/entities/function/mod.rs
@@ -473,9 +473,9 @@ where
 /// Represents a low-level Wasm static host function. See
 /// [`crate::Function::new_typed`] and
 /// [`crate::Function::new_typed_with_env`] to learn more.
-pub(crate) struct StaticFunction<F, T> {
+pub(crate) struct StaticFunction<F, T, Object> {
     pub(crate) raw_store: *mut u8,
-    pub(crate) env: FunctionEnv<T>,
+    pub(crate) env: FunctionEnv<T, Object>,
     pub(crate) func: F,
 }
 

--- a/lib/api/src/backend/sys/entities/module.rs
+++ b/lib/api/src/backend/sys/entities/module.rs
@@ -139,11 +139,11 @@ impl Module {
     }
 
     #[allow(clippy::result_large_err)]
-    pub(crate) fn instantiate(
+    pub(crate) fn instantiate<Store: AsStoreMut>(
         &self,
-        store: &mut impl AsStoreMut,
+        store: &mut Store,
         imports: &[crate::Extern],
-    ) -> Result<VMInstance, InstantiationError> {
+    ) -> Result<VMInstance<Store::Object>, InstantiationError> {
         if !self.artifact.allocated() {
             // Return an error mentioning that the artifact is compiled for a different
             // platform.

--- a/lib/api/src/backend/sys/entities/store/mod.rs
+++ b/lib/api/src/backend/sys/entities/store/mod.rs
@@ -114,7 +114,7 @@ impl crate::BackendStore {
     }
 }
 
-impl crate::Store {
+impl<Object> crate::Store<Object> {
     /// Consume [`self`] into [`crate::backend::sys::store::Store`].
     pub(crate) fn into_sys(self) -> crate::backend::sys::store::Store {
         self.inner.store.into_sys()

--- a/lib/api/src/backend/sys/entities/store/mod.rs
+++ b/lib/api/src/backend/sys/entities/store/mod.rs
@@ -42,6 +42,8 @@ impl Store {
 }
 
 impl AsEngineRef for Store {
+    type Object = std::convert::Infallible;
+
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef::new(&self.engine)
     }

--- a/lib/api/src/backend/sys/entities/store/obj.rs
+++ b/lib/api/src/backend/sys/entities/store/obj.rs
@@ -2,9 +2,9 @@ use wasmer_vm::StoreId;
 
 use crate::AsStoreMut;
 
-impl crate::StoreObjects {
+impl<Object> crate::StoreObjects<Object> {
     /// Consume store objects into [`crate::backend::sys::store::StoreObjects`].
-    pub fn into_sys(self) -> crate::backend::sys::store::StoreObjects {
+    pub fn into_sys(self) -> crate::backend::sys::store::StoreObjects<Object> {
         match self {
             Self::Sys(s) => s,
             _ => panic!("Not a `sys` store!"),
@@ -12,7 +12,7 @@ impl crate::StoreObjects {
     }
 
     /// Convert a reference to store objects into a reference [`crate::backend::sys::store::StoreObjects`].
-    pub fn as_sys(&self) -> &crate::backend::sys::store::StoreObjects {
+    pub fn as_sys(&self) -> &crate::backend::sys::store::StoreObjects<Object> {
         match self {
             Self::Sys(s) => s,
             _ => panic!("Not a `sys` store!"),
@@ -20,7 +20,7 @@ impl crate::StoreObjects {
     }
 
     /// Convert a mutable reference to store objects into a mutable reference [`crate::backend::sys::store::StoreObjects`].
-    pub fn as_sys_mut(&mut self) -> &mut crate::backend::sys::store::StoreObjects {
+    pub fn as_sys_mut(&mut self) -> &mut crate::backend::sys::store::StoreObjects<Object> {
         match self {
             Self::Sys(s) => s,
             _ => panic!("Not a `sys` store!"),

--- a/lib/api/src/entities/engine/engine_ref.rs
+++ b/lib/api/src/entities/engine/engine_ref.rs
@@ -25,6 +25,9 @@ impl<'a> EngineRef<'a> {
 
 /// Helper trait for a value that is convertible to a [`EngineRef`].
 pub trait AsEngineRef {
+    // TODO maybe this should be called `StoreObject`
+    type Object;
+
     /// Create an [`EngineRef`] pointing to the underlying context.
     fn as_engine_ref(&self) -> EngineRef<'_>;
 
@@ -32,12 +35,14 @@ pub trait AsEngineRef {
     ///
     /// NOTE: this function will return [`None`] if the [`AsEngineRef`] implementor is not an
     /// actual [`crate::Store`].
-    fn maybe_as_store(&self) -> Option<StoreRef<'_>> {
+    fn maybe_as_store(&self) -> Option<StoreRef<'_, Self::Object>> {
         None
     }
 }
 
 impl AsEngineRef for EngineRef<'_> {
+    type Object = std::convert::Infallible;
+
     #[inline]
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef { inner: self.inner }
@@ -49,17 +54,21 @@ where
     P: std::ops::Deref,
     P::Target: AsEngineRef,
 {
+    type Object = <P::Target as AsEngineRef>::Object;
+
     #[inline]
     fn as_engine_ref(&self) -> EngineRef<'_> {
         (**self).as_engine_ref()
     }
 
-    fn maybe_as_store(&self) -> Option<StoreRef<'_>> {
+    fn maybe_as_store(&self) -> Option<StoreRef<'_, Self::Object>> {
         (**self).maybe_as_store()
     }
 }
 
 impl AsEngineRef for Engine {
+    type Object = std::convert::Infallible;
+
     #[inline]
     fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef { inner: self }

--- a/lib/api/src/entities/engine/engine_ref.rs
+++ b/lib/api/src/entities/engine/engine_ref.rs
@@ -26,6 +26,7 @@ impl<'a> EngineRef<'a> {
 /// Helper trait for a value that is convertible to a [`EngineRef`].
 pub trait AsEngineRef {
     // TODO maybe this should be called `StoreObject`
+    /// The type of objects associated with this engine seen as a store, if any.
     type Object;
 
     /// Create an [`EngineRef`] pointing to the underlying context.

--- a/lib/api/src/entities/engine/engine_ref.rs
+++ b/lib/api/src/entities/engine/engine_ref.rs
@@ -61,7 +61,7 @@ where
 
 impl AsEngineRef for Engine {
     #[inline]
-    fn as_engine_ref(&self) -> EngineRef {
+    fn as_engine_ref(&self) -> EngineRef<'_> {
         EngineRef { inner: self }
     }
 }

--- a/lib/api/src/entities/engine/inner.rs
+++ b/lib/api/src/entities/engine/inner.rs
@@ -12,7 +12,10 @@ use crate::{
     BackendKind, IntoBytes, Store,
 };
 
-gen_rt_ty!(Engine @derives Debug, Clone);
+gen_rt_ty! {
+    #[derive(Debug, Clone)]
+    pub(crate) BackendEngine(engine::Engine);
+}
 
 impl BackendEngine {
     /// Returns the deterministic id of this engine.

--- a/lib/api/src/entities/exception/exnref/inner.rs
+++ b/lib/api/src/entities/exception/exnref/inner.rs
@@ -5,7 +5,10 @@ use crate::macros::backend::{gen_rt_ty, match_rt};
 use crate::vm::VMExceptionRef;
 use crate::StoreRef;
 
-gen_rt_ty!(ExceptionRef @derives derive_more::From, Debug, Clone ; @path exception);
+gen_rt_ty! {
+    #[derive(derive_more::From, Debug, Clone)]
+    pub(crate) BackendExceptionRef(exception::ExceptionRef);
+}
 
 impl BackendExceptionRef {
     /// Make a new extern reference

--- a/lib/api/src/entities/exception/inner.rs
+++ b/lib/api/src/entities/exception/inner.rs
@@ -10,10 +10,11 @@ use crate::{
 /// It consists of an individual value and a flag indicating whether it is mutable.
 ///
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#global-instances>
-gen_rt_ty!(Exception
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Debug, Clone, PartialEq, Eq, derive_more::From
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+    pub(crate) BackendException(exception::Exception);
+}
 
 impl BackendException {
     /// Create a new exception with the given tag type and payload.

--- a/lib/api/src/entities/exports.rs
+++ b/lib/api/src/entities/exports.rs
@@ -175,7 +175,7 @@ impl Exports {
     }
 
     /// Get an iterator over the exports.
-    pub fn iter(&self) -> ExportsIterator<impl Iterator<Item = (&String, &Extern)>> {
+    pub fn iter(&self) -> ExportsIterator<'_, impl Iterator<Item = (&String, &Extern)>> {
         ExportsIterator {
             iter: self.map.iter(),
         }

--- a/lib/api/src/entities/external/extref/inner.rs
+++ b/lib/api/src/entities/external/extref/inner.rs
@@ -5,7 +5,10 @@ use crate::macros::backend::{gen_rt_ty, match_rt};
 use crate::vm::VMExternRef;
 use crate::StoreRef;
 
-gen_rt_ty!(ExternRef @derives derive_more::From, Debug, Clone ; @path external);
+gen_rt_ty! {
+    #[derive(derive_more::From, Debug, Clone)]
+    pub(crate) BackendExternRef(external::ExternRef);
+}
 
 impl BackendExternRef {
     /// Make a new extern reference

--- a/lib/api/src/entities/function/env/inner.rs
+++ b/lib/api/src/entities/function/env/inner.rs
@@ -8,10 +8,10 @@ gen_rt_ty! {
     /// An opaque reference to a function environment.
     /// The function environment data is owned by the `Store`.
     #[derive(Debug, derive_more::From)]
-    pub BackendFunctionEnv<T, Object>(function::env::FunctionEnv<T, Object>);
+    pub BackendFunctionEnv<T>(function::env::FunctionEnv<T>);
 }
 
-impl<T, Object> Clone for BackendFunctionEnv<T, Object> {
+impl<T> Clone for BackendFunctionEnv<T> {
     fn clone(&self) -> Self {
         match self {
             #[cfg(feature = "sys")]
@@ -31,9 +31,9 @@ impl<T, Object> Clone for BackendFunctionEnv<T, Object> {
     }
 }
 
-impl<T, Object> BackendFunctionEnv<T, Object> {
+impl<T> BackendFunctionEnv<T> {
     /// Make a new FunctionEnv
-    pub fn new(store: &mut impl AsStoreMut<Object = Object>, value: T) -> Self
+    pub fn new(store: &mut impl AsStoreMut, value: T) -> Self
     where
         T: Any + Send + 'static + Sized,
     {
@@ -145,7 +145,7 @@ impl<T: Send + 'static, Object> BackendFunctionEnvMut<'_, T, Object> {
     }
 
     /// Borrows a new mutable reference
-    pub fn as_mut(&mut self) -> FunctionEnvMut<'_, T> {
+    pub fn as_mut(&mut self) -> FunctionEnvMut<'_, T, Object> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(ref mut f) => BackendFunctionEnvMut::Sys(f.as_mut()).into(),
@@ -163,7 +163,7 @@ impl<T: Send + 'static, Object> BackendFunctionEnvMut<'_, T, Object> {
     }
 
     /// Borrows a new mutable reference of both the attached Store and host state
-    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut<'_>) {
+    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut<'_, Object>) {
         match_rt!(on self => f {
             f.data_and_store_mut()
         })
@@ -181,7 +181,7 @@ impl<T, Object> AsStoreRef for BackendFunctionEnvMut<'_, T, Object> {
 }
 
 impl<T, Object> AsStoreMut for BackendFunctionEnvMut<'_, T, Object> {
-    fn as_store_mut(&mut self) -> StoreMut<'_> {
+    fn as_store_mut(&mut self) -> StoreMut<'_, Object> {
         match_rt!(on self => s {
             s.as_store_mut()
         })

--- a/lib/api/src/entities/function/env/inner.rs
+++ b/lib/api/src/entities/function/env/inner.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use std::{any::Any, marker::PhantomData};
 
+use wasmer_types::Upcast;
+
 gen_rt_ty! {
     /// An opaque reference to a function environment.
     /// The function environment data is owned by the `Store`.
@@ -33,10 +35,7 @@ impl<T> Clone for BackendFunctionEnv<T> {
 
 impl<T> BackendFunctionEnv<T> {
     /// Make a new FunctionEnv
-    pub fn new(store: &mut impl AsStoreMut, value: T) -> Self
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn new(store: &mut impl AsStoreMut<Object: Upcast<T>>, value: T) -> Self {
         match store.as_store_mut().inner.store {
             #[cfg(feature = "sys")]
             crate::BackendStore::Sys(_) => Self::Sys(
@@ -74,20 +73,14 @@ impl<T> BackendFunctionEnv<T> {
     //}
 
     /// Get the data as reference
-    pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef) -> &'a T
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef<Object: Upcast<T>>) -> &'a T {
         match_rt!(on self => f {
             f.as_ref(store)
         })
     }
 
     /// Get the data as mutable
-    pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut) -> &'a mut T
-    where
-        T: Any + Send + 'static + Sized,
-    {
+    pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut<Object: Upcast<T>>) -> &'a mut T {
         match_rt!(on self => s {
             s.as_mut(store)
         })
@@ -111,7 +104,7 @@ gen_rt_ty! {
     pub BackendFunctionEnvMut<'a, T, Object>(function::env::FunctionEnvMut<'a, T, Object>);
 }
 
-impl<T: Send + 'static, Object> BackendFunctionEnvMut<'_, T, Object> {
+impl<T, Object: Upcast<T>> BackendFunctionEnvMut<'_, T, Object> {
     /// Returns a reference to the host state in this function environement.
     pub fn data(&self) -> &T {
         match_rt!(on self => f {
@@ -194,10 +187,7 @@ impl<T, Object> AsStoreMut for BackendFunctionEnvMut<'_, T, Object> {
     }
 }
 
-impl<T, Object> std::fmt::Debug for BackendFunctionEnvMut<'_, T, Object>
-where
-    T: Send + std::fmt::Debug + 'static,
-{
+impl<T: std::fmt::Debug, Object: Upcast<T>> std::fmt::Debug for BackendFunctionEnvMut<'_, T, Object> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match_rt!(on self => s {
             write!(f, "{s:?}")

--- a/lib/api/src/entities/function/env/inner.rs
+++ b/lib/api/src/entities/function/env/inner.rs
@@ -111,7 +111,7 @@ impl<T> BackendFunctionEnv<T> {
     }
 
     /// Convert it into a `FunctionEnvMut`
-    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<T>
+    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<'_, T>
     where
         T: Any + Send + 'static + Sized,
     {
@@ -199,7 +199,7 @@ impl<T: Send + 'static> BackendFunctionEnvMut<'_, T> {
     }
 
     /// Borrows a new mutable reference of both the attached Store and host state
-    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut) {
+    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut<'_>) {
         match_rt!(on self => f {
             f.data_and_store_mut()
         })

--- a/lib/api/src/entities/function/env/mod.rs
+++ b/lib/api/src/entities/function/env/mod.rs
@@ -7,15 +7,15 @@ use std::{any::Any, fmt::Debug, marker::PhantomData};
 #[derive(Debug, derive_more::From)]
 /// An opaque reference to a function environment.
 /// The function environment data is owned by the `Store`.
-pub struct FunctionEnv<T>(pub(crate) BackendFunctionEnv<T>);
+pub struct FunctionEnv<T, Object>(pub(crate) BackendFunctionEnv<T, Object>);
 
-impl<T> Clone for FunctionEnv<T> {
+impl<T, Object> Clone for FunctionEnv<T, Object> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<T> FunctionEnv<T> {
+impl<T, Object> FunctionEnv<T, Object> {
     /// Make a new FunctionEnv
     pub fn new(store: &mut impl AsStoreMut, value: T) -> Self
     where
@@ -30,7 +30,7 @@ impl<T> FunctionEnv<T> {
     //}
 
     /// Get the data as reference
-    pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef) -> &'a T
+    pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef<Object = Object>) -> &'a T
     where
         T: Any + Send + 'static + Sized,
     {
@@ -38,7 +38,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Get the data as mutable
-    pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut) -> &'a mut T
+    pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut<Object = Object>) -> &'a mut T
     where
         T: Any + Send + 'static + Sized,
     {
@@ -46,7 +46,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Convert it into a `FunctionEnvMut`
-    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<'_, T>
+    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<'_, T, Object>
     where
         T: Any + Send + 'static + Sized,
     {

--- a/lib/api/src/entities/function/env/mod.rs
+++ b/lib/api/src/entities/function/env/mod.rs
@@ -46,7 +46,7 @@ impl<T> FunctionEnv<T> {
     }
 
     /// Convert it into a `FunctionEnvMut`
-    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<T>
+    pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<'_, T>
     where
         T: Any + Send + 'static + Sized,
     {
@@ -80,7 +80,7 @@ impl<T: Send + 'static> FunctionEnvMut<'_, T> {
     }
 
     /// Borrows a new mutable reference of both the attached Store and host state
-    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut) {
+    pub fn data_and_store_mut(&mut self) -> (&mut T, StoreMut<'_>) {
         self.0.data_and_store_mut()
     }
 }

--- a/lib/api/src/entities/function/env/mod.rs
+++ b/lib/api/src/entities/function/env/mod.rs
@@ -4,7 +4,7 @@ pub(crate) use inner::*;
 use crate::{macros::backend::match_rt, AsStoreMut, AsStoreRef, StoreMut, StoreRef};
 use std::{any::Any, fmt::Debug, marker::PhantomData};
 
-use wasmer_types::Upcast;
+use wasmer_types::{BoxStoreObject, Upcast};
 
 #[derive(Debug, derive_more::From)]
 /// An opaque reference to a function environment.
@@ -49,7 +49,7 @@ impl<T> FunctionEnv<T> {
 
 /// A temporary handle to a [`FunctionEnv`].
 #[derive(derive_more::From)]
-pub struct FunctionEnvMut<'a, T, Object>(pub(crate) BackendFunctionEnvMut<'a, T, Object>);
+pub struct FunctionEnvMut<'a, T, Object = BoxStoreObject>(pub(crate) BackendFunctionEnvMut<'a, T, Object>);
 
 impl<T, Object: Upcast<T>> FunctionEnvMut<'_, T, Object> {
     /// Returns a reference to the host state in this function environement.

--- a/lib/api/src/entities/function/host/imp.rs
+++ b/lib/api/src/entities/function/host/imp.rs
@@ -12,12 +12,12 @@ use wasmer_types::{NativeWasmType, RawValue};
 macro_rules! impl_host_function {
     ([$c_struct_representation:ident] $c_struct_name:ident, $( $x:ident ),* ) => {
         #[allow(unused_parens)]
-        impl< $( $x, )* Rets, RetsAsResult, T, Func> crate::HostFunction<T, ( $( $x ),* ), Rets, WithEnv> for Func where
+        impl< $( $x, )* Rets, RetsAsResult, T, Func, Object> crate::HostFunction<T, Object, ( $( $x ),* ), Rets, WithEnv> for Func where
             $( $x: FromToNativeWasmType, )*
             Rets: WasmTypeList,
             RetsAsResult: IntoResult<Rets>,
             T: Send + 'static,
-            Func: Fn(FunctionEnvMut<'_, T>, $( $x , )*) -> RetsAsResult + 'static,
+            Func: Fn(FunctionEnvMut<'_, T, Object>, $( $x , )*) -> RetsAsResult + 'static,
         {
             #[allow(non_snake_case)]
             fn function_callback(&self, rt: crate::backend::BackendKind) -> crate::vm::VMFunctionCallback {
@@ -70,8 +70,8 @@ macro_rules! impl_host_function {
 
         // Implement `HostFunction` for a function that has the same arity than the tuple.
         #[allow(unused_parens)]
-        impl< $( $x, )* Rets, RetsAsResult, Func >
-            crate::HostFunction<(), ( $( $x ),* ), Rets, WithoutEnv>
+        impl< $( $x, )* Rets, RetsAsResult, Func, Object >
+            crate::HostFunction<(), Object, ( $( $x ),* ), Rets, WithoutEnv>
         for
             Func
         where

--- a/lib/api/src/entities/function/host/imp.rs
+++ b/lib/api/src/entities/function/host/imp.rs
@@ -85,11 +85,11 @@ macro_rules! impl_host_function {
                 paste::paste! {
                     match rt {
                         #[cfg(feature = "sys")]
-                        crate::backend::BackendKind::Headless => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>](self)),
+                        crate::backend::BackendKind::Headless => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>]::<$($x,)* Rets, RetsAsResult, Object, _>(self)),
                         #[cfg(feature = "llvm")]
-                        crate::backend::BackendKind::LLVM => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>](self)),
+                        crate::backend::BackendKind::LLVM => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>]::<$($x,)* Rets, RetsAsResult, Object, _>(self)),
                         #[cfg(feature = "cranelift")]
-                        crate::backend::BackendKind::Cranelift => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>](self)),
+                        crate::backend::BackendKind::Cranelift => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>]::<$($x,)* Rets, RetsAsResult, Object, _>(self)),
                         #[cfg(feature = "singlepass")]
                         crate::backend::BackendKind::Singlepass => crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>](self)),
                         #[cfg(feature = "js")]
@@ -110,7 +110,7 @@ macro_rules! impl_host_function {
             #[cfg(feature = "sys")]
             fn function_callback_sys(&self) -> crate::vm::VMFunctionCallback {
                 paste::paste! {
-                    crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>](self))
+                    crate::vm::VMFunctionCallback::Sys(crate::backend::sys::function::[<gen_fn_callback_ $c_struct_name:lower _no_env>]::<$($x,)* Rets, RetsAsResult, Object, _>(self))
                 }
             }
 

--- a/lib/api/src/entities/function/host/mod.rs
+++ b/lib/api/src/entities/function/host/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 /// can be used as host function. To uphold this statement, it is
 /// necessary for a function to be transformed into a
 /// `VMFunctionCallback`.
-pub trait HostFunction<T, Args, Rets, Kind>
+pub trait HostFunction<T, Object, Args, Rets, Kind>
 where
     Args: WasmTypeList,
     Rets: WasmTypeList,

--- a/lib/api/src/entities/function/inner.rs
+++ b/lib/api/src/entities/function/inner.rs
@@ -87,8 +87,8 @@ impl BackendFunction {
     /// });
     /// ```
     #[inline]
-    pub fn new_with_env<FT, F, T: Send + 'static>(
-        store: &mut impl AsStoreMut,
+    pub fn new_with_env<Object, FT, F, T>(
+        store: &mut impl AsStoreMut<Object>,
         env: &FunctionEnv<T>,
         ty: FT,
         func: F,
@@ -197,8 +197,8 @@ impl BackendFunction {
     /// let f = Function::new_typed_with_env(&mut store, &env, sum);
     /// ```
     #[inline]
-    pub fn new_typed_with_env<T: Send + 'static, F, Args, Rets>(
-        store: &mut impl AsStoreMut,
+    pub fn new_typed_with_env<Object, T, F, Args, Rets>(
+        store: &mut impl AsStoreMut<Object>,
         env: &FunctionEnv<T>,
         func: F,
     ) -> Self

--- a/lib/api/src/entities/function/inner.rs
+++ b/lib/api/src/entities/function/inner.rs
@@ -1,4 +1,4 @@
-use wasmer_types::{FunctionType, RawValue};
+use wasmer_types::{FunctionType, RawValue, Upcast};
 
 use crate::{
     error::RuntimeError,
@@ -37,7 +37,7 @@ impl BackendFunction {
     /// If you know the signature of the host function at compile time,
     /// consider using [`Self::new_typed`] for less runtime overhead.
     #[inline]
-    pub fn new<FT, F>(store: &mut impl AsStoreMut, ty: FT, func: F) -> Self
+    pub fn new<FT, F>(store: &mut impl AsStoreMut<Object: Upcast<()>>, ty: FT, func: F) -> Self
     where
         FT: Into<FunctionType>,
         F: Fn(&[Value]) -> Result<Vec<Value>, RuntimeError> + 'static + Send + Sync,
@@ -145,7 +145,7 @@ impl BackendFunction {
     #[inline]
     pub fn new_typed<S, F, Args, Rets>(store: &mut S, func: F) -> Self
     where
-        S: AsStoreMut,
+        S: AsStoreMut<Object: Upcast<()>>,
         F: HostFunction<(), S::Object, Args, Rets, WithoutEnv> + 'static + Send + Sync,
         Args: WasmTypeList,
         Rets: WasmTypeList,

--- a/lib/api/src/entities/function/inner.rs
+++ b/lib/api/src/entities/function/inner.rs
@@ -25,10 +25,11 @@ use crate::{
 ///   with native functions. Attempting to create a native `Function` with one will
 ///   result in a panic.
 ///   [Closures as host functions tracking issue](https://github.com/wasmerio/wasmer/issues/1840)
-gen_rt_ty!(Function
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Debug, Clone, PartialEq, Eq
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) BackendFunction(function::Function);
+}
 
 impl BackendFunction {
     /// Creates a new host `Function` (dynamic) with the provided signature.

--- a/lib/api/src/entities/function/inner.rs
+++ b/lib/api/src/entities/function/inner.rs
@@ -87,14 +87,14 @@ impl BackendFunction {
     /// });
     /// ```
     #[inline]
-    pub fn new_with_env<S, FT, F, T: Send + 'static>(
+    pub fn new_with_env<S, FT, F, T: 'static>(
         store: &mut S,
         env: &FunctionEnv<T>,
         ty: FT,
         func: F,
     ) -> Self
     where
-        S: AsStoreMut,
+        S: AsStoreMut<Object: Upcast<T>>,
         FT: Into<FunctionType>,
         F: Fn(FunctionEnvMut<T, S::Object>, &[Value]) -> Result<Vec<Value>, RuntimeError>
             + 'static
@@ -199,13 +199,13 @@ impl BackendFunction {
     /// let f = Function::new_typed_with_env(&mut store, &env, sum);
     /// ```
     #[inline]
-    pub fn new_typed_with_env<S, T: Send + 'static, F, Args, Rets>(
+    pub fn new_typed_with_env<S, T: 'static, F, Args, Rets>(
         store: &mut S,
         env: &FunctionEnv<T>,
         func: F,
     ) -> Self
     where
-        S: AsStoreMut,
+        S: AsStoreMut<Object: Upcast<T>>,
         F: HostFunction<T, S::Object, Args, Rets, WithEnv> + 'static + Send + Sync,
         Args: WasmTypeList,
         Rets: WasmTypeList,

--- a/lib/api/src/entities/function/mod.rs
+++ b/lib/api/src/entities/function/mod.rs
@@ -10,7 +10,7 @@ pub use host::*;
 pub(crate) mod env;
 pub use env::*;
 
-use wasmer_types::{FunctionType, RawValue};
+use wasmer_types::{FunctionType, RawValue, Upcast};
 
 use crate::{
     error::RuntimeError,
@@ -45,7 +45,7 @@ impl Function {
     ///
     /// If you know the signature of the host function at compile time,
     /// consider using [`Function::new_typed`] for less runtime overhead.
-    pub fn new<FT, F>(store: &mut impl AsStoreMut, ty: FT, func: F) -> Self
+    pub fn new<FT, F>(store: &mut impl AsStoreMut<Object: Upcast<()>>, ty: FT, func: F) -> Self
     where
         FT: Into<FunctionType>,
         F: Fn(&[Value]) -> Result<Vec<Value>, RuntimeError> + 'static + Send + Sync,
@@ -110,7 +110,7 @@ impl Function {
     /// Creates a new host `Function` from a native function.
     pub fn new_typed<S, F, Args, Rets>(store: &mut S, func: F) -> Self
     where
-        S: AsStoreMut,
+        S: AsStoreMut<Object: Upcast<()>>,
         F: HostFunction<(), S::Object, Args, Rets, WithoutEnv> + 'static + Send + Sync,
         Args: WasmTypeList,
         Rets: WasmTypeList,

--- a/lib/api/src/entities/function/mod.rs
+++ b/lib/api/src/entities/function/mod.rs
@@ -90,15 +90,16 @@ impl Function {
     ///     Ok(vec![Value::I32(sum)])
     /// });
     /// ```
-    pub fn new_with_env<FT, F, T: Send + 'static, S: AsStoreMut>(
+    pub fn new_with_env<S, FT, F, T: Send + 'static>(
         store: &mut S,
-        env: &FunctionEnv<T, S::Object>,
+        env: &FunctionEnv<T>,
         ty: FT,
         func: F,
     ) -> Self
     where
+        S: AsStoreMut,
         FT: Into<FunctionType>,
-        F: Fn(FunctionEnvMut<T>, &[Value]) -> Result<Vec<Value>, RuntimeError>
+        F: Fn(FunctionEnvMut<T, S::Object>, &[Value]) -> Result<Vec<Value>, RuntimeError>
             + 'static
             + Send
             + Sync,
@@ -107,9 +108,10 @@ impl Function {
     }
 
     /// Creates a new host `Function` from a native function.
-    pub fn new_typed<F, Args, Rets>(store: &mut impl AsStoreMut, func: F) -> Self
+    pub fn new_typed<S, F, Args, Rets>(store: &mut S, func: F) -> Self
     where
-        F: HostFunction<(), Args, Rets, WithoutEnv> + 'static + Send + Sync,
+        S: AsStoreMut,
+        F: HostFunction<(), S::Object, Args, Rets, WithoutEnv> + 'static + Send + Sync,
         Args: WasmTypeList,
         Rets: WasmTypeList,
     {
@@ -134,13 +136,14 @@ impl Function {
     ///
     /// let f = Function::new_typed_with_env(&mut store, &env, sum);
     /// ```
-    pub fn new_typed_with_env<T: Send + 'static, F, Args, Rets>(
-        store: &mut impl AsStoreMut,
+    pub fn new_typed_with_env<S, T: Send + 'static, F, Args, Rets>(
+        store: &mut S,
         env: &FunctionEnv<T>,
         func: F,
     ) -> Self
     where
-        F: HostFunction<T, Args, Rets, WithEnv> + 'static + Send + Sync,
+        S: AsStoreMut,
+        F: HostFunction<T, S::Object, Args, Rets, WithEnv> + 'static + Send + Sync,
         Args: WasmTypeList,
         Rets: WasmTypeList,
     {

--- a/lib/api/src/entities/function/mod.rs
+++ b/lib/api/src/entities/function/mod.rs
@@ -90,9 +90,9 @@ impl Function {
     ///     Ok(vec![Value::I32(sum)])
     /// });
     /// ```
-    pub fn new_with_env<FT, F, T: Send + 'static>(
-        store: &mut impl AsStoreMut,
-        env: &FunctionEnv<T>,
+    pub fn new_with_env<FT, F, T: Send + 'static, S: AsStoreMut>(
+        store: &mut S,
+        env: &FunctionEnv<T, S::Object>,
         ty: FT,
         func: F,
     ) -> Self

--- a/lib/api/src/entities/function/mod.rs
+++ b/lib/api/src/entities/function/mod.rs
@@ -90,14 +90,14 @@ impl Function {
     ///     Ok(vec![Value::I32(sum)])
     /// });
     /// ```
-    pub fn new_with_env<S, FT, F, T: Send + 'static>(
+    pub fn new_with_env<S, FT, F, T: 'static>(
         store: &mut S,
         env: &FunctionEnv<T>,
         ty: FT,
         func: F,
     ) -> Self
     where
-        S: AsStoreMut,
+        S: AsStoreMut<Object: Upcast<T>>,
         FT: Into<FunctionType>,
         F: Fn(FunctionEnvMut<T, S::Object>, &[Value]) -> Result<Vec<Value>, RuntimeError>
             + 'static
@@ -136,13 +136,13 @@ impl Function {
     ///
     /// let f = Function::new_typed_with_env(&mut store, &env, sum);
     /// ```
-    pub fn new_typed_with_env<S, T: Send + 'static, F, Args, Rets>(
+    pub fn new_typed_with_env<S, T: 'static, F, Args, Rets>(
         store: &mut S,
         env: &FunctionEnv<T>,
         func: F,
     ) -> Self
     where
-        S: AsStoreMut,
+        S: AsStoreMut<Object: Upcast<T>>,
         F: HostFunction<T, S::Object, Args, Rets, WithEnv> + 'static + Send + Sync,
         Args: WasmTypeList,
         Rets: WasmTypeList,

--- a/lib/api/src/entities/global/inner.rs
+++ b/lib/api/src/entities/global/inner.rs
@@ -14,10 +14,11 @@ use wasmer_types::{GlobalType, Mutability};
 /// It consists of an individual value and a flag indicating whether it is mutable.
 ///
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#global-instances>
-gen_rt_ty!(Global
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Debug, Clone, PartialEq, Eq, derive_more::From
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+    pub(crate) BackendGlobal(global::Global);
+}
 
 impl BackendGlobal {
     /// Create a new global with the initial [`Value`].

--- a/lib/api/src/entities/instance.rs
+++ b/lib/api/src/entities/instance.rs
@@ -179,4 +179,7 @@ impl std::fmt::Debug for Instance {
 }
 
 /// An enumeration of all the possible instances kind supported by the runtimes.
-gen_rt_ty!(Instance @derives Clone, PartialEq, Eq);
+gen_rt_ty! {
+    #[derive(Clone, PartialEq, Eq)]
+    pub(crate) BackendInstance(instance::Instance);
+}

--- a/lib/api/src/entities/memory/buffer/inner.rs
+++ b/lib/api/src/entities/memory/buffer/inner.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 
 /// Underlying buffer for a memory.
-gen_rt_ty!(MemoryBuffer<'a>
-    @derives Debug, Copy, Clone, derive_more::From;
-    @path memory
-);
+gen_rt_ty! {
+    #[derive(Debug, Copy, Clone, derive_more::From)]
+    pub(crate) BackendMemoryBuffer<'a>(memory::MemoryBuffer<'a>);
+}
 
 impl BackendMemoryBuffer<'_> {
     #[allow(unused)]

--- a/lib/api/src/entities/memory/inner.rs
+++ b/lib/api/src/entities/memory/inner.rs
@@ -7,10 +7,11 @@ use crate::{
     AsStoreMut, AsStoreRef, ExportError, Exportable, Extern, StoreMut, StoreRef,
 };
 
-gen_rt_ty!(Memory
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Debug, Clone, PartialEq, Eq, derive_more::From
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+    pub(crate) BackendMemory(memory::Memory);
+}
 
 impl BackendMemory {
     /// Creates a new host [`BackendMemory`] from the provided [`MemoryType`].

--- a/lib/api/src/entities/memory/view/inner.rs
+++ b/lib/api/src/entities/memory/view/inner.rs
@@ -13,7 +13,10 @@ use crate::{
 ///
 /// After a memory is grown a view must not be used anymore. Views are
 /// created using the Memory.view() method.
-gen_rt_ty!(MemoryView<'a> @derives Debug, derive_more::From ; @path memory::view);
+gen_rt_ty! {
+    #[derive(Debug, derive_more::From)]
+    pub(crate) BackendMemoryView<'a>(memory::view::MemoryView<'a>);
+}
 
 impl<'a> BackendMemoryView<'a> {
     #[inline]

--- a/lib/api/src/entities/module/inner.rs
+++ b/lib/api/src/entities/module/inner.rs
@@ -26,10 +26,11 @@ use crate::{
 ///
 /// Cloning a module is cheap: it does a shallow copy of the compiled
 /// contents rather than a deep copy.
-gen_rt_ty!(Module
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Clone, PartialEq, Eq, derive_more::From
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Clone, PartialEq, Eq, derive_more::From)]
+    pub(crate) BackendModule(module::Module);
+}
 
 impl BackendModule {
     #[inline]

--- a/lib/api/src/entities/store/inner.rs
+++ b/lib/api/src/entities/store/inner.rs
@@ -17,7 +17,7 @@ pub(crate) struct StoreInner<Object> {
     pub(crate) objects: StoreObjects<Object>,
 
     pub(crate) store: BackendStore,
-    pub(crate) on_called: Option<OnCalledHandler>,
+    pub(crate) on_called: Option<OnCalledHandler<Object>>,
 }
 
 impl<Object> std::fmt::Debug for StoreInner<Object> {
@@ -32,9 +32,9 @@ impl<Object> std::fmt::Debug for StoreInner<Object> {
 
 /// Call handler for a store.
 // TODO: better documentation!
-pub type OnCalledHandler = Box<
+pub type OnCalledHandler<Object> = Box<
     dyn FnOnce(
-        StoreMut<'_>,
+        StoreMut<'_, Object>,
     )
         -> Result<wasmer_types::OnCalledAction, Box<dyn std::error::Error + Send + Sync>>,
 >;

--- a/lib/api/src/entities/store/inner.rs
+++ b/lib/api/src/entities/store/inner.rs
@@ -39,7 +39,10 @@ pub type OnCalledHandler = Box<
         -> Result<wasmer_types::OnCalledAction, Box<dyn std::error::Error + Send + Sync>>,
 >;
 
-gen_rt_ty!(Store @derives derive_more::From, Debug; @path store);
+gen_rt_ty! {
+    #[derive(derive_more::From, Debug)]
+    pub(crate) BackendStore(store::Store);
+}
 
 impl BackendStore {
     #[inline]

--- a/lib/api/src/entities/store/inner.rs
+++ b/lib/api/src/entities/store/inner.rs
@@ -13,7 +13,7 @@ use wasmer_vm::TrapHandlerFn;
 /// We require the context to have a fixed memory address for its lifetime since
 /// various bits of the VM have raw pointers that point back to it. Hence we
 /// wrap the actual context in a box.
-pub(crate) struct StoreInner<Object = wasmer_types::BoxStoreObject> {
+pub(crate) struct StoreInner<Object> {
     pub(crate) objects: StoreObjects<Object>,
 
     pub(crate) store: BackendStore,
@@ -61,6 +61,8 @@ impl BackendStore {
 }
 
 impl AsEngineRef for BackendStore {
+    type Object = ();
+
     #[inline]
     fn as_engine_ref(&self) -> crate::EngineRef<'_> {
         match_rt!(on self => s {

--- a/lib/api/src/entities/store/inner.rs
+++ b/lib/api/src/entities/store/inner.rs
@@ -13,8 +13,9 @@ use wasmer_vm::TrapHandlerFn;
 /// We require the context to have a fixed memory address for its lifetime since
 /// various bits of the VM have raw pointers that point back to it. Hence we
 /// wrap the actual context in a box.
-pub(crate) struct StoreInner<Object = Box<dyn std::any::Any + Send>> {
+pub(crate) struct StoreInner<Object = wasmer_types::BoxStoreObject> {
     pub(crate) objects: StoreObjects<Object>,
+
     pub(crate) store: BackendStore,
     pub(crate) on_called: Option<OnCalledHandler>,
 }

--- a/lib/api/src/entities/store/inner.rs
+++ b/lib/api/src/entities/store/inner.rs
@@ -13,13 +13,13 @@ use wasmer_vm::TrapHandlerFn;
 /// We require the context to have a fixed memory address for its lifetime since
 /// various bits of the VM have raw pointers that point back to it. Hence we
 /// wrap the actual context in a box.
-pub(crate) struct StoreInner {
-    pub(crate) objects: StoreObjects,
+pub(crate) struct StoreInner<Object = Box<dyn std::any::Any + Send>> {
+    pub(crate) objects: StoreObjects<Object>,
     pub(crate) store: BackendStore,
     pub(crate) on_called: Option<OnCalledHandler>,
 }
 
-impl std::fmt::Debug for StoreInner {
+impl<Object> std::fmt::Debug for StoreInner<Object> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("StoreInner")
             .field("objects", &self.objects)

--- a/lib/api/src/entities/store/mod.rs
+++ b/lib/api/src/entities/store/mod.rs
@@ -28,8 +28,8 @@ use wasmer_vm::TrapHandlerFn;
 ///
 /// For more informations, check out the [related WebAssembly specification]
 /// [related WebAssembly specification]: <https://webassembly.github.io/spec/core/exec/runtime.html#store>
-pub struct Store {
-    pub(crate) inner: Box<StoreInner>,
+pub struct Store<Object = Box<dyn std::any::Any + Send>> {
+    pub(crate) inner: Box<StoreInner<Object>>,
 }
 
 impl Store {

--- a/lib/api/src/entities/store/mod.rs
+++ b/lib/api/src/entities/store/mod.rs
@@ -32,7 +32,7 @@ pub struct Store<Object = BoxStoreObject> {
     pub(crate) inner: Box<StoreInner<Object>>,
 }
 
-impl Store {
+impl<Object> Store<Object> {
     /// Creates a new `Store` with a specific [`Engine`].
     pub fn new(engine: impl Into<Engine>) -> Self {
         let engine: Engine = engine.into();
@@ -152,7 +152,7 @@ impl<Object> AsStoreRef for Store<Object> {
         StoreRef { inner: &self.inner }
     }
 }
-impl AsStoreMut for Store {
+impl<Object> AsStoreMut for Store<Object> {
     fn as_store_mut(&mut self) -> StoreMut<'_, Self::Object> {
         StoreMut {
             inner: &mut self.inner,

--- a/lib/api/src/entities/store/mod.rs
+++ b/lib/api/src/entities/store/mod.rs
@@ -13,7 +13,7 @@ pub use obj::*;
 
 use crate::{AsEngineRef, BackendEngine, Engine, EngineRef};
 pub(crate) use inner::*;
-use wasmer_types::StoreId;
+use wasmer_types::{BoxStoreObject, StoreId};
 
 #[cfg(feature = "sys")]
 use wasmer_vm::TrapHandlerFn;
@@ -28,7 +28,7 @@ use wasmer_vm::TrapHandlerFn;
 ///
 /// For more informations, check out the [related WebAssembly specification]
 /// [related WebAssembly specification]: <https://webassembly.github.io/spec/core/exec/runtime.html#store>
-pub struct Store<Object = Box<dyn std::any::Any + Send>> {
+pub struct Store<Object = BoxStoreObject> {
     pub(crate) inner: Box<StoreInner<Object>>,
 }
 
@@ -118,8 +118,8 @@ impl PartialEq for Store {
 
 // This is required to be able to set the trap_handler in the
 // Store.
-unsafe impl Send for Store {}
-unsafe impl Sync for Store {}
+unsafe impl<Object: Send> Send for Store<Object> {}
+unsafe impl<Object: Sync> Sync for Store<Object> {}
 
 impl Default for Store {
     fn default() -> Self {
@@ -127,35 +127,39 @@ impl Default for Store {
     }
 }
 
-impl std::fmt::Debug for Store {
+impl<Object> std::fmt::Debug for Store<Object> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("Store").finish()
     }
 }
 
-impl AsEngineRef for Store {
+impl<Object> AsEngineRef for Store<Object> {
+    type Object = Object;
+
     fn as_engine_ref(&self) -> EngineRef<'_> {
         self.inner.store.as_engine_ref()
     }
 
-    fn maybe_as_store(&self) -> Option<StoreRef<'_>> {
+    fn maybe_as_store(&self) -> Option<StoreRef<'_, Object>> {
         Some(self.as_store_ref())
     }
 }
 
-impl AsStoreRef for Store {
-    fn as_store_ref(&self) -> StoreRef<'_> {
+impl<Object> AsStoreRef for Store<Object> {
+    type Object = Object;
+
+    fn as_store_ref(&self) -> StoreRef<'_, Object> {
         StoreRef { inner: &self.inner }
     }
 }
 impl AsStoreMut for Store {
-    fn as_store_mut(&mut self) -> StoreMut<'_> {
+    fn as_store_mut(&mut self) -> StoreMut<'_, Self::Object> {
         StoreMut {
             inner: &mut self.inner,
         }
     }
 
-    fn objects_mut(&mut self) -> &mut StoreObjects {
+    fn objects_mut(&mut self) -> &mut StoreObjects<Self::Object> {
         &mut self.inner.objects
     }
 }

--- a/lib/api/src/entities/store/obj.rs
+++ b/lib/api/src/entities/store/obj.rs
@@ -2,12 +2,14 @@ use wasmer_types::StoreId;
 
 use crate::{macros::backend::match_rt, BackendStore};
 
+/// Set of `?Send` objects managed by a context.
+pub type LocalStoreObjects = StoreObjects<Box<dyn std::any::Any>>;
+
 /// Set of objects managed by a context.
-#[derive(Debug)]
-pub enum StoreObjects {
+pub enum StoreObjects<Object = Box<dyn std::any::Any + Send>> {
     #[cfg(feature = "sys")]
     /// Store objects for the `sys` runtime.
-    Sys(crate::backend::sys::store::StoreObjects),
+    Sys(crate::backend::sys::store::StoreObjects<Object>),
 
     #[cfg(feature = "wamr")]
     /// Store objects for the `wamr` runtime.
@@ -30,7 +32,28 @@ pub enum StoreObjects {
     Jsc(crate::backend::jsc::store::StoreObjects),
 }
 
-impl StoreObjects {
+impl<Object> std::fmt::Debug for StoreObjects<Object> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use StoreObjects::*;
+
+        match self {
+            #[cfg(feature = "sys")]
+            Sys(store) => f.debug_tuple("Sys").field(&store).finish(),
+            #[cfg(feature = "wamr")]
+            Wamr(store) => f.debug_tuple("Wamr").field(&store).finish(),
+            #[cfg(feature = "wasmi")]
+            Wasmi(store) => f.debug_tuple("Wasmi").field(&store).finish(),
+            #[cfg(feature = "v8")]
+            V8(store) => f.debug_tuple("V8").field(&store).finish(),
+            #[cfg(feature = "js")]
+            Js(store) => f.debug_tuple("Js").field(&store).finish(),
+            #[cfg(feature = "jsc")]
+            Jsc(store) => f.debug_tuple("Jsc").field(&store).finish(),
+        }
+    }
+}
+
+impl<Object> StoreObjects<Object> {
     /// Checks whether two stores are identical. A store is considered
     /// equal to another store if both have the same engine.
     #[inline]

--- a/lib/api/src/entities/store/obj.rs
+++ b/lib/api/src/entities/store/obj.rs
@@ -2,9 +2,6 @@ use wasmer_types::StoreId;
 
 use crate::{macros::backend::match_rt, BackendStore};
 
-/// Set of `?Send` objects managed by a context.
-pub type LocalStoreObjects = StoreObjects<Box<dyn std::any::Any>>;
-
 /// Set of objects managed by a context.
 pub enum StoreObjects<Object = Box<dyn std::any::Any + Send>> {
     #[cfg(feature = "sys")]

--- a/lib/api/src/entities/store/store_ref.rs
+++ b/lib/api/src/entities/store/store_ref.rs
@@ -9,9 +9,14 @@ use wasmer_types::{ExternType, OnCalledAction};
 use wasmer_vm::TrapHandlerFn;
 
 /// A temporary handle to a [`crate::Store`].
-#[derive(Debug)]
 pub struct StoreRef<'a, Object = Box<dyn std::any::Any + Send>> {
     pub(crate) inner: &'a StoreInner<Object>,
+}
+
+impl<Object> std::fmt::Debug for StoreRef<'_, Object> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("StoreRef").field("inner", &self.inner).finish()
+    }
 }
 
 impl<'a, Object> StoreRef<'a, Object> {

--- a/lib/api/src/entities/store/store_ref.rs
+++ b/lib/api/src/entities/store/store_ref.rs
@@ -91,6 +91,7 @@ impl<Object> StoreMut<'_, Object> {
 
 /// Helper trait for a value that is convertible to a [`StoreRef`].
 pub trait AsStoreRef {
+    /// The type of type-erased objects stored in this store.
     type Object;
 
     /// Returns a `StoreRef` pointing to the underlying context.

--- a/lib/api/src/entities/store/store_ref.rs
+++ b/lib/api/src/entities/store/store_ref.rs
@@ -80,7 +80,7 @@ impl<Object> StoreMut<'_, Object> {
     /// Sets the unwind callback which will be invoked when the call finishes
     pub fn on_called<F>(&mut self, callback: F)
     where
-        F: FnOnce(StoreMut<'_>) -> Result<OnCalledAction, Box<dyn std::error::Error + Send + Sync>>
+        F: FnOnce(StoreMut<'_, Object>) -> Result<OnCalledAction, Box<dyn std::error::Error + Send + Sync>>
             + Send
             + Sync
             + 'static,

--- a/lib/api/src/entities/table/inner.rs
+++ b/lib/api/src/entities/table/inner.rs
@@ -16,10 +16,11 @@ use crate::{
 /// mutable from both host and WebAssembly.
 ///
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#table-instances>
-gen_rt_ty!(Table
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Debug, Clone, PartialEq, Eq, derive_more::From
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+    pub(crate) BackendTable(table::Table);
+}
 
 impl BackendTable {
     /// Creates a new table with the provided [`TableType`] definition.

--- a/lib/api/src/entities/tag/inner.rs
+++ b/lib/api/src/entities/tag/inner.rs
@@ -12,10 +12,11 @@ use crate::{
 /// It consists of an individual value and a flag indicating whether it is mutable.
 ///
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#global-instances>
-gen_rt_ty!(Tag
-    @cfg feature = "artifact-size" => derive(loupe::MemoryUsage)
-    @derives Debug, Clone, PartialEq, Eq, derive_more::From
-);
+gen_rt_ty! {
+    #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
+    #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+    pub(crate) BackendTag(tag::Tag);
+}
 
 impl BackendTag {
     /// Create a new tag with event of type P -> [], that is a function that takes parameters `P`

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -185,7 +185,7 @@
 //! only perform computation without side effects and call other functions.
 //!
 //! Wasm functions take 0 or more arguments and return 0 or more results.
-//! Wasm functions can only deal with the primitive types defined in
+//! Wasm functions can only deal with the primitive type sdefined in
 //! [`Value`].
 //!
 //! A Host function is any function implemented on the host, in this case in
@@ -439,11 +439,12 @@ pub use backend::*;
 mod vm;
 
 pub use wasmer_types::{
-    is_wasm, Bytes, CompileError, DeserializeError, ExportIndex, ExportType, ExternType, FrameInfo,
-    FunctionType, GlobalInit, GlobalType, ImportType, LocalFunctionIndex, MemoryError, MemoryStyle,
-    MemoryType, Mutability, OnCalledAction, Pages, ParseCpuFeatureError, SerializeError,
-    TableStyle, TableType, TagKind, TagType, Type, ValueType, WasmError, WasmResult,
-    WASM_MAX_PAGES, WASM_MIN_PAGES, WASM_PAGE_SIZE,
+    is_wasm, BoxStoreObject, LocalBoxStoreObject, Bytes, CompileError, DeserializeError,
+    ExportIndex, ExportType, ExternType, FrameInfo, FunctionType, GlobalInit, GlobalType,
+    ImportType, LocalFunctionIndex, MemoryError, MemoryStyle, MemoryType, Mutability,
+    OnCalledAction, Pages, ParseCpuFeatureError, SerializeError, TableStyle, TableType, TagKind,
+    TagType, Type, Upcast, ValueType, WasmError, WasmResult, WASM_MAX_PAGES, WASM_MIN_PAGES,
+    WASM_PAGE_SIZE,
 };
 
 #[cfg(feature = "wasmparser")]

--- a/lib/api/src/utils/macros/backend.rs
+++ b/lib/api/src/utils/macros/backend.rs
@@ -4,17 +4,17 @@ macro_rules! gen_rt_ty {
     {
         $(#[$meta:meta])*
         $vis:vis
-        $id:ident<
+        $id:ident$(<
             $($lt:lifetime),*
             $(,)?
             $($param:ident),*
-        >(
+        >)?(
             $path:path
         ) $(;)?
     } => {
         paste::paste! {
             $(#[$meta])*
-            $vis enum $id<$($lt,)* $($param),*> {
+            $vis enum $id $(<$($lt,)* $($param,)*>)? {
                 #[cfg(feature = "sys")]
                 /// The implementation from the `sys` backend.
                 Sys(crate::backend::sys::entities::$path),
@@ -39,20 +39,6 @@ macro_rules! gen_rt_ty {
                 /// The implementation from the `jsc` backend.
                 Jsc(crate::backend::jsc::entities::$path),
             }
-        }
-    };
-
-    {
-        $(#[$meta:meta])*
-        $vis:vis
-        $id:ident(
-            $path:path
-        )
-        $(;)?
-    } => {
-        $crate::macros::backend::gen_rt_ty! {
-            $(#[$meta])*
-            $vis $id<>($path);
         }
     };
 }

--- a/lib/api/src/utils/macros/backend.rs
+++ b/lib/api/src/utils/macros/backend.rs
@@ -1,134 +1,58 @@
 /// Automatically generate "backend" types.
 #[macro_use]
 macro_rules! gen_rt_ty {
-    // In this case we automatically try to create the struct following the canonical path to the
-    // same entity in each backend.
-    ($id:ident) => {
+    {
+        $(#[$meta:meta])*
+        $vis:vis
+        $id:ident<
+            $($lt:lifetime),*
+            $(,)?
+            $($param:ident),*
+        >(
+            $path:path
+        ) $(;)?
+    } => {
         paste::paste! {
-            pub(crate) enum [<Backend $id>] {
+            $(#[$meta])*
+            $vis enum $id<$($lt,)* $($param),*> {
                 #[cfg(feature = "sys")]
                 /// The implementation from the `sys` backend.
-                Sys(crate::backend::sys::entities::[<$id:lower>]::$id),
+                Sys(crate::backend::sys::entities::$path),
 
                 #[cfg(feature = "v8")]
                 /// The implementation from the `v8` backend.
-                V8(crate::backend::v8::entities::[<$id:lower>]::$id),
+                V8(crate::backend::v8::entities::$path),
 
                 #[cfg(feature = "wamr")]
                 /// The implementation from the `wamr` backend.
-                Wamr(crate::backend::wamr::entities::[<$id:lower>]::$id),
+                Wamr(crate::backend::wamr::entities::$path),
 
                 #[cfg(feature = "wasmi")]
                 /// The implementation from the `wasmi` backend.
-                Wasmi(crate::backend::wasmi::entities::[<$id:lower>]::$id),
+                Wasmi(crate::backend::wasmi::entities::$path),
 
                 #[cfg(feature = "js")]
                 /// The implementation from the `js` backend.
-                Js(crate::backend::js::entities::[<$id:lower>]::$id),
+                Js(crate::backend::js::entities::$path),
 
                 #[cfg(feature = "jsc")]
                 /// The implementation from the `jsc` backend.
-                Jsc(crate::backend::jsc::entities::[<$id:lower>]::$id),
+                Jsc(crate::backend::jsc::entities::$path),
             }
         }
     };
 
-    ($id:ident$(<$lt:lifetime>)? $(@cfg $($if:meta => $then: meta),*)? @derives $($derive:path),*) => {
-        paste::paste! {
-            $($(#[cfg_attr($if, $then)])*)?
-            #[derive($($derive,)*)]
-            pub(crate) enum [<Backend $id>]$(<$lt>)? {
-                #[cfg(feature = "sys")]
-                /// The implementation from the `sys` backend.
-                Sys(crate::backend::sys::entities::[<$id:lower>]::$id$(<$lt>)?),
-
-                #[cfg(feature = "v8")]
-                /// The implementation from the `v8` backend.
-                V8(crate::backend::v8::entities::[<$id:lower>]::$id$(<$lt>)?),
-
-                #[cfg(feature = "wamr")]
-                /// The implementation from the `wamr` backend.
-                Wamr(crate::backend::wamr::entities::[<$id:lower>]::$id$(<$lt>)?),
-
-                #[cfg(feature = "wasmi")]
-                /// The implementation from the `wasmi` backend.
-                Wasmi(crate::backend::wasmi::entities::[<$id:lower>]::$id$(<$lt>)?),
-
-                #[cfg(feature = "js")]
-                /// The implementation from the `js` backend.
-                Js(crate::backend::js::entities::[<$id:lower>]::$id$(<$lt>)?),
-
-
-                #[cfg(feature = "jsc")]
-                /// The implementation from the `jsc` backend.
-                Jsc(crate::backend::jsc::entities::[<$id:lower>]::$id$(<$lt>)?),
-            }
-        }
-    };
-
-    ($id:ident$(<$lt:lifetime>)? $(@cfg $($if:meta => $then: meta),*)? @derives $($derive:path),* ; @path $path:path ) => {
-        paste::paste! {
-            $($(#[cfg_attr($if, $then)])*)?
-            #[derive($($derive,)*)]
-            pub(crate) enum [<Backend $id>]$(<$lt>)? {
-                #[cfg(feature = "sys")]
-                /// The implementation from the `sys` backend.
-                Sys(crate::backend::sys::entities::$path::$id$(<$lt>)?),
-
-                #[cfg(feature = "v8")]
-                /// The implementation from the `v8` backend.
-                V8(crate::backend::v8::entities::$path::$id$(<$lt>)?),
-
-                #[cfg(feature = "wamr")]
-                /// The implementation from the `wamr` backend.
-                Wamr(crate::backend::wamr::entities::$path::$id$(<$lt>)?),
-
-                #[cfg(feature = "wasmi")]
-                /// The implementation from the `wasmi` backend.
-                Wasmi(crate::backend::wasmi::entities::$path::$id$(<$lt>)?),
-
-                #[cfg(feature = "js")]
-                /// The implementation from the `js` backend.
-                Js(crate::backend::js::entities::$path::$id$(<$lt>)?),
-
-
-                #[cfg(feature = "jsc")]
-                /// The implementation from the `jsc` backend.
-                Jsc(crate::backend::jsc::entities::$path::$id$(<$lt>)?),
-            }
-        }
-    };
-
-
-    ($id:ident @derives $($derive:path),* ; @path $path:path) => {
-        paste::paste! {
-            #[derive($($derive,)*)]
-            pub(crate) enum [<Backend $id>] {
-                #[cfg(feature = "sys")]
-                /// The implementation from the `sys` backend.
-                Sys(crate::backend::sys::entities::$path::$id),
-
-                #[cfg(feature = "v8")]
-                /// The implementation from the `v8` backend.
-                V8(crate::backend::v8::entities::$path::$id),
-
-                #[cfg(feature = "wamr")]
-                /// The implementation from the `wamr` backend.
-                Wamr(crate::backend::wamr::entities::$path::$id),
-
-                #[cfg(feature = "wasmi")]
-                /// The implementation from the `wasmi` backend.
-                Wasmi(crate::backend::wasmi::entities::$path::$id),
-
-                #[cfg(feature = "js")]
-                /// The implementation from the `js` backend.
-                Js(crate::backend::js::entities::$path::$id),
-
-
-                #[cfg(feature = "jsc")]
-                /// The implementation from the `jsc` backend.
-                Jsc(crate::backend::jsc::entities::$path::$id),
-            }
+    {
+        $(#[$meta:meta])*
+        $vis:vis
+        $id:ident(
+            $path:path
+        )
+        $(;)?
+    } => {
+        $crate::macros::backend::gen_rt_ty! {
+            $(#[$meta])*
+            $vis $id<>($path);
         }
     };
 }

--- a/lib/api/src/vm/mod.rs
+++ b/lib/api/src/vm/mod.rs
@@ -3,16 +3,17 @@
 mod impls;
 
 use crate::VMExternToExtern;
-use wasmer_types::RawValue;
+use wasmer_types::{BoxStoreObject, RawValue};
 
 macro_rules! define_vm_like {
-    ($name: ident) => {
+    ($name: ident $(<$($params:ident $(= $defaults:ty)?),*>)? $(, $meta:meta)* $(,)?) => {
         paste::paste! {
         /// The enum for all those VM values of this kind.
+        $(#[$meta])*
         #[repr(C)]
-        pub enum [<VM $name>] {
+        pub enum [<VM $name>] $(<$($params $(= $defaults)?),*>)? {
             #[cfg(feature = "sys")]
-            Sys(crate::backend::sys::vm::[<VM $name>]),
+            Sys(crate::backend::sys::vm::[<VM $name>] $(<$($params),*>)?),
 
             #[cfg(feature = "wamr")]
             Wamr(crate::backend::wamr::vm::[<VM $name>]),
@@ -33,10 +34,10 @@ macro_rules! define_vm_like {
 
         }
 
-        impl [<VM $name>] {
+        impl $(<$($params),*>)? [<VM $name>] $(<$($params),*>)? {
             #[cfg(feature = "sys")]
             /// Consume `self` into a `sys` VM kind.
-            pub fn into_sys(self) -> crate::backend::sys::vm::[<VM $name>] {
+            pub fn into_sys(self) -> crate::backend::sys::vm::[<VM $name>] $(<$($params),*>)? {
                 match self {
                     [<VM $name>]::Sys(s) => s,
                     _ => panic!("Not a `sys` value!")
@@ -45,7 +46,7 @@ macro_rules! define_vm_like {
 
             #[cfg(feature = "sys")]
             /// Convert a reference to [`self`] into a reference to the same `sys` VM kind.
-            pub fn as_sys(&self) -> &crate::backend::sys::vm::[<VM $name>] {
+            pub fn as_sys(&self) -> &crate::backend::sys::vm::[<VM $name>] $(<$($params),*>)? {
                 match self {
                     [<VM $name>]::Sys(s) => s,
                     _ => panic!("Not a `sys` value!")
@@ -54,7 +55,7 @@ macro_rules! define_vm_like {
 
             #[cfg(feature = "sys")]
             /// Convert a mutable reference to [`self`] into a mutable reference to the same `sys` VM kind.
-            pub fn as_sys_mut(&mut self) -> &mut crate::backend::sys::vm::[<VM $name>] {
+            pub fn as_sys_mut(&mut self) -> &mut crate::backend::sys::vm::[<VM $name>] $(<$($params),*>)? {
                 match self {
                     [<VM $name>]::Sys(s) => s,
                     _ => panic!("Not a `sys` value!")
@@ -193,194 +194,6 @@ macro_rules! define_vm_like {
                 match self {
                     [<VM $name>]::Jsc(s) => s,
                     _ => panic!("Not a `jsc` value!")
-                }
-            }
-        }
-        }
-    };
-
-    ($name: ident $(, $derive:ident)*) => {
-        paste::paste! {
-        /// The enum for all those VM values of this kind.
-        $(#[derive($derive)])*
-        #[repr(C)]
-        pub enum [<VM $name>] {
-            #[cfg(feature = "sys")]
-            Sys(crate::backend::sys::vm::[<VM $name>]),
-            #[cfg(feature = "wamr")]
-            Wamr(crate::backend::wamr::vm::[<VM $name>]),
-            #[cfg(feature = "wasmi")]
-            Wasmi(crate::backend::wasmi::vm::[<VM $name>]),
-            #[cfg(feature = "v8")]
-            V8(crate::backend::v8::vm::[<VM $name>]),
-            #[cfg(feature = "js")]
-            Js(crate::backend::js::vm::[<VM $name>]),
-            #[cfg(feature = "jsc")]
-            Jsc(crate::backend::jsc::vm::[<VM $name>]),
-        }
-
-        impl [<VM $name>] {
-            #[cfg(feature = "sys")]
-            /// Consume `self` into a `sys` VM kind.
-            pub fn into_sys(self) -> crate::backend::sys::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Sys(s) => s,
-                    _ => panic!("Not a `sys` value!")
-                }
-            }
-
-            #[cfg(feature = "sys")]
-            /// Convert a reference to [`self`] into a reference to the same `sys` VM kind.
-            pub fn as_sys(&self) -> &crate::backend::sys::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Sys(s) => s,
-                    _ => panic!("Not a `sys` value!")
-                }
-            }
-
-            #[cfg(feature = "sys")]
-            /// Convert a mutable reference to [`self`] into a mutable reference to the same `sys` VM kind.
-            pub fn as_sys_mut(&mut self) -> &mut crate::backend::sys::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Sys(s) => s,
-                    _ => panic!("Not a `sys` value!")
-                }
-            }
-
-            #[cfg(feature = "wamr")]
-            /// Consume `self` into a `wamr` VM kind.
-            pub fn into_wamr(self) -> crate::backend::wamr::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Wamr(s) => s,
-                    _ => panic!("Not a `wamr` value!")
-                }
-            }
-
-            #[cfg(feature = "wamr")]
-            /// Convert a reference to [`self`] into a reference to the same `wamr` VM kind.
-            pub fn as_wamr(&self) -> &crate::backend::wamr::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Wamr(s) => s,
-                    _ => panic!("Not a `wamr` value!")
-                }
-            }
-
-            #[cfg(feature = "wamr")]
-            /// Convert a mutable reference to [`self`] into a mutable reference to the same `wamr` VM kind.
-            pub fn as_wamr_mut(&mut self) -> &mut crate::backend::wamr::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Wamr(s) => s,
-                    _ => panic!("Not a `wamr` value!")
-                }
-            }
-
-            #[cfg(feature = "wasmi")]
-            /// Consume `self` into a `wasmi` VM kind.
-            pub fn into_wasmi(self) -> crate::backend::wasmi::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Wasmi(s) => s,
-                    _ => panic!("Not a `wasmi` value!")
-                }
-            }
-
-            #[cfg(feature = "wasmi")]
-            /// Convert a reference to [`self`] into a reference to the same `wasmi` VM kind.
-            pub fn as_wasmi(&self) -> &crate::backend::wasmi::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Wasmi(s) => s,
-                    _ => panic!("Not a `wasmi` value!")
-                }
-            }
-
-            #[cfg(feature = "wasmi")]
-            /// Convert a mutable reference to [`self`] into a mutable reference to the same `wasmi` VM kind.
-            pub fn as_wasmi_mut(&mut self) -> &mut crate::backend::wasmi::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Wasmi(s) => s,
-                    _ => panic!("Not a `wasmi` value!")
-                }
-            }
-
-
-            #[cfg(feature = "js")]
-            /// Consume `self` into a `js` VM kind.
-            pub fn into_js(self) -> crate::backend::js::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Js(s) => s,
-                    _ => panic!("Not a `js` value!")
-                }
-            }
-
-            #[cfg(feature = "js")]
-            /// Convert a reference to [`self`] into a reference to the same `js` VM kind.
-            pub fn as_js(&self) -> &crate::backend::js::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Js(s) => s,
-                    _ => panic!("Not a `js` value!")
-                }
-            }
-
-            #[cfg(feature = "js")]
-            /// Convert a mutable reference to [`self`] into a mutable reference to the same `js` VM kind.
-            pub fn as_js_mut(&mut self) -> &mut crate::backend::js::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Js(s) => s,
-                    _ => panic!("Not a `js` value!")
-                }
-            }
-
-            #[cfg(feature = "jsc")]
-            /// Consume `self` into a `jsc` VM kind.
-            pub fn into_jsc(self) -> crate::backend::jsc::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Jsc(s) => s,
-                    _ => panic!("Not a `jsc` value!")
-                }
-            }
-
-            #[cfg(feature = "jsc")]
-            /// Convert a reference to [`self`] into a reference to the same `jsc` VM kind.
-            pub fn as_jsc(&self) -> &crate::backend::jsc::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Jsc(s) => s,
-                    _ => panic!("Not a `jsc` value!")
-                }
-            }
-
-            #[cfg(feature = "jsc")]
-            /// Convert a mutable reference to [`self`] into a mutable reference to the same `jsc` VM kind.
-            pub fn as_jsc_mut(&mut self) -> &mut crate::backend::jsc::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::Jsc(s) => s,
-                    _ => panic!("Not a `jsc` value!")
-                }
-            }
-
-
-            #[cfg(feature = "v8")]
-            /// Consume `self` into a `v8` VM kind.
-            pub fn into_v8(self) -> crate::backend::v8::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::V8(s) => s,
-                    _ => panic!("Not a `v8` value!")
-                }
-            }
-
-            #[cfg(feature = "v8")]
-            /// Convert a reference to [`self`] into a reference to the same `v8` VM kind.
-            pub fn as_v8(&self) -> &crate::backend::v8::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::V8(s) => s,
-                    _ => panic!("Not a `v8` value!")
-                }
-            }
-
-            #[cfg(feature = "v8")]
-            /// Convert a mutable reference to [`self`] into a mutable reference to the same `v8` VM kind.
-            pub fn as_v8_mut(&mut self) -> &mut crate::backend::v8::vm::[<VM $name>] {
-                match self {
-                    [<VM $name>]::V8(s) => s,
-                    _ => panic!("Not a `v8` value!")
                 }
             }
         }
@@ -397,18 +210,18 @@ define_vm_like!(ExternTable);
 //define_vm_like!(ExternObj, Debug);
 define_vm_like!(FunctionCallback);
 define_vm_like!(FunctionBody);
-define_vm_like!(FunctionEnvironment, Debug);
-define_vm_like!(Instance, Debug);
+define_vm_like!(FunctionEnvironment, derive(Debug));
+define_vm_like!(Instance<Object = BoxStoreObject>, derive_where::derive_where(Debug));
 define_vm_like!(Trampoline);
 
 //define_vm_like!(Config);
-define_vm_like!(Function, Debug);
-define_vm_like!(Global, Debug);
-define_vm_like!(Tag, Debug);
-define_vm_like!(Exception, Debug);
-define_vm_like!(Memory, Debug);
+define_vm_like!(Function, derive(Debug));
+define_vm_like!(Global, derive(Debug));
+define_vm_like!(Tag, derive(Debug));
+define_vm_like!(Exception, derive(Debug));
+define_vm_like!(Memory, derive(Debug));
 define_vm_like!(SharedMemory);
-define_vm_like!(Table, Debug);
+define_vm_like!(Table, derive(Debug));
 
 define_vm_like!(ExceptionRef);
 define_vm_like!(ExternRef);

--- a/lib/compiler/src/engine/resolver.rs
+++ b/lib/compiler/src/engine/resolver.rs
@@ -44,7 +44,7 @@ fn get_extern_from_import(module: &ModuleInfo, import_index: &ImportIndex) -> Ex
 }
 
 /// Get an `ExternType` given an export (and Engine signatures in case is a function).
-fn get_extern_type(context: &StoreObjects, extern_: &VMExtern) -> ExternType {
+fn get_extern_type<Object>(context: &StoreObjects<Object>, extern_: &VMExtern) -> ExternType {
     match extern_ {
         VMExtern::Tag(f) => ExternType::Tag(wasmer_types::TagType::from_fn_type(
             wasmer_types::TagKind::Exception,
@@ -60,7 +60,7 @@ fn get_extern_type(context: &StoreObjects, extern_: &VMExtern) -> ExternType {
     }
 }
 
-fn get_runtime_size(context: &StoreObjects, extern_: &VMExtern) -> Option<u32> {
+fn get_runtime_size<Object>(context: &StoreObjects<Object>, extern_: &VMExtern) -> Option<u32> {
     match extern_ {
         VMExtern::Table(t) => Some(t.get(context).get_runtime_size()),
         VMExtern::Memory(m) => Some(m.get(context).get_runtime_size()),
@@ -73,10 +73,10 @@ fn get_runtime_size(context: &StoreObjects, extern_: &VMExtern) -> Option<u32> {
 ///
 /// If all imports are satisfied returns an `Imports` instance required for a module instantiation.
 #[allow(clippy::result_large_err)]
-pub fn resolve_imports(
+pub fn resolve_imports<Object>(
     module: &ModuleInfo,
     imports: &[VMExtern],
-    context: &mut StoreObjects,
+    context: &mut StoreObjects<Object>,
     finished_dynamic_function_trampolines: &BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     memory_styles: &PrimaryMap<MemoryIndex, MemoryStyle>,
     _table_styles: &PrimaryMap<TableIndex, TableStyle>,

--- a/lib/compiler/src/engine/trap/frame_info.rs
+++ b/lib/compiler/src/engine/trap/frame_info.rs
@@ -70,7 +70,7 @@ impl ModuleInfoFrameInfo {
     fn function_debug_info(
         &self,
         local_index: LocalFunctionIndex,
-    ) -> CompiledFunctionFrameInfoVariant {
+    ) -> CompiledFunctionFrameInfoVariant<'_> {
         self.frame_infos.get(local_index).unwrap()
     }
 
@@ -202,7 +202,7 @@ pub enum FrameInfosVariant {
 
 impl FrameInfosVariant {
     /// Gets the frame info for a given local function index
-    pub fn get(&self, index: LocalFunctionIndex) -> Option<CompiledFunctionFrameInfoVariant> {
+    pub fn get(&self, index: LocalFunctionIndex) -> Option<CompiledFunctionFrameInfoVariant<'_>> {
         match self {
             Self::Owned(map) => map.get(index).map(CompiledFunctionFrameInfoVariant::Ref),
             Self::Archived(archive) => archive
@@ -236,7 +236,7 @@ impl CompiledFunctionFrameInfoVariant<'_> {
     }
 
     /// Gets the traps for the frame info
-    pub fn traps(&self) -> VecTrapInformationVariant {
+    pub fn traps(&self) -> VecTrapInformationVariant<'_> {
         match self {
             CompiledFunctionFrameInfoVariant::Ref(info) => {
                 VecTrapInformationVariant::Ref(&info.traps)
@@ -275,7 +275,7 @@ pub enum FunctionAddressMapVariant<'a> {
 }
 
 impl FunctionAddressMapVariant<'_> {
-    pub fn instructions(&self) -> FunctionAddressMapInstructionVariant {
+    pub fn instructions(&self) -> FunctionAddressMapInstructionVariant<'_> {
         match self {
             FunctionAddressMapVariant::Ref(map) => {
                 FunctionAddressMapInstructionVariant::Owned(&map.instructions)

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -37,7 +37,7 @@ const DWARF_SECTION_NAME: &[u8] = b".eh_frame";
 /// # Ok(())
 /// # }
 /// ```
-pub fn get_object_for_target(triple: &Triple) -> Result<Object, ObjectError> {
+pub fn get_object_for_target(triple: &Triple) -> Result<Object<'_>, ObjectError> {
     let obj_binary_format = match triple.binary_format {
         BinaryFormat::Elf => object::BinaryFormat::Elf,
         BinaryFormat::Macho => object::BinaryFormat::MachO,

--- a/lib/types/src/entity/boxed_slice.rs
+++ b/lib/types/src/entity/boxed_slice.rs
@@ -88,22 +88,22 @@ where
     }
 
     /// Iterate over all the values in this map.
-    pub fn values(&self) -> slice::Iter<V> {
+    pub fn values(&self) -> slice::Iter<'_, V> {
         self.elems.iter()
     }
 
     /// Iterate over all the values in this map, mutable edition.
-    pub fn values_mut(&mut self) -> slice::IterMut<V> {
+    pub fn values_mut(&mut self) -> slice::IterMut<'_, V> {
         self.elems.iter_mut()
     }
 
     /// Iterate over all the keys and values in this map.
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter::new(self.elems.iter())
     }
 
     /// Iterate over all the keys and values in this map, mutable edition.
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut::new(self.elems.iter_mut())
     }
 

--- a/lib/types/src/entity/primary_map.rs
+++ b/lib/types/src/entity/primary_map.rs
@@ -109,22 +109,22 @@ where
     }
 
     /// Iterate over all the values in this map.
-    pub fn values(&self) -> slice::Iter<V> {
+    pub fn values(&self) -> slice::Iter<'_, V> {
         self.elems.iter()
     }
 
     /// Iterate over all the values in this map, mutable edition.
-    pub fn values_mut(&mut self) -> slice::IterMut<V> {
+    pub fn values_mut(&mut self) -> slice::IterMut<'_, V> {
         self.elems.iter_mut()
     }
 
     /// Iterate over all the keys and values in this map.
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter::new(self.elems.iter())
     }
 
     /// Iterate over all the keys and values in this map, mutable edition.
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut::new(self.elems.iter_mut())
     }
 
@@ -283,12 +283,12 @@ where
     V::Archived: std::fmt::Debug,
 {
     /// Iterator over all values in the `ArchivedPrimaryMap`
-    pub fn values(&self) -> slice::Iter<Archived<V>> {
+    pub fn values(&self) -> slice::Iter<'_, Archived<V>> {
         self.elems.iter()
     }
 
     /// Iterate over all the keys and values in this map.
-    pub fn iter(&self) -> Iter<K, Archived<V>> {
+    pub fn iter(&self) -> Iter<'_, K, Archived<V>> {
         Iter::new(self.elems.iter())
     }
 }

--- a/lib/types/src/entity/primary_map.rs
+++ b/lib/types/src/entity/primary_map.rs
@@ -169,6 +169,14 @@ where
     pub fn into_boxed_slice(self) -> BoxedSlice<K, V> {
         unsafe { BoxedSlice::<K, V>::from_raw(Box::<[V]>::into_raw(self.elems.into_boxed_slice())) }
     }
+
+    /// Maps a function over the values of the `PrimaryMap`.
+    pub fn map_values<V_>(self, function: impl FnMut(V) -> V_) -> PrimaryMap<K, V_> {
+        PrimaryMap {
+            elems: self.elems.into_iter().map(function).collect(),
+            unused: Default::default(),
+        }
+    }
 }
 
 impl<K, V> ArchivedPrimaryMap<K, V>

--- a/lib/types/src/entity/secondary_map.rs
+++ b/lib/types/src/entity/secondary_map.rs
@@ -121,12 +121,12 @@ where
     }
 
     /// Iterate over all the keys and values in this map.
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         Iter::new(self.elems.iter())
     }
 
     /// Iterate over all the keys and values in this map, mutable edition.
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut::new(self.elems.iter_mut())
     }
 
@@ -136,12 +136,12 @@ where
     }
 
     /// Iterate over all the values in this map.
-    pub fn values(&self) -> slice::Iter<V> {
+    pub fn values(&self) -> slice::Iter<'_, V> {
         self.elems.iter()
     }
 
     /// Iterate over all the values in this map, mutable edition.
-    pub fn values_mut(&mut self) -> slice::IterMut<V> {
+    pub fn values_mut(&mut self) -> slice::IterMut<'_, V> {
         self.elems.iter_mut()
     }
 
@@ -162,12 +162,12 @@ where
     }
 
     /// Iterator over all values in the `ArchivedPrimaryMap`
-    pub fn values(&self) -> slice::Iter<Archived<V>> {
+    pub fn values(&self) -> slice::Iter<'_, Archived<V>> {
         self.elems.iter()
     }
 
     /// Iterate over all the keys and values in this map.
-    pub fn iter(&self) -> Iter<K, Archived<V>> {
+    pub fn iter(&self) -> Iter<'_, K, Archived<V>> {
         Iter::new(self.elems.iter())
     }
 }

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -61,6 +61,7 @@ mod module_hash;
 mod serialize;
 mod stack;
 mod store_id;
+mod store_object;
 mod table;
 pub mod target;
 mod trapcode;
@@ -100,6 +101,7 @@ pub use crate::units::{
 };
 pub use value::{RawValue, ValueType};
 
+pub use crate::store_object::{Upcast, BoxStoreObject, LocalBoxStoreObject};
 pub use crate::libcalls::LibCall;
 pub use crate::memory::MemoryStyle;
 pub use crate::table::TableStyle;

--- a/lib/types/src/store_object.rs
+++ b/lib/types/src/store_object.rs
@@ -1,0 +1,55 @@
+use std::any::Any;
+
+/// Type-erased objects stored in a [`Store`].
+pub type BoxStoreObject = Box<dyn Any + Send>;
+/// Type-erased objects stored in a `?Send` [`Store`].
+pub type LocalBoxStoreObject = Box<dyn Any>;
+
+/// TODO document
+// TODO is this name too low-level?
+pub trait Upcast<T>: Sized {
+    /// TODO document
+    fn upcast(value: T) -> Self;
+    /// TODO document
+    fn downcast(self) -> Result<Box<T>, Self>;
+    /// TODO document
+    fn downcast_ref(&self) -> Option<&T>;
+    /// TODO document
+    fn downcast_mut(&mut self) -> Option<&mut T>;
+}
+
+impl<T: Send + 'static> Upcast<T> for BoxStoreObject {
+    fn upcast(value: T) -> Self {
+        Box::new(value) as _
+    }
+
+    fn downcast(self) -> Result<Box<T>, Self> {
+        self.downcast()
+    }
+
+    fn downcast_ref(&self) -> Option<&T> {
+        (**self).downcast_ref()
+    }
+
+    fn downcast_mut(&mut self) -> Option<&mut T> {
+        (**self).downcast_mut()
+    }
+}
+
+impl<T: 'static> Upcast<T> for LocalBoxStoreObject {
+    fn upcast(value: T) -> Self {
+        Box::new(value) as _
+    }
+
+    fn downcast(self) -> Result<Box<T>, Self> {
+        self.downcast()
+    }
+
+    fn downcast_ref(&self) -> Option<&T> {
+        (**self).downcast_ref()
+    }
+
+    fn downcast_mut(&mut self) -> Option<&mut T> {
+        (**self).downcast_mut()
+    }
+}

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -32,7 +32,6 @@ fnv = "1.0.3"
 tracing = { workspace = true, optional = true }
 crossbeam-queue = "0.3.8"
 loupe = { workspace = true, optional = true }
-paste = "1.0.15"
 
 [target.'cfg(any(target_family = "unix", all(target_family = "windows", target_env = "gnu")))'.dependencies]
 libunwind = "1.3.3"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -32,6 +32,7 @@ fnv = "1.0.3"
 tracing = { workspace = true, optional = true }
 crossbeam-queue = "0.3.8"
 loupe = { workspace = true, optional = true }
+paste = "1.0.15"
 
 [target.'cfg(any(target_family = "unix", all(target_family = "windows", target_env = "gnu")))'.dependencies]
 libunwind = "1.3.3"

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -32,6 +32,7 @@ fnv = "1.0.3"
 tracing = { workspace = true, optional = true }
 crossbeam-queue = "0.3.8"
 loupe = { workspace = true, optional = true }
+derive-where = "1.5.0"
 
 [target.'cfg(any(target_family = "unix", all(target_family = "windows", target_env = "gnu")))'.dependencies]
 libunwind = "1.3.3"

--- a/lib/vm/src/function_env.rs
+++ b/lib/vm/src/function_env.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 /// Underlying FunctionEnvironment used by a `VMFunction`.
-pub struct VMFunctionEnvironment<Object = Box<dyn Any + Send>> {
+pub struct VMFunctionEnvironment<Object = wasmer_types::BoxStoreObject> {
     /// The contents of the environment.
     pub contents: Object,
 }

--- a/lib/vm/src/function_env.rs
+++ b/lib/vm/src/function_env.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use wasmer_types::Upcast;
 
 /// Underlying FunctionEnvironment used by a `VMFunction`.
 pub struct VMFunctionEnvironment<Object = wasmer_types::BoxStoreObject> {
@@ -14,11 +14,11 @@ impl<Object> std::fmt::Debug for VMFunctionEnvironment<Object> {
     }
 }
 
-impl VMFunctionEnvironment {
+impl<Object> VMFunctionEnvironment<Object> {
     /// Wraps the given value to expose it to Wasm code as a function context.
-    pub fn new(val: impl Any + Send + 'static) -> Self {
+    pub fn new<T>(val: T) -> Self where Object: Upcast<T> {
         Self {
-            contents: Box::new(val),
+            contents: Object::upcast(val),
         }
     }
 }

--- a/lib/vm/src/function_env.rs
+++ b/lib/vm/src/function_env.rs
@@ -1,15 +1,15 @@
 use std::any::Any;
 
 /// Underlying FunctionEnvironment used by a `VMFunction`.
-pub struct VMFunctionEnvironment {
+pub struct VMFunctionEnvironment<Object = Box<dyn Any + Send>> {
     /// The contents of the environment.
-    pub contents: Box<dyn Any + Send + 'static>,
+    pub contents: Object,
 }
 
-impl std::fmt::Debug for VMFunctionEnvironment {
+impl<Object> std::fmt::Debug for VMFunctionEnvironment<Object> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VMFunctionEnvironment")
-            .field("contents", &(&*self.contents as *const _))
+            .field("contents", &"...")
             .finish()
     }
 }
@@ -21,16 +21,18 @@ impl VMFunctionEnvironment {
             contents: Box::new(val),
         }
     }
+}
 
+impl<Object> VMFunctionEnvironment<Object> {
     #[allow(clippy::should_implement_trait)]
     /// Returns a reference to the underlying value.
-    pub fn as_ref(&self) -> &(dyn Any + Send + 'static) {
-        &*self.contents
+    pub fn as_ref(&self) -> &Object {
+        &self.contents
     }
 
     #[allow(clippy::should_implement_trait)]
     /// Returns a mutable reference to the underlying value.
-    pub fn as_mut(&mut self) -> &mut (dyn Any + Send + 'static) {
-        &mut *self.contents
+    pub fn as_mut(&mut self) -> &mut Object {
+        &mut self.contents
     }
 }

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -1298,7 +1298,7 @@ impl VMInstance {
     /// Specifically, it provides access to the key-value pairs, where the keys
     /// are export names, and the values are export declarations which can be
     /// resolved `lookup_by_declaration`.
-    pub fn exports(&self) -> indexmap::map::Iter<String, ExportIndex> {
+    pub fn exports(&self) -> indexmap::map::Iter<'_, String, ExportIndex> {
         self.module().exports.iter()
     }
 

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -263,7 +263,7 @@ impl<Object, T: StoreObject<Object>> StoreHandle<T, Object> {
 /// Unlike `StoreHandle` this does not track the context ID: it is only
 /// intended to be used within objects already owned by a context.
 #[repr(transparent)]
-pub struct InternalStoreHandle<T, Object = Box<dyn std::any::Any + Send>> {
+pub struct InternalStoreHandle<T, Object = BoxStoreObject> {
     // Use a NonZero here to reduce the size of Option<InternalStoreHandle>.
     idx: NonZeroUsize,
     marker: PhantomData<fn(Object) -> (T, Object)>,

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -17,43 +17,37 @@ pub trait StoreObject<Object = BoxStoreObject>: Sized {
     /// List the objects in the store, mutably.
     fn list_mut(ctx: &mut StoreObjects<Object>) -> &mut Vec<Self::Data>;
 }
-pub mod handle {
-    use super::{NonZeroUsize, StoreObjects};
 
-    macro_rules! impl_context_object {
-        ($($field:ident => $Data:ident$(<$($params:ty),*>)?,)*) => {
-            paste::paste! {
-                $(
-                    #[derive(Debug, Clone, Copy)]
-                    pub struct $Data(NonZeroUsize);
+use super::{NonZeroUsize, StoreObjects};
 
-                    impl<Object> super::StoreObject<Object> for $Data {
-                        type Data = super::$Data$(<$($params),*>)?;
-
-                        fn list(ctx: &StoreObjects<Object>) -> &Vec<Self::Data> {
-                            &ctx.$field
-                        }
-
-                        fn list_mut(ctx: &mut StoreObjects<Object>) -> &mut Vec<Self::Data> {
-                            &mut ctx.$field
-                        }
+macro_rules! impl_context_object {
+    ($($field:ident => $Data:ident$(<$($params:ty),*>)?,)*) => {
+        paste::paste! {
+            $(
+                impl<Object> super::StoreObject<Object> for $Data {
+                    fn list(ctx: &StoreObjects<Object>) -> &Vec<Self::Data<$(params),*>> {
+                        &ctx.$field
                     }
-                )*
-            }
-        };
-    }
 
-    impl_context_object! {
-        functions => VMFunction,
-        tables => VMTable,
-        globals => VMGlobal,
-        instances => VMInstance,
-        memories => VMMemory,
-        extern_objs => VMExternObj,
-        exceptions => VMExceptionObj,
-        tags => VMTag,
-        function_environments => VMFunctionEnvironment,
-    }
+                    fn list_mut(ctx: &mut StoreObjects<Object>) -> &mut Vec<Self::Data<$(params),*>> {
+                        &mut ctx.$field
+                    }
+                }
+            )*
+        }
+    };
+}
+
+impl_context_object! {
+    functions => VMFunction,
+    tables => VMTable,
+    globals => VMGlobal,
+    instances => VMInstance,
+    memories => VMMemory,
+    extern_objs => VMExternObj,
+    exceptions => VMExceptionObj,
+    tags => VMTag,
+    function_environments => VMFunctionEnvironment<Object>,
 }
 
 /// Set of objects managed by a context.

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 use core::slice::Iter;
 use std::{cell::UnsafeCell, fmt, marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
-use wasmer_types::StoreId;
+use wasmer_types::{BoxStoreObject, StoreId};
 
 /// Trait to represent an object managed by a context. This is implemented on
 /// the VM types managed by the context.
-pub trait StoreObject<Object = Box<dyn std::any::Any + Send>>: Sized {
+pub trait StoreObject<Object = BoxStoreObject>: Sized {
     /// List the objects in the store.
     fn list(ctx: &StoreObjects<Object>) -> &Vec<Self>;
 
@@ -42,7 +42,7 @@ impl_context_object! {
 }
 
 /// Set of objects managed by a context.
-pub struct StoreObjects<Object = Box<dyn std::any::Any + Send>> {
+pub struct StoreObjects<Object = BoxStoreObject> {
     id: StoreId,
     memories: Vec<VMMemory>,
     tables: Vec<VMTable>,
@@ -175,7 +175,7 @@ impl<Object> StoreObjects<Object> {
 /// Internally this is just an integer index into a context. A reference to the
 /// context must be passed in separately to access the actual object.
 #[cfg_attr(feature = "artifact-size", derive(loupe::MemoryUsage))]
-pub struct StoreHandle<T, Object = Box<dyn std::any::Any + Send>> {
+pub struct StoreHandle<T, Object = BoxStoreObject> {
     id: StoreId,
     internal: InternalStoreHandle<T, Object>,
 }

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -269,6 +269,9 @@ pub struct InternalStoreHandle<T, Object = Box<dyn std::any::Any + Send>> {
     marker: PhantomData<fn(Object) -> (T, Object)>,
 }
 
+unsafe impl<Object> Send for InternalStoreHandle<Object> {}
+unsafe impl<Object> Sync for InternalStoreHandle<Object> {}
+
 #[cfg(feature = "artifact-size")]
 impl<T, Object> loupe::MemoryUsage for InternalStoreHandle<T, Object> {
     fn size_of_val(&self, _tracker: &mut dyn loupe::MemoryUsageTracker) -> usize {

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -115,7 +115,7 @@ impl StoreObjects {
     }
 
     /// Return an immutable iterator over all globals
-    pub fn iter_globals(&self) -> Iter<VMGlobal> {
+    pub fn iter_globals(&self) -> Iter<'_, VMGlobal> {
         self.globals.iter()
     }
 

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -41,7 +41,7 @@ impl_context_object! {
     functions => VMFunction,
     tables => VMTable,
     globals => VMGlobal,
-    instances => VMInstance,
+    instances => VMInstance<Object>,
     memories => VMMemory,
     extern_objs => VMExternObj,
     exceptions => VMExceptionObj,
@@ -56,7 +56,7 @@ pub struct StoreObjects<Object = BoxStoreObject> {
     tables: Vec<VMTable>,
     globals: Vec<VMGlobal>,
     functions: Vec<VMFunction>,
-    instances: Vec<VMInstance>,
+    instances: Vec<VMInstance<Object>>,
     extern_objs: Vec<VMExternObj>,
     exceptions: Vec<VMExceptionObj>,
     tags: Vec<VMTag>,
@@ -106,7 +106,7 @@ impl<Object> StoreObjects<Object> {
         tables: Vec<VMTable>,
         globals: Vec<VMGlobal>,
         functions: Vec<VMFunction>,
-        instances: Vec<VMInstance>,
+        instances: Vec<VMInstance<Object>>,
         extern_objs: Vec<VMExternObj>,
         exceptions: Vec<VMExceptionObj>,
         tags: Vec<VMTag>,
@@ -328,11 +328,7 @@ impl<T> InternalStoreHandle<T> {
     where
         T: StoreObject,
     {
-        Self::new_in_list(T::list_mut(ctx), val)
-    }
-
-    /// Move the object into a pre-selected list, returning a handle to it.
-    pub fn new_in_list<Object>(list: &mut Vec<T::Data<Object>>, val: T::Data<Object>) -> Self where T: StoreObject {
+        let list = T::list_mut(ctx);
         let idx = NonZeroUsize::new(list.len() + 1).unwrap();
         list.push(val);
         Self {

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -799,12 +799,12 @@ impl VMContext {
     #[allow(clippy::cast_ptr_alignment)]
     #[inline]
     pub(crate) unsafe fn instance(&self) -> &Instance {
-        &*((self as *const Self as *mut u8).offset(-Instance::vmctx_offset()) as *const Instance)
+        &*((self as *const Self as *mut u8).offset(-Instance::<()>::vmctx_offset()) as *const Instance)
     }
 
     #[inline]
     pub(crate) unsafe fn instance_mut(&mut self) -> &mut Instance {
-        &mut *((self as *const Self as *mut u8).offset(-Instance::vmctx_offset()) as *mut Instance)
+        &mut *((self as *const Self as *mut u8).offset(-Instance::<()>::vmctx_offset()) as *mut Instance)
     }
 }
 


### PR DESCRIPTION
This PR is currently a draft, as the work needs to be ported to the other (non-`sys`) backends and also needs documentation in some places, but contains all public API changes so I'm submitting it early for feedback.

# Description

Apropos of https://github.com/wasmerio/wasmer/pull/4634, parameterize the `Store` on a type of type-erased `Object`s.  This enables building stores where the internal `Object` is `Box<dyn Any>` (instead of `Box<dyn Any + Send>`) to permit the storage of non-`Send` objects in the store.

Type defaults have been used to maintain API compatibility for the most part.  However, this is still technically a breaking change, since it changes some public but less-used APIs in incompatible ways (e.g. adding `type Object` to `AsStoreRef`).

A trait `Upcast<T>` is introduced to `wasmer-types` for types that can type-erase `T`, and implemented for `Box<dyn Any>` and `Box<dyn Any + Send>`.
