### PR TITLE
Cache downloaded v8 artifact during builds of wasmer with the V8 feature enabled

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -145,14 +145,7 @@ cranelift = ["compiler", "wasmer-compiler-cranelift"]
 llvm = ["compiler", "wasmer-compiler-llvm"]
 
 # --- Enable the v8 backend and use it as default backend.
-v8 = [
-  "wasm-c-api",
-  "std",
-  "dep:tempfile",
-  "dep:which",
-  "dep:xz",
-  "dep:ureq",
-]
+v8 = ["wasm-c-api", "std", "dep:tempfile", "dep:which", "dep:xz", "dep:ureq"]
 # --- Enable the v8 backend and use it as defaul backend only if it is the only one enabled.
 v8-default = ["v8", "wat"]
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -145,7 +145,14 @@ cranelift = ["compiler", "wasmer-compiler-cranelift"]
 llvm = ["compiler", "wasmer-compiler-llvm"]
 
 # --- Enable the v8 backend and use it as default backend.
-v8 = ["wasm-c-api", "std", "dep:which", "dep:xz", "dep:ureq"]
+v8 = [
+  "wasm-c-api",
+  "std",
+  "dep:tempfile",
+  "dep:which",
+  "dep:xz",
+  "dep:ureq",
+]
 # --- Enable the v8 backend and use it as defaul backend only if it is the only one enabled.
 v8-default = ["v8", "wat"]
 
@@ -178,6 +185,7 @@ static-artifact-create = ["wasmer-compiler/static-artifact-create"]
 [build-dependencies]
 cmake.workspace = true
 tar.workspace = true
