### PR TITLE
fix(Artifact): move new enum values to the end

### DIFF
--- a/lib/types/src/libcalls.rs
+++ b/lib/types/src/libcalls.rs
@@ -32,13 +32,6 @@ pub enum LibCall {
 
     /// nearest.f64
     NearestF64,
-
-    /// sqrt.f32
-    SqrtF32,
-
-    /// sqrt.f64
-    SqrtF64,
-
     /// trunc.f32
     TruncF32,
 
@@ -248,6 +241,13 @@ pub enum LibCall {
     Gtsf2,
     /// __gtdf2
     Gtdf2,
+
+    // TODO: move earlier during a artifact format version bump
+    /// sqrt.f32
+    SqrtF32,
+
+    /// sqrt.f64
+    SqrtF64,
 }
 
 impl LibCall {


### PR DESCRIPTION
@pmikolajczyk41 The libcalls enum variant was extended in #6672, but unfortunately the new values very not put at the end, but in the middle of the variant space. That broke already existing artifacts.