### PR TITLE
fix: wasmer-cli - panic when command name shadows dependency entry

### DIFF
--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -181,9 +181,9 @@ fn load_binary_command(
                 resolved_package_id=%id,
                 "command atom resolution: resolved dependency",
             );
-            let container = containers.get(id).with_context(|| {
-                format!(
-                    "Unable to find the \"{id}\" dependency for the \"{command_name}\" command in \"{package_id}\""
+            let container = containers.get(id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "The \"{command_name}\" command in \"{package_id}\" shadows a entry/command of the \"{dep}\" dependency. Rename the local command."
                 )
             })?;
 
@@ -321,7 +321,7 @@ async fn fetch_dependencies(
     pkg: &ResolvedPackage,
     graph: &DependencyGraph,
 ) -> Result<HashMap<PackageId, Container>, Error> {
-    let packages = packages_needed_for_load(pkg, graph);
+    let packages = packages_needed_for_load(pkg);
 
     let packages = packages.into_iter().filter_map(|id| {
         let crate::runtime::resolver::Node { pkg, dist, .. } = &graph[&id];
@@ -345,17 +345,11 @@ async fn fetch_dependencies(
     Ok(packages)
 }
 
-fn packages_needed_for_load(pkg: &ResolvedPackage, graph: &DependencyGraph) -> HashSet<PackageId> {
+fn packages_needed_for_load(pkg: &ResolvedPackage) -> HashSet<PackageId> {
     let mut packages = HashSet::new();
 
     for loc in pkg.commands.values() {
         packages.insert(loc.package.clone());
-
-        if let Some(owner) = graph.packages().get(&loc.package).copied() {
-            for edge in graph.graph().edges(owner) {
-                packages.insert(graph[edge.target()].id.clone());
-            }
-        }
     }
 
     for mapping in &pkg.filesystem {
@@ -618,10 +612,11 @@ fn filesystem_v2(
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::{BTreeMap, HashMap, HashSet},
+        collections::{BTreeMap, HashMap},
         path::{Path, PathBuf},
     };
 
+    use anyhow::Error;
     use ciborium::value::Value;
     use petgraph::graph::DiGraph;
     use virtual_fs::FileSystem;
@@ -630,8 +625,10 @@ mod tests {
         Container,
         indexmap::IndexMap,
         metadata::{
-            Manifest,
-            annotations::{FileSystemMapping, FileSystemMappings},
+            Command as WebcCommand, Manifest,
+            annotations::{
+                Atom as AtomAnnotation, FileSystemMapping, FileSystemMappings, WASI_RUNNER_URI,
+            },
         },
         v2::{
             SignatureAlgorithm,
@@ -640,12 +637,33 @@ mod tests {
         },
     };
 
-    use super::{
-        ResolvedFileSystemMapping, ResolvedPackage, filesystem_v2, packages_needed_for_load,
+    use super::{ResolvedFileSystemMapping, ResolvedPackage, filesystem_v2};
+    use crate::runtime::{
+        package_loader::PackageLoader,
+        resolver::{
+            Command, DependencyGraph, DistributionInfo, Edge, ItemLocation, Node, PackageInfo,
+            PackageSummary, Resolution, WebcHash,
+        },
     };
-    use crate::runtime::resolver::{
-        Command, DependencyGraph, Edge, ItemLocation, Node, PackageInfo,
-    };
+
+    #[derive(Debug, Default)]
+    struct TestLoader;
+
+    #[async_trait::async_trait]
+    impl PackageLoader for TestLoader {
+        async fn load(&self, summary: &PackageSummary) -> Result<Container, Error> {
+            anyhow::bail!("unexpected dependency fetch: {}", summary.package_id())
+        }
+
+        async fn load_package_tree(
+            &self,
+            root: &Container,
+            resolution: &Resolution,
+            root_is_local_dir: bool,
+        ) -> Result<crate::bin_factory::BinaryPackage, Error> {
+            super::load_package_tree(root, self, resolution, root_is_local_dir).await
+        }
+    }
 
     #[test]
     fn v2_filesystem_mapping_resolves_mount_paths() {
@@ -714,10 +732,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn command_owner_dependencies_are_fetched_when_dependency_command_is_shadowed() {
+    #[tokio::test]
+    async fn load_package_tree_reports_shadowed_dependency_command_without_panic() {
         let root_id = PackageId::new_named("root", "0.1.0".parse().unwrap());
         let dep_id = PackageId::new_named("wasmer/static-web-server", "1.0.0".parse().unwrap());
+        let dep_alias = "wasmer/static-web-server";
 
         let root_info = PackageInfo {
             id: root_id.clone(),
@@ -737,6 +756,10 @@ mod tests {
             dependencies: Vec::new(),
             filesystem: Vec::new(),
         };
+        let root_container = test_container([(
+            "webserver",
+            command_for_atom("webserver", Some(dep_alias.to_string())),
+        )]);
 
         let mut graph = DiGraph::new();
         let root = graph.add_node(Node {
@@ -747,13 +770,18 @@ mod tests {
         let dep = graph.add_node(Node {
             id: dep_id.clone(),
             pkg: dep_info,
-            dist: None,
+            dist: Some(DistributionInfo {
+                webc: "http://localhost/wasmer-static-web-server.webc"
+                    .parse()
+                    .unwrap(),
+                webc_sha256: WebcHash::from([0; 32]),
+            }),
         });
         graph.add_edge(
             root,
             dep,
             Edge {
-                alias: "wasmer/static-web-server".to_string(),
+                alias: dep_alias.to_string(),
             },
         );
 
@@ -768,17 +796,55 @@ mod tests {
                 "webserver".to_string(),
                 ItemLocation {
                     name: "webserver".to_string(),
-                    package: root_id,
+                    package: root_id.clone(),
                 },
             )]),
             entrypoint: Some("webserver".to_string()),
             filesystem: Vec::new(),
         };
 
-        assert_eq!(
-            packages_needed_for_load(&pkg, &dependency_graph),
-            HashSet::from([dep_id])
+        let err = super::load_package_tree(
+            &root_container,
+            &TestLoader,
+            &Resolution {
+                package: pkg,
+                graph: dependency_graph,
+            },
+            false,
+        )
+        .await
+        .unwrap_err();
+        let message = format!("{err:#}");
+
+        assert!(message.contains("The \"webserver\" command in \"root@0.1.0\" references the \"wasmer/static-web-server\" dependency (wasmer/static-web-server@1.0.0), but that dependency is not loaded"));
+        assert!(message.contains("local command shadows a dependency command"));
+    }
+
+    fn command_for_atom(atom: &str, dependency: Option<String>) -> WebcCommand {
+        let mut annotations = IndexMap::new();
+        annotations.insert(
+            AtomAnnotation::KEY.to_string(),
+            Value::serialized(&AtomAnnotation::new(atom, dependency)).unwrap(),
         );
+
+        WebcCommand {
+            runner: WASI_RUNNER_URI.to_string(),
+            annotations,
+        }
+    }
+
+    fn test_container<'a>(commands: impl IntoIterator<Item = (&'a str, WebcCommand)>) -> Container {
+        let mut manifest = Manifest::default();
+
+        for (name, command) in commands {
+            manifest.commands.insert(name.to_string(), command);
+        }
+
+        let writer = Writer::default().write_manifest(&manifest).unwrap();
+        let writer = writer.write_atoms(BTreeMap::new()).unwrap();
+        let bytes = writer.finish(SignatureAlgorithm::None).unwrap();
+        let reader = OwnedReader::parse(bytes).unwrap();
+        Container::from(reader)
     }
 
     #[test]

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -109,9 +109,15 @@ fn commands(
         },
     ) in commands
     {
-        let webc = &containers[package];
+        let webc = containers.get(package).with_context(|| {
+            format!("Unable to find the \"{package}\" package for the \"{name}\" command")
+        })?;
         let manifest = webc.manifest();
-        let command_metadata = &manifest.commands[original_name];
+        let command_metadata = manifest.commands.get(original_name).with_context(|| {
+            format!(
+                "Unable to find the \"{original_name}\" command metadata in the \"{package}\" package"
+            )
+        })?;
 
         if let Some(cmd) =
             load_binary_command(package, name, command_metadata, containers, resolution)?
@@ -149,7 +155,9 @@ fn load_binary_command(
         }
     };
 
-    let package = &containers[package_id];
+    let package = containers
+        .get(package_id)
+        .with_context(|| format!("Unable to find the \"{package_id}\" package"))?;
 
     let (webc, resolved_package_id) = match dependency {
         Some(dep) => {
@@ -173,7 +181,13 @@ fn load_binary_command(
                 resolved_package_id=%id,
                 "command atom resolution: resolved dependency",
             );
-            (&containers[id], id)
+            let container = containers.get(id).with_context(|| {
+                format!(
+                    "Unable to find the \"{id}\" dependency for the \"{command_name}\" command in \"{package_id}\""
+                )
+            })?;
+
+            (container, id)
         }
         None => (package, package_id),
     };
@@ -307,18 +321,7 @@ async fn fetch_dependencies(
     pkg: &ResolvedPackage,
     graph: &DependencyGraph,
 ) -> Result<HashMap<PackageId, Container>, Error> {
-    let mut packages = HashSet::new();
-
-    for loc in pkg.commands.values() {
-        packages.insert(loc.package.clone());
-    }
-
-    for mapping in &pkg.filesystem {
-        packages.insert(mapping.package.clone());
-    }
-
-    // We don't need to download the root package
-    packages.remove(&pkg.root_package);
+    let packages = packages_needed_for_load(pkg, graph);
 
     let packages = packages.into_iter().filter_map(|id| {
         let crate::runtime::resolver::Node { pkg, dist, .. } = &graph[&id];
@@ -340,6 +343,29 @@ async fn fetch_dependencies(
         .await?;
 
     Ok(packages)
+}
+
+fn packages_needed_for_load(pkg: &ResolvedPackage, graph: &DependencyGraph) -> HashSet<PackageId> {
+    let mut packages = HashSet::new();
+
+    for loc in pkg.commands.values() {
+        packages.insert(loc.package.clone());
+
+        if let Some(owner) = graph.packages().get(&loc.package).copied() {
+            for edge in graph.graph().edges(owner) {
+                packages.insert(graph[edge.target()].id.clone());
+            }
+        }
+    }
+
+    for mapping in &pkg.filesystem {
+        packages.insert(mapping.package.clone());
+    }
+
+    // We don't need to download the root package
+    packages.remove(&pkg.root_package);
+
+    packages
 }
 
 /// How many bytes worth of files does a directory contain?
@@ -592,11 +618,12 @@ fn filesystem_v2(
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::{BTreeMap, HashMap},
+        collections::{BTreeMap, HashMap, HashSet},
         path::{Path, PathBuf},
     };
 
     use ciborium::value::Value;
+    use petgraph::graph::DiGraph;
     use virtual_fs::FileSystem;
     use wasmer_config::package::PackageId;
     use webc::{
@@ -613,7 +640,12 @@ mod tests {
         },
     };
 
-    use super::{ResolvedFileSystemMapping, ResolvedPackage, filesystem_v2};
+    use super::{
+        ResolvedFileSystemMapping, ResolvedPackage, filesystem_v2, packages_needed_for_load,
+    };
+    use crate::runtime::resolver::{
+        Command, DependencyGraph, Edge, ItemLocation, Node, PackageInfo,
+    };
 
     #[test]
     fn v2_filesystem_mapping_resolves_mount_paths() {
@@ -679,6 +711,73 @@ mod tests {
                 .metadata(Path::new("/public/index.html"))
                 .unwrap()
                 .is_file()
+        );
+    }
+
+    #[test]
+    fn command_owner_dependencies_are_fetched_when_dependency_command_is_shadowed() {
+        let root_id = PackageId::new_named("root", "0.1.0".parse().unwrap());
+        let dep_id = PackageId::new_named("wasmer/static-web-server", "1.0.0".parse().unwrap());
+
+        let root_info = PackageInfo {
+            id: root_id.clone(),
+            commands: vec![Command {
+                name: "webserver".to_string(),
+            }],
+            entrypoint: Some("webserver".to_string()),
+            dependencies: Vec::new(),
+            filesystem: Vec::new(),
+        };
+        let dep_info = PackageInfo {
+            id: dep_id.clone(),
+            commands: vec![Command {
+                name: "webserver".to_string(),
+            }],
+            entrypoint: Some("webserver".to_string()),
+            dependencies: Vec::new(),
+            filesystem: Vec::new(),
+        };
+
+        let mut graph = DiGraph::new();
+        let root = graph.add_node(Node {
+            id: root_id.clone(),
+            pkg: root_info,
+            dist: None,
+        });
+        let dep = graph.add_node(Node {
+            id: dep_id.clone(),
+            pkg: dep_info,
+            dist: None,
+        });
+        graph.add_edge(
+            root,
+            dep,
+            Edge {
+                alias: "wasmer/static-web-server".to_string(),
+            },
+        );
+
+        let dependency_graph = DependencyGraph::new(
+            root,
+            graph,
+            BTreeMap::from([(root_id.clone(), root), (dep_id.clone(), dep)]),
+        );
+        let pkg = ResolvedPackage {
+            root_package: root_id.clone(),
+            commands: BTreeMap::from([(
+                "webserver".to_string(),
+                ItemLocation {
+                    name: "webserver".to_string(),
+                    package: root_id,
+                },
+            )]),
+            entrypoint: Some("webserver".to_string()),
+            filesystem: Vec::new(),
+        };
+
+        assert_eq!(
+            packages_needed_for_load(&pkg, &dependency_graph),
+            HashSet::from([dep_id])
         );
     }
 

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -183,7 +183,7 @@ fn load_binary_command(
             );
             let container = containers.get(id).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "The \"{command_name}\" command in \"{package_id}\" shadows a entry/command of the \"{dep}\" dependency. Rename the local command."
+                    "The \"{command_name}\" command in \"{package_id}\" shadows an entry/command of the \"{dep}\" dependency. Rename the local command."
                 )
             })?;
 
@@ -816,8 +816,8 @@ mod tests {
         .unwrap_err();
         let message = format!("{err:#}");
 
-        assert!(message.contains("The \"webserver\" command in \"root@0.1.0\" references the \"wasmer/static-web-server\" dependency (wasmer/static-web-server@1.0.0), but that dependency is not loaded"));
-        assert!(message.contains("local command shadows a dependency command"));
+        assert!(message.contains("shadows an entry/command"));
+        assert!(message.contains("Rename the local command"));
     }
 
     fn command_for_atom(atom: &str, dependency: Option<String>) -> WebcCommand {

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -953,7 +953,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "TODO: Re-order the way commands are resolved"]
     async fn commands_in_root_shadow_their_dependencies() {
         let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
         let dep_id = PackageId::new_named("dep", "1.0.0".parse().unwrap());
@@ -986,7 +985,7 @@ mod tests {
                         package: builder.get(&root_id).package_id(),
                      },
                 },
-                entrypoint: None,
+                entrypoint: Some("command".to_string()),
                 filesystem: Vec::new(),
             }
         );


### PR DESCRIPTION
# Description
When a package defines a command whose name matches a command exposed by one of its dependencies, Wasmer can resolve the root command correctly but fail later while loading the package tree. In that case, the dependency package may not be fetched even though the root command’s atom annotation points into that dependency, causing the CLI to panic with a missing map entry instead of returning a normal error.

Reproduce with:
```
[package]
…
entrypoint = "webserver"

[dependencies]
"wasmer/static-web-server" = "^1"

[[command]]
name = "webserver"
module = "wasmer/static-web-server:webserver"
runner = "https://webc.org/runner/wasi"
```

Run:
`wasmer run .`

# Changes
- Updated `load_binary_command` to return user friendly error when command resolving fails due to shadowing

- Replaced unchecked map indexing with contextual errors to avoid panics

- Added a regression test for the dependency command shadowing

- Re-enabled and updated the existing resolver test for shadowing 
