### PR TITLE
chore: drop .cargo/config.toml

### DIFF
--- a/.github/cross-linux-riscv64/Dockerfile
+++ b/.github/cross-linux-riscv64/Dockerfile
@@ -71,3 +71,6 @@ COPY build_openssl.sh /
 RUN /build_openssl.sh
 ENV RISCV64GC_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR=/openssl_riscv64/include
 ENV RISCV64GC_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/openssl_riscv64/lib
+
+RUN mkdir .cargo
+COPY config.toml .cargo/config.toml

--- a/.github/cross-linux-riscv64/config.toml
+++ b/.github/cross-linux-riscv64/config.toml
@@ -1,0 +1,3 @@
+[target.riscv64gc-unknown-linux-gnu]
+linker = "riscv64-linux-gnu-gcc"
+runner = "qemu-riscv64 -L /usr/riscv64-linux-gnu/"


### PR DESCRIPTION
The config is problematic as one can't distinguish in between native and cross run. Thus, people should put the linker/runner to `~/.cargo/config.toml` if interested.