### PR TITLE
Use wasmerignore for bundling and gitignore for remote builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7753,9 +7753,9 @@ dependencies = [
 
 [[package]]
 name = "webc"
-version = "9.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38544ae3a351279fa913b4dee9c548f0aa3b27ca05756531c3f2e6bc4e22c27d"
+checksum = "637506ca3c48eae3301e97f0167aa1b46cdfdd479d008b868a19715182e48ae3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,8 @@ members = [
 	"tests/lib/compiler-test-derive",
 	"tests/lib/wast",
 	"tests/wasi-wast",
-	"tests/wasmer-argus", "lib/sdk",
+	"tests/wasmer-argus",
+	"lib/sdk",
 ]
 exclude = ["./lib/cli/tests/packages/axum"]
 resolver = "2"
@@ -95,7 +96,7 @@ wasmer-wasix = { path = "./lib/wasix" }
 wasmer-sdk = { path = "./lib/sdk" }
 
 # Wasmer-owned crates
-webc = "=9.0"
+webc = "=10.0.1"
 shared-buffer = "0.1.4"
 loupe = "0.2.0"
 

--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -736,7 +736,6 @@ the app:\n"
             let cmd_deploy = CmdAppDeploy {
                 quiet: false,
                 env: self.env.clone(),
-                no_ignore: false,
                 fmt: ItemFormatOpts {
                     format: self.fmt.format,
                 },

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -72,13 +72,6 @@ pub struct CmdAppDeploy {
     #[clap(long)]
     pub no_persist_id: bool,
 
-    /// Do not respected `.gitignore` and `.wasmerignore` files when building a package.
-    ///
-    /// NOTE: FOR NOW this flag is only used when `--build-remote` is also specified.
-    // TODO: implement no-ignore support for local builds too.
-    #[clap(long)]
-    pub no_ignore: bool,
-
     /// Specify the owner (user or namespace) of the app.
     ///
     /// If specified via this flag, the owner will be overridden.  Otherwise, the `app.yaml` is
@@ -308,7 +301,6 @@ impl CmdAppDeploy {
             DeployRemoteOpts {
                 app: app_config.clone(),
                 owner: Some(owner.clone()),
-                no_ignore: self.no_ignore,
             },
             &base_dir_path,
             remote_progress_handler(self.quiet),
@@ -549,11 +541,6 @@ impl AsyncCliCommand for CmdAppDeploy {
 
         if self.build_remote && self.publish_package {
             anyhow::bail!("--build-remote cannot be combined with --publish-package");
-        }
-
-        // TODO: implement no-ignore support for local builds too.
-        if self.no_ignore && !self.build_remote {
-            anyhow::bail!("--no-ignore is currently only supported with --build-remote");
         }
 
         if self.build_remote {

--- a/lib/package/src/package/mod.rs
+++ b/lib/package/src/package/mod.rs
@@ -7,7 +7,10 @@ pub(crate) mod volume;
 
 pub use self::{
     manifest::ManifestError,
-    package::{Package, WasmerPackageError},
+    package::{
+        include_everything_walker, wasmer_ignore_walker, Package, WalkBuilderFactory,
+        WasmerPackageError,
+    },
     strictness::Strictness,
     volume::{fs::*, in_memory::*, WasmerPackageVolume},
 };

--- a/lib/package/src/package/package.rs
+++ b/lib/package/src/package/package.rs
@@ -129,6 +129,74 @@ pub enum WasmerPackageError {
     DetectError(#[from] DetectError),
 }
 
+// Serious Java vibes from this one! Still better than repeating the
+// function type everywhere.
+// I'm opting not to use a trait object here to avoid generics and boxing.
+#[derive(Clone, Copy)]
+pub struct WalkBuilderFactory {
+    pub walker_factory: fn(&Path) -> ignore::WalkBuilder,
+}
+
+impl Debug for WalkBuilderFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WalkBuilderFactory").finish()
+    }
+}
+
+impl WalkBuilderFactory {
+    pub fn new(walker_factory: fn(&Path) -> ignore::WalkBuilder) -> Self {
+        Self { walker_factory }
+    }
+
+    pub fn create_walk_builder(&self, path: &Path) -> ignore::WalkBuilder {
+        (self.walker_factory)(path)
+    }
+}
+
+fn is_wasmer_ignore_present(path: &Path) -> bool {
+    path.ancestors().any(|p| p.join(".wasmerignore").is_file())
+}
+
+/// Create and configure a default ignore walker for building packages that:
+///   * If a `.wasmerignore` file is present, it will be used to ignore files.
+///   * Otherwise, only `.git` folders will be ignored.
+pub fn wasmer_ignore_walker() -> WalkBuilderFactory {
+    fn walker_factory(root_dir: &Path) -> ignore::WalkBuilder {
+        let mut builder = ignore::WalkBuilder::new(root_dir);
+        // We always add .wasmerignore because it could exist in a sub-directory.
+        builder
+            .standard_filters(false)
+            .follow_links(false)
+            .parents(true)
+            .add_custom_ignore_filename(".wasmerignore");
+
+        // However, if there is no .wasmerignore in the root directory,
+        // we want to at least ignore .git folders. This setup creates the
+        // very niche edge case of having .wasmerignore in a subdirectory
+        // causing .git folders to be ignored in other directories, but
+        // that seems acceptable given how rare that would be. The proper
+        // solution would be to do this logic per-directory, but that's
+        // not supported by `ignore`.
+        if !is_wasmer_ignore_present(root_dir) {
+            let mut overrides = ignore::overrides::OverrideBuilder::new(root_dir);
+            overrides.add("!.git").expect("valid override");
+            builder.overrides(overrides.build().expect("valid overrides"));
+        }
+
+        builder
+    }
+    WalkBuilderFactory::new(walker_factory)
+}
+
+pub fn include_everything_walker() -> WalkBuilderFactory {
+    fn walker_factory(root_dir: &Path) -> ignore::WalkBuilder {
+        let mut builder = ignore::WalkBuilder::new(root_dir);
+        builder.standard_filters(false).follow_links(false);
+        builder
+    }
+    WalkBuilderFactory::new(walker_factory)
+}
+
 /// A Wasmer package that will be lazily loaded from disk.
 #[derive(Debug)]
 pub struct Package {
@@ -150,8 +218,26 @@ impl Package {
     /// This will unpack the tarball to a temporary directory on disk and use
     /// memory-mapped files in order to reduce RAM usage.
     pub fn from_tarball_file(path: impl AsRef<Path>) -> Result<Self, WasmerPackageError> {
-        Package::from_tarball_file_with_strictness(path.as_ref(), Strictness::default())
+        Package::from_tarball_file_with_walker(path.as_ref(), include_everything_walker())
     }
+
+    /// Load a [`Package`] from a `*.tar.gz` file on disk.
+    ///
+    /// # Implementation Details
+    ///
+    /// This will unpack the tarball to a temporary directory on disk and use
+    /// memory-mapped files in order to reduce RAM usage.
+    pub fn from_tarball_file_with_walker(
+        path: impl AsRef<Path>,
+        walker_factory: WalkBuilderFactory,
+    ) -> Result<Self, WasmerPackageError> {
+        Package::from_tarball_file_with_strictness(
+            path.as_ref(),
+            Strictness::default(),
+            walker_factory,
+        )
+    }
+
     /// Load a [`Package`] from a `*.tar.gz` file on disk.
     ///
     /// # Implementation Details
@@ -161,6 +247,7 @@ impl Package {
     pub fn from_tarball_file_with_strictness(
         path: impl AsRef<Path>,
         strictness: Strictness,
+        walker_factory: WalkBuilderFactory,
     ) -> Result<Self, WasmerPackageError> {
         let path = path.as_ref();
         let f = File::open(path).map_err(|error| WasmerPackageError::FileOpen {
@@ -168,18 +255,27 @@ impl Package {
             error,
         })?;
 
-        Package::from_tarball_with_strictness(BufReader::new(f), strictness)
+        Package::from_tarball_with_strictness(BufReader::new(f), strictness, walker_factory)
     }
 
     /// Load a package from a `*.tar.gz` archive.
     pub fn from_tarball(tarball: impl BufRead) -> Result<Self, WasmerPackageError> {
-        Package::from_tarball_with_strictness(tarball, Strictness::default())
+        Package::from_tarball_with_walker(tarball, include_everything_walker())
+    }
+
+    /// Load a package from a `*.tar.gz` archive.
+    pub fn from_tarball_with_walker(
+        tarball: impl BufRead,
+        walker_factory: WalkBuilderFactory,
+    ) -> Result<Self, WasmerPackageError> {
+        Package::from_tarball_with_strictness(tarball, Strictness::default(), walker_factory)
     }
 
     /// Load a package from a `*.tar.gz` archive.
     pub fn from_tarball_with_strictness(
         tarball: impl BufRead,
         strictness: Strictness,
+        walker_factory: WalkBuilderFactory,
     ) -> Result<Self, WasmerPackageError> {
         let tarball = GzDecoder::new(tarball);
         let temp = tempdir().map_err(WasmerPackageError::TempDir)?;
@@ -188,18 +284,27 @@ impl Package {
 
         let (_manifest_path, manifest) = read_manifest(temp.path())?;
 
-        Package::load(manifest, temp, strictness)
+        Package::load(manifest, temp, strictness, walker_factory)
     }
 
     /// Load a package from a `wasmer.toml` manifest on disk.
     pub fn from_manifest(wasmer_toml: impl AsRef<Path>) -> Result<Self, WasmerPackageError> {
-        Package::from_manifest_with_strictness(wasmer_toml, Strictness::default())
+        Package::from_manifest_with_walker(wasmer_toml, wasmer_ignore_walker())
+    }
+
+    /// Load a package from a `wasmer.toml` manifest on disk.
+    pub fn from_manifest_with_walker(
+        wasmer_toml: impl AsRef<Path>,
+        walker_factory: WalkBuilderFactory,
+    ) -> Result<Self, WasmerPackageError> {
+        Package::from_manifest_with_strictness(wasmer_toml, Strictness::default(), walker_factory)
     }
 
     /// Load a package from a `wasmer.toml` manifest on disk.
     pub fn from_manifest_with_strictness(
         wasmer_toml: impl AsRef<Path>,
         strictness: Strictness,
+        walker_factory: WalkBuilderFactory,
     ) -> Result<Self, WasmerPackageError> {
         let path = wasmer_toml.as_ref();
         let path = path
@@ -231,7 +336,7 @@ impl Package {
             }
         }
 
-        Package::load(wasmer_toml, base_dir, strictness)
+        Package::load(wasmer_toml, base_dir, strictness, walker_factory)
     }
 
     /// (Re)loads a package from a manifest.json file which was created as the result of calling [`Container::unpack`](crate::Container::unpack)
@@ -286,6 +391,7 @@ impl Package {
                         base_dir.path().to_owned(),
                         BTreeSet::new(),
                         dirs,
+                        include_everything_walker(),
                     )),
                 );
             }
@@ -325,6 +431,7 @@ impl Package {
                 base_dir.path().join(FsVolume::METADATA).to_owned(),
                 files,
                 BTreeSet::new(),
+                include_everything_walker(),
             )),
         );
 
@@ -394,6 +501,7 @@ impl Package {
         wasmer_toml: WasmerManifest,
         base_dir: impl Into<BaseDir>,
         strictness: Strictness,
+        walker_factory: WalkBuilderFactory,
     ) -> Result<Self, WasmerPackageError> {
         let base_dir = base_dir.into();
 
@@ -421,7 +529,7 @@ impl Package {
         let metadata_volume = FsVolume::new_metadata(&wasmer_toml, base_dir_path.clone())?;
         // Create assets volume
         let mut volumes: BTreeMap<String, Arc<dyn WasmerPackageVolume + Send + Sync + 'static>> = {
-            let old = FsVolume::new_assets(&wasmer_toml, &base_dir_path)?;
+            let old = FsVolume::new_assets(&wasmer_toml, &base_dir_path, walker_factory)?;
             let mut new = BTreeMap::new();
 
             for (k, v) in old.into_iter() {
@@ -994,8 +1102,8 @@ mod tests {
             nested_dir_volume.read_file("README.md").unwrap(),
             (b"please".as_slice().into(), Some(readme_hash)),
         );
-        assert!(nested_dir_volume.read_file(".wasmerignore").is_none());
-        assert!(nested_dir_volume.read_file(".hidden").is_none());
+        assert!(nested_dir_volume.read_file(".wasmerignore").is_some());
+        assert!(nested_dir_volume.read_file(".hidden").is_some());
         assert!(nested_dir_volume.read_file("ignore_me").is_none());
         assert_eq!(
             nested_dir_volume

--- a/lib/package/src/package/volume/fs.rs
+++ b/lib/package/src/package/volume/fs.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
     fs::File,
     io::Read,
     path::{Path, PathBuf},
@@ -17,7 +18,7 @@ use webc::{
     AbstractVolume, Metadata, PathSegment, PathSegments, Timestamps, ToPathSegments,
 };
 
-use crate::package::Strictness;
+use crate::package::{Strictness, WalkBuilderFactory};
 
 use super::WasmerPackageVolume;
 
@@ -26,7 +27,6 @@ use super::WasmerPackageVolume;
 /// Note that it is the package resolver's role to interpret a package's
 /// [`crate::metadata::annotations::FileSystemMappings`]. A [`Volume`] contains
 /// directories as they were when the package was published.
-#[derive(Debug, Clone, PartialEq)]
 pub struct FsVolume {
     /// Name of the volume
     name: String,
@@ -39,6 +39,20 @@ pub struct FsVolume {
     mapped_directories: BTreeSet<PathBuf>,
     /// The base directory all [`PathSegments`] will be resolved relative to.
     base_dir: PathBuf,
+    /// The walker builder factory to use when reading directories.
+    walker_factory: WalkBuilderFactory,
+}
+
+impl Debug for FsVolume {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FsVolume")
+            .field("name", &self.name)
+            .field("intermediate_directories", &self.intermediate_directories)
+            .field("metadata_files", &self.metadata_files)
+            .field("mapped_directories", &self.mapped_directories)
+            .field("base_dir", &self.base_dir)
+            .finish()
+    }
 }
 
 impl FsVolume {
@@ -76,12 +90,14 @@ impl FsVolume {
             base_dir,
             files,
             BTreeSet::new(),
+            crate::package::include_everything_walker(),
         ))
     }
 
     pub(crate) fn new_assets(
         manifest: &wasmer_config::package::Manifest,
         base_dir: &Path,
+        walker_factory: crate::package::WalkBuilderFactory,
     ) -> Result<BTreeMap<String, Self>, Error> {
         // Create asset volumes
         let dirs: BTreeSet<_> = manifest
@@ -116,6 +132,7 @@ impl FsVolume {
                     base_dir.to_path_buf(),
                     BTreeSet::new(),
                     dirs,
+                    walker_factory,
                 ),
             );
         }
@@ -128,6 +145,7 @@ impl FsVolume {
         base_dir: PathBuf,
         whitelisted_files: BTreeSet<PathBuf>,
         whitelisted_directories: BTreeSet<PathBuf>,
+        walker_factory: crate::package::WalkBuilderFactory,
     ) -> Self {
         let mut intermediate_directories: BTreeSet<PathBuf> = whitelisted_files
             .iter()
@@ -147,6 +165,7 @@ impl FsVolume {
             metadata_files: whitelisted_files,
             mapped_directories: whitelisted_directories,
             base_dir,
+            walker_factory,
         }
     }
 
@@ -155,6 +174,7 @@ impl FsVolume {
         base_dir: PathBuf,
         whitelisted_files: BTreeSet<PathBuf>,
         whitelisted_directories: BTreeSet<PathBuf>,
+        walker_factory: crate::package::WalkBuilderFactory,
     ) -> Self {
         FsVolume {
             name,
@@ -162,6 +182,7 @@ impl FsVolume {
             metadata_files: whitelisted_files,
             mapped_directories: whitelisted_directories,
             base_dir,
+            walker_factory,
         }
     }
 
@@ -214,12 +235,9 @@ impl FsVolume {
     ) -> Option<Vec<(PathSegment, Option<[u8; 32]>, Metadata)>> {
         let resolved = self.resolve(path)?;
 
-        let walker = ignore::WalkBuilder::new(&resolved)
-            .require_git(true)
-            .add_custom_ignore_filename(".wasmerignore")
-            .follow_links(false)
-            .max_depth(Some(1))
-            .build();
+        let mut walker_builder = self.walker_factory.create_walk_builder(&resolved);
+        walker_builder.max_depth(Some(1));
+        let walker = walker_builder.build();
 
         let mut entries = Vec::new();
 
@@ -316,7 +334,7 @@ impl FsVolume {
             Ok(root)
         } else {
             let paths: Vec<_> = self.mapped_directories.iter().cloned().collect();
-            directory_tree(paths, &self.base_dir)
+            directory_tree(paths, &self.base_dir, self.walker_factory)
         }
     }
 }
@@ -359,6 +377,7 @@ fn resolve(base_dir: &Path, path: &PathSegments) -> PathBuf {
 fn directory_tree(
     paths: impl IntoIterator<Item = PathBuf>,
     base_dir: &Path,
+    walker_factory: crate::package::WalkBuilderFactory,
 ) -> Result<Directory<'static>, Error> {
     let paths: Vec<_> = paths.into_iter().collect();
     let mut root = Directory::default();
@@ -373,7 +392,11 @@ fn directory_tree(
                 println!("Warning: {path:?} already exists. Overriding the old entry");
             }
         } else {
-            let dir = webc::v3::write::Directory::from_path_with_ignore(&path).map_err(|e| {
+            let dir = webc::v3::write::Directory::from_path_with_walker(
+                &path,
+                walker_factory.create_walk_builder(&path).build(),
+            )
+            .map_err(|e| {
                 Error::from(e).context(format!(
                     "Unable to add \"{}\" to the directory tree",
                     path.display()
@@ -483,12 +506,21 @@ mod tests {
 
         let manifest: Manifest = toml::from_str(wasmer_toml).unwrap();
 
-        let volume = FsVolume::new_assets(&manifest, temp.path()).unwrap();
+        let volume = FsVolume::new_assets(
+            &manifest,
+            temp.path(),
+            crate::package::wasmer_ignore_walker(),
+        )
+        .unwrap();
 
         let volume = &volume["/etc"];
 
         let entries = volume.read_dir(&PathSegments::ROOT).unwrap();
-        let expected = [PathSegment::parse("share").unwrap()];
+        let expected = [
+            PathSegment::parse(".hidden").unwrap(),
+            PathSegment::parse(".wasmerignore").unwrap(),
+            PathSegment::parse("share").unwrap(),
+        ];
 
         for i in 0..expected.len() {
             assert_eq!(entries[i].0, expected[i]);
@@ -509,11 +541,15 @@ mod tests {
         // Create a directory that will be used as the base directory
         let base_dir = temp.path().to_path_buf();
 
-        // Create a non-existent path that will cause `from_path_with_ignore` to fail
+        // Create a non-existent path that will cause `from_path_with_walker` to fail
         let non_existent_path = base_dir.join("non_existent_dir");
 
         // Try to create a directory tree with a non-existent path
-        let result = directory_tree(std::iter::once(non_existent_path.clone()), &base_dir);
+        let result = directory_tree(
+            std::iter::once(non_existent_path.clone()),
+            &base_dir,
+            crate::package::wasmer_ignore_walker(),
+        );
 
         // Verify that the error is propagated
         assert!(result.is_err());

--- a/lib/sdk/tests/publish_integration.rs
+++ b/lib/sdk/tests/publish_integration.rs
@@ -62,6 +62,7 @@ main-args = ["--root", "/public"]
         version: Some(Version::parse("0.0.1")?),
         timeout: Duration::from_secs(180),
         wait: PublishWait::None,
+        walker_factory: wasmer_package::package::wasmer_ignore_walker(),
     };
 
     // Execute the publish logic.


### PR DESCRIPTION
Note: This PR can only be merged after webc v10.0.0 is released, and the path dependency in `Cargo.toml` must be changed. Creating as draft for review purposes.