### PR TITLE
fix(compiler): rename option to prevent option clash

### DIFF
--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -192,7 +192,7 @@ pub struct RuntimeOptions {
     ///
     /// Available for cranelift, LLVM and singlepass.
     #[clap(long, alias = "llvm-debug-dir")]
-    debug_dir: Option<PathBuf>,
+    compiler_debug_dir: Option<PathBuf>,
 
     /// Enable a profiler.
     ///
@@ -474,7 +474,7 @@ impl RuntimeOptions {
                         Profiler::Perfmap => config.enable_perfmap(),
                     }
                 }
-                if let Some(mut debug_dir) = self.debug_dir.clone() {
+                if let Some(mut debug_dir) = self.compiler_debug_dir.clone() {
                     use wasmer_compiler_cranelift::CraneliftCallbacks;
 
                     debug_dir.push("cranelift");
@@ -496,7 +496,7 @@ impl RuntimeOptions {
                     config.num_threads(num_threads);
                 }
 
-                if let Some(mut debug_dir) = self.debug_dir.clone() {
+                if let Some(mut debug_dir) = self.compiler_debug_dir.clone() {
                     debug_dir.push("llvm");
                     config.callbacks(Some(LLVMCallbacks::new(debug_dir)?));
                 }
@@ -606,7 +606,7 @@ impl BackendType {
                         Profiler::Perfmap => config.enable_perfmap(),
                     }
                 }
-                if let Some(mut debug_dir) = runtime_opts.debug_dir.clone() {
+                if let Some(mut debug_dir) = runtime_opts.compiler_debug_dir.clone() {
                     use wasmer_compiler_cranelift::CraneliftCallbacks;
 
                     debug_dir.push("cranelift");
@@ -626,7 +626,7 @@ impl BackendType {
 
                 let mut config = wasmer_compiler_llvm::LLVM::new();
 
-                if let Some(mut debug_dir) = runtime_opts.debug_dir.clone() {
+                if let Some(mut debug_dir) = runtime_opts.compiler_debug_dir.clone() {
                     debug_dir.push("llvm");
                     config.callbacks(Some(LLVMCallbacks::new(debug_dir)?));
                 }

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -49,8 +49,8 @@ pub struct CreateExe {
     #[clap(name = "OUTPUT PATH", short = 'o')]
     output: PathBuf,
 
-    /// Optional directorey used for debugging: if present, will output the zig command
-    /// for reproducing issues in a debug directory
+    /// Optional directory used for debugging: if present, will output the zig command
+    /// for reproducing issues in a debug directory.
     #[clap(long, name = "DEBUG PATH")]
     debug_dir: Option<PathBuf>,
 

--- a/lib/cli/src/commands/create_obj.rs
+++ b/lib/cli/src/commands/create_obj.rs
@@ -21,8 +21,8 @@ pub struct CreateObj {
     #[clap(name = "OUTPUT_PATH", short = 'o')]
     output: PathBuf,
 
-    /// Optional directorey used for debugging: if present, will
-    /// output the files to a debug instead of a temp directory
+    /// Optional directory used for debugging: if present, will
+    /// output the files to a debug instead of a temporary directory.
     #[clap(long, name = "DEBUG PATH")]
     debug_dir: Option<PathBuf>,
 


### PR DESCRIPTION
Fixes:
```
Command create-obj: Long option names must be unique for each argument,
but '--debug-dir' is in use by both 'DEBUG PATH' and 'debug_dir'
```