### PR TITLE
Fix mounts not being handled properly when running a package directly…

### DIFF
--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -242,7 +242,7 @@ impl Run {
 
         if let ExecutableTarget::Package(ref pkg) = target {
             self.wasi
-                .all_volumes()
+                .volumes
                 .extend(pkg.additional_host_mapped_directories.clone());
         }
 
@@ -557,14 +557,14 @@ impl Run {
 
         let mut runner = WasiRunner::new();
 
-        let (is_home_mapped, mapped_diretories) = self.wasi.build_mapped_directories(is_wasix)?;
+        let (is_home_mapped, mapped_directories) = self.wasi.build_mapped_directories(is_wasix)?;
 
         runner
             .with_args(&self.args)
             .with_injected_packages(packages)
             .with_envs(self.wasi.env_vars.clone())
             .with_mapped_host_commands(self.wasi.build_mapped_commands()?)
-            .with_mapped_directories(mapped_diretories)
+            .with_mapped_directories(mapped_directories)
             .with_home_mapped(is_home_mapped)
             .with_forward_host_env(self.wasi.forward_host_env)
             .with_capabilities(self.wasi.capabilities());

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -67,7 +67,7 @@ pub struct Wasi {
         name = "[HOST_DIR:]GUEST_DIR",
         value_parser = parse_volume,
     )]
-    volumes: Vec<MappedDirectory>,
+    pub(crate) volumes: Vec<MappedDirectory>,
 
     // Legacy option
     #[clap(long = "dir", group = "wasi", hide = true)]

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -864,7 +864,7 @@ impl WasiEnvBuilder {
                 }
                 Err(err) => {
                     return Err(WasiStateCreationError::WasiFsSetupError(format!(
-                        "Could check specified current directory at '{}': {err}",
+                        "Could not check specified current directory at '{}': {err}",
                         dir.display()
                     )));
                 }


### PR DESCRIPTION
… from disk (via wasmer.toml)

This PR fixes a regression that caused mapped directories specified in `wasmer.toml` to not be mounted into guests' FS when running directly from disk (such as `wasmer run .`).
