### PR TITLE
fix(wasix): Interrupt atomic waiters on signals

### DIFF
--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -931,11 +931,7 @@ impl Instance {
         };
         match unsafe { memory.do_wait(dst, expected, timeout) } {
             Ok(count) => Ok(count),
-            Err(_err) => {
-                // ret is None if there is more than 2^32 waiter in queue or some other error
-                // TODO: why THIS specific trap code tho? -.-
-                Err(Trap::lib(TrapCode::TableAccessOutOfBounds))
-            }
+            Err(_err) => Err(Trap::lib(TrapCode::HostInterrupt)),
         }
     }
 

--- a/lib/vm/src/threadconditions.rs
+++ b/lib/vm/src/threadconditions.rs
@@ -172,6 +172,10 @@ impl ThreadConditions {
 
             *mutex_guard -= 1;
 
+            if self.inner.closed.load(Ordering::Acquire) {
+                return Err(WaiterError::AtomicsDisabled);
+            }
+
             ret
         } else {
             1 // value mismatch
@@ -230,6 +234,8 @@ impl ThreadConditions {
 
     /// Disable the use of atomics, leading to all atomic waits failing with
     /// an error, which leads to a Webassembly trap.
+    ///
+    /// NOTE: will also wake up all current waiters.
     ///
     /// Useful for force-closing instances that keep waiting on atomics.
     pub fn disable_atomics(&self) {

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 use tracing::trace;
-use wasmer::FunctionEnvMut;
+use wasmer::{FunctionEnvMut, SharedMemory};
 use wasmer_types::ModuleHash;
 use wasmer_wasix_types::{
     types::Signal,
@@ -179,6 +179,10 @@ pub struct WasiProcessInner {
     pub snapshot_on: HashSet<SnapshotTrigger>,
     /// Any wakers waiting on this process (for example for a checkpoint)
     pub wakers: Vec<Waker>,
+    /// If true then the process has started cleaning up
+    pub cleanup_started: bool,
+    /// Shared process memory.
+    pub memory: Option<SharedMemory>,
     /// The snapshot memory significantly reduce the amount of
     /// duplicate entries in the journal for memory that has not changed
     #[cfg(feature = "journal")]
@@ -432,6 +436,8 @@ impl WasiProcess {
                 children: Default::default(),
                 checkpoint: WasiProcessCheckpoint::Execute,
                 wakers: Default::default(),
+                cleanup_started: false,
+                memory: Default::default(),
                 waiting: waiting.clone(),
                 #[cfg(feature = "journal")]
                 snapshot_on: Default::default(),
@@ -469,6 +475,18 @@ impl WasiProcess {
             ),
             waiting,
             cpu_run_tokens: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    /// Tries to start the cleanup process, returns true if this is the first
+    /// thread to start the cleanup.
+    pub fn try_start_cleanup(&self) -> bool {
+        let mut guard = self.inner.0.lock().unwrap();
+        if guard.cleanup_started {
+            false
+        } else {
+            guard.cleanup_started = true;
+            true
         }
     }
 
@@ -580,6 +598,8 @@ impl WasiProcess {
         tracing::trace!(%pid, %tid, "signal-thread({:?})", signal);
 
         let inner = self.inner.0.lock().unwrap();
+
+        wake_atomic_waiters(&inner, signal);
         if let Some(thread) = inner.threads.get(&tid) {
             thread.signal(signal);
         } else {
@@ -595,6 +615,12 @@ impl WasiProcess {
     /// Signals all the threads in this process
     pub fn signal_process(&self, signal: Signal) {
         signal_process_internal(&self.inner, signal);
+    }
+
+    /// Registers the shared memory used by this process.
+    pub fn register_memory(&self, memory: SharedMemory) {
+        let mut inner = self.inner.0.lock().unwrap();
+        inner.memory = Some(memory);
     }
 
     /// Takes a snapshot of the process and disables journaling returning
@@ -833,6 +859,8 @@ impl WasiProcess {
 
     /// Terminate the process and all its threads
     pub fn terminate(&self, exit_code: ExitCode) {
+        let pid = self.pid;
+        tracing::trace!(%pid, %exit_code, "process-terminate");
         // FIXME: this is wrong, threads might still be running!
         // Need special logic for the main thread.
         let guard = self.inner.0.lock().unwrap();
@@ -885,9 +913,48 @@ fn signal_process_internal(process: &LockableWasiProcessInner, signal: Signal) {
     }
 
     // Otherwise just send the signal to all the threads
+    wake_atomic_waiters(&guard, signal);
     for thread in guard.threads.values() {
         thread.signal(signal);
     }
+}
+
+fn wake_atomic_waiters(process: &WasiProcessInner, signal: Signal) {
+    let Some(memory) = &process.memory else {
+        return;
+    };
+
+    if signal == Signal::Sigkill {
+        // On kill, disable atomics to prevent threads from resuming.
+        // NOTE: disable_atomics also wakes all current waiters.
+        if let Err(err) = memory.disable_atomics() {
+            tracing::trace!(
+                pid=%process.pid,
+                error = &err as &dyn std::error::Error,
+                "failed to wake atomic waiters"
+            );
+        }
+    }
+
+    // TODO: Should other signals also wake up waiters?
+    // We have low confidence this is useful outside the kill path.
+    // SEE https://github.com/wasmerio/wasmer/pull/6536
+    //
+    // Atomic wait wakeups are memory-wide, so only use them for signals
+    // that should interrupt or terminate execution anyway.
+    // if matches!(
+    //     signal,
+    //     Signal::Sigkill
+    //         | Signal::Sigterm
+    //         | Signal::Sigabrt
+    //         | Signal::Sigquit
+    //         | Signal::Sigint
+    //         | Signal::Sigstop
+    //         | Signal::Sigpipe
+    //         | Signal::Sigwakeup
+    // ) {
+    //    memory.wake_all_atomic_waiters();
+    // }
 }
 
 impl SignalHandlerAbi for WasiProcess {

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1287,25 +1287,27 @@ impl WasiEnv {
             let timeout = self.tasks().sleep_now(CLEANUP_TIMEOUT);
             let state = self.state.clone();
             Box::pin(async move {
-                if !disable_fs_cleanup {
-                    tracing::trace!(pid = %pid, "cleaning up open file handles");
+                if process.try_start_cleanup() {
+                    if !disable_fs_cleanup {
+                        tracing::trace!(pid = %pid, "cleaning up open file handles");
 
-                    // Perform the clean operation using the asynchronous runtime
-                    tokio::select! {
-                        _ = timeout => {
-                            tracing::debug!(
-                                "WasiEnv::cleanup has timed out after {CLEANUP_TIMEOUT:?}"
-                            );
-                        },
-                        _ = state.fs.close_all() => { }
+                        // Perform the clean operation using the asynchronous runtime
+                        tokio::select! {
+                            _ = timeout => {
+                                tracing::debug!(
+                                    "WasiEnv::cleanup has timed out after {CLEANUP_TIMEOUT:?}"
+                                );
+                            },
+                            _ = state.fs.close_all() => { }
+                        }
                     }
 
                     // Now send a signal that the thread is terminated
                     process.signal_process(Signal::Sigquit);
-                }
 
-                // Terminate the process
-                process.terminate(process_exit_code);
+                    // Terminate the process
+                    process.terminate(process_exit_code);
+                }
             })
         } else {
             Box::pin(async {})

--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -174,6 +174,7 @@ impl WasiFunctionEnv {
         let new_inner = handles;
 
         let main_module_handles = new_inner.main_module_instance_handles();
+        let shared_memory = main_module_handles.memory().as_shared(store);
         let stack_pointer = main_module_handles.stack_pointer.clone();
         let data_end = main_module_handles.data_end.clone();
         let stack_low = main_module_handles.stack_low.clone();
@@ -181,6 +182,9 @@ impl WasiFunctionEnv {
         let tls_base = main_module_handles.tls_base.clone();
 
         let env = self.data_mut(store);
+        if let Some(shared_memory) = shared_memory {
+            env.process.register_memory(shared_memory);
+        }
         env.set_inner(new_inner);
 
         env.state.fs.set_is_wasix(is_wasix_module);

--- a/lib/wasix/src/syscalls/wasix/proc_fork.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork.rs
@@ -111,6 +111,9 @@ pub fn proc_fork<M: MemorySize>(
             // We first fork the environment and replace the current environment
             // so that the process can continue to prepare for the real fork as
             // if it had actually forked
+            if let Some(memory) = ctx.data().process.lock().memory.clone() {
+                child_env.process.register_memory(memory);
+            }
             child_env.swap_inner(ctx.data_mut());
             std::mem::swap(ctx.data_mut(), &mut child_env);
             let previous_vfork = ctx.data_mut().vfork.replace(WasiVFork {

--- a/lib/wasix/src/syscalls/wasix/proc_fork_env.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork_env.rs
@@ -51,6 +51,9 @@ pub fn proc_fork_env<M: MemorySize>(
             return Ok(Errno::Perm);
         }
     };
+    if let Some(memory) = env.process.lock().memory.clone() {
+        child_env.process.register_memory(memory);
+    }
 
     // Write the child's PID to the provided pointer
     let memory = unsafe { env.memory_view(&ctx) };

--- a/lib/wasix/tests/wasm_tests/process_tests.rs
+++ b/lib/wasix/tests/wasm_tests/process_tests.rs
@@ -1,0 +1,278 @@
+use std::path::PathBuf;
+
+use super::{
+    run_build_script, run_wasm_with_runner_config, run_wasm_with_runner_config_checked,
+    MappedDirectory,
+};
+
+fn assert_success(result: &super::WasmRunResult) {
+    assert_eq!(
+        result.exit_code,
+        Some(0),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+fn assert_stdout_contains(result: &super::WasmRunResult, expected: &str) {
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(
+        stdout.lines().any(|line| line == expected),
+        "missing stdout line {expected:?}\n{}",
+        super::format_captured_output(result)
+    );
+}
+
+fn run_with_arg(wasm: &PathBuf, arg: &str) {
+    let result = run_wasm_with_runner_config(wasm, wasm.parent().unwrap(), |runner| {
+        runner.with_args([arg]);
+    })
+    .unwrap();
+    assert_success(&result);
+}
+
+fn run_with_arg_in_home(wasm: &PathBuf, arg: &str) {
+    let test_dir = wasm.parent().unwrap();
+    let result = run_wasm_with_runner_config(wasm, test_dir, |runner| {
+        runner
+            .with_mapped_directories([MappedDirectory {
+                guest: "/home".to_string(),
+                host: test_dir.to_path_buf(),
+            }])
+            .with_current_dir("/home")
+            .with_args([arg]);
+    })
+    .unwrap();
+    assert_success(&result);
+}
+
+fn assert_stdout_zero(
+    wasm: &PathBuf,
+    configure_runner: impl FnOnce(&mut wasmer_wasix::runners::wasi::WasiRunner),
+) {
+    let result =
+        run_wasm_with_runner_config(wasm, wasm.parent().unwrap(), configure_runner).unwrap();
+    assert_success(&result);
+    assert_eq!(String::from_utf8_lossy(&result.stdout).trim(), "0");
+}
+
+#[test]
+fn test_atomic_wait_signal_wakes_main_thread() {
+    let wasm = run_build_script(file!(), "atomic-wait-signal").unwrap();
+    let result = run_wasm_with_runner_config(&wasm, wasm.parent().unwrap(), |_| {}).unwrap();
+
+    assert!(
+        result.exit_code != Some(0),
+        "expected signal termination\n{}",
+        super::format_captured_output(&result)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&result.stdout).trim(),
+        "waiting",
+        "{}",
+        super::format_captured_output(&result)
+    );
+}
+
+fn run_atomic_wait_signal_children_variant(wasm: &PathBuf, arg: &str, expected_stdout: &[&str]) {
+    let result = run_wasm_with_runner_config(wasm, wasm.parent().unwrap(), |runner| {
+        runner.with_args([arg]);
+    })
+    .unwrap();
+
+    assert_success(&result);
+    for expected in expected_stdout {
+        assert_stdout_contains(&result, expected);
+    }
+}
+
+#[test]
+fn test_atomic_wait_signal_targeted_child() {
+    let wasm = run_build_script(file!(), "atomic-wait-signal-children").unwrap();
+    run_atomic_wait_signal_children_variant(
+        &wasm,
+        "targeted",
+        &["targeted child waiting", "targeted parent survived"],
+    );
+}
+
+#[test]
+// TODO: Should other signals also wake up waiters?
+// We have low confidence this is useful outside the kill path.
+// SEE https://github.com/wasmerio/wasmer/pull/6536
+#[ignore = "SIGTERM atomic waiter wakeups are currently scoped back"]
+fn test_atomic_wait_signal_forwarded_to_children() {
+    let wasm = run_build_script(file!(), "atomic-wait-signal-children").unwrap();
+    run_atomic_wait_signal_children_variant(
+        &wasm,
+        "forwarded",
+        &[
+            "forwarding parent waiting",
+            "forwarded child 1 waiting",
+            "forwarded child 2 waiting",
+            "forwarding parent survived",
+        ],
+    );
+}
+
+#[test]
+fn test_atomic_wait_signal_vfork_child() {
+    let wasm = run_build_script(file!(), "atomic-wait-signal-children").unwrap();
+    run_atomic_wait_signal_children_variant(
+        &wasm,
+        "vfork",
+        &["vfork child waiting", "vfork parent survived"],
+    );
+}
+
+#[test]
+fn test_posix_spawn() {
+    let wasm = run_build_script(file!(), "posix-spawn").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    run_wasm_with_runner_config_checked(&wasm, test_dir, |runner| {
+        runner
+            .with_mapped_directories([MappedDirectory {
+                guest: "/home".to_string(),
+                host: test_dir.to_path_buf(),
+            }])
+            .with_current_dir("/home");
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_cloexec() {
+    let wasm = run_build_script(file!(), "cloexec").unwrap();
+    run_with_arg(&wasm, "flag_tests");
+    run_with_arg(&wasm, "exec_tests");
+    run_with_arg(&wasm, "pipe2_cloexec_test");
+}
+
+#[test]
+fn test_cross_fs_rename() {
+    let wasm = run_build_script(file!(), "cross-fs-rename").unwrap();
+    let temp1 = tempfile::tempdir().unwrap();
+    let temp2 = tempfile::tempdir().unwrap();
+    assert_stdout_zero(&wasm, |runner| {
+        runner.with_mapped_directories([
+            MappedDirectory {
+                guest: "/temp1".to_string(),
+                host: temp1.path().to_path_buf(),
+            },
+            MappedDirectory {
+                guest: "/temp2".to_string(),
+                host: temp2.path().to_path_buf(),
+            },
+        ]);
+    });
+}
+
+#[test]
+fn test_fork() {
+    let wasm = run_build_script(file!(), "fork").unwrap();
+    run_with_arg(&wasm, "failing_exec");
+    run_with_arg(&wasm, "cloexec");
+}
+
+#[test]
+fn test_popen() {
+    let wasm = run_build_script(file!(), "popen").unwrap();
+    run_with_arg(&wasm, "posix_spawn_direct");
+    run_with_arg(&wasm, "pipe2_cloexec");
+    run_with_arg(&wasm, "popen");
+}
+
+#[test]
+fn test_legacy_proc_exec() {
+    let wasm = run_build_script(file!(), "legacy-proc-exec").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    assert_stdout_zero(&wasm, |runner| {
+        runner.with_mapped_directories([MappedDirectory {
+            guest: "/code".to_string(),
+            host: test_dir.to_path_buf(),
+        }]);
+    });
+}
+
+#[test]
+fn test_legacy_proc_exec2() {
+    let wasm = run_build_script(file!(), "legacy-proc-exec2").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    assert_stdout_zero(&wasm, |runner| {
+        runner.with_mapped_directories([MappedDirectory {
+            guest: "/code".to_string(),
+            host: test_dir.to_path_buf(),
+        }]);
+    });
+}
+
+wasm_test!(
+    test_share_tmp_after_fork,
+    "share-tmp-after-fork",
+    stdout = "0"
+);
+
+#[test]
+fn test_share_tmp_after_proc_exec() {
+    let wasm = run_build_script(file!(), "share-tmp-after-proc-exec").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    assert_stdout_zero(&wasm, |runner| {
+        runner.with_mapped_directories([MappedDirectory {
+            guest: "/code".to_string(),
+            host: test_dir.to_path_buf(),
+        }]);
+    });
+}
+
+#[test]
+fn test_share_tmp_after_proc_exec2() {
+    let wasm = run_build_script(file!(), "share-tmp-after-proc-exec2").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    assert_stdout_zero(&wasm, |runner| {
+        runner.with_mapped_directories([MappedDirectory {
+            guest: "/code".to_string(),
+            host: test_dir.to_path_buf(),
+        }]);
+    });
+}
+
+fn run_vfork_variant(wasm: &PathBuf, arg: &str) {
+    run_with_arg_in_home(wasm, arg);
+}
+
+fn run_vfork_suite(wasm: &PathBuf) {
+    run_vfork_variant(wasm, "successful_exec");
+    run_vfork_variant(wasm, "successful_execlp");
+    run_vfork_variant(wasm, "failing_exec");
+    run_vfork_variant(wasm, "cloexec");
+    run_vfork_variant(wasm, "nested_vfork");
+    run_vfork_variant(wasm, "exiting_child");
+    run_vfork_variant(wasm, "trapping_child");
+}
+
+#[test]
+fn test_vfork_asyncify() {
+    let wasm = run_build_script(file!(), "vfork").unwrap();
+    run_vfork_suite(&wasm);
+}
+
+#[test]
+fn test_vfork_eh() {
+    let wasm = run_build_script(file!(), "vfork").unwrap();
+    run_vfork_suite(&wasm.with_file_name("main-eh.wasm"));
+}
+
+#[test]
+#[ignore = "undefined behavior in legacy fixture"]
+fn test_vfork_exit_before_exec() {
+    let wasm = run_build_script(file!(), "vfork").unwrap();
+    run_vfork_variant(&wasm, "exit_before_exec");
+}
+
+#[test]
+#[ignore = "undefined behavior in legacy fixture"]
+fn test_vfork_trap_before_exec() {
+    let wasm = run_build_script(file!(), "vfork").unwrap();
+    run_vfork_variant(&wasm, "trap_before_exec");
+}

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
+##Config: targeted
+##Args: targeted
+##ExpectedStdout: targeted child waiting
+##ExpectedStdout: targeted parent survived
+##Config: forwarded
+##Args: forwarded
+##ExpectedStdout: forwarding parent waiting
+##ExpectedStdout: forwarded child 1 waiting
+##ExpectedStdout: forwarded child 2 waiting
+##ExpectedStdout: forwarding parent survived
+##Ignored: SIGTERM atomic waiter wakeups are currently scoped back
+##Config: vfork
+##Args: vfork
+##ExpectedStdout: vfork child waiting
+##ExpectedStdout: vfork parent survived
+set -euo pipefail
+
+"$CC" -pthread main.c -o main

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/main.c
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/main.c
@@ -1,0 +1,181 @@
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int wait_word = 0;
+
+static int expect_atomic_wait_timeout(const char* name) {
+  int result = __builtin_wasm_memory_atomic_wait32(&wait_word, 0, 1000000LL);
+  if (result != 2) {
+    printf("%s expected atomic wait timeout, got %d\n", name, result);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+static void wait_forever(const char* name) {
+  printf("%s waiting\n", name);
+  fflush(stdout);
+
+  __builtin_wasm_memory_atomic_wait32(&wait_word, 0, -1LL);
+
+  printf("%s woken\n", name);
+  fflush(stdout);
+
+  sleep(1);
+  _Exit(42);
+}
+
+static int wait_for_children(int count) {
+  for (int i = 0; i < count; i++) {
+    int status;
+    pid_t pid;
+
+    do {
+      pid = wait(&status);
+    } while (pid < 0 && errno == EINTR);
+
+    if (pid < 0) {
+      perror("wait");
+      return EXIT_FAILURE;
+    }
+  }
+
+  return EXIT_SUCCESS;
+}
+
+static int targeted_child(void) {
+  pid_t child = fork();
+  if (child < 0) {
+    perror("fork");
+    return EXIT_FAILURE;
+  }
+
+  if (child == 0) {
+    wait_forever("targeted child");
+  }
+
+  usleep(100 * 1000);
+  if (kill(child, SIGKILL) != 0) {
+    perror("kill");
+    return EXIT_FAILURE;
+  }
+
+  if (wait_for_children(1) != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+
+  if (expect_atomic_wait_timeout("targeted parent") != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+
+  puts("targeted parent survived");
+  return EXIT_SUCCESS;
+}
+
+static void* kill_current_process(void* arg) {
+  pid_t pid = *(pid_t*)arg;
+  usleep(100 * 1000);
+  if (kill(pid, SIGKILL) != 0) {
+    perror("kill");
+  }
+  return NULL;
+}
+
+static int vfork_child(void) {
+  pid_t child = vfork();
+  if (child < 0) {
+    perror("vfork");
+    return EXIT_FAILURE;
+  }
+
+  if (child == 0) {
+    pid_t child_pid = getpid();
+    pthread_t signaler;
+    if (pthread_create(&signaler, NULL, kill_current_process, &child_pid) !=
+        0) {
+      perror("pthread_create");
+      _Exit(EXIT_FAILURE);
+    }
+
+    puts("vfork child waiting");
+    fflush(stdout);
+
+    __builtin_wasm_memory_atomic_wait32(&wait_word, 0, -1LL);
+    sleep(1);
+    _Exit(42);
+  }
+
+  if (wait_for_children(1) != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+
+  puts("vfork parent survived");
+  return EXIT_SUCCESS;
+}
+
+static int forwarded_to_children(void) {
+  pid_t parent = getpid();
+
+  for (int i = 0; i < 2; i++) {
+    pid_t child = fork();
+    if (child < 0) {
+      perror("fork");
+      return EXIT_FAILURE;
+    }
+
+    if (child == 0) {
+      wait_forever(i == 0 ? "forwarded child 1" : "forwarded child 2");
+    }
+  }
+
+  pid_t signaler = fork();
+  if (signaler < 0) {
+    perror("fork");
+    return EXIT_FAILURE;
+  }
+
+  if (signaler == 0) {
+    usleep(100 * 1000);
+    if (kill(parent, SIGTERM) != 0) {
+      perror("kill");
+      _Exit(EXIT_FAILURE);
+    }
+    _Exit(EXIT_SUCCESS);
+  }
+
+  puts("forwarding parent waiting");
+  fflush(stdout);
+
+  if (wait_for_children(3) != EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+
+  puts("forwarding parent survived");
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    return EXIT_FAILURE;
+  }
+
+  if (strcmp(argv[1], "targeted") == 0) {
+    return targeted_child();
+  }
+
+  if (strcmp(argv[1], "forwarded") == 0) {
+    return forwarded_to_children();
+  }
+
+  if (strcmp(argv[1], "vfork") == 0) {
+    return vfork_child();
+  }
+
+  return EXIT_FAILURE;
+}

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
+##MustFail: true
+##ExpectedStdout: waiting
+set -euo pipefail
+
+"$CC" -pthread main.c -o main

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/main.c
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/main.c
@@ -1,0 +1,39 @@
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static int wait_word = 0;
+
+int main(void) {
+  pid_t parent = getpid();
+  pid_t child = fork();
+
+  if (child < 0) {
+    perror("fork");
+    return EXIT_FAILURE;
+  }
+
+  if (child == 0) {
+    usleep(100 * 1000);
+    if (kill(parent, SIGKILL) != 0) {
+      perror("kill");
+      _Exit(EXIT_FAILURE);
+    }
+    _Exit(EXIT_SUCCESS);
+  }
+
+  puts("waiting");
+  fflush(stdout);
+
+  __builtin_wasm_memory_atomic_wait32(&wait_word, 0, -1LL);
+
+  puts("woken");
+  fflush(stdout);
+
+  // The atomic wait wakeup makes the main thread runnable again. This syscall
+  // gives WASIX a chance to process the pending terminating signal.
+  sleep(1);
+
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
Previously threads could get stuck idefinitely , even on KILL signals,
because they would be stuck in atomic waiting.

The downside of this implementation is that it can lead to spurious
wakeups, but most data structures building on top of atomics can usually
handle these!

Closes #6585 
