### PR TITLE
feat(V8): enable some WASIX tests on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ endif
 ##
 
 ifeq ($(ENABLE_LLVM), 1)
-	ifneq (, $(filter 1, $(IS_WINDOWS) $(IS_DARWIN) $(IS_LINUX) $(IS_FREEBSD)))
+	ifneq (, $(filter 1, $(IS_DARWIN) $(IS_LINUX) $(IS_FREEBSD)))
 		ifeq ($(IS_AMD64), 1)
 			compilers_engines += llvm
 		else ifeq ($(IS_AARCH64), 1)

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,10 @@ endif
 compilers := $(strip $(compilers))
 build_compilers := $(strip $(build_compilers) $(compilers))
 
+ifeq ($(IS_WINDOWS), 1)
+	build_compilers := $(filter-out llvm,$(build_compilers))
+endif
+
 
 #####
 #
@@ -304,6 +308,9 @@ else ifeq ($(IS_AARCH64), 1)
 	endif
 endif
 test_compilers := $(strip $(test_compilers))
+ifeq ($(IS_WINDOWS), 1)
+	test_compilers := $(filter-out llvm,$(test_compilers))
+endif
 
 # Define the compiler Cargo features for all crates.
 compiler_features := --features $(subst $(space),$(comma),$(compilers)),wasmer-artifact-create,static-artifact-create,wasmer-artifact-load,static-artifact-load

