### PR TITLE
fix(wasix): add missing return

### DIFF
--- a/lib/wasix/src/bin_factory/mod.rs
+++ b/lib/wasix/src/bin_factory/mod.rs
@@ -170,7 +170,7 @@ impl BinFactory {
         {
             let cache = self.local.read().unwrap();
             if let Some(data) = cache.get(&name) {
-                data.clone().map(Executable::BinaryPackage);
+                return data.clone().map(Executable::BinaryPackage);
             }
         }
 


### PR DESCRIPTION
# Description

`BinFactory::get_executable` was missing a `return` keyword, making an early return silently do nothing instead.

- added `return`
- added `#![deny(unused_must_use)]` to hopefully make the linter catch this in the future
- added `let _` discards for intended violations of `unused_must_use`