### PR TITLE
CI: do not run test as part of binary build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -431,15 +431,6 @@ jobs:
           docker build -t wasmer/riscv64 ${GITHUB_WORKSPACE}/.github/cross-linux-riscv64/
         env:
           CROSS_DOCKER_IN_DOCKER: true
-      - name: "Run wast test suite for all compilers"
-        run: test-stage-0-wast
-        env:
-          CARGO_BINARY: docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${GITHUB_WORKSPACE}:/project -w /project wasmer/riscv64:latest cargo
-          CROSS_DOCKER_IN_DOCKER: true
-          CARGO_TARGET: riscv64gc-unknown-linux-gnu
-          PKG_CONFIG_PATH: /usr/lib/riscv64-linux-gnu/pkgconfig
-          PKG_CONFIG_ALLOW_CROSS: true
-          ENABLE_LLVM: 0
       - name: Build Wasmer binary
         run: |
           make build-wasmer

--- a/lib/compiler-singlepass/src/emitter_riscv.rs
+++ b/lib/compiler-singlepass/src/emitter_riscv.rs
@@ -12,7 +12,6 @@ pub use crate::{
     machine::{Label, Offset},
     riscv_decl::{FPR, GPR},
 };
-use dynasm::dynasm;
 use dynasmrt::{DynasmApi, DynasmLabelApi, VecAssembler, riscv::RiscvRelocation};
 use wasmer_compiler::types::{
     function::FunctionBody,


### PR DESCRIPTION
The tests are part of the `test.yml` configuration, no need to run them as part of release build.