### PR TITLE
fix(cicd): Swap to new organizational ciuser token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1149,5 +1149,6 @@ jobs:
     uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@main
     with:
       fetch_artifact: "wasmer-cli-linux-x64"
+      registry: wasmer.io
     secrets:
-      token: ${{ secrets.WAPM_DEV_TOKEN }}
+      token: ${{ secrets.PROD_BACKEND_CIUSER_TOKEN }}


### PR DESCRIPTION
# Description
The integratoin test suite already supports fetching the most recent artifact, so it'll run the tests using the newly built "wasmer-cli-linux-x64".

The old behaviour here was to test against the dev environment. But I'm swapping to instead run against production, which is much more stable. This way we can see if there are any changes in the runtime which will break any functionality exposed via the integration tests.


Closes: [SRE-1203: Fix wasmer runtime integration tests](https://linear.app/wasmer/issue/SRE-1203/fix-wasmer-runtime-integration-tests)