### PR TITLE
Fix `isize` overflow in `AArch64` PC-relative relocation range assertions

### DIFF
--- a/lib/compiler/src/engine/link.rs
+++ b/lib/compiler/src/engine/link.rs
@@ -213,7 +213,7 @@ fn apply_relocation(
         RelocationKind::Aarch64AdrPrelPgHi21 => unsafe {
             let (reloc_address, delta) = r.for_address(body, target_func_address as u64);
 
-            let delta = delta as isize;
+            let delta = delta as i64;
             assert!(
                 ((-1 << 32)..(1 << 32)).contains(&delta),
                 "can't generate page-relative relocation with ±4GB `adrp` instruction"
@@ -231,7 +231,7 @@ fn apply_relocation(
         RelocationKind::Aarch64AdrPrelLo21 => unsafe {
             let (reloc_address, delta) = r.for_address(body, target_func_address as u64);
 
-            let delta = delta as isize;
+            let delta = delta as i64;
             assert!(
                 ((-1 << 20)..(1 << 20)).contains(&delta),
                 "can't generate an ADR_PREL_LO21 relocation with an immediate larger than 20 bits"


### PR DESCRIPTION
# Description

The two range assertions:
```rust
((-1 << 32)..(1 << 32)).contains(&delta)  // Aarch64AdrPrelPgHi21
((-1 << 20)..(1 << 20)).contains(&delta)  // Aarch64AdrPrelLo21
```

cast the `u64` delta from `for_address()` to `isize` before the check. On a 32-bit host, `isize` is 32 bits, so `1 << 32` overflows and panics in debug builds. This is reproducible when cross-compiling `wasmer` for `AArch64` from a 32-bit host.

Fix: cast to `i64`, which is the correct type for a signed 64-bit offset regardless of the host pointer width.