### PR TITLE
chore: fix duplicated words in wasix and vm doc comments

### DIFF
--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -497,7 +497,7 @@ impl WasiProcess {
         self.inner.0.lock().unwrap()
     }
 
-    /// Creates a a thread and returns it
+    /// Creates a thread and returns it
     pub fn new_thread(
         &self,
         layout: WasiMemoryLayout,
@@ -520,7 +520,7 @@ impl WasiProcess {
         self.new_thread_with_id(layout, start, tid)
     }
 
-    /// Creates a a thread and returns it
+    /// Creates a thread and returns it
     pub fn new_thread_with_id(
         &self,
         layout: WasiMemoryLayout,

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -354,7 +354,7 @@ where
 
 pub type DynRuntime = dyn Runtime + Send + Sync;
 
-/// Load a a Webassembly module, trying to use a pre-compiled version if possible.
+/// Load a Webassembly module, trying to use a pre-compiled version if possible.
 ///
 // This function exists to provide a reusable baseline implementation for
 // implementing [`Runtime::load_module`], so custom logic can be added on top.


### PR DESCRIPTION
Three small comment-only typos: doubled `a a` in `lib/wasix/src/os/task/process.rs` (two lines) and `lib/wasix/src/runtime/mod.rs`. No functional change.