### PR TITLE
fix(perfmap): support shared libraries (append to file)

### DIFF
--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -566,10 +566,7 @@ impl EngineInner {
                 .create(true)
                 .open(&filename)
                 .map_err(|e| {
-                    CompileError::Codegen(format!(
-                        "failed to open perf map file {}: {}",
-                        filename, e
-                    ))
+                    CompileError::Codegen(format!("failed to open perf map file {filename}: {e}"))
                 })?;
             let mut file = std::io::BufWriter::new(file);
 
@@ -578,8 +575,8 @@ impl EngineInner {
                 if let Some(func_name) = module_info.function_names.get(&func_index) {
                     let sanitized_name = func_name.replace(['\n', '\r'], "_");
                     let line = format!(
-                        "{:p} {:x} {}\n",
-                        code.ptr.0 as *const _, code.length, sanitized_name
+                        "{:p} {:x} {sanitized_name}\n",
+                        code.ptr.0 as *const _, code.length
                     );
                     write!(file, "{line}").map_err(|e| CompileError::Codegen(e.to_string()))?;
                 }


### PR DESCRIPTION
Noticed that when using multiple shared libraries, the `/tmp/perf-{pid}.map` file was being overwritten. Also, we don’t need to replicate addresses for unnamed symbols, and there’s no need to flush on every loop iteration.