### PR TITLE
Fix wasm32 target compile warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
       - name: Install libtinfo
         shell: bash
         run: |
@@ -88,6 +89,7 @@ jobs:
           ENABLE_CRANELIFT: "1"
           ENABLE_LLVM: "1"
           ENABLE_SINGLEPASS: "1"
+      - run: make lint-js
       - name: Assert no files have changed
         run: |
           git status

--- a/Makefile
+++ b/Makefile
@@ -687,6 +687,9 @@ test-js: test-js-api test-js-wasi
 test-js-api:
 	cd lib/api && wasm-pack test --node -- --no-default-features --features js-default,wat
 
+lint-js:
+	cargo clippy --target wasm32-unknown-unknown --manifest-path lib/api/Cargo.toml --no-default-features --features "js-default" --locked -- -D clippy::all
+
 test-js-wasi:
 	cd lib/wasix && wasm-pack test --node -- --no-default-features --features test-js,wasmer/js,wasmer/std
 

--- a/lib/api/src/backend/js/entities/engine.rs
+++ b/lib/api/src/backend/js/entities/engine.rs
@@ -31,13 +31,13 @@ impl Engine {
 
 impl Default for Engine {
     fn default() -> Self {
-        Engine
+        Self
     }
 }
 
 /// Returns the default engine for the JS engine
 pub(crate) fn default_engine() -> Engine {
-    Engine::default()
+    Engine
 }
 
 impl crate::Engine {
@@ -71,11 +71,11 @@ impl crate::Engine {
     }
 }
 
-impl Into<crate::Engine> for Engine {
-    fn into(self) -> crate::Engine {
-        crate::Engine {
-            be: crate::BackendEngine::Js(self),
-            id: crate::Engine::atomic_next_engine_id(),
+impl From<Engine> for crate::Engine {
+    fn from(val: Engine) -> Self {
+        Self {
+            be: crate::BackendEngine::Js(val),
+            id: Self::atomic_next_engine_id(),
         }
     }
 }

--- a/lib/api/src/backend/js/entities/function/env.rs
+++ b/lib/api/src/backend/js/entities/function/env.rs
@@ -103,7 +103,7 @@ pub struct FunctionEnvMut<'a, T: 'a> {
     pub(crate) func_env: FunctionEnv<T>,
 }
 
-impl<'a, T> Debug for FunctionEnvMut<'a, T>
+impl<T> Debug for FunctionEnvMut<'_, T>
 where
     T: Send + Debug + 'static,
 {
@@ -202,6 +202,6 @@ impl<'a, T> From<FunctionEnvMut<'a, T>> for crate::FunctionEnvMut<'a, T> {
 
 impl<T> From<FunctionEnv<T>> for crate::FunctionEnv<T> {
     fn from(value: FunctionEnv<T>) -> Self {
-        crate::FunctionEnv(crate::BackendFunctionEnv::Js(value))
+        Self(crate::BackendFunctionEnv::Js(value))
     }
 }

--- a/lib/api/src/backend/js/entities/function/mod.rs
+++ b/lib/api/src/backend/js/entities/function/mod.rs
@@ -94,7 +94,7 @@ impl Function {
                     .map(|(i, param)| js_value_to_wasmer(param, &args.get(i as u32)))
                     .collect::<Vec<_>>();
                 let results = func(env, &wasm_arguments)?;
-                return Ok(wasmer_value_to_js(&results[0]));
+                Ok(wasmer_value_to_js(&results[0]))
             })
                 as Box<dyn FnMut(&Array) -> Result<JsValue, JsValue>>)
             .into_js_value(),
@@ -108,7 +108,7 @@ impl Function {
                     .map(|(i, param)| js_value_to_wasmer(param, &args.get(i as u32)))
                     .collect::<Vec<_>>();
                 let results = func(env, &wasm_arguments)?;
-                return Ok(wasmer_array_to_js_array(&results));
+                Ok(wasmer_array_to_js_array(&results))
             })
                 as Box<dyn FnMut(&Array) -> Result<Array, JsValue>>)
             .into_js_value(),

--- a/lib/api/src/backend/js/entities/instance.rs
+++ b/lib/api/src/backend/js/entities/instance.rs
@@ -27,9 +27,9 @@ impl Instance {
         let instance = module
             .as_js()
             .instantiate(&mut store, imports)
-            .map_err(|e| InstantiationError::Start(e))?;
+            .map_err(InstantiationError::Start)?;
 
-        Self::from_module_and_instance(store, &module, instance)
+        Self::from_module_and_instance(store, module, instance)
     }
 
     pub(crate) fn new_by_index(
@@ -62,13 +62,13 @@ impl Instance {
                 let js_export =
                     unsafe { js_sys::Reflect::get(&instance_exports, &name.into()).unwrap() };
                 let extern_ = Extern::from_jsvalue(&mut store, extern_type, &js_export)
-                    .map_err(|e| wasm_bindgen::JsValue::from(e))
+                    .map_err(wasm_bindgen::JsValue::from)
                     .unwrap();
                 Ok((name.to_string(), extern_))
             })
             .collect::<Result<Exports, InstantiationError>>()?;
 
-        let instance = Instance {
+        let instance = Self {
             _handle: JsHandle::new(instance),
         };
 

--- a/lib/api/src/backend/js/entities/memory/buffer.rs
+++ b/lib/api/src/backend/js/entities/memory/buffer.rs
@@ -10,7 +10,7 @@ pub(crate) struct MemoryBuffer<'a> {
     pub(crate) marker: PhantomData<(&'a Memory, &'a StoreObjects)>,
 }
 
-impl<'a> MemoryBuffer<'a> {
+impl MemoryBuffer<'_> {
     pub(crate) fn read(&self, offset: u64, buf: &mut [u8]) -> Result<(), MemoryAccessError> {
         let end = offset
             .checked_add(buf.len() as u64)
@@ -26,7 +26,7 @@ impl<'a> MemoryBuffer<'a> {
             return Err(MemoryAccessError::HeapOutOfBounds);
         }
         view.subarray(offset as _, end as _)
-            .copy_to(unsafe { &mut slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.len()) });
+            .copy_to(unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.len()) });
         Ok(())
     }
 
