### PR TITLE
chore: address cargo warnings + adjust .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,18 @@
 {
     "rust-analyzer.cargo.features": [
-        "llvm",
-        "cranelift",
-        "singlepass",
-        "v8",
-        "wasmer-artifact-create",
-        "wasmer-artifact-load",
+        "wasmer-workspace/llvm",
+        "wasmer-workspace/cranelift",
+        "wasmer-workspace/singlepass",
+        "wasmer-workspace/v8",
+        "wasmer-workspace/wasmer-artifact-create",
+        "wasmer-workspace/wasmer-artifact-load",
+        "wasmer/llvm",
+        "wasmer/cranelift",
+        "wasmer/singlepass",
         "wasmer/experimental-async",
         "wasmer/experimental-host-interrupt",
+        "wasmer-bin-fuzz/llvm",
+        "wasmer-bin-fuzz/cranelift",
+        "wasmer-bin-fuzz/singlepass"
     ],
 }

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -346,7 +346,7 @@ impl BinaryPackage {
 mod tests {
     use sha2::Digest;
     use tempfile::TempDir;
-    use virtual_fs::{AsyncReadExt, FileSystem as _};
+    use virtual_fs::AsyncReadExt;
     use wasmer_package::utils::from_disk;
 
     use crate::{

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1273,7 +1273,7 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                 for file_system in config
                     .file_systems
                     .as_ref()
-                    .unwrap_or_else(|| &default_file_systems)
+                    .unwrap_or(&default_file_systems)
                 {
                     for engine in &supported_engines {
                         // In general, the WASIX tests expect support for more advanced WebAssembly extensions (like exception handling),
@@ -1303,8 +1303,8 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
                         for sysroot in TESTED_LIBC_VERSIONS {
                             // For performance reasons, run the wasix-libc compatibility tests
                             // only with the Cranelift compiler.
-                            if (sysroot.is_some()
-                                && (*engine != Engine::Cranelift || cfg!(target_os = "windows")))
+                            if sysroot.is_some()
+                                && (*engine != Engine::Cranelift || cfg!(target_os = "windows"))
                             {
                                 continue;
                             }

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1238,7 +1238,6 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         .filter_map(Result::ok)
         .filter(|e| e.path() != tests_dir)
         .filter(|e| e.path().strip_prefix(&tests_build_root).is_err())
-        // Skip temporary helper directories (like 'a', 'b', etc.).
         .filter(|e| e.file_type().is_dir())
         .filter(|e| has_primary_source_file(e.path()))
     {


### PR DESCRIPTION
The `settings.json` allows editing `lib/wasix/tests/wasm_tests/mod.rs` without Rust Analyzer complaining about invalid features.