### PR TITLE
build: drop dependency on homebrew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,10 +183,6 @@ jobs:
           echo LLVM_ENABLE=1 >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
-      - name: Add `brew` libraries (Apple Silicon)
-        run: |
-          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
-        if: matrix.os == 'macos-14' || matrix.os == 'depot-macos-14'
       - name: Set up dependencies for Mac OS
         run: |
           brew install automake

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -705,12 +705,6 @@ jobs:
           echo "LLVM_SYS_211_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
-      - name: Add `brew` libs to `RUSTFLAGS`
-        if: matrix.metadata.os == 'macos-14'
-        shell: bash
-        run: |
-          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
-          echo "RUSTDOCFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
       - name: Setup Rust target
         shell: bash
         run: |
@@ -997,12 +991,6 @@ jobs:
           echo "ENABLE_LLVM=1" >> $GITHUB_ENV
         env:
           LLVM_DIR: .llvm
-      - name: Add `brew` libs to `RUSTFLAGS`
-        if: matrix.metadata.os == 'macos-14' || matrix.metadata.os == 'depot-macos-14'
-        shell: bash
-        run: |
-          echo "RUSTFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
-          echo "RUSTDOCFLAGS=-L/opt/homebrew/lib" >> $GITHUB_ENV
       - name: Setup Rust target
         shell: bash
         run: |

--- a/tests/wasmer-argus/README.md
+++ b/tests/wasmer-argus/README.md
@@ -6,19 +6,6 @@ Automatically test packages from the registry.
 If you want to use the local `wasmer` crate, you shall 
 build the project with `cargo build --package wasmer-argus --features wasmer_lib`.
 
-On macOS, you may encounter an error where the linker does not find `zstd`: a possible 
-solution to this problem is to install `zstd` using `brew` (`brew install zstd`) and 
-using the following command: 
-
-`RUSTFLAGS="-L$(brew --prefix)/lib" cargo build --package wasmer-argus --features wasmer_lib`
-
-Another possiblity is to add the your brew prefix with `/lib` (probably = `/opt/homebrew/lib/`) 
-to the global Cargo config something like:
-```
-[target.aarch64-apple-darwin]
-rustflags = ["-L/opt/homebrew/lib"]
-```
-
 ## Usage
 This binary fetches packages from the graphql endpoint  of a registry. By
 default, it uses `http://registry.wasmer.io/graphql`; and the needed


### PR DESCRIPTION
Verified the built binary does not depend on anything from brew:
```
❯ : otool -L wasmer
wasmer:
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3208.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.105.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /usr/lib/libffi.dylib (compatibility version 1.0.0, current version 39.0.0)
        /usr/lib/libxml2.2.dylib (compatibility version 10.0.0, current version 10.9.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61439.60.117)
        /usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
```

Fixes: #6384