### PR TITLE
wasix(tests): Make test runnable on MacOS

### DIFF
--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -184,6 +184,13 @@ wasmer = { path = "../api", version = "=7.1.0-alpha.1", default-features = false
 	"cranelift",
 ] }
 
+[target.'cfg(all(not(target_arch = "wasm32"), target_os = "macos"))'.dev-dependencies]
+wasmer = { path = "../api", version = "=7.1.0-alpha.1", default-features = false, features = [
+	"wat",
+	"js-serializable-module",
+	"llvm",
+] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom03]
 # Enable wasm_js for the getrandom 0.3.x instance pulled in by rand 0.9.
 package = "getrandom"

--- a/lib/wasix/tests/wasix-wasm.rs
+++ b/lib/wasix/tests/wasix-wasm.rs
@@ -1,2 +1,2 @@
-#![cfg(all(unix, not(target_os = "macos"), not(feature = "js")))]
+#![cfg(all(unix, not(feature = "js")))]
 mod wasm_tests;

--- a/lib/wasix/tests/wasm_tests/context_switching.rs
+++ b/lib/wasix/tests/wasm_tests/context_switching.rs
@@ -1,3 +1,4 @@
+#[cfg(all(unix, not(target_os = "macos")))]
 use super::{run_build_script, run_wasm};
 
 // macOS is currently disabled, because cranelift does not

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -20,6 +20,7 @@ use std::pin::Pin;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use wasmer::{sys::EngineBuilder, sys::LLVMOptLevel, sys::Target};
 use wasmer_wasix::VirtualFile as VirtualFileTrait;
 use wasmer_wasix::runners::MappedDirectory;
 use wasmer_wasix::runners::wasi::{RuntimeOrEngine, WasiRunner};
@@ -273,6 +274,35 @@ fn get_cache_dir() -> PathBuf {
     }
 }
 
+fn create_engine_for_wasm(wasm_bytes: &[u8]) -> wasmer::Engine {
+    #[cfg(target_os = "macos")]
+    {
+        // On macOS, the default Cranelift backend has limited support for the features
+        // required by these tests, especially exception handling. Use the slower LLVM
+        // backend instead so the WASIX test suite can run reliably on macOS.
+        let target = Target::default();
+        let features = wasmer_types::Features::detect_from_wasm(wasm_bytes).unwrap_or_else(|_| {
+            wasmer::Engine::default_features_for_backend(&wasmer::BackendKind::LLVM, &target)
+        });
+
+        // Reduce opt level as it speeds up compilation dramatically and for tests no opt is fine
+        let mut compiler = wasmer::sys::LLVM::default();
+        compiler.opt_level(LLVMOptLevel::None);
+
+        return EngineBuilder::new(compiler)
+            .set_features(Some(features))
+            .set_target(Some(target))
+            .engine()
+            .into();
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = wasm_bytes;
+        wasmer::Engine::default()
+    }
+}
+
 /// Result from running a WASM program, including captured output and exit status
 pub struct WasmRunResult {
     #[allow(dead_code)]
@@ -302,9 +332,9 @@ pub fn run_wasm_with_result(
 ) -> Result<WasmRunResult, anyhow::Error> {
     // Load the compiled WASM module
     let wasm_bytes = std::fs::read(wasm_path)?;
+    let engine = create_engine_for_wasm(&wasm_bytes);
     let module_data = HashedModuleData::new(wasm_bytes);
     let hash = *module_data.hash();
-    let engine = wasmer::Engine::default();
 
     // Create buffers to capture stdout and stderr
     let stdout_buffer = Arc::new(Mutex::new(Vec::new()));


### PR DESCRIPTION
- New wasix tests were disabled on MacOS completely, but it can actually run fine on Mac
- Main issue that it was using default engine (=Cranelift) which has very limited support on Mac, so for MacOS we simply switch to LLVM
- Also this PR drops LLVM optimisation to None for MacOS which makes tests dramatically faster to run and for tests we don't care about runtime performance that much

This is preparation PR for the upcoming POSIX tests syscalls merging as it will make my life a bit easier :) 