### PR TITLE
fix: deadlock while signal handling with intervals

### DIFF
--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -706,7 +706,7 @@ impl WasiEnv {
             let mut now = 0;
             {
                 let mut has_signal_interval = false;
-                let inner = env.process.inner.0.lock().unwrap();
+                let mut inner = env.process.inner.0.lock().unwrap();
                 if !inner.signal_intervals.is_empty() {
                     now = platform_clock_time_get(Snapshot0Clockid::Monotonic, 1_000_000).unwrap()
                         as u128;
@@ -719,7 +719,6 @@ impl WasiEnv {
                     }
                 }
                 if has_signal_interval {
-                    let mut inner = env.process.inner.0.lock().unwrap();
                     for signal in inner.signal_intervals.values_mut() {
                         let elapsed = now - signal.last_signal;
                         if elapsed >= signal.interval.as_nanos() {


### PR DESCRIPTION
Hey, I'm new here!

While investigating #5907, I realized that there are several issues that eventually lead to `SIGALARM` not being handled. I also raised #6284 and explained another issue under #5904. But in this PR, I only fixed the part where the handling of the intervals deadlocks since the same Mutex is tried to be locked when the interval is hit. 