### PR TITLE
deps(Cranelift): bump to 0.131.0

### DIFF
--- a/.github/cross-linux-riscv64/Dockerfile
+++ b/.github/cross-linux-riscv64/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update  && \
 # install rust tools
 RUN curl --proto "=https" --tlsv1.2 --retry 3 -sSfL https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup -v toolchain install 1.91
+RUN rustup -v toolchain install 1.92
 # add docker the manual way
 COPY install_docker.sh /
 RUN /install_docker.sh
@@ -61,7 +61,7 @@ ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc
     RUST_TEST_THREADS=1 \
     PKG_CONFIG_PATH="/usr/lib/riscv64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
 
-RUN rustup target add riscv64gc-unknown-linux-gnu --toolchain 1.91-x86_64-unknown-linux-gnu
+RUN rustup target add riscv64gc-unknown-linux-gnu --toolchain 1.92-x86_64-unknown-linux-gnu
 
 # quickly install cargo nextest by using pre-built binary
 RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,27 +1076,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
+checksum = "6edb5bdd1af46714e3224a017fabbbd57f70df4e840eb5ad6a7429dc456119d6"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
+checksum = "a819599186e1b1a1f88d464e06045696afc7aa3e0cc018aa0b2999cb63d1d088"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
+checksum = "36e2c152d488e03c87b913bc2ed3414416eb1e0d66d61b49af60bf456a9665c7"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1104,18 +1104,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
+checksum = "b6559d4fbc253d1396e1f6beeae57fa88a244f02aaf0cde2a735afd3492d9b2e"
 dependencies = [
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
+checksum = "96d9315d98d6e0a64454d4c83be2ee0e8055c3f80c3b2d7bcad7079f281a06ff"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
+checksum = "d89c00a88081c55e3087c45bebc77e0cc973de2d7b44ef6a943c7122647b89f5"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1154,24 +1154,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
+checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
+checksum = "498dc1f17a6910c88316d49c7176d8fa97cf10c30859c32a266040449317f963"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
+checksum = "c2acba797f6a46042ce82aaf7680d0c3567fe2001e238db9df649fd104a2727f"
 dependencies = [
  "cranelift-bitset",
  "wasmtime-internal-core",
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
+checksum = "4dca3df1d107d98d88f159ad1d5eaa2d5cdb678b3d5bcfadc6fc83d8ebb448ea"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.16.1",
@@ -1192,15 +1192,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
+checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.1"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
+checksum = "090ee5de58c6f17eb5e3a5ae8cf1695c7efea04ec4dd0ecba6a5b996c9bad7dc"
 
 [[package]]
 name = "crc"
@@ -4236,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.1"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
+checksum = "df866b7fd522992ccc6682e58b2741cc7972b163b661db24c4328f4c914cb09d"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4247,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.1"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
+checksum = "f7dfa8354acc622b3857e1bb1a4e4315d3bc1a44ad31d5653c3e87c0da9306d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7810,9 +7810,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.1"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
+checksum = "816a61a75275c6be435131fc625a4f5956daf24d9f9f59443e81cbef228929b3"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ edition = "2024"
 homepage = "https://wasmer.io/"
 license = "MIT"
 repository = "https://github.com/wasmerio/wasmer"
-rust-version = "1.91"
+rust-version = "1.92"
 version = "7.2.0-alpha.1"
 
 [workspace.dependencies]
@@ -135,9 +135,9 @@ console = "0.16.1"
 console-subscriber = "0.5.0"
 cooked-waker = "5"
 corosensei = "0.3.0"
-cranelift-codegen = { version = "=0.130.1", default-features = false }
-cranelift-entity = { version = "=0.130.1", default-features = false }
-cranelift-frontend = { version = "=0.130.1", default-features = false }
+cranelift-codegen = { version = "=0.131.0", default-features = false }
+cranelift-entity = { version = "=0.131.0", default-features = false }
+cranelift-frontend = { version = "=0.131.0", default-features = false }
 crc32fast = "1.5.0"
 criterion = { version = "0.8.1", default-features = false }
 crossbeam-channel = "0.5.15"

--- a/lib/compiler-cranelift/src/func_environ.rs
+++ b/lib/compiler-cranelift/src/func_environ.rs
@@ -1605,7 +1605,6 @@ impl FuncEnvironment<'_> {
             base: heap_base,
             min_size: 0,
             max_size: None,
-            memory_type: None,
             offset_guard_size: offset_guard_size.into(),
             style: heap_style,
             index_type: I32,
@@ -2300,10 +2299,6 @@ impl FuncEnvironment<'_> {
     }
 
     pub(crate) fn heap_access_spectre_mitigation(&self) -> bool {
-        false
-    }
-
-    pub(crate) fn proof_carrying_code(&self) -> bool {
         false
     }
 

--- a/lib/compiler-cranelift/src/heap.rs
+++ b/lib/compiler-cranelift/src/heap.rs
@@ -1,6 +1,6 @@
 //! Heaps to implement WebAssembly linear memories.
 
-use cranelift_codegen::ir::{GlobalValue, MemoryType, Type};
+use cranelift_codegen::ir::{GlobalValue, Type};
 use wasmer_types::entity::entity_impl;
 
 /// An opaque reference to a [`HeapData`][crate::HeapData].
@@ -78,9 +78,6 @@ pub struct HeapData {
     ///
     /// Heap accesses larger than this will always trap.
     pub max_size: Option<u64>,
-
-    /// The memory type for the pointed-to memory, if using proof-carrying code.
-    pub memory_type: Option<MemoryType>,
 
     /// Size in bytes of the offset-guard pages following the heap.
     pub offset_guard_size: u64,

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -2765,11 +2765,6 @@ fn prepare_addr(
     let mut flags = MemFlags::new();
     flags.set_endianness(ir::Endianness::Little);
 
-    if heap.memory_type.is_some() {
-        // Proof-carrying code is enabled; check this memory access.
-        flags.set_checked();
-    }
-
     // The access occurs to the `heap` disjoint category of abstract
     // state. This may allow alias analysis to merge redundant loads,
     // etc. when heap accesses occur interleaved with other (table,

--- a/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
@@ -320,23 +320,14 @@ fn get_dynamic_heap_bound(
     heap: &HeapData,
 ) -> ir::Value {
     match (heap.max_size, &heap.style) {
-        // The heap has a constant size, no need to actually load the
-        // bound.  TODO: this is currently disabled for PCC because we
-        // can't easily prove that the GV load indeed results in a
-        // constant (that information is lost in the CLIF). We'll want
-        // to create an `iconst` GV expression kind to reify this fact
-        // in the GV, then re-enable this opt. (Or, alternately,
-        // compile such memories with a static-bound memtype and
-        // facts.)
-        (Some(max_size), HeapStyle::Dynamic { bound_gv }) if heap.min_size == max_size => {
+        // The heap has a constant size, no need to actually load the bound.
+        (Some(max_size), HeapStyle::Dynamic { .. }) if heap.min_size == max_size => {
             builder.ins().iconst(env.pointer_type(), max_size as i64)
         }
-
         // Load the heap bound from its global variable.
         (_, HeapStyle::Dynamic { bound_gv }) => {
             builder.ins().global_value(env.pointer_type(), *bound_gv)
         }
-
         (_, HeapStyle::Static { .. }) => unreachable!("not a dynamic heap"),
     }
 }

--- a/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
@@ -28,7 +28,6 @@ use Reachability::*;
 use cranelift_codegen::{
     cursor::{Cursor, FuncCursor},
     ir::{self, InstBuilder, RelSourceLoc, condcodes::IntCC},
-    ir::{Expr, Fact},
 };
 use cranelift_frontend::FunctionBuilder;
 use wasmer_types::WasmResult;
@@ -49,73 +48,22 @@ pub fn bounds_check_and_compute_addr(
     // Static size of the heap access.
     access_size: u8,
 ) -> WasmResult<Reachability<ir::Value>> {
-    let pointer_bit_width = u16::try_from(env.pointer_type().bits()).unwrap();
-    let orig_index = index;
     let index = cast_index_to_pointer_ty(
         index,
         heap.index_type,
         env.pointer_type(),
-        heap.memory_type.is_some(),
         &mut builder.cursor(),
     );
     let offset_and_size = offset_plus_size(offset, access_size);
     let spectre_mitigations_enabled = env.heap_access_spectre_mitigation();
-    let pcc = env.proof_carrying_code();
 
     let host_page_size_log2 = env.target_config().page_size_align_log2;
     let can_use_virtual_memory = heap.page_size_log2 >= host_page_size_log2;
 
-    let make_compare = |builder: &mut FunctionBuilder,
-                        compare_kind: IntCC,
-                        lhs: ir::Value,
-                        lhs_off: Option<i64>,
-                        rhs: ir::Value,
-                        rhs_off: Option<i64>| {
-        let result = builder.ins().icmp(compare_kind, lhs, rhs);
-        if pcc {
-            // Name the original value as a def of the SSA value;
-            // if the value was extended, name that as well with a
-            // dynamic range, overwriting the basic full-range
-            // fact that we previously put on the uextend.
-            builder.func.dfg.facts[orig_index] = Some(Fact::Def { value: orig_index });
-            if index != orig_index {
-                builder.func.dfg.facts[index] = Some(Fact::value(pointer_bit_width, orig_index));
-            }
-
-            // Create a fact on the LHS that is a "trivial symbolic
-            // fact": v1 has range v1+LHS_off..=v1+LHS_off
-            builder.func.dfg.facts[lhs] = Some(Fact::value_offset(
-                pointer_bit_width,
-                orig_index,
-                lhs_off.unwrap(),
-            ));
-            // If the RHS is a symbolic value (v1 or gv1), we can
-            // emit a Compare fact.
-            if let Some(rhs) = builder.func.dfg.facts[rhs]
-                .as_ref()
-                .and_then(|f| f.as_symbol())
-            {
-                builder.func.dfg.facts[result] = Some(Fact::Compare {
-                    kind: compare_kind,
-                    lhs: Expr::offset(&Expr::value(orig_index), lhs_off.unwrap()).unwrap(),
-                    rhs: Expr::offset(rhs, rhs_off.unwrap()).unwrap(),
-                });
-            }
-            // Likewise, if the RHS is a constant, we can emit a
-            // Compare fact.
-            if let Some(k) = builder.func.dfg.facts[rhs]
-                .as_ref()
-                .and_then(|f| f.as_const(pointer_bit_width))
-            {
-                builder.func.dfg.facts[result] = Some(Fact::Compare {
-                    kind: compare_kind,
-                    lhs: Expr::offset(&Expr::value(orig_index), lhs_off.unwrap()).unwrap(),
-                    rhs: Expr::constant((k as i64).checked_add(rhs_off.unwrap()).unwrap()),
-                });
-            }
-        }
-        result
-    };
+    let make_compare =
+        |builder: &mut FunctionBuilder, compare_kind: IntCC, lhs: ir::Value, rhs: ir::Value| {
+            builder.ins().icmp(compare_kind, lhs, rhs)
+        };
 
     // We need to emit code that will trap (or compute an address that will trap
     // when accessed) if
@@ -143,25 +91,16 @@ pub fn bounds_check_and_compute_addr(
         //
         //            index + 1 > bound
         //        ==> index >= bound
-        HeapStyle::Dynamic { bound_gv } if offset_and_size == 1 => {
+        HeapStyle::Dynamic { .. } if offset_and_size == 1 => {
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let oob = make_compare(
-                builder,
-                IntCC::UnsignedGreaterThanOrEqual,
-                index,
-                Some(0),
-                bound,
-                Some(0),
-            );
+            let oob = make_compare(builder, IntCC::UnsignedGreaterThanOrEqual, index, bound);
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
-                access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -191,27 +130,18 @@ pub fn bounds_check_and_compute_addr(
         //    offset immediates -- which is a common code pattern when accessing
         //    multiple fields in the same struct that is in linear memory --
         //    will all emit the same `index > bound` check, which we can GVN.
-        HeapStyle::Dynamic { bound_gv }
+        HeapStyle::Dynamic { .. }
             if can_use_virtual_memory && offset_and_size <= heap.offset_guard_size =>
         {
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let oob = make_compare(
-                builder,
-                IntCC::UnsignedGreaterThan,
-                index,
-                Some(0),
-                bound,
-                Some(0),
-            );
+            let oob = make_compare(builder, IntCC::UnsignedGreaterThan, index, bound);
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
-                access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -223,39 +153,19 @@ pub fn bounds_check_and_compute_addr(
         //
         //            index + offset + access_size > bound
         //        ==> index > bound - (offset + access_size)
-        HeapStyle::Dynamic { bound_gv } if offset_and_size <= heap.min_size => {
+        HeapStyle::Dynamic { .. } if offset_and_size <= heap.min_size => {
             let bound = get_dynamic_heap_bound(builder, env, heap);
             let adjustment = offset_and_size as i64;
             let adjustment_value = builder.ins().iconst(env.pointer_type(), adjustment);
-            if pcc {
-                builder.func.dfg.facts[adjustment_value] =
-                    Some(Fact::constant(pointer_bit_width, offset_and_size));
-            }
             let adjusted_bound = builder.ins().isub(bound, adjustment_value);
-            if pcc {
-                builder.func.dfg.facts[adjusted_bound] = Some(Fact::global_value_offset(
-                    pointer_bit_width,
-                    bound_gv,
-                    -adjustment,
-                ));
-            }
-            let oob = make_compare(
-                builder,
-                IntCC::UnsignedGreaterThan,
-                index,
-                Some(0),
-                adjusted_bound,
-                Some(adjustment),
-            );
+            let oob = make_compare(builder, IntCC::UnsignedGreaterThan, index, adjusted_bound);
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
-                access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -265,46 +175,26 @@ pub fn bounds_check_and_compute_addr(
         //        index + offset + access_size > bound
         //
         //    And we have to handle the overflow case in the left-hand side.
-        HeapStyle::Dynamic { bound_gv } => {
+        HeapStyle::Dynamic { .. } => {
             let access_size_val = builder
                 .ins()
                 // Explicit cast from u64 to i64: we just want the raw
                 // bits, and iconst takes an `Imm64`.
                 .iconst(env.pointer_type(), offset_and_size as i64);
-            if pcc {
-                builder.func.dfg.facts[access_size_val] =
-                    Some(Fact::constant(pointer_bit_width, offset_and_size));
-            }
             let adjusted_index = builder.ins().uadd_overflow_trap(
                 index,
                 access_size_val,
                 ir::TrapCode::HEAP_OUT_OF_BOUNDS,
             );
-            if pcc {
-                builder.func.dfg.facts[adjusted_index] = Some(Fact::value_offset(
-                    pointer_bit_width,
-                    index,
-                    i64::try_from(offset_and_size).unwrap(),
-                ));
-            }
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let oob = make_compare(
-                builder,
-                IntCC::UnsignedGreaterThan,
-                adjusted_index,
-                i64::try_from(offset_and_size).ok(),
-                bound,
-                Some(0),
-            );
+            let oob = make_compare(builder, IntCC::UnsignedGreaterThan, adjusted_index, bound);
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
-                access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -379,7 +269,6 @@ pub fn bounds_check_and_compute_addr(
                 env.pointer_type(),
                 index,
                 offset,
-                AddrPcc::static32(heap.memory_type, bound + heap.offset_guard_size),
             ))
         }
 
@@ -405,17 +294,11 @@ pub fn bounds_check_and_compute_addr(
             let adjusted_bound_value = builder
                 .ins()
                 .iconst(env.pointer_type(), adjusted_bound as i64);
-            if pcc {
-                builder.func.dfg.facts[adjusted_bound_value] =
-                    Some(Fact::constant(pointer_bit_width, adjusted_bound));
-            }
             let oob = make_compare(
                 builder,
                 IntCC::UnsignedGreaterThan,
                 index,
-                Some(0),
                 adjusted_bound_value,
-                Some(0),
             );
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
@@ -423,9 +306,7 @@ pub fn bounds_check_and_compute_addr(
                 env.pointer_type(),
                 index,
                 offset,
-                access_size,
                 spectre_mitigations_enabled,
-                AddrPcc::static32(heap.memory_type, bound),
                 oob,
             ))
         }
@@ -438,9 +319,7 @@ fn get_dynamic_heap_bound(
     env: &mut FuncEnvironment<'_>,
     heap: &HeapData,
 ) -> ir::Value {
-    let enable_pcc = heap.memory_type.is_some();
-
-    let (value, gv) = match (heap.max_size, &heap.style) {
+    match (heap.max_size, &heap.style) {
         // The heap has a constant size, no need to actually load the
         // bound.  TODO: this is currently disabled for PCC because we
         // can't easily prove that the GV load indeed results in a
@@ -449,41 +328,23 @@ fn get_dynamic_heap_bound(
         // in the GV, then re-enable this opt. (Or, alternately,
         // compile such memories with a static-bound memtype and
         // facts.)
-        (Some(max_size), HeapStyle::Dynamic { bound_gv })
-            if heap.min_size == max_size && !enable_pcc =>
-        {
-            (
-                builder.ins().iconst(env.pointer_type(), max_size as i64),
-                *bound_gv,
-            )
+        (Some(max_size), HeapStyle::Dynamic { bound_gv }) if heap.min_size == max_size => {
+            builder.ins().iconst(env.pointer_type(), max_size as i64)
         }
 
         // Load the heap bound from its global variable.
-        (_, HeapStyle::Dynamic { bound_gv }) => (
-            builder.ins().global_value(env.pointer_type(), *bound_gv),
-            *bound_gv,
-        ),
+        (_, HeapStyle::Dynamic { bound_gv }) => {
+            builder.ins().global_value(env.pointer_type(), *bound_gv)
+        }
 
         (_, HeapStyle::Static { .. }) => unreachable!("not a dynamic heap"),
-    };
-
-    // If proof-carrying code is enabled, apply a fact to the range to
-    // tie it to the GV.
-    if enable_pcc {
-        builder.func.dfg.facts[value] = Some(Fact::global_value(
-            u16::try_from(env.pointer_type().bits()).unwrap(),
-            gv,
-        ));
     }
-
-    value
 }
 
 fn cast_index_to_pointer_ty(
     index: ir::Value,
     index_ty: ir::Type,
     pointer_ty: ir::Type,
-    pcc: bool,
     pos: &mut FuncCursor,
 ) -> ir::Value {
     if index_ty == pointer_ty {
@@ -498,14 +359,6 @@ fn cast_index_to_pointer_ty(
     // Convert `index` to `addr_ty`.
     let extended_index = pos.ins().uextend(pointer_ty, index);
 
-    // Add a range fact on the extended value.
-    if pcc {
-        pos.func.dfg.facts[extended_index] = Some(Fact::max_range_for_width_extended(
-            u16::try_from(index_ty.bits()).unwrap(),
-            u16::try_from(pointer_ty.bits()).unwrap(),
-        ));
-    }
-
     // Add debug value-label alias so that debuginfo can name the extended
     // value as the address
     let loc = pos.srcloc();
@@ -516,25 +369,6 @@ fn cast_index_to_pointer_ty(
         .add_value_label_alias(extended_index, loc, index);
 
     extended_index
-}
-
-/// Which facts do we want to emit for proof-carrying code, if any, on
-/// address computations?
-#[derive(Clone, Copy, Debug)]
-enum AddrPcc {
-    /// A 32-bit static memory with the given size.
-    Static32(ir::MemoryType, u64),
-    /// Dynamic bounds-check, with actual memory size (the `GlobalValue`)
-    /// expressed symbolically.
-    Dynamic(ir::MemoryType, ir::GlobalValue),
-}
-impl AddrPcc {
-    fn static32(memory_type: Option<ir::MemoryType>, size: u64) -> Option<Self> {
-        memory_type.map(|ty| Self::Static32(ty, size))
-    }
-    fn dynamic(memory_type: Option<ir::MemoryType>, bound: ir::GlobalValue) -> Option<Self> {
-        memory_type.map(|ty| Self::Dynamic(ty, bound))
-    }
 }
 
 /// Emit explicit checks on the given out-of-bounds condition for the Wasm
@@ -549,11 +383,8 @@ fn explicit_check_oob_condition_and_compute_addr(
     addr_ty: ir::Type,
     index: ir::Value,
     offset: u32,
-    access_size: u8,
     // Whether Spectre mitigations are enabled for heap accesses.
     spectre_mitigations_enabled: bool,
-    // Whether we're emitting PCC facts.
-    pcc: Option<AddrPcc>,
     // The `i8` boolean value that is non-zero when the heap access is out of
     // bounds (and therefore we should trap) and is zero when the heap access is
     // in bounds (and therefore we can proceed).
@@ -564,42 +395,11 @@ fn explicit_check_oob_condition_and_compute_addr(
             .trapnz(oob_condition, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
     }
 
-    let mut addr = compute_addr(pos, heap, addr_ty, index, offset, pcc);
+    let mut addr = compute_addr(pos, heap, addr_ty, index, offset);
 
     if spectre_mitigations_enabled {
         let null = pos.ins().iconst(addr_ty, 0);
         addr = pos.ins().select_spectre_guard(oob_condition, null, addr);
-
-        match pcc {
-            None => {}
-            Some(AddrPcc::Static32(ty, size)) => {
-                pos.func.dfg.facts[null] =
-                    Some(Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), 0));
-                pos.func.dfg.facts[addr] = Some(Fact::Mem {
-                    ty,
-                    min_offset: 0,
-                    max_offset: size.checked_sub(u64::from(access_size)).unwrap(),
-                    nullable: true,
-                });
-            }
-            Some(AddrPcc::Dynamic(ty, gv)) => {
-                pos.func.dfg.facts[null] =
-                    Some(Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), 0));
-                pos.func.dfg.facts[addr] = Some(Fact::DynamicMem {
-                    ty,
-                    min: Expr::constant(0),
-                    max: Expr::offset(
-                        &Expr::global_value(gv),
-                        i64::try_from(heap.offset_guard_size)
-                            .unwrap()
-                            .checked_sub(i64::from(access_size))
-                            .unwrap(),
-                    )
-                    .unwrap(),
-                    nullable: true,
-                });
-            }
-        }
     }
 
     addr
@@ -617,53 +417,12 @@ fn compute_addr(
     addr_ty: ir::Type,
     index: ir::Value,
     offset: u32,
-    pcc: Option<AddrPcc>,
 ) -> ir::Value {
     debug_assert_eq!(pos.func.dfg.value_type(index), addr_ty);
 
     let heap_base = pos.ins().global_value(addr_ty, heap.base);
 
-    match pcc {
-        None => {}
-        Some(AddrPcc::Static32(ty, _size)) => {
-            pos.func.dfg.facts[heap_base] = Some(Fact::Mem {
-                ty,
-                min_offset: 0,
-                max_offset: 0,
-                nullable: false,
-            });
-        }
-        Some(AddrPcc::Dynamic(ty, _limit)) => {
-            pos.func.dfg.facts[heap_base] = Some(Fact::dynamic_base_ptr(ty));
-        }
-    }
-
     let base_and_index = pos.ins().iadd(heap_base, index);
-
-    match pcc {
-        None => {}
-        Some(AddrPcc::Static32(ty, _) | AddrPcc::Dynamic(ty, _)) => {
-            if let Some(idx) = pos.func.dfg.facts[index]
-                .as_ref()
-                .and_then(|f| f.as_symbol())
-                .cloned()
-            {
-                pos.func.dfg.facts[base_and_index] = Some(Fact::DynamicMem {
-                    ty,
-                    min: idx.clone(),
-                    max: idx,
-                    nullable: false,
-                });
-            } else {
-                pos.func.dfg.facts[base_and_index] = Some(Fact::Mem {
-                    ty,
-                    min_offset: 0,
-                    max_offset: u64::from(u32::MAX),
-                    nullable: false,
-                });
-            }
-        }
-    }
 
     if offset == 0 {
         base_and_index
@@ -674,46 +433,7 @@ fn compute_addr(
         // 4GiB of memory.
         let offset_val = pos.ins().iconst(addr_ty, i64::from(offset));
 
-        if pcc.is_some() {
-            pos.func.dfg.facts[offset_val] = Some(Fact::constant(
-                u16::try_from(addr_ty.bits()).unwrap(),
-                u64::from(offset),
-            ));
-        }
-
-        let result = pos.ins().iadd(base_and_index, offset_val);
-
-        match pcc {
-            None => {}
-            Some(AddrPcc::Static32(ty, _) | AddrPcc::Dynamic(ty, _)) => {
-                if let Some(idx) = pos.func.dfg.facts[index]
-                    .as_ref()
-                    .and_then(|f| f.as_symbol())
-                {
-                    pos.func.dfg.facts[result] = Some(Fact::DynamicMem {
-                        ty,
-                        min: idx.clone(),
-                        // Safety: adding an offset to an expression with
-                        // zero offset -- add cannot wrap, so `unwrap()`
-                        // cannot fail.
-                        max: Expr::offset(idx, i64::from(offset)).unwrap(),
-                        nullable: false,
-                    });
-                } else {
-                    pos.func.dfg.facts[result] = Some(Fact::Mem {
-                        ty,
-                        min_offset: u64::from(offset),
-                        // Safety: can't overflow -- two u32s summed in a
-                        // 64-bit add. TODO: when memory64 is supported here,
-                        // `u32::MAX` is no longer true, and we'll need to
-                        // handle overflow here.
-                        max_offset: u64::from(u32::MAX) + u64::from(offset),
-                        nullable: false,
-                    });
-                }
-            }
-        }
-        result
+        pos.ins().iadd(base_and_index, offset_val)
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.92"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
The latest Cranelift release increases MSRV (aligned with our requirements) and they decided to drop the PPC (proof-carrying code), that's why the removal changes.