### PR TITLE
wasix: Track origin package in commands

### DIFF
--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -24,6 +24,17 @@ pub struct BinaryPackageCommand {
     pub(crate) atom: SharedBytes,
     hash: ModuleHash,
     features: Option<wasmer_types::Features>,
+    /// Package that declares this command in the resolved manifest graph.
+    ///
+    /// This identifies "who owns the command name" (the package that exposes
+    /// the command entry), even if execution uses an atom from another package.
+    package: PackageId,
+    /// Package that provides the module this command actually executes.
+    ///
+    /// Usually this matches `package`. It differs when the command's atom
+    /// annotation points at a dependency, so the command is declared by one
+    /// package but runs code from another package.
+    origin_package: PackageId,
 }
 
 impl BinaryPackageCommand {
@@ -33,6 +44,8 @@ impl BinaryPackageCommand {
         atom: SharedBytes,
         hash: ModuleHash,
         features: Option<wasmer_types::Features>,
+        package: PackageId,
+        origin_package: PackageId,
     ) -> Self {
         Self {
             name,
@@ -40,6 +53,8 @@ impl BinaryPackageCommand {
             atom,
             hash,
             features,
+            package,
+            origin_package,
         }
     }
 
@@ -65,6 +80,14 @@ impl BinaryPackageCommand {
 
     pub fn hash(&self) -> &ModuleHash {
         &self.hash
+    }
+
+    pub fn package(&self) -> &PackageId {
+        &self.package
+    }
+
+    pub fn origin_package(&self) -> &PackageId {
+        &self.origin_package
     }
 
     /// Get the WebAssembly features required by this command's module
@@ -214,6 +237,11 @@ impl BinaryPackage {
 
     pub fn get_command(&self, name: &str) -> Option<&BinaryPackageCommand> {
         self.commands.iter().find(|cmd| cmd.name() == name)
+    }
+
+    pub fn get_command_origin_package(&self, name: &str) -> Option<&PackageId> {
+        self.get_command(name)
+            .map(BinaryPackageCommand::origin_package)
     }
 
     /// Resolve the entrypoint command name to a [`BinaryPackageCommand`].
@@ -387,5 +415,8 @@ mod tests {
         let atom_sha256_hash = sha2::Sha256::digest(webc.get_atom("foo").unwrap()).into();
         let module_hash = ModuleHash::from_bytes(atom_sha256_hash);
         assert_eq!(command.hash(), &module_hash);
+        assert_eq!(command.package(), &pkg.id);
+        assert_eq!(pkg.get_command_origin_package("cmd"), Some(&pkg.id));
+        assert_eq!(command.origin_package(), &pkg.id);
     }
 }

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -52,6 +52,7 @@ pub enum TaintReason {
 /// different sources.
 ///
 /// All variants are wrapped in `Cow` to allow for zero-copy usage when possible.
+#[allow(clippy::large_enum_variant)]
 pub enum ModuleInput<'a> {
     /// Raw bytes.
     Bytes(Cow<'a, [u8]>),

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -65,8 +65,7 @@ pub async fn load_package_tree(
     let fs_opt = filesystem(&containers, &resolution.package, root_is_local_dir)?;
 
     let root = &resolution.package.root_package;
-    let commands: Vec<BinaryPackageCommand> =
-        commands(&resolution.package.commands, &containers, resolution)?;
+    let commands = commands(&resolution.package.commands, &containers, resolution)?;
 
     let file_system_memory_footprint = if let Some(fs) = &fs_opt {
         count_file_system(fs, Path::new("/"))
@@ -184,7 +183,7 @@ fn load_binary_command(
 
     if atom.is_none() && cmd.annotations.is_empty() {
         tracing::info!("applying legacy atom hack");
-        return legacy_atom_hack(webc, command_name, cmd);
+        return legacy_atom_hack(webc, package_id, command_name, cmd);
     }
 
     let hash = to_module_hash(webc.manifest().atom_signature(&atom_name)?);
@@ -212,8 +211,15 @@ fn load_binary_command(
         None
     };
 
-    let cmd =
-        BinaryPackageCommand::new(command_name.to_string(), cmd.clone(), atom, hash, features);
+    let cmd = BinaryPackageCommand::new(
+        command_name.to_string(),
+        cmd.clone(),
+        atom,
+        hash,
+        features,
+        package_id.clone(),
+        resolved_package_id.clone(),
+    );
 
     Ok(Some(cmd))
 }
@@ -260,6 +266,7 @@ fn atom_name_for_command(
 /// for more.
 fn legacy_atom_hack(
     webc: &Container,
+    package_id: &PackageId,
     command_name: &str,
     metadata: &webc::metadata::Command,
 ) -> Result<Option<BinaryPackageCommand>, anyhow::Error> {
@@ -291,6 +298,8 @@ fn legacy_atom_hack(
         atom,
         hash,
         features,
+        package_id.clone(),
+        package_id.clone(),
     )))
 }
 

--- a/lib/wasix/tests/binary_package.rs
+++ b/lib/wasix/tests/binary_package.rs
@@ -1,0 +1,172 @@
+#![cfg(not(target_family = "wasm"))]
+
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::{Context, Error};
+use tempfile::TempDir;
+use url::Url;
+use wasmer_config::package::{PackageId, PackageSource};
+use wasmer_package::package::Package;
+use wasmer_wasix::{
+    PluggableRuntime,
+    bin_factory::BinaryPackage,
+    runtime::{
+        package_loader::{PackageLoader, load_package_tree},
+        resolver::{
+            DistributionInfo, InMemorySource, PackageInfo, PackageSummary, Resolution, WebcHash,
+        },
+        task_manager::VirtualTaskManager,
+    },
+};
+use webc::Container;
+
+#[derive(Debug)]
+struct InMemoryPackageLoader {
+    containers: HashMap<PackageId, Container>,
+}
+
+#[async_trait::async_trait]
+impl PackageLoader for InMemoryPackageLoader {
+    async fn load(&self, summary: &PackageSummary) -> Result<Container, Error> {
+        let id = summary.package_id();
+        self.containers
+            .get(&id)
+            .cloned()
+            .with_context(|| format!("No container found for \"{id}\""))
+    }
+
+    async fn load_package_tree(
+        &self,
+        root: &Container,
+        resolution: &Resolution,
+        root_is_local_dir: bool,
+    ) -> Result<BinaryPackage, Error> {
+        load_package_tree(root, self, resolution, root_is_local_dir).await
+    }
+}
+
+fn task_manager() -> Arc<dyn VirtualTaskManager + Send + Sync> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "sys-thread")] {
+            Arc::new(
+                wasmer_wasix::runtime::task_manager::tokio::TokioTaskManager::new(
+                    tokio::runtime::Handle::current(),
+                ),
+            )
+        } else {
+            unimplemented!("Unable to get the task manager")
+        }
+    }
+}
+
+fn write_package(dir: &std::path::Path, manifest: &str, wasm_files: &[&str]) {
+    std::fs::write(dir.join("wasmer.toml"), manifest).unwrap();
+    for file in wasm_files {
+        std::fs::write(dir.join(file), b"").unwrap();
+    }
+}
+
+fn summary_for(container: &Container, id: PackageId) -> PackageSummary {
+    let manifest = container.manifest();
+
+    PackageSummary {
+        pkg: PackageInfo::from_manifest(id.clone(), manifest, container.version()).unwrap(),
+        dist: DistributionInfo {
+            webc: Url::parse(&format!("https://example.invalid/{id}.webc")).unwrap(),
+            webc_sha256: WebcHash::sha256(id.to_string()),
+        },
+    }
+}
+
+#[tokio::test]
+#[cfg_attr(
+    not(feature = "sys-thread"),
+    ignore = "The tokio task manager isn't available on this platform"
+)]
+async fn command_tracks_declaring_package_and_atom_provider_package() {
+    let temp = TempDir::new().unwrap();
+    let dep_dir = temp.path().join("dep");
+    let root_dir = temp.path().join("root");
+    std::fs::create_dir_all(&dep_dir).unwrap();
+    std::fs::create_dir_all(&root_dir).unwrap();
+
+    write_package(
+        &dep_dir,
+        r#"
+            [package]
+            name = "wasmer/bash"
+            version = "1.0.0"
+            description = "bash package"
+
+            [[module]]
+            name = "bash"
+            source = "bash.wasm"
+            abi = "wasi"
+
+            [[command]]
+            name = "bash"
+            module = "bash"
+        "#,
+        &["bash.wasm"],
+    );
+
+    write_package(
+        &root_dir,
+        r#"
+            [package]
+            name = "acme/app"
+            version = "1.0.0"
+            description = "root package"
+
+            [dependencies]
+            "wasmer/bash" = "1.0.0"
+
+            [[command]]
+            name = "after_deploy"
+            module = "wasmer/bash:bash"
+        "#,
+        &[],
+    );
+
+    let dep_container: Container = Package::from_manifest(&dep_dir.join("wasmer.toml"))
+        .unwrap()
+        .into();
+    let root_container: Container = Package::from_manifest(&root_dir.join("wasmer.toml"))
+        .unwrap()
+        .into();
+
+    let dep_id = PackageId::new_named("wasmer/bash", "1.0.0".parse().unwrap());
+    let root_id = PackageId::new_named("acme/app", "1.0.0".parse().unwrap());
+
+    let dep_summary = summary_for(&dep_container, dep_id.clone());
+    let root_summary = summary_for(&root_container, root_id.clone());
+
+    let mut source = InMemorySource::new();
+    source.add(dep_summary);
+    source.add(root_summary);
+
+    let loader = InMemoryPackageLoader {
+        containers: HashMap::from([
+            (dep_id.clone(), dep_container),
+            (root_id.clone(), root_container),
+        ]),
+    };
+
+    let mut runtime = PluggableRuntime::new(task_manager());
+    runtime.set_source(source);
+    runtime.set_package_loader(loader);
+
+    let specifier: PackageSource = "acme/app".parse().unwrap();
+    let pkg = BinaryPackage::from_registry(&specifier, &runtime)
+        .await
+        .unwrap();
+
+    let command = pkg.get_command("after_deploy").unwrap();
+
+    assert_eq!(command.package(), &root_id);
+    assert_eq!(command.origin_package(), &dep_id);
+    assert_eq!(
+        pkg.get_command_origin_package("after_deploy"),
+        Some(&dep_id)
+    );
+}


### PR DESCRIPTION
Track the package providing the actual executed module in the
BinaryPackageCommand, not just the defining package.
This makes it possible to get the original module-providing package for
alias commands.

Closes #6256
Closes RUN-891
