### PR TITLE
build(v8): bump V8 backend to 15.0.1

### DIFF
--- a/.github/workflows/android-v8-check.yml
+++ b/.github/workflows/android-v8-check.yml
@@ -1,0 +1,97 @@
+name: Android V8 cross-compile
+# Informational check that wasmer's v8 backend cross-compiles to
+# aarch64-linux-android. Same caveats as ios-v8-check.yml: the v8
+# feature isn't exercised by the main build.yml matrix, and this
+# workflow sits on top of a third-party prebuilt V8 archive plus
+# the NDK clang toolchain, both of which drift independently of
+# wasmer itself. `continue-on-error: true` keeps failures visible
+# without blocking merges.
+#
+# Only aarch64 is covered — Google Play requires 64-bit ARM since
+# 2021, the upstream wee8-custom-builds / synchwire/v8-custom-builds
+# only ship aarch64 android archives, and wasmer's build.rs URL
+# map only knows about aarch64-android. armv7 and x86_64 android
+# are out of scope.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  android-v8:
+    name: cargo build --target aarch64-linux-android --features v8
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      # The repo pins a toolchain via rust-toolchain.toml (channel = "1.91").
+      # Using dtolnay/rust-toolchain@stable would install stable but cargo
+      # would still invoke the pinned 1.91, which wouldn't have the Android
+      # target installed. Install the pinned version explicitly and add the
+      # Android target to *that* toolchain.
+      - uses: ./.github/actions/load_toolchain
+        id: load_toolchain
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.load_toolchain.outputs.rust_toolchain }}
+          targets: aarch64-linux-android
+      # Point cc-rs, the linker, and PATH at the Android NDK's clang
+      # rather than the default cross-gcc the system ships. wasmer's v8
+      # build.rs compiles a small C++ shim that uses C++20 features
+      # (class-type non-type template parameters via V8 13.6 headers),
+      # which the older GCC in the cross-rs image can't parse but
+      # modern NDK clang handles fine. The NDK also ships llvm-objcopy
+      # that wasmer's build.rs shells out to for the wee8 symbol-rename
+      # step, so prepending the NDK bin dir to PATH covers both needs.
+      #
+      # API level 24 is Android 7.0 — the common minimum for Rust
+      # Android cross-compiles and above V8's 5.0 requirement.
+      - name: Set up Android NDK clang for aarch64-linux-android
+        run: |
+          NDK_BIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          test -d "$NDK_BIN"
+          echo "$NDK_BIN" >> "$GITHUB_PATH"
+          {
+            echo "CC_aarch64_linux_android=$NDK_BIN/aarch64-linux-android24-clang"
+            echo "CXX_aarch64_linux_android=$NDK_BIN/aarch64-linux-android24-clang++"
+            echo "AR_aarch64_linux_android=$NDK_BIN/llvm-ar"
+            echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$NDK_BIN/aarch64-linux-android24-clang"
+          } >> "$GITHUB_ENV"
+      - name: Show toolchain versions
+        run: |
+          rustup show active-toolchain
+          rustc --version
+          cargo --version
+          "$CXX_aarch64_linux_android" --version
+          "$AR_aarch64_linux_android" --version
+          llvm-objcopy --version
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: android-v8-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Build wasmer crate for Android with v8
+        run: |
+          cargo build \
+            --target aarch64-linux-android \
+            --package wasmer \
+            --no-default-features \
+            --features v8 \
+            --release
+      - name: Confirm resulting rlib is aarch64 Android
+        run: |
+          RLIB=$(find target/aarch64-linux-android/release/deps -maxdepth 1 -name 'libwasmer-*.rlib' | head -1)
+          echo "checking $RLIB"
+          test -n "$RLIB"
+          TMP=$(mktemp -d)
+          ( cd "$TMP" && "$AR_aarch64_linux_android" x "$GITHUB_WORKSPACE/$RLIB" )
+          OBJ=$(find "$TMP" -name '*.o' | head -1)
+          file "$OBJ"
+          file "$OBJ" | grep -q 'ARM aarch64'

