### PR TITLE
feat(cli): Add loading spinner when compiling modules in TTY

### DIFF
--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -18,7 +18,9 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Error};
 use clap::{Parser, ValueEnum};
+use futures::future::BoxFuture;
 use indicatif::{MultiProgress, ProgressBar};
+use is_terminal::IsTerminal as _;
 use once_cell::sync::Lazy;
 use tempfile::NamedTempFile;
 use url::Url;
@@ -40,7 +42,7 @@ use wasmer_types::ModuleHash;
 #[cfg(feature = "journal")]
 use wasmer_wasix::journal::{LogFileJournal, SnapshotTrigger};
 use wasmer_wasix::{
-    bin_factory::BinaryPackage,
+    bin_factory::{BinaryPackage, BinaryPackageCommand},
     journal::CompactingLogFileJournal,
     runners::{
         dcgi::{DcgiInstanceFactory, DcgiRunner},
@@ -55,7 +57,7 @@ use wasmer_wasix::{
         resolver::QueryError,
         task_manager::VirtualTaskManagerExt,
     },
-    Runtime, WasiError,
+    Runtime, SpawnError, WasiError,
 };
 use webc::metadata::Manifest;
 use webc::Container;
@@ -1091,6 +1093,90 @@ impl<R: wasmer_wasix::Runtime + Send + Sync> wasmer_wasix::Runtime for Monitorin
     #[cfg(feature = "journal")]
     fn active_journal(&self) -> Option<&'_ wasmer_wasix::journal::DynJournal> {
         self.runtime.active_journal()
+    }
+
+    fn load_hashed_module(
+        &self,
+        module: HashedModuleData,
+        engine: Option<&Engine>,
+    ) -> BoxFuture<'_, Result<Module, SpawnError>> {
+        let hash = *module.hash();
+        let fut = self.runtime.load_hashed_module(module, engine);
+        Box::pin(compile_with_progress(fut, hash, None))
+    }
+
+    fn load_hashed_module_sync(
+        &self,
+        wasm: HashedModuleData,
+        engine: Option<&Engine>,
+    ) -> Result<Module, wasmer_wasix::SpawnError> {
+        let hash = *wasm.hash();
+        compile_with_progress_sync(
+            || self.runtime.load_hashed_module_sync(wasm, engine),
+            &hash,
+            None,
+        )
+    }
+
+    fn load_command_module(
+        &self,
+        cmd: &BinaryPackageCommand,
+    ) -> BoxFuture<'_, Result<Module, SpawnError>> {
+        let fut = self.runtime.load_command_module(cmd);
+
+        Box::pin(compile_with_progress(
+            fut,
+            *cmd.hash(),
+            Some(cmd.name().to_owned()),
+        ))
+    }
+
+    fn load_command_module_sync(
+        &self,
+        cmd: &wasmer_wasix::bin_factory::BinaryPackageCommand,
+    ) -> Result<Module, wasmer_wasix::SpawnError> {
+        compile_with_progress_sync(
+            || self.runtime.load_command_module_sync(cmd),
+            cmd.hash(),
+            Some(cmd.name()),
+        )
+    }
+}
+
+async fn compile_with_progress<'a, F, T>(fut: F, hash: ModuleHash, name: Option<String>) -> T
+where
+    F: std::future::Future<Output = T> + Send + 'a,
+    T: Send + 'static,
+{
+    let mut pb = new_progressbar_compile(&hash, name.as_deref());
+    let res = fut.await;
+    pb.finish_and_clear();
+    res
+}
+
+fn compile_with_progress_sync<F, T>(f: F, hash: &ModuleHash, name: Option<&str>) -> T
+where
+    F: FnOnce() -> T,
+{
+    let mut pb = new_progressbar_compile(hash, name);
+    let res = f();
+    pb.finish_and_clear();
+    res
+}
+
+fn new_progressbar_compile(hash: &ModuleHash, name: Option<&str>) -> ProgressBar {
+    // Only show a spinner if we're running in a TTY
+    if std::io::stderr().is_terminal() {
+        let msg = if let Some(name) = name {
+            format!("Compiling WebAssembly module for command '{name}' ({hash})...")
+        } else {
+            format!("Compiling WebAssembly module {hash}...")
+        };
+        let pb = ProgressBar::new_spinner().with_message(msg);
+        pb.enable_steady_tick(Duration::from_millis(100));
+        pb
+    } else {
+        ProgressBar::hidden()
     }
 }
 


### PR DESCRIPTION
When running with a TTY, show a loading spinner when modules are being
compiled.

This improves user experience a lot.

Note: in the future we could add a CLI flag to always show progress, or to
always turn it off.

Closes #5772 
