### PR TITLE
fix(v8): passing the InnerTrap::User through the v8 backend

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,5 @@
         "v8",
         "wasmer-artifact-create",
         "wasmer-artifact-load",
-        "napi-v8"
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "llvm",
         "cranelift",
         "singlepass",
+        "v8",
         "wasmer-artifact-create",
         "wasmer-artifact-load",
         "napi-v8"

--- a/lib/api/src/backend/v8/entities/engine.rs
+++ b/lib/api/src/backend/v8/entities/engine.rs
@@ -63,7 +63,7 @@ impl Engine {
         features.simd(true);
         features.threads(true);
         features.multi_value(true);
-        features.exceptions(false);
+        features.exceptions(true);
         features
     }
 

--- a/lib/api/src/backend/v8/error.rs
+++ b/lib/api/src/backend/v8/error.rs
@@ -80,7 +80,9 @@ impl Trap {
                     wasm_byte_vec_new(&mut data, error_message.len(), error_message.as_ptr() as _)
                 };
                 let store = store.as_store_mut();
-                unsafe { wasm_trap_new(store.inner.store.as_v8().inner, &mut data) }
+                let trap = unsafe { wasm_trap_new(store.inner.store.as_v8().inner, &mut data) };
+                unsafe { wasm_byte_vec_delete(&mut data) };
+                trap
             }
         }
     }

--- a/lib/api/src/backend/v8/error.rs
+++ b/lib/api/src/backend/v8/error.rs
@@ -72,25 +72,18 @@ impl Trap {
             InnerTrap::CApi(t) => t,
             InnerTrap::User(err) => {
                 let err_ptr = Box::leak(Box::new(err));
+                // UNSAFE: The boxed error is propagated by passing the string
+                // with the pointer to the struct instance, later on decoded.
                 let mut data = unsafe { std::mem::zeroed() };
-                // let x = format!("")
-                let s1 = format!("🐛{err_ptr:p}");
-                let _s = s1.into_bytes().into_boxed_slice();
-                unsafe { wasm_byte_vec_new(&mut data, _s.len(), _s.as_ptr() as _) };
-                std::mem::forget(_s);
+                let error_message = format!("🐛{err_ptr:p}");
+                unsafe {
+                    wasm_byte_vec_new(&mut data, error_message.len(), error_message.as_ptr() as _)
+                };
                 let store = store.as_store_mut();
                 unsafe { wasm_trap_new(store.inner.store.as_v8().inner, &mut data) }
             }
         }
     }
-
-    // pub unsafe fn deserialize_from_wasm_trap(trap: *mut wasm_trap_t) -> Self {
-    //     let mut data = std::mem::zeroed();
-    //     wasm_trap_message(trap, data);
-    //     println!("data: {data:p}");
-
-    //     std::ptr::read(data as *const _)
-    // }
 }
 
 impl From<*mut wasm_trap_t> for Trap {
@@ -104,8 +97,9 @@ impl From<*mut wasm_trap_t> for Trap {
                 .unwrap()
         };
 
-        if message.starts_with("Exception: 🐛") {
-            let ptr_str = message.replace("Exception: 🐛", "");
+        // User traps are encoded by `into_wasm_trap` as a leaked `Box` pointer
+        // prefixed with this marker.
+        if let Some((_, ptr_str)) = message.split_once("🐛") {
             let ptr: Box<dyn Error + Send + Sync + 'static> = unsafe {
                 let r = ptr_str.trim_start_matches("0x");
                 std::ptr::read(usize::from_str_radix(r, 16).unwrap()

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -488,6 +488,34 @@ fn run_no_start_wasm_report_error() {
     assert.stderr(contains("The module doesn't export a \"_start\" function"));
 }
 
+#[cfg(feature = "v8")]
+#[test]
+fn run_v8_wasi_proc_exit_zero_is_success() {
+    let wasi_wat = "
+    (module
+        (import \"wasi_snapshot_preview1\" \"proc_exit\"
+          (func $__wasi_proc_exit (param i32)))
+        (func $_start
+          i32.const 0
+          call $__wasi_proc_exit)
+        (memory 1)
+        (export \"memory\" (memory 0))
+        (export \"_start\" (func $_start))
+      )
+    ";
+
+    let temp = TempDir::new().unwrap();
+    let module_file = temp.path().join("proc_exit_zero.wat");
+    std::fs::write(&module_file, wasi_wat.as_bytes()).unwrap();
+
+    Command::new(get_wasmer_path())
+        .arg("run")
+        .arg("--v8")
+        .arg(&module_file)
+        .assert()
+        .success();
+}
+
 // Test that wasmer can run a complex path
 #[test]
 fn test_wasmer_run_complex_url() {


### PR DESCRIPTION
Fixes: #6540