### PR TITLE
fix: do not call `detect_features_from_wasm` with WAT content

### DIFF
--- a/lib/cli/src/commands/inspect.rs
+++ b/lib/cli/src/commands/inspect.rs
@@ -30,12 +30,7 @@ impl Inspect {
         let iswasm = is_wasm(&module_contents);
 
         if !iswasm {
-            if self
-                .path
-                .extension()
-                .and_then(|e| e.to_str())
-                == Some("wat")
-            {
+            if self.path.extension().and_then(|e| e.to_str()) == Some("wat") {
                 module_contents = wat2wasm(&module_contents)
                     .map_err(|e| anyhow::anyhow!("Cannot convert WAT to WASM: {e}"))?
                     .to_vec();

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -163,27 +163,22 @@ impl Run {
                             tracing::info!("Failed to read file: {}", path.display());
                         }
                     }
-                    TargetOnDisk::Wat => {
-                        match std::fs::read(path) {
-                            Ok(data) => match wat2wasm(&data) {
-                                Ok(wasm) => {
-                                    wasm_bytes = Some(wasm.to_vec());
-                                }
-                                Err(e) => {
-                                    tracing::info!(
-                                        "Failed to convert WAT to Wasm for {}: {e}",
-                                        path.display()
-                                    );
-                                }
-                            },
+                    TargetOnDisk::Wat => match std::fs::read(path) {
+                        Ok(data) => match wat2wasm(&data) {
+                            Ok(wasm) => {
+                                wasm_bytes = Some(wasm.to_vec());
+                            }
                             Err(e) => {
                                 tracing::info!(
-                                    "Failed to read WAT file {}: {e}",
+                                    "Failed to convert WAT to Wasm for {}: {e}",
                                     path.display()
                                 );
                             }
+                        },
+                        Err(e) => {
+                            tracing::info!("Failed to read WAT file {}: {e}", path.display());
                         }
-                    }
+                    },
                     _ => {}
                 }
             } else {


### PR DESCRIPTION
So far, the `wasmer run` has been calling `detect_features_from_wasm` with the textual representation. Because of that, the function fails terribly. I noticed that while trying to run an exception snippet in a `.wat` file.