### PR TITLE
Prevent failure due to rate limits when installing `wasixcc`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -176,6 +176,8 @@ jobs:
 
       - name: Install wasixcc
         uses: wasix-org/wasixcc@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tool versions
         run: |
@@ -874,6 +876,8 @@ jobs:
       - name: Install wasixcc
         if: matrix.metadata.build != 'windows-x64'
         uses: wasix-org/wasixcc@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install LLVM
         shell: bash


### PR DESCRIPTION
This PR attempts to fix random failures during `wasixcc` installation in the CI pipelines. The wasixcc install action makes about 10 calls to GitHub to determine the latest versions of `wasixcc` and its dependencies, and to download them from the GitHub release. The installation sometimes failed due to rate limits. By passing the `GITHUB_TOKEN` to that action, we can increase the rate limit and get fewer failures.
