### PR TITLE
chore: simplify how we display CPU flags

### DIFF
--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -544,15 +544,11 @@ fn print_version(verbose: bool) -> Result<(), anyhow::Error> {
     }
     println!("host: {}", target_lexicon::HOST);
 
-    let cpu_features = {
-        let feats = wasmer_types::target::CpuFeature::for_host();
-        let all = wasmer_types::target::CpuFeature::all();
-        all.iter()
-            .map(|f| format!("{}={}", f, feats.contains(f)))
-            .collect::<Vec<_>>()
-            .join(",")
-    };
-    println!("cpu: {cpu_features}");
+    let cpu_features = wasmer_types::target::CpuFeature::for_host()
+        .iter()
+        .map(|f| f.to_string())
+        .join(" ");
+    println!("CPU flags: {cpu_features}");
 
     let mut runtimes = Vec::new();
     if cfg!(feature = "singlepass") {


### PR DESCRIPTION
I would like to follow what `/proc/cpuinfo` does:
```
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpuid_fault cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid overflow_recov succor smca fsrm flush_l1d amd_lbr_pmc_freeze
```

and so now, we'll print: `CPU flags: sse2 sse3 ssse3 sse4.1 sse4.2 popcnt avx bmi bmi2 avx2 avx512dq avx512vl avx512f lzcnt fma`

instead of `cpu: sse2=true,sse3=true,ssse3=true,sse4.1=true,sse4.2=true,popcnt=true,avx=true,bmi=true,bmi2=true,avx2=true,avx512dq=true,avx512vl=true,avx512f=true,lzcnt=true,neon=false,fma=true`