### PR TITLE
CI: run macos-15-intel only on main (not in PRs)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -923,7 +923,7 @@ jobs:
         if: matrix.metadata.target
       - name: Cache
         # TODO: fix disk space issue for linux-musl connected to the cache size
-        if: matrix.stage.make != 'test-stage-5-test-examples' || matrix.stage.build != 'linux-musl'
+        if: matrix.stage.make != 'test-stage-5-test-examples' || matrix.metadata.build != 'linux-musl'
         # TODO: v3 is unable to Restore the cache for some reason
         uses: whywaita/actions-cache-s3@v2
         with:


### PR DESCRIPTION
Depot does not provide macOS Intel runners, and so let's demote them as something we'll be testing only on `main` branch (or a release branch).