### PR TITLE
docs: fix stale build instructions for Cranelift and LLVM

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -87,8 +87,8 @@ make build-wasmer
 
 **Note**: you should see `cranelift` appear in the `Enabled Compilers: ...` message in the console.
 
-You may disable the Cranelift backend with the `ENABLE_SINGLEPASS=0` environment
-variable, and force its enabling with `ENABLE_SINGLEPASS=1`.
+You may disable the Cranelift backend with the `ENABLE_CRANELIFT=0` environment
+variable, and force its enabling with `ENABLE_CRANELIFT=1`.
 
 ### LLVM Compiler
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please use the issue template and provide a failing example if possible to help 
 
 ## Pull Requests
 
-For large changes, please try reaching communicating with the Wasmer maintainers via GitHub Issues or Spectrum Chat to ensure we can accept the change once it is ready.
+For large changes, please try reaching out to the Wasmer maintainers via GitHub Issues or Spectrum Chat to ensure we can accept the change once it is ready.
 
 We recommend trying the following commands before sending a pull request to ensure code quality:
 
@@ -24,5 +24,5 @@ A comprehensive CI test suite will be run by a Wasmer team member after the PR h
 
 `Didn't find usable system-wide LLVM`
 
-Building Wasmer with the LLVM backend requires LLVM 14 or better to be installed
-On debian family you need `sudo apt install llvm14 libclang-common-14-dev libpolly-14-dev`
+Building Wasmer with the LLVM backend requires LLVM 22 to be installed.
+See [Building Wasmer from Source](./BUILD.md#llvm-compiler) for the current installation instructions.


### PR DESCRIPTION
Docs are a bit stale here.

`docs/BUILD.md` says to toggle Cranelift with `ENABLE_SINGLEPASS`, but that flag actually toggles Singlepass.
`docs/CONTRIBUTING.md` also still says LLVM 14, while the repo now expects LLVM 22.

Repro:
1. Run `make -n build-wasmer ENABLE_SINGLEPASS=0`
2. It still prints `Enabled Compilers: cranelift`
3. Run `make -n build-wasmer ENABLE_CRANELIFT=0`
4. Cranelift is gone

Fix:
- use `ENABLE_CRANELIFT` in the Cranelift section
- point CONTRIBUTING to the current LLVM 22 build docs
