### PR TITLE
fix(wasix): Fix behaviour of eventfd polling to match POSIX

### DIFF
--- a/lib/wasix/src/fs/notification.rs
+++ b/lib/wasix/src/fs/notification.rs
@@ -12,8 +12,6 @@ struct NotificationState {
     /// Used for event notifications by the user application or operating system
     /// (positive number means there are events waiting to be processed)
     counter: u64,
-    /// Counter used to prevent duplicate notification events
-    last_poll: u64,
     /// Flag that indicates if this is operating
     is_semaphore: bool,
     /// All the registered wakers
@@ -32,7 +30,6 @@ impl NotificationState {
     }
 
     fn wake_all(&mut self) {
-        self.last_poll = u64::MAX;
         while let Some(waker) = self.wakers.pop_front() {
             waker.wake();
         }
@@ -75,7 +72,6 @@ impl NotificationInner {
         Self {
             state: Mutex::new(NotificationState {
                 counter: initial_val,
-                last_poll: u64::MAX,
                 is_semaphore,
                 wakers: Default::default(),
                 interest_handler: None,
@@ -86,8 +82,7 @@ impl NotificationInner {
         let mut state = self.state.lock().unwrap();
         state.add_waker(waker);
 
-        if state.last_poll != state.counter {
-            state.last_poll = state.counter;
+        if state.counter > 0 {
             Poll::Ready(state.counter as usize)
         } else {
             Poll::Pending
@@ -118,7 +113,7 @@ impl NotificationInner {
 
     pub fn reset(&self) {
         let mut state = self.state.lock().unwrap();
-        state.last_poll = u64::MAX;
+        state.counter = 0;
     }
 
     pub fn set_interest_handler(&self, handler: Box<dyn InterestHandler>) {

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-event-readable/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-event-readable/main.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <poll.h>
+#include <stdint.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+/* Poll the fd with timeout=0 (non-blocking). Returns the revents mask, or 0 if
+   poll() returned no events. Fails the test if poll() itself errors. */
+static short poll_events(int fd) {
+  struct pollfd pfd = {.fd = fd, .events = POLLIN};
+  int poll_result = poll(&pfd, 1, 0);
+
+  assert(poll_result == 0 || poll_result == 1);
+
+  return poll_result == 1 ? pfd.revents : 0;
+}
+
+int main(void) {
+  int efd = eventfd(0, 0);
+  assert(efd >= 0);
+
+  /* counter=0: must not be readable and must not look like a hangup */
+  assert(poll_events(efd) == 0);
+
+  /* write 1 -> counter becomes 1: must be readable */
+  uint64_t val = 1;
+  assert(write(efd, &val, sizeof(val)) == sizeof(val));
+  assert(poll_events(efd) & POLLIN);
+
+  /* still readable without an intervening read */
+  assert(poll_events(efd) & POLLIN);
+
+  /* read drains the counter, must not be readable afterwards */
+  uint64_t result;
+  assert(read(efd, &result, sizeof(result)) == sizeof(result));
+  assert(result == 1);
+  assert(poll_events(efd) == 0);
+
+  close(efd);
+}


### PR DESCRIPTION
# Description

`NotificationInner::poll()` gated wakeups with an edge-triggered check (`last_poll != counter`), which had two bugs:

- **Spurious `Ready(0)` on first poll.** A new eventfd starts with `counter=0` and `last_poll=u64::MAX`, so the check fires immediately and the caller sees `POLLIN|POLLHUP`. A subsequent `read()` then blocks on a zero counter and hangs.
- **Missed wakeups.** After a write, the first `poll()` fires and sets `last_poll = counter`. If a second `poll()` runs before any `read()`, it returns `Pending`. An event loop that polls twice per iteration without reading silently drops the event.

Per [eventfd(2)](https://man7.org/linux/man-pages/man2/eventfd.2.html#:~:text=%E2%80%A2%20The%20file%20descriptor%20is%20readable%20%28the%20select%282%29%20readfds%20argument%3B%20the%20poll%282%29%20POLLIN%20flag%29%20if%20the%20counter%20has%20a%20value%20greater%20than%200%2E), the fd is readable iff the counter is greater than 0.

## Changes
- `notification.rs`: drop `last_poll` and check `counter > 0` directly.
- `fd-event-readable`: C test covering both failure modes above. Run with:
  ```
  cargo test -p wasmer-wasix --features sys wasm_tests::fd_tests::test_fd_event_readable
  ```