### PR TITLE
fix(wasix): initialize WasiEnv before side-module TLS init on spawn

### DIFF
--- a/lib/wasix/src/state/linker/instance_group.rs
+++ b/lib/wasix/src/state/linker/instance_group.rs
@@ -29,6 +29,11 @@ pub(super) struct DlInstance {
     pub(super) tls_base: Option<u64>,
 }
 
+pub(super) struct PreparedSideFromLinker {
+    pub(super) module_handle: ModuleHandle,
+    pub(super) instance: Instance,
+}
+
 pub(super) struct InstanceGroupState {
     pub(super) main_instance: Option<Instance>,
     pub(super) main_instance_tls_base: Option<u64>,
@@ -190,15 +195,14 @@ impl InstanceGroupState {
         Ok(())
     }
 
-    // For when we receive a module loaded DL operation
-    pub(super) fn instantiate_side_module_from_linker(
+    pub(super) fn prepare_side_module_from_linker(
         &mut self,
         linker_state: &LinkerState,
         store: &mut impl AsStoreMut,
         env: &FunctionEnv<WasiEnv>,
         module_handle: ModuleHandle,
         pending_resolutions: &mut PendingResolutionsFromLinker,
-    ) -> Result<(), LinkError> {
+    ) -> Result<PreparedSideFromLinker, LinkError> {
         if self.side_instances.contains_key(&module_handle) {
             panic!(
                 "Internal error: Module with handle {module_handle:?} \
@@ -234,9 +238,22 @@ impl InstanceGroupState {
 
         let instance = Instance::new(store, &dl_module.module, &imports)?;
 
-        // This is a non-main instance of a side module, so it needs a new TLS area
-        let tls_base = call_initialization_function::<i32>(&instance, store, "__wasix_init_tls")?
-            .map(|v| v as u64);
+        Ok(PreparedSideFromLinker {
+            module_handle,
+            instance,
+        })
+    }
+
+    pub(super) fn complete_side_module_from_linker(
+        &mut self,
+        prepared: PreparedSideFromLinker,
+        tls_base: Option<u64>,
+        store: &mut impl AsStoreMut,
+    ) -> Result<(), LinkError> {
+        let PreparedSideFromLinker {
+            module_handle,
+            instance,
+        } = prepared;
 
         let instance_handles = WasiModuleInstanceHandles::new(
             self.memory.clone(),
@@ -260,6 +277,31 @@ impl InstanceGroupState {
         trace!(?module_handle, "Existing module instantiated successfully");
 
         Ok(())
+    }
+
+    // For when we receive a module loaded DL operation
+    pub(super) fn instantiate_side_module_from_linker(
+        &mut self,
+        linker_state: &LinkerState,
+        store: &mut impl AsStoreMut,
+        env: &FunctionEnv<WasiEnv>,
+        module_handle: ModuleHandle,
+        pending_resolutions: &mut PendingResolutionsFromLinker,
+    ) -> Result<(), LinkError> {
+        let prepared = self.prepare_side_module_from_linker(
+            linker_state,
+            store,
+            env,
+            module_handle,
+            pending_resolutions,
+        )?;
+
+        // This is a non-main instance of a side module, so it needs a new TLS area
+        let tls_base =
+            call_initialization_function::<i32>(&prepared.instance, store, "__wasix_init_tls")?
+                .map(|v| v as u64);
+
+        self.complete_side_module_from_linker(prepared, tls_base, store)
     }
 
     pub(super) fn finalize_pending_resolutions_from_linker(

--- a/lib/wasix/src/state/linker/mod.rs
+++ b/lib/wasix/src/state/linker/mod.rs
@@ -790,9 +790,9 @@ impl Linker {
             trace!(?module_handle, "Instantiating existing side module");
             let prepared = {
                 let mut guard = instance_group_state.lock().unwrap();
-                let group = guard.as_mut().expect(
-                    "Internal error: instance group state was cleared during spawn",
-                );
+                let group = guard
+                    .as_mut()
+                    .expect("Internal error: instance group state was cleared during spawn");
                 group.prepare_side_module_from_linker(
                     &ls_write,
                     store,
@@ -804,18 +804,15 @@ impl Linker {
 
             // Guest code may reenter the linker (e.g. via sched_yield); do not hold the
             // instance-group mutex across __wasix_init_tls.
-            let tls_base = call_initialization_function::<i32>(
-                &prepared.instance,
-                store,
-                "__wasix_init_tls",
-            )?
-            .map(|v| v as u64);
+            let tls_base =
+                call_initialization_function::<i32>(&prepared.instance, store, "__wasix_init_tls")?
+                    .map(|v| v as u64);
 
             {
                 let mut guard = instance_group_state.lock().unwrap();
-                let group = guard.as_mut().expect(
-                    "Internal error: instance group state was cleared during spawn",
-                );
+                let group = guard
+                    .as_mut()
+                    .expect("Internal error: instance group state was cleared during spawn");
                 group.complete_side_module_from_linker(prepared, tls_base, store)?;
             }
         }
@@ -823,18 +820,18 @@ impl Linker {
         trace!("Finalizing pending functions");
         {
             let guard = instance_group_state.lock().unwrap();
-            let group = guard.as_ref().expect(
-                "Internal error: instance group state was cleared during spawn",
-            );
+            let group = guard
+                .as_ref()
+                .expect("Internal error: instance group state was cleared during spawn");
             group.finalize_pending_resolutions_from_linker(&pending_resolutions, store)?;
         }
 
         trace!("Applying externally-requested function table entries");
         {
             let guard = instance_group_state.lock().unwrap();
-            let group = guard.as_ref().expect(
-                "Internal error: instance group state was cleared during spawn",
-            );
+            let group = guard
+                .as_ref()
+                .expect("Internal error: instance group state was cleared during spawn");
             group.apply_requested_symbols_from_linker(store, &ls_write)?;
         }
 

--- a/lib/wasix/src/state/linker/mod.rs
+++ b/lib/wasix/src/state/linker/mod.rs
@@ -757,29 +757,11 @@ impl Linker {
 
         instance_group.main_instance = Some(main_instance.clone());
 
-        for side in &ls_write.side_modules {
-            trace!(module_handle = ?side.0, "Instantiating existing side module");
-            instance_group.instantiate_side_module_from_linker(
-                &ls_write,
-                store,
-                &func_env.env,
-                *side.0,
-                &mut pending_resolutions,
-            )?;
-        }
-
-        trace!("Finalizing pending functions");
-        instance_group.finalize_pending_resolutions_from_linker(&pending_resolutions, store)?;
-
-        trace!("Applying externally-requested function table entries");
-        instance_group.apply_requested_symbols_from_linker(store, &ls_write)?;
-
-        drop(ls_write);
-        drop(topology_hold);
+        let instance_group_state = Arc::new(Mutex::new(Some(instance_group)));
 
         let linker = Self {
-            shared: linker_shared,
-            instance_group_state: Arc::new(Mutex::new(Some(instance_group))),
+            shared: linker_shared.clone(),
+            instance_group_state: instance_group_state.clone(),
         };
 
         let module_handles = WasiModuleTreeHandles::Dynamic {
@@ -801,6 +783,63 @@ impl Linker {
                 false,
             )
             .map_err(LinkError::MainModuleHandleInitFailed)?;
+
+        let side_module_handles: Vec<ModuleHandle> =
+            ls_write.side_modules.keys().copied().collect();
+        for module_handle in side_module_handles {
+            trace!(?module_handle, "Instantiating existing side module");
+            let prepared = {
+                let mut guard = instance_group_state.lock().unwrap();
+                let group = guard.as_mut().expect(
+                    "Internal error: instance group state was cleared during spawn",
+                );
+                group.prepare_side_module_from_linker(
+                    &ls_write,
+                    store,
+                    &func_env.env,
+                    module_handle,
+                    &mut pending_resolutions,
+                )?
+            };
+
+            // Guest code may reenter the linker (e.g. via sched_yield); do not hold the
+            // instance-group mutex across __wasix_init_tls.
+            let tls_base = call_initialization_function::<i32>(
+                &prepared.instance,
+                store,
+                "__wasix_init_tls",
+            )?
+            .map(|v| v as u64);
+
+            {
+                let mut guard = instance_group_state.lock().unwrap();
+                let group = guard.as_mut().expect(
+                    "Internal error: instance group state was cleared during spawn",
+                );
+                group.complete_side_module_from_linker(prepared, tls_base, store)?;
+            }
+        }
+
+        trace!("Finalizing pending functions");
+        {
+            let guard = instance_group_state.lock().unwrap();
+            let group = guard.as_ref().expect(
+                "Internal error: instance group state was cleared during spawn",
+            );
+            group.finalize_pending_resolutions_from_linker(&pending_resolutions, store)?;
+        }
+
+        trace!("Applying externally-requested function table entries");
+        {
+            let guard = instance_group_state.lock().unwrap();
+            let group = guard.as_ref().expect(
+                "Internal error: instance group state was cleared during spawn",
+            );
+            group.apply_requested_symbols_from_linker(store, &ls_write)?;
+        }
+
+        drop(ls_write);
+        drop(topology_hold);
 
         trace!("Instance group spawned successfully");
 

--- a/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/build.sh
+++ b/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/build.sh
@@ -7,8 +7,21 @@ export WASIXCC_PIC=1
 
 NUM_SIDES=8
 
+case "${WASMER_BACKEND}" in
+  v8)
+    # V8 retains more per-spawn state; keep contention but avoid JS heap OOM.
+    SPAWN_BATCH=16
+    SPAWN_ROUNDS=24
+    ;;
+  *)
+    SPAWN_BATCH=32
+    SPAWN_ROUNDS=64
+    ;;
+esac
+
 for i in $(seq 0 $((NUM_SIDES - 1))); do
   $CC -DNAME_SUFFIX="$i" side.c -o "libside_${i}.so" -Wl,-shared
 done
 
-$CC -DNUM_SIDES="$NUM_SIDES" main.c -o main -Wl,-pie
+$CC -DNUM_SIDES="$NUM_SIDES" -DSPAWN_BATCH="$SPAWN_BATCH" -DSPAWN_ROUNDS="$SPAWN_ROUNDS" \
+  main.c -o main -Wl,-pie

--- a/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/build.sh
+++ b/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+##ExpectedStdout: topology dl-spawn-tls-init-under-contention ok
+set -euo pipefail
+
+export WASIXCC_WASM_EXCEPTIONS=1
+export WASIXCC_PIC=1
+
+NUM_SIDES=8
+
+for i in $(seq 0 $((NUM_SIDES - 1))); do
+  $CC -DNAME_SUFFIX="$i" side.c -o "libside_${i}.so" -Wl,-shared
+done
+
+$CC -DNUM_SIDES="$NUM_SIDES" main.c -o main -Wl,-pie

--- a/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/main.c
+++ b/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/main.c
@@ -9,8 +9,13 @@
 #error "NUM_SIDES must be defined by build.sh"
 #endif
 
-#define SPAWN_BATCH 32
-#define SPAWN_ROUNDS 64
+#ifndef SPAWN_BATCH
+#error "SPAWN_BATCH must be defined by build.sh"
+#endif
+
+#ifndef SPAWN_ROUNDS
+#error "SPAWN_ROUNDS must be defined by build.sh"
+#endif
 
 static atomic_int stop_pressure = 0;
 
@@ -80,7 +85,8 @@ int main(void) {
       if (pthread_create(&spawned[i], NULL, noop_thread, NULL) != 0) {
         atomic_store(&stop_pressure, 1);
         pthread_join(pressure, NULL);
-        fprintf(stderr, "pthread_create failed at round %d thread %d\n", round, i);
+        fprintf(stderr, "pthread_create failed at round %d thread %d\n", round,
+                i);
         return 3;
       }
     }
@@ -88,7 +94,8 @@ int main(void) {
       if (pthread_join(spawned[i], NULL) != 0) {
         atomic_store(&stop_pressure, 1);
         pthread_join(pressure, NULL);
-        fprintf(stderr, "pthread_join failed at round %d thread %d\n", round, i);
+        fprintf(stderr, "pthread_join failed at round %d thread %d\n", round,
+                i);
         return 4;
       }
     }

--- a/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/main.c
+++ b/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/main.c
@@ -1,0 +1,106 @@
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef NUM_SIDES
+#error "NUM_SIDES must be defined by build.sh"
+#endif
+
+#define SPAWN_BATCH 32
+#define SPAWN_ROUNDS 64
+
+static atomic_int stop_pressure = 0;
+
+static void* noop_thread(void* arg) {
+  (void)arg;
+  return NULL;
+}
+
+static void* malloc_pressure(void* arg) {
+  (void)arg;
+  while (!atomic_load(&stop_pressure)) {
+    void* p = aligned_alloc(16, 64);
+    if (p) {
+      *((volatile char*)p) = 1;
+      free(p);
+    }
+    p = malloc(256);
+    if (p) {
+      *((volatile char*)p) = 1;
+      free(p);
+    }
+  }
+  return NULL;
+}
+
+static int preload_tls_sides(void) {
+  for (int i = 0; i < NUM_SIDES; i++) {
+    char path[32];
+    char sym[32];
+    snprintf(path, sizeof(path), "./libside_%d.so", i);
+    snprintf(sym, sizeof(sym), "side_touch_%d", i);
+
+    void* handle = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+    if (!handle) {
+      fprintf(stderr, "dlopen %s failed: %s\n", path, dlerror());
+      return 1;
+    }
+
+    typedef int (*touch_fn)(void);
+    touch_fn touch = (touch_fn)dlsym(handle, sym);
+    if (!touch) {
+      fprintf(stderr, "dlsym %s failed: %s\n", sym, dlerror());
+      return 1;
+    }
+    if (touch() == 0) {
+      fprintf(stderr, "side_touch_%d returned zero tls base\n", i);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int main(void) {
+  if (preload_tls_sides() != 0) {
+    return 1;
+  }
+
+  pthread_t pressure;
+  if (pthread_create(&pressure, NULL, malloc_pressure, NULL) != 0) {
+    fprintf(stderr, "failed to start malloc pressure thread\n");
+    return 2;
+  }
+
+  for (int round = 0; round < SPAWN_ROUNDS; round++) {
+    pthread_t spawned[SPAWN_BATCH];
+    for (int i = 0; i < SPAWN_BATCH; i++) {
+      if (pthread_create(&spawned[i], NULL, noop_thread, NULL) != 0) {
+        atomic_store(&stop_pressure, 1);
+        pthread_join(pressure, NULL);
+        fprintf(stderr, "pthread_create failed at round %d thread %d\n", round, i);
+        return 3;
+      }
+    }
+    for (int i = 0; i < SPAWN_BATCH; i++) {
+      if (pthread_join(spawned[i], NULL) != 0) {
+        atomic_store(&stop_pressure, 1);
+        pthread_join(pressure, NULL);
+        fprintf(stderr, "pthread_join failed at round %d thread %d\n", round, i);
+        return 4;
+      }
+    }
+  }
+
+  atomic_store(&stop_pressure, 1);
+  if (pthread_join(pressure, NULL) != 0) {
+    fprintf(stderr, "failed to join malloc pressure thread\n");
+    return 5;
+  }
+
+  printf("topology dl-spawn-tls-init-under-contention ok\n");
+  fflush(stdout);
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/side.c
+++ b/lib/wasix/tests/wasm_tests/dynamic_library_tests/dl-spawn-tls-init-under-contention/side.c
@@ -1,0 +1,15 @@
+#ifndef NAME_SUFFIX
+#define NAME_SUFFIX 0
+#endif
+
+#define CAT(a, b) CAT_INNER(a, b)
+#define CAT_INNER(a, b) a##b
+
+// Per-module TLS ensures __wasix_init_tls is exported and replayed on spawn.
+_Thread_local int CAT(side_tls_, NAME_SUFFIX) = NAME_SUFFIX;
+
+// Unique entry point per copy so main can dlopen/dlsym each module.
+int CAT(side_touch_, NAME_SUFFIX)(void) {
+  CAT(side_tls_, NAME_SUFFIX) = 1;
+  return (int)__builtin_wasm_tls_base();
+}

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -21,6 +21,9 @@
 //!
 //! `BuildEnv:{key}={value}` sets an environment variable before building.
 //!
+//! The harness also sets `WASMER_BACKEND` to the engine name (`cranelift`, `v8`,
+//! etc.) before every build so shell scripts can tune compile-time parameters per backend.
+//!
 //! `Env:{key}={value}` sets an environment variable before running.
 //!
 //! `ExpectedStdout:{line}` appends one expected stdout line.
@@ -609,6 +612,7 @@ fn run_build_script(config: &Config) -> anyhow::Result<PathBuf> {
     for (k, v) in &config.build_env {
         cmd.env(k, v);
     }
+    cmd.env("WASMER_BACKEND", config.engine.name());
     let output = cmd.output()?;
 
     if !output.status.success() {


### PR DESCRIPTION
## Summary

- Adds `dl-spawn-tls-init-under-contention`, a wasm repro that reliably hits the production crash when a spawned thread replays side modules during `create_instance_group` on a pool worker.
- Fixes the root cause by calling `initialize_handles_and_layout` (setting `WasiEnv::inner`) immediately after the main instance is created, **before** replaying side modules and calling `__wasix_init_tls`.
- Releases the instance-group mutex before guest TLS init so `sched_yield` reentry during musl malloc does not self-deadlock on the group lock.

This addresses the crash seen after the linker refactor (#6587): cloned `WasiEnv` on spawn had empty `inner` while `__wasix_init_tls` → `aligned_alloc` → `sched_yield` → `do_pending_link_operations` called `inner().expect()`.