### PR TITLE
Add "print-artifact-version" command

### DIFF
--- a/lib/cli/src/commands/artifact_version.rs
+++ b/lib/cli/src/commands/artifact_version.rs
@@ -1,0 +1,16 @@
+use clap::Parser;
+use wasmer_types::MetadataHeader;
+
+use crate::commands::CliCommand;
+
+#[derive(Debug, Parser)]
+pub struct CmdArtifactVersion {}
+
+impl CliCommand for CmdArtifactVersion {
+    type Output = ();
+
+    fn run(self) -> Result<Self::Output, anyhow::Error> {
+        println!("{}", MetadataHeader::CURRENT_VERSION);
+        Ok(())
+    }
+}

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! The commands available in the Wasmer binary.
 mod add;
 mod app;
+mod artifact_version;
 mod auth;
 #[cfg(target_os = "linux")]
 mod binfmt;
@@ -215,6 +216,7 @@ impl WasmerCmd {
             Some(Cmd::Ssh(ssh)) => ssh.run(),
             Some(Cmd::Namespace(namespace)) => namespace.run(),
             Some(Cmd::Domain(namespace)) => namespace.run(),
+            Some(Cmd::ArtifactVersion(cmd)) => cmd.run(),
             None => {
                 WasmerCmd::command().print_long_help()?;
                 // Note: clap uses an exit code of 2 when CLI parsing fails
@@ -445,6 +447,10 @@ enum Cmd {
     /// Generate man pages
     #[clap(name = "gen-man", hide = true)]
     GenManPage(crate::commands::gen_manpage::CmdGenManPage),
+
+    /// Print the current artifact version
+    #[clap(name = "print-artifact-version", hide = true)]
+    ArtifactVersion(crate::commands::artifact_version::CmdArtifactVersion),
 }
 
 fn is_binfmt_interpreter() -> bool {


### PR DESCRIPTION
This PR adds a (hidden) `print-artifact-version` command, which can be used to decide if the artifact version has changed since the last Wasmer version. Mainly useful for CI.