### PR TITLE
Singlepass: simplify dynamic regs usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,6 +1607,19 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "dynasm"
 version = "3.2.1"
+dependencies = [
+ "bitflags 2.9.2",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "dynasm"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
 dependencies = [
@@ -1626,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
 dependencies = [
  "byteorder",
- "dynasm",
+ "dynasm 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv",
  "memmap2 0.9.7",
 ]
@@ -7051,7 +7064,7 @@ name = "wasmer-compiler-singlepass"
 version = "6.1.0-rc.3"
 dependencies = [
  "byteorder",
- "dynasm",
+ "dynasm 3.2.1",
  "dynasmrt",
  "enumset",
  "gimli 0.28.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -394,9 +394,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blake3"
@@ -1127,7 +1127,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "parking_lot",
  "rustix 0.38.44",
@@ -1606,24 +1606,11 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynasm"
-version = "3.2.1"
-dependencies = [
- "bitflags 2.9.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "dynasm"
-version = "3.2.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
+checksum = "24967d5bd87a526280b7b02e0ee5a8b8b2d2483100b04b26f25206afb818dbce"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "byteorder",
  "lazy_static",
  "proc-macro-error2",
@@ -1634,14 +1621,14 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "3.2.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
+checksum = "93c1f5d6b3eed74a1180308dcd72873989dc66cda4e113b7f2674022d66d02f9"
 dependencies = [
  "byteorder",
- "dynasm 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dynasm",
  "fnv",
- "memmap2 0.9.7",
+ "memmap2 0.9.8",
 ]
 
 [[package]]
@@ -2758,7 +2745,7 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6250a98af259a26fd5a4a6081fccea9ac116e4c3178acf4aeb86d32d2b7715"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "cc",
  "handlebars",
  "lazy_static",
@@ -2784,7 +2771,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -2958,7 +2945,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall",
 ]
@@ -3215,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
 ]
@@ -3380,7 +3367,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3553,7 +3540,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4230,7 +4217,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -4527,7 +4514,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4540,7 +4527,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -4747,7 +4734,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4760,7 +4747,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5701,7 +5688,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -5720,7 +5707,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -7064,7 +7051,7 @@ name = "wasmer-compiler-singlepass"
 version = "6.1.0-rc.3"
 dependencies = [
  "byteorder",
- "dynasm 3.2.1",
+ "dynasm",
  "dynasmrt",
  "enumset",
  "gimli 0.28.1",
@@ -7555,7 +7542,7 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "indexmap 2.10.0",
  "semver 1.0.26",
 ]
@@ -7566,7 +7553,7 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "indexmap 2.10.0",
  "semver 1.0.26",
 ]
@@ -7577,7 +7564,7 @@ version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -7586,7 +7573,7 @@ version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "indexmap 2.10.0",
 ]
 
@@ -7596,7 +7583,7 @@ version = "0.236.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
  "indexmap 2.10.0",
  "semver 1.0.26",
 ]
@@ -8110,7 +8097,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.4",
 ]
 
 [[package]]

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -20,7 +20,7 @@ hashbrown = { workspace = true, optional = true }
 gimli = { workspace = true, optional = true }
 enumset.workspace = true
 more-asserts.workspace = true
-dynasm = "3.2.0"
+dynasm = { path = "/home/marxin/Programming/dynasm-rs/plugin" }
 dynasmrt = "3.2.0"
 byteorder.workspace = true
 smallvec.workspace = true

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -20,8 +20,8 @@ hashbrown = { workspace = true, optional = true }
 gimli = { workspace = true, optional = true }
 enumset.workspace = true
 more-asserts.workspace = true
-dynasm = { path = "/home/marxin/Programming/dynasm-rs/plugin" }
-dynasmrt = "3.2.0"
+dynasm = "4.0.0"
+dynasmrt = "4.0.0"
 byteorder.workspace = true
 smallvec.workspace = true
 

--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -48,6 +48,12 @@ pub enum GPR {
     XzrSp = 31,
 }
 
+impl From<GPR> for u8 {
+    fn from(val: GPR) -> Self {
+        val as u8
+    }
+}
+
 /// NEON registers.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -86,6 +92,12 @@ pub enum NEON {
     V29 = 29,
     V30 = 30,
     V31 = 31,
+}
+
+impl From<NEON> for u8 {
+    fn from(val: NEON) -> Self {
+        val as u8
+    }
 }
 
 impl AbstractReg for GPR {

--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -534,51 +534,36 @@ impl EmitterARM64 for Assembler {
     fn emit_str(&mut self, sz: Size, reg: Location, addr: Location) -> Result<(), CompileError> {
         match (sz, reg, addr) {
             (Size::S64, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x7) == 0 && (disp < 0x8000));
                 dynasm!(self ; str X(reg), [X(addr), disp]);
             }
             (Size::S32, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x3) == 0 && (disp < 0x4000));
                 dynasm!(self ; str W(reg), [X(addr), disp]);
             }
             (Size::S16, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x1) == 0 && (disp < 0x2000));
                 dynasm!(self ; strh W(reg), [X(addr), disp]);
             }
             (Size::S8, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!(disp < 0x1000);
                 dynasm!(self ; strb W(reg), [X(addr), disp]);
             }
             (Size::S64, Location::SIMD(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x7) == 0 && (disp < 0x8000));
                 dynasm!(self ; str D(reg), [X(addr), disp]);
             }
             (Size::S32, Location::SIMD(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x3) == 0 && (disp < 0x4000));
                 dynasm!(self ; str S(reg), [X(addr), disp]);
             }
             (Size::S64, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -588,9 +573,6 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S32, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -606,37 +588,26 @@ impl EmitterARM64 for Assembler {
     fn emit_ldr(&mut self, sz: Size, reg: Location, addr: Location) -> Result<(), CompileError> {
         match (sz, reg, addr) {
             (Size::S64, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 assert!((disp & 0x7) == 0 && (disp < 0x8000));
                 let disp = disp as u32;
                 dynasm!(self ; ldr X(reg), [X(addr), disp]);
             }
             (Size::S32, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 assert!((disp & 0x3) == 0 && (disp < 0x4000));
                 let disp = disp as u32;
                 dynasm!(self ; ldr W(reg), [X(addr), disp]);
             }
             (Size::S16, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 assert!((disp & 0x1 == 0) && (disp < 0x2000));
                 let disp = disp as u32;
                 dynasm!(self ; ldrh W(reg), [X(addr), disp]);
             }
             (Size::S8, Location::GPR(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 assert!(disp < 0x1000);
                 let disp = disp as u32;
                 dynasm!(self ; ldrb W(reg), [X(addr), disp]);
             }
             (Size::S64, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -646,9 +617,6 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S32, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -658,23 +626,16 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S64, Location::SIMD(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x7) == 0 && (disp < 0x8000));
                 dynasm!(self ; ldr D(reg), [X(addr), disp]);
             }
             (Size::S32, Location::SIMD(reg), Location::Memory(addr, disp)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let disp = disp as u32;
                 assert!((disp & 0x3) == 0 && (disp < 0x4000));
                 dynasm!(self ; ldr S(reg), [X(addr), disp]);
             }
             (Size::S64, Location::SIMD(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -684,9 +645,6 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S32, Location::SIMD(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -709,23 +667,15 @@ impl EmitterARM64 for Assembler {
         assert!((-255..=255).contains(&offset));
         match (sz, reg) {
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; stur X(reg), [X(addr), offset]);
             }
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; stur W(reg), [X(addr), offset]);
             }
             (Size::S64, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; stur D(reg), [X(addr), offset]);
             }
             (Size::S32, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; stur S(reg), [X(addr), offset]);
             }
             _ => codegen_error!(
@@ -748,23 +698,15 @@ impl EmitterARM64 for Assembler {
         assert!((-255..=255).contains(&offset));
         match (sz, reg) {
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldur X(reg), [X(addr), offset]);
             }
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldur W(reg), [X(addr), offset]);
             }
             (Size::S64, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldur D(reg), [X(addr), offset]);
             }
             (Size::S32, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldur S(reg), [X(addr), offset]);
             }
             _ => codegen_error!(
@@ -788,13 +730,9 @@ impl EmitterARM64 for Assembler {
         assert!(offset <= 255);
         match (sz, reg) {
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; str X(reg), [X(addr), -(offset as i32)]!);
             }
             (Size::S64, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; str D(reg), [X(addr), -(offset as i32)]!);
             }
             _ => codegen_error!("singlepass can't emit STRDB"),
@@ -811,13 +749,9 @@ impl EmitterARM64 for Assembler {
         assert!(offset <= 255);
         match (sz, reg) {
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; str X(reg), [X(addr)], offset as i32);
             }
             (Size::S64, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; str D(reg), [X(addr)], offset as i32);
             }
             _ => codegen_error!("singlepass can't emit STRIA"),
@@ -834,13 +768,9 @@ impl EmitterARM64 for Assembler {
         assert!(offset <= 255);
         match (sz, reg) {
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldr X(reg), [X(addr)], offset as _);
             }
             (Size::S64, Location::SIMD(reg)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldr D(reg), [X(addr)], offset as _);
             }
             _ => codegen_error!("singlepass can't emit LDRIA"),
