### PR TITLE
fix(c-api): use Option types for nullable C-API parameters (v2)

### DIFF
--- a/lib/c-api/src/wasm_c_api/externals/function.rs
+++ b/lib/c-api/src/wasm_c_api/externals/function.rs
@@ -3,6 +3,7 @@ use super::super::trap::wasm_trap_t;
 use super::super::types::{wasm_functype_t, wasm_valkind_enum};
 use super::super::value::{wasm_val_inner, wasm_val_t, wasm_val_vec_t};
 use super::wasm_extern_t;
+use crate::error::update_last_error;
 use crate::wasm_c_api::function_env::FunctionCEnv;
 use libc::c_void;
 use std::convert::TryInto;
@@ -228,14 +229,20 @@ pub unsafe extern "C" fn wasm_func_call(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_param_arity(func: Option<&wasm_func_t>) -> usize {
-    let Some(func) = func else { return 0 };
+    let Some(func) = func else {
+        update_last_error("func pointer is null");
+        return 0;
+    };
     let store_ref = unsafe { func.extern_.store.store() };
     func.extern_.function().ty(&store_ref).params().len()
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_func_result_arity(func: Option<&wasm_func_t>) -> usize {
-    let Some(func) = func else { return 0 };
+    let Some(func) = func else {
+        update_last_error("func pointer is null");
+        return 0;
+    };
     let store_ref = unsafe { func.extern_.store.store() };
     func.extern_.function().ty(&store_ref).results().len()
 }

--- a/lib/c-api/src/wasm_c_api/externals/global.rs
+++ b/lib/c-api/src/wasm_c_api/externals/global.rs
@@ -1,3 +1,5 @@
+use crate::error::update_last_error;
+
 use super::super::store::wasm_store_t;
 use super::super::types::wasm_globaltype_t;
 use super::super::value::wasm_val_t;
@@ -59,8 +61,14 @@ pub unsafe extern "C" fn wasm_global_get(
     // own
     out: Option<&mut wasm_val_t>,
 ) {
-    let Some(global) = global else { return };
-    let Some(out) = out else { return };
+    let Some(global) = global else {
+        update_last_error("global pointer is null");
+        return;
+    };
+    let Some(out) = out else {
+        update_last_error("out pointer is null");
+        return;
+    };
     let wasm_global = global.extern_.global();
     let mut store_mut = unsafe { global.extern_.store.store_mut() };
     let value = wasm_global.get(&mut store_mut);
@@ -74,8 +82,14 @@ pub unsafe extern "C" fn wasm_global_set(
     global: Option<&mut wasm_global_t>,
     val: Option<&wasm_val_t>,
 ) {
-    let Some(global) = global else { return };
-    let Some(val) = val else { return };
+    let Some(global) = global else {
+        update_last_error("global pointer is null");
+        return;
+    };
+    let Some(val) = val else {
+        update_last_error("val pointer is null");
+        return;
+    };
     let value: Value = c_try!(val.try_into(); otherwise ());
     let wasm_global = global.extern_.global();
     let mut store_mut = unsafe { global.extern_.store.store_mut() };

--- a/lib/c-api/src/wasm_c_api/externals/memory.rs
+++ b/lib/c-api/src/wasm_c_api/externals/memory.rs
@@ -1,3 +1,5 @@
+use crate::error::update_last_error;
+
 use super::super::types::wasm_memorytype_t;
 use super::{super::store::wasm_store_t, wasm_extern_t};
 use wasmer_api::{Extern, Memory, Pages};
@@ -65,6 +67,7 @@ pub unsafe extern "C" fn wasm_memory_type(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_data(memory: Option<&mut wasm_memory_t>) -> *mut u8 {
     let Some(memory) = memory else {
+        update_last_error("memory pointer is null");
         return std::ptr::null_mut();
     };
     let store_ref = unsafe { memory.extern_.store.store() };
@@ -74,7 +77,10 @@ pub unsafe extern "C" fn wasm_memory_data(memory: Option<&mut wasm_memory_t>) ->
 // size in bytes
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_data_size(memory: Option<&wasm_memory_t>) -> usize {
-    let Some(memory) = memory else { return 0 };
+    let Some(memory) = memory else {
+        update_last_error("memory pointer is null");
+        return 0;
+    };
     let store_ref = unsafe { memory.extern_.store.store() };
     memory.extern_.memory().view(&store_ref).size().bytes().0
 }
@@ -82,7 +88,10 @@ pub unsafe extern "C" fn wasm_memory_data_size(memory: Option<&wasm_memory_t>) -
 // size in pages
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_size(memory: Option<&wasm_memory_t>) -> u32 {
-    let Some(memory) = memory else { return 0 };
+    let Some(memory) = memory else {
+        update_last_error("memory pointer is null");
+        return 0;
+    };
     let store_ref = unsafe { memory.extern_.store.store() };
     memory.extern_.memory().view(&store_ref).size().0 as _
 }
@@ -90,7 +99,10 @@ pub unsafe extern "C" fn wasm_memory_size(memory: Option<&wasm_memory_t>) -> u32
 // delta is in pages
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_memory_grow(memory: Option<&mut wasm_memory_t>, delta: u32) -> bool {
-    let Some(memory) = memory else { return false };
+    let Some(memory) = memory else {
+        update_last_error("memory pointer is null");
+        return false;
+    };
     let wasm_memory = memory.extern_.memory();
     let mut store_mut = unsafe { memory.extern_.store.store_mut() };
     wasm_memory.grow(&mut store_mut, Pages(delta)).is_ok()

--- a/lib/c-api/src/wasm_c_api/externals/table.rs
+++ b/lib/c-api/src/wasm_c_api/externals/table.rs
@@ -1,3 +1,5 @@
+use crate::error::update_last_error;
+
 use super::super::store::wasm_store_t;
 use super::super::types::{wasm_ref_t, wasm_table_size_t, wasm_tabletype_t};
 use super::wasm_extern_t;
@@ -40,7 +42,10 @@ pub unsafe extern "C" fn wasm_table_copy(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasm_table_size(table: Option<&wasm_table_t>) -> usize {
-    let Some(table) = table else { return 0 };
+    let Some(table) = table else {
+        update_last_error("table pointer is null");
+        return 0;
+    };
     let store_ref = unsafe { table.extern_.store.store() };
     table.extern_.table().size(&store_ref) as _
 }


### PR DESCRIPTION
It's a follow-up of #6246.