### PR TITLE
fix(wasix): Don't log error on HostInterrupt as it's expected behaviour

### DIFF
--- a/lib/wasix/src/bin_factory/exec.rs
+++ b/lib/wasix/src/bin_factory/exec.rs
@@ -381,8 +381,16 @@ fn call_module(
             Some(s) => s,
             None => {
                 let err_display = err.display(&mut store);
-                error!("{err_display}");
-                eprintln!("{err_display}");
+                if matches!(
+                    err,
+                    WasiRuntimeError::Runtime(runtime_err)
+                        if runtime_err.clone().to_trap() == Some(wasmer_types::TrapCode::HostInterrupt)
+                ) {
+                    debug!("{err_display}");
+                } else {
+                    error!("{err_display}");
+                    eprintln!("{err_display}");
+                }
                 Errno::Noexec.into()
             }
         }

--- a/lib/wasix/src/syscalls/wasix/thread_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/thread_spawn.rs
@@ -280,7 +280,11 @@ fn handle_thread_result(
             Ok(Some(ExitCode::from(129)))
         }
         Err(err) => {
-            eprintln!("Thread {tid} of process {pid} failed with runtime error: {err}");
+            if err.clone().to_trap() == Some(wasmer_types::TrapCode::HostInterrupt) {
+                debug!(%tid, %pid, error = %err, "thread interrupted by host");
+            } else {
+                eprintln!("Thread {tid} of process {pid} failed with runtime error: {err}");
+            }
             env.data(&store)
                 .runtime
                 .on_taint(TaintReason::RuntimeError(err));


### PR DESCRIPTION
We've introduced new `HostInterrupt` behaviour a few weeks ago and currently we are almost hitting rate limits in Sentry in Edge. I think we should simply silence that as it's totally normal behavour

Fixes https://linear.app/wasmer/issue/EDGE-1775/sentry-runtimeerror-interrupted-by-host