### PR TITLE
chore: add progress to publish.py script

### DIFF
--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -120,13 +120,14 @@ class Publisher:
             version = data["workspace"]["package"]["version"]
         self.version: str = version
 
-        if self.verbose and not self.dry_run:
-            print(f"Publishing version {self.version}")
-        elif self.verbose and self.dry_run:
-            print(f"Publishing version {self.version} dry run!")
+        if self.verbose:
+            if self.dry_run:
+                print(f"Publishing version {self.version} dry run!")
+            else:
+                print(f"Publishing version {self.version}")
 
-        print(data["dependencies"])
-        print("wasmer-package" in data["workspace"]["dependencies"])
+            print("Dependencies:")
+            print(data["dependencies"])
 
         def check_local_workspace_dep(t):
             return (
@@ -153,9 +154,12 @@ class Publisher:
                 lambda p: p + "/Cargo.toml",
                 filter(
                     lambda path: (
-                        path.startswith("lib/") and os.path.exists(path + "/Cargo.toml")
-                    )
-                    or path in SETTINGS["non-lib-workspace-members"],
+                        (
+                            path.startswith("lib/")
+                            and os.path.exists(path + "/Cargo.toml")
+                        )
+                        or path in SETTINGS["non-lib-workspace-members"]
+                    ),
                     itertools.chain(
                         data["workspace"]["members"],
                         map(
@@ -180,9 +184,11 @@ class Publisher:
                         acc.update(
                             list(
                                 map(
-                                    lambda dep: dep[1]["package"]
-                                    if "package" in dep[1]
-                                    else dep[0],
+                                    lambda dep: (
+                                        dep[1]["package"]
+                                        if "package" in dep[1]
+                                        else dep[0]
+                                    ),
                                     filter(
                                         check_local_dep_fn, toml["dependencies"].items()
                                     ),
@@ -193,9 +199,11 @@ class Publisher:
                         acc.update(
                             list(
                                 map(
-                                    lambda dep: dep[1]["package"]
-                                    if "package" in dep[1]
-                                    else dep[0],
+                                    lambda dep: (
+                                        dep[1]["package"]
+                                        if "package" in dep[1]
+                                        else dep[0]
+                                    ),
                                     filter(
                                         check_local_dep_fn,
                                         toml["dev-dependencies"].items(),
@@ -297,8 +305,8 @@ class Publisher:
         status = {}
         failures = 0
 
-        for crate_name in self.publish_order:
-            print(f"Publishing `{crate_name}`...")
+        for i, crate_name in enumerate(self.publish_order):
+            print(f"Publishing `{crate_name}` ({i + 1}/{len(self.publish_order)}) ...")
             if not self.is_crate_already_published(crate_name):
                 status[crate_name] = self.publish_crate(crate_name)
                 if status[crate_name]:


### PR DESCRIPTION
Sample output:
```
❯ ./scripts/publish.py publish
Publishing `wasmer-types` (1/30) ...
`wasmer-types` was already published!
Publishing `wasmer-config` (2/30) ...
`wasmer-config` was already published!
Publishing `wasmer-capi-examples-runner` (3/30) ...
`wasmer-capi-examples-runner` was already published!
Publishing `virtual-mio` (4/30) ...
`virtual-mio` was already published!
Publishing `macro-wasmer-universal-test` (5/30) ...
`macro-wasmer-universal-test` was already published!
...
```