### PR TITLE
Simplify FunctionMiddleware trait: remove lifetime parameter

### DIFF
--- a/lib/api/src/backend/sys/entities/global.rs
+++ b/lib/api/src/backend/sys/entities/global.rs
@@ -48,17 +48,9 @@ impl Global {
 
     pub(crate) fn get(&self, store: &mut impl AsStoreMut) -> Value {
         unsafe {
-            let raw = self
-                .handle
-                .get(store.as_store_ref().objects().as_sys())
-                .vmglobal()
-                .as_ref()
-                .val;
-            let ty = self
-                .handle
-                .get(store.as_store_ref().objects().as_sys())
-                .ty()
-                .ty;
+            let global = self.handle.get(store.as_store_ref().objects().as_sys());
+            let raw = global.vmglobal().as_ref().val;
+            let ty = global.ty().ty;
             Value::from_raw(store, ty, raw)
         }
     }
@@ -67,22 +59,20 @@ impl Global {
         if !val.is_from_store(store) {
             return Err(RuntimeError::new("cross-`Store` values are not supported"));
         }
-        if self.ty(store).mutability != Mutability::Var {
+        let global = self.handle.get_mut(store.objects_mut().as_sys_mut());
+        if global.ty().mutability != Mutability::Var {
             return Err(RuntimeError::new("Attempted to set an immutable global"));
         }
-        if val.ty() != self.ty(store).ty {
+        if val.ty() != global.ty().ty {
             return Err(RuntimeError::new(format!(
                 "Attempted to operate on a global of type {expected} as a global of type {found}",
-                expected = self.ty(store).ty,
+                expected = global.ty().ty,
                 found = val.ty(),
             )));
         }
         unsafe {
-            self.handle
-                .get_mut(store.as_store_mut().objects_mut().as_sys_mut())
-                .vmglobal()
-                .as_mut()
-                .val = val.as_raw(store);
+            let mut dest = global.vmglobal();
+            dest.as_mut().val = val.as_raw(store);
         }
         Ok(())
     }

--- a/lib/compiler/src/translator/middleware.rs
+++ b/lib/compiler/src/translator/middleware.rs
@@ -18,10 +18,10 @@ pub trait ModuleMiddleware: Debug + Send + Sync {
     /// Here we generate a separate object for each function instead of executing directly on per-function operators,
     /// in order to enable concurrent middleware application. Takes immutable `&self` because this function can be called
     /// concurrently from multiple compilation threads.
-    fn generate_function_middleware(
+    fn generate_function_middleware<'a>(
         &self,
         local_function_index: LocalFunctionIndex,
-    ) -> Box<dyn FunctionMiddleware>;
+    ) -> Box<dyn FunctionMiddleware<'a> + 'a>;
 
     /// Transforms a `ModuleInfo` struct in-place. This is called before application on functions begins.
     fn transform_module_info(&self, _: &mut ModuleInfo) -> Result<(), MiddlewareError> {
@@ -30,9 +30,12 @@ pub trait ModuleMiddleware: Debug + Send + Sync {
 }
 
 /// A function middleware specialized for a single function.
-pub trait FunctionMiddleware: Debug {
+pub trait FunctionMiddleware<'a>: Debug {
+    /// Provide info on the function's locals. This is called before feed.
+    fn locals_info(&mut self, _locals: &[ValType]) {}
+
     /// Processes the given operator.
-    fn feed<'a>(
+    fn feed(
         &mut self,
         operator: Operator<'a>,
         state: &mut MiddlewareReaderState<'a>,
@@ -48,7 +51,7 @@ pub struct MiddlewareBinaryReader<'a> {
     state: MiddlewareReaderState<'a>,
 
     /// The backing middleware chain for this reader.
-    chain: Vec<Box<dyn FunctionMiddleware>>,
+    chain: Vec<Box<dyn FunctionMiddleware<'a> + 'a>>,
 }
 
 enum MiddlewareInnerReader<'a> {
@@ -66,15 +69,24 @@ pub struct MiddlewareReaderState<'a> {
 
     /// The pending operations added by the middleware.
     pending_operations: VecDeque<Operator<'a>>,
+
+    /// Number of local declarations that will ever be read.
+    local_decls: u32,
+
+    /// Number of local declarations read so far.
+    local_decls_read: u32,
+
+    /// Locals read so far.
+    locals: Vec<ValType>,
 }
 
 /// Trait for generating middleware chains from "prototype" (generator) chains.
 pub trait ModuleMiddlewareChain {
     /// Generates a function middleware chain.
-    fn generate_function_middleware_chain(
+    fn generate_function_middleware_chain<'a>(
         &self,
         local_function_index: LocalFunctionIndex,
-    ) -> Vec<Box<dyn FunctionMiddleware>>;
+    ) -> Vec<Box<dyn FunctionMiddleware<'a> + 'a>>;
 
     /// Applies the chain on a `ModuleInfo` struct.
     fn apply_on_module_info(&self, module_info: &mut ModuleInfo) -> Result<(), MiddlewareError>;
@@ -82,10 +94,10 @@ pub trait ModuleMiddlewareChain {
 
 impl<T: Deref<Target = dyn ModuleMiddleware>> ModuleMiddlewareChain for [T] {
     /// Generates a function middleware chain.
-    fn generate_function_middleware_chain(
+    fn generate_function_middleware_chain<'a>(
         &self,
         local_function_index: LocalFunctionIndex,
-    ) -> Vec<Box<dyn FunctionMiddleware>> {
+    ) -> Vec<Box<dyn FunctionMiddleware<'a> + 'a>> {
         self.iter()
             .map(|x| x.generate_function_middleware(local_function_index))
             .collect()
@@ -130,20 +142,30 @@ impl<'a> MiddlewareBinaryReader<'a> {
                     reader: inner,
                 }),
                 pending_operations: VecDeque::new(),
+                local_decls: 0,
+                local_decls_read: 0,
+                locals: vec![],
             },
             chain: vec![],
         }
     }
 
     /// Replaces the middleware chain with a new one.
-    pub fn set_middleware_chain(&mut self, stages: Vec<Box<dyn FunctionMiddleware>>) {
+    pub fn set_middleware_chain(&mut self, stages: Vec<Box<dyn FunctionMiddleware<'a> + 'a>>) {
         self.chain = stages;
+    }
+
+    /// Pass info about the locals of a function to all middlewares
+    fn emit_locals_info(&mut self) {
+        for middleware in &mut self.chain {
+            middleware.locals_info(&self.state.locals)
+        }
     }
 }
 
 impl<'a> FunctionBinaryReader<'a> for MiddlewareBinaryReader<'a> {
     fn read_local_count(&mut self) -> WasmResult<u32> {
-        match self.state.inner.as_mut().expect("inner state must exist") {
+        let total = match self.state.inner.as_mut().expect("inner state must exist") {
             MiddlewareInnerReader::Binary { reader, .. } => reader
                 .read_var_u32()
                 .map_err(from_binaryreadererror_wasmerror),
@@ -151,11 +173,17 @@ impl<'a> FunctionBinaryReader<'a> for MiddlewareBinaryReader<'a> {
                 message: "locals must be read before the function body".to_string(),
                 offset: self.current_position(),
             }),
+        }?;
+        self.state.local_decls = total;
+        self.state.locals.reserve(total as usize);
+        if total == 0 {
+            self.emit_locals_info();
         }
+        Ok(total)
     }
 
     fn read_local_decl(&mut self) -> WasmResult<(u32, ValType)> {
-        match self.state.inner.as_mut().expect("inner state must exist") {
+        let (count, ty) = match self.state.inner.as_mut().expect("inner state must exist") {
             MiddlewareInnerReader::Binary { reader, .. } => {
                 let count = reader
                     .read_var_u32()
@@ -169,7 +197,16 @@ impl<'a> FunctionBinaryReader<'a> for MiddlewareBinaryReader<'a> {
                 message: "locals must be read before the function body".to_string(),
                 offset: self.current_position(),
             }),
+        }?;
+        for _ in 0..count {
+            self.state.locals.push(ty);
         }
+
+        self.state.local_decls_read += 1;
+        if self.state.local_decls_read == self.state.local_decls {
+            self.emit_locals_info();
+        }
+        Ok((count, ty))
     }
 
     fn read_operator(&mut self) -> WasmResult<Operator<'a>> {

--- a/lib/middlewares/src/metering.rs
+++ b/lib/middlewares/src/metering.rs
@@ -150,7 +150,10 @@ impl<F: Fn(&Operator) -> u64 + Send + Sync> fmt::Debug for Metering<F> {
 
 impl<F: Fn(&Operator) -> u64 + Send + Sync + 'static> ModuleMiddleware for Metering<F> {
     /// Generates a `FunctionMiddleware` for a given function.
-    fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
+    fn generate_function_middleware<'a>(
+        &self,
+        _: LocalFunctionIndex,
+    ) -> Box<dyn FunctionMiddleware<'a> + 'a> {
         Box::new(FunctionMetering {
             cost_function: self.cost_function.clone(),
             global_indexes: self.global_indexes.lock().unwrap().clone().unwrap(),
@@ -250,8 +253,8 @@ impl<F: Fn(&Operator) -> u64 + Send + Sync> fmt::Debug for FunctionMetering<F> {
     }
 }
 
-impl<F: Fn(&Operator) -> u64 + Send + Sync> FunctionMiddleware for FunctionMetering<F> {
-    fn feed<'a>(
+impl<'a, F: Fn(&Operator) -> u64 + Send + Sync> FunctionMiddleware<'a> for FunctionMetering<F> {
+    fn feed(
         &mut self,
         operator: Operator<'a>,
         state: &mut MiddlewareReaderState<'a>,

--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -217,6 +217,12 @@ impl MiddlewareError {
     }
 }
 
+impl From<MiddlewareError> for CompileError {
+    fn from(error: MiddlewareError) -> Self {
+        WasmError::Middleware(error).into()
+    }
+}
+
 /// A WebAssembly translation error.
 ///
 /// When a WebAssembly function can't be translated, one of these error codes will be returned

--- a/tests/compilers/middlewares.rs
+++ b/tests/compilers/middlewares.rs
@@ -16,15 +16,18 @@ struct Add2Mul {
 }
 
 impl ModuleMiddleware for Add2MulGen {
-    fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
+    fn generate_function_middleware<'a>(
+        &self,
+        _: LocalFunctionIndex,
+    ) -> Box<dyn FunctionMiddleware<'a> + 'a> {
         Box::new(Add2Mul {
             value_off: self.value_off,
         })
     }
 }
 
-impl FunctionMiddleware for Add2Mul {
-    fn feed<'a>(
+impl<'a> FunctionMiddleware<'a> for Add2Mul {
+    fn feed(
         &mut self,
         operator: Operator<'a>,
         state: &mut MiddlewareReaderState<'a>,
@@ -56,13 +59,16 @@ struct Fusion {
 }
 
 impl ModuleMiddleware for FusionGen {
-    fn generate_function_middleware(&self, _: LocalFunctionIndex) -> Box<dyn FunctionMiddleware> {
+    fn generate_function_middleware<'a>(
+        &self,
+        _: LocalFunctionIndex,
+    ) -> Box<dyn FunctionMiddleware<'a> + 'a> {
         Box::new(Fusion { state: 0 })
     }
 }
 
-impl FunctionMiddleware for Fusion {
-    fn feed<'a>(
+impl<'a> FunctionMiddleware<'a> for Fusion {
+    fn feed(
         &mut self,
         operator: Operator<'a>,
         state: &mut MiddlewareReaderState<'a>,


### PR DESCRIPTION
# Description

- Add lifetime parameter to FunctionMiddleware trait for more expressive borrowing
- Add locals_info() callback so middlewares can inspect function local types before operator processing
- Add From<MiddlewareError> for CompileError for ergonomic error handling
- Deduplicate store handle lookups in Global get()/set()

 ## Motivation                                                                                                                                                                                  
                                                                                                                                                                                              
OffchainLabs maintains a fork of wasmer with changes needed for Arbitrum Stylus (on-chain WASM execution). These changes have been carried across multiple wasmer version upgrades (v4.2.3 → v4.3.7 → v7.1.0). Proposing them upstream would reduce the maintenance burden and benefit other wasmer users who need richer middleware capabilities. 

The current middleware API prevents implementing middlewares that need to buffer operators or know about function locals. Specifically:

1. Operator buffering: With the lifetime on `feed` (`fn feed<'a>(..., op: Operator<'a>)`), a middleware cannot store `Operator<'a>` in its own fields — `'a` is a per-call parameter unrelated to `Self`. Moving it to the trait (`FunctionMiddleware<'a>`) lets implementations accumulate operators. This is needed for whole-function analysis passes (e.g., computing worst-case stack depth before emitting instrumented output).                                                                                                                             
                                                                                                                                                                                              
2. Locals info: Middleware that computes stack frame sizes needs the number of locals, but locals are parsed before operators and never passed to the middleware. The `locals_info` callback fills this gap. It has a default no-op implementation, so existing code is unaffected. 