@@ -859,9 +789,6 @@ impl EmitterARM64 for Assembler {
         assert!(offset <= 255);
         match (sz, reg1, reg2) {
             (Size::S64, Location::GPR(reg1), Location::GPR(reg2)) => {
-                let reg1 = reg1.into_index() as u32;
-                let reg2 = reg2.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; stp X(reg1), X(reg2), [X(addr), -(offset as i32)]!);
             }
             _ => codegen_error!("singlepass can't emit STPDB"),
@@ -879,9 +806,6 @@ impl EmitterARM64 for Assembler {
         assert!(offset <= 255);
         match (sz, reg1, reg2) {
             (Size::S64, Location::GPR(reg1), Location::GPR(reg2)) => {
-                let reg1 = reg1.into_index() as u32;
-                let reg2 = reg2.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 dynasm!(self ; ldp X(reg1), X(reg2), [X(addr)], offset as _);
             }
             _ => codegen_error!("singlepass can't emit LDPIA"),
@@ -892,16 +816,11 @@ impl EmitterARM64 for Assembler {
     fn emit_ldrb(&mut self, _sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (reg, dst) {
             (Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!(offset < 0x1000);
                 dynasm!(self ; ldrb W(reg), [X(addr), offset]);
             }
             (Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -917,16 +836,11 @@ impl EmitterARM64 for Assembler {
     fn emit_ldrh(&mut self, _sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (reg, dst) {
             (Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!((offset & 1 == 0) && (offset < 0x2000));
                 dynasm!(self ; ldrh W(reg), [X(addr), offset]);
             }
             (Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -942,23 +856,16 @@ impl EmitterARM64 for Assembler {
     fn emit_ldrsb(&mut self, sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, reg, dst) {
             (Size::S64, Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!(offset < 0x1000);
                 dynasm!(self ; ldrsb X(reg), [X(addr), offset]);
             }
             (Size::S32, Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!(offset < 0x1000);
                 dynasm!(self ; ldrsb W(reg), [X(addr), offset]);
             }
             (Size::S64, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -968,9 +875,6 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S32, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -986,23 +890,16 @@ impl EmitterARM64 for Assembler {
     fn emit_ldrsh(&mut self, sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, reg, dst) {
             (Size::S64, Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!((offset & 1 == 0) && (offset < 0x2000));
                 dynasm!(self ; ldrsh X(reg), [X(addr), offset]);
             }
             (Size::S32, Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!((offset & 1 == 0) && (offset < 0x2000));
                 dynasm!(self ; ldrsh W(reg), [X(addr), offset]);
             }
             (Size::S64, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -1012,9 +909,6 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S32, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -1030,16 +924,11 @@ impl EmitterARM64 for Assembler {
     fn emit_ldrsw(&mut self, sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, reg, dst) {
             (Size::S64, Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!((offset & 3 == 0) && (offset < 0x4000));
                 dynasm!(self ; ldrsw X(reg), [X(addr), offset]);
             }
             (Size::S64, Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -1055,16 +944,11 @@ impl EmitterARM64 for Assembler {
     fn emit_strb(&mut self, _sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (reg, dst) {
             (Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!(offset < 0x1000);
                 dynasm!(self ; strb W(reg), [X(addr), offset]);
             }
             (Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -1080,16 +964,11 @@ impl EmitterARM64 for Assembler {
     fn emit_strh(&mut self, _sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (reg, dst) {
             (Location::GPR(reg), Location::Memory(addr, offset)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
                 let offset = offset as u32;
                 assert!((offset & 1 == 0) && (offset < 0x2000));
                 dynasm!(self ; strh W(reg), [X(addr), offset]);
             }
             (Location::GPR(reg), Location::Memory2(addr, r2, mult, offs)) => {
-                let reg = reg.into_index() as u32;
-                let addr = addr.into_index() as u32;
-                let r2 = r2.into_index() as u32;
                 assert!(offs == 0);
                 let mult = mult as u32;
                 match mult {
@@ -1106,13 +985,9 @@ impl EmitterARM64 for Assembler {
     fn emit_ldaxr(&mut self, sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, reg, dst) {
             (Size::S32, Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ldaxr W(reg), [X(dst)]);
             }
             (Size::S64, Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ldaxr X(reg), [X(dst)]);
             }
             _ => codegen_error!("singlepass can't emit LDAXR {:?}, {:?}", reg, dst),
@@ -1122,8 +997,6 @@ impl EmitterARM64 for Assembler {
     fn emit_ldaxrb(&mut self, _sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (reg, dst) {
             (Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ldaxrb W(reg), [X(dst)]);
             }
             _ => codegen_error!("singlepass can't emit LDAXRB {:?}, {:?}", reg, dst),
@@ -1133,8 +1006,6 @@ impl EmitterARM64 for Assembler {
     fn emit_ldaxrh(&mut self, _sz: Size, reg: Location, dst: Location) -> Result<(), CompileError> {
         match (reg, dst) {
             (Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ldaxrh W(reg), [X(dst)]);
             }
             _ => codegen_error!("singlepass can't emit LDAXRH {:?}, {:?}", reg, dst),
@@ -1150,15 +1021,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, status, reg, dst) {
             (Size::S32, Location::GPR(status), Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
-                let status = status.into_index() as u32;
                 dynasm!(self ; stlxr W(status), W(reg), [X(dst)]);
             }
             (Size::S64, Location::GPR(status), Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
-                let status = status.into_index() as u32;
                 dynasm!(self ; stlxr W(status), X(reg), [X(dst)]);
             }
             _ => codegen_error!("singlepass can't emit STLXR {:?}, {:?}", reg, dst),
@@ -1174,9 +1039,6 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (status, reg, dst) {
             (Location::GPR(status), Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
-                let status = status.into_index() as u32;
                 dynasm!(self ; stlxrb W(status), W(reg), [X(dst)]);
             }
             _ => codegen_error!("singlepass can't emit STLXRB {:?}, {:?}", reg, dst),
@@ -1192,9 +1054,6 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (status, reg, dst) {
             (Location::GPR(status), Location::GPR(reg), Location::GPR(dst)) => {
-                let reg = reg.into_index() as u32;
-                let dst = dst.into_index() as u32;
-                let status = status.into_index() as u32;
                 dynasm!(self ; stlxrh W(status), W(reg), [X(dst)]);
             }
             _ => codegen_error!("singlepass can't emit STLXRH {:?}, {:?}", reg, dst),
@@ -1205,47 +1064,30 @@ impl EmitterARM64 for Assembler {
     fn emit_mov(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov X(dst), X(src));
             }
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov W(dst), W(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov V(dst).D[0], V(src).D[0]);
             }
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov V(dst).S[0], V(src).S[0]);
             }
             (Size::S64, Location::GPR(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov V(dst).D[0], X(src));
             }
             (Size::S32, Location::GPR(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov V(dst).S[0], W(src));
             }
             (Size::S64, Location::SIMD(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov X(dst), V(src).D[0]);
             }
             (Size::S32, Location::SIMD(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mov W(dst), V(src).S[0]);
             }
             (Size::S32, Location::Imm32(val), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if val < 0x1000 || encode_logical_immediate_32bit(val as _).is_some() {
                     dynasm!(self ; mov W(dst), val);
                 } else {
@@ -1255,7 +1097,6 @@ impl EmitterARM64 for Assembler {
                 }
             }
             (Size::S64, Location::Imm32(val), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if val < 0x1000 {
                     dynasm!(self ; mov W(dst), val);
                 } else if encode_logical_immediate_64bit(val as _).is_some() {
@@ -1267,7 +1108,6 @@ impl EmitterARM64 for Assembler {
                 }
             }
             (Size::S64, Location::Imm64(val), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if val < 0x1000 || encode_logical_immediate_64bit(val as _).is_some() {
                     dynasm!(self ; mov X(dst), val as _);
                 } else {
@@ -1286,11 +1126,9 @@ impl EmitterARM64 for Assembler {
     fn emit_movn(&mut self, sz: Size, reg: Location, val: u32) -> Result<(), CompileError> {
         match (sz, reg) {
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; movn W(reg), val);
             }
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; movn X(reg), val);
             }
             _ => codegen_error!("singlepass can't emit MOVN"),
@@ -1300,7 +1138,6 @@ impl EmitterARM64 for Assembler {
     fn emit_movz(&mut self, reg: Location, val: u32) -> Result<(), CompileError> {
         match reg {
             Location::GPR(reg) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; movz W(reg), val);
             }
             _ => codegen_error!("singlepass can't emit MOVZ"),
@@ -1310,7 +1147,6 @@ impl EmitterARM64 for Assembler {
     fn emit_movk(&mut self, reg: Location, val: u32, shift: u32) -> Result<(), CompileError> {
         match reg {
             Location::GPR(reg) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; movk X(reg), val, LSL shift);
             }
             _ => codegen_error!("singlepass can't emit MOVK"),
@@ -1321,7 +1157,6 @@ impl EmitterARM64 for Assembler {
     fn emit_mov_imm(&mut self, dst: Location, val: u64) -> Result<(), CompileError> {
         match dst {
             Location::GPR(dst) => {
-                let dst = dst.into_index() as u32;
                 let offset = val.trailing_zeros() & 48;
                 let masked = 0xffff & (val >> offset);
                 if (masked << offset) == val {
@@ -1362,27 +1197,17 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; add XSP(dst), XSP(src1), X(src2), UXTX);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; add WSP(dst), WSP(src1), W(src2), UXTX);
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; add XSP(dst), XSP(src1), imm as _);
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     unreachable!();
                 }
@@ -1390,8 +1215,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm64(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     unreachable!();
                 }
@@ -1400,14 +1223,10 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; add WSP(dst), WSP(src1), imm as u32);
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     unreachable!();
                 }
@@ -1432,46 +1251,30 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self; sub XSP(dst), XSP(src1), X(src2), UXTX 0);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sub WSP(dst), WSP(src1), W(src2), UXTX 0);
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sub XSP(dst), XSP(src1), imm as u32);
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sub WSP(dst), WSP(src1), imm as u32);
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     unreachable!();
                 }
                 dynasm!(self ; sub WSP(dst), WSP(src1), imm);
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     unreachable!();
                 }
                 dynasm!(self ; sub XSP(dst), XSP(src1), imm);
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     unreachable!();
                 }
@@ -1496,15 +1299,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mul X(dst), X(src1), X(src2));
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; mul W(dst), W(src1), W(src2));
             }
             _ => codegen_error!(
@@ -1526,27 +1323,17 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; adds X(dst), X(src1), X(src2));
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; adds W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; adds X(dst), XSP(src1), imm as u32);
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     codegen_error!("singlepass ADD.S with imm too large {}", imm);
                 }
@@ -1554,14 +1341,10 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; adds W(dst), WSP(src1), imm as u32);
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     codegen_error!("singlepass ADD.S with imm too large {}", imm);
                 }
@@ -1586,25 +1369,15 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; subs X(dst), X(src1), X(src2));
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; subs W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; subs X(dst), XSP(src1), imm as u32);
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; subs W(dst), WSP(src1), imm as u32);
             }
             _ => codegen_error!(
@@ -1627,9 +1400,6 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; add X(dst), X(src1), X(src2), LSL lsl);
             }
             _ => codegen_error!(
@@ -1647,39 +1417,30 @@ impl EmitterARM64 for Assembler {
     fn emit_cmp(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; cmp X(dst), X(src));
             }
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; cmp W(dst), W(src));
             }
             (Size::S64, Location::Imm8(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; cmp XSP(dst), imm as u32);
             }
             (Size::S64, Location::Imm32(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     codegen_error!("singlepass CMP with imm too large {}", imm);
                 }
                 dynasm!(self ; cmp XSP(dst), imm as u32);
             }
             (Size::S64, Location::Imm64(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     codegen_error!("singlepass CMP with imm too large {}", imm);
                 }
                 dynasm!(self ; cmp XSP(dst), imm as u32);
             }
             (Size::S32, Location::Imm8(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; cmp WSP(dst), imm as u32);
             }
             (Size::S32, Location::Imm32(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if imm >= 0x1000 {
                     codegen_error!("singlepass CMP with imm too large {}", imm);
                 }
@@ -1693,31 +1454,24 @@ impl EmitterARM64 for Assembler {
     fn emit_tst(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; tst X(dst), X(src));
             }
             (Size::S64, Location::Imm32(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if encode_logical_immediate_64bit(imm as u64).is_none() {
                     codegen_error!("singlepass TST with incompatible imm {}", imm);
                 }
                 dynasm!(self ; tst X(dst), imm as u64);
             }
             (Size::S64, Location::Imm64(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if encode_logical_immediate_64bit(imm as u64).is_none() {
                     codegen_error!("singlepass TST with incompatible imm {}", imm);
                 }
                 dynasm!(self ; tst X(dst), imm as u64);
             }
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; tst W(dst), W(src));
             }
             (Size::S32, Location::Imm32(imm), Location::GPR(dst)) => {
-                let dst = dst.into_index() as u32;
                 if encode_logical_immediate_64bit(imm as u64).is_none() {
                     codegen_error!("singlepass TST with incompatible imm {}", imm);
                 }
@@ -1737,30 +1491,21 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; lsl X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 if imm > 63 {
                     codegen_error!("singlepass LSL with incompatible imm {}", imm);
                 }
                 let imm = imm as u32;
-                let dst = dst.into_index() as u32;
+
                 dynasm!(self ; lsl X(dst), X(src1), imm);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; lsl W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm > 63 {
                     codegen_error!("singlepass LSL with incompatible imm {}", imm);
                 }
@@ -1768,8 +1513,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm64(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm > 63 {
                     codegen_error!("singlepass LSL with incompatible imm {}", imm);
                 }
@@ -1777,8 +1520,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm > 31 {
                     codegen_error!("singlepass LSL with incompatible imm {}", imm);
                 }
@@ -1786,8 +1527,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm > 31 {
                     codegen_error!("singlepass LSL with incompatible imm {}", imm);
                 }
@@ -1812,30 +1551,21 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; asr X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let imm = imm as u32;
-                let dst = dst.into_index() as u32;
+
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass ASR with incompatible imm {}", imm);
                 }
                 dynasm!(self ; asr X(dst), X(src1), imm);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; asr W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass ASR with incompatible imm {}", imm);
                 }
@@ -1843,8 +1573,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm64(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass ASR with incompatible imm {}", imm);
                 }
@@ -1852,8 +1580,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 31 {
                     codegen_error!("singlepass ASR with incompatible imm {}", imm);
                 }
@@ -1861,8 +1587,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 31 {
                     codegen_error!("singlepass ASR with incompatible imm {}", imm);
                 }
@@ -1887,30 +1611,21 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; lsr X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let imm = imm as u32;
-                let dst = dst.into_index() as u32;
+
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass LSR with incompatible imm {}", imm);
                 }
                 dynasm!(self ; lsr X(dst), X(src1), imm);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; lsr W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass LSR with incompatible imm {}", imm);
                 }
@@ -1918,8 +1633,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm64(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass LSR with incompatible imm {}", imm);
                 }
@@ -1927,8 +1640,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 31 {
                     codegen_error!("singlepass LSR with incompatible imm {}", imm);
                 }
@@ -1936,8 +1647,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 31 {
                     codegen_error!("singlepass LSR with incompatible imm {}", imm);
                 }
@@ -1962,16 +1671,12 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ror X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let imm = imm as u32;
-                let dst = dst.into_index() as u32;
+
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass ROR with incompatible imm {}", imm);
                 }
@@ -1979,9 +1684,8 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm64(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let imm = imm as u32;
-                let dst = dst.into_index() as u32;
+
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass ROR with incompatible imm {}", imm);
                 }
@@ -1989,23 +1693,16 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm32(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 31 {
                     codegen_error!("singlepass ROR with incompatible imm {}", imm);
                 }
                 dynasm!(self ; ror W(dst), W(src1), imm as u32);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ror W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S64, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 63 {
                     codegen_error!("singlepass ROR with incompatible imm {}", imm);
                 }
@@ -2013,8 +1710,6 @@ impl EmitterARM64 for Assembler {
             }
             (Size::S32, Location::GPR(src1), Location::Imm8(imm), Location::GPR(dst))
             | (Size::S32, Location::Imm8(imm), Location::GPR(src1), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 if imm == 0 || imm > 31 {
                     codegen_error!("singlepass ROR with incompatible imm {}", imm);
                 }
@@ -2040,33 +1735,25 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; orr X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let src2 = src2 as u64;
-                let dst = dst.into_index() as u32;
+
                 if encode_logical_immediate_64bit(src2 as u64).is_none() {
                     codegen_error!("singlepass OR with incompatible imm {}", src2);
                 }
                 dynasm!(self ; orr XSP(dst), X(src1), src2);
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let src2 = src2 as u32;
-                let dst = dst.into_index() as u32;
+
                 if encode_logical_immediate_32bit(src2).is_none() {
                     codegen_error!("singlepass OR with incompatible imm {}", src2);
                 }
                 dynasm!(self ; orr WSP(dst), W(src1), src2);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; orr W(dst), W(src1), W(src2));
             }
             _ => codegen_error!(
@@ -2088,33 +1775,25 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; and X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let src2 = src2 as u64;
-                let dst = dst.into_index() as u32;
+
                 if encode_logical_immediate_64bit(src2 as u64).is_none() {
                     codegen_error!("singlepass AND with incompatible imm {}", src2);
                 }
                 dynasm!(self ; and XSP(dst), X(src1), src2);
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let src2 = src2 as u32;
-                let dst = dst.into_index() as u32;
+
                 if encode_logical_immediate_32bit(src2).is_none() {
                     codegen_error!("singlepass AND with incompatible imm {}", src2);
                 }
                 dynasm!(self ; and WSP(dst), W(src1), src2);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; and W(dst), W(src1), W(src2));
             }
             _ => codegen_error!(
@@ -2136,33 +1815,25 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; eor X(dst), X(src1), X(src2));
             }
             (Size::S64, Location::GPR(src1), Location::Imm64(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let src2 = src2 as u64;
-                let dst = dst.into_index() as u32;
+
                 if encode_logical_immediate_64bit(src2 as u64).is_none() {
                     codegen_error!("singlepass EOR with incompatible imm {}", src2);
                 }
                 dynasm!(self ; eor XSP(dst), X(src1), src2);
             }
             (Size::S32, Location::GPR(src1), Location::Imm32(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
                 let src2 = src2 as u32;
-                let dst = dst.into_index() as u32;
+
                 if encode_logical_immediate_32bit(src2).is_none() {
                     codegen_error!("singlepass EOR with incompatible imm {}", src2);
                 }
                 dynasm!(self ; eor WSP(dst), W(src1), src2);
             }
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; eor W(dst), W(src1), W(src2));
             }
             _ => codegen_error!(
@@ -2185,10 +1856,10 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, dst) {
             (Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; bfc W(dst as u32), lsb, width);
+                dynasm!(self ; bfc W(dst), lsb, width);
             }
             (Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; bfc X(dst as u32), lsb, width);
+                dynasm!(self ; bfc X(dst), lsb, width);
             }
             _ => codegen_error!("singlepass can't emit BFC"),
         }
@@ -2204,10 +1875,10 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!(self ; bfi W(dst as u32), W(src as u32), lsb, width);
+                dynasm!(self ; bfi W(dst), W(src), lsb, width);
             }
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!(self ; bfi X(dst as u32), X(src as u32), lsb, width);
+                dynasm!(self ; bfi X(dst), X(src), lsb, width);
             }
             _ => codegen_error!("singlepass can't emit BFI"),
         }
@@ -2223,15 +1894,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; udiv W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; udiv X(dst), X(src1), X(src2));
             }
             _ => codegen_error!(
@@ -2253,15 +1918,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sdiv W(dst), W(src1), W(src2));
             }
             (Size::S64, Location::GPR(src1), Location::GPR(src2), Location::GPR(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sdiv X(dst), X(src1), X(src2));
             }
             _ => codegen_error!(
@@ -2292,10 +1951,6 @@ impl EmitterARM64 for Assembler {
                 Location::GPR(c),
                 Location::GPR(dst),
             ) => {
-                let a = a.into_index() as u32;
-                let b = b.into_index() as u32;
-                let c = c.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; msub W(dst), W(a), W(b), W(c));
             }
             (
@@ -2305,10 +1960,6 @@ impl EmitterARM64 for Assembler {
                 Location::GPR(c),
                 Location::GPR(dst),
             ) => {
-                let a = a.into_index() as u32;
-                let b = b.into_index() as u32;
-                let c = c.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; msub X(dst), X(a), X(b), X(c));
             }
             _ => codegen_error!(
@@ -2326,13 +1977,9 @@ impl EmitterARM64 for Assembler {
     fn emit_sxtb(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sxtb W(dst), W(src));
             }
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sxtb X(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit SXTB {:?} {:?} {:?}", sz, src, dst),
@@ -2342,13 +1989,9 @@ impl EmitterARM64 for Assembler {
     fn emit_sxth(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sxth W(dst), W(src));
             }
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sxth X(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit SXTH {:?} {:?} {:?}", sz, src, dst),
@@ -2358,8 +2001,6 @@ impl EmitterARM64 for Assembler {
     fn emit_sxtw(&mut self, _sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (src, dst) {
             (Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; sxtw X(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit SXTW {:?} {:?}", src, dst),
@@ -2369,8 +2010,6 @@ impl EmitterARM64 for Assembler {
     fn emit_uxtb(&mut self, _sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (src, dst) {
             (Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; uxtb W(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit UXTB {:?} {:?}", src, dst),
@@ -2380,8 +2019,6 @@ impl EmitterARM64 for Assembler {
     fn emit_uxth(&mut self, _sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (src, dst) {
             (Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; uxth W(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit UXTH {:?} {:?}", src, dst),
@@ -2391,92 +2028,80 @@ impl EmitterARM64 for Assembler {
 
     fn emit_cset(&mut self, sz: Size, dst: Location, cond: Condition) -> Result<(), CompileError> {
         match (sz, dst) {
-            (Size::S32, Location::GPR(reg)) => {
-                let reg = reg as u32;
-                match cond {
-                    Condition::Eq => dynasm!(self ; cset W(reg), eq),
-                    Condition::Ne => dynasm!(self ; cset W(reg), ne),
-                    Condition::Cs => dynasm!(self ; cset W(reg), cs),
-                    Condition::Cc => dynasm!(self ; cset W(reg), cc),
-                    Condition::Mi => dynasm!(self ; cset W(reg), mi),
-                    Condition::Pl => dynasm!(self ; cset W(reg), pl),
-                    Condition::Vs => dynasm!(self ; cset W(reg), vs),
-                    Condition::Vc => dynasm!(self ; cset W(reg), vc),
-                    Condition::Hi => dynasm!(self ; cset W(reg), hi),
-                    Condition::Ls => dynasm!(self ; cset W(reg), ls),
-                    Condition::Ge => dynasm!(self ; cset W(reg), ge),
-                    Condition::Lt => dynasm!(self ; cset W(reg), lt),
-                    Condition::Gt => dynasm!(self ; cset W(reg), gt),
-                    Condition::Le => dynasm!(self ; cset W(reg), le),
-                    Condition::Al => dynasm!(self ; cset W(reg), al),
-                }
-            }
-            (Size::S64, Location::GPR(reg)) => {
-                let reg = reg as u32;
-                match cond {
-                    Condition::Eq => dynasm!(self ; cset X(reg), eq),
-                    Condition::Ne => dynasm!(self ; cset X(reg), ne),
-                    Condition::Cs => dynasm!(self ; cset X(reg), cs),
-                    Condition::Cc => dynasm!(self ; cset X(reg), cc),
-                    Condition::Mi => dynasm!(self ; cset X(reg), mi),
-                    Condition::Pl => dynasm!(self ; cset X(reg), pl),
-                    Condition::Vs => dynasm!(self ; cset X(reg), vs),
-                    Condition::Vc => dynasm!(self ; cset X(reg), vc),
-                    Condition::Hi => dynasm!(self ; cset X(reg), hi),
-                    Condition::Ls => dynasm!(self ; cset X(reg), ls),
-                    Condition::Ge => dynasm!(self ; cset X(reg), ge),
-                    Condition::Lt => dynasm!(self ; cset X(reg), lt),
-                    Condition::Gt => dynasm!(self ; cset X(reg), gt),
-                    Condition::Le => dynasm!(self ; cset X(reg), le),
-                    Condition::Al => dynasm!(self ; cset X(reg), al),
-                }
-            }
+            (Size::S32, Location::GPR(reg)) => match cond {
+                Condition::Eq => dynasm!(self ; cset W(reg), eq),
+                Condition::Ne => dynasm!(self ; cset W(reg), ne),
+                Condition::Cs => dynasm!(self ; cset W(reg), cs),
+                Condition::Cc => dynasm!(self ; cset W(reg), cc),
+                Condition::Mi => dynasm!(self ; cset W(reg), mi),
+                Condition::Pl => dynasm!(self ; cset W(reg), pl),
+                Condition::Vs => dynasm!(self ; cset W(reg), vs),
+                Condition::Vc => dynasm!(self ; cset W(reg), vc),
+                Condition::Hi => dynasm!(self ; cset W(reg), hi),
+                Condition::Ls => dynasm!(self ; cset W(reg), ls),
+                Condition::Ge => dynasm!(self ; cset W(reg), ge),
+                Condition::Lt => dynasm!(self ; cset W(reg), lt),
+                Condition::Gt => dynasm!(self ; cset W(reg), gt),
+                Condition::Le => dynasm!(self ; cset W(reg), le),
+                Condition::Al => dynasm!(self ; cset W(reg), al),
+            },
+            (Size::S64, Location::GPR(reg)) => match cond {
+                Condition::Eq => dynasm!(self ; cset X(reg), eq),
+                Condition::Ne => dynasm!(self ; cset X(reg), ne),
+                Condition::Cs => dynasm!(self ; cset X(reg), cs),
+                Condition::Cc => dynasm!(self ; cset X(reg), cc),
+                Condition::Mi => dynasm!(self ; cset X(reg), mi),
+                Condition::Pl => dynasm!(self ; cset X(reg), pl),
+                Condition::Vs => dynasm!(self ; cset X(reg), vs),
+                Condition::Vc => dynasm!(self ; cset X(reg), vc),
+                Condition::Hi => dynasm!(self ; cset X(reg), hi),
+                Condition::Ls => dynasm!(self ; cset X(reg), ls),
+                Condition::Ge => dynasm!(self ; cset X(reg), ge),
+                Condition::Lt => dynasm!(self ; cset X(reg), lt),
+                Condition::Gt => dynasm!(self ; cset X(reg), gt),
+                Condition::Le => dynasm!(self ; cset X(reg), le),
+                Condition::Al => dynasm!(self ; cset X(reg), al),
+            },
             _ => codegen_error!("singlepass can't emit CSET {:?} {:?} {:?}", sz, dst, cond),
         }
         Ok(())
     }
     fn emit_csetm(&mut self, sz: Size, dst: Location, cond: Condition) -> Result<(), CompileError> {
         match (sz, dst) {
-            (Size::S32, Location::GPR(reg)) => {
-                let reg = reg as u32;
-                match cond {
-                    Condition::Eq => dynasm!(self ; csetm W(reg), eq),
-                    Condition::Ne => dynasm!(self ; csetm W(reg), ne),
-                    Condition::Cs => dynasm!(self ; csetm W(reg), cs),
-                    Condition::Cc => dynasm!(self ; csetm W(reg), cc),
-                    Condition::Mi => dynasm!(self ; csetm W(reg), mi),
-                    Condition::Pl => dynasm!(self ; csetm W(reg), pl),
-                    Condition::Vs => dynasm!(self ; csetm W(reg), vs),
-                    Condition::Vc => dynasm!(self ; csetm W(reg), vc),
-                    Condition::Hi => dynasm!(self ; csetm W(reg), hi),
-                    Condition::Ls => dynasm!(self ; csetm W(reg), ls),
-                    Condition::Ge => dynasm!(self ; csetm W(reg), ge),
-                    Condition::Lt => dynasm!(self ; csetm W(reg), lt),
-                    Condition::Gt => dynasm!(self ; csetm W(reg), gt),
-                    Condition::Le => dynasm!(self ; csetm W(reg), le),
-                    Condition::Al => dynasm!(self ; csetm W(reg), al),
-                }
-            }
-            (Size::S64, Location::GPR(reg)) => {
-                let reg = reg as u32;
-                match cond {
-                    Condition::Eq => dynasm!(self ; csetm X(reg), eq),
-                    Condition::Ne => dynasm!(self ; csetm X(reg), ne),
-                    Condition::Cs => dynasm!(self ; csetm X(reg), cs),
-                    Condition::Cc => dynasm!(self ; csetm X(reg), cc),
-                    Condition::Mi => dynasm!(self ; csetm X(reg), mi),
-                    Condition::Pl => dynasm!(self ; csetm X(reg), pl),
-                    Condition::Vs => dynasm!(self ; csetm X(reg), vs),
-                    Condition::Vc => dynasm!(self ; csetm X(reg), vc),
-                    Condition::Hi => dynasm!(self ; csetm X(reg), hi),
-                    Condition::Ls => dynasm!(self ; csetm X(reg), ls),
-                    Condition::Ge => dynasm!(self ; csetm X(reg), ge),
-                    Condition::Lt => dynasm!(self ; csetm X(reg), lt),
-                    Condition::Gt => dynasm!(self ; csetm X(reg), gt),
-                    Condition::Le => dynasm!(self ; csetm X(reg), le),
-                    Condition::Al => dynasm!(self ; csetm X(reg), al),
-                }
-            }
+            (Size::S32, Location::GPR(reg)) => match cond {
+                Condition::Eq => dynasm!(self ; csetm W(reg), eq),
+                Condition::Ne => dynasm!(self ; csetm W(reg), ne),
+                Condition::Cs => dynasm!(self ; csetm W(reg), cs),
+                Condition::Cc => dynasm!(self ; csetm W(reg), cc),
+                Condition::Mi => dynasm!(self ; csetm W(reg), mi),
+                Condition::Pl => dynasm!(self ; csetm W(reg), pl),
+                Condition::Vs => dynasm!(self ; csetm W(reg), vs),
+                Condition::Vc => dynasm!(self ; csetm W(reg), vc),
+                Condition::Hi => dynasm!(self ; csetm W(reg), hi),
+                Condition::Ls => dynasm!(self ; csetm W(reg), ls),
+                Condition::Ge => dynasm!(self ; csetm W(reg), ge),
+                Condition::Lt => dynasm!(self ; csetm W(reg), lt),
+                Condition::Gt => dynasm!(self ; csetm W(reg), gt),
+                Condition::Le => dynasm!(self ; csetm W(reg), le),
+                Condition::Al => dynasm!(self ; csetm W(reg), al),
+            },
+            (Size::S64, Location::GPR(reg)) => match cond {
+                Condition::Eq => dynasm!(self ; csetm X(reg), eq),
+                Condition::Ne => dynasm!(self ; csetm X(reg), ne),
+                Condition::Cs => dynasm!(self ; csetm X(reg), cs),
+                Condition::Cc => dynasm!(self ; csetm X(reg), cc),
+                Condition::Mi => dynasm!(self ; csetm X(reg), mi),
+                Condition::Pl => dynasm!(self ; csetm X(reg), pl),
+                Condition::Vs => dynasm!(self ; csetm X(reg), vs),
+                Condition::Vc => dynasm!(self ; csetm X(reg), vc),
+                Condition::Hi => dynasm!(self ; csetm X(reg), hi),
+                Condition::Ls => dynasm!(self ; csetm X(reg), ls),
+                Condition::Ge => dynasm!(self ; csetm X(reg), ge),
+                Condition::Lt => dynasm!(self ; csetm X(reg), lt),
+                Condition::Gt => dynasm!(self ; csetm X(reg), gt),
+                Condition::Le => dynasm!(self ; csetm X(reg), le),
+                Condition::Al => dynasm!(self ; csetm X(reg), al),
+            },
             _ => codegen_error!("singlepass can't emit CSETM {:?} {:?} {:?}", sz, dst, cond),
         }
         Ok(())
@@ -2490,8 +2115,6 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 match cond {
                     Condition::Eq => dynasm!(self ; cinc W(dst), W(src), eq),
                     Condition::Ne => dynasm!(self ; cinc W(dst), W(src), ne),
@@ -2511,8 +2134,6 @@ impl EmitterARM64 for Assembler {
                 };
             }
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 match cond {
                     Condition::Eq => dynasm!(self ; cinc X(src), X(dst), eq),
                     Condition::Ne => dynasm!(self ; cinc X(src), X(dst), ne),
@@ -2539,13 +2160,9 @@ impl EmitterARM64 for Assembler {
     fn emit_clz(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; clz X(dst), X(src));
             }
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; clz W(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit CLS {:?} {:?} {:?}", sz, src, dst),
@@ -2555,13 +2172,9 @@ impl EmitterARM64 for Assembler {
     fn emit_rbit(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; rbit X(dst), X(src));
             }
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; rbit W(dst), W(src));
             }
             _ => codegen_error!("singlepass can't emit CLS {:?} {:?} {:?}", sz, src, dst),
@@ -2574,7 +2187,6 @@ impl EmitterARM64 for Assembler {
         Ok(())
     }
     fn emit_load_label(&mut self, reg: GPR, label: Label) -> Result<(), CompileError> {
-        let reg = reg.into_index() as u32;
         dynasm!(self ; adr X(reg), =>label);
         Ok(())
     }
@@ -2591,11 +2203,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, reg) {
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; cbz W(reg), =>label);
             }
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; cbz X(reg), =>label);
             }
             _ => codegen_error!("singlepass can't emit CBZ {:?} {:?} {:?}", sz, reg, label),
@@ -2610,11 +2220,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, reg) {
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; cbnz W(reg), =>label);
             }
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; cbnz X(reg), =>label);
             }
             _ => codegen_error!("singlepass can't emit CBNZ {:?} {:?} {:?}", sz, reg, label),
@@ -2632,13 +2240,10 @@ impl EmitterARM64 for Assembler {
 
         match (sz, reg) {
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
-
                 dynasm!(self ; cbz W(reg), => near_label);
                 dynasm!(self ; b => continue_label);
             }
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; cbz X(reg), => near_label);
                 dynasm!(self ; b => continue_label);
             }
@@ -2660,11 +2265,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, reg) {
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; tbz W(reg), n, =>label);
             }
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; tbz X(reg), n, =>label);
             }
             _ => codegen_error!(
@@ -2686,11 +2289,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, reg) {
             (Size::S32, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; tbnz W(reg), n, =>label);
             }
             (Size::S64, Location::GPR(reg)) => {
-                let reg = reg.into_index() as u32;
                 dynasm!(self ; tbnz X(reg), n, =>label);
             }
             _ => codegen_error!(
@@ -2751,16 +2352,14 @@ impl EmitterARM64 for Assembler {
         self.emit_label(cont)?;
         Ok(())
     }
-    fn emit_b_register(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; br X(reg.into_index() as u32));
+    fn emit_b_register(&mut self, _reg: GPR) -> Result<(), CompileError> {
         Ok(())
     }
     fn emit_call_label(&mut self, label: Label) -> Result<(), CompileError> {
         dynasm!(self ; bl =>label);
         Ok(())
     }
-    fn emit_call_register(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; blr X(reg.into_index() as u32));
+    fn emit_call_register(&mut self, _reg: GPR) -> Result<(), CompileError> {
         Ok(())
     }
     fn emit_ret(&mut self) -> Result<(), CompileError> {
@@ -2784,13 +2383,9 @@ impl EmitterARM64 for Assembler {
     fn emit_fcmp(&mut self, sz: Size, src1: Location, src2: Location) -> Result<(), CompileError> {
         match (sz, src1, src2) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
                 dynasm!(self ; fcmp S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
                 dynasm!(self ; fcmp D(src1), D(src2));
             }
             _ => codegen_error!("singlepass can't emit FCMP {:?} {:?} {:?}", sz, src1, src2),
@@ -2801,13 +2396,9 @@ impl EmitterARM64 for Assembler {
     fn emit_fneg(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fneg S(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fneg D(dst), D(src));
             }
             _ => codegen_error!("singlepass can't emit FNEG {:?} {:?} {:?}", sz, src, dst),
@@ -2817,13 +2408,9 @@ impl EmitterARM64 for Assembler {
     fn emit_fsqrt(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fsqrt S(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fsqrt D(dst), D(src));
             }
             _ => codegen_error!("singlepass can't emit FSQRT {:?} {:?} {:?}", sz, src, dst),
@@ -2840,15 +2427,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fadd S(dst), S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fadd D(dst), D(src1), D(src2));
             }
             _ => codegen_error!(
@@ -2870,15 +2451,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fsub S(dst), S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fsub D(dst), D(src1), D(src2));
             }
             _ => codegen_error!(
@@ -2900,15 +2475,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fmul S(dst), S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fmul D(dst), D(src1), D(src2));
             }
             _ => codegen_error!(
@@ -2930,15 +2499,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fdiv S(dst), S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fdiv D(dst), D(src1), D(src2));
             }
             _ => codegen_error!(
@@ -2961,15 +2524,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fmin S(dst), S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fmin D(dst), D(src1), D(src2));
             }
             _ => codegen_error!(
@@ -2991,15 +2548,9 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz, src1, src2, dst) {
             (Size::S32, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fmax S(dst), S(src1), S(src2));
             }
             (Size::S64, Location::SIMD(src1), Location::SIMD(src2), Location::SIMD(dst)) => {
-                let src1 = src1.into_index() as u32;
-                let src2 = src2.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fmax D(dst), D(src1), D(src2));
             }
             _ => codegen_error!(
@@ -3016,13 +2567,9 @@ impl EmitterARM64 for Assembler {
     fn emit_frintz(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintz S(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintz D(dst), D(src));
             }
             _ => codegen_error!("singlepass can't emit FRINTZ {:?} {:?} {:?}", sz, src, dst),
@@ -3032,13 +2579,9 @@ impl EmitterARM64 for Assembler {
     fn emit_frintn(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintn S(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintn D(dst), D(src));
             }
             _ => codegen_error!("singlepass can't emit FRINTN {:?} {:?} {:?}", sz, src, dst),
@@ -3048,13 +2591,9 @@ impl EmitterARM64 for Assembler {
     fn emit_frintm(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintm S(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintm D(dst), D(src));
             }
             _ => codegen_error!("singlepass can't emit FRINTM {:?} {:?} {:?}", sz, src, dst),
@@ -3064,13 +2603,9 @@ impl EmitterARM64 for Assembler {
     fn emit_frintp(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintp S(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; frintp D(dst), D(src));
             }
             _ => codegen_error!("singlepass can't emit FRINTP {:?} {:?} {:?}", sz, src, dst),
@@ -3087,23 +2622,15 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz_in, src, sz_out, dst) {
             (Size::S32, Location::GPR(src), Size::S32, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; scvtf S(dst), W(src));
             }
             (Size::S64, Location::GPR(src), Size::S32, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; scvtf S(dst), X(src));
             }
             (Size::S32, Location::GPR(src), Size::S64, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; scvtf D(dst), W(src));
             }
             (Size::S64, Location::GPR(src), Size::S64, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; scvtf D(dst), X(src));
             }
             _ => codegen_error!(
@@ -3125,23 +2652,15 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz_in, src, sz_out, dst) {
             (Size::S32, Location::GPR(src), Size::S32, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ucvtf S(dst), W(src));
             }
             (Size::S64, Location::GPR(src), Size::S32, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ucvtf S(dst), X(src));
             }
             (Size::S32, Location::GPR(src), Size::S64, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ucvtf D(dst), W(src));
             }
             (Size::S64, Location::GPR(src), Size::S64, Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; ucvtf D(dst), X(src));
             }
             _ => codegen_error!(
@@ -3157,13 +2676,9 @@ impl EmitterARM64 for Assembler {
     fn emit_fcvt(&mut self, sz_in: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz_in, src, dst) {
             (Size::S32, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvt D(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Location::SIMD(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvt S(dst), D(src));
             }
             _ => codegen_error!(
@@ -3184,23 +2699,15 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz_in, src, sz_out, dst) {
             (Size::S32, Location::SIMD(src), Size::S32, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzs W(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Size::S32, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzs W(dst), D(src));
             }
             (Size::S32, Location::SIMD(src), Size::S64, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzs X(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Size::S64, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzs X(dst), D(src));
             }
             _ => codegen_error!(
@@ -3222,23 +2729,15 @@ impl EmitterARM64 for Assembler {
     ) -> Result<(), CompileError> {
         match (sz_in, src, sz_out, dst) {
             (Size::S32, Location::SIMD(src), Size::S32, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzu W(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Size::S32, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzu W(dst), D(src));
             }
             (Size::S32, Location::SIMD(src), Size::S64, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzu X(dst), S(src));
             }
             (Size::S64, Location::SIMD(src), Size::S64, Location::GPR(dst)) => {
-                let src = src.into_index() as u32;
-                let dst = dst.into_index() as u32;
                 dynasm!(self ; fcvtzu X(dst), D(src));
             }
             _ => codegen_error!(
@@ -3254,30 +2753,30 @@ impl EmitterARM64 for Assembler {
 
     // 1 011 0100 0100 000 => fpcr
     fn emit_read_fpcr(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; mrs X(reg as u32), 0b1_011_0100_0100_000);
+        dynasm!(self ; mrs X(reg), 0b1_011_0100_0100_000);
         Ok(())
     }
     fn emit_write_fpcr(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; msr 0b1_011_0100_0100_000, X(reg as u32));
+        dynasm!(self ; msr 0b1_011_0100_0100_000, X(reg));
         Ok(())
     }
     // 1 011 0100 0100 001 => fpsr
     fn emit_read_fpsr(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; mrs X(reg as u32), 0b1_011_0100_0100_001);
+        dynasm!(self ; mrs X(reg), 0b1_011_0100_0100_001);
         Ok(())
     }
     fn emit_write_fpsr(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; msr 0b1_011_0100_0100_001, X(reg as u32));
+        dynasm!(self ; msr 0b1_011_0100_0100_001, X(reg));
         Ok(())
     }
 
     fn emit_cnt(&mut self, src: NEON, dst: NEON) -> Result<(), CompileError> {
-        dynasm!(self ; cnt V(dst.into_index() as u32).B8, V(src.into_index() as u32).B8);
+        dynasm!(self ; cnt V(dst).B8, V(src).B8);
         Ok(())
     }
 
     fn emit_addv(&mut self, src: NEON, dst: NEON) -> Result<(), CompileError> {
-        dynasm!(self ; addv B(dst.into_index() as u32), V(src.into_index() as u32).B8);
+        dynasm!(self ; addv B(dst), V(src).B8);
         Ok(())
     }
 
@@ -3293,8 +2792,8 @@ impl EmitterARM64 for Assembler {
         match (src, dst) {
             (AbstractLocation::GPR(src), AbstractLocation::SIMD(dst)) => {
                 match (src_size, dst_size) {
-                    (Size::S32, Size::S32) => dynasm!(self ; fmov S(dst as u32), W(src as u32)),
-                    (Size::S64, Size::S64) => dynasm!(self ; fmov D(dst as u32), X(src as u32)),
+                    (Size::S32, Size::S32) => dynasm!(self ; fmov S(dst), W(src)),
+                    (Size::S64, Size::S64) => dynasm!(self ; fmov D(dst), X(src)),
                     _ => {
                         err = true;
                     }
@@ -3302,8 +2801,8 @@ impl EmitterARM64 for Assembler {
             }
             (AbstractLocation::SIMD(src), AbstractLocation::GPR(dst)) => {
                 match (src_size, dst_size) {
-                    (Size::S32, Size::S32) => dynasm!(self ; fmov W(dst as u32), S(src as u32)),
-                    (Size::S64, Size::S64) => dynasm!(self ; fmov X(dst as u32), D(src as u32)),
+                    (Size::S32, Size::S32) => dynasm!(self ; fmov W(dst), S(src)),
+                    (Size::S64, Size::S64) => dynasm!(self ; fmov X(dst), D(src)),
                     _ => {
                         err = true;
                     }
@@ -3342,10 +2841,10 @@ pub fn gen_std_trampoline_arm64(
     dynasm!(a
         ; sub sp, sp, 32
         ; stp x29, x30, [sp]
-        ; stp X(fptr as u32), X(args as u32), [sp, 16]
+        ; stp X(fptr), X(args), [sp, 16]
         ; mov x29, sp
-        ; mov X(fptr as u32), x1
-        ; mov X(args as u32), x2
+        ; mov X(fptr), x1
+        ; mov X(args), x2
     );
 
     let stack_args = sig.params().len().saturating_sub(7); //1st arg is ctx, not an actual arg
@@ -3427,7 +2926,7 @@ pub fn gen_std_trampoline_arm64(
         }
     }
 
-    dynasm!(a  ; blr X(fptr as u32));
+    dynasm!(a  ; blr X(fptr));
 
     // Write return value.
     if !sig.results().is_empty() {
@@ -3436,7 +2935,7 @@ pub fn gen_std_trampoline_arm64(
 
     // Restore stack.
     dynasm!(a
-        ; ldp X(fptr as u32), X(args as u32), [x29, 16]
+        ; ldp X(fptr), X(args), [x29, 16]
         ; ldp x29, x30, [x29]
         ; add sp, sp, 32 + stack_offset as u32
         ; ret

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -2380,9 +2380,13 @@ impl EmitterX64 for AssemblerX64 {
         dynasm!(self ; ud2);
         Ok(())
     }
+    #[allow(clippy::useless_conversion)]
     fn emit_ud1_payload(&mut self, payload: u8) -> Result<(), CompileError> {
         assert!(payload & 0xf0 == 0);
-        dynasm!(self ; ud1 Rd((payload>>3)&1), Rd(payload&7));
+        let reg1 = (payload >> 3) & 1;
+        let reg2 = payload & 7;
+
+        dynasm!(self ; ud1 Rd(reg1), Rd(reg2));
         Ok(())
     }
     fn emit_ret(&mut self) -> Result<(), CompileError> {

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -476,10 +476,10 @@ macro_rules! unop_gpr {
     ($ins:ident, $assembler:tt, $sz:expr, $loc:expr, $otherwise:block) => {
         match ($sz, $loc) {
             (Size::S32, Location::GPR(loc)) => {
-                dynasm!($assembler ; $ins Rd(loc as u8));
+                dynasm!($assembler ; $ins Rd(loc));
             },
             (Size::S64, Location::GPR(loc)) => {
-                dynasm!($assembler ; $ins Rq(loc as u8));
+                dynasm!($assembler ; $ins Rq(loc));
             },
             _ => $otherwise
         }
@@ -490,10 +490,10 @@ macro_rules! unop_mem {
     ($ins:ident, $assembler:tt, $sz:expr, $loc:expr, $otherwise:block) => {
         match ($sz, $loc) {
             (Size::S32, Location::Memory(loc, disp)) => {
-                dynasm!($assembler ; $ins DWORD [Rq(loc as u8) + disp] );
+                dynasm!($assembler ; $ins DWORD [Rq(loc) + disp] );
             },
             (Size::S64, Location::Memory(loc, disp)) => {
-                dynasm!($assembler ; $ins QWORD [Rq(loc as u8) + disp] );
+                dynasm!($assembler ; $ins QWORD [Rq(loc) + disp] );
             },
             _ => $otherwise
         }
@@ -512,10 +512,10 @@ macro_rules! binop_imm32_gpr {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S32, Location::Imm32(src), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rd(dst as u8), src as i32); // IMM32_2GPR
+                dynasm!($assembler ; $ins Rd(dst), src as i32); // IMM32_2GPR
             },
             (Size::S64, Location::Imm32(src), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rq(dst as u8), src as i32); // IMM32_2GPR
+                dynasm!($assembler ; $ins Rq(dst), src as i32); // IMM32_2GPR
             },
             _ => $otherwise
         }
@@ -526,10 +526,10 @@ macro_rules! binop_imm32_mem {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S32, Location::Imm32(src), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins DWORD [Rq(dst as u8) + disp], src as i32);
+                dynasm!($assembler ; $ins DWORD [Rq(dst) + disp], src as i32);
             },
             (Size::S64, Location::Imm32(src), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins QWORD [Rq(dst as u8) + disp], src as i32);
+                dynasm!($assembler ; $ins QWORD [Rq(dst) + disp], src as i32);
             },
             _ => $otherwise
         }
@@ -540,7 +540,7 @@ macro_rules! binop_imm64_gpr {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S64, Location::Imm64(src), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rq(dst as u8), QWORD src as i64); // IMM32_2GPR
+                dynasm!($assembler ; $ins Rq(dst), QWORD src as i64); // IMM32_2GPR
             },
             _ => $otherwise
         }
@@ -551,10 +551,10 @@ macro_rules! binop_gpr_gpr {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rd(dst as u8), Rd(src as u8)); // GPR2GPR
+                dynasm!($assembler ; $ins Rd(dst), Rd(src)); // GPR2GPR
             },
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rq(dst as u8), Rq(src as u8)); // GPR2GPR
+                dynasm!($assembler ; $ins Rq(dst), Rq(src)); // GPR2GPR
             },
             _ => $otherwise
         }
@@ -565,10 +565,10 @@ macro_rules! binop_gpr_mem {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S32, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins [Rq(dst as u8) + disp], Rd(src as u8)); // GPR2MEM
+                dynasm!($assembler ; $ins [Rq(dst) + disp], Rd(src)); // GPR2MEM
             },
             (Size::S64, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins [Rq(dst as u8) + disp], Rq(src as u8)); // GPR2MEM
+                dynasm!($assembler ; $ins [Rq(dst) + disp], Rq(src)); // GPR2MEM
             },
             _ => $otherwise
         }
@@ -579,10 +579,10 @@ macro_rules! binop_mem_gpr {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S32, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rd(dst as u8), [Rq(src as u8) + disp]); // MEM2GPR
+                dynasm!($assembler ; $ins Rd(dst), [Rq(src) + disp]); // MEM2GPR
             },
             (Size::S64, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rq(dst as u8), [Rq(src as u8) + disp]); // MEM2GPR
+                dynasm!($assembler ; $ins Rq(dst), [Rq(src) + disp]); // MEM2GPR
             },
             _ => $otherwise
         }
@@ -607,28 +607,28 @@ macro_rules! binop_shift {
     ($ins:ident, $assembler:tt, $sz:expr, $src:expr, $dst:expr, $otherwise:block) => {
         match ($sz, $src, $dst) {
             (Size::S32, Location::GPR(GPR::RCX), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rd(dst as u8), cl);
+                dynasm!($assembler ; $ins Rd(dst), cl);
             },
             (Size::S32, Location::GPR(GPR::RCX), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins DWORD [Rq(dst as u8) + disp], cl);
+                dynasm!($assembler ; $ins DWORD [Rq(dst) + disp], cl);
             },
             (Size::S32, Location::Imm8(imm), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rd(dst as u8), imm as i8);
+                dynasm!($assembler ; $ins Rd(dst), imm as i8);
             },
             (Size::S32, Location::Imm8(imm), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins DWORD [Rq(dst as u8) + disp], imm as i8);
+                dynasm!($assembler ; $ins DWORD [Rq(dst) + disp], imm as i8);
             },
             (Size::S64, Location::GPR(GPR::RCX), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rq(dst as u8), cl);
+                dynasm!($assembler ; $ins Rq(dst), cl);
             },
             (Size::S64, Location::GPR(GPR::RCX), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins QWORD [Rq(dst as u8) + disp], cl);
+                dynasm!($assembler ; $ins QWORD [Rq(dst) + disp], cl);
             },
             (Size::S64, Location::Imm8(imm), Location::GPR(dst)) => {
-                dynasm!($assembler ; $ins Rq(dst as u8), imm as i8);
+                dynasm!($assembler ; $ins Rq(dst), imm as i8);
             },
             (Size::S64, Location::Imm8(imm), Location::Memory(dst, disp)) => {
-                dynasm!($assembler ; $ins QWORD [Rq(dst as u8) + disp], imm as i8);
+                dynasm!($assembler ; $ins QWORD [Rq(dst) + disp], imm as i8);
             },
             _ => $otherwise
         }
@@ -653,40 +653,40 @@ fn move_src_to_dst(emitter: &mut AssemblerX64, precision: Precision, src: XMM, d
     }
     match precision {
         Precision::Single => match src {
-            XMM::XMM0 => dynasm!(emitter ; movss Rx((dst as u8)), xmm0),
-            XMM::XMM1 => dynasm!(emitter ; movss Rx((dst as u8)), xmm1),
-            XMM::XMM2 => dynasm!(emitter ; movss Rx((dst as u8)), xmm2),
-            XMM::XMM3 => dynasm!(emitter ; movss Rx((dst as u8)), xmm3),
-            XMM::XMM4 => dynasm!(emitter ; movss Rx((dst as u8)), xmm4),
-            XMM::XMM5 => dynasm!(emitter ; movss Rx((dst as u8)), xmm5),
-            XMM::XMM6 => dynasm!(emitter ; movss Rx((dst as u8)), xmm6),
-            XMM::XMM7 => dynasm!(emitter ; movss Rx((dst as u8)), xmm7),
-            XMM::XMM8 => dynasm!(emitter ; movss Rx((dst as u8)), xmm8),
-            XMM::XMM9 => dynasm!(emitter ; movss Rx((dst as u8)), xmm9),
-            XMM::XMM10 => dynasm!(emitter ; movss Rx((dst as u8)), xmm10),
-            XMM::XMM11 => dynasm!(emitter ; movss Rx((dst as u8)), xmm11),
-            XMM::XMM12 => dynasm!(emitter ; movss Rx((dst as u8)), xmm12),
-            XMM::XMM13 => dynasm!(emitter ; movss Rx((dst as u8)), xmm13),
-            XMM::XMM14 => dynasm!(emitter ; movss Rx((dst as u8)), xmm14),
-            XMM::XMM15 => dynasm!(emitter ; movss Rx((dst as u8)), xmm15),
+            XMM::XMM0 => dynasm!(emitter ; movss Rx(dst), xmm0),
+            XMM::XMM1 => dynasm!(emitter ; movss Rx(dst), xmm1),
+            XMM::XMM2 => dynasm!(emitter ; movss Rx(dst), xmm2),
+            XMM::XMM3 => dynasm!(emitter ; movss Rx(dst), xmm3),
+            XMM::XMM4 => dynasm!(emitter ; movss Rx(dst), xmm4),
+            XMM::XMM5 => dynasm!(emitter ; movss Rx(dst), xmm5),
+            XMM::XMM6 => dynasm!(emitter ; movss Rx(dst), xmm6),
+            XMM::XMM7 => dynasm!(emitter ; movss Rx(dst), xmm7),
+            XMM::XMM8 => dynasm!(emitter ; movss Rx(dst), xmm8),
+            XMM::XMM9 => dynasm!(emitter ; movss Rx(dst), xmm9),
+            XMM::XMM10 => dynasm!(emitter ; movss Rx(dst), xmm10),
+            XMM::XMM11 => dynasm!(emitter ; movss Rx(dst), xmm11),
+            XMM::XMM12 => dynasm!(emitter ; movss Rx(dst), xmm12),
+            XMM::XMM13 => dynasm!(emitter ; movss Rx(dst), xmm13),
+            XMM::XMM14 => dynasm!(emitter ; movss Rx(dst), xmm14),
+            XMM::XMM15 => dynasm!(emitter ; movss Rx(dst), xmm15),
         },
         Precision::Double => match src {
-            XMM::XMM0 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm0),
-            XMM::XMM1 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm1),
-            XMM::XMM2 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm2),
-            XMM::XMM3 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm3),
-            XMM::XMM4 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm4),
-            XMM::XMM5 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm5),
-            XMM::XMM6 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm6),
-            XMM::XMM7 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm7),
-            XMM::XMM8 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm8),
-            XMM::XMM9 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm9),
-            XMM::XMM10 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm10),
-            XMM::XMM11 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm11),
-            XMM::XMM12 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm12),
-            XMM::XMM13 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm13),
-            XMM::XMM14 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm14),
-            XMM::XMM15 => dynasm!(emitter ; movsd Rx((dst as u8)), xmm15),
+            XMM::XMM0 => dynasm!(emitter ; movsd Rx(dst), xmm0),
+            XMM::XMM1 => dynasm!(emitter ; movsd Rx(dst), xmm1),
+            XMM::XMM2 => dynasm!(emitter ; movsd Rx(dst), xmm2),
+            XMM::XMM3 => dynasm!(emitter ; movsd Rx(dst), xmm3),
+            XMM::XMM4 => dynasm!(emitter ; movsd Rx(dst), xmm4),
+            XMM::XMM5 => dynasm!(emitter ; movsd Rx(dst), xmm5),
+            XMM::XMM6 => dynasm!(emitter ; movsd Rx(dst), xmm6),
+            XMM::XMM7 => dynasm!(emitter ; movsd Rx(dst), xmm7),
+            XMM::XMM8 => dynasm!(emitter ; movsd Rx(dst), xmm8),
+            XMM::XMM9 => dynasm!(emitter ; movsd Rx(dst), xmm9),
+            XMM::XMM10 => dynasm!(emitter ; movsd Rx(dst), xmm10),
+            XMM::XMM11 => dynasm!(emitter ; movsd Rx(dst), xmm11),
+            XMM::XMM12 => dynasm!(emitter ; movsd Rx(dst), xmm12),
+            XMM::XMM13 => dynasm!(emitter ; movsd Rx(dst), xmm13),
+            XMM::XMM14 => dynasm!(emitter ; movsd Rx(dst), xmm14),
+            XMM::XMM15 => dynasm!(emitter ; movsd Rx(dst), xmm15),
         },
     }
 }
