### PR TITLE
Singlepass: refactor condition jumps to single fn (`jmp_on_condition`)

### DIFF
--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -58,6 +58,16 @@ pub const NATIVE_PAGE_SIZE: usize = 4096;
 
 pub struct MachineStackOffset(pub usize);
 
+#[allow(dead_code)]
+pub enum UnsignedCondition {
+    Equal,
+    NotEqual,
+    Above,
+    AboveEqual,
+    Below,
+    BelowEqual,
+}
+
 #[allow(unused)]
 pub trait Machine {
     type GPR: Copy + Eq + Debug + Reg;
@@ -382,24 +392,16 @@ pub trait Machine {
 
     /// jmp without condidtion
     fn jmp_unconditionnal(&mut self, label: Label) -> Result<(), CompileError>;
-    /// jmp on equal (src==dst)
-    /// like Equal set on x86_64
-    fn jmp_on_equal(&mut self, label: Label) -> Result<(), CompileError>;
-    /// jmp on different (src!=dst)
-    /// like NotEqual set on x86_64
-    fn jmp_on_different(&mut self, label: Label) -> Result<(), CompileError>;
-    /// jmp on above (src>dst)
-    /// like Above set on x86_64
-    fn jmp_on_above(&mut self, label: Label) -> Result<(), CompileError>;
-    /// jmp on above (src>=dst)
-    /// like Above or Equal set on x86_64
-    fn jmp_on_aboveequal(&mut self, label: Label) -> Result<(), CompileError>;
-    /// jmp on above (src<=dst)
-    /// like Below or Equal set on x86_64
-    fn jmp_on_belowequal(&mut self, label: Label) -> Result<(), CompileError>;
-    /// jmp on overflow
-    /// like Carry set on x86_64
-    fn jmp_on_overflow(&mut self, label: Label) -> Result<(), CompileError>;
+
+    /// jmp to label if the provided condition is true (when comparing source and dest)
+    fn jmp_on_condition(
+        &mut self,
+        cond: UnsignedCondition,
+        size: Size,
+        source: Location<Self::GPR, Self::SIMD>,
+        dest: Location<Self::GPR, Self::SIMD>,
+        label: Label,
+    ) -> Result<(), CompileError>;
 
     /// jmp using a jump table at lable with cond as the indice
     fn emit_jmp_to_jumptable(

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -2604,23 +2604,25 @@ impl Machine for MachineARM64 {
     fn jmp_unconditionnal(&mut self, label: Label) -> Result<(), CompileError> {
         self.assembler.emit_b_label(label)
     }
-    fn jmp_on_equal(&mut self, label: Label) -> Result<(), CompileError> {
-        self.assembler.emit_bcond_label_far(Condition::Eq, label)
-    }
-    fn jmp_on_different(&mut self, label: Label) -> Result<(), CompileError> {
-        self.assembler.emit_bcond_label_far(Condition::Ne, label)
-    }
-    fn jmp_on_above(&mut self, label: Label) -> Result<(), CompileError> {
-        self.assembler.emit_bcond_label_far(Condition::Hi, label)
-    }
-    fn jmp_on_aboveequal(&mut self, label: Label) -> Result<(), CompileError> {
-        self.assembler.emit_bcond_label_far(Condition::Cs, label)
-    }
-    fn jmp_on_belowequal(&mut self, label: Label) -> Result<(), CompileError> {
-        self.assembler.emit_bcond_label_far(Condition::Ls, label)
-    }
-    fn jmp_on_overflow(&mut self, label: Label) -> Result<(), CompileError> {
-        self.assembler.emit_bcond_label_far(Condition::Cs, label)
+
+    fn jmp_on_condition(
+        &mut self,
+        cond: UnsignedCondition,
+        size: Size,
+        source: AbstractLocation<Self::GPR, Self::SIMD>,
+        dest: AbstractLocation<Self::GPR, Self::SIMD>,
+        label: Label,
+    ) -> Result<(), CompileError> {
+        self.emit_relaxed_binop(Assembler::emit_cmp, size, source, dest, false)?;
+        let cond = match cond {
+            UnsignedCondition::Equal => Condition::Eq,
+            UnsignedCondition::NotEqual => Condition::Ne,
+            UnsignedCondition::Above => Condition::Hi,
+            UnsignedCondition::AboveEqual => Condition::Cs,
+            UnsignedCondition::Below => Condition::Cc,
+            UnsignedCondition::BelowEqual => Condition::Ls,
+        };
+        self.assembler.emit_bcond_label_far(cond, label)
     }
 
     // jmp table


### PR DESCRIPTION
For the purpose of the upcoming RISC-V support (#5711), I would like to merge the `location_cmp/emit_relaxed_cmp` and `jmp_on_$condition` into a single function. Mainly motivated by the fact the RISC-V architecture does not profile the FLAGS register used for the jump instruction. On the other hand, it provides [direct compare and jump instructions](https://projectf.io/posts/riscv-branch-set/#branch) that, with register operations, directly map to the newly introduced `jmp_on_condition`. Right now, the RISC-V PR contains unnecessary changes where a new temporary register is first used for comparison, and then `jmp_on_true/false` function do the actual jump.

Note the currently used approach might be seen tricky as the codegen is responsible that no other FLAGS-modifying instructions sneaks in between the CMP and the consequent JUMP instruction.