### PR TITLE
fix(cranelift): support ::Exn (fix php/php-32 compilation)

### DIFF
--- a/lib/compiler-cranelift/src/translator/func_translator.rs
+++ b/lib/compiler-cranelift/src/translator/func_translator.rs
@@ -203,7 +203,8 @@ fn declare_locals<FE: FuncEnvironment + ?Sized>(
         Ref(ty) => {
             if ty.is_func_ref() || ty.is_extern_ref() {
                 builder.ins().iconst(environ.reference_type(), 0)
-            } else if ty == RefType::EXNREF {
+            } else if ty == RefType::EXNREF || ty == RefType::EXN {
+                // no `.is_exnref` yet
                 builder.ins().iconst(EXN_REF_TYPE, 0)
             } else {
                 return Err(wasm_unsupported!("unsupported reference type: {:?}", ty));

--- a/lib/compiler-cranelift/src/translator/translation_utils.rs
+++ b/lib/compiler-cranelift/src/translator/translation_utils.rs
@@ -113,7 +113,8 @@ pub fn block_with_params<'a, PE: TargetEnvironment + ?Sized>(
             wasmparser::ValType::Ref(ty) => {
                 if ty.is_extern_ref() || ty.is_func_ref() {
                     builder.append_block_param(block, environ.reference_type());
-                } else if ty == &RefType::EXNREF {
+                } else if ty == &RefType::EXNREF || ty == &RefType::EXN {
+                    // no `.is_exnref` yet
                     builder.append_block_param(block, EXN_REF_TYPE);
                 } else {
                     return Err(WasmError::Unsupported(format!(


### PR DESCRIPTION
Fixes:
```
     Running `target/debug/wasmer run --disable-cache -c php/php-32 -- --version`
error: Spawn failed
╰─▶ 1: compile error: Wasm(Unsupported("unsupported reference type: (ref exn)"))
```

where now we get:
```
❯ cn r -p wasmer-cli --features=llvm,cranelift,singlepass run --disable-cache -c python/python -- --version
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/wasmer run --disable-cache -c python/python -- --version`
Python 3.13.0rc2
```