### PR TITLE
Port to powerpc64 Linux

### DIFF
--- a/lib/vm/src/libcalls/eh/gcc.rs
+++ b/lib/vm/src/libcalls/eh/gcc.rs
@@ -99,6 +99,9 @@ const UNWIND_DATA_REG: (i32, i32) = (10, 11); // x10, x11
 #[cfg(target_arch = "loongarch64")]
 const UNWIND_DATA_REG: (i32, i32) = (4, 5); // a0, a1
 
+#[cfg(target_arch = "powerpc64")]
+const UNWIND_DATA_REG: (i32, i32) = (3, 4); // R3, R4
+
 #[unsafe(no_mangle)]
 /// The implementation of Wasmer's personality function.
 ///

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -348,6 +348,9 @@ cfg_if::cfg_if! {
                 } else if #[cfg(all(target_os = "linux", target_arch = "loongarch64"))] {
                     pc = context.uc_mcontext.__gregs[1] as usize;
                     sp = context.uc_mcontext.__gregs[3] as usize;
+                } else if #[cfg(all(target_os = "linux", target_arch = "powerpc64"))] {
+                    pc = (*context.uc_mcontext.regs).nip as usize;
+                    sp = (*context.uc_mcontext.regs).gpr[1] as usize;
                 } else {
                     compile_error!("Unsupported platform");
                 }
@@ -478,6 +481,14 @@ cfg_if::cfg_if! {
                     context.uc_mcontext.__gregs[4] = a0;
                     context.uc_mcontext.__gregs[5] = a1;
                     context.uc_mcontext.__gregs[22] = fp;
+                } else if #[cfg(all(target_os = "linux", target_arch = "powerpc64"))] {
+                    let TrapHandlerRegs { pc, sp, r3, r4, r31, lr } = regs;
+                    (*context.uc_mcontext.regs).nip = pc;
+                    (*context.uc_mcontext.regs).gpr[1] = sp;
+                    (*context.uc_mcontext.regs).gpr[3] = r3;
+                    (*context.uc_mcontext.regs).gpr[4] = r4;
+                    (*context.uc_mcontext.regs).gpr[31] = r31;
+                    (*context.uc_mcontext.regs).link = lr;
                 } else {
                     compile_error!("Unsupported platform");
                 }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
The PR adds the support for PowerPC64 Linux (the dependent PR [
Add ucontext_t and {get,set,make,swap}context for powerpc64-linux (cont.)](https://github.com/rust-lang/libc/pull/4696#issuecomment-3317427269) has been approved but not yet merged).