### PR TITLE
fix poll_read_ready underflow when the file cursor is past EOF

### DIFF
--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -584,7 +584,7 @@ impl VirtualFile for File {
         };
         let _ = self.inner_std.seek(io::SeekFrom::Start(cursor));
 
-        let remaining = end - cursor;
+        let remaining = end.saturating_sub(cursor);
         Poll::Ready(Ok(remaining as usize))
     }
 

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -406,15 +406,15 @@ impl VirtualFile for FileHandle {
         let inode = fs.storage.get_mut(self.inode);
         match inode {
             Some(Node::File(node)) => {
-                let remaining = node.file.buffer.len() - (self.cursor as usize);
+                let remaining = node.file.buffer.len().saturating_sub(self.cursor as usize);
                 Poll::Ready(Ok(remaining))
             }
             Some(Node::OffloadedFile(node)) => {
-                let remaining = node.file.len() as usize - (self.cursor as usize);
+                let remaining = (node.file.len() as usize).saturating_sub(self.cursor as usize);
                 Poll::Ready(Ok(remaining))
             }
             Some(Node::ReadOnlyFile(node)) => {
-                let remaining = node.file.buffer.len() - (self.cursor as usize);
+                let remaining = node.file.buffer.len().saturating_sub(self.cursor as usize);
                 Poll::Ready(Ok(remaining))
             }
             Some(Node::CustomFile(node)) => {
@@ -846,6 +846,34 @@ mod test_virtual_file {
         assert!(matches!(
             Pin::new(file.as_mut()).poll_write_ready(&mut cx),
             Poll::Ready(Ok(8192))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_poll_read_ready_after_seek_past_end() {
+        let fs = FileSystem::default();
+        let mut file = fs
+            .new_open_options()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path!("/foo.txt"))
+            .expect("failed to create a new file");
+        file.write_all(b"hello").await.expect("failed to write");
+
+        // POSIX allows seeking past the end of a file.
+        file.seek(io::SeekFrom::Start(4096))
+            .await
+            .expect("failed to seek past the end");
+
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+
+        // No bytes are readable at or past the end, so the count of readable
+        // bytes must be 0 rather than underflowing.
+        assert!(matches!(
+            Pin::new(file.as_mut()).poll_read_ready(&mut cx),
+            Poll::Ready(Ok(0))
         ));
     }
 }

--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -241,8 +241,11 @@ impl VirtualFile for File {
         self: Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
     ) -> Poll<std::io::Result<usize>> {
-        let bytes_remaining =
-            self.content.get_ref().len() - usize::try_from(self.content.position()).unwrap();
+        let bytes_remaining = self
+            .content
+            .get_ref()
+            .len()
+            .saturating_sub(usize::try_from(self.content.position()).unwrap_or(usize::MAX));
         Poll::Ready(Ok(bytes_remaining))
     }
 


### PR DESCRIPTION
1. poll_read_ready reports the readable byte count as `len - cursor`, but the cursor can sit past EOF after a seek (POSIX allows seeking beyond the end), so the subtraction underflows.
2. This reaches the mem_fs File/OffloadedFile/ReadOnlyFile handles, the host_fs file, and the webc volume file. In release builds it wraps to a near-`usize::MAX` count that gets reported back through poll_oneoff/epoll, and in debug builds it panics with "attempt to subtract with overflow". A guest reaches it by seeking a fd past the end and then polling it for readability.
3. Switched each site to `saturating_sub`, so the count is 0 once the cursor is at or past the end, which matches how the read paths already treat EOF.

Added a mem_fs regression test that seeks past the end and checks that poll_read_ready returns 0.