### PR TITLE
LLVM codegen: truncate stack to correct size when leaving a WASM block

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -189,6 +189,7 @@ jobs:
       - name: Install wasixcc, sysroot and LLVM
         run: |
           export RUST_LOG=wasixcc=trace
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           rustup toolchain install 1.89 --profile minimal --no-self-update
           cargo +1.89 install wasixcc -F bin
           mkdir wasixcc-install

--- a/lib/compiler-llvm/src/translator/state.rs
+++ b/lib/compiler-llvm/src/translator/state.rs
@@ -471,6 +471,7 @@ impl<'ctx> State<'ctx> {
         });
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn push_if(
         &mut self,
         if_then: BasicBlock<'ctx>,

--- a/tests/wast/wasmer/README.md
+++ b/tests/wast/wasmer/README.md
@@ -36,3 +36,7 @@ This is a simple test to check that a divide by zero is correctly trapped
 ## Atomic Load: `atomic_load.wast`
 
 This is a simple test to check that load an atomic "to far" in memory trigger a OutOfBound trap
+
+## Nested Unreachable Blocks: `nested_unreachable_blocks.wast`
+
+This was broken at one point in our LLVM backend. Otherwise, it's nothing specific.

--- a/tests/wast/wasmer/nested-unreachable-blocks.wast
+++ b/tests/wast/wasmer/nested-unreachable-blocks.wast
@@ -1,0 +1,18 @@
+;; This doesn't test anything in particular; this is just something
+;; that was broken in our LLVM backend at one point.
+
+(module
+  (func (export "f") (result i32)
+    i32.const 1
+    i32.const 2
+    (block $outer (param i32) (result i32)
+      (block (param i32) (result i32)
+        br $outer
+      )
+      unreachable
+    )
+    i32.add
+  )
+)
+
+(assert_return (invoke "f") (i32.const 3))


### PR DESCRIPTION
We would generate the wrong code for this WAT module:

```wat
(module
    (func (export "f") (result i32)
        i32.const 1
        i32.const 2
        (block $outer (param i32) (result i32)
            (block (param i32) (result i32)
                br $outer
            )
            unreachable
        )
        i32.add
    )
)
```

This PR fixes that.