### PR TITLE
Enable riscv32 target in LLVM compiler & relocations fixes

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -183,8 +183,14 @@ impl LLVMCompiler {
             || {
                 let target_machine = self.config().target_machine(target);
                 let target_machine_no_opt = self.config().target_machine_with_opt(target, false);
-                FuncTranslator::new(target_machine, Some(target_machine_no_opt), binary_format)
-                    .unwrap()
+                let pointer_width = target.triple().pointer_width().unwrap().bytes();
+                FuncTranslator::new(
+                    target_machine,
+                    Some(target_machine_no_opt),
+                    binary_format,
+                    pointer_width,
+                )
+                .unwrap()
             },
             |func_translator, (i, input)| {
                 let module = func_translator.translate_to_module(
@@ -399,10 +405,12 @@ impl Compiler for LLVMCompiler {
                         let target_machine = self.config().target_machine_with_opt(target, true);
                         let target_machine_no_opt =
                             self.config().target_machine_with_opt(target, false);
+                        let pointer_width = target.triple().pointer_width().unwrap().bytes();
                         FuncTranslator::new(
                             target_machine,
                             Some(target_machine_no_opt),
                             binary_format,
+                            pointer_width,
                         )
                         .unwrap()
                     },

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -244,14 +244,16 @@ impl LLVM {
                 info: true,
                 machine_code: true,
             }),
-            Architecture::Riscv64(_) => InkwellTarget::initialize_riscv(&InitializationConfig {
-                asm_parser: true,
-                asm_printer: true,
-                base: true,
-                disassembler: true,
-                info: true,
-                machine_code: true,
-            }),
+            Architecture::Riscv64(_) | Architecture::Riscv32(_) => {
+                InkwellTarget::initialize_riscv(&InitializationConfig {
+                    asm_parser: true,
+                    asm_printer: true,
+                    base: true,
+                    disassembler: true,
+                    info: true,
+                    machine_code: true,
+                })
+            }
             Architecture::LoongArch64 => {
                 InkwellTarget::initialize_loongarch(&InitializationConfig {
                     asm_parser: true,
@@ -286,11 +288,13 @@ impl LLVM {
         let mut llvm_target_machine_options = TargetMachineOptions::new()
             .set_cpu(match triple.architecture {
                 Architecture::Riscv64(_) => "generic-rv64",
+                Architecture::Riscv32(_) => "generic-rv32",
                 Architecture::LoongArch64 => "generic-la64",
                 _ => "generic",
             })
             .set_features(match triple.architecture {
                 Architecture::Riscv64(_) => "+m,+a,+c,+d,+f",
+                Architecture::Riscv32(_) => "+m,+a,+c,+d,+f",
                 Architecture::LoongArch64 => "+f,+d",
                 _ => &llvm_cpu_features,
             })
@@ -301,7 +305,9 @@ impl LLVM {
             })
             .set_reloc_mode(self.reloc_mode(self.target_binary_format(target)))
             .set_code_model(match triple.architecture {
-                Architecture::LoongArch64 | Architecture::Riscv64(_) => CodeModel::Medium,
+                Architecture::LoongArch64 | Architecture::Riscv64(_) | Architecture::Riscv32(_) => {
+                    CodeModel::Medium
+                }
                 _ => self.code_model(self.target_binary_format(target)),
             });
         if let Architecture::Riscv64(_) = triple.architecture {

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -455,21 +455,28 @@ where
                     0,
                 ) => RelocationKind::Arm64Movw3,
                 (
-                    object::Architecture::Riscv64,
+                    object::Architecture::Riscv64 | object::Architecture::Riscv32,
+                    object::RelocationFlags::Elf {
+                        r_type: object::elf::R_RISCV_64,
+                    },
+                    64,
+                ) => RelocationKind::Abs8,
+                (
+                    object::Architecture::Riscv64 | object::Architecture::Riscv32,
                     object::RelocationFlags::Elf {
                         r_type: object::elf::R_RISCV_CALL_PLT,
                     },
                     0,
                 ) => RelocationKind::RiscvCall,
                 (
-                    object::Architecture::Riscv64,
+                    object::Architecture::Riscv64 | object::Architecture::Riscv32,
                     object::RelocationFlags::Elf {
                         r_type: object::elf::R_RISCV_PCREL_HI20,
                     },
                     0,
                 ) => RelocationKind::RiscvPCRelHi20,
                 (
-                    object::Architecture::Riscv64,
+                    object::Architecture::Riscv64 | object::Architecture::Riscv32,
                     object::RelocationFlags::Elf {
                         r_type: object::elf::R_RISCV_PCREL_LO12_I,
                     },
@@ -573,13 +580,6 @@ where
                     },
                     32,
                 ) => RelocationKind::Abs4,
-                (
-                    object::Architecture::Riscv64,
-                    object::RelocationFlags::Elf {
-                        r_type: object::elf::R_RISCV_64,
-                    },
-                    64,
-                ) => RelocationKind::Abs8,
                 (
                     object::Architecture::Riscv64,
                     object::RelocationFlags::Elf {

--- a/lib/compiler-llvm/src/translator/intrinsics.rs
+++ b/lib/compiler-llvm/src/translator/intrinsics.rs
@@ -1287,6 +1287,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
         cache_builder: &'a Builder<'ctx>,
         abi: &'a dyn Abi,
         config: &'a LLVM,
+        pointer_width: u8,
     ) -> CtxType<'ctx, 'a> {
         CtxType {
             config,
@@ -1303,8 +1304,7 @@ impl<'ctx, 'a> CtxType<'ctx, 'a> {
             cached_functions: HashMap::new(),
             cached_memory_op: HashMap::new(),
 
-            // TODO: pointer width
-            offsets: VMOffsets::new(8, wasm_module),
+            offsets: VMOffsets::new(pointer_width, wasm_module),
         }
     }
 

--- a/lib/compiler/src/artifact_builders/trampoline.rs
+++ b/lib/compiler/src/artifact_builders/trampoline.rs
@@ -40,6 +40,14 @@ const RISCV64_TRAMPOLINE: [u8; 24] = [
     0, 0, 0, 0,
 ];
 
+// AUIPC t1,0     17 03 00 00
+// LW t1, 12(t1)  03 a3 c2 00
+// JR t1          67 00 03 00
+// JMPADDR        00 00 00 00
+const RISCV32_TRAMPOLINE: [u8; 16] = [
+    0x17, 0x03, 0x00, 0x00, 0x03, 0xa3, 0xc2, 0x00, 0x67, 0x00, 0x03, 0x00, 0, 0, 0, 0,
+];
+
 // PCADDI r12, 0      0c 00 00 18
 // LD.D r12, r12, 16  8c 41 c0 28
 // JR r12             80 01 00 4c [00 00 00 00]
@@ -83,6 +91,15 @@ fn make_trampoline(
                 addend: 0,
             });
         }
+        Architecture::Riscv32(_) => {
+            code.extend(RISCV32_TRAMPOLINE);
+            relocations.push(Relocation {
+                kind: RelocationKind::Abs4,
+                reloc_target: RelocationTarget::LibCall(libcall),
+                offset: code.len() as u32 - 4,
+                addend: 0,
+            });
+        }
         Architecture::LoongArch64 => {
             code.extend(LOONGARCH64_TRAMPOLINE);
             relocations.push(Relocation {
@@ -102,6 +119,7 @@ pub fn libcall_trampoline_len(target: &Target) -> usize {
         Architecture::Aarch64(_) => AARCH64_TRAMPOLINE.len(),
         Architecture::X86_64 => X86_64_TRAMPOLINE.len(),
         Architecture::Riscv64(_) => RISCV64_TRAMPOLINE.len(),
+        Architecture::Riscv32(_) => RISCV32_TRAMPOLINE.len(),
         Architecture::LoongArch64 => LOONGARCH64_TRAMPOLINE.len(),
         arch => panic!("Unsupported architecture: {arch}"),
     }

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -1121,11 +1121,13 @@ impl Artifact {
             _ => 1,
         };
 
+        // MetadataHeader::parse requires that metadata must be aligned
+        // by 8 bytes.
         let offset = emit_data(
             &mut obj,
             object_name.as_bytes(),
             metadata_builder.placeholder_data(),
-            default_align,
+            std::cmp::max(8, default_align),
         )
         .map_err(to_compile_error)?;
         metadata_builder.set_section_offset(offset);

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -51,6 +51,7 @@ pub fn get_object_for_target(triple: &Triple) -> Result<Object<'static>, ObjectE
         Architecture::X86_64 => object::Architecture::X86_64,
         Architecture::Aarch64(_) => object::Architecture::Aarch64,
         Architecture::Riscv64(_) => object::Architecture::Riscv64,
+        Architecture::Riscv32(_) => object::Architecture::Riscv32,
         Architecture::LoongArch64 => object::Architecture::LoongArch64,
         architecture => {
             return Err(ObjectError::UnsupportedArchitecture(format!(
@@ -241,11 +242,12 @@ pub fn emit_compilation(
                 section: SymbolSection::Section(section_id),
                 flags: SymbolFlags::None,
             });
-            obj.add_symbol_data(symbol_id, section_id, &function.body, default_align);
-            (section_id, symbol_id)
+            let symbol_offset =
+                obj.add_symbol_data(symbol_id, section_id, &function.body, default_align);
+            (section_id, symbol_id, symbol_offset)
         })
         .collect::<PrimaryMap<LocalFunctionIndex, _>>();
-    for (i, (_, symbol_id)) in function_symbol_ids.iter() {
+    for (i, (_, symbol_id, _)) in function_symbol_ids.iter() {
         relocs_builder.setup_function_pointer(obj, i.index(), *symbol_id)?;
     }
 
@@ -296,7 +298,7 @@ pub fn emit_compilation(
     let mut all_relocations = Vec::new();
 
     for (function_local_index, relocations) in function_relocations.into_iter() {
-        let (section_id, symbol_id) = function_symbol_ids.get(function_local_index).unwrap();
+        let (section_id, symbol_id, _) = function_symbol_ids.get(function_local_index).unwrap();
         all_relocations.push((*section_id, *symbol_id, relocations))
     }
 
@@ -415,6 +417,17 @@ pub fn emit_compilation(
                     r_pcrel: false,
                     r_length: 32,
                 },
+                // For RISC-V relocations, please refer to:
+                // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/2484f950a551c653f1823f1bd11926bf5a57fae3/riscv-elf.adoc#relocations
+                Reloc::RiscvPCRelHi20 => RelocationFlags::Elf {
+                    r_type: elf::R_RISCV_PCREL_HI20,
+                },
+                Reloc::RiscvPCRelLo12I => RelocationFlags::Elf {
+                    r_type: elf::R_RISCV_PCREL_LO12_I,
+                },
+                Reloc::RiscvCall => RelocationFlags::Elf {
+                    r_type: elf::R_RISCV_CALL_PLT,
+                },
                 other => {
                     return Err(ObjectError::UnsupportedArchitecture(format!(
                         "{} (relocation: {other:?})",
@@ -425,17 +438,50 @@ pub fn emit_compilation(
 
             match r.reloc_target {
                 RelocationTarget::LocalFunc(index) => {
-                    let (_, target_symbol) = function_symbol_ids.get(index).unwrap();
-                    obj.add_relocation(
-                        section_id,
-                        Relocation {
-                            offset: relocation_address,
-                            flags: relocation_flags,
-                            symbol: *target_symbol,
-                            addend: r.addend,
-                        },
-                    )
-                    .map_err(ObjectError::Write)?;
+                    let (target_section, target_symbol, target_symbol_offset) =
+                        function_symbol_ids.get(index).unwrap();
+                    if r.kind == Reloc::RiscvPCRelLo12I && r.addend != 0 {
+                        // R_RISCV_PCREL_LO12_I requires addend must be zero, lld would ignore
+                        // non-zero addend values, resulting in linking failures. We must create
+                        // new symbols for R_RISCV_PCREL_LO12_I targets(R_RISCV_PCREL_HI20 addresses).
+                        let function_name =
+                            symbol_registry.symbol_to_name(Symbol::LocalFunction(index));
+                        let hi_symbol_name = format!("{}_offset_{}", function_name, r.addend);
+                        let hi_symbol =
+                            obj.symbol_id(hi_symbol_name.as_bytes()).unwrap_or_else(|| {
+                                obj.add_symbol(ObjSymbol {
+                                    name: hi_symbol_name.as_bytes().to_vec(),
+                                    value: *target_symbol_offset + r.addend as u64,
+                                    size: 0,
+                                    kind: SymbolKind::Label,
+                                    scope: SymbolScope::Compilation,
+                                    weak: false,
+                                    section: SymbolSection::Section(*target_section),
+                                    flags: SymbolFlags::None,
+                                })
+                            });
+                        obj.add_relocation(
+                            section_id,
+                            Relocation {
+                                offset: relocation_address,
+                                flags: relocation_flags,
+                                symbol: hi_symbol,
+                                addend: 0,
+                            },
+                        )
+                        .map_err(ObjectError::Write)?;
+                    } else {
+                        obj.add_relocation(
+                            section_id,
+                            Relocation {
+                                offset: relocation_address,
+                                flags: relocation_flags,
+                                symbol: *target_symbol,
+                                addend: r.addend,
+                            },
+                        )
+                        .map_err(ObjectError::Write)?;
+                    }
                 }
                 RelocationTarget::DynamicTrampoline(_) => todo!("Not supported yet"),
                 RelocationTarget::LibCall(libcall) => {

--- a/lib/types/src/vmoffsets.rs
+++ b/lib/types/src/vmoffsets.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use more_asserts::assert_lt;
 use std::convert::TryFrom;
-use std::mem::size_of;
 
 /// An index type for builtin functions.
 #[derive(Copy, Clone, Debug)]
@@ -329,16 +328,17 @@ impl VMOffsets {
             base.checked_add(num_items.checked_mul(item_size).unwrap())
                 .unwrap()
         }
-        /// Offset base by num_items items of size item_size, panicking on overflow
-        /// Also, will align the value on pointer size boundary,
-        /// to avoid misalignement issue
-        fn offset_by_aligned(base: u32, num_items: u32, item_size: u32) -> u32 {
+        // Offset base by num_items items of size item_size, panicking on overflow
+        // Also, will align the value on pointer size boundary,
+        // to avoid misalignement issue
+        let pointer_size = self.pointer_size as u32;
+        let offset_by_aligned = |base: u32, num_items: u32, item_size: u32| -> u32 {
             align(
                 base.checked_add(num_items.checked_mul(item_size).unwrap())
                     .unwrap(),
-                size_of::<&u32>() as u32,
+                pointer_size,
             )
-        }
+        };
 
         self.vmctx_signature_ids_begin = 0;
         self.vmctx_imported_functions_begin = offset_by_aligned(


### PR DESCRIPTION
This commit contains several RISC-V fixes we've accumulated:

* Handle more RISC-V allocations
* Metadata must be aligned by 8
* Pass pointer width instead of hardcoding it to 8
* Implement trampoline for rv32

It fixes problems using wasmer in rv32, but for now the code does not aim to enable rv32. I feel like it is a bigger decision.
