### PR TITLE
chore: always use Rayon thread pool (even for one thread)

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -501,10 +501,6 @@ impl Compiler for LLVMCompiler {
             })
             .collect::<PrimaryMap<LocalFunctionIndex, _>>();
 
-        let pool = ThreadPoolBuilder::new()
-            .num_threads(self.config.num_threads.get())
-            .build()
-            .map_err(|e| CompileError::Resource(e.to_string()))?;
         let function_call_trampolines = pool.install(|| {
             module
                 .signatures


### PR DESCRIPTION
It's a super rate path when one uses just a single thread, and even then, we'll get a comparable compilation speed.
Let's simplify the code logic.