### PR TITLE
fix(virtual-fs): resolve symlinks in host_fs root check

### DIFF
--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -83,6 +83,14 @@ impl FileSystem {
             return Err(FsError::InvalidInput);
         }
 
+        // Resolve symlinks so the root check below sees through aliases, example `/var` -> `/private/var`
+        // on macOS. Skip relative paths to avoid resolving against the process CWD.
+        let path = if path.is_absolute() {
+            dunce::canonicalize(&path).unwrap_or(path)
+        } else {
+            path
+        };
+
         if self.root != Path::new("/") && path.starts_with(&self.root) {
             return Err(FsError::InvalidInput);
         }


### PR DESCRIPTION
On macOS `TempDir` returns paths under `/var/folders/...`, but `/var` is a symlink to `/private/var`. This PR canonicalize absolute paths in `prepare_path` before the root check so it sees through symlink aliases uniformly across platforms. 

It's not only MacOS specific, so fix is applied to all platforms.

Should fix https://github.com/wasmerio/wasmer/issues/6477