### PR TITLE
fix(wasix): Child exit code race on cleanup

### DIFF
--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1305,11 +1305,11 @@ impl WasiEnv {
                         }
                     }
 
-                    // Now send a signal that the thread is terminated
-                    process.signal_process(Signal::Sigquit);
-
-                    // Terminate the process
+                    // Record the real exit code before broadcasting Sigquit.
+                    // Otherwise a pending Sigquit can win the status race and
+                    // make waiters observe a successful exit.
                     process.terminate(process_exit_code);
+                    process.signal_process(Signal::Sigquit);
                 }
             })
         } else {

--- a/lib/wasix/tests/wasm_tests/process_tests/spawn-exec-nonzero-exit-loop/build.sh
+++ b/lib/wasix/tests/wasm_tests/process_tests/spawn-exec-nonzero-exit-loop/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
+##CurrentDirectory: /home
+##MappedDirectory: .:/home
+##ExpectedStdout: spawn-exec-nonzero-exit-loop passed
+set -euo pipefail
+
+case "${WASMER_BACKEND}" in
+  v8)
+    # V8 keeps more per-process state alive; lower spawn pressure to stay within CI memory.
+    CHILDREN_PER_ROUND=4
+    ROUNDS=64
+    ;;
+  *)
+    CHILDREN_PER_ROUND=8
+    ROUNDS=250
+    ;;
+esac
+
+"$CC" -DCHILDREN_PER_ROUND="$CHILDREN_PER_ROUND" -DROUNDS="$ROUNDS" main.c -o main
+cp main main.wasm

--- a/lib/wasix/tests/wasm_tests/process_tests/spawn-exec-nonzero-exit-loop/main.c
+++ b/lib/wasix/tests/wasm_tests/process_tests/spawn-exec-nonzero-exit-loop/main.c
@@ -1,0 +1,61 @@
+//#ExpectedStdout: spawn-exec-nonzero-exit-loop passed
+
+#include <assert.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef ROUNDS
+#error "ROUNDS must be defined by build.sh"
+#endif
+
+#ifndef CHILDREN_PER_ROUND
+#error "CHILDREN_PER_ROUND must be defined by build.sh"
+#endif
+
+static void spawn_launcher(pid_t* pid) {
+  posix_spawn_file_actions_t actions;
+  posix_spawnattr_t attr;
+  char* argv[] = {"main", "launcher", NULL};
+  char* envp[] = {NULL};
+
+  assert(posix_spawn_file_actions_init(&actions) == 0);
+  assert(posix_spawnattr_init(&attr) == 0);
+  assert(posix_spawn(pid, "./main", &actions, &attr, argv, envp) == 0);
+  assert(posix_spawn_file_actions_destroy(&actions) == 0);
+  assert(posix_spawnattr_destroy(&attr) == 0);
+}
+
+int main(int argc, char** argv) {
+  if (argc == 2 && strcmp(argv[1], "leaf") == 0) {
+    return 1;
+  }
+
+  if (argc == 2 && strcmp(argv[1], "launcher") == 0) {
+    execl("./main.wasm", "main.wasm", "leaf", NULL);
+    return 127;
+  }
+
+  for (int round = 0; round < ROUNDS; ++round) {
+    pid_t pids[CHILDREN_PER_ROUND];
+
+    for (int slot = 0; slot < CHILDREN_PER_ROUND; ++slot) {
+      spawn_launcher(&pids[slot]);
+    }
+
+    for (int slot = 0; slot < CHILDREN_PER_ROUND; ++slot) {
+      int status = 0;
+      assert(waitpid(pids[slot], &status, 0) == pids[slot]);
+      if (!WIFEXITED(status) || WEXITSTATUS(status) != 1) {
+        printf("round %d slot %d: expected exit 1, got %d\n", round, slot,
+               WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+        return 1;
+      }
+    }
+  }
+
+  puts("spawn-exec-nonzero-exit-loop passed");
+  return 0;
+}


### PR DESCRIPTION
Wasix could sometimes report a spawned child as exiting with 0 even when the child actually exited nonzero. The root cause was a cleanup race: `Sigquit` was broadcast before the real process exit code was recorded, and because task status is effectively first-write-wins, waiters could observe the synthetic success status instead of the real child result.

The fix is to record the real exit code first and only then broadcast `Sigquit`. This keeps the actual child status authoritative and prevents `waitpid() / join` callers from seeing a false successful exit.

That resolves our ongoing issue with `wp core is-installed` returning 0 exit code sometimes, even when DB doesn't exist