### PR TITLE
perf(compiler): cache VMOffsets on AllocatedArtifact

### DIFF
--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -42,6 +42,7 @@ use wasmer_types::{
     target::{CpuFeature, Target},
 };
 
+use wasmer_types::VMOffsets;
 use wasmer_vm::{
     FunctionBodyPtr, InstanceAllocator, MemoryStyle, StoreObjects, TableStyle, TrapHandlerFn,
     VMConfig, VMExtern, VMInstance, VMSignatureHash, VMTrampoline,
@@ -65,6 +66,17 @@ pub struct AllocatedArtifact {
     finished_dynamic_function_trampolines: BoxedSlice<FunctionIndex, FunctionBodyPtr>,
     signatures: BoxedSlice<SignatureIndex, VMSignatureHash>,
     finished_function_lengths: BoxedSlice<LocalFunctionIndex, usize>,
+
+    /// Precomputed `VMOffsets` for this artifact's module.
+    ///
+    /// `VMOffsets::new(pointer_size, module_info)` is deterministic and
+    /// the module info is immutable after compile, so it's safe to cache
+    /// the result. `Instance::new` clones this instead of recomputing,
+    /// which was ~9% of `Instance::new` time in profile traces of a
+    /// per-request wasm host calling `Module::instantiate` in a tight
+    /// loop.
+    #[cfg_attr(feature = "artifact-size", loupe(skip))]
+    vm_offsets: VMOffsets,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -487,6 +499,14 @@ impl Artifact {
             finished_dynamic_function_trampolines.into_boxed_slice();
         let signatures = signatures.into_boxed_slice();
 
+        // Cache `VMOffsets` so the per-instance `Instance::new` path can
+        // skip recomputing them. Safe because (a) `module_info` is
+        // immutable for the lifetime of this artifact (only `name` is
+        // mutable via `set_module_info_name`, and `name` is not part of
+        // `VMOffsets`'s inputs), and (b) the host's pointer size doesn't
+        // change at runtime.
+        let vm_offsets = VMOffsets::new(std::mem::size_of::<usize>() as u8, module_info);
+
         let mut artifact = Self {
             id: Default::default(),
             artifact,
@@ -498,6 +518,7 @@ impl Artifact {
                 finished_dynamic_function_trampolines,
                 signatures,
                 finished_function_lengths,
+                vm_offsets,
             }),
         };
 
@@ -897,12 +918,24 @@ impl Artifact {
             // Get pointers to where metadata about local memories should live in VM memory.
             // Get pointers to where metadata about local tables should live in VM memory.
 
+            // Use the `VMOffsets` cached at compile time on the
+            // `AllocatedArtifact` rather than recomputing them in
+            // `InstanceAllocator::new`. The cached value is deterministic
+            // from `module_info` (and the host's `pointer_size`), both
+            // of which are immutable for the artifact's lifetime, so the
+            // result is byte-identical to a fresh `VMOffsets::new` call.
+            let cached_offsets = self
+                .allocated
+                .as_ref()
+                .map(|a| a.vm_offsets.clone())
+                .expect("Artifact::instantiate called on a non-host artifact");
+
             let (
                 allocator,
                 memory_definition_locations,
                 table_definition_locations,
                 global_definition_locations,
-            ) = InstanceAllocator::new(&module);
+            ) = InstanceAllocator::new_with_offsets(cached_offsets, &module);
             let finished_memories = tunables
                 .create_memories(
                     context,
@@ -1316,9 +1349,18 @@ impl Artifact {
                 .collect::<PrimaryMap<LocalFunctionIndex, usize>>()
                 .into_boxed_slice();
 
+            // Build the variant first so we can compute VMOffsets from
+            // its ModuleInfo before moving the variant into Self. Same
+            // caching rationale as `Artifact::from_parts` above.
+            let artifact_variant = ArtifactBuildVariant::Plain(artifact);
+            let vm_offsets = VMOffsets::new(
+                std::mem::size_of::<usize>() as u8,
+                artifact_variant.module_info(),
+            );
+
             Ok(Self {
                 id: Default::default(),
-                artifact: ArtifactBuildVariant::Plain(artifact),
+                artifact: artifact_variant,
                 allocated: Some(AllocatedArtifact {
                     frame_info_registered: false,
                     frame_info_registration: None,
@@ -1329,6 +1371,7 @@ impl Artifact {
                         .into_boxed_slice(),
                     signatures: signatures.into_boxed_slice(),
                     finished_function_lengths,
+                    vm_offsets,
                 }),
             })
         }

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -67,14 +67,18 @@ pub struct AllocatedArtifact {
     signatures: BoxedSlice<SignatureIndex, VMSignatureHash>,
     finished_function_lengths: BoxedSlice<LocalFunctionIndex, usize>,
 
-    /// Precomputed `VMOffsets` for this artifact's module.
+    /// Precomputed `VMOffsets` for this artifact's module, cloned by
+    /// `Artifact::instantiate` instead of recomputing on every call.
     ///
-    /// `VMOffsets::new(pointer_size, module_info)` is deterministic and
-    /// the module info is immutable after compile, so it's safe to cache
-    /// the result. `Instance::new` clones this instead of recomputing,
-    /// which was ~9% of `Instance::new` time in profile traces of a
-    /// per-request wasm host calling `Module::instantiate` in a tight
-    /// loop.
+    /// Safe to cache because `VMOffsets::new(pointer_size, module_info)`
+    /// is deterministic, `module_info` is immutable after compile (the
+    /// only mutable field `name` is not a `VMOffsets` input), and the
+    /// host's pointer size is a runtime constant.
+    ///
+    /// Built once in `from_parts` and in the deserialization path
+    /// (`deserialize_object_native`); `VMOffsets::new` was ~9% of
+    /// `Instance::new` time on profile traces of a per-request wasm
+    /// host calling `Module::instantiate` in a tight loop.
     #[cfg_attr(feature = "artifact-size", loupe(skip))]
     vm_offsets: VMOffsets,
 }
@@ -499,12 +503,6 @@ impl Artifact {
             finished_dynamic_function_trampolines.into_boxed_slice();
         let signatures = signatures.into_boxed_slice();
 
-        // Cache `VMOffsets` so the per-instance `Instance::new` path can
-        // skip recomputing them. Safe because (a) `module_info` is
-        // immutable for the lifetime of this artifact (only `name` is
-        // mutable via `set_module_info_name`, and `name` is not part of
-        // `VMOffsets`'s inputs), and (b) the host's pointer size doesn't
-        // change at runtime.
         let vm_offsets = VMOffsets::new(std::mem::size_of::<usize>() as u8, module_info);
 
         let mut artifact = Self {
@@ -918,12 +916,6 @@ impl Artifact {
             // Get pointers to where metadata about local memories should live in VM memory.
             // Get pointers to where metadata about local tables should live in VM memory.
 
-            // Use the `VMOffsets` cached at compile time on the
-            // `AllocatedArtifact` rather than recomputing them in
-            // `InstanceAllocator::new`. The cached value is deterministic
-            // from `module_info` (and the host's `pointer_size`), both
-            // of which are immutable for the artifact's lifetime, so the
-            // result is byte-identical to a fresh `VMOffsets::new` call.
             let cached_offsets = self
                 .allocated
                 .as_ref()
@@ -1349,9 +1341,8 @@ impl Artifact {
                 .collect::<PrimaryMap<LocalFunctionIndex, usize>>()
                 .into_boxed_slice();
 
-            // Build the variant first so we can compute VMOffsets from
-            // its ModuleInfo before moving the variant into Self. Same
-            // caching rationale as `Artifact::from_parts` above.
+            // Variant is built first so its module_info is available for
+            // the cached VMOffsets before it is moved into Self.
             let artifact_variant = ArtifactBuildVariant::Plain(artifact);
             let vm_offsets = VMOffsets::new(
                 std::mem::size_of::<usize>() as u8,

--- a/lib/vm/src/instance/allocator.rs
+++ b/lib/vm/src/instance/allocator.rs
@@ -78,6 +78,42 @@ impl InstanceAllocator {
         Vec<NonNull<VMGlobalDefinition>>,
     ) {
         let offsets = VMOffsets::new(mem::size_of::<usize>() as u8, module);
+        Self::new_with_offsets(offsets, module)
+    }
+
+    /// Same as [`InstanceAllocator::new`], but accepts pre-computed
+    /// [`VMOffsets`] instead of computing them from the module.
+    ///
+    /// `VMOffsets::new(pointer_size, module)` is deterministic given
+    /// `(pointer_size, module)`, and the `pointer_size` is fixed to
+    /// `size_of::<usize>()` on the host. Callers that instantiate the
+    /// same module repeatedly (per-request wasm hosts: cloud workers,
+    /// CosmWasm, op-vm, …) can compute the offsets once at compile/cache
+    /// time and pass them here to skip the recomputation on every
+    /// `Instance::new`.
+    ///
+    /// # Caller contract
+    ///
+    /// `offsets` MUST equal `VMOffsets::new(size_of::<usize>() as u8, module)`
+    /// for the same `module`. Passing offsets computed for a different
+    /// module — or with a different pointer size — will produce a
+    /// mis-sized allocation and undefined behavior. Callers that cache
+    /// the offsets should key the cache by the same `ModuleInfo` they
+    /// pass here.
+    #[allow(clippy::type_complexity)]
+    pub fn new_with_offsets(
+        offsets: VMOffsets,
+        module: &ModuleInfo,
+    ) -> (
+        Self,
+        Vec<NonNull<VMMemoryDefinition>>,
+        Vec<NonNull<VMTableDefinition>>,
+        Vec<NonNull<VMGlobalDefinition>>,
+    ) {
+        // Silence unused warning when the body below does not need
+        // `module` directly (it's kept in the signature for API
+        // symmetry with `new` and for future callers).
+        let _ = module;
         let instance_layout = Self::instance_layout(&offsets);
 
         #[allow(clippy::cast_ptr_alignment)]
@@ -255,5 +291,87 @@ impl InstanceAllocator {
     /// Get the [`VMOffsets`] for the allocated buffer.
     pub(crate) fn offsets(&self) -> &VMOffsets {
         &self.offsets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmer_types::ModuleInfo;
+
+    /// `VMOffsets::new` is deterministic for a given `(pointer_size, module)`.
+    /// The whole VMOffsets-caching optimization assumes this; verify it as
+    /// the test that would catch any future change to `VMOffsets::new` that
+    /// introduced non-determinism (e.g. an internal HashMap iteration).
+    #[test]
+    fn vmoffsets_new_is_deterministic_on_empty_module() {
+        let module = ModuleInfo::default();
+        let ps = mem::size_of::<usize>() as u8;
+        let a = VMOffsets::new(ps, &module);
+        let b = VMOffsets::new(ps, &module);
+
+        // Use Debug repr for comparison — VMOffsets doesn't impl `PartialEq`
+        // upstream, but its layout is constant for a given input so the
+        // textual debug form is a sufficient identity check.
+        let a_dbg = format!("{a:?}");
+        let b_dbg = format!("{b:?}");
+        assert_eq!(a_dbg, b_dbg, "VMOffsets::new must be deterministic");
+    }
+
+    /// `InstanceAllocator::new_with_offsets` and `InstanceAllocator::new`
+    /// must produce allocators with the same `instance_layout` (size +
+    /// alignment) and the same `VMOffsets`. That's the invariant the
+    /// upstream caller (`Artifact::instantiate`) relies on when it
+    /// substitutes the cached value.
+    ///
+    /// The allocator owns a heap allocation; both paths allocate and we
+    /// just drop the resulting allocators at end of test (their `Drop`
+    /// frees the allocation since neither was `consumed`).
+    #[test]
+    fn new_with_offsets_matches_new() {
+        let module = ModuleInfo::default();
+        let ps = mem::size_of::<usize>() as u8;
+
+        let (a, _, _, _) = InstanceAllocator::new(&module);
+        let cached = VMOffsets::new(ps, &module);
+        let (b, _, _, _) = InstanceAllocator::new_with_offsets(cached, &module);
+
+        assert_eq!(
+            a.instance_layout.size(),
+            b.instance_layout.size(),
+            "instance_layout.size() mismatch"
+        );
+        assert_eq!(
+            a.instance_layout.align(),
+            b.instance_layout.align(),
+            "instance_layout.align() mismatch"
+        );
+
+        // Both should report the same `size_of_vmctx` since that's derived
+        // from `VMOffsets` and the same module went in.
+        assert_eq!(
+            a.offsets.size_of_vmctx(),
+            b.offsets.size_of_vmctx(),
+            "size_of_vmctx mismatch — caching broke the layout invariant"
+        );
+    }
+
+    /// Stress: build the allocator many times. Catches any state that
+    /// leaks between calls (e.g. a `Vec` returned in the offsets that
+    /// references a previous module). Each iteration should drop cleanly.
+    #[test]
+    fn new_with_offsets_many_times() {
+        let module = ModuleInfo::default();
+        let ps = mem::size_of::<usize>() as u8;
+        let expected_size = {
+            let (a, _, _, _) = InstanceAllocator::new(&module);
+            a.instance_layout.size()
+        };
+
+        for _ in 0..1024 {
+            let cached = VMOffsets::new(ps, &module);
+            let (b, _, _, _) = InstanceAllocator::new_with_offsets(cached, &module);
+            assert_eq!(b.instance_layout.size(), expected_size);
+        }
     }
 }

--- a/lib/vm/src/instance/allocator.rs
+++ b/lib/vm/src/instance/allocator.rs
@@ -96,10 +96,10 @@ impl InstanceAllocator {
     ///
     /// `offsets` MUST equal `VMOffsets::new(size_of::<usize>() as u8, module)`
     /// for the same `module`. Passing offsets computed for a different
-    /// module — or with a different pointer size — will produce a
-    /// mis-sized allocation and undefined behavior. Callers that cache
-    /// the offsets should key the cache by the same `ModuleInfo` they
-    /// pass here.
+    /// module, or with a different pointer size, will produce an
+    /// incorrectly sized allocation and undefined behavior. Callers that
+    /// cache the offsets should key the cache by the same `ModuleInfo`
+    /// they pass here.
     #[allow(clippy::type_complexity)]
     pub fn new_with_offsets(
         offsets: VMOffsets,
@@ -310,7 +310,7 @@ mod tests {
         let a = VMOffsets::new(ps, &module);
         let b = VMOffsets::new(ps, &module);
 
-        // Use Debug repr for comparison — VMOffsets doesn't impl `PartialEq`
+        // Use Debug repr for comparison, VMOffsets doesn't impl `PartialEq`
         // upstream, but its layout is constant for a given input so the
         // textual debug form is a sufficient identity check.
         let a_dbg = format!("{a:?}");
@@ -352,7 +352,7 @@ mod tests {
         assert_eq!(
             a.offsets.size_of_vmctx(),
             b.offsets.size_of_vmctx(),
-            "size_of_vmctx mismatch — caching broke the layout invariant"
+            "size_of_vmctx mismatch, caching broke the layout invariant"
         );
     }
 


### PR DESCRIPTION
## Summary

Computes `VMOffsets` once at artifact build / deserialize time and reuses it on every `Instance::new` for the artifact. Around 7% faster on the warm `Instance::new` path and around 12% faster on a steady-state cached instantiate-and-call cycle, measured on Singlepass-compiled wasm.

No public API change, no serialization format change, no behavior change.

## Why

`VMOffsets::new(pointer_size, module_info)` runs on every `Instance::new` today. The allocator at `lib/vm/src/instance/allocator.rs` reads `module_info.functions.len()`, `module_info.tables.len()`, all the import and local counts, and walks them to compute the layout of a `VMContext` (function table offsets, table offsets, memory offsets, signature ID offsets, and so on). For a non-trivial module this is roughly 200 reads off `ModuleInfo` plus a handful of integer multiplies.

For workloads with a warm code cache (the standard "compile once, instantiate many" pattern that dominates production wasmer use) `Instance::new` is the hot path. The arithmetic itself is cheap but `ModuleInfo` is large, so `VMOffsets::new` touches a bunch of cold cache lines on every call. On a `perf record` run against a Singlepass-built one-function module on Intel i9-10940X, `VMOffsets::new` shows up at around 9.5% of `Instance::new` samples.

The result is purely a function of `(pointer_size, module_info)`, both of which are fixed for the lifetime of a compiled artifact:

* `ModuleInfo` is immutable after compile. The only mutable field on the struct is the optional `name`, which is not an input to `VMOffsets`.
* Host pointer size does not change at runtime.

So computing once at build / deserialize time and reusing the value gives byte-identical output to recomputing each call.

## The change

Two files: `lib/vm/src/instance/allocator.rs` and `lib/compiler/src/engine/artifact.rs`.

### wasmer-vm

* New constructor `InstanceAllocator::new_with_offsets(VMOffsets, &ModuleInfo)` that takes a pre-computed `VMOffsets`.
* The existing `InstanceAllocator::new(&ModuleInfo)` keeps its signature and delegates internally (still computes `VMOffsets` itself for callers that do not have it cached). No API break.

### wasmer-compiler

* `AllocatedArtifact` gets a `vm_offsets: VMOffsets` field.
* `Artifact::from_parts` computes `VMOffsets` once after `module_info` is known and stashes it on the allocated artifact.
* The deserialization path (`Artifact::deserialize_object_native`) does the same: builds the artifact variant first, computes `VMOffsets` from the variant's `module_info()`, then constructs the `AllocatedArtifact`.
* `Artifact::instantiate` clones the cached `VMOffsets` and passes it to `InstanceAllocator::new_with_offsets`.

The cache lives on `AllocatedArtifact`, which is the in-memory-only side of `Artifact` (constructed when an artifact is bound to a target). Cross-compilation, where the artifact has `allocated: None`, is unaffected.

## Why this is safe

`VMOffsets::new` is deterministic, so caching the result and recomputing later are observationally identical. Walking the proof:

* All inputs come from `ModuleInfo`'s `IndexMap` and `PrimaryMap` counts (`functions.len()`, etc.) and the small integer arithmetic that turns those into a layout. Both are deterministic.
* `VMOffsets::new` only reads `ModuleInfo` fields that never change after compile (function, table, memory and global counts, plus the import slice). It does not read `name`, which is the only mutable field.
* Host pointer size is a runtime constant.

If a future refactor ever introduced non-determinism into `VMOffsets::new`, the new test `vmoffsets_new_is_deterministic_on_empty_module` catches it.

## Tests

Three new unit tests in `lib/vm/src/instance/allocator.rs`:

* `vmoffsets_new_is_deterministic_on_empty_module`: locks in the determinism invariant the cache depends on. Two `VMOffsets::new` calls on identical inputs produce identical results.
* `new_with_offsets_matches_new`: builds an `InstanceAllocator` via both paths and checks they produce identical state. Same `instance_layout.size()`, same `align()`, same `size_of_vmctx()`.
* `new_with_offsets_many_times`: 1024 iterations against the same module to catch any state leak between calls.

```
$ cargo test -p wasmer-vm
test result: ok. 31 passed; 0 failed
$ cargo test -p wasmer-compiler
test result: ok. (compiler unit + doctests all pass)
```

## Numbers

Intel i9-10940X (14 cores / 28 threads), CPU governor `performance`, glibc malloc, otherwise idle. Criterion: 100 samples, 5 second measurement per case. Baseline is upstream main at `d529bf7f`; patched is this branch.

The wasm module under test is a single function `(i32.const 1) (i32.const 1) i32.add` compiled with Singlepass. The cache is pre-populated, so only `Instance::new` (and the end-to-end cycle around it) is measured.

| metric | baseline | patched | delta | p |
|---|---|---|---|---|
| `stage/instantiate_from_cached_module` | 742.41 ns | 692.62 ns | **-6.89%** | 0.00 |
| `e2e/warm_arc_cache_hit` (instantiate + typed call + drop) | 971.48 ns | 851.98 ns | **-12.29%** | 0.00 |
| `stage/deserialize` | 12.51 µs | 12.44 µs | -0.49% | 0.07 (no change) |
| `e2e/warm_serialized_cache_hit` (deserialize + instantiate + call + drop) | 12.69 µs | 12.83 µs | +1.28% | within noise |

Notes on the four lines:

* `stage/deserialize` shows no significant change. The added VMOffsets computation at deserialize time is a tiny fraction of overall deserialize cost (the bulk is `Module::deserialize` itself plus mprotect on the executable mapping). The added work is amortized over every later instantiation.
* `e2e/warm_arc_cache_hit` is the steady-state hot path: warm code cache, instantiate, typed call, drop. The bigger improvement reflects that we also stop re-fetching cold `ModuleInfo` cache lines on each call, not just the arithmetic.
* `e2e/warm_serialized_cache_hit` is a different pattern (deserialize on every iter). Per-call cost is dominated by the 12 µs deserialize, so the Instance::new savings are masked by run-to-run noise on the deserialize.

`perf record` on the hot loop:

* Before: `VMOffsets::new` at around 9.5% of `Instance::new` samples.
* After: `VMOffsets::new` gone from the top 15 hot symbols.

## Compatibility

* No public API signature change. `InstanceAllocator::new(&ModuleInfo)` still works.
* No serialization format change. `vm_offsets` lives on `AllocatedArtifact`, which is the in-memory-only side. The serialized `ArtifactBuild` and `ModuleInfo` are unchanged. `MetadataHeader::version` is unchanged.
* Cross-compilation path (`allocated: None`) is untouched. The cache only matters when actually instantiating, which already required `allocated.is_some()`.

## Out of scope

Still high in the post-patch profile and addressable independently:

* `indexmap::insert_full` during import resolution.
* `Tunables::create_memories`, dominated by linear memory mmap setup.
* The empty-imports resolver path, which still walks the full imports table to confirm it is empty.

Happy to follow up on any of these in separate PRs if there is interest.
