### PR TITLE
Improve WASIX TTY

### DIFF
--- a/lib/wasix/src/os/tty/mod.rs
+++ b/lib/wasix/src/os/tty/mod.rs
@@ -116,8 +116,7 @@ impl TtyOptions {
     }
 
     pub fn ignore_cr(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.ignore_cr
+        self.inner.lock().unwrap().ignore_cr
     }
 
     pub fn set_ignore_cr(&self, ignore_cr: bool) {
@@ -126,8 +125,7 @@ impl TtyOptions {
     }
 
     pub fn map_cr_to_lf(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.map_cr_to_lf
+        self.inner.lock().unwrap().map_cr_to_lf
     }
 
     pub fn set_map_cr_to_lf(&self, map_cr_to_lf: bool) {
@@ -136,8 +134,7 @@ impl TtyOptions {
     }
 
     pub fn map_lf_to_cr(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.map_lf_to_cr
+        self.inner.lock().unwrap().map_lf_to_cr
     }
 
     pub fn set_map_lf_to_cr(&self, map_lf_to_cr: bool) {
@@ -224,10 +221,12 @@ impl LineDiscipline {
         removed
     }
 
+    // Erase the whitespace run immediately before the cursor, then the preceding
+    // non-whitespace run. For example, with "foo_bar baz" and the cursor at EOL,
+    // the first ctrl-w removes "baz" and the next removes "foo_bar".
     fn ctrl_w(&mut self) -> usize {
         // TODO: This currently uses whitespace boundaries.
         // Linux n_tty ALTWERASE semantics are closer to [A-Za-z0-9_] word classes.
-        // Example: with "foo_bar baz", ctrl-w should usually erase "baz", then "foo_bar" as one word.
         let start = self.chars.len();
         while self.cursor > 0 && self.chars[self.cursor - 1].is_whitespace() {
             self.cursor -= 1;
@@ -289,10 +288,47 @@ enum EscapeMatch {
     Complete(ParsedInput),
 }
 
+const KNOWN_ESCAPE_SEQUENCES: [(&[u8], ParsedInput); 28] = [
+    (b"\x1b[D", ParsedInput::CursorLeft),
+    (b"\x1b[C", ParsedInput::CursorRight),
+    (b"\x1b[A", ParsedInput::CursorUp),
+    (b"\x1b[B", ParsedInput::CursorDown),
+    (b"\x1bOD", ParsedInput::CursorLeft),
+    (b"\x1bOC", ParsedInput::CursorRight),
+    (b"\x1bOA", ParsedInput::CursorUp),
+    (b"\x1bOB", ParsedInput::CursorDown),
+    (b"\x1b[H", ParsedInput::Home),
+    (b"\x1b[F", ParsedInput::End),
+    (b"\x1b[1~", ParsedInput::Home),
+    (b"\x1b[4~", ParsedInput::End),
+    (b"\x1b[7~", ParsedInput::Home),
+    (b"\x1b[8~", ParsedInput::End),
+    (b"\x1b[5~", ParsedInput::PageUp),
+    (b"\x1b[6~", ParsedInput::PageDown),
+    (b"\x1bOP", ParsedInput::F1),
+    (b"\x1bOQ", ParsedInput::F2),
+    (b"\x1bOR", ParsedInput::F3),
+    (b"\x1bOS", ParsedInput::F4),
+    (b"\x1b[15~", ParsedInput::F5),
+    (b"\x1b[17~", ParsedInput::F6),
+    (b"\x1b[18~", ParsedInput::F7),
+    (b"\x1b[19~", ParsedInput::F8),
+    (b"\x1b[20~", ParsedInput::F9),
+    (b"\x1b[21~", ParsedInput::F10),
+    (b"\x1b[23~", ParsedInput::F11),
+    (b"\x1b[24~", ParsedInput::F12),
+];
+
 #[derive(Debug, Default)]
 struct InputParser {
+    // Bytes of an in-flight escape sequence so CSI/SS3 fragments can be matched
+    // across separate websocket or PTY frames.
     esc_buf: Vec<u8>,
+    // Trailing bytes of an incomplete UTF-8 codepoint, replayed into the next
+    // chunk before decoding plain text.
     utf8_buf: Vec<u8>,
+    // When CR is mapped to LF, suppress the LF in a following CRLF pair so the
+    // parser emits only one Enter event.
     pending_lf_after_cr: bool,
 }
 
@@ -310,54 +346,8 @@ impl InputParser {
         self.pending_lf_after_cr = false;
     }
 
-    fn known_sequences() -> [(&'static [u8], ParsedInput); 26] {
-        [
-            (b"\x1b[D", ParsedInput::CursorLeft),
-            (b"\x1b[C", ParsedInput::CursorRight),
-            (b"\x1b[A", ParsedInput::CursorUp),
-            (b"\x1b[B", ParsedInput::CursorDown),
-            (b"\x1bOD", ParsedInput::CursorLeft),
-            (b"\x1bOC", ParsedInput::CursorRight),
-            (b"\x1bOA", ParsedInput::CursorUp),
-            (b"\x1bOB", ParsedInput::CursorDown),
-            (b"\x1b[H", ParsedInput::Home),
-            (b"\x1b[F", ParsedInput::End),
-            (b"\x1b[1~", ParsedInput::Home),
-            (b"\x1b[4~", ParsedInput::End),
-            (b"\x1b[7~", ParsedInput::Home),
-            (b"\x1b[8~", ParsedInput::End),
-            (b"\x1b[5~", ParsedInput::PageUp),
-            (b"\x1b[6~", ParsedInput::PageDown),
-            (b"\x1bOP", ParsedInput::F1),
-            (b"\x1bOQ", ParsedInput::F2),
-            (b"\x1bOR", ParsedInput::F3),
-            (b"\x1bOS", ParsedInput::F4),
-            (b"\x1b[15~", ParsedInput::F5),
-            (b"\x1b[17~", ParsedInput::F6),
-            (b"\x1b[18~", ParsedInput::F7),
-            (b"\x1b[19~", ParsedInput::F8),
-            (b"\x1b[20~", ParsedInput::F9),
-            (b"\x1b[21~", ParsedInput::F10),
-        ]
-    }
-
-    fn known_sequences_tail() -> [(&'static [u8], ParsedInput); 2] {
-        [
-            (b"\x1b[23~", ParsedInput::F11),
-            (b"\x1b[24~", ParsedInput::F12),
-        ]
-    }
-
     fn match_escape(seq: &[u8]) -> EscapeMatch {
-        for (known, parsed) in Self::known_sequences() {
-            if known == seq {
-                return EscapeMatch::Complete(parsed);
-            }
-            if known.starts_with(seq) {
-                return EscapeMatch::Prefix;
-            }
-        }
-        for (known, parsed) in Self::known_sequences_tail() {
+        for (known, parsed) in KNOWN_ESCAPE_SEQUENCES {
             if known == seq {
                 return EscapeMatch::Complete(parsed);
             }


### PR DESCRIPTION
This TTY refactor aligns WASIX behavior with Linux `n_tty` line-discipline semantics, and is validated against OpenSSH regress and behavioral tests. Loosely based on `https://github.com/torvalds/linux/blob/master/drivers/tty/n_tty.c`.

Primal reason for refactoring is unstable SSH behavior and animalities with command execution. First phase of this refactoring was to add a comprehensive test suite (ported from other open source TTY implementation and known issues in wasmer SSH) and originally only 13 tests passed from a total of 55. After matching overall parsing design to the Linux TTY we have all tests passing now.

---

1. [x] Collect tests from other projects and cover TTY logic with comprehensive test suite
2. [x] Refactor current design to match existing TTY emulators and other reference implementation to be more robust
3. [x] Resolve all the failing tests
4. [x]  Manually test that new implementation works with new wasmer/cli package and apps like nano in there

Current status:
```
- ✅ Checks that application cursor-left (`ESCOD`) moves cursor for inline insert (`tty_application_cursor_left_sequence_moves_cursor`).
- ✅ Checks that ASCII backspace (`\b`) behaves the same as DEL (`tty_backspace_ascii_bs_alias_matches_del`).
- ✅ Checks that backspace on an empty canonical line does nothing (`tty_canonical_backspace_on_empty_line_is_noop`).
- ✅ Checks that backspace removes the last ASCII character in canonical mode (`tty_canonical_backspace_removes_last_ascii_char`).
- ✅ Checks that canonical mode still forwards input when echo is disabled (`tty_canonical_echo_disabled_still_forwards_line`).
- ✅ Checks that Enter flushes canonical line content to stdin (`tty_canonical_enter_flushes_line_to_stdin`).
- ✅ Checks that LF is treated as Enter in canonical mode (`tty_canonical_lf_is_enter`).
- ✅ Checks that consecutive canonical lines stay isolated and do not bleed (`tty_canonical_multiple_lines_do_not_bleed_into_each_other`).
- ✅ Checks UTF-8 roundtrip in canonical mode for single-chunk input (`tty_canonical_utf8_single_chunk_roundtrip`).
- ✅ Checks that command and Enter split across chunks still flush correctly (`tty_chunk_split_command_plus_enter_flushes`).
- ✅ Checks that consecutive Enter presses emit empty lines (`tty_consecutive_enters_emit_empty_lines`).
- ✅ Checks that split CR then LF is handled as a single Enter (`tty_cr_then_lf_split_is_single_enter`).
- ✅ Checks that CRLF in one chunk is treated as one Enter (`tty_crlf_single_chunk_is_treated_as_one_enter`).
- ✅ Checks that Ctrl-\ emits SIGQUIT and clears the current line (`tty_ctrl_backslash_signals_sigquit_and_clears_line`).
- ✅ Checks that Ctrl-C emits SIGINT and clears buffered line input (`tty_ctrl_c_signals_and_clears_buffered_line`).
- ✅ Checks that Ctrl-C clears buffered line even without a signaler (`tty_ctrl_c_without_signaler_clears_buffer`).
- ✅ Checks that Ctrl-C without signaler clears line and echoes newline feedback (`tty_ctrl_c_without_signaler_clears_buffer_and_echoes_newline`).
- ✅ Checks that Ctrl-D on empty line is not buffered as normal text (`tty_ctrl_d_on_empty_line_is_not_buffered_as_text`).
- ✅ Checks that Ctrl-D with buffered text flushes without appending newline (`tty_ctrl_d_with_buffered_text_flushes_without_newline`).
- ✅ Checks that Ctrl-U emits expected terminal erase feedback (`tty_ctrl_u_echoes_line_erase_feedback`).
- ✅ Checks that Ctrl-U kills the current line contents (`tty_ctrl_u_kills_current_line`).
- ✅ Checks that Ctrl-W emits expected word-erase feedback (`tty_ctrl_w_echoes_word_erase_feedback`).
- ✅ Checks that Ctrl-W erases the previous word in canonical editing (`tty_ctrl_w_erases_previous_word`).
- ✅ Checks that Ctrl-Z emits SIGTSTP and clears line (`tty_ctrl_z_signals_sigtstp_and_clears_line`).
- ✅ Checks that disabling CR→LF mapping treats CR as data (`tty_disable_cr_to_lf_mapping_treats_cr_as_data`).
- ✅ Checks that extended navigation/function-key sequences are consumed (`tty_extended_navigation_and_function_keys_are_consumed`).
- ✅ Checks that Home/End tilde variants are consumed (`tty_home_end_tilde_variants_are_consumed`).
- ✅ Checks that Home key moves cursor to start for insertion (`tty_home_key_moves_cursor_to_start`).
- ✅ Checks that ignore-CR option ignores carriage returns (`tty_ignore_cr_option_ignores_carriage_return`).
- ✅ Checks that key events are no-op for data pipeline (`tty_key_event_is_noop`).
- ✅ Checks that left-arrow inline insert emits cursor-repair echo behavior (`tty_left_arrow_inline_insert_echoes_cursor_repair`).
- ✅ Checks that inline insert repaint updates tail text exactly (`tty_left_arrow_inline_insert_repaints_tail_exactly`).
- ✅ Checks that left-arrow moves cursor for inline insertion (`tty_left_arrow_moves_cursor_for_inline_insert`).
- ✅ Checks that duplicate mobile data frames are suppressed (`tty_mobile_duplicate_data_is_suppressed`).
- ✅ Checks that mode switches clear pending parser/escape state (`tty_mode_switch_clears_pending_parser_state`).
- ✅ Checks that non-mobile duplicate data is not suppressed (`tty_non_mobile_duplicate_data_is_not_suppressed`).
- ✅ Checks that partial escape state does not block subsequent Ctrl-C interrupt handling (`tty_partial_escape_then_ctrl_c_still_interrupts`).
- ✅ Checks that partial escape followed by Enter still preserves Enter semantics (`tty_partial_escape_then_enter_preserves_enter_semantics`).
- ✅ Checks that raw input events are handled like raw data events (`tty_raw_input_event_behaves_like_data_input_event`).
- ✅ Checks that backspace is forwarded as raw data in raw mode (`tty_raw_mode_backspace_is_forwarded`).
- ✅ Checks that raw mode can still echo input when enabled (`tty_raw_mode_can_echo`).
- ✅ Checks that Ctrl-C is forwarded as data in raw mode (`tty_raw_mode_ctrl_c_is_forwarded_as_data`).
- ✅ Checks that escape sequences are forwarded in raw mode (`tty_raw_mode_escape_sequence_is_forwarded`).
- ✅ Checks that raw mode forwards bytes without line buffering (`tty_raw_mode_forwards_without_line_buffering`).
- ✅ Checks single-chunk text+backspace+Enter canonical edit behavior (`tty_single_chunk_text_backspace_enter_edits_line`).
- ✅ Checks single-chunk text+Ctrl-C+Enter clears line and still signals (`tty_single_chunk_text_ctrlc_enter_clears_line_with_signaler`).
- ✅ Checks that single-frame command+Enter executes correctly (`tty_single_frame_command_plus_enter_is_executed`).
- ✅ Checks that special keys do not edit/forward by default (`tty_special_keys_do_not_edit_or_forward_by_default`).
- ✅ Checks that split F5 escape sequence is consumed (`tty_split_f5_escape_sequence_is_consumed`).
- ✅ Checks that split left-arrow escape sequence is consumed (`tty_split_left_arrow_escape_sequence_is_consumed`).
- ✅ Checks UTF-8 codepoint split across raw chunks is reconstructed (`tty_split_utf8_codepoint_across_raw_chunks`).
- ✅ Checks replacing stdin sink redirects future writes (`tty_stdin_replace_redirects_future_writes`).
- ✅ Checks that tab is consumed without forwarding (`tty_tab_is_consumed_without_forwarding`).
- ✅ Checks that unknown escape sequence is buffered as literal data (`tty_unknown_escape_sequence_is_buffered_as_data`).
- ✅ Checks that UTF-8 backspace removes a full codepoint (`tty_utf8_backspace_removes_full_character`).
```