### PR TITLE
virtual-fs: Hide package contents under bind‑mounts by filtering overlay secondaries

### DIFF
--- a/lib/virtual-fs/src/overlay_fs.rs
+++ b/lib/virtual-fs/src/overlay_fs.rs
@@ -65,6 +65,7 @@ use crate::{
 pub struct OverlayFileSystem<P, S> {
     primary: Arc<P>,
     secondaries: S,
+    opaque_prefixes: Vec<PathBuf>,
 }
 
 impl<P, S> OverlayFileSystem<P, S>
@@ -78,6 +79,21 @@ where
         OverlayFileSystem {
             primary: Arc::new(primary),
             secondaries,
+            opaque_prefixes: Vec::new(),
+        }
+    }
+
+    /// Create a new [`FileSystem`] with opaque prefixes that hide any secondary
+    /// entries under those paths.
+    pub fn new_with_opaque_prefixes(
+        primary: P,
+        secondaries: S,
+        opaque_prefixes: Vec<PathBuf>,
+    ) -> Self {
+        OverlayFileSystem {
+            primary: Arc::new(primary),
+            secondaries,
+            opaque_prefixes,
         }
     }
 
@@ -96,8 +112,31 @@ where
         &mut self.secondaries
     }
 
+    fn is_opaque(&self, path: &Path) -> bool {
+        let normalized = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            Path::new("/").join(path)
+        };
+
+        self.opaque_prefixes
+            .iter()
+            .any(|prefix| normalized.starts_with(prefix))
+    }
+
+    fn secondaries_iter<'a>(
+        &'a self,
+        path: &Path,
+    ) -> Box<dyn Iterator<Item = &'a (dyn FileSystem + Send)> + 'a> {
+        if self.is_opaque(path) {
+            Box::new(std::iter::empty())
+        } else {
+            Box::new(self.secondaries.filesystems().into_iter())
+        }
+    }
+
     fn permission_error_or_not_found(&self, path: &Path) -> Result<(), FsError> {
-        for fs in self.secondaries.filesystems() {
+        for fs in self.secondaries_iter(path) {
             if ops::exists(fs, path) {
                 return Err(FsError::PermissionDenied);
             }
@@ -132,7 +171,7 @@ where
         }
 
         // Otherwise scan the secondaries
-        for fs in self.secondaries.filesystems() {
+        for fs in self.secondaries_iter(path) {
             match fs.readlink(path) {
                 Err(e) if should_continue(e) => continue,
                 other => return other,
@@ -148,7 +187,7 @@ where
         let mut white_outs = HashSet::new();
 
         let filesystems = std::iter::once(&self.primary as &(dyn FileSystem + Send))
-            .chain(self.secondaries().filesystems());
+            .chain(self.secondaries_iter(path));
 
         for fs in filesystems {
             match fs.read_dir(path) {
@@ -255,7 +294,7 @@ where
         // If the directory is contained in a secondary file system then we need to create a
         // whiteout file so that it is suppressed and is no longer returned in `readdir` calls.
 
-        let had_at_least_one_success = self.secondaries.filesystems().into_iter().any(|fs| {
+        let had_at_least_one_success = self.secondaries_iter(path).any(|fs| {
             fs.read_dir(path).is_ok() && ops::create_white_out(&self.primary, path).is_ok()
         });
 
@@ -313,7 +352,8 @@ where
             // the secondaries, in which case we need to copy it to the
             // primary rather than rename it
             if !had_at_least_one_success {
-                for fs in self.secondaries.filesystems() {
+                let secondaries: Vec<_> = self.secondaries_iter(&from).collect();
+                for fs in secondaries {
                     if fs.metadata(&from).is_ok() {
                         ops::copy_reference_ext(fs, &self.primary, &from, &to).await?;
                         had_at_least_one_success = true;
@@ -325,7 +365,8 @@ where
             // If the rename operation was a success then we need to update any
             // whiteout files on the primary before we return success.
             if had_at_least_one_success {
-                for fs in self.secondaries.filesystems() {
+                let secondaries: Vec<_> = self.secondaries_iter(&from).collect();
+                for fs in secondaries {
                     if fs.metadata(&from).is_ok() {
                         tracing::trace!(
                             path=%from.display(),
@@ -363,7 +404,7 @@ where
         }
 
         // Otherwise scan the secondaries
-        for fs in self.secondaries.filesystems() {
+        for fs in self.secondaries_iter(path) {
             match fs.metadata(path) {
                 Err(e) if should_continue(e) => continue,
                 other => return other,
@@ -392,7 +433,7 @@ where
         }
 
         // Otherwise scan the secondaries
-        for fs in self.secondaries.filesystems() {
+        for fs in self.secondaries_iter(path) {
             match fs.symlink_metadata(path) {
                 Err(e) if should_continue(e) => continue,
                 other => return other,
@@ -411,7 +452,7 @@ where
 
         // If the file is contained in a secondary then then we need to create a
         // whiteout file so that it is suppressed.
-        let had_at_least_one_success = self.secondaries.filesystems().into_iter().any(|fs| {
+        let had_at_least_one_success = self.secondaries_iter(path).any(|fs| {
             fs.metadata(path).is_ok() && ops::create_white_out(&self.primary, path).is_ok()
         });
 
@@ -510,7 +551,7 @@ where
 
         // If the file is on a secondary then we should open it
         if !ops::has_white_out(&self.primary, path) {
-            for fs in self.secondaries.filesystems() {
+            for fs in self.secondaries_iter(path) {
                 let mut sub_conf = conf.clone();
                 sub_conf.create = false;
                 sub_conf.create_new = false;
@@ -1173,6 +1214,72 @@ mod tests {
         assert_eq!(
             entries,
             vec![PathBuf::from("/app/wp-content/themes/twentytwentyfour")],
+        );
+    }
+
+    #[test]
+    fn overlay_opaque_prefix_hides_secondaries() {
+        let primary = MemFS::default();
+        let secondary = MemFS::default();
+
+        ops::create_dir_all(&primary, "/app/wp-content").unwrap();
+        primary
+            .new_open_options()
+            .create(true)
+            .write(true)
+            .open("/app/wp-content/host.txt")
+            .unwrap();
+
+        ops::create_dir_all(&secondary, "/app/wp-content/themes/twentyten").unwrap();
+
+        let overlay = OverlayFileSystem::new_with_opaque_prefixes(
+            primary,
+            [secondary],
+            vec![PathBuf::from("/app/wp-content")],
+        );
+
+        let entries: Vec<_> = overlay
+            .read_dir(Path::new("/app/wp-content"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path)
+            .collect();
+
+        assert_eq!(entries, vec![PathBuf::from("/app/wp-content/host.txt")]);
+        assert_eq!(
+            overlay
+                .metadata(Path::new("/app/wp-content/themes"))
+                .unwrap_err(),
+            FsError::EntryNotFound
+        );
+    }
+
+    #[test]
+    fn overlay_opaque_prefix_prevents_parent_copy_up_on_create() {
+        let primary = MemFS::default();
+        let secondary = MemFS::default();
+
+        ops::create_dir_all(&secondary, "/app/wp-content/themes").unwrap();
+
+        let overlay = OverlayFileSystem::new_with_opaque_prefixes(
+            primary,
+            [secondary],
+            vec![PathBuf::from("/app/wp-content")],
+        );
+
+        let err = overlay
+            .new_open_options()
+            .create(true)
+            .write(true)
+            .open("/app/wp-content/themes/foo.txt")
+            .unwrap_err();
+        assert_eq!(err, FsError::EntryNotFound);
+
+        assert_eq!(
+            overlay
+                .primary()
+                .metadata(Path::new("/app/wp-content/themes"))
+                .unwrap_err(),
+            FsError::EntryNotFound
         );
     }
 

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -220,6 +220,7 @@ fn prepare_filesystem(
 ) -> Result<WasiFsRoot, Error> {
     let mut root_layers: Vec<Arc<dyn FileSystem + Send + Sync>> = Vec::new();
     let mount_fs = MountFileSystem::new();
+    let mut opaque_prefixes = Vec::new();
 
     for MountedDirectory { guest, fs } in mounted_dirs {
         let guest_path = normalized_mount_path(guest)?;
@@ -228,6 +229,7 @@ fn prepare_filesystem(
         if guest_path == Path::new("/") {
             root_layers.push(fs.clone());
         } else {
+            opaque_prefixes.push(guest_path.clone());
             match conflict_behavior {
                 ExistingMountConflictBehavior::Fail => mount_fs
                     .mount(&guest_path, fs.clone())
@@ -265,9 +267,10 @@ fn prepare_filesystem(
     let root_mount: Arc<dyn FileSystem + Send + Sync> = if root_layers.is_empty() {
         base_root
     } else {
-        Arc::new(OverlayFileSystem::new(
+        Arc::new(OverlayFileSystem::new_with_opaque_prefixes(
             ArcFileSystem::new(base_root),
             root_layers,
+            opaque_prefixes,
         ))
     };
 
@@ -853,6 +856,58 @@ mod tests {
                 .to_string()
                 .contains("parent traversal escapes the virtual root"),
             "{error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_mount_replaces_container_root_subtree() {
+        use virtual_fs::FileSystem;
+
+        let user_mount = TmpFileSystem::new();
+        user_mount
+            .new_open_options()
+            .create(true)
+            .write(true)
+            .open(Path::new("/diag.php"))
+            .unwrap();
+
+        let package_root = TmpFileSystem::new();
+        virtual_fs::create_dir_all(&package_root, Path::new("/app/wp-content/themes")).unwrap();
+        package_root
+            .new_open_options()
+            .create(true)
+            .write(true)
+            .open(Path::new("/app/wp-content/themes/style.css"))
+            .unwrap();
+
+        let mounted_dirs = [MountedDirectory {
+            guest: "/app/wp-content".to_string(),
+            fs: Arc::new(user_mount),
+        }];
+
+        let container_mounts = MountFileSystem::new();
+        container_mounts
+            .mount(Path::new("/"), Arc::new(package_root))
+            .unwrap();
+
+        let root_fs = RootFileSystemBuilder::default().build();
+        let fs = prepare_filesystem(
+            base_root(&root_fs),
+            None,
+            &mounted_dirs,
+            Some(&package_mounts(container_mounts)),
+            ExistingMountConflictBehavior::Override,
+        )
+        .unwrap();
+
+        assert!(
+            fs.metadata(Path::new("/app/wp-content/diag.php"))
+                .unwrap()
+                .is_file()
+        );
+        assert_eq!(
+            fs.metadata(Path::new("/app/wp-content/themes")),
+            Err(virtual_fs::FsError::EntryNotFound)
         );
     }
 


### PR DESCRIPTION
Host bind‑mounts were incorrectly merged with package filesystem contents, causing package files (and even directories) to appear inside the mounted path and leak back to the host. 

```bash
$ cd /tmp
$ touch foo.txt
$ # Folders from the package merged with the mounted folder
$ wasmer run --registry wasmer.wtf wasmer/bash --use sha256:3a4d0b7932f16e70bdd38cd84ad478129c8e9dedd4ed41040938799ad21e6993 --mapdir /app/wp-content:$(pwd) -- -c "ls -a /app/wp-content; ls  /app/wp-content"
themes
plugins
foo.txt
$ ls /tmp # Folders from package itself leak to the host after
themes 
plugins
```

This PR makes bind‑mounted paths opaque to the overlay by filtering secondary filesystems under those prefixes, so the host mount replaces the package path (basically like in Docker) while keeping package mounts working for other paths.

