### PR TITLE
feat: drop x86_64-darwin target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,16 +62,6 @@ jobs:
             # V8 issue broken right now: https://github.com/wasmerio/wasmer/pull/6124
             enable_v8: false
             enable_napi_v8: true
-          - build: macos-x64
-            os: macos-15-intel
-            llvm_url: "https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-darwin-amd64.tar.xz"
-            artifact_name: "wasmer-darwin-amd64"
-            cross_compilation_artifact_name: "cross_compiled_from_mac"
-            build_wasm: false
-            enable_llvm: true
-            # V8 issue broken right now: https://github.com/wasmerio/wasmer/pull/6124
-            enable_v8: false
-            enable_napi_v8: false
           - build: macos-arm
             os: depot-macos-14
             target: aarch64-apple-darwin
@@ -147,10 +137,6 @@ jobs:
         with:
           toolchain: ${{ steps.load_toolchain.outputs.rust_toolchain }}
           target: ${{ matrix.target }}
-      - name: Install LLVM (macOS Intel)
-        if: matrix.os == 'macos-15-intel' && !matrix.llvm_url
-        run: |
-          brew install llvm
       - name: Install LLVM
         if: ${{ matrix.llvm_url && matrix.enable_llvm == true }}
         shell: bash
@@ -598,16 +584,7 @@ jobs:
           #    asset_path: artifacts/wasmer-linux-musl-amd64/wasmer.tar.gz
           #    asset_name: wasmer-linux-musl-amd64.tar.gz
           #    asset_content_type: application/gzip
-      - name: Upload Release Asset Mac amd64
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/wasmer-darwin-amd64/wasmer.tar.gz
-          asset_name: wasmer-darwin-amd64.tar.gz
-          asset_content_type: application/gzip
-      - name: Upload Release Asset Mac arm64
+      - name: Upload Release Asset macOS arm64
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -492,12 +492,6 @@ jobs:
             exe: ""
             llvm_url: "https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-linux-aarch64.tar.xz"
             supports_v8: false
-          - build: macos-x64
-            os: macos-15-intel
-            target: x86_64-apple-darwin
-            exe: ""
-            llvm_url: "https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-darwin-amd64.tar.xz"
-            supports_v8: true
           - build: macos-arm
             os: depot-macos-14
             target: aarch64-apple-darwin
@@ -523,9 +517,6 @@ jobs:
         exclude:
           - skip_macos: true
             metadata:
-              build: macos-x64
-          - skip_macos: true
-            metadata:
               build: macos-arm
     container: ${{ matrix.metadata.container }}
     steps:
@@ -549,13 +540,6 @@ jobs:
         if: matrix.metadata.build == 'linux-musl'
         run: |
           ./scripts/alpine-linux-install-deps.sh
-      - name: Set up dependencies for Mac OS
-        run: |
-          brew install automake
-          # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
-          brew install gnu-tar
-          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-15-intel'
       - uses: ./.github/actions/load_toolchain
         id: load_toolchain
       - name: Install Rust
