### PR TITLE
fix(wasix): honor socket connect_timeout in TCP connect

### DIFF
--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -582,7 +582,9 @@ impl InodeSocket {
         let new_write_timeout;
         let new_read_timeout;
 
-        let timeout = timeout.unwrap_or(Duration::from_secs(30));
+        let timeout = timeout
+            .or_else(|| self.opt_time(TimeType::ConnectTimeout).ok().flatten())
+            .unwrap_or(Duration::from_secs(30));
 
         let handler;
         let connect = {

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -80,10 +80,7 @@ pub(crate) fn sock_connect_internal(
                 .auto_bind_udp(tasks.deref(), net.deref())
                 .await?
                 .unwrap_or(socket);
-            let timeout = socket
-                .opt_time(TimeType::ConnectTimeout)
-                .ok()
-                .flatten();
+            let timeout = socket.opt_time(TimeType::ConnectTimeout).ok().flatten();
             socket
                 .connect(
                     tasks.deref(),

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::syscalls::*;
-
+use crate::net::socket::TimeType;
 /// ### `sock_connect()`
 /// Initiate a connection on a socket to the specified address
 ///
@@ -79,12 +79,16 @@ pub(crate) fn sock_connect_internal(
                 .auto_bind_udp(tasks.deref(), net.deref())
                 .await?
                 .unwrap_or(socket);
+            let timeout = socket
+                .opt_time(TimeType::ConnectTimeout)
+                .ok()
+                .flatten();
             socket
                 .connect(
                     tasks.deref(),
                     net.deref(),
                     addr,
-                    None,
+                    timeout,
                     flags.contains(Fdflags::NONBLOCK),
                 )
                 .await

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -1,6 +1,7 @@
 use super::*;
-use crate::syscalls::*;
 use crate::net::socket::TimeType;
+use crate::syscalls::*;
+
 /// ### `sock_connect()`
 /// Initiate a connection on a socket to the specified address
 ///

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::net::socket::TimeType;
 use crate::syscalls::*;
 
 /// ### `sock_connect()`
@@ -80,13 +79,12 @@ pub(crate) fn sock_connect_internal(
                 .auto_bind_udp(tasks.deref(), net.deref())
                 .await?
                 .unwrap_or(socket);
-            let timeout = socket.opt_time(TimeType::ConnectTimeout).ok().flatten();
             socket
                 .connect(
                     tasks.deref(),
                     net.deref(),
                     addr,
-                    timeout,
+                    None,
                     flags.contains(Fdflags::NONBLOCK),
                 )
                 .await


### PR DESCRIPTION
## Problem
When a WASI program calls `settimeout()` on a socket and then `connect()`, 
Wasmer ignores the timeout and blocks for up to 30 seconds instead.

This is because `sock_connect_internal` hardcoded `None` as the timeout 
argument to `socket.connect()`, which caused it to always fall back to the 
30s default inside `socket.rs`.

## Fix
Read `connect_timeout` from the socket via `opt_time(TimeType::ConnectTimeout)` 
and pass it through to `socket.connect()`, so the user-set timeout is respected.

This follows the exact same pattern already used in `sock_accept` for 
`accept_timeout`.

## Testing
The original reproducer from the issue:
```python
import socket, time
sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.settimeout(0.001)
t1 = time.monotonic()
try:
    sock.connect(("pythontest.net", 56666))
except Exception as e:
    print(type(e).__name__, getattr(e, "errno", None))
finally:
    print("elapsed", time.monotonic() - t1)
    sock.close()
```
Should now timeout in ~0.001s instead of ~30s.

Fixes #6450