@@ -696,40 +696,40 @@ macro_rules! avx_fn {
         // Dynasm bug: AVX instructions are not encoded correctly.
         match $src2 {
             XMMOrMemory::XMM(x) => match $src1 {
-                XMM::XMM0 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm0, Rx((x as u8))),
-                XMM::XMM1 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm1, Rx((x as u8))),
-                XMM::XMM2 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm2, Rx((x as u8))),
-                XMM::XMM4 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm4, Rx((x as u8))),
-                XMM::XMM3 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm3, Rx((x as u8))),
-                XMM::XMM5 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm5, Rx((x as u8))),
-                XMM::XMM6 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm6, Rx((x as u8))),
-                XMM::XMM7 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm7, Rx((x as u8))),
-                XMM::XMM8 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm8, Rx((x as u8))),
-                XMM::XMM9 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm9, Rx((x as u8))),
-                XMM::XMM10 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm10, Rx((x as u8))),
-                XMM::XMM11 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm11, Rx((x as u8))),
-                XMM::XMM12 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm12, Rx((x as u8))),
-                XMM::XMM13 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm13, Rx((x as u8))),
-                XMM::XMM14 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm14, Rx((x as u8))),
-                XMM::XMM15 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm15, Rx((x as u8))),
+                XMM::XMM0 => dynasm!($emitter ; $ins Rx($dst), xmm0, Rx(x)),
+                XMM::XMM1 => dynasm!($emitter ; $ins Rx($dst), xmm1, Rx(x)),
+                XMM::XMM2 => dynasm!($emitter ; $ins Rx($dst), xmm2, Rx(x)),
+                XMM::XMM4 => dynasm!($emitter ; $ins Rx($dst), xmm4, Rx(x)),
+                XMM::XMM3 => dynasm!($emitter ; $ins Rx($dst), xmm3, Rx(x)),
+                XMM::XMM5 => dynasm!($emitter ; $ins Rx($dst), xmm5, Rx(x)),
+                XMM::XMM6 => dynasm!($emitter ; $ins Rx($dst), xmm6, Rx(x)),
+                XMM::XMM7 => dynasm!($emitter ; $ins Rx($dst), xmm7, Rx(x)),
+                XMM::XMM8 => dynasm!($emitter ; $ins Rx($dst), xmm8, Rx(x)),
+                XMM::XMM9 => dynasm!($emitter ; $ins Rx($dst), xmm9, Rx(x)),
+                XMM::XMM10 => dynasm!($emitter ; $ins Rx($dst), xmm10, Rx(x)),
+                XMM::XMM11 => dynasm!($emitter ; $ins Rx($dst), xmm11, Rx(x)),
+                XMM::XMM12 => dynasm!($emitter ; $ins Rx($dst), xmm12, Rx(x)),
+                XMM::XMM13 => dynasm!($emitter ; $ins Rx($dst), xmm13, Rx(x)),
+                XMM::XMM14 => dynasm!($emitter ; $ins Rx($dst), xmm14, Rx(x)),
+                XMM::XMM15 => dynasm!($emitter ; $ins Rx($dst), xmm15, Rx(x)),
             },
             XMMOrMemory::Memory(base, disp) => match $src1 {
-                XMM::XMM0 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm0, [Rq((base as u8)) + disp]),
-                XMM::XMM1 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm1, [Rq((base as u8)) + disp]),
-                XMM::XMM2 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm2, [Rq((base as u8)) + disp]),
-                XMM::XMM3 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm3, [Rq((base as u8)) + disp]),
-                XMM::XMM4 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm4, [Rq((base as u8)) + disp]),
-                XMM::XMM5 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm5, [Rq((base as u8)) + disp]),
-                XMM::XMM6 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm6, [Rq((base as u8)) + disp]),
-                XMM::XMM7 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm7, [Rq((base as u8)) + disp]),
-                XMM::XMM8 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm8, [Rq((base as u8)) + disp]),
-                XMM::XMM9 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm9, [Rq((base as u8)) + disp]),
-                XMM::XMM10 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm10, [Rq((base as u8)) + disp]),
-                XMM::XMM11 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm11, [Rq((base as u8)) + disp]),
-                XMM::XMM12 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm12, [Rq((base as u8)) + disp]),
-                XMM::XMM13 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm13, [Rq((base as u8)) + disp]),
-                XMM::XMM14 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm14, [Rq((base as u8)) + disp]),
-                XMM::XMM15 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm15, [Rq((base as u8)) + disp]),
+                XMM::XMM0 => dynasm!($emitter ; $ins Rx($dst), xmm0, [Rq(base) + disp]),
+                XMM::XMM1 => dynasm!($emitter ; $ins Rx($dst), xmm1, [Rq(base) + disp]),
+                XMM::XMM2 => dynasm!($emitter ; $ins Rx($dst), xmm2, [Rq(base) + disp]),
+                XMM::XMM3 => dynasm!($emitter ; $ins Rx($dst), xmm3, [Rq(base) + disp]),
+                XMM::XMM4 => dynasm!($emitter ; $ins Rx($dst), xmm4, [Rq(base) + disp]),
+                XMM::XMM5 => dynasm!($emitter ; $ins Rx($dst), xmm5, [Rq(base) + disp]),
+                XMM::XMM6 => dynasm!($emitter ; $ins Rx($dst), xmm6, [Rq(base) + disp]),
+                XMM::XMM7 => dynasm!($emitter ; $ins Rx($dst), xmm7, [Rq(base) + disp]),
+                XMM::XMM8 => dynasm!($emitter ; $ins Rx($dst), xmm8, [Rq(base) + disp]),
+                XMM::XMM9 => dynasm!($emitter ; $ins Rx($dst), xmm9, [Rq(base) + disp]),
+                XMM::XMM10 => dynasm!($emitter ; $ins Rx($dst), xmm10, [Rq(base) + disp]),
+                XMM::XMM11 => dynasm!($emitter ; $ins Rx($dst), xmm11, [Rq(base) + disp]),
+                XMM::XMM12 => dynasm!($emitter ; $ins Rx($dst), xmm12, [Rq(base) + disp]),
+                XMM::XMM13 => dynasm!($emitter ; $ins Rx($dst), xmm13, [Rq(base) + disp]),
+                XMM::XMM14 => dynasm!($emitter ; $ins Rx($dst), xmm14, [Rq(base) + disp]),
+                XMM::XMM15 => dynasm!($emitter ; $ins Rx($dst), xmm15, [Rq(base) + disp]),
             },
         }
     }
