### PR TITLE
fix(wasix): handle pipe-backed stdio in flush, fd_sync, and poll

### DIFF
--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -404,22 +404,6 @@ impl InodeValFileReadGuard {
     }
 }
 
-impl InodeValFileReadGuard {
-    pub fn into_poll_guard(
-        self,
-        fd: u32,
-        peb: PollEventSet,
-        subscription: Subscription,
-    ) -> InodeValFilePollGuard {
-        InodeValFilePollGuard {
-            fd,
-            peb,
-            subscription,
-            mode: InodeValFilePollGuardMode::File(self.guard.into_inner()),
-        }
-    }
-}
-
 impl Deref for InodeValFileReadGuard {
     type Target = dyn VirtualFile + Send + Sync + 'static;
     fn deref(&self) -> &Self::Target {

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -60,6 +60,21 @@ use crate::{ALL_RIGHTS, bin_factory::BinaryPackage, state::PreopenedDir};
 // use a Linux-like 64k ceiling until WASIX models per-process fd limits.
 pub(crate) const MAX_FD: WasiFd = (64 * 1024) - 1;
 
+pub(crate) struct FlushPoller {
+    pub(crate) file: Arc<RwLock<Box<dyn VirtualFile + Send + Sync>>>,
+}
+
+impl Future for FlushPoller {
+    type Output = Result<(), Errno>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut file = self.file.write().unwrap();
+        Pin::new(file.as_mut())
+            .poll_flush(cx)
+            .map_err(|_| Errno::Io)
+    }
+}
+
 /// the fd value of the virtual root
 ///
 /// Used for interacting with the file system when it has no
@@ -1698,19 +1713,6 @@ impl WasiFs {
                     }
                 };
                 drop(fd);
-
-                struct FlushPoller {
-                    file: Arc<RwLock<Box<dyn VirtualFile + Send + Sync>>>,
-                }
-                impl Future for FlushPoller {
-                    type Output = Result<(), Errno>;
-                    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                        let mut file = self.file.write().unwrap();
-                        Pin::new(file.as_mut())
-                            .poll_flush(cx)
-                            .map_err(|_| Errno::Io)
-                    }
-                }
                 FlushPoller { file }.await?;
             }
         }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -331,19 +331,11 @@ impl WasiInodes {
         }
     }
 
-    /// Get the `VirtualFile` object at stdout
-    pub(crate) fn stdout(fd_map: &RwLock<FdList>) -> Result<InodeValFileReadGuard, FsError> {
-        Self::std_dev_get(fd_map, __WASI_STDOUT_FILENO)
-    }
     /// Get the `VirtualFile` object at stdout mutably
     pub(crate) fn stdout_mut(fd_map: &RwLock<FdList>) -> Result<InodeValFileWriteGuard, FsError> {
         Self::std_dev_get_mut(fd_map, __WASI_STDOUT_FILENO)
     }
 
-    /// Get the `VirtualFile` object at stderr
-    pub(crate) fn stderr(fd_map: &RwLock<FdList>) -> Result<InodeValFileReadGuard, FsError> {
-        Self::std_dev_get(fd_map, __WASI_STDERR_FILENO)
-    }
     /// Get the `VirtualFile` object at stderr mutably
     pub(crate) fn stderr_mut(fd_map: &RwLock<FdList>) -> Result<InodeValFileWriteGuard, FsError> {
         Self::std_dev_get_mut(fd_map, __WASI_STDERR_FILENO)

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -31,7 +31,6 @@ use crate::{
 use futures::{Future, future::BoxFuture};
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 use tracing::{debug, trace};
 use virtual_fs::{
     ArcFileSystem, FileSystem, FsError, MountFileSystem, OpenOptions, OverlayFileSystem,
@@ -52,7 +51,6 @@ pub(crate) use self::inode_guard::{
     InodeValFileReadGuard, InodeValFileWriteGuard, WasiStateFileGuard,
 };
 pub use self::notification::NotificationInner;
-use crate::syscalls::map_io_err;
 use crate::{ALL_RIGHTS, bin_factory::BinaryPackage, state::PreopenedDir};
 
 // POSIX bounds descriptor numbers by the process fd limit (`OPEN_MAX`,
@@ -1680,43 +1678,29 @@ impl WasiFs {
         }
     }
 
-    #[allow(clippy::await_holding_lock)]
     pub async fn flush(&self, fd: WasiFd) -> Result<(), Errno> {
-        match fd {
-            __WASI_STDIN_FILENO => (),
-            __WASI_STDOUT_FILENO => {
-                let mut file =
-                    WasiInodes::stdout_mut(&self.fd_map).map_err(fs_error_into_wasi_err)?;
-                file.flush().await.map_err(map_io_err)?
-            }
-            __WASI_STDERR_FILENO => {
-                let mut file =
-                    WasiInodes::stderr_mut(&self.fd_map).map_err(fs_error_into_wasi_err)?;
-                file.flush().await.map_err(map_io_err)?
-            }
-            _ => {
-                let fd = self.get_fd(fd)?;
-                if !fd.inner.rights.contains(Rights::FD_DATASYNC) {
-                    return Err(Errno::Access);
-                }
-
-                let file = {
-                    let guard = fd.inode.read();
-                    match guard.deref() {
-                        Kind::File {
-                            handle: Some(file), ..
-                        } => file.clone(),
-                        // TODO: verify this behavior
-                        Kind::Dir { .. } => return Err(Errno::Isdir),
-                        Kind::Buffer { .. } => return Ok(()),
-                        _ => return Err(Errno::Io),
-                    }
-                };
-                drop(fd);
-                FlushPoller { file }.await?;
-            }
+        let fd_entry = self.get_fd(fd)?;
+        if !fd_entry.inner.rights.contains(Rights::FD_DATASYNC) {
+            return Err(Errno::Access);
         }
-        Ok(())
+
+        let file = {
+            let guard = fd_entry.inode.read();
+            match guard.deref() {
+                Kind::File {
+                    handle: Some(file), ..
+                } => file.clone(),
+                // TODO: verify this behavior
+                Kind::Dir { .. } => return Err(Errno::Isdir),
+                Kind::Buffer { .. } => return Ok(()),
+                // Linux fsync(2) returns EINVAL for fds "bound to a special
+                // file (e.g., a pipe, FIFO, or socket) which does not support
+                // synchronization.", mirror that behaviour
+                _ => return Err(Errno::Inval),
+            }
+        };
+        drop(fd_entry);
+        FlushPoller { file }.await
     }
 
     /// Creates an inode and inserts it given a Kind and some extra data

--- a/lib/wasix/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_close.rs
@@ -1,22 +1,6 @@
 use super::*;
+use crate::fs::FlushPoller;
 use crate::syscalls::*;
-use std::{future::Future, pin::Pin, sync::Arc, task::Context, task::Poll};
-use virtual_fs::VirtualFile;
-
-struct FlushPoller {
-    file: Arc<std::sync::RwLock<Box<dyn VirtualFile + Send + Sync>>>,
-}
-
-impl Future for FlushPoller {
-    type Output = Result<(), Errno>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut file = self.file.write().unwrap();
-        Pin::new(file.as_mut())
-            .poll_flush(cx)
-            .map_err(|_| Errno::Io)
-    }
-}
 
 /// ### `fd_close()`
 /// Close an open file descriptor

--- a/lib/wasix/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_close.rs
@@ -31,7 +31,12 @@ pub fn fd_close(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errn
     // Keep stdio behavior unchanged: flush before close.
     if fd <= __WASI_STDERR_FILENO {
         match __asyncify_light(env, None, state.fs.flush(fd))? {
-            Ok(_) | Err(Errno::Isdir) | Err(Errno::Io) | Err(Errno::Access) => {}
+            Ok(_)
+            | Err(Errno::Isdir)
+            | Err(Errno::Io)
+            | Err(Errno::Access)
+            // EINVAL is returned by e.g. pipe-backed stdio and is safe to ignore.
+            | Err(Errno::Inval) => {}
             Err(e) => {
                 return Ok(e);
             }

--- a/lib/wasix/src/syscalls/wasi/fd_renumber.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_renumber.rs
@@ -1,23 +1,6 @@
 use super::*;
-use crate::fs::MAX_FD;
+use crate::fs::{FlushPoller, MAX_FD};
 use crate::syscalls::*;
-use std::{future::Future, pin::Pin, sync::Arc, task::Context, task::Poll};
-use virtual_fs::VirtualFile;
-
-struct FlushPoller {
-    file: Arc<std::sync::RwLock<Box<dyn VirtualFile + Send + Sync>>>,
-}
-
-impl Future for FlushPoller {
-    type Output = Result<(), Errno>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut file = self.file.write().unwrap();
-        Pin::new(file.as_mut())
-            .poll_flush(cx)
-            .map_err(|_| Errno::Io)
-    }
-}
 
 /// ### `fd_renumber()`
 /// Atomically copy file descriptor

--- a/lib/wasix/src/syscalls/wasi/fd_sync.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_sync.rs
@@ -54,6 +54,9 @@ pub fn fd_sync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno
                 }
             }
             Kind::Root { .. } | Kind::Dir { .. } => return Ok(Errno::Isdir),
+            // Linux fsync(2) returns EINVAL for fds "bound to a special file
+            // (e.g., a pipe, FIFO, or socket) which does not support
+            // synchronization.", mirror that behaviour
             Kind::Buffer { .. }
             | Kind::Symlink { .. }
             | Kind::Socket { .. }

--- a/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
+++ b/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
@@ -3,7 +3,6 @@ use wasmer_wasix_types::wasi::{Subclockflags, SubscriptionClock, Userdata};
 
 use super::*;
 use crate::{
-    WasiInodes,
     fs::{InodeValFilePollGuard, InodeValFilePollGuardJoin},
     state::PollEventSet,
     syscalls::*,
@@ -175,40 +174,22 @@ pub(crate) fn poll_fd_guard(
     fd: WasiFd,
     s: Subscription,
 ) -> Result<InodeValFilePollGuard, Errno> {
-    Ok(match fd {
-        __WASI_STDERR_FILENO => WasiInodes::stderr(&state.fs.fd_map)
-            .map(|g| g.into_poll_guard(fd, peb, s))
-            .map_err(fs_error_into_wasi_err)?,
-        __WASI_STDOUT_FILENO => WasiInodes::stdout(&state.fs.fd_map)
-            .map(|g| g.into_poll_guard(fd, peb, s))
-            .map_err(fs_error_into_wasi_err)?,
-        _ => {
-            let fd_entry = state.fs.get_fd(fd)?;
-            let requires_access = match s.type_ {
-                Eventtype::FdRead => Rights::FD_READ,
-                Eventtype::FdWrite => Rights::FD_WRITE,
-                _ => Rights::empty(),
-            };
+    let fd_entry = state.fs.get_fd(fd)?;
+    let requires_access = match s.type_ {
+        Eventtype::FdRead => Rights::FD_READ,
+        Eventtype::FdWrite => Rights::FD_WRITE,
+        _ => Rights::empty(),
+    };
 
-            if !(fd_entry.inner.rights.contains(Rights::POLL_FD_READWRITE)
-                && fd_entry.inner.rights.contains(requires_access))
-            {
-                return Err(Errno::Access);
-            }
-            let inode = fd_entry.inode;
+    if !(fd_entry.inner.rights.contains(Rights::POLL_FD_READWRITE)
+        && fd_entry.inner.rights.contains(requires_access))
+    {
+        return Err(Errno::Access);
+    }
+    let inode = fd_entry.inode;
 
-            {
-                let guard = inode.read();
-                if let Some(guard) =
-                    crate::fs::InodeValFilePollGuard::new(fd, peb, s, guard.deref())
-                {
-                    guard
-                } else {
-                    return Err(Errno::Badf);
-                }
-            }
-        }
-    })
+    let guard = inode.read();
+    crate::fs::InodeValFilePollGuard::new(fd, peb, s, guard.deref()).ok_or(Errno::Badf)
 }
 
 /// ### `poll_oneoff()`

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-close-pipe-stdio/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-close-pipe-stdio/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <errno.h>
+#include <unistd.h>
+
+// close should always succeed on a valid fd
+// Guards against a regression where previously EINVAL would be incorrectly
+// propagated from an internal call to flush
+static void assert_close_ok_after_dup2(int stdio_fd) {
+  int fds[2];
+  assert(pipe(fds) == 0);
+
+  assert(dup2(fds[1], stdio_fd) == stdio_fd);
+  close(fds[1]);
+
+  errno = 0;
+  int ret = close(stdio_fd);
+  assert(ret == 0);
+
+  close(fds[0]);
+}
+
+int main(void) {
+  assert_close_ok_after_dup2(STDOUT_FILENO);
+  assert_close_ok_after_dup2(STDERR_FILENO);
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-datasync-pipe/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-datasync-pipe/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <errno.h>
+#include <unistd.h>
+
+int main(void) {
+  int fds[2];
+  assert(pipe(fds) == 0);
+
+  // Flushing pipes should fail with EINVAL as it does on Linux
+  // Regression test for this previously returning EIO
+  errno = 0;
+  assert(fdatasync(fds[0]) == -1);
+  assert(errno == EINVAL);
+
+  errno = 0;
+  assert(fdatasync(fds[1]) == -1);
+  assert(errno == EINVAL);
+
+  // Similarly, this should also fail with EINVAL
+  // Regression test for this previously returning success
+  // from special handling of stdin
+  assert(dup2(fds[0], STDIN_FILENO) == STDIN_FILENO);
+  errno = 0;
+  assert(fdatasync(STDIN_FILENO) == -1);
+  assert(errno == EINVAL);
+
+  close(fds[0]);
+  close(fds[1]);
+  close(STDIN_FILENO);
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-poll-pipe-stdio/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-poll-pipe-stdio/main.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+#include <errno.h>
+#include <poll.h>
+#include <unistd.h>
+
+// Regression test for a bug where special handling of stdio was causing
+// redirected stdio to error out on basic operations
+static void assert_pollout_ready_after_dup2(int stdio_fd) {
+  int fds[2];
+  assert(pipe(fds) == 0);
+
+  assert(dup2(fds[1], stdio_fd) == stdio_fd);
+  close(fds[1]);
+
+  struct pollfd pfd = {.fd = stdio_fd, .events = POLLOUT, .revents = 0};
+  errno = 0;
+  int ready = poll(&pfd, 1, 10);
+  assert(ready == 1);
+  assert(pfd.revents & POLLOUT);
+
+  close(fds[0]);
+  close(stdio_fd);
+}
+
+int main(void) {
+  assert_pollout_ready_after_dup2(STDOUT_FILENO);
+  assert_pollout_ready_after_dup2(STDERR_FILENO);
+  return 0;
+}


### PR DESCRIPTION

# Description

After `dup2(pipe_write_end, STDOUT_FILENO)`, any `fsync` or `fdatasync` on stdout would fail.

The implementations all special-cased stdio, which (as far as I can tell) originated as a workaround for a bug that no longer exists, thus making the special case redundant. This special handling only handled files, so non-file stdio would always fail with `FsError::NotAFile`.

  Changes:

  - `WasiFs::flush()`: remove stdout/stderr special case; unify all fds through get_fd + kind-match; add pipe/socket as a no-op
  - `fd_sync`: pipes/sockets return `Errno::Success` instead of `Errno::Inval` since syncing them is a no-op
  - `poll_fd_guard`: remove stdout/stderr special case; `InodeValFilePollGuard::new` already handles `Kind::PipeTx`/`PipeRx`/`DuplexPipe`, it was just never reached for stdio
  - `FlushPoller`: deduplicate from three identical local definitions into one `pub(crate) struct` in `fs/mod.rs`.
  - Add regression test: dup2 write-end of pipe onto stdout, then fsync and assert success.
