### PR TITLE
chore(cli): package unpack command: add shortform -u

### DIFF
--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -10,6 +10,14 @@ use wasmer_package::utils::from_disk;
 use crate::config::WasmerEnv;
 
 /// Download a package from the registry.
+///
+/// Examples:
+/// * `wasmer package download wasmer/hello`
+///   Download the `wasmer/hello` package, writing to `./hello@<version>.webc`.
+///
+/// * `wasmer package download --unpack wasmer/hello@0.1.0 -o hello.webc`
+///    Download the `wasmer/hello` package version `0.1.0`, writing to `./hello.webc`,
+///    and unpacking it to `./hello.webc.unpacked/`.
 #[derive(clap::Parser, Debug)]
 pub struct PackageDownload {
     #[clap(flatten)]
@@ -26,15 +34,14 @@ pub struct PackageDownload {
 
     /// Run the download command without any output
     #[clap(long)]
-    pub quiet: bool,
+    quiet: bool,
 
     /// Unpack the downloaded package.
     ///
-    /// The output directory will be next to the downloaded file.
+    /// The unpacked directory will be next to the downloaded file, with a `.unpacked` suffix.
     ///
-    /// Note: unpacking can also be done manually with the `wasmer package unpack`
-    /// command.
-    #[clap(long)]
+    /// Note: unpacking can also be done manually with the `wasmer package unpack` command.
+    #[clap(short, long)]
     unpack: bool,
 
     /// The package to download.


### PR DESCRIPTION
In the `wasmer package unpack` command,
allow -u instead of --unpack to make it more convenient to use.

Closes #5781