@@ -740,15 +740,15 @@ macro_rules! sse_fn {
         match $src2 {
             XMMOrMemory::XMM(x) => {
                 if x == $dst {
-                    dynasm!($emitter ; $ins Rx(($dst as u8)), Rx(($src1 as u8)))
+                    dynasm!($emitter ; $ins Rx($dst), Rx($src1))
                 } else {
                     move_src_to_dst($emitter, $precision, $src1, $dst);
-                    dynasm!($emitter ; $ins Rx(($dst as u8)), Rx((x as u8)))
+                    dynasm!($emitter ; $ins Rx($dst), Rx(x))
                 }
             }
             XMMOrMemory::Memory(base, disp) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter ; $ins Rx(($dst as u8)), [Rq((base as u8)) + disp])
+                dynasm!($emitter ; $ins Rx($dst), [Rq(base) + disp])
             }
         }
     };
@@ -756,11 +756,11 @@ macro_rules! sse_fn {
         match $src2 {
             XMMOrMemory::XMM(x) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter ; $ins Rx(($dst as u8)), Rx((x as u8)), $mode)
+                dynasm!($emitter ; $ins Rx($dst), Rx(x), $mode)
             }
             XMMOrMemory::Memory(base, disp) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter ; $ins Rx(($dst as u8)), [Rq((base as u8)) + disp], $mode)
