### PR TITLE
fix(V8): use proper new memory sharing mechanism (take 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ axum = { version = "=0.6.9", default-features = false }
 backtrace = "0.3"
 base64 = "0.22.1"
 bincode = "=2.0.1"
-bindgen = "0.72.1"
+bindgen = { version = "0.72.1", default-features = false }
 bitflags = "2.11.0"
 blake3 = "1.0"
 build-deps = "0.1.4"

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,8 @@ build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra
 
 test_compilers := $(compilers)
 ifeq ($(IS_AMD64), 1)
-	ifneq (, $(filter 1, $(IS_LINUX) $(IS_WINDOWS)))
+	# TODO: enable on Windows
+	ifneq (, $(filter 1, $(IS_LINUX)))
 		test_compilers += v8
 	endif
 else ifeq ($(IS_AARCH64), 1)

--- a/Makefile
+++ b/Makefile
@@ -293,14 +293,14 @@ space := $() $()
 comma := ,
 build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra_features))
 
-# Right now, we do not support V8 for all our targets and it will change with:
-# https://github.com/wasmerio/v8-custom-builds/pull/12
 test_compilers := $(compilers)
-ifeq ($(IS_LINUX), 1)
-	ifeq ($(IS_AMD64), 1)
-		ifneq ($(LIBC), musl)
-			test_compilers += v8
-		endif
+ifeq ($(IS_AMD64), 1)
+	ifneq (, $(filter 1, $(IS_LINUX) $(IS_WINDOWS)))
+		test_compilers += v8
+	endif
+else ifeq ($(IS_AARCH64), 1)
+	ifeq ($(IS_DARWIN), 1)
+		test_compilers += v8
 	endif
 endif
 test_compilers := $(strip $(test_compilers))

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -185,7 +185,17 @@ ureq = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
 xz = { workspace = true, optional = true }
 zip = { workspace = true, optional = true, features = ["deflate"] }
