### PR TITLE
fix(wasix): Fix WASIX rename of path to itself

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -139,6 +139,12 @@ pub fn path_rename_internal(
         }
     };
 
+    if source_parent_inode.ino() == target_parent_inode.ino()
+        && source_entry_name == target_entry_name
+    {
+        return Ok(Errno::Success);
+    }
+
     let source_entry = {
         let mut guard = source_parent_inode.write();
         match guard.deref_mut() {

--- a/lib/wasix/tests/wasm_tests/path_tests.rs
+++ b/lib/wasix/tests/wasm_tests/path_tests.rs
@@ -35,3 +35,13 @@ fn test_create_move_open() {
     assert_eq!(String::from_utf8_lossy(&result.stdout).trim(), "0");
     assert_eq!(result.exit_code, Some(0));
 }
+
+#[test]
+fn test_rename_same_path() {
+    let wasm = run_build_script(file!(), "rename-same-path").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    remove_path_if_exists(&test_dir.join("same-path"));
+    let result = run_wasm_with_result(&wasm, test_dir).unwrap();
+    remove_path_if_exists(&test_dir.join("same-path"));
+    assert_eq!(result.exit_code, Some(0));
+}

--- a/lib/wasix/tests/wasm_tests/path_tests/rename-same-path/main.c
+++ b/lib/wasix/tests/wasm_tests/path_tests/rename-same-path/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/tmp/same-path", O_CREAT | O_RDWR, 0644);
+  assert(write(fd, "ok", 2) == 2);
+  assert(close(fd) == 0);
+
+  assert(rename("/tmp/same-path", "/tmp/same-path") == 0);
+
+  char buf[3] = {0};
+  fd = open("/tmp/same-path", O_RDONLY);
+  assert(fd >= 0);
+  assert(read(fd, buf, sizeof(buf)) == 2);
+  assert(strcmp(buf, "ok") == 0);
+}


### PR DESCRIPTION
WASIX `path_rename` currently panics on `rename(path, path)`. When source and target point to the same directory entry, the implementation removes the source entry first, which also removes the target, then later expects the target inode to still exist and panics.

This fixes the issue by detecting same-parent, same-name renames before mutating directory entries and returning success instead, matching native/POSIX no-op behavior.