@@ -606,10 +590,6 @@ jobs:
           mkdir -p package
           mkdir -p package/winsdk
           cp -r /tmp/winsdk/* package/winsdk
-      - name: Install LLVM (macOS Intel)
-        if: matrix.metadata.os == 'macos-15-intel' && !matrix.metadata.llvm_url
-        run: |
-          brew install llvm
       - name: Install LLVM
         shell: bash
         if: matrix.metadata.llvm_url
@@ -651,7 +631,7 @@ jobs:
       - name: Build C-API
         shell: bash
         run: ${{ matrix.build-what.build-cmd }}
-        if: ${{ matrix.build-what.key == 'capi' && matrix.metadata.build != 'macos-x64' }}
+        if: ${{ matrix.build-what.key == 'capi' }}
         env:
           TARGET: ${{ matrix.metadata.target }}
           TARGET_DIR: target/${{ matrix.metadata.target }}/release
@@ -662,7 +642,7 @@ jobs:
         if: ${{ matrix.build-what.key == 'capi-v8' && matrix.metadata.supports_v8 == true  }}
       - name: Build Wasmer
         shell: bash
-        if: ${{ matrix.build-what.key == 'wasmer' && matrix.metadata.build != 'windows-gnu' && matrix.metadata.build != 'macos-x64' }}
+        if: ${{ matrix.build-what.key == 'wasmer' && matrix.metadata.build != 'windows-gnu'}}
         run: ${{ matrix.build-what.build-cmd }}
         env:
           TARGET: ${{ matrix.metadata.target }}
@@ -670,11 +650,11 @@ jobs:
           CARGO_TARGET: ${{ matrix.metadata.target }}
       - name: Check `wasmer` crate with all the `sys` features enabled
         shell: bash
-        if: ${{ matrix.build-what.key == 'api-feats' && matrix.metadata.build != 'windows-gnu' && matrix.metadata.build != 'macos-x64' }}
+        if: ${{ matrix.build-what.key == 'api-feats' && matrix.metadata.build != 'windows-gnu' }}
         run: ${{ matrix.build-what.build-cmd }}
       - name: Lint C-API
         shell: bash
-        if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl'  || matrix.metadata.build == 'windows-gnu' || matrix.metadata.build == 'macos-x64') }}
+        if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl'  || matrix.metadata.build == 'windows-gnu') }}
         run: make lint-capi-ci
         env:
           TARGET: ${{ matrix.metadata.target }}
@@ -682,7 +662,7 @@ jobs:
           CARGO_TARGET: ${{ matrix.metadata.target }}
       - name: Test C-API
         shell: bash
-        if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl'  || matrix.metadata.build == 'windows-gnu' || matrix.metadata.build == 'macos-x64') }}
+        if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl'  || matrix.metadata.build == 'windows-gnu') }}
         run: make test-capi-ci
         env:
           TARGET: ${{ matrix.metadata.target }}
@@ -691,7 +671,7 @@ jobs:
       # C-API tests were disabled for linux-musl and macos-arm (we can't run them)
       - name: Test C-API integration
         shell: bash
-        if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl' || matrix.metadata.build == 'windows-gnu' || matrix.metadata.build == 'macos-x64') }}
+        if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl' || matrix.metadata.build == 'windows-gnu') }}
         run: export WASMER_DIR=`pwd`/package && make test-stage-7-capi-integration-tests
         env:
           TARGET: ${{ matrix.metadata.target }}
@@ -746,11 +726,6 @@ jobs:
             target: aarch64-unknown-linux-gnu
             exe: ""
             llvm_url: "https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-linux-aarch64.tar.xz"
-          - build: macos-x64
-            os: macos-15-intel
-            target: x86_64-apple-darwin
-            exe: ""
-            llvm_url: "https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-darwin-amd64.tar.xz"
           - build: macos-arm
             os: depot-macos-14
             target: aarch64-apple-darwin
@@ -767,9 +742,6 @@ jobs:
             exe: ""
             container: "alpine:edge"
         exclude:
-          - skip_macos: true
-            metadata:
-              build: macos-x64
           - skip_macos: true
             metadata:
               build: macos-arm
@@ -823,13 +795,6 @@ jobs:
         shell: bash
         run: rm /usr/bin/link.exe
         if: ${{ matrix.metadata.build == 'windows-x64' }}
-      - name: Set up dependencies for Mac OS
-        run: |
-          brew install automake
-          # using gnu-tar is a workaround for https://github.com/actions/cache/issues/403
-          brew install gnu-tar zstd
-          echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
-        if: matrix.metadata.os == 'macos-15-intel'
       - uses: ./.github/actions/load_toolchain
         id: load_toolchain
       - name: Install Rust
@@ -839,11 +804,6 @@ jobs:
           target: ${{ matrix.metadata.target }}
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
-      - name: Install LLVM (macOS Intel)
-        if: matrix.metadata.os == 'macos-15-intel' && !matrix.metadata.llvm_url
-        run: |
-          brew install llvm
-          echo "/opt/homebrew/opt/llvm/bin" >> GITHUB_PATH
       - name: Install wasixcc
         if: matrix.metadata.build != 'windows-x64'
         uses: wasix-org/wasixcc@v0.4.3

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -67,7 +67,6 @@ There are a couple of problems with the scripts that you should watch out for:
   to be fixed up to make any sense for a reader
 - The release notes should just highlight the most important changes for a release, not dump everything.
 - The following files should be released (TODO: more consistent naming schema):
-  - wasmer-darwin-amd64.tar.gz
   - wasmer-darwin-arm64.tar.gz
   - wasmer-linux-aarch64.tar.gz
   - wasmer-linux-amd64.tar.gz

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -17,9 +17,6 @@ fn build_v8() {
         ("macos", "aarch64", _) => {
             "https://github.com/wasmerio/wee8-custom-builds/releases/download/11.8/wee8-darwin-aarch64.tar.xz"
         }
-        ("macos", "x86_64", _) => {
-            "https://github.com/wasmerio/wee8-custom-builds/releases/download/11.8/wee8-darwin-amd64.tar.xz"
-        }
         ("linux", "x86_64", "gnu") => {
             "https://github.com/wasmerio/wee8-custom-builds/releases/download/11.8/wee8-linux-amd64.tar.xz"
         }

--- a/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
@@ -17,7 +17,7 @@
 //!
 //!     {
 //!         wasm_name_t triple_name;
-//!         wasm_name_new_from_string(&triple_name, "x86_64-apple-darwin");
+//!         wasm_name_new_from_string(&triple_name, "aarch64-apple-darwin");
 //!
 //!         triple = wasmer_triple_new(&triple_name);
 //!

--- a/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/target_lexicon.rs
@@ -116,7 +116,7 @@ pub extern "C" fn wasmer_target_delete(_target: Option<Box<wasmer_target_t>>) {}
 /// #
 /// int main() {
 ///     wasm_name_t triple_name;
-///     wasm_name_new_from_string(&triple_name, "x86_64-apple-darwin");
+///     wasm_name_new_from_string(&triple_name, "aarch64-apple-darwin");
 ///
 ///     wasmer_triple_t* triple = wasmer_triple_new(&triple_name);
 ///     assert(triple);

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -290,10 +290,6 @@ pkg-fmt = "tgz"
 pkg-url = "{ repo }/releases/download/v{ version }/wasmer-darwin-arm64.{ archive-format }"
 bin-dir = "bin/{ bin }"
 
-[package.metadata.binstall.overrides.x86_64-apple-darwin]
-pkg-url = "{ repo }/releases/download/v{ version }/wasmer-darwin-amd64.{ archive-format }"
-bin-dir = "bin/{ bin }"
-
 [package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
 pkg-url = "{ repo }/releases/download/v{ version }/wasmer-linux-aarch64.{ archive-format }"
 bin-dir = "bin/{ bin }"

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -73,7 +73,6 @@ pub struct CreateExe {
     ///
     /// - "x86_64-linux-gnu"
     /// - "aarch64-linux-gnu"
-    /// - "x86_64-apple-darwin"
     /// - "arm64-apple-darwin"
     /// - "x86_64-windows-gnu"
     #[clap(long = "target")]

--- a/lib/cli/src/commands/create_exe.rs
+++ b/lib/cli/src/commands/create_exe.rs
@@ -2021,7 +2021,6 @@ pub(super) mod utils {
     fn test_filter_tarball() {
         use std::str::FromStr;
         let test_paths = [
-            "/test/wasmer-darwin-amd64.tar.gz",
             "/test/wasmer-darwin-arm64.tar.gz",
             "/test/wasmer-linux-aarch64.tar.gz",
             "/test/wasmer-linux-amd64.tar.gz",
@@ -2065,17 +2064,6 @@ pub(super) mod utils {
                 ))
                 .collect::<Vec<_>>(),
             vec![&Path::new("/test/wasmer-windows-gnu64.tar.gz")],
-        );
-
-        assert_eq!(
-            paths
-                .iter()
-                .filter(|p| crate::commands::utils::filter_tarball(
-                    p,
-                    &Triple::from_str("x86_64-darwin").unwrap()
-                ))
-                .collect::<Vec<_>>(),
-            vec![&Path::new("/test/wasmer-darwin-amd64.tar.gz")],
         );
 
         assert_eq!(

--- a/lib/cli/src/commands/create_obj.rs
+++ b/lib/cli/src/commands/create_obj.rs
@@ -45,7 +45,6 @@ pub struct CreateObj {
     ///
     /// - "x86_64-linux-gnu"
     /// - "aarch64-linux-gnu"
-    /// - "x86_64-apple-darwin"
     /// - "arm64-apple-darwin"
     /// - "x86_64-windows-gnu"
     #[clap(long = "target")]

--- a/lib/cli/src/commands/gen_c_header.rs
+++ b/lib/cli/src/commands/gen_c_header.rs
@@ -40,7 +40,6 @@ pub struct GenCHeader {
     ///
     /// - "x86_64-linux-gnu"
     /// - "aarch64-linux-gnu"
-    /// - "x86_64-apple-darwin"
     /// - "arm64-apple-darwin"
     /// - "x86_64-windows-gnu"
     #[clap(long = "target")]

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -385,7 +385,6 @@ enum Cmd {
     //
     // - "x86_64-linux-gnu"
     // - "aarch64-linux-gnu"
-    // - "x86_64-apple-darwin"
     // - "arm64-apple-darwin"
     // #[cfg(any(feature = "static-artifact-create", feature = "wasmer-artifact-create"))]
     // #[clap(name = "create-exe", verbatim_doc_comment)]

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -416,7 +416,6 @@ enum Cmd {
     ///
     /// - "x86_64-linux-gnu"
     /// - "aarch64-linux-gnu"
-    /// - "x86_64-apple-darwin"
     /// - "arm64-apple-darwin"
     // #[cfg(feature = "static-artifact-create")]
     // #[structopt(name = "create-obj", verbatim_doc_comment)]

--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -789,7 +789,6 @@ fn test_cross_compile_python_windows() {
         ("aarch64-darwin", "llvm"), // LLVM: aarch64 not supported relocation Arm64MovwG0 not supported
         ("aarch64-linux-gnu", "llvm"), // LLVM: aarch64 not supported relocation Arm64MovwG0 not supported
         // https://github.com/ziglang/zig/issues/13729
-        ("x86_64-darwin", "llvm"), // undefined reference to symbol 'wasmer_vm_raise_trap' kind Unknown
         ("x86_64-windows-gnu", "llvm"), // unimplemented symbol `wasmer_vm_raise_trap` kind Unknown
     ];
 
@@ -847,7 +846,6 @@ fn assert_tarball_is_present_local(target: &str) -> Result<PathBuf, anyhow::Erro
     let wasmer_dir = std::env::var("WASMER_DIR").expect("no WASMER_DIR set");
     let directory = match target {
         "aarch64-darwin" => "wasmer-darwin-arm64.tar.gz",
-        "x86_64-darwin" => "wasmer-darwin-amd64.tar.gz",
         "x86_64-linux-gnu" => "wasmer-linux-amd64.tar.gz",
         "aarch64-linux-gnu" => "wasmer-linux-aarch64.tar.gz",
         "x86_64-windows-gnu" => "wasmer-windows-gnu64.tar.gz",

--- a/tests/integration/cli/tests/create_exe.rs
+++ b/tests/integration/cli/tests/create_exe.rs
@@ -766,16 +766,10 @@ fn test_cross_compile_python_windows() {
     let temp_dir = TempDir::new().unwrap();
 
     let targets: &[&str] = if cfg!(windows) {
-        &[
-            "aarch64-darwin",
-            "x86_64-darwin",
-            "x86_64-linux-gnu",
-            "aarch64-linux-gnu",
-        ]
+        &["aarch64-darwin", "x86_64-linux-gnu", "aarch64-linux-gnu"]
     } else {
         &[
             "aarch64-darwin",
-            "x86_64-darwin",
             "x86_64-linux-gnu",
             "aarch64-linux-gnu",
             "x86_64-windows-gnu",

--- a/tests/integration/cli/tests/snapshot.rs
+++ b/tests/integration/cli/tests/snapshot.rs
@@ -437,13 +437,7 @@ macro_rules! function {
     }};
 }
 
-#[cfg_attr(
-    any(
-        all(target_os = "macos", target_arch = "x86_64"), // Output is slightly different in macos x86_64
-        target_os = "windows"
-    ),
-    ignore
-)]
+#[cfg_attr(target_os = "windows", ignore)]
 #[test]
 fn test_snapshot_condvar() {
     let snapshot = TestBuilder::new()


### PR DESCRIPTION
Given the prevalence of AArch64 on the Darwin platform, we decided to drop Intel support.
