### PR TITLE
fix(llvm): recognise soft-float libcalls when cross-compiling to RISC-V

### DIFF
--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -375,8 +375,8 @@ where
                         // Maybe a libcall then?
                     } else if let Some(libcall) = lookup_libcall(symbol_name, binary_fmt, triple) {
                         RelocationTarget::LibCall(libcall)
-                    } else if let Some(reloc_target) =
-                        symbol_name_to_relocation_target(symbol_name)?
+                    } else if let Ok(Some(reloc_target)) =
+                        symbol_name_to_relocation_target(symbol_name)
                     {
                         reloc_target
                     } else if let object::SymbolSection::Section(section_index) = symbol.section() {

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -1,5 +1,5 @@
 use object::{Object, ObjectSection, ObjectSymbol};
-use target_lexicon::{Architecture, BinaryFormat, Triple};
+use target_lexicon::{Architecture, BinaryFormat, Riscv32Architecture, Riscv64Architecture, Triple};
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
@@ -204,6 +204,21 @@ static LIBCALLS_MACHO: phf::Map<&'static str, LibCall> = phf::phf_map! {
     "_wasmer_vm_dbg_str" => LibCall::DebugStr,
 };
 
+/// Returns whether `arch` is a RISC-V variant that lacks hardware floating-point
+/// (i.e. does not include the F/D ISA extensions, either explicitly or via the `gc` profile).
+fn is_riscv_softfloat(arch: &Architecture) -> bool {
+    match arch {
+        Architecture::Riscv64(
+            Riscv64Architecture::Riscv64gc | Riscv64Architecture::Riscv64a23,
+        )
+        | Architecture::Riscv32(
+            Riscv32Architecture::Riscv32gc | Riscv32Architecture::Riscv32imafc,
+        ) => false,
+        Architecture::Riscv64(_) | Architecture::Riscv32(_) => true,
+        _ => false,
+    }
+}
+
 fn lookup_libcall(name: &str, fmt: BinaryFormat, triple: &Triple) -> Option<LibCall> {
     let base = match fmt {
         BinaryFormat::Elf => &LIBCALLS_ELF,
@@ -213,16 +228,10 @@ fn lookup_libcall(name: &str, fmt: BinaryFormat, triple: &Triple) -> Option<LibC
     if let Some(&lc) = base.get(name) {
         return Some(lc);
     }
-    // Consult the soft-float table for any RISC-V ELF target.  We check
-    // architecture only and not whether hardware-float is enabled: if the target
-    // does have hardware float, LLVM will not emit these symbols and the lookup
-    // simply misses — so over-including is harmless.
-    if fmt == BinaryFormat::Elf
-        && matches!(
-            triple.architecture,
-            Architecture::Riscv32(_) | Architecture::Riscv64(_)
-        )
-    {
+    // Soft-float libcalls are only emitted by LLVM for RISC-V targets without
+    // hardware floating-point.  We use the runtime LLVM output triple rather than
+    // the host target_arch so that cross-compilation (e.g. macOS → riscv64) works.
+    if fmt == BinaryFormat::Elf && is_riscv_softfloat(&triple.architecture) {
         if let Some(&lc) = SOFTFLOAT_LIBCALLS_ELF.get(name) {
             return Some(lc);
         }

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -374,8 +374,8 @@ where
                         // Maybe a libcall then?
                     } else if let Some(libcall) = lookup_libcall(symbol_name, binary_fmt, triple) {
                         RelocationTarget::LibCall(libcall)
-                    } else if let Ok(Some(reloc_target)) =
-                        symbol_name_to_relocation_target(symbol_name)
+                    } else if let Some(reloc_target) =
+                        symbol_name_to_relocation_target(symbol_name)?
                     {
                         reloc_target
                     } else if let object::SymbolSection::Section(section_index) = symbol.section() {

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -231,10 +231,11 @@ fn lookup_libcall(name: &str, fmt: BinaryFormat, triple: &Triple) -> Option<LibC
     // Soft-float libcalls are only emitted by LLVM for RISC-V targets without
     // hardware floating-point.  We use the runtime LLVM output triple rather than
     // the host target_arch so that cross-compilation (e.g. macOS → riscv64) works.
-    if fmt == BinaryFormat::Elf && is_riscv_softfloat(&triple.architecture) {
-        if let Some(&lc) = SOFTFLOAT_LIBCALLS_ELF.get(name) {
-            return Some(lc);
-        }
+    if fmt == BinaryFormat::Elf
+        && is_riscv_softfloat(&triple.architecture)
+        && let Some(&lc) = SOFTFLOAT_LIBCALLS_ELF.get(name)
+    {
+        return Some(lc);
     }
     None
 }

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -92,10 +92,10 @@ static LIBCALLS_ELF: phf::Map<&'static str, LibCall> = phf::phf_map! {
     "wasmer_vm_dbg_str" => LibCall::DebugStr,
 };
 
-// Soft-float routines emitted by LLVM for targets without hardware floating-point.
-// This map is intentionally unconditional: `load_object_file` runs on the host, but the
-// ELF it processes was compiled for the LLVM *output* target (a runtime value). Wasmer
-// may cross-compile to soft-float RISC-V from any host, so the table must always be present.
+// Soft-float routines that LLVM may emit for RISC-V ELF targets.  The map is
+// unconditional because `load_object_file` runs on the host while the ELF it
+// processes was compiled for the LLVM output target (a runtime value); gating
+// on host target_arch would break cross-compilation (e.g. macOS → riscv64).
 static SOFTFLOAT_LIBCALLS_ELF: phf::Map<&'static str, LibCall> = phf::phf_map! {
     // §3.2.1 Arithmetic
     "__addsf3" => LibCall::Addsf3,
@@ -213,9 +213,10 @@ fn lookup_libcall(name: &str, fmt: BinaryFormat, triple: &Triple) -> Option<LibC
     if let Some(&lc) = base.get(name) {
         return Some(lc);
     }
-    // Soft-float libcalls are only emitted by LLVM when targeting RISC-V without
-    // hardware floating-point.  Check the runtime LLVM output triple rather than
-    // the host target_arch, so cross-compilation (e.g. macOS → riscv64) works.
+    // Consult the soft-float table for any RISC-V ELF target.  We check
+    // architecture only and not whether hardware-float is enabled: if the target
+    // does have hardware float, LLVM will not emit these symbols and the lookup
+    // simply misses — so over-including is harmless.
     if fmt == BinaryFormat::Elf
         && matches!(
             triple.architecture,

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -1,5 +1,5 @@
 use object::{Object, ObjectSection, ObjectSymbol};
-use target_lexicon::BinaryFormat;
+use target_lexicon::{Architecture, BinaryFormat, Triple};
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
@@ -204,7 +204,7 @@ static LIBCALLS_MACHO: phf::Map<&'static str, LibCall> = phf::phf_map! {
     "_wasmer_vm_dbg_str" => LibCall::DebugStr,
 };
 
-fn lookup_libcall(name: &str, fmt: BinaryFormat) -> Option<LibCall> {
+fn lookup_libcall(name: &str, fmt: BinaryFormat, triple: &Triple) -> Option<LibCall> {
     let base = match fmt {
         BinaryFormat::Elf => &LIBCALLS_ELF,
         BinaryFormat::Macho => &LIBCALLS_MACHO,
@@ -213,7 +213,15 @@ fn lookup_libcall(name: &str, fmt: BinaryFormat) -> Option<LibCall> {
     if let Some(&lc) = base.get(name) {
         return Some(lc);
     }
-    if fmt == BinaryFormat::Elf {
+    // Soft-float libcalls are only emitted by LLVM when targeting RISC-V without
+    // hardware floating-point.  Check the runtime LLVM output triple rather than
+    // the host target_arch, so cross-compilation (e.g. macOS → riscv64) works.
+    if fmt == BinaryFormat::Elf
+        && matches!(
+            triple.architecture,
+            Architecture::Riscv32(_) | Architecture::Riscv64(_)
+        )
+    {
         if let Some(&lc) = SOFTFLOAT_LIBCALLS_ELF.get(name) {
             return Some(lc);
         }
@@ -227,6 +235,7 @@ pub fn load_object_file<F>(
     root_section_reloc_target: RelocationTarget,
     mut symbol_name_to_relocation_target: F,
     binary_fmt: BinaryFormat,
+    triple: &Triple,
 ) -> Result<CompiledFunction, CompileError>
 where
     F: FnMut(&str) -> Result<Option<RelocationTarget>, CompileError>,
@@ -363,7 +372,7 @@ where
                             }
                         }
                         // Maybe a libcall then?
-                    } else if let Some(libcall) = lookup_libcall(symbol_name, binary_fmt) {
+                    } else if let Some(libcall) = lookup_libcall(symbol_name, binary_fmt, triple) {
                         RelocationTarget::LibCall(libcall)
                     } else if let Ok(Some(reloc_target)) =
                         symbol_name_to_relocation_target(symbol_name)

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -93,10 +93,9 @@ static LIBCALLS_ELF: phf::Map<&'static str, LibCall> = phf::phf_map! {
 };
 
 // Soft-float routines emitted by LLVM for targets without hardware floating-point.
-#[cfg(all(
-    any(target_arch = "riscv32", target_arch = "riscv64"),
-    not(target_feature = "f")
-))]
+// This map is intentionally unconditional: `load_object_file` runs on the host, but the
+// ELF it processes was compiled for the LLVM *output* target (a runtime value). Wasmer
+// may cross-compile to soft-float RISC-V from any host, so the table must always be present.
 static SOFTFLOAT_LIBCALLS_ELF: phf::Map<&'static str, LibCall> = phf::phf_map! {
     // §3.2.1 Arithmetic
     "__addsf3" => LibCall::Addsf3,
@@ -214,10 +213,6 @@ fn lookup_libcall(name: &str, fmt: BinaryFormat) -> Option<LibCall> {
     if let Some(&lc) = base.get(name) {
         return Some(lc);
     }
-    #[cfg(all(
-        any(target_arch = "riscv32", target_arch = "riscv64"),
-        not(target_feature = "f")
-    ))]
     if fmt == BinaryFormat::Elf {
         if let Some(&lc) = SOFTFLOAT_LIBCALLS_ELF.get(name) {
             return Some(lc);

--- a/lib/compiler-llvm/src/object_file.rs
+++ b/lib/compiler-llvm/src/object_file.rs
@@ -1,5 +1,7 @@
 use object::{Object, ObjectSection, ObjectSymbol};
-use target_lexicon::{Architecture, BinaryFormat, Riscv32Architecture, Riscv64Architecture, Triple};
+use target_lexicon::{
+    Architecture, BinaryFormat, Riscv32Architecture, Riscv64Architecture, Triple,
+};
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
@@ -208,9 +210,7 @@ static LIBCALLS_MACHO: phf::Map<&'static str, LibCall> = phf::phf_map! {
 /// (i.e. does not include the F/D ISA extensions, either explicitly or via the `gc` profile).
 fn is_riscv_softfloat(arch: &Architecture) -> bool {
     match arch {
-        Architecture::Riscv64(
-            Riscv64Architecture::Riscv64gc | Riscv64Architecture::Riscv64a23,
-        )
+        Architecture::Riscv64(Riscv64Architecture::Riscv64gc | Riscv64Architecture::Riscv64a23)
         | Architecture::Riscv32(
             Riscv32Architecture::Riscv32gc | Riscv32Architecture::Riscv32imafc,
         ) => false,

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -509,6 +509,7 @@ impl FuncTranslator {
                 })
             },
             self.binary_fmt,
+            &self.target_triple,
         )
     }
 }

