### PR TITLE
Support compressed package downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -7319,6 +7321,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "env_logger",
+ "flate2",
  "futures",
  "getrandom 0.2.17",
  "heapless 0.9.2",
@@ -7388,6 +7391,7 @@ dependencies = [
  "weezl",
  "windows-sys 0.61.2",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]
@@ -8166,4 +8170,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ env_logger = { version = "0.11.5", default-features = false }
 field-offset = "0.3.3"
 filetime = "0.2.18"
 flate2 = "1.0.34"
+zstd = "0.13.2"
 fnv = "1.0.3"
 fs_extra = { version = "1.3.0" }
 futures = "0.3.30"

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -253,6 +253,7 @@ reqwest = { workspace = true, default-features = false, features = [
 	"json",
 	"multipart",
 	"gzip",
+	"zstd",
 ] }
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))'.dependencies]
@@ -260,6 +261,7 @@ reqwest = { workspace = true, default-features = false, features = [
 	"native-tls",
 	"json",
 	"multipart",
+	"zstd",
 ] }
 
 

--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -204,7 +204,10 @@ impl PackageDownload {
 
         let b = client
             .get(download_url)
-            .header(http::header::ACCEPT, "application/webc");
+            .header(http::header::ACCEPT, "application/webc")
+            // NOTE: reqwest handles gzip/zstd decoding the response body
+            // automatically when the relevant features are enabled.
+            .header(http::header::ACCEPT_ENCODING, "zstd;q=1.0, gzip;q=0.8");
 
         pb.println(format!(
             "{} {DOWNLOADING_PACKAGE_EMOJI}Downloading package {ident} ...",

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -100,6 +100,7 @@ bytecheck.workspace = true
 blake3.workspace = true
 petgraph.workspace = true
 lz4_flex.workspace = true
+flate2.workspace = true
 rayon = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
@@ -152,6 +153,7 @@ windows-sys = { workspace = true, features = [
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 terminal_size.workspace = true
+zstd.workspace = true
 
 [dev-dependencies]
 wasmer = { path = "../api", version = "=7.0.0-alpha.2", default-features = false, features = [


### PR DESCRIPTION
Add support for compressed package downloads, both in the CLI and
in WASIX.

Uses the builtin reqwest support in the CLI, and custom decoding logic in 
the WASIX BuiltinPackageLoader.

Resolves: #6060
