### PR TITLE
Fixed proc spawn2 when duplicating stdio fds

### DIFF
--- a/lib/wasix/src/syscalls/wasix/proc_spawn2.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn2.rs
@@ -215,8 +215,9 @@ fn apply_fd_op<M: MemorySize>(
                 );
             }
 
-            // We don't want to close the stdin, stdout, or stderr file descriptors
-            if !(op.src_fd == op.fd && op.fd < 3) && env.state.fs.get_fd(op.fd).is_ok() {
+            // According to POSIX dup2 semantics, the target fd should always be closed before duplication
+            // EXCEPT when duplicating a fd to itself (src_fd == fd), which is a no-op.
+            if op.src_fd != op.fd && env.state.fs.get_fd(op.fd).is_ok() {
                 env.state.fs.close_fd(op.fd)?;
             }
 


### PR DESCRIPTION
There is an issue where `proc_spawn2` was closing stdio files automatically (when passed as file actions), which then prevented them to be duplicated, and caused `proc_spawn2` to fail before spawning the executable