### PR TITLE
fix(SRE-1412): Add first-class support for bugtopia

### DIFF
--- a/lib/cli/src/config/env.rs
+++ b/lib/cli/src/config/env.rs
@@ -35,6 +35,7 @@ pub struct WasmerEnv {
 impl WasmerEnv {
     const APP_DOMAIN_PROD: &'static str = "wasmer.app";
     const APP_DOMAIN_DEV: &'static str = "wasmer.dev";
+    const APP_DOMAIN_BUGT: &'static str = "wasmerfun.app";
 
     pub fn new(
         wasmer_dir: PathBuf,
@@ -147,6 +148,8 @@ impl WasmerEnv {
             Ok(Self::APP_DOMAIN_PROD.to_string())
         } else if domain.ends_with("wasmer.wtf") {
             Ok(Self::APP_DOMAIN_DEV.to_string())
+        } else if domain.ends_with("wasmer.fun") {
+            Ok(Self::APP_DOMAIN_BUGT.to_string())
         } else {
             anyhow::bail!(
                 "could not determine app domain for backend url '{domain}': unknown backend"
@@ -296,6 +299,18 @@ mod tests {
             };
 
             assert_eq!(env.app_domain().unwrap(), "wasmer.dev");
+        }
+
+        // Bugtopia
+        {
+            let env = WasmerEnv {
+                wasmer_dir: PathBuf::from("/tmp"),
+                registry: Some(UserRegistry::from("https://registry.wasmer.fun/graphql")),
+                cache_dir: PathBuf::from("/tmp/cache"),
+                token: None,
+            };
+
+            assert_eq!(env.app_domain().unwrap(), "wasmerfun.app");
         }
     }
 


### PR DESCRIPTION
# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
I've been trying to dodge this for the longest time but now it's crashing the integration-tests for bugtopia which I'd like to have green coming Q2.

The 'ssh' command fails when trying to target bugtopia as it tries to lookup the backend app domain based on the registry. This commit adds first-class support for bugtopia to wasmer.

## Validation
1. Set `WASMER_REGISTRY=https://registry.wasmer.fun/graphql`
1. Set `WASMER_TOKEN=<token from some account in bugtopia>`
1. `wasmer ssh` -> Expect failure due to missing backend

Re-compile wasmer and run again -> Expect it to work