### PR TITLE
fix(DynamicFunction): allocate space for trap on host stack

### DIFF
--- a/lib/api/src/backend/sys/entities/function/mod.rs
+++ b/lib/api/src/backend/sys/entities/function/mod.rs
@@ -445,7 +445,7 @@ where
 
         match result {
             Ok(Ok(())) => {}
-            Ok(Err(trap)) => raise_user_trap(Box::new(trap)),
+            Ok(Err(trap)) => raise_user_trap(on_host_stack(|| Box::new(trap))),
             Err(panic) => resume_panic(panic),
         }
     }


### PR DESCRIPTION
# Description

We encountered problem where our `calc-stack-height` utility (calculates wasm-level stack height limit) corrupted the allocator on Windows and hung in `RtlpLowFragHeapAllocFromContext`. The source code is available here: https://github.com/gear-tech/gear/blob/master/utils/calc-stack-height/src/main.rs (calc-stack-height), https://github.com/gear-tech/gear/blob/master/examples/wat/spec/inf_recursion.wat (wasm program before instrumentation), https://github.com/gear-tech/gear/blob/master/utils/wasm-instrument/tests/expectations/stack-height/empty_functions.wat (stack limiter example after instrumentation).

Recommended way to reproduce problem:
```
git clone --branch av/wasmer-v6 https://github.com/gear-tech/gear.git
cd gear
cargo +beta run -p calc-stack-height --release
cargo +nightly-2025-08-17 run -p calc-stack-height --release
```

We are using Windows Server 2022, build `10.0.20348.4052`. It is also possible that this issue can be reproduced on other versions, but I couldn't on Windows 11. Also, the Rust toolchain version `nightly-2025-07-11` and newer is somehow involved in this (maybe the codegen just changed and this started happening more often). Previously, we had another UB in #5585 and after its fix, our tests in wine still crashed and we decided to abandon wine support.

<img width="1132" height="669" alt="image" src="https://github.com/user-attachments/assets/d575d17b-a36b-4f6d-a0d4-7fe78aa2fcfa" />

<img width="968" height="829" alt="image" src="https://github.com/user-attachments/assets/72c70661-98ba-4838-8879-4356e0f272fa" />

# Fix

The `Box::new` on lin 448 cannot be called while on the wasm stack. It must be called inside `on_host_stack`. Otherwise we get a stack overflow in the heap allocator and the trap handler will longjmp out of it, leaving corrupt state.