### PR TITLE
Make it easier to identify modules without debug information

### DIFF
--- a/lib/types/src/module.rs
+++ b/lib/types/src/module.rs
@@ -564,7 +564,14 @@ impl ModuleInfo {
     pub fn name(&self) -> String {
         match self.name {
             Some(ref name) => name.to_string(),
-            None => "<module>".to_string(),
+            None => {
+                format!(
+                    "<module ({} imported globals) ({} imported functions) ({} functions)>",
+                    self.num_imported_globals,
+                    self.num_imported_functions,
+                    self.functions.len()
+                )
+            }
         }
     }
 


### PR DESCRIPTION
This pull request updates the behavior of the `name()` method in the `ModuleInfo` struct to provide more informative output when a module name is not set. Instead of returning a generic placeholder, it now includes details about the module's imported globals, imported functions, and total functions.

This makes it possible to identify which modules are involved in a stack trace when no debugging information is present. Without this information, it is tough to pin down where a trap originated.

#### before:

```
Uncaught exception with payload: [I32(...)]
  at _Unwind_RaiseException (python.wasm[8529]:0xffffffff)
  at __cxa_throw (python.wasm[8480]:0xffffffff)
  at <unnamed>(<module>[766]:0xffffffff)
  at <unnamed>(<module>[760]:0xffffffff)
  at <unnamed>(<module>[896]:0xffffffff)
  at _PyWASIX_TrampolineCall (python.wasm[11395]:0xffffffff)
  ...
 ```

#### after:

```
Uncaught exception with payload: [I32(...)]
  at _Unwind_RaiseException (python.wasm[8529]:0xffffffff)
  at __cxa_throw (python.wasm[8480]:0xffffffff)
  at <unnamed>(<module (461 imported globals) (157 imported functions) (343 functions)>[766]:0xffffffff)
  at <unnamed>(<module (461 imported globals) (157 imported functions) (343 functions)>[760]:0xffffffff)
  at <unnamed>(<module (461 imported globals) (157 imported functions) (343 functions)>[896]:0xffffffff)
  at _PyWASIX_TrampolineCall (python.wasm[11395]:0xffffffff)
  ...
 ```