+                dynasm!($emitter ; $ins Rx($dst), [Rq(base) + disp], $mode)
             }
         }
     };
@@ -770,40 +770,40 @@ macro_rules! avx_i2f_64_fn {
     ($ins:ident, $emitter:ident, $src1:ident, $src2:ident, $dst:ident) => {
         match $src2 {
             GPROrMemory::GPR(x) => match $src1 {
-                XMM::XMM0 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm0, Rq((x as u8))),
-                XMM::XMM1 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm1, Rq((x as u8))),
-                XMM::XMM2 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm2, Rq((x as u8))),
-                XMM::XMM3 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm3, Rq((x as u8))),
-                XMM::XMM4 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm4, Rq((x as u8))),
-                XMM::XMM5 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm5, Rq((x as u8))),
-                XMM::XMM6 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm6, Rq((x as u8))),
-                XMM::XMM7 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm7, Rq((x as u8))),
-                XMM::XMM8 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm8, Rq((x as u8))),
-                XMM::XMM9 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm9, Rq((x as u8))),
-                XMM::XMM10 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm10, Rq((x as u8))),
-                XMM::XMM11 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm11, Rq((x as u8))),
-                XMM::XMM12 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm12, Rq((x as u8))),
-                XMM::XMM13 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm13, Rq((x as u8))),
-                XMM::XMM14 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm14, Rq((x as u8))),
-                XMM::XMM15 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm15, Rq((x as u8))),
+                XMM::XMM0 => dynasm!($emitter ; $ins Rx($dst), xmm0, Rq(x)),
+                XMM::XMM1 => dynasm!($emitter ; $ins Rx($dst), xmm1, Rq(x)),
+                XMM::XMM2 => dynasm!($emitter ; $ins Rx($dst), xmm2, Rq(x)),
+                XMM::XMM3 => dynasm!($emitter ; $ins Rx($dst), xmm3, Rq(x)),
+                XMM::XMM4 => dynasm!($emitter ; $ins Rx($dst), xmm4, Rq(x)),
+                XMM::XMM5 => dynasm!($emitter ; $ins Rx($dst), xmm5, Rq(x)),
+                XMM::XMM6 => dynasm!($emitter ; $ins Rx($dst), xmm6, Rq(x)),
+                XMM::XMM7 => dynasm!($emitter ; $ins Rx($dst), xmm7, Rq(x)),
+                XMM::XMM8 => dynasm!($emitter ; $ins Rx($dst), xmm8, Rq(x)),
+                XMM::XMM9 => dynasm!($emitter ; $ins Rx($dst), xmm9, Rq(x)),
+                XMM::XMM10 => dynasm!($emitter ; $ins Rx($dst), xmm10, Rq(x)),
+                XMM::XMM11 => dynasm!($emitter ; $ins Rx($dst), xmm11, Rq(x)),
+                XMM::XMM12 => dynasm!($emitter ; $ins Rx($dst), xmm12, Rq(x)),
+                XMM::XMM13 => dynasm!($emitter ; $ins Rx($dst), xmm13, Rq(x)),
+                XMM::XMM14 => dynasm!($emitter ; $ins Rx($dst), xmm14, Rq(x)),
+                XMM::XMM15 => dynasm!($emitter ; $ins Rx($dst), xmm15, Rq(x)),
             },
             GPROrMemory::Memory(base, disp) => match $src1 {
-                XMM::XMM0 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm0, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM1 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm1, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM2 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm2, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM3 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm3, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM4 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm4, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM5 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm5, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM6 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm6, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM7 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm7, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM8 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm8, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM9 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm9, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM10 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm10, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM11 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm11, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM12 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm12, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM13 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm13, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM14 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm14, QWORD [Rq((base as u8)) + disp]),
-                XMM::XMM15 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm15, QWORD [Rq((base as u8)) + disp]),
+                XMM::XMM0 => dynasm!($emitter ; $ins Rx($dst), xmm0, QWORD [Rq(base) + disp]),
+                XMM::XMM1 => dynasm!($emitter ; $ins Rx($dst), xmm1, QWORD [Rq(base) + disp]),
+                XMM::XMM2 => dynasm!($emitter ; $ins Rx($dst), xmm2, QWORD [Rq(base) + disp]),
+                XMM::XMM3 => dynasm!($emitter ; $ins Rx($dst), xmm3, QWORD [Rq(base) + disp]),
+                XMM::XMM4 => dynasm!($emitter ; $ins Rx($dst), xmm4, QWORD [Rq(base) + disp]),
+                XMM::XMM5 => dynasm!($emitter ; $ins Rx($dst), xmm5, QWORD [Rq(base) + disp]),
+                XMM::XMM6 => dynasm!($emitter ; $ins Rx($dst), xmm6, QWORD [Rq(base) + disp]),
+                XMM::XMM7 => dynasm!($emitter ; $ins Rx($dst), xmm7, QWORD [Rq(base) + disp]),
+                XMM::XMM8 => dynasm!($emitter ; $ins Rx($dst), xmm8, QWORD [Rq(base) + disp]),
+                XMM::XMM9 => dynasm!($emitter ; $ins Rx($dst), xmm9, QWORD [Rq(base) + disp]),
+                XMM::XMM10 => dynasm!($emitter ; $ins Rx($dst), xmm10, QWORD [Rq(base) + disp]),
+                XMM::XMM11 => dynasm!($emitter ; $ins Rx($dst), xmm11, QWORD [Rq(base) + disp]),
+                XMM::XMM12 => dynasm!($emitter ; $ins Rx($dst), xmm12, QWORD [Rq(base) + disp]),
+                XMM::XMM13 => dynasm!($emitter ; $ins Rx($dst), xmm13, QWORD [Rq(base) + disp]),
+                XMM::XMM14 => dynasm!($emitter ; $ins Rx($dst), xmm14, QWORD [Rq(base) + disp]),
+                XMM::XMM15 => dynasm!($emitter ; $ins Rx($dst), xmm15, QWORD [Rq(base) + disp]),
             },
         }
     }
