### PR TITLE
feat(runtime): Add cache eviction method to BuiltinPackageLoader

### DIFF
--- a/lib/wasix/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasix/src/runtime/package_loader/builtin_loader.rs
@@ -876,6 +876,18 @@ mod tests {
         cache_misses_will_trigger_a_download_internal().await
     }
 
+    #[tokio::test]
+    async fn evict_cached_removes_in_memory_container() {
+        let loader = BuiltinPackageLoader::new();
+        let container = from_bytes(PYTHON).unwrap();
+        let hash: WebcHash = [0xaa; 32].into();
+        loader.insert_cached(hash, &container);
+        let evicted = loader.evict_cached(&hash);
+        assert!(evicted.is_some());
+        assert!(!loader.in_memory.0.read().unwrap().contains_key(&hash));
+        assert!(loader.evict_cached(&hash).is_none());
+    }
+
     /// Small helper to construct headers with a given content-encoding.
     fn headers_with_encoding(content_encoding: Option<&str>) -> HeaderMap {
         let mut headers = HeaderMap::new();


### PR DESCRIPTION
Add `BuiltinPackageLoader::evict_cached()` to allow callers to remove a cached in-memory WEBC Container by hash. This is needed by Edge, where pruning a WEBC from disk may not reclaim space because the runtime still retains the mmap-backed container and keeps the deleted file alive in-process.