### PR TITLE
Fix mem-fs cursor after truncating open file

### DIFF
--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -224,6 +224,8 @@ impl VirtualFile for FileHandle {
             _ => return Err(FsError::NotAFile),
         }
 
+        // Update current cursor position if file got truncated
+        self.cursor = self.cursor.min(new_size);
         Ok(())
     }
 

--- a/lib/wasix/tests/wasm_tests/fd_tests.rs
+++ b/lib/wasix/tests/wasm_tests/fd_tests.rs
@@ -1,2 +1,3 @@
 wasm_test!(test_fd_allocate, "fd-allocate");
+wasm_test!(test_fd_append_after_truncate, "fd-append-after-truncate");
 wasm_test!(test_fd_open_readonly, "fd-open-readonly");

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-append-after-truncate/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-append-after-truncate/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/tmp/x", O_CREAT | O_RDWR | O_APPEND, 0644);
+  assert(write(fd, "12345678901234567", 17) == 17);
+  assert(ftruncate(fd, 0) == 0);
+  assert(write(fd, "Z", 1) == 1);
+  close(fd);
+
+  fd = open("/tmp/x", O_RDONLY);
+  char b[8] = {0};
+  assert(read(fd, b, sizeof(b)) == 1);
+  assert(strcmp(b, "Z") == 0);
+}


### PR DESCRIPTION
Fixes a `mem_fs` panic when writing to an `O_APPEND` file after `ftruncate(0)`. The truncate resized the backing buffer but left the open `FileHandle` cursor past EOF, so the next write attempted to slice beyond the empty buffer.

Fixes https://github.com/wasmerio/wasmer/issues/6542