### PR TITLE
fix(singlepass): read float return values from SIMD registers per C ABI

### DIFF
--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -663,7 +663,8 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             _ => Size::S64,
         };
         let param_sizes = params_type.map(get_size).collect_vec();
-        let return_value_sizes = return_types.map(get_size).collect_vec();
+        let return_wptypes = return_types.collect_vec();
+        let return_value_sizes = return_wptypes.iter().map(|t| get_size(*t)).collect_vec();
 
         /* We're going to reuse the memory param locations for the return values. Any extra needed slots will be allocated on stack. */
         let used_stack_params = stack_params
@@ -711,6 +712,18 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 &mut stack_offset,
                 self.calling_convention,
             ));
+        }
+        // The C ABI returns floating-point values in SIMD registers (XMM0 on x86_64,
+        // V0 on ARM64, FA0 on RISC-V), not in GPRs. Fix up the return value locations
+        // so that we read float results from the correct registers.
+        let mut float_idx = 0usize;
+        for (i, wp_type) in return_wptypes.iter().enumerate() {
+            if matches!(wp_type, WpType::F32 | WpType::F64) {
+                if let Some(simd_loc) = self.machine.get_simd_return_register(float_idx) {
+                    return_args[i] = simd_loc;
+                }
+                float_idx += 1;
+            }
         }
 
         // Allocate space for arguments relative to SP.

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -247,6 +247,9 @@ pub trait Machine {
         idx: usize,
         calling_convention: CallingConvention,
     ) -> Location<Self::GPR, Self::SIMD>;
+    /// Get the SIMD register used for the nth floating-point return value in the
+    /// platform's C ABI. Returns `None` if the value would be on the stack.
+    fn get_simd_return_register(&self, float_idx: usize) -> Option<Location<Self::GPR, Self::SIMD>>;
     /// move a location to another
     fn move_location(
         &mut self,

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -1830,6 +1830,17 @@ impl Machine for MachineARM64 {
         )
     }
 
+    fn get_simd_return_register(&self, float_idx: usize) -> Option<AbstractLocation<Self::GPR, Self::SIMD>> {
+        // AAPCS64: floating-point return values are in V0-V7.
+        const AAPCS64_FLOAT_RETURN_REGISTERS: [NEON; 8] = [
+            NEON::V0, NEON::V1, NEON::V2, NEON::V3,
+            NEON::V4, NEON::V5, NEON::V6, NEON::V7,
+        ];
+        AAPCS64_FLOAT_RETURN_REGISTERS
+            .get(float_idx)
+            .map(|&reg| AbstractLocation::SIMD(reg))
+    }
+
     // move a location to another
     fn move_location(
         &mut self,

--- a/lib/compiler-singlepass/src/machine_riscv.rs
+++ b/lib/compiler-singlepass/src/machine_riscv.rs
@@ -2304,6 +2304,14 @@ impl Machine for MachineRiscv {
         )
     }
 
+    fn get_simd_return_register(&self, float_idx: usize) -> Option<AbstractLocation<Self::GPR, Self::SIMD>> {
+        // RISC-V: floating-point return values are in FA0 (F10) and FA1 (F11).
+        const RISCV_FLOAT_RETURN_REGISTERS: [FPR; 2] = [FPR::F10, FPR::F11];
+        RISCV_FLOAT_RETURN_REGISTERS
+            .get(float_idx)
+            .map(|&reg| AbstractLocation::SIMD(reg))
+    }
+
     // move a location to another
     fn move_location(
         &mut self,

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -2397,6 +2397,15 @@ impl Machine for MachineX86_64 {
         )
     }
 
