### PR TITLE
CI(cranelift): fix macos x64

### DIFF
--- a/lib/wasix/tests/context_switching.rs
+++ b/lib/wasix/tests/context_switching.rs
@@ -45,7 +45,7 @@ fn test_with_wasixcc(name: &str) -> Result<(), anyhow::Error> {
     )
 }
 
-// macOS si currently disabled, because cranelift does not
+// macOS is currently disabled, because cranelift does not
 // support exception handling on that platform yet.
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]


### PR DESCRIPTION
Fixes newly enabled tests on macOS where EH is unsupported right now:
```
    Compiling test case: contexts_with_pipes
    Running wasixcc: cd "/Users/runner/work/wasmer/wasmer/lib/wasix/tests/context_switching" && "wasixcc" "/Users/runner/work/wasmer/wasmer/lib/wasix/tests/context_switching/contexts_with_pipes.c" "-fwasm-exceptions" "-o" "/Users/runner/work/wasmer/wasmer/lib/wasix/tests/context_switching/contexts_with_pipes.test.wasm"

    thread 'test_contexts_with_pipes' panicked at lib/wasix/tests/context_switching.rs:36:52:
    Failed to create module: Validate("exceptions proposal not enabled (at offset 0x31d)")
    stack backtrace:
       0: __rustc::rust_begin_unwind
       1: core::panicking::panic_fmt
       2: core::result::unwrap_failed
       3: context_switching::test_with_wasixcc
       4: core::ops::function::FnOnce::call_once
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```