### PR TITLE
fix(wasix): Restore proper webc v2 mount handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7316,6 +7316,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
+ "ciborium",
  "cooked-waker",
  "crossbeam-channel",
  "dashmap",

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -171,6 +171,7 @@ wasm-bindgen-test.workspace = true
 env_logger = { workspace = true, default-features = false }
 log.workspace = true
 assert-panic.workspace = true
+ciborium.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -581,30 +581,21 @@ fn filesystem_v2(
             format!("The \"{package}\" package doesn't have a \"{volume_name}\" volume")
         })?;
 
-        let mount_path_clone = mount_path.clone();
-        // Get a filesystem which will map "$mount_dir/some-path" to
-        // "$original_path/some-path" on the original volume
+        // UnionFileSystem strips the mount point before forwarding paths to the
+        // mounted filesystem. That means paths are already relative to the
+        // mount root and shouldn't be stripped by mount_path.
         let fs = if let Some(original) = original_path {
             let original = PathBuf::from(original);
 
             MappedPathFileSystem::new(
                 WebcVolumeFileSystem::new(volume.clone()),
-                Box::new(move |path: &Path| {
-                    let without_mount_dir = path
-                        .strip_prefix(&mount_path_clone)
-                        .map_err(|_| virtual_fs::FsError::BaseNotDirectory)?;
-                    Ok(original.join(without_mount_dir))
-                }) as DynPathMapper,
+                Box::new(move |path: &Path| Ok(original.join(strip_root_prefix(path))))
+                    as DynPathMapper,
             )
         } else {
             MappedPathFileSystem::new(
                 WebcVolumeFileSystem::new(volume.clone()),
-                Box::new(move |path: &Path| {
-                    let without_mount_dir = path
-                        .strip_prefix(&mount_path_clone)
-                        .map_err(|_| virtual_fs::FsError::BaseNotDirectory)?;
-                    Ok(without_mount_dir.to_owned())
-                }) as DynPathMapper,
+                Box::new(move |path: &Path| Ok(strip_root_prefix(path))) as DynPathMapper,
             )
         };
 
@@ -612,6 +603,10 @@ fn filesystem_v2(
     }
 
     Ok(union_fs)
+}
+
+fn strip_root_prefix(path: &Path) -> PathBuf {
+    path.strip_prefix("/").unwrap_or(path).to_owned()
 }
 
 type DynPathMapper = Box<dyn Fn(&Path) -> Result<PathBuf, virtual_fs::FsError> + Send + Sync>;
@@ -702,6 +697,98 @@ where
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, HashMap},
+        path::{Path, PathBuf},
+    };
+
+    use ciborium::value::Value;
+    use virtual_fs::FileSystem;
+    use wasmer_config::package::PackageId;
+    use webc::{
+        Container,
+        indexmap::IndexMap,
+        metadata::{
+            Manifest,
+            annotations::{FileSystemMapping, FileSystemMappings},
+        },
+        v2::{
+            SignatureAlgorithm,
+            read::OwnedReader,
+            write::{DirEntry, Directory, FileEntry, Writer},
+        },
+    };
+
+    use super::{ResolvedFileSystemMapping, ResolvedPackage, filesystem_v2};
+
+    #[test]
+    fn v2_filesystem_mapping_resolves_mount_paths() {
+        // Regression test: v2 fs mounts are already relative to the mount root,
+        // so stripping the mount path again breaks lookups like /public.
+        let mut manifest = Manifest::default();
+        let fs = FileSystemMappings(vec![FileSystemMapping {
+            from: None,
+            volume_name: "atom".to_string(),
+            host_path: Some("/public".to_string()),
+            mount_path: "/public".to_string(),
+        }]);
+        let mut package = IndexMap::new();
+        package.insert(
+            FileSystemMappings::KEY.to_string(),
+            Value::serialized(&fs).unwrap(),
+        );
+        manifest.package = package;
+
+        let mut public_children = BTreeMap::new();
+        public_children.insert(
+            "index.html".parse().unwrap(),
+            DirEntry::File(FileEntry::from(b"ok".as_slice())),
+        );
+        let public_dir = Directory {
+            children: public_children,
+        };
+        let mut root_children = BTreeMap::new();
+        root_children.insert("public".parse().unwrap(), DirEntry::Dir(public_dir));
+        let atom_dir = Directory {
+            children: root_children,
+        };
+
+        let writer = Writer::default().write_manifest(&manifest).unwrap();
+        let writer = writer.write_atoms(BTreeMap::new()).unwrap();
+        let writer = writer.with_volume("atom", atom_dir).unwrap();
+        let bytes = writer.finish(SignatureAlgorithm::None).unwrap();
+
+        let reader = OwnedReader::parse(bytes).unwrap();
+        let container = Container::from(reader);
+
+        let pkg_id = PackageId::new_named("ns/pkg", "0.1.0".parse().unwrap());
+        let mut packages = HashMap::new();
+        packages.insert(pkg_id.clone(), container);
+
+        let pkg = ResolvedPackage {
+            root_package: pkg_id.clone(),
+            commands: BTreeMap::new(),
+            entrypoint: None,
+            filesystem: vec![ResolvedFileSystemMapping {
+                mount_path: PathBuf::from("/public"),
+                volume_name: "atom".to_string(),
+                original_path: Some("/public".to_string()),
+                package: pkg_id,
+            }],
+        };
+
+        let union_fs = filesystem_v2(&packages, &pkg, false).unwrap();
+        assert!(union_fs.metadata(Path::new("/public")).unwrap().is_dir());
+        assert!(
+            union_fs
+                .metadata(Path::new("/public/index.html"))
+                .unwrap()
+                .is_file()
+        );
+    }
+}
 impl<F, M> virtual_fs::FileOpener for MappedPathFileSystem<F, M>
 where
     F: FileSystem,


### PR DESCRIPTION
Commit f8ce5e3 changed union fs mounting semantics of package volumes.

This broke mounting for some webc v2 volumes.
Example broken package:  syrusakbary/web@^0.3.0

This commit fixes v2 mounting logic again by aligning with path
stripping semantics.

No impact on v3 webcs, those use a separate code path.

Closes #6111
