### PR TITLE
Revert "ci: disable flaky tests"

### DIFF
--- a/lib/wasix/tests/wasm_tests/exit_tests.rs
+++ b/lib/wasix/tests/wasm_tests/exit_tests.rs
@@ -2,7 +2,6 @@ wasm_test!(test_exit_zero, "exit-zero");
 wasm_test!(test_exit_nonzero, "exit-nonzero", should_fail);
 wasm_test!(test_exit_zero_in_thread, "exit-zero-in-thread");
 wasm_test!(
-    #[ignore = "flaky test (#6538)"]
     test_exit_nonzero_in_thread,
     "exit-nonzero-in-thread",
     should_fail
@@ -18,7 +17,6 @@ wasm_test!(
     "exit-zero-in-closure-call-thread"
 );
 wasm_test!(
-    #[ignore = "flaky test (#6538)"]
     test_exit_nonzero_in_closure_call_thread,
     "exit-nonzero-in-closure-call-thread",
     should_fail
@@ -28,7 +26,6 @@ wasm_test!(
     "exit-zero-in-call-dynamic-thread"
 );
 wasm_test!(
-    #[ignore = "flaky test (#6538)"]
     test_exit_nonzero_in_call_dynamic_thread,
     "exit-nonzero-in-call-dynamic-thread",
     should_fail
@@ -36,7 +33,6 @@ wasm_test!(
 
 const SIGABRT_EXIT_CODE: i32 = 134;
 wasm_test!(
-    #[ignore = "flaky test (#6538)"]
     test_abort_in_thread,
     "abort-in-thread",
     exit_code = SIGABRT_EXIT_CODE


### PR DESCRIPTION
I believe the issue was already resolved when we merged #6552, as that introduced a lock that prevents these tests running in parallel, which was the cause of the flakiness. This also resolves #6538.