### PR TITLE
Singlepass: to_dwarf - use directly `gimli::Register` type

### DIFF
--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -153,8 +153,44 @@ impl AbstractReg for GPR {
         ];
         GPRS.iter()
     }
-    fn to_dwarf(self) -> u16 {
-        self.into_index() as u16
+    #[cfg(feature = "unwind")]
+    fn to_dwarf(self) -> gimli::Register {
+        use gimli::AArch64;
+
+        match self {
+            GPR::X0 => AArch64::X0,
+            GPR::X1 => AArch64::X1,
+            GPR::X2 => AArch64::X2,
+            GPR::X3 => AArch64::X3,
+            GPR::X4 => AArch64::X4,
+            GPR::X5 => AArch64::X5,
+            GPR::X6 => AArch64::X6,
+            GPR::X7 => AArch64::X7,
+            GPR::X8 => AArch64::X8,
+            GPR::X9 => AArch64::X9,
+            GPR::X10 => AArch64::X10,
+            GPR::X11 => AArch64::X11,
+            GPR::X12 => AArch64::X12,
+            GPR::X13 => AArch64::X13,
+            GPR::X14 => AArch64::X14,
+            GPR::X15 => AArch64::X15,
+            GPR::X16 => AArch64::X16,
+            GPR::X17 => AArch64::X17,
+            GPR::X18 => AArch64::X18,
+            GPR::X19 => AArch64::X19,
+            GPR::X20 => AArch64::X20,
+            GPR::X21 => AArch64::X21,
+            GPR::X22 => AArch64::X22,
+            GPR::X23 => AArch64::X23,
+            GPR::X24 => AArch64::X24,
+            GPR::X25 => AArch64::X25,
+            GPR::X26 => AArch64::X26,
+            GPR::X27 => AArch64::X27,
+            GPR::X28 => AArch64::X28,
+            GPR::X29 => AArch64::X29,
+            GPR::X30 => AArch64::X30,
+            GPR::XzrSp => AArch64::SP,
+        }
     }
 }
 
@@ -211,8 +247,44 @@ impl AbstractReg for NEON {
         ];
         NEONS.iter()
     }
-    fn to_dwarf(self) -> u16 {
-        self.into_index() as u16 + 64
+    #[cfg(feature = "unwind")]
+    fn to_dwarf(self) -> gimli::Register {
+        use gimli::AArch64;
+
+        match self {
+            NEON::V0 => AArch64::V0,
+            NEON::V1 => AArch64::V1,
+            NEON::V2 => AArch64::V2,
+            NEON::V3 => AArch64::V3,
+            NEON::V4 => AArch64::V4,
+            NEON::V5 => AArch64::V5,
+            NEON::V6 => AArch64::V6,
+            NEON::V7 => AArch64::V7,
+            NEON::V8 => AArch64::V8,
+            NEON::V9 => AArch64::V9,
+            NEON::V10 => AArch64::V10,
+            NEON::V11 => AArch64::V11,
+            NEON::V12 => AArch64::V12,
+            NEON::V13 => AArch64::V13,
+            NEON::V14 => AArch64::V14,
+            NEON::V15 => AArch64::V15,
+            NEON::V16 => AArch64::V16,
+            NEON::V17 => AArch64::V17,
+            NEON::V18 => AArch64::V18,
+            NEON::V19 => AArch64::V19,
+            NEON::V20 => AArch64::V20,
+            NEON::V21 => AArch64::V21,
+            NEON::V22 => AArch64::V22,
+            NEON::V23 => AArch64::V23,
+            NEON::V24 => AArch64::V24,
+            NEON::V25 => AArch64::V25,
+            NEON::V26 => AArch64::V26,
+            NEON::V27 => AArch64::V27,
+            NEON::V28 => AArch64::V28,
+            NEON::V29 => AArch64::V29,
+            NEON::V30 => AArch64::V30,
+            NEON::V31 => AArch64::V31,
+        }
     }
 }
 

--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -314,15 +314,6 @@ impl CombinedRegister for ARM64Register {
     fn from_simd(x: u16) -> Self {
         ARM64Register::NEON(NEON::from_index(x as usize).unwrap())
     }
-
-    /// Converts a DWARF regnum to ARM64Register.
-    fn _from_dwarf_regnum(x: u16) -> Option<ARM64Register> {
-        Some(match x {
-            0..=31 => ARM64Register::GPR(GPR::from_index(x as usize).unwrap()),
-            64..=95 => ARM64Register::NEON(NEON::from_index(x as usize - 64).unwrap()),
-            _ => return None,
-        })
-    }
 }
 
 /// An allocator that allocates registers for function arguments according to the System V ABI.

