### PR TITLE
fix(sdk): Inaccurate handling of command-line arguments in `proc_exec`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7386,6 +7386,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "itertools 0.14.0",
  "js-sys",
  "libc",
  "linked_hash_set",

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -41,6 +41,7 @@ shared-buffer.workspace = true
 hyper = { workspace = true, features = ["server"], optional = true }
 derive_more.workspace = true
 wasm-encoder.workspace = true
+itertools.workspace = true
 
 xxhash-rust = { workspace = true, features = ["xxh64"] }
 rusty_pool = { workspace = true, optional = true }

--- a/lib/wasix/src/syscalls/wasix/proc_exec3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_exec3.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use wasmer::FromToNativeWasmType;
 
 use super::*;
@@ -55,8 +56,8 @@ pub fn proc_exec3<M: MemorySize>(
     })?;
     let args: Vec<_> = args
         .split(&['\n', '\r'])
+        .dropping_back(1) // `split` returns one last (empty) element
         .map(|a| a.to_string())
-        .filter(|a| !a.is_empty())
         .collect();
 
     let envs = if !envs.is_null() {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
In POSIX, invoking a program from the shell with empty arguments (e.g., `funky fir "" tern`) should pass all arguments, including the empty ones, to the subprocess.

The implementation was filtering by `.is_empty`, presumably to get rid of the last element returned from `.split`, as the arguments are passed as a string, as per the WASI specifications, and the last argument has a trailing EOL.
