### PR TITLE
fix(V8): use proper new memory sharing mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ axum = { version = "=0.6.9", default-features = false }
 backtrace = "0.3"
 base64 = "0.22.1"
 bincode = "=2.0.1"
-bindgen = "0.72.1"
+bindgen = { version = "0.72.1", default-features = false }
 bitflags = "2.11.0"
 blake3 = "1.0"
 build-deps = "0.1.4"

--- a/Makefile
+++ b/Makefile
@@ -294,11 +294,13 @@ comma := ,
 build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra_features))
 
 test_compilers := $(compilers)
-ifeq ($(IS_LINUX), 1)
-	ifeq ($(IS_AMD64), 1)
-		ifneq ($(LIBC), musl)
-			test_compilers += v8
-		endif
+ifeq ($(IS_AMD64), 1)
+	ifneq (, $(filter 1, $(IS_LINUX) $(IS_WINDOWS)))
+		test_compilers += v8
+	endif
+else ifeq ($(IS_AARCH64), 1)
+	ifeq ($(IS_DARWIN), 1)
+		test_compilers += v8
 	endif
 endif
 test_compilers := $(strip $(test_compilers))

--- a/Makefile
+++ b/Makefile
@@ -293,8 +293,6 @@ space := $() $()
 comma := ,
 build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra_features))
 
-# Right now, we do not support V8 for all our targets and it will change with:
-# https://github.com/wasmerio/v8-custom-builds/pull/12
 test_compilers := $(compilers)
 ifeq ($(IS_LINUX), 1)
 	ifeq ($(IS_AMD64), 1)

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -185,7 +185,16 @@ ureq = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
 xz = { workspace = true, optional = true }
 zip = { workspace = true, optional = true, features = ["deflate"] }
