### PR TITLE
chore: relax overaggresive lints in LLVM compiler

### DIFF
--- a/lib/compiler-llvm/src/abi/mod.rs
+++ b/lib/compiler-llvm/src/abi/mod.rs
@@ -3,7 +3,7 @@
 // optimizer by exposing operations to the optimizer, but it requires that the
 // frontend know exactly what IR to produce in order to get the right ABI.
 
-#![deny(dead_code, missing_docs)]
+#![deny(missing_docs)]
 
 use crate::error::err;
 use crate::translator::intrinsics::{Intrinsics, type_to_llvm};

--- a/lib/compiler-llvm/src/lib.rs
+++ b/lib/compiler-llvm/src/lib.rs
@@ -1,15 +1,3 @@
-#![deny(
-    nonstandard_style,
-    unused_imports,
-    unused_mut,
-    unused_variables,
-    unused_unsafe,
-    unreachable_patterns
-)]
-#![cfg_attr(
-    all(not(target_os = "windows"), not(target_arch = "aarch64")),
-    deny(dead_code)
-)]
 #![doc(html_favicon_url = "https://wasmer.io/images/icons/favicon-32x32.png")]
 #![doc(html_logo_url = "https://github.com/wasmerio.png?size=200")]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
I take the clippy lints seriously, but having it `deny` makes any prototypes in the LLVM compiler much more difficult.