### PR TITLE
ci: bump actions-cache-s3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
           echo '/opt/llvm-21/bin' >> $GITHUB_PATH
           echo 'LLVM_SYS_211_PREFIX=/opt/llvm-21' >> $GITHUB_ENV
       - name: Cache
-        uses: whywaita/actions-cache-s3@v2
+        uses: whywaita/actions-cache-s3@v3
         with:
           path: |
             ~/.cargo/*
@@ -691,7 +691,7 @@ jobs:
         if: ${{ matrix.build-what.key == 'capi' && matrix.metadata.build == 'windows-x64' }}
         run: ls -R $CARGO_ROOT_DIR
       - name: Cache
-        uses: whywaita/actions-cache-s3@v2
+        uses: whywaita/actions-cache-s3@v3
         with:
           path: |
             ~/.cargo/*
@@ -920,7 +920,7 @@ jobs:
           EOF
         if: matrix.metadata.target
       - name: Cache
-        uses: whywaita/actions-cache-s3@v2
+        uses: whywaita/actions-cache-s3@v3
         with:
           path: |
             ~/.cargo/*
@@ -1003,7 +1003,7 @@ jobs:
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
       - name: Cache
-        uses: whywaita/actions-cache-s3@v2
+        uses: whywaita/actions-cache-s3@v3
         with:
           path: |
             ~/.cargo/*


### PR DESCRIPTION
Should address the MUSL target where we `tar` binary fails due to unknown option `--posix`.

Related: #5891