### PR TITLE
fix(wasix): make sock_send/sock_recv handle PipeTx/PipeRx like pipe-backed sockets

### DIFF
--- a/lib/wasix/src/syscalls/wasix/sock_recv.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_recv.rs
@@ -31,8 +31,8 @@ pub fn sock_recv<M: MemorySize>(
     let env = ctx.data();
     let fd_entry = wasi_try_ok!(env.state.fs.get_fd(sock));
     let guard = fd_entry.inode.read();
-    // We need this hack because we use a pipe to back socket pairs
-    let use_read = matches!(guard.deref(), Kind::DuplexPipe { .. });
+    // Some guests route socket-like wakeups through pipe-backed fds.
+    let use_read = matches!(guard.deref(), Kind::DuplexPipe { .. } | Kind::PipeRx { .. });
     drop(guard);
     if use_read {
         fd_read(ctx, sock, ri_data, ri_data_len, ro_data_len)

--- a/lib/wasix/src/syscalls/wasix/sock_send.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send.rs
@@ -31,8 +31,8 @@ pub fn sock_send<M: MemorySize>(
     let fd_entry = wasi_try_ok!(env.state.fs.get_fd(fd));
     let enable_journal = env.enable_journal;
     let guard = fd_entry.inode.read();
-    // We need this hack because we use a pipe to back socket pairs
-    let use_write = matches!(guard.deref(), Kind::DuplexPipe { .. });
+    // Some guests route socket-like wakeups through pipe-backed fds.
+    let use_write = matches!(guard.deref(), Kind::DuplexPipe { .. } | Kind::PipeTx { .. });
     drop(guard);
 
     let bytes_written = if use_write {

--- a/lib/wasix/tests/socket_wasm.rs
+++ b/lib/wasix/tests/socket_wasm.rs
@@ -1,0 +1,3 @@
+#![cfg(all(target_os = "macos", not(feature = "js")))]
+
+mod wasm_tests;

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -11,6 +11,7 @@ mod longjmp_tests;
 mod reflection_tests;
 mod semaphore_tests;
 mod shared_library_tests;
+mod socket_tests;
 mod threadlocal_tests;
 
 use std::borrow::Cow;

--- a/lib/wasix/tests/wasm_tests/socket_tests.rs
+++ b/lib/wasix/tests/wasm_tests/socket_tests.rs
@@ -1,0 +1,18 @@
+use super::{run_build_script, run_wasm_with_result};
+use wasmer::Engine;
+use wasmer::sys::{Features, LLVM, NativeEngineExt, Target};
+
+#[test]
+fn test_pipe_send_recv_compat() {
+    let wasm = run_build_script(file!(), "pipe_send_recv_compat").unwrap();
+    let result = run_wasm_with_result(&wasm, wasm.parent().unwrap()).unwrap();
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "pipe send/recv works",
+        "exit_code={:?}\nstdout:\n{}\nstderr:\n{}",
+        result.exit_code,
+        stdout,
+        String::from_utf8_lossy(&result.stderr)
+    );
+}

--- a/lib/wasix/tests/wasm_tests/socket_tests/pipe_send_recv_compat/build.sh
+++ b/lib/wasix/tests/wasm_tests/socket_tests/pipe_send_recv_compat/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/socket_tests/pipe_send_recv_compat/main.c
+++ b/lib/wasix/tests/wasm_tests/socket_tests/pipe_send_recv_compat/main.c
@@ -1,0 +1,40 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void)
+{
+    int pipefd[2];
+    if (pipe(pipefd) != 0)
+    {
+        perror("pipe");
+        return 1;
+    }
+
+    int sent = send(pipefd[1], "ping", 4, 0);
+    if (sent != 4)
+    {
+        perror("send");
+        return 1;
+    }
+
+    char buf[5];
+    int received = recv(pipefd[0], buf, 4, 0);
+    if (received != 4)
+    {
+        perror("recv");
+        return 1;
+    }
+
+    buf[received] = '\0';
+    if (strcmp(buf, "ping") != 0)
+    {
+        fprintf(stderr, "unexpected payload: %s\n", buf);
+        return 1;
+    }
+
+    printf("pipe send/recv works\n");
+    return 0;
+}


### PR DESCRIPTION
This restores the `sock_send`/`sock_recv` compatibility path for plain pipe endpoints (`Kind::PipeTx` / `Kind::PipeRx`), which was regressed in 85a3551ae29 when the socketpair fix narrowed the special-case handling to `Kind::DuplexPipe` only. 

In practice this caused guests that use `fd_pipe()` for socket-like wakeups, including the Python `asyncio` repro, to hit `ENOTSOCK` on `send()`/`recv()` and stall. The PR also adds a `lib/wasix/tests/wasm_tests` regression that builds a small C guest and verifies `send()`/`recv()` works across a pipe under the LLVM-backed Wasix test runner.
