### PR TITLE
Enable WASIX tests on macOS LLVM

### DIFF
--- a/lib/wasix/tests/wasm_tests/README.md
+++ b/lib/wasix/tests/wasm_tests/README.md
@@ -48,9 +48,9 @@ Cargo and nextest filtering both work. Before running the suite, make sure
 `wasixcc` is installed and available in your shell environment.
 
 On macOS, this suite is opt-in because Cranelift exception-handling support is
-still incomplete there. Pass `--enable-macos-wasm-tests` after Cargo's `--` to
-collect and run the macOS-supported LLVM variants:
+still incomplete there. Set `WASMER_ENABLE_MACOS_WASM_TESTS=1` to collect and
+run the macOS-supported LLVM variants:
 
 ```sh
-cargo test --test wasm_tests -- --enable-macos-wasm-tests wasm/context_switching/contexts_with_signals
+WASMER_ENABLE_MACOS_WASM_TESTS=1 cargo test --test wasm_tests wasm/context_switching/contexts_with_signals
 ```

--- a/lib/wasix/tests/wasm_tests/README.md
+++ b/lib/wasix/tests/wasm_tests/README.md
@@ -46,3 +46,11 @@ the primary source, for example `//#BuildEnv: WASIXCC_PIC=1` in C/C++ sources or
 These tests run through the normal `wasix` integration test target, so standard
 Cargo and nextest filtering both work. Before running the suite, make sure
 `wasixcc` is installed and available in your shell environment.
+
+On macOS, this suite is opt-in because Cranelift exception-handling support is
+still incomplete there. Pass `--enable-macos-wasm-tests` after Cargo's `--` to
+collect and run the macOS-supported LLVM variants:
+
+```sh
+cargo test --test wasm_tests -- --enable-macos-wasm-tests wasm/context_switching/contexts_with_signals
+```

--- a/lib/wasix/tests/wasm_tests/README.md
+++ b/lib/wasix/tests/wasm_tests/README.md
@@ -49,7 +49,3 @@ Cargo and nextest filtering both work. Before running the suite, make sure
 
 On macOS, this suite collects and runs the LLVM variants only because Cranelift
 exception-handling support is still incomplete there:
-
-```sh
-cargo test --test wasm_tests wasm/context_switching/contexts_with_signals
-```

--- a/lib/wasix/tests/wasm_tests/README.md
+++ b/lib/wasix/tests/wasm_tests/README.md
@@ -47,10 +47,9 @@ These tests run through the normal `wasix` integration test target, so standard
 Cargo and nextest filtering both work. Before running the suite, make sure
 `wasixcc` is installed and available in your shell environment.
 
-On macOS, this suite is opt-in because Cranelift exception-handling support is
-still incomplete there. Set `WASMER_ENABLE_MACOS_WASM_TESTS=1` to collect and
-run the macOS-supported LLVM variants:
+On macOS, this suite collects and runs the LLVM variants only because Cranelift
+exception-handling support is still incomplete there:
 
 ```sh
-WASMER_ENABLE_MACOS_WASM_TESTS=1 cargo test --test wasm_tests wasm/context_switching/contexts_with_signals
+cargo test --test wasm_tests wasm/context_switching/contexts_with_signals
 ```

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -55,8 +55,6 @@ use walkdir::WalkDir;
 
 mod runner;
 
