### PR TITLE
fix(virtual-fs): remove anyhow from offloaded file test

### DIFF
--- a/lib/virtual-fs/src/mem_fs/offloaded_file.rs
+++ b/lib/virtual-fs/src/mem_fs/offloaded_file.rs
@@ -394,10 +394,11 @@ impl OffloadedFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
 
     #[test]
     #[tracing_test::traced_test]
-    pub fn test_offload_file() -> anyhow::Result<()> {
+    pub fn test_offload_file() -> io::Result<()> {
         let buffer = OwnedBuffer::from_bytes(std::iter::repeat_n(12u8, 100).collect::<Vec<_>>());
         let test_data2 = buffer.clone();
 


### PR DESCRIPTION
# Description

Small test-only fix in `virtual-fs`.

`mem_fs::offloaded_file::tests::test_offload_file` returned `anyhow::Result<()>`, but `anyhow` is optional and not enabled for `--no-default-features --features host-fs`. So a real host-fs test build just falls over.

Swapped it to `std::io::Result<()>`. Same test behavior, no runtime change, just removes that accidental feature tie-in

Repro:
`cargo test -p virtual-fs --no-default-features --features host-fs test_remove_file -- --nocapture`

Before this PR it fails with:
`error[E0433]: failed to resolve: use of unresolved module or unlinked crate anyhow`

After this PR that command passes, and `cargo test -p virtual-fs --no-default-features --features host-fs test_offload_file -- --nocapture` still passes too.
