### PR TITLE
ci(alpine): install build-base so rustc can link host build scripts

### DIFF
--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -4,5 +4,10 @@
 # This script is used by the CI!
 
 apk update
-apk add bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
+# `build-base` provides gcc, g++, libc-dev (musl-dev), binutils, and the
+# /usr/bin/cc -> /usr/bin/gcc symlink that rustc invokes to link host-side
+# build scripts (proc-macro2, quote, libc, serde_core, ...). Without it,
+# `cargo build` fails with `error: linker 'cc' not found` on alpine:edge
+# images that no longer ship a host C toolchain by default.
+apk add build-base bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
 ln -s /usr/bin/llvm-config-22 /usr/bin/llvm-config


### PR DESCRIPTION
The C-API (linux-musl) and test-wasmer-cli (linux-musl) jobs both fail on `alpine:edge` with:

    error: linker `cc` not found
    could not compile `quote` (build script)
    could not compile `proc-macro2` (build script)
    could not compile `libc` (build script)
    could not compile `serde_core` (build script)

Recent `alpine:edge` images no longer ship a host C toolchain by default, so rustc has no `cc` to invoke when linking the host-side build-script binaries that proc-macro / serde / libc require.

Add `build-base` to scripts/alpine-linux-install-deps.sh. It's Alpine's meta-package for "I need to compile C" and pulls in gcc, binutils, libc-dev (musl-dev), and the /usr/bin/cc -> /usr/bin/gcc symlink that rustc looks for. ~50 MiB image growth in exchange for the linux-musl jobs going green again.