### PR TITLE
CI: simplify and unify job names

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -359,7 +359,7 @@ jobs:
       matrix:
         build-what:
           - key: wast-tests
-            build-cmd: "make test-stage-0-wast"
+            build-cmd: "make test-wast"
             name: "WAST tests"
           - key: capi
             build-cmd: "make build-capi && make package-capi"
@@ -631,7 +631,7 @@ jobs:
       - name: Test C-API integration
         shell: bash
         if: ${{ matrix.build-what.key == 'capi' && !(matrix.metadata.build == 'linux-musl' || matrix.metadata.build == 'windows-gnu') }}
-        run: export WASMER_DIR=`pwd`/package && make test-stage-7-capi-integration-tests
+        run: export WASMER_DIR=`pwd`/package && make test-capi-integration-tests
         env:
           TARGET: ${{ matrix.metadata.target }}
           TARGET_DIR: target/${{ matrix.metadata.target }}/release
@@ -660,18 +660,14 @@ jobs:
         skip_macos:
           - ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'macos') }}
         stage:
-          - description: "WAST (all comp.)"
-            make: "test-stage-0-wast"
-          - description: "Packages - std"
-            make: "test-stage-1-test-all"
-          - description: "Cranelift - no-std"
-            make: "test-stage-2-test-compiler-cranelift-nostd"
-          - description: "Singlepass - no-std"
-            make: "test-stage-3-test-compiler-singlepass-nostd"
+          - description: "All tests"
+            make: "test-all"
+          - description: "Compilers (std only)"
+            make: "check-compilers-only-std"
           - description: "Wasmer-cli"
-            make: "test-stage-4-wasmer-cli"
+            make: "test-wasmer-cli"
           - description: "Examples"
-            make: "test-stage-5-test-examples"
+            make: "test-examples"
           - description: "CLI integ. tests"
             make: test-integration-cli-ci
         metadata:
@@ -800,7 +796,7 @@ jobs:
           path: |
             ~/.cargo/*
             ./target/*
-          key: cache-v${{ env.S3_CACHE_VERSION }}-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-wasmer-make-test-stage-${{ matrix.stage.make }}-${{ matrix.metadata.build }}
+          key: cache-v${{ env.S3_CACHE_VERSION }}-${{ github.repository }}-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-wasmer-test-${{ matrix.stage.make }}-${{ matrix.metadata.build }}
           aws-s3-bucket: wasmer-rust-artifacts-cache
           aws-access-key-id: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_TOKEN }}
           aws-secret-access-key: ${{ secrets.CLOUDFLARE_ARTIFACTS_CACHE_ACCESS_KEY }}

--- a/.github/workflows/wasmer-config.yaml
+++ b/.github/workflows/wasmer-config.yaml
@@ -12,28 +12,6 @@ concurrency:
 env:
   DEFAULT_CRATE_NAME: wasmer_toml
 jobs:
-  check:
-    name: Compile and Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: true
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-      - name: Setup Rust
-        uses: dsherret/rust-toolchain-file@v1
-      - name: Install Nextest
-        uses: taiki-e/install-action@nextest
-      - name: Type Checking
-        run: |
-          cd lib/config && cargo check --verbose --locked
-      - name: Build
-        run: |
-          cd lib/config && cargo build --verbose --locked
-      - name: Test
-        run: |
-          cd lib/config && cargo nextest run --verbose --locked
   lints:
     name: Linting and Formatting
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -550,39 +550,32 @@ build-capi-headless-ios:
 #
 #####
 
-# test compilers (intentionally not using nextest as it runs tests in separate processes)
-test-stage-0-wast:
+# intentionally not using nextest as it runs tests in separate processes
+test-wast:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release $(compiler_features) --locked
-
-# test packages
-test-stage-1-test-all:
-	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
+test-all:
+	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
 	$(CARGO_BINARY) test --doc $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked
-test-stage-2-test-compiler-cranelift-nostd:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-cranelift/Cargo.toml --release --no-default-features --features=std --locked
-test-stage-3-test-compiler-singlepass-nostd:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-singlepass/Cargo.toml --release --no-default-features --features=std --locked
-test-stage-4-wasmer-cli:
+test-compilers-only-std:
+	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-cranelift/Cargo.toml --no-default-features --features=std --locked && \
+	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-singlepass/Cargo.toml --no-default-features --features=std --locked
+test-wasmer-cli:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/virtual-fs/Cargo.toml --release --locked && \
 $(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --release --locked
-
 # test examples
-test-stage-5-test-examples:
+test-examples:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) $(compiler_features) --features wasi --examples --locked
-test-stage-6-test-examples-release:
+test-examples-release:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release $(compiler_features) --features wasi --examples --locked
-
-test-stage-7-capi-integration-tests:
+test-capi-integration-tests:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --package wasmer-c-api-test-runner --locked && \
-$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --package wasmer-capi-examples-runner --locked
+	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --package wasmer-capi-examples-runner --locked
 
-test: test-compilers test-packages test-examples
+test: test-packages test-examples
 
-test-compilers: test-stage-0-wast
+test-packages: test-all test-test-compilers-only-std test-wasmer-cli
 
-test-packages: test-stage-1-test-all test-stage-2-test-compiler-cranelift-nostd test-stage-3-test-compiler-singlepass-nostd test-stage-4-wasmer-cli
-
-test-examples: test-stage-5-test-examples test-stage-6-test-examples-release
+test-examples: test-examples test-release
 
 
 test-v8: test-v8-api

--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ build-capi-headless-ios:
 test-wast:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release $(compiler_features) --locked
 test-all:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
+	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
 	$(CARGO_BINARY) test --doc $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked
 check-compilers-only-std:
 	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-cranelift/Cargo.toml --no-default-features --features=std --locked && \

--- a/Makefile
+++ b/Makefile
@@ -556,26 +556,22 @@ test-wast:
 test-all:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
 	$(CARGO_BINARY) test --doc $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked
-test-compilers-only-std:
+check-compilers-only-std:
 	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-cranelift/Cargo.toml --no-default-features --features=std --locked && \
 	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-singlepass/Cargo.toml --no-default-features --features=std --locked
 test-wasmer-cli:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/virtual-fs/Cargo.toml --release --locked && \
-$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --release --locked
+	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --manifest-path lib/cli/Cargo.toml $(compiler_features) --release --locked
 # test examples
 test-examples:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) $(compiler_features) --features wasi --examples --locked
-test-examples-release:
-	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release $(compiler_features) --features wasi --examples --locked
 test-capi-integration-tests:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --package wasmer-c-api-test-runner --locked && \
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release --package wasmer-capi-examples-runner --locked
 
-test: test-packages test-examples
+test: test-all test-examples
 
-test-packages: test-all test-test-compilers-only-std test-wasmer-cli
-
-test-examples: test-examples test-release
+test-packages: test-all check-compilers-only-std test-wasmer-cli
 
 
 test-v8: test-v8-api


### PR DESCRIPTION
The PR simplifies the CI jobs in the following manner:
- extra `lib/config` checks dropped (part of `All tests`)
- `Packages` renamed to `All tests` and `WAST` got dropped as they are effectively part of `All tests`
- the `cranelift/singlepass` `std` tests used to have a confusing name - rename to `only-std` and unified under one job run
- the `stage-X` Makefile targets dropped - don't see a reason for that