### PR TITLE
feat(cli): use percent indication in progress bar

### DIFF
--- a/lib/cli/src/commands/run/runtime.rs
+++ b/lib/cli/src/commands/run/runtime.rs
@@ -150,11 +150,14 @@ impl<R: wasmer_wasix::Runtime + Send + Sync> wasmer_wasix::Runtime for Monitorin
                             pb.set_length(step_count);
                             pb.set_position(step);
                             // Note: writing to strings can not fail.
-                            let _ = write!(
-                                &mut msg,
-                                " ({:.0}%)",
-                                100.0 * step as f32 / step_count as f32
-                            );
+                            if step_count != 0 {
+                                write!(
+                                    &mut msg,
+                                    " ({:.0}%)",
+                                    100.0 * step as f32 / step_count as f32
+                                )
+                                .unwrap();
+                            }
                         };
                         pb.tick();
 


### PR DESCRIPTION
With the recent change of the progress bar steps (byte size of the input module), the numbers started to be quite big, thus I would rather display percent numbers.