### PR TITLE
refactor(singlepass): swap jmp_on_condition arguments

### DIFF
--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -2821,8 +2821,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.jmp_on_condition(
                     UnsignedCondition::BelowEqual,
                     Size::S32,
-                    func_index,
                     Location::GPR(table_count),
+                    func_index,
                     self.special_labels.table_access_oob,
                 )?;
                 self.machine
@@ -2849,8 +2849,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.jmp_on_condition(
                     UnsignedCondition::Equal,
                     Size::S64,
-                    Location::Imm32(0),
                     Location::GPR(table_count),
+                    Location::Imm32(0),
                     self.special_labels.indirect_call_null,
                 )?;
                 self.machine.move_location(
@@ -2986,8 +2986,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.jmp_on_condition(
                     UnsignedCondition::Equal,
                     Size::S32,
-                    Location::Imm32(0),
                     cond,
+                    Location::Imm32(0),
                     label_else,
                 )?;
             }
@@ -3060,8 +3060,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.jmp_on_condition(
                     UnsignedCondition::Equal,
                     Size::S32,
-                    Location::Imm32(0),
                     cond,
+                    Location::Imm32(0),
                     zero_label,
                 )?;
                 match cncl {
@@ -4064,8 +4064,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.jmp_on_condition(
                     UnsignedCondition::Equal,
                     Size::S32,
-                    Location::Imm32(0),
                     cond,
+                    Location::Imm32(0),
                     after,
                 )?;
 
@@ -4113,8 +4113,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.jmp_on_condition(
                     UnsignedCondition::AboveEqual,
                     Size::S32,
-                    Location::Imm32(targets.len() as u32),
                     cond,
+                    Location::Imm32(targets.len() as u32),
                     default_br,
                 )?;
 

--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -235,7 +235,7 @@ pub trait EmitterARM64 {
         dst: Location,
     ) -> Result<(), CompileError>;
 
-    fn emit_cmp(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError>;
+    fn emit_cmp(&mut self, sz: Size, left: Location, right: Location) -> Result<(), CompileError>;
     fn emit_tst(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError>;
 
     fn emit_lsl(
@@ -1414,8 +1414,13 @@ impl EmitterARM64 for Assembler {
         Ok(())
     }
 
-    fn emit_cmp(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
-        match (sz, src, dst) {
+    /// Emit a CMP instruction that compares `left` against `right`.
+    ///
+    /// Note: callers sometimes pass operands in the opposite order compared
+    /// to other binary operators. This function performs the comparison as
+    /// provided (i.e. it emits `cmp left, right` semantics).
+    fn emit_cmp(&mut self, sz: Size, left: Location, right: Location) -> Result<(), CompileError> {
+        match (sz, left, right) {
             (Size::S64, Location::GPR(src), Location::GPR(dst)) => {
                 dynasm!(self ; cmp X(dst), X(src));
             }
@@ -1446,7 +1451,7 @@ impl EmitterARM64 for Assembler {
                 }
                 dynasm!(self ; cmp WSP(dst), imm as u32);
             }
-            _ => codegen_error!("singlepass can't emit CMP {:?} {:?} {:?}", sz, src, dst),
+            _ => codegen_error!("singlepass can't emit CMP {:?} {:?} {:?}", sz, left, right),
         }
         Ok(())
     }

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -1259,6 +1259,12 @@ impl EmitterX64 for AssemblerX64 {
         }
         Ok(())
     }
+
+    /// Emit a CMP instruction that compares `left` against `right`.
+    ///
+    /// Note: callers sometimes pass operands in the opposite order compared
+    /// to other binary operators. This function performs the comparison as
+    /// provided (i.e. it emits `cmp left, right` semantics).
     fn emit_cmp(&mut self, sz: Size, left: Location, right: Location) -> Result<(), CompileError> {
         // Constant elimination for comparison between consts.
         //

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -393,13 +393,13 @@ pub trait Machine {
     /// jmp without condidtion
     fn jmp_unconditionnal(&mut self, label: Label) -> Result<(), CompileError>;
 
-    /// jmp to label if the provided condition is true (when comparing source and dest)
+    /// jmp to label if the provided condition is true (when comparing loc_a and loc_b)
     fn jmp_on_condition(
         &mut self,
         cond: UnsignedCondition,
         size: Size,
-        source: Location<Self::GPR, Self::SIMD>,
-        dest: Location<Self::GPR, Self::SIMD>,
+        loc_a: Location<Self::GPR, Self::SIMD>,
+        loc_b: Location<Self::GPR, Self::SIMD>,
         label: Label,
     ) -> Result<(), CompileError>;
 

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -2532,11 +2532,11 @@ impl Machine for MachineARM64 {
         &mut self,
         cond: UnsignedCondition,
         size: Size,
-        source: AbstractLocation<Self::GPR, Self::SIMD>,
-        dest: AbstractLocation<Self::GPR, Self::SIMD>,
+        loc_a: AbstractLocation<Self::GPR, Self::SIMD>,
+        loc_b: AbstractLocation<Self::GPR, Self::SIMD>,
         label: Label,
     ) -> Result<(), CompileError> {
-        self.emit_relaxed_binop(Assembler::emit_cmp, size, source, dest, false)?;
+        self.emit_relaxed_binop(Assembler::emit_cmp, size, loc_b, loc_a, false)?;
         let cond = match cond {
             UnsignedCondition::Equal => Condition::Eq,
             UnsignedCondition::NotEqual => Condition::Ne,

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -2718,11 +2718,11 @@ impl Machine for MachineX86_64 {
         &mut self,
         cond: UnsignedCondition,
         size: Size,
-        source: AbstractLocation<Self::GPR, Self::SIMD>,
-        dest: AbstractLocation<Self::GPR, Self::SIMD>,
+        loc_a: AbstractLocation<Self::GPR, Self::SIMD>,
+        loc_b: AbstractLocation<Self::GPR, Self::SIMD>,
         label: Label,
     ) -> Result<(), CompileError> {
-        self.assembler.emit_cmp(size, source, dest)?;
+        self.assembler.emit_cmp(size, loc_b, loc_a)?;
         let cond = match cond {
             UnsignedCondition::Equal => Condition::Equal,
             UnsignedCondition::NotEqual => Condition::NotEqual,


### PR DESCRIPTION
When calling the jmp_on_condition, we should really compare loc_a and loc_b in the particular order. Right now, the function has swapped arguments, as the `emit_cmp` assembler function actually needs to be called with swapped args in order to do: `loc_a` CMP `loc_b`.
