### PR TITLE
fix(LLVM): use -O1 for large functions

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -1,4 +1,5 @@
 use crate::config::LLVM;
+use crate::config::OptimizationStyle;
 use crate::translator::FuncTrampoline;
 use crate::translator::FuncTranslator;
 use inkwell::DLLStorageClass;
@@ -191,13 +192,17 @@ impl LLVMCompiler {
 
         let merged_bitcode = function_body_inputs.into_iter().par_bridge().map_init(
             || {
-                let target_machine = self.config().target_machine(target);
-                let target_machine_no_opt = self.config().target_machine_with_opt(target, false);
+                let target_machine = self
+                    .config()
+                    .target_machine_with_opt(target, OptimizationStyle::ForSpeed);
+                let target_machine_for_size = self
+                    .config()
+                    .target_machine_with_opt(target, OptimizationStyle::ForSize);
                 let pointer_width = target.triple().pointer_width().unwrap().bytes();
                 FuncTranslator::new(
                     target.triple().clone(),
                     target_machine,
-                    Some(target_machine_no_opt),
+                    Some(target_machine_for_size),
                     binary_format,
                     pointer_width,
                     *target.cpu_features(),
@@ -216,6 +221,7 @@ impl LLVMCompiler {
                     &compile_info.table_styles,
                     symbol_registry,
                     target.triple(),
+                    OptimizationStyle::ForSpeed,
                 )?;
 
                 Ok(module.write_bitcode_to_memory().as_slice().to_vec())
@@ -435,14 +441,17 @@ impl Compiler for LLVMCompiler {
             &pool,
             || {
                 let compiler = &self;
-                let target_machine = compiler.config().target_machine_with_opt(target, true);
-                let target_machine_no_opt =
-                    compiler.config().target_machine_with_opt(target, false);
+                let target_machine = compiler
+                    .config()
+                    .target_machine_with_opt(target, OptimizationStyle::ForSpeed);
+                let target_machine_for_size = compiler
+                    .config()
+                    .target_machine_with_opt(target, OptimizationStyle::ForSize);
                 let pointer_width = target.triple().pointer_width().unwrap().bytes();
                 FuncTranslator::new(
                     target.triple().clone(),
                     target_machine,
-                    Some(target_machine_no_opt),
+                    Some(target_machine_for_size),
                     binary_format,
                     pointer_width,
                     *target.cpu_features(),

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -116,6 +116,12 @@ pub struct LLVM {
     pub(crate) verbose_asm: bool,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum OptimizationStyle {
+    ForSpeed,
+    ForSize,
+}
+
 impl LLVM {
     /// Creates a new configuration object with the default configuration
     /// specified.
@@ -250,13 +256,13 @@ impl LLVM {
 
     /// Generates the target machine for the current target
     pub fn target_machine(&self, target: &Target) -> TargetMachine {
-        self.target_machine_with_opt(target, true)
+        self.target_machine_with_opt(target, OptimizationStyle::ForSpeed)
     }
 
     pub(crate) fn target_machine_with_opt(
         &self,
         target: &Target,
-        enable_optimization: bool,
+        opt_style: OptimizationStyle,
     ) -> TargetMachine {
         let triple = target.triple();
         let cpu_features = &target.cpu_features();
@@ -326,10 +332,9 @@ impl LLVM {
                 Architecture::LoongArch64 => "+f,+d",
                 _ => &llvm_cpu_features,
             })
-            .set_level(if enable_optimization {
-                self.opt_level
-            } else {
-                LLVMOptLevel::None
+            .set_level(match opt_style {
+                OptimizationStyle::ForSpeed => self.opt_level,
+                OptimizationStyle::ForSize => LLVMOptLevel::Less,
             })
             .set_reloc_mode(self.reloc_mode(self.target_binary_format(target)))
             .set_code_model(match triple.architecture {

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -7,7 +7,7 @@ use super::{
     // stackmap::{StackmapEntry, StackmapEntryKind, StackmapRegistry, ValueSemantic},
     state::{ControlFrame, ExtraInfo, IfElseState, State, TagCatchInfo},
 };
-use crate::compiler::ModuleBasedSymbolRegistry;
+use crate::{compiler::ModuleBasedSymbolRegistry, config::OptimizationStyle};
 use enumset::EnumSet;
 use inkwell::{
     AddressSpace, AtomicOrdering, AtomicRMWBinOp, DLLStorageClass, FloatPredicate, IntPredicate,
@@ -72,7 +72,7 @@ pub struct FuncTranslator {
     ctx: Context,
     target_triple: Triple,
     target_machine: TargetMachine,
-    target_machine_no_opt: Option<TargetMachine>,
+    target_machine_for_size: Option<TargetMachine>,
     abi: Box<dyn Abi>,
     binary_fmt: BinaryFormat,
     func_section: String,
@@ -87,7 +87,7 @@ impl FuncTranslator {
     pub fn new(
         target_triple: Triple,
         target_machine: TargetMachine,
-        target_machine_no_opt: Option<TargetMachine>,
+        target_machine_for_size: Option<TargetMachine>,
         binary_fmt: BinaryFormat,
         pointer_width: u8,
         cpu_features: EnumSet<CpuFeature>,
@@ -98,7 +98,7 @@ impl FuncTranslator {
             ctx: Context::create(),
             target_triple,
             target_machine,
-            target_machine_no_opt,
+            target_machine_for_size,
             abi,
             func_section: match binary_fmt {
                 BinaryFormat::Elf => FUNCTION_SECTION_ELF.to_string(),
@@ -128,6 +128,7 @@ impl FuncTranslator {
         _table_styles: &PrimaryMap<TableIndex, TableStyle>,
         symbol_registry: &dyn SymbolRegistry,
         target: &Triple,
+        opt_style: OptimizationStyle,
     ) -> Result<Module<'_>, CompileError> {
         // The function type, used for the callbacks.
         let func_index = wasm_module.func_index(*local_func_index);
@@ -365,41 +366,48 @@ impl FuncTranslator {
         }
 
         let mut passes = vec![];
-
         if config.enable_verifier {
             passes.push("verify");
         }
 
-        passes.push("sccp");
-        passes.push("early-cse");
-        //passes.push("deadargelim");
-        passes.push("adce");
-        passes.push("sroa");
-        passes.push("aggressive-instcombine");
-        passes.push("jump-threading");
-        //passes.push("ipsccp");
-        passes.push("simplifycfg");
-        passes.push("reassociate");
-        passes.push("loop-rotate");
-        passes.push("indvars");
-        //passes.push("lcssa");
-        //passes.push("licm");
-        //passes.push("instcombine");
-        passes.push("sccp");
-        passes.push("reassociate");
-        passes.push("simplifycfg");
-        passes.push("gvn");
-        passes.push("memcpyopt");
-        passes.push("dse");
-        passes.push("dce");
-        //passes.push("instcombine");
-        passes.push("reassociate");
-        passes.push("simplifycfg");
-        passes.push("mem2reg");
+        match opt_style {
+            OptimizationStyle::ForSize => {
+                // Apparently, the default<Os> could be much slower compared to -O1.
+                passes.push("default<O1>");
+            }
+            OptimizationStyle::ForSpeed => {
+                passes.push("sccp");
+                passes.push("early-cse");
+                //passes.push("deadargelim");
+                passes.push("adce");
+                passes.push("sroa");
+                passes.push("aggressive-instcombine");
+                passes.push("jump-threading");
+                //passes.push("ipsccp");
+                passes.push("simplifycfg");
+                passes.push("reassociate");
+                passes.push("loop-rotate");
+                passes.push("indvars");
+                //passes.push("lcssa");
+                //passes.push("licm");
+                //passes.push("instcombine");
+                passes.push("sccp");
+                passes.push("reassociate");
+                passes.push("simplifycfg");
+                passes.push("gvn");
+                passes.push("memcpyopt");
+                passes.push("dse");
+                passes.push("dce");
+                //passes.push("instcombine");
+                passes.push("reassociate");
+                passes.push("simplifycfg");
+                passes.push("mem2reg");
+            }
+        }
 
         module
             .run_passes(
-                passes.join(",").as_str(),
+                &passes.join(","),
                 target_machine,
                 PassBuilderOptions::create(),
             )
@@ -425,6 +433,11 @@ impl FuncTranslator {
         symbol_registry: &ModuleBasedSymbolRegistry,
         target: &Triple,
     ) -> Result<CompiledFunction, CompileError> {
+        let opt_style = if function_body.data.len() as u64 > WASM_LARGE_FUNCTION_THRESHOLD {
+            OptimizationStyle::ForSize
+        } else {
+            OptimizationStyle::ForSpeed
+        };
         let module = self.translate_to_module(
             wasm_module,
             module_translation,
@@ -435,19 +448,21 @@ impl FuncTranslator {
             table_styles,
             symbol_registry,
             target,
+            opt_style,
         )?;
         let function = CompiledKind::Local(
             *local_func_index,
             wasm_module.get_function_name(wasm_module.func_index(*local_func_index)),
         );
 
-        let target_machine = if function_body.data.len() as u64 > WASM_LARGE_FUNCTION_THRESHOLD {
-            self.target_machine_no_opt
+        let target_machine = match opt_style {
+            OptimizationStyle::ForSize => self
+                .target_machine_for_size
                 .as_ref()
-                .unwrap_or(&self.target_machine)
-        } else {
-            &self.target_machine
+                .unwrap_or(&self.target_machine),
+            OptimizationStyle::ForSpeed => &self.target_machine,
         };
+
         let memory_buffer = target_machine
             .write_to_memory_buffer(&module, FileType::Object)
             .unwrap();


### PR DESCRIPTION
In #5997 we stopped optimizing very large functions and that rapidly increased stack memory footprint for certail workloads (e.g. Python). And so, the PR uses -O1 (and the corresponding default list of opt. passes) for such functions instead.

For the reported test-case, even using the --stack-size 50K, the workload runs correctly. While before the change, 3M stack size was necessary.

Build time diff:
python: 15 -> 18s
php-32: 15 -> 16s
static-web-server: 8 -> 13s

Fixes #6302