### PR TITLE
fix(wasix): Fix connect_tcp readiness, and epoll del cleanup

### DIFF
--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -175,7 +175,16 @@ impl VirtualNetworking for LocalNetworking {
             return Err(NetworkError::PermissionDenied);
         }
 
-        let stream = mio::net::TcpStream::connect(peer).map_err(io_err_into_net_error)?;
+        // This future may be polled outside Tokio's executor context, so run
+        // the connect itself on the stored runtime handle to guarantee a reactor.
+        let stream = self
+            .handle
+            .spawn(tokio::net::TcpStream::connect(peer))
+            .await
+            .map_err(|_| NetworkError::IOError)?
+            .map_err(io_err_into_net_error)?;
+        let stream = stream.into_std().map_err(io_err_into_net_error)?;
+        let stream = mio::net::TcpStream::from_std(stream);
 
         if let Ok(p) = stream.peer_addr() {
             peer = p;

--- a/lib/wasix/src/os/epoll/mod.rs
+++ b/lib/wasix/src/os/epoll/mod.rs
@@ -262,12 +262,14 @@ impl EpollState {
     }
 
     pub(crate) fn apply_del(&self, fd: WasiFd) -> Result<(), Errno> {
-        self.subscriptions
+        let removed = self
+            .subscriptions
             .lock()
             .unwrap()
             .remove(&fd)
-            .map(|_| ())
-            .ok_or(Errno::Noent)
+            .ok_or(Errno::Noent)?;
+        removed.detach_joins();
+        Ok(())
     }
 
     pub(crate) fn rollback_registration(&self, fd: WasiFd, previous: Option<Arc<EpollSubState>>) {
@@ -684,6 +686,8 @@ pub(crate) fn epoll_empty_dequeue_entry() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::RwLock;
+    use virtual_fs::Pipe;
 
     fn test_epoll_event_ctl(fd: WasiFd) -> EpollEventCtl {
         EpollEventCtl {
@@ -940,5 +944,38 @@ mod tests {
         assert!(sub.enqueued.load(Ordering::Acquire));
         let queued = epoll_state.ready.lock().unwrap().pop_front().unwrap();
         assert_eq!(queued.fd, 44);
+    }
+
+    #[test]
+    fn apply_del_detaches_joins_even_if_subscription_stays_alive() {
+        let epoll_state = Arc::new(EpollState::new());
+        let event = test_epoll_event_ctl(55);
+        let sub = Arc::new(EpollSubState::new(EpollFd::from_event_ctl(55, &event), 1));
+        epoll_state.insert_subscription(55, sub.clone());
+
+        let (tx, _rx) = Pipe::new().split();
+        sub.add_join(EpollJoinGuard::new(InodeValFilePollGuard {
+            fd: 55,
+            peb: PollEventBuilder::new().build(),
+            subscription: Subscription {
+                userdata: 0,
+                type_: Eventtype::FdRead,
+                data: SubscriptionUnion {
+                    fd_readwrite: SubscriptionFsReadwrite {
+                        file_descriptor: 55,
+                    },
+                },
+            },
+            mode: InodeValFilePollGuardMode::PipeTx {
+                tx: Arc::new(RwLock::new(Box::new(tx))),
+            },
+        }));
+
+        let leaked_ref = sub.clone();
+        assert_eq!(leaked_ref.joins.lock().unwrap().len(), 1);
+
+        epoll_state.apply_del(55).unwrap();
+
+        assert_eq!(leaked_ref.joins.lock().unwrap().len(), 0);
     }
 }


### PR DESCRIPTION
- `EPOLL_CTL_DEL` removed subscriptions from the epoll map but did not detach their join guards, which allowed stale deleted subscriptions to interfere with later watchers on the same fd.
- `LocalNetworking::connect_tcp()`now returns an already connected TCP stream. Previously `connect_tcp()` returned `mio::net::TcpStream::connect(peer)` directly, which exposed a socket that could still be in the middle of a nonblocking connect. Some async guest networking paths expect `connect_tcp()` to complete connection establishment before the socket is handed back.

Basically that PR plus a previous one #6297 fixes that Puthon repro:
```python
import asyncio, httpx

def req_sync():
  print(httpx.get("https://example.com/", timeout=15.0).status_code) # works fine

async def main():
    async with httpx.AsyncClient(timeout=15.0) as c:
        print((await c.get("https://example.com/")).status_code) # ERROR TIMEOUT

asyncio.run(main())
```


