### PR TITLE
fix(wasix): report /dev/null as a character device

### DIFF
--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -256,9 +256,11 @@ impl FileSystem {
             file: Mutex::new(file),
             metadata: {
                 let time = time();
+                let is_char_device = path.starts_with("/dev");
                 Metadata {
                     ft: FileType {
-                        file: true,
+                        file: !is_char_device,
+                        char_device: is_char_device,
                         ..Default::default()
                     },
                     accessed: time,

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -2434,11 +2434,18 @@ impl FileSystem for FallbackFileSystem {
 }
 
 pub fn virtual_file_type_to_wasi_file_type(file_type: virtual_fs::FileType) -> Filetype {
-    // TODO: handle other file types
     if file_type.is_dir() {
         Filetype::Directory
     } else if file_type.is_file() {
         Filetype::RegularFile
+    } else if file_type.is_char_device() {
+        Filetype::CharacterDevice
+    } else if file_type.is_block_device() {
+        Filetype::BlockDevice
+    } else if file_type.is_socket() {
+        Filetype::SocketStream
+    } else if file_type.is_fifo() {
+        Filetype::Unknown
     } else if file_type.is_symlink() {
         Filetype::SymbolicLink
     } else {

--- a/tests/wasix/dev-null-stat/main.c
+++ b/tests/wasix/dev-null-stat/main.c
@@ -1,0 +1,41 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static void fail(const char* msg) {
+  perror(msg);
+  exit(1);
+}
+
+int main(void) {
+  struct stat st;
+
+  if (stat("/dev/null", &st) != 0) {
+    fail("stat /dev/null");
+  }
+  if (!S_ISCHR(st.st_mode)) {
+    fprintf(stderr, "stat(/dev/null) mode %#o is not char device\n",
+            st.st_mode);
+    return 1;
+  }
+
+  int fd = open("/dev/null", O_RDWR);
+  if (fd < 0) {
+    fail("open /dev/null");
+  }
+  if (fstat(fd, &st) != 0) {
+    fail("fstat /dev/null");
+  }
+  if (!S_ISCHR(st.st_mode)) {
+    fprintf(stderr, "fstat(/dev/null) mode %#o is not char device\n",
+            st.st_mode);
+    close(fd);
+    return 1;
+  }
+
+  close(fd);
+  printf("0");
+  return 0;
+}

--- a/tests/wasix/dev-null-stat/run.sh
+++ b/tests/wasix/dev-null-stat/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+$WASMER_RUN ./main.wasm > output
+
+printf "0" | diff -u output - 1>/dev/null


### PR DESCRIPTION
Fix WASIX `/dev/null` metadata so it stats as a character device instead of a regular file.

Previously, `/dev/null` behaved like a null device for I/O, but `stat()`/`fstat()` reported it as a regular file. 