### PR TITLE
tests(wasix): Add call_dynamic/context POSIX tests

### DIFF
--- a/lib/wasix/tests/wasm_tests/call_dynamic.rs
+++ b/lib/wasix/tests/wasm_tests/call_dynamic.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn call_dynamic() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/call_dynamic/build.sh
+++ b/lib/wasix/tests/wasm_tests/call_dynamic/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/call_dynamic/main.c
+++ b/lib/wasix/tests/wasm_tests/call_dynamic/main.c
@@ -1,0 +1,274 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <wasi/api_wasi.h>
+#include <wasi/api_wasix.h>
+
+static volatile int backing_calls = 0;
+static volatile uint32_t seen_a = 0;
+static volatile uint64_t seen_b = 0;
+static volatile uint32_t seen_user = 0;
+
+static void closure_backing(uint8_t* values, uint8_t* results,
+                            void* user_data) {
+  uint32_t a = 0;
+  uint64_t b = 0;
+  uint32_t user = 0;
+  uint32_t out = 0;
+
+  backing_calls++;
+
+  memcpy(&a, values, sizeof(a));
+  memcpy(&b, values + sizeof(a), sizeof(b));
+  memcpy(&user, user_data, sizeof(user));
+
+  seen_a = a;
+  seen_b = b;
+  seen_user = user;
+
+  out = a + (uint32_t)b + user;
+  memcpy(results, &out, sizeof(out));
+}
+
+static __wasi_function_pointer_t backing_function_id(void) {
+  void (*fn)(uint8_t*, uint8_t*, void*) = closure_backing;
+  return (__wasi_function_pointer_t)(uintptr_t)fn;
+}
+
+static __wasi_function_pointer_t prepare_closure(uint32_t user_data) {
+  __wasi_function_pointer_t closure_id = 0;
+  __wasi_wasm_value_type_t arg_types[2] = {
+      __WASI_WASM_VALUE_TYPE_I32,
+      __WASI_WASM_VALUE_TYPE_I64,
+  };
+  __wasi_wasm_value_type_t res_types[1] = {
+      __WASI_WASM_VALUE_TYPE_I32,
+  };
+  __wasi_errno_t err;
+
+  assert(__wasi_closure_allocate(&closure_id) == __WASI_ERRNO_SUCCESS);
+
+  err = __wasi_closure_prepare(backing_function_id(), closure_id, arg_types, 2,
+                               res_types, 1, (uint8_t*)&user_data);
+  assert(err == __WASI_ERRNO_SUCCESS);
+
+  return closure_id;
+}
+
+static void reset_backing_state(void) {
+  backing_calls = 0;
+  seen_a = 0;
+  seen_b = 0;
+  seen_user = 0;
+}
+
+static void test_strict_success(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 7;
+  uint32_t a = 5;
+  uint64_t b = 9;
+  uint8_t values[12];
+  uint8_t results[4] = {0};
+  uint32_t out = 0;
+  __wasi_errno_t err;
+
+  printf("Test 1: strict call_dynamic success\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+  memcpy(values + sizeof(a), &b, sizeof(b));
+
+  reset_backing_state();
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results,
+                            sizeof(results), __WASI_BOOL_TRUE);
+  assert(err == __WASI_ERRNO_SUCCESS);
+
+  memcpy(&out, results, sizeof(out));
+  assert(backing_calls == 1);
+  assert(seen_a == a);
+  assert(seen_b == b);
+  assert(seen_user == user_data);
+  assert(out == (uint32_t)(a + (uint32_t)b + user_data));
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_strict_values_len_too_short(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 1;
+  uint32_t a = 11;
+  uint8_t values[4];
+  uint8_t results[4] = {0};
+  __wasi_errno_t err;
+
+  printf("Test 2: strict values too short -> EINVAL\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results,
+                            sizeof(results), __WASI_BOOL_TRUE);
+  assert(err == __WASI_ERRNO_INVAL);
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_strict_values_len_too_long(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 2;
+  uint32_t a = 1;
+  uint64_t b = 2;
+  uint8_t values[16];
+  uint8_t results[4] = {0};
+  __wasi_errno_t err;
+
+  printf("Test 3: strict values too long -> EINVAL\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+  memcpy(values + sizeof(a), &b, sizeof(b));
+  memset(values + 12, 0xCC, 4);
+
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results,
+                            sizeof(results), __WASI_BOOL_TRUE);
+  assert(err == __WASI_ERRNO_INVAL);
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_strict_results_len_too_short(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 3;
+  uint32_t a = 10;
+  uint64_t b = 20;
+  uint8_t values[12];
+  uint8_t results[1] = {0};
+  __wasi_errno_t err;
+
+  printf("Test 4: strict results too short -> EINVAL\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+  memcpy(values + sizeof(a), &b, sizeof(b));
+
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results,
+                            sizeof(results), __WASI_BOOL_TRUE);
+  assert(err == __WASI_ERRNO_INVAL);
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_non_strict_defaults(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 4;
+  uint32_t a = 7;
+  uint8_t values[4];
+  uint8_t results[4] = {0};
+  uint32_t out = 0;
+  __wasi_errno_t err;
+
+  printf("Test 5: non-strict defaults missing values\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+
+  reset_backing_state();
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results,
+                            sizeof(results), __WASI_BOOL_FALSE);
+  assert(err == __WASI_ERRNO_SUCCESS);
+
+  memcpy(&out, results, sizeof(out));
+  assert(backing_calls == 1);
+  assert(seen_a == a);
+  assert(seen_b == 0);
+  assert(seen_user == user_data);
+  assert(out == (uint32_t)(a + user_data));
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_non_strict_extra_values(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 5;
+  uint32_t a = 3;
+  uint64_t b = 4;
+  uint8_t values[20];
+  uint8_t results[4] = {0};
+  uint32_t out = 0;
+  __wasi_errno_t err;
+
+  printf("Test 6: non-strict ignores extra values\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+  memcpy(values + sizeof(a), &b, sizeof(b));
+  memset(values + 12, 0xAB, 8);
+
+  reset_backing_state();
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results,
+                            sizeof(results), __WASI_BOOL_FALSE);
+  assert(err == __WASI_ERRNO_SUCCESS);
+
+  memcpy(&out, results, sizeof(out));
+  assert(backing_calls == 1);
+  assert(seen_a == a);
+  assert(seen_b == b);
+  assert(seen_user == user_data);
+  assert(out == (uint32_t)(a + (uint32_t)b + user_data));
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_non_strict_results_len_zero(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 6;
+  uint32_t a = 1;
+  uint64_t b = 2;
+  uint8_t values[12];
+  uint8_t results[4];
+  __wasi_errno_t err;
+
+  printf("Test 7: non-strict results too short succeeds\n");
+
+  closure_id = prepare_closure(user_data);
+  memcpy(values, &a, sizeof(a));
+  memcpy(values + sizeof(a), &b, sizeof(b));
+  memset(results, 0xAA, sizeof(results));
+
+  reset_backing_state();
+  err = __wasi_call_dynamic(closure_id, values, sizeof(values), results, 0,
+                            __WASI_BOOL_FALSE);
+  assert(err == __WASI_ERRNO_SUCCESS);
+
+  assert(backing_calls == 1);
+  assert(results[0] == 0xAA);
+  assert(results[1] == 0xAA);
+  assert(results[2] == 0xAA);
+  assert(results[3] == 0xAA);
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+static void test_invalid_pointer(void) {
+  __wasi_function_pointer_t closure_id;
+  uint32_t user_data = 8;
+  const uint8_t* bad_ptr = (const uint8_t*)0xFFFFFFFFu;
+  uint8_t results[4] = {0};
+  __wasi_errno_t err;
+
+  printf("Test 8: invalid pointer returns MEMVIOLATION\n");
+
+  closure_id = prepare_closure(user_data);
+  err = __wasi_call_dynamic(closure_id, bad_ptr, 4, results, sizeof(results),
+                            __WASI_BOOL_FALSE);
+  assert(err == __WASI_ERRNO_MEMVIOLATION);
+  assert(__wasi_closure_free(closure_id) == __WASI_ERRNO_SUCCESS);
+}
+
+int main(void) {
+  printf("WASIX call_dynamic integration tests\n");
+  test_strict_success();
+  test_strict_values_len_too_short();
+  test_strict_values_len_too_long();
+  test_strict_results_len_too_short();
+  test_non_strict_defaults();
+  test_non_strict_extra_values();
+  test_non_strict_results_len_zero();
+  test_invalid_pointer();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/closure_free.rs
+++ b/lib/wasix/tests/wasm_tests/closure_free.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn closure_free() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/closure_free/build.sh
+++ b/lib/wasix/tests/wasm_tests/closure_free/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/closure_free/main.c
+++ b/lib/wasix/tests/wasm_tests/closure_free/main.c
@@ -1,0 +1,121 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <wasi/api_wasix.h>
+
+static void test_invalid_index(void) {
+  __wasi_function_pointer_t invalid_index = 999999;
+  __wasi_errno_t ret;
+
+  printf("Test 1: closure_free with unallocated index (idempotent)\n");
+
+  ret = __wasi_closure_free(invalid_index);
+  assert(ret == 0);
+}
+
+static void test_allocate_and_free(void) {
+  __wasi_function_pointer_t closure_index = 0;
+  __wasi_errno_t ret_alloc;
+  __wasi_errno_t ret_free;
+
+  printf("Test 2: closure_allocate + closure_free (basic lifecycle)\n");
+
+  ret_alloc = __wasi_closure_allocate(&closure_index);
+  assert(ret_alloc == 0);
+  assert(closure_index != 0);
+
+  ret_free = __wasi_closure_free(closure_index);
+  assert(ret_free == 0);
+}
+
+static void test_double_free(void) {
+  __wasi_function_pointer_t closure_index = 0;
+  __wasi_errno_t ret_alloc;
+  __wasi_errno_t ret_free1;
+  __wasi_errno_t ret_free2;
+
+  printf("Test 3: double-free safety\n");
+
+  ret_alloc = __wasi_closure_allocate(&closure_index);
+  assert(ret_alloc == 0);
+
+  ret_free1 = __wasi_closure_free(closure_index);
+  assert(ret_free1 == 0);
+
+  ret_free2 = __wasi_closure_free(closure_index);
+  assert(ret_free2 == 0);
+}
+
+static void test_multiple_cycles(void) {
+  int i;
+
+  printf("Test 4: multiple allocate/free cycles\n");
+
+  for (i = 0; i < 10; i++) {
+    __wasi_function_pointer_t closure_index = 0;
+    __wasi_errno_t ret_alloc = __wasi_closure_allocate(&closure_index);
+    __wasi_errno_t ret_free;
+
+    assert(ret_alloc == 0);
+
+    ret_free = __wasi_closure_free(closure_index);
+    assert(ret_free == 0);
+  }
+}
+
+static void test_index_zero(void) {
+  __wasi_errno_t ret;
+
+  printf("Test 5: closure_free with index 0\n");
+
+  ret = __wasi_closure_free(0);
+  assert(ret == 0);
+}
+
+static void test_max_index(void) {
+  uint32_t max_index = 0xFFFFFFFFu;
+  __wasi_errno_t ret;
+
+  printf("Test 6: closure_free with u32::MAX\n");
+
+  ret = __wasi_closure_free(max_index);
+  assert(ret == 0);
+}
+
+static void test_multiple_allocations(void) {
+  const int count = 5;
+  __wasi_function_pointer_t indices[5];
+  int i;
+  int j;
+
+  printf("Test 7: multiple allocations, free in reverse order\n");
+
+  for (i = 0; i < count; i++) {
+    __wasi_errno_t ret = __wasi_closure_allocate(&indices[i]);
+    assert(ret == 0);
+  }
+
+  for (i = 0; i < count; i++) {
+    for (j = i + 1; j < count; j++) {
+      assert(indices[i] != indices[j]);
+    }
+  }
+
+  for (i = count - 1; i >= 0; i--) {
+    __wasi_errno_t ret = __wasi_closure_free(indices[i]);
+    assert(ret == 0);
+  }
+}
+
+int main(void) {
+  printf("WASIX closure_free integration tests\n");
+  test_invalid_index();
+  test_allocate_and_free();
+  test_double_free();
+  test_multiple_cycles();
+  test_index_zero();
+  test_max_index();
+  test_multiple_allocations();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/context_destroy.rs
+++ b/lib/wasix/tests/wasm_tests/context_destroy.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn context_destroy() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/context_destroy/build.sh
+++ b/lib/wasix/tests/wasm_tests/context_destroy/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/context_destroy/main.c
+++ b/lib/wasix/tests/wasm_tests/context_destroy/main.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <wasi/api_wasix.h>
+#include <wasix/context.h>
+
+static int context_supported = 0;
+
+static void test_destroy_main_context(void) {
+  __wasi_context_id_t main_id = wasix_context_main;
+  __wasi_errno_t err;
+
+  printf("Test 1: destroy main context\n");
+
+  err = __wasi_context_destroy(main_id);
+  assert(err == __WASI_ERRNO_NOTSUP || err == __WASI_ERRNO_INVAL);
+  context_supported = (err != __WASI_ERRNO_NOTSUP);
+}
+
+static void test_destroy_missing_context(void) {
+  __wasi_context_id_t missing = 0xDEADBEEFu;
+  __wasi_errno_t err;
+
+  printf("Test 2: destroy missing context\n");
+
+  err = __wasi_context_destroy(missing);
+  if (!context_supported) {
+    assert(err == __WASI_ERRNO_NOTSUP);
+    return;
+  }
+
+  assert(err == __WASI_ERRNO_SUCCESS);
+}
+
+int main(void) {
+  printf("WASIX context_destroy integration tests\n");
+  test_destroy_main_context();
+  test_destroy_missing_context();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/context_switch.rs
+++ b/lib/wasix/tests/wasm_tests/context_switch.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn context_switch() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/context_switch/build.sh
+++ b/lib/wasix/tests/wasm_tests/context_switch/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/context_switch/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switch/main.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <wasix/context.h>
+
+static wasix_context_id_t ctx1;
+static int phase = 0;
+
+static void context1_fn(void) {
+  int ret;
+
+  ret = wasix_context_destroy(ctx1);
+  assert(ret == -1);
+  assert(errno == EINVAL);
+
+  phase = 1;
+  wasix_context_switch(wasix_context_main);
+  wasix_context_switch(wasix_context_main);
+}
+
+int main(void) {
+  int ret;
+
+  printf("WASIX context_switch integration tests\n");
+
+  ret = wasix_context_create(&ctx1, context1_fn);
+  assert(ret == 0);
+
+  printf("Test 1: switch to main (no-op)\n");
+  ret = wasix_context_switch(wasix_context_main);
+  assert(ret == 0);
+
+  printf("Test 2: switch to new context and back\n");
+  ret = wasix_context_switch(ctx1);
+  assert(ret == 0);
+  assert(phase == 1);
+
+  printf("Test 3: destroy main context fails\n");
+  ret = wasix_context_destroy(wasix_context_main);
+  assert(ret == -1);
+  assert(errno == EINVAL);
+
+  printf("Test 4: destroy context succeeds\n");
+  ret = wasix_context_destroy(ctx1);
+  assert(ret == 0);
+
+  printf("Test 5: switching to destroyed context fails\n");
+  errno = 0;
+  ret = wasix_context_switch(ctx1);
+  assert(ret == -1);
+  assert(errno == EINVAL);
+
+  printf("Test 6: destroy already destroyed context is no-op\n");
+  ret = wasix_context_destroy(ctx1);
+  assert(ret == 0);
+
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/context_switching.rs
+++ b/lib/wasix/tests/wasm_tests/context_switching.rs
@@ -1,9 +1,7 @@
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 use super::{run_build_script, run_wasm};
 
-// macOS is currently disabled, because cranelift does not
-// support exception handling on that platform yet.
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_simple_switching() {
     let wasm_path = run_build_script(file!(), "simple_switching").unwrap();
@@ -11,7 +9,7 @@ fn test_simple_switching() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_switching_with_main() {
     let wasm_path = run_build_script(file!(), "switching_with_main").unwrap();
@@ -19,7 +17,7 @@ fn test_switching_with_main() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_switching_to_a_deleted_context() {
     let wasm_path = run_build_script(file!(), "switching_to_a_deleted_context").unwrap();
@@ -27,7 +25,7 @@ fn test_switching_to_a_deleted_context() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_switching_threads() {
     let wasm_path = run_build_script(file!(), "switching_in_threads").unwrap();
@@ -35,7 +33,7 @@ fn test_switching_threads() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_multiple_contexts() {
     let wasm_path = run_build_script(file!(), "multiple_contexts").unwrap();
@@ -43,7 +41,7 @@ fn test_multiple_contexts() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_error_handling() {
     let wasm_path = run_build_script(file!(), "error_handling").unwrap();
@@ -51,7 +49,7 @@ fn test_error_handling() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_nested_switches() {
     let wasm_path = run_build_script(file!(), "nested_switches").unwrap();
@@ -59,7 +57,7 @@ fn test_nested_switches() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_contexts_with_mutexes() {
     let wasm_path = run_build_script(file!(), "contexts_with_mutexes").unwrap();
@@ -67,7 +65,7 @@ fn test_contexts_with_mutexes() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_contexts_with_env_vars() {
     let wasm_path = run_build_script(file!(), "contexts_with_env_vars").unwrap();
@@ -75,7 +73,7 @@ fn test_contexts_with_env_vars() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_contexts_with_signals() {
     let wasm_path = run_build_script(file!(), "contexts_with_signals").unwrap();
@@ -83,7 +81,7 @@ fn test_contexts_with_signals() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_contexts_with_timers() {
     let wasm_path = run_build_script(file!(), "contexts_with_timers").unwrap();
@@ -91,7 +89,7 @@ fn test_contexts_with_timers() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_contexts_with_pipes() {
     let wasm_path = run_build_script(file!(), "contexts_with_pipes").unwrap();
@@ -99,7 +97,7 @@ fn test_contexts_with_pipes() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_pending_file_operations() {
     let wasm_path = run_build_script(file!(), "pending_file_operations").unwrap();
@@ -107,7 +105,7 @@ fn test_pending_file_operations() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_recursive_host_calls() {
     let wasm_path = run_build_script(file!(), "recursive_host_calls").unwrap();
@@ -115,7 +113,7 @@ fn test_recursive_host_calls() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_malloc_during_switch() {
     let wasm_path = run_build_script(file!(), "malloc_during_switch").unwrap();
@@ -123,7 +121,7 @@ fn test_malloc_during_switch() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_nested_host_call_switch() {
     let wasm_path = run_build_script(file!(), "nested_host_call_switch").unwrap();
@@ -131,7 +129,7 @@ fn test_nested_host_call_switch() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_switch_to_never_resumed() {
     let wasm_path = run_build_script(file!(), "switch_to_never_resumed").unwrap();
@@ -139,7 +137,7 @@ fn test_switch_to_never_resumed() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_three_way_recursion() {
     let wasm_path = run_build_script(file!(), "three_way_recursion").unwrap();
@@ -147,7 +145,7 @@ fn test_three_way_recursion() {
     run_wasm(&wasm_path, test_dir).unwrap();
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 #[test]
 fn test_contexts_with_setjmp() {
     let wasm_path = run_build_script(file!(), "contexts_with_setjmp").unwrap();

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1,4 +1,8 @@
 mod basic_tests;
+mod call_dynamic;
+mod closure_free;
+mod context_destroy;
+mod context_switch;
 mod context_switching;
 mod dynamic_library_tests;
 mod edge_case_tests;
@@ -11,6 +15,7 @@ mod lifecycle_tests;
 mod longjmp_tests;
 mod path_tests;
 mod poll_tests;
+mod reflect_signature;
 mod reflection_tests;
 mod semaphore_tests;
 mod shared_library_tests;
@@ -310,11 +315,11 @@ fn create_engine_for_wasm(wasm_bytes: &[u8]) -> wasmer::Engine {
 
         let compiler = wasmer::sys::LLVM::default();
 
-        return EngineBuilder::new(compiler)
+        EngineBuilder::new(compiler)
             .set_features(Some(features))
             .set_target(Some(target))
             .engine()
-            .into();
+            .into()
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/lib/wasix/tests/wasm_tests/reflect_signature.rs
+++ b/lib/wasix/tests/wasm_tests/reflect_signature.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn reflect_signature() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/reflect_signature/build.sh
+++ b/lib/wasix/tests/wasm_tests/reflect_signature/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/reflect_signature/main.c
+++ b/lib/wasix/tests/wasm_tests/reflect_signature/main.c
@@ -1,0 +1,224 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <wasix/closure.h>
+#include <wasix/function_pointer.h>
+#include <wasix/reflection.h>
+#include <wasix/value_type.h>
+
+static int32_t test_signature(int32_t a, int64_t b, float c, double d) {
+  return (int32_t)(a + (int32_t)b + (int32_t)c + (int32_t)d);
+}
+
+static void closure_backing(uint8_t* values, uint8_t* results,
+                            void* user_data) {
+  (void)values;
+  (void)results;
+  (void)user_data;
+}
+
+static wasix_function_pointer_t function_id_of_test_signature(void) {
+  int32_t (*fn)(int32_t, int64_t, float, double) = test_signature;
+  return (wasix_function_pointer_t)(uintptr_t)fn;
+}
+
+static wasix_function_pointer_t function_id_of_closure_backing(void) {
+  void (*fn)(uint8_t*, uint8_t*, void*) = closure_backing;
+  return (wasix_function_pointer_t)(uintptr_t)fn;
+}
+
+static void test_basic_signature(void) {
+  wasix_function_pointer_t fn_id = function_id_of_test_signature();
+  wasix_value_type_t args[4] = {0};
+  wasix_value_type_t results[1] = {0};
+  wasix_reflection_result_t info = {0};
+  int rc;
+
+  printf("Test 1: basic signature reflection\n");
+
+  rc = wasix_reflect_signature(fn_id, args, 4, results, 1, &info);
+  assert(rc == 0);
+  assert(info.cacheable == __WASI_BOOL_TRUE);
+  assert(info.arguments == 4);
+  assert(info.results == 1);
+
+  assert(args[0] == WASIX_VALUE_TYPE_I32);
+  assert(args[1] == WASIX_VALUE_TYPE_I64);
+  assert(args[2] == WASIX_VALUE_TYPE_F32);
+  assert(args[3] == WASIX_VALUE_TYPE_F64);
+  assert(results[0] == WASIX_VALUE_TYPE_I32);
+}
+
+static void test_extra_buffer_unchanged(void) {
+  wasix_function_pointer_t fn_id = function_id_of_test_signature();
+  wasix_value_type_t args[6];
+  wasix_value_type_t results[3];
+  wasix_reflection_result_t info = {0};
+  int rc;
+
+  printf("Test 2: extra buffer bytes remain unchanged\n");
+
+  memset(args, 0xAA, sizeof(args));
+  memset(results, 0xBB, sizeof(results));
+
+  rc = wasix_reflect_signature(fn_id, args, 6, results, 3, &info);
+  assert(rc == 0);
+  assert(info.arguments == 4);
+  assert(info.results == 1);
+
+  assert(args[0] == WASIX_VALUE_TYPE_I32);
+  assert(args[1] == WASIX_VALUE_TYPE_I64);
+  assert(args[2] == WASIX_VALUE_TYPE_F32);
+  assert(args[3] == WASIX_VALUE_TYPE_F64);
+  assert(args[4] == (wasix_value_type_t)0xAA);
+  assert(args[5] == (wasix_value_type_t)0xAA);
+
+  assert(results[0] == WASIX_VALUE_TYPE_I32);
+  assert(results[1] == (wasix_value_type_t)0xBB);
+  assert(results[2] == (wasix_value_type_t)0xBB);
+}
+
+static void test_overflow_arguments(void) {
+  wasix_function_pointer_t fn_id = function_id_of_test_signature();
+  wasix_value_type_t args[4];
+  wasix_value_type_t results[1];
+  wasix_reflection_result_t info = {0};
+  size_t i;
+  int rc;
+
+  printf("Test 3: overflow on arguments buffer\n");
+
+  memset(args, 0xCC, sizeof(args));
+  memset(results, 0xDD, sizeof(results));
+
+  errno = 0;
+  rc = wasix_reflect_signature(fn_id, args, 1, results, 1, &info);
+  assert(rc == -1);
+  assert(errno == EOVERFLOW);
+  assert(info.arguments == 4);
+  assert(info.results == 1);
+
+  for (i = 0; i < 4; i++) {
+    assert(args[i] == (wasix_value_type_t)0xCC);
+  }
+  assert(results[0] == (wasix_value_type_t)0xDD);
+}
+
+static void test_overflow_results(void) {
+  wasix_function_pointer_t fn_id = function_id_of_test_signature();
+  wasix_value_type_t args[4];
+  wasix_reflection_result_t info = {0};
+  size_t i;
+  int rc;
+
+  printf("Test 4: overflow on results buffer\n");
+
+  memset(args, 0xEE, sizeof(args));
+
+  errno = 0;
+  rc = wasix_reflect_signature(fn_id, args, 4, NULL, 0, &info);
+  assert(rc == -1);
+  assert(errno == EOVERFLOW);
+  assert(info.arguments == 4);
+  assert(info.results == 1);
+
+  for (i = 0; i < 4; i++) {
+    assert(args[i] == (wasix_value_type_t)0xEE);
+  }
+}
+
+static void test_invalid_function_id_zero(void) {
+  wasix_value_type_t args[1] = {0};
+  wasix_value_type_t results[1] = {0};
+  wasix_reflection_result_t info = {0};
+  int rc;
+
+  printf("Test 5: invalid function id (zero)\n");
+
+  errno = 0;
+  rc = wasix_reflect_signature(0, args, 1, results, 1, &info);
+  assert(rc == -1);
+  assert(errno == EINVAL);
+  assert(info.cacheable == __WASI_BOOL_TRUE);
+  assert(info.arguments == 0);
+  assert(info.results == 0);
+}
+
+static void test_invalid_function_id_oob(void) {
+  wasix_value_type_t args[1] = {0};
+  wasix_value_type_t results[1] = {0};
+  wasix_reflection_result_t info = {0};
+  int rc;
+
+  printf("Test 6: invalid function id (out of bounds)\n");
+
+  errno = 0;
+  rc = wasix_reflect_signature(0xFFFFFFFFu, args, 1, results, 1, &info);
+  assert(rc == -1);
+  assert(errno == EINVAL);
+  assert(info.cacheable == __WASI_BOOL_FALSE);
+  assert(info.arguments == 0);
+  assert(info.results == 0);
+}
+
+static void test_null_result_pointer(void) {
+  wasix_function_pointer_t fn_id = function_id_of_test_signature();
+  wasix_value_type_t args[4] = {0};
+  wasix_value_type_t results[1] = {0};
+  int rc;
+
+  printf("Test 7: null result pointer\n");
+
+  errno = 0;
+  rc = wasix_reflect_signature(fn_id, args, 4, results, 1, NULL);
+  assert(rc == -1);
+  assert(errno == EMEMVIOLATION);
+}
+
+static void test_closure_cacheable_flag(void) {
+  wasix_function_pointer_t backing_id = function_id_of_closure_backing();
+  wasix_function_pointer_t closure_id = 0;
+  wasix_value_type_t arg_types[2] = {WASIX_VALUE_TYPE_I32,
+                                     WASIX_VALUE_TYPE_I64};
+  wasix_value_type_t res_types[1] = {WASIX_VALUE_TYPE_I32};
+  wasix_value_type_t args_out[2] = {0};
+  wasix_value_type_t results_out[1] = {0};
+  wasix_reflection_result_t info = {0};
+  int rc;
+
+  printf("Test 8: closure cacheable flag\n");
+
+  rc = wasix_closure_allocate(&closure_id);
+  assert(rc == 0);
+
+  rc = wasix_closure_prepare(backing_id, closure_id, arg_types, 2, res_types, 1,
+                             NULL);
+  assert(rc == 0);
+
+  rc = wasix_reflect_signature(closure_id, args_out, 2, results_out, 1, &info);
+  assert(rc == 0);
+  assert(info.cacheable == __WASI_BOOL_FALSE);
+  assert(info.arguments == 2);
+  assert(info.results == 1);
+  assert(args_out[0] == WASIX_VALUE_TYPE_I32);
+  assert(args_out[1] == WASIX_VALUE_TYPE_I64);
+  assert(results_out[0] == WASIX_VALUE_TYPE_I32);
+
+  rc = wasix_closure_free(closure_id);
+  assert(rc == 0);
+}
+
+int main(void) {
+  test_basic_signature();
+  test_extra_buffer_unchanged();
+  test_overflow_arguments();
+  test_overflow_results();
+  test_invalid_function_id_zero();
+  test_invalid_function_id_oob();
+  test_null_result_pointer();
+  test_closure_cacheable_flag();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/shared_library_tests.rs
+++ b/lib/wasix/tests/wasm_tests/shared_library_tests.rs
@@ -1,4 +1,4 @@
-#![cfg(all(unix, not(target_os = "macos"), not(feature = "js")))]
+#![cfg(all(unix, not(feature = "js")))]
 //! Shared library tests from wasix-tests directory
 //!
 //! These tests verify that shared libraries (.so) work correctly:


### PR DESCRIPTION
This starts the POSIX test migration from `tests/wasix-tests`. This PR migrates the first small tests-only batch with no syscall behavior changes and no special runner requirements.

LLVM backend is enforced in wasix test runner, so I've re-enabled some old tests as we can run those just fine.

Included migrations:
- `call_dynamic`
- `closure_free`
- `context_destroy`
- `context_switch`
- `reflect_signature`