### PR TITLE
chore(LLVM): use descriptive names for trampoline wrappers

### DIFF
--- a/lib/compiler-llvm/src/translator/trampoline.rs
+++ b/lib/compiler-llvm/src/translator/trampoline.rs
@@ -473,6 +473,7 @@ impl FuncTrampoline {
                     ));
                 }
             };
+        func_ptr.set_name("func_ptr");
 
         let mut args_vec = Vec::with_capacity(func_sig.params().len() + 3);
 
@@ -487,6 +488,7 @@ impl FuncTrampoline {
             args_vec.push(err!(builder.build_alloca(sret_ty, "sret")).into());
         }
 
+        callee_vmctx_ptr.set_name("vmctx");
         args_vec.push(callee_vmctx_ptr.into());
 
         if enable_m0_optimization(compile_info) {
@@ -652,8 +654,10 @@ impl FuncTrampoline {
         let callee =
             err!(builder.build_load(intrinsics.ptr_ty, callee_ty.into_pointer_value(), ""))
                 .into_pointer_value();
+        callee.set_name("func_ptr");
 
         let values_ptr = err!(builder.build_pointer_cast(values, intrinsics.ptr_ty, ""));
+        values_ptr.set_name("value_ptr");
         err!(builder.build_indirect_call(
             callee_ptr_ty,
             callee,


### PR DESCRIPTION
Will emit something like:
```
 379 │   call void %func_ptr(ptr nofree nonnull align 16 %vmctx, ptr %trmpl_m0_base_ptr, i32 %arg, i32 %arg2, i32 %arg4, i32 %arg6, i64 %arg8, i32 %arg10, i32 %arg12, i
     │ 32 %arg14, i32 %arg16, i32 %arg18, i32 %arg20)
...
 363 │   call void %func_ptr(ptr %vmctx, ptr %value_ptr)
```