### PR TITLE
sanitize volume and atom names in webc_to_package_dir

### DIFF
--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -305,6 +305,7 @@ impl PackageDownload {
             let unpack_cmd = super::unpack::PackageUnpack {
                 out_dir,
                 overwrite: false,
+                allow_escape: false,
                 quiet: self.quiet,
                 package_path: out_path,
                 format: super::unpack::Format::Package,

--- a/lib/cli/src/commands/package/unpack.rs
+++ b/lib/cli/src/commands/package/unpack.rs
@@ -18,6 +18,14 @@ pub struct PackageUnpack {
     #[clap(long)]
     pub overwrite: bool,
 
+    /// Allow volume/atom names from the package to be written outside the
+    /// output directory (e.g. names containing "..").
+    ///
+    /// Only applies to the `package` format. Off by default, in which case an
+    /// escaping name is an error.
+    #[clap(long)]
+    pub allow_escape: bool,
+
     /// Run the unpack command without any output
     #[clap(long)]
     pub quiet: bool,
@@ -81,7 +89,7 @@ impl PackageUnpack {
 
         match self.format {
             Format::Package => {
-                wasmer_package::convert::webc_to_package_dir(&pkg, outdir)
+                wasmer_package::convert::webc_to_package_dir(&pkg, outdir, self.allow_escape)
                     .with_context(|| "could not extract package")?;
             }
             Format::Webc => {
@@ -122,6 +130,7 @@ mod tests {
         let cmd = PackageUnpack {
             out_dir: dir.path().to_owned(),
             overwrite: false,
+            allow_escape: false,
             package_path,
             quiet: true,
             format: Format::Webc,

--- a/lib/package/src/convert/webc_to_package.rs
+++ b/lib/package/src/convert/webc_to_package.rs
@@ -90,7 +90,12 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
                 ))
             })?;
 
-            let volume_path = target_dir.join(mapping.volume_name.trim_start_matches('/'));
+            // The volume name is taken verbatim from the (untrusted) webc and
+            // is used to build an on-disk path. Without normalization a name
+            // such as "../x" would unpack outside target_dir, so route it
+            // through the same sanitizer used elsewhere in the crate.
+            let volume_subpath = webc::sanitize_path(&mapping.volume_name);
+            let volume_path = target_dir.join(volume_subpath.trim_start_matches('/'));
 
             std::fs::create_dir_all(&volume_path).map_err(|err| {
                 ConversionError::with_cause(
@@ -139,7 +144,10 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
             )
         })?;
         for (atom_name, data) in atoms {
-            let atom_path = module_dir.join(&atom_name);
+            // Atom names also come from the container, so sanitize before
+            // joining to keep the write inside module_dir.
+            let atom_subpath = webc::sanitize_path(&atom_name);
+            let atom_path = module_dir.join(atom_subpath.trim_start_matches('/'));
 
             std::fs::write(&atom_path, &data).map_err(|err| {
                 ConversionError::with_cause(
@@ -229,6 +237,73 @@ mod tests {
     use crate::{package::Package, utils::from_bytes};
 
     use super::*;
+
+    // A hostile webc can name a volume "../something". Extracting it must not
+    // escape the requested output directory.
+    #[test]
+    fn webc_to_package_dir_contains_volume_name_traversal() {
+        use std::collections::BTreeMap;
+
+        use webc::{
+            PathSegment,
+            metadata::{
+                Manifest,
+                annotations::{FileSystemMapping, FileSystemMappings},
+            },
+            v3::{
+                ChecksumAlgorithm, SignatureAlgorithm, Timestamps,
+                write::{DirEntry, Directory, FileEntry, Writer},
+            },
+        };
+
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path();
+        // The caller creates the output directory before invoking the converter.
+        let target_dir = root.join("out");
+        create_dir_all(&target_dir).unwrap();
+
+        let escaping_name = "../escaped";
+
+        let mut manifest = Manifest::default();
+        let mappings = FileSystemMappings(vec![FileSystemMapping {
+            from: None,
+            volume_name: escaping_name.to_string(),
+            host_path: None,
+            mount_path: "/data".to_string(),
+        }]);
+        manifest.package.insert(
+            FileSystemMappings::KEY.to_string(),
+            ciborium::Value::serialized(&mappings).unwrap(),
+        );
+
+        let mut children: BTreeMap<PathSegment, DirEntry> = BTreeMap::new();
+        children.insert(
+            "secret".parse().unwrap(),
+            DirEntry::File(FileEntry::owned(b"PWNED".to_vec(), Timestamps::default())),
+        );
+        let volume = Directory::new(children, Timestamps::default());
+
+        let mut writer = Writer::new(ChecksumAlgorithm::Sha256)
+            .write_manifest(&manifest)
+            .unwrap()
+            .write_atoms(BTreeMap::new())
+            .unwrap();
+        writer.write_volume(escaping_name, volume).unwrap();
+        let bytes = writer.finish(SignatureAlgorithm::None).unwrap();
+
+        let container = from_bytes(bytes).unwrap();
+
+        webc_to_package_dir(&container, &target_dir).unwrap();
+
+        // The volume contents must stay under target_dir, never in a sibling.
+        let escaped = root.join("escaped").join("secret");
+        assert!(
+            !escaped.exists(),
+            "volume escaped the output directory to {}",
+            escaped.display()
+        );
+        assert!(target_dir.join("escaped").join("secret").exists());
+    }
 
     // Build a webc from a package directory, and then restore the directory
     // from the webc.

--- a/lib/package/src/convert/webc_to_package.rs
+++ b/lib/package/src/convert/webc_to_package.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Component, Path};
 
 use wasmer_config::package::ModuleReference;
 
@@ -6,9 +6,40 @@ use webc::Container;
 
 use super::ConversionError;
 
+/// Returns true if interpreting `name` as a path relative to a root directory
+/// would resolve to a location outside of that root (i.e. it contains enough
+/// `..` components to climb above the root).
+fn escapes_root(name: &str) -> bool {
+    let mut depth: i32 = 0;
+    for component in Path::new(name).components() {
+        match component {
+            Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    return true;
+                }
+            }
+            Component::Normal(_) => depth += 1,
+            // RootDir / CurDir / Prefix don't change the depth.
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Convert a webc image into a directory with a wasmer.toml file that can
 /// be used for generating a new package.
-pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), ConversionError> {
+///
+/// Volume and atom names are taken verbatim from the (untrusted) webc. If one
+/// of them would resolve outside `target_dir` (for example a volume named
+/// `../x`), the conversion fails unless `allow_escape` is set. The names are
+/// otherwise written as-is so that the result stays consistent with the
+/// generated wasmer.toml.
+pub fn webc_to_package_dir(
+    webc: &Container,
+    target_dir: &Path,
+    allow_escape: bool,
+) -> Result<(), ConversionError> {
     let mut pkg_manifest = wasmer_config::package::Manifest::new_empty();
 
     let manifest = webc.manifest();
@@ -90,12 +121,14 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
                 ))
             })?;
 
-            // The volume name is taken verbatim from the (untrusted) webc and
-            // is used to build an on-disk path. Without normalization a name
-            // such as "../x" would unpack outside target_dir, so route it
-            // through the same sanitizer used elsewhere in the crate.
-            let volume_subpath = webc::sanitize_path(&mapping.volume_name);
-            let volume_path = target_dir.join(volume_subpath.trim_start_matches('/'));
+            if !allow_escape && escapes_root(&mapping.volume_name) {
+                return Err(ConversionError::msg(format!(
+                    "volume name '{}' would extract outside the output directory; \
+                     pass --allow-escape to allow this",
+                    mapping.volume_name
+                )));
+            }
+            let volume_path = target_dir.join(mapping.volume_name.trim_start_matches('/'));
 
             std::fs::create_dir_all(&volume_path).map_err(|err| {
                 ConversionError::with_cause(
@@ -144,10 +177,13 @@ pub fn webc_to_package_dir(webc: &Container, target_dir: &Path) -> Result<(), Co
             )
         })?;
         for (atom_name, data) in atoms {
-            // Atom names also come from the container, so sanitize before
-            // joining to keep the write inside module_dir.
-            let atom_subpath = webc::sanitize_path(&atom_name);
-            let atom_path = module_dir.join(atom_subpath.trim_start_matches('/'));
+            if !allow_escape && escapes_root(&atom_name) {
+                return Err(ConversionError::msg(format!(
+                    "atom name '{atom_name}' would be written outside the output directory; \
+                     pass --allow-escape to allow this"
+                )));
+            }
+            let atom_path = module_dir.join(atom_name.trim_start_matches('/'));
 
             std::fs::write(&atom_path, &data).map_err(|err| {
                 ConversionError::with_cause(
@@ -238,10 +274,11 @@ mod tests {
 
     use super::*;
 
-    // A hostile webc can name a volume "../something". Extracting it must not
-    // escape the requested output directory.
+    // A hostile webc can name a volume "../something". By default extracting it
+    // must fail rather than silently write outside the output directory, but the
+    // escape can be opted into explicitly.
     #[test]
-    fn webc_to_package_dir_contains_volume_name_traversal() {
+    fn webc_to_package_dir_rejects_volume_name_traversal() {
         use std::collections::BTreeMap;
 
         use webc::{
@@ -256,53 +293,67 @@ mod tests {
             },
         };
 
-        let tmpdir = tempfile::tempdir().unwrap();
-        let root = tmpdir.path();
-        // The caller creates the output directory before invoking the converter.
-        let target_dir = root.join("out");
-        create_dir_all(&target_dir).unwrap();
-
         let escaping_name = "../escaped";
 
-        let mut manifest = Manifest::default();
-        let mappings = FileSystemMappings(vec![FileSystemMapping {
-            from: None,
-            volume_name: escaping_name.to_string(),
-            host_path: None,
-            mount_path: "/data".to_string(),
-        }]);
-        manifest.package.insert(
-            FileSystemMappings::KEY.to_string(),
-            ciborium::Value::serialized(&mappings).unwrap(),
-        );
+        let build_container = || {
+            let mut manifest = Manifest::default();
+            let mappings = FileSystemMappings(vec![FileSystemMapping {
+                from: None,
+                volume_name: escaping_name.to_string(),
+                host_path: None,
+                mount_path: "/data".to_string(),
+            }]);
+            manifest.package.insert(
+                FileSystemMappings::KEY.to_string(),
+                ciborium::Value::serialized(&mappings).unwrap(),
+            );
 
-        let mut children: BTreeMap<PathSegment, DirEntry> = BTreeMap::new();
-        children.insert(
-            "secret".parse().unwrap(),
-            DirEntry::File(FileEntry::owned(b"PWNED".to_vec(), Timestamps::default())),
-        );
-        let volume = Directory::new(children, Timestamps::default());
+            let mut children: BTreeMap<PathSegment, DirEntry> = BTreeMap::new();
+            children.insert(
+                "secret".parse().unwrap(),
+                DirEntry::File(FileEntry::owned(b"PWNED".to_vec(), Timestamps::default())),
+            );
+            let volume = Directory::new(children, Timestamps::default());
 
-        let mut writer = Writer::new(ChecksumAlgorithm::Sha256)
-            .write_manifest(&manifest)
-            .unwrap()
-            .write_atoms(BTreeMap::new())
-            .unwrap();
-        writer.write_volume(escaping_name, volume).unwrap();
-        let bytes = writer.finish(SignatureAlgorithm::None).unwrap();
+            let mut writer = Writer::new(ChecksumAlgorithm::Sha256)
+                .write_manifest(&manifest)
+                .unwrap()
+                .write_atoms(BTreeMap::new())
+                .unwrap();
+            writer.write_volume(escaping_name, volume).unwrap();
+            let bytes = writer.finish(SignatureAlgorithm::None).unwrap();
+            from_bytes(bytes).unwrap()
+        };
 
-        let container = from_bytes(bytes).unwrap();
+        // Default: the escaping volume is rejected and nothing is written to a
+        // sibling of the output directory.
+        {
+            let tmpdir = tempfile::tempdir().unwrap();
+            let root = tmpdir.path();
+            let target_dir = root.join("out");
+            create_dir_all(&target_dir).unwrap();
 
-        webc_to_package_dir(&container, &target_dir).unwrap();
+            let err = webc_to_package_dir(&build_container(), &target_dir, false).unwrap_err();
+            assert!(
+                err.to_string().contains("output directory"),
+                "unexpected error: {err}"
+            );
+            assert!(
+                !root.join("escaped").join("secret").exists(),
+                "volume escaped the output directory"
+            );
+        }
 
-        // The volume contents must stay under target_dir, never in a sibling.
-        let escaped = root.join("escaped").join("secret");
-        assert!(
-            !escaped.exists(),
-            "volume escaped the output directory to {}",
-            escaped.display()
-        );
-        assert!(target_dir.join("escaped").join("secret").exists());
+        // With allow_escape the original (escaping) behavior is preserved.
+        {
+            let tmpdir = tempfile::tempdir().unwrap();
+            let root = tmpdir.path();
+            let target_dir = root.join("out");
+            create_dir_all(&target_dir).unwrap();
+
+            webc_to_package_dir(&build_container(), &target_dir, true).unwrap();
+            assert!(root.join("escaped").join("secret").exists());
+        }
     }
 
     // Build a webc from a package directory, and then restore the directory
@@ -359,7 +410,7 @@ main-args = ["/mounted/script.py"]
         };
 
         let dir_output = dir.join("output");
-        webc_to_package_dir(&webc, &dir_output).unwrap();
+        webc_to_package_dir(&webc, &dir_output, false).unwrap();
 
         assert_eq!(
             std::fs::read_to_string(dir_output.join("public/index.html")).unwrap(),


### PR DESCRIPTION
# Description

1. `webc_to_package_dir` builds the on-disk destination for each volume as `target_dir.join(mapping.volume_name.trim_start_matches('/'))`, and for each atom as `module_dir.join(atom_name)`. Both names come straight from the (untrusted) webc, and `trim_start_matches('/')` only removes a leading slash, not `..`.
2. A package whose filesystem annotation names a volume `../escaped` then makes `volume.unpack` write under the parent of `target_dir`, so `wasmer package unpack` of a hostile package can drop files outside the chosen output directory.
3. Names are written verbatim (so unpack stays consistent with the generated wasmer.toml and remains round-trippable), but before joining we now check whether a volume or atom name would resolve outside the output directory. If it would and the new `--allow-escape` flag is not set, the conversion errors out with a hint to use the flag; with the flag set the original behavior is preserved.

Added a regression test that unpacks a webc whose volume is named `../escaped` and checks that the default rejects it (writing nothing to a sibling directory) while `allow_escape` lets it through.