### PR TITLE
CI(compiler): fix cargo deny issues connected to licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -119,6 +119,9 @@ exceptions = [
 	# Each entry is the crate and version constraint, and its specific allow
 	# list
 	#{ allow = ["Zlib"], crate = "adler32" },
+
+	{ allow = ["BUSL-1.1"], crate = "wasmer-compiler-singlepass" },
+	{ allow = ["BUSL-1.1"], crate = "wasmer-compiler-llvm" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -126,14 +129,14 @@ exceptions = [
 # licensing information
 [[licenses.clarify]]
 crate = "wasmer-compiler-singlepass"
-expression = "ISC"
+expression = "BUSL-1.1"
 license-files = [
     { path = "LICENSE", hash = 0x11303e40 },
 ]
 
 [[licenses.clarify]]
 crate = "wasmer-compiler-llvm"
-expression = "ISC"
+expression = "BUSL-1.1"
 license-files = [
     { path = "LICENSE", hash = 0x79b6d01b },
 ]


### PR DESCRIPTION
Fixes the issue where cargo deny no longer matches our `LICENSE` file to a known one:
```
2 │ name = "wasmer-compiler-singlepass"
  │         ━━━━━━━━━━━━━━━━━━━━━━━━━━ a valid license expression could not be retrieved for the crate
3 │ version = "6.1.0"
4 │ license = ""
  │            ─ license expression was not specified
5 │ license-files = [
6 │     { path = "/home/marxin/Programming/wasmer/lib/compiler-singlepass/LICENSE", hash = 0x11303e40, score = 0.59, license = "BUSL-1.1" },
  │                                                                                                            ──── low confidence in the license text
```