### PR TITLE
Fix WASIX networking w.r.t. aiohttp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6198,6 +6198,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "typetag",
+ "virtual-mio",
  "wasmer-package",
  "web-time",
  "webc",

--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 wasmer-package.workspace = true
+virtual-mio = { path = "../virtual-io", version = "0.601.0-rc.2", default-features = false }
 dashmap.workspace = true
 derive_more.workspace = true
 dunce = "1.0.4"
@@ -40,7 +41,7 @@ serde = { workspace = true, default-features = false, features = [
 	"derive",
 ], optional = true }
 getrandom.workspace = true
-web-time = { version = "1.1", optional = true}
+web-time = { version = "1.1", optional = true }
 
 [dev-dependencies]
 pretty_assertions.workspace = true
@@ -64,10 +65,7 @@ host-fs = [
 webc-fs = ["webc", "anyhow"]
 static-fs = ["webc", "anyhow"]
 enable-serde = ["typetag", "serde"]
-js = [
-	"dep:web-time",
-	"getrandom/js",
-]
+js = ["dep:web-time", "getrandom/js"]
 # Enables memory tracking/limiting functionality for the in-memory filesystem.
 tracking = []
 futures = []

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -117,8 +117,15 @@ impl VirtualNetworking for LocalNetworking {
 
         #[cfg(not(windows))]
         let socket = {
-            let std_sock =
-                Socket::new(Domain::IPV4, Type::DGRAM, None).map_err(io_err_into_net_error)?;
+            let domain = if addr.is_ipv4() {
+                Domain::IPV4
+            } else {
+                Domain::IPV6
+            };
+            let std_sock = Socket::new(domain, Type::DGRAM, None).map_err(io_err_into_net_error)?;
+            std_sock
+                .set_nonblocking(true)
+                .map_err(io_err_into_net_error)?;
             std_sock
                 .set_reuse_address(reuse_addr)
                 .map_err(io_err_into_net_error)?;

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -134,7 +134,6 @@ pub struct InodeValFilePollGuardJoin {
     fd: u32,
     peb: PollEventSet,
     subscription: Subscription,
-    spent: bool,
 }
 
 impl InodeValFilePollGuardJoin {
@@ -144,7 +143,6 @@ impl InodeValFilePollGuardJoin {
             fd: guard.fd,
             peb: guard.peb,
             subscription: guard.subscription,
-            spent: false,
         }
     }
     pub(crate) fn fd(&self) -> u32 {
@@ -152,22 +150,6 @@ impl InodeValFilePollGuardJoin {
     }
     pub(crate) fn peb(&self) -> PollEventSet {
         self.peb
-    }
-    pub fn is_spent(&self) -> bool {
-        self.spent
-    }
-    pub fn reset(&mut self) {
-        match &self.mode {
-            InodeValFilePollGuardMode::File(_) => {}
-            InodeValFilePollGuardMode::EventNotifications(inner) => {
-                inner.reset();
-            }
-            InodeValFilePollGuardMode::Socket { .. }
-            | InodeValFilePollGuardMode::PipeRx { .. }
-            | InodeValFilePollGuardMode::PipeTx { .. }
-            | InodeValFilePollGuardMode::DuplexPipe { .. } => {}
-        }
-        self.spent = false;
     }
 }
 
@@ -403,7 +385,6 @@ impl Future for InodeValFilePollGuardJoin {
             };
         }
         if !ret.is_empty() {
-            self.spent = true;
             return Poll::Ready(ret);
         }
         Poll::Pending

--- a/lib/wasix/src/journal/effector/syscalls/sock_send_to.rs
+++ b/lib/wasix/src/journal/effector/syscalls/sock_send_to.rs
@@ -48,7 +48,7 @@ impl JournalEffector {
     }
 
     pub fn apply_sock_send_to<M: MemorySize>(
-        ctx: &FunctionEnvMut<'_, WasiEnv>,
+        ctx: &mut FunctionEnvMut<'_, WasiEnv>,
         sock: Fd,
         si_data: Cow<'_, [u8]>,
         si_flags: SiFlags,

--- a/lib/wasix/src/syscalls/journal/play_event.rs
+++ b/lib/wasix/src/syscalls/journal/play_event.rs
@@ -730,11 +730,19 @@ impl<'a> JournalSyscallPlayer<'a, '_> {
                     tracing::trace!(%fd, "Replay journal - SocketSendTo data={} bytes", data.len());
                     if is_64bit {
                         JournalEffector::apply_sock_send_to::<Memory64>(
-                            &self.ctx, fd, data, flags, addr,
+                            &mut self.ctx,
+                            fd,
+                            data,
+                            flags,
+                            addr,
                         )
                     } else {
                         JournalEffector::apply_sock_send_to::<Memory32>(
-                            &self.ctx, fd, data, flags, addr,
+                            &mut self.ctx,
+                            fd,
+                            data,
+                            flags,
+                            addr,
                         )
                     }
                     .map_err(anyhow_err_to_runtime_err)?

--- a/lib/wasix/src/syscalls/wasix/epoll_wait.rs
+++ b/lib/wasix/src/syscalls/wasix/epoll_wait.rs
@@ -85,13 +85,6 @@ pub fn epoll_wait<M: MemorySize + 'static>(
                             }
                         };
 
-                        // We have to renew any joins that have now been spent
-                        for join in joins {
-                            if join.is_spent() {
-                                join.renew();
-                            }
-                        }
-
                         // Record the event
                         ret.push((fd.clone(), readiness));
                         if ret.len() + POLL_GUARD_MAX_RET >= (maxevents as usize) {

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -61,6 +61,11 @@ pub(crate) fn sock_connect_internal(
         sock,
         Rights::SOCK_CONNECT,
         move |mut socket, flags| async move {
+            // Auto-bind UDP
+            socket = socket
+                .auto_bind_udp(tasks.deref(), net.deref())
+                .await?
+                .unwrap_or(socket);
             socket
                 .connect(
                     tasks.deref(),


### PR DESCRIPTION
This PR is a collection of fixes required to get aiohttp working properly.

The most important change is to the epoll system. Previously, epoll for anything besides sockets would rely on a custom `Waker` to get notified of changes to the FD's status. This was, however, broken, because:

* The old system would rely on polling the FD for read-readiness, with the custom `Waker` pushing events to the epoll instance once it was woken
  * This is already a misuse of the waker system, but let's leave that aside
* Once the waker was triggered, an event would be pushed to the epoll instance
* The instance would then try to "re-arm" the waker by polling for read-readiness again
* However, since the FD would already be ready to read more data (at this point, user code wouldn't have had a chance to read anything yet), the call would just go through and the waker wouldn't get registered

The new approach uses an `InterestHandler` instead. This is well-tested (sockets already use it), is explicit, and is not hacky.

PR in draft status for now until I figure out if more fixes are needed.