### PR TITLE
Fix typo in CompileError doc comment

### DIFF
--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -147,7 +147,7 @@ use crate::lib::std::string::String;
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(Error))]
 pub enum CompileError {
-    /// A Wasm translation error occured.
+    /// A Wasm translation error occurred.
     #[cfg_attr(feature = "std", error("WebAssembly translation error: {0}"))]
     Wasm(WasmError),
 


### PR DESCRIPTION
### Motivation
- Fix a spelling mistake in the documentation to improve clarity and consistency.
- The change targets the `CompileError` documentation for the `Wasm` variant in `lib/types/src/error.rs`.

### Description
- Corrected the doc comment from "A Wasm translation error occured." to "A Wasm translation error occurred." in `lib/types/src/error.rs`.
- This is a documentation-only change and does not alter runtime behavior or APIs.

### Testing
- No automated tests were run for this change. 
- The edit is a single-line doc comment update and should not affect compilation or test outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e8315c4a4832e876d67cff1d85658)