### PR TITLE
CI: skip zig step (unused)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1001,7 +1001,7 @@ jobs:
 
     container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v6      
+      - uses: actions/checkout@v6
       - name: Set up base deps on musl
         if: matrix.build == 'linux-musl'
         run: |


### PR DESCRIPTION
Fixes:
```
/opt/homebrew/bin/gtar --posix -cf cache.tzst --exclude cache.tzst -P -C /Users/runner/work/wasmer/wasmer --files-from manifest.txt --delay-directory-restore --use-compress-program zstdmt
Warning: Failed to save: uploadChunk (start: 0, end: 33554431) failed: Cache service responded with 500
/Users/runner/work/_actions/goto-bus-stop/setup-zig/v2/dist/index.js:62201
                throw new Error(`Cache upload failed because file read failed with ${error.message}`);
```