@@ -814,11 +814,11 @@ macro_rules! sse_i2f_64_fn {
         match $src2 {
             GPROrMemory::GPR(x) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter ; $ins Rx(($dst as u8)), Rq((x as u8)))
+                dynasm!($emitter ; $ins Rx($dst), Rq(x))
             },
             GPROrMemory::Memory(base, disp) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter ; $ins Rx(($dst as u8)), QWORD [Rq((base as u8)) + disp])
+                dynasm!($emitter ; $ins Rx($dst), QWORD [Rq(base) + disp])
             }
         }
     }
@@ -828,40 +828,40 @@ macro_rules! avx_i2f_32_fn {
     ($ins:ident, $emitter:ident, $src1:ident, $src2:ident, $dst:ident) => {
         match $src2 {
             GPROrMemory::GPR(x) => match $src1 {
-                XMM::XMM0 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm0, Rd((x as u8))),
-                XMM::XMM1 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm1, Rd((x as u8))),
-                XMM::XMM2 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm2, Rd((x as u8))),
-                XMM::XMM3 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm3, Rd((x as u8))),
-                XMM::XMM4 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm4, Rd((x as u8))),
-                XMM::XMM5 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm5, Rd((x as u8))),
-                XMM::XMM6 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm6, Rd((x as u8))),
-                XMM::XMM7 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm7, Rd((x as u8))),
-                XMM::XMM8 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm8, Rd((x as u8))),
-                XMM::XMM9 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm9, Rd((x as u8))),
-                XMM::XMM10 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm10, Rd((x as u8))),
-                XMM::XMM11 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm11, Rd((x as u8))),
-                XMM::XMM12 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm12, Rd((x as u8))),
-                XMM::XMM13 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm13, Rd((x as u8))),
-                XMM::XMM14 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm14, Rd((x as u8))),
-                XMM::XMM15 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm15, Rd((x as u8))),
+                XMM::XMM0 => dynasm!($emitter ; $ins Rx($dst), xmm0, Rd(x)),
+                XMM::XMM1 => dynasm!($emitter ; $ins Rx($dst), xmm1, Rd(x)),
+                XMM::XMM2 => dynasm!($emitter ; $ins Rx($dst), xmm2, Rd(x)),
+                XMM::XMM3 => dynasm!($emitter ; $ins Rx($dst), xmm3, Rd(x)),
+                XMM::XMM4 => dynasm!($emitter ; $ins Rx($dst), xmm4, Rd(x)),
+                XMM::XMM5 => dynasm!($emitter ; $ins Rx($dst), xmm5, Rd(x)),
+                XMM::XMM6 => dynasm!($emitter ; $ins Rx($dst), xmm6, Rd(x)),
+                XMM::XMM7 => dynasm!($emitter ; $ins Rx($dst), xmm7, Rd(x)),
+                XMM::XMM8 => dynasm!($emitter ; $ins Rx($dst), xmm8, Rd(x)),
+                XMM::XMM9 => dynasm!($emitter ; $ins Rx($dst), xmm9, Rd(x)),
+                XMM::XMM10 => dynasm!($emitter ; $ins Rx($dst), xmm10, Rd(x)),
+                XMM::XMM11 => dynasm!($emitter ; $ins Rx($dst), xmm11, Rd(x)),
+                XMM::XMM12 => dynasm!($emitter ; $ins Rx($dst), xmm12, Rd(x)),
+                XMM::XMM13 => dynasm!($emitter ; $ins Rx($dst), xmm13, Rd(x)),
+                XMM::XMM14 => dynasm!($emitter ; $ins Rx($dst), xmm14, Rd(x)),
+                XMM::XMM15 => dynasm!($emitter ; $ins Rx($dst), xmm15, Rd(x)),
             },
             GPROrMemory::Memory(base, disp) => match $src1 {
-                XMM::XMM0 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm0, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM1 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm1, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM2 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm2, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM3 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm3, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM4 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm4, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM5 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm5, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM6 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm6, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM7 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm7, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM8 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm8, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM9 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm9, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM10 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm10, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM11 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm11, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM12 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm12, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM13 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm13, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM14 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm14, DWORD [Rq((base as u8)) + disp]),
-                XMM::XMM15 => dynasm!($emitter ; $ins Rx(($dst as u8)), xmm15, DWORD [Rq((base as u8)) + disp]),
+                XMM::XMM0 => dynasm!($emitter ; $ins Rx($dst), xmm0, DWORD [Rq(base) + disp]),
+                XMM::XMM1 => dynasm!($emitter ; $ins Rx($dst), xmm1, DWORD [Rq(base) + disp]),
+                XMM::XMM2 => dynasm!($emitter ; $ins Rx($dst), xmm2, DWORD [Rq(base) + disp]),
+                XMM::XMM3 => dynasm!($emitter ; $ins Rx($dst), xmm3, DWORD [Rq(base) + disp]),
+                XMM::XMM4 => dynasm!($emitter ; $ins Rx($dst), xmm4, DWORD [Rq(base) + disp]),
+                XMM::XMM5 => dynasm!($emitter ; $ins Rx($dst), xmm5, DWORD [Rq(base) + disp]),
+                XMM::XMM6 => dynasm!($emitter ; $ins Rx($dst), xmm6, DWORD [Rq(base) + disp]),
+                XMM::XMM7 => dynasm!($emitter ; $ins Rx($dst), xmm7, DWORD [Rq(base) + disp]),
+                XMM::XMM8 => dynasm!($emitter ; $ins Rx($dst), xmm8, DWORD [Rq(base) + disp]),
+                XMM::XMM9 => dynasm!($emitter ; $ins Rx($dst), xmm9, DWORD [Rq(base) + disp]),
+                XMM::XMM10 => dynasm!($emitter ; $ins Rx($dst), xmm10, DWORD [Rq(base) + disp]),
+                XMM::XMM11 => dynasm!($emitter ; $ins Rx($dst), xmm11, DWORD [Rq(base) + disp]),
+                XMM::XMM12 => dynasm!($emitter ; $ins Rx($dst), xmm12, DWORD [Rq(base) + disp]),
+                XMM::XMM13 => dynasm!($emitter ; $ins Rx($dst), xmm13, DWORD [Rq(base) + disp]),
+                XMM::XMM14 => dynasm!($emitter ; $ins Rx($dst), xmm14, DWORD [Rq(base) + disp]),
+                XMM::XMM15 => dynasm!($emitter ; $ins Rx($dst), xmm15, DWORD [Rq(base) + disp]),
             },
         }
     }
@@ -872,11 +872,11 @@ macro_rules! sse_i2f_32_fn {
         match $src2 {
             GPROrMemory::GPR(x) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter; $ins Rx(($src1 as u8)), Rd((x as u8)))
+                dynasm!($emitter; $ins Rx($src1), Rd(x))
             },
             GPROrMemory::Memory(base, disp) => {
                 move_src_to_dst($emitter, $precision, $src1, $dst);
-                dynasm!($emitter; $ins Rx(($dst as u8)), DWORD [Rq((base as u8)) + disp])
+                dynasm!($emitter; $ins Rx($dst), DWORD [Rq(base) + disp])
             }
         }
     }
@@ -885,8 +885,8 @@ macro_rules! sse_i2f_32_fn {
 macro_rules! avx_round_fn {
     ($ins:ident, $mode:expr, $emitter:ident, $src1:ident, $src2:ident, $dst:ident) => {
         match $src2 {
-            XMMOrMemory::XMM(x) => dynasm!($emitter ; $ins Rx(($dst as u8)), Rx(($src1 as u8)), Rx((x as u8)), $mode),
-            XMMOrMemory::Memory(base, disp) => dynasm!($emitter ; $ins Rx(($dst as u8)), Rx(($src1 as u8)), [Rq((base as u8)) + disp], $mode),
+            XMMOrMemory::XMM(x) => dynasm!($emitter ; $ins Rx($dst), Rx($src1), Rx(x), $mode),
+            XMMOrMemory::Memory(base, disp) => dynasm!($emitter ; $ins Rx($dst), Rx($src1), [Rq(base) + disp], $mode),
         }
     }
 }
@@ -898,10 +898,10 @@ macro_rules! sse_round_fn {
                 if x != $dst {
                     move_src_to_dst($emitter, $precision, $src1, $dst);
                 }
-                dynasm!($emitter ; $ins Rx((x as u8)), Rx(($dst as u8)), $mode)
+                dynasm!($emitter ; $ins Rx(x), Rx($dst), $mode)
             }
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!($emitter ; $ins Rx(($dst as u8)), [Rq((base as u8)) + disp], $mode)
+                dynasm!($emitter ; $ins Rx($dst), [Rq(base) + disp], $mode)
             },
         }
     }
@@ -1032,7 +1032,7 @@ impl EmitterX64 for AssemblerX64 {
     fn emit_mov(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         // fast path
         if let (Location::Imm32(0), Location::GPR(x)) = (src, dst) {
-            dynasm!(self ; xor Rd(x as u8), Rd(x as u8));
+            dynasm!(self ; xor Rd(x), Rd(x));
             return Ok(());
         }
 
@@ -1040,83 +1040,83 @@ impl EmitterX64 for AssemblerX64 {
             binop_imm64_gpr!(mov, self, sz, src, dst, {
                 match (sz, src, dst) {
                     (Size::S8, Location::GPR(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov [Rq(dst as u8) + disp], Rb(src as u8));
+                        dynasm!(self ; mov [Rq(dst) + disp], Rb(src));
                     }
                     (Size::S8, Location::Memory(src, disp), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rb(dst as u8), [Rq(src as u8) + disp]);
+                        dynasm!(self ; mov Rb(dst), [Rq(src) + disp]);
                     }
                     (Size::S8, Location::Imm32(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rb(dst as u8), src as i8);
+                        dynasm!(self ; mov Rb(dst), src as i8);
                     }
                     (Size::S8, Location::Imm64(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rb(dst as u8), src as i8);
+                        dynasm!(self ; mov Rb(dst), src as i8);
                     }
                     (Size::S8, Location::Imm32(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov BYTE [Rq(dst as u8) + disp], src as i8);
+                        dynasm!(self ; mov BYTE [Rq(dst) + disp], src as i8);
                     }
                     (Size::S8, Location::Imm64(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov BYTE [Rq(dst as u8) + disp], src as i8);
+                        dynasm!(self ; mov BYTE [Rq(dst) + disp], src as i8);
                     }
                     (Size::S16, Location::GPR(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov [Rq(dst as u8) + disp], Rw(src as u8));
+                        dynasm!(self ; mov [Rq(dst) + disp], Rw(src));
                     }
                     (Size::S16, Location::Memory(src, disp), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rw(dst as u8), [Rq(src as u8) + disp]);
+                        dynasm!(self ; mov Rw(dst), [Rq(src) + disp]);
                     }
                     (Size::S16, Location::Imm32(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rw(dst as u8), src as i16);
+                        dynasm!(self ; mov Rw(dst), src as i16);
                     }
                     (Size::S16, Location::Imm64(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rw(dst as u8), src as i16);
+                        dynasm!(self ; mov Rw(dst), src as i16);
                     }
                     (Size::S16, Location::Imm32(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov WORD [Rq(dst as u8) + disp], src as i16);
+                        dynasm!(self ; mov WORD [Rq(dst) + disp], src as i16);
                     }
                     (Size::S16, Location::Imm64(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov WORD [Rq(dst as u8) + disp], src as i16);
+                        dynasm!(self ; mov WORD [Rq(dst) + disp], src as i16);
                     }
                     (Size::S32, Location::Imm64(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rd(dst as u8), src as i32);
+                        dynasm!(self ; mov Rd(dst), src as i32);
                     }
                     (Size::S32, Location::Imm64(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; mov DWORD [Rq(dst as u8) + disp], src as i32);
+                        dynasm!(self ; mov DWORD [Rq(dst) + disp], src as i32);
                     }
                     (Size::S32, Location::GPR(src), Location::SIMD(dst)) => {
-                        dynasm!(self ; movd Rx(dst as u8), Rd(src as u8));
+                        dynasm!(self ; movd Rx(dst), Rd(src));
                     }
                     (Size::S32, Location::SIMD(src), Location::GPR(dst)) => {
-                        dynasm!(self ; movd Rd(dst as u8), Rx(src as u8));
+                        dynasm!(self ; movd Rd(dst), Rx(src));
                     }
                     (Size::S32, Location::Memory(src, disp), Location::SIMD(dst)) => {
-                        dynasm!(self ; movd Rx(dst as u8), [Rq(src as u8) + disp]);
+                        dynasm!(self ; movd Rx(dst), [Rq(src) + disp]);
                     }
                     (Size::S32, Location::SIMD(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; movd [Rq(dst as u8) + disp], Rx(src as u8));
+                        dynasm!(self ; movd [Rq(dst) + disp], Rx(src));
                     }
                     (Size::S64, Location::Imm64(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rd(dst as u8), src as i32);
+                        dynasm!(self ; mov Rd(dst), src as i32);
                     }
                     (Size::S64, Location::Imm32(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rd(dst as u8), src as i32);
+                        dynasm!(self ; mov Rd(dst), src as i32);
                     }
                     (Size::S64, Location::Imm8(src), Location::GPR(dst)) => {
-                        dynasm!(self ; mov Rd(dst as u8), src as i32);
+                        dynasm!(self ; mov Rd(dst), src as i32);
                     }
 
                     (Size::S64, Location::GPR(src), Location::SIMD(dst)) => {
-                        dynasm!(self ; movq Rx(dst as u8), Rq(src as u8));
+                        dynasm!(self ; movq Rx(dst), Rq(src));
                     }
                     (Size::S64, Location::SIMD(src), Location::GPR(dst)) => {
-                        dynasm!(self ; movq Rq(dst as u8), Rx(src as u8));
+                        dynasm!(self ; movq Rq(dst), Rx(src));
                     }
                     (Size::S64, Location::Memory(src, disp), Location::SIMD(dst)) => {
-                        dynasm!(self ; movq Rx(dst as u8), [Rq(src as u8) + disp]);
+                        dynasm!(self ; movq Rx(dst), [Rq(src) + disp]);
                     }
                     (Size::S64, Location::SIMD(src), Location::Memory(dst, disp)) => {
-                        dynasm!(self ; movq [Rq(dst as u8) + disp], Rx(src as u8));
+                        dynasm!(self ; movq [Rq(dst) + disp], Rx(src));
                     }
                     (_, Location::SIMD(src), Location::SIMD(dst)) => {
-                        dynasm!(self ; movq Rx(dst as u8), Rx(src as u8));
+                        dynasm!(self ; movq Rx(dst), Rx(src));
                     }
 
                     _ => codegen_error!("singlepass can't emit MOV {:?} {:?} {:?}", sz, src, dst),
@@ -1128,42 +1128,42 @@ impl EmitterX64 for AssemblerX64 {
     fn emit_lea(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S32, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!(self ; lea Rd(dst as u8), [Rq(src as u8) + disp]);
+                dynasm!(self ; lea Rd(dst), [Rq(src) + disp]);
             }
             (Size::S64, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!(self ; lea Rq(dst as u8), [Rq(src as u8) + disp]);
+                dynasm!(self ; lea Rq(dst), [Rq(src) + disp]);
             }
             (Size::S32, Location::Memory2(src1, src2, mult, disp), Location::GPR(dst)) => {
                 match mult {
-                    Multiplier::Zero => dynasm!(self ; lea Rd(dst as u8), [Rq(src1 as u8) + disp]),
+                    Multiplier::Zero => dynasm!(self ; lea Rd(dst), [Rq(src1) + disp]),
                     Multiplier::One => {
-                        dynasm!(self ; lea Rd(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) + disp])
+                        dynasm!(self ; lea Rd(dst), [Rq(src1) + Rq(src2) + disp])
                     }
                     Multiplier::Two => {
-                        dynasm!(self ; lea Rd(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) * 2 + disp])
+                        dynasm!(self ; lea Rd(dst), [Rq(src1) + Rq(src2) * 2 + disp])
                     }
                     Multiplier::Four => {
-                        dynasm!(self ; lea Rd(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) * 4 + disp])
+                        dynasm!(self ; lea Rd(dst), [Rq(src1) + Rq(src2) * 4 + disp])
                     }
                     Multiplier::Height => {
-                        dynasm!(self ; lea Rd(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) * 8 + disp])
+                        dynasm!(self ; lea Rd(dst), [Rq(src1) + Rq(src2) * 8 + disp])
                     }
                 };
             }
             (Size::S64, Location::Memory2(src1, src2, mult, disp), Location::GPR(dst)) => {
                 match mult {
-                    Multiplier::Zero => dynasm!(self ; lea Rq(dst as u8), [Rq(src1 as u8) + disp]),
+                    Multiplier::Zero => dynasm!(self ; lea Rq(dst), [Rq(src1) + disp]),
                     Multiplier::One => {
-                        dynasm!(self ; lea Rq(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) + disp])
+                        dynasm!(self ; lea Rq(dst), [Rq(src1) + Rq(src2) + disp])
                     }
                     Multiplier::Two => {
-                        dynasm!(self ; lea Rq(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) * 2 + disp])
+                        dynasm!(self ; lea Rq(dst), [Rq(src1) + Rq(src2) * 2 + disp])
                     }
                     Multiplier::Four => {
-                        dynasm!(self ; lea Rq(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) * 4 + disp])
+                        dynasm!(self ; lea Rq(dst), [Rq(src1) + Rq(src2) * 4 + disp])
                     }
                     Multiplier::Height => {
-                        dynasm!(self ; lea Rq(dst as u8), [Rq(src1 as u8) + Rq(src2 as u8) * 8 + disp])
+                        dynasm!(self ; lea Rq(dst), [Rq(src1) + Rq(src2) * 8 + disp])
                     }
                 };
             }
