### PR TITLE
fix(_Unwind_RaiseException): ignore return value as it's unreliable

### DIFF
--- a/lib/vm/src/libcalls/eh/gcc.rs
+++ b/lib/vm/src/libcalls/eh/gcc.rs
@@ -298,7 +298,7 @@ pub unsafe fn throw(ctx: &StoreObjects, exnref: u32) -> ! {
             InternalStoreHandle::from_index(exnref as usize).unwrap(),
         ));
         log!(
-            "[wasmer][eh] throw -> URC_END_OF_STACK (personality={:p})",
+            "[wasmer][eh] throw -> _Unwind_RaiseException returned (personality={:p})",
             wasmer_eh_personality as *const ()
         );
         crate::raise_lib_trap(crate::Trap::uncaught_exception(exnref, ctx))


### PR DESCRIPTION
Demonstrates on the AArch64 platform for instance.
GCC upstream issue: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114843.