### PR TITLE
fix(cli): return an error when binfmt_misc is missing

### DIFF
--- a/lib/cli/src/commands/binfmt.rs
+++ b/lib/cli/src/commands/binfmt.rs
@@ -64,7 +64,7 @@ impl Binfmt {
     /// execute [Binfmt]
     pub fn execute(&self) -> Result<()> {
         if !self.binfmt_misc.exists() {
-            panic!("{} does not exist", self.binfmt_misc.to_string_lossy());
+            bail!("{} does not exist", self.binfmt_misc.to_string_lossy());
         }
         let temp_dir;
         let specs = match self.action {
@@ -160,5 +160,27 @@ impl Binfmt {
                 .collect::<Result<Vec<_>>>()?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_binfmt_mount_returns_error() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let missing = tempdir.path().join("missing-binfmt-misc");
+        let cmd = Binfmt {
+            binfmt_misc: missing.clone(),
+            action: Action::Register,
+        };
+
+        let error = cmd.execute().unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!("{} does not exist", missing.display())
+        );
     }
 }


### PR DESCRIPTION
# Description
`wasmer binfmt` panics if `--binfmt-misc` points to a path that does not exist.

This is easy to hit in practice because the flag is user supplied, and `binfmt_misc` is not always mounted either. Small papercut, but the panic is kinda rough rn.

This swaps the panic for a normal CLI error and adds a regression test.

Repro:
`cargo run -p wasmer-cli --no-default-features --features 'backend,sys' -- binfmt --binfmt-misc /tmp/wasmer-binfmt-missing register`

Before:
panics in `lib/cli/src/commands/binfmt.rs`

After:
`error: /tmp/wasmer-binfmt-missing does not exist`
