### PR TITLE
wasix: fix sock_set_opt_size option validation

### DIFF
--- a/lib/wasix/src/syscalls/wasix/sock_set_opt_size.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_set_opt_size.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{net::socket::TimeType, syscalls::*};
+use crate::{net::socket::WasiSocketOption, syscalls::*};
 
 /// ### `sock_set_opt_size()
 /// Set size of particular option for this socket
@@ -38,16 +38,17 @@ pub(crate) fn sock_set_opt_size_internal(
     opt: Sockoption,
     size: Filesize,
 ) -> Result<Result<(), Errno>, WasiError> {
-    let ty = match opt {
-        Sockoption::RecvTimeout => TimeType::ReadTimeout,
-        Sockoption::SendTimeout => TimeType::WriteTimeout,
-        Sockoption::ConnectTimeout => TimeType::ConnectTimeout,
-        Sockoption::AcceptTimeout => TimeType::AcceptTimeout,
-        Sockoption::Linger => TimeType::Linger,
-        _ => return Ok(Err(Errno::Inval)),
-    };
+    if !matches!(
+        opt,
+        Sockoption::RecvBufSize
+            | Sockoption::SendBufSize
+            | Sockoption::Ttl
+            | Sockoption::MulticastTtlV4
+    ) {
+        return Ok(Err(Errno::Inval));
+    }
 
-    let option: crate::net::socket::WasiSocketOption = match opt.try_into() {
+    let option: WasiSocketOption = match opt.try_into() {
         Ok(o) => o,
         Err(_) => return Ok(Err(Errno::Inval)),
     };
@@ -55,11 +56,11 @@ pub(crate) fn sock_set_opt_size_internal(
         ctx,
         sock,
         Rights::empty(),
-        |mut socket, _| match opt {
-            Sockoption::RecvBufSize => socket.set_recv_buf_size(size as usize),
-            Sockoption::SendBufSize => socket.set_send_buf_size(size as usize),
-            Sockoption::Ttl => socket.set_ttl(size as u32),
-            Sockoption::MulticastTtlV4 => socket.set_multicast_ttl_v4(size as u32),
+        |mut socket, _| match option {
+            WasiSocketOption::RecvBufSize => socket.set_recv_buf_size(size as usize),
+            WasiSocketOption::SendBufSize => socket.set_send_buf_size(size as usize),
+            WasiSocketOption::Ttl => socket.set_ttl(size as u32),
+            WasiSocketOption::MulticastTtlV4 => socket.set_multicast_ttl_v4(size as u32),
             _ => Err(Errno::Inval),
         }
     ));


### PR DESCRIPTION
Syscall `sock_set_opt_size_internal` supports following options:
```rust
Sockoption::RecvBufSize,
Sockoption::SendBufSize,
Sockoption::Ttl,
Sockoption::MulticastTtlV4,
```

but validation was wrong - it was checking for options that are not even accepted by this syscall. My bet it was a copy-paste error from another syscall `sock_set_opt_time.r` https://github.com/wasmerio/wasmer/blob/17b23c124032153ee3fd43a3e6370b930303018f/lib/wasix/src/syscalls/wasix/sock_set_opt_time.rs#L31-L38

```rust
let ty = match opt {
        Sockoption::RecvTimeout => TimeType::ReadTimeout,
        Sockoption::SendTimeout => TimeType::WriteTimeout,
        Sockoption::ConnectTimeout => TimeType::ConnectTimeout,
        Sockoption::AcceptTimeout => TimeType::AcceptTimeout,
        Sockoption::Linger => TimeType::Linger,
        _ => return Ok(Err(Errno::Inval)),
    };
```

This PR fixes that and does proper validation.

Closes https://github.com/wasmerio/wasmer/issues/6141