+    fn get_simd_return_register(&self, float_idx: usize) -> Option<Location> {
+        // System V AMD64 ABI: floating-point return values are in XMM0-XMM1.
+        // Windows x64: floating-point return value is in XMM0 only.
+        const SYSV_FLOAT_RETURN_REGISTERS: [XMM; 2] = [XMM::XMM0, XMM::XMM1];
+        SYSV_FLOAT_RETURN_REGISTERS
+            .get(float_idx)
+            .map(|&reg| Location::SIMD(reg))
+    }
+
     // move a location to another
     fn move_location(
         &mut self,

--- a/tests/compilers/imports.rs
+++ b/tests/compilers/imports.rs
@@ -513,3 +513,62 @@ fn instance_local_memory_lifetime(config: crate::Config) -> Result<()> {
 
     Ok(())
 }
+
+/// Test that floating-point return values from imported host functions are
+/// correctly propagated back to WASM. This covers f32 and f64 return values
+/// which use SIMD registers (XMM0 on x86_64, V0 on ARM64, FA0 on RISC-V)
+/// per the platform's C ABI, whereas singlepass internally expects all return
+/// values in GPR registers.
+#[compiler_test(imports)]
+fn float_return_values_from_imports(config: crate::Config) -> Result<()> {
+    let mut store = config.store();
+
+    // Test f32 return from import
+    let wat_f32 = r#"(module
+        (import "host" "get" (func $get (result f32)))
+        (func (export "test") (result f32) call $get)
+    )"#;
+    let module = Module::new(&store, wat_f32)?;
+    let get_f32 = Function::new_typed(&mut store, || -> f32 { -0.125 });
+    let imports = imports! { "host" => { "get" => get_f32 } };
+    let instance = Instance::new(&mut store, &module, &imports)?;
+    let test: TypedFunction<(), f32> = instance.exports.get_typed_function(&store, "test")?;
+    assert_eq!(test.call(&mut store)?, -0.125f32);
+
+    // Test f64 return from import
+    let wat_f64 = r#"(module
+        (import "host" "get" (func $get (result f64)))
+        (func (export "test") (result f64) call $get)
+    )"#;
+    let module = Module::new(&store, wat_f64)?;
+    let get_f64 = Function::new_typed(&mut store, || -> f64 { 128.25 });
+    let imports = imports! { "host" => { "get" => get_f64 } };
+    let instance = Instance::new(&mut store, &module, &imports)?;
+    let test: TypedFunction<(), f64> = instance.exports.get_typed_function(&store, "test")?;
+    assert_eq!(test.call(&mut store)?, 128.25f64);
+
+    // Verify i32 and i64 still work (regression guard)
+    let wat_i32 = r#"(module
+        (import "host" "get" (func $get (result i32)))
+        (func (export "test") (result i32) call $get)
+    )"#;
+    let module = Module::new(&store, wat_i32)?;
+    let get_i32 = Function::new_typed(&mut store, || -> i32 { 42 });
+    let imports = imports! { "host" => { "get" => get_i32 } };
+    let instance = Instance::new(&mut store, &module, &imports)?;
+    let test: TypedFunction<(), i32> = instance.exports.get_typed_function(&store, "test")?;
+    assert_eq!(test.call(&mut store)?, 42);
+
+    let wat_i64 = r#"(module
+        (import "host" "get" (func $get (result i64)))
+        (func (export "test") (result i64) call $get)
+    )"#;
+    let module = Module::new(&store, wat_i64)?;
+    let get_i64 = Function::new_typed(&mut store, || -> i64 { 123456789 });
+    let imports = imports! { "host" => { "get" => get_i64 } };
+    let instance = Instance::new(&mut store, &module, &imports)?;
+    let test: TypedFunction<(), i64> = instance.exports.get_typed_function(&store, "test")?;
+    assert_eq!(test.call(&mut store)?, 123456789i64);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The singlepass compiler's `emit_call_native` reads all return values from GPR registers (RAX/RDX on x86_64, X0-X7 on ARM64, X10+ on RISC-V). However, the platform C ABIs return floating-point values in SIMD registers:
- **x86_64 System V**: XMM0-XMM1
- **ARM64 AAPCS64**: V0-V7
- **RISC-V**: FA0 (F10), FA1 (F11)

This causes **f32/f64 return values from imported host functions to contain garbage data**.

## Root Cause

This regression was introduced when return value handling was moved from the type-aware `Operator::Call` handler into `emit_call_native`, which uses `get_return_value_location()` — a function that unconditionally returns GPR locations regardless of the return value type.

In older wasmer versions (pre-4.x refactor), the `Operator::Call` handler checked `is_float()` on each return type and read from the appropriate SIMD register (e.g., `get_simd_for_ret()` returning V0) for float types, and GPR for integer types. After the refactoring, this type-awareness was lost.

## Fix

- Adds `get_simd_return_register(float_idx)` to the `Machine` trait, returning the correct SIMD register for the nth float return value per the platform's C ABI
- In `emit_call_native`, after building the return value location list, float entries are replaced with the correct SIMD register
- Implementations provided for all three backends: ARM64, x86_64, and RISC-V

## Minimal Reproduction

```rust
use wasmer::{Store, Module, Instance, Function, imports};

fn main() {
    let wat = r#"(module
        (import "host" "get" (func $get (result f32)))
        (func (export "test") (result f32) call $get)
    )"#;

    let engine = wasmer::sys::EngineBuilder::new(
        wasmer::sys::Singlepass::new()
    ).engine().into();
    let mut store = Store::new(engine);
    let module = Module::new(&store.engine().clone(), wat).unwrap();
    let get = Function::new_typed(&mut store, || -> f32 { -0.125 });
    let imports = imports! { "host" => { "get" => get } };
    let instance = Instance::new(&mut store, &module, &imports).unwrap();
    let test = instance.exports.get_function("test").unwrap();
    let result = test.call(&mut store, &[]).unwrap();
    // Before fix: garbage value (e.g., 0x54304080)
    // After fix: correct value -0.125 (bits 0xBE000000)
    println!("{:?}", result);
}
```

## Test Plan

- [x] Added `float_return_values_from_imports` test in `tests/compilers/imports.rs` covering f32, f64, i32, and i64 return values from imports
- [x] All existing import tests pass on both singlepass and cranelift
- [x] Verified fix on ARM64 (Apple Silicon) with singlepass

🤖 Generated with [Claude Code](https://claude.com/claude-code)