### PR TITLE
CI: shorten job names for UI purpose

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -521,12 +521,12 @@ jobs:
             {
               key: "check",
               build-cmd: "make check",
-              name: "Wasmer API (all sys)",
+              name: "Wasmer API (sys)",
             },
             {
               key: "api-feats",
               build-cmd: "make check-api-features",
-              name: "API (all sys)",
+              name: "API (sys)",
             },
           ]
         metadata: [


### PR DESCRIPTION
The current job names cannot fit into the Github Web view:
<img width="472" height="1806" alt="screenshot-2025-12-01_14-39-36" src="https://github.com/user-attachments/assets/da5cee46-5c7f-4718-aec3-e62aded43451" />