### PR TITLE
compiler/engine: fix 'occured' -> 'occurred' in error doc comment

### DIFF
--- a/lib/compiler/src/engine/error.rs
+++ b/lib/compiler/src/engine/error.rs
@@ -45,7 +45,7 @@ pub enum InstantiationError {
     #[error("module compiled with CPU feature that is missing from host")]
     CpuFeature(String),
 
-    /// A runtime error occured while invoking the start function
+    /// A runtime error occurred while invoking the start function
     #[cfg(not(target_arch = "wasm32"))]
     #[error(transparent)]
     Start(Trap),


### PR DESCRIPTION
Doc comment in `lib/compiler/src/engine/error.rs` line 48 reads `A runtime error occured`. Fixed to `occurred`. Comment-only change.