@@ -1174,7 +1174,7 @@ impl EmitterX64 for AssemblerX64 {
     fn emit_lea_label(&mut self, label: Label, dst: Location) -> Result<(), CompileError> {
         match dst {
             Location::GPR(x) => {
-                dynasm!(self ; lea Rq(x as u8), [=>label]);
+                dynasm!(self ; lea Rq(x), [=>label]);
             }
             _ => codegen_error!("singlepass can't emit LEA label={:?} {:?}", label, dst),
         }
@@ -1214,26 +1214,26 @@ impl EmitterX64 for AssemblerX64 {
     }
     fn emit_jmp_location(&mut self, loc: Location) -> Result<(), CompileError> {
         match loc {
-            Location::GPR(x) => dynasm!(self ; jmp Rq(x as u8)),
-            Location::Memory(base, disp) => dynasm!(self ; jmp QWORD [Rq(base as u8) + disp]),
+            Location::GPR(x) => dynasm!(self ; jmp Rq(x)),
+            Location::Memory(base, disp) => dynasm!(self ; jmp QWORD [Rq(base) + disp]),
             _ => codegen_error!("singlepass can't emit JMP {:?}", loc),
         }
         Ok(())
     }
     fn emit_set(&mut self, condition: Condition, dst: GPR) -> Result<(), CompileError> {
         match condition {
-            Condition::Above => dynasm!(self ; seta Rb(dst as u8)),
-            Condition::AboveEqual => dynasm!(self ; setae Rb(dst as u8)),
-            Condition::Below => dynasm!(self ; setb Rb(dst as u8)),
-            Condition::BelowEqual => dynasm!(self ; setbe Rb(dst as u8)),
-            Condition::Greater => dynasm!(self ; setg Rb(dst as u8)),
-            Condition::GreaterEqual => dynasm!(self ; setge Rb(dst as u8)),
-            Condition::Less => dynasm!(self ; setl Rb(dst as u8)),
-            Condition::LessEqual => dynasm!(self ; setle Rb(dst as u8)),
-            Condition::Equal => dynasm!(self ; sete Rb(dst as u8)),
-            Condition::NotEqual => dynasm!(self ; setne Rb(dst as u8)),
-            Condition::Signed => dynasm!(self ; sets Rb(dst as u8)),
-            Condition::Carry => dynasm!(self ; setc Rb(dst as u8)),
+            Condition::Above => dynasm!(self ; seta Rb(dst)),
+            Condition::AboveEqual => dynasm!(self ; setae Rb(dst)),
+            Condition::Below => dynasm!(self ; setb Rb(dst)),
+            Condition::BelowEqual => dynasm!(self ; setbe Rb(dst)),
+            Condition::Greater => dynasm!(self ; setg Rb(dst)),
+            Condition::GreaterEqual => dynasm!(self ; setge Rb(dst)),
+            Condition::Less => dynasm!(self ; setl Rb(dst)),
+            Condition::LessEqual => dynasm!(self ; setle Rb(dst)),
+            Condition::Equal => dynasm!(self ; sete Rb(dst)),
+            Condition::NotEqual => dynasm!(self ; setne Rb(dst)),
+            Condition::Signed => dynasm!(self ; sets Rb(dst)),
+            Condition::Carry => dynasm!(self ; setc Rb(dst)),
             _ => codegen_error!("singlepass can't emit SET {:?} {:?}", condition, dst),
         }
         Ok(())
@@ -1241,9 +1241,9 @@ impl EmitterX64 for AssemblerX64 {
     fn emit_push(&mut self, sz: Size, src: Location) -> Result<(), CompileError> {
         match (sz, src) {
             (Size::S64, Location::Imm32(src)) => dynasm!(self ; push src as i32),
-            (Size::S64, Location::GPR(src)) => dynasm!(self ; push Rq(src as u8)),
+            (Size::S64, Location::GPR(src)) => dynasm!(self ; push Rq(src)),
             (Size::S64, Location::Memory(src, disp)) => {
-                dynasm!(self ; push QWORD [Rq(src as u8) + disp])
+                dynasm!(self ; push QWORD [Rq(src) + disp])
             }
             _ => codegen_error!("singlepass can't emit PUSH {:?} {:?}", sz, src),
         }
@@ -1251,9 +1251,9 @@ impl EmitterX64 for AssemblerX64 {
     }
     fn emit_pop(&mut self, sz: Size, dst: Location) -> Result<(), CompileError> {
         match (sz, dst) {
-            (Size::S64, Location::GPR(dst)) => dynasm!(self ; pop Rq(dst as u8)),
+            (Size::S64, Location::GPR(dst)) => dynasm!(self ; pop Rq(dst)),
             (Size::S64, Location::Memory(dst, disp)) => {
-                dynasm!(self ; pop QWORD [Rq(dst as u8) + disp])
+                dynasm!(self ; pop QWORD [Rq(dst) + disp])
             }
             _ => codegen_error!("singlepass can't emit POP {:?} {:?}", sz, dst),
         }
@@ -1306,21 +1306,21 @@ impl EmitterX64 for AssemblerX64 {
     }
     fn emit_neg(&mut self, sz: Size, value: Location) -> Result<(), CompileError> {
         match (sz, value) {
-            (Size::S8, Location::GPR(value)) => dynasm!(self ; neg Rb(value as u8)),
+            (Size::S8, Location::GPR(value)) => dynasm!(self ; neg Rb(value)),
             (Size::S8, Location::Memory(value, disp)) => {
-                dynasm!(self ; neg [Rq(value as u8) + disp])
+                dynasm!(self ; neg [Rq(value) + disp])
             }
-            (Size::S16, Location::GPR(value)) => dynasm!(self ; neg Rw(value as u8)),
+            (Size::S16, Location::GPR(value)) => dynasm!(self ; neg Rw(value)),
             (Size::S16, Location::Memory(value, disp)) => {
-                dynasm!(self ; neg [Rq(value as u8) + disp])
+                dynasm!(self ; neg [Rq(value) + disp])
             }
-            (Size::S32, Location::GPR(value)) => dynasm!(self ; neg Rd(value as u8)),
+            (Size::S32, Location::GPR(value)) => dynasm!(self ; neg Rd(value)),
             (Size::S32, Location::Memory(value, disp)) => {
-                dynasm!(self ; neg [Rq(value as u8) + disp])
+                dynasm!(self ; neg [Rq(value) + disp])
             }
-            (Size::S64, Location::GPR(value)) => dynasm!(self ; neg Rq(value as u8)),
+            (Size::S64, Location::GPR(value)) => dynasm!(self ; neg Rq(value)),
             (Size::S64, Location::Memory(value, disp)) => {
-                dynasm!(self ; neg [Rq(value as u8) + disp])
+                dynasm!(self ; neg [Rq(value) + disp])
             }
             _ => codegen_error!("singlepass can't emit NEG {:?} {:?}", sz, value),
         }
@@ -1335,7 +1335,7 @@ impl EmitterX64 for AssemblerX64 {
         Ok(())
     }
     fn emit_imul_imm32_gpr64(&mut self, src: u32, dst: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; imul Rq(dst as u8), Rq(dst as u8), src as i32);
+        dynasm!(self ; imul Rq(dst), Rq(dst), src as i32);
         Ok(())
     }
     fn emit_div(&mut self, sz: Size, divisor: Location) -> Result<(), CompileError> {
@@ -1431,57 +1431,57 @@ impl EmitterX64 for AssemblerX64 {
     ) -> Result<(), CompileError> {
         match (sz_src, src, sz_dst, dst) {
             (Size::S8, Location::GPR(src), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rd(dst as u8), Rb(src as u8));
+                dynasm!(self ; movzx Rd(dst), Rb(src));
             }
             (Size::S16, Location::GPR(src), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rd(dst as u8), Rw(src as u8));
+                dynasm!(self ; movzx Rd(dst), Rw(src));
             }
             (Size::S8, Location::Memory(src, disp), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rd(dst as u8), BYTE [Rq(src as u8) + disp]);
+                dynasm!(self ; movzx Rd(dst), BYTE [Rq(src) + disp]);
             }
             (Size::S16, Location::Memory(src, disp), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rd(dst as u8), WORD [Rq(src as u8) + disp]);
+                dynasm!(self ; movzx Rd(dst), WORD [Rq(src) + disp]);
             }
             (Size::S16, Location::Imm32(imm), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rd(dst as u8), imm as i32);
+                dynasm!(self ; mov Rd(dst), imm as i32);
             }
             (Size::S8, Location::GPR(src), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rq(dst as u8), Rb(src as u8));
+                dynasm!(self ; movzx Rq(dst), Rb(src));
             }
             (Size::S16, Location::GPR(src), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rq(dst as u8), Rw(src as u8));
+                dynasm!(self ; movzx Rq(dst), Rw(src));
             }
             (Size::S8, Location::Memory(src, disp), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rq(dst as u8), BYTE [Rq(src as u8) + disp]);
+                dynasm!(self ; movzx Rq(dst), BYTE [Rq(src) + disp]);
             }
             (Size::S16, Location::Memory(src, disp), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movzx Rq(dst as u8), WORD [Rq(src as u8) + disp]);
+                dynasm!(self ; movzx Rq(dst), WORD [Rq(src) + disp]);
             }
             (Size::S32, Location::GPR(src), Size::S64, Location::GPR(dst)) => {
                 if src != dst {
-                    dynasm!(self ; mov Rd(dst as u8), Rd(src as u8));
+                    dynasm!(self ; mov Rd(dst), Rd(src));
                 }
             }
             (Size::S32, Location::Memory(src, disp), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rd(dst as u8), DWORD [Rq(src as u8) + disp]);
+                dynasm!(self ; mov Rd(dst), DWORD [Rq(src) + disp]);
             }
             (Size::S8, Location::Imm32(imm), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rq(dst as u8), imm as i32);
+                dynasm!(self ; mov Rq(dst), imm as i32);
             }
             (Size::S16, Location::Imm32(imm), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rq(dst as u8), imm as i32);
+                dynasm!(self ; mov Rq(dst), imm as i32);
             }
             (Size::S32, Location::Imm32(imm), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rq(dst as u8), imm as i32);
+                dynasm!(self ; mov Rq(dst), imm as i32);
             }
             (Size::S8, Location::Imm64(imm), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rq(dst as u8), imm as i32);
+                dynasm!(self ; mov Rq(dst), imm as i32);
             }
             (Size::S16, Location::Imm64(imm), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rq(dst as u8), imm as i32);
+                dynasm!(self ; mov Rq(dst), imm as i32);
             }
             (Size::S32, Location::Imm64(imm), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; mov Rq(dst as u8), imm as i32);
+                dynasm!(self ; mov Rq(dst), imm as i32);
             }
             _ => {
                 codegen_error!(
@@ -1504,34 +1504,34 @@ impl EmitterX64 for AssemblerX64 {
     ) -> Result<(), CompileError> {
         match (sz_src, src, sz_dst, dst) {
             (Size::S8, Location::GPR(src), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rd(dst as u8), Rb(src as u8));
+                dynasm!(self ; movsx Rd(dst), Rb(src));
             }
             (Size::S16, Location::GPR(src), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rd(dst as u8), Rw(src as u8));
+                dynasm!(self ; movsx Rd(dst), Rw(src));
             }
             (Size::S8, Location::Memory(src, disp), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rd(dst as u8), BYTE [Rq(src as u8) + disp]);
+                dynasm!(self ; movsx Rd(dst), BYTE [Rq(src) + disp]);
             }
             (Size::S16, Location::Memory(src, disp), Size::S32, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rd(dst as u8), WORD [Rq(src as u8) + disp]);
+                dynasm!(self ; movsx Rd(dst), WORD [Rq(src) + disp]);
             }
             (Size::S8, Location::GPR(src), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rq(dst as u8), Rb(src as u8));
+                dynasm!(self ; movsx Rq(dst), Rb(src));
             }
             (Size::S16, Location::GPR(src), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rq(dst as u8), Rw(src as u8));
+                dynasm!(self ; movsx Rq(dst), Rw(src));
             }
             (Size::S32, Location::GPR(src), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rq(dst as u8), Rd(src as u8));
+                dynasm!(self ; movsx Rq(dst), Rd(src));
             }
             (Size::S8, Location::Memory(src, disp), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rq(dst as u8), BYTE [Rq(src as u8) + disp]);
+                dynasm!(self ; movsx Rq(dst), BYTE [Rq(src) + disp]);
             }
             (Size::S16, Location::Memory(src, disp), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rq(dst as u8), WORD [Rq(src as u8) + disp]);
