### PR TITLE
refactor: remove unused parts of FunctionStateMap

### DIFF
--- a/lib/compiler-singlepass/src/arm64_decl.rs
+++ b/lib/compiler-singlepass/src/arm64_decl.rs
@@ -4,7 +4,6 @@ use crate::{
     common_decl::{MachineState, MachineValue, RegisterIndex},
     location::{CombinedRegister, Reg as AbstractReg},
 };
-use std::collections::BTreeMap;
 use std::slice::Iter;
 use wasmer_types::target::CallingConvention;
 use wasmer_types::{CompileError, Type};
@@ -436,7 +435,6 @@ pub fn new_machine_state() -> MachineState {
     MachineState {
         stack_values: vec![],
         register_values: vec![MachineValue::Undefined; 32 + 32],
-        prev_frame: BTreeMap::new(),
         wasm_stack: vec![],
         wasm_inst_offset: usize::MAX,
     }

--- a/lib/compiler-singlepass/src/common_decl.rs
+++ b/lib/compiler-singlepass/src/common_decl.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct RegisterIndex(pub usize);
 
@@ -19,44 +17,10 @@ pub struct MachineState {
     pub stack_values: Vec<MachineValue>,
     /// Register values.
     pub register_values: Vec<MachineValue>,
-    /// Previous frame.
-    pub prev_frame: BTreeMap<usize, MachineValue>,
     /// Wasm stack.
     pub wasm_stack: Vec<WasmAbstractValue>,
     /// Wasm instruction offset.
     pub wasm_inst_offset: usize,
-}
-
-/// A diff of two `MachineState`s.
-///
-/// A `MachineStateDiff` can only be applied after the `MachineStateDiff` its `last` field
-/// points to is already applied.
-#[derive(Clone, Debug, Default)]
-#[allow(dead_code)]
-pub struct MachineStateDiff {
-    /// Link to the previous diff this diff is based on, or `None` if this is the first diff.
-    pub last: Option<usize>,
-
-    /// What values are pushed onto the stack?
-    pub stack_push: Vec<MachineValue>,
-
-    /// How many values are popped from the stack?
-    pub stack_pop: usize,
-
-    /// Register diff.
-    pub reg_diff: Vec<(RegisterIndex, MachineValue)>,
-
-    /// Changes in the previous frame's data.
-    pub prev_frame_diff: BTreeMap<usize, Option<MachineValue>>, // None for removal
-
-    /// Values pushed to the Wasm stack.
-    pub wasm_stack_push: Vec<WasmAbstractValue>,
-
-    /// # of values popped from the Wasm stack.
-    pub wasm_stack_pop: usize,
-
-    /// Wasm instruction offset.
-    pub wasm_inst_offset: usize, // absolute value; not a diff.
 }
 
 /// A kind of machine value.
@@ -82,130 +46,10 @@ pub enum MachineValue {
     _TwoHalves(Box<(MachineValue, MachineValue)>), // 32-bit values. TODO: optimize: add another type for inner "half" value to avoid boxing?
 }
 
-/// A map of function states.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub struct FunctionStateMap {
-    /// Initial.
-    pub initial: MachineState,
-    /// Local Function Id.
-    pub local_function_id: usize,
-    /// Locals.
-    pub locals: Vec<WasmAbstractValue>,
-    /// Shadow size.
-    pub shadow_size: usize, // for single-pass backend, 32 bytes on x86-64
-    /// Diffs.
-    pub diffs: Vec<MachineStateDiff>,
-}
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Size {
     S8,
     S16,
     S32,
     S64,
-}
-
-/// A kind of suspend offset.
-#[allow(dead_code)]
-#[derive(Clone, Copy, Debug)]
-pub enum SuspendOffset {
-    /// A loop.
-    _Loop(usize),
-    /// A call.
-    Call(usize),
-    /// A trappable.
-    Trappable(usize),
-}
-
-/// Description of a machine code range following an offset.
-#[allow(dead_code)]
-#[derive(Clone, Debug)]
-pub struct OffsetInfo {
-    /// Exclusive range-end offset.
-    pub end_offset: usize,
-    /// Index pointing to the `MachineStateDiff` entry.
-    pub diff_id: usize,
-    /// Offset at which execution can be continued.
-    pub activate_offset: usize,
-}
-
-impl FunctionStateMap {
-    /// Creates a new `FunctionStateMap` with the given parameters.
-    pub fn new(
-        initial: MachineState,
-        local_function_id: usize,
-        shadow_size: usize,
-        locals: Vec<WasmAbstractValue>,
-    ) -> FunctionStateMap {
-        FunctionStateMap {
-            initial,
-            local_function_id,
-            shadow_size,
-            locals,
-            diffs: vec![],
-        }
-    }
-}
-
-impl MachineState {
-    /// Creates a `MachineStateDiff` from self and the given `&MachineState`.
-    pub fn diff(&self, old: &MachineState) -> MachineStateDiff {
-        let first_diff_stack_depth: usize = self
-            .stack_values
-            .iter()
-            .zip(old.stack_values.iter())
-            .enumerate()
-            .find(|&(_, (a, b))| a != b)
-            .map(|x| x.0)
-            .unwrap_or_else(|| old.stack_values.len().min(self.stack_values.len()));
-        assert_eq!(self.register_values.len(), old.register_values.len());
-        let reg_diff: Vec<_> = self
-            .register_values
-            .iter()
-            .zip(old.register_values.iter())
-            .enumerate()
-            .filter(|&(_, (a, b))| a != b)
-            .map(|(i, (a, _))| (RegisterIndex(i), a.clone()))
-            .collect();
-        let prev_frame_diff: BTreeMap<usize, Option<MachineValue>> = self
-            .prev_frame
-            .iter()
-            .filter(|(k, v)| {
-                if let Some(ref old_v) = old.prev_frame.get(k) {
-                    v != old_v
-                } else {
-                    true
-                }
-            })
-            .map(|(&k, v)| (k, Some(v.clone())))
-            .chain(
-                old.prev_frame
-                    .iter()
-                    .filter(|(k, _)| !self.prev_frame.contains_key(k))
-                    .map(|(&k, _)| (k, None)),
-            )
-            .collect();
-        let first_diff_wasm_stack_depth: usize = self
-            .wasm_stack
-            .iter()
-            .zip(old.wasm_stack.iter())
-            .enumerate()
-            .find(|&(_, (a, b))| a != b)
-            .map(|x| x.0)
-            .unwrap_or_else(|| old.wasm_stack.len().min(self.wasm_stack.len()));
-        MachineStateDiff {
-            last: None,
-            stack_push: self.stack_values[first_diff_stack_depth..].to_vec(),
-            stack_pop: old.stack_values.len() - first_diff_stack_depth,
-            reg_diff,
-
-            prev_frame_diff,
-
-            wasm_stack_push: self.wasm_stack[first_diff_wasm_stack_depth..].to_vec(),
-            wasm_stack_pop: old.wasm_stack.len() - first_diff_wasm_stack_depth,
-
-            wasm_inst_offset: self.wasm_inst_offset,
-        }
-    }
 }

--- a/lib/compiler-singlepass/src/x64_decl.rs
+++ b/lib/compiler-singlepass/src/x64_decl.rs
@@ -4,7 +4,6 @@
 use crate::common_decl::{MachineState, MachineValue, RegisterIndex};
 use crate::location::CombinedRegister;
 use crate::location::Reg as AbstractReg;
-use std::collections::BTreeMap;
 use std::slice::Iter;
 use wasmer_types::{CompileError, Type, target::CallingConvention};
 
@@ -353,7 +352,6 @@ pub fn new_machine_state() -> MachineState {
     MachineState {
         stack_values: vec![],
         register_values: vec![MachineValue::Undefined; 16 + 8],
-        prev_frame: BTreeMap::new(),
         wasm_stack: vec![],
         wasm_inst_offset: usize::MAX,
     }


### PR DESCRIPTION
While working on the Singlepass implementation of the `Operator::Unreachable` to directly make it happen via a function call, I noticed there are plenty of data structures filled by the compiler, but unused. Thus I am suggesting to remove them.
When it comes to `Unreachable` support in VM, the key mapping from offset to WASM offset is based on `InstructionAddressMap`, which I preserve.