### PR TITLE
test: temporarily disable CLI integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -609,8 +609,9 @@ jobs:
             make: "test-wasmer-cli"
           - description: "Examples"
             make: "test-examples"
-          - description: "CLI integ. tests"
-            make: test-integration-cli-ci
+        # TODO: temporarily disabled
+        #          - description: "CLI integ. tests"
+        #            make: test-integration-cli-ci
         metadata:
           - build: linux-x64
             os: ubuntu-22.04


### PR DESCRIPTION
The wasmer.wtf has switched to the Rust back-end, but it seems unstable right now.