### PR TITLE
CI: skip linux-musl for PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -567,6 +567,8 @@ jobs:
       matrix:
         skip_macos:
           - ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'macos') }}
+        skip_musl:
+          - ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'musl') }}
         stage:
           - description: "All tests"
             make: "test-all"
@@ -610,6 +612,9 @@ jobs:
           - skip_macos: true
             metadata:
               build: macos-arm
+          - skip_musl: true
+            metadata:
+              build: linux-musl
     container:
       image: ${{ matrix.metadata.container }}
       volumes:


### PR DESCRIPTION
With the recent extension of WASIX tests, the CI job can easily take almost one hour (compared to 30 minutes for linux-x64), so it seems the runners are really slow.