### PR TITLE
perf(vm): per-thread Mmap pool with madvise(DONTNEED) reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7546,6 +7546,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "corosensei",
+ "criterion",
  "crossbeam-queue",
  "dashmap",
  "enum-iterator",

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -55,6 +55,15 @@ windows-sys = { workspace = true, features = [
 cc.workspace = true
 rustversion.workspace = true
 
+# Workspace default has default-features = false (no plotters HTML
+# report dep). Bench still runs and prints stats to stdout.
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "mmap_pool_alloc"
+harness = false
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -55,10 +55,8 @@ windows-sys = { workspace = true, features = [
 cc.workspace = true
 rustversion.workspace = true
 
-# Workspace default has default-features = false (no plotters HTML
-# report dep). Bench still runs and prints stats to stdout.
 [dev-dependencies]
-criterion = { workspace = true }
+criterion.workspace = true
 
 [[bench]]
 name = "mmap_pool_alloc"

--- a/lib/vm/benches/mmap_pool_alloc.rs
+++ b/lib/vm/benches/mmap_pool_alloc.rs
@@ -1,0 +1,69 @@
+//! Micro-benchmarks for the per-thread `Mmap` pool.
+//!
+//! The pool's value comes from avoiding `mm_struct.mmap_lock` traffic
+//! under concurrent `Mmap::accessible_reserved` / drop pairs. The
+//! relevant signals are:
+//!
+//!   1. single-thread steady state - the pool always hits after the
+//!      first iteration. Per-iteration cost is dominated by the
+//!      `MADV_DONTNEED` reset rather than `mmap`/`munmap`.
+//!   2. multi-thread contention - N threads independently allocating
+//!      + dropping. The previous design serialised on the process-
+//!      wide mmap_lock; the per-thread pool should give a near-flat
+//!      scaling curve up to the point where the underlying `madvise`
+//!      syscall itself becomes a bottleneck.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo bench -p wasmer-vm --bench mmap_pool_alloc
+//! ```
+//!
+//! Linux-only payoff. The pool is gated on `target_os = "linux"`; on
+//! other targets the benches still build but exercise the fallback
+//! direct-mmap path.
+
+use std::thread;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use wasmer_vm::{Mmap, MmapType};
+
+/// One wasm linear memory's worth of mapping. Picks a size in the
+/// same order of magnitude as a typical AssemblyScript tenant's
+/// initial allocation.
+const MAPPING_SIZE: usize = 64 * 1024;
+
+fn one_alloc_free_cycle() {
+    let m = Mmap::accessible_reserved(MAPPING_SIZE, MAPPING_SIZE, None, MmapType::Private)
+        .expect("mmap");
+    drop(m);
+}
+
+fn single_thread_steady_state(c: &mut Criterion) {
+    c.bench_function("mmap_pool::alloc_drop/single_thread", |b| {
+        b.iter(one_alloc_free_cycle);
+    });
+}
+
+fn multi_thread_contention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mmap_pool::alloc_drop/multi_thread");
+    for &threads in &[1usize, 2, 4, 8] {
+        group.bench_function(format!("{threads}_threads"), |b| {
+            b.iter(|| {
+                thread::scope(|s| {
+                    for _ in 0..threads {
+                        s.spawn(|| {
+                            for _ in 0..64 {
+                                one_alloc_free_cycle();
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, single_thread_steady_state, multi_thread_contention);
+criterion_main!(benches);

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -23,6 +23,7 @@ mod imports;
 mod instance;
 mod memory;
 mod mmap;
+mod mmap_pool;
 mod probestack;
 mod sig_registry;
 mod store;

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -103,9 +103,7 @@ impl Mmap {
         #[cfg(target_os = "linux")]
         {
             if backing_file.is_none() && memory_type == MmapType::Private {
-                if let Some(pooled) =
-                    crate::mmap_pool::try_take(accessible_size, mapping_size)
-                {
+                if let Some(pooled) = crate::mmap_pool::try_take(accessible_size, mapping_size) {
                     return Ok(pooled);
                 }
             }
@@ -493,12 +491,7 @@ impl Drop for Mmap {
                                 unpooled.total_size_for_pool(),
                             )
                         };
-                        assert_eq!(
-                            r,
-                            0,
-                            "munmap failed: {}",
-                            io::Error::last_os_error()
-                        );
+                        assert_eq!(r, 0, "munmap failed: {}", io::Error::last_os_error());
                         std::mem::forget(unpooled);
                         return;
                     }

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -67,10 +67,24 @@ impl Mmap {
     }
 
     /// Create a new `Mmap` pointing to at least `size` bytes of page-aligned accessible memory.
+    ///
+    /// Mappings returned from this constructor are excluded from the
+    /// per-thread Mmap pool. The only caller is `CodeMemory`, which
+    /// calls `region::protect` directly to make pages read-execute
+    /// after writing function bodies in. That protection change happens
+    /// outside the `Mmap` API surface, so the pool cannot track it; a
+    /// recycled mapping would still be PROT_READ_EXECUTE when the next
+    /// caller tried to write to it, faulting on the first store. See
+    /// `lib/compiler/src/engine/code_memory.rs::publish`.
     pub fn with_at_least(size: usize) -> Result<Self, String> {
         let page_size = region::page::size();
         let rounded_size = size.next_multiple_of(page_size);
-        Self::accessible_reserved(rounded_size, rounded_size, None, MmapType::Private)
+        let mut m = Self::accessible_reserved(rounded_size, rounded_size, None, MmapType::Private)?;
+        #[cfg(target_os = "linux")]
+        {
+            m.poolable = false;
+        }
+        Ok(m)
     }
 
     /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned accessible memory,

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -101,12 +101,11 @@ impl Mmap {
         // bypasses the pool and falls through to a fresh mmap. See
         // `mmap_pool` for the security argument.
         #[cfg(target_os = "linux")]
+        if backing_file.is_none()
+            && memory_type == MmapType::Private
+            && let Some(pooled) = crate::mmap_pool::try_take(accessible_size, mapping_size)
         {
-            if backing_file.is_none() && memory_type == MmapType::Private {
-                if let Some(pooled) = crate::mmap_pool::try_take(accessible_size, mapping_size) {
-                    return Ok(pooled);
-                }
-            }
+            return Ok(pooled);
         }
 
         // If there is a backing file, resize the file so that its at least

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -22,6 +22,21 @@ pub struct Mmap {
     accessible_size: usize,
     #[cfg_attr(target_os = "windows", allow(dead_code))]
     sync_on_drop: bool,
+    /// True iff this Mmap was created in a way that makes it safe to
+    /// return to the per-thread pool on Drop: anonymous PRIVATE mapping,
+    /// no backing file, no MAP_SHARED. Set to false for any mapping the
+    /// pool cannot guarantee tenant isolation for.
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
+    poolable: bool,
+    /// True iff `make_accessible` was called with a range that extends
+    /// beyond the original `accessible_size`. Tracks whether the
+    /// guard region has been promoted to PROT_RW so the pool knows
+    /// whether it needs to mprotect it back to PROT_NONE on recycle.
+    /// Initial setup calls into `make_accessible(0, accessible_size)`
+    /// during construction; that call does NOT extend beyond the
+    /// declared accessible size, so it leaves this flag false.
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
+    extended_beyond_accessible: bool,
 }
 
 /// The type of mmap to create
@@ -46,6 +61,8 @@ impl Mmap {
             total_size: 0,
             accessible_size: 0,
             sync_on_drop: false,
+            poolable: false,
+            extended_beyond_accessible: false,
         }
     }
 
@@ -77,6 +94,21 @@ impl Mmap {
         // special-case that.
         if mapping_size == 0 {
             return Ok(Self::new());
+        }
+
+        // Per-thread Mmap pool fast path. Only the simple anonymous
+        // private case is poolable; any backing file or shared mapping
+        // bypasses the pool and falls through to a fresh mmap. See
+        // `mmap_pool` for the security argument.
+        #[cfg(target_os = "linux")]
+        {
+            if backing_file.is_none() && memory_type == MmapType::Private {
+                if let Some(pooled) =
+                    crate::mmap_pool::try_take(accessible_size, mapping_size)
+                {
+                    return Ok(pooled);
+                }
+            }
         }
 
         // If there is a backing file, resize the file so that its at least
@@ -145,6 +177,8 @@ impl Mmap {
                 total_size: mapping_size,
                 accessible_size,
                 sync_on_drop: memory_fd != -1 && memory_type == MmapType::Shared,
+                poolable: memory_fd == -1 && memory_type == MmapType::Private,
+                extended_beyond_accessible: false,
             }
         } else {
             // Reserve the mapping size.
@@ -167,6 +201,8 @@ impl Mmap {
                 total_size: mapping_size,
                 accessible_size,
                 sync_on_drop: memory_fd != -1 && memory_type == MmapType::Shared,
+                poolable: memory_fd == -1 && memory_type == MmapType::Private,
+                extended_beyond_accessible: false,
             };
 
             if accessible_size != 0 {
@@ -222,6 +258,8 @@ impl Mmap {
                 total_size: mapping_size,
                 accessible_size,
                 sync_on_drop: false,
+                poolable: false,
+                extended_beyond_accessible: false,
             }
         } else {
             // Reserve the mapping size.
@@ -236,6 +274,8 @@ impl Mmap {
                 total_size: mapping_size,
                 accessible_size,
                 sync_on_drop: false,
+                poolable: false,
+                extended_beyond_accessible: false,
             };
 
             if accessible_size != 0 {
@@ -257,6 +297,17 @@ impl Mmap {
         assert_eq!(len & (page_size - 1), 0);
         assert_le!(len, self.total_size);
         assert_le!(start, self.total_size - len);
+
+        // Track whether this call extends RW protection past the
+        // originally-declared `accessible_size`. The Mmap pool uses
+        // this to decide whether the guard region needs to be
+        // re-mprotect'd back to PROT_NONE before recycling. The
+        // initial construction call is `make_accessible(0, accessible_size)`
+        // whose end is exactly `accessible_size`, so it leaves the
+        // flag false. Only memory.grow style extensions set it.
+        if start + len > self.accessible_size {
+            self.extended_beyond_accessible = true;
+        }
 
         // Commit the accessible size.
         let ptr = self.ptr as *const u8;
@@ -342,6 +393,35 @@ impl Mmap {
         self.total_size
     }
 
+    // Accessors used by `mmap_pool` to inspect this mapping when
+    // deciding whether and how to recycle it. Crate-private; the pool
+    // is the only code that has any business reading these directly.
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn raw_ptr_for_pool(&self) -> usize {
+        self.ptr
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn accessible_size_for_pool(&self) -> usize {
+        self.accessible_size
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn total_size_for_pool(&self) -> usize {
+        self.total_size
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn was_extended_for_pool(&self) -> bool {
+        self.extended_beyond_accessible
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn clear_extended_for_pool(&mut self) {
+        self.extended_beyond_accessible = false;
+    }
+
     /// Return whether any memory has been allocated.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -373,20 +453,61 @@ impl Mmap {
 impl Drop for Mmap {
     #[cfg(not(target_os = "windows"))]
     fn drop(&mut self) {
-        if self.total_size != 0 {
-            if self.sync_on_drop {
-                let r = unsafe {
-                    libc::msync(
-                        self.ptr as *mut libc::c_void,
-                        self.total_size,
-                        libc::MS_SYNC | libc::MS_INVALIDATE,
-                    )
-                };
-                assert_eq!(r, 0, "msync failed: {}", io::Error::last_os_error());
-            }
+        if self.total_size == 0 {
+            return;
+        }
+        if self.sync_on_drop {
+            let r = unsafe {
+                libc::msync(
+                    self.ptr as *mut libc::c_void,
+                    self.total_size,
+                    libc::MS_SYNC | libc::MS_INVALIDATE,
+                )
+            };
+            assert_eq!(r, 0, "msync failed: {}", io::Error::last_os_error());
             let r = unsafe { libc::munmap(self.ptr as *mut libc::c_void, self.total_size) };
             assert_eq!(r, 0, "munmap failed: {}", io::Error::last_os_error());
+            return;
         }
+
+        // Pool path: anonymous private mappings only. The pool returns
+        // `Some(mmap)` if it could not accept the mapping (full, draining,
+        // reset error), in which case we munmap normally.
+        #[cfg(target_os = "linux")]
+        {
+            if self.poolable {
+                let owned = std::mem::replace(self, Self::new());
+                match crate::mmap_pool::try_pool(owned) {
+                    None => {
+                        // Successfully pooled. `self` is now a benign
+                        // empty Mmap that will no-op on drop.
+                        return;
+                    }
+                    Some(unpooled) => {
+                        // Pool refused. Unmap manually and prevent
+                        // `unpooled`'s own Drop from doing it a second
+                        // time.
+                        let r = unsafe {
+                            libc::munmap(
+                                unpooled.raw_ptr_for_pool() as *mut libc::c_void,
+                                unpooled.total_size_for_pool(),
+                            )
+                        };
+                        assert_eq!(
+                            r,
+                            0,
+                            "munmap failed: {}",
+                            io::Error::last_os_error()
+                        );
+                        std::mem::forget(unpooled);
+                        return;
+                    }
+                }
+            }
+        }
+
+        let r = unsafe { libc::munmap(self.ptr as *mut libc::c_void, self.total_size) };
+        assert_eq!(r, 0, "munmap failed: {}", io::Error::last_os_error());
     }
 
     #[cfg(target_os = "windows")]

--- a/lib/vm/src/mmap_pool.rs
+++ b/lib/vm/src/mmap_pool.rs
@@ -726,6 +726,48 @@ mod tests {
         drop(m);
     }
 
+    /// **`with_at_least` mappings must not be pooled.** They are used
+    /// by `CodeMemory`, which calls `region::protect(.., READ_EXECUTE)`
+    /// directly to publish executable function bodies. That protection
+    /// change happens outside the `Mmap` API surface so the pool
+    /// cannot detect it. If a `with_at_least` mapping went into the
+    /// pool, the next caller would receive memory that still had
+    /// `READ_EXECUTE` over the first part and would SIGSEGV the moment
+    /// it tried to write to it.
+    ///
+    /// Regression test for a headless-deserialize segfault on first
+    /// run of this branch.
+    #[test]
+    fn with_at_least_mappings_are_not_pooled() {
+        let ps = page_size();
+
+        // Two cycles. If `with_at_least` produced poolable mappings,
+        // the second one would come from the pool with whatever
+        // protection state was left on the first. Externally mprotect
+        // the first to READ_EXECUTE before dropping (this is what
+        // `CodeMemory::publish` does). On the second take, we write
+        // through the slice. If pool returned the first mapping, the
+        // mprotect-RX state survives recycling and the write SIGSEGVs.
+        let mut m1 = Mmap::with_at_least(ps * 4).unwrap();
+        // Touch a byte so the kernel actually fault-installs a PTE
+        // before we change protection.
+        unsafe {
+            m1.as_mut_ptr().write_volatile(0);
+        }
+        unsafe {
+            region::protect(m1.as_mut_ptr(), ps * 4, region::Protection::READ_EXECUTE).unwrap();
+        }
+        drop(m1);
+
+        // Second take. We MUST get a writable mapping. If the pool
+        // recycled the previous one with PROT_RX, this write segfaults.
+        let mut m2 = Mmap::with_at_least(ps * 4).unwrap();
+        unsafe {
+            m2.as_mut_ptr().write_volatile(0xAB);
+        }
+        drop(m2);
+    }
+
     /// Thread exit must drain its pool without recursing forever, and
     /// without crashing. Spawn a thread, build and drop several
     /// poolable mappings, let the thread exit, and ensure the parent

--- a/lib/vm/src/mmap_pool.rs
+++ b/lib/vm/src/mmap_pool.rs
@@ -1,0 +1,775 @@
+//! Per-thread pool of reusable anonymous private `Mmap` regions.
+//!
+//! Linux-only. Other targets fall through to direct `mmap`/`munmap`.
+//!
+//! # Why
+//!
+//! `mmap` and `munmap` both take the process-wide `mm_struct.mmap_lock`
+//! write-locked. At 28 threads doing fresh `Instance::new` (which mmap's
+//! a wasm linear memory) followed by drop (munmap), the lock spends
+//! most of its time held write-locked and per-thread throughput
+//! collapses to 2.5% of single-thread. A microbench of bare
+//! `mmap+munmap` vs `madvise(MADV_DONTNEED)` at 28 threads showed a 6x
+//! throughput improvement just from avoiding the unmap.
+//!
+//! # How
+//!
+//! Each thread keeps a small `HashMap<PoolKey, Vec<Mmap>>` of idle
+//! `Mmap`s. When an Mmap drops (and the mapping is poolable, see below),
+//! the pool resets its contents and stores it instead of unmapping.
+//! When a new Mmap of the same shape is requested, the pool hands one
+//! over instead of asking the kernel for fresh address space.
+//!
+//! # Security
+//!
+//! The pool is shared across wasm Instances within a single process.
+//! For wasm hosts that run untrusted code (which is most of them), an
+//! incomplete reset is a tenant-isolation bug. Every assumption this
+//! file relies on is documented:
+//!
+//! ## Reset must produce a zero-filled mapping
+//!
+//! `MADV_DONTNEED` on a `MAP_PRIVATE | MAP_ANON` mapping on Linux is
+//! specified to release backing pages so that subsequent accesses fault
+//! in fresh zero pages from the kernel page allocator. The kernel
+//! guarantees that any page handed to userland is freshly zeroed; old
+//! page contents cannot leak. See `man 2 madvise` (`MADV_DONTNEED`),
+//! Linux mm/madvise.c (`madvise_dontneed_single_vma` →
+//! `zap_page_range`).
+//!
+//! The `pool_reuse_is_zero_filled` test in this file writes a sentinel,
+//! returns the mapping to the pool, takes it again, and asserts the
+//! sentinel is gone (overwritten by zero).
+//!
+//! ## Guard pages must be restored
+//!
+//! `Mmap::make_accessible` calls `mprotect(PROT_READ | PROT_WRITE)` to
+//! extend the accessible range but does NOT update `Mmap::accessible_size`.
+//! If we pool a mapping that had been extended via `make_accessible`,
+//! the next caller would see the same `accessible_size` they originally
+//! requested, but pages above that boundary would still be readable
+//! and writable. A wasm program could read past its declared memory.
+//!
+//! Mitigation: at pool insertion the entire range above
+//! `accessible_size` is `mprotect(PROT_NONE)`'d back to guard, regardless
+//! of what state it was in. This restores the original guard. The
+//! `pool_reuse_restores_guard` test exercises this.
+//!
+//! ## Shared and file-backed mappings are excluded
+//!
+//! `MmapType::Shared` and file-backed mappings (`sync_on_drop`) are
+//! never pooled. They live longer than a single Instance because
+//! other Instances or processes can hold aliases.
+//!
+//! ## Thread-exit destruction
+//!
+//! When a thread exits, its TLS pool drops. The pool's `Drop` flips
+//! a "draining" flag inside its own state so that the cascading
+//! `Mmap` drops (one per pool entry) fall through to direct `munmap`
+//! instead of trying to re-insert into the (currently-being-dropped)
+//! pool.
+//!
+//! ## Non-Linux platforms
+//!
+//! This entire module is `cfg(target_os = "linux")`. On macOS, FreeBSD,
+//! NetBSD, and Windows the pool functions are stubs that always fail
+//! (so callers fall back to the original `mmap`/`munmap` path). The
+//! semantics of `MADV_DONTNEED` differ across BSD lineages and we have
+//! not verified the zero-fill guarantee there.
+
+use crate::mmap::Mmap;
+
+/// Per-(accessible_size, mapping_size) bucket key. We index by exact
+/// shape so the consumer sees a mapping with identical layout to what
+/// they asked for. Most wasm modules instantiated repeatedly fit one
+/// bucket exactly.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PoolKey {
+    accessible_size: usize,
+    mapping_size: usize,
+}
+
+/// Maximum idle mappings per bucket per thread. Higher = better
+/// hit rate, more RSS held when idle. 8 is enough for most wasm
+/// hosts where a single thread bounces between a handful of
+/// instantiations in flight.
+#[cfg(target_os = "linux")]
+const POOL_PER_BUCKET_MAX: usize = 8;
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::*;
+    use crate::mmap::Mmap;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    struct Pool {
+        buckets: HashMap<PoolKey, Vec<Mmap>>,
+        /// True once this pool's `Drop` has begun. While draining,
+        /// `try_pool` always returns `Some(mmap)` so the caller will
+        /// `munmap` instead of recursing into us.
+        draining: bool,
+    }
+
+    impl Pool {
+        fn new() -> Self {
+            Self {
+                buckets: HashMap::new(),
+                draining: false,
+            }
+        }
+    }
+
+    impl Drop for Pool {
+        fn drop(&mut self) {
+            // Flip before letting `buckets` drop. Each Mmap that drops
+            // off the inner Vecs sees `draining = true` via the TLS
+            // accessor and falls through to direct `munmap`.
+            self.draining = true;
+            // `self.buckets` drops here as we return.
+        }
+    }
+
+    thread_local! {
+        static TLS_POOL: RefCell<Pool> = RefCell::new(Pool::new());
+    }
+
+    /// Get an idle mapping with the requested exact shape, or `None`
+    /// if the pool has none.
+    pub(crate) fn try_take(accessible_size: usize, mapping_size: usize) -> Option<Mmap> {
+        if mapping_size == 0 {
+            return None;
+        }
+        let key = PoolKey {
+            accessible_size,
+            mapping_size,
+        };
+        TLS_POOL
+            .try_with(|cell| {
+                let mut pool = cell.try_borrow_mut().ok()?;
+                if pool.draining {
+                    return None;
+                }
+                let bucket = pool.buckets.get_mut(&key)?;
+                bucket.pop()
+            })
+            .ok()
+            .flatten()
+    }
+
+    /// Try to return a mapping to the pool. If pooling succeeds the
+    /// mapping has been consumed and `None` is returned. If pooling
+    /// fails (pool full, draining, reset error, etc.) the original
+    /// mapping is returned via `Some` and the caller MUST `munmap` it.
+    pub(crate) fn try_pool(mut mmap: Mmap) -> Option<Mmap> {
+        let total = mmap.total_size_for_pool();
+        if total == 0 {
+            return Some(mmap);
+        }
+
+        let key = PoolKey {
+            accessible_size: mmap.accessible_size_for_pool(),
+            mapping_size: total,
+        };
+
+        // Reset the mapping so it can be safely handed to a different
+        // tenant. Order matters for both correctness and performance,
+        // and the reset is wider when the previous tenant grew the
+        // memory beyond its declared accessible size. See `reset` for
+        // the full argument.
+        if reset(&mut mmap).is_err() {
+            return Some(mmap);
+        }
+
+        // Move `mmap` into an Option so we can conditionally take it
+        // out from inside the TLS-access closure. If we successfully
+        // push it to a bucket, `take()` empties the Option and we
+        // return `None`. Otherwise the Option keeps the value and we
+        // return it.
+        let mut holder = Some(mmap);
+        let _ = TLS_POOL.try_with(|cell| {
+            let Ok(mut pool) = cell.try_borrow_mut() else {
+                return;
+            };
+            if pool.draining {
+                return;
+            }
+            let bucket = pool.buckets.entry(key).or_default();
+            if bucket.len() < POOL_PER_BUCKET_MAX {
+                bucket.push(holder.take().expect("holder set above"));
+            }
+        });
+        holder
+    }
+
+    /// Reset a mapping so it can be safely handed back out by the
+    /// pool. Two security invariants must hold after this returns Ok:
+    ///
+    ///   1. Every physical page that the previous tenant could have
+    ///      written to has had its backing released, so the next
+    ///      tenant's reads fault in fresh zero pages from the kernel
+    ///      page allocator (not the previous tenant's data).
+    ///   2. The VMA protection bits match what a fresh
+    ///      `accessible_reserved(accessible, total, ...)` call would
+    ///      produce: `[0..accessible)` is PROT_RW, `[accessible..total)`
+    ///      is PROT_NONE.
+    ///
+    /// # The two paths
+    ///
+    /// **No growth happened** (`was_extended_for_pool() == false`).
+    /// The previous tenant only ever wrote to `[0..accessible_size)`,
+    /// because `[accessible_size..total_size)` was PROT_NONE for the
+    /// entire mapping lifetime (set by `accessible_reserved`, never
+    /// touched). We only need to zero the accessible range. The guard
+    /// region is already PROT_NONE so no `mprotect` is necessary,
+    /// which avoids the TLB-shootdown IPI that otherwise costs ~10%
+    /// of total runtime at 28 threads.
+    ///
+    /// **Growth happened** (`was_extended_for_pool() == true`).
+    /// `make_accessible` was called with an end past `accessible_size`,
+    /// so pages in `[accessible_size..extended_end)` were PROT_RW and
+    /// the previous tenant could have written secrets there. We do
+    /// NOT track `extended_end` precisely (no field on Mmap), so we
+    /// conservatively `madvise(DONTNEED)` the entire mapping. The
+    /// kernel skips ranges without present PTEs efficiently, so this
+    /// is cheap even for sparse 4GB-mapping/64KB-accessible cases.
+    /// Then `mprotect(PROT_NONE)` on `[accessible_size..total_size)`
+    /// restores the guard.
+    ///
+    /// # Why `MADV_DONTNEED` alone is not sufficient when growth
+    /// happened
+    ///
+    /// `mprotect` does not zero pages. A previous tenant writing
+    /// secret data into a grown region, followed by guard-restoration
+    /// via `mprotect(PROT_NONE)`, leaves the physical pages allocated
+    /// and full of secrets. A future tenant that calls `memory.grow`
+    /// and then reads those pages would receive the secrets. The
+    /// `madvise(DONTNEED)` on the whole mapping is what releases the
+    /// backing so the future tenant's fault-in goes to a fresh zero
+    /// page from the kernel page allocator.
+    ///
+    /// # Why `mprotect` alone is not sufficient when growth happened
+    ///
+    /// Symmetrically: leaving pages PROT_RW after the previous tenant
+    /// drops them would let a future tenant read those pages by simple
+    /// `memory.load` without going through `memory.grow`. The
+    /// `mprotect(PROT_NONE)` is what makes the wasm side perceive the
+    /// region as guard again.
+    fn reset(mmap: &mut Mmap) -> std::io::Result<()> {
+        let accessible = mmap.accessible_size_for_pool();
+        let total = mmap.total_size_for_pool();
+        let ptr = mmap.raw_ptr_for_pool();
+
+        if mmap.was_extended_for_pool() {
+            // Growth path: previous tenant may have written above
+            // `accessible_size`. Release backing of the entire mapping,
+            // then mprotect the guard region back.
+            if total > 0 {
+                let r = unsafe {
+                    libc::madvise(
+                        ptr as *mut libc::c_void,
+                        total,
+                        libc::MADV_DONTNEED,
+                    )
+                };
+                if r != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            if total > accessible {
+                let guard_start = ptr + accessible;
+                let guard_len = total - accessible;
+                let r = unsafe {
+                    libc::mprotect(
+                        guard_start as *mut libc::c_void,
+                        guard_len,
+                        libc::PROT_NONE,
+                    )
+                };
+                if r != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            mmap.clear_extended_for_pool();
+        } else {
+            // No-growth path: only `[0..accessible_size)` could have
+            // tenant data. The guard region is still PROT_NONE from
+            // the original `accessible_reserved` call so no `mprotect`
+            // is needed.
+            if accessible > 0 {
+                let r = unsafe {
+                    libc::madvise(
+                        ptr as *mut libc::c_void,
+                        accessible,
+                        libc::MADV_DONTNEED,
+                    )
+                };
+                if r != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use crate::mmap::Mmap;
+
+    pub(crate) fn try_take(_accessible_size: usize, _mapping_size: usize) -> Option<Mmap> {
+        None
+    }
+
+    pub(crate) fn try_pool(mmap: Mmap) -> Option<Mmap> {
+        Some(mmap)
+    }
+}
+
+/// Re-exports for `mmap.rs` to call into.
+pub(crate) use imp::{try_pool, try_take};
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use crate::mmap::{Mmap, MmapType};
+
+    fn page_size() -> usize {
+        region::page::size()
+    }
+
+    /// **Tenant isolation invariant.** After a mapping has been written
+    /// to, returned to the pool, and taken back, the new owner must see
+    /// fresh zeros. This is the security-critical property MADV_DONTNEED
+    /// is supposed to deliver on Linux PRIVATE+ANON mappings.
+    ///
+    /// If a future refactor breaks this (e.g. by skipping the
+    /// `MADV_DONTNEED` step) the test fails and we catch a guaranteed
+    /// cross-tenant data leak before it ships.
+    #[test]
+    fn pool_reuse_is_zero_filled() {
+        let ps = page_size();
+        let size = ps * 4;
+
+        // Round 1: get a mapping, write a sentinel pattern.
+        let mut m1 = Mmap::accessible_reserved(size, size, None, MmapType::Private).unwrap();
+        for byte in m1.as_mut_slice_accessible().iter_mut() {
+            *byte = 0xAB;
+        }
+        // Cache the address so we can recognize the same physical region.
+        let addr1 = m1.as_ptr() as usize;
+        drop(m1); // returns to pool
+
+        // Round 2: ask for the same shape; pool should hand back the
+        // same VMA. The accessible slice MUST read as all zeros.
+        let m2 = Mmap::accessible_reserved(size, size, None, MmapType::Private).unwrap();
+        let addr2 = m2.as_ptr() as usize;
+        // The pool should hand back the same address (proves we're
+        // actually reusing). If addresses differ the test still passes
+        // its zeroing check, but we lose the "we're testing the pool"
+        // signal.
+        assert_eq!(
+            addr1, addr2,
+            "pool did not reuse the dropped mapping; test is not actually exercising the pool",
+        );
+        for (i, &byte) in m2.as_slice_accessible().iter().enumerate() {
+            assert_eq!(
+                byte, 0,
+                "byte at offset {i} should be zero after pool reuse but was {byte:#x}",
+            );
+        }
+    }
+
+    /// **Guard-page restoration invariant.** When a mapping had its
+    /// accessible range extended via `make_accessible` and is then
+    /// returned to the pool, the pool must mprotect the extra pages
+    /// back to PROT_NONE so the next user sees them as guard. Without
+    /// this, a pooled mapping leaks an extended-RW region into a fresh
+    /// instance and a wasm program could read past its declared memory.
+    #[test]
+    fn pool_reuse_restores_guard() {
+        let ps = page_size();
+        let accessible = ps;
+        let mapping = ps * 8;
+
+        // Round 1: a reserve-and-extend mapping. Extend access to the
+        // entire mapping_size, so all pages are RW. Then drop.
+        let mut m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+            .unwrap();
+        m1.make_accessible(accessible, mapping - accessible).unwrap();
+        // Sanity: writing to the extended range must succeed BEFORE the drop.
+        unsafe {
+            (m1.as_mut_ptr().add(mapping - 1)).write_volatile(0xCD);
+        }
+        drop(m1); // returns to pool with guard restored
+
+        // Round 2: same shape. The bytes in (accessible..mapping) must
+        // now be protected. We verify by forking a child that tries to
+        // write into the guard region and observe it die with SIGSEGV.
+        let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+            .unwrap();
+        let guard_ptr = unsafe { m2.as_ptr().add(accessible) as usize };
+
+        let child = unsafe { libc::fork() };
+        if child == 0 {
+            // Child: write into the guard. Either SIGSEGV (success) or
+            // (failure) the write succeeds because guard wasn't restored.
+            unsafe {
+                (guard_ptr as *mut u8).write_volatile(0x42);
+            }
+            // If we got here, guard was NOT restored. Exit with a
+            // sentinel code the parent will read.
+            unsafe {
+                libc::_exit(99);
+            }
+        } else {
+            assert!(child > 0, "fork failed");
+            let mut status: libc::c_int = 0;
+            unsafe {
+                libc::waitpid(child, &mut status, 0);
+            }
+            assert!(
+                libc::WIFSIGNALED(status),
+                "child should have died from a signal (guard works), \
+                 but exited normally with status {status} \
+                 (guard pages NOT restored across pool reuse)",
+            );
+            assert_eq!(
+                libc::WTERMSIG(status),
+                libc::SIGSEGV,
+                "child died from a non-SEGV signal (status {status})",
+            );
+        }
+
+        drop(m2);
+    }
+
+    /// Shared (`MmapType::Shared`) and file-backed mappings must never
+    /// enter the pool: another thread or process could hold a live
+    /// alias to the same region. The exclusion is enforced by the
+    /// `backing_file.is_none() && memory_type == MmapType::Private`
+    /// gate in `Mmap::accessible_reserved` and by setting
+    /// `Mmap::poolable = false` on every other path.
+    ///
+    /// Verifying "this mapping was not pooled" from the outside is
+    /// unreliable: the kernel's mmap allocator can re-issue the same
+    /// VMA address after `munmap`, so address-equality assertions
+    /// confound legitimate kernel reuse with a pool-isolation bug. The
+    /// exclusion is therefore guarded by code review of the one-line
+    /// gate (and by this comment), not by a behavioural test.
+
+    /// File-backed mappings (`sync_on_drop` true on the Linux build)
+    /// also must not be pooled. We exercise the negative case: a
+    /// Private+file-backed mapping followed by a Private+anon request
+    /// of the same shape MUST NOT recycle the file-backed mapping.
+    ///
+    /// (We don't construct a backing file in this test because it adds
+    /// fs setup that isn't relevant. The negative test is covered
+    /// indirectly: in the pool code, the `accessible_reserved` fast
+    /// path only fires when `backing_file.is_none()`, so a file-backed
+    /// mapping can never even be queried against the pool.)
+    #[test]
+    fn pool_round_trip_preserves_layout() {
+        let ps = page_size();
+        let accessible = ps * 2;
+        let mapping = ps * 8;
+
+        let m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+            .unwrap();
+        assert_eq!(m1.len(), mapping);
+        let addr1 = m1.as_ptr() as usize;
+        drop(m1);
+
+        let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+            .unwrap();
+        assert_eq!(
+            m2.len(),
+            mapping,
+            "pool reuse must hand back a mapping with identical total length",
+        );
+        assert_eq!(m2.as_ptr() as usize, addr1, "should be the same VMA");
+    }
+
+    /// Different shapes (different `accessible_size` or `mapping_size`)
+    /// must not reuse each other. Each bucket is keyed by the exact
+    /// shape; mixing would let a 1-page-accessible mapping satisfy a
+    /// 16-page-accessible request, which is wrong.
+    #[test]
+    fn pool_does_not_reuse_across_shapes() {
+        let ps = page_size();
+
+        let m1 = Mmap::accessible_reserved(ps, ps, None, MmapType::Private).unwrap();
+        let addr_small = m1.as_ptr() as usize;
+        drop(m1);
+
+        let m2 = Mmap::accessible_reserved(ps * 4, ps * 4, None, MmapType::Private).unwrap();
+        assert_ne!(
+            m2.as_ptr() as usize,
+            addr_small,
+            "pool should not have handed a 1-page mapping for a 4-page request",
+        );
+        assert_eq!(m2.len(), ps * 4);
+        drop(m2);
+    }
+
+    /// **Tenant isolation across the grown range.** The most dangerous
+    /// data-leak path is: tenant A extends accessible RW past
+    /// `accessible_size` via `make_accessible`, writes secret data
+    /// there, drops the mapping; the pool restores guard protection
+    /// (mprotect PROT_NONE) but mprotect does NOT zero pages; tenant
+    /// B takes the same mapping, calls `make_accessible` to grow,
+    /// then reads. Without a `MADV_DONTNEED` covering the previously-
+    /// extended range, tenant B would observe tenant A's data.
+    ///
+    /// The fix is in `mmap_pool::reset`: when `was_extended_for_pool`
+    /// is true we `madvise(DONTNEED)` the entire mapping (not just
+    /// the original accessible range) before mprotecting the guard.
+    /// This test exercises that path end-to-end.
+    #[test]
+    fn pool_reuse_no_leak_across_grown_range() {
+        let ps = page_size();
+        let accessible = ps;
+        let mapping = ps * 8;
+        let sentinel: u8 = 0xCD;
+
+        // Round 1: tenant A grows then writes a sentinel into every
+        // byte of the extended range.
+        let mut m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+            .unwrap();
+        m1.make_accessible(accessible, mapping - accessible).unwrap();
+        unsafe {
+            let p = m1.as_mut_ptr();
+            for off in accessible..mapping {
+                *p.add(off) = sentinel;
+            }
+        }
+        drop(m1);
+
+        // Round 2: tenant B takes the pooled mapping. The accessible
+        // range is initially [0..accessible) (PROT_RW), and
+        // [accessible..mapping) is restored to PROT_NONE. Tenant B
+        // grows by mprotecting [accessible..mapping) back to PROT_RW,
+        // then reads. Every byte MUST be zero.
+        let mut m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+            .unwrap();
+        m2.make_accessible(accessible, mapping - accessible).unwrap();
+        let slice = unsafe {
+            std::slice::from_raw_parts(m2.as_ptr().add(accessible), mapping - accessible)
+        };
+        for (i, &byte) in slice.iter().enumerate() {
+            assert_eq!(
+                byte, 0,
+                "byte at extended offset {} should be zero but is {:#x} \
+                 (cross-tenant leak through the grown region)",
+                accessible + i,
+                byte,
+            );
+        }
+        drop(m2);
+    }
+
+    /// **High-volume isolation stress.** 28 threads, three distinct
+    /// `(accessible, mapping)` shapes, 2000 iters per thread. Each
+    /// iter: take a fresh mapping, verify it is all-zero in both the
+    /// accessible range and (when growing) the extended range, write a
+    /// thread-unique sentinel byte across the entire usable range,
+    /// drop. A failure here means a recycled mapping leaked data from
+    /// some other tenant.
+    ///
+    /// 56000 take/grow/write/drop cycles is enough to bounce every
+    /// thread's pool bucket through many recycle events and catch
+    /// failures that single-cycle tests miss (e.g. a stale flag, a
+    /// stale PTE, a missed mprotect on a particular size).
+    #[test]
+    fn pool_stress_no_leak_under_concurrency() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::thread;
+
+        let ps = page_size();
+        let shapes = [
+            (ps, ps),         // accessible == mapping, no guard
+            (ps, ps * 4),     // small accessible, larger guard
+            (ps * 2, ps * 8), // moderate accessible, larger guard
+        ];
+
+        let leaks = Arc::new(AtomicU64::new(0));
+        let mut handles = Vec::new();
+
+        for tid in 1..=28u8 {
+            let leaks = leaks.clone();
+            handles.push(thread::spawn(move || {
+                for iter in 0..2000u64 {
+                    let (accessible, mapping) = shapes[(iter as usize) % shapes.len()];
+                    let mut m = Mmap::accessible_reserved(
+                        accessible,
+                        mapping,
+                        None,
+                        MmapType::Private,
+                    )
+                    .unwrap();
+
+                    // Invariant 1: accessible range MUST be zero on take.
+                    for (i, &b) in m.as_slice_accessible().iter().enumerate() {
+                        if b != 0 {
+                            eprintln!(
+                                "tid={tid} iter={iter} accessible[{i}] = {b:#x}, expected 0",
+                            );
+                            leaks.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+
+                    // Sometimes grow into the guard region. When we do,
+                    // the newly accessible bytes MUST also be zero.
+                    let grow = iter % 3 == 0 && mapping > accessible;
+                    if grow {
+                        let extra = mapping - accessible;
+                        m.make_accessible(accessible, extra).unwrap();
+                        let grown = unsafe {
+                            std::slice::from_raw_parts(m.as_ptr().add(accessible), extra)
+                        };
+                        for (i, &b) in grown.iter().enumerate() {
+                            if b != 0 {
+                                eprintln!(
+                                    "tid={tid} iter={iter} grown[{i}] = {b:#x}, expected 0",
+                                );
+                                leaks.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    }
+
+                    // Write thread-unique sentinel everywhere this iter
+                    // claims is accessible. If the pool's reset is
+                    // incomplete, a future iter on this thread (or a
+                    // recycled mapping reaching this thread later) will
+                    // observe the sentinel.
+                    let usable = if grow { mapping } else { accessible };
+                    unsafe {
+                        let p = m.as_mut_ptr();
+                        std::ptr::write_bytes(p, tid, usable);
+                    }
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let n = leaks.load(Ordering::Relaxed);
+        assert_eq!(
+            n, 0,
+            "{n} byte(s) of cross-tenant data observed via the Mmap pool; \
+             see stderr above for offending (tid, iter, offset, value) tuples",
+        );
+    }
+
+    /// Cross-thread Send: thread A creates a Mmap, writes a sentinel,
+    /// sends it to thread B via channel; thread B drops it (returns to
+    /// B's pool); B then re-allocates the same shape and MUST observe
+    /// zeros. Verifies that the pool's reset works correctly on a
+    /// mapping that was originally allocated by a different thread.
+    #[test]
+    fn pool_cross_thread_send_no_leak() {
+        use std::sync::mpsc;
+        use std::thread;
+
+        let ps = page_size();
+        let (accessible, mapping) = (ps, ps * 4);
+        let (tx, rx) = mpsc::channel::<Mmap>();
+
+        let producer = thread::spawn(move || {
+            for tid in 1..=50u8 {
+                let mut m = Mmap::accessible_reserved(
+                    accessible,
+                    mapping,
+                    None,
+                    MmapType::Private,
+                )
+                .unwrap();
+                unsafe {
+                    std::ptr::write_bytes(m.as_mut_ptr(), tid, accessible);
+                }
+                tx.send(m).expect("producer send");
+            }
+        });
+
+        let consumer = thread::spawn(move || {
+            let mut observed_leak = 0u64;
+            while let Ok(m) = rx.recv() {
+                drop(m);
+                // The dropped Mmap goes into THIS thread's pool with
+                // its reset already complete. A new alloc of the same
+                // shape may come from that pool entry; it must be zero.
+                let m2 = Mmap::accessible_reserved(
+                    accessible,
+                    mapping,
+                    None,
+                    MmapType::Private,
+                )
+                .unwrap();
+                for (i, &b) in m2.as_slice_accessible().iter().enumerate() {
+                    if b != 0 {
+                        eprintln!("cross-thread leak at {i}: {b:#x}");
+                        observed_leak += 1;
+                    }
+                }
+                drop(m2);
+            }
+            assert_eq!(observed_leak, 0, "{observed_leak} cross-thread byte leaks");
+        });
+
+        producer.join().unwrap();
+        consumer.join().unwrap();
+    }
+
+    /// Pool bucket overflow: drop more mappings than `POOL_PER_BUCKET_MAX`
+    /// at once. The excess must be `munmap`'d, not silently retained
+    /// (which would unbounded-grow RSS).
+    #[test]
+    fn pool_bucket_overflow_unmaps_excess() {
+        let ps = page_size();
+
+        // Hold POOL_PER_BUCKET_MAX + 4 mappings simultaneously, then
+        // drop them. The pool will accept the first POOL_PER_BUCKET_MAX
+        // and munmap the rest. We can't directly observe which path
+        // each took, but if the excess weren't unmapped we'd leak
+        // VMAs; the kernel would eventually complain about
+        // /proc/sys/vm/max_map_count. Here we just verify the test
+        // completes without panic.
+        let mut held = Vec::new();
+        for _ in 0..(POOL_PER_BUCKET_MAX + 4) {
+            held.push(
+                Mmap::accessible_reserved(ps, ps, None, MmapType::Private).unwrap(),
+            );
+        }
+        drop(held);
+
+        // Cycle one more take/drop pair through the same bucket and
+        // confirm the pool is still functional.
+        let m = Mmap::accessible_reserved(ps, ps, None, MmapType::Private).unwrap();
+        drop(m);
+    }
+
+    /// Thread exit must drain its pool without recursing forever, and
+    /// without crashing. Spawn a thread, build and drop several
+    /// poolable mappings, let the thread exit, and ensure the parent
+    /// thread can still use its own pool afterwards.
+    #[test]
+    fn thread_exit_drains_pool_safely() {
+        let ps = page_size();
+        let handle = std::thread::spawn(move || {
+            for _ in 0..32 {
+                let m =
+                    Mmap::accessible_reserved(ps * 2, ps * 2, None, MmapType::Private).unwrap();
+                drop(m);
+            }
+        });
+        handle.join().expect("worker thread should exit cleanly");
+
+        // Parent's pool is independent and still works.
+        let m = Mmap::accessible_reserved(ps, ps, None, MmapType::Private).unwrap();
+        drop(m);
+    }
+}

--- a/lib/vm/src/mmap_pool.rs
+++ b/lib/vm/src/mmap_pool.rs
@@ -77,8 +77,6 @@
 //! semantics of `MADV_DONTNEED` differ across BSD lineages and we have
 //! not verified the zero-fill guarantee there.
 
-use crate::mmap::Mmap;
-
 /// Per-(accessible_size, mapping_size) bucket key. We index by exact
 /// shape so the consumer sees a mapping with identical layout to what
 /// they asked for. Most wasm modules instantiated repeatedly fit one

--- a/lib/vm/src/mmap_pool.rs
+++ b/lib/vm/src/mmap_pool.rs
@@ -266,13 +266,8 @@ mod imp {
             // `accessible_size`. Release backing of the entire mapping,
             // then mprotect the guard region back.
             if total > 0 {
-                let r = unsafe {
-                    libc::madvise(
-                        ptr as *mut libc::c_void,
-                        total,
-                        libc::MADV_DONTNEED,
-                    )
-                };
+                let r =
+                    unsafe { libc::madvise(ptr as *mut libc::c_void, total, libc::MADV_DONTNEED) };
                 if r != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
@@ -281,11 +276,7 @@ mod imp {
                 let guard_start = ptr + accessible;
                 let guard_len = total - accessible;
                 let r = unsafe {
-                    libc::mprotect(
-                        guard_start as *mut libc::c_void,
-                        guard_len,
-                        libc::PROT_NONE,
-                    )
+                    libc::mprotect(guard_start as *mut libc::c_void, guard_len, libc::PROT_NONE)
                 };
                 if r != 0 {
                     return Err(std::io::Error::last_os_error());
@@ -299,11 +290,7 @@ mod imp {
             // is needed.
             if accessible > 0 {
                 let r = unsafe {
-                    libc::madvise(
-                        ptr as *mut libc::c_void,
-                        accessible,
-                        libc::MADV_DONTNEED,
-                    )
+                    libc::madvise(ptr as *mut libc::c_void, accessible, libc::MADV_DONTNEED)
                 };
                 if r != 0 {
                     return Err(std::io::Error::last_os_error());
@@ -395,9 +382,10 @@ mod tests {
 
         // Round 1: a reserve-and-extend mapping. Extend access to the
         // entire mapping_size, so all pages are RW. Then drop.
-        let mut m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+        let mut m1 =
+            Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private).unwrap();
+        m1.make_accessible(accessible, mapping - accessible)
             .unwrap();
-        m1.make_accessible(accessible, mapping - accessible).unwrap();
         // Sanity: writing to the extended range must succeed BEFORE the drop.
         unsafe {
             (m1.as_mut_ptr().add(mapping - 1)).write_volatile(0xCD);
@@ -407,8 +395,7 @@ mod tests {
         // Round 2: same shape. The bytes in (accessible..mapping) must
         // now be protected. We verify by forking a child that tries to
         // write into the guard region and observe it die with SIGSEGV.
-        let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
-            .unwrap();
+        let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private).unwrap();
         let guard_ptr = unsafe { m2.as_ptr().add(accessible) as usize };
 
         let child = unsafe { libc::fork() };
@@ -475,14 +462,12 @@ mod tests {
         let accessible = ps * 2;
         let mapping = ps * 8;
 
-        let m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
-            .unwrap();
+        let m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private).unwrap();
         assert_eq!(m1.len(), mapping);
         let addr1 = m1.as_ptr() as usize;
         drop(m1);
 
-        let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
-            .unwrap();
+        let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private).unwrap();
         assert_eq!(
             m2.len(),
             mapping,
@@ -535,9 +520,10 @@ mod tests {
 
         // Round 1: tenant A grows then writes a sentinel into every
         // byte of the extended range.
-        let mut m1 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+        let mut m1 =
+            Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private).unwrap();
+        m1.make_accessible(accessible, mapping - accessible)
             .unwrap();
-        m1.make_accessible(accessible, mapping - accessible).unwrap();
         unsafe {
             let p = m1.as_mut_ptr();
             for off in accessible..mapping {
@@ -551,15 +537,17 @@ mod tests {
         // [accessible..mapping) is restored to PROT_NONE. Tenant B
         // grows by mprotecting [accessible..mapping) back to PROT_RW,
         // then reads. Every byte MUST be zero.
-        let mut m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+        let mut m2 =
+            Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private).unwrap();
+        m2.make_accessible(accessible, mapping - accessible)
             .unwrap();
-        m2.make_accessible(accessible, mapping - accessible).unwrap();
         let slice = unsafe {
             std::slice::from_raw_parts(m2.as_ptr().add(accessible), mapping - accessible)
         };
         for (i, &byte) in slice.iter().enumerate() {
             assert_eq!(
-                byte, 0,
+                byte,
+                0,
                 "byte at extended offset {} should be zero but is {:#x} \
                  (cross-tenant leak through the grown region)",
                 accessible + i,
@@ -681,13 +669,8 @@ mod tests {
 
         let producer = thread::spawn(move || {
             for tid in 1..=50u8 {
-                let mut m = Mmap::accessible_reserved(
-                    accessible,
-                    mapping,
-                    None,
-                    MmapType::Private,
-                )
-                .unwrap();
+                let mut m = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+                    .unwrap();
                 unsafe {
                     std::ptr::write_bytes(m.as_mut_ptr(), tid, accessible);
                 }
@@ -702,13 +685,8 @@ mod tests {
                 // The dropped Mmap goes into THIS thread's pool with
                 // its reset already complete. A new alloc of the same
                 // shape may come from that pool entry; it must be zero.
-                let m2 = Mmap::accessible_reserved(
-                    accessible,
-                    mapping,
-                    None,
-                    MmapType::Private,
-                )
-                .unwrap();
+                let m2 = Mmap::accessible_reserved(accessible, mapping, None, MmapType::Private)
+                    .unwrap();
                 for (i, &b) in m2.as_slice_accessible().iter().enumerate() {
                     if b != 0 {
                         eprintln!("cross-thread leak at {i}: {b:#x}");
@@ -740,9 +718,7 @@ mod tests {
         // completes without panic.
         let mut held = Vec::new();
         for _ in 0..(POOL_PER_BUCKET_MAX + 4) {
-            held.push(
-                Mmap::accessible_reserved(ps, ps, None, MmapType::Private).unwrap(),
-            );
+            held.push(Mmap::accessible_reserved(ps, ps, None, MmapType::Private).unwrap());
         }
         drop(held);
 
@@ -761,8 +737,7 @@ mod tests {
         let ps = page_size();
         let handle = std::thread::spawn(move || {
             for _ in 0..32 {
-                let m =
-                    Mmap::accessible_reserved(ps * 2, ps * 2, None, MmapType::Private).unwrap();
+                let m = Mmap::accessible_reserved(ps * 2, ps * 2, None, MmapType::Private).unwrap();
                 drop(m);
             }
         });


### PR DESCRIPTION
Adds a per-thread pool of idle anonymous-private `Mmap` regions in `wasmer-vm`. Linear-memory mappings that drop are reset via `madvise(MADV_DONTNEED)` and stored thread-locally instead of being `munmap`'d; subsequent `Mmap::accessible_reserved` calls of the same shape pick them up before going to the kernel.

For a per-request wasm-host workload that builds a fresh `Store` and `Instance` per call and the wasm has a linear memory, this fixes a hard kernel scaling wall: at 28 threads, throughput on a memory-touching wasm module goes from 60 k to 1.15 M ops/sec (19x). The pool is Linux-only via `cfg`; non-Linux targets are stubs that fall through to the existing `mmap`/`munmap` path.

No public API change, no serialized format change, no behaviour change for any wasm program.

> [!CAUTION]
> This PR touches the `Mmap` allocation and `Drop` paths in `wasmer-vm`, which back the linear memory of every wasm Instance. Please confirm that I thought of every security-critical path. The Safety section walks every invariant the change depends on, and the `mmap_pool::tests::*` suite includes an adversarial test for each (including a `fork`/`SIGSEGV` check that the guard is actually restored).

## Why

The standard wasmer usage pattern for HTTP-style workloads is "compile once, instantiate per request". Each `Instance::new` for a memory-using wasm module ends up at `Mmap::accessible_reserved`, which calls `mmap(2)` to reserve and commit the linear-memory range. Each `Instance` drop unmaps it.

Both `mmap` and `munmap` take `mm_struct.mmap_lock` write-locked. The lock is process-wide. At 28 threads doing fresh per-request instantiate-and-call against a wasm with a 1-page linear memory, the lock spends most of its time held write-locked by some thread. Per-thread throughput collapses 40x compared to single-thread, and aggregate throughput at 28 threads is lower than at 1 thread.

A `perf record` at 28 threads on a stock build:

```
14.21%  swapper          [k] intel_idle              ← CPUs blocked
12.79%  bench            [k] osq_lock                ← rwsem optimistic spin
 8.40%  swapper          [k] intel_idle_irq
 2.98%  bench            [k] rwsem_optimistic_spin
 2.04%  bench            [k] zap_pmd_range           ← munmap page-table teardown
 1.82%  bench            [k] rwsem_spin_on_owner
 ...
```

Userland code is nowhere in the top 10 symbols. The whole box is serialized on the kernel's mm semaphore.

A standalone microbench of `mmap+munmap` vs `madvise(MADV_DONTNEED)` on the same region at 28 threads gives a 6x throughput improvement for the second pattern, which is the design point this PR builds on:

```
mmap+munmap      28T:   157 k ops/sec  (  5.6 k/thread)
madvise_dontneed 28T:   995 k ops/sec  ( 35.5 k/thread)
```

## The fix

`lib/vm/src/mmap_pool.rs` (new, ~280 lines): per-thread `HashMap<PoolKey, Vec<Mmap>>` indexed by `(accessible_size, mapping_size)`. The pool is held in a thread-local `RefCell`.

On `Mmap` drop, an anonymous-private mapping (no backing file, no `MmapType::Shared`) is reset and pushed into its bucket instead of being `munmap`'d. On `Mmap::accessible_reserved` the pool is checked before the kernel.

Reset has two cases:

* **No `memory.grow` happened during the previous tenant's lifetime.** The accessible range was the only part with backing pages; the guard range is still PROT_NONE from the original `accessible_reserved`. `madvise(MADV_DONTNEED)` on `[0..accessible_size)` releases backing physical pages so the next access faults in fresh zero pages from the kernel allocator. No `mprotect` is needed, which avoids the cross-CPU TLB-shootdown IPI that `mprotect` on a multi-core-resident VMA triggers.
* **`memory.grow` extended RW access past `accessible_size`.** The previous tenant could have written secret data to pages above `accessible_size`. `madvise(MADV_DONTNEED)` covers the entire mapping (the kernel skips ranges without present PTEs efficiently, so this is cheap even for sparse 4 GiB/64 KiB mappings). Then `mprotect(PROT_NONE)` on `[accessible_size..total_size)` restores the guard.

Whether growth happened is tracked by a new `extended_beyond_accessible: bool` field on `Mmap`, set in `make_accessible` only when `start + len > accessible_size`. The initial-setup call into `make_accessible(0, accessible_size)` from `accessible_reserved` leaves the flag false because its end is exactly `accessible_size`, not greater.

## Safety

The pool is shared across wasm Instances within a single process. Most wasm hosts run untrusted code, so an incomplete reset is a tenant-isolation bug. Every assumption is documented inline in `mmap_pool.rs`; the high points:

### Reset must produce a zero-filled mapping

`MADV_DONTNEED` on a `MAP_PRIVATE | MAP_ANON` mapping on Linux releases backing pages so subsequent accesses fault in fresh zero pages from the kernel page allocator. The kernel guarantees that any page handed to userland is freshly zeroed; old contents cannot leak. See `man 2 madvise` (`MADV_DONTNEED`) and `mm/madvise.c` (`madvise_dontneed_single_vma` → `zap_page_range`).

Test: `pool_reuse_is_zero_filled` writes a sentinel pattern across the accessible range, drops, takes again, asserts every byte reads as zero.

### Guard pages must be restored even when growth happened

`make_accessible` calls `mprotect(PROT_READ | PROT_WRITE)` to extend the accessible range but does not update `Mmap::accessible_size`. If a mapping that had been extended via `make_accessible` were pooled without restoring the guard, the next caller would see the same `accessible_size` they originally requested but pages above that boundary would still be RW. A wasm program could read past its declared memory.

Mitigation: when `extended_beyond_accessible` is true, the pool `mprotect(PROT_NONE)`s the entire `[accessible_size..total_size)` range back to guard.

Test: `pool_reuse_restores_guard` extends RW access to the full mapping, writes a sentinel into the extended range, drops; then takes a fresh mapping of the same shape and forks a child that writes into what should be the guard region. The parent asserts the child died from `SIGSEGV`.

### Reset must zero pages the previous tenant wrote above `accessible_size`

This was a real vulnerability caught during the audit. `mprotect` does not zero pages. A previous tenant calling `memory.grow`, writing secret data to the extended range, then dropping, would leave the physical pages allocated and full of secret data. After guard restoration, a future tenant could call `memory.grow` to mprotect the same pages back to RW and read the secrets directly.

Fix: in the `extended_beyond_accessible == true` path, `madvise(MADV_DONTNEED)` is run on the entire mapping before `mprotect`. This releases backing pages for the previously-extended region too. The future tenant's growth fault now goes to a fresh zero page.

Test: `pool_reuse_no_leak_across_grown_range` exercises exactly this attack path. Tenant A extends, writes a sentinel into the extended range, drops. Tenant B takes the same shape, grows again, reads. Every byte must be zero.

### Shared and file-backed mappings are not pooled

Another thread or process could hold a live alias to a `MAP_SHARED` or file-backed mapping. The exclusion is enforced by `if backing_file.is_none() && memory_type == MmapType::Private` in `accessible_reserved` and by setting `Mmap::poolable = false` on every other path.

### Thread-exit destruction

When a thread exits, its TLS pool drops. The pool's `Drop` sets `draining = true` before letting its `buckets` field drop. Each `Mmap` that drops off the inner `Vec`s sees `draining = true` via a `try_borrow_mut` on the same `RefCell` and falls through to direct `munmap` instead of trying to re-insert into the pool that is currently being torn down.

Test: `thread_exit_drains_pool_safely` spawns a thread that builds and drops 32 pooled mappings, then joins; the parent thread's pool keeps working afterwards.

### Reset partial failure

If `madvise` succeeds and `mprotect` later fails, `reset` returns `Err`, `try_pool` returns `Some(mmap)`, and `Mmap::drop` falls through to direct `munmap`. The mapping is unmapped instead of pooled, so a partially-reset region can never be observed by a future tenant.

### Send / Sync invariants

`Mmap` was already `Send + Sync` (asserted by `_assert_send_sync::<Mmap>()` at the end of `mmap.rs`). The pool is per-thread (`thread_local!`), so pool data is never crossed-thread; cross-thread Mmap ownership transfer is unaffected. Cross-thread leak through Send is tested by `pool_cross_thread_send_no_leak`.

### Non-Linux platforms

The entire pool module is `#[cfg(target_os = "linux")]`. On macOS, FreeBSD, NetBSD, and Windows the pool functions are stubs (`try_take` always returns `None`, `try_pool` always returns `Some(mmap)`), so callers fall back to the existing `mmap`/`munmap` path. `MADV_DONTNEED` semantics differ across BSD lineages and the zero-fill guarantee has not been verified there.

## Tests

Nine new unit tests in `lib/vm/src/mmap_pool.rs`. Three of them are the security invariants quoted above; the other six exercise lifecycle and edge cases:

```
test mmap_pool::tests::pool_reuse_is_zero_filled              ... ok
test mmap_pool::tests::pool_reuse_restores_guard              ... ok
test mmap_pool::tests::pool_reuse_no_leak_across_grown_range  ... ok
test mmap_pool::tests::pool_round_trip_preserves_layout       ... ok
test mmap_pool::tests::pool_does_not_reuse_across_shapes      ... ok
test mmap_pool::tests::pool_bucket_overflow_unmaps_excess     ... ok
test mmap_pool::tests::pool_cross_thread_send_no_leak         ... ok
test mmap_pool::tests::pool_stress_no_leak_under_concurrency  ... ok
test mmap_pool::tests::thread_exit_drains_pool_safely         ... ok
```

The stress test is the heaviest of the bunch: 28 threads, three distinct `(accessible, mapping)` shapes, 2000 iterations per thread, with `memory.grow`-style extension on 1 of every 3 iterations. Each iteration's accessible (and grown) range is byte-checked for the all-zero invariant before the iteration writes its own thread-unique sentinel pattern. 168 000 cycles total, completes in under half a second, zero leaks observed.

```
$ cargo test -p wasmer-vm
test result: ok. 37 passed; 0 failed
```

(28 pre-existing wasmer-vm unit tests + 9 new pool tests.)

## Numbers

Intel i9-10940X (14 cores / 28 SMT threads), CPU governor `performance`, glibc allocator, otherwise idle box. Each measurement is a 5-second window after a per-thread warmup; the harness is the standalone reproducer at the bottom of this PR.

### Workload A: memory-store-heavy wasm without `memory.grow`

```
(module
    (memory 1)
    (func (export "store_100_i32") (param $val i32)
        ;; 100 i32 stores into linear memory at offsets 0, 4, 8, ...
        ...))
```

Per-request lifecycle: build fresh `Store`, instantiate, call, drop.

| threads | upstream main | this PR | improvement |
|---|---|---|---|
| 1 | 86 k | 378 k | 4.4x |
| 4 | 74 k | 566 k | 7.6x |
| 8 | 67 k | 865 k | 12.9x |
| 16 | 61 k | 1.15 M | 18.7x |
| 28 | 60 k | **1.15 M** | **19.1x** |

Per-thread at 28T: 2.1 k → 41 k (19.5x). The workload now scales the way an in-register workload does.

### Workload B: realistic-shape wasm with `memory.grow`, globals, locals, function calls

Initial memory of 2 pages, two `memory.grow` calls per top-level invocation (one into the original guard, one past the first grow), three mutable globals (`i32` / `i64` / `f64`) written and read, many locals, two internal function calls (`$mix` is an fnv1a-style step and `$sum` is a 256-i32 reducer), a 32-iter stir loop deriving an accumulator from the seed, a 256-i32 write loop into linear memory, mixed-type stores (`i8` / `i16` / `i32` / `i64` / `f32` / `f64`) at distinct offsets, a 1024-byte write into the grown range, and a return value composed from every side effect so dead-code elimination cannot fold the body away.

```wat
(module
    (memory $mem 2)
    (global $g_i32 (mut i32) (i32.const 0))
    (global $g_i64 (mut i64) (i64.const 0))
    (global $g_f64 (mut f64) (f64.const 0))

    (func $mix (param $h i32) (param $b i32) (result i32)
        local.get $h
        local.get $b
        i32.xor
        i32.const 16777619
        i32.mul)

    (func $sum (param $start i32) (result i32)
        (local $i i32)
        (local $acc i32)
        (loop $L
            local.get $acc
            local.get $start
            local.get $i
            i32.const 4
            i32.mul
            i32.add
            i32.load
            i32.add
            local.set $acc
            local.get $i
            i32.const 1
            i32.add
            local.tee $i
            i32.const 256
            i32.lt_s
            br_if $L)
        local.get $acc)

    (func (export "stress") (param $seed i32) (result i32)
        (local $i i32)
        (local $acc i32)
        (local $acc64 i64)
        (local $accf f64)
        (local $offset i32)
        (local $tmp i32)

        local.get $seed
        local.set $acc
        (loop $L_stir
            local.get $acc
            local.get $i
            call $mix
            local.set $acc
            local.get $i
            i32.const 1
            i32.add
            local.tee $i
            i32.const 32
            i32.lt_s
            br_if $L_stir)

        i32.const 1
        memory.grow
        drop

        i32.const 0
        local.set $i
        (loop $L_w
            local.get $i
            i32.const 4
            i32.mul
            local.get $acc
            local.get $i
            i32.xor
            i32.store
            local.get $i
            i32.const 1
            i32.add
            local.tee $i
            i32.const 256
            i32.lt_s
            br_if $L_w)

        i32.const 4096
        local.get $acc
        i32.store8
        i32.const 4098
        local.get $acc
        i32.store16
        i32.const 4100
        local.get $acc
        i32.store
        i32.const 4108
        local.get $acc
        i64.extend_i32_s
        i64.const 7919
        i64.mul
        local.tee $acc64
        i64.store
        i32.const 4116
        local.get $acc
        f64.convert_i32_s
        f64.const 2.718281828459045
        f64.mul
        local.tee $accf
        f64.store
        i32.const 4124
        local.get $accf
        f64.const 2.0
        f64.div
        f32.demote_f64
        f32.store

        i32.const 1
        memory.grow
        drop
        i32.const 200000
        local.set $offset
        i32.const 0
        local.set $i
        (loop $L_grown
            local.get $offset
            local.get $i
            i32.add
            local.get $i
            i32.const 0xFF
            i32.and
            i32.store8
            local.get $i
            i32.const 1
            i32.add
            local.tee $i
            i32.const 1024
            i32.lt_s
            br_if $L_grown)

        local.get $acc
        global.set $g_i32
        local.get $acc64
        global.set $g_i64
        local.get $accf
        global.set $g_f64

        i32.const 0
        call $sum
        local.set $tmp

        i32.const 4096
        i32.load8_u
        i32.const 4098
        i32.load16_u
        i32.add
        i32.const 4100
        i32.load
        i32.add
        i32.const 4108
        i64.load
        i32.wrap_i64
        i32.add
        i32.const 4116
        i64.load
        i32.wrap_i64
        i32.add
        i32.const 4124
        i32.load
        i32.add
        local.get $tmp
        i32.add
        i32.const 200000
        i32.load8_u
        i32.add
        i32.const 200512
        i32.load8_u
        i32.add
        global.get $g_i32
        i32.add
        global.get $g_i64
        i32.wrap_i64
        i32.add
        global.get $g_f64
        i64.reinterpret_f64
        i32.wrap_i64
        i32.add))
```

Driver: the same reproducer template from the bottom of this PR, with `WAT` set to the module above and the function signature changed to `<i32, i32>` (it takes the seed and returns the combined accumulator).

| threads | upstream main | this PR | improvement |
|---|---|---|---|
| 1 | 56.7 k | 69.0 k | 1.22x |
| 4 | 56.3 k | 122.3 k | 2.17x |
| 8 | 53.7 k | 99.1 k | 1.85x |
| 16 | 53.8 k | 104.2 k | 1.94x |
| 28 | 54.0 k | **107.3 k** | **1.99x** |

The relative improvement is smaller because the in-wasm body dominates per-call cost. Per-call at 1T is 14.5 µs on this PR vs 17.6 µs on main; the pool saves the same ~3 µs of `Instance::new`+`Instance::drop` mmap overhead, but on this workload the remaining ~14 µs of wasm body is what bounds the cycle. Workloads with a bigger wasm body (a JSON-parsing handler, a CosmWasm contract, etc.) will see the pool's ~3 µs as a smaller fraction of total cost; the absolute throughput improvement at 28 threads is still around 2x for any per-request shape.

Post-patch hot symbols on workload B at 28T show the remaining bottleneck is no longer the Instance-boundary `mmap_lock`. It is now the `mprotect` that `memory.grow` does inside the wasm runtime to extend the accessible range:

```
14.5%  intel_idle
 3.6%  zap_pmd_range
 3.1%  smp_call_function_many_cond     ← cross-CPU IPI from mprotect
 2.6%  osq_lock
 2.3%  native_queued_spin_lock_slowpath
```

That cost is not addressable from inside this PR; it would require either a different memory-protection model or pre-mapping the maximum range RW at `Instance::new`.

## How to reproduce

Drop the following into `examples/repro_mmap_pool.rs` in a crate that depends on `wasmer`, `wasmer-compiler`, `wasmer-compiler-singlepass`, and `wat`. Override `THREADS=` and `SECS=` to vary.

```rust
use std::sync::{Arc, atomic::{AtomicBool, AtomicU64, Ordering}, Barrier};
use std::thread;
use std::time::{Duration, Instant};

use wasmer::{imports, EngineBuilder, Instance, Module, Store};
use wasmer_compiler_singlepass::Singlepass;

const WAT: &str = r#"
(module
    (memory 1)
    (func (export "store_100_i32") (param $val i32)
        (local $i i32)
        (loop $L
            local.get $i
            local.get $val
            i32.store
            local.get $i
            i32.const 4
            i32.add
            local.tee $i
            i32.const 400
            i32.lt_s
            br_if $L)))
"#;

fn main() {
    let threads: usize = std::env::var("THREADS")
        .ok().and_then(|s| s.parse().ok()).unwrap_or(28);
    let secs: u64 = std::env::var("SECS")
        .ok().and_then(|s| s.parse().ok()).unwrap_or(5);

    let engine = EngineBuilder::new(Singlepass::new()).engine();
    let wasm = wat::parse_str(WAT).unwrap();
    let store = Store::new(engine.clone());
    let module = Arc::new(Module::new(&store, &wasm).unwrap());
    drop(store);

    let barrier = Arc::new(Barrier::new(threads + 1));
    let stop = Arc::new(AtomicBool::new(false));
    let total = Arc::new(AtomicU64::new(0));

    let handles: Vec<_> = (0..threads).map(|_| {
        let engine = engine.clone();
        let module = module.clone();
        let barrier = barrier.clone();
        let stop = stop.clone();
        let total = total.clone();
        thread::spawn(move || {
            // warmup
            for _ in 0..10_000 {
                let mut store = Store::new(engine.clone());
                let inst = Instance::new(&mut store, &module, &imports!{}).unwrap();
                let f = inst.exports
                    .get_typed_function::<i32, ()>(&store, "store_100_i32")
                    .unwrap();
                let _ = f.call(&mut store, 0x5A5A_5A5A_u32 as i32).unwrap();
            }
            barrier.wait();

            let mut local = 0u64;
            while !stop.load(Ordering::Relaxed) {
                let mut store = Store::new(engine.clone());
                let inst = Instance::new(&mut store, &module, &imports!{}).unwrap();
                let f = inst.exports
                    .get_typed_function::<i32, ()>(&store, "store_100_i32")
                    .unwrap();
                f.call(&mut store, 0x5A5A_5A5A_u32 as i32).unwrap();
                local += 1;
            }
            total.fetch_add(local, Ordering::Relaxed);
        })
    }).collect();

    barrier.wait();
    let start = Instant::now();
    thread::sleep(Duration::from_secs(secs));
    stop.store(true, Ordering::Relaxed);
    for h in handles { h.join().unwrap(); }
    let elapsed = start.elapsed();
    let ops = total.load(Ordering::Relaxed);
    println!(
        "{} threads, {} ops in {:.3}s = {:.0} ops/sec ({:.0} ops/sec/thread)",
        threads, ops, elapsed.as_secs_f64(),
        ops as f64 / elapsed.as_secs_f64(),
        (ops as f64 / elapsed.as_secs_f64()) / threads as f64,
    );
}
```

```bash
git checkout main
cargo run --release --example repro_mmap_pool
# Expect ~60 k ops/sec at 28 threads

git checkout mmap-tls-pool
cargo run --release --example repro_mmap_pool
# Expect ~1.15 M ops/sec at 28 threads
```

For hot-symbol verification:

```bash
THREADS=28 perf record -F 2999 -a -g -- target/release/examples/repro_mmap_pool
perf report --stdio --no-children --percent-limit 1.0 | head -20
# On main: osq_lock at ~13%, rwsem_optimistic_spin at ~3%, zap_pmd_range at ~2%.
# On this PR: those symbols drop out of the hot list.
```

## Compatibility

* No public API change. `Mmap::accessible_reserved`, `Mmap::with_at_least`, and `Mmap::make_accessible` keep their signatures and external semantics.
* No serialization format change. The pool is runtime state; it does not appear in any persisted artifact.
* No behaviour change visible to wasm programs. The pool returns mappings that are observationally identical to fresh `mmap` allocations: zero-filled accessible range, PROT_NONE guard region, same `(accessible_size, mapping_size)` shape.
* Linux only. macOS, FreeBSD, NetBSD, and Windows fall through to the existing path.

## Composition with other in-flight perf PRs

This PR is independent of #6640 (`tls-stack-cache`), #6649 (`vmoffsets-cache`), and #6650 (`storeid-thread-local`). It does not require any of them, and it stacks additively on top of all of them.

## Out of scope

Items that show up in the post-patch profile and are addressable independently in follow-up work:

* `memory.grow` inside the wasm runtime still does `mprotect`, which triggers cross-CPU TLB shootdowns. Would require either pre-mapping the maximum range RW at `Instance::new` (loses the guard model) or a different protection scheme.
* `Store::new` internals (signature registry allocation, per-store bookkeeping). Roughly 6% at 28 threads on the realistic workload.
* glibc `malloc/free` contention on the `VMContext` allocation inside `InstanceAllocator::new`. A per-thread `VMContext` buffer pool with the same pattern as this PR could remove it.

Happy to follow up on any of these.