+                dynasm!(self ; movsx Rq(dst), WORD [Rq(src) + disp]);
             }
             (Size::S32, Location::Memory(src, disp), Size::S64, Location::GPR(dst)) => {
-                dynasm!(self ; movsx Rq(dst as u8), DWORD [Rq(src as u8) + disp]);
+                dynasm!(self ; movsx Rq(dst), DWORD [Rq(src) + disp]);
             }
             _ => {
                 codegen_error!(
@@ -1549,40 +1549,40 @@ impl EmitterX64 for AssemblerX64 {
     fn emit_xchg(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S8, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rb(dst as u8), Rb(src as u8));
+                dynasm!(self ; xchg Rb(dst), Rb(src));
             }
             (Size::S16, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rw(dst as u8), Rw(src as u8));
+                dynasm!(self ; xchg Rw(dst), Rw(src));
             }
             (Size::S32, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rd(dst as u8), Rd(src as u8));
+                dynasm!(self ; xchg Rd(dst), Rd(src));
             }
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rq(dst as u8), Rq(src as u8));
+                dynasm!(self ; xchg Rq(dst), Rq(src));
             }
             (Size::S8, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rb(dst as u8), [Rq(src as u8) + disp]);
+                dynasm!(self ; xchg Rb(dst), [Rq(src) + disp]);
             }
             (Size::S8, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; xchg [Rq(dst as u8) + disp], Rb(src as u8));
+                dynasm!(self ; xchg [Rq(dst) + disp], Rb(src));
             }
             (Size::S16, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rw(dst as u8), [Rq(src as u8) + disp]);
+                dynasm!(self ; xchg Rw(dst), [Rq(src) + disp]);
             }
             (Size::S16, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; xchg [Rq(dst as u8) + disp], Rw(src as u8));
+                dynasm!(self ; xchg [Rq(dst) + disp], Rw(src));
             }
             (Size::S32, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rd(dst as u8), [Rq(src as u8) + disp]);
+                dynasm!(self ; xchg Rd(dst), [Rq(src) + disp]);
             }
             (Size::S32, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; xchg [Rq(dst as u8) + disp], Rd(src as u8));
+                dynasm!(self ; xchg [Rq(dst) + disp], Rd(src));
             }
             (Size::S64, Location::Memory(src, disp), Location::GPR(dst)) => {
-                dynasm!(self ; xchg Rq(dst as u8), [Rq(src as u8) + disp]);
+                dynasm!(self ; xchg Rq(dst), [Rq(src) + disp]);
             }
             (Size::S64, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; xchg [Rq(dst as u8) + disp], Rq(src as u8));
+                dynasm!(self ; xchg [Rq(dst) + disp], Rq(src));
             }
             _ => codegen_error!("singlepass can't emit XCHG {:?} {:?} {:?}", sz, src, dst),
         }
@@ -1597,16 +1597,16 @@ impl EmitterX64 for AssemblerX64 {
     ) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S8, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock xadd [Rq(dst as u8) + disp], Rb(src as u8));
+                dynasm!(self ; lock xadd [Rq(dst) + disp], Rb(src));
             }
             (Size::S16, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock xadd [Rq(dst as u8) + disp], Rw(src as u8));
+                dynasm!(self ; lock xadd [Rq(dst) + disp], Rw(src));
             }
             (Size::S32, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock xadd [Rq(dst as u8) + disp], Rd(src as u8));
+                dynasm!(self ; lock xadd [Rq(dst) + disp], Rd(src));
             }
             (Size::S64, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock xadd [Rq(dst as u8) + disp], Rq(src as u8));
+                dynasm!(self ; lock xadd [Rq(dst) + disp], Rq(src));
             }
             _ => codegen_error!(
                 "singlepass can't emit LOCK XADD {:?} {:?} {:?}",
@@ -1626,16 +1626,16 @@ impl EmitterX64 for AssemblerX64 {
     ) -> Result<(), CompileError> {
         match (sz, src, dst) {
             (Size::S8, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock cmpxchg [Rq(dst as u8) + disp], Rb(src as u8));
+                dynasm!(self ; lock cmpxchg [Rq(dst) + disp], Rb(src));
             }
             (Size::S16, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock cmpxchg [Rq(dst as u8) + disp], Rw(src as u8));
+                dynasm!(self ; lock cmpxchg [Rq(dst) + disp], Rw(src));
             }
             (Size::S32, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock cmpxchg [Rq(dst as u8) + disp], Rd(src as u8));
+                dynasm!(self ; lock cmpxchg [Rq(dst) + disp], Rd(src));
             }
             (Size::S64, Location::GPR(src), Location::Memory(dst, disp)) => {
-                dynasm!(self ; lock cmpxchg [Rq(dst as u8) + disp], Rq(src as u8));
+                dynasm!(self ; lock cmpxchg [Rq(dst) + disp], Rq(src));
             }
             _ => codegen_error!(
                 "singlepass can't emit LOCK CMPXCHG {:?} {:?} {:?}",
@@ -1652,35 +1652,35 @@ impl EmitterX64 for AssemblerX64 {
         Ok(())
     }
     fn emit_btc_gpr_imm8_32(&mut self, src: u8, dst: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; btc Rd(dst as u8), BYTE src as i8);
+        dynasm!(self ; btc Rd(dst), BYTE src as i8);
         Ok(())
     }
 
     fn emit_btc_gpr_imm8_64(&mut self, src: u8, dst: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; btc Rq(dst as u8), BYTE src as i8);
+        dynasm!(self ; btc Rq(dst), BYTE src as i8);
         Ok(())
     }
 
     fn emit_cmovae_gpr_32(&mut self, src: GPR, dst: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; cmovae Rd(dst as u8), Rd(src as u8));
+        dynasm!(self ; cmovae Rd(dst), Rd(src));
         Ok(())
     }
 
     fn emit_cmovae_gpr_64(&mut self, src: GPR, dst: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; cmovae Rq(dst as u8), Rq(src as u8));
+        dynasm!(self ; cmovae Rq(dst), Rq(src));
         Ok(())
     }
 
     fn emit_vmovaps(&mut self, src: XMMOrMemory, dst: XMMOrMemory) -> Result<(), CompileError> {
         match (src, dst) {
             (XMMOrMemory::XMM(src), XMMOrMemory::XMM(dst)) => {
-                dynasm!(self ; movaps Rx(dst as u8), Rx(src as u8))
+                dynasm!(self ; movaps Rx(dst), Rx(src))
             }
             (XMMOrMemory::Memory(base, disp), XMMOrMemory::XMM(dst)) => {
-                dynasm!(self ; movaps Rx(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; movaps Rx(dst), [Rq(base) + disp])
             }
             (XMMOrMemory::XMM(src), XMMOrMemory::Memory(base, disp)) => {
-                dynasm!(self ; movaps [Rq(base as u8) + disp], Rx(src as u8))
+                dynasm!(self ; movaps [Rq(base) + disp], Rx(src))
             }
             _ => codegen_error!("singlepass can't emit VMOVAPS {:?} {:?}", src, dst),
         };
@@ -1690,13 +1690,13 @@ impl EmitterX64 for AssemblerX64 {
     fn emit_vmovapd(&mut self, src: XMMOrMemory, dst: XMMOrMemory) -> Result<(), CompileError> {
         match (src, dst) {
             (XMMOrMemory::XMM(src), XMMOrMemory::XMM(dst)) => {
-                dynasm!(self ; movapd Rx(dst as u8), Rx(src as u8))
+                dynasm!(self ; movapd Rx(dst), Rx(src))
             }
             (XMMOrMemory::Memory(base, disp), XMMOrMemory::XMM(dst)) => {
-                dynasm!(self ; movapd Rx(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; movapd Rx(dst), [Rq(base) + disp])
             }
             (XMMOrMemory::XMM(src), XMMOrMemory::Memory(base, disp)) => {
-                dynasm!(self ; movapd [Rq(base as u8) + disp], Rx(src as u8))
+                dynasm!(self ; movapd [Rq(base) + disp], Rx(src))
             }
             _ => codegen_error!("singlepass can't emit VMOVAPD {:?} {:?}", src, dst),
         };
@@ -2257,20 +2257,20 @@ impl EmitterX64 for AssemblerX64 {
             Some(CpuFeature::AVX) => match src2 {
                 XMMOrMemory::XMM(src2) => {
                     // TODO: this argument order does not match the documentation??
-                    dynasm!( self; vblendvps Rx(dst as u8), Rx(mask as u8), Rx(src2 as u8), Rx(src1 as u8))
+                    dynasm!( self; vblendvps Rx(dst), Rx(mask), Rx(src2), Rx(src1))
                 }
                 XMMOrMemory::Memory(base, disp) => {
-                    dynasm!( self; vblendvps Rx(dst as u8), Rx(mask as u8), [Rq(base as u8) + disp], Rx(src1 as u8))
+                    dynasm!( self; vblendvps Rx(dst), Rx(mask), [Rq(base) + disp], Rx(src1))
                 }
             },
             Some(CpuFeature::SSE42) => match src2 {
                 XMMOrMemory::XMM(src2) => {
                     move_src_to_dst(self, Precision::Single, src1, dst);
-                    dynasm!( self; blendvps Rx(dst as u8), Rx(src2 as u8))
+                    dynasm!( self; blendvps Rx(dst), Rx(src2))
                 }
                 XMMOrMemory::Memory(base, disp) => {
                     move_src_to_dst(self, Precision::Single, src1, dst);
-                    dynasm!( self; blendvps Rx(dst as u8), [Rq(base as u8) + disp])
+                    dynasm!( self; blendvps Rx(dst), [Rq(base) + disp])
                 }
             },
             _ => {}
@@ -2290,20 +2290,20 @@ impl EmitterX64 for AssemblerX64 {
             Some(CpuFeature::AVX) => match src2 {
                 XMMOrMemory::XMM(src2) => {
                     // TODO: this argument order does not match the documentation??
-                    dynasm!( self; vblendvpd Rx(dst as u8), Rx(mask as u8), Rx(src2 as u8), Rx(src1 as u8))
+                    dynasm!( self; vblendvpd Rx(dst), Rx(mask), Rx(src2), Rx(src1))
                 }
                 XMMOrMemory::Memory(base, disp) => {
-                    dynasm!( self; vblendvpd Rx(dst as u8), Rx(mask as u8), [Rq(base as u8) + disp], Rx(src1 as u8))
+                    dynasm!( self; vblendvpd Rx(dst), Rx(mask), [Rq(base) + disp], Rx(src1))
                 }
             },
             Some(CpuFeature::SSE42) => match src2 {
                 XMMOrMemory::XMM(src2) => {
                     move_src_to_dst(self, Precision::Double, src1, dst);
-                    dynasm!( self; blendvpd Rx(dst as u8), Rx(src2 as u8))
+                    dynasm!( self; blendvpd Rx(dst), Rx(src2))
                 }
                 XMMOrMemory::Memory(base, disp) => {
                     move_src_to_dst(self, Precision::Double, src1, dst);
-                    dynasm!( self; blendvpd Rx(dst as u8), [Rq(base as u8) + disp])
+                    dynasm!( self; blendvpd Rx(dst), [Rq(base) + disp])
                 }
             },
             _ => {}
@@ -2313,9 +2313,9 @@ impl EmitterX64 for AssemblerX64 {
 
     fn emit_ucomiss(&mut self, src: XMMOrMemory, dst: XMM) -> Result<(), CompileError> {
         match src {
-            XMMOrMemory::XMM(x) => dynasm!(self ; ucomiss Rx(dst as u8), Rx(x as u8)),
+            XMMOrMemory::XMM(x) => dynasm!(self ; ucomiss Rx(dst), Rx(x)),
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; ucomiss Rx(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; ucomiss Rx(dst), [Rq(base) + disp])
             }
         }
         Ok(())
@@ -2323,9 +2323,9 @@ impl EmitterX64 for AssemblerX64 {
 
     fn emit_ucomisd(&mut self, src: XMMOrMemory, dst: XMM) -> Result<(), CompileError> {
         match src {
-            XMMOrMemory::XMM(x) => dynasm!(self ; ucomisd Rx(dst as u8), Rx(x as u8)),
+            XMMOrMemory::XMM(x) => dynasm!(self ; ucomisd Rx(dst), Rx(x)),
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; ucomisd Rx(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; ucomisd Rx(dst), [Rq(base) + disp])
             }
         }
         Ok(())
@@ -2333,9 +2333,9 @@ impl EmitterX64 for AssemblerX64 {
 
     fn emit_cvttss2si_32(&mut self, src: XMMOrMemory, dst: GPR) -> Result<(), CompileError> {
         match src {
-            XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rd(dst as u8), Rx(x as u8)),
+            XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rd(dst), Rx(x)),
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttss2si Rd(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; cvttss2si Rd(dst), [Rq(base) + disp])
             }
         }
         Ok(())
@@ -2343,9 +2343,9 @@ impl EmitterX64 for AssemblerX64 {
 
     fn emit_cvttss2si_64(&mut self, src: XMMOrMemory, dst: GPR) -> Result<(), CompileError> {
         match src {
-            XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rq(dst as u8), Rx(x as u8)),
+            XMMOrMemory::XMM(x) => dynasm!(self ; cvttss2si Rq(dst), Rx(x)),
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttss2si Rq(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; cvttss2si Rq(dst), [Rq(base) + disp])
             }
         }
         Ok(())
@@ -2353,9 +2353,9 @@ impl EmitterX64 for AssemblerX64 {
 
     fn emit_cvttsd2si_32(&mut self, src: XMMOrMemory, dst: GPR) -> Result<(), CompileError> {
         match src {
-            XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rd(dst as u8), Rx(x as u8)),
+            XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rd(dst), Rx(x)),
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttsd2si Rd(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; cvttsd2si Rd(dst), [Rq(base) + disp])
             }
         }
         Ok(())
@@ -2363,16 +2363,16 @@ impl EmitterX64 for AssemblerX64 {
 
     fn emit_cvttsd2si_64(&mut self, src: XMMOrMemory, dst: GPR) -> Result<(), CompileError> {
         match src {
-            XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rq(dst as u8), Rx(x as u8)),
+            XMMOrMemory::XMM(x) => dynasm!(self ; cvttsd2si Rq(dst), Rx(x)),
             XMMOrMemory::Memory(base, disp) => {
-                dynasm!(self ; cvttsd2si Rq(dst as u8), [Rq(base as u8) + disp])
+                dynasm!(self ; cvttsd2si Rq(dst), [Rq(base) + disp])
             }
         }
         Ok(())
     }
 
     fn emit_test_gpr_64(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; test Rq(reg as u8), Rq(reg as u8));
+        dynasm!(self ; test Rq(reg), Rq(reg));
         Ok(())
     }
 
@@ -2396,15 +2396,15 @@ impl EmitterX64 for AssemblerX64 {
     }
     fn emit_call_location(&mut self, loc: Location) -> Result<(), CompileError> {
         match loc {
-            Location::GPR(x) => dynasm!(self ; call Rq(x as u8)),
-            Location::Memory(base, disp) => dynasm!(self ; call QWORD [Rq(base as u8) + disp]),
+            Location::GPR(x) => dynasm!(self ; call Rq(x)),
+            Location::Memory(base, disp) => dynasm!(self ; call QWORD [Rq(base) + disp]),
             _ => codegen_error!("singlepass can't emit CALL {:?}", loc),
         }
         Ok(())
     }
 
     fn emit_call_register(&mut self, reg: GPR) -> Result<(), CompileError> {
-        dynasm!(self ; call Rq(reg as u8));
+        dynasm!(self ; call Rq(reg));
         Ok(())
     }
 

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -30,6 +30,12 @@ pub enum GPR {
     R15 = 15,
 }
 
+impl From<GPR> for u8 {
+    fn from(val: GPR) -> Self {
+        val as u8
+    }
+}
+
 /// XMM registers.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -51,6 +57,12 @@ pub enum XMM {
     XMM13 = 13,
     XMM14 = 14,
     XMM15 = 15,
+}
+
+impl From<XMM> for u8 {
+    fn from(val: XMM) -> Self {
+        val as u8
+    }
 }
 
 impl AbstractReg for GPR {


### PR DESCRIPTION
With the latest release of `dynasm-rs` release, dynamic register arguments are supported for all types supporting `Into<u8>` and thus, the current implementation can be rapidly simplified.