### PR TITLE
Duplex pipe readiness

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -2110,7 +2110,7 @@ impl WasiFs {
         }
     }
 
-    fn virtual_root_fd(root_inode: InodeGuard) -> Fd {
+    pub(crate) fn virtual_root_fd(root_inode: InodeGuard) -> Fd {
         Fd {
             inner: FdInner {
                 rights: ALL_RIGHTS,
@@ -2157,13 +2157,14 @@ impl WasiFs {
                 return Ok(None);
             }
 
-            if let Some(target_fd) = fd_map.get(dst)
+            let displaced_preopen = if let Some(target_fd) = fd_map.get(dst)
                 && !target_fd.is_stdio
                 && target_fd.inode.is_preopened
             {
-                warn!("Refusing dup2({src}, {dst}) because FD {dst} is pre-opened");
-                return Err(Errno::Notsup);
-            }
+                Some(target_fd.clone())
+            } else {
+                None
+            };
 
             let new_fd_entry = Fd {
                 inner: FdInner {
@@ -2185,6 +2186,20 @@ impl WasiFs {
                 .and_then(|fd| Self::file_flush_target(&fd.inode));
 
             fd_map.remove(dst);
+
+            if let Some(displaced_preopen) = displaced_preopen {
+                let relocated = fd_map.insert_first_free_after(displaced_preopen, dst + 1);
+                if let Some(preopen_fd) = self
+                    .preopen_fds
+                    .write()
+                    .unwrap()
+                    .iter_mut()
+                    .find(|fd| **fd == dst)
+                {
+                    *preopen_fd = relocated;
+                }
+                trace!("Relocated pre-opened FD {dst} to {relocated} before dup2({src}, {dst})");
+            }
 
             if !fd_map.insert(true, dst, new_fd_entry) {
                 panic!("Internal error: expected FD {dst} to be free after remove in dup2_at");

--- a/lib/wasix/src/os/epoll/mod.rs
+++ b/lib/wasix/src/os/epoll/mod.rs
@@ -39,15 +39,18 @@
 //!
 use std::{
     collections::VecDeque,
+    pin::Pin,
     sync::{
         Arc, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     },
+    task::{Context, Poll},
 };
 
 use fnv::FnvHashMap;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
+use virtual_fs::VirtualFile;
 use virtual_mio::{InterestHandler, InterestType};
 use virtual_net::net_error_into_io_err;
 use wasmer_wasix_types::wasi::{
@@ -462,6 +465,44 @@ fn prime_immediate_writable_if_applicable(
     }
 }
 
+fn prime_immediate_readable_if_applicable(
+    event: &EpollFd,
+    fd_guard: &InodeValFilePollGuard,
+    epoll_state: &Arc<EpollState>,
+    sub_state: &Arc<EpollSubState>,
+) {
+    if !event.events().contains(EpollType::EPOLLIN) {
+        return;
+    }
+
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let readable_now = match &fd_guard.mode {
+        InodeValFilePollGuardMode::DuplexPipe { pipe } => {
+            let mut guard = pipe.write().unwrap();
+            let pipe = Pin::new(guard.as_mut());
+            matches!(pipe.poll_read_ready(&mut cx), Poll::Ready(Ok(n)) if n > 0)
+        }
+        InodeValFilePollGuardMode::PipeRx { rx } => {
+            let mut guard = rx.write().unwrap();
+            let rx = Pin::new(guard.as_mut());
+            matches!(rx.poll_read_ready(&mut cx), Poll::Ready(Ok(n)) if n > 0)
+        }
+        _ => false,
+    };
+
+    if !readable_now {
+        return;
+    }
+
+    sub_state
+        .pending_bits
+        .fetch_or(READABLE_BIT, Ordering::AcqRel);
+    if sub_state.mark_enqueued() {
+        epoll_state.enqueue_ready(event.fd(), sub_state.generation());
+    }
+}
+
 /// Re-enqueues a subscription if new pending bits arrived during/after consumer drain.
 fn repair_ready_queue_after_drain(
     epoll_state: &Arc<EpollState>,
@@ -642,6 +683,7 @@ pub(crate) fn register_epoll_handler(
         }
     }
 
+    prime_immediate_readable_if_applicable(event, &fd_guard, &epoll_state, &sub_state);
     prime_immediate_writable_if_applicable(event, &fd_guard, &epoll_state, &sub_state);
 
     Ok(Some(EpollJoinGuard::new(fd_guard)))
@@ -660,7 +702,10 @@ pub(crate) fn epoll_empty_dequeue_entry() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::RwLock;
+    use std::{
+        io::{Read, Write},
+        sync::RwLock,
+    };
     use virtual_fs::Pipe;
 
     fn test_epoll_event_ctl(fd: WasiFd) -> EpollEventCtl {
@@ -905,6 +950,45 @@ mod tests {
         assert!(sub.enqueued.load(Ordering::Acquire));
         let queued = epoll_state.ready.lock().unwrap().pop_front().unwrap();
         assert_eq!(queued.fd, 44);
+    }
+
+    #[test]
+    fn prime_immediate_readable_catches_prequeued_duplex_pipe_data() {
+        let (mut parent_end, mut child_end) = Pipe::channel();
+        child_end.write_all(b"online").unwrap();
+
+        let fd = 14;
+        let event = EpollFd::new(EpollType::EPOLLIN, 0, fd, 0, 0);
+        let epoll_state = Arc::new(EpollState::new());
+        let sub_state = test_sub_state(fd, 1);
+        epoll_state.insert_subscription(fd, sub_state.clone());
+        let fd_guard = InodeValFilePollGuard {
+            fd,
+            peb: PollEventBuilder::new().add(PollEvent::PollIn).build(),
+            subscription: Subscription {
+                userdata: 0,
+                type_: Eventtype::FdRead,
+                data: SubscriptionUnion {
+                    fd_readwrite: SubscriptionFsReadwrite {
+                        file_descriptor: fd,
+                    },
+                },
+            },
+            mode: InodeValFilePollGuardMode::DuplexPipe {
+                pipe: Arc::new(RwLock::new(Box::new(parent_end.clone()))),
+            },
+        };
+
+        prime_immediate_readable_if_applicable(&event, &fd_guard, &epoll_state, &sub_state);
+
+        let events = drain_ready_events(&epoll_state, 1);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0.fd(), fd);
+        assert_eq!(events[0].1, EpollType::EPOLLIN);
+
+        let mut buf = [0; 6];
+        assert_eq!(parent_end.read(&mut buf).unwrap(), 6);
+        assert_eq!(&buf, b"online");
     }
 
     #[test]

--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -220,15 +220,20 @@ fn path_open_internal_with_symlink_depth(
     let state = env.state.deref();
     let inodes = &state.inodes;
     let follow_symlinks = dirflags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0;
-    let effective_dirfd = if path.starts_with('/') {
+    let is_absolute_path = path.starts_with('/');
+    let effective_dirfd = if is_absolute_path {
         VIRTUAL_ROOT_FD
     } else {
         dirfd
     };
     let path_arg = std::path::PathBuf::from(path);
-    let working_dir = match state.fs.get_fd(effective_dirfd) {
-        Ok(fd) => fd,
-        Err(err) => return Ok(Err(err)),
+    let working_dir = if is_absolute_path {
+        WasiFs::virtual_root_fd(state.fs.root_inode.clone())
+    } else {
+        match state.fs.get_fd(effective_dirfd) {
+            Ok(fd) => fd,
+            Err(err) => return Ok(Err(err)),
+        }
     };
     let maybe_inode = state
         .fs

--- a/lib/wasix/src/syscalls/wasix/sock_pair.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_pair.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use virtual_fs::Pipe;
 
 use super::*;
@@ -79,21 +80,24 @@ pub(crate) fn sock_pair_internal(
     with_fd1: Option<WasiFd>,
     with_fd2: Option<WasiFd>,
 ) -> Result<(WasiFd, WasiFd), Errno> {
+    static NEXT_SOCKETPAIR_ID: AtomicU64 = AtomicU64::new(0);
+
     let env = ctx.data();
     let (memory, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
     let (end1, end2) = Pipe::channel();
+    let pair_id = NEXT_SOCKETPAIR_ID.fetch_add(1, Ordering::Relaxed);
 
     let inode1 = state.fs.create_inode_with_default_stat(
         inodes,
         Kind::DuplexPipe { pipe: end1 },
         false,
-        "socketpair".into(),
+        format!("socketpair:{pair_id}:0").into(),
     );
     let inode2 = state.fs.create_inode_with_default_stat(
         inodes,
         Kind::DuplexPipe { pipe: end2 },
         false,
-        "socketpair".into(),
+        format!("socketpair:{pair_id}:1").into(),
     );
 
     let rights = Rights::all_socket();


### PR DESCRIPTION
## Summary

Fixes two WASIX runtime issues that blocked Node/EdgeJS-style child IPC over `socketpair()`:

- allows child-process fd actions to place the IPC channel on fd `3` without colliding with the virtual root/preopen fd;
- fixes `DuplexPipe` readiness delivery so epoll/poll can observe already-queued socketpair data.

## Motivation

Node/libuv cluster and child-process IPC expect the child IPC channel to be available on fd `3`. In WASIX, fd `3` can also be occupied by the virtual root/preopen entry, so spawn fd actions that duplicate the IPC socketpair endpoint onto fd `3` could fail or leave path resolution in a bad state.

After the fd setup was fixed, the child could write the IPC message, but the parent could still miss it if the data was already queued before epoll registered its interest handler. That left the parent waiting even though the `DuplexPipe` had readable bytes.

Together these issues prevented cluster/diagnostics-channel IPC from making progress.

## Changes

- Relocate a displaced preopen fd when `dup2_at(src, dst)` targets that fd, instead of refusing the operation.
- Make the virtual root fd available internally so absolute path opens can resolve from the root inode even when the virtual root is not present at its usual fd slot.
- Prime EPOLLIN readiness for `DuplexPipe` and `PipeRx` when registering epoll interest if data is already readable.
- Give socketpair-backed `DuplexPipe` inodes unique names to make debugging and tracing endpoint ownership clearer.
- Add unit coverage for prequeued `DuplexPipe` data being visible through epoll readiness.

## Context

This was found while debugging EdgeJS/QuickJS WASIX Node tests. The failing path was:

```text
sock_pair_internal()
  -> Kind::DuplexPipe

proc_spawn2 fd actions
  -> dup2 IPC child endpoint onto fd 3

child writes IPC payload on fd 3
parent waits for readable event on the other endpoint