### PR TITLE
fix(wasix): Guard WASIX fd operations against huge fd targets

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -55,6 +55,11 @@ pub use self::notification::NotificationInner;
 use crate::syscalls::map_io_err;
 use crate::{ALL_RIGHTS, bin_factory::BinaryPackage, state::PreopenedDir};
 
+// POSIX bounds descriptor numbers by the process fd limit (`OPEN_MAX`,
+// `RLIMIT_NOFILE` on Linux). Other OSes commonly override the default, so
+// use a Linux-like 64k ceiling until WASIX models per-process fd limits.
+pub(crate) const MAX_FD: WasiFd = (64 * 1024) - 1;
+
 /// the fd value of the virtual root
 ///
 /// Used for interacting with the file system when it has no
@@ -1862,6 +1867,9 @@ impl WasiFs {
 
         match idx {
             Some(idx) => {
+                if idx > MAX_FD {
+                    return Err(Errno::Badf);
+                }
                 if guard.insert(exclusive, idx, fd) {
                     Ok(idx)
                 } else {
@@ -1883,6 +1891,9 @@ impl WasiFs {
         cloexec: Option<bool>,
     ) -> Result<WasiFd, Errno> {
         let fd = self.get_fd(fd)?;
+        if min_result_fd > MAX_FD {
+            return Err(Errno::Inval);
+        }
         Ok(self.fd_map.write().unwrap().insert_first_free_after(
             Fd {
                 inner: FdInner {

--- a/lib/wasix/src/syscalls/wasi/fd_renumber.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_renumber.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::fs::MAX_FD;
 use crate::syscalls::*;
 use std::{future::Future, pin::Pin, sync::Arc, task::Context, task::Poll};
 use virtual_fs::VirtualFile;
@@ -54,8 +55,8 @@ pub(crate) fn fd_renumber_internal(
     from: WasiFd,
     to: WasiFd,
 ) -> Result<Errno, WasiError> {
-    if from == to {
-        return Ok(Errno::Success);
+    if to > MAX_FD {
+        return Ok(Errno::Badf);
     }
     let env = ctx.data();
     let (_, mut state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
@@ -69,6 +70,9 @@ pub(crate) fn fd_renumber_internal(
 
         // Validate the source first. If `from` is invalid we must not mutate `to`.
         let fd_entry = wasi_try_ok!(fd_map.get(from).ok_or(Errno::Badf));
+        if from == to {
+            return Ok(Errno::Success);
+        }
 
         // Never allow renumbering over preopens.
         if let Some(target_fd) = fd_map.get(to)

--- a/lib/wasix/src/syscalls/wasix/proc_spawn2.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn2.rs
@@ -4,6 +4,7 @@ use wasmer_wasix_types::wasi::ProcSpawnFdOpName;
 use super::*;
 use crate::{
     VIRTUAL_ROOT_FD, WasiFs,
+    fs::MAX_FD,
     os::task::{OwnedTaskStatus, TaskStatus},
     syscalls::*,
 };
@@ -203,6 +204,10 @@ fn apply_fd_op<M: MemorySize>(
             env.state.fs.close_fd(op.fd)
         }
         ProcSpawnFdOpName::Dup2 => {
+            if op.fd > MAX_FD {
+                return Err(Errno::Badf);
+            }
+
             let target_fd = env.state.fs.get_fd(op.fd).ok();
             if let Some(fd) = target_fd.as_ref()
                 && !fd.is_stdio

--- a/lib/wasix/tests/wasm_tests/fd_tests.rs
+++ b/lib/wasix/tests/wasm_tests/fd_tests.rs
@@ -1,2 +1,9 @@
 wasm_test!(test_fd_allocate, "fd-allocate");
+wasm_test!(test_fd_dup2_huge_min, "fd-dup2-huge-min");
 wasm_test!(test_fd_open_readonly, "fd-open-readonly");
+wasm_test!(
+    test_fd_renumber_negative_target,
+    "fd-renumber-negative-target"
+);
+wasm_test!(test_proc_spawn2_dup2_huge_fd, "proc-spawn2-dup2-huge-fd");
+wasm_test!(test_proc_spawn2_open_huge_fd, "proc-spawn2-open-huge-fd");

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-dup2-huge-min/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-dup2-huge-min/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <wasi/api_wasix.h>
+
+int main(void) {
+  int fd = open("/tmp/dup2-huge-min", O_CREAT | O_RDWR, 0644);
+  assert(fd >= 0);
+
+  __wasi_fd_t ret = 0;
+  __wasi_errno_t err = __wasi_fd_dup2((__wasi_fd_t)fd, 65536, 0, &ret);
+  assert(err == __WASI_ERRNO_INVAL);
+
+  assert(close(fd) == 0);
+}

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-renumber-negative-target/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-renumber-negative-target/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/tmp/renumber-negative-target", O_CREAT | O_RDWR, 0644);
+  assert(fd >= 0);
+
+  errno = 0;
+  assert(dup2(fd, -1) == -1);
+  assert(errno == EBADF);
+
+  errno = 0;
+  assert(dup2(-1, -1) == -1);
+  assert(errno == EBADF);
+
+  assert(close(fd) == 0);
+}

--- a/lib/wasix/tests/wasm_tests/fd_tests/proc-spawn2-dup2-huge-fd/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/proc-spawn2-dup2-huge-fd/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <wasi/api_wasix.h>
+
+int main(void) {
+  int fd = open("/tmp/proc-spawn2-dup2-huge-fd", O_CREAT | O_RDWR, 0644);
+  assert(fd >= 0);
+
+  __wasi_proc_spawn_fd_op_t op = {0};
+  op.cmd = __WASI_PROC_SPAWN_FD_OP_NAME_DUP2;
+  op.fd = 65536;
+  op.src_fd = (__wasi_fd_t)fd;
+
+  __wasi_pid_t pid = 0;
+  __wasi_errno_t err =
+      __wasi_proc_spawn2("missing-process", "", "", &op, 1, 0, 0, 0, "", &pid);
+  assert(err == __WASI_ERRNO_BADF);
+
+  assert(close(fd) == 0);
+}

--- a/lib/wasix/tests/wasm_tests/fd_tests/proc-spawn2-open-huge-fd/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/proc-spawn2-open-huge-fd/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <wasi/api_wasix.h>
+
+int main(void) {
+  const char* path = "/tmp/proc-spawn2-open-huge-fd";
+  int fd = open(path, O_CREAT | O_RDWR, 0644);
+  assert(fd >= 0);
+  assert(close(fd) == 0);
+
+  __wasi_proc_spawn_fd_op_t op = {0};
+  op.cmd = __WASI_PROC_SPAWN_FD_OP_NAME_OPEN;
+  op.fd = 65536;
+  op.path = (uint8_t*)path;
+  op.path_len = strlen(path);
+  op.fs_rights_base = __WASI_RIGHTS_FD_READ;
+  op.fs_rights_inheriting = __WASI_RIGHTS_FD_READ;
+
+  __wasi_pid_t pid = 0;
+  __wasi_errno_t err =
+      __wasi_proc_spawn2("missing-process", "", "", &op, 1, 0, 0, 0, "", &pid);
+  assert(err == __WASI_ERRNO_BADF);
+}


### PR DESCRIPTION
WASIX could crash the host process when guest code passed an out-of-range fd target, such as `dup2(fd, -1)`. The negative POSIX fd is represented at the WASIX boundary as a huge unsigned fd, and the dense `FdList` attempted to resize to that value, leading to `OOM/SIGKILL` instead of returning an error.

This adds a 64k fd ceiling for guest-controlled fd targets until WASIX has a real per-process fd limit. Out-of-range exact-target operations now fail with `EBADF`, while `F_DUPFD`-style minimum fd allocation fails with `EINVAL`, matching POSIX/Linux behavior.

Updated syscall paths:

- `fd_renumber`: rejects out-of-range target fd with `EBADF` before touching FdList.
- `fd_dup2`: rejects out-of-range minimum fd with `EINVAL` through `clone_fd_ext`.
- `proc_spawn2`: rejects out-of-range Dup2 fd ops with `EBADF`.
- `proc_spawn2`: rejects out-of-range Open fd ops via fixed-fd creation with `EBADF`