--- a/Makefile
+++ b/Makefile
@@ -295,8 +295,7 @@ build_wasmer_extra_features_csv = $(subst $(space),$(comma),$(build_wasmer_extra
 
 test_compilers := $(compilers)
 ifeq ($(IS_AMD64), 1)
-	# TODO: enable on Windows
-	ifneq (, $(filter 1, $(IS_LINUX)))
+	ifneq (, $(filter 1, $(IS_LINUX) $(IS_WINDOWS)))
 		test_compilers += v8
 	endif
 else ifeq ($(IS_AARCH64), 1)

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -7,7 +7,7 @@ fn build_v8() {
         sync::{LazyLock, Mutex},
     };
 
-    const WEE8_RELEASE_VERSION: &str = "11.9.6";
+    const WEE8_RELEASE_VERSION: &str = "11.9.7";
 
     let (asset_name, platform_name) = match (
         env::var("CARGO_CFG_TARGET_OS").unwrap().as_str(),

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -193,7 +193,6 @@ wasmer = { path = "../api", version = "=7.2.0-alpha.3", default-features = false
   "wat",
   "js-serializable-module",
   "cranelift",
-  "llvm",
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom03]
@@ -233,8 +232,10 @@ journal = ["tokio/fs", "wasmer-journal/log-file"]
 
 # Deprecated. Kept it for compatibility
 compiler = []
+
 singlepass = ["wasmer/singlepass"]
 v8 = ["wasmer/v8"]
+llvm = ["wasmer/llvm"]
 
 js = [
   "virtual-fs/js",

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -642,7 +642,7 @@ fn copy_test_tree(from: &Path, to: &Path) -> Result<()> {
                     .with_context(|| format!("failed to create {}", parent.display()))?;
             }
             copy_symlink(entry.path(), &target)
-                .with_context(|| format!("cannot copy symlink: {}", to))?;
+                .with_context(|| format!("cannot copy symlink: {}", entry.path().display()))?;
         }
     }
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -641,7 +641,8 @@ fn copy_test_tree(from: &Path, to: &Path) -> Result<()> {
                 create_dir_all(parent)
                     .with_context(|| format!("failed to create {}", parent.display()))?;
             }
-            copy_symlink(entry.path(), &target)?;
+            copy_symlink(entry.path(), &target)
+                .with_context(|| format!("cannot copy symlink: {}", to))?;
         }
     }
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -616,8 +616,14 @@ fn copy_test_tree(from: &Path, to: &Path) -> Result<()> {
 
     // Preserve symlink fixtures, including broken links, when staging tests.
     for entry in WalkDir::new(from).min_depth(1).follow_links(false) {
-        let entry = entry?;
-        let relative = entry.path().strip_prefix(from)?;
+        let entry = entry.with_context(|| anyhow!("cannot get dir entry"))?;
+        let relative = entry.path().strip_prefix(from).with_context(|| {
+            anyhow!(
+                "cannot strip prefix: {} from {}",
+                from.display(),
+                entry.path().display()
+            )
+        })?;
         let target = to.join(relative);
         let file_type = entry.file_type();
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -986,6 +986,13 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                         continue;
                     }
 
+                    // WASIXCC toolchain does not cover Windows yet.
+                    if cfg!(target_os = "windows")
+                        && !matches!(config.source, PrimarySource::RustSourceFile(..))
+                    {
+                        continue;
+                    }
+
                     let mut config = config.clone();
                     config.engine = *engine;
                     tests.push(libtest_mimic::Trial::ignorable_test(

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -663,7 +663,9 @@ fn copy_symlink(from: &Path, to: &Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn copy_symlink(from: &Path, _to: &Path) -> Result<()> {
-    bail!("cannot copy symlink {} on this host", from.display())
+    // Avoid treating this as an error because symlink support is not guaranteed
+    // on Windows.
+    Ok(())
 }
 
 fn run_integration_test(config: Config) -> Result<libtest_mimic::Completion> {

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1006,7 +1006,7 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                         config.full_test_name(),
                         move || {
                             run_integration_test(config)
-                                .map_err(|e| libtest_mimic::Failed::from(e.to_string()))
+                                .map_err(|e| libtest_mimic::Failed::from(format!("{e:#}")))
                         },
                     ));
                 }

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -119,6 +119,7 @@ struct MappedDirectory {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Engine {
     Cranelift,
+    #[cfg(feature = "llvm")]
     LLVM,
     #[cfg(feature = "singlepass")]
     Singlepass,
@@ -130,6 +131,7 @@ impl Engine {
     pub fn name(self) -> &'static str {
         match self {
             Self::Cranelift => "cranelift",
+            #[cfg(feature = "llvm")]
             Self::LLVM => "llvm",
             #[cfg(feature = "singlepass")]
             Self::Singlepass => "singlepass",
@@ -390,7 +392,16 @@ fn process_directive(
                 .split_once(':')
                 .ok_or_else(|| anyhow!("missing colon separator for SkipEngine"))?;
             if let Some(engine) = match engine.to_lowercase().as_str() {
-                "llvm" => Some(Engine::LLVM),
+                "llvm" => {
+                    #[cfg(feature = "llvm")]
+                    {
+                        Some(Engine::LLVM)
+                    }
+                    #[cfg(not(feature = "llvm"))]
+                    {
+                        None
+                    }
+                }
                 "cranelift" => Some(Engine::Cranelift),
                 "v8" => {
                     #[cfg(feature = "v8")]
@@ -921,11 +932,6 @@ fn has_primary_source_file(path: &Path) -> bool {
 }
 
 fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
-    // Windows runtime support is still limited, so skip these tests on that platform.
-    if cfg!(target_os = "windows") {
-        return Ok(());
-    }
-
     let tests_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))?.join("tests/wasm_tests/");
     let tests_build_root = tests_dir.join("build");
 
@@ -943,10 +949,11 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         let test_name = relative_test_path.display().to_string();
         let primary_sources = identify_primary_sources(entry.path())?;
 
-        let mut supported_engines = vec![Engine::LLVM];
+        let mut supported_engines = vec![];
+        #[cfg(feature = "llvm")]
+        supported_engines.push(Engine::LLVM);
         #[cfg(feature = "singlepass")]
         supported_engines.push(Engine::Singlepass);
-
         #[cfg(feature = "v8")]
         supported_engines.push(Engine::V8);
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -533,6 +533,18 @@ fn read_fixture_bytes(test_src_dir: &Path, arg: &str, directive: &str) -> Result
         .with_context(|| format!("failed to read {directive} {}", path.display()))
 }
 
+fn rustc_command(toolchain: Option<&str>) -> Command {
+    if let Some(toolchain) = toolchain {
+        // rustc +version multiplexing is unsupported on Windows, use the documented approach:
+        // https://rust-lang.github.io/rustup/concepts/toolchains.html#custom-toolchains
+        let mut cmd = Command::new("rustup");
+        cmd.arg("run").arg(toolchain).arg("rustc");
+        cmd
+    } else {
+        Command::new("rustc")
+    }
+}
+
 fn run_build_script(config: &Config) -> anyhow::Result<PathBuf> {
     // First, copy the test source directory to the 'build' subfolder that will
     // be unique for each configuration of a test.
@@ -584,10 +596,7 @@ fn run_build_script(config: &Config) -> anyhow::Result<PathBuf> {
             let primary_source = build_test_path.join(filename);
             let source = std::fs::read_to_string(&primary_source)
                 .with_context(|| format!("Failed to read {}", primary_source.display()))?;
-            let mut cmd = Command::new("rustc");
-            if source.contains("#![feature(") {
-                cmd.arg("+nightly");
-            }
+            let mut cmd = rustc_command(source.contains("#![feature(").then(|| "nightly"));
             cmd.arg("--target=wasm32-wasip1")
                 .arg("-o")
                 .arg("main")

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1008,7 +1008,7 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                         config.full_test_name(),
                         move || {
                             run_integration_test(config)
-                                .map_err(|e| libtest_mimic::Failed::from(format!("{e:#}")))
+                                .map_err(|e| libtest_mimic::Failed::from(format!("{e:?}")))
                         },
                     ));
                 }

--- a/lib/wasix/tests/wasm_tests/runner.rs
+++ b/lib/wasix/tests/wasm_tests/runner.rs
@@ -264,6 +264,7 @@ fn create_engine_for_wasm(wasm_bytes: &[u8], engine: Engine) -> wasmer::Engine {
     let target = Target::default();
     let backend = match engine {
         Engine::Cranelift => wasmer::BackendKind::Cranelift,
+        #[cfg(feature = "llvm")]
         Engine::LLVM => wasmer::BackendKind::LLVM,
         #[cfg(feature = "singlepass")]
         Engine::Singlepass => wasmer::BackendKind::Singlepass,
@@ -280,6 +281,7 @@ fn create_engine_for_wasm(wasm_bytes: &[u8], engine: Engine) -> wasmer::Engine {
             config.num_threads(NonZero::new(1).unwrap());
             EngineBuilder::new(config)
         }
+        #[cfg(feature = "llvm")]
         Engine::LLVM => {
             let mut config = wasmer::sys::LLVM::default();
             config.num_threads(NonZero::new(1).unwrap());

--- a/lib/wasix/tests/wasm_tests/wasi_fyi/fs_sandbox_symlink.rs
+++ b/lib/wasix/tests/wasm_tests/wasi_fyi/fs_sandbox_symlink.rs
@@ -1,4 +1,5 @@
 //#AbstractConfigFile: wasi-fyi.config
+//#UnixOnly: true
 #[link(wasm_import_module = "wasi_snapshot_preview1")]
 extern "C" {
     pub fn path_open(

--- a/lib/wasix/tests/wasm_tests/wasi_fyi/ported_readlink.rs
+++ b/lib/wasix/tests/wasm_tests/wasi_fyi/ported_readlink.rs
@@ -1,4 +1,5 @@
 //#AbstractConfigFile: wasi-fyi.config
+//#UnixOnly: true
 //#ExpectedStdoutFile: ported_readlink.stdout
 // WASI:
 // dir: test_fs

--- a/tests/lib/wast/src/wast.rs
+++ b/tests/lib/wast/src/wast.rs
@@ -2,7 +2,7 @@ use crate::error::{DirectiveError, DirectiveErrors};
 use crate::spectest::spectest_importobject;
 use anyhow::{Result, anyhow, bail};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str;
 use wasmer::*;
 use wast::core::{AbstractHeapType, HeapType, WastArgCore, WastRetCore};
@@ -24,7 +24,7 @@ pub struct Wast {
     /// Allowed failures (ideally this should be empty)
     allowed_instantiation_failures: HashSet<String>,
     /// Allowed directive failures in a specific file at a specific 1-based line.
-    allowed_directive_failures: HashSet<(String, usize, String)>,
+    allowed_directive_failures: HashSet<(PathBuf, usize, String)>,
     /// If the (expected from .wast, actual) message pair is in this list,
     /// treat the strings as matching.
     match_trap_messages: Vec<(String, String)>,
@@ -70,8 +70,11 @@ impl Wast {
 
     /// A directive failure to allow in a specific file at a specific 1-based line.
     pub fn allow_directive_failures_at_line(&mut self, line: usize, filename: &str, failure: &str) {
-        self.allowed_directive_failures
-            .insert((filename.to_string(), line, failure.to_string()));
+        self.allowed_directive_failures.insert((
+            PathBuf::from(filename),
+            line,
+            failure.to_string(),
+        ));
     }
 
     /// A list of alternative messages to permit for a trap failure.


### PR DESCRIPTION
The PR enables testing V8 for the compiler tests and some of the WASIX tests (note `wasixcc` does not support Windows yet).

A proper enabling of the V8 for wasmer-cli will come in a subsequent PR.

Issue: #6121