### PR TITLE
ci(windows): align unsafe functions for Windows target

### DIFF
--- a/lib/vm/src/libcalls/eh/mod.rs
+++ b/lib/vm/src/libcalls/eh/mod.rs
@@ -6,10 +6,21 @@ mod dwarf;
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_env = "msvc", target_family = "wasm"))] {
+        /// The implementation of Wasmer's personality function.
+        ///
+        /// # Safety
+        ///
+        /// Performs libunwind unwinding magic.
         pub unsafe fn wasmer_eh_personality() {
             panic!()
         }
 
+        /// The second stage of the personality function. See module level documentation
+        /// for an explanation of the exact procedure used during unwinding.
+        ///
+        /// # Safety
+        ///
+        /// Does pointer accesses, which must be valid.
         pub unsafe fn wasmer_eh_personality2() {
             panic!()
         }
@@ -18,10 +29,19 @@ cfg_if::cfg_if! {
             panic!()
         }
 
+        /// # Safety
+        ///
+        /// Performs libunwind unwinding magic. Highly unsafe.
         pub unsafe fn throw(_ctx: &crate::StoreObjects, _exnref: u32) -> ! {
             panic!()
         }
 
+        /// Given a pointer to a caught exception, return the exnref contained within.
+        ///
+        /// # Safety
+        ///
+        /// `exception` must be a pointer the platform-specific exception type; this is
+        /// `UwExceptionWrapper` for gcc.
         pub unsafe fn delete_exception(_exception: *mut std::ffi::c_void) {
             panic!()
         }


### PR DESCRIPTION
Fixes:

```
warning: unnecessary `unsafe` block
   --> lib\vm\src\libcalls.rs:744:5
    |
744 |     unsafe { eh::throw(instance.context(), exnref) }
    |     ^^^^^^ unnecessary `unsafe` block
    |
    = note: `#[warn(unused_unsafe)]` on by default

warning: unnecessary `unsafe` block
   --> lib\vm\src\libcalls.rs:784:5
    |
784 |     unsafe {
    |     ^^^^^^ unnecessary `unsafe` block
```