### PR TITLE
tests(WASIX): add support for V8

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -3,7 +3,7 @@ fn build_v8() {
     use bindgen::callbacks::ParseCallbacks;
     use std::{
         env, fs,
-        path::{Path, PathBuf},
+        path::PathBuf,
         sync::{LazyLock, Mutex},
     };
 

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -233,6 +233,7 @@ journal = ["tokio/fs", "wasmer-journal/log-file"]
 
 # Deprecated. Kept it for compatibility
 compiler = []
+v8 = ["wasmer/v8"]
 
 js = [
   "virtual-fs/js",

--- a/lib/wasix/tests/wasm_tests/context_switch/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switch/main.c
@@ -1,3 +1,5 @@
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/contexts_with_env_vars/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/contexts_with_env_vars/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/contexts_with_mutexes/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/contexts_with_mutexes/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/contexts_with_pipes/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/contexts_with_pipes/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/contexts_with_setjmp/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/contexts_with_setjmp/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <setjmp.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/contexts_with_signals/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/contexts_with_signals/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <signal.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/contexts_with_timers/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/contexts_with_timers/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/error_handling/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/error_handling/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/legacy_process_switching/build.sh
+++ b/lib/wasix/tests/wasm_tests/context_switching/legacy_process_switching/build.sh
@@ -1,8 +1,8 @@
+#!/usr/bin/env bash
 ##AbstractConfig:base
 ##SkipEngine:V8:async functions are not supported yet
 ##UnixOnly: true
 
-#!/usr/bin/env bash
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
 ##Config: test_legacy_process_switching_basic_switching:base
 ##Args: basic_switching

--- a/lib/wasix/tests/wasm_tests/context_switching/legacy_process_switching/build.sh
+++ b/lib/wasix/tests/wasm_tests/context_switching/legacy_process_switching/build.sh
@@ -1,28 +1,27 @@
+##AbstractConfig:base
+##SkipEngine:V8:async functions are not supported yet
+##UnixOnly: true
+
 #!/usr/bin/env bash
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
-##Config: test_legacy_process_switching_basic_switching
-##UnixOnly: true
+##Config: test_legacy_process_switching_basic_switching:base
 ##Args: basic_switching
 
-##Config: test_legacy_process_switching_vfork_after_switching
-##UnixOnly: true
+##Config: test_legacy_process_switching_vfork_after_switching:base
 ##Args: vfork_after_switching
 
-##Config: test_legacy_process_switching_vfork_after_switching2
+##Config: test_legacy_process_switching_vfork_after_switching2:base
 ##UnixOnly: true
 ##Args: vfork_after_switching2
 
-##Config: test_legacy_process_switching_fork_after_switching
-##UnixOnly: true
+##Config: test_legacy_process_switching_fork_after_switching:base
 ##Ignored: flaky test (#6538)
 ##Args: fork_after_switching
 
-##Config: test_legacy_process_switching_fork_and_vfork_only_work_in_main_context
-##UnixOnly: true
+##Config: test_legacy_process_switching_fork_and_vfork_only_work_in_main_context:base
 ##Args: fork_and_vfork_only_work_in_main_context
 
-##Config: test_legacy_process_switching_posix_spawning_a_forking_subprocess_from_a_context
-##UnixOnly: true
+##Config: test_legacy_process_switching_posix_spawning_a_forking_subprocess_from_a_context:base
 ##Args: posix_spawning_a_forking_subprocess_from_a_context
 
 set -euo pipefail

--- a/lib/wasix/tests/wasm_tests/context_switching/malloc_during_switch/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/malloc_during_switch/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 // Test memory allocations during context switches
 // This can trigger store context issues if malloc implementation
 // does host calls while the store is borrowed

--- a/lib/wasix/tests/wasm_tests/context_switching/multiple_contexts/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/multiple_contexts/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/nested_host_call_switch/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/nested_host_call_switch/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 // Test switching contexts while nested in the middle of syscalls
 // This directly tries to trigger "store context still borrowed" by
 // calling wasix_context_switch during operations that hold a store borrow

--- a/lib/wasix/tests/wasm_tests/context_switching/nested_switches/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/nested_switches/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/pending_file_operations/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/pending_file_operations/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/recursive_host_calls/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/recursive_host_calls/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 // Test context switching during recursive system calls
 // This tries to trigger the store context borrow error by doing
 // complex syscalls that might borrow the store while switching

--- a/lib/wasix/tests/wasm_tests/context_switching/simple_switching/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/simple_switching/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/switch_to_never_resumed/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/switch_to_never_resumed/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 // Test that switching to a never-resumed context activates the correct context
 // This test creates 3 contexts and switches between them to verify
 // that the correct entrypoint is called for each

--- a/lib/wasix/tests/wasm_tests/context_switching/switching_in_threads/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/switching_in_threads/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/switching_to_a_deleted_context/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/switching_to_a_deleted_context/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/switching_with_main/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/switching_with_main/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/context_switching/three_way_recursion/main.c
+++ b/lib/wasix/tests/wasm_tests/context_switching/three_way_recursion/main.c
@@ -1,4 +1,6 @@
 //#UnixOnly: true
+//#SkipEngine:V8:async functions are not supported yet
+
 // Minimal: 3 mutually recursive funcs, 3 contexts, circular pattern
 #include <assert.h>
 #include <stdio.h>

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -661,8 +661,9 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                 for engine in [
                     Engine::Cranelift,
                     Engine::LLVM,
-                    #[cfg(feature = "v8")]
-                    Engine::V8,
+                    // TODO: enable once the WASIX tests are green with V8
+                    //#[cfg(feature = "v8")]
+                    //Engine::V8,
                 ] {
                     // The EH support for macOS is still missing: #6419
                     if cfg!(target_os = "macos") {

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -28,6 +28,9 @@
 //!
 //! `Ignored:{reason}` marks the configuration as ignored with the given reason.
 //!
+//! `SkipEngine:{engine}:{reason}` marks the configuration as ignored for
+//! a given engine (LLVM, Cranelift, V8).
+//!
 //! `UnixOnly:{bool}` ignores the configuration on non-Unix hosts when true.
 //!
 //! `MappedDirectory:{host}:{guest}` maps a host directory into the guest. Relative
@@ -126,6 +129,7 @@ struct Config {
     arguments: Vec<String>,
     build_env: Vec<(String, String)>,
     ignored: Option<String>,
+    skipped_engines: Vec<(Engine, String)>,
     unix_only: bool,
     mapped_directories: Vec<MappedDirectory>,
     current_directory: Option<String>,
@@ -154,6 +158,7 @@ impl Config {
             expected_exit_code: 0,
             expected_stdout: Vec::new(),
             ignored: None,
+            skipped_engines: Vec::new(),
             unix_only: false,
             mapped_directories: Vec::new(),
             current_directory: None,
@@ -304,6 +309,19 @@ fn process_directive(
             config.expected_exit_code = arg.parse::<i32>()?;
         }
         "Ignored" => config.ignored = Some(arg.to_owned()),
+        "SkipEngine" => {
+            let (engine, reason) = arg
+                .split_once(':')
+                .ok_or_else(|| anyhow!("missing colon separator for SkipEngine"))?;
+            if let Some(engine) = match engine.to_lowercase().as_str() {
+                "llvm" => Some(Engine::LLVM),
+                "cranelift" => Some(Engine::Cranelift),
+                "v8" => None,
+                _ => bail!("unsupported engine: '{engine}'"),
+            } {
+                config.skipped_engines.push((engine, reason.to_owned()));
+            }
+        }
         "UnixOnly" => config.unix_only = arg.parse::<bool>()?,
         "MappedDirectory" => {
             let (host, guest) = arg
@@ -417,6 +435,13 @@ fn run_integration_test(config: Config) -> Result<libtest_mimic::Completion> {
     }
     if !cfg!(unix) && config.unix_only {
         return Ok(libtest_mimic::Completion::ignored_with("Unix only"));
+    }
+    if let Some((_, reason)) = config
+        .skipped_engines
+        .iter()
+        .find(|(engine, _)| *engine == config.engine)
+    {
+        return Ok(libtest_mimic::Completion::ignored_with(reason.clone()));
     }
 
     let wasm = run_build_script(&config)?;

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -100,6 +100,8 @@ struct MappedDirectory {
 pub enum Engine {
     Cranelift,
     LLVM,
+    #[cfg(feature = "v8")]
+    V8,
 }
 
 impl Engine {
@@ -107,6 +109,8 @@ impl Engine {
         match self {
             Self::Cranelift => "cranelift",
             Self::LLVM => "llvm",
+            #[cfg(feature = "v8")]
+            Self::V8 => "v8",
         }
     }
 }
@@ -316,7 +320,16 @@ fn process_directive(
             if let Some(engine) = match engine.to_lowercase().as_str() {
                 "llvm" => Some(Engine::LLVM),
                 "cranelift" => Some(Engine::Cranelift),
-                "v8" => None,
+                "v8" => {
+                    #[cfg(feature = "v8")]
+                    {
+                        Some(Engine::V8)
+                    }
+                    #[cfg(not(feature = "v8"))]
+                    {
+                        None
+                    }
+                }
                 _ => bail!("unsupported engine: '{engine}'"),
             } {
                 config.skipped_engines.push((engine, reason.to_owned()));
@@ -645,7 +658,12 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
             ))?;
 
             for config in configs {
-                for engine in [Engine::Cranelift, Engine::LLVM] {
+                for engine in [
+                    Engine::Cranelift,
+                    Engine::LLVM,
+                    #[cfg(feature = "v8")]
+                    Engine::V8,
+                ] {
                     // The EH support for macOS is still missing: #6419
                     if cfg!(target_os = "macos") {
                         return Ok(());

--- a/lib/wasix/tests/wasm_tests/runner.rs
+++ b/lib/wasix/tests/wasm_tests/runner.rs
@@ -265,6 +265,8 @@ fn create_engine_for_wasm(wasm_bytes: &[u8], engine: Engine) -> wasmer::Engine {
     let backend = match engine {
         Engine::Cranelift => wasmer::BackendKind::Cranelift,
         Engine::LLVM => wasmer::BackendKind::LLVM,
+        #[cfg(feature = "v8")]
+        Engine::V8 => wasmer::BackendKind::V8,
     };
     let features = wasmer_types::Features::detect_from_wasm(wasm_bytes)
         .unwrap_or_else(|_| wasmer::Engine::default_features_for_backend(&backend, &target));
@@ -281,6 +283,8 @@ fn create_engine_for_wasm(wasm_bytes: &[u8], engine: Engine) -> wasmer::Engine {
             config.num_threads(NonZero::new(1).unwrap());
             EngineBuilder::new(config)
         }
+        #[cfg(feature = "v8")]
+        Engine::V8 => return wasmer::v8::engine::Engine::new().into(),
     };
     engine
         .set_features(Some(features))


### PR DESCRIPTION
Disabled by default right now, but can be used for a local testing even now: `cargo test --features v8`.

Issue: #6121