### PR TITLE
tests(wasix): migrate fd_dup2, fd_fdflags_*, fd_tell tests

### DIFF
--- a/lib/wasix/tests/wasm_tests/fd_dup2.rs
+++ b/lib/wasix/tests/wasm_tests/fd_dup2.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn fd_dup2() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/fd_dup2/build.sh
+++ b/lib/wasix/tests/wasm_tests/fd_dup2/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/fd_dup2/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_dup2/main.c
@@ -1,0 +1,113 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int create_file(const char* name) {
+  int fd = open(name, O_CREAT | O_TRUNC | O_RDWR, 0644);
+  assert(fd >= 0);
+  return fd;
+}
+
+static void test_dupfd_minimum_available(void) {
+  // From LTP fcntl01.c: F_DUPFD returns the lowest available fd >= min.
+  printf("Test 1: F_DUPFD returns minimum available\n");
+  int fd = create_file("fd_dup2_min_file");
+  int hole_fd = create_file("fd_dup2_min_file2");
+  assert(close(hole_fd) == 0);
+
+  int dup_fd = fcntl(fd, F_DUPFD, hole_fd);
+  assert(dup_fd == hole_fd);
+
+  assert(close(dup_fd) == 0);
+  assert(close(fd) == 0);
+  assert(unlink("fd_dup2_min_file") == 0);
+  assert(unlink("fd_dup2_min_file2") == 0);
+}
+
+static void test_dupfd_minimums(void) {
+  // From LTP fcntl02.c and gVisor fcntl.cc: returned fd >= min.
+  printf("Test 2: F_DUPFD respects minimums\n");
+  static const int min_fds[] = {0, 1, 2, 3, 10, 100};
+
+  int fd = create_file("fd_dup2_minimums");
+
+  for (size_t i = 0; i < sizeof(min_fds) / sizeof(min_fds[0]); i++) {
+    int min_fd = min_fds[i];
+    int dup_fd = fcntl(fd, F_DUPFD, min_fd);
+    assert(dup_fd >= min_fd);
+    assert(dup_fd != fd);
+    assert(close(dup_fd) == 0);
+  }
+
+  assert(close(fd) == 0);
+  assert(unlink("fd_dup2_minimums") == 0);
+}
+
+static void test_dupfd_shared_offset(void) {
+  // Based on dup semantics: the duplicated fd shares file offset.
+  printf("Test 3: F_DUPFD shares file offset\n");
+  const char payload[] = "abcdef";
+  char ch = '\0';
+
+  int fd = create_file("fd_dup2_offset");
+  assert(write(fd, payload, sizeof(payload)) == (ssize_t)sizeof(payload));
+  assert(lseek(fd, 0, SEEK_SET) == 0);
+
+  int dup_fd = fcntl(fd, F_DUPFD, 0);
+  assert(dup_fd >= 0);
+  assert(read(dup_fd, &ch, 1) == 1);
+  assert(lseek(fd, 0, SEEK_CUR) == 1);
+
+  assert(close(dup_fd) == 0);
+  assert(close(fd) == 0);
+  assert(unlink("fd_dup2_offset") == 0);
+}
+
+static void test_dupfd_cloexec(void) {
+  // From LTP fcntl29.c and gVisor fcntl.cc: F_DUPFD_CLOEXEC sets FD_CLOEXEC.
+  printf("Test 4: F_DUPFD_CLOEXEC sets FD_CLOEXEC\n");
+  int fd = create_file("fd_dup2_cloexec");
+  int dup_fd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
+  assert(dup_fd >= 0);
+
+  int flags = fcntl(dup_fd, F_GETFD);
+  assert(flags >= 0);
+  assert((flags & FD_CLOEXEC) != 0);
+
+  int dup_fd2 = fcntl(fd, F_DUPFD, 0);
+  assert(dup_fd2 >= 0);
+  flags = fcntl(dup_fd2, F_GETFD);
+  assert(flags >= 0);
+  assert((flags & FD_CLOEXEC) == 0);
+
+  flags = fcntl(fd, F_GETFD);
+  assert(flags >= 0);
+  assert((flags & FD_CLOEXEC) == 0);
+
+  assert(close(dup_fd) == 0);
+  assert(close(dup_fd2) == 0);
+  assert(close(fd) == 0);
+  assert(unlink("fd_dup2_cloexec") == 0);
+}
+
+static void test_dupfd_bad_fd(void) {
+  // From LTP fcntl12.c: invalid fd yields EBADF.
+  printf("Test 5: F_DUPFD invalid fd\n");
+  errno = 0;
+  int ret = fcntl(-1, F_DUPFD, 0);
+  assert(ret == -1);
+  assert(errno == EBADF);
+}
+
+int main(void) {
+  test_dupfd_minimum_available();
+  test_dupfd_minimums();
+  test_dupfd_shared_offset();
+  test_dupfd_cloexec();
+  test_dupfd_bad_fd();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd_fdflags_get.rs
+++ b/lib/wasix/tests/wasm_tests/fd_fdflags_get.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn fd_fdflags_get() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/fd_fdflags_get/build.sh
+++ b/lib/wasix/tests/wasm_tests/fd_fdflags_get/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/fd_fdflags_get/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_fdflags_get/main.c
@@ -1,0 +1,274 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <wasi/api.h>
+#include <wasi/api_wasix.h>
+
+// Scan a small fd window for the first preopened directory exposed by the
+// current harness instead of assuming a fixed descriptor number.
+#define PREOPEN_SCAN_LIMIT 32
+
+static __wasi_fd_t find_preopen_directory_fd(void) {
+  for (__wasi_fd_t fd = 3; fd < PREOPEN_SCAN_LIMIT; fd++) {
+    __wasi_prestat_t prestat;
+    __wasi_errno_t ret = __wasi_fd_prestat_get(fd, &prestat);
+    if (ret == __WASI_ERRNO_SUCCESS && prestat.tag == __WASI_PREOPENTYPE_DIR) {
+      return fd;
+    }
+  }
+
+  assert(!"failed to find a preopened directory fd");
+  return 0;
+}
+
+static void test_stdin_stdout_stderr(void) {
+  printf("Test 1: fd_fdflags_get on stdin/stdout/stderr\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  ret = __wasi_fd_fdflags_get(0, &flags);
+  assert(ret == 0 && "fd_fdflags_get(stdin) should succeed");
+  printf("  stdin: flags=0x%x\n", flags);
+
+  ret = __wasi_fd_fdflags_get(1, &flags);
+  assert(ret == 0 && "fd_fdflags_get(stdout) should succeed");
+  printf("  stdout: flags=0x%x\n", flags);
+
+  ret = __wasi_fd_fdflags_get(2, &flags);
+  assert(ret == 0 && "fd_fdflags_get(stderr) should succeed");
+  printf("  stderr: flags=0x%x\n", flags);
+}
+
+static void test_invalid_fd(void) {
+  printf("\nTest 2: fd_fdflags_get with invalid fd (EBADF)\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  ret = __wasi_fd_fdflags_get(9999, &flags);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "fd_fdflags_get(9999) should return EBADF");
+  printf("  Invalid fd 9999 returned EBADF (errno=%d)\n", ret);
+
+  ret = __wasi_fd_fdflags_get(1500, &flags);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "fd_fdflags_get(1500) should return EBADF");
+  printf("  Invalid fd 1500 returned EBADF (errno=%d)\n", ret);
+}
+
+static void test_set_invalid_fd(void) {
+  printf("\nTest 3: fd_fdflags_set with invalid fd (EBADF)\n");
+
+  __wasi_errno_t ret;
+
+  ret = __wasi_fd_fdflags_set(9999, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "fd_fdflags_set(9999) should return EBADF");
+  printf("  Invalid fd 9999 returned EBADF (errno=%d)\n", ret);
+
+  ret = __wasi_fd_fdflags_set(1500, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "fd_fdflags_set(1500) should return EBADF");
+  printf("  Invalid fd 1500 returned EBADF (errno=%d)\n", ret);
+}
+
+static void test_fdflags_consistency(void) {
+  printf("\nTest 4: fd_fdflags_get consistency (repeated calls)\n");
+
+  __wasi_fdflagsext_t flags1, flags2, flags3;
+  __wasi_errno_t ret;
+
+  ret = __wasi_fd_fdflags_get(0, &flags1);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+
+  ret = __wasi_fd_fdflags_get(0, &flags2);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+
+  ret = __wasi_fd_fdflags_get(0, &flags3);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+
+  assert(flags1 == flags2 && "flags should match");
+  assert(flags1 == flags3 && "flags should match");
+
+  printf("  All three calls returned consistent results (flags=0x%x)\n",
+         flags1);
+}
+
+static void test_all_standard_fds(void) {
+  printf("\nTest 5: fd_fdflags_get on all standard fds\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  for (__wasi_fd_t fd = 0; fd <= 2; fd++) {
+    ret = __wasi_fd_fdflags_get(fd, &flags);
+    assert(ret == 0 && "fd_fdflags_get should succeed on standard fd");
+    printf("  fd %d: flags=0x%x\n", fd, flags);
+  }
+}
+
+static void test_cloexec_flag(void) {
+  printf("\nTest 6: CLOEXEC flag set/get operations\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  int file_fd = open("test_cloexec_file.txt", O_CREAT | O_RDWR, 0644);
+  assert(file_fd >= 0 && "open(test_cloexec_file.txt) should succeed");
+
+  ret = __wasi_fd_fdflags_get(file_fd, &flags);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+  printf("  Initial flags: 0x%x\n", flags);
+
+  ret = __wasi_fd_fdflags_set(file_fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == 0 && "fd_fdflags_set should succeed");
+  printf("  Set CLOEXEC flag\n");
+
+  ret = __wasi_fd_fdflags_get(file_fd, &flags);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) != 0 &&
+         "CLOEXEC flag should be set");
+  printf("  CLOEXEC flag verified: 0x%x\n", flags);
+
+  ret = __wasi_fd_fdflags_set(file_fd, 0);
+  assert(ret == 0 && "fd_fdflags_set should succeed");
+  printf("  Cleared CLOEXEC flag\n");
+
+  ret = __wasi_fd_fdflags_get(file_fd, &flags);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) == 0 &&
+         "CLOEXEC flag should be cleared");
+  printf("  CLOEXEC flag cleared: 0x%x\n", flags);
+
+  close(file_fd);
+  unlink("test_cloexec_file.txt");
+}
+
+static void test_flags_after_close(void) {
+  printf("\nTest 7: fd_fdflags_get after fd close (EBADF)\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  int file_fd = open("test_close_file.txt", O_CREAT | O_RDWR, 0644);
+  assert(file_fd >= 0 && "open(test_close_file.txt) should succeed");
+
+  ret = __wasi_fd_fdflags_get(file_fd, &flags);
+  assert(ret == 0 && "fd_fdflags_get should succeed before close");
+  printf("  Flags before close: 0x%x\n", flags);
+
+  close(file_fd);
+  printf("  Closed fd %d\n", file_fd);
+
+  ret = __wasi_fd_fdflags_get(file_fd, &flags);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "fd_fdflags_get should return EBADF after close");
+  printf("  fd_fdflags_get after close returned EBADF (errno=%d)\n", ret);
+
+  unlink("test_close_file.txt");
+}
+
+static void test_set_flags_on_closed_fd(void) {
+  printf("\nTest 8: fd_fdflags_set on closed fd (EBADF)\n");
+
+  __wasi_errno_t ret;
+
+  int file_fd = open("test_set_close_file.txt", O_CREAT | O_RDWR, 0644);
+  assert(file_fd >= 0 && "open(test_set_close_file.txt) should succeed");
+
+  close(file_fd);
+  printf("  Closed fd %d\n", file_fd);
+
+  ret = __wasi_fd_fdflags_set(file_fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "fd_fdflags_set should return EBADF on closed fd");
+  printf("  fd_fdflags_set on closed fd returned EBADF (errno=%d)\n", ret);
+
+  unlink("test_set_close_file.txt");
+}
+
+static void test_fd_range(void) {
+  printf("\nTest 9: File descriptor range testing\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  int invalid_fds[] = {100, 500, 1000, 5000, 10000, 65535};
+  int invalid_count = sizeof(invalid_fds) / sizeof(invalid_fds[0]);
+
+  for (int i = 0; i < invalid_count; i++) {
+    ret = __wasi_fd_fdflags_get(invalid_fds[i], &flags);
+    assert(ret == __WASI_ERRNO_BADF && "invalid fd should return EBADF");
+  }
+
+  printf("  All %d invalid fds returned EBADF\n", invalid_count);
+}
+
+static void test_negative_fd(void) {
+  printf("\nTest 10: Negative fd testing\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_errno_t ret;
+
+  ret = __wasi_fd_fdflags_get((__wasi_fd_t)-1, &flags);
+  assert(ret == __WASI_ERRNO_BADF &&
+         "negative (wrapped) fd should return EBADF");
+  printf("  Negative (wrapped) fd returned EBADF\n");
+}
+
+static void test_preopen_directory(void) {
+  printf("\nTest 11: fd_fdflags_get on preopen directory\n");
+
+  __wasi_fdflagsext_t flags;
+  __wasi_fd_t preopen_fd = find_preopen_directory_fd();
+  __wasi_errno_t ret = __wasi_fd_fdflags_get(preopen_fd, &flags);
+
+  assert(ret == 0 && "fd_fdflags_get should succeed on preopen directory");
+  printf("  Preopen directory fd %d flags: 0x%x\n", preopen_fd, flags);
+}
+
+static void test_fdflags_vs_fdstat(void) {
+  printf("\nTest 12: fd_fdflags_get vs fd_fdstat_get comparison\n");
+
+  __wasi_fdflagsext_t fdflags;
+  __wasi_fdstat_t fdstat;
+  __wasi_errno_t ret;
+
+  ret = __wasi_fd_fdflags_get(0, &fdflags);
+  assert(ret == 0 && "fd_fdflags_get should succeed");
+
+  ret = __wasi_fd_fdstat_get(0, &fdstat);
+  assert(ret == 0 && "fd_fdstat_get should succeed");
+
+  printf("  fd_fdflags_get returned: 0x%x\n", fdflags);
+  printf("  fd_fdstat_get fs_flags: 0x%x\n", fdstat.fs_flags);
+  printf(
+      "  Both syscalls succeeded (values may differ - different flag types)\n");
+}
+
+int main(void) {
+  printf("WASIX fd_fdflags_get Integration Tests\n");
+  printf("=======================================\n\n");
+
+  test_stdin_stdout_stderr();
+  test_invalid_fd();
+  test_set_invalid_fd();
+  test_fdflags_consistency();
+  test_all_standard_fds();
+  test_cloexec_flag();
+  test_flags_after_close();
+  test_set_flags_on_closed_fd();
+  test_fd_range();
+  test_negative_fd();
+  test_preopen_directory();
+  test_fdflags_vs_fdstat();
+
+  printf("\n=======================================\n");
+  printf("All fd_fdflags_get tests completed!\n");
+
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd_fdflags_set.rs
+++ b/lib/wasix/tests/wasm_tests/fd_fdflags_set.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn fd_fdflags_set() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/fd_fdflags_set/build.sh
+++ b/lib/wasix/tests/wasm_tests/fd_fdflags_set/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/fd_fdflags_set/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_fdflags_set/main.c
@@ -1,0 +1,104 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <wasi/api.h>
+#include <wasi/api_wasix.h>
+
+static int create_file(const char* name) {
+  int fd = open(name, O_CREAT | O_TRUNC | O_RDWR, 0644);
+  assert(fd >= 0);
+  return fd;
+}
+
+static void test_set_cloexec(void) {
+  // From LTP fcntl01.c and gVisor fcntl.cc: set FD_CLOEXEC.
+  printf("Test 1: set CLOEXEC\n");
+  int fd = create_file("fd_fdflags_set_file");
+
+  __wasi_fdflagsext_t flags = 0;
+  __wasi_errno_t ret = __wasi_fd_fdflags_get(fd, &flags);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) == 0);
+
+  ret = __wasi_fd_fdflags_set(fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+
+  flags = 0;
+  ret = __wasi_fd_fdflags_get(fd, &flags);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) != 0);
+
+  assert(close(fd) == 0);
+  assert(unlink("fd_fdflags_set_file") == 0);
+}
+
+static void test_clear_cloexec(void) {
+  // From gVisor fcntl.cc: clear FD_CLOEXEC.
+  printf("Test 2: clear CLOEXEC\n");
+  int fd = create_file("fd_fdflags_clear_file");
+
+  __wasi_errno_t ret = __wasi_fd_fdflags_set(fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+
+  ret = __wasi_fd_fdflags_set(fd, 0);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+
+  __wasi_fdflagsext_t flags = __WASI_FDFLAGSEXT_CLOEXEC;
+  ret = __wasi_fd_fdflags_get(fd, &flags);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) == 0);
+
+  assert(close(fd) == 0);
+  assert(unlink("fd_fdflags_clear_file") == 0);
+}
+
+static void test_independent_flags(void) {
+  // From gVisor fcntl.cc: descriptor flags are per-fd.
+  printf("Test 3: independent descriptor flags\n");
+  int fd = create_file("fd_fdflags_independent_file");
+  int dup_fd = fcntl(fd, F_DUPFD, 0);
+  assert(dup_fd >= 0);
+  assert(dup_fd != fd);
+
+  __wasi_errno_t ret = __wasi_fd_fdflags_set(fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+
+  __wasi_fdflagsext_t flags = 0;
+  ret = __wasi_fd_fdflags_get(dup_fd, &flags);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) == 0);
+
+  ret = __wasi_fd_fdflags_set(dup_fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+
+  flags = 0;
+  ret = __wasi_fd_fdflags_get(fd, &flags);
+  assert(ret == __WASI_ERRNO_SUCCESS);
+  assert((flags & __WASI_FDFLAGSEXT_CLOEXEC) != 0);
+
+  assert(close(dup_fd) == 0);
+  assert(close(fd) == 0);
+  assert(unlink("fd_fdflags_independent_file") == 0);
+}
+
+static void test_bad_fd(void) {
+  // From gVisor fcntl.cc: EBADF on closed fd.
+  printf("Test 4: bad fd\n");
+  int fd = create_file("fd_fdflags_bad_fd");
+  assert(close(fd) == 0);
+
+  __wasi_errno_t ret = __wasi_fd_fdflags_set(fd, __WASI_FDFLAGSEXT_CLOEXEC);
+  assert(ret == __WASI_ERRNO_BADF);
+
+  assert(unlink("fd_fdflags_bad_fd") == 0);
+}
+
+int main(void) {
+  test_set_cloexec();
+  test_clear_cloexec();
+  test_independent_flags();
+  test_bad_fd();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd_fdstat_set_rights.rs
+++ b/lib/wasix/tests/wasm_tests/fd_fdstat_set_rights.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn fd_fdstat_set_rights() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/fd_fdstat_set_rights/build.sh
+++ b/lib/wasix/tests/wasm_tests/fd_fdstat_set_rights/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/fd_fdstat_set_rights/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_fdstat_set_rights/main.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <wasi/api_wasi.h>
+
+static int create_file(const char* name) {
+  unlink(name);
+  int fd = open(name, O_CREAT | O_TRUNC | O_RDWR, 0644);
+  assert(fd >= 0);
+  assert(write(fd, "hello", 5) == 5);
+  assert(lseek(fd, 0, SEEK_SET) == 0);
+  return fd;
+}
+
+static void test_bad_fd(void) {
+  // From wasmtime p2_adapter_badfd.rs: EBADF on invalid fd.
+  printf("Test 1: bad fd\n");
+  __wasi_errno_t err = __wasi_fd_fdstat_set_rights(9999, 0, 0);
+  assert(err == __WASI_ERRNO_BADF);
+}
+
+static void test_drop_read_rights(void) {
+  printf("Test 2: drop read rights\n");
+  int fd = create_file("fd_fdstat_set_rights_file");
+
+  __wasi_fdstat_t stat;
+  __wasi_errno_t err = __wasi_fd_fdstat_get(fd, &stat);
+  assert(err == __WASI_ERRNO_SUCCESS);
+  assert((stat.fs_rights_base & (__wasi_rights_t)__WASI_RIGHTS_FD_READ) != 0);
+
+  __wasi_rights_t orig_base = stat.fs_rights_base;
+  __wasi_rights_t orig_inherit = stat.fs_rights_inheriting;
+  __wasi_rights_t new_base =
+      orig_base & ~(__wasi_rights_t)__WASI_RIGHTS_FD_READ;
+
+  err = __wasi_fd_fdstat_set_rights(fd, new_base, orig_inherit);
+  assert(err == __WASI_ERRNO_SUCCESS);
+
+  err = __wasi_fd_fdstat_get(fd, &stat);
+  assert(err == __WASI_ERRNO_SUCCESS);
+  assert(stat.fs_rights_base == new_base);
+  assert(stat.fs_rights_inheriting == orig_inherit);
+
+  char buffer[4] = {0};
+  __wasi_iovec_t iov = {.buf = (uint8_t*)buffer, .buf_len = sizeof(buffer)};
+  __wasi_size_t nread = 0;
+  err = __wasi_fd_read(fd, &iov, 1, &nread);
+  assert(err == __WASI_ERRNO_ACCES);
+
+  err = __wasi_fd_fdstat_set_rights(fd, orig_base, orig_inherit);
+  assert(err == __WASI_ERRNO_NOTCAPABLE);
+
+  assert(close(fd) == 0);
+  assert(unlink("fd_fdstat_set_rights_file") == 0);
+}
+
+int main(void) {
+  test_bad_fd();
+  test_drop_read_rights();
+  printf("All tests passed!\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd_tell.rs
+++ b/lib/wasix/tests/wasm_tests/fd_tell.rs
@@ -1,0 +1,7 @@
+use super::{run_build_script, run_wasm};
+
+#[test]
+fn fd_tell() {
+    let wasm = run_build_script(file!(), "").unwrap();
+    run_wasm(&wasm, wasm.parent().unwrap()).unwrap();
+}

--- a/lib/wasix/tests/wasm_tests/fd_tell/build.sh
+++ b/lib/wasix/tests/wasm_tests/fd_tell/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/fd_tell/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tell/main.c
@@ -1,0 +1,294 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void test_initial_offset(void) {
+  printf("Test: Initial offset is 0\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  long pos = ftell(f);
+  assert(pos == 0);
+
+  printf("  Initial offset = 0\n");
+  fclose(f);
+}
+
+static void test_offset_after_write(void) {
+  printf("\nTest: Offset advances after write\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  char data[100];
+  memset(data, 'A', 100);
+  size_t written = fwrite(data, 1, 100, f);
+  assert(written == 100);
+
+  long pos = ftell(f);
+  assert(pos == 100);
+
+  printf("  After writing 100 bytes, offset = %ld\n", pos);
+  fclose(f);
+}
+
+static void test_offset_after_read(void) {
+  printf("\nTest: Offset advances after read\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  fprintf(f, "hello");
+  rewind(f);
+
+  char buf[6];
+  size_t read_bytes = fread(buf, 1, 5, f);
+  assert(read_bytes == 5);
+
+  long pos = ftell(f);
+  assert(pos == 5);
+
+  printf("  After reading 5 bytes ('hello'), offset = %ld\n", pos);
+  fclose(f);
+}
+
+static void test_seek_operations(void) {
+  printf("\nTest: Offset reflects seek operations\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  char data[100];
+  memset(data, 'X', 100);
+  fwrite(data, 1, 100, f);
+
+  fseek(f, 42, SEEK_SET);
+  long pos = ftell(f);
+  assert(pos == 42);
+  printf("  After SEEK_SET to 42, offset = %ld\n", pos);
+
+  fseek(f, -20, SEEK_CUR);
+  pos = ftell(f);
+  assert(pos == 22);
+  printf("  After SEEK_CUR -20, offset = %ld\n", pos);
+
+  fseek(f, 0, SEEK_END);
+  pos = ftell(f);
+  assert(pos == 100);
+  printf("  After SEEK_END, offset = %ld\n", pos);
+
+  fclose(f);
+}
+
+static void test_seek_beyond_eof(void) {
+  printf("\nTest: Seek beyond EOF\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  char data[100];
+  memset(data, 'Y', 100);
+  fwrite(data, 1, 100, f);
+
+  fseek(f, 1000, SEEK_SET);
+  long pos = ftell(f);
+  assert(pos == 1000);
+
+  printf("  After seeking to 1000 (beyond 100-byte file), offset = %ld\n", pos);
+  fclose(f);
+}
+
+static void test_ftell_equivalence_with_lseek(void) {
+  printf("\nTest: ftell equivalent to lseek(fd, 0, SEEK_CUR)\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+  int fd = fileno(f);
+
+  fprintf(f, "test data");
+  fseek(f, 4, SEEK_SET);
+
+  long ftell_pos = ftell(f);
+  off_t lseek_pos = lseek(fd, 0, SEEK_CUR);
+
+  assert(ftell_pos == lseek_pos);
+  printf("  ftell = %ld, lseek(0, SEEK_CUR) = %lld (equivalent)\n", ftell_pos,
+         (long long)lseek_pos);
+
+  fclose(f);
+}
+
+static void test_append_mode(void) {
+  printf("\nTest: O_APPEND flag behavior\n");
+
+  char template[] = "/tmp/fd_tell_append_XXXXXX";
+  int fd = mkstemp(template);
+  assert(fd > 0);
+
+  write(fd, "initial ", 8);
+
+  close(fd);
+  fd = open(template, O_RDWR | O_APPEND);
+  assert(fd > 0);
+
+  FILE* f = fdopen(fd, "a+");
+  assert(f != NULL);
+
+  long initial_pos = ftell(f);
+  printf("  Initial offset with O_APPEND: %ld\n", initial_pos);
+
+  fprintf(f, "appended");
+  fflush(f);
+
+  long pos = ftell(f);
+  assert(pos == 16);
+  printf("  After appending 8 bytes to an 8-byte file, offset = %ld\n", pos);
+
+  fclose(f);
+  unlink(template);
+}
+
+static void test_multiple_operations(void) {
+  printf("\nTest: Multiple consecutive operations\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  char data1[50];
+  memset(data1, 'A', 50);
+  fwrite(data1, 1, 50, f);
+
+  char data2[30];
+  memset(data2, 'B', 30);
+  fwrite(data2, 1, 30, f);
+
+  fseek(f, 10, SEEK_SET);
+
+  char buf[20];
+  fread(buf, 1, 20, f);
+
+  long pos = ftell(f);
+  assert(pos == 30);
+
+  printf(
+      "  Multiple operations: write(50) -> write(30) -> seek(10) -> read(20) "
+      "-> offset = %ld\n",
+      pos);
+  fclose(f);
+}
+
+static void test_rewind(void) {
+  printf("\nTest: rewind() sets offset to 0\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  fprintf(f, "test data");
+  rewind(f);
+
+  long pos = ftell(f);
+  assert(pos == 0);
+
+  printf("  After rewind(), offset = %ld\n", pos);
+  fclose(f);
+}
+
+static void test_large_offset(void) {
+  printf("\nTest: Large offset handling\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  long large_offset = 1000000000L;
+  fseek(f, large_offset, SEEK_SET);
+
+  long pos = ftell(f);
+  assert(pos == large_offset);
+
+  printf("  Large offset (1GB): offset = %ld\n", pos);
+  fclose(f);
+}
+
+static void test_consistency(void) {
+  printf("\nTest: Consistency across multiple ftell calls\n");
+
+  FILE* f = tmpfile();
+  assert(f != NULL);
+
+  fprintf(f, "ab");
+
+  long pos1 = ftell(f);
+  long pos2 = ftell(f);
+  long pos3 = ftell(f);
+
+  assert(pos1 == pos2);
+  assert(pos2 == pos3);
+
+  printf("  Multiple ftell calls return same value: %ld\n", pos1);
+  fclose(f);
+}
+
+static void test_stdin_stdout_stderr(void) {
+  printf("\nTest: Standard file descriptors\n");
+
+  long stdin_pos = ftell(stdin);
+  long stdout_pos = ftell(stdout);
+  long stderr_pos = ftell(stderr);
+
+  printf("  stdin offset: %ld\n", stdin_pos);
+  printf("  stdout offset: %ld\n", stdout_pos);
+  printf("  stderr offset: %ld\n", stderr_pos);
+  printf("  Standard fds have valid offsets\n");
+}
+
+static void test_fdopen_preserves_offset(void) {
+  printf("\nTest: fdopen() preserves fd offset\n");
+
+  char template[] = "/tmp/fd_tell_fdopen_XXXXXX";
+  int fd = mkstemp(template);
+  assert(fd > 0);
+
+  ssize_t written = write(fd, "hello\n", 6);
+  assert(written == 6);
+
+  FILE* f = fdopen(fd, "rb");
+  assert(f != NULL);
+
+  off_t pos = ftello(f);
+  assert(pos == 6);
+  printf("  After write(fd, 6 bytes) then fdopen(), ftello = %lld\n",
+         (long long)pos);
+
+  fseeko(f, 0, SEEK_SET);
+  char buf[7];
+  fgets(buf, sizeof(buf), f);
+  assert(strcmp(buf, "hello\n") == 0);
+
+  fclose(f);
+  unlink(template);
+}
+
+int main(void) {
+  printf("=== fd_tell (ftell/lseek) Integration Tests ===\n\n");
+
+  test_initial_offset();
+  test_offset_after_write();
+  test_offset_after_read();
+  test_seek_operations();
+  test_seek_beyond_eof();
+  test_ftell_equivalence_with_lseek();
+  test_append_mode();
+  test_multiple_operations();
+  test_rewind();
+  test_large_offset();
+  test_consistency();
+  test_stdin_stdout_stderr();
+  test_fdopen_preserves_offset();
+
+  printf("\n=== All fd_tell tests passed! ===\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -4,6 +4,11 @@ mod dynamic_library_tests;
 mod edge_case_tests;
 mod exception_tests;
 mod exit_tests;
+mod fd_dup2;
+mod fd_fdflags_get;
+mod fd_fdflags_set;
+mod fd_fdstat_set_rights;
+mod fd_tell;
 mod fd_tests;
 mod ffi_tests;
 mod libc_tests;
@@ -310,11 +315,11 @@ fn create_engine_for_wasm(wasm_bytes: &[u8]) -> wasmer::Engine {
 
         let compiler = wasmer::sys::LLVM::default();
 
-        return EngineBuilder::new(compiler)
+        EngineBuilder::new(compiler)
             .set_features(Some(features))
             .set_target(Some(target))
             .engine()
-            .into();
+            .into()
     }
 
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
This migrates the next tests-only POSIX batch from `tests/wasix-tests` into `lib/wasix/tests/wasm_tests`.

This PR focuses on fd-related coverage only and does not include runtime or syscall implementation changes.

Included migrations:
- `fd_dup2`
- `fd_fdflags_get`
- `fd_fdflags_set`
- `fd_fdstat_set_rights`
- `fd_tell`
