### PR TITLE
Fix append + Seek and support of writing beyond EOF

### DIFF
--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -809,10 +809,6 @@ impl AsyncRead for FileHandle {
 
 impl AsyncSeek for FileHandle {
     fn start_seek(mut self: Pin<&mut Self>, position: io::SeekFrom) -> io::Result<()> {
-        if self.append_mode {
-            return Ok(());
-        }
-
         let mut cursor = self.cursor;
         let ret = {
             let mut fs = self
@@ -868,24 +864,6 @@ impl AsyncSeek for FileHandle {
     }
 
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        // In `append` mode, it's not possible to seek in the file. In
-        // [`open(2)`](https://man7.org/linux/man-pages/man2/open.2.html),
-        // the `O_APPEND` option describes this behavior well:
-        //
-        // > Before each write(2), the file offset is positioned at
-        // > the end of the file, as if with lseek(2).  The
-        // > modification of the file offset and the write operation
-        // > are performed as a single atomic step.
-        // >
-        // > O_APPEND may lead to corrupted files on NFS filesystems
-        // > if more than one process appends data to a file at once.
-        // > This is because NFS does not support appending to a file,
-        // > so the client kernel has to simulate it, which can't be
-        // > done without a race condition.
-        if self.append_mode {
-            return Poll::Ready(Ok(0));
-        }
-
         let mut fs = self
             .filesystem
             .inner
@@ -1505,6 +1483,12 @@ impl File {
 impl File {
     pub fn read(&self, buf: &mut [u8], cursor: &mut u64) -> io::Result<usize> {
         let cur_pos = *cursor as usize;
+
+        // POSIX regular files return EOF, not an error, when reading at or beyond EOF.
+        if cur_pos >= self.buffer.len() {
+            return Ok(0);
+        }
+
         let max_to_read = cmp::min(self.buffer.len() - cur_pos, buf.len());
         let data_to_copy = &self.buffer[cur_pos..][..max_to_read];
 
@@ -1546,10 +1530,8 @@ impl File {
             ));
         }
 
-        // In this implementation, it's an error to seek beyond the
-        // end of the buffer.
         let next_cursor = next_cursor.try_into().map_err(to_err)?;
-        *cursor = cmp::min(self.buffer.len() as u64, next_cursor);
+        *cursor = next_cursor;
 
         let cursor = *cursor;
         Ok(cursor)
@@ -1559,15 +1541,23 @@ impl File {
 impl File {
     pub fn write(&mut self, buf: &[u8], cursor: &mut u64) -> io::Result<usize> {
         let position = *cursor as usize;
+        let end = position
+            .checked_add(buf.len())
+            .ok_or(io::ErrorKind::InvalidInput)?;
 
-        if position + buf.len() > self.buffer.len() {
+        if position > self.buffer.len() {
+            // Materialize the sparse gap with zeroes in this contiguous in-memory buffer.
+            self.buffer.resize(position, 0)?;
+        }
+
+        if end > self.buffer.len() {
             // Writing past the end of the current buffer, must reallocate
-            let len_after_end = (position + buf.len()) - self.buffer.len();
+            let len_after_end = end - self.buffer.len();
             let let_to_end = buf.len() - len_after_end;
-            self.buffer[position..position + let_to_end].copy_from_slice(&buf[0..let_to_end]);
+            self.buffer[position..end - len_after_end].copy_from_slice(&buf[0..let_to_end]);
             self.buffer.extend_from_slice(&buf[let_to_end..buf.len()])?;
         } else {
-            self.buffer[position..position + buf.len()].copy_from_slice(buf);
+            self.buffer[position..end].copy_from_slice(buf);
         }
 
         *cursor += buf.len() as u64;

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -100,6 +100,14 @@ impl FileHandle {
             .map_err(|err| *err)?
             .as_mut())
     }
+
+    fn write_cursor(&self, file_size: u64) -> u64 {
+        if self.append_mode {
+            file_size
+        } else {
+            self.cursor
+        }
+    }
 }
 
 impl VirtualFile for FileHandle {
@@ -917,7 +925,7 @@ impl AsyncWrite for FileHandle {
             )));
         }
 
-        let mut cursor = self.cursor;
+        let mut cursor;
         let bytes_written = {
             let mut fs = self
                 .filesystem
@@ -928,25 +936,29 @@ impl AsyncWrite for FileHandle {
             let inode = fs.storage.get_mut(self.inode);
             match inode {
                 Some(Node::File(node)) => {
+                    cursor = self.write_cursor(node.file.len() as u64);
                     let bytes_written = node.file.write(buf, &mut cursor)?;
                     node.metadata.len = node.file.len().try_into().unwrap();
                     bytes_written
                 }
                 Some(Node::OffloadedFile(node)) => {
+                    cursor = self.write_cursor(node.file.len());
                     let bytes_written = node.file.write(OffloadWrite::Buffer(buf), &mut cursor)?;
                     node.metadata.len = node.file.len();
                     bytes_written
                 }
                 Some(Node::ReadOnlyFile(node)) => {
+                    cursor = self.write_cursor(node.file.len() as u64);
                     let bytes_written = node.file.write(buf, &mut cursor)?;
                     node.metadata.len = node.file.len().try_into().unwrap();
                     bytes_written
                 }
                 Some(Node::CustomFile(node)) => {
                     let mut guard = node.file.lock().unwrap();
+                    cursor = self.write_cursor(guard.size());
 
                     let file = Pin::new(guard.as_mut());
-                    if let Err(err) = file.start_seek(io::SeekFrom::Start(self.cursor)) {
+                    if let Err(err) = file.start_seek(io::SeekFrom::Start(cursor)) {
                         return Poll::Ready(Err(err));
                     }
 
@@ -1006,6 +1018,7 @@ impl AsyncWrite for FileHandle {
             let inode = fs.storage.get_mut(self.inode);
             match inode {
                 Some(Node::File(node)) => {
+                    cursor = self.write_cursor(node.file.len() as u64);
                     let buf = bufs
                         .iter()
                         .find(|b| !b.is_empty())
@@ -1015,6 +1028,7 @@ impl AsyncWrite for FileHandle {
                     Poll::Ready(Ok(bytes_written))
                 }
                 Some(Node::OffloadedFile(node)) => {
+                    cursor = self.write_cursor(node.file.len());
                     let buf = bufs
                         .iter()
                         .find(|b| !b.is_empty())
@@ -1024,6 +1038,7 @@ impl AsyncWrite for FileHandle {
                     Poll::Ready(Ok(bytes_written))
                 }
                 Some(Node::ReadOnlyFile(node)) => {
+                    cursor = self.write_cursor(node.file.len() as u64);
                     let buf = bufs
                         .iter()
                         .find(|b| !b.is_empty())

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -366,7 +366,7 @@ impl crate::FileOpener for FileSystem {
             }
         };
 
-        let mut cursor = 0u64;
+        let cursor = 0u64;
         let inode_of_file = match maybe_inode_of_file {
             // The file already exists, and a _new_ one _must_ be
             // created; it's not OK.
@@ -395,11 +395,6 @@ impl crate::FileOpener for FileSystem {
                             file.truncate();
                             metadata.len = 0;
                         }
-
-                        // Move the cursor to the end if needed.
-                        if append {
-                            cursor = file.len() as u64;
-                        }
                     }
 
                     Some(Node::OffloadedFile(OffloadedFileNode { metadata, file, .. })) => {
@@ -410,11 +405,6 @@ impl crate::FileOpener for FileSystem {
                         if truncate {
                             file.truncate();
                             metadata.len = 0;
-                        }
-
-                        // Move the cursor to the end if needed.
-                        if append {
-                            cursor = file.len();
                         }
                     }
 
@@ -438,11 +428,6 @@ impl crate::FileOpener for FileSystem {
                             file.set_len(0)?;
                             node.metadata.len = 0;
                         }
-
-                        // Move the cursor to the end if needed.
-                        if append {
-                            cursor = file.size();
-                        }
                     }
 
                     Some(Node::ArcFile(node)) => {
@@ -464,11 +449,6 @@ impl crate::FileOpener for FileSystem {
                         if truncate {
                             file.set_len(0)?;
                             node.metadata.len = 0;
-                        }
-
-                        // Move the cursor to the end if needed.
-                        if append {
-                            cursor = file.size();
                         }
                     }
 

--- a/lib/virtual-fs/src/mem_fs/offloaded_file.rs
+++ b/lib/virtual-fs/src/mem_fs/offloaded_file.rs
@@ -174,10 +174,8 @@ impl OffloadedFile {
             ));
         }
 
-        // In this implementation, it's an error to seek beyond the
-        // end of the buffer.
         let next_cursor = next_cursor.try_into().map_err(to_err)?;
-        *cursor = cmp::min(self.len(), next_cursor);
+        *cursor = next_cursor;
         Ok(*cursor)
     }
 

--- a/lib/wasix/tests/wasm_tests/fd_tests.rs
+++ b/lib/wasix/tests/wasm_tests/fd_tests.rs
@@ -1,3 +1,8 @@
 wasm_test!(test_fd_allocate, "fd-allocate");
 wasm_test!(test_fd_append_after_truncate, "fd-append-after-truncate");
+wasm_test!(test_fd_append_seek_read, "fd-append-seek-read");
 wasm_test!(test_fd_open_readonly, "fd-open-readonly");
+wasm_test!(
+    test_fd_sparse_write_after_truncate,
+    "fd-sparse-write-after-truncate"
+);

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-append-seek-read/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-append-seek-read/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/tmp/append_seek", O_CREAT | O_RDWR | O_APPEND, 0644);
+  write(fd, "abc", 3);
+  lseek(fd, 0, SEEK_SET);
+
+  char b[4] = {0};
+  assert(read(fd, b, sizeof(b)) == 3);
+  assert(strcmp(b, "abc") == 0);
+}

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-sparse-write-after-truncate/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-sparse-write-after-truncate/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/tmp/sparse", O_CREAT | O_RDWR, 0644);
+  write(fd, "12345678901234567", 17);
+  ftruncate(fd, 0);
+  write(fd, "Z", 1);
+  lseek(fd, 0, SEEK_SET);
+
+  char b[32] = {1};
+  assert(read(fd, b, sizeof(b)) == 18);
+  for (int i = 0; i < 17; i++) {
+    assert(b[i] == 0);
+  }
+  assert(b[17] == 'Z');
+}


### PR DESCRIPTION
DEPENDS ON https://github.com/wasmerio/wasmer/pull/6545 and could be merged (rebased) only after that.

## Append + Seek

`mem_fs` treated `O_APPEND` as if seeking was disabled for the descriptor. I assume that came from reading the POSIX/Linux `O_APPEND` wording too broadly: the spec says the file offset is moved to `EOF` before each `write()`, but it does not make `lseek()` a no-op. The expected behavior is that `lseek()` still updates the descriptor offset for reads/tells, while writes on an append-mode descriptor are still performed at EOF.

This matters for log readers/rotators or database-style append logs that open a file with `O_APPEND` for safe appends, but also seek around the same descriptor to read headers, inspect existing records, or recover the last valid entry. Those reads must use the position set by `lseek()`, even though writes still append at `EOF`.

## Sparse

This PR also fixes sparse writes by allowing regular-file seeks past `EOF`, returning `EOF` for reads at or beyond `EOF`, and zero-filling the gap when a later write materializes the sparse region. 

This matters for tools that preallocate or patch files by seeking to an offset before writing, such as archive writers, database files, binary patchers, and language runtimes that use `ftruncate()`/`lseek()` to resize or rewrite structured files. Without sparse write support, Wasmer writes at the wrong offset after truncation or seek-past-EOF, corrupting the file layout instead of preserving the expected zero-filled hole.

Fixes https://github.com/wasmerio/wasmer/issues/6543