--- a/lib/compiler-llvm/src/translator/trampoline.rs
+++ b/lib/compiler-llvm/src/translator/trampoline.rs
@@ -217,6 +217,7 @@ impl FuncTrampoline {
                 )))
             },
             self.binary_fmt,
+            &self.target_triple,
         )?;
         let mut all_sections_are_eh_sections = true;
         let mut unwind_section_indices = eh_frame_section_indices;
@@ -368,6 +369,7 @@ impl FuncTrampoline {
                 )))
             },
             self.binary_fmt,
+            &self.target_triple,
         )?;
 
         if !compiled_function.relocations.is_empty() {


### PR DESCRIPTION
### Problem

`SOFTFLOAT_LIBCALLS_ELF` and its lookup branch were gated on `#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"), not(target_feature = "f"))]`, which checks the **host** architecture, not the LLVM output target. Cross-compiling a WASM module to soft-float RISC-V from a macOS or x86-64 host panics with `"relocation targets unknown symbol '__floatdidf'"` because the table was compiled out entirely.

Relevant changes: https://github.com/wasmerio/wasmer/pull/6604

### Fix

Thread the LLVM output `Triple` through `load_object_file` → `lookup_libcall` and gate the soft-float lookup on the runtime target architecture instead. `SOFTFLOAT_LIBCALLS_ELF` is now unconditional — it is small static data, and if the target has hardware float, LLVM never emits these symbols so the lookup simply misses.
