### PR TITLE
fix(wasix): return ENOTDIR for create under non-directory path

### DIFF
--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -362,7 +362,7 @@ pub(crate) fn path_open_internal(
                         new_path.push(&new_entity_name);
                         new_path
                     }
-                    _ => return Ok(Err(Errno::Inval)),
+                    _ => return Ok(Err(Errno::Notdir)),
                 }
             };
             // once we got the data we need from the parent, we lookup the host file

--- a/tests/wasix/open-under-file/main.c
+++ b/tests/wasix/open-under-file/main.c
@@ -1,0 +1,29 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("parent", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  if (fd < 0) {
+    perror("open parent");
+    return 1;
+  }
+  close(fd);
+
+  fd = open("parent/child", O_CREAT | O_EXCL | O_RDWR, 0600);
+  if (fd != -1) {
+    fprintf(stderr, "open unexpectedly succeeded\n");
+    close(fd);
+    return 1;
+  }
+
+  if (errno != ENOTDIR) {
+    fprintf(stderr, "expected ENOTDIR, got %d\n", errno);
+    return 1;
+  }
+
+  printf("0");
+  return 0;
+}

--- a/tests/wasix/open-under-file/run.sh
+++ b/tests/wasix/open-under-file/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+$WASMER_RUN main.wasm --volume . > output
+
+rm -f parent 2>/dev/null && printf "0" | diff -u output - 1>/dev/null


### PR DESCRIPTION
Fix WASIX create-open error reporting when a parent path component is not a directory.

Previously, creating a file at a path like `parent/child` where `parent` is a regular file returned `EINVAL`. POSIX behavior here is `ENOTDIR`, and Python surfaces that as `NotADirectoryError`.

Fixes https://github.com/wasmerio/wasmer/issues/6444