### PR TITLE
Remove ucontext_t definition for FreeBSD for aarch64

### DIFF
--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -54,10 +54,7 @@ struct ucontext_t {
     uc_mcontext: libc::mcontext_t,
 }
 
-#[cfg(all(
-    unix,
-    not(all(target_arch = "aarch64", target_os = "macos"))
-))]
+#[cfg(all(unix, not(all(target_arch = "aarch64", target_os = "macos"))))]
 use libc::ucontext_t;
 
 /// Default stack size is 1MB.


### PR DESCRIPTION
Remove ucontext_t definition for FreeBSD for aarch64 because it is already defined in rust libc.