### PR TITLE
fix(wasix-fs): resolve absolute symlink targets from virtual root

### DIFF
--- a/tests/wasix/symlink-open-read-write/main.c
+++ b/tests/wasix/symlink-open-read-write/main.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static void fail(const char *msg)
@@ -15,14 +16,21 @@ int main(void)
 {
     const char *target = "/host/target.txt";
     const char *linkname = "hello";
+    const char *nested_dir = "nested";
+    const char *nested_linkname = "nested/hello";
     const char *suffix = " bla";
     char prefix[128] = {0};
     char buf[256] = {0};
 
     unlink(linkname);
+    unlink(nested_linkname);
+    mkdir(nested_dir, 0777);
 
     if (symlink(target, linkname) != 0) {
         fail("symlink");
+    }
+    if (symlink(target, nested_linkname) != 0) {
+        fail("symlink nested");
     }
 
     int fd = open(target, O_RDONLY);
@@ -67,6 +75,25 @@ int main(void)
 
     if (strcmp(buf, expected) != 0) {
         fprintf(stderr, "unexpected symlink content: '%s'\n", buf);
+        return 1;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    fd = open(nested_linkname, O_RDONLY);
+    if (fd < 0) {
+        fail("open nested symlink for read");
+    }
+    n = read(fd, buf, sizeof(buf) - 1);
+    if (n < 0) {
+        fail("read through nested symlink");
+    }
+    if (close(fd) != 0) {
+        fail("close nested symlink read fd");
+    }
+    buf[n] = '\0';
+
+    if (strcmp(buf, expected) != 0) {
+        fprintf(stderr, "unexpected nested symlink content: '%s'\n", buf);
         return 1;
     }
 


### PR DESCRIPTION
The WASIX symlink resolver incorrectly treated absolute symlink targets as
if they were relative to the directory containing the symlink.

This caused lookups like:
- create /test/hello -> /test2/hello
- open/cat /test/hello

to fail with ENOENT when the symlink lived below a non-root directory,
because resolution restarted from base_po_dir/path_to_symlink context
instead of the virtual root.

What changed:
- fs resolver (WasiFs::get_inode_at_path_inner):
  - for Kind::Symlink, detect relative_path.is_absolute()
  - resolve absolute targets from VIRTUAL_ROOT_FD
  - keep existing relative-target behavior (resolve from symlink parent)
- open syscall resolver (path_open_internal in path_open2):
  - mirror the same absolute-vs-relative split before recursive reopen
  - use VIRTUAL_ROOT_FD for absolute targets

Why both places:
- path traversal and open have separate symlink follow paths; fixing only one
  leaves inconsistent behavior between inode walking and open-by-path.

Tests:
- extended tests/wasix/symlink-open-read-write/main.c with a regression case
  where a nested symlink (nested/hello) points to an absolute target
  (/host/target.txt) and must open/read successfully.
- added required <sys/stat.h> include for mkdir in that test.

Validation performed:
- cargo test -p wasmer-wasix test_relative_path_to_absolute --lib passes.
- WASIX C integration test compile/run was not executed locally because
  wasixcc is not available in this environment.
