### PR TITLE
fix(wasix): Fix EPOLL to deliver multiple events per FD at the same time to avoid race conditions

### DIFF
--- a/lib/wasix/src/os/epoll/mod.rs
+++ b/lib/wasix/src/os/epoll/mod.rs
@@ -405,45 +405,31 @@ fn interest_to_pending_bit(interest: InterestType) -> u8 {
 }
 
 /// Converts consumed pending bits into caller-visible epoll events.
-fn pending_bits_to_events(bits: u8, mask: EpollType) -> Vec<EpollType> {
-    let mut events = Vec::with_capacity(4);
+fn pending_bits_to_event(bits: u8, mask: EpollType) -> EpollType {
+    let mut event = EpollType::empty();
     if let Some(bit) = epoll_type_to_pending_bit(EpollType::EPOLLIN)
         && (bits & bit) != 0
         && mask.contains(EpollType::EPOLLIN)
     {
-        events.push(EpollType::EPOLLIN);
+        event |= EpollType::EPOLLIN;
     }
     if let Some(bit) = epoll_type_to_pending_bit(EpollType::EPOLLOUT)
         && (bits & bit) != 0
         && mask.contains(EpollType::EPOLLOUT)
     {
-        events.push(EpollType::EPOLLOUT);
+        event |= EpollType::EPOLLOUT;
     }
     if let Some(bit) = epoll_type_to_pending_bit(EpollType::EPOLLHUP)
         && (bits & bit) != 0
     {
-        events.push(EpollType::EPOLLHUP);
+        event |= EpollType::EPOLLHUP;
     }
     if let Some(bit) = epoll_type_to_pending_bit(EpollType::EPOLLERR)
         && (bits & bit) != 0
     {
-        events.push(EpollType::EPOLLERR);
+        event |= EpollType::EPOLLERR;
     }
-    events
-}
-
-fn epoll_mask_to_pending_bits(mask: EpollType) -> u8 {
-    let mut bits = 0;
-    if mask.contains(EpollType::EPOLLIN) {
-        bits |= READABLE_BIT;
-    }
-    if mask.contains(EpollType::EPOLLOUT) {
-        bits |= WRITABLE_BIT;
-    }
-    // EPOLLHUP/EPOLLERR are always reported by epoll when present.
-    bits |= HUP_BIT;
-    bits |= ERR_BIT;
-    bits
+    event
 }
 
 fn prime_immediate_writable_if_applicable(
@@ -523,21 +509,9 @@ pub(crate) fn drain_ready_events(
         }
 
         let event = sub_state.fd_meta();
-        let mut undispatched_bits = bits & epoll_mask_to_pending_bits(event.events());
-        for readiness in pending_bits_to_events(bits, event.events()) {
-            if ret.len() >= maxevents {
-                break;
-            }
-            ret.push((event.clone(), readiness));
-            if let Some(bit) = epoll_type_to_pending_bit(readiness) {
-                undispatched_bits &= !bit;
-            }
-        }
-
-        if undispatched_bits != 0 {
-            sub_state
-                .pending_bits
-                .fetch_or(undispatched_bits, Ordering::AcqRel);
+        let readiness = pending_bits_to_event(bits, event.events());
+        if readiness != EpollType::empty() {
+            ret.push((event, readiness));
         }
         repair_ready_queue_after_drain(epoll_state, item.fd, &sub_state);
 
@@ -840,16 +814,9 @@ mod tests {
     }
 
     #[test]
-    fn pending_bits_to_events_always_includes_hup_and_err() {
-        let events = pending_bits_to_events(HUP_BIT | ERR_BIT, EpollType::EPOLLIN);
-        assert_eq!(events, vec![EpollType::EPOLLHUP, EpollType::EPOLLERR]);
-    }
-
-    #[test]
-    fn epoll_mask_to_pending_bits_always_tracks_hup_and_err() {
-        let bits = epoll_mask_to_pending_bits(EpollType::empty());
-        assert_eq!(bits & HUP_BIT, HUP_BIT);
-        assert_eq!(bits & ERR_BIT, ERR_BIT);
+    fn pending_bits_to_event_always_includes_hup_and_err() {
+        let event = pending_bits_to_event(HUP_BIT | ERR_BIT, EpollType::EPOLLIN);
+        assert_eq!(event, EpollType::EPOLLHUP | EpollType::EPOLLERR);
     }
 
     #[test]
@@ -879,7 +846,7 @@ mod tests {
     }
 
     #[test]
-    fn drain_ready_events_requeues_undispatched_bits_when_budget_exhausted() {
+    fn drain_ready_events_coalesces_readiness_bits_for_one_fd() {
         let epoll_state = Arc::new(EpollState::new());
         let sub = Arc::new(EpollSubState::new(
             EpollFd::new(EpollType::EPOLLIN | EpollType::EPOLLOUT, 0, 90, 0, 0),
@@ -894,14 +861,8 @@ mod tests {
 
         let first = drain_ready_events(&epoll_state, 1);
         assert_eq!(first.len(), 1);
-        assert_eq!(first[0].1, EpollType::EPOLLIN);
-        assert_eq!(sub.pending_bits(), WRITABLE_BIT);
-        assert!(sub.enqueued.load(Ordering::Acquire));
-        assert_eq!(epoll_state.ready.lock().unwrap().len(), 1);
-
-        let second = drain_ready_events(&epoll_state, 1);
-        assert_eq!(second.len(), 1);
-        assert_eq!(second[0].1, EpollType::EPOLLOUT);
+        assert_eq!(first[0].0.fd(), 90);
+        assert_eq!(first[0].1, EpollType::EPOLLIN | EpollType::EPOLLOUT);
         assert_eq!(sub.pending_bits(), 0);
         assert!(!sub.enqueued.load(Ordering::Acquire));
         assert_eq!(epoll_state.ready.lock().unwrap().len(), 0);

--- a/lib/wasix/tests/wasm_tests/poll_tests/epoll-fd-reuse-file-corruption/main.c
+++ b/lib/wasix/tests/wasm_tests/poll_tests/epoll-fd-reuse-file-corruption/main.c
@@ -1,0 +1,65 @@
+//#ExpectedStdout: 0
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  unlink("victim.php");
+
+  // Build a real TCP loopback connection. The accepted socket is the fd watched
+  // by epoll, matching the socket lifecycle used by HTTP servers.
+  int listener = socket(AF_INET, SOCK_STREAM, 0);
+  struct sockaddr_in addr = {.sin_family = AF_INET,
+                             .sin_addr.s_addr = htonl(INADDR_LOOPBACK)};
+  bind(listener, (struct sockaddr*)&addr, sizeof(addr));
+  listen(listener, 1);
+  socklen_t addr_len = sizeof(addr);
+  getsockname(listener, (struct sockaddr*)&addr, &addr_len);
+  int client = socket(AF_INET, SOCK_STREAM, 0);
+  connect(client, (struct sockaddr*)&addr, sizeof(addr));
+  int fd = accept(listener, NULL, NULL);
+  int epoll_fd = epoll_create1(0);
+
+  // Watch the socket for both read and write readiness, then make it readable.
+  // Correct epoll behavior is to report one event with EPOLLIN | EPOLLOUT.
+  struct epoll_event event = {.events = EPOLLIN | EPOLLOUT, .data.fd = fd};
+  epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &event);
+  write(client, "x", 1);
+  usleep(10000);
+
+  // The buggy WASIX implementation split those readiness bits into multiple
+  // events for the same fd. If we get fewer than two events, the fix is
+  // working.
+  struct epoll_event events[8];
+  int n = epoll_wait(epoll_fd, events, 8, 1000);
+  if (n < 2) {
+    printf("0");
+    return 0;
+  }
+
+  // Simulate the app handling the first event by closing the socket. The next
+  // file open should reuse the same numeric fd, creating the stale-fd hazard.
+  close(fd);
+  int victim_fd = open("victim.php", O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  if (victim_fd != fd) return 2;
+
+  // A stale second epoll event still carries the old fd number. With the bug,
+  // writing through that stale event writes into victim.php instead of a
+  // socket.
+  write(victim_fd, "<?php echo 'ok'; ?>\n", 19);
+  write(events[1].data.fd, "TLS_HANDSHAKE_BYTES", 19);
+  close(victim_fd);
+
+  // The test passes only when the stale socket bytes never appear in the file.
+  char buf[256] = {0};
+  victim_fd = open("victim.php", O_RDONLY);
+  read(victim_fd, buf, sizeof(buf) - 1);
+  if (strstr(buf, "TLS_HANDSHAKE_BYTES") != NULL) return 1;
+  printf("0");
+  return 0;
+}


### PR DESCRIPTION
Fix WASIX epoll readiness handling so multiple readiness bits for the same FD are returned as a single coalesced event, matching Linux epoll behavior.

Previously, WASIX could split readiness like `EPOLLIN | EPOLLOUT` into two separate events for the same FD. If the app handled the first event by closing the socket, the numeric FD could be reused for another resource before the stale second event was processed. In production this manifested as sporadic `Bad file descriptor` errors in PHP/WordPress workloads, and may also explain rare file corruption where bytes intended for a socket were written to a newly opened file that reused the same FD.

The fix coalesces pending readiness bits into one `epoll_event` per FD, so callers no longer receive stale follow-up events for an FD they already handled and closed. A WASIX regression test covers the FD reuse/file corruption scenario.

Based on  https://man7.org/linux/man-pages/man7/epoll.7.html 
```
- If more than one event occurs between [epoll_wait(2)](https://man7.org/linux/man-pages/man2/epoll_wait.2.html) calls, are they combined or reported separately?
- They will be combined.
```
