### PR TITLE
compiler: Ensure unique function symbols by appending function index

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -98,7 +98,7 @@ impl ModuleBasedSymbolRegistry {
                 .iter()
                 .map(|(f, v)| (wasm_module.local_func_index(*f), v))
                 .filter(|(f, _)| f.is_some())
-                .map(|(f, v)| (v.clone(), f.unwrap())),
+                .map(|(f, v)| (format!("{}_{}", v.clone(), f.unwrap().as_u32()), f.unwrap())),
         );
         Self {
             wasm_module,
@@ -115,7 +115,7 @@ impl SymbolRegistry for ModuleBasedSymbolRegistry {
                 .wasm_module
                 .function_names
                 .get(&self.wasm_module.func_index(index))
-                .cloned()
+                .map(|name| format!("{}_{}", name, index.as_u32()))
                 .unwrap_or(self.short_names.symbol_to_name(symbol)),
             _ => self.short_names.symbol_to_name(symbol),
         }


### PR DESCRIPTION
When executing `dprint-plugin-typescript.wasm` with the LLVM backend, frequent crashes were observed. The root cause is the presence of multiple functions sharing the same name within the module. Because `SymbolRegistry` does not reliably resolve name collisions, indirect calls may be bound to incorrect targets.

This patch guarantees uniqueness of function symbols by appending the corresponding function index to each name. This prevents symbol clashes and ensures that functions are linked to the correct callee.
