### PR TITLE
fix: do not use engine.new_module_with_progress for non-sys Engines

### DIFF
--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -366,8 +366,12 @@ pub async fn load_module(
         });
         #[cfg(feature = "sys-default")]
         {
-            use wasmer::sys::NativeEngineExt;
-            engine.new_module_with_progress(input.wasm(), p)
+            if engine.is_sys() {
+                use wasmer::sys::NativeEngineExt;
+                engine.new_module_with_progress(input.wasm(), p)
+            } else {
+                Module::new(&engine, input.wasm())
+            }
         }
         #[cfg(not(feature = "sys-default"))]
         {


### PR DESCRIPTION
We regressed in the revision where the progress bar for `wasmer cli` got merged.