### PR TITLE
Use correct asyncify_stop_rewind instead of asynify_stop_unwind

### DIFF
--- a/lib/wasix/src/state/handles/mod.rs
+++ b/lib/wasix/src/state/handles/mod.rs
@@ -93,7 +93,7 @@ pub struct WasiModuleInstanceHandles {
     pub(crate) asyncify_stop_unwind: Option<TypedFunction<(), ()>>,
 
     /// asyncify_start_rewind(data : i32): call this to start rewinding the
-    /// stack vack up to the location stored in the provided data. This prepares
+    /// stack back up to the location stored in the provided data. This prepares
     /// for the rewind; to start it, you must call the first function in the
     /// call stack to be unwound.
     // TODO: review allow...

--- a/lib/wasix/src/syscalls/mod.rs
+++ b/lib/wasix/src/syscalls/mod.rs
@@ -1163,7 +1163,7 @@ where
     {
         asyncify_start_unwind.call(&mut ctx, asyncify_data);
     } else {
-        warn!("failed to unwind the stack because the asyncify_start_rewind export is missing");
+        warn!("failed to unwind the stack because the asyncify_start_unwind export is missing");
         return Err(WasiError::Exit(Errno::Noexec.into()));
     }
 
@@ -1229,7 +1229,7 @@ where
         {
             asyncify_stop_unwind.call(&mut ctx);
         } else {
-            warn!("failed to unwind the stack because the asyncify_start_rewind export is missing");
+            warn!("failed to unwind the stack because the asyncify_stop_unwind export is missing");
             return Ok(OnCalledAction::Finish);
         }
 
@@ -1444,12 +1444,12 @@ where
         if let Some(asyncify_stop_rewind) = env
             .inner()
             .static_module_instance_handles()
-            .and_then(|handles| handles.asyncify_stop_unwind.clone())
+            .and_then(|handles| handles.asyncify_stop_rewind.clone())
         {
             asyncify_stop_rewind.call(ctx);
         } else {
             warn!(
-                "failed to handle rewind because the asyncify_start_rewind export is missing or inaccessible"
+                "failed to handle rewind because the asyncify_stop_rewind export is missing or inaccessible"
             );
             return Some(None);
         }


### PR DESCRIPTION
Fix semantically incorrect code for asyncify
```diff
if let Some(asyncify_stop_rewind) = env // We check for asyncify_stop_rewind here 
            .inner()
            .static_module_instance_handles()
---            .and_then(|handles| handles.asyncify_stop_unwind.clone())
+++            .and_then(|handles| handles.asyncify_stop_rewind.clone()) // We should call for that in here
```

Under the hood both functions does exactly the same, so it's a safe change, but I think it's worth doing it to avoid any nasty surprises in the future which will be very difficult to debug.
https://github.com/WebAssembly/binaryen/blob/d966ed564b490538f2584e105defa67476979e4e/src/passes/Asyncify.cpp#L2003-L2005 
```
  makeFunction(ASYNCIFY_STOP_UNWIND, false, State::Normal);
  makeFunction(ASYNCIFY_START_REWIND, true, State::Rewinding);
  makeFunction(ASYNCIFY_STOP_REWIND, false, State::Normal);
```
also fix incorrect log comments which could confuse during debugging