### PR TITLE
Pin wasix libc version in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -200,7 +200,8 @@ jobs:
           echo "$(pwd)/wasixcc-install" >> $GITHUB_PATH
           mkdir -p ~/.wasixcc/llvm
           mkdir -p ~/.wasixcc/sysroot
-          wasixcc --download-all
+          wasixcc --download-sysroot v2025-11-06.1
+          wasixcc --download-llvm
 
       - name: Tool versions
         run: |


### PR DESCRIPTION
Previously we would always download the latest sysroot from wasix-libc in the CI. This change pins it to a known compatible version
