### PR TITLE
fix(linker): handle DlOperation::ResolveFunction on demand

### DIFF
--- a/lib/wasix/src/state/linker/instance_group.rs
+++ b/lib/wasix/src/state/linker/instance_group.rs
@@ -395,11 +395,6 @@ impl InstanceGroupState {
                 }
                 self.finalize_pending_resolutions_from_linker(&pending_functions, store)?;
             }
-            DlOperation::ResolveFunction {
-                name,
-                resolved_from,
-                function_table_index,
-            } => self.apply_resolved_function(store, &name, resolved_from, function_table_index)?,
             DlOperation::AllocateFunctionTable { index, size } => {
                 self.apply_function_table_allocation(store, index, size)?
             }

--- a/lib/wasix/src/state/linker/instance_group/table.rs
+++ b/lib/wasix/src/state/linker/instance_group/table.rs
@@ -129,7 +129,7 @@ impl InstanceGroupState {
         Ok(())
     }
 
-    pub(super) fn apply_resolved_function(
+    pub(crate) fn apply_resolved_function(
         &self,
         store: &mut impl AsStoreMut,
         name: &str,
@@ -155,6 +155,16 @@ impl InstanceGroupState {
             .map_err(LinkError::TableAllocationError)?;
 
         Ok(())
+    }
+
+    pub(in crate::state::linker) fn has_function_table_entry(
+        &self,
+        store: &mut impl AsStoreMut,
+        index: u32,
+    ) -> bool {
+        let table = &self.indirect_function_table;
+        index < table.size(store)
+            && matches!(table.get(store, index), Some(Value::FuncRef(Some(_))))
     }
 
     pub(super) fn apply_function_table_allocation(

--- a/lib/wasix/src/state/linker/mod.rs
+++ b/lib/wasix/src/state/linker/mod.rs
@@ -1207,8 +1207,17 @@ impl Linker {
             match resolution {
                 SymbolResolutionResult::FunctionPointer {
                     function_table_index: addr,
-                    ..
+                    resolved_from,
                 } => {
+                    let mut store = ctx.as_store_mut();
+                    if !group_state.has_function_table_entry(&mut store, *addr) {
+                        group_state.apply_resolved_function(
+                            &mut store,
+                            symbol,
+                            *resolved_from,
+                            *addr,
+                        )?;
+                    }
                     return Ok(ResolvedExport::Function {
                         func_ptr: *addr as u64,
                     });
@@ -1234,9 +1243,10 @@ impl Linker {
             }
         }
 
-        let (topology_token, mut linker_state) = self
+        let mut linker_state = self
             .shared
-            .write_linker_state_with_topology(group_state, ctx)?;
+            .write_linker_state_with_topology(group_state, ctx)?
+            .1;
 
         let mut store = ctx.as_store_mut();
 
@@ -1284,18 +1294,10 @@ impl Linker {
                     },
                 );
 
-                self.shared.synchronize_link_operation(
-                    topology_token,
-                    DlOperation::ResolveFunction {
-                        name: symbol.to_string(),
-                        resolved_from,
-                        function_table_index: func_ptr,
-                    },
-                    linker_state,
-                    group_state,
-                    &ctx.data().process,
-                    ctx.data().tid(),
-                );
+                // Function pointer resolution is safe to replicate lazily. A synchronous
+                // all-group barrier can deadlock when another thread is running guest code and
+                // cannot enter the cooperative DL path; follower groups fill this table slot when
+                // they observe the cached FunctionPointer record.
 
                 Ok(ResolvedExport::Function {
                     func_ptr: func_ptr as u64,

--- a/lib/wasix/src/state/linker/sync/mod.rs
+++ b/lib/wasix/src/state/linker/sync/mod.rs
@@ -127,8 +127,5 @@ pub(super) use lock_instance_group_state;
 pub(super) enum DlOperation {
     LoadModules(Vec<ModuleHandle>),
     // Allocates slots in the function table
-    AllocateFunctionTable {
-        index: u32,
-        size: u32,
-    },
+    AllocateFunctionTable { index: u32, size: u32 },
 }

--- a/lib/wasix/src/state/linker/sync/mod.rs
+++ b/lib/wasix/src/state/linker/sync/mod.rs
@@ -126,13 +126,6 @@ pub(super) use lock_instance_group_state;
 #[derive(Debug, Clone)]
 pub(super) enum DlOperation {
     LoadModules(Vec<ModuleHandle>),
-    ResolveFunction {
-        name: String,
-        resolved_from: ModuleHandle,
-        // This should match the current length of each instance group's function table
-        // minus one. Otherwise, we're out of sync and an error has been encountered.
-        function_table_index: u32,
-    },
     // Allocates slots in the function table
     AllocateFunctionTable {
         index: u32,


### PR DESCRIPTION
Fix a deadlock spotted in `dl-concurrent-open-and-spawn` test by resolving an export on demand.

Fixes #6654