### PR TITLE
fix(wasix): Linker must re-use the same Engine

### DIFF
--- a/examples/wasi.rs
+++ b/examples/wasi.rs
@@ -43,7 +43,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Compiling module...");
     // Let's compile the Wasm module.
-    let module = runtime.load_module_sync(&wasm_bytes[..])?;
+    let data = wasmer_wasix::runtime::module_cache::HashedModuleData::new_sha256(wasm_bytes);
+    let module = runtime.load_module_sync(data)?;
 
     // Create a pipe for the module's stdout.
     let (stdout_tx, mut stdout_rx) = Pipe::channel();

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -50,7 +50,9 @@ use wasmer_wasix::{
         MappedCommand, MappedDirectory, Runner,
     },
     runtime::{
-        module_cache::CacheError, package_loader::PackageLoader, resolver::QueryError,
+        module_cache::{CacheError, HashedModuleData},
+        package_loader::PackageLoader,
+        resolver::QueryError,
         task_manager::VirtualTaskManagerExt,
     },
     Runtime, WasiError,
@@ -843,15 +845,17 @@ impl ExecutableTarget {
         match TargetOnDisk::from_file(path)? {
             TargetOnDisk::WebAssemblyBinary | TargetOnDisk::Wat => {
                 let wasm = std::fs::read(path)?;
+                let module_data = HashedModuleData::new_xxhash(wasm);
+                let module_hash = module_data.hash().clone();
 
                 pb.set_message("Compiling to WebAssembly");
                 let module = runtime
-                    .load_module_sync(&wasm)
+                    .load_module_sync(module_data, None)
                     .with_context(|| format!("Unable to compile \"{}\"", path.display()))?;
 
                 Ok(ExecutableTarget::WebAssembly {
                     module,
-                    module_hash: ModuleHash::xxhash(&wasm),
+                    module_hash,
                     path: path.to_path_buf(),
                 })
             }

--- a/lib/package/src/utils.rs
+++ b/lib/package/src/utils.rs
@@ -62,6 +62,11 @@ pub fn from_disk(path: impl AsRef<Path>) -> Result<Container, WasmerPackageError
     }
 }
 
+/// Check if the data looks like a webc.
+pub fn is_container(bytes: &[u8]) -> bool {
+    is_tarball(std::io::Cursor::new(bytes)) || webc::detect(bytes).is_ok()
+}
+
 pub fn from_bytes(bytes: impl Into<Bytes>) -> Result<Container, WasmerPackageError> {
     let bytes: Bytes = bytes.into();
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -412,6 +412,16 @@ pub trait VirtualFile:
         })
     }
 
+    /// Get the full contents of this file as an [`OwnedBuffer`].
+    ///
+    /// **NOTE**: Only implement this if the file is already available in-memory
+    /// and can be cloned cheaply!
+    ///
+    /// Allows consumers to do zero-copy cloning of the underlying data.
+    fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
+        None
+    }
+
     /// Polls the file for when there is data to be read
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>>;
 

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -507,6 +507,17 @@ impl VirtualFile for FileHandle {
         self.cursor = cursor;
         Ok(())
     }