--- a/.github/workflows/ios-v8-check.yml
+++ b/.github/workflows/ios-v8-check.yml
@@ -1,0 +1,85 @@
+name: iOS V8 cross-compile
+# Informational check that wasmer's v8 backend cross-compiles to
+# aarch64-apple-ios. The upstream build.yml matrix has enable_v8:
+# false on every entry (V8 marked broken per wasmerio/wasmer#6124),
+# so none of the existing jobs exercise the v8 code path. This job
+# plugs that gap for the iOS target specifically.
+#
+# `continue-on-error: true` on the job keeps this workflow
+# informational rather than blocking: mobile targets sit on top of
+# third-party prebuilt V8 archives and NDK/Xcode toolchains, which
+# drift faster than wasmer itself. Surfacing failures visibly
+# without gating merges matches what the wasmer team asked for
+# when this support was contributed back.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  ios-v8:
+    name: cargo build --target aarch64-apple-ios --features v8
+    runs-on: macos-15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Pick a stable Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      # wasmer's build.rs shells out to llvm-objcopy / objcopy / gobjcopy
+      # during the wee8 symbol-rename step. macOS runners have none of
+      # those on PATH by default (Xcode ships llvm-objcopy only under
+      # xcrun, not at a stable PATH location), so install the brew
+      # LLVM toolchain and prepend its bin dir.
+      - name: Install LLVM (for llvm-objcopy)
+        run: |
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+      # The repo pins a toolchain via rust-toolchain.toml (channel = "1.91").
+      # Using dtolnay/rust-toolchain@stable would install stable but cargo
+      # would still invoke the pinned 1.91, which wouldn't have the iOS
+      # target installed. Install the pinned version explicitly and add the
+      # iOS target to *that* toolchain.
+      - uses: ./.github/actions/load_toolchain
+        id: load_toolchain
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.load_toolchain.outputs.rust_toolchain }}
+          targets: aarch64-apple-ios
+      - name: Show toolchain versions
+        run: |
+          rustup show active-toolchain
+          rustc --version
+          cargo --version
+          clang++ --version
+          xcrun --sdk iphoneos --show-sdk-path
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ios-v8-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Build wasmer crate for iOS with v8
+        run: |
+          cargo build \
+            --target aarch64-apple-ios \
+            --package wasmer \
+            --no-default-features \
+            --features v8 \
+            --release
+      - name: Confirm resulting rlib is arm64 iOS
+        run: |
+          RLIB=$(find target/aarch64-apple-ios/release/deps -maxdepth 1 -name 'libwasmer-*.rlib' | head -1)
+          echo "checking $RLIB"
+          test -n "$RLIB"
+          # An rlib is an ar archive; extract one object and inspect it.
+          TMP=$(mktemp -d)
+          ( cd "$TMP" && ar x "$GITHUB_WORKSPACE/$RLIB" )
+          OBJ=$(find "$TMP" -name '*.o' | head -1)
+          file "$OBJ"
+          file "$OBJ" | grep -q 'arm64'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -204,11 +204,11 @@ jobs:
           components: clippy
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
-      - name: Install `ninja`, clang`, `binutils` and `mold` on Ubuntu
+      - name: Install `ninja`, clang`, `binutils`, `mold` and `llvm` on Ubuntu
         if: startsWith(matrix.metadata.build, 'linux-')
         shell: bash
         run: |