+tempfile = { workspace = true, optional = true }
 ureq = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
 xz = { workspace = true, optional = true }

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -29,7 +29,8 @@ fn build_v8() {
     let out_path = PathBuf::from(&out_dir);
     let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
     let v8_header_path = PathBuf::from(&crate_root).join("third-party").join("wee8");
-    let cache_dir = stable_target_dir(&out_path)
+    let cache_dir = out_path
+        .join("../../../../")
         .join("wee8-artifacts")
         .join(WEE8_RELEASE_VERSION)
         .join(platform_name);
@@ -252,16 +253,6 @@ fn build_v8() {
     }
 
     println!("cargo:rustc-link-lib=static=v8prefixed");
-
-    fn stable_target_dir(out_path: &Path) -> PathBuf {
-        let mut dir = out_path;
-        for _ in 0..4 {
-            dir = dir
-                .parent()
-                .expect("OUT_DIR is not inside Cargo's target build output");
-        }
-        dir.to_path_buf()
-    }
 }
 
 #[allow(unused)]

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -2,40 +2,24 @@
 fn build_v8() {
     use bindgen::callbacks::ParseCallbacks;
     use std::{
-        env,
-        path::PathBuf,
+        env, fs,
+        path::{Path, PathBuf},
         sync::{LazyLock, Mutex},
     };
 
     const WEE8_RELEASE_VERSION: &str = "11.9.5";
 
-    let url = match (
+    let (asset_name, platform_name) = match (
         env::var("CARGO_CFG_TARGET_OS").unwrap().as_str(),
         env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str(),
         env::var("CARGO_CFG_TARGET_ENV")
             .unwrap_or_default()
             .as_str(),
     ) {
-        ("macos", "aarch64", _) => {
-            format!(
-                "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/v8-darwin-aarch64.tar.xz"
-            )
-        }
-        ("linux", "x86_64", "gnu") => {
-            format!(
-                "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/v8-linux-amd64.tar.xz"
-            )
-        }
-        ("linux", "x86_64", "musl") => {
-            format!(
-                "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/v8-linux-musl-amd64.tar.xz"
-            )
-        }
-        ("android", "aarch64", _) => {
-            format!(
-                "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/v8-android-arm64.tar.xz"
-            )
-        }
+        ("macos", "aarch64", _) => ("v8-darwin-aarch64.tar.xz", "darwin-aarch64"),
+        ("linux", "x86_64", "gnu") => ("v8-linux-amd64.tar.xz", "linux-amd64"),
+        ("linux", "x86_64", "musl") => ("v8-linux-musl-amd64.tar.xz", "linux-musl-amd64"),
+        ("android", "aarch64", _) => ("v8-android-arm64.tar.xz", "android-arm64"),
         // Not supported in 6.0.0-alpha1
         //("windows", "x86_64", _) => "https://github.com/wasmerio/wee8-custom-builds/releases/download/11.7-custom1/wee8-windows-amd64.tar.xz",
         (os, arch, _) => panic!("target os + arch combination not supported: {os}, {arch}"),
@@ -45,29 +29,60 @@ fn build_v8() {
     let out_path = PathBuf::from(&out_dir);
     let crate_root = env::var("CARGO_MANIFEST_DIR").unwrap();
     let v8_header_path = PathBuf::from(&crate_root).join("third-party").join("wee8");
+    let cache_dir = stable_target_dir(&out_path)
+        .join("wee8-artifacts")
+        .join(WEE8_RELEASE_VERSION)
+        .join(platform_name);
+    let archive_path = cache_dir.join(asset_name);
+    let v8_lib_dir = cache_dir.join("lib");
+    let v8_lib_path = v8_lib_dir.join("libv8.a");
 
-    let tar_data = ureq::get(url)
-        .call()
-        .expect("failed to download v8")
-        .body_mut()
-        .with_config()
-        .limit(50 * 1024 * 1024) // 50MB
-        .read_to_vec()
-        .expect("failed to download v8 lib");
+    if !v8_lib_path.exists() {
+        fs::create_dir_all(&cache_dir).unwrap_or_else(|err| {
+            panic!(
+                "failed to create v8 cache dir {}: {err}",
+                cache_dir.display()
+            )
+        });
 
-    let tar = xz::read::XzDecoder::new(tar_data.as_slice());
-    let mut archive = tar::Archive::new(tar);
+        if !archive_path.exists() {
+            let url = format!(
+                "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/{asset_name}"
+            );
+            let tar_data = ureq::get(&url)
+                .call()
+                .expect("failed to download v8")
+                .body_mut()
+                .with_config()
+                .limit(50 * 1024 * 1024) // 50MB
+                .read_to_vec()
+                .expect("failed to download v8 lib");
 
-    for entry in archive.entries().unwrap() {
-        eprintln!("entry: {:?}", entry.unwrap().path());
+            fs::write(&archive_path, tar_data).unwrap_or_else(|err| {
+                panic!(
+                    "failed to write v8 archive cache {}: {err}",
+                    archive_path.display()
+                )
+            });
+        }
+
+        let tar_data = fs::read(&archive_path).unwrap_or_else(|err| {
+            panic!(
+                "failed to read v8 archive cache {}: {err}",
+                archive_path.display()
+            )
+        });
+        let tar = xz::read::XzDecoder::new(tar_data.as_slice());
+        let mut archive = tar::Archive::new(tar);
+        archive.unpack(&cache_dir).unwrap_or_else(|err| {
+            panic!(
+                "failed to unpack v8 archive cache {} into {}: {err}",
+                archive_path.display(),
+                cache_dir.display()
+            )
+        });
     }
 
-    let tar = xz::read::XzDecoder::new(tar_data.as_slice());
-    let mut archive = tar::Archive::new(tar);
-
-    archive.unpack(out_dir.clone()).unwrap();
-    let v8_lib_dir = out_path.join("lib");
-    let v8_lib_path = v8_lib_dir.join("libv8.a");
     println!("cargo:rustc-link-search=native={}", v8_lib_dir.display());
 
     if cfg!(any(target_os = "linux",)) {
@@ -179,6 +194,16 @@ fn build_v8() {
     }
 
     println!("cargo:rustc-link-lib=static=v8prefixed");
+
+    fn stable_target_dir(out_path: &Path) -> PathBuf {
+        let mut dir = out_path;
+        for _ in 0..4 {
+            dir = dir
+                .parent()
+                .expect("OUT_DIR is not inside Cargo's target build output");
+        }
+        dir.to_path_buf()
+    }
 }
 
 #[allow(unused)]

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -45,6 +45,33 @@ fn build_v8() {
             )
         });
 
+        // Unpack into a staging directory first, then rename `lib` into place. If the
+        // process dies during extract, the next build only sees either missing `libv8.a`
+        // or a complete tree — never a half-written `lib/` next to the cached archive.
+        let unpack_staging = cache_dir.join(".wee8-unpack-staging");
+        if unpack_staging.exists() {
+            fs::remove_dir_all(&unpack_staging).unwrap_or_else(|err| {
+                panic!(
+                    "failed to remove stale wee8 unpack staging {}: {err}",
+                    unpack_staging.display()
+                )
+            });
+        }
+        if v8_lib_dir.exists() && !v8_lib_path.exists() {
+            fs::remove_dir_all(&v8_lib_dir).unwrap_or_else(|err| {
+                panic!(
+                    "failed to remove incomplete wee8 lib dir {}: {err}",
+                    v8_lib_dir.display()
+                )
+            });
+        }
+        fs::create_dir_all(&unpack_staging).unwrap_or_else(|err| {
+            panic!(
+                "failed to create wee8 unpack staging {}: {err}",
+                unpack_staging.display()
+            )
+        });
+
         if !archive_path.exists() {
             let url = format!(
                 "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/{asset_name}"
@@ -58,9 +85,29 @@ fn build_v8() {
                 .read_to_vec()
                 .expect("failed to download v8 lib");
 
-            fs::write(&archive_path, tar_data).unwrap_or_else(|err| {
+            // Write to a temp file in the same directory, then rename into place so an
+            // interrupted build cannot leave a partially-written archive at `archive_path`
+            // (which would confuse the next unpack).
+            let tmp_name = format!(
+                "{}.partial.{}",
+                archive_path
+                    .file_name()
+                    .expect("archive path must have a file name")
+                    .to_string_lossy(),
+                std::process::id()
+            );
+            let tmp_path = cache_dir.join(tmp_name);
+            fs::write(&tmp_path, &tar_data).unwrap_or_else(|err| {
+                let _ = fs::remove_file(&tmp_path);
                 panic!(
-                    "failed to write v8 archive cache {}: {err}",
+                    "failed to write v8 archive cache temp {}: {err}",
+                    tmp_path.display()
+                )
+            });
+            fs::rename(&tmp_path, &archive_path).unwrap_or_else(|err| {
+                let _ = fs::remove_file(&tmp_path);
+                panic!(
+                    "failed to finalize v8 archive cache {}: {err}",
                     archive_path.display()
                 )
             });
@@ -74,13 +121,43 @@ fn build_v8() {
         });
         let tar = xz::read::XzDecoder::new(tar_data.as_slice());
         let mut archive = tar::Archive::new(tar);
-        archive.unpack(&cache_dir).unwrap_or_else(|err| {
+        archive.unpack(&unpack_staging).unwrap_or_else(|err| {
+            let _ = fs::remove_file(&archive_path);
+            let _ = fs::remove_dir_all(&unpack_staging);
             panic!(
-                "failed to unpack v8 archive cache {} into {}: {err}",
+                "failed to unpack v8 archive cache {} into {} (cache removed so the next build can re-download): {err}",
                 archive_path.display(),
-                cache_dir.display()
+                unpack_staging.display()
             )
         });
+        let staged_lib = unpack_staging.join("lib");
+        if !staged_lib.is_dir() {
+            let _ = fs::remove_file(&archive_path);
+            let _ = fs::remove_dir_all(&unpack_staging);
+            panic!(
+                "v8 archive {} did not contain a top-level `lib/` directory after unpack (expected {})",
+                archive_path.display(),
+                staged_lib.display()
+            );
+        }
+        if v8_lib_dir.exists() {
+            fs::remove_dir_all(&v8_lib_dir).unwrap_or_else(|err| {
+                panic!(
+                    "failed to remove existing wee8 lib dir {} before rename: {err}",
+                    v8_lib_dir.display()
+                )
+            });
+        }
+        fs::rename(&staged_lib, &v8_lib_dir).unwrap_or_else(|err| {
+            let _ = fs::remove_file(&archive_path);
+            let _ = fs::remove_dir_all(&unpack_staging);
+            panic!(
+                "failed to move unpacked wee8 lib from {} to {}: {err}",
+                staged_lib.display(),
+                v8_lib_dir.display()
+            )
+        });
+        let _ = fs::remove_dir_all(&unpack_staging);
     }
 
     println!("cargo:rustc-link-search=native={}", v8_lib_dir.display());

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -45,18 +45,6 @@ fn build_v8() {
             )
         });
 
-        // Unpack into a staging directory first, then rename `lib` into place. If the
-        // process dies during extract, the next build only sees either missing `libv8.a`
-        // or a complete tree — never a half-written `lib/` next to the cached archive.
-        let unpack_staging = cache_dir.join(".wee8-unpack-staging");
-        if unpack_staging.exists() {
-            fs::remove_dir_all(&unpack_staging).unwrap_or_else(|err| {
-                panic!(
-                    "failed to remove stale wee8 unpack staging {}: {err}",
-                    unpack_staging.display()
-                )
-            });
-        }
         if v8_lib_dir.exists() && !v8_lib_path.exists() {
             fs::remove_dir_all(&v8_lib_dir).unwrap_or_else(|err| {
                 panic!(
@@ -65,14 +53,10 @@ fn build_v8() {
                 )
             });
         }
-        fs::create_dir_all(&unpack_staging).unwrap_or_else(|err| {
-            panic!(
-                "failed to create wee8 unpack staging {}: {err}",
-                unpack_staging.display()
-            )
-        });
 
         if !archive_path.exists() {
+            use std::io::Write;
+
             let url = format!(
                 "https://github.com/wasmerio/wee8-custom-builds/releases/download/{WEE8_RELEASE_VERSION}/{asset_name}"
             );
@@ -85,30 +69,25 @@ fn build_v8() {
                 .read_to_vec()
                 .expect("failed to download v8 lib");
 
-            // Write to a temp file in the same directory, then rename into place so an
-            // interrupted build cannot leave a partially-written archive at `archive_path`
-            // (which would confuse the next unpack).
-            let tmp_name = format!(
-                "{}.partial.{}",
-                archive_path
-                    .file_name()
-                    .expect("archive path must have a file name")
-                    .to_string_lossy(),
-                std::process::id()
-            );
-            let tmp_path = cache_dir.join(tmp_name);
-            fs::write(&tmp_path, &tar_data).unwrap_or_else(|err| {
-                let _ = fs::remove_file(&tmp_path);
+            let mut archive_tmp =
+                tempfile::NamedTempFile::new_in(&cache_dir).unwrap_or_else(|err| {
+                    panic!(
+                        "failed to create temporary v8 archive download file in {}: {err}",
+                        cache_dir.display()
+                    )
+                });
+            archive_tmp.write_all(&tar_data).unwrap_or_else(|err| {
                 panic!(
-                    "failed to write v8 archive cache temp {}: {err}",
-                    tmp_path.display()
+                    "failed to write temporary v8 archive download file {}: {err}",
+                    archive_tmp.path().display()
                 )
             });
-            fs::rename(&tmp_path, &archive_path).unwrap_or_else(|err| {
-                let _ = fs::remove_file(&tmp_path);
+            archive_tmp.persist(&archive_path).unwrap_or_else(|err| {
                 panic!(
-                    "failed to finalize v8 archive cache {}: {err}",
-                    archive_path.display()
+                    "failed to finalize v8 archive cache {} from temporary file {}: {}",
+                    archive_path.display(),
+                    err.file.path().display(),
+                    err.error
                 )
             });
         }
@@ -119,21 +98,25 @@ fn build_v8() {
                 archive_path.display()
             )
         });
+        let unpack_tmp = tempfile::TempDir::new_in(&cache_dir).unwrap_or_else(|err| {
+            panic!(
+                "failed to create temporary wee8 unpack directory in {}: {err}",
+                cache_dir.display()
+            )
+        });
         let tar = xz::read::XzDecoder::new(tar_data.as_slice());
         let mut archive = tar::Archive::new(tar);
-        archive.unpack(&unpack_staging).unwrap_or_else(|err| {
+        archive.unpack(unpack_tmp.path()).unwrap_or_else(|err| {
             let _ = fs::remove_file(&archive_path);
-            let _ = fs::remove_dir_all(&unpack_staging);
             panic!(
                 "failed to unpack v8 archive cache {} into {} (cache removed so the next build can re-download): {err}",
                 archive_path.display(),
-                unpack_staging.display()
+                unpack_tmp.path().display()
             )
         });
-        let staged_lib = unpack_staging.join("lib");
+        let staged_lib = unpack_tmp.path().join("lib");
         if !staged_lib.is_dir() {
             let _ = fs::remove_file(&archive_path);
-            let _ = fs::remove_dir_all(&unpack_staging);
             panic!(
                 "v8 archive {} did not contain a top-level `lib/` directory after unpack (expected {})",
                 archive_path.display(),
@@ -150,14 +133,12 @@ fn build_v8() {
         }
         fs::rename(&staged_lib, &v8_lib_dir).unwrap_or_else(|err| {
             let _ = fs::remove_file(&archive_path);
-            let _ = fs::remove_dir_all(&unpack_staging);
             panic!(
                 "failed to move unpacked wee8 lib from {} to {}: {err}",
                 staged_lib.display(),
                 v8_lib_dir.display()
             )
         });
-        let _ = fs::remove_dir_all(&unpack_staging);
     }
 
     println!("cargo:rustc-link-search=native={}", v8_lib_dir.display());


### PR DESCRIPTION
Per title. Downloading the whole archive once per build on a slow internet connection takes a lot of time.