### PR TITLE
Run tests under cargo test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -627,7 +627,7 @@ build-capi-headless-ios:
 
 # test compilers
 test-stage-0-wast:
-	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --release $(compiler_features) --locked
+	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release $(compiler_features) --locked
 
 # test packages
 test-stage-1-test-all:


### PR DESCRIPTION
Testing macos failure when it comes to exception handling.