--- a/lib/compiler-singlepass/src/location.rs
+++ b/lib/compiler-singlepass/src/location.rs
@@ -73,8 +73,6 @@ pub trait Descriptor<R: Reg, S: Reg> {
 pub trait CombinedRegister: Copy + Clone + Eq + PartialEq + Debug {
     /// Returns the index of the register.
     fn to_index(&self) -> RegisterIndex;
-    /// Converts a DWARF regnum to CombinedRegister.
-    fn _from_dwarf_regnum(x: u16) -> Option<Self>;
     /// Convert from a GPR register
     fn from_gpr(x: u16) -> Self;
     /// Convert from an SIMD register

--- a/lib/compiler-singlepass/src/location.rs
+++ b/lib/compiler-singlepass/src/location.rs
@@ -45,7 +45,9 @@ pub trait Reg: Copy + Clone + Eq + PartialEq + Debug + Hash + Ord {
     fn into_index(self) -> usize;
     fn from_index(i: usize) -> Result<Self, ()>;
     fn iterator() -> Iter<'static, Self>;
-    fn to_dwarf(self) -> u16;
+
+    #[cfg(feature = "unwind")]
+    fn to_dwarf(self) -> gimli::Register;
 }
 
 #[allow(unused)]

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -23,88 +23,11 @@ use crate::{
     emitter_arm64::*,
     location::{Location as AbstractLocation, Reg},
     machine::*,
-    unwind::{UnwindInstructions, UnwindOps},
+    unwind::{UnwindInstructions, UnwindOps, UnwindRegister},
 };
 
 type Assembler = VecAssembler<Aarch64Relocation>;
 type Location = AbstractLocation<GPR, NEON>;
-
-#[cfg(feature = "unwind")]
-fn dwarf_index(reg: u16) -> gimli::Register {
-    static DWARF_GPR: [gimli::Register; 32] = [
-        AArch64::X0,
-        AArch64::X1,
-        AArch64::X2,
-        AArch64::X3,
-        AArch64::X4,
-        AArch64::X5,
-        AArch64::X6,
-        AArch64::X7,
-        AArch64::X8,
-        AArch64::X9,
-        AArch64::X10,
-        AArch64::X11,
-        AArch64::X12,
-        AArch64::X13,
-        AArch64::X14,
-        AArch64::X15,
-        AArch64::X16,
-        AArch64::X17,
-        AArch64::X18,
-        AArch64::X19,
-        AArch64::X20,
-        AArch64::X21,
-        AArch64::X22,
-        AArch64::X23,
-        AArch64::X24,
-        AArch64::X25,
-        AArch64::X26,
-        AArch64::X27,
-        AArch64::X28,
-        AArch64::X29,
-        AArch64::X30,
-        AArch64::SP,
-    ];
-    static DWARF_NEON: [gimli::Register; 32] = [
-        AArch64::V0,
-        AArch64::V1,
-        AArch64::V2,
-        AArch64::V3,
-        AArch64::V4,
-        AArch64::V5,
-        AArch64::V6,
-        AArch64::V7,
-        AArch64::V8,
-        AArch64::V9,
-        AArch64::V10,
-        AArch64::V11,
-        AArch64::V12,
-        AArch64::V13,
-        AArch64::V14,
-        AArch64::V15,
-        AArch64::V16,
-        AArch64::V17,
-        AArch64::V18,
-        AArch64::V19,
-        AArch64::V20,
-        AArch64::V21,
-        AArch64::V22,
-        AArch64::V23,
-        AArch64::V24,
-        AArch64::V25,
-        AArch64::V26,
-        AArch64::V27,
-        AArch64::V28,
-        AArch64::V29,
-        AArch64::V30,
-        AArch64::V31,
-    ];
-    match reg {
-        0..=31 => DWARF_GPR[reg as usize],
-        64..=95 => DWARF_NEON[reg as usize - 64],
-        _ => panic!("Unknown register index {reg}"),
-    }
-}
 
 pub struct MachineARM64 {
     assembler: Assembler,
@@ -119,7 +42,7 @@ pub struct MachineARM64 {
     /// is last push on a 8byte multiple or 16bytes?
     pushed: bool,
     /// Vector of unwind operations with offset
-    unwind_ops: Vec<(usize, UnwindOps)>,
+    unwind_ops: Vec<(usize, UnwindOps<GPR, NEON>)>,
     /// A boolean flag signaling if this machine supports NEON.
     has_neon: bool,
 }
@@ -1410,7 +1333,7 @@ impl MachineARM64 {
         self.used_simd &= !(1 << r.into_index());
         ret
     }
-    fn emit_unwind_op(&mut self, op: UnwindOps) {
+    fn emit_unwind_op(&mut self, op: UnwindOps<GPR, NEON>) {
         self.unwind_ops.push((self.get_offset().0, op));
     }
     fn emit_illegal_op_internal(&mut self, trap: TrapCode) -> Result<(), CompileError> {
@@ -1802,11 +1725,11 @@ impl Machine for MachineARM64 {
         }
         match location {
             Location::GPR(x) => self.emit_unwind_op(UnwindOps::SaveRegister {
-                reg: x.to_dwarf(),
+                reg: UnwindRegister::<GPR, NEON>::GPR(x),
                 bp_neg_offset: stack_offset,
             }),
             Location::SIMD(x) => self.emit_unwind_op(UnwindOps::SaveRegister {
-                reg: x.to_dwarf(),
+                reg: UnwindRegister::FPR(x),
                 bp_neg_offset: stack_offset,
             }),
             _ => (),
@@ -2325,14 +2248,14 @@ impl Machine for MachineARM64 {
     fn emit_function_prolog(&mut self) -> Result<(), CompileError> {
         self.emit_double_push(Size::S64, Location::GPR(GPR::X29), Location::GPR(GPR::X30))?; // save LR too
         self.emit_unwind_op(UnwindOps::Push2Regs {
-            reg1: GPR::X29.to_dwarf(),
-            reg2: GPR::X30.to_dwarf(),
+            reg1: UnwindRegister::GPR(GPR::X29),
+            reg2: UnwindRegister::GPR(GPR::X30),
             up_to_sp: 16,
         });
         self.emit_double_push(Size::S64, Location::GPR(GPR::X27), Location::GPR(GPR::X28))?;
         self.emit_unwind_op(UnwindOps::Push2Regs {
-            reg1: GPR::X27.to_dwarf(),
-            reg2: GPR::X28.to_dwarf(),
+            reg1: UnwindRegister::GPR(GPR::X27),
+            reg2: UnwindRegister::GPR(GPR::X28),
             up_to_sp: 32,
         });
         // cannot use mov, because XSP is XZR there. Need to use ADD with #0
@@ -8543,11 +8466,11 @@ impl Machine for MachineARM64 {
                     ));
                     instructions.push((
                         instruction_offset,
-                        CallFrameInstruction::Offset(dwarf_index(reg2), -(up_to_sp as i32) + 8),
+                        CallFrameInstruction::Offset(reg2.to_dwarf(), -(up_to_sp as i32) + 8),
                     ));
                     instructions.push((
                         instruction_offset,
-                        CallFrameInstruction::Offset(dwarf_index(reg1), -(up_to_sp as i32)),
+                        CallFrameInstruction::Offset(reg1.to_dwarf(), -(up_to_sp as i32)),
                     ));
                 }
                 UnwindOps::DefineNewFrame => {
@@ -8558,7 +8481,7 @@ impl Machine for MachineARM64 {
                 }
                 UnwindOps::SaveRegister { reg, bp_neg_offset } => instructions.push((
                     instruction_offset,
-                    CallFrameInstruction::Offset(dwarf_index(reg), -bp_neg_offset),
+                    CallFrameInstruction::Offset(reg.to_dwarf(), -bp_neg_offset),
                 )),
             }
         }

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -8466,11 +8466,11 @@ impl Machine for MachineARM64 {
                     ));
                     instructions.push((
                         instruction_offset,
-                        CallFrameInstruction::Offset(reg2.to_dwarf(), -(up_to_sp as i32) + 8),
+                        CallFrameInstruction::Offset(reg2.dwarf_index(), -(up_to_sp as i32) + 8),
                     ));
                     instructions.push((
                         instruction_offset,
-                        CallFrameInstruction::Offset(reg1.to_dwarf(), -(up_to_sp as i32)),
+                        CallFrameInstruction::Offset(reg1.dwarf_index(), -(up_to_sp as i32)),
                     ));
                 }
                 UnwindOps::DefineNewFrame => {
@@ -8481,7 +8481,7 @@ impl Machine for MachineARM64 {
                 }
                 UnwindOps::SaveRegister { reg, bp_neg_offset } => instructions.push((
                     instruction_offset,
-                    CallFrameInstruction::Offset(reg.to_dwarf(), -bp_neg_offset),
+                    CallFrameInstruction::Offset(reg.dwarf_index(), -bp_neg_offset),
                 )),
             }
         }

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -6,7 +6,7 @@ use crate::{
     emitter_x64::*,
     location::{Location as AbstractLocation, Reg},
     machine::*,
-    unwind::{UnwindInstructions, UnwindOps},
+    unwind::{UnwindInstructions, UnwindOps, UnwindRegister},
     x64_decl::{new_machine_state, ArgumentRegisterAllocator, X64Register, GPR, XMM},
 };
 use dynasmrt::{x64::X64Relocation, DynasmError, VecAssembler};
@@ -85,51 +85,6 @@ impl DerefMut for AssemblerX64 {
 
 type Location = AbstractLocation<GPR, XMM>;
 
-#[cfg(feature = "unwind")]
-fn dwarf_index(reg: u16) -> gimli::Register {
-    static DWARF_GPR: [gimli::Register; 16] = [
-        X86_64::RAX,
-        X86_64::RDX,
-        X86_64::RCX,
-        X86_64::RBX,
-        X86_64::RSI,
-        X86_64::RDI,
-        X86_64::RBP,
-        X86_64::RSP,
-        X86_64::R8,
-        X86_64::R9,
-        X86_64::R10,
-        X86_64::R11,
-        X86_64::R12,
-        X86_64::R13,
-        X86_64::R14,
-        X86_64::R15,
-    ];
-    static DWARF_XMM: [gimli::Register; 16] = [
-        X86_64::XMM0,
-        X86_64::XMM1,
-        X86_64::XMM2,
-        X86_64::XMM3,
-        X86_64::XMM4,
-        X86_64::XMM5,
-        X86_64::XMM6,
-        X86_64::XMM7,
-        X86_64::XMM8,
-        X86_64::XMM9,
-        X86_64::XMM10,
-        X86_64::XMM11,
-        X86_64::XMM12,
-        X86_64::XMM13,
-        X86_64::XMM14,
-        X86_64::XMM15,
-    ];
-    match reg {
-        0..=15 => DWARF_GPR[reg as usize],
-        17..=24 => DWARF_XMM[reg as usize - 17],
-        _ => panic!("Unknown register index {reg}"),
-    }
-}
-
 pub struct MachineX86_64 {
     assembler: AssemblerX64,
     used_gprs: u32,
@@ -142,7 +97,7 @@ pub struct MachineX86_64 {
     /// The source location for the current operator.
     src_loc: u32,
     /// Vector of unwind operations with offset
-    unwind_ops: Vec<(usize, UnwindOps)>,
+    unwind_ops: Vec<(usize, UnwindOps<GPR, XMM>)>,
 }
 
 impl MachineX86_64 {
@@ -1923,7 +1878,7 @@ impl MachineX86_64 {
         self.used_simd &= !(1 << r.into_index());
         ret
     }
-    fn emit_unwind_op(&mut self, op: UnwindOps) -> Result<(), CompileError> {
+    fn emit_unwind_op(&mut self, op: UnwindOps<GPR, XMM>) -> Result<(), CompileError> {
         self.unwind_ops.push((self.get_offset().0, op));
         Ok(())
     }
@@ -2246,11 +2201,11 @@ impl Machine for MachineX86_64 {
         )?;
         match location {
             Location::GPR(x) => self.emit_unwind_op(UnwindOps::SaveRegister {
-                reg: x.to_dwarf(),
+                reg: UnwindRegister::GPR(x),
                 bp_neg_offset: stack_offset,
             }),
             Location::SIMD(x) => self.emit_unwind_op(UnwindOps::SaveRegister {
-                reg: x.to_dwarf(),
+                reg: UnwindRegister::FPR(x),
                 bp_neg_offset: stack_offset,
             }),
             _ => Ok(()),
@@ -8264,7 +8219,7 @@ impl Machine for MachineX86_64 {
                 }
                 UnwindOps::SaveRegister { reg, bp_neg_offset } => instructions.push((
                     instruction_offset,
-                    CallFrameInstruction::Offset(dwarf_index(reg), -bp_neg_offset),
+                    CallFrameInstruction::Offset(reg.to_dwarf(), -bp_neg_offset),
                 )),
                 UnwindOps::Push2Regs { .. } => unimplemented!(),
             }

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -8219,7 +8219,7 @@ impl Machine for MachineX86_64 {
                 }
                 UnwindOps::SaveRegister { reg, bp_neg_offset } => instructions.push((
                     instruction_offset,
-                    CallFrameInstruction::Offset(reg.to_dwarf(), -bp_neg_offset),
+                    CallFrameInstruction::Offset(reg.dwarf_index(), -bp_neg_offset),
                 )),
                 UnwindOps::Push2Regs { .. } => unimplemented!(),
             }

--- a/lib/compiler-singlepass/src/unwind.rs
+++ b/lib/compiler-singlepass/src/unwind.rs
@@ -10,11 +10,13 @@ use crate::location;
 
 #[derive(Clone, Debug, Copy)]
 #[allow(clippy::upper_case_acronyms)]
+#[cfg(feature = "unwind")]
 pub enum UnwindRegister<R: location::Reg, S: location::Reg> {
     GPR(R),
     FPR(S),
 }
 
+#[cfg(feature = "unwind")]
 impl<R: location::Reg, S: location::Reg> UnwindRegister<R, S> {
     pub(crate) fn dwarf_index(&self) -> gimli::Register {
         match self {

--- a/lib/compiler-singlepass/src/unwind.rs
+++ b/lib/compiler-singlepass/src/unwind.rs
@@ -6,12 +6,38 @@ use std::fmt::Debug;
 #[cfg(feature = "unwind")]
 use wasmer_types::target::Architecture;
 
+use crate::location;
+
+#[derive(Clone, Debug, Copy)]
+pub enum UnwindRegister<R: location::Reg, S: location::Reg> {
+    GPR(R),
+    FPR(S),
+}
+
+impl<R: location::Reg, S: location::Reg> UnwindRegister<R, S> {
+    pub(crate) fn to_dwarf(&self) -> gimli::Register {
+        match self {
+            Self::GPR(reg) => reg.to_dwarf(),
+            Self::FPR(reg) => reg.to_dwarf(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
-pub enum UnwindOps {
-    PushFP { up_to_sp: u32 },
-    Push2Regs { reg1: u16, reg2: u16, up_to_sp: u32 },
+pub enum UnwindOps<R: location::Reg, S: location::Reg> {
+    PushFP {
+        up_to_sp: u32,
+    },
+    Push2Regs {
+        reg1: UnwindRegister<R, S>,
+        reg2: UnwindRegister<R, S>,
+        up_to_sp: u32,
+    },
     DefineNewFrame,
-    SaveRegister { reg: u16, bp_neg_offset: i32 },
+    SaveRegister {
+        reg: UnwindRegister<R, S>,
+        bp_neg_offset: i32,
+    },
 }
 
 #[cfg(not(feature = "unwind"))]

--- a/lib/compiler-singlepass/src/unwind.rs
+++ b/lib/compiler-singlepass/src/unwind.rs
@@ -9,13 +9,14 @@ use wasmer_types::target::Architecture;
 use crate::location;
 
 #[derive(Clone, Debug, Copy)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum UnwindRegister<R: location::Reg, S: location::Reg> {
     GPR(R),
     FPR(S),
 }
 
 impl<R: location::Reg, S: location::Reg> UnwindRegister<R, S> {
-    pub(crate) fn to_dwarf(&self) -> gimli::Register {
+    pub(crate) fn dwarf_index(&self) -> gimli::Register {
         match self {
             Self::GPR(reg) => reg.to_dwarf(),
             Self::FPR(reg) => reg.to_dwarf(),

--- a/lib/compiler-singlepass/src/unwind.rs
+++ b/lib/compiler-singlepass/src/unwind.rs
@@ -10,7 +10,6 @@ use crate::location;
 
 #[derive(Clone, Debug, Copy)]
 #[allow(clippy::upper_case_acronyms)]
-#[cfg(feature = "unwind")]
 pub enum UnwindRegister<R: location::Reg, S: location::Reg> {
     GPR(R),
     FPR(S),

--- a/lib/compiler-singlepass/src/unwind_winx64.rs
+++ b/lib/compiler-singlepass/src/unwind_winx64.rs
@@ -1,6 +1,7 @@
 //! Windows x64 ABI unwind information.
 
 use crate::{
+    location::Reg,
     unwind::{UnwindOps, UnwindRegister},
     x64_decl::{GPR, XMM},
 };
@@ -263,14 +264,16 @@ pub(crate) fn create_unwind_info_from_insts(
                 unwind_codes.push(UnwindCode::SetFPReg { instruction_offset });
             }
             UnwindOps::SaveRegister { reg, bp_neg_offset } => match reg {
-                UnwindRegister::GPR(_) => unwind_codes.push(UnwindCode::SaveReg {
+                UnwindRegister::GPR(reg) => unwind_codes.push(UnwindCode::SaveReg {
                     instruction_offset,
-                    reg: reg.windows_unwind_index(),
+                    // NOTE: We declare the register order in the same way as expected by the x64 exception handling ABI.
+                    reg: reg.into_index() as u8,
                     stack_offset: bp_neg_offset as u32,
                 }),
-                UnwindRegister::FPR(_) => unwind_codes.push(UnwindCode::SaveXmm {
+                UnwindRegister::FPR(reg) => unwind_codes.push(UnwindCode::SaveXmm {
                     instruction_offset,
-                    reg: reg.windows_unwind_index(),
+                    // NOTE: We declare the register order in the same way as expected by the x64 exception handling ABI.
+                    reg: reg.into_index() as u8,
                     stack_offset: bp_neg_offset as u32,
                 }),
             },

--- a/lib/compiler-singlepass/src/unwind_winx64.rs
+++ b/lib/compiler-singlepass/src/unwind_winx64.rs
@@ -1,6 +1,9 @@
 //! Windows x64 ABI unwind information.
 
-use crate::unwind::UnwindOps;
+use crate::{
+    unwind::{UnwindOps, UnwindRegister},
+    x64_decl::{GPR, XMM},
+};
 
 /// Maximum (inclusive) size of a "small" stack allocation
 const SMALL_ALLOC_MAX_SIZE: u32 = 128;
@@ -240,7 +243,9 @@ impl UnwindInfo {
 
 const UNWIND_RBP_REG: u8 = 5;
 
-pub(crate) fn create_unwind_info_from_insts(insts: &[(usize, UnwindOps)]) -> Option<UnwindInfo> {
+pub(crate) fn create_unwind_info_from_insts(
+    insts: &[(usize, UnwindOps<GPR, XMM>)],
+) -> Option<UnwindInfo> {
     let mut unwind_codes = vec![];
     let mut frame_register_offset = 0;
     let mut max_unwind_offset = 0;
@@ -258,26 +263,16 @@ pub(crate) fn create_unwind_info_from_insts(insts: &[(usize, UnwindOps)]) -> Opt
                 unwind_codes.push(UnwindCode::SetFPReg { instruction_offset });
             }
             UnwindOps::SaveRegister { reg, bp_neg_offset } => match reg {
-                0..=15 => {
-                    // GPR reg
-                    static FROM_DWARF: [u8; 16] =
-                        [0, 2, 1, 3, 6, 7, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15];
-                    unwind_codes.push(UnwindCode::SaveReg {
-                        instruction_offset,
-                        reg: FROM_DWARF[reg as usize],
-                        stack_offset: bp_neg_offset as u32,
-                    });
-                }
-                17..=32 => {
-                    unwind_codes.push(UnwindCode::SaveXmm {
-                        instruction_offset,
-                        reg: reg as u8 - 17,
-                        stack_offset: bp_neg_offset as u32,
-                    });
-                }
-                _ => {
-                    unreachable!("unknown register index {}", reg);
-                }
+                UnwindRegister::GPR(_) => unwind_codes.push(UnwindCode::SaveReg {
+                    instruction_offset,
+                    reg: reg.windows_unwind_index(),
+                    stack_offset: bp_neg_offset as u32,
+                }),
+                UnwindRegister::FPR(_) => unwind_codes.push(UnwindCode::SaveXmm {
+                    instruction_offset,
+                    reg: reg.windows_unwind_index(),
+                    stack_offset: bp_neg_offset as u32,
+                }),
             },
             UnwindOps::Push2Regs { .. } => {
                 unreachable!("no aarch64 on x64");

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -234,6 +234,7 @@ impl CombinedRegister for X64Register {
     fn from_simd(x: u16) -> Self {
         X64Register::XMM(XMM::from_index(x as usize).unwrap())
     }
+
     /* x86_64-abi-0.99.pdf
      * Register Name                    | Number | Abbreviation
      * General Purpose Register RAX     | 0      | %rax
@@ -267,32 +268,6 @@ impl CombinedRegister for X64Register {
      * x87 Control Word                 | 65     | %fcw
      * x87 Status Word                  | 66     | %fsw
      */
-    /// Converts a DWARF regnum to X64Register.
-    fn _from_dwarf_regnum(x: u16) -> Option<X64Register> {
-        static DWARF_REGS: [GPR; 16] = [
-            GPR::RAX,
-            GPR::RDX,
-            GPR::RCX,
-            GPR::RBX,
-            GPR::RSI,
-            GPR::RDI,
-            GPR::RBP,
-            GPR::RSP,
-            GPR::R8,
-            GPR::R9,
-            GPR::R10,
-            GPR::R11,
-            GPR::R12,
-            GPR::R13,
-            GPR::R14,
-            GPR::R15,
-        ];
-        Some(match x {
-            0..=15 => X64Register::GPR(DWARF_REGS[x as usize]),
-            17..=24 => X64Register::XMM(XMM::from_index(x as usize - 17).unwrap()),
-            _ => return None,
-        })
-    }
 }
 
 /// An allocator that allocates registers for function arguments according to the System V ABI.

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -4,7 +4,6 @@
 use crate::common_decl::{MachineState, MachineValue, RegisterIndex};
 use crate::location::CombinedRegister;
 use crate::location::Reg as AbstractReg;
-use crate::unwind::UnwindRegister;
 use std::collections::BTreeMap;
 use std::slice::Iter;
 use wasmer_types::{target::CallingConvention, CompileError, Type};
@@ -113,13 +112,13 @@ impl AbstractReg for GPR {
 
         match self {
             GPR::RAX => X86_64::RAX,
-            GPR::RDX => X86_64::RDX,
             GPR::RCX => X86_64::RCX,
+            GPR::RDX => X86_64::RDX,
             GPR::RBX => X86_64::RBX,
+            GPR::RSP => X86_64::RSP,
+            GPR::RBP => X86_64::RBP,
             GPR::RSI => X86_64::RSI,
             GPR::RDI => X86_64::RDI,
-            GPR::RBP => X86_64::RBP,
-            GPR::RSP => X86_64::RSP,
             GPR::R8 => X86_64::R8,
             GPR::R9 => X86_64::R9,
             GPR::R10 => X86_64::R10,
@@ -194,17 +193,6 @@ impl AbstractReg for XMM {
             XMM::XMM13 => X86_64::XMM13,
             XMM::XMM14 => X86_64::XMM14,
             XMM::XMM15 => X86_64::XMM15,
-        }
-    }
-}
-
-impl UnwindRegister<GPR, XMM> {
-    pub(crate) fn windows_unwind_index(&self) -> u8 {
-        match self {
-            UnwindRegister::GPR(reg) => {
-                [0, 2, 1, 3, 6, 7, 5, 4, 8, 9, 10, 11, 12, 13, 14, 15][reg.into_index()]
-            }
-            UnwindRegister::FPR(reg) => reg.into_index() as u8,
         }
     }
 }


### PR DESCRIPTION
The PR simplifies the logic where right now, `to_dwarf` function returns an index value (both for GPR and FPR types) and later on, the `u16` is mapped to the `gimli::Register` type. I think it would be better to have the direct mapping between our register values and the `gimli::Registers` at one place (e.g. `GPR::X26 => AArch64::X26`). Plus, having that, we can simplify the `create_unwind_info_from_insts` function as the register order for the GPR `X64` registers maps to the expected order by Windows EH.