### PR TITLE
fix(cli): missing progress bar

### DIFF
--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -225,6 +225,7 @@ sys = [
   "ctrlc",
   "wasmer/wat",
   "wasmer/js-serializable-module",
+  "wasmer/sys",
 ]
 sys-default = ["sys", "wasmer/sys"]
 sys-poll = []

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -227,7 +227,7 @@ sys = [
   "wasmer/js-serializable-module",
   "wasmer/sys",
 ]
-sys-default = ["sys", "wasmer/sys"]
+sys-default = ["sys"]
 sys-poll = []
 extra-logging = []
 sys-thread = ["tokio/rt", "tokio/time", "tokio/rt-multi-thread", "rusty_pool"]

--- a/lib/wasix/src/runtime/mod.rs
+++ b/lib/wasix/src/runtime/mod.rs
@@ -392,7 +392,7 @@ pub async fn load_module(
         let p = CompilationProgressCallback::new(move |p| {
             progress.notify(ModuleLoadProgress::CompilingModule(p))
         });
-        #[cfg(feature = "sys-default")]
+        #[cfg(feature = "sys")]
         {
             if engine.is_sys() {
                 use wasmer::sys::NativeEngineExt;
@@ -401,7 +401,7 @@ pub async fn load_module(
                 Module::new(&engine, input.wasm())
             }
         }
-        #[cfg(not(feature = "sys-default"))]
+        #[cfg(not(feature = "sys"))]
         {
             Module::new(&engine, input.wasm())
         }


### PR DESCRIPTION
After #6648, we accidentally lost the progress bar support due to us not accidentally enabling `wasmer-wasix/sys-default` from tests. Better than that, we should not depend on `sys-default`, but just on `sys` feature.