### PR TITLE
fix(singlepass): properly align stack slots in deallocation

### DIFF
--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -294,20 +294,15 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         &mut self,
         locs: &[LocationWithCanonicalization<M>],
     ) -> Result<(), CompileError> {
-        let mut delta_stack_offset: usize = 0;
-
         for (loc, _) in locs.iter().rev() {
             if let Location::Memory(..) = *loc {
                 self.check_location_on_stack(loc, self.stack_offset)?;
                 self.stack_offset -= 8;
-                delta_stack_offset += 8;
+                self.machine
+                    .truncate_stack(self.machine.round_stack_adjust(8) as u32)?;
             }
         }
 
-        let delta_stack_offset = self.machine.round_stack_adjust(delta_stack_offset);
-        if delta_stack_offset != 0 {
-            self.machine.truncate_stack(delta_stack_offset as u32)?;
-        }
         Ok(())
     }
 
@@ -315,7 +310,6 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         &mut self,
         stack_depth: usize,
     ) -> Result<(), CompileError> {
-        let mut delta_stack_offset: usize = 0;
         let mut stack_offset = self.stack_offset;
         let locs = &self.value_stack[stack_depth..];
 
@@ -323,14 +317,11 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             if let Location::Memory(..) = *loc {
                 self.check_location_on_stack(loc, stack_offset)?;
                 stack_offset -= 8;
-                delta_stack_offset += 8;
+                self.machine
+                    .truncate_stack(self.machine.round_stack_adjust(8) as u32)?;
             }
         }
 
-        let delta_stack_offset = self.machine.round_stack_adjust(delta_stack_offset);
-        if delta_stack_offset != 0 {
-            self.machine.truncate_stack(delta_stack_offset as u32)?;
-        }
         Ok(())
     }
 


### PR DESCRIPTION
The rounding process happens to be called for each stack allocation. When deallocating a collection of stack slots, we must round after each slot, e.g. for alignment of 16B and 3 slots, `align(3 * 8) != 3 * align(8)`.