### PR TITLE
CI: leave MacOS 13 for x86_64 target.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         if: ${{ matrix.use_sccache != true && matrix.use_rustcache != false }}
-      - name: Install LLVM (macOS Apple Silicon)
+      - name: Install LLVM (macOS Intel)
         if: matrix.os == 'macos-15-intel' && !matrix.llvm_url
         run: |
           brew install llvm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -648,7 +648,7 @@ jobs:
           mkdir -p package
           mkdir -p package/winsdk
           cp -r /tmp/winsdk/* package/winsdk
-      - name: Install LLVM (macOS Apple Silicon)
+      - name: Install LLVM (macOS Intel)
         if: matrix.metadata.os == 'macos-15-intel' && !matrix.metadata.llvm_url
         run: |
           brew install llvm
@@ -885,7 +885,7 @@ jobs:
           target: ${{ matrix.metadata.target }}
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
-      - name: Install LLVM (macOS Apple Silicon)
+      - name: Install LLVM (macOS Intel)
         if: matrix.metadata.os == 'macos-15-intel' && !matrix.metadata.llvm_url
         run: |
           brew install llvm


### PR DESCRIPTION
The GitHub runners are already being disabled:
https://github.com/actions/runner-images/issues/13046