### PR TITLE
fix(virtual-fs): Use non zero default mtime/access time/creation time

### DIFF
--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -12,6 +12,8 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+const DEFAULT_METADATE_TIME: u64 = 1_000_000_000; // 1 second in nano seconds
+
 type DynFileSystem = Arc<dyn FileSystem + Send + Sync>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -175,9 +177,9 @@ impl MountFileSystem {
     fn directory_metadata() -> Metadata {
         Metadata {
             ft: FileType::new_dir(),
-            accessed: 0,
-            created: 0,
-            modified: 0,
+            accessed: DEFAULT_METADATE_TIME,
+            created: DEFAULT_METADATE_TIME,
+            modified: DEFAULT_METADATE_TIME,
             len: 0,
         }
     }


### PR DESCRIPTION
0 mtime/creation/access time is invalid and the value should be positive. Basically does the same as https://github.com/wasmerio/wasmer/pull/6486, but much simpler