### PR TITLE
fix(wasix-fs): Fix symlink behaviour

### DIFF
--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -254,6 +254,64 @@ impl FileSystem {
 
         Ok(())
     }
+
+    pub fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+        let (inode_of_parent, name_of_symlink) = {
+            let guard = self.inner.read().map_err(|_| FsError::Lock)?;
+            let path = guard.canonicalize_without_inode(target)?;
+            let parent_of_path = path.parent().ok_or(FsError::BaseNotDirectory)?;
+            let name_of_symlink = path
+                .file_name()
+                .ok_or(FsError::InvalidInput)?
+                .to_os_string();
+            let inode_of_parent = match guard.inode_of_parent(parent_of_path)? {
+                InodeResolution::Found(a) => a,
+                InodeResolution::Redirect(fs, mut redirected_path) => {
+                    redirected_path.push(&name_of_symlink);
+                    drop(guard);
+                    let fs_ref: &dyn crate::FileSystem = fs.as_ref();
+                    if let Some(mem_fs) = fs_ref.downcast_ref::<Self>() {
+                        return mem_fs.create_symlink(source, redirected_path.as_path());
+                    }
+                    return Err(FsError::Unsupported);
+                }
+            };
+            (inode_of_parent, name_of_symlink)
+        };
+
+        let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+        if fs.canonicalize(target).is_ok() {
+            return Err(FsError::AlreadyExists);
+        }
+
+        let inode_of_symlink = fs.storage.vacant_entry().key();
+        let real_inode_of_symlink = fs.storage.insert(Node::Symlink(SymlinkNode {
+            inode: inode_of_symlink,
+            name: name_of_symlink,
+            target: source.to_path_buf(),
+            metadata: {
+                let time = time();
+                Metadata {
+                    ft: FileType {
+                        symlink: true,
+                        ..Default::default()
+                    },
+                    accessed: time,
+                    created: time,
+                    modified: time,
+                    len: source.as_os_str().len() as u64,
+                }
+            },
+        }));
+
+        assert_eq!(
+            inode_of_symlink, real_inode_of_symlink,
+            "new symlink inode should have been correctly calculated",
+        );
+
+        fs.add_child_to_node(inode_of_parent, inode_of_symlink)?;
+        Ok(())
+    }
 }
 
 impl crate::FileSystem for FileSystem {
@@ -264,7 +322,10 @@ impl crate::FileSystem for FileSystem {
         // Canonicalize the path.
         let (_, inode_of_directory) = guard.canonicalize(path)?;
         match inode_of_directory {
-            InodeResolution::Found(_) => Err(FsError::InvalidInput),
+            InodeResolution::Found(inode) => match guard.storage.get(inode) {
+                Some(Node::Symlink(SymlinkNode { target, .. })) => Ok(target.clone()),
+                _ => Err(FsError::InvalidInput),
+            },
             InodeResolution::Redirect(fs, path) => fs.readlink(path.as_path()),
         }
     }
@@ -880,6 +941,7 @@ impl FileSystemInner {
                     | Node::ReadOnlyFile(ReadOnlyFileNode { inode, name, .. })
                     | Node::CustomFile(CustomFileNode { inode, name, .. })
                     | Node::ArcFile(ArcFileNode { inode, name, .. })
+                    | Node::Symlink(SymlinkNode { inode, name, .. })
                         if name.as_os_str() == name_of_file =>
                     {
                         Some(Some((nth, InodeResolution::Found(*inode))))
@@ -1084,6 +1146,7 @@ impl fmt::Debug for FileSystemInner {
                         Node::ReadOnlyFile { .. } => "ro-file",
                         Node::ArcFile { .. } => "arc-file",
                         Node::CustomFile { .. } => "custom-file",
+                        Node::Symlink { .. } => "symlink",
                         Node::Directory { .. } => "dir",
                         Node::ArcDirectory { .. } => "arc-dir",
                     },

--- a/lib/virtual-fs/src/mem_fs/mod.rs
+++ b/lib/virtual-fs/src/mem_fs/mod.rs
@@ -86,12 +86,21 @@ struct ArcDirectoryNode {
 }
 
 #[derive(Debug)]
+struct SymlinkNode {
+    inode: Inode,
+    name: OsString,
+    target: PathBuf,
+    metadata: Metadata,
+}
+
+#[derive(Debug)]
 enum Node {
     File(FileNode),
     OffloadedFile(OffloadedFileNode),
     ReadOnlyFile(ReadOnlyFileNode),
     ArcFile(ArcFileNode),
     CustomFile(CustomFileNode),
+    Symlink(SymlinkNode),
     Directory(DirectoryNode),
     ArcDirectory(ArcDirectoryNode),
 }
@@ -104,6 +113,7 @@ impl Node {
             Self::ReadOnlyFile(ReadOnlyFileNode { inode, .. }) => inode,
             Self::ArcFile(ArcFileNode { inode, .. }) => inode,
             Self::CustomFile(CustomFileNode { inode, .. }) => inode,
+            Self::Symlink(SymlinkNode { inode, .. }) => inode,
             Self::Directory(DirectoryNode { inode, .. }) => inode,
             Self::ArcDirectory(ArcDirectoryNode { inode, .. }) => inode,
         }
@@ -116,6 +126,7 @@ impl Node {
             Self::ReadOnlyFile(ReadOnlyFileNode { name, .. }) => name.as_os_str(),
             Self::ArcFile(ArcFileNode { name, .. }) => name.as_os_str(),
             Self::CustomFile(CustomFileNode { name, .. }) => name.as_os_str(),
+            Self::Symlink(SymlinkNode { name, .. }) => name.as_os_str(),
             Self::Directory(DirectoryNode { name, .. }) => name.as_os_str(),
             Self::ArcDirectory(ArcDirectoryNode { name, .. }) => name.as_os_str(),
         }
@@ -128,6 +139,7 @@ impl Node {
             Self::ReadOnlyFile(ReadOnlyFileNode { metadata, .. }) => metadata,
             Self::ArcFile(ArcFileNode { metadata, .. }) => metadata,
             Self::CustomFile(CustomFileNode { metadata, .. }) => metadata,
+            Self::Symlink(SymlinkNode { metadata, .. }) => metadata,
             Self::Directory(DirectoryNode { metadata, .. }) => metadata,
             Self::ArcDirectory(ArcDirectoryNode { metadata, .. }) => metadata,
         }
@@ -140,6 +152,7 @@ impl Node {
             Self::ReadOnlyFile(ReadOnlyFileNode { metadata, .. }) => metadata,
             Self::ArcFile(ArcFileNode { metadata, .. }) => metadata,
             Self::CustomFile(CustomFileNode { metadata, .. }) => metadata,
+            Self::Symlink(SymlinkNode { metadata, .. }) => metadata,
             Self::Directory(DirectoryNode { metadata, .. }) => metadata,
             Self::ArcDirectory(ArcDirectoryNode { metadata, .. }) => metadata,
         }
@@ -152,6 +165,7 @@ impl Node {
             Self::ReadOnlyFile(ReadOnlyFileNode { name, .. }) => *name = new_name,
             Self::ArcFile(ArcFileNode { name, .. }) => *name = new_name,
             Self::CustomFile(CustomFileNode { name, .. }) => *name = new_name,
+            Self::Symlink(SymlinkNode { name, .. }) => *name = new_name,
             Self::Directory(DirectoryNode { name, .. }) => *name = new_name,
             Self::ArcDirectory(ArcDirectoryNode { name, .. }) => *name = new_name,
         }

--- a/lib/virtual-fs/src/tmp_fs.rs
+++ b/lib/virtual-fs/src/tmp_fs.rs
@@ -58,6 +58,10 @@ impl TmpFileSystem {
     pub fn canonicalize_unchecked(&self, path: &Path) -> Result<PathBuf> {
         self.fs.canonicalize_unchecked(path)
     }
+
+    pub fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+        self.fs.create_symlink(source, target)
+    }
 }
 
 impl FileSystem for TmpFileSystem {

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -98,6 +98,23 @@ pub fn path_rename_internal(
         Path::new(target_path),
         true
     ));
+    let host_adjusted_source_path = {
+        let guard = source_parent_inode.read();
+        match guard.deref() {
+            Kind::Dir { path, .. } => path.join(&source_entry_name),
+            Kind::Root { .. } => return Ok(Errno::Notcapable),
+            Kind::Socket { .. }
+            | Kind::PipeTx { .. }
+            | Kind::PipeRx { .. }
+            | Kind::DuplexPipe { .. }
+            | Kind::EventNotifications { .. }
+            | Kind::Epoll { .. } => return Ok(Errno::Inval),
+            Kind::Symlink { .. } | Kind::File { .. } | Kind::Buffer { .. } => {
+                debug!("fatal internal logic error: parent of inode is not a directory");
+                return Ok(Errno::Inval);
+            }
+        }
+    };
     let mut need_create = true;
     let host_adjusted_target_path = {
         let guard = target_parent_inode.read();
@@ -169,7 +186,7 @@ pub fn path_rename_internal(
                 } else {
                     let mut guard = source_entry.write();
                     if let Kind::File { path, .. } = guard.deref_mut() {
-                        *path = host_adjusted_target_path;
+                        *path = host_adjusted_target_path.clone();
                     } else {
                         unreachable!()
                     }
@@ -195,8 +212,49 @@ pub fn path_rename_internal(
                     rename_inode_tree(&source_entry, &source_dir_path, &host_adjusted_target_path);
                 }
             }
+            Kind::Symlink {
+                base_po_dir,
+                path_to_symlink,
+                relative_path,
+            } => {
+                let is_ephemeral = state
+                    .fs
+                    .ephemeral_symlink_at(host_adjusted_source_path.as_path())
+                    .is_some();
+                let res = {
+                    let state = state;
+                    let from = host_adjusted_source_path.clone();
+                    let to = host_adjusted_target_path.clone();
+                    __asyncify_light(env, None, async move { state.fs_rename(from, to).await })?
+                };
+                match (res, is_ephemeral) {
+                    (Ok(()), _) | (Err(Errno::Noent), true) => {}
+                    (Err(e), _) => {
+                        let mut guard = source_parent_inode.write();
+                        if let Kind::Dir { entries, .. } = guard.deref_mut() {
+                            entries.insert(source_entry_name, source_entry.clone());
+                            return Ok(e);
+                        }
+                    }
+                }
+
+                let (new_base_po_dir, new_path_to_symlink) =
+                    wasi_try_ok!(state.fs.path_into_pre_open_and_relative_path_owned(
+                        host_adjusted_target_path.as_path()
+                    ));
+                *base_po_dir = new_base_po_dir;
+                *path_to_symlink = new_path_to_symlink.clone();
+                if is_ephemeral {
+                    state.fs.move_ephemeral_symlink(
+                        host_adjusted_source_path.as_path(),
+                        host_adjusted_target_path.as_path(),
+                        new_base_po_dir,
+                        new_path_to_symlink,
+                        relative_path.clone(),
+                    );
+                }
+            }
             Kind::Buffer { .. }
-            | Kind::Symlink { .. }
             | Kind::Socket { .. }
             | Kind::PipeTx { .. }
             | Kind::PipeRx { .. }
@@ -227,6 +285,12 @@ pub fn path_rename_internal(
         .expect("Expected target inode to exist, and it's too late to safely fail");
     *target_inode.name.write().unwrap() = target_entry_name.into();
     target_inode.stat.write().unwrap().st_size = source_size;
+
+    // If the rename replaced an existing destination entry, clear any stale
+    // ephemeral symlink mapping for that path.
+    state
+        .fs
+        .unregister_ephemeral_symlink(host_adjusted_target_path.as_path());
 
     Ok(Errno::Success)
 }

--- a/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
@@ -62,6 +62,16 @@ pub(crate) fn path_unlink_file_internal(
         std::path::Path::new(path),
         false
     ));
+    let host_adjusted_path = {
+        let guard = parent_inode.read();
+        match guard.deref() {
+            Kind::Dir { path, .. } => path.join(&childs_name),
+            Kind::Root { .. } => return Ok(Errno::Access),
+            _ => unreachable!(
+                "Internal logic error in wasi::path_unlink_file, parent is not a directory"
+            ),
+        }
+    };
 
     let removed_inode = {
         let mut guard = parent_inode.write();
@@ -104,7 +114,18 @@ pub(crate) fn path_unlink_file_internal(
                 }
                 Kind::Dir { .. } | Kind::Root { .. } => return Ok(Errno::Isdir),
                 Kind::Symlink { .. } => {
-                    // TODO: actually delete real symlinks and do nothing for virtual symlinks
+                    match state.fs_remove_file(host_adjusted_path.as_path()) {
+                        Ok(()) => {}
+                        Err(Errno::Noent)
+                            if state
+                                .fs
+                                .ephemeral_symlink_at(host_adjusted_path.as_path())
+                                .is_some() => {}
+                        Err(err) => return Ok(err),
+                    }
+                    state
+                        .fs
+                        .unregister_ephemeral_symlink(host_adjusted_path.as_path());
                 }
                 _ => unimplemented!("wasi::path_unlink_file for Buffer"),
             }


### PR DESCRIPTION
 fix(wasix-fs): align symlink semantics across resolution, persistence, and mutation flows

    This consolidates and finalizes the symlink fixes so runtime-created and backing-FS symlinks follow the same representation and resolve consistently across WASIX filesystem code paths.

    Implemented changes:
    - Fixed absolute symlink target resolution in both core path traversal and `path_open2` symlink-reopen flow by resolving absolute targets from `VIRTUAL_ROOT_FD`.
    - Standardized runtime-created symlink representation to match backing-FS-discovered symlinks:
      `(base_po_dir, path_to_symlink_within_preopen, relative_path_raw_target)`.
    - Removed depth-based `..` rewriting in `path_symlink`; now stores raw `old_path` symlink targets.
    - Added `WasiFs::path_into_pre_open_and_relative_path_owned` helper for owned-path conversion.

    Backing FS + mem-fs integration:
    - Added symlink-node support in mem-fs:
      - new `Node::Symlink` variant,
      - symlink target persistence,
      - `readlink()` support,
      - `create_symlink(source, target)` support.
    - Exposed mem-fs symlink creation via `TmpFileSystem::create_symlink()`.
    - Updated mem-fs redirect behavior for symlink creation:
      - delegate to redirected mem-fs when possible,
      - return `FsError::Unsupported` otherwise.
    - Updated `path_symlink` to persist symlinks in backing FS when supported (sandbox / overlay primary).
    - Fallback to ephemeral symlink registration is now only used on `FsError::Unsupported`; other backing-FS errors are propagated.

    Ephemeral symlink behavior:
    - Kept ephemeral symlink registry for filesystems without native symlink creation.
    - Hardened key normalization:
      - prevent `..` from escaping above `/`,
      - ignore `Component::Prefix(_)` for virtual key normalization.
    - Ephemeral symlinks are resolved transiently and not inserted into directory-entry caches.
    - Added `WasiFs` helpers for ephemeral lifecycle:
      - `unregister_ephemeral_symlink`,
      - `move_ephemeral_symlink`.

    Mutation-flow consistency:
    - `path_rename` now handles symlink inodes coherently:
      - attempts backing-FS rename for real symlinks,
      - allows `Errno::Noent` only for known ephemeral symlinks,
      - updates stored symlink location (`base_po_dir`, `path_to_symlink`) after rename,
      - moves ephemeral registry entries for renamed ephemeral symlinks.
    - `path_unlink_file` now handles symlink deletion coherently:
      - removes real symlinks from backing FS,
      - unregisters ephemeral symlink entries when applicable,
      - preserves removal error behavior for real failures.

    Tests and validation:
    - Extended `tests/wasix/symlink-open-read-write/main.c` coverage with nested symlink open/read checks.
    - Fixed test setup robustness by allowing `EEXIST` from `mkdir`.
    - Verified with:
      - `cargo test -p wasmer-wasix test_relative_path_to_absolute --lib`
      - `cargo test --release --features cranelift --locked --test compilers path_symlink::cranelift::cranelift`
      - `cargo test --release --features cranelift --locked --test compilers path_rename::cranelift::cranelift` (selection builds; cases are ignored in this suite)