@@ -56,7 +56,7 @@ impl<'a> MemoryBuffer<'a> {
         }
         let buf_ptr = buf.as_mut_ptr() as *mut u8;
         view.subarray(offset as _, end as _)
-            .copy_to(unsafe { &mut slice::from_raw_parts_mut(buf_ptr, buf.len()) });
+            .copy_to(unsafe { slice::from_raw_parts_mut(buf_ptr, buf.len()) });
 
         Ok(unsafe { slice::from_raw_parts_mut(buf_ptr, buf.len()) })
     }

--- a/lib/api/src/backend/js/entities/memory/mod.rs
+++ b/lib/api/src/backend/js/entities/memory/mod.rs
@@ -186,7 +186,7 @@ impl std::cmp::PartialEq for Memory {
 
 impl From<Memory> for crate::Memory {
     fn from(value: Memory) -> Self {
-        crate::Memory(crate::BackendMemory::Js(value))
+        Self(crate::BackendMemory::Js(value))
     }
 }
 

--- a/lib/api/src/backend/js/entities/module.rs
+++ b/lib/api/src/backend/js/entities/module.rs
@@ -73,11 +73,8 @@ impl Module {
     ) -> Result<Self, CompileError> {
         let js_bytes = Uint8Array::view(binary);
         let module = WebAssembly::Module::new(&js_bytes.into()).map_err(|e| {
-            CompileError::Validate(format!(
-                "{}",
-                e.as_string()
-                    .unwrap_or("Unknown validation error".to_string())
-            ))
+            CompileError::Validate(e.as_string()
+                    .unwrap_or("Unknown validation error".to_string()).to_string())
         })?;
         Ok(Self::from_js_module(module, binary))
     }
@@ -205,8 +202,8 @@ impl Module {
             // in case the import is not found, the JS Wasm VM will handle
             // the error for us, so we don't need to handle it
         }
-        Ok(WebAssembly::Instance::new(&self.module, &imports_object)
-            .map_err(|e: JsValue| -> RuntimeError { e.into() })?)
+        WebAssembly::Instance::new(&self.module, &imports_object)
+            .map_err(|e: JsValue| -> RuntimeError { e.into() })
     }
 
     pub fn name(&self) -> Option<&str> {
@@ -459,8 +456,8 @@ impl Module {
 
 impl From<WebAssembly::Module> for Module {
     #[track_caller]
-    fn from(module: WebAssembly::Module) -> Module {
-        Module {
+    fn from(module: WebAssembly::Module) -> Self {
+        Self {
             module: JsHandle::new(module),
             name: None,
             type_hints: None,
@@ -471,9 +468,9 @@ impl From<WebAssembly::Module> for Module {
 }
 
 impl<T: IntoBytes> From<(WebAssembly::Module, T)> for crate::module::Module {
-    fn from((module, binary): (WebAssembly::Module, T)) -> crate::module::Module {
+    fn from((module, binary): (WebAssembly::Module, T)) -> Self {
         unsafe {
-            crate::module::Module(BackendModule::Js(Module::from_js_module(
+            Self(BackendModule::Js(Module::from_js_module(
                 module,
                 binary.into_bytes(),
             )))
@@ -482,8 +479,8 @@ impl<T: IntoBytes> From<(WebAssembly::Module, T)> for crate::module::Module {
 }
 
 impl From<WebAssembly::Module> for crate::module::Module {
-    fn from(module: WebAssembly::Module) -> crate::module::Module {
-        crate::module::Module(BackendModule::Js(module.into()))
+    fn from(module: WebAssembly::Module) -> Self {
+        Self(BackendModule::Js(module.into()))
     }
 }
 impl From<crate::module::Module> for WebAssembly::Module {

--- a/lib/api/src/backend/js/entities/table.rs
+++ b/lib/api/src/backend/js/entities/table.rs
@@ -71,7 +71,7 @@ impl Table {
     }
 
     pub fn get(&self, store: &mut impl AsStoreMut, index: u32) -> Option<Value> {
-        if let Some(func) = self.handle.table.get(index).ok() {
+        if let Ok(func) = self.handle.table.get(index) {
             let ty = FunctionType::new(vec![], vec![]);
             let vm_function = VMFunction::new(func, ty);
             let function = crate::Function::from_vm_extern(

--- a/lib/api/src/backend/js/entities/tag.rs
+++ b/lib/api/src/backend/js/entities/tag.rs
@@ -24,7 +24,7 @@ impl Tag {
         let descriptor = js_sys::Object::new();
         let params: Box<[Type]> = params.into();
         let parameters: Vec<String> = params
-            .into_iter()
+            .iter()
             .map(|param| match param {
                 Type::I32 => "i32".to_string(),
                 Type::I64 => "i64".to_string(),
@@ -62,7 +62,7 @@ impl Tag {
 
 impl crate::Tag {
     /// Consume [`self`] into [`crate::backend::js::tag::Tag`].
-    pub fn into_js(self) -> crate::backend::js::tag::Tag {
+    pub(crate) fn into_js(self) -> crate::backend::js::tag::Tag {
         match self.0 {
             BackendTag::Js(s) => s,
             _ => panic!("Not a `js` tag!"),
@@ -70,7 +70,7 @@ impl crate::Tag {
     }
 
     /// Convert a reference to [`self`] into a reference [`crate::backend::js::tag::Tag`].
-    pub fn as_js(&self) -> &crate::backend::js::tag::Tag {
+    pub(crate) fn as_js(&self) -> &crate::backend::js::tag::Tag {
         match self.0 {
             BackendTag::Js(ref s) => s,
             _ => panic!("Not a `js` tag!"),
@@ -78,7 +78,7 @@ impl crate::Tag {
     }
 
     /// Convert a mutable reference to [`self`] into a mutable reference [`crate::backend::js::tag::Tag`].
-    pub fn as_js_mut(&mut self) -> &mut crate::backend::js::tag::Tag {
+    pub(crate) fn as_js_mut(&mut self) -> &mut crate::backend::js::tag::Tag {
         match self.0 {
             BackendTag::Js(ref mut s) => s,
             _ => panic!("Not a `js` tag!"),

--- a/lib/api/src/backend/js/error.rs
+++ b/lib/api/src/backend/js/error.rs
@@ -87,7 +87,7 @@ impl From<JsValue> for RuntimeError {
             }
         }
 
-        RuntimeError::from(Trap {
+        Self::from(Trap {
             inner: InnerTrap::Js(value.into()),
         })
     }
@@ -111,10 +111,7 @@ fn downcast_from_ptr(value: &JsValue) -> Option<Trap> {
         .and_then(|v: JsValue| v.dyn_into())
         .ok();
 
-    if marker_func.is_none() {
-        // We couldn't find the marker, so it's something else.
-        return None;
-    }
+    marker_func.as_ref()?;
 
     // Safety: The marker function exists, therefore it's safe to convert back
     // to a Trap.
@@ -150,27 +147,27 @@ impl From<JsValue> for JsTrap {
     fn from(value: JsValue) -> Self {
         // Let's try some easy special cases first
         if let Some(error) = value.dyn_ref::<js_sys::Error>() {
-            return JsTrap::Message(error.message().into());
+            return Self::Message(error.message().into());
         }
 
         if let Some(s) = value.as_string() {
-            return JsTrap::Message(s);
+            return Self::Message(s);
         }
 
         // Otherwise, we'll try to stringify the error and hope for the best
         if let Some(obj) = value.dyn_ref::<js_sys::Object>() {
-            return JsTrap::Message(obj.to_string().into());
+            return Self::Message(obj.to_string().into());
         }
 
-        JsTrap::Unknown
+        Self::Unknown
     }
 }
 
 impl std::fmt::Display for JsTrap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            JsTrap::Message(m) => write!(f, "{m}"),
-            JsTrap::Unknown => write!(f, "unknown"),
+            Self::Message(m) => write!(f, "{m}"),
+            Self::Unknown => write!(f, "unknown"),
         }
     }
 }
@@ -195,13 +192,13 @@ impl From<Trap> for RuntimeError {
             return trap.downcast::<Self>().unwrap();
         }
 
-        RuntimeError::new_from_source(crate::BackendTrap::Js(trap), vec![], None)
+        Self::new_from_source(crate::BackendTrap::Js(trap), vec![], None)
     }
 }
 
 impl From<RuntimeError> for wasm_bindgen::JsValue {
     fn from(value: RuntimeError) -> Self {
-        wasm_bindgen::JsValue::from(value.to_string())
+        Self::from(value.to_string())
     }
 }
 

--- a/lib/api/src/backend/js/utils/convert.rs
+++ b/lib/api/src/backend/js/utils/convert.rs
@@ -237,7 +237,7 @@ impl AsJs for Instance {
         let js_instance: js_sys::WebAssembly::Instance = value.clone().into();
         let (instance, exports) = JsInstance::from_module_and_instance(store, module, js_instance)
             .map_err(|e| JsError::new(&format!("Can't get the instance: {:?}", e)))?;
-        Ok(Instance {
+        Ok(Self {
             _inner: crate::BackendInstance::Js(instance),
             module: module.clone(),
             exports,
@@ -258,9 +258,9 @@ impl AsJs for Memory {
         value: &JsValue,
     ) -> Result<Self, JsError> {
         if let Some(memory) = value.dyn_ref::<JsMemory>() {
-            Ok(Memory::from_vm_extern(
+            Ok(Self::from_vm_extern(
                 store,
-                crate::vm::VMExternMemory::Js(VMMemory::new(memory.clone(), memory_type.clone())),
+                crate::vm::VMExternMemory::Js(VMMemory::new(memory.clone(), *memory_type)),
             ))
         } else {
             Err(JsError::new(&format!(
@@ -284,7 +284,7 @@ impl AsJs for Function {
         value: &JsValue,
     ) -> Result<Self, JsError> {
         if value.is_instance_of::<JsFunction>() {
-            Ok(Function::from_vm_extern(
+            Ok(Self::from_vm_extern(
                 store,
                 crate::vm::VMExternFunction::Js(VMFunction::new(
                     value.clone().unchecked_into::<JsFunction>(),
@@ -312,7 +312,7 @@ impl AsJs for Tag {
         value: &JsValue,
     ) -> Result<Self, JsError> {
         if value.is_instance_of::<JsTag>() {
-            Ok(Tag::from_vm_extern(
+            Ok(Self::from_vm_extern(
                 store,
                 crate::vm::VMExternTag::Js(VMTag::new(
                     value.clone().unchecked_into::<JsTag>(),
@@ -341,11 +341,11 @@ impl AsJs for Global {
         value: &JsValue,
     ) -> Result<Self, JsError> {
         if value.is_instance_of::<JsGlobal>() {
-            Ok(Global::from_vm_extern(
+            Ok(Self::from_vm_extern(
                 store,
                 crate::vm::VMExternGlobal::Js(VMGlobal::new(
                     value.clone().unchecked_into::<JsGlobal>(),
-                    global_type.clone(),
+                    *global_type,
                 )),
             ))
         } else {
@@ -370,11 +370,11 @@ impl AsJs for Table {
         value: &JsValue,
     ) -> Result<Self, JsError> {
         if value.is_instance_of::<JsTable>() {
-            Ok(Table::from_vm_extern(
+            Ok(Self::from_vm_extern(
                 store,
                 crate::vm::VMExternTable::Js(VMTable::new(
                     value.clone().unchecked_into::<JsTable>(),
-                    table_type.clone(),
+                    *table_type,
                 )),
             ))
         } else {

--- a/lib/api/src/backend/js/utils/js_handle.rs
+++ b/lib/api/src/backend/js/utils/js_handle.rs
@@ -19,7 +19,7 @@ pub(crate) struct JsHandle<T> {
 impl<T> JsHandle<T> {
     #[track_caller]
     pub fn new(value: T) -> Self {
-        JsHandle {
+        Self {
             value,
             integrity: IntegrityCheck::new(std::any::type_name::<T>()),
         }
@@ -34,7 +34,7 @@ impl<T> JsHandle<T> {
 
 impl<T: PartialEq> PartialEq for JsHandle<T> {
     fn eq(&self, other: &Self) -> bool {
-        let JsHandle {
+        let Self {
             value,
             integrity: _,
         } = self;
@@ -48,11 +48,11 @@ impl<T: Eq> Eq for JsHandle<T> {}
 impl<T> From<T> for JsHandle<T> {
     #[track_caller]
     fn from(value: T) -> Self {
-        JsHandle::new(value)
+        Self::new(value)
     }
 }
 
-impl<T: Into<JsValue>> From<JsHandle<T>> for JsValue {
+impl<T: Into<Self>> From<JsHandle<T>> for JsValue {
     fn from(value: JsHandle<T>) -> Self {
         value.into_inner().into()
     }
@@ -120,7 +120,7 @@ mod integrity_check {
     impl IntegrityCheck {
         #[track_caller]
         pub(crate) fn new(type_name: &'static str) -> Self {
-            IntegrityCheck {
+            Self {
                 original_thread: super::current_thread_id(),
                 created: Location::caller(),
                 type_name,
@@ -133,7 +133,7 @@ mod integrity_check {
             let current_thread = super::current_thread_id();
 
             if current_thread != self.original_thread {
-                let IntegrityCheck {
+                let Self {
                     original_thread,
                     created,
                     type_name,

--- a/lib/api/src/backend/js/vm/memory.rs
+++ b/lib/api/src/backend/js/vm/memory.rs
@@ -42,12 +42,12 @@ impl VMMemory {
     }
 
     /// Attempts to clone this memory (if its clonable)
-    pub(crate) fn try_clone(&self) -> Result<VMMemory, MemoryError> {
+    pub(crate) fn try_clone(&self) -> Result<Self, MemoryError> {
         Ok(self.clone())
     }
 
     /// Copies this memory to a new memory
-    pub fn copy(&mut self) -> Result<VMMemory, wasmer_types::MemoryError> {
+    pub fn copy(&mut self) -> Result<Self, wasmer_types::MemoryError> {
         let new_memory = crate::js::memory::Memory::js_memory_from_type(&self.ty)?;
 
         let src = crate::js::memory::MemoryView::new_raw(&self.memory);
@@ -87,14 +87,14 @@ impl VMMemory {
 
         Ok(Self {
             memory: JsHandle::new(new_memory),
-            ty: self.ty.clone(),
+            ty: self.ty,
         })
     }
 }
 
 impl From<VMMemory> for JsValue {
     fn from(value: VMMemory) -> Self {
-        JsValue::from(value.memory)
+        Self::from(value.memory)
     }
 }
 

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -3,8 +3,7 @@ use std::sync::{
     Arc,
 };
 use wasmer::{
-    imports, Instance, Memory, MemoryAccessError, MemoryLocation, MemoryType, Module, Store,
-    WasmSlice,
+    imports, Instance, Memory, MemoryLocation, MemoryType, Module, Store,
 };
 
 #[test]

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -15,22 +15,19 @@ use crate::{Compiler, CompilerConfig};
 #[cfg(not(target_arch = "wasm32"))]
 use shared_buffer::OwnedBuffer;
 
-#[cfg(not(target_arch = "wasm32"))]
-use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::{Arc, Mutex};
-use std::{
-    io::Write,
-    sync::atomic::{AtomicUsize, Ordering::SeqCst},
-};
+#[cfg(not(target_arch = "wasm32"))]
+use std::{io::Write, path::Path};
 
 #[cfg(feature = "compiler")]
 use wasmer_types::Features;
 #[cfg(not(target_arch = "wasm32"))]
 use wasmer_types::{
     entity::PrimaryMap, DeserializeError, FunctionIndex, FunctionType, LocalFunctionIndex,
-    SignatureIndex,
+    ModuleInfo, SignatureIndex,
 };
-use wasmer_types::{target::Target, CompileError, HashAlgorithm, ModuleInfo};
+use wasmer_types::{target::Target, CompileError, HashAlgorithm};
 
 #[cfg(not(target_arch = "wasm32"))]
 use wasmer_vm::{
@@ -98,9 +95,9 @@ impl Engine {
 
     /// Returns the deterministic id of this engine
     pub fn deterministic_id(&self) -> String {
-        let i = self.inner();
         #[cfg(feature = "compiler")]
         {
+            let i = self.inner();
             if let Some(ref c) = i.compiler {
                 return c.deterministic_id();
             } else {
@@ -305,13 +302,13 @@ impl Engine {
     /// more optimizations.
     pub fn with_opts(
         &mut self,
-        suggested_opts: &wasmer_types::target::UserCompilerOptimizations,
+        _suggested_opts: &wasmer_types::target::UserCompilerOptimizations,
     ) -> Result<(), CompileError> {
         #[cfg(feature = "compiler")]
         {
             let mut i = self.inner_mut();
             if let Some(ref mut c) = i.compiler {
-                c.with_opts(suggested_opts)?;
+                c.with_opts(_suggested_opts)?;
             }
         }
 


### PR DESCRIPTION
Fix compilation warnings for `wasm32` target:

- Fix compile warnings - mostly about unused, because of conditional compilation
- Fix clippy warnings, basically https://github.com/wasmerio/wasmer/commit/af12593710449da12a957bc1c836b4049c41fc7f was done by running `clippy --fix`
- Add `make lint-js` and run it on Github action `lint` step

Closes https://github.com/wasmerio/wasmer/issues/5786