+
+    fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
+        let fs = self.filesystem.inner.read().ok()?;
+
+        let inode = fs.storage.get(self.inode)?;
+        match inode {
+            Node::ReadOnlyFile(f) => Some(f.file.buffer.clone()),
+            Node::CustomFile(f) => f.file.lock().ok()?.as_owned_buffer(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -251,6 +251,10 @@ impl VirtualFile for File {
     ) -> Poll<std::io::Result<usize>> {
         Poll::Ready(Err(std::io::ErrorKind::PermissionDenied.into()))
     }
+
+    fn as_owned_buffer(&self) -> Option<SharedBytes> {
+        Some(self.content.get_ref().clone())
+    }
 }
 
 impl AsyncRead for File {

--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -6,6 +6,7 @@ use crate::{
         TaskJoinHandle,
     },
     runtime::{
+        module_cache::HashedModuleData,
         task_manager::{
             TaskWasm, TaskWasmRecycle, TaskWasmRecycleProperties, TaskWasmRunProperties,
         },
@@ -43,7 +44,7 @@ pub async fn spawn_exec(
 
 #[tracing::instrument(level = "trace", skip_all, fields(%name))]
 pub async fn spawn_exec_wasm(
-    wasm: &[u8],
+    wasm: HashedModuleData,
     name: &str,
     env: WasiEnv,
     runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
@@ -85,7 +86,7 @@ pub fn package_command_by_name<'a>(
 
 pub async fn spawn_load_module(
     name: &str,
-    wasm: &[u8],
+    wasm: HashedModuleData,
     runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
 ) -> Result<Module, SpawnError> {
     match runtime.load_module(wasm).await {

--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -89,7 +89,7 @@ pub async fn spawn_load_module(
     wasm: HashedModuleData,
     runtime: &Arc<dyn Runtime + Send + Sync + 'static>,
 ) -> Result<Module, SpawnError> {
-    match runtime.load_module(wasm).await {
+    match runtime.load_module(wasm, None).await {
         Ok(module) => Ok(module),
         Err(err) => {
             tracing::error!(

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -17,7 +17,7 @@ use std::{
 
 use futures::future::BoxFuture;
 use virtual_net::{DynVirtualNetworking, VirtualNetworking};
-use wasmer::{CompileError, Module, RuntimeError};
+use wasmer::{CompileError, Engine, Module, RuntimeError};
 use wasmer_wasix_types::wasi::ExitCode;
 
 #[cfg(feature = "journal")]
@@ -155,8 +155,9 @@ where
     fn load_module<'a>(
         &'a self,
         module: HashedModuleData,
+        engine: Option<&wasmer::Engine>,
     ) -> BoxFuture<'a, Result<Module, SpawnError>> {
-        let engine = self.engine();
+        let engine = engine.cloned().unwrap_or_else(|| self.engine());
         let module_cache = self.module_cache();
 
         let task = async move { load_module(&engine, &module_cache, &module).await };
@@ -167,8 +168,12 @@ where
     /// Load a a Webassembly module, trying to use a pre-compiled version if possible.
     ///
     /// Non-async version of [`Self::load_module`].
-    fn load_module_sync(&self, wasm: HashedModuleData) -> Result<Module, SpawnError> {
-        InlineWaker::block_on(self.load_module(wasm))
+    fn load_module_sync(
+        &self,
+        wasm: HashedModuleData,
+        engine: Option<&Engine>,
+    ) -> Result<Module, SpawnError> {
+        InlineWaker::block_on(self.load_module(wasm, engine))
     }
 
     /// Callback thats invokes whenever the instance is tainted, tainting can occur
@@ -630,23 +635,30 @@ impl Runtime for OverriddenRuntime {
     fn load_module<'a>(
         &'a self,
         data: HashedModuleData,
+        engine: Option<&wasmer::Engine>,
     ) -> BoxFuture<'a, Result<Module, SpawnError>> {
-        if self.engine.is_some() || self.module_cache.is_some() {
-            let engine = self.engine();
-            let module_cache = self.module_cache();
+        let engine = engine.or_else(|| self.engine.as_ref());
 
+        if let (Some(engine), Some(module_cache)) = (engine, self.module_cache.clone()) {
+            let engine = engine.clone();
             let task = async move { load_module(&engine, &module_cache, &data).await };
             Box::pin(task)
         } else {
-            self.inner.load_module(data)
+            self.inner.load_module(data, engine)
         }
     }
 
-    fn load_module_sync(&self, wasm: HashedModuleData) -> Result<Module, SpawnError> {
-        if self.engine.is_some() || self.module_cache.is_some() {
-            InlineWaker::block_on(self.load_module(wasm))
+    fn load_module_sync(
+        &self,
+        wasm: HashedModuleData,
+        engine: Option<&Engine>,
+    ) -> Result<Module, SpawnError> {
+        let engine = engine.or_else(|| self.engine.as_ref());
+
+        if engine.is_some() || self.module_cache.is_some() {
+            InlineWaker::block_on(self.load_module(wasm, engine))
         } else {
-            self.inner.load_module_sync(wasm)
+            self.inner.load_module_sync(wasm, engine)
         }
     }
 }

--- a/lib/wasix/src/runtime/module_cache/hashed_module.rs
+++ b/lib/wasix/src/runtime/module_cache/hashed_module.rs
@@ -1,0 +1,60 @@
+use shared_buffer::OwnedBuffer;
+use wasmer_types::ModuleHash;
+
+use crate::bin_factory::BinaryPackageCommand;
+
+/// A wrapper around Webassembly code and its hash.
+///
+/// Allows passing around WASM code and it's hash without the danger of
+/// using a wrong hash.
+///
+/// Safe by construction: can only be created from a [`BinaryCommand`], which
+/// already has the hash embedded, or from bytes that will be hashed in the
+/// constructor.
+///
+/// Can be cloned cheaply.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HashedModuleData {
+    hash: ModuleHash,
+    wasm: OwnedBuffer,
+}
+
+impl HashedModuleData {
+    pub fn new_sha256(bytes: impl Into<OwnedBuffer>) -> Self {
+        let wasm = bytes.into();
+        let hash = ModuleHash::sha256(&wasm);
+        Self { hash, wasm }
+    }
+
+    /// Create new [`HashedModuleData`] from the given bytes, hashing the
+    /// the bytes into a [`ModuleHash`] with xxhash.
+    pub fn new_xxhash(bytes: impl Into<OwnedBuffer>) -> Self {
+        let wasm = bytes.into();
+        let hash = ModuleHash::xxhash(&wasm);
+        Self { hash, wasm }
+    }
+
+    /// Create new [`HashedModuleData`] from the given [`BinaryPackageCommand`].
+    ///
+    /// This is very cheap, as the hash is already available in the command.
+    pub fn from_command(command: &BinaryPackageCommand) -> Self {
+        Self {
+            hash: command.hash().clone(),
+            wasm: command.atom(),
+        }
+    }
+
+    /// Get the module hash.
+    pub fn hash(&self) -> &ModuleHash {
+        &self.hash
+    }
+
+    /// Get the WASM code.
+    pub fn wasm(&self) -> &OwnedBuffer {
+        &self.wasm
+    }
+
+    pub fn into_parts(self) -> (ModuleHash, OwnedBuffer) {
+        (self.hash, self.wasm)
+    }
+}

--- a/lib/wasix/src/runtime/module_cache/mod.rs
+++ b/lib/wasix/src/runtime/module_cache/mod.rs
@@ -31,6 +31,8 @@
 //! caching strategies. For example, you could use the [`FallbackCache`] to
 //! chain a fast in-memory cache with a slower file-based cache as a fallback.
 
+mod hashed_module;
+
 mod fallback;
 #[cfg(feature = "sys-thread")]
 mod filesystem;
@@ -40,6 +42,7 @@ mod types;
 
 pub use self::{
     fallback::FallbackCache,
+    hashed_module::HashedModuleData,
     shared::SharedCache,
     thread_local::ThreadLocalCache,
     types::{CacheError, ModuleCache},

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -421,6 +421,7 @@ impl WasiEnv {
         let pid = self.process.pid();
 
         let mut store = store.as_store_mut();
+        let engine = self.runtime().engine();
         let mut func_env = WasiFunctionEnv::new(&mut store, self);
 
         let is_dl = super::linker::is_dynamically_linked(&module);
@@ -451,6 +452,7 @@ impl WasiEnv {
 
                     // TODO: make stack size configurable
                     Linker::new(
+                        engine,
                         &module,
                         &mut store,
                         memory,

--- a/lib/wasix/src/state/linker.rs
+++ b/lib/wasix/src/state/linker.rs
@@ -277,8 +277,8 @@ use tracing::trace;
 use virtual_fs::{AsyncReadExt, FileSystem, FsError};
 use virtual_mio::InlineWaker;
 use wasmer::{
-    AsStoreMut, AsStoreRef, ExportError, Exportable, Extern, ExternType, Function, FunctionEnv,
-    FunctionEnvMut, FunctionType, Global, GlobalType, ImportType, Imports, Instance,
+    AsStoreMut, AsStoreRef, Engine, ExportError, Exportable, Extern, ExternType, Function,
+    FunctionEnv, FunctionEnvMut, FunctionType, Global, GlobalType, ImportType, Imports, Instance,
     InstantiationError, Memory, MemoryError, Module, RuntimeError, StoreMut, Table, Tag, Type,
     Value, WasmTypeList, WASM_PAGE_SIZE,
 };
@@ -817,6 +817,8 @@ struct InstanceGroupState {
 
 // There is only one LinkerState for all instance groups
 struct LinkerState {
+    engine: Engine,
+
     main_module: Module,
     main_module_dylink_info: DylinkInfo,
 
@@ -947,6 +949,7 @@ impl Linker {
     /// running, and a Linker instance is returned which can then be used for the
     /// loading/linking of further side modules.
     pub fn new(
+        engine: Engine,
         main_module: &Module,
         store: &mut StoreMut<'_>,
         memory: Option<Memory>,
@@ -1082,6 +1085,7 @@ impl Linker {
         };
 
         let mut linker_state = LinkerState {
+            engine,
             main_module: main_module.clone(),
             main_module_dylink_info: dylink_section,
             side_modules: BTreeMap::new(),
@@ -2314,13 +2318,10 @@ impl LinkerState {
                     Some((full_path, ld_library_path)),
                 )
             }
-            DlModuleSpec::Memory { bytes, .. } => (
-                HashedModuleData::new_sha256(bytes),
-                None,
-            ),
+            DlModuleSpec::Memory { bytes, .. } => (HashedModuleData::new_sha256(bytes), None),
         };
 
-        let module = runtime.load_module_sync(module_data)?;
+        let module = runtime.load_module_sync(module_data, Some(&self.engine))?;
 
         let dylink_info = parse_dylink0_section(&module)?;
 


### PR DESCRIPTION
The Linker must re-use the same Engine for all loaded modules.
If we try to combine dynamic libraries built by different engines, we get call type mismatch errors when modules call into each other.

