### PR TITLE
fix(singlepass): support 1K function call arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7567,6 +7567,7 @@ dependencies = [
  "criterion",
  "crossbeam-queue",
  "glob",
+ "itertools 0.12.1",
  "reqwest",
  "rustc_version 0.4.1",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 	"fmt",
 ] }
 reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
+itertools.workspace = true
 
 [features]
 # Don't add the compiler features in default, please add them on the Makefile

--- a/tests/compilers/issues.rs
+++ b/tests/compilers/issues.rs
@@ -1,5 +1,6 @@
 //! This file is mainly to assure specific issues are working well
-use anyhow::Result;
+use anyhow::{Context, Result};
+use itertools::Itertools;
 use wasmer::FunctionEnv;
 use wasmer::*;
 
@@ -529,6 +530,61 @@ fn issue_5309_reftype_panic(mut config: crate::Config) -> Result<()> {
 
     let mut store = config.store();
     let _ = Module::new(&store, wat);
+
+    Ok(())
+}
+
+fn gen_wat_sum_function(arguments: usize) -> String {
+    assert!(arguments > 0);
+    let arg_types = std::iter::repeat_n("i64", arguments).collect_vec();
+    let params = (0..arguments)
+        .map(|idx| format!("(param $p{} i64)", idx + 1))
+        .collect_vec();
+    let fn_body = (2..=arguments)
+        .map(|idx| format!("local.get $p{idx}\ni64.add"))
+        .collect_vec();
+
+    format!(
+        r#"
+    (module
+    (type $sum_t (func (param {}) (result i64)))
+    (func $sum_f (type $sum_t)
+    {}
+    (result i64)
+    local.get $p1
+    {}
+    )
+    (export "sum" (func $sum_f)))
+    "#,
+        arg_types.join(" "),
+        params.join(" "),
+        fn_body.join("\n")
+    )
+}
+
+#[compiler_test(issues)]
+fn huge_number_of_arguments_fn(
+    mut config: crate::Config,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for params in [1, 10, 100, 500, 1000] {
+        println!("Testing sum fn with {params} parameters");
+        let mut store = config.store();
+        let wat_body = gen_wat_sum_function(params as usize);
+        let wat = wat2wasm(wat_body.as_bytes())
+            .with_context(|| format!("Cannot build sum function with {params} parameters"))?;
+
+        let mut env = FunctionEnv::new(&mut store, ());
+        let module = Module::new(&store, wat).unwrap();
+        let imports: Imports = imports! {};
+        let instance = Instance::new(&mut store, &module, &imports)?;
+        let args = (1..=params).map(Value::I64).collect_vec();
+        let result = instance
+            .exports
+            .get_function("sum")?
+            .call(&mut store, &args)
+            .unwrap();
+        assert_eq!(&Value::I64((1..=params).sum()), result.first().unwrap());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Right now, the test fails on `arm64` due to the following error:
```
Cannot assemble this Aarch64 instruction. Immediate 7952 is out of range.
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:75:14
   2: dynasmrt::aarch64::immediate_out_of_range_unsigned_32
             at /home/marxin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dynasmrt-4.0.1/src/aarch64.rs:216:5
   3: wasmer_compiler_singlepass::emitter_arm64::gen_std_trampoline_arm64
             at ./lib/compiler-singlepass/src/emitter_arm64.rs:2859:33
   4: <wasmer_compiler_singlepass::machine_arm64::MachineARM64 as wasmer_compiler_singlepass::machine::Machine>::gen_std_trampoline
             at ./lib/compiler-singlepass/src/machine_arm64.rs:8423:9
   5: wasmer_compiler_singlepass::machine::gen_std_trampoline
             at ./lib/compiler-singlepass/src/machine.rs:2425:13
```