### PR TITLE
Fix impossible relocation error in emit srem64, urem64 for singlepass compiler/Aarch64

### DIFF
--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -5040,7 +5040,7 @@ impl Machine for MachineARM64 {
             dest
         };
         self.assembler
-            .emit_cbz_label(Size::S64, src2, integer_division_by_zero)?;
+            .emit_cbz_label_far(Size::S64, src2, integer_division_by_zero)?;
         let offset = self.mark_instruction_with_trap_code(TrapCode::IntegerOverflow);
         self.assembler.emit_udiv(Size::S64, src1, src2, dest)?;
         // unsigned remainder : src1 - (src1/src2)*src2
@@ -5078,7 +5078,7 @@ impl Machine for MachineARM64 {
             dest
         };
         self.assembler
-            .emit_cbz_label(Size::S64, src2, integer_division_by_zero)?;
+            .emit_cbz_label_far(Size::S64, src2, integer_division_by_zero)?;
         let offset = self.mark_instruction_with_trap_code(TrapCode::IntegerOverflow);
         self.assembler.emit_sdiv(Size::S64, src1, src2, dest)?;
         // unsigned remainder : src1 - (src1/src2)*src2

--- a/tests/compilers/issues.rs
+++ b/tests/compilers/issues.rs
@@ -469,35 +469,41 @@ fn issue_4519(mut config: crate::Config) -> Result<()> {
 #[cfg(target_arch = "aarch64")]
 #[compiler_test(issues)]
 /// Singlepass panics on aarch64 for long relocations.
-/// This test specifically targets the emission of the sdiv64 binop.
+/// This test specifically targets the emission of sdiv64, srem64, urem64 binops.
 ///
 /// Note: this one is specific to Singlepass, but we want to test in all
 /// available compilers.
 ///
 /// https://github.com/wasmerio/wasmer/issues/4519
-fn issue_4519_sdiv64(mut config: crate::Config) -> Result<()> {
-    const REPEATS_TO_REPRODUCE: usize = 16_000;
+fn issue_4519_sdiv64_srem64_urem64(mut config: crate::Config) -> Result<()> {
+    const REPEATS_TO_REPRODUCE: usize = 30_000;
 
-    let sdiv64 = r#"
-        i64.const 3155225962131072202
-        i64.const -6717269760755396770
-        i64.div_s
-        drop
-    "#;
+    let ops = ["i64.div_s", "i64.rem_s", "i64.rem_u"];
 
-    let wat = format!(
-        r#"
-      (module
-        (func (;0;)
-            {}
+    for op in ops {
+        let sdiv64 = format!(
+            r#"
+            i64.const 3155225962131072202
+            i64.const -6717269760755396770
+            {op}
+            drop
+        "#
+        );
+
+        let wat = format!(
+            r#"
+        (module
+            (func (;0;)
+                {}
+            )
         )
-      )
-    "#,
-        sdiv64.repeat(REPEATS_TO_REPRODUCE)
-    );
+        "#,
+            sdiv64.repeat(REPEATS_TO_REPRODUCE)
+        );
 
-    let mut store = config.store();
-    let module = Module::new(&store, wat)?;
+        let mut store = config.store();
+        let module = Module::new(&store, wat)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Fixes reoccurring error `ImpossibleRelocation(Dynamic(DynamicLabel(0)))` with singlepass compiler for aarch64 targets
when generating `srem64` `urem64` binops.

See https://github.com/wasmerio/wasmer/issues/4519 for more info.
Follow up for https://github.com/wasmerio/wasmer/pull/4956

# What's done

- Use `emit_cbz_label_far` when emitting `srem64` `urem64` binops
- Update `issue_4519_sdiv64` test

