### PR TITLE
chore(clippy): fix remaining issues

### DIFF
--- a/lib/api/src/backend/sys/entities/instance.rs
+++ b/lib/api/src/backend/sys/entities/instance.rs
@@ -14,22 +14,6 @@ pub struct Instance {
     _handle: StoreHandle<VMInstance>,
 }
 
-#[cfg(test)]
-mod send_test {
-    use super::*;
-
-    // Only here to statically ensure that `Instance` is `Send`.
-    // Will fail to compile otherwise.
-    #[allow(dead_code)]
-    fn instance_is_send(inst: Instance) {
-        fn is_send(t: impl Send) {
-            let _ = t;
-        }
-
-        is_send(inst);
-    }
-}
-
 impl From<wasmer_compiler::InstantiationError> for InstantiationError {
     fn from(other: wasmer_compiler::InstantiationError) -> Self {
         match other {
@@ -103,5 +87,21 @@ impl crate::BackendInstance {
             Self::Sys(s) => s,
             _ => panic!("Not a `sys` instance"),
         }
+    }
+}
+
+#[cfg(test)]
+mod send_test {
+    use super::*;
+
+    // Only here to statically ensure that `Instance` is `Send`.
+    // Will fail to compile otherwise.
+    #[allow(dead_code)]
+    fn instance_is_send(inst: Instance) {
+        fn is_send(t: impl Send) {
+            let _ = t;
+        }
+
+        is_send(inst);
     }
 }

--- a/lib/api/src/utils/macros/backend.rs
+++ b/lib/api/src/utils/macros/backend.rs
@@ -37,6 +37,7 @@ macro_rules! gen_rt_ty {
         paste::paste! {
             $($(#[cfg_attr($if, $then)])*)?
             #[derive($($derive,)*)]
+            #[allow(clippy::large_enum_variant)]
             pub(crate) enum [<Backend $id>]$(<$lt>)? {
                 #[cfg(feature = "sys")]
                 /// The implementation from the `sys` backend.

--- a/lib/api/tests/memory.rs
+++ b/lib/api/tests/memory.rs
@@ -3,8 +3,6 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 use wasmer::{Instance, Memory, MemoryLocation, MemoryType, Module, Store, imports};
-#[cfg(feature = "sys")]
-use wasmer::{MemoryAccessError, WasmSlice};
 
 #[test]
 #[cfg_attr(feature = "wamr", ignore = "wamr ignores import memories")]

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -147,3 +147,6 @@ jit = ["compiler"]
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/lib/c-api/src/wasm_c_api/engine/mod.rs
+++ b/lib/c-api/src/wasm_c_api/engine/mod.rs
@@ -290,7 +290,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_engine_new() {
         (assert_c! {

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -105,7 +105,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_set_host_global_immutable() {
         (assert_c! {
@@ -142,7 +142,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_set_guest_global_immutable() {
         (assert_c! {

--- a/lib/c-api/src/wasm_c_api/externals/mod.rs
+++ b/lib/c-api/src/wasm_c_api/externals/mod.rs
@@ -142,7 +142,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_extern_copy() {
         (assert_c! {

--- a/lib/c-api/src/wasm_c_api/instance.rs
+++ b/lib/c-api/src/wasm_c_api/instance.rs
@@ -222,7 +222,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_instance_new() {
         (assert_c! {

--- a/lib/c-api/src/wasm_c_api/module.rs
+++ b/lib/c-api/src/wasm_c_api/module.rs
@@ -491,7 +491,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_module_validate() {
         (assert_c! {
@@ -523,7 +523,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_module_new() {
         (assert_c! {
@@ -557,7 +557,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_module_exports() {
         (assert_c! {
@@ -670,7 +670,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_module_imports() {
         (assert_c! {
@@ -793,7 +793,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_module_serialize() {
         (assert_c! {
@@ -832,7 +832,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_module_serialize_and_deserialize() {
         (assert_c! {

--- a/lib/c-api/src/wasm_c_api/trap.rs
+++ b/lib/c-api/src/wasm_c_api/trap.rs
@@ -154,7 +154,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_trap_message_null_terminated() {
         (assert_c! {
@@ -191,7 +191,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_trap_message_not_null_terminated() {
         (assert_c! {

--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -651,7 +651,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_wasi_get_wasi_version_snapshot0() {
         (assert_c! {
@@ -689,7 +689,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_wasi_get_wasi_version_snapshot1() {
         (assert_c! {
@@ -727,7 +727,7 @@ mod tests {
         unexpected_cfgs,
         reason = "tools like cargo-llvm-coverage pass --cfg coverage"
     )]
-    #[cfg_attr(coverage, ignore)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[test]
     fn test_wasi_get_wasi_version_invalid() {
         (assert_c! {


### PR DESCRIPTION
Most notable change is connected to the LLVM coverage, where the proper way how to be excluded from coverage is documented here: https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#exclude-code-from-coverage
