### PR TITLE
cicd: Disable integration tests (temporarily... hopefully)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1144,6 +1144,8 @@ jobs:
           #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-wasmer-integration-tests:
+    # TODO(SRE-1320): Re-enable once integration test are consistently green
+    if: ${{ false }}
     name: "Remote integ. tests"
     needs: [build]
     uses: wasmerio/wasmer-integration-tests/.github/workflows/integration-test-workflow.yaml@main


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
The integration tests are currently not stable, mostly due to the backend and/or our internal service provider migrations. As they are very flaky, they rarely provide any useful insight.

Ticket for re-enabling is here: [SRE-1320: Re-enable integration-tests for wasmer repo](https://linear.app/wasmer/issue/SRE-1320/re-enable-integration-tests-for-wasmer-repo).

So this is the plan B as I don't have enough time to stabilize infra + backend at the moment, too many other pressing things. 