### PR TITLE
chore(cli): Provide fallback login instructions in login command

### DIFF
--- a/lib/cli/src/commands/auth/login/mod.rs
+++ b/lib/cli/src/commands/auth/login/mod.rs
@@ -101,6 +101,10 @@ impl Login {
 
         // if failed to open the browser, then don't error out just print the auth_url with a message
         println!("Opening auth link in your default browser: {}", &auth_url);
+        println!(
+            "{}: If browser driven login does not work, manually create a token at https://wasmer.io/settings/access-tokens and log in with `wasmer login <TOKEN>`",
+            "NOTE".yellow().bold()
+        );
         opener::open_browser(&auth_url).unwrap_or_else(|_| {
             println!(
                 "⚠️ Failed to open the browser.\n


### PR DESCRIPTION
Browser driven login can sometimes fail, so we provide fallback instructions
for manual login.

Closes #5768
