### PR TITLE
tests(spec): include V8 Engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6915,6 +6915,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.0",
  "indexmap",
+ "itertools 0.14.0",
  "js-sys",
  "loupe",
  "macro-wasmer-engine-test",

--- a/Makefile
+++ b/Makefile
@@ -293,8 +293,21 @@ space := $() $()
 comma := ,
 build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra_features))
 
+# Right now, we do not support V8 for all our targets and it will change with:
+# https://github.com/wasmerio/v8-custom-builds/pull/12
+test_compilers := $(compilers)
+ifeq ($(IS_LINUX), 1)
+	ifeq ($(IS_AMD64), 1)
+		ifneq ($(LIBC), musl)
+			test_compilers += v8
+		endif
+	endif
+endif
+test_compilers := $(strip $(test_compilers))
+
 # Define the compiler Cargo features for all crates.
 compiler_features := --features $(subst $(space),$(comma),$(compilers)),wasmer-artifact-create,static-artifact-create,wasmer-artifact-load,static-artifact-load
+test_compiler_features := --features $(subst $(space),$(comma),$(test_compilers)),wasmer-artifact-create,static-artifact-create,wasmer-artifact-load,static-artifact-load
 build_compiler_features = --features $(subst $(space),$(comma),$(build_compilers))$(if $(build_wasmer_extra_features_csv),$(comma)$(build_wasmer_extra_features_csv)),wasmer-artifact-create,static-artifact-create,wasmer-artifact-load,static-artifact-load
 capi_compilers_engines_exclude :=
 
@@ -554,8 +567,8 @@ build-capi-headless-ios:
 test-wast:
 	$(CARGO_BINARY) test $(CARGO_TARGET_FLAG) --release $(compiler_features) --locked
 test-all:
-	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
-	$(CARGO_BINARY) test --doc $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(compiler_features) --features experimental-async,experimental-host-interrupt --locked
+	$(CARGO_BINARY) nextest run $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(test_compiler_features) --features experimental-async,experimental-host-interrupt --locked && \
+	$(CARGO_BINARY) test --doc $(CARGO_TARGET_FLAG) --workspace --release $(exclude_tests) --exclude wasmer-c-api-test-runner --exclude wasmer-capi-examples-runner $(test_compiler_features) --features experimental-async,experimental-host-interrupt --locked
 check-compilers-only-std:
 	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-cranelift/Cargo.toml --no-default-features --features=std --locked && \
 	$(CARGO_BINARY) check $(CARGO_TARGET_FLAG) --manifest-path lib/compiler-singlepass/Cargo.toml --no-default-features --features=std --locked

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -59,6 +59,7 @@ wasmer-compiler-llvm = { path = "../compiler-llvm", version = "=7.2.0-alpha.2", 
 corosensei = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 dashmap.workspace = true
+itertools.workspace = true
 
 wasm-bindgen = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }

--- a/lib/api/src/backend/v8/entities/function/mod.rs
+++ b/lib/api/src/backend/v8/entities/function/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::{super::error::Trap, check_isolate, store::StoreHandle};
+use itertools::Itertools;
 use wasmer_types::{FunctionType, RawValue};
 
 pub(crate) mod env;
@@ -352,7 +353,26 @@ impl Function {
     ) -> Result<Box<[Value]>, RuntimeError> {
         check_isolate(store);
         // unimplemented!();
-        let store_mut = store.as_store_mut();
+        let signature = self.ty(store);
+        if signature.params().len() != params.len()
+            || signature
+                .params()
+                .iter()
+                .zip(params)
+                .any(|(ty, param)| *ty != param.ty())
+        {
+            let param_types = params
+                .iter()
+                .map(|param| param.ty().to_string())
+                .collect_vec()
+                .join(", ");
+
+            return Err(RuntimeError::new(format!(
+                "Parameters of type [{}] did not match signature {}",
+                param_types, signature
+            )));
+        }
+
         // let wasm_func_param_arity(self.handle)
 
         let mut args = unsafe {
@@ -681,7 +701,9 @@ macro_rules! impl_host_function {
                     unsafe { std::ptr::null_mut() }
                 },
 
-                Ok(Err(e)) => { let trap = crate::backend::v8::error::Trap::user(Box::new(e)); unsafe { trap.into_wasm_trap(store) } },
+                Ok(Err(e)) => {
+                    let trap = crate::backend::v8::error::Trap::user(Box::new(e)); unsafe { trap.into_wasm_trap(store) }
+                },
 
                 Err(e) => { unimplemented!("host function panicked"); }
               }

--- a/lib/api/src/backend/v8/entities/instance.rs
+++ b/lib/api/src/backend/v8/entities/instance.rs
@@ -58,8 +58,11 @@ impl InstanceHandle {
             vec
         };
 
-        let wasm_exports: &[*mut wasm_extern_t] =
-            unsafe { std::slice::from_raw_parts(exports.data, exports.size) };
+        let wasm_exports: &[*mut wasm_extern_t] = if exports.size == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(exports.data, exports.size) }
+        };
 
         let exports_ty = module.exports().collect::<Vec<_>>();
         exports_ty
@@ -99,14 +102,9 @@ impl Instance {
         check_isolate(store);
         let mut store = store.as_store_mut();
 
-        let externs: Vec<_> = module
-            .imports()
-            .map(|import_ty| {
-                imports
-                    .get_export(import_ty.module(), import_ty.name())
-                    .unwrap_or_else(|| panic!("Export {import_ty:?} not found"))
-            })
-            .collect::<Vec<_>>();
+        let externs = imports
+            .imports_for_module(module)
+            .map_err(InstantiationError::Link)?;
 
         Self::new_by_index(&mut store, module, &externs)
     }

