### PR TITLE
Improve dependency unification + add 'package tree' command

### DIFF
--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -197,6 +197,7 @@ impl WasmerCmd {
                 Package::Tag(cmd) => cmd.run(),
                 Package::Push(cmd) => cmd.run(),
                 Package::Publish(cmd) => cmd.run().map(|_| ()),
+                Package::Tree(cmd) => cmd.run(),
                 Package::Unpack(cmd) => cmd.execute(),
                 Package::Search(cmd) => cmd.run(),
                 Package::Get(cmd) => cmd.run(),

--- a/lib/cli/src/commands/package/mod.rs
+++ b/lib/cli/src/commands/package/mod.rs
@@ -6,6 +6,7 @@ pub mod publish;
 mod push;
 mod search;
 mod tag;
+mod tree;
 mod unpack;
 
 pub use build::PackageBuild;
@@ -23,6 +24,7 @@ pub enum Package {
     Tag(tag::PackageTag),
     Push(push::PackagePush),
     Publish(publish::PackagePublish),
+    Tree(tree::PackageTree),
     Unpack(unpack::PackageUnpack),
     Search(search::PackageSearch),
     Get(get::PackageGet),

--- a/lib/cli/src/commands/package/tree.rs
+++ b/lib/cli/src/commands/package/tree.rs
@@ -149,10 +149,17 @@ fn format_dependency(alias: &str, dependency: &Dependency, resolved_id: &Package
             .map_or("*".to_string(), |tag| tag.to_string());
 
         if is_fixed_to_resolved(&dependency.pkg, resolved_id) {
-            return format!("{alias}: @{specified_version}");
+            return format!(
+                "{alias}: {}@{specified_version}",
+                aliased_package_name(alias, &specified.full_name())
+            );
         }
 
-        return format!("{alias}: @{specified_version}=>{}", resolved.version);
+        return format!(
+            "{alias}: {}@{specified_version}=>{}",
+            aliased_package_name(alias, &specified.full_name()),
+            resolved.version
+        );
     }
 
     if is_fixed_to_resolved(&dependency.pkg, resolved_id) {
@@ -160,6 +167,10 @@ fn format_dependency(alias: &str, dependency: &Dependency, resolved_id: &Package
     } else {
         format!("{alias}: {} -> {resolved_id}", dependency.pkg)
     }
+}
+
+fn aliased_package_name<'a>(alias: &str, full_name: &'a str) -> &'a str {
+    if alias == full_name { "" } else { full_name }
 }
 
 fn is_fixed_to_resolved(specified: &PackageSource, resolved_id: &PackageId) -> bool {
@@ -179,6 +190,31 @@ fn is_fixed_to_resolved(specified: &PackageSource, resolved_id: &PackageId) -> b
             }
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_dependency_includes_package_name_for_aliases() {
+        let dependency = Dependency {
+            alias: "logger".to_string(),
+            pkg: PackageSource::from(
+                wasmer_config::package::NamedPackageIdent::try_from_full_name_and_version(
+                    "wasmer/log",
+                    "^1",
+                )
+                .unwrap(),
+            ),
+        };
+        let resolved_id = PackageId::new_named("wasmer/log", "1.2.3".parse().unwrap());
+
+        assert_eq!(
+            format_dependency("logger", &dependency, &resolved_id),
+            "logger: wasmer/log@^1=>1.2.3"
+        );
     }
 }
 

