### PR TITLE
fix(llvm): fix compilation error with: CARGO_TARGET=riscv64gc-unknown…

### DIFF
--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -287,10 +287,15 @@ impl LLVM {
 
                 let my_target_machine: MyTargetMachine = std::mem::transmute(llvm_target_machine);
 
-                *((my_target_machine.target_machine as *mut u8).offset(0x410) as *mut u64) = 5;
+                #[cfg(target_arch = "riscv64")]
+                let target_machine_ptr = my_target_machine.target_machine as *mut u8;
+                #[cfg(not(target_arch = "riscv64"))]
+                let target_machine_ptr = my_target_machine.target_machine as *mut i8;
+
+                *(target_machine_ptr.offset(0x410) as *mut u64) = 5;
                 std::ptr::copy_nonoverlapping(
                     c"lp64d".as_ptr(),
-                    (my_target_machine.target_machine as *mut i8).offset(0x418),
+                    target_machine_ptr.offset(0x418),
                     6,
                 );
 


### PR DESCRIPTION
…-linux-gnu

Build error:
```
error[E0308]: mismatched types
    --> lib/compiler-llvm/src/config.rs:293:21
     |
291  |                 std::ptr::copy_nonoverlapping(
     |                 ----------------------------- arguments to this function are incorrect
292  |                     c"lp64d".as_ptr(),
293  |                     (my_target_machine.target_machine as *mut u8).offset(0x418),
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*mut i8`, found `*mut u8`
     |
     = note: expected raw pointer `*mut i8`
                found raw pointer `*mut u8`
```