-bindgen.workspace = true
+
+[target.'cfg(not(target_env = "musl"))'.build-dependencies]
+bindgen = { workspace = true, default-features = true }
+
+[target.'cfg(target_env = "musl")'.build-dependencies]
+bindgen = { workspace = true, default-features = false, features = [
+  "logging",
+  "prettyplease",
+  "static",
+] }
 
 [package.metadata.docs.rs]
 features = [

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -189,6 +189,7 @@ zip = { workspace = true, optional = true, features = ["deflate"] }
 [target.'cfg(not(target_env = "musl"))'.build-dependencies]
 bindgen = { workspace = true, default-features = true }
 
+# must does not support dlopen/dlsym functionality used by the bindgen (using libclang).
 [target.'cfg(target_env = "musl")'.build-dependencies]
 bindgen = { workspace = true, default-features = false, features = [
   "logging",

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -65,7 +65,8 @@ fn build_v8() {
                 .expect("failed to download v8")
                 .body_mut()
                 .with_config()
-                .limit(200 * 1024 * 1024) // Windows prebuilts are substantially larger.
+                // Windows prebuilts are substantially larger.
+                .limit(200 * 1024 * 1024)
                 .read_to_vec()
                 .expect("failed to download v8 lib");
 

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -35,7 +35,11 @@ fn build_v8() {
         .join(platform_name);
     let archive_path = cache_dir.join(asset_name);
     let v8_lib_dir = cache_dir.join("lib");
-    let v8_lib_path = v8_lib_dir.join("libv8.a");
+    let v8_lib_path = v8_lib_dir.join(if cfg!(target_os = "windows") {
+        "libv8.lib"
+    } else {
+        "libv8.a"
+    });
 
     if !v8_lib_path.exists() {
         fs::create_dir_all(&cache_dir).unwrap_or_else(|err| {

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -18,10 +18,9 @@ fn build_v8() {
     ) {
         ("macos", "aarch64", _) => ("v8-darwin-aarch64.tar.xz", "darwin-aarch64"),
         ("linux", "x86_64", "gnu") => ("v8-linux-amd64.tar.xz", "linux-amd64"),
-        ("linux", "x86_64", "musl") => ("v8-linux-musl-amd64.tar.xz", "linux-musl-amd64"),
+        ("linux", "x86_64", "musl") => ("v8-linux-musl.tar.xz", "linux-musl"),
+        ("windows", "x86_64", _) => ("v8-windows-amd64.tar.xz", "windows-amd64"),
         ("android", "aarch64", _) => ("v8-android-arm64.tar.xz", "android-arm64"),
-        // Not supported in 6.0.0-alpha1
-        //("windows", "x86_64", _) => "https://github.com/wasmerio/wee8-custom-builds/releases/download/11.7-custom1/wee8-windows-amd64.tar.xz",
         (os, arch, _) => panic!("target os + arch combination not supported: {os}, {arch}"),
     };
 
@@ -66,7 +65,7 @@ fn build_v8() {
                 .expect("failed to download v8")
                 .body_mut()
                 .with_config()
-                .limit(50 * 1024 * 1024) // 50MB
+                .limit(200 * 1024 * 1024) // Windows prebuilts are substantially larger.
                 .read_to_vec()
                 .expect("failed to download v8 lib");
 

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -36,7 +36,7 @@ fn build_v8() {
     let archive_path = cache_dir.join(asset_name);
     let v8_lib_dir = cache_dir.join("lib");
     let v8_lib_path = v8_lib_dir.join(if cfg!(target_os = "windows") {
-        "libv8.lib"
+        "v8.lib"
     } else {
         "libv8.a"
     });

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -182,6 +182,9 @@ impl Memory {
 
         let memorytype = unsafe { wasm_memorytype_new(&limits) };
         let copied_memory = unsafe { wasm_memory_new(v8_store.inner, memorytype) };
+        unsafe {
+            wasm_memorytype_delete(memorytype);
+        }
         if copied_memory.is_null() {
             return Err(MemoryError::Generic(
                 "failed to allocate copied V8 memory".to_owned(),

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -1,7 +1,7 @@
 //! Data types, functions and traits for `v8` runtime's `Memory` implementation.
 use std::{marker::PhantomData, mem::MaybeUninit};
 
-use tracing::{debug, warn};
+use tracing::warn;
 pub use wasmer_types::MemoryError;
 use wasmer_types::{MemoryType, Pages, WASM_PAGE_SIZE};
 
@@ -170,16 +170,16 @@ impl Memory {
         let store_ref = store.as_store_ref();
         let v8_store = store_ref.inner.store.as_v8();
 
-        let limits = Box::into_raw(Box::new(wasm_limits_t {
+        let limits = wasm_limits_t {
             min: ty.minimum.0,
             max: ty.maximum.unwrap_or(Pages::max_value()).0,
             // This copy is returned as a `SharedMemory` so it can be moved to
             // another store/thread and attached there. Keep the copied memory
             // independent from the source, but make the copy shareable.
             shared: true,
-        }));
+        };
 
-        let memorytype = unsafe { wasm_memorytype_new(limits) };
+        let memorytype = unsafe { wasm_memorytype_new(&limits) };
         let copied_memory = unsafe { wasm_memory_new(v8_store.inner, memorytype) };
         if copied_memory.is_null() {
             return Err(MemoryError::Generic(

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -173,10 +173,7 @@ impl Memory {
         let limits = wasm_limits_t {
             min: ty.minimum.0,
             max: ty.maximum.unwrap_or(Pages::max_value()).0,
-            // This copy is returned as a `SharedMemory` so it can be moved to
-            // another store/thread and attached there. Keep the copied memory
-            // independent from the source, but make the copy shareable.
-            shared: true,
+            shared: ty.shared,
         };
 
         let memorytype = unsafe { wasm_memorytype_new(&limits) };

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -82,12 +82,15 @@ impl Memory {
         let memory_type: *mut wasm_memorytype_t =
             unsafe { wasm_memory_type(self.handle.as_memory()) };
         let limits: *const wasm_limits_t = unsafe { wasm_memorytype_limits(memory_type) };
+        unsafe {
+            wasm_memorytype_delete(memory_type);
+        }
 
         MemoryType {
             shared: unsafe { (*limits).shared },
             minimum: unsafe { wasmer_types::Pages((*limits).min) },
             maximum: unsafe { Some(wasmer_types::Pages((*limits).max)) },
-        }
+        };
     }
 
     pub fn size(&self, store: &impl AsStoreRef) -> Pages {
@@ -223,6 +226,10 @@ impl Memory {
     }
 
     pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
+        if !self.ty(store).shared {
+            return None;
+        }
+
         Some(SharedMemory::from_vm_memory(crate::vm::VMMemory::V8(
             self.handle.try_clone().ok()?,
         )))

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -1,7 +1,7 @@
 //! Data types, functions and traits for `v8` runtime's `Memory` implementation.
 use std::{marker::PhantomData, mem::MaybeUninit};
 
-use tracing::warn;
+use tracing::{debug, warn};
 pub use wasmer_types::MemoryError;
 use wasmer_types::{MemoryType, Pages, WASM_PAGE_SIZE};
 
@@ -58,25 +58,29 @@ impl Memory {
         let c_memory = unsafe { wasm_memory_new(v8_store.inner, memorytype) };
 
         Ok(Self {
-            handle: VMMemory(c_memory),
+            handle: VMMemory::attached(c_memory),
         })
     }
 
     pub fn new_from_existing(new_store: &mut impl AsStoreMut, memory: VMMemory) -> Self {
         check_isolate(new_store);
         let store_mut = new_store.as_store_mut();
-        Self { handle: memory }
+        let v8_store = store_mut.inner.store.as_v8();
+        Self {
+            handle: memory.obtain(v8_store.inner),
+        }
     }
 
     pub(crate) fn to_vm_extern(&self) -> VMExtern {
-        VMExtern::V8(unsafe { wasm_memory_as_extern(self.handle.0) })
+        VMExtern::V8(unsafe { wasm_memory_as_extern(self.handle.as_memory()) })
     }
 
     pub fn ty(&self, store: &impl AsStoreRef) -> MemoryType {
         check_isolate(store);
         let store = store.as_store_ref();
 
-        let memory_type: *mut wasm_memorytype_t = unsafe { wasm_memory_type(self.handle.0) };
+        let memory_type: *mut wasm_memorytype_t =
+            unsafe { wasm_memory_type(self.handle.as_memory()) };
         let limits: *const wasm_limits_t = unsafe { wasm_memorytype_limits(memory_type) };
 
         MemoryType {
@@ -88,7 +92,7 @@ impl Memory {
 
     pub fn size(&self, store: &impl AsStoreRef) -> Pages {
         check_isolate(store);
-        let size = unsafe { wasm_memory_size(self.handle.0) };
+        let size = unsafe { wasm_memory_size(self.handle.as_memory()) };
         Pages(size)
     }
 
@@ -111,9 +115,9 @@ impl Memory {
         let store_mut = store.as_store_mut();
         unsafe {
             let delta: Pages = delta.into();
-            let current = Pages(wasm_memory_size(self.handle.0));
+            let current = Pages(wasm_memory_size(self.handle.as_memory()));
 
-            if !wasm_memory_grow(self.handle.0, delta.0) {
+            if !wasm_memory_grow(self.handle.as_memory(), delta.0) {
                 Err(MemoryError::CouldNotGrow {
                     current,
                     attempted_delta: delta,
@@ -136,7 +140,7 @@ impl Memory {
         })?;
 
         unsafe {
-            let current_pages = wasm_memory_size(self.handle.0);
+            let current_pages = wasm_memory_size(self.handle.as_memory());
             if min_size.0 > current_pages {
                 self.grow(store, Pages(min_size.0 - current_pages))?;
             }
@@ -155,17 +159,65 @@ impl Memory {
     pub(crate) fn from_vm_extern(store: &mut impl AsStoreMut, internal: VMExternMemory) -> Self {
         check_isolate(store);
         Self {
-            handle: VMMemory(internal.unwrap_v_8()),
+            handle: VMMemory::attached(internal.unwrap_v_8()),
         }
     }
 
     pub fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         check_isolate(store);
 
-        // FIXME: implement memory copying
-        Err(MemoryError::UnsupportedOperation {
-            message: "copy is not supported for V8 memory because the wasm C API can only clone the memory reference".to_owned(),
-        })
+        let ty = self.ty(store);
+        let store_ref = store.as_store_ref();
+        let v8_store = store_ref.inner.store.as_v8();
+
+        let limits = Box::into_raw(Box::new(wasm_limits_t {
+            min: ty.minimum.0,
+            max: ty.maximum.unwrap_or(Pages::max_value()).0,
+            // This copy is returned as a `SharedMemory` so it can be moved to
+            // another store/thread and attached there. Keep the copied memory
+            // independent from the source, but make the copy shareable.
+            shared: true,
+        }));
+
+        let memorytype = unsafe { wasm_memorytype_new(limits) };
+        let copied_memory = unsafe { wasm_memory_new(v8_store.inner, memorytype) };
+        if copied_memory.is_null() {
+            return Err(MemoryError::Generic(
+                "failed to allocate copied V8 memory".to_owned(),
+            ));
+        }
+
+        let copied = Self {
+            handle: VMMemory::attached(copied_memory),
+        };
+
+        let src_view = self.view(store);
+        let dst_view = copied.view(store);
+        let src_pages = src_view.size();
+        let dst_pages = dst_view.size();
+
+        if src_pages > dst_pages {
+            let delta = src_pages.0.checked_sub(dst_pages.0).ok_or_else(|| {
+                MemoryError::Generic("failed to calculate V8 memory copy growth".to_owned())
+            })?;
+
+            if !unsafe { wasm_memory_grow(copied.handle.as_memory(), delta) } {
+                return Err(MemoryError::CouldNotGrow {
+                    current: dst_pages,
+                    attempted_delta: Pages(delta),
+                });
+            }
+        }
+
+        let src_view = self.view(store);
+        let dst_view = copied.view(store);
+        src_view
+            .copy_to_memory(src_view.data_size(), &dst_view)
+            .map_err(|err| MemoryError::Generic(format!("failed to copy V8 memory: {err}")))?;
+
+        Ok(SharedMemory::from_vm_memory(crate::vm::VMMemory::V8(
+            copied.handle.try_clone()?,
+        )))
     }
 
     pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
@@ -182,7 +234,7 @@ impl Memory {
 
 impl std::cmp::PartialEq for Memory {
     fn eq(&self, other: &Self) -> bool {
-        self.handle.0 == other.handle.0
+        self.handle.as_memory() == other.handle.as_memory()
     }
 }
 

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -82,15 +82,12 @@ impl Memory {
         let memory_type: *mut wasm_memorytype_t =
             unsafe { wasm_memory_type(self.handle.as_memory()) };
         let limits: *const wasm_limits_t = unsafe { wasm_memorytype_limits(memory_type) };
-        unsafe {
-            wasm_memorytype_delete(memory_type);
-        }
 
         MemoryType {
             shared: unsafe { (*limits).shared },
             minimum: unsafe { wasmer_types::Pages((*limits).min) },
             maximum: unsafe { Some(wasmer_types::Pages((*limits).max)) },
-        };
+        }
     }
 
     pub fn size(&self, store: &impl AsStoreRef) -> Pages {
@@ -170,6 +167,10 @@ impl Memory {
         check_isolate(store);
 
         let ty = self.ty(store);
+        if !ty.shared {
+            return Err(MemoryError::MemoryNotShared);
+        }
+
         let store_ref = store.as_store_ref();
         let v8_store = store_ref.inner.store.as_v8();
 
@@ -226,10 +227,6 @@ impl Memory {
     }
 
     pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
-        if !self.ty(store).shared {
-            return None;
-        }
-
         Some(SharedMemory::from_vm_memory(crate::vm::VMMemory::V8(
             self.handle.try_clone().ok()?,
         )))

--- a/lib/api/src/backend/v8/entities/memory/view.rs
+++ b/lib/api/src/backend/v8/entities/memory/view.rs
@@ -6,7 +6,6 @@ use super::{Memory, MemoryBuffer};
 use crate::{
     AsStoreRef, MemoryAccessError,
     backend::v8::bindings::{wasm_memory_data, wasm_memory_data_size, wasm_memory_size},
-    v8::bindings::wasm_memory_t,
 };
 
 /// A WebAssembly `memory` view.
@@ -23,7 +22,7 @@ pub struct MemoryView<'a> {
 
 impl<'a> MemoryView<'a> {
     pub(crate) fn new(memory: &Memory, store: &'a (impl AsStoreRef + ?Sized)) -> Self {
-        let c_memory: *mut wasm_memory_t = memory.handle.0;
+        let c_memory = memory.handle.as_memory();
 
         let len = unsafe { wasm_memory_data_size(c_memory as _) };
         let base: *mut u8 = unsafe { wasm_memory_data(c_memory as _) as _ };

--- a/lib/api/src/backend/v8/vm/mod.rs
+++ b/lib/api/src/backend/v8/vm/mod.rs
@@ -146,7 +146,10 @@ impl VMExceptionRef {
 }
 
 #[derive(Debug, Clone)]
-pub struct VMMemory(pub(super) *mut wasm_memory_t);
+pub enum VMMemory {
+    Attached(*mut wasm_memory_t),
+    Shared(*mut wasm_shared_memory_t),
+}
 pub type VMSharedMemory = VMMemory;
 pub(crate) type VMExternMemory = *mut wasm_memory_t;
 
@@ -156,19 +159,44 @@ unsafe impl Send for VMMemory {}
 unsafe impl Sync for VMMemory {}
 
 impl VMMemory {
+    pub(crate) fn attached(memory: *mut wasm_memory_t) -> Self {
+        Self::Attached(memory)
+    }
+
+    pub(crate) fn as_memory(&self) -> *mut wasm_memory_t {
+        match self {
+            Self::Attached(memory) => *memory,
+            Self::Shared(_) => {
+                panic!("V8 shared memory must be attached to a store before it can be used")
+            }
+        }
+    }
+
+    pub(crate) fn obtain(&self, store: *mut wasm_store_t) -> Self {
+        match self {
+            Self::Attached(memory) => Self::Attached(*memory),
+            Self::Shared(shared) => Self::Attached(unsafe { wasm_memory_obtain(store, *shared) }),
+        }
+    }
+
     pub(crate) fn try_clone(&self) -> Result<Self, MemoryError> {
-        let memory_type = unsafe { wasm_memory_type(self.0) };
+        if let Self::Shared(shared) = self {
+            return Ok(Self::Shared(*shared));
+        }
+
+        let memory = self.as_memory();
+        let memory_type = unsafe { wasm_memory_type(memory) };
         let limits = unsafe { wasm_memorytype_limits(memory_type) };
         if !unsafe { (*limits).shared } {
             return Err(MemoryError::MemoryNotShared);
         }
 
-        let cloned = unsafe { wasm_memory_copy(self.0) };
-        if cloned.is_null() {
+        let shared = unsafe { wasm_memory_share(memory) };
+        if shared.is_null() {
             return Err(MemoryError::Generic(
                 "Failed to clone the memory".to_string(),
             ));
         }
-        Ok(Self(cloned))
+        Ok(Self::Shared(shared))
     }
 }

--- a/lib/api/src/backend/v8/vm/mod.rs
+++ b/lib/api/src/backend/v8/vm/mod.rs
@@ -194,8 +194,15 @@ impl VMMemory {
         let memory = self.as_memory();
         let memory_type = unsafe { wasm_memory_type(memory) };
         let limits = unsafe { wasm_memorytype_limits(memory_type) };
+
         if !unsafe { (*limits).shared } {
+            unsafe {
+                wasm_memorytype_delete(memory_type);
+            }
             return Err(MemoryError::MemoryNotShared);
+        }
+        unsafe {
+            wasm_memorytype_delete(memory_type);
         }
 
         let shared = unsafe { wasm_memory_share(memory) };

--- a/lib/api/src/backend/v8/vm/mod.rs
+++ b/lib/api/src/backend/v8/vm/mod.rs
@@ -175,7 +175,14 @@ impl VMMemory {
     pub(crate) fn obtain(&self, store: *mut wasm_store_t) -> Self {
         match self {
             Self::Attached(memory) => Self::Attached(*memory),
-            Self::Shared(shared) => Self::Attached(unsafe { wasm_memory_obtain(store, *shared) }),
+            Self::Shared(shared) => {
+                let memory = unsafe { wasm_memory_obtain(store, *shared) };
+                assert!(
+                    !memory.is_null(),
+                    "Failed to obtain V8 shared memory: wasm_memory_obtain returned null"
+                );
+                Self::Attached(memory)
+            }
         }
     }
 

--- a/lib/api/src/backend/v8/vm/mod.rs
+++ b/lib/api/src/backend/v8/vm/mod.rs
@@ -194,16 +194,22 @@ impl VMMemory {
         let memory = self.as_memory();
         let memory_type = unsafe { wasm_memory_type(memory) };
         let limits = unsafe { wasm_memorytype_limits(memory_type) };
-        if !unsafe { (*limits).shared } {
-            return Err(MemoryError::MemoryNotShared);
+        if unsafe { (*limits).shared } {
+            let shared = unsafe { wasm_memory_share(memory) };
+            if shared.is_null() {
+                return Err(MemoryError::Generic(
+                    "Failed to share the memory".to_string(),
+                ));
+            }
+            Ok(Self::Shared(shared))
+        } else {
+            let cloned = unsafe { wasm_memory_copy(memory) };
+            if cloned.is_null() {
+                return Err(MemoryError::Generic(
+                    "Failed to clone the memory".to_string(),
+                ));
+            }
+            Ok(Self::Attached(cloned))
         }
-
-        let shared = unsafe { wasm_memory_share(memory) };
-        if shared.is_null() {
-            return Err(MemoryError::Generic(
-                "Failed to clone the memory".to_string(),
-            ));
-        }
-        Ok(Self::Shared(shared))
     }
 }

--- a/lib/api/src/backend/v8/vm/mod.rs
+++ b/lib/api/src/backend/v8/vm/mod.rs
@@ -174,7 +174,7 @@ impl VMMemory {
 
     pub(crate) fn obtain(&self, store: *mut wasm_store_t) -> Self {
         match self {
-            Self::Attached(memory) => Self::Attached(*memory),
+            Self::Attached(memory) => panic!("Cannot obtain an attached memory"),
             Self::Shared(shared) => {
                 let memory = unsafe { wasm_memory_obtain(store, *shared) };
                 assert!(
@@ -194,22 +194,16 @@ impl VMMemory {
         let memory = self.as_memory();
         let memory_type = unsafe { wasm_memory_type(memory) };
         let limits = unsafe { wasm_memorytype_limits(memory_type) };
-        if unsafe { (*limits).shared } {
-            let shared = unsafe { wasm_memory_share(memory) };
-            if shared.is_null() {
-                return Err(MemoryError::Generic(
-                    "Failed to share the memory".to_string(),
-                ));
-            }
-            Ok(Self::Shared(shared))
-        } else {
-            let cloned = unsafe { wasm_memory_copy(memory) };
-            if cloned.is_null() {
-                return Err(MemoryError::Generic(
-                    "Failed to clone the memory".to_string(),
-                ));
-            }
-            Ok(Self::Attached(cloned))
+        if !unsafe { (*limits).shared } {
+            return Err(MemoryError::MemoryNotShared);
         }
+
+        let shared = unsafe { wasm_memory_share(memory) };
+        if shared.is_null() {
+            return Err(MemoryError::Generic(
+                "Failed to clone the memory".to_string(),
+            ));
+        }
+        Ok(Self::Shared(shared))
     }
 }

--- a/lib/api/third-party/wee8/wasm.h
+++ b/lib/api/third-party/wee8/wasm.h
@@ -498,7 +498,7 @@ WASM_API_EXTERN bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, was
 
 // Memory Instances
 
-WASM_DECLARE_REF(memory)
+WASM_DECLARE_SHARABLE_REF(memory)
 
 typedef uint32_t wasm_memory_pages_t;
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -651,9 +651,8 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
 
         let mut supported_engines = vec![Engine::LLVM];
 
-        // TODO: enable once the WASIX tests are green with V8
-        // #[cfg(feature = "v8")]
-        // supported_engines.push(Engine::V8);
+        #[cfg(feature = "v8")]
+        supported_engines.push(Engine::V8);
 
         // Cranelift EH support for macOS is still missing: #6419.
         if !cfg!(target_os = "macos") {

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
+
+##AbstractConfig: base
+##SkipEngine:V8:SharedMemoryOps are not support yet
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
-##Config: targeted
+
+##Config: targeted:base
 ##Args: targeted
 ##ExpectedStdout: targeted child waiting
 ##ExpectedStdout: targeted parent survived
-##Config: forwarded
+
+##Config: forwarded:base
 ##Args: forwarded
 ##ExpectedStdout: forwarding parent waiting
 ##ExpectedStdout: forwarded child 1 waiting
 ##ExpectedStdout: forwarded child 2 waiting
 ##ExpectedStdout: forwarding parent survived
 ##Ignored: SIGTERM atomic waiter wakeups are currently scoped back
-##Config: vfork
+
+##Config: vfork:base
 ##Args: vfork
 ##ExpectedStdout: vfork child waiting
 ##ExpectedStdout: vfork parent survived
+
 set -euo pipefail
 
 "$CC" -pthread main.c -o main

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ##AbstractConfig: base
-##SkipEngine:V8:SharedMemoryOps are not support yet
+##SkipEngine:V8:SharedMemoryOps are not supported yet
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
 
 ##Config: targeted:base

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
@@ -2,7 +2,7 @@
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
 ##MustFail: true
 ##ExpectedStdout: waiting
-##SkipEngine:V8:SharedMemoryOps are not support yet
+##SkipEngine:V8:SharedMemoryOps are not supported yet
 
 set -euo pipefail
 

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
@@ -2,6 +2,8 @@
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
 ##MustFail: true
 ##ExpectedStdout: waiting
+##SkipEngine:V8:SharedMemoryOps are not support yet
+
 set -euo pipefail
 
 "$CC" -pthread main.c -o main

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -4,5 +4,5 @@
 # This script is used by the CI!
 
 apk update
-apk add bash make curl cmake ninja clang22 clang22-dev zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
+apk add bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
 ln -s /usr/bin/llvm-config-22 /usr/bin/llvm-config

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -4,5 +4,5 @@
 # This script is used by the CI!
 
 apk update
-apk add bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
+apk add bash make curl cmake ninja clang22 clang22-dev zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
 ln -s /usr/bin/llvm-config-22 /usr/bin/llvm-config

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -5,4 +5,16 @@
 
 apk update
 apk add bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
-ln -s /usr/bin/llvm-config-22 /usr/bin/llvm-config
+
+# A workardound for an unreleased clang-sys crate fix:
+# https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-2367084230
+cat >/usr/bin/llvm-config <<'EOF'
+#!/usr/bin/env bash
+
+if [ "$1" = "--libs" ]; then
+    echo `/usr/bin/llvm-config-22 "$@" "--link-static"` -lzstd
+else
+    /usr/bin/llvm-config-22 "$@"
+fi
+EOF
+chmod +x /usr/bin/llvm-config


### PR DESCRIPTION
The PR migrates to the new memory sharing API and enables WASIX tests on V8 for platforms where we build wee8 library.

Issue: #6121