### PR TITLE
CI: skip tests on RISC-V and LoongArch64

### DIFF
--- a/tests/compilers/deterministic.rs
+++ b/tests/compilers/deterministic.rs
@@ -13,7 +13,7 @@ fn compile_and_compare(config: crate::Config, wasm: &[u8]) -> Result<()> {
             return Ok(());
         }
         Ok(module) => module,
-        _ => unreachable!(),
+        Err(e) => return Err(e.into()),
     };
     let first = module.serialize()?;
 

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -58,7 +58,7 @@ llvm+riscv64      spec::simd::simd_f64x2_rounding::llvm::universal
 llvm+riscv64      wasmer::nan_canonicalization::llvm::universal
 
 #6032
-llvm+riscv64          wasmer::stack_overflow_sret::llvm
+llvm+riscv64      wasmer::stack_overflow_sret::llvm
 llvm+loongarch64      wasmer::stack_overflow_sret::llvm
 
 # riscv support on Cranelift is also very young


### PR DESCRIPTION
With the change of `ignores.txt`, tests are now green on the aforementioned secondary platforms.