### PR TITLE
perf(types): chunked thread-local StoreId allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7519,6 +7519,7 @@ version = "7.2.0-alpha.3"
 dependencies = [
  "bytecheck",
  "crc32fast",
+ "criterion",
  "enum-iterator",
  "enumset",
  "getrandom 0.4.2",

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -38,7 +38,9 @@ features = ["wasm_js"]
 
 [dev-dependencies]
 memoffset.workspace = true
-criterion = { workspace = true, default-features = true }
+# Workspace default has default-features = false (no HTML report
+# dep on plotters/rayon). Keeps Cargo.lock unchanged.
+criterion = { workspace = true }
 
 [[bench]]
 name = "store_id_alloc"

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -38,9 +38,7 @@ features = ["wasm_js"]
 
 [dev-dependencies]
 memoffset.workspace = true
-# Workspace default has default-features = false (no HTML report
-# dep on plotters/rayon). Keeps Cargo.lock unchanged.
-criterion = { workspace = true }
+criterion.workspace = true
 
 [[bench]]
 name = "store_id_alloc"

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -38,6 +38,11 @@ features = ["wasm_js"]
 
 [dev-dependencies]
 memoffset.workspace = true
+criterion = { workspace = true, default-features = true }
+
+[[bench]]
+name = "store_id_alloc"
+harness = false
 
 [features]
 default = ["std"]

--- a/lib/types/benches/store_id_alloc.rs
+++ b/lib/types/benches/store_id_alloc.rs
@@ -1,0 +1,59 @@
+//! Micro-benchmarks for `StoreId::default()`.
+//!
+//! The chunked thread-local allocator amortizes the global atomic
+//! cross every `CHUNK_SIZE` allocations, so the relevant signals are:
+//!
+//!   1. **single-thread hot path** — every call returns from the
+//!      TLS cursor except 1-in-`CHUNK_SIZE` that hits the global
+//!      atomic.
+//!   2. **multi-thread contention** — N threads racing on
+//!      `Default::default` concurrently. The previous design hit the
+//!      global `AtomicUsize` on every call and cross-core ping-pong
+//!      dominated the cost; the chunked design should show near-flat
+//!      scaling.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo bench -p wasmer-types --bench store_id_alloc
+//! ```
+
+use std::thread;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use wasmer_types::StoreId;
+
+fn single_thread_default(c: &mut Criterion) {
+    c.bench_function("store_id::default/single_thread", |b| {
+        b.iter(StoreId::default);
+    });
+}
+
+fn multi_thread_default(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store_id::default/multi_thread");
+    // Sample at a few worker counts so the scaling curve is visible
+    // in the report.
+    for &threads in &[1usize, 2, 4, 8] {
+        group.bench_function(format!("{threads}_threads"), |b| {
+            b.iter(|| {
+                thread::scope(|s| {
+                    for _ in 0..threads {
+                        s.spawn(|| {
+                            // Burn a CHUNK_SIZE-class run per worker
+                            // so the per-iter timing is dominated by
+                            // the steady-state TLS path plus a
+                            // handful of global-atomic refills.
+                            for _ in 0..1024 {
+                                let _ = std::hint::black_box(StoreId::default());
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, single_thread_default, multi_thread_default);
+criterion_main!(benches);

--- a/lib/types/src/store_id.rs
+++ b/lib/types/src/store_id.rs
@@ -1,5 +1,6 @@
 use core::fmt::Display;
 use std::{
+    cell::Cell,
     num::NonZeroUsize,
     sync::atomic::{AtomicUsize, Ordering},
 };
@@ -26,13 +27,52 @@ impl StoreId {
     }
 }
 
+/// Number of IDs each thread reserves from the global counter at a time.
+///
+/// `Default::default` used to hit a single global `AtomicUsize` on every
+/// call, so multiple `Store::new` callers on different cores would
+/// ping-pong the same cache line. With chunked allocation, each thread
+/// reserves `CHUNK_SIZE` consecutive IDs in one atomic step and then
+/// hands them out from a thread-local cursor with zero cross-thread
+/// traffic until the chunk is exhausted.
+///
+/// 256 keeps the global atomic out of the picture for any normal
+/// workload while leaving the total ID space unchanged: the global
+/// counter still grows by the same total amount, just in batches.
+const CHUNK_SIZE: usize = 256;
+
+/// Global pointer to the first ID of the next available chunk.
+///
+/// Starts at 1 so the first ID handed out is non-zero (the wrapper is
+/// `NonZeroUsize`).
+static NEXT_CHUNK_START: AtomicUsize = AtomicUsize::new(1);
+
+thread_local! {
+    /// Per-thread cursor inside the currently-held chunk.
+    ///
+    /// Tuple is `(next_id_to_hand_out, end_of_chunk_exclusive)`. The
+    /// initial `(0, 0)` triggers a chunk reservation on the first
+    /// `Default::default` call for this thread.
+    static LOCAL_CURSOR: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
+}
+
 impl Default for StoreId {
     // Allocates a unique ID for a new context.
     fn default() -> Self {
-        // No overflow checking is needed here: overflowing this would take
-        // thousands of years.
-        static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
-        Self(NonZeroUsize::new(NEXT_ID.fetch_add(1, Ordering::Relaxed)).unwrap())
+        // No overflow checking is needed here: the global counter is
+        // `AtomicUsize`. On 64-bit hosts, exhausting it at one
+        // `Store::new` per nanosecond on every core would still take
+        // centuries.
+        let raw = LOCAL_CURSOR.with(|cell| {
+            let (mut next, mut end) = cell.get();
+            if next == end {
+                next = NEXT_CHUNK_START.fetch_add(CHUNK_SIZE, Ordering::Relaxed);
+                end = next + CHUNK_SIZE;
+            }
+            cell.set((next + 1, end));
+            next
+        });
+        Self(NonZeroUsize::new(raw).expect("chunked allocator never returns 0"))
     }
 }
 
@@ -43,6 +83,76 @@ impl Display for StoreId {
             write!(f, "unknown")
         } else {
             write!(f, "{}", self.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    use std::thread;
+
+    /// Many sequential `default()` calls from one thread produce unique
+    /// IDs across at least three chunk boundaries (catches off-by-one
+    /// errors at the chunk seam).
+    #[test]
+    fn ids_unique_within_a_thread_across_chunk_boundaries() {
+        let n = CHUNK_SIZE * 3 + 17;
+        let mut seen = HashSet::with_capacity(n);
+        for _ in 0..n {
+            let id = StoreId::default();
+            assert!(
+                seen.insert(id.as_raw()),
+                "duplicate ID handed out within a single thread",
+            );
+        }
+    }
+
+    /// Two threads each pulling many chunks must never see overlap. This
+    /// is the property the global `fetch_add` is preserving: the chunks
+    /// are disjoint windows of the integer space.
+    #[test]
+    fn ids_unique_across_threads_under_load() {
+        const THREADS: usize = 16;
+        const PER_THREAD: usize = CHUNK_SIZE * 8;
+        let collected: Mutex<HashSet<NonZeroUsize>> =
+            Mutex::new(HashSet::with_capacity(THREADS * PER_THREAD));
+        thread::scope(|s| {
+            for _ in 0..THREADS {
+                s.spawn(|| {
+                    let mut local = Vec::with_capacity(PER_THREAD);
+                    for _ in 0..PER_THREAD {
+                        local.push(StoreId::default().as_raw());
+                    }
+                    let mut guard = collected.lock().unwrap();
+                    for id in local {
+                        assert!(
+                            guard.insert(id),
+                            "duplicate ID handed out across threads: {id}",
+                        );
+                    }
+                });
+            }
+        });
+        let total = collected.into_inner().unwrap().len();
+        assert_eq!(
+            total,
+            THREADS * PER_THREAD,
+            "expected every produced ID to be unique",
+        );
+    }
+
+    /// `StoreId` is `NonZeroUsize`-backed, so the allocator must never
+    /// hand out zero. The chunk start is initialised to 1 and chunk
+    /// reservations only ever increase it, so a zero would indicate a
+    /// regression in chunk bookkeeping.
+    #[test]
+    fn allocator_never_returns_zero() {
+        for _ in 0..10_000 {
+            let id = StoreId::default();
+            assert_ne!(id.as_raw().get(), 0);
         }
     }
 }

--- a/lib/types/src/store_id.rs
+++ b/lib/types/src/store_id.rs
@@ -47,13 +47,23 @@ const CHUNK_SIZE: usize = 256;
 /// `NonZeroUsize`).
 static NEXT_CHUNK_START: AtomicUsize = AtomicUsize::new(1);
 
+/// Per-thread chunk cursor. `next` is the ID we hand out on the next
+/// `Default::default` call; `end` is the exclusive upper bound of the
+/// currently-held chunk. `next == end` (initially `0 == 0`) signals
+/// that the thread must reserve a fresh chunk from the global counter.
+#[derive(Clone, Copy)]
+struct ChunkCursor {
+    next: usize,
+    end: usize,
+}
+
+impl ChunkCursor {
+    const EMPTY: Self = Self { next: 0, end: 0 };
+}
+
 thread_local! {
     /// Per-thread cursor inside the currently-held chunk.
-    ///
-    /// Tuple is `(next_id_to_hand_out, end_of_chunk_exclusive)`. The
-    /// initial `(0, 0)` triggers a chunk reservation on the first
-    /// `Default::default` call for this thread.
-    static LOCAL_CURSOR: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
+    static LOCAL_CURSOR: Cell<ChunkCursor> = const { Cell::new(ChunkCursor::EMPTY) };
 }
 
 impl Default for StoreId {
@@ -64,13 +74,15 @@ impl Default for StoreId {
         // `Store::new` per nanosecond on every core would still take
         // centuries.
         let raw = LOCAL_CURSOR.with(|cell| {
-            let (mut next, mut end) = cell.get();
-            if next == end {
-                next = NEXT_CHUNK_START.fetch_add(CHUNK_SIZE, Ordering::Relaxed);
-                end = next + CHUNK_SIZE;
+            let mut cursor = cell.get();
+            if cursor.next == cursor.end {
+                cursor.next = NEXT_CHUNK_START.fetch_add(CHUNK_SIZE, Ordering::Relaxed);
+                cursor.end = cursor.next + CHUNK_SIZE;
             }
-            cell.set((next + 1, end));
-            next
+            let id = cursor.next;
+            cursor.next += 1;
+            cell.set(cursor);
+            id
         });
         Self(NonZeroUsize::new(raw).expect("chunked allocator never returns 0"))
     }


### PR DESCRIPTION
`StoreId::default` used to hit a single global `AtomicUsize` on every call, so `Store::new` callers on different cores contended for the same cache line. This PR replaces that with a chunked thread-local allocator: each thread reserves 256 IDs in one `fetch_add` then hands them out from a thread-local cursor.

The fix removes the contended atomic. Whether it shows up on a macro benchmark depends on what other bottlenecks remain, see Numbers below.

> **Depends on / composes with #6640.** Against current `main` this change is a small no-op on macro benchmarks because the stack-pool `SegQueue::pop` in `wasmer-vm` accounts for ~56% of total runtime at 28 threads and dominates everything else. Once #6640 (thread-local stack cache for `on_wasm_stack`) lands, `SegQueue::pop` drops out of the hot list and `StoreId::default` becomes the next ceiling, at which point this PR is worth around +32% throughput at 28 threads. Numbers for both configurations below.

## Why

`Store::new` is on the hot path for any wasmer caller that builds a fresh store per request. Today `Store::new` ends up at `StoreId::default()` which does:

```rust
// lib/types/src/store_id.rs (current main)
static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
Self(NonZeroUsize::new(NEXT_ID.fetch_add(1, Ordering::Relaxed)).unwrap())
```

That single static is shared across the entire process. Every `Store::new` from every thread reads and writes the same cache line. Profiled at 28 threads against a one-function Singlepass-compiled module (warm code cache, single instantiate-and-call per loop iteration), `StoreId::default` shows up at **8.14% of total runtime** in `perf record`:

```
 8.14%  [.] <wasmer_types::store_id::StoreId as core::default::Default>::default
        --8.13%--<wasmer_types::store_id::StoreId as core::default::Default>::default
```

It's not the per-call CPU cost that matters (a single `fetch_add` is a few ns); it's the cross-core cache-coherency traffic. Each fetch_add invalidates the line on every other core, so every other thread's next call stalls on the bus until the line migrates.

## The fix

Chunked thread-local allocation: each thread reserves `CHUNK_SIZE = 256` consecutive IDs in one global `fetch_add`, then hands them out from a thread-local cursor with no cross-thread traffic until the chunk is exhausted.

```rust
const CHUNK_SIZE: usize = 256;
static NEXT_CHUNK_START: AtomicUsize = AtomicUsize::new(1);

thread_local! {
    static LOCAL_CURSOR: Cell<(usize, usize)> = const { Cell::new((0, 0)) };
}

impl Default for StoreId {
    fn default() -> Self {
        let raw = LOCAL_CURSOR.with(|cell| {
            let (mut next, mut end) = cell.get();
            if next == end {
                next = NEXT_CHUNK_START.fetch_add(CHUNK_SIZE, Ordering::Relaxed);
                end = next + CHUNK_SIZE;
            }
            cell.set((next + 1, end));
            next
        });
        Self(NonZeroUsize::new(raw).expect("chunked allocator never returns 0"))
    }
}
```

The shared atomic is hit once per 256 calls per thread instead of once per call. The total ID space is unchanged (still 2^usize - 1); the global counter still grows by the same total amount per ID, just in batches.

`CHUNK_SIZE = 256` is large enough that contention is effectively zero for any normal workload while leaving 2^56 chunks of headroom on 64-bit hosts. Picked as a round number; no benchmarking shows 256 is special vs 128 or 512.

## Why this is safe

The `StoreId` contract is "unique ID to identify a context, used to check that a handle is always used with the correct context." Caching the contract:

* **Uniqueness across threads.** Each thread's chunk is `[next, next + CHUNK_SIZE)`. Chunks are reserved via the shared `NEXT_CHUNK_START.fetch_add(CHUNK_SIZE)` which atomically advances the cursor. Two threads can never get overlapping chunks; therefore two threads can never hand out the same ID. Verified by the `ids_unique_across_threads_under_load` test.
* **Uniqueness within a thread.** Cursor advances by 1 per call, never reused. Verified by `ids_unique_within_a_thread_across_chunk_boundaries`.
* **NonZero invariant.** Chunk start is initialised to 1 and the global counter only ever grows, so the allocator never returns 0. Verified by `allocator_never_returns_zero`.
* **No ordering surprises.** Relaxed memory ordering is sufficient because uniqueness depends only on the atomicity of `fetch_add`, not on happens-before with any other memory. The previous implementation also used Relaxed.
* **Display formatting unchanged.** The `usize::MAX → "unknown"` special case still works identically.

## Tests

Three new unit tests in `lib/types/src/store_id.rs`:

```
test store_id::tests::ids_unique_within_a_thread_across_chunk_boundaries ... ok
test store_id::tests::ids_unique_across_threads_under_load ... ok
test store_id::tests::allocator_never_returns_zero ... ok
```

* `ids_unique_within_a_thread_across_chunk_boundaries`: calls `default()` `CHUNK_SIZE * 3 + 17` times sequentially from one thread, asserts no duplicates. Catches off-by-one errors at the chunk seam.
* `ids_unique_across_threads_under_load`: 16 threads each pull `CHUNK_SIZE * 8` IDs. All 32768 IDs across all threads must be unique. Catches any chunk-overlap regression.
* `allocator_never_returns_zero`: 10000 successive calls, all must yield non-zero (the `NonZeroUsize` wrapper would panic otherwise; this is belt-and-suspenders).

```
$ cargo test -p wasmer-types
test result: ok. 44 passed; 0 failed
```

(41 pre-existing wasmer-types unit tests + 3 new.)

## Numbers

Hardware: **Intel i9-10940X (14 cores / 28 SMT threads), CPU governor `performance`, glibc malloc, otherwise idle box.**

Wasm module: single-function `(i32.const 1) (i32.const 1) i32.add`, Singlepass-compiled, module reused across iterations. Inner loop builds a fresh `Store`, instantiates the module, runs the typed call, drops the store.

### Configuration A: against current `main` (no #6640)

Both branches built from the same toolchain, immediately after each other on an idle machine. 5 second measurement window, per-thread warmup of 10000 ops.

| threads | main (ops/sec) | this PR (ops/sec) | delta |
|---|---|---|---|
| 1 | 1.21 M | 1.21 M | flat |
| 28 | 2.20 M (6.5% eff) | 2.21 M (6.4% eff) | flat |

The bench is dominated by `SegQueue::pop` on the stack pool at 56% of runtime, so removing the 8% StoreId atomic frees up cycles that immediately stall on `SegQueue::pop` instead. Throughput unchanged, **but the cache-line ping-pong on `StoreId` is gone from the profile**:

```
# before: top symbols at 28T on `main`
56.0%  crossbeam_queue::seg_queue::SegQueue<T>::pop
 8.1%  StoreId::default               <-- this PR removes this
 3.3%  crossbeam_queue::seg_queue::SegQueue<T>::push
 ...

# after: top symbols at 28T on this PR (StoreId gone, SegQueue unchanged)
56.0%  crossbeam_queue::seg_queue::SegQueue<T>::pop
 3.3%  crossbeam_queue::seg_queue::SegQueue<T>::push
 2.3%  std::thread::local::LocalKey<T>::with
 ...
```

So in isolation this is "remove a hot cache-line ping-pong, no throughput regression." Reasonable on its own, but the headline result is when stacked.

### Configuration B: stacked with #6640 (thread-local stack cache)

Same hardware, same benchmark. Baseline is `main` + #6640 applied. This PR adds the StoreId fix on top.

| threads | baseline (ops/sec) | + this PR (ops/sec) | delta |
|---|---|---|---|
| 1 (per_call) | 38.04 ns | 37.70 ns | flat |
| 1 (ops/sec) | 1.32 M | 1.36 M | flat (noise) |
| 8 | 6.71 M (64% eff) | 8.82 M (84% eff) | **+31%** |
| 16 | 7.95 M (38% eff) | 11.48 M (53% eff) | **+44%** |
| 28 | 9.22 M (25% eff) | 12.62 M (33% eff) | **+37%** |

`StoreId::default` falls out of the top 20 symbols, confirming the cache-line move:

```
# top symbols at 28T, stacked baseline
10.6%  wasmer::entities::store::Store::new
 9.4%  std::thread::local::LocalKey<T>::with
 8.1%  StoreId::default               <-- this PR removes this
 5.5%  malloc
 ...

# top symbols at 28T, stacked + this PR
15.2%  std::thread::local::LocalKey<T>::with
 7.0%  malloc
 6.5%  _int_free
 6.1%  Store::new
 ...                                  (StoreId gone from top 20)
```

The remaining bottleneck shifts to the glibc allocator at ~20% combined malloc + free, which is a separate fix.

### Single-thread

Per-call latency on the warm hot path is unchanged (38.04 ns → 37.70 ns, within run-to-run noise). The previous implementation's `fetch_add` was a single uncontended relaxed atomic; the new one is a TLS read + branch + same single uncontended fetch_add only every 256 calls. The arithmetic difference per call is below the bench's noise floor.

## How to reproduce

Drop the following into a new `examples/repro_store_id.rs` in a wasmer-side crate that depends on `wasmer`, `wasmer-compiler`, `wasmer-compiler-singlepass`, and `wat`:

```rust
use std::sync::Arc;
use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
use std::thread;
use std::time::{Duration, Instant};

use wasmer::{imports, EngineBuilder, Instance, Module, Store};
use wasmer_compiler_singlepass::Singlepass;

const WAT: &str = r#"
(module
    (func (export "lit") (result i32)
        i32.const 1
        i32.const 1
        i32.add))
"#;

fn main() {
    let threads: usize = std::env::var("THREADS")
        .ok().and_then(|s| s.parse().ok()).unwrap_or(28);
    let secs: u64 = std::env::var("SECS")
        .ok().and_then(|s| s.parse().ok()).unwrap_or(5);

    let engine = EngineBuilder::new(Singlepass::new()).engine();
    let wasm = wat::parse_str(WAT).unwrap();
    let pre_store = Store::new(engine.clone());
    let module = Arc::new(Module::new(&pre_store, &wasm).unwrap());
    drop(pre_store);

    let stop = Arc::new(AtomicBool::new(false));
    let total = Arc::new(AtomicU64::new(0));

    let handles: Vec<_> = (0..threads).map(|_| {
        let engine = engine.clone();
        let module = module.clone();
        let stop = stop.clone();
        let total = total.clone();
        thread::spawn(move || {
            // warmup
            for _ in 0..10_000 {
                let mut store = Store::new(engine.clone());
                let inst = Instance::new(&mut store, &module, &imports!{}).unwrap();
                let f = inst.exports
                    .get_typed_function::<(), i32>(&store, "lit").unwrap();
                let _ = f.call(&mut store).unwrap();
            }
            let mut local = 0u64;
            while !stop.load(Ordering::Relaxed) {
                let mut store = Store::new(engine.clone());
                let inst = Instance::new(&mut store, &module, &imports!{}).unwrap();
                let f = inst.exports
                    .get_typed_function::<(), i32>(&store, "lit").unwrap();
                let _ = f.call(&mut store).unwrap();
                local += 1;
            }
            total.fetch_add(local, Ordering::Relaxed);
        })
    }).collect();

    thread::sleep(Duration::from_millis(200)); // let warmups finish
    let start = Instant::now();
    thread::sleep(Duration::from_secs(secs));
    stop.store(true, Ordering::Relaxed);
    for h in handles { h.join().unwrap(); }
    let elapsed = start.elapsed();
    let ops = total.load(Ordering::Relaxed);
    println!(
        "{} threads, {} ops in {:.3}s = {:.0} ops/sec",
        threads, ops, elapsed.as_secs_f64(),
        ops as f64 / elapsed.as_secs_f64(),
    );
}
```

To compare:

```bash
# baseline
git checkout main
cargo run --release --example repro_store_id
# THREADS=28, expect ~2.2 M ops/sec on the bare-main config
# or ~9.2 M ops/sec on the stacked config (#6640 applied)

# this PR
git checkout storeid-thread-local
cargo run --release --example repro_store_id
# THREADS=28, expect ~2.2 M (bare) or ~12.6 M ops/sec (stacked)
```

For the hot-symbol verification:

```bash
THREADS=28 perf record -F 2999 -a -g -- target/release/examples/repro_store_id
perf report --stdio --no-children --percent-limit 1.0 | head -20
# StoreId::default should not appear in the top 20 on the patched branch.
```

## Compatibility

* No public API change. `StoreId` is the same struct with the same `Default`, `Display`, and `as_raw` impls.
* No serialization format change. `StoreId` is runtime-only; it does not appear in any persisted artifact.
* No feature-flag interaction. The change is in the default codepath for `StoreId::default()` and applies to every consumer unconditionally.
* `std`-only. The `thread_local!` macro requires `std`. `wasmer-types` already depends on `std` in the default configuration, no `no_std` regression.

## Out of scope

Other items that show up in the post-patch 28-thread profile, each independently addressable in follow-up PRs:

* `Store::new` internals at 6%, includes the signature registry and a few other per-store allocations.
* `VMInstance::new` + `finish_instantiation` at ~7% combined, layout calc + alloc + initial setup.
* glibc `malloc/free` at ~20% combined, addressable with a per-thread pool for `instance_layout`-sized buffers (same pattern as #6640).
* `LocalKey::with` at 15% across three separate sites, some of which could be merged.

Happy to follow up on any of these in subsequent PRs.
