### PR TITLE
refactor(singlepass): factor out registers used for calling a fn

### DIFF
--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -188,6 +188,8 @@ pub trait Machine {
         &self,
         calling_convention: CallingConvention,
     ) -> Vec<Location<Self::GPR, Self::SIMD>>;
+    /// Get registers for first N function call parameters.
+    fn get_param_registers(&self, calling_convention: CallingConvention) -> &'static [Self::GPR];
     /// Get param location (to build a call, using SP for stack args)
     fn get_param_location(
         &self,


### PR DESCRIPTION
I'm going to need more fined-grained control over the used registers in `acquire_locations` when it comes to the upcoming **multi-value support**.  Although this is preparatory work, it's a sensible refactor on its own.