### PR TITLE
fix err_buf_len underflow in write_dl_error

### DIFF
--- a/lib/wasix/src/syscalls/wasix/dlopen.rs
+++ b/lib/wasix/src/syscalls/wasix/dlopen.rs
@@ -94,14 +94,13 @@ pub(crate) fn write_dl_error<M: MemorySize>(
         err = &err[..err_len];
     }
 
-    let mut buf = vec![0; err_len + 1];
-    buf[0..err_len].copy_from_slice(err.as_bytes());
-
     let Ok(err_len_offset) = M::Offset::try_from(err_len + 1) else {
         panic!("Failed to convert size to offset")
     };
     let mut err_buf = err_buf.slice(memory, err_len_offset)?.access()?;
-    err_buf.copy_from_slice(&buf[..]);
+    let dst = err_buf.as_mut();
+    dst[..err_len].copy_from_slice(err.as_bytes());
+    dst[err_len] = 0;
 
     Ok(())
 }

--- a/lib/wasix/src/syscalls/wasix/dlopen.rs
+++ b/lib/wasix/src/syscalls/wasix/dlopen.rs
@@ -77,10 +77,20 @@ pub(crate) fn write_dl_error<M: MemorySize>(
     err_buf: WasmPtr<u8, M>,
     err_buf_len: u64,
 ) -> Result<(), MemoryAccessError> {
+    let err_buf_len = err_buf_len as usize;
+
+    // The message is always written with a trailing NUL, so a zero-length
+    // buffer leaves no room for anything.
+    if err_buf_len == 0 {
+        return Ok(());
+    }
+
+    // Reserve one byte for the trailing NUL.
+    let max_err_len = err_buf_len - 1;
     let mut err_len = err.len();
 
-    if err_len > err_buf_len as usize {
-        err_len = err_buf_len as usize - 1;
+    if err_len > max_err_len {
+        err_len = max_err_len;
         err = &err[..err_len];
     }
 
@@ -94,4 +104,42 @@ pub(crate) fn write_dl_error<M: MemorySize>(
     err_buf.copy_from_slice(&buf[..]);
 
     Ok(())
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::write_dl_error;
+    use wasmer::{Memory, Memory32, MemoryType, Store, WasmPtr};
+
+    #[test]
+    fn write_dl_error_zero_len_buffer_writes_nothing() {
+        let mut store = Store::default();
+        let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
+        let view = memory.view(&store);
+
+        // A guest-supplied err_buf_len of 0 leaves no room even for the NUL
+        // terminator. The old accounting computed `0 - 1`, underflowing usize.
+        let err_buf = WasmPtr::<u8, Memory32>::new(0);
+        let res = write_dl_error::<Memory32>("failed to load module", &view, err_buf, 0);
+        assert!(res.is_ok());
+        assert_eq!(view.read_u8(0).unwrap(), 0);
+    }
+
+    #[test]
+    fn write_dl_error_reserves_room_for_nul() {
+        let mut store = Store::default();
+        let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
+        let view = memory.view(&store);
+
+        // err_buf_len equal to the message length must still keep the NUL
+        // inside the buffer rather than spilling one byte past it.
+        let msg = "abcd";
+        let err_buf = WasmPtr::<u8, Memory32>::new(0);
+        write_dl_error::<Memory32>(msg, &view, err_buf, msg.len() as u64).unwrap();
+
+        let mut got = [1u8; 5];
+        view.read(0, &mut got).unwrap();
+        assert_eq!(&got[..4], b"abc\0");
+        assert_eq!(got[4], 0);
+    }
 }


### PR DESCRIPTION
1. err_buf_len is the guest-supplied error buffer length passed to dlopen/dlsym; the truncation path computed `err_buf_len - 1`, which underflows usize when a guest passes 0 (subtract-overflow panic in debug, wraps to a bad str slice in release).
2. when err_buf_len equals the message length the writer emitted the message plus its NUL, one byte past the guest buffer.
Reserve a byte for the terminator and return early on an empty buffer. Added two regression tests covering the zero-length and exact-length cases.