-          sudo apt-get update -y && sudo apt-get install ninja-build clang mold binutils -y
+          sudo apt-get update -y && sudo apt-get install ninja-build clang mold binutils llvm -y
       - name: Install `ninja` and (brew's) `llvm` on macOS
         if: startsWith(matrix.metadata.build, 'macos-')
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,12 @@ build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra
 
 test_compilers := $(compilers)
 ifeq ($(IS_AMD64), 1)
-	ifneq (, $(filter 1, $(IS_LINUX) $(IS_WINDOWS)))
+	# V8 is tested on linux-amd64 only. The synchwire/v8-custom-builds
+	# Windows recipe builds v8_monolith, which does not export the wasm_*
+	# C-API symbols the V8 backend links against, so V8 on Windows is not
+	# wired up (see lib/api/build.rs). Re-add IS_WINDOWS here once a Windows
+	# wee8 archive with the C-API is available.
+	ifneq (, $(filter 1, $(IS_LINUX)))
 		test_compilers += v8
 	endif
 else ifeq ($(IS_AARCH64), 1)

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -7,7 +7,11 @@ fn build_v8() {
         sync::{LazyLock, Mutex},
     };
 
-    const WEE8_RELEASE_VERSION: &str = "11.9.7";
+    // V8 15.0.1 release built from synchwire/v8-custom-builds (see PR
+    // wasmerio/v8-custom-builds#12). The tar layout ships include/ plus
+    // lib/libv8.a (the wee8 static archive renamed). The same tag provides
+    // binaries for every supported target.
+    const WEE8_RELEASE_VERSION: &str = "15.0.1-3";
 
     let (asset_name, platform_name) = match (
         env::var("CARGO_CFG_TARGET_OS").unwrap().as_str(),
@@ -19,8 +23,13 @@ fn build_v8() {
         ("macos", "aarch64", _) => ("v8-darwin-aarch64.tar.xz", "darwin-aarch64"),
         ("linux", "x86_64", "gnu") => ("v8-linux-amd64.tar.xz", "linux-amd64"),
         ("linux", "x86_64", "musl") => ("v8-linux-musl.tar.xz", "linux-musl"),
-        ("windows", "x86_64", _) => ("v8-windows-amd64.tar.xz", "windows-amd64"),
-        ("android", "aarch64", _) => ("v8-android-arm64.tar.xz", "android-arm64"),
+        ("android", "aarch64", _) => ("v8-android.tar.xz", "android-arm64"),
+        // Windows is not wired up: the v8-custom-builds Windows recipe builds
+        // the v8_monolith ninja target (wee8 has dllimport/dllexport issues on
+        // Windows), and v8_monolith doesn't export the wasm_* C-API symbols
+        // wasmer links against. Re-enable only once wee8 builds on Windows.
+        //("windows", "x86_64", _) => ("v8-windows-amd64.tar.xz", "windows-amd64"),
+        ("ios", "aarch64", _) => ("v8-ios.tar.xz", "ios-arm64"),
         (os, arch, _) => panic!("target os + arch combination not supported: {os}, {arch}"),
     };
 
@@ -62,7 +71,7 @@ fn build_v8() {
             use std::io::Write;
 
             let url = format!(
-                "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/{asset_name}"
+                "https://github.com/synchwire/v8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/{asset_name}"
             );
             let tar_data = ureq::get(&url)
                 .call()
@@ -207,7 +216,19 @@ fn build_v8() {
         .write_to_file(out_path.join("v8_bindings.rs"))
         .expect("Couldn't write bindings");
 
-    let objcopy_names = ["llvm-objcopy", "objcopy", "gobjcopy"];
+    // llvm-objcopy is required for V8 15+: its object files use SHT_CREL
+    // sections (an LLVM ELF extension) that GNU objcopy silently skips,
+    // leaving wasm_* symbols unrenamed and breaking the link step.
+    let objcopy_names = [
+        "llvm-objcopy",
+        "llvm-objcopy-18",
+        "llvm-objcopy-17",
+        "llvm-objcopy-16",
+        "llvm-objcopy-15",
+        "llvm-objcopy-14",
+        "objcopy",
+        "gobjcopy",
+    ];
 
     let mut objcopy = None;
     for n in objcopy_names {
@@ -253,6 +274,26 @@ fn build_v8() {
             "{objcopy} failed with error code {}: {}",
             output.status,
             String::from_utf8(output.stderr).unwrap()
+        );
+    }
+
+    // Sanity-check that symbols were actually renamed. GNU objcopy silently
+    // exits 0 on V8 15+ object files (SHT_CREL sections it doesn't recognise),
+    // leaving wasm_* symbols untouched — the link then fails with undefined
+    // references. Fail loudly here with an actionable message instead.
+    let nm_out = std::process::Command::new("nm")
+        .arg("--defined-only")
+        .arg(prefixed_v8_lib_path.display().to_string())
+        .output()
+        .expect("nm not found — cannot verify symbol renaming");
+    if !String::from_utf8_lossy(&nm_out.stdout).contains("wee8_") {
+        panic!(
+            "{objcopy} did not rename any wasm_* symbols in {} — the link step \
+             will fail with undefined references. This usually means GNU objcopy \
+             was used on V8 15+ object files (SHT_CREL sections). Install \
+             llvm-objcopy (e.g. `apt install llvm`) and ensure it precedes GNU \
+             binutils objcopy in PATH.",
+            prefixed_v8_lib_path.display()
         );
     }
 

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -11,7 +11,7 @@ fn build_v8() {
     // wasmerio/v8-custom-builds#12). The tar layout ships include/ plus
     // lib/libv8.a (the wee8 static archive renamed). The same tag provides
     // binaries for every supported target.
-    const WEE8_RELEASE_VERSION: &str = "15.0.1-3";
+    const WEE8_RELEASE_VERSION: &str = "15.0.1-4";
 
     let (asset_name, platform_name) = match (
         env::var("CARGO_CFG_TARGET_OS").unwrap().as_str(),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -11,7 +11,7 @@ fn build_v8() {
     // wasmerio/v8-custom-builds#12). The tar layout ships include/ plus
     // lib/libv8.a (the wee8 static archive renamed). The same tag provides
     // binaries for every supported target.
-    const WEE8_RELEASE_VERSION: &str = "15.0.1-4";
+    const WEE8_RELEASE_VERSION: &str = "15.0.1-5";
 
     let (asset_name, platform_name) = match (
         env::var("CARGO_CFG_TARGET_OS").unwrap().as_str(),

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -482,7 +482,7 @@ fn call_signature_mismatch(config: crate::Config) -> Result<()> {
     if matches!(config.compiler, Compiler::V8) {
         assert_eq!(
             format!("{err}"),
-            "RuntimeError: wasm-c-api trap: Uncaught RuntimeError: null function or function signature mismatch"
+            "RuntimeError: wasm-c-api trap: Uncaught RuntimeError: function signature mismatch"
         );
     } else {
         assert_eq!(

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -65,11 +65,12 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
         "out of bounds memory access",
         "Validation error: multiple memories",
     );
-    // V8-specific
-    wast.allow_trap_message(
-        "uninitialized element",
-        "null function or function signature mismatch",
-    );
+    // V8-specific. V8 15 splits the old combined "null function or function
+    // signature mismatch" trap into "null function" (null/uninitialized element)
+    // and "function signature mismatch" (call_indirect type mismatch); allow
+    // both so this matches across V8 versions.
+    wast.allow_trap_message("uninitialized element", "null function");
+    wast.allow_trap_message("uninitialized element", "function signature mismatch");
     wast.allow_trap_message("out of bounds table access", "table index is out of bounds");
     wast.allow_trap_message("out of bounds memory access", "memory access out of bounds");
     wast.allow_trap_message("out of bounds memory access", "is out of bounds");
@@ -77,10 +78,8 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
         "out of bounds table access",
         "element segment out of bounds",
     );
-    wast.allow_trap_message(
-        "indirect call type mismatch",
-        "null function or function signature mismatch",
-    );
+    wast.allow_trap_message("indirect call type mismatch", "null function");
+    wast.allow_trap_message("indirect call type mismatch", "function signature mismatch");
     wast.allow_trap_message("undefined element", "table index is out of bounds");
     wast.allow_trap_message(
         "unaligned atomic",
@@ -96,10 +95,8 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
     wast.allow_trap_message("integer overflow", "float unrepresentable in integer range");
     wast.allow_trap_message("call stack exhausted", "Maximum call stack size exceeded");
     wast.allow_trap_message("cast failure", "illegal cast");
-    wast.allow_trap_message(
-        "uninitialized element 2",
-        "null function or function signature mismatch",
-    );
+    wast.allow_trap_message("uninitialized element 2", "null function");
+    wast.allow_trap_message("uninitialized element 2", "function signature mismatch");
 
     if cfg!(feature = "coverage") {
         wast.disable_assert_and_exhaustion();


### PR DESCRIPTION
Bumps the V8 backend to **V8 15.0.1**, using release assets from
[synchwire/v8-custom-builds](https://github.com/synchwire/v8-custom-builds)
tag `15.0.1-4` (tracking [v8-custom-builds#12](https://github.com/wasmerio/v8-custom-builds/pull/12)).
Replaces the previous 11.9.7 `wee8` prebuilt from `wasmerio/wee8-custom-builds`.

## Dependency

Requires v8-custom-builds release **15.0.1-4**, which forward-ports two
wasm-c-api patches the V8 backend links against:

- **shared-memory (`0007`)** — makes wasm-c-api memory a *sharable ref*,
  providing `wasm_memory_share` / `wasm_shared_memory_delete`. Without it the
  V8 test binaries fail to link (undefined references).
- **funcref-null (`0006`)** — initialises C-API funcref tables with the
  internal wasm-null sentinel.

`build.rs` points at `synchwire/v8-custom-builds`; once v8-custom-builds#12
merges and tags under `wasmerio/`, only the release URL/version constant needs
updating.

## Changes

**`build.rs`** — download the V8 15.0.1-4 assets and keep the `wee8_` symbol
prefixing. V8 15 object files use `SHT_CREL` sections (an LLVM ELF extension)
that GNU objcopy silently skips, leaving symbols unrenamed and breaking the
link. `build.rs` now prefers versioned `llvm-objcopy` and fails the build with
an actionable message (verified via `nm`) if nothing was renamed. The linux V8
CI job installs `llvm` so `llvm-objcopy` is on `PATH`.

**Trap messages** — V8 15 splits the old combined `call_indirect` trap
`"null function or function signature mismatch"` into `"null function"`
(null / uninitialized element) and `"function signature mismatch"` (signature
mismatch on a present entry). Spec-test and `traps.rs` expectations updated to
accept both.

**Windows** — V8 on Windows is not wired up: the v8-custom-builds Windows recipe
builds `v8_monolith`, which does not export the `wasm_*` C-API symbols the
backend links against. `build.rs` disables the Windows arm and `make test-all`
no longer adds V8 to the Windows test compilers.

**CI** — two informational (`continue-on-error: true`) cross-compile checks:
Android (green) and iOS (fails until a `v8-ios` asset is published — mobile is
tracked separately).

## Known V8 15 behavior differences

- Unbounded memory reports its type maximum as the 32-bit spec cap
  (65536 pages) instead of `None`. Only affects doctests run under a v8-only
  build, not the default multi-backend test config.
