### PR TITLE
fix(LLVM): properly handling `ref.is_null` for exnref types

### DIFF
--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -11183,8 +11183,19 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                 self.state.push1(ty.const_zero());
             }
             Operator::RefIsNull => {
-                let value = self.state.pop1()?.into_pointer_value();
-                let is_null = err!(self.builder.build_is_null(value, ""));
+                let value = self.state.pop1()?;
+                let is_null = match value {
+                    BasicValueEnum::IntValue(value) => err!(self.builder.build_int_compare(
+                        IntPredicate::EQ,
+                        value,
+                        value.get_type().const_zero(),
+                        "",
+                    )),
+                    BasicValueEnum::PointerValue(value) => {
+                        err!(self.builder.build_is_null(value, ""))
+                    }
+                    _ => unreachable!("ref.is_null only accepts reference types"),
+                };
                 let is_null = err!(self.builder.build_int_z_extend(
                     is_null,
                     self.intrinsics.i32_ty,

--- a/tests/wast/wasmer/exception-handling.wast
+++ b/tests/wast/wasmer/exception-handling.wast
@@ -28,3 +28,13 @@
     ref.null exn
     i32.const 0)
 )
+
+(module
+(func (export "exnref_is_null") (result i32)
+    (local $e exnref)
+    local.get $e
+    ref.is_null
+  )
+)
+
+(assert_return (invoke "exnref_is_null") (i32.const 1))


### PR DESCRIPTION
Fixes: #6537