### PR TITLE
Print more meaningful error message when `__tls_base` export is missing and tls symbols are used.

### DIFF
--- a/lib/wasix/src/state/linker.rs
+++ b/lib/wasix/src/state/linker.rs
@@ -3132,11 +3132,9 @@ impl InstanceGroupState {
                             ));
                         }
                         Err(e) => {
-                            panic!("Internal error: failed to resolve exported symbol: {}", e)
+                            panic!("Internal error: failed to resolve exported symbol: {e}")
                         }
                     };
-
-                    // .expect("Internal error: bad in-progress symbol resolution");
 
                     match export {
                         PartiallyResolvedExport::Global(addr) => {


### PR DESCRIPTION
Previously it was fine not to exports `__tls_base` from the main module, #5852 changed that to be an error. This PR prints a more meaningful error message when the `__tls_base` export is missing but tls symbols are used.