--- a/lib/cli/src/commands/package/tree.rs
+++ b/lib/cli/src/commands/package/tree.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use semver::{Op, Version, VersionReq};
+use wasmer_config::package::{PackageId, PackageIdent, PackageSource, Tag};
+use wasmer_wasix::runtime::resolver::{
+    BackendSource, Dependency, DependencyGraph, FileSystemSource, MultiSource, Source, WebSource,
+};
+
+use crate::{
+    commands::AsyncCliCommand,
+    config::WasmerEnv,
+    utils::{WAPM_SOURCE_CACHE_TIMEOUT, registry_query_cache_dir},
+};
+
+/// Print a package's resolved dependency tree.
+#[derive(clap::Parser, Debug)]
+pub struct PackageTree {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    /// Disable the cache for package metadata queries.
+    #[clap(long = "disable-cache")]
+    disable_cache: bool,
+
+    /// The package identifier to resolve, either a package name or sha256 hash.
+    package: PackageIdent,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for PackageTree {
+    type Output = ();
+
+    async fn run_async(self) -> Result<Self::Output> {
+        let source = self.prepare_source()?;
+        let package = PackageSource::Ident(self.package);
+
+        let root_summary = source.latest(&package).await.map_err(|error| {
+            wasmer_wasix::runtime::resolver::ResolveError::Registry {
+                package: package.clone(),
+                error,
+            }
+        })?;
+        let root_id = root_summary.package_id();
+
+        let graph = wasmer_wasix::runtime::resolver::resolve_dependency_graph(
+            &root_id,
+            &root_summary.pkg,
+            &source,
+        )
+        .await
+        .context("Dependency graph resolution failed")?;
+
+        println!("{}", format_root(&package, graph.id()));
+        print_dependencies(&graph, graph.id(), "");
+
+        wasmer_wasix::runtime::resolver::validate_dependency_graph(&graph)
+            .context("Dependency graph cannot be unified")?;
+
+        Ok(())
+    }
+}
+
+impl PackageTree {
+    fn prepare_source(&self) -> Result<MultiSource> {
+        let client =
+            wasmer_wasix::http::default_http_client().context("No HTTP client available")?;
+        let client = Arc::new(client);
+
+        let mut source = MultiSource::default();
+
+        let registry_endpoint = self.env.registry_endpoint()?;
+        let mut registry = BackendSource::new(registry_endpoint.clone(), client.clone());
+        if !self.disable_cache {
+            let cache_dir = registry_query_cache_dir(self.env.cache_dir(), &registry_endpoint);
+            registry = registry.with_local_cache(cache_dir, WAPM_SOURCE_CACHE_TIMEOUT);
+        }
+        if let Some(token) = self.env.token() {
+            registry = registry.with_auth_token(token);
+        }
+        source.add_source(registry);
+
+        let downloads_cache_dir = self.env.cache_dir().join("downloads");
+        source.add_source(WebSource::new(downloads_cache_dir, client));
+        source.add_source(FileSystemSource::default());
+
+        Ok(source)
+    }
+}
+
+fn print_dependencies(graph: &DependencyGraph, package_id: &PackageId, prefix: &str) {
+    let dependencies = dependency_edges(graph, package_id);
+
+    for (index, (alias, dependency, resolved_id)) in dependencies.iter().enumerate() {
+        let is_last = index + 1 == dependencies.len();
+        let connector = if is_last { "`-- " } else { "|-- " };
+
+        println!(
+            "{prefix}{connector}{}",
+            format_dependency(alias, dependency, resolved_id)
+        );
+
+        let child_prefix = if is_last { "    " } else { "|   " };
+        print_dependencies(graph, resolved_id, &format!("{prefix}{child_prefix}"));
+    }
+}
+
+fn dependency_edges(
+    graph: &DependencyGraph,
+    package_id: &PackageId,
+) -> Vec<(String, Dependency, PackageId)> {
+    let dependency_ids = graph
+        .iter_dependencies()
+        .find(|(id, _)| *id == package_id)
+        .map(|(_, dependencies)| dependencies)
+        .unwrap_or_default();
+
+    let package = &graph[package_id].pkg;
+
+    dependency_ids
+        .into_iter()
+        .filter_map(|(alias, resolved_id)| {
+            let dependency = package
+                .dependencies
+                .iter()
+                .find(|dependency| dependency.alias() == alias)?;
+
+            Some((alias.to_string(), dependency.clone(), resolved_id.clone()))
+        })
+        .collect()
+}
+
+fn format_root(specified: &PackageSource, resolved_id: &PackageId) -> String {
+    if is_fixed_to_resolved(specified, resolved_id) {
+        resolved_id.to_string()
+    } else {
+        format!("{specified} -> {resolved_id}")
+    }
+}
+
+fn format_dependency(alias: &str, dependency: &Dependency, resolved_id: &PackageId) -> String {
+    if let (PackageSource::Ident(PackageIdent::Named(specified)), PackageId::Named(resolved)) =
+        (&dependency.pkg, resolved_id)
+        && specified.full_name() == resolved.full_name
+    {
+        let specified_version = specified
+            .tag
+            .as_ref()
+            .map_or("*".to_string(), |tag| tag.to_string());
+
+        if is_fixed_to_resolved(&dependency.pkg, resolved_id) {
+            return format!("{alias}: @{specified_version}");
+        }
+
+        return format!("{alias}: @{specified_version}=>{}", resolved.version);
+    }
+
+    if is_fixed_to_resolved(&dependency.pkg, resolved_id) {
+        format!("{alias}: {}", dependency.pkg)
+    } else {
+        format!("{alias}: {} -> {resolved_id}", dependency.pkg)
+    }
+}
+
+fn is_fixed_to_resolved(specified: &PackageSource, resolved_id: &PackageId) -> bool {
+    match (specified, resolved_id) {
+        (PackageSource::Ident(PackageIdent::Hash(specified)), PackageId::Hash(resolved)) => {
+            specified == resolved
+        }
+        (PackageSource::Ident(PackageIdent::Named(specified)), PackageId::Named(resolved)) => {
+            if specified.full_name() != resolved.full_name {
+                return false;
+            }
+
+            match &specified.tag {
+                Some(Tag::Named(tag)) => tag == &resolved.version.to_string(),
+                Some(Tag::VersionReq(req)) => version_req_is_exact(req, &resolved.version),
+                None => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn version_req_is_exact(req: &VersionReq, version: &Version) -> bool {
+    let [comparator] = req.comparators.as_slice() else {
+        return false;
+    };
+
+    comparator.op == Op::Exact
+        && comparator.major == version.major
+        && comparator.minor == Some(version.minor)
+        && comparator.patch == Some(version.patch)
+        && comparator.pre == version.pre
+}

--- a/lib/cli/src/commands/package/tree.rs
+++ b/lib/cli/src/commands/package/tree.rs
@@ -91,13 +91,13 @@ impl PackageTree {
 fn print_dependencies(graph: &DependencyGraph, package_id: &PackageId, prefix: &str) {
     let dependencies = dependency_edges(graph, package_id);
 
-    for (index, (alias, dependency, resolved_id)) in dependencies.iter().enumerate() {
+    for (index, (_alias, dependency, resolved_id)) in dependencies.iter().enumerate() {
         let is_last = index + 1 == dependencies.len();
         let connector = if is_last { "`-- " } else { "|-- " };
 
         println!(
             "{prefix}{connector}{}",
-            format_dependency(alias, dependency, resolved_id)
+            format_dependency(dependency, resolved_id)
         );
 
         let child_prefix = if is_last { "    " } else { "|   " };
@@ -138,7 +138,7 @@ fn format_root(specified: &PackageSource, resolved_id: &PackageId) -> String {
     }
 }
 
-fn format_dependency(alias: &str, dependency: &Dependency, resolved_id: &PackageId) -> String {
+fn format_dependency(dependency: &Dependency, resolved_id: &PackageId) -> String {
     if let (PackageSource::Ident(PackageIdent::Named(specified)), PackageId::Named(resolved)) =
         (&dependency.pkg, resolved_id)
         && specified.full_name() == resolved.full_name
@@ -149,28 +149,21 @@ fn format_dependency(alias: &str, dependency: &Dependency, resolved_id: &Package
             .map_or("*".to_string(), |tag| tag.to_string());
 
         if is_fixed_to_resolved(&dependency.pkg, resolved_id) {
-            return format!(
-                "{alias}: {}@{specified_version}",
-                aliased_package_name(alias, &specified.full_name())
-            );
+            return format!("{}@{specified_version}", specified.full_name());
         }
 
         return format!(
-            "{alias}: {}@{specified_version}=>{}",
-            aliased_package_name(alias, &specified.full_name()),
+            "{}@{specified_version}=>{}",
+            specified.full_name(),
             resolved.version
         );
     }
 
     if is_fixed_to_resolved(&dependency.pkg, resolved_id) {
-        format!("{alias}: {}", dependency.pkg)
+        dependency.pkg.to_string()
     } else {
-        format!("{alias}: {} -> {resolved_id}", dependency.pkg)
+        format!("{} -> {resolved_id}", dependency.pkg)
     }
-}
-
-fn aliased_package_name<'a>(alias: &str, full_name: &'a str) -> &'a str {
-    if alias == full_name { "" } else { full_name }
 }
 
 fn is_fixed_to_resolved(specified: &PackageSource, resolved_id: &PackageId) -> bool {
@@ -198,7 +191,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_dependency_includes_package_name_for_aliases() {
+    fn format_dependency_never_includes_aliases() {
         let dependency = Dependency {
             alias: "logger".to_string(),
             pkg: PackageSource::from(
@@ -212,8 +205,8 @@ mod tests {
         let resolved_id = PackageId::new_named("wasmer/log", "1.2.3".parse().unwrap());
 
         assert_eq!(
-            format_dependency("logger", &dependency, &resolved_id),
-            "logger: wasmer/log@^1=>1.2.3"
+            format_dependency(&dependency, &resolved_id),
+            "wasmer/log@^1=>1.2.3"
         );
     }
 }

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -51,15 +51,16 @@ use wasmer_wasix::{
 
 use crate::{
     config::{UserRegistry, WasmerEnv},
-    utils::{parse_envvar, parse_mapdir, parse_volume},
+    utils::{
+        WAPM_SOURCE_CACHE_TIMEOUT, parse_envvar, parse_mapdir, parse_volume,
+        registry_query_cache_dir,
+    },
 };
 
 use super::{
     CliPackageSource, ExecutableTarget,
     capabilities::{self, PkgCapabilityCache},
 };
-
-const WAPM_SOURCE_CACHE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Debug, Parser, Clone, Default)]
 /// WASI Options
@@ -257,13 +258,6 @@ pub struct RunProperties {
     pub path: PathBuf,
     pub invoke: Option<String>,
     pub args: Vec<String>,
-}
-
-fn endpoint_to_folder(url: &Url) -> String {
-    url.to_string()
-        .replace("registry.wasmer.io", "wasmer.io")
-        .replace("registry.wasmer.wtf", "wasmer.wtf")
-        .replace(|c| "/:?&=#%\\".contains(c), "_")
 }
 
 #[allow(dead_code)]
@@ -726,10 +720,7 @@ impl Wasi {
         source.add_source(preloaded);
 
         let graphql_endpoint = self.graphql_endpoint(env)?;
-        let cache_dir = env
-            .cache_dir()
-            .join("queries")
-            .join(endpoint_to_folder(&graphql_endpoint));
+        let cache_dir = registry_query_cache_dir(env.cache_dir(), &graphql_endpoint);
         let mut wapm_source = BackendSource::new(graphql_endpoint, Arc::clone(&client))
             .with_local_cache(cache_dir, WAPM_SOURCE_CACHE_TIMEOUT)
             .with_preferred_webc_version(preferred_webc_version);

--- a/lib/cli/src/utils/mod.rs
+++ b/lib/cli/src/utils/mod.rs
@@ -6,10 +6,29 @@ pub(crate) mod render;
 pub(crate) mod timestamp;
 pub(crate) mod unpack;
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use anyhow::{Context as _, Result, bail};
+use url::Url;
 use wasmer_wasix::runners::MappedDirectory;
+
+pub(crate) const WAPM_SOURCE_CACHE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+pub(crate) fn registry_query_cache_dir(cache_dir: &Path, endpoint: &Url) -> PathBuf {
+    cache_dir
+        .join("queries")
+        .join(endpoint_to_cache_folder(endpoint))
+}
+
+fn endpoint_to_cache_folder(url: &Url) -> String {
+    url.to_string()
+        .replace("registry.wasmer.io", "wasmer.io")
+        .replace("registry.wasmer.wtf", "wasmer.wtf")
+        .replace(|c| "/:?&=#%\\".contains(c), "_")
+}
 
 fn retrieve_alias_pathbuf(host_dir: &str, guest_dir: &str) -> Result<MappedDirectory> {
     let host_dir_path = PathBuf::from(&host_dir).canonicalize()?;

--- a/lib/wasix/src/runtime/resolver/mod.rs
+++ b/lib/wasix/src/runtime/resolver/mod.rs
@@ -22,7 +22,7 @@ pub use self::{
         DependencyGraph, Edge, ItemLocation, Node, Resolution, ResolvedFileSystemMapping,
         ResolvedPackage,
     },
-    resolve::{ResolveError, resolve},
+    resolve::{ResolveError, resolve, resolve_dependency_graph, validate_dependency_graph},
     source::{QueryError, Source},
     web_source::WebSource,
 };

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -422,7 +422,10 @@ async fn discover_dependencies_with_backtracking(
 
         let Some((task, remaining)) = state.pending.split_first() else {
             if petgraph::algo::toposort(&state.graph, None).is_ok() {
-                return Ok(Some(state.finish()));
+                let discovered = state.finish();
+                if discovered_packages_are_unified(&discovered) {
+                    return Ok(Some(discovered));
+                }
             }
             continue;
         };
@@ -1571,6 +1574,35 @@ mod tests {
             .insert(leaf_id.clone())
             .with_dependency(&common_id);
         dependency_graph.insert(common_id.clone());
+        assert_eq!(deps(&resolution), dependency_graph.finish());
+    }
+
+    #[tokio::test]
+    async fn backtracking_skips_acyclic_graphs_that_are_not_unified() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let feature_id = PackageId::new_named("feature", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("feature", "^1.0.0");
+        builder.register("root", "1.1.0");
+        builder.register("feature", "1.0.0");
+        builder
+            .register("feature", "1.1.0")
+            .with_dependency("root", "^1.0.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        let mut dependency_graph = builder.start_dependency_graph();
+        dependency_graph
+            .insert(root_id.clone())
+            .with_dependency(&feature_id);
+        dependency_graph.insert(feature_id.clone());
         assert_eq!(deps(&resolution), dependency_graph.finish());
     }
 

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
     path::PathBuf,
 };
 
@@ -8,15 +8,19 @@ use petgraph::{
     visit::EdgeRef,
 };
 use semver::Version;
-use wasmer_config::package::{PackageId, PackageSource};
+use wasmer_config::package::{NamedPackageIdent, PackageId, PackageSource};
 
 use crate::runtime::resolver::{
-    DependencyGraph, ItemLocation, PackageInfo, PackageSummary, QueryError, Resolution,
+    Dependency, DependencyGraph, ItemLocation, PackageInfo, PackageSummary, QueryError, Resolution,
     ResolvedPackage, Source,
     outputs::{Edge, Node},
 };
 
 use super::ResolvedFileSystemMapping;
+
+const MAX_DISCOVERED_PACKAGES: usize = 1_000;
+const MAX_PENDING_DEPENDENCIES: usize = 4_000;
+const MAX_BACKTRACK_STATES: usize = 10_000;
 
 /// Given the [`PackageInfo`] for a root package, resolve its dependency graph
 /// and figure out how it could be executed.
@@ -27,6 +31,7 @@ pub async fn resolve(
     source: &dyn Source,
 ) -> Result<Resolution, ResolveError> {
     let graph = resolve_dependency_graph(root_id, root, source).await?;
+    validate_dependency_graph(&graph)?;
     let package = resolve_package(&graph)?;
 
     Ok(Resolution { graph, package })
@@ -49,6 +54,12 @@ pub enum ResolveError {
     DuplicateVersions {
         package_name: String,
         versions: Vec<Version>,
+    },
+    #[error("Dependency resolution exceeded safety limits ({resource}={value}, limit={limit})")]
+    TooComplex {
+        resource: &'static str,
+        value: usize,
+        limit: usize,
     },
 }
 
@@ -81,6 +92,11 @@ fn print_cycle(packages: &[PackageId]) -> String {
         .join(" → ")
 }
 
+/// Given the [`PackageInfo`] for a root package, discover its dependency graph.
+///
+/// Unlike [`resolve()`], this only queries and links packages. It does not apply
+/// runtime compatibility checks such as rejecting duplicate package versions.
+#[tracing::instrument(level = "debug", skip_all)]
 async fn resolve_dependency_graph(
     root_id: &PackageId,
     root: &PackageInfo,
@@ -89,11 +105,10 @@ async fn resolve_dependency_graph(
     let DiscoveredPackages {
         root,
         graph,
-        indices,
         packages,
+        ..
     } = discover_dependencies(root_id, root, source).await?;
 
-    check_for_duplicate_versions(indices.iter().copied().map(|ix| &graph[ix].id))?;
     log_dependencies(&graph, root);
 
     let graph = DependencyGraph::new(root, graph, packages);
@@ -101,10 +116,70 @@ async fn resolve_dependency_graph(
     Ok(graph)
 }
 
+/// Validate whether a dependency graph can be unified into a runnable package.
+fn validate_dependency_graph(graph: &DependencyGraph) -> Result<(), ResolveError> {
+    check_for_duplicate_versions(
+        petgraph::algo::toposort(graph.graph(), None)
+            .expect("dependency graph is acyclic")
+            .iter()
+            .map(|ix| &graph[*ix].id),
+    )
+}
+
 async fn discover_dependencies(
     root_id: &PackageId,
     root: &PackageInfo,
     source: &dyn Source,
+) -> Result<DiscoveredPackages, ResolveError> {
+    // First try a fast fixpoint pass that merges obviously compatible versions.
+    let heuristic = discover_merged_dependencies(root_id, root, source).await?;
+    if discovered_packages_are_unified(&heuristic) {
+        return Ok(heuristic);
+    }
+
+    // If the greedy pass still leaves duplicate named packages behind, search
+    // alternate version choices so lower direct versions can win when they are
+    // the only way to keep the full graph consistent.
+    if let Some(discovered) = discover_dependencies_with_backtracking(root_id, root, source).await?
+    {
+        return Ok(discovered);
+    }
+
+    Ok(heuristic)
+}
+
+async fn discover_merged_dependencies(
+    root_id: &PackageId,
+    root: &PackageInfo,
+    source: &dyn Source,
+) -> Result<DiscoveredPackages, ResolveError> {
+    let mut selected_named = BTreeMap::new();
+    let mut candidate_cache = BTreeMap::new();
+    let mut seen_selections = BTreeSet::from([named_selection_signature(&selected_named)]);
+
+    loop {
+        let discovered = discover_dependencies_once(root_id, root, source, &selected_named).await?;
+        let constraints = named_dependency_constraints(&discovered.graph);
+        let next_selected =
+            select_named_dependencies(constraints, source, &mut candidate_cache).await?;
+
+        if same_named_selection(&selected_named, &next_selected) {
+            return Ok(discovered);
+        }
+
+        if !seen_selections.insert(named_selection_signature(&next_selected)) {
+            return Ok(discovered);
+        }
+
+        selected_named = next_selected;
+    }
+}
+
+async fn discover_dependencies_once(
+    root_id: &PackageId,
+    root: &PackageInfo,
+    source: &dyn Source,
+    selected_named: &BTreeMap<String, PackageSummary>,
 ) -> Result<DiscoveredPackages, ResolveError> {
     let mut nodes: BTreeMap<PackageId, NodeIndex> = BTreeMap::new();
     let mut graph: DiGraph<Node, Edge> = DiGraph::new();
@@ -123,19 +198,13 @@ async fn discover_dependencies(
         let mut to_add = Vec::new();
 
         for dep in &graph[index].pkg.dependencies {
-            // Get the latest version that satisfies our requirement. If we were
-            // doing this more rigorously, we would be narrowing the version
-            // down using existing requirements and trying to reuse the same
-            // dependency when possible.
-            let dep_summary =
-                source
-                    .latest(&dep.pkg)
-                    .await
-                    .map_err(|error| ResolveError::Registry {
-                        package: dep.pkg.clone(),
-                        error,
-                    })?;
-            let dep_id = dep_summary.package_id().clone();
+            let dep_summary = resolve_dependency(dep, source, selected_named)
+                .await
+                .map_err(|error| ResolveError::Registry {
+                    package: dep.pkg.clone(),
+                    error,
+                })?;
+            let dep_id = dep_summary.package_id();
 
             let PackageSummary { pkg, dist } = dep_summary;
 
@@ -156,11 +225,25 @@ async fn discover_dependencies(
             let dep_index = match nodes.get(&dep_id) {
                 Some(&ix) => ix,
                 None => {
+                    if nodes.len() >= MAX_DISCOVERED_PACKAGES {
+                        return Err(ResolveError::TooComplex {
+                            resource: "packages",
+                            value: nodes.len() + 1,
+                            limit: MAX_DISCOVERED_PACKAGES,
+                        });
+                    }
                     // Create a new node and schedule its dependencies to be
                     // retrieved
                     let ix = graph.add_node(node);
                     nodes.insert(dep_id, ix);
                     to_visit.push_back(ix);
+                    if to_visit.len() > MAX_PENDING_DEPENDENCIES {
+                        return Err(ResolveError::TooComplex {
+                            resource: "pending_dependencies",
+                            value: to_visit.len(),
+                            limit: MAX_PENDING_DEPENDENCIES,
+                        });
+                    }
                     ix
                 }
             };
@@ -169,14 +252,310 @@ async fn discover_dependencies(
         }
     }
 
-    let sorted_indices = petgraph::algo::toposort(&graph, None).map_err(|_| cycle_error(&graph))?;
+    petgraph::algo::toposort(&graph, None).map_err(|_| cycle_error(&graph))?;
 
     Ok(DiscoveredPackages {
         root: root_index,
         graph,
-        indices: sorted_indices,
         packages: nodes,
     })
+}
+
+async fn resolve_dependency(
+    dep: &Dependency,
+    source: &dyn Source,
+    selected_named: &BTreeMap<String, PackageSummary>,
+) -> Result<PackageSummary, QueryError> {
+    let candidates = source.query(&dep.pkg).await?;
+
+    match dep.pkg.as_named() {
+        Some(named) => {
+            if let Some(selected) = selected_named.get(&named.full_name())
+                && let Some(id) = selected.pkg.id.as_named()
+                && named.matches_id(id)
+            {
+                return Ok(selected.clone());
+            }
+
+            select_latest_named_dependency(candidates, dep)
+        }
+        None => candidates
+            .into_iter()
+            .next()
+            .ok_or_else(|| QueryError::NotFound {
+                query: dep.pkg.clone(),
+            }),
+    }
+}
+
+fn select_latest_named_dependency(
+    candidates: Vec<PackageSummary>,
+    dep: &Dependency,
+) -> Result<PackageSummary, QueryError> {
+    candidates
+        .into_iter()
+        .max_by(|left, right| {
+            let left_version = left.pkg.id.as_named().map(|id| &id.version);
+            let right_version = right.pkg.id.as_named().map(|id| &id.version);
+
+            left_version.cmp(&right_version)
+        })
+        .ok_or_else(|| QueryError::NoMatches {
+            query: dep.pkg.clone(),
+            archived_versions: Vec::new(),
+        })
+}
+
+fn named_dependency_constraints(
+    graph: &DiGraph<Node, Edge>,
+) -> BTreeMap<String, Vec<NamedPackageIdent>> {
+    let mut constraints: BTreeMap<String, Vec<NamedPackageIdent>> = BTreeMap::new();
+
+    graph
+        .node_weights()
+        .flat_map(|node| &node.pkg.dependencies)
+        .filter_map(|dep| dep.pkg.as_named())
+        .for_each(|named| {
+            constraints
+                .entry(named.full_name())
+                .or_default()
+                .push(named.clone());
+        });
+
+    constraints
+}
+
+async fn select_named_dependencies(
+    constraints: BTreeMap<String, Vec<NamedPackageIdent>>,
+    source: &dyn Source,
+    candidate_cache: &mut BTreeMap<String, Vec<PackageSummary>>,
+) -> Result<BTreeMap<String, PackageSummary>, ResolveError> {
+    let mut selected = BTreeMap::new();
+
+    for (full_name, constraints) in constraints {
+        let Some(summary) =
+            select_unified_named_dependency(&constraints, source, candidate_cache).await?
+        else {
+            continue;
+        };
+        selected.insert(full_name, summary);
+    }
+
+    Ok(selected)
+}
+
+async fn select_unified_named_dependency(
+    constraints: &[NamedPackageIdent],
+    source: &dyn Source,
+    candidate_cache: &mut BTreeMap<String, Vec<PackageSummary>>,
+) -> Result<Option<PackageSummary>, ResolveError> {
+    let [first, remaining @ ..] = constraints else {
+        return Ok(None);
+    };
+
+    let mut candidates = named_dependency_candidates(first, source, candidate_cache).await?;
+
+    for constraint in remaining {
+        let matching_ids: HashSet<_> =
+            named_dependency_candidates(constraint, source, candidate_cache)
+                .await?
+                .into_iter()
+                .map(|summary| summary.package_id())
+                .collect();
+
+        candidates.retain(|candidate| matching_ids.contains(&candidate.package_id()));
+    }
+
+    Ok(candidates.into_iter().max_by(|left, right| {
+        let left_version = left.pkg.id.as_named().map(|id| &id.version);
+        let right_version = right.pkg.id.as_named().map(|id| &id.version);
+
+        left_version.cmp(&right_version)
+    }))
+}
+
+fn same_named_selection(
+    left: &BTreeMap<String, PackageSummary>,
+    right: &BTreeMap<String, PackageSummary>,
+) -> bool {
+    left.len() == right.len()
+        && left.iter().all(|(name, summary)| {
+            right
+                .get(name)
+                .is_some_and(|other| summary.package_id() == other.package_id())
+        })
+}
+
+fn named_selection_signature(
+    selected: &BTreeMap<String, PackageSummary>,
+) -> Vec<(String, PackageId)> {
+    selected
+        .iter()
+        .map(|(name, summary)| (name.clone(), summary.package_id()))
+        .collect()
+}
+
+fn discovered_packages_are_unified(discovered: &DiscoveredPackages) -> bool {
+    check_for_duplicate_versions(
+        petgraph::algo::toposort(&discovered.graph, None)
+            .expect("dependency graph is acyclic")
+            .iter()
+            .map(|ix| &discovered.graph[*ix].id),
+    )
+    .is_ok()
+}
+
+async fn discover_dependencies_with_backtracking(
+    root_id: &PackageId,
+    root: &PackageInfo,
+    source: &dyn Source,
+) -> Result<Option<DiscoveredPackages>, ResolveError> {
+    let mut candidate_cache = BTreeMap::new();
+    let mut stack = vec![PartialDiscovery::new(root_id, root)];
+    let mut states_explored = 0usize;
+
+    while let Some(state) = stack.pop() {
+        states_explored += 1;
+        if states_explored > MAX_BACKTRACK_STATES {
+            return Err(ResolveError::TooComplex {
+                resource: "backtrack_states",
+                value: states_explored,
+                limit: MAX_BACKTRACK_STATES,
+            });
+        }
+
+        let Some((task, remaining)) = state.pending.split_first() else {
+            if petgraph::algo::toposort(&state.graph, None).is_ok() {
+                return Ok(Some(state.finish()));
+            }
+            continue;
+        };
+
+        let candidates = dependency_candidates(
+            task.dep(),
+            source,
+            &state.selected_named,
+            &mut candidate_cache,
+        )
+        .await?;
+
+        for candidate in candidates.into_iter().rev() {
+            let mut next = state.clone();
+            next.pending = remaining.to_vec();
+            next.add_dependency(task.parent(), task.dep(), candidate);
+            stack.push(next);
+        }
+    }
+
+    Ok(None)
+}
+
+async fn dependency_candidates(
+    dep: &Dependency,
+    source: &dyn Source,
+    selected_named: &BTreeMap<String, PackageSummary>,
+    candidate_cache: &mut BTreeMap<String, Vec<PackageSummary>>,
+) -> Result<Vec<PackageSummary>, ResolveError> {
+    match dep.pkg.as_named() {
+        Some(named) => {
+            if let Some(selected) = selected_named.get(&named.full_name()) {
+                let matches = if named
+                    .tag
+                    .as_ref()
+                    .is_some_and(|tag| tag.as_named().is_some())
+                {
+                    named_dependency_candidates(named, source, candidate_cache)
+                        .await?
+                        .into_iter()
+                        .any(|candidate| candidate.package_id() == selected.package_id())
+                } else {
+                    selected
+                        .pkg
+                        .id
+                        .as_named()
+                        .is_some_and(|id| named.matches_id(id))
+                };
+                return Ok(matches.then(|| vec![selected.clone()]).unwrap_or_default());
+            }
+
+            let candidates = named_dependency_candidates(named, source, candidate_cache).await?;
+            Ok(candidates
+                .into_iter()
+                .filter(|candidate| candidate_matches_named_query(named, candidate))
+                .collect())
+        }
+        None => Ok(vec![
+            source
+                .query(&dep.pkg)
+                .await
+                .map_err(|error| ResolveError::Registry {
+                    package: dep.pkg.clone(),
+                    error,
+                })?
+                .into_iter()
+                .next()
+                .ok_or_else(|| ResolveError::Registry {
+                    package: dep.pkg.clone(),
+                    error: QueryError::NotFound {
+                        query: dep.pkg.clone(),
+                    },
+                })?,
+        ]),
+    }
+}
+
+async fn named_dependency_candidates(
+    named: &NamedPackageIdent,
+    source: &dyn Source,
+    candidate_cache: &mut BTreeMap<String, Vec<PackageSummary>>,
+) -> Result<Vec<PackageSummary>, ResolveError> {
+    let cache_key = named.build();
+
+    let candidates = match candidate_cache.get(&cache_key) {
+        Some(candidates) => candidates.clone(),
+        None => {
+            let query = PackageSource::from(named.clone());
+
+            let mut candidates =
+                source
+                    .query(&query)
+                    .await
+                    .map_err(|error| ResolveError::Registry {
+                        package: query.clone(),
+                        error,
+                    })?;
+            sort_named_candidates_desc(&mut candidates);
+            candidate_cache.insert(cache_key, candidates.clone());
+            candidates
+        }
+    };
+
+    Ok(candidates)
+}
+
+fn candidate_matches_named_query(named: &NamedPackageIdent, candidate: &PackageSummary) -> bool {
+    let Some(id) = candidate.pkg.id.as_named() else {
+        return false;
+    };
+
+    if named
+        .tag
+        .as_ref()
+        .is_some_and(|tag| tag.as_named().is_some())
+    {
+        named.full_name() == id.full_name
+    } else {
+        named.matches_id(id)
+    }
+}
+
+fn sort_named_candidates_desc(candidates: &mut [PackageSummary]) {
+    candidates.sort_by(|left, right| {
+        let left_version = left.pkg.id.as_named().map(|id| &id.version);
+        let right_version = right.pkg.id.as_named().map(|id| &id.version);
+
+        right_version.cmp(&left_version)
+    });
 }
 
 fn cycle_error(graph: &petgraph::Graph<Node, Edge>) -> ResolveError {
@@ -210,9 +589,108 @@ fn cycle_error(graph: &petgraph::Graph<Node, Edge>) -> ResolveError {
 struct DiscoveredPackages {
     root: NodeIndex,
     graph: DiGraph<Node, Edge>,
-    /// All node indices, in topologically sorted order.
-    indices: Vec<NodeIndex>,
     packages: BTreeMap<PackageId, NodeIndex>,
+}
+
+#[derive(Debug, Clone)]
+struct PartialDiscovery {
+    root: NodeIndex,
+    graph: DiGraph<Node, Edge>,
+    packages: BTreeMap<PackageId, NodeIndex>,
+    pending: Vec<PendingDependency>,
+    selected_named: BTreeMap<String, PackageSummary>,
+}
+
+impl PartialDiscovery {
+    fn new(root_id: &PackageId, root: &PackageInfo) -> Self {
+        let mut graph = DiGraph::new();
+        let root_index = graph.add_node(Node {
+            id: root_id.clone(),
+            pkg: root.clone(),
+            dist: None,
+        });
+
+        let packages = BTreeMap::from([(root_id.clone(), root_index)]);
+        let pending = root
+            .dependencies
+            .iter()
+            .cloned()
+            .map(|dep| PendingDependency {
+                parent: root_index,
+                dep,
+            })
+            .collect();
+
+        PartialDiscovery {
+            root: root_index,
+            graph,
+            packages,
+            pending,
+            selected_named: BTreeMap::new(),
+        }
+    }
+
+    fn add_dependency(&mut self, parent: NodeIndex, dep: &Dependency, summary: PackageSummary) {
+        let package_id = summary.package_id();
+        let PackageSummary { pkg, dist } = summary.clone();
+
+        if let Some(id) = pkg.id.as_named() {
+            self.selected_named
+                .entry(id.full_name.clone())
+                .or_insert(summary);
+        }
+
+        let child = match self.packages.get(&package_id) {
+            Some(&index) => index,
+            None => {
+                let index = self.graph.add_node(Node {
+                    id: package_id.clone(),
+                    pkg: pkg.clone(),
+                    dist: Some(dist),
+                });
+                self.packages.insert(package_id, index);
+                self.pending.extend(
+                    pkg.dependencies
+                        .iter()
+                        .cloned()
+                        .map(|dep| PendingDependency { parent: index, dep }),
+                );
+                index
+            }
+        };
+
+        self.graph.add_edge(
+            parent,
+            child,
+            Edge {
+                alias: dep.alias().to_string(),
+            },
+        );
+    }
+
+    fn finish(self) -> DiscoveredPackages {
+        DiscoveredPackages {
+            root: self.root,
+            graph: self.graph,
+            packages: self.packages,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PendingDependency {
+    parent: NodeIndex,
+    dep: Dependency,
+}
+
+impl PendingDependency {
+    fn parent(&self) -> NodeIndex {
+        self.parent
+    }
+
+    fn dep(&self) -> &Dependency {
+        &self.dep
+    }
 }
 
 #[tracing::instrument(level = "debug", name = "dependencies", skip_all)]
@@ -380,9 +858,9 @@ fn resolve_package(dependency_graph: &DependencyGraph) -> Result<ResolvedPackage
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, time::Duration};
 
-    use wasmer_config::package::NamedPackageIdent;
+    use wasmer_config::package::{NamedPackageIdent, PackageIdent, Tag};
 
     use crate::runtime::resolver::{
         Dependency, InMemorySource, MultiSource,
@@ -426,6 +904,13 @@ mod tests {
             registry
         }
 
+        fn finish_with_tags(&self, tags: BTreeMap<(String, String), String>) -> TagResolvingSource {
+            TagResolvingSource {
+                inner: self.finish(),
+                tags,
+            }
+        }
+
         fn get(&self, id: &PackageId) -> &PackageSummary {
             self.0.get(id).unwrap()
         }
@@ -452,6 +937,22 @@ mod tests {
     impl AddPackageVersion<'_> {
         fn with_dependency(&mut self, name: &str, version_constraint: &str) -> &mut Self {
             self.with_aliased_dependency(name, name, version_constraint)
+        }
+
+        fn with_tagged_dependency(&mut self, name: &str, tag: &str) -> &mut Self {
+            let pkg = PackageSource::from(NamedPackageIdent {
+                registry: None,
+                namespace: None,
+                name: name.to_string(),
+                tag: Some(Tag::Named(tag.to_string())),
+            });
+
+            self.summary.pkg.dependencies.push(Dependency {
+                alias: name.to_string(),
+                pkg,
+            });
+
+            self
         }
 
         fn with_aliased_dependency(
@@ -517,6 +1018,43 @@ mod tests {
                 dependency_name: Some(dependency.to_string()),
             });
             self
+        }
+    }
+
+    #[derive(Debug)]
+    struct TagResolvingSource {
+        inner: MultiSource,
+        tags: BTreeMap<(String, String), String>,
+    }
+
+    #[async_trait::async_trait]
+    impl Source for TagResolvingSource {
+        async fn query(&self, package: &PackageSource) -> Result<Vec<PackageSummary>, QueryError> {
+            let rewritten = match package {
+                PackageSource::Ident(PackageIdent::Named(named)) => {
+                    match named.tag.as_ref().and_then(|tag| tag.as_named()) {
+                        Some(tag) => {
+                            let version = self
+                                .tags
+                                .get(&(named.full_name(), tag.clone()))
+                                .ok_or_else(|| QueryError::NotFound {
+                                    query: package.clone(),
+                                })?;
+                            PackageSource::from(
+                                NamedPackageIdent::try_from_full_name_and_version(
+                                    &named.full_name(),
+                                    &format!("={version}"),
+                                )
+                                .unwrap(),
+                            )
+                        }
+                        None => package.clone(),
+                    }
+                }
+                _ => package.clone(),
+            };
+
+            self.inner.query(&rewritten).await
         }
     }
 
@@ -807,48 +1345,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn version_merging_isnt_implemented_yet() {
-        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
-        let mut builder = RegistryBuilder::new();
-        builder
-            .register("root", "1.0.0")
-            .with_dependency("first", "=1.0.0")
-            .with_dependency("second", "=1.0.0");
-        builder
-            .register("first", "1.0.0")
-            .with_dependency("common", "^1.0.0");
-        builder
-            .register("second", "1.0.0")
-            .with_dependency("common", ">1.1,<1.3");
-        builder.register("common", "1.0.0");
-        builder.register("common", "1.1.0");
-        builder.register("common", "1.2.0");
-        builder.register("common", "1.5.0");
-        let registry = builder.finish();
-        let root = builder.get(&root_id);
-
-        let result = resolve(&root.package_id(), &root.pkg, &registry).await;
-
-        match result {
-            Err(ResolveError::DuplicateVersions {
-                package_name,
-                versions,
-            }) => {
-                assert_eq!(package_name, "common");
-                assert_eq!(
-                    versions,
-                    [
-                        Version::parse("1.2.0").unwrap(),
-                        Version::parse("1.5.0").unwrap(),
-                    ]
-                );
-            }
-            _ => unreachable!("Expected a duplicate versions error, found {:?}", result),
-        }
-    }
-
-    #[tokio::test]
-    #[ignore = "Version merging isn't implemented"]
     async fn merge_compatible_versions() {
         let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
         let first_id = PackageId::new_named("first", "1.0.0".parse().unwrap());
@@ -899,6 +1395,357 @@ mod tests {
                 filesystem: Vec::new(),
             }
         );
+    }
+
+    #[tokio::test]
+    async fn merge_compatible_versions_when_constraints_appear_later() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let first_id = PackageId::new_named("first", "1.0.0".parse().unwrap());
+        let second_id = PackageId::new_named("second", "1.0.0".parse().unwrap());
+        let mid_id = PackageId::new_named("mid", "1.0.0".parse().unwrap());
+        let common_id = PackageId::new_named("common", "1.2.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("first", "=1.0.0")
+            .with_dependency("second", "=1.0.0");
+        builder
+            .register("first", "1.0.0")
+            .with_dependency("common", "^1.0.0");
+        builder
+            .register("second", "1.0.0")
+            .with_dependency("mid", "=1.0.0");
+        builder
+            .register("mid", "1.0.0")
+            .with_dependency("common", "<=1.2.0");
+        builder.register("common", "1.2.0");
+        builder.register("common", "1.5.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        let mut dependency_graph = builder.start_dependency_graph();
+        dependency_graph
+            .insert(root_id.clone())
+            .with_dependency(&first_id)
+            .with_dependency(&second_id);
+        dependency_graph
+            .insert(first_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph
+            .insert(second_id.clone())
+            .with_dependency(&mid_id);
+        dependency_graph
+            .insert(mid_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph.insert(common_id.clone());
+        assert_eq!(deps(&resolution), dependency_graph.finish());
+    }
+
+    #[tokio::test]
+    async fn pick_a_lower_direct_dependency_to_preserve_transitive_unification() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let feature_id = PackageId::new_named("feature", "1.0.0".parse().unwrap());
+        let common_id = PackageId::new_named("common", "1.5.0".parse().unwrap());
+        let shared_id = PackageId::new_named("shared", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("feature", "^1.0.0")
+            .with_dependency("shared", "=1.0.0");
+        builder
+            .register("feature", "1.0.0")
+            .with_dependency("common", "^1.0.0");
+        builder
+            .register("feature", "1.1.0")
+            .with_dependency("common", "^2.0.0");
+        builder
+            .register("shared", "1.0.0")
+            .with_dependency("common", "=1.5.0");
+        builder.register("common", "1.5.0");
+        builder.register("common", "2.1.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        let mut dependency_graph = builder.start_dependency_graph();
+        dependency_graph
+            .insert(root_id.clone())
+            .with_dependency(&feature_id)
+            .with_dependency(&shared_id);
+        dependency_graph
+            .insert(feature_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph
+            .insert(shared_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph.insert(common_id.clone());
+        assert_eq!(deps(&resolution), dependency_graph.finish());
+    }
+
+    #[tokio::test]
+    async fn pick_a_lower_dependency_after_branching_transitive_constraints() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let feature_id = PackageId::new_named("feature", "1.0.0".parse().unwrap());
+        let aggregator_id = PackageId::new_named("aggregator", "1.0.0".parse().unwrap());
+        let leaf_id = PackageId::new_named("leaf", "1.0.0".parse().unwrap());
+        let common_id = PackageId::new_named("common", "1.4.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("feature", "^1.0.0")
+            .with_dependency("aggregator", "=1.0.0");
+        builder
+            .register("feature", "1.0.0")
+            .with_dependency("common", "^1.0.0");
+        builder
+            .register("feature", "1.1.0")
+            .with_dependency("common", "^2.0.0");
+        builder
+            .register("aggregator", "1.0.0")
+            .with_dependency("leaf", "=1.0.0");
+        builder
+            .register("leaf", "1.0.0")
+            .with_dependency("common", "<=1.4.0");
+        builder.register("common", "1.4.0");
+        builder.register("common", "2.0.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        let mut dependency_graph = builder.start_dependency_graph();
+        dependency_graph
+            .insert(root_id.clone())
+            .with_dependency(&feature_id)
+            .with_dependency(&aggregator_id);
+        dependency_graph
+            .insert(feature_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph
+            .insert(aggregator_id.clone())
+            .with_dependency(&leaf_id);
+        dependency_graph
+            .insert(leaf_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph.insert(common_id.clone());
+        assert_eq!(deps(&resolution), dependency_graph.finish());
+    }
+
+    #[tokio::test]
+    async fn oscillating_greedy_selection_falls_back_to_backtracking() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let a_id = PackageId::new_named("a", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("a", "^1.0.0");
+        builder.register("a", "1.0.0");
+        builder
+            .register("a", "2.0.0")
+            .with_dependency("x", "=1.0.0");
+        builder
+            .register("x", "1.0.0")
+            .with_dependency("a", "=1.0.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            discover_merged_dependencies(&root.package_id(), &root.pkg, &registry),
+        )
+        .await
+        .expect("greedy dependency discovery did not terminate")
+        .unwrap();
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        let mut dependency_graph = builder.start_dependency_graph();
+        dependency_graph
+            .insert(root_id.clone())
+            .with_dependency(&a_id);
+        dependency_graph.insert(a_id.clone());
+        assert_eq!(deps(&resolution), dependency_graph.finish());
+    }
+
+    #[tokio::test]
+    async fn named_tags_are_resolved_through_the_source_during_backtracking() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let feature_id = PackageId::new_named("feature", "1.0.0".parse().unwrap());
+        let common_id = PackageId::new_named("common", "1.5.0".parse().unwrap());
+        let shared_id = PackageId::new_named("shared", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("feature", "^1.0.0")
+            .with_dependency("shared", "=1.0.0");
+        builder
+            .register("feature", "1.0.0")
+            .with_tagged_dependency("common", "stable");
+        builder
+            .register("feature", "1.1.0")
+            .with_dependency("common", "^2.0.0");
+        builder
+            .register("shared", "1.0.0")
+            .with_dependency("common", "=1.5.0");
+        builder.register("common", "1.5.0");
+        builder.register("common", "2.1.0");
+        let registry = builder.finish_with_tags(BTreeMap::from([(
+            ("common".to_string(), "stable".to_string()),
+            "1.5.0".to_string(),
+        )]));
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        let mut dependency_graph = builder.start_dependency_graph();
+        dependency_graph
+            .insert(root_id.clone())
+            .with_dependency(&feature_id)
+            .with_dependency(&shared_id);
+        dependency_graph
+            .insert(feature_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph
+            .insert(shared_id.clone())
+            .with_dependency(&common_id);
+        dependency_graph.insert(common_id.clone());
+        assert_eq!(deps(&resolution), dependency_graph.finish());
+    }
+
+    #[tokio::test]
+    async fn incompatible_versions_still_report_duplicates() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("first", "=1.0.0")
+            .with_dependency("second", "=1.0.0");
+        builder
+            .register("first", "1.0.0")
+            .with_dependency("common", "=1.0.0");
+        builder
+            .register("second", "1.0.0")
+            .with_dependency("common", "=2.0.0");
+        builder.register("common", "1.0.0");
+        builder.register("common", "2.0.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let result = resolve(&root.package_id(), &root.pkg, &registry).await;
+
+        match result {
+            Err(ResolveError::DuplicateVersions {
+                package_name,
+                versions,
+            }) => {
+                assert_eq!(package_name, "common");
+                assert_eq!(
+                    versions,
+                    [
+                        Version::parse("1.0.0").unwrap(),
+                        Version::parse("2.0.0").unwrap(),
+                    ]
+                );
+            }
+            _ => unreachable!("Expected a duplicate versions error, found {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn incompatible_parent_versions_still_report_duplicates_when_no_solution_exists() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("feature", "^1.0.0")
+            .with_dependency("shared", "=1.0.0");
+        builder
+            .register("feature", "1.0.0")
+            .with_dependency("common", "^1.0.0");
+        builder
+            .register("feature", "1.1.0")
+            .with_dependency("common", "^2.0.0");
+        builder
+            .register("shared", "1.0.0")
+            .with_dependency("common", "=3.0.0");
+        builder.register("common", "1.5.0");
+        builder.register("common", "2.1.0");
+        builder.register("common", "3.0.0");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let result = resolve(&root.package_id(), &root.pkg, &registry).await;
+
+        match result {
+            Err(ResolveError::DuplicateVersions {
+                package_name,
+                versions,
+            }) => {
+                assert_eq!(package_name, "common");
+                assert_eq!(
+                    versions,
+                    [
+                        Version::parse("2.1.0").unwrap(),
+                        Version::parse("3.0.0").unwrap(),
+                    ]
+                );
+            }
+            _ => unreachable!("Expected a duplicate versions error, found {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn very_large_dependency_graphs_fail_with_a_clear_limit_error() {
+        let root_id = PackageId::new_named("pkg0", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        for ix in 0..=MAX_DISCOVERED_PACKAGES {
+            let name = format!("pkg{ix}");
+            let version = "1.0.0";
+            let mut pkg = builder.register(&name, version);
+            if ix < MAX_DISCOVERED_PACKAGES {
+                let dep_name = format!("pkg{}", ix + 1);
+                pkg.with_dependency(&dep_name, "=1.0.0");
+            }
+        }
+
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let result = resolve(&root.package_id(), &root.pkg, &registry).await;
+
+        match result {
+            Err(ResolveError::TooComplex {
+                resource,
+                value,
+                limit,
+            }) => {
+                assert_eq!(resource, "packages");
+                assert_eq!(limit, MAX_DISCOVERED_PACKAGES);
+                assert!(value > limit);
+            }
+            _ => unreachable!("Expected a complexity limit error, found {:?}", result),
+        }
     }
 
     #[tokio::test]

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -97,7 +97,7 @@ fn print_cycle(packages: &[PackageId]) -> String {
 /// Unlike [`resolve()`], this only queries and links packages. It does not apply
 /// runtime compatibility checks such as rejecting duplicate package versions.
 #[tracing::instrument(level = "debug", skip_all)]
-async fn resolve_dependency_graph(
+pub async fn resolve_dependency_graph(
     root_id: &PackageId,
     root: &PackageInfo,
     source: &dyn Source,
@@ -117,13 +117,11 @@ async fn resolve_dependency_graph(
 }
 
 /// Validate whether a dependency graph can be unified into a runnable package.
-fn validate_dependency_graph(graph: &DependencyGraph) -> Result<(), ResolveError> {
-    check_for_duplicate_versions(
-        petgraph::algo::toposort(graph.graph(), None)
-            .expect("dependency graph is acyclic")
-            .iter()
-            .map(|ix| &graph[*ix].id),
-    )
+pub fn validate_dependency_graph(graph: &DependencyGraph) -> Result<(), ResolveError> {
+    let sorted =
+        petgraph::algo::toposort(graph.graph(), None).map_err(|_| cycle_error(graph.graph()))?;
+
+    check_for_duplicate_versions(sorted.iter().map(|ix| &graph[*ix].id))
 }
 
 async fn discover_dependencies(
@@ -396,13 +394,11 @@ fn named_selection_signature(
 }
 
 fn discovered_packages_are_unified(discovered: &DiscoveredPackages) -> bool {
-    check_for_duplicate_versions(
-        petgraph::algo::toposort(&discovered.graph, None)
-            .expect("dependency graph is acyclic")
-            .iter()
-            .map(|ix| &discovered.graph[*ix].id),
-    )
-    .is_ok()
+    let Ok(sorted) = petgraph::algo::toposort(&discovered.graph, None) else {
+        return false;
+    };
+
+    check_for_duplicate_versions(sorted.iter().map(|ix| &discovered.graph[*ix].id)).is_ok()
 }
 
 async fn discover_dependencies_with_backtracking(
@@ -440,9 +436,11 @@ async fn discover_dependencies_with_backtracking(
         .await?;
 
         for candidate in candidates.into_iter().rev() {
+            // This still clones the graph state per candidate, but the clone is
+            // bounded by the state, package, and pending-dependency limits.
             let mut next = state.clone();
             next.pending = remaining.to_vec();
-            next.add_dependency(task.parent(), task.dep(), candidate);
+            next.add_dependency(task.parent(), task.dep(), candidate)?;
             stack.push(next);
         }
     }
@@ -475,7 +473,11 @@ async fn dependency_candidates(
                         .as_named()
                         .is_some_and(|id| named.matches_id(id))
                 };
-                return Ok(matches.then(|| vec![selected.clone()]).unwrap_or_default());
+                return Ok(if matches {
+                    vec![selected.clone()]
+                } else {
+                    Vec::new()
+                });
             }
 
             let candidates = named_dependency_candidates(named, source, candidate_cache).await?;
@@ -562,7 +564,12 @@ fn cycle_error(graph: &petgraph::Graph<Node, Edge>) -> ResolveError {
     // We know the graph has at least one cycle, so use SCC to find it.
     let mut cycle = petgraph::algo::kosaraju_scc(graph)
         .into_iter()
-        .find(|cycle| cycle.len() > 1)
+        .find(|cycle| {
+            cycle.len() > 1
+                || cycle
+                    .first()
+                    .is_some_and(|node| graph.edges(*node).any(|edge| edge.target() == *node))
+        })
         .expect("We know there is at least one cycle");
 
     // we want the loop's starting node to be deterministic (for tests), and
@@ -630,7 +637,12 @@ impl PartialDiscovery {
         }
     }
 
-    fn add_dependency(&mut self, parent: NodeIndex, dep: &Dependency, summary: PackageSummary) {
+    fn add_dependency(
+        &mut self,
+        parent: NodeIndex,
+        dep: &Dependency,
+        summary: PackageSummary,
+    ) -> Result<(), ResolveError> {
         let package_id = summary.package_id();
         let PackageSummary { pkg, dist } = summary.clone();
 
@@ -643,6 +655,23 @@ impl PartialDiscovery {
         let child = match self.packages.get(&package_id) {
             Some(&index) => index,
             None => {
+                if self.packages.len() >= MAX_DISCOVERED_PACKAGES {
+                    return Err(ResolveError::TooComplex {
+                        resource: "packages",
+                        value: self.packages.len() + 1,
+                        limit: MAX_DISCOVERED_PACKAGES,
+                    });
+                }
+
+                let pending_len = self.pending.len() + pkg.dependencies.len();
+                if pending_len > MAX_PENDING_DEPENDENCIES {
+                    return Err(ResolveError::TooComplex {
+                        resource: "pending_dependencies",
+                        value: pending_len,
+                        limit: MAX_PENDING_DEPENDENCIES,
+                    });
+                }
+
                 let index = self.graph.add_node(Node {
                     id: package_id.clone(),
                     pkg: pkg.clone(),
@@ -666,6 +695,8 @@ impl PartialDiscovery {
                 alias: dep.alias().to_string(),
             },
         );
+
+        Ok(())
     }
 
     fn finish(self) -> DiscoveredPackages {
@@ -1746,6 +1777,165 @@ mod tests {
             }
             _ => unreachable!("Expected a complexity limit error, found {:?}", result),
         }
+    }
+
+    #[test]
+    fn validate_dependency_graph_reports_cycles_without_panicking() {
+        let mut builder = RegistryBuilder::new();
+        builder.register("root", "1.0.0");
+        builder.register("dep", "1.0.0");
+
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let dep_id = PackageId::new_named("dep", "1.0.0".parse().unwrap());
+
+        let root = builder.get(&root_id);
+        let dep = builder.get(&dep_id);
+
+        let mut graph = DiGraph::new();
+        let root_ix = graph.add_node(Node {
+            id: root_id.clone(),
+            pkg: root.pkg.clone(),
+            dist: Some(root.dist.clone()),
+        });
+        let dep_ix = graph.add_node(Node {
+            id: dep_id.clone(),
+            pkg: dep.pkg.clone(),
+            dist: Some(dep.dist.clone()),
+        });
+
+        graph.add_edge(
+            root_ix,
+            dep_ix,
+            Edge {
+                alias: "dep".to_string(),
+            },
+        );
+        graph.add_edge(
+            dep_ix,
+            root_ix,
+            Edge {
+                alias: "root".to_string(),
+            },
+        );
+
+        let graph = DependencyGraph::new(
+            root_ix,
+            graph,
+            BTreeMap::from([(root_id, root_ix), (dep_id, dep_ix)]),
+        );
+
+        assert!(matches!(
+            validate_dependency_graph(&graph),
+            Err(ResolveError::Cycle(_))
+        ));
+    }
+
+    #[test]
+    fn backtracking_partial_discovery_enforces_pending_dependency_limit() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+        let child_id = PackageId::new_named("child", "1.0.0".parse().unwrap());
+
+        let root = PackageInfo {
+            id: root_id.clone(),
+            dependencies: vec![Dependency {
+                alias: "child".to_string(),
+                pkg: PackageSource::from(
+                    NamedPackageIdent::try_from_full_name_and_version("child", "=1.0.0").unwrap(),
+                ),
+            }],
+            commands: Vec::new(),
+            entrypoint: None,
+            filesystem: Vec::new(),
+        };
+        let mut child = PackageInfo {
+            id: child_id.clone(),
+            dependencies: Vec::new(),
+            commands: Vec::new(),
+            entrypoint: None,
+            filesystem: Vec::new(),
+        };
+        for ix in 0..=MAX_PENDING_DEPENDENCIES {
+            let name = format!("leaf{ix}");
+            child.dependencies.push(Dependency {
+                alias: name.clone(),
+                pkg: PackageSource::from(
+                    NamedPackageIdent::try_from_full_name_and_version(&name, "=1.0.0").unwrap(),
+                ),
+            });
+        }
+        let dist = DistributionInfo {
+            webc: "http://localhost/child@1.0.0".parse().unwrap(),
+            webc_sha256: [0; 32].into(),
+        };
+
+        let mut discovery = PartialDiscovery::new(&root_id, &root);
+        let task = discovery.pending.remove(0);
+        let result = discovery.add_dependency(
+            task.parent(),
+            task.dep(),
+            PackageSummary { pkg: child, dist },
+        );
+
+        match result {
+            Err(ResolveError::TooComplex {
+                resource,
+                value,
+                limit,
+            }) => {
+                assert_eq!(resource, "pending_dependencies");
+                assert_eq!(limit, MAX_PENDING_DEPENDENCIES);
+                assert!(value > limit);
+            }
+            _ => unreachable!("Expected a complexity limit error, found {:?}", result),
+        }
+    }
+
+    #[tokio::test]
+    async fn backtracking_handles_deep_incompatible_candidate_tree_with_state_limit() {
+        let root_id = PackageId::new_named("root", "1.0.0".parse().unwrap());
+
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("root", "1.0.0")
+            .with_dependency("branch0", "^1.0.0")
+            .with_dependency("pinner", "=1.0.0");
+
+        for branch in 0..8 {
+            for version in 0..8 {
+                let name = format!("branch{branch}");
+                let version = format!("1.{version}.0");
+                let mut pkg = builder.register(&name, &version);
+                pkg.with_dependency("common", "=2.0.0");
+                if branch < 7 {
+                    pkg.with_dependency(&format!("branch{}", branch + 1), "^1.0.0");
+                }
+            }
+        }
+
+        builder
+            .register("pinner", "1.0.0")
+            .with_dependency("common", "=1.0.0");
+        builder.register("common", "1.0.0");
+        builder.register("common", "2.0.0");
+
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            resolve(&root.package_id(), &root.pkg, &registry),
+        )
+        .await
+        .expect("backtracking did not finish within the test budget");
+
+        assert!(matches!(
+            result,
+            Err(ResolveError::DuplicateVersions { .. })
+                | Err(ResolveError::TooComplex {
+                    resource: "backtrack_states",
+                    ..
+                })
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR does two things.

A) improve dependency unification

Improve the dependency resolver to unify dependencies, so overlapping
dependencies with slightly different version ranges are still accepted.

Previously, when separate dependencies pulled in the same package, but with 
different minimum versions, resolution would be rejected.

The new code instead properly fetches all relevant deps first, then unifies to
the most compatible versions.

B) Add 'package tree' CLI command

It shows the dependency tree of a package, including specified and resolved
versions.