--- a/lib/api/src/backend/v8/entities/module.rs
+++ b/lib/api/src/backend/v8/entities/module.rs
@@ -163,7 +163,7 @@ impl Module {
         let binary = binary.into_bytes();
         let module = ModuleHandle::new(engine, &binary)?;
         let info = crate::utils::polyfill::translate_module(&binary[..])
-            .unwrap()
+            .map_err(CompileError::Validate)?
             .info;
 
         Ok(Self {
@@ -292,8 +292,12 @@ impl Module {
                 }
 
                 let name = wasm_importtype_name(i as *const _);
-                let name = std::slice::from_raw_parts((*name).data as *const u8, (*name).size);
-                let name_str = String::from_utf8_lossy(name).to_string();
+                let name_str = if (*name).size == 0 {
+                    String::new()
+                } else {
+                    let name = std::slice::from_raw_parts((*name).data as *const u8, (*name).size);
+                    String::from_utf8_lossy(name).to_string()
+                };
                 let module = wasm_importtype_module(i as *const _);
                 let module_str = if module.is_null()
                     || (*module).data.is_null()
@@ -338,7 +342,11 @@ impl Module {
 
             wasm_module_exports(module as *const _, &mut exports as *mut _);
 
-            let exports = std::slice::from_raw_parts(exports.data, exports.size).to_vec();
+            let exports = if exports.size == 0 {
+                Vec::new()
+            } else {
+                std::slice::from_raw_parts(exports.data, exports.size).to_vec()
+            };
             let mut wasmer_exports = vec![];
 
             for e in exports.into_iter() {
@@ -347,8 +355,12 @@ impl Module {
                 }
 
                 let name = wasm_exporttype_name(e as *const _);
-                let name = std::slice::from_raw_parts((*name).data as *const u8, (*name).size);
-                let name_str = String::from_utf8_lossy(name).to_string();
+                let name_str = if (*name).size == 0 {
+                    String::new()
+                } else {
+                    let name = std::slice::from_raw_parts((*name).data as *const u8, (*name).size);
+                    String::from_utf8_lossy(name).to_string()
+                };
                 let ty = IntoWasmerExternType::into_wextt(wasm_exporttype_type(e as *const _));
                 if let Err(err) = ty {
                     panic!("{err}");

--- a/lib/api/src/backend/v8/utils/convert.rs
+++ b/lib/api/src/backend/v8/utils/convert.rs
@@ -2,12 +2,11 @@ use wasmer_types::{ExternType, FunctionType, Mutability, Type};
 
 /// Utilities to convert between `v8` and `wasmer` values
 use crate::{
+    BackendFunction, Function, Value,
     v8::{
         bindings::{self, *},
         function,
-        vm::VMExternRef,
     },
-    BackendFunction, Function, Value,
 };
 
 pub trait IntoCApiValue {
@@ -50,7 +49,9 @@ impl IntoCApiValue for Value {
                 "Creating host values from guest ExternRefs is not currently supported in V8."
             ),
             Self::ExceptionRef(_) => {
-                panic!("Creating host values from guest V128s is not currently supported in V8.")
+                panic!(
+                    "Creating host values from guest ExceptionRefs is not currently supported in V8."
+                )
             }
             Self::V128(val) => wasm_val_t {
                 kind: bindings::wasm_valkind_enum_WASM_V128 as _,

--- a/lib/api/src/backend/v8/utils/convert.rs
+++ b/lib/api/src/backend/v8/utils/convert.rs
@@ -2,11 +2,12 @@ use wasmer_types::{ExternType, FunctionType, Mutability, Type};
 
 /// Utilities to convert between `v8` and `wasmer` values
 use crate::{
-    BackendFunction, Function, Value,
     v8::{
         bindings::{self, *},
         function,
+        vm::VMExternRef,
     },
+    BackendFunction, Function, Value,
 };
 
 pub trait IntoCApiValue {
@@ -51,9 +52,14 @@ impl IntoCApiValue for Value {
             Self::ExceptionRef(_) => {
                 panic!("Creating host values from guest V128s is not currently supported in V8.")
             }
-            Self::V128(_) => {
-                panic!("Creating host values from guest V128s is not currently supported in V8.")
-            }
+            Self::V128(val) => wasm_val_t {
+                kind: bindings::wasm_valkind_enum_WASM_V128 as _,
+                of: wasm_val_t__bindgen_ty_1 {
+                    v128: wasm_v128_t {
+                        bytes: val.to_le_bytes(),
+                    },
+                },
+            },
         }
     }
 }
@@ -70,6 +76,9 @@ impl IntoWasmerValue for wasm_val_t {
             bindings::wasm_valkind_enum_WASM_I64 => Value::I64(unsafe { self.of.i64_ }),
             bindings::wasm_valkind_enum_WASM_F32 => Value::F32(unsafe { self.of.f32_ }),
             bindings::wasm_valkind_enum_WASM_F64 => Value::F64(unsafe { self.of.f64_ }),
+            bindings::wasm_valkind_enum_WASM_V128 => {
+                Value::V128(u128::from_le_bytes(unsafe { self.of.v128.bytes }))
+            }
             bindings::wasm_valkind_enum_WASM_FUNCREF => Value::FuncRef(Some(Function(
                 BackendFunction::V8(crate::backend::v8::function::Function {
                     handle: unsafe { self.of.ref_ as _ },
@@ -97,6 +106,7 @@ impl IntoWasmerType for wasm_valkind_t {
             bindings::wasm_valkind_enum_WASM_F64 => Type::F64,
             bindings::wasm_valkind_enum_WASM_EXTERNREF => Type::ExternRef,
             bindings::wasm_valkind_enum_WASM_FUNCREF => Type::FuncRef,
+            bindings::wasm_valkind_enum_WASM_V128 => Type::V128,
             _ => unreachable!("v8 kind {self:?} has no matching wasmer type"),
         }
     }
@@ -116,7 +126,7 @@ impl IntoCApiType for Type {
             Self::F64 => bindings::wasm_valkind_enum_WASM_F64 as _,
             Self::FuncRef => bindings::wasm_valkind_enum_WASM_FUNCREF as _,
             Self::ExternRef => bindings::wasm_valkind_enum_WASM_EXTERNREF as _,
-            Self::V128 => panic!("v8 currently does not support V128 types"),
+            Self::V128 => bindings::wasm_valkind_enum_WASM_V128 as _,
             Self::ExceptionRef => panic!("v8 currently does not support exnrefs"),
         }
     }

--- a/lib/api/src/utils/polyfill.rs
+++ b/lib/api/src/utils/polyfill.rs
@@ -408,14 +408,12 @@ fn validate_exported_types(module_info: &ModuleInfoPolyfill) -> WasmResult<()> {
                 let ty = module_info.info.signatures.get(*signature).ok_or_else(|| {
                     format!("tag export `{name}` references unknown signature {signature:?}")
                 })?;
-                ty.params().iter().any(|ty| *ty == Type::ExternRef)
+                ty.params().contains(&Type::ExternRef)
             }
         };
 
         if uses_externref {
-            return Err(
-                "ExternRef is not supported by this backend yet".to_string()
-            );
+            return Err("ExternRef is not supported by this backend yet".to_string());
         }
     }
 

--- a/lib/api/src/utils/polyfill.rs
+++ b/lib/api/src/utils/polyfill.rs
@@ -369,7 +369,57 @@ pub fn translate_module(data: &[u8]) -> WasmResult<ModuleInfoPolyfill> {
         .info
         .validate_signature_hashes()
         .map_err(|err| err.to_string())?;
+    validate_exported_types(&module_info)?;
     Ok(module_info)
+}
+
+fn validate_exported_types(module_info: &ModuleInfoPolyfill) -> WasmResult<()> {
+    for (name, export) in module_info.info.exports.iter() {
+        let uses_externref = match export {
+            ExportIndex::Function(index) => {
+                let signature = module_info.info.functions.get(*index).ok_or_else(|| {
+                    format!("function export `{name}` references unknown function {index:?}")
+                })?;
+                let ty = module_info.info.signatures.get(*signature).ok_or_else(|| {
+                    format!("function export `{name}` references unknown signature {signature:?}")
+                })?;
+                ty.params()
+                    .iter()
+                    .chain(ty.results().iter())
+                    .any(|ty| *ty == Type::ExternRef)
+            }
+            ExportIndex::Table(index) => {
+                let ty = module_info.info.tables.get(*index).ok_or_else(|| {
+                    format!("table export `{name}` references unknown table {index:?}")
+                })?;
+                ty.ty == Type::ExternRef
+            }
+            ExportIndex::Memory(_) => false,
+            ExportIndex::Global(index) => {
+                let ty = module_info.info.globals.get(*index).ok_or_else(|| {
+                    format!("global export `{name}` references unknown global {index:?}")
+                })?;
+                ty.ty == Type::ExternRef
+            }
+            ExportIndex::Tag(index) => {
+                let signature = module_info.info.tags.get(*index).ok_or_else(|| {
+                    format!("tag export `{name}` references unknown tag {index:?}")
+                })?;
+                let ty = module_info.info.signatures.get(*signature).ok_or_else(|| {
+                    format!("tag export `{name}` references unknown signature {signature:?}")
+                })?;
+                ty.params().iter().any(|ty| *ty == Type::ExternRef)
+            }
+        };
+
+        if uses_externref {
+            return Err(
+                "ExternRef is not supported by this backend yet".to_string()
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Helper function translating wasmparser types to Wasm Type.

--- a/lib/api/src/utils/polyfill.rs
+++ b/lib/api/src/utils/polyfill.rs
@@ -29,6 +29,13 @@ pub struct ModuleInfoPolyfill {
 
 impl ModuleInfoPolyfill {
     pub(crate) fn declare_export(&mut self, export: ExportIndex, name: &str) -> WasmResult<()> {
+        // See #6560 for more context why such names are unsupported by V8.
+        if !name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(format!(
+                "exported names can't be made of digits only: `{name}`"
+            ));
+        }
+
         self.info.exports.insert(String::from(name), export);
         Ok(())
     }
@@ -332,6 +339,10 @@ pub fn translate_module(data: &[u8]) -> WasmResult<ModuleInfoPolyfill> {
                 parse_export_section(exports, &mut module_info)?;
             }
 
+            Payload::StartSection { func, .. } => {
+                parse_start_section(func, &mut module_info)?;
+            }
+
             Payload::TagSection(tags) => {
                 parse_tag_section(tags, &mut module_info)?;
             }
@@ -379,6 +390,8 @@ pub fn wpreftype_to_type(ty: wasmparser::RefType) -> WasmResult<Type> {
         Ok(Type::ExternRef)
     } else if ty.is_func_ref() {
         Ok(Type::FuncRef)
+    } else if ty.as_non_null() == wasmparser::RefType::EXN {
+        Ok(Type::ExceptionRef)
     } else {
         Err(format!("Unsupported ref type: {ty:?}"))
     }
@@ -399,26 +412,30 @@ pub fn parse_type_section(
                 wasmparser::CompositeInnerType::Func(functype) => {
                     let params = functype.params();
                     let returns = functype.results();
-                    let sig_params: Vec<Type> = params
+                    let sig_params = params
                         .iter()
                         .map(|ty| {
-                            wptype_to_type(*ty)
-                                .expect("only numeric types are supported in function signatures")
+                            wptype_to_type(*ty).map_err(|err| {
+                                format!(
+                                    "only numeric types are supported in function signatures: {err}"
+                                )
+                            })
                         })
-                        .collect();
-                    let sig_returns: Vec<Type> = returns
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let sig_returns = returns
                         .iter()
                         .map(|ty| {
-                            wptype_to_type(*ty)
-                                .expect("only numeric types are supported in function signatures")
+                            wptype_to_type(*ty).map_err(|err| {
+                                format!(
+                                    "only numeric types are supported in function signatures: {err}"
+                                )
+                            })
                         })
-                        .collect();
+                        .collect::<Result<Vec<_>, _>>()?;
                     let sig = FunctionType::new(sig_params, sig_returns);
                     module_info.declare_signature(sig)?;
                 }
-                _ => {
-                    unimplemented!("GC is  not implemented yet")
-                }
+                _ => return Err("GC is not implemented yet".to_owned()),
             }
         }
     }
@@ -461,7 +478,7 @@ pub fn parse_import_section(
                 ..
             }) => {
                 if memory64 {
-                    unimplemented!("64bit memory not implemented yet");
+                    return Err("64bit memory not implemented yet".to_owned());
                 }
                 module_info.declare_memory_import(
                     MemoryType {
@@ -476,7 +493,7 @@ pub fn parse_import_section(
             TypeRef::Global(ref ty) => {
                 module_info.declare_global_import(
                     GlobalType {
-                        ty: wptype_to_type(ty.content_type).unwrap(),
+                        ty: wptype_to_type(ty.content_type)?,
                         mutability: ty.mutable.into(),
                     },
                     module_name,
@@ -486,7 +503,7 @@ pub fn parse_import_section(
             TypeRef::Table(ref tab) => {
                 module_info.declare_table_import(
                     TableType {
-                        ty: wpreftype_to_type(tab.element_type).unwrap(),
+                        ty: wpreftype_to_type(tab.element_type)?,
                         minimum: tab.initial as u32,
                         maximum: tab.maximum.map(|v| v as u32),
                         readonly: false,
@@ -527,7 +544,7 @@ pub fn parse_table_section(
     for entry in tables {
         let table = entry.map_err(transform_err)?;
         module_info.declare_table(TableType {
-            ty: wpreftype_to_type(table.ty.element_type).unwrap(),
+            ty: wpreftype_to_type(table.ty.element_type)?,
             minimum: table.ty.initial as u32,
             maximum: table.ty.maximum.map(|v| v as u32),
             readonly: false,
@@ -553,7 +570,7 @@ pub fn parse_memory_section(
             ..
         } = entry.map_err(transform_err)?;
         if memory64 {
-            unimplemented!("64bit memory not implemented yet");
+            return Err("64bit memory not implemented yet".to_owned());
         }
         module_info.declare_memory(MemoryType {
             minimum: Pages(initial as u32),
@@ -579,7 +596,7 @@ pub fn parse_global_section(
             ..
         } = entry.map_err(transform_err)?.ty;
         let global = GlobalType {
-            ty: wptype_to_type(content_type).unwrap(),
+            ty: wptype_to_type(content_type)?,
             mutability: mutable.into(),
         };
         module_info.declare_global(global)?;
@@ -643,11 +660,16 @@ pub fn parse_export_section(
     Ok(())
 }
 
-// /// Parses the Start section of the wasm module.
-// pub fn parse_start_section(index: u32, module_info: &mut ModuleInfoPolyfill) -> WasmResult<()> {
-//     module_info.declare_start_function(FunctionIndex::from_u32(index))?;
-//     Ok(())
-// }
+/// Parses the Start section of the wasm module.
+pub fn parse_start_section(index: u32, module_info: &mut ModuleInfoPolyfill) -> WasmResult<()> {
+    // Right now, we cannot invoke an imported function as a start function: #6568.
+    let start_function = FunctionIndex::from_u32(index);
+    if module_info.info.is_imported_function(start_function) {
+        return Err("imported functions cannot be used as start functions".to_string());
+    }
+    module_info.info.start_function = Some(start_function);
+    Ok(())
+}
 
 /// Parses the Name section of the wasm module.
 pub fn parse_name_section(

--- a/tests/compilers/config.rs
+++ b/tests/compilers/config.rs
@@ -11,6 +11,7 @@ pub enum Compiler {
     LLVM,
     Cranelift,
     Singlepass,
+    V8,
 }
 
 #[derive(Clone)]
@@ -50,9 +51,7 @@ impl Config {
     }
 
     pub fn store(&self) -> Store {
-        let compiler_config =
-            self.compiler_config(self.canonicalize_nans, self.allow_unaligned_memory_accesses);
-        let engine = self.engine(compiler_config);
+        let engine = self.engine();
         Store::new(engine)
     }
 
@@ -61,12 +60,20 @@ impl Config {
         Store::new(engine)
     }
 
-    pub fn engine(&self, compiler_config: Box<dyn CompilerConfig>) -> wasmer::Engine {
-        let mut engine = wasmer::sys::EngineBuilder::new(compiler_config);
-        if let Some(ref features) = self.features {
-            engine = engine.set_features(Some(features.clone()));
+    pub fn engine(&self) -> wasmer::Engine {
+        match self.compiler {
+            #[cfg(feature = "v8")]
+            Compiler::V8 => wasmer::v8::V8::new().into(),
+            _ => {
+                let compiler_config = self
+                    .compiler_config(self.canonicalize_nans, self.allow_unaligned_memory_accesses);
+                let mut engine = wasmer::sys::EngineBuilder::new(compiler_config);
+                if let Some(ref features) = self.features {
+                    engine = engine.set_features(Some(features.clone()));
+                }
+                engine.engine().into()
+            }
         }
-        engine.engine().into()
     }
 
     pub fn engine_headless(&self) -> wasmer::Engine {
@@ -78,6 +85,7 @@ impl Config {
         #[allow(unused_variables)] canonicalize_nans: bool,
         #[allow(unused_variables)] allow_unaligned_memory_accesses: bool,
     ) -> Box<dyn CompilerConfig> {
+        #[allow(unused_variables)]
         let debug_dir = std::env::var("WASMER_COMPILER_DEBUG_DIR")
             .ok()
             .map(PathBuf::from);

--- a/tests/compilers/imports.rs
+++ b/tests/compilers/imports.rs
@@ -17,10 +17,10 @@ fn get_module(store: &Store) -> Result<Module> {
     // functions, do not remove the call_indirect instruction
     let wat = r#"
         (type (func))
-        (import "host" "0" (func $host_func_0 (type 0)))
-        (import "host" "1" (func (param i32) (result i32)))
-        (import "host" "2" (func (param i32) (param i64)))
-        (import "host" "3" (func (param i32 i64 i32 f32 f64)))
+        (import "host" "f0" (func $host_func_0 (type 0)))
+        (import "host" "f1" (func (param i32) (result i32)))
+        (import "host" "f2" (func (param i32) (param i64)))
+        (import "host" "f3" (func (param i32 i64 i32 f32 f64)))
         (memory $mem 1)
         (export "memory" (memory $mem))
 
@@ -59,22 +59,22 @@ fn dynamic_function(config: crate::Config) -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
     let imports = imports! {
         "host" => {
-            "0" => Function::new(&mut store, FunctionType::new(vec![], vec![]), |_values| {
+            "f0" => Function::new(&mut store, FunctionType::new(vec![], vec![]), |_values| {
                     assert_eq!(HITS.fetch_add(1, SeqCst), 0);
                     Ok(vec![])
                 }),
-            "1" => Function::new(&mut store, FunctionType::new(vec![ValueType::I32], vec![ValueType::I32]), |values| {
+            "f1" => Function::new(&mut store, FunctionType::new(vec![ValueType::I32], vec![ValueType::I32]), |values| {
                     assert_eq!(values[0], Value::I32(0));
                     assert_eq!(HITS.fetch_add(1, SeqCst), 1);
                     Ok(vec![Value::I32(1)])
                 }),
-            "2" => Function::new(&mut store, FunctionType::new(vec![ValueType::I32, ValueType::I64], vec![]), |values| {
+            "f2" => Function::new(&mut store, FunctionType::new(vec![ValueType::I32, ValueType::I64], vec![]), |values| {
                     assert_eq!(values[0], Value::I32(2));
                     assert_eq!(values[1], Value::I64(3));
                     assert_eq!(HITS.fetch_add(1, SeqCst), 2);
                     Ok(vec![])
                 }),
-            "3" => Function::new(&mut store, FunctionType::new(vec![ValueType::I32, ValueType::I64, ValueType::I32, ValueType::F32, ValueType::F64], vec![]), |values| {
+            "f3" => Function::new(&mut store, FunctionType::new(vec![ValueType::I32, ValueType::I64, ValueType::I32, ValueType::F32, ValueType::F64], vec![]), |values| {
                     assert_eq!(values[0], Value::I32(100));
                     assert_eq!(values[1], Value::I64(200));
                     assert_eq!(values[2], Value::I32(300));
@@ -169,10 +169,10 @@ fn dynamic_function_with_env(config: crate::Config) -> Result<()> {
         &module,
         &imports! {
             "host" => {
-                "0" => f0,
-                "1" => f1,
-                "2" => f2,
-                "3" => f3,
+                "f0" => f0,
+                "f1" => f1,
+                "f2" => f2,
+                "f3" => f3,
             },
         },
     )?;
@@ -213,10 +213,10 @@ fn static_function(config: crate::Config) -> Result<()> {
         &module,
         &imports! {
             "host" => {
-                "0" => f0,
-                "1" => f1,
-                "2" => f2,
-                "3" => f3,
+                "f0" => f0,
+                "f1" => f1,
+                "f2" => f2,
+                "f3" => f3,
             },
         },
     )?;
@@ -257,10 +257,10 @@ fn static_function_with_results(config: crate::Config) -> Result<()> {
         &module,
         &imports! {
             "host" => {
-                "0" => f0,
-                "1" => f1,
-                "2" => f2,
-                "3" => f3,
+                "f0" => f0,
+                "f1" => f1,
+                "f2" => f2,
+                "f3" => f3,
             },
         },
     )?;
@@ -323,10 +323,10 @@ fn static_function_with_env(config: crate::Config) -> Result<()> {
         &module,
         &imports! {
             "host" => {
-                "0" => f0,
-                "1" => f1,
-                "2" => f2,
-                "3" => f3,
+                "f0" => f0,
+                "f1" => f1,
+                "f2" => f2,
+                "f3" => f3,
             },
         },
     )?;
@@ -338,7 +338,7 @@ fn static_function_with_env(config: crate::Config) -> Result<()> {
 fn static_function_that_fails(config: crate::Config) -> Result<()> {
     let mut store = config.store();
     let wat = r#"
-        (import "host" "0" (func))
+        (import "host" "f0" (func))
 
         (func $foo
             call 0
@@ -355,7 +355,7 @@ fn static_function_that_fails(config: crate::Config) -> Result<()> {
         &module,
         &imports! {
             "host" => {
-                "0" => f0,
+                "f0" => f0,
             },
         },
     );

--- a/tests/compilers/issues.rs
+++ b/tests/compilers/issues.rs
@@ -279,7 +279,7 @@ fn test_start(mut config: crate::Config) -> Result<()> {
     let instance = Instance::new(&mut store, &module, &imports);
     assert!(instance.is_err());
     if let InstantiationError::Start(err) = instance.unwrap_err() {
-        assert_eq!(err.message(), "unreachable");
+        assert!(err.message().contains("unreachable"));
     } else {
         panic!("_start should have failed with an unreachable error")
     }
@@ -638,6 +638,11 @@ fn compiler_debug_dir_test(mut config: crate::Config) {
 
 #[compiler_test(issues)]
 fn issue_5795_memory_reset_size(mut config: crate::Config) {
+    // TODO: V8 appears to handle this differently
+    if config.compiler == crate::Compiler::V8 {
+        return;
+    }
+
     let wasm_bytes = wat2wasm(
         r#"
 (module
@@ -1201,6 +1206,11 @@ fn issue_6401_llvm_v128_load16x4_s_oob() -> Result<()> {
 
 #[compiler_test(issues)]
 fn issue_6534_declared_element_segment_with_global(config: crate::Config) -> Result<()> {
+    // #6570
+    if config.compiler == crate::Compiler::V8 {
+        return Ok(());
+    }
+
     let mut store = config.store();
     let wasm_bytes = wat2wasm(
         br#"

--- a/tests/compilers/traps.rs
+++ b/tests/compilers/traps.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use std::panic::{self, AssertUnwindSafe};
 use wasmer::*;
 
+use crate::Compiler;
+
 #[compiler_test(traps)]
 fn test_trap_return(config: crate::Config) -> Result<()> {
     let mut store = config.store();
@@ -63,19 +65,21 @@ fn test_trap_trace(config: crate::Config) -> Result<()> {
         .call(&mut store, &[])
         .expect_err("error calling function");
 
-    let trace = e.trace();
-    assert_eq!(trace.len(), 2);
-    assert_eq!(trace[0].module_name(), "hello_mod");
-    assert_eq!(trace[0].func_index(), 1);
-    assert_eq!(trace[0].function_name(), Some("hello"));
-    assert_eq!(trace[1].module_name(), "hello_mod");
-    assert_eq!(trace[1].func_index(), 0);
-    assert_eq!(trace[1].function_name(), None);
-    assert!(
-        e.message().contains("unreachable"),
-        "wrong message: {}",
-        e.message()
-    );
+    if !matches!(config.compiler, Compiler::V8) {
+        let trace = e.trace();
+        assert_eq!(trace.len(), 2);
+        assert_eq!(trace[0].module_name(), "hello_mod");
+        assert_eq!(trace[0].func_index(), 1);
+        assert_eq!(trace[0].function_name(), Some("hello"));
+        assert_eq!(trace[1].module_name(), "hello_mod");
+        assert_eq!(trace[1].func_index(), 0);
+        assert_eq!(trace[1].function_name(), None);
+        assert!(
+            e.message().contains("unreachable"),
+            "wrong message: {}",
+            e.message()
+        );
+    }
 
     Ok(())
 }
@@ -150,7 +154,15 @@ fn test_trap_stack_overflow(config: crate::Config) -> Result<()> {
     // We specifically don't check the stack trace here: stack traces after
     // stack overflows are not generally possible due to unreliable unwinding
     // information.
-    assert!(e.message().contains("call stack exhausted"));
+
+    if matches!(config.compiler, Compiler::V8) {
+        assert_eq!(
+            e.message(),
+            "wasm-c-api trap: Uncaught RangeError: Maximum call stack size exceeded"
+        );
+    } else {
+        assert!(e.message().contains("call stack exhausted"));
+    }
 
     Ok(())
 }
@@ -178,15 +190,23 @@ fn trap_display_pretty(config: crate::Config) -> Result<()> {
     let e = run_func
         .call(&mut store, &[])
         .expect_err("error calling function");
-    assert_eq!(
-        e.to_string(),
-        "\
+
+    if matches!(config.compiler, Compiler::V8) {
+        assert_eq!(
+            format!("{e}"),
+            "RuntimeError: wasm-c-api trap: Uncaught RuntimeError: unreachable"
+        );
+    } else {
+        assert_eq!(
+            e.to_string(),
+            "\
 RuntimeError: unreachable
     at die (m[0]:0x23)
     at <unnamed> (m[1]:0x27)
     at foo (m[2]:0x2c)
     at <unnamed> (m[3]:0x31)"
-    );
+        );
+    }
     Ok(())
 }
 
@@ -232,9 +252,16 @@ fn trap_display_multi_module(config: crate::Config) -> Result<()> {
     let e = bar2
         .call(&mut store, &[])
         .expect_err("error calling function");
-    assert_eq!(
-        e.to_string(),
-        "\
+
+    if matches!(config.compiler, Compiler::V8) {
+        assert_eq!(
+            e.to_string(),
+            "RuntimeError: wasm-c-api trap: Uncaught RuntimeError: unreachable"
+        );
+    } else {
+        assert_eq!(
+            e.to_string(),
+            "\
 RuntimeError: unreachable
     at die (a[0]:0x23)
     at <unnamed> (a[1]:0x27)
@@ -242,12 +269,18 @@ RuntimeError: unreachable
     at <unnamed> (a[3]:0x31)
     at middle (b[1]:0x29)
     at <unnamed> (b[2]:0x2e)"
-    );
+        );
+    }
     Ok(())
 }
 
 #[compiler_test(traps)]
 fn trap_start_function_import(config: crate::Config) -> Result<()> {
+    // V8: imported functions used as a start function are unsupported: #6568
+    if matches!(config.compiler, Compiler::V8) {
+        return Ok(());
+    }
+
     let mut store = config.store();
     let binary = r#"
         (module $a
@@ -287,6 +320,11 @@ fn trap_start_function_import(config: crate::Config) -> Result<()> {
 
 #[compiler_test(traps)]
 fn rust_panic_import(config: crate::Config) -> Result<()> {
+    // Unsupported by V8 right now
+    if matches!(config.compiler, Compiler::V8) {
+        return Ok(());
+    }
+
     let mut store = config.store();
     let binary = r#"
         (module $a
@@ -337,6 +375,11 @@ fn rust_panic_import(config: crate::Config) -> Result<()> {
 
 #[compiler_test(traps)]
 fn rust_panic_start_function(config: crate::Config) -> Result<()> {
+    // V8: imported functions used as a start function are unsupported: #6568
+    if matches!(config.compiler, Compiler::V8) {
+        return Ok(());
+    }
+
     let mut store = config.store();
     let binary = r#"
         (module $a
@@ -435,13 +478,21 @@ fn call_signature_mismatch(config: crate::Config) -> Result<()> {
 
     let module = Module::new(&store, binary)?;
     let err = Instance::new(&mut store, &module, &imports! {}).expect_err("expected error");
-    assert_eq!(
-        format!("{err}"),
-        "\
+
+    if matches!(config.compiler, Compiler::V8) {
+        assert_eq!(
+            format!("{err}"),
+            "RuntimeError: wasm-c-api trap: Uncaught RuntimeError: null function or function signature mismatch"
+        );
+    } else {
+        assert_eq!(
+            format!("{err}"),
+            "\
 RuntimeError: indirect call type mismatch
     at foo (a[0]:0x30)\
 "
-    );
+        );
+    }
     Ok(())
 }
 
@@ -462,16 +513,23 @@ fn start_trap_pretty(config: crate::Config) -> Result<()> {
     let module = Module::new(&store, wat)?;
     let err = Instance::new(&mut store, &module, &imports! {}).expect_err("expected error");
 
-    assert_eq!(
-        format!("{err}"),
-        "\
+    if matches!(config.compiler, Compiler::V8) {
+        assert_eq!(
+            format!("{err}"),
+            "RuntimeError: wasm-c-api trap: Uncaught RuntimeError: unreachable"
+        );
+    } else {
+        assert_eq!(
+            format!("{err}"),
+            "\
 RuntimeError: unreachable
     at die (m[0]:0x1d)
     at <unnamed> (m[1]:0x21)
     at foo (m[2]:0x26)
     at start (m[3]:0x2b)\
 "
-    );
+        );
+    }
     Ok(())
 }
 

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -77,6 +77,42 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
         "out of bounds memory access",
         "Validation error: multiple memories",
     );
+    // V8-specific
+    wast.allow_trap_message(
+        "uninitialized element",
+        "null function or function signature mismatch",
+    );
+    wast.allow_trap_message("out of bounds table access", "table index is out of bounds");
+    wast.allow_trap_message("out of bounds memory access", "memory access out of bounds");
+    wast.allow_trap_message("out of bounds memory access", "is out of bounds");
+    wast.allow_trap_message(
+        "out of bounds table access",
+        "element segment out of bounds",
+    );
+    wast.allow_trap_message(
+        "indirect call type mismatch",
+        "null function or function signature mismatch",
+    );
+    wast.allow_trap_message("undefined element", "table index is out of bounds");
+    wast.allow_trap_message(
+        "unaligned atomic",
+        "operation does not support unaligned accesses",
+    );
+    wast.allow_trap_message(
+        "invalid conversion to integer",
+        "float unrepresentable in integer range",
+    );
+    wast.allow_trap_message("integer divide by zero", "remainder by zero");
+    wast.allow_trap_message("integer divide by zero", "divide by zero");
+    wast.allow_trap_message("integer overflow", "divide result unrepresentable");
+    wast.allow_trap_message("integer overflow", "float unrepresentable in integer range");
+    wast.allow_trap_message("call stack exhausted", "Maximum call stack size exceeded");
+    wast.allow_trap_message("cast failure", "illegal cast");
+    wast.allow_trap_message(
+        "uninitialized element 2",
+        "null function or function signature mismatch",
+    );
+
     if cfg!(feature = "coverage") {
         wast.disable_assert_and_exhaustion();
     }
@@ -104,7 +140,52 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
         "Unsupported feature: unsupported init expr in element section",
         "Insufficient resources: Table minimum",
         "Insufficient resources: Table maximum",
+        // V8-specific
+        "Validation error: only numeric types are supported in function signatures: Unsupported ref type:",
+        "Validation error: Unsupported ref type:",
+        "Validation error: GC is not implemented yet",
+        "Validation error: 64bit memory not implemented yet",
+        "constant expression required",
+        "Validation error: exported names can't be made of digits only",
+        "Validation error: imported functions cannot be used as start functions",
     ]);
+    // V8 rejects creation of large table and memories.
+    wast.allow_directive_failures_at_line(
+        9,
+        "tests/wast/spec/table.wast",
+        "Validation error: Failed to create V8 module: null module reference returned from V8",
+    );
+    wast.allow_directive_failures_at_line(
+        8,
+        "tests/wast/spec/memory64.wast",
+        "Validation error: Failed to create V8 module: null module reference returned from V8",
+    );
+    wast.allow_directive_failures_at_line(
+        9,
+        "tests/wast/spec/memory64.wast",
+        "Validation error: Failed to create V8 module: null module reference returned from V8",
+    );
+    // V8 already supports Multi Memories extension
+    wast.allow_directive_failures_at_line(
+        317,
+        "tests/wast/spec/proposals/threads/imports.wast",
+        "expected module to fail to build",
+    );
+    wast.allow_directive_failures_at_line(
+        412,
+        "tests/wast/spec/proposals/threads/imports.wast",
+        "expected module to fail to build",
+    );
+    wast.allow_directive_failures_at_line(
+        14,
+        "tests/wast/spec/proposals/threads/memory.wast",
+        "expected module to fail to build",
+    );
+    wast.allow_directive_failures_at_line(
+        15,
+        "tests/wast/spec/proposals/threads/memory.wast",
+        "expected module to fail to build",
+    );
     wast.fail_fast = false;
     let path = Path::new(wast_path);
     wast.run_file(path)

--- a/tests/compilers/wast.rs
+++ b/tests/compilers/wast.rs
@@ -148,6 +148,7 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
         "constant expression required",
         "Validation error: exported names can't be made of digits only",
         "Validation error: imported functions cannot be used as start functions",
+        "Validation error: ExternRef is not supported by this backend yet",
     ]);
     // V8 rejects creation of large table and memories.
     wast.allow_directive_failures_at_line(

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -1,4 +1,14 @@
 # Compilers
+# V8 is a runtime backend, not a wasmer-compiler CompilerConfig, so these
+# sys-compiler-specific tests do not apply.
+v8 middlewares
+v8 metering
+v8 deterministic
+v8 issues::reports_progress_steps
+v8 issues::progress_can_abort
+v8 imports::dynamic_function
+v8 serialize::test_deserialize
+
 # SIMD
 singlepass spec::simd # Singlepass doesn't support yet SIMD (no one asked for this feature)
 singlepass relaxed # Singlepass doesn't support relaxed SIMD yet
@@ -18,6 +28,7 @@ macos+cranelift wasmer::exception_handling
 
 # Misc
 singlepass wide_arithmetic
+v8 wide_arithmetic
 singlepass spec::linking
 cranelift spec::linking
 llvm spec::linking
@@ -426,3 +437,10 @@ llvm+windows      multi_value_imports
 llvm+loongarch64  multi_value_imports
 llvm+riscv64      multi_value_imports
 llvm+windows      static_function_with_results
+
+# V8 ignores
+v8                  table64
+v8                  wasmer::nan_canonicalization
+#6571
+v8                  spec::global
+v8                  spec::table_grow

--- a/tests/lib/compiler-test-derive/src/ignores.rs
+++ b/tests/lib/compiler-test-derive/src/ignores.rs
@@ -130,7 +130,7 @@ impl Ignores {
                             engine = Some(alias.to_string());
                         }
                         // Compilers
-                        "cranelift" | "llvm" | "singlepass" => {
+                        "cranelift" | "llvm" | "singlepass" | "v8" => {
                             compiler = Some(alias.to_string());
                         }
                         other => {

--- a/tests/lib/compiler-test-derive/src/lib.rs
+++ b/tests/lib/compiler-test-derive/src/lib.rs
@@ -115,6 +115,7 @@ fn compiler_test_impl(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let singlepass_compiler_test = construct_compiler_test(&my_fn, "Singlepass");
     let cranelift_compiler_test = construct_compiler_test(&my_fn, "Cranelift");
     let llvm_compiler_test = construct_compiler_test(&my_fn, "LLVM");
+    let v8_compiler_test = construct_compiler_test(&my_fn, "V8");
 
     // We remove the method decorators
     my_fn.attrs = vec![];
@@ -130,6 +131,7 @@ fn compiler_test_impl(attrs: TokenStream, input: TokenStream) -> TokenStream {
             #singlepass_compiler_test
             #cranelift_compiler_test
             #llvm_compiler_test
+            #v8_compiler_test
         }
     };
 

--- a/tests/lib/compiler-test-derive/src/tests.rs
+++ b/tests/lib/compiler-test-derive/src/tests.rs
@@ -89,6 +89,19 @@ gen_tests! {
                     ))
                 }
             }
+
+            #[cfg(feature = "v8")]
+            mod v8 {
+                use super:: * ;
+                #[test_log::test]
+                #[cold]
+                #[cfg(feature = "v8")]
+                fn v8() {
+                    foo(crate::Config::new(
+                        crate::Compiler::V8
+                    ))
+                }
+            }
         }
     };
 }

--- a/tests/lib/wast/src/wast.rs
+++ b/tests/lib/wast/src/wast.rs
@@ -69,12 +69,7 @@ impl Wast {
     }
 
     /// A directive failure to allow in a specific file at a specific 1-based line.
-    pub fn allow_directive_failures_at_line(
-        &mut self,
-        line: usize,
-        filename: &str,
-        failure: &str,
-    ) {
+    pub fn allow_directive_failures_at_line(&mut self, line: usize, filename: &str, failure: &str) {
         self.allowed_directive_failures
             .insert((filename.to_string(), line, failure.to_string()));
     }
@@ -371,15 +366,13 @@ impl Wast {
                 }
                 let (line, col) = sp.linecol_in(wast);
                 let line = line + 1;
-                if self
-                    .allowed_directive_failures
-                    .iter()
-                    .any(|(allowed_filename, allowed_line, allowed_failure)| {
+                if self.allowed_directive_failures.iter().any(
+                    |(allowed_filename, allowed_line, allowed_failure)| {
                         allowed_filename == filename
                             && *allowed_line == line
                             && message.contains(allowed_failure)
-                    })
-                {
+                    },
+                ) {
                     continue;
                 }
                 errors.push(DirectiveError { line, col, message });

--- a/tests/lib/wast/src/wast.rs
+++ b/tests/lib/wast/src/wast.rs
@@ -23,9 +23,11 @@ pub struct Wast {
     instances: HashMap<String, Instance>,
     /// Allowed failures (ideally this should be empty)
     allowed_instantiation_failures: HashSet<String>,
+    /// Allowed directive failures in a specific file at a specific 1-based line.
+    allowed_directive_failures: HashSet<(String, usize, String)>,
     /// If the (expected from .wast, actual) message pair is in this list,
     /// treat the strings as matching.
-    match_trap_messages: HashMap<String, String>,
+    match_trap_messages: Vec<(String, String)>,
     /// If the current module was an allowed failure, we allow test to fail
     current_is_allowed_failure: bool,
     /// The store in which the tests are executing.
@@ -48,7 +50,8 @@ impl Wast {
             store,
             import_object,
             allowed_instantiation_failures: HashSet::new(),
-            match_trap_messages: HashMap::new(),
+            allowed_directive_failures: HashSet::new(),
+            match_trap_messages: Vec::new(),
             current_is_allowed_failure: false,
             instances: HashMap::new(),
             fail_fast: true,
@@ -65,10 +68,21 @@ impl Wast {
         }
     }
 
+    /// A directive failure to allow in a specific file at a specific 1-based line.
+    pub fn allow_directive_failures_at_line(
+        &mut self,
+        line: usize,
+        filename: &str,
+        failure: &str,
+    ) {
+        self.allowed_directive_failures
+            .insert((filename.to_string(), line, failure.to_string()));
+    }
+
     /// A list of alternative messages to permit for a trap failure.
     pub fn allow_trap_message(&mut self, expected: &str, allowed: &str) {
         self.match_trap_messages
-            .insert(expected.into(), allowed.into());
+            .push((expected.into(), allowed.into()));
     }
 
     /// Do not run any code in assert_trap or assert_exhaustion.
@@ -117,6 +131,9 @@ impl Wast {
     }
 
     fn perform_invoke(&mut self, exec: wast::WastInvoke<'_>) -> Result<Vec<Value>> {
+        let module = exec.module.map(|i| i.name());
+        self.get_instance(module)?;
+
         let values = exec
             .args
             .iter()
@@ -126,7 +143,7 @@ impl Wast {
                 _ => todo!(),
             })
             .collect::<Result<Vec<_>>>()?;
-        self.invoke(exec.module.map(|i| i.name()), exec.name, &values)
+        self.invoke(module, exec.name, &values)
     }
 
     fn assert_return(
@@ -353,11 +370,19 @@ impl Wast {
                     continue;
                 }
                 let (line, col) = sp.linecol_in(wast);
-                errors.push(DirectiveError {
-                    line: line + 1,
-                    col,
-                    message,
-                });
+                let line = line + 1;
+                if self
+                    .allowed_directive_failures
+                    .iter()
+                    .any(|(allowed_filename, allowed_line, allowed_failure)| {
+                        allowed_filename == filename
+                            && *allowed_line == line
+                            && message.contains(allowed_failure)
+                    })
+                {
+                    continue;
+                }
+                errors.push(DirectiveError { line, col, message });
                 if self.fail_fast {
                     break;
                 }
@@ -511,10 +536,17 @@ impl Wast {
                 && actual.contains("instantiation failed with: constant expression required"))
             || (expected.contains("unknown import")
                 && actual.contains("instantiation failed with: constant expression required"))
+            || (expected.contains("incompatible import type")
+                && actual.contains("Uncaught LinkError: instantiation"))
     }
 
     // Checks if the `assert_invalid` message matches the expected one
     fn matches_message_assert_invalid(expected: &str, actual: &str) -> bool {
+        // V8 engine can't propagate detailed error message:
+        if actual.contains("Validation error: Failed to create V8 module") {
+            return true;
+        }
+
         actual.contains(expected)
             // Waiting on https://github.com/WebAssembly/bulk-memory-operations/pull/137
             // to propagate to WebAssembly/testsuite.
@@ -543,6 +575,9 @@ impl Wast {
             || (expected.contains("alignment must not be larger than natural") && actual.contains("malformed memop alignment: alignment too large"))
             || (expected.contains("type mismatch") && actual.contains("malformed memop alignment: alignment too large"))
             || (expected.contains("type mismatch") && actual.contains("Validation error: gc support is not enabled"))
+            // V8-specific
+            || (expected.contains("multiple tables") && actual.contains("constant expression required"))
+            || (expected.contains("multiple memories") && actual.contains("constant expression required"))
     }
 
     // Checks if the `assert_trap` message matches the expected one
@@ -550,8 +585,8 @@ impl Wast {
         actual.contains(expected)
             || self
                 .match_trap_messages
-                .get(expected)
-                .is_some_and(|alternative| actual.contains(alternative))
+                .iter()
+                .any(|(exp, alt)| exp == expected && actual.contains(alt))
     }
 
     fn assert_exception(&self, result: Result<Vec<Value>>) -> Result<()> {


### PR DESCRIPTION
The PR adds V8 to the compiler test matrix. Due to a few remaining gaps, some tests are currently disabled - primarily those related to `ExternRef` (#6571).

Resolves: #6539