-const ENABLE_MACOS_WASM_TESTS_ENV: &str = "WASMER_ENABLE_MACOS_WASM_TESTS";
-
 fn should_emit_colour() -> bool {
     std::io::stdout().is_terminal()
         || std::env::var("CARGO_TERM_COLOR").as_deref() == Ok("always")
@@ -64,7 +62,7 @@ fn should_emit_colour() -> bool {
 }
 
 fn main() -> Result<std::process::ExitCode> {
-    let mut args = libtest_mimic::Arguments::from_iter(std::env::args_os());
+    let mut args = libtest_mimic::Arguments::from_args();
     if should_emit_colour() {
         args.color = Some(libtest_mimic::ColorSetting::Always);
     }
@@ -585,9 +583,6 @@ fn identify_primary_sources(test_src_dir: &Path) -> Result<Vec<PrimarySource>> {
 fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     // Windows runtime support is still limited, so skip these tests on that platform.
     if cfg!(target_os = "windows") {
-        return Ok(());
-    }
-    if cfg!(target_os = "macos") && std::env::var_os(ENABLE_MACOS_WASM_TESTS_ENV).is_none() {
         return Ok(());
     }
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -42,6 +42,7 @@
 //! `PrefilledFile:{relative_path}:{contents}` writes a file before the test runs.
 //!
 //! `ExpectedFile:{relative_path}:{contents}` checks a file after the test runs.
+//! 
 
 use anyhow::{Context, Result, anyhow, ensure};
 use itertools::Itertools;

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -43,6 +43,7 @@
 use anyhow::{Context, Result, anyhow, ensure};
 use itertools::Itertools;
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs::{File, create_dir_all, read_dir, remove_dir_all};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -55,19 +56,48 @@ use walkdir::WalkDir;
 
 mod runner;
 
+const ENABLE_MACOS_WASM_TESTS_FLAG: &str = "--enable-macos-wasm-tests";
+
+struct HarnessOptions {
+    args: libtest_mimic::Arguments,
+    macos_tests_enabled: bool,
+}
+
 fn should_emit_colour() -> bool {
     std::io::stdout().is_terminal()
         || std::env::var("CARGO_TERM_COLOR").as_deref() == Ok("always")
         || std::env::var("NEXTEST").is_ok()
 }
 
+fn parse_harness_options() -> HarnessOptions {
+    let mut macos_tests_enabled = false;
+    let args = std::env::args_os()
+        .filter(|arg| {
+            if arg.as_os_str() == OsStr::new(ENABLE_MACOS_WASM_TESTS_FLAG) {
+                macos_tests_enabled = true;
+                false
+            } else {
+                true
+            }
+        })
+        .collect_vec();
+
+    HarnessOptions {
+        args: libtest_mimic::Arguments::from_iter(args),
+        macos_tests_enabled,
+    }
+}
+
 fn main() -> Result<std::process::ExitCode> {
-    let mut args = libtest_mimic::Arguments::from_args();
+    let HarnessOptions {
+        mut args,
+        macos_tests_enabled,
+    } = parse_harness_options();
     if should_emit_colour() {
         args.color = Some(libtest_mimic::ColorSetting::Always);
     }
     let mut tests = Vec::new();
-    collect_tests(&mut tests)?;
+    collect_tests(&mut tests, macos_tests_enabled)?;
     Ok(libtest_mimic::run(&args, tests).exit_code())
 }
 
@@ -580,9 +610,12 @@ fn identify_primary_sources(test_src_dir: &Path) -> Result<Vec<PrimarySource>> {
     );
 }
 
-fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
+fn collect_tests(tests: &mut Vec<Trial>, macos_tests_enabled: bool) -> Result<()> {
     // Windows runtime support is still limited, so skip these tests on that platform.
     if cfg!(target_os = "windows") {
+        return Ok(());
+    }
+    if cfg!(target_os = "macos") && !macos_tests_enabled {
         return Ok(());
     }
 
@@ -621,9 +654,11 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
 
             for config in configs {
                 for engine in [Engine::Cranelift, Engine::LLVM] {
-                    // The EH support for macOS is still missing: #6419
-                    if cfg!(target_os = "macos") {
-                        return Ok(());
+                    // Cranelift EH support for macOS is still missing: #6419.
+                    // Keep collecting LLVM trials so focused macOS filters do
+                    // not silently report zero tests.
+                    if cfg!(target_os = "macos") && engine == Engine::Cranelift {
+                        continue;
                     }
 
                     let mut config = config.clone();

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -43,7 +43,6 @@
 use anyhow::{Context, Result, anyhow, ensure};
 use itertools::Itertools;
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fs::{File, create_dir_all, read_dir, remove_dir_all};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
@@ -56,12 +55,7 @@ use walkdir::WalkDir;
 
 mod runner;
 
-const ENABLE_MACOS_WASM_TESTS_FLAG: &str = "--enable-macos-wasm-tests";
-
-struct HarnessOptions {
-    args: libtest_mimic::Arguments,
-    macos_tests_enabled: bool,
-}
+const ENABLE_MACOS_WASM_TESTS_ENV: &str = "WASMER_ENABLE_MACOS_WASM_TESTS";
 
 fn should_emit_colour() -> bool {
     std::io::stdout().is_terminal()
@@ -69,35 +63,13 @@ fn should_emit_colour() -> bool {
         || std::env::var("NEXTEST").is_ok()
 }
 
-fn parse_harness_options() -> HarnessOptions {
-    let mut macos_tests_enabled = false;
-    let args = std::env::args_os()
-        .filter(|arg| {
-            if arg.as_os_str() == OsStr::new(ENABLE_MACOS_WASM_TESTS_FLAG) {
-                macos_tests_enabled = true;
-                false
-            } else {
-                true
-            }
-        })
-        .collect_vec();
-
-    HarnessOptions {
-        args: libtest_mimic::Arguments::from_iter(args),
-        macos_tests_enabled,
-    }
-}
-
 fn main() -> Result<std::process::ExitCode> {
-    let HarnessOptions {
-        mut args,
-        macos_tests_enabled,
-    } = parse_harness_options();
+    let mut args = libtest_mimic::Arguments::from_iter(std::env::args_os());
     if should_emit_colour() {
         args.color = Some(libtest_mimic::ColorSetting::Always);
     }
     let mut tests = Vec::new();
-    collect_tests(&mut tests, macos_tests_enabled)?;
+    collect_tests(&mut tests)?;
     Ok(libtest_mimic::run(&args, tests).exit_code())
 }
 
@@ -610,12 +582,12 @@ fn identify_primary_sources(test_src_dir: &Path) -> Result<Vec<PrimarySource>> {
     );
 }
 
-fn collect_tests(tests: &mut Vec<Trial>, macos_tests_enabled: bool) -> Result<()> {
+fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     // Windows runtime support is still limited, so skip these tests on that platform.
     if cfg!(target_os = "windows") {
         return Ok(());
     }
-    if cfg!(target_os = "macos") && !macos_tests_enabled {
+    if cfg!(target_os = "macos") && std::env::var_os(ENABLE_MACOS_WASM_TESTS_ENV).is_none() {
         return Ok(());
     }
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -656,7 +656,6 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         // supported_engines.push(Engine::V8);
 
         // Cranelift EH support for macOS is still missing: #6419.
-        // Keep collecting LLVM trials so focused macOS filters do not silently report zero tests.
         if !cfg!(target_os = "macos") {
             supported_engines.push(Engine::Cranelift);
         }
@@ -673,7 +672,6 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                 for engine in &supported_engines {
                     let mut config = config.clone();
                     config.engine = *engine;
-                    
                     tests.push(libtest_mimic::Trial::ignorable_test(
                         config.full_test_name(),
                         move || {

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -649,43 +649,6 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         let test_name = relative_test_path.display().to_string();
         let primary_sources = identify_primary_sources(entry.path())?;
 
-        for primary_source in primary_sources {
-            let configs = parse_configs(&Config::new(
-                primary_source,
-                entry.path().to_path_buf(),
-                tests_build_root.clone(),
-                test_name.clone(),
-            ))?;
-
-            let supported_engines = [
-                    Engine::Cranelift,
-                    Engine::LLVM,
-                    // TODO: enable once the WASIX tests are green with V8
-                    #[cfg(feature = "v8")]
-                    Engine::V8,
-                ];
-
-            for config in configs {
-                for engine in &supported_engines {
-                    // Cranelift EH support for macOS is still missing: #6419.
-                    // Keep collecting LLVM trials so focused macOS filters do
-                    // not silently report zero tests.
-                    if cfg!(target_os = "macos") && engine == Engine::Cranelift {
-                        return Ok(());
-                    }
-
-                    let mut config = config.clone();
-                    config.engine = *engine;
-                    tests.push(libtest_mimic::Trial::ignorable_test(
-                        config.full_test_name(),
-                        move || {
-                            run_integration_test(config)
-                                .map_err(|e| libtest_mimic::Failed::from(e.to_string()))
-                        },
-                    ));
-                }
-            }
-        }
         let mut supported_engines = vec![Engine::LLVM];
 
         // TODO: enable once the WASIX tests are green with V8

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -42,7 +42,6 @@
 //! `PrefilledFile:{relative_path}:{contents}` writes a file before the test runs.
 //!
 //! `ExpectedFile:{relative_path}:{contents}` checks a file after the test runs.
-//! 
 
 use anyhow::{Context, Result, anyhow, ensure};
 use itertools::Itertools;


### PR DESCRIPTION
Allow WASIX tests to run on macOS.

See also https://github.com/wasix-org/wasix-libc/pull/112

~This is enabled with explicit command line option: `--enable-macos-wasm-tests`, e.g.~

~cargo test --test wasm_tests -- --enable-macos-wasm-tests wasm/context_switching/contexts_with_signals~

This is enabled with explicit environment variable: `WASMER_ENABLE_MACOS_WASM_TESTS=1`.

Rationale: Currently WASIX tests are disabled on macOS, and this is to allow them to run.