### PR TITLE
fix: Prevent memory leak for subprocesses

### DIFF
--- a/lib/api/src/entities/memory/mod.rs
+++ b/lib/api/src/entities/memory/mod.rs
@@ -1,4 +1,4 @@
-pub use shared::SharedMemory;
+pub use shared::{MemoryOps, SharedMemory};
 use wasmer_types::{MemoryError, MemoryType, Pages};
 
 use crate::{

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -14,9 +14,24 @@ pub struct SharedMemory {
     ops: Option<Arc<dyn SharedMemoryOps + Send + Sync>>,
 }
 
+/// Shared memory operations that do not hold the underlying memory alive.
+///
+/// This handle is intended for operations, such as waking atomic waiters, that
+/// may be attempted after the original memory owner has started shutting down.
+#[derive(Clone)]
+pub struct MemoryOps {
+    ops: Option<Arc<dyn SharedMemoryOps + Send + Sync>>,
+}
+
 impl std::fmt::Debug for SharedMemory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SharedMemory").finish()
+    }
+}
+
+impl std::fmt::Debug for MemoryOps {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryOps").finish()
     }
 }
 
@@ -54,8 +69,15 @@ impl SharedMemory {
         Memory::new_from_existing(store, self.memory)
     }
 
+    /// Create an operations handle that does not keep the underlying memory alive.
+    pub fn ops(&self) -> MemoryOps {
+        MemoryOps {
+            ops: self.ops.clone(),
+        }
+    }
+
     #[inline]
-    fn ops(&self) -> Result<&(dyn SharedMemoryOps + Send + Sync), AtomicsError> {
+    fn shared_ops(&self) -> Result<&(dyn SharedMemoryOps + Send + Sync), AtomicsError> {
         self.ops
             .as_ref()
             .map(|ops| ops.as_ref())
@@ -64,7 +86,7 @@ impl SharedMemory {
 
     /// Notify up to `count` waiters waiting for the memory location.
     pub fn notify(&self, location: MemoryLocation, count: u32) -> Result<u32, AtomicsError> {
-        self.ops()?.notify(location, count)
+        self.shared_ops()?.notify(location, count)
     }
 
     /// Wait for the memory location to be notified.
@@ -73,7 +95,7 @@ impl SharedMemory {
         location: MemoryLocation,
         timeout: Option<std::time::Duration>,
     ) -> Result<u32, AtomicsError> {
-        self.ops()?.wait(location, timeout)
+        self.shared_ops()?.wait(location, timeout)
     }
 
     /// Disable atomics for this memory.
@@ -86,7 +108,7 @@ impl SharedMemory {
     /// NOTE: this operation might not be supported by all memory implementations.
     /// In that case, this function will return an error.
     pub fn disable_atomics(&self) -> Result<(), AtomicsError> {
-        self.ops()?.disable_atomics()
+        self.shared_ops()?.disable_atomics()
     }
 
     /// Wake up all atomic waiters.
@@ -96,17 +118,61 @@ impl SharedMemory {
     /// NOTE: this operation might not be supported by all memory implementations.
     /// In that case, this function will return an error.
     pub fn wake_all_atomic_waiters(&self) -> Result<(), AtomicsError> {
-        self.ops()?.wake_all_atomic_waiters()
+        self.shared_ops()?.wake_all_atomic_waiters()
+    }
+}
+
+impl MemoryOps {
+    #[inline]
+    fn shared_ops(&self) -> Result<&(dyn SharedMemoryOps + Send + Sync), AtomicsError> {
+        self.ops
+            .as_ref()
+            .map(|ops| ops.as_ref())
+            .ok_or(AtomicsError::Unimplemented)
+    }
+
+    /// Notify up to `count` waiters waiting for the memory location.
+    pub fn notify(&self, location: MemoryLocation, count: u32) -> Result<u32, AtomicsError> {
+        self.shared_ops()?.notify(location, count)
+    }
+
+    /// Wait for the memory location to be notified.
+    pub fn wait(
+        &self,
+        location: MemoryLocation,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<u32, AtomicsError> {
+        self.shared_ops()?.wait(location, timeout)
+    }
+
+    /// Disable atomics for this memory if it is still alive.
+    ///
+    /// All subsequent atomic wait calls will produce a trap.
+    pub fn disable_atomics(&self) -> Result<(), AtomicsError> {
+        self.shared_ops()?.disable_atomics()
+    }
+
+    /// Wake up all atomic waiters if the memory is still alive.
+    pub fn wake_all_atomic_waiters(&self) -> Result<(), AtomicsError> {
+        self.shared_ops()?.wake_all_atomic_waiters()
+    }
+}
+
+impl From<SharedMemory> for MemoryOps {
+    fn from(memory: SharedMemory) -> Self {
+        memory.ops()
     }
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    pub fn ensure_shared_memory_is_send_and_sync() {
+    pub fn ensure_shared_memory_handles_are_send_and_sync() {
         fn assert_send<T: Send>() {}
         fn assert_sync<T: Sync>() {}
         assert_send::<super::SharedMemory>();
         assert_sync::<super::SharedMemory>();
+        assert_send::<super::MemoryOps>();
+        assert_sync::<super::MemoryOps>();
     }
 }

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 use tracing::trace;
-use wasmer::{FunctionEnvMut, SharedMemory};
+use wasmer::{FunctionEnvMut, MemoryOps};
 use wasmer_types::ModuleHash;
 use wasmer_wasix_types::{
     types::Signal,
@@ -182,7 +182,7 @@ pub struct WasiProcessInner {
     /// If true then the process has started cleaning up
     pub cleanup_started: bool,
     /// Shared process memory.
-    pub memory: Option<SharedMemory>,
+    pub memory: Option<MemoryOps>,
     /// The snapshot memory significantly reduce the amount of
     /// duplicate entries in the journal for memory that has not changed
     #[cfg(feature = "journal")]
@@ -618,9 +618,9 @@ impl WasiProcess {
     }
 
     /// Registers the shared memory used by this process.
-    pub fn register_memory(&self, memory: SharedMemory) {
+    pub fn register_memory(&self, memory: impl Into<MemoryOps>) {
         let mut inner = self.inner.0.lock().unwrap();
-        inner.memory = Some(memory);
+        inner.memory = Some(memory.into());
     }
 
     /// Takes a snapshot of the process and disables journaling returning


### PR DESCRIPTION
A previous modification registered memory on process handles.

Since process lifetime management is not properly implemented, this lead
to leaking the memory of subprocesses until the main process exits.

Fixed by just keeping a handle to the memory, which exposes operations
through a weak reference.

Fixes #6637 
