### PR TITLE
Make proper atomic loads from the guest's memory in the atomics libcalls

### DIFF
--- a/lib/vm/src/threadconditions.rs
+++ b/lib/vm/src/threadconditions.rs
@@ -1,8 +1,7 @@
 use std::{
-    sync::atomic::AtomicPtr,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -143,14 +142,12 @@ impl ThreadConditions {
             ExpectedValue::None => true,
             ExpectedValue::U32(expected_val) => unsafe {
                 let src = dst.memory_base.offset(dst.address as isize) as *mut u32;
-                let atomic_src = AtomicPtr::new(src);
-                let read_val = *atomic_src.load(Ordering::Acquire);
+                let read_val = AtomicU32::from_ptr(src).load(Ordering::Acquire);
                 read_val == expected_val
             },
             ExpectedValue::U64(expected_val) => unsafe {
                 let src = dst.memory_base.offset(dst.address as isize) as *mut u64;
-                let atomic_src = AtomicPtr::new(src);
-                let read_val = *atomic_src.load(Ordering::Acquire);
+                let read_val = AtomicU64::from_ptr(src).load(Ordering::Acquire);
                 read_val == expected_val
             },
         };

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -15,7 +15,7 @@ use crate::{VMBuiltinFunctionIndex, VMFunction};
 use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use std::ptr::{self, NonNull};
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use wasmer_types::RawValue;
 
 /// Union representing the first parameter passed when calling a function.
@@ -411,8 +411,7 @@ pub(crate) unsafe fn memory32_atomic_check32(
         // Bounds and casts are checked above, by this point we know that
         // everything is safe.
         let dst = mem.base.offset(dst) as *mut u32;
-        let atomic_dst = AtomicPtr::new(dst);
-        let read_val = *atomic_dst.load(Ordering::Acquire);
+        let read_val = AtomicU32::from_ptr(dst).load(Ordering::Acquire);
         let ret = if read_val == val { 0 } else { 1 };
         Ok(ret)
     }
@@ -444,8 +443,7 @@ pub(crate) unsafe fn memory32_atomic_check64(
         // Bounds and casts are checked above, by this point we know that
         // everything is safe.
         let dst = mem.base.offset(dst) as *mut u64;
-        let atomic_dst = AtomicPtr::new(dst);
-        let read_val = *atomic_dst.load(Ordering::Acquire);
+        let read_val = AtomicU64::from_ptr(dst).load(Ordering::Acquire);
         let ret = if read_val == val { 0 } else { 1 };
         Ok(ret)
     }


### PR DESCRIPTION
Previously, we were constructing an `AtomicPtr` and then loading from it, which does the wrong thing; it loads the _pointer_ atomically, then make a non-atomic read of the target address. This change fixes that mistake by using `AtomicU32/U64::from_ptr` which will load the target value atomically.

I tried implementing a test that would catch the regression, but couldn't build one that failed with the existing impl.

Thanks to @sadhbh-c0d3 for discovering the issue!