### PR TITLE
Make commands work when called from /usr/bin

### DIFF
--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1106,8 +1106,11 @@ impl WasiEnv {
 
                 let mut package = pkg.clone();
                 package.entrypoint_cmd = Some(command.name().to_string());
+                let package_arc = Arc::new(package);
                 self.bin_factory
-                    .set_binary(path.as_os_str().to_string_lossy().as_ref(), package);
+                    .set_binary(path.to_string_lossy().as_ref(), &package_arc);
+                self.bin_factory
+                    .set_binary(path2.to_string_lossy().as_ref(), &package_arc);
 
                 tracing::debug!(
                     package=%pkg.id,


### PR DESCRIPTION
We currently mount commands to `/bin/command` and `/usr/bin/command`. However, we only implement special treatment for the commands in `/bin` but not for the commands in `/usr/bin`. 

This PR adds the same treatment for commands in both locations