### PR TITLE
fix(WASIX): fix flakiness of `poll_oneoff`

### DIFF
--- a/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
+++ b/lib/wasix/src/syscalls/wasi/poll_oneoff.rs
@@ -413,6 +413,7 @@ where
     // Build the trigger using the timeout
     let trigger = async move {
         tokio::select! {
+            biased;
             res = batch => res,
             _ = timeout => Err(Errno::Timedout)
         }


### PR DESCRIPTION
The test calls select `select` with 0 timeout and so both arms of the `select` are typically available to succeed.

Issue: #6694