-bindgen.workspace = true
+
+[target.'cfg(not(target_env = "musl"))'.build-dependencies]
+bindgen = { workspace = true, default-features = true }
+
+# must does not support dlopen/dlsym functionality used by the bindgen (using libclang).
+[target.'cfg(target_env = "musl")'.build-dependencies]
+bindgen = { workspace = true, default-features = false, features = [
+  "logging",
+  "prettyplease",
+  "static",
+] }
 
 [package.metadata.docs.rs]
 features = [

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -189,7 +189,7 @@ zip = { workspace = true, optional = true, features = ["deflate"] }
 [target.'cfg(not(target_env = "musl"))'.build-dependencies]
 bindgen = { workspace = true, default-features = true }
 
-# must does not support dlopen/dlsym functionality used by the bindgen (using libclang).
+# musl does not support dlopen/dlsym functionality used by the bindgen (using libclang).
 [target.'cfg(target_env = "musl")'.build-dependencies]
 bindgen = { workspace = true, default-features = false, features = [
   "logging",

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -18,10 +18,9 @@ fn build_v8() {
     ) {
         ("macos", "aarch64", _) => ("v8-darwin-aarch64.tar.xz", "darwin-aarch64"),
         ("linux", "x86_64", "gnu") => ("v8-linux-amd64.tar.xz", "linux-amd64"),
-        ("linux", "x86_64", "musl") => ("v8-linux-musl-amd64.tar.xz", "linux-musl-amd64"),
+        ("linux", "x86_64", "musl") => ("v8-linux-musl.tar.xz", "linux-musl"),
+        ("windows", "x86_64", _) => ("v8-windows-amd64.tar.xz", "windows-amd64"),
         ("android", "aarch64", _) => ("v8-android-arm64.tar.xz", "android-arm64"),
-        // Not supported in 6.0.0-alpha1
-        //("windows", "x86_64", _) => "https://github.com/wasmerio/wee8-custom-builds/releases/download/11.7-custom1/wee8-windows-amd64.tar.xz",
         (os, arch, _) => panic!("target os + arch combination not supported: {os}, {arch}"),
     };
 
@@ -36,7 +35,11 @@ fn build_v8() {
         .join(platform_name);
     let archive_path = cache_dir.join(asset_name);
     let v8_lib_dir = cache_dir.join("lib");
-    let v8_lib_path = v8_lib_dir.join("libv8.a");
+    let v8_lib_path = v8_lib_dir.join(if cfg!(target_os = "windows") {
+        "v8.lib"
+    } else {
+        "libv8.a"
+    });
 
     if !v8_lib_path.exists() {
         fs::create_dir_all(&cache_dir).unwrap_or_else(|err| {
@@ -66,7 +69,8 @@ fn build_v8() {
                 .expect("failed to download v8")
                 .body_mut()
                 .with_config()
-                .limit(50 * 1024 * 1024) // 50MB
+                // Windows prebuilts are substantially larger.
+                .limit(200 * 1024 * 1024)
                 .read_to_vec()
                 .expect("failed to download v8 lib");
 

--- a/lib/api/src/backend/js/entities/memory/mod.rs
+++ b/lib/api/src/backend/js/entities/memory/mod.rs
@@ -156,7 +156,7 @@ impl Memory {
     }
 
     pub fn copy(&self, _store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
-        Ok(SharedMemory::from_vm_memory(crate::vm::VMMemory::Js(
+        Ok(SharedMemory::new(crate::vm::VMSharedMemory::Js(
             self.handle.copy()?,
         )))
     }
@@ -165,13 +165,13 @@ impl Memory {
         true
     }
 
-    pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
+    pub fn as_shared(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         if !self.ty(store).shared {
-            return None;
+            return Err(MemoryError::MemoryNotShared);
         }
 
-        Some(SharedMemory::from_vm_memory(crate::vm::VMMemory::Js(
-            self.handle.try_clone().ok()?,
+        Ok(SharedMemory::new(crate::vm::VMSharedMemory::Js(
+            self.handle.try_clone()?,
         )))
     }
 }

--- a/lib/api/src/backend/sys/entities/memory/mod.rs
+++ b/lib/api/src/backend/sys/entities/memory/mod.rs
@@ -108,23 +108,21 @@ impl Memory {
         self.handle.store_id() == store.as_store_ref().objects().id()
     }
 
-    pub(crate) fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
+    pub(crate) fn as_shared(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         if self.ty(store).shared {
             let mem = self.handle.get(store.as_store_ref().objects().as_sys());
-            let copied = mem.copy().ok()?;
+            let copied = mem.copy()?;
             let ops: Option<Arc<dyn SharedMemoryOps + Send + Sync>> = copied
                 .thread_conditions()
                 .map(|conditions| Arc::new(conditions.downgrade()) as Arc<_>);
-            let memory = crate::vm::VMMemory::Sys(SysVMMemory::from(copied))
-                .as_shared()
-                .ok()?;
+            let memory = crate::vm::VMMemory::Sys(SysVMMemory::from(copied)).as_shared()?;
 
-            Some(match ops {
+            Ok(match ops {
                 Some(ops) => SharedMemory::new_with_ops(memory, ops),
                 None => SharedMemory::new(memory),
             })
         } else {
-            None
+            Err(MemoryError::MemoryNotShared)
         }
     }
 

--- a/lib/api/src/backend/sys/entities/memory/mod.rs
+++ b/lib/api/src/backend/sys/entities/memory/mod.rs
@@ -108,33 +108,24 @@ impl Memory {
         self.handle.store_id() == store.as_store_ref().objects().id()
     }
 
-    pub(crate) fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
+    pub(crate) fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
         if self.ty(store).shared {
             let mem = self.handle.get(store.as_store_ref().objects().as_sys());
-            let copied = mem.copy()?;
+            let copied = mem.copy().ok()?;
             let ops: Option<Arc<dyn SharedMemoryOps + Send + Sync>> = copied
                 .thread_conditions()
                 .map(|conditions| Arc::new(conditions.downgrade()) as Arc<_>);
-            let memory = crate::vm::VMMemory::Sys(SysVMMemory::from(copied));
+            let memory = crate::vm::VMMemory::Sys(SysVMMemory::from(copied))
+                .as_shared()
+                .ok()?;
 
-            Ok(match ops {
-                Some(ops) => SharedMemory::from_vm_memory_and_ops(memory, ops),
-                None => SharedMemory::from_vm_memory(memory),
+            Some(match ops {
+                Some(ops) => SharedMemory::new_with_ops(memory, ops),
+                None => SharedMemory::new(memory),
             })
         } else {
-            Err(MemoryError::MemoryNotShared)
+            None
         }
-    }
-
-    pub(crate) fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
-        let mem = self.handle.get(store.as_store_ref().objects().as_sys());
-        let conds = mem.thread_conditions()?.downgrade();
-        let cloned = mem.try_clone().ok()?;
-
-        Some(SharedMemory::from_vm_memory_and_ops(
-            crate::vm::VMMemory::Sys(cloned),
-            Arc::new(conds),
-        ))
     }
 
     /// To `VMExtern`.

--- a/lib/api/src/backend/sys/entities/memory/mod.rs
+++ b/lib/api/src/backend/sys/entities/memory/mod.rs
@@ -108,7 +108,7 @@ impl Memory {
         self.handle.store_id() == store.as_store_ref().objects().id()
     }
 
-    pub(crate) fn as_shared(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
+    pub(crate) fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         if self.ty(store).shared {
             let mem = self.handle.get(store.as_store_ref().objects().as_sys());
             let copied = mem.copy()?;
@@ -124,6 +124,20 @@ impl Memory {
         } else {
             Err(MemoryError::MemoryNotShared)
         }
+    }
+
+    pub(crate) fn as_shared(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
+        let mem = self.handle.get(store.as_store_ref().objects().as_sys());
+        let conds = mem
+            .thread_conditions()
+            .ok_or(MemoryError::MemoryNotShared)?
+            .downgrade();
+        let cloned = mem.try_clone()?;
+
+        Ok(SharedMemory::new_with_ops(
+            crate::vm::VMMemory::Sys(cloned).as_shared()?,
+            Arc::new(conds),
+        ))
     }
 
     /// To `VMExtern`.

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -162,10 +162,62 @@ impl Memory {
     pub fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         check_isolate(store);
 
-        // FIXME: implement memory copying
-        Err(MemoryError::UnsupportedOperation {
-            message: "copy is not supported for V8 memory because the wasm C API can only clone the memory reference".to_owned(),
-        })
+        let ty = self.ty(store);
+        if !ty.shared {
+            return Err(MemoryError::MemoryNotShared);
+        }
+
+        let store_ref = store.as_store_ref();
+        let v8_store = store_ref.inner.store.as_v8();
+
+        let limits = wasm_limits_t {
+            min: ty.minimum.0,
+            max: ty.maximum.unwrap_or(Pages::max_value()).0,
+            shared: ty.shared,
+        };
+
+        let memorytype = unsafe { wasm_memorytype_new(&limits) };
+        let copied_memory = unsafe { wasm_memory_new(v8_store.inner, memorytype) };
+        unsafe {
+            wasm_memorytype_delete(memorytype);
+        }
+        if copied_memory.is_null() {
+            return Err(MemoryError::Generic(
+                "failed to allocate copied V8 memory".to_owned(),
+            ));
+        }
+
+        let copied = Self {
+            handle: VMMemory(copied_memory),
+        };
+
+        let src_view = self.view(store);
+        let dst_view = copied.view(store);
+        let src_pages = src_view.size();
+        let dst_pages = dst_view.size();
+
+        if src_pages > dst_pages {
+            let delta = src_pages.0.checked_sub(dst_pages.0).ok_or_else(|| {
+                MemoryError::Generic("failed to calculate V8 memory copy growth".to_owned())
+            })?;
+
+            if !unsafe { wasm_memory_grow(copied.handle.0, delta) } {
+                return Err(MemoryError::CouldNotGrow {
+                    current: dst_pages,
+                    attempted_delta: Pages(delta),
+                });
+            }
+        }
+
+        let src_view = self.view(store);
+        let dst_view = copied.view(store);
+        src_view
+            .copy_to_memory(src_view.data_size(), &dst_view)
+            .map_err(|err| MemoryError::Generic(format!("failed to copy V8 memory: {err}")))?;
+
+        Ok(SharedMemory::new(crate::vm::VMSharedMemory::V8(
+            copied.handle.as_shared()?,
+        )))
     }
 
     pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -173,9 +173,9 @@ impl Memory {
         true
     }
 
-    pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
-        Some(SharedMemory::new(crate::vm::VMSharedMemory::V8(
-            self.handle.as_shared().ok()?,
+    pub fn as_shared(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
+        Ok(SharedMemory::new(crate::vm::VMSharedMemory::V8(
+            self.handle.as_shared()?,
         )))
     }
 }

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -226,6 +226,7 @@ impl Memory {
     }
 
     pub fn as_shared(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
+        check_isolate(store);
         Ok(SharedMemory::new(crate::vm::VMSharedMemory::V8(
             self.handle.as_shared()?,
         )))

--- a/lib/api/src/backend/v8/entities/memory/mod.rs
+++ b/lib/api/src/backend/v8/entities/memory/mod.rs
@@ -174,8 +174,8 @@ impl Memory {
     }
 
     pub fn as_shared(&self, store: &impl AsStoreRef) -> Option<SharedMemory> {
-        Some(SharedMemory::from_vm_memory(crate::vm::VMMemory::V8(
-            self.handle.try_clone().ok()?,
+        Some(SharedMemory::new(crate::vm::VMSharedMemory::V8(
+            self.handle.as_shared().ok()?,
         )))
     }
 }

--- a/lib/api/src/backend/v8/vm/mod.rs
+++ b/lib/api/src/backend/v8/vm/mod.rs
@@ -1,11 +1,16 @@
 mod env;
+use std::sync::Arc;
+
 pub use env::*;
 
 use super::{
     bindings::*, entities::function::env::FunctionEnv, function::Function, global::Global,
     memory::Memory, table::Table,
 };
-use crate::{AsStoreMut, BackendFunction, BackendGlobal, BackendMemory, BackendTable, Extern};
+use crate::{
+    AsStoreMut, BackendFunction, BackendGlobal, BackendMemory, BackendTable, Extern,
+    v8::store::Store,
+};
 use wasmer_types::{MemoryError, RawValue};
 
 pub use super::error::Trap;
@@ -147,28 +152,72 @@ impl VMExceptionRef {
 
 #[derive(Debug, Clone)]
 pub struct VMMemory(pub(super) *mut wasm_memory_t);
-pub type VMSharedMemory = VMMemory;
+struct SharedMemoryPointer(*mut wasm_shared_memory_t);
+pub struct VMSharedMemory(Arc<SharedMemoryPointer>);
 pub(crate) type VMExternMemory = *mut wasm_memory_t;
 
-/// # SAFETY: WASM memories are safe to send across thread boundaries.
+impl SharedMemoryPointer {
+    fn new(ptr: *mut wasm_shared_memory_t) -> Self {
+        Self(ptr)
+    }
+}
+
+impl Drop for SharedMemoryPointer {
+    fn drop(&mut self) {
+        unsafe {
+            wasm_shared_memory_delete(self.0);
+        }
+    }
+}
+
+/// # SAFETY: The WASM V8 memory is attached to a Store and cannot be accessed
+/// from a different thread (long-term goal would removal of the unsafe Send/Sync).
 unsafe impl Send for VMMemory {}
-/// # SAFETY: WASM memories are safe to send across thread boundaries.
 unsafe impl Sync for VMMemory {}
 
+/// # SAFETY: Shared memory handles are safe to send across thread boundaries.
+unsafe impl Send for SharedMemoryPointer {}
+unsafe impl Sync for SharedMemoryPointer {}
+
 impl VMMemory {
-    pub(crate) fn try_clone(&self) -> Result<Self, MemoryError> {
+    /// Created a shared detached memory that can be attached in another Store.
+    pub(crate) fn as_shared(&self) -> Result<VMSharedMemory, MemoryError> {
         let memory_type = unsafe { wasm_memory_type(self.0) };
         let limits = unsafe { wasm_memorytype_limits(memory_type) };
         if !unsafe { (*limits).shared } {
+            unsafe {
+                wasm_memorytype_delete(memory_type);
+            }
             return Err(MemoryError::MemoryNotShared);
         }
+        unsafe {
+            wasm_memorytype_delete(memory_type);
+        }
 
-        let cloned = unsafe { wasm_memory_copy(self.0) };
-        if cloned.is_null() {
+        let shared = unsafe { wasm_memory_share(self.0) };
+        if shared.is_null() {
             return Err(MemoryError::Generic(
                 "Failed to clone the memory".to_string(),
             ));
         }
-        Ok(Self(cloned))
+
+        Ok(VMSharedMemory(Arc::new(SharedMemoryPointer::new(shared))))
+    }
+}
+
+impl VMSharedMemory {
+    /// We can clone a shared memory handle as we want.
+    pub(crate) fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+
+    /// Attach the shared memory handle to a new Store and convert it to VMMemory
+    pub(crate) fn into_vm_memory(self, store: &mut Store) -> VMMemory {
+        let memory = unsafe { wasm_memory_obtain(store.inner, self.0.0) };
+        assert!(
+            !memory.is_null(),
+            "Failed to obtain V8 shared memory: wasm_memory_obtain returned null"
+        );
+        VMMemory(memory)
     }
 }

--- a/lib/api/src/entities/memory/inner.rs
+++ b/lib/api/src/entities/memory/inner.rs
@@ -217,7 +217,7 @@ impl BackendMemory {
     #[inline]
     pub fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         match_rt!(on self => s {
-            s.copy(store)
+            s.as_shared(store).ok_or_else(|| MemoryError::Generic("Cannot share a memory".to_owned()))
         })
     }
 

--- a/lib/api/src/entities/memory/inner.rs
+++ b/lib/api/src/entities/memory/inner.rs
@@ -217,7 +217,7 @@ impl BackendMemory {
     #[inline]
     pub fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         match_rt!(on self => s {
-            s.as_shared(store).ok_or_else(|| MemoryError::Generic("Cannot share a memory".to_owned()))
+            s.as_shared(store)
         })
     }
 
@@ -256,7 +256,7 @@ impl BackendMemory {
         }
 
         match_rt!(on self => s {
-            s.as_shared(store)
+            s.as_shared(store).ok()
         })
     }
 

--- a/lib/api/src/entities/memory/inner.rs
+++ b/lib/api/src/entities/memory/inner.rs
@@ -217,7 +217,7 @@ impl BackendMemory {
     #[inline]
     pub fn copy(&self, store: &impl AsStoreRef) -> Result<SharedMemory, MemoryError> {
         match_rt!(on self => s {
-            s.as_shared(store)
+            s.copy(store)
         })
     }
 

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -5,12 +5,13 @@ use crate::{
     error::AtomicsError,
     location::{MemoryLocation, SharedMemoryOps},
     vm::VMMemory,
+    vm::VMSharedMemory,
 };
 
 /// A shared memory instance that can be shared across multiple stores and threads,
 /// not attached to any specific store.
 pub struct SharedMemory {
-    memory: VMMemory,
+    memory: VMSharedMemory,
     ops: Option<Arc<dyn SharedMemoryOps + Send + Sync>>,
 }
 
@@ -22,25 +23,22 @@ impl std::fmt::Debug for SharedMemory {
 
 impl Clone for SharedMemory {
     fn clone(&self) -> Self {
-        let Ok(memory) = self.memory.try_clone() else {
-            unreachable!("Internal error: shared memory is always cloneable");
-        };
         Self {
-            memory,
+            memory: self.memory.clone(),
             ops: self.ops.clone(),
         }
     }
 }
 
 impl SharedMemory {
-    /// Create a new shared memory from an existing VMMemory.
-    pub(crate) fn from_vm_memory(memory: VMMemory) -> Self {
+    /// Create a new shared memory.
+    pub(crate) fn new(memory: VMSharedMemory) -> Self {
         Self { memory, ops: None }
     }
 
-    /// Create a new shared memory from an existing VMMemory.
-    pub(crate) fn from_vm_memory_and_ops(
-        memory: VMMemory,
+    /// Create a new shared memory with memory operations.
+    pub(crate) fn new_with_ops(
+        memory: VMSharedMemory,
         ops: Arc<dyn SharedMemoryOps + Send + Sync>,
     ) -> Self {
         Self {
@@ -51,7 +49,8 @@ impl SharedMemory {
 
     /// Attach this shared memory to the provided store.
     pub fn attach(self, store: &mut impl AsStoreMut) -> Memory {
-        Memory::new_from_existing(store, self.memory)
+        let memory = self.memory.into_vm_memory(store);
+        Memory::new_from_existing(store, memory)
     }
 
     #[inline]

--- a/lib/api/src/vm/impls.rs
+++ b/lib/api/src/vm/impls.rs
@@ -57,7 +57,7 @@ impl VMMemory {
     pub(crate) fn as_shared(&self) -> Result<VMSharedMemory, wasmer_types::MemoryError> {
         match self {
             #[cfg(feature = "sys")]
-            Self::Sys(s) => s.as_shared().map(VMSharedMemory::Sys),
+            Self::Sys(s) => s.0.as_shared().map(VMSharedMemory::Sys),
             #[cfg(feature = "v8")]
             Self::V8(s) => s.as_shared().map(VMSharedMemory::V8),
             #[cfg(feature = "js")]

--- a/lib/api/src/vm/impls.rs
+++ b/lib/api/src/vm/impls.rs
@@ -1,4 +1,5 @@
 use crate::{AsStoreMut, macros::backend::match_rt};
+use wasmer_vm::LinearMemory;
 
 use super::*;
 
@@ -57,8 +58,7 @@ impl VMMemory {
     pub(crate) fn as_shared(&self) -> Result<VMSharedMemory, wasmer_types::MemoryError> {
         match self {
             #[cfg(feature = "sys")]
-            Self::Sys(s) => todo!(),
-            // Self::Sys(s) => s.as_shared().map(VMSharedMemory::Sys),
+            Self::Sys(s) => s.as_shared().map(VMSharedMemory::Sys),
             #[cfg(feature = "v8")]
             Self::V8(s) => s.as_shared().map(VMSharedMemory::V8),
             #[cfg(feature = "js")]
@@ -72,7 +72,7 @@ impl VMSharedMemory {
     pub(crate) fn clone(&self) -> Self {
         match self {
             #[cfg(feature = "sys")]
-            Self::Sys(s) => todo!(),
+            Self::Sys(s) => Self::Sys(s.clone()),
             #[cfg(feature = "v8")]
             Self::V8(s) => Self::V8(s.clone()),
             // TODO
@@ -84,7 +84,7 @@ impl VMSharedMemory {
     pub(crate) fn into_vm_memory(self, store: &mut impl AsStoreMut) -> VMMemory {
         match self {
             #[cfg(feature = "sys")]
-            Self::Sys(s) => todo!(),
+            Self::Sys(s) => VMMemory::Sys(s.into()),
             #[cfg(feature = "v8")]
             Self::V8(s) => {
                 let mut store = store.as_store_mut();

--- a/lib/api/src/vm/impls.rs
+++ b/lib/api/src/vm/impls.rs
@@ -1,5 +1,4 @@
 use crate::{AsStoreMut, macros::backend::match_rt};
-use wasmer_vm::LinearMemory;
 
 use super::*;
 
@@ -62,7 +61,7 @@ impl VMMemory {
             #[cfg(feature = "v8")]
             Self::V8(s) => s.as_shared().map(VMSharedMemory::V8),
             #[cfg(feature = "js")]
-            Self::Js(s) => s.try_clone().map(Self::Js),
+            Self::Js(s) => s.try_clone().map(VMSharedMemory::Js),
         }
     }
 }
@@ -75,9 +74,11 @@ impl VMSharedMemory {
             Self::Sys(s) => Self::Sys(s.clone()),
             #[cfg(feature = "v8")]
             Self::V8(s) => Self::V8(s.clone()),
-            // TODO
             #[cfg(feature = "js")]
-            Self::Js(s) => s.try_clone().map(Self::Js),
+            Self::Js(s) => Self::Js(
+                s.try_clone()
+                    .expect("cloning JavaScript shared memory should not fail"),
+            ),
         }
     }
 
@@ -90,9 +91,8 @@ impl VMSharedMemory {
                 let mut store = store.as_store_mut();
                 VMMemory::V8(s.into_vm_memory(store.inner.store.as_v8_mut()))
             }
-            // TODO
             #[cfg(feature = "js")]
-            Self::Js(s) => s.try_clone().map(Self::Js),
+            Self::Js(s) => VMMemory::Js(s),
         }
     }
 }

--- a/lib/api/src/vm/impls.rs
+++ b/lib/api/src/vm/impls.rs
@@ -1,4 +1,4 @@
-use crate::macros::backend::match_rt;
+use crate::{AsStoreMut, macros::backend::match_rt};
 
 use super::*;
 
@@ -53,13 +53,44 @@ impl VMExternRef {
 }
 
 impl VMMemory {
-    /// Attempts to clone this memory handle.
-    pub(crate) fn try_clone(&self) -> Result<Self, wasmer_types::MemoryError> {
+    /// Attempts to share this memory and return a shared detached memory.
+    pub(crate) fn as_shared(&self) -> Result<VMSharedMemory, wasmer_types::MemoryError> {
         match self {
             #[cfg(feature = "sys")]
-            Self::Sys(s) => s.try_clone().map(Self::Sys),
+            Self::Sys(s) => todo!(),
+            // Self::Sys(s) => s.as_shared().map(VMSharedMemory::Sys),
             #[cfg(feature = "v8")]
-            Self::V8(s) => s.try_clone().map(Self::V8),
+            Self::V8(s) => s.as_shared().map(VMSharedMemory::V8),
+            #[cfg(feature = "js")]
+            Self::Js(s) => s.try_clone().map(Self::Js),
+        }
+    }
+}
+
+impl VMSharedMemory {
+    /// Clones this shared memory handle.
+    pub(crate) fn clone(&self) -> Self {
+        match self {
+            #[cfg(feature = "sys")]
+            Self::Sys(s) => todo!(),
+            #[cfg(feature = "v8")]
+            Self::V8(s) => Self::V8(s.clone()),
+            // TODO
+            #[cfg(feature = "js")]
+            Self::Js(s) => s.try_clone().map(Self::Js),
+        }
+    }
+
+    pub(crate) fn into_vm_memory(self, store: &mut impl AsStoreMut) -> VMMemory {
+        match self {
+            #[cfg(feature = "sys")]
+            Self::Sys(s) => todo!(),
+            #[cfg(feature = "v8")]
+            Self::V8(s) => {
+                let mut store = store.as_store_mut();
+                VMMemory::V8(s.into_vm_memory(store.inner.store.as_v8_mut()))
+            }
+            // TODO
             #[cfg(feature = "js")]
             Self::Js(s) => s.try_clone().map(Self::Js),
         }

--- a/lib/api/third-party/wee8/wasm.h
+++ b/lib/api/third-party/wee8/wasm.h
@@ -498,7 +498,7 @@ WASM_API_EXTERN bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, was
 
 // Memory Instances
 
-WASM_DECLARE_REF(memory)
+WASM_DECLARE_SHARABLE_REF(memory)
 
 typedef uint32_t wasm_memory_pages_t;
 

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -452,6 +452,11 @@ impl LinearMemory for VMOwnedMemory {
         let forked = Self::copy(self)?;
         Ok(Box::new(forked))
     }
+
+    /// Return a concrete shared memory handle for detached API sharing.
+    fn as_shared(&self) -> Result<VMSharedMemory, MemoryError> {
+        Err(MemoryError::MemoryNotShared)
+    }
 }
 
 /// A shared linear memory instance.
@@ -606,6 +611,11 @@ impl LinearMemory for VMSharedMemory {
         Ok(Box::new(forked))
     }
 
+    /// Return a concrete shared memory handle for detached API sharing.
+    fn as_shared(&self) -> Result<VMSharedMemory, MemoryError> {
+        Ok(self.clone())
+    }
+
     // Add current thread to waiter list
     unsafe fn do_wait(
         &mut self,
@@ -706,6 +716,10 @@ impl LinearMemory for VMMemory {
     /// Copies this memory to a new memory
     fn copy(&self) -> Result<Box<dyn LinearMemory + Send + Sync + 'static>, MemoryError> {
         self.0.copy()
+    }
+
+    fn as_shared(&self) -> Result<VMSharedMemory, MemoryError> {
+        self.0.as_shared()
     }
 
     // Add current thread to waiter list
@@ -870,6 +884,11 @@ where
 
     /// Copies this memory to a new memory
     fn copy(&self) -> Result<Box<dyn LinearMemory + Send + Sync + 'static>, MemoryError>;
+
+    /// Returns a concrete shared memory handle if this memory is shared.
+    fn as_shared(&self) -> Result<VMSharedMemory, MemoryError> {
+        Err(MemoryError::MemoryNotShared)
+    }
 
     /// Add current thread to the waiter hash, and wait until notified or timeout.
     /// Return 0 if the waiter has been notified, 1 if there was a value mismatch,

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -931,9 +931,8 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
 
         let mut supported_engines = vec![Engine::LLVM];
 
-        // TODO: enable once the WASIX tests are green with V8
-        // #[cfg(feature = "v8")]
-        // supported_engines.push(Engine::V8);
+        #[cfg(feature = "v8")]
+        supported_engines.push(Engine::V8);
 
         // Cranelift EH support for macOS is still missing: #6419.
         if !cfg!(target_os = "macos") {

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal-children/build.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
+
+##AbstractConfig: base
+##SkipEngine:V8:SharedMemoryOps are not supported yet
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
-##Config: targeted
+
+##Config: targeted:base
 ##Args: targeted
 ##ExpectedStdout: targeted child waiting
 ##ExpectedStdout: targeted parent survived
-##Config: forwarded
+
+##Config: forwarded:base
 ##Args: forwarded
 ##ExpectedStdout: forwarding parent waiting
 ##ExpectedStdout: forwarded child 1 waiting
 ##ExpectedStdout: forwarded child 2 waiting
 ##ExpectedStdout: forwarding parent survived
 ##Ignored: SIGTERM atomic waiter wakeups are currently scoped back
-##Config: vfork
+
+##Config: vfork:base
 ##Args: vfork
 ##ExpectedStdout: vfork child waiting
 ##ExpectedStdout: vfork parent survived
+
 set -euo pipefail
 
 "$CC" -pthread main.c -o main

--- a/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/atomic-wait-signal/build.sh
@@ -2,6 +2,8 @@
 ##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
 ##MustFail: true
 ##ExpectedStdout: waiting
+##SkipEngine:V8:SharedMemoryOps are not supported yet
+
 set -euo pipefail
 
 "$CC" -pthread main.c -o main

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -9,7 +9,7 @@ apk update
 # build scripts (proc-macro2, quote, libc, serde_core, ...). Without it,
 # `cargo build` fails with `error: linker 'cc' not found` on alpine:edge
 # images that no longer ship a host C toolchain by default.
-apk add build-base bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
+apk add build-base bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static xz-static
 
 # A workardound for an unreleased clang-sys crate fix:
 # https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-2367084230

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -5,4 +5,16 @@
 
 apk update
 apk add bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static
-ln -s /usr/bin/llvm-config-22 /usr/bin/llvm-config
+
+# A workardound for an unreleased clang-sys crate fix:
+# https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-2367084230
+cat >/usr/bin/llvm-config <<'EOF'
+#!/usr/bin/env bash
+
+if [ "$1" = "--libs" ]; then
+    echo `/usr/bin/llvm-config-22 "$@" "--link-static"` -lzstd
+else
+    /usr/bin/llvm-config-22 "$@"
+fi
+EOF
+chmod +x /usr/bin/llvm-config

--- a/scripts/alpine-linux-install-deps.sh
+++ b/scripts/alpine-linux-install-deps.sh
@@ -11,7 +11,7 @@ apk update
 # images that no longer ship a host C toolchain by default.
 apk add build-base bash make curl cmake ninja clang22 zstd-static llvm22-dev clang22-static llvm22-static ncurses-static zlib-static tar libxml2-static xz-static
 
-# A workardound for an unreleased clang-sys crate fix:
+# A workaround for an unreleased clang-sys crate fix:
 # https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-2367084230
 cat >/usr/bin/llvm-config <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
This is a second integration attempt for the V8 back-end where we properly distinguish between a memory attached to a Store (`VMMemory`) and a shared one, `VMSharedMemory` that can be later used in a different `Store`. With that, we can properly shared and access memory in between different Isolates. From the implementation point of view - am pretty keen on the V8 integration, for the `Sys` back-end the story is more complicated as the back-end does not properly define `VMMemory` (and `VMStaredMemory`), but relies on the generic (parent) types.

Right the, PR newly enables V8 for `linux-musl` and `macos-asm64` targets. For Windows, we're missing `wee8` build and it might take a bit longer (separate PR).

Issue: https://github.com/wasmerio/wasmer/issues/6121