### PR TITLE
docs: fetch lib/napi submodule in BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -47,11 +47,12 @@ For reproducible builds, set `WASMER_REPRODUCIBLE_BUILD=1` in the build
 environment. This removes the build timestamp from `wasmer --version -v`
 by omitting the verbose `commit-date:` line.
 
-First, let's clone Wasmer:
+First, let's clone Wasmer and fetch the required submodule:
 
 ```text
 git clone https://github.com/wasmerio/wasmer.git
 cd wasmer
+git submodule update --init lib/napi
 ```
 
 Wasmer supports six different backends at the moment: `singlepass`,

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -47,12 +47,10 @@ For reproducible builds, set `WASMER_REPRODUCIBLE_BUILD=1` in the build
 environment. This removes the build timestamp from `wasmer --version -v`
 by omitting the verbose `commit-date:` line.
 
-First, let's clone Wasmer and fetch the required submodule:
+First, let's clone Wasmer along with its submodules:
 
 ```text
-git clone https://github.com/wasmerio/wasmer.git
-cd wasmer
-git submodule update --init lib/napi
+git clone --recursive https://github.com/wasmerio/wasmer.git
 ```
 
 Wasmer supports six different backends at the moment: `singlepass`,

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -51,6 +51,7 @@ First, let's clone Wasmer along with its submodules:
 
 ```text
 git clone --recursive https://github.com/wasmerio/wasmer.git
+cd wasmer
 ```
 
 Wasmer supports six different backends at the moment: `singlepass`,


### PR DESCRIPTION
## Description

Fix build failure when following `BUILD.md` instructions after a fresh clone.

The current documentation clones the repository without fetching submodules,
which causes `make build-wasmer` to fail due to the missing `lib/napi` dependency.

This change adds a step to fetch the required submodule:

```sh
git submodule update --init lib/napi
```
---
## Motivaiton
Ensure that the documented build steps work as expected for new contributors.

Without this change, users following `BUILD.md` may encounter a build failure
early in the setup process due to missing submodules, which can be confusing
and slow down onboarding.

Fixes #6509 