### PR TITLE
Fix order of arguments when spawning processes from WASI

### DIFF
--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1287,12 +1287,11 @@ impl WasiEnv {
                     .extend_from_slice(env_vars.as_slice());
             }
 
-            if let Some(args) = main_args {
-                self.state
-                    .args
-                    .lock()
-                    .unwrap()
-                    .extend_from_slice(args.as_slice());
+            if let Some(main_args) = main_args {
+                let mut args: std::sync::MutexGuard<'_, Vec<String>> =
+                    self.state.args.lock().unwrap();
+                // Insert main-args before user args
+                args.splice(1..1, main_args);
             }
 
             if let Some(exec_name) = exec_name {


### PR DESCRIPTION
The current behaviour is that the `main-args` from `wasmer.toml` get appended to the passed args when spawning a process inside WASI. This is not the expected behaviour and does not align with the behaviour when 

For example running `something --help` in the example above would result in `something --help main-args-from-wasmer-toml`.  The correct behaviour should be to insert main-args before user-specified arguments like: `something main-args-from-wasmer-toml --help`.