### PR TITLE
fix(wasix): Fix race conditions in {fd,path}_filestat_get

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -1497,6 +1497,16 @@ impl WasiFs {
         self.get_inode_at_path_inner(inodes, base_inode, path, 0, follow_symlinks)
     }
 
+    pub(crate) fn get_inode_at_path_from_inode(
+        &self,
+        inodes: &WasiInodes,
+        base_inode: InodeGuard,
+        path: &str,
+        follow_symlinks: bool,
+    ) -> Result<InodeGuard, Errno> {
+        self.get_inode_at_path_inner(inodes, base_inode, path, 0, follow_symlinks)
+    }
+
     /// Returns the parent Dir or Root that the file at a given path is in and the file name
     /// stripped off
     pub(crate) fn get_parent_inode_at_path(

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1087,6 +1087,10 @@ impl WasiEnv {
         (state, inodes)
     }
 
+    pub(crate) fn get_wasi_state(&self) -> &WasiState {
+        self.state.deref()
+    }
+
     pub fn use_package(&self, pkg: &BinaryPackage) -> Result<(), WasiStateCreationError> {
         block_on(self.use_package_async(pkg))
     }

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
@@ -49,13 +49,14 @@ pub(crate) fn fd_filestat_get_internal(
     fd: WasiFd,
 ) -> Result<Filestat, Errno> {
     let env = ctx.data();
-    let (_, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let (_, state, _) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
     let fd_entry = state.fs.get_fd(fd)?;
     if !fd_entry.inner.rights.contains(Rights::FD_FILESTAT_GET) {
         return Err(Errno::Access);
     }
 
-    state.fs.filestat_fd(fd)
+    let guard = fd_entry.inode.stat.read().unwrap();
+    Ok(*guard.deref())
 }
 
 /// ### `fd_filestat_get_old()`

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
@@ -49,7 +49,7 @@ pub(crate) fn fd_filestat_get_internal(
     fd: WasiFd,
 ) -> Result<Filestat, Errno> {
     let env = ctx.data();
-    let (_, state, _) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let state = env.get_wasi_state();
     let fd_entry = state.fs.get_fd(fd)?;
     if !fd_entry.inner.rights.contains(Rights::FD_FILESTAT_GET) {
         return Err(Errno::Access);

--- a/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
@@ -72,9 +72,9 @@ pub(crate) fn path_filestat_get_internal(
     if !root_dir.inner.rights.contains(Rights::PATH_FILESTAT_GET) {
         return Err(Errno::Access);
     }
-    let file_inode = state.fs.get_inode_at_path(
+    let file_inode = state.fs.get_inode_at_path_from_inode(
         inodes,
-        fd,
+        root_dir.inode,
         path_string,
         flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
     )?;


### PR DESCRIPTION
Previously the fd was re-acccessed at a later point in the syscall,
leading to potential race conditions.

This resulted in real bugs in applications with parallelism.

Closes #6582 
