### PR TITLE
fix(wasix): Make connect nonblocking when requested and implement real socket::status

### DIFF
--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -19,7 +19,7 @@ use std::os::fd::RawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -175,16 +175,7 @@ impl VirtualNetworking for LocalNetworking {
             return Err(NetworkError::PermissionDenied);
         }
 
-        // This future may be polled outside Tokio's executor context, so run
-        // the connect itself on the stored runtime handle to guarantee a reactor.
-        let stream = self
-            .handle
-            .spawn(tokio::net::TcpStream::connect(peer))
-            .await
-            .map_err(|_| NetworkError::IOError)?
-            .map_err(io_err_into_net_error)?;
-        let stream = stream.into_std().map_err(io_err_into_net_error)?;
-        let stream = mio::net::TcpStream::from_std(stream);
+        let stream = mio::net::TcpStream::connect(peer).map_err(io_err_into_net_error)?;
 
         if let Ok(p) = stream.peer_addr() {
             peer = p;
@@ -387,6 +378,13 @@ impl VirtualIoSource for LocalTcpListener {
 }
 
 #[derive(Debug)]
+enum ConnectState {
+    Unknown,
+    Opened,
+    Failed,
+}
+
+#[derive(Debug)]
 pub struct LocalTcpStream {
     stream: mio::net::TcpStream,
     addr: SocketAddr,
@@ -394,6 +392,7 @@ pub struct LocalTcpStream {
     selector: Arc<Selector>,
     handler_guard: HandlerGuardState,
     buffer: BytesMut,
+    connect_state: Mutex<ConnectState>,
 }
 
 impl LocalTcpStream {
@@ -406,6 +405,7 @@ impl LocalTcpStream {
             selector,
             handler_guard: HandlerGuardState::None,
             buffer: BytesMut::new(),
+            connect_state: Mutex::new(ConnectState::Unknown),
         };
 
         // In windows we can not poll the socket as it is not supported and hence
@@ -614,7 +614,41 @@ impl VirtualSocket for LocalTcpStream {
     }
 
     fn status(&self) -> Result<SocketStatus> {
-        Ok(SocketStatus::Opened)
+        // `take_error()` consumes the latched socket error, so once the
+        // connect resolves we cache the terminal state to keep status() stable.
+        let mut connect_state = self.connect_state.lock().unwrap();
+        match *connect_state {
+            ConnectState::Opened => return Ok(SocketStatus::Opened),
+            ConnectState::Failed => return Ok(SocketStatus::Failed),
+            ConnectState::Unknown => {}
+        }
+
+        if self
+            .with_sock_ref(|sockref| sockref.take_error())
+            .map_err(io_err_into_net_error)?
+            .is_some()
+        {
+            *connect_state = ConnectState::Failed;
+            return Ok(SocketStatus::Failed); // connect error on the socket
+        }
+        match self.stream.peer_addr() {
+            Ok(_) => {
+                *connect_state = ConnectState::Opened;
+                Ok(SocketStatus::Opened) // TCP handshake completed.
+            }
+            Err(err) => {
+                if matches!(
+                    err.kind(),
+                    io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock
+                ) {
+                    Ok(SocketStatus::Opening) // The connect is still in progress
+                } else {
+                    // TODO: Store the concrete err so we can return it later on
+                    *connect_state = ConnectState::Failed;
+                    Ok(SocketStatus::Failed) // Any other error means the socket is unusable
+                }
+            }
+        }
     }
 
     fn set_handler(&mut self, mut handler: Box<dyn InterestHandler + Send + Sync>) -> Result<()> {

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -474,3 +474,77 @@ async fn test_google_epoll() {
 
     tracing::info!("done");
 }
+
+#[cfg(not(target_os = "windows"))]
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_connect_tcp_returns_immediately_for_in_progress_connect() {
+    use tokio::time::{Duration, Instant, timeout};
+
+    // This address is intentionally blackholed in typical dev/prod networks:
+    // a blocking connect will hang for many seconds, while a nonblocking
+    // connect should return immediately with a socket that becomes writable
+    // later when the connect either succeeds or fails.
+    let peer = SocketAddr::from((Ipv4Addr::new(10, 255, 255, 1), 443));
+    let networking = LocalNetworking::new();
+
+    let started = Instant::now();
+    let connect = networking.connect_tcp(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)), peer);
+    let result = timeout(Duration::from_millis(250), connect).await;
+
+    match result {
+        Ok(Ok(_socket)) => {
+            assert!(
+                started.elapsed() < Duration::from_millis(250),
+                "connect_tcp unexpectedly took too long for a nonblocking connect attempt: {:?}",
+                started.elapsed()
+            );
+        }
+        Ok(Err(err)) => {
+            panic!("connect_tcp returned an unexpected immediate error: {err:?}");
+        }
+        Err(_) => {
+            panic!(
+                "connect_tcp did not return promptly for an in-progress connect; elapsed={:?}",
+                started.elapsed()
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_failed_connect_status_stays_failed() {
+    use tokio::time::{Duration, Instant, sleep};
+
+    let probe = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let peer = probe.local_addr().unwrap();
+    drop(probe);
+
+    let networking = LocalNetworking::new();
+    let socket = networking
+        .connect_tcp(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)), peer)
+        .await
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        match socket.status().unwrap() {
+            SocketStatus::Failed => break,
+            SocketStatus::Opening => {
+                assert!(
+                    Instant::now() < deadline,
+                    "connect status never reached Failed before timeout"
+                );
+                sleep(Duration::from_millis(10)).await;
+            }
+            SocketStatus::Opened => panic!("unused localhost port unexpectedly connected"),
+            SocketStatus::Closed => panic!("connect status unexpectedly reported Closed"),
+        }
+    }
+
+    assert!(matches!(socket.status().unwrap(), SocketStatus::Failed));
+}

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -667,7 +667,13 @@ impl InodeSocket {
         Ok(match &inner.kind {
             InodeSocketKind::PreSocket { .. } => WasiSocketStatus::Opening,
             InodeSocketKind::TcpListener { .. } => WasiSocketStatus::Opened,
-            InodeSocketKind::TcpStream { .. } => WasiSocketStatus::Opened,
+            InodeSocketKind::TcpStream { socket, .. } => match socket.status() {
+                Ok(virtual_net::SocketStatus::Opening) => WasiSocketStatus::Opening,
+                Ok(virtual_net::SocketStatus::Opened) => WasiSocketStatus::Opened,
+                Ok(virtual_net::SocketStatus::Closed) => WasiSocketStatus::Closed,
+                Ok(virtual_net::SocketStatus::Failed) => WasiSocketStatus::Failed,
+                Err(_) => WasiSocketStatus::Failed,
+            },
             InodeSocketKind::UdpSocket { .. } => WasiSocketStatus::Opened,
             InodeSocketKind::RemoteSocket { is_dead, .. } => match is_dead {
                 true => WasiSocketStatus::Closed,
@@ -1584,7 +1590,7 @@ pub(crate) fn all_socket_rights() -> Rights {
 
 #[cfg(test)]
 mod tests {
-    use super::{InodeSocket, InodeSocketKind};
+    use super::{InodeSocket, InodeSocketKind, WasiSocketStatus};
     use std::{
         mem::MaybeUninit,
         net::{Ipv4Addr, Shutdown, SocketAddr},
@@ -1606,6 +1612,17 @@ mod tests {
     struct MockTcpSocket {
         read_calls: Arc<AtomicUsize>,
         write_calls: Arc<AtomicUsize>,
+        status: Arc<AtomicUsize>,
+    }
+
+    const MOCK_STATUS_OPENING: usize = 0;
+    const MOCK_STATUS_OPENED: usize = 1;
+
+    fn decode_mock_status(value: usize) -> SocketStatus {
+        match value {
+            MOCK_STATUS_OPENED => SocketStatus::Opened,
+            _ => SocketStatus::Opening,
+        }
     }
 
     impl VirtualIoSource for MockTcpSocket {
@@ -1618,6 +1635,7 @@ mod tests {
 
         fn poll_write_ready(&mut self, _cx: &mut Context<'_>) -> Poll<NetResult<usize>> {
             self.write_calls.fetch_add(1, Ordering::Relaxed);
+            self.status.store(MOCK_STATUS_OPENED, Ordering::Relaxed);
             Poll::Ready(Ok(7))
         }
     }
@@ -1636,7 +1654,7 @@ mod tests {
         }
 
         fn status(&self) -> NetResult<SocketStatus> {
-            Ok(SocketStatus::Opened)
+            Ok(decode_mock_status(self.status.load(Ordering::Relaxed)))
         }
 
         fn set_handler(
@@ -1731,10 +1749,12 @@ mod tests {
     fn inode_socket_poll_write_ready_uses_write_path() {
         let read_calls = Arc::new(AtomicUsize::new(0));
         let write_calls = Arc::new(AtomicUsize::new(0));
+        let status = Arc::new(AtomicUsize::new(MOCK_STATUS_OPENED));
         let mut inode = InodeSocket::new(InodeSocketKind::TcpStream {
             socket: Box::new(MockTcpSocket {
                 read_calls: read_calls.clone(),
                 write_calls: write_calls.clone(),
+                status,
             }),
             write_timeout: None,
             read_timeout: None,
@@ -1747,5 +1767,23 @@ mod tests {
         assert!(matches!(ready, Poll::Ready(Ok(7))));
         assert_eq!(read_calls.load(Ordering::Relaxed), 0);
         assert_eq!(write_calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn inode_socket_status_tracks_tcp_socket_status() {
+        let status = Arc::new(AtomicUsize::new(MOCK_STATUS_OPENING));
+        let inode = InodeSocket::new(InodeSocketKind::TcpStream {
+            socket: Box::new(MockTcpSocket {
+                read_calls: Arc::new(AtomicUsize::new(0)),
+                write_calls: Arc::new(AtomicUsize::new(0)),
+                status: status.clone(),
+            }),
+            write_timeout: None,
+            read_timeout: None,
+        });
+
+        assert!(matches!(inode.status().unwrap(), WasiSocketStatus::Opening));
+        status.store(MOCK_STATUS_OPENED, Ordering::Relaxed);
+        assert!(matches!(inode.status().unwrap(), WasiSocketStatus::Opened));
     }
 }

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -48,6 +48,15 @@ pub fn sock_connect<M: MemorySize>(
     Ok(Errno::Success)
 }
 
+fn nonblocking_connect_result(status: crate::net::socket::WasiSocketStatus) -> Result<(), Errno> {
+    match status {
+        crate::net::socket::WasiSocketStatus::Opening => Err(Errno::Inprogress),
+        crate::net::socket::WasiSocketStatus::Opened => Ok(()),
+        crate::net::socket::WasiSocketStatus::Closed
+        | crate::net::socket::WasiSocketStatus::Failed => Err(Errno::Notconn),
+    }
+}
+
 pub(crate) fn sock_connect_internal(
     ctx: &mut FunctionEnvMut<'_, WasiEnv>,
     sock: WasiFd,
@@ -56,6 +65,10 @@ pub(crate) fn sock_connect_internal(
     let env = ctx.data();
     let net = env.net().clone();
     let tasks = ctx.data().tasks().clone();
+    let nonblocking = match env.state.fs.get_fd(sock) {
+        Ok(fd_entry) => fd_entry.inner.flags.contains(Fdflags::NONBLOCK),
+        Err(err) => return Ok(Err(err)),
+    };
     wasi_try_ok_ok!(__sock_upgrade(
         ctx,
         sock,
@@ -78,5 +91,37 @@ pub(crate) fn sock_connect_internal(
         }
     ));
 
+    if nonblocking {
+        let status = match __sock_actor(ctx, sock, Rights::empty(), |socket, _| socket.status()) {
+            Ok(status) => status,
+            Err(err) => return Ok(Err(err)),
+        };
+        return Ok(nonblocking_connect_result(status));
+    }
+
     Ok(Ok(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nonblocking_connect_result;
+    use crate::net::socket::WasiSocketStatus;
+    use wasmer_wasix_types::wasi::Errno;
+
+    #[test]
+    fn nonblocking_connect_result_maps_socket_states() {
+        assert_eq!(
+            nonblocking_connect_result(WasiSocketStatus::Opening),
+            Err(Errno::Inprogress)
+        );
+        assert_eq!(nonblocking_connect_result(WasiSocketStatus::Opened), Ok(()));
+        assert_eq!(
+            nonblocking_connect_result(WasiSocketStatus::Failed),
+            Err(Errno::Notconn)
+        );
+        assert_eq!(
+            nonblocking_connect_result(WasiSocketStatus::Closed),
+            Err(Errno::Notconn)
+        );
+    }
 }

--- a/lib/wasix/tests/wasm_tests/socket_tests.rs
+++ b/lib/wasix/tests/wasm_tests/socket_tests.rs
@@ -16,6 +16,21 @@ fn test_pipe_send_recv_compat() {
 }
 
 #[test]
+fn test_nonblocking_connect() {
+    let wasm = run_build_script(file!(), "nonblocking-connect").unwrap();
+    let result = run_wasm_with_result(&wasm, wasm.parent().unwrap()).unwrap();
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "nonblocking connect returned immediately",
+        "exit_code={:?}\nstdout:\n{}\nstderr:\n{}",
+        result.exit_code,
+        stdout,
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+#[test]
 // https://github.com/wasmerio/wasmer/issues/6366
 #[ignore = "flaky test (#6366)"]
 fn test_socket_pair() {

--- a/lib/wasix/tests/wasm_tests/socket_tests/nonblocking-connect/build.sh
+++ b/lib/wasix/tests/wasm_tests/socket_tests/nonblocking-connect/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+$CC main.c -o main

--- a/lib/wasix/tests/wasm_tests/socket_tests/nonblocking-connect/main.c
+++ b/lib/wasix/tests/wasm_tests/socket_tests/nonblocking-connect/main.c
@@ -1,0 +1,85 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+static long elapsed_ms(struct timeval start, struct timeval end) {
+  long seconds = end.tv_sec - start.tv_sec;
+  long useconds = end.tv_usec - start.tv_usec;
+  return seconds * 1000 + useconds / 1000;
+}
+
+int main(void) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags < 0) {
+    perror("fcntl(F_GETFL)");
+    close(fd);
+    return 1;
+  }
+
+  if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+    perror("fcntl(F_SETFL)");
+    close(fd);
+    return 1;
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(443);
+  if (inet_pton(AF_INET, "10.255.255.1", &addr.sin_addr) != 1) {
+    fprintf(stderr, "inet_pton failed\n");
+    close(fd);
+    return 1;
+  }
+
+  struct timeval start;
+  struct timeval end;
+  gettimeofday(&start, NULL);
+  int rc = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
+  gettimeofday(&end, NULL);
+
+  long ms = elapsed_ms(start, end);
+  close(fd);
+
+  if (ms > 1000) {
+    fprintf(stderr,
+            "nonblocking connect took too long: %ldms (expected immediate "
+            "return)\n",
+            ms);
+    return 1;
+  }
+
+  if (rc == 0) {
+    fprintf(
+        stderr,
+        "unexpected immediate success for blackholed nonblocking connect\n");
+    return 1;
+  }
+
+  switch (errno) {
+    case EINPROGRESS:
+    case EALREADY:
+    case EWOULDBLOCK:
+    case ENETUNREACH:
+    case EHOSTUNREACH:
+    case ECONNREFUSED:
+      printf("nonblocking connect returned immediately\n");
+      return 0;
+    default:
+      fprintf(stderr, "unexpected connect result: rc=%d errno=%d (%s)\n", rc,
+              errno, strerror(errno));
+      return 1;
+  }
+}


### PR DESCRIPTION
Around a month ago we had an issue where Python was getting a timeout when trying to connect to external hosts in nonblocking mode. In [#6298](https://github.com/wasmerio/wasmer/pull/6298) I tried to fix it, but did it in the wrong way: I made WASIX only return the socket after the connection was fully established. It fixed the Python issue, but it also effectively made `connect()` blocking.

This PR reverts that and fixes the real issue instead: `socket::status()` was always returning hardcoded `Ready` for TCP sockets.

So what was really happening was:
- nonblocking connect() returned a socket
- client code checked its status
- status said Ready
- client started sending data,
- but the TCP handshake could still still be in progress.
So it was racy and wrong.

This change keeps `connect()` nonblocking again and fixes `socket::status()` so it returns the real state of the socket instead of always pretending it is already ready.