### PR TITLE
fix(c-api): add null safety to wasi_filesystem_delete

### DIFF
--- a/lib/c-api/src/wasm_c_api/wasi/mod.rs
+++ b/lib/c-api/src/wasm_c_api/wasi/mod.rs
@@ -198,9 +198,7 @@ pub unsafe extern "C" fn wasi_filesystem_init_static_memory(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasi_filesystem_delete(ptr: *mut wasi_filesystem_t) {
-    let _ = unsafe { Box::from_raw(ptr) };
-}
+pub unsafe extern "C" fn wasi_filesystem_delete(_ptr: Option<Box<wasi_filesystem_t>>) {}
 
 /// Initializes the `imports` with an import object that links to
 /// the custom file system


### PR DESCRIPTION
## Summary
- `wasi_filesystem_delete` used `Box::from_raw(ptr)` on a raw pointer without a null check, causing undefined behavior when called with a null pointer
- Changed to use the `Option<Box<T>>` pattern already used by every other delete function in the C-API (`wasm_memory_delete`, `wasm_func_delete`, `wasm_global_delete`, `wasm_table_delete`, etc.)

## Details
The previous implementation:
```rust
pub unsafe extern "C" fn wasi_filesystem_delete(ptr: *mut wasi_filesystem_t) {
    let _ = unsafe { Box::from_raw(ptr) };
}
```

This would dereference a null pointer if a C caller passed NULL, leading to undefined behavior. The fix uses the same `Option<Box<T>>` pattern that all other delete functions in the C-API already use:
```rust
pub unsafe extern "C" fn wasi_filesystem_delete(_ptr: Option<Box<wasi_filesystem_t>>) {}
```

When a C caller passes NULL, the `Option` becomes `None` and the function is a no-op, which is the expected behavior for delete/free functions.

## Testing
- Verify that passing NULL to `wasi_filesystem_delete` no longer causes a crash
- Existing C-API tests should continue to pass since non-null behavior is unchanged