### PR TITLE
fix(wasix):  path_rename panics when renaming a directory into its child

### DIFF
--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -77,7 +77,7 @@ pub fn path_rename_internal(
     }
 
     // this is to be sure the source file is fetched from the filesystem if needed
-    wasi_try_ok!(
+    let source_inode = wasi_try_ok!(
         state
             .fs
             .get_inode_at_path(inodes, source_fd, source_path, true)
@@ -143,6 +143,14 @@ pub fn path_rename_internal(
         && source_entry_name == target_entry_name
     {
         return Ok(Errno::Success);
+    }
+
+    let source_is_dir = {
+        let guard = source_inode.read();
+        matches!(guard.deref(), Kind::Dir { .. })
+    };
+    if source_is_dir && host_adjusted_target_path.starts_with(&host_adjusted_source_path) {
+        return Ok(Errno::Inval);
     }
 
     let source_entry = {

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -77,11 +77,12 @@ pub fn path_rename_internal(
     }
 
     // this is to be sure the source file is fetched from the filesystem if needed
-    let source_inode = wasi_try_ok!(
-        state
-            .fs
-            .get_inode_at_path(inodes, source_fd, source_path, true)
-    );
+    let source_inode = wasi_try_ok!(state.fs.get_inode_at_path(
+        inodes,
+        source_fd,
+        source_path,
+        true
+    ));
     // Create the destination inode if the file exists.
     let _ = state
         .fs

--- a/lib/wasix/tests/wasm_tests/path_tests.rs
+++ b/lib/wasix/tests/wasm_tests/path_tests.rs
@@ -49,10 +49,7 @@ fn test_rename_same_path() {
 #[test]
 fn test_rename_dir_into_child() {
     let wasm = run_build_script(file!(), "rename-dir-into-child").unwrap();
-    let test_dir = wasm.parent().unwrap();
-    remove_path_if_exists(&test_dir.join("rename-parent"));
-    let result = run_wasm_with_result(&wasm, test_dir).unwrap();
-    remove_path_if_exists(&test_dir.join("rename-parent"));
+    let test_dir = tempfile::tempdir().unwrap();
+    let result = run_wasm_with_result(&wasm, test_dir.path()).unwrap();
     assert_eq!(result.exit_code, Some(0));
 }
-

--- a/lib/wasix/tests/wasm_tests/path_tests.rs
+++ b/lib/wasix/tests/wasm_tests/path_tests.rs
@@ -45,3 +45,14 @@ fn test_rename_same_path() {
     remove_path_if_exists(&test_dir.join("same-path"));
     assert_eq!(result.exit_code, Some(0));
 }
+
+#[test]
+fn test_rename_dir_into_child() {
+    let wasm = run_build_script(file!(), "rename-dir-into-child").unwrap();
+    let test_dir = wasm.parent().unwrap();
+    remove_path_if_exists(&test_dir.join("rename-parent"));
+    let result = run_wasm_with_result(&wasm, test_dir).unwrap();
+    remove_path_if_exists(&test_dir.join("rename-parent"));
+    assert_eq!(result.exit_code, Some(0));
+}
+

--- a/lib/wasix/tests/wasm_tests/path_tests/rename-dir-into-child/main.c
+++ b/lib/wasix/tests/wasm_tests/path_tests/rename-dir-into-child/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+int main(void) {
+  assert(mkdir("/tmp/rename-parent", 0755) == 0);
+
+  errno = 0;
+  int ret = rename("/tmp/rename-parent", "/tmp/rename-parent/child");
+  assert(ret == -1);
+  assert(errno == EINVAL);
+  assert(mkdir("/tmp/rename-parent/still-here", 0755) == 0);
+}

--- a/lib/wasix/tests/wasm_tests/path_tests/rename-dir-into-child/main.c
+++ b/lib/wasix/tests/wasm_tests/path_tests/rename-dir-into-child/main.c
@@ -4,11 +4,11 @@
 #include <sys/stat.h>
 
 int main(void) {
-  assert(mkdir("/tmp/rename-parent", 0755) == 0);
+  assert(mkdir("rename-parent", 0755) == 0);
 
   errno = 0;
-  int ret = rename("/tmp/rename-parent", "/tmp/rename-parent/child");
+  int ret = rename("rename-parent", "rename-parent/child");
   assert(ret == -1);
   assert(errno == EINVAL);
-  assert(mkdir("/tmp/rename-parent/still-here", 0755) == 0);
+  assert(mkdir("rename-parent/still-here", 0755) == 0);
 }


### PR DESCRIPTION
- Fix a `path_rename` host panic when a directory is renamed into one of its own descendants.
- Return `EINVAL` before mutating the in-memory inode tree, avoiding the later `Expected target inode to exist` crash.
