### PR TITLE
 feat(cli): add package show 

### DIFF
--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1717,6 +1717,31 @@ pub async fn get_package(
         .map(|x| x.get_package)
 }
 
+/// Retrieve the published version numbers of a package, if it exists.
+///
+/// Returns `None` when the package does not exist in the registry, and an
+/// (possibly empty) list of version strings otherwise.
+pub async fn get_package_version_numbers(
+    client: &WasmerClient,
+    name: String,
+) -> Result<Option<Vec<String>>, anyhow::Error> {
+    let package = client
+        .run_graphql_strict(types::GetPackageVersionNumbers::build(
+            types::GetPackageVars { name },
+        ))
+        .await?
+        .get_package;
+
+    Ok(package.map(|p| {
+        p.versions
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|v| v.version)
+            .collect()
+    }))
+}
+
 /// Retrieve a package version by its name.
 pub async fn get_package_version(
     client: &WasmerClient,

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -200,6 +200,10 @@ mod queries {
         pub id: cynic::Id,
         pub version: String,
         pub created_at: DateTime,
+        pub description: String,
+        pub license: Option<String>,
+        pub homepage: Option<String>,
+        pub repository: Option<String>,
         pub pirita_manifest: Option<JSONString>,
         pub package: Package,
 

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -438,6 +438,25 @@ mod queries {
         pub get_package: Option<Package>,
     }
 
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", variables = "GetPackageVars")]
+    pub struct GetPackageVersionNumbers {
+        #[arguments(name: $name)]
+        pub get_package: Option<PackageVersionNumbers>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Package")]
+    pub struct PackageVersionNumbers {
+        pub versions: Option<Vec<Option<PackageVersionNumber>>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "PackageVersion")]
+    pub struct PackageVersionNumber {
+        pub version: String,
+    }
+
     #[derive(cynic::QueryVariables, Debug)]
     pub struct GetPackageVersionVars {
         pub name: String,

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -199,6 +199,7 @@ impl WasmerCmd {
                 Package::Publish(cmd) => cmd.run().map(|_| ()),
                 Package::Unpack(cmd) => cmd.execute(),
                 Package::Search(cmd) => cmd.run(),
+                Package::Get(cmd) => cmd.run(),
             },
             Some(Cmd::Container(cmd)) => match cmd {
                 crate::commands::Container::Unpack(cmd) => cmd.execute(),

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -248,21 +248,38 @@ pub(super) async fn login_user(
     env.client()
 }
 
-pub(super) fn make_package_url(client: &WasmerClient, pkg: &NamedPackageIdent) -> String {
+/// Resolve a registry's web frontend host from its GraphQL endpoint, falling
+/// back to the endpoint's own domain for custom registries.
+pub(super) fn registry_web_host(client: &WasmerClient) -> String {
     let host = client.graphql_endpoint().domain().unwrap_or("wasmer.io");
 
     // Our special cases..
-    let host = match host {
-        _ if host.contains("wasmer.wtf") => "wasmer.wtf",
-        _ if host.contains("wasmer.io") => "wasmer.io",
-        _ => host,
-    };
+    match host {
+        _ if host.contains("wasmer.wtf") => "wasmer.wtf".to_string(),
+        _ if host.contains("wasmer.io") => "wasmer.io".to_string(),
+        _ => host.to_string(),
+    }
+}
 
-    format!(
-        "https://{host}/{}@{}",
-        pkg.full_name(),
-        pkg.version_or_default().to_string().replace('=', "")
-    )
+/// Build a package's web frontend URL. `version` is rendered verbatim, so pass a
+/// display string like `0.1.3`, not a parsed `VersionReq`.
+pub(super) fn package_web_url(
+    client: &WasmerClient,
+    full_name: &str,
+    version: Option<&str>,
+) -> String {
+    let host = registry_web_host(client);
+    match version {
+        Some(version) => format!("https://{host}/{full_name}@{version}"),
+        None => format!("https://{host}/{full_name}"),
+    }
+}
+
+/// Adapter over [`package_web_url`] for a [`NamedPackageIdent`].
+pub(super) fn package_web_url_for_ident(client: &WasmerClient, pkg: &NamedPackageIdent) -> String {
+    // `*` when no version; an exact requirement renders as `=x.y.z`.
+    let version = pkg.version_or_default().to_string().replace('=', "");
+    package_web_url(client, &pkg.full_name(), Some(&version))
 }
 
 #[cfg(test)]

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -136,7 +136,7 @@ pub(super) async fn upload(
 pub(super) fn get_manifest(path: &Path) -> anyhow::Result<(PathBuf, Manifest)> {
     // Check if the path is a .webc file
     if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("webc") {
-        return Ok((path.to_path_buf(), get_manifest_from_webc(path)?));
+        return Ok((path.to_path_buf(), get_manifest_from_webc_file(path)?));
     }
 
     load_package_manifest(path).and_then(|j| {
@@ -145,14 +145,23 @@ pub(super) fn get_manifest(path: &Path) -> anyhow::Result<(PathBuf, Manifest)> {
 }
 
 /// Load a manifest from a .webc file
-fn get_manifest_from_webc(path: &Path) -> anyhow::Result<Manifest> {
+fn get_manifest_from_webc_file(path: &Path) -> anyhow::Result<Manifest> {
     use wasmer_package::utils::from_disk;
 
     let container = from_disk(path)
         .map_err(|e| anyhow::anyhow!("Failed to load webc file '{}': {}", path.display(), e))?;
 
-    let webc_manifest = container.manifest();
+    manifest_from_webc_metadata(container.manifest())
+}
 
+/// Convert a webc manifest into a [`Manifest`], extracting the package metadata.
+///
+/// Note: only the package metadata (name, version, description, etc.) is
+/// extracted; modules, commands, and filesystem mappings are not, because they
+/// are already baked into the webc and are not needed to describe the package.
+pub(super) fn manifest_from_webc_metadata(
+    webc_manifest: &webc::metadata::Manifest,
+) -> anyhow::Result<Manifest> {
     // Extract package information from the webc manifest
     let mut manifest = Manifest::new_empty();
 

--- a/lib/cli/src/commands/package/get.rs
+++ b/lib/cli/src/commands/package/get.rs
@@ -1,0 +1,260 @@
+use std::path::Path;
+
+use anyhow::{Context, bail};
+use dialoguer::console::style;
+use wasmer_config::package::{Manifest, PackageIdent, PackageSource};
+
+use super::common::{get_manifest, manifest_from_webc_metadata, package_web_url};
+use crate::commands::AsyncCliCommand;
+use crate::config::WasmerEnv;
+
+/// Show basic metadata of a package without unpacking or downloading it.
+///
+/// The package can be a directory containing a `wasmer.toml` file, a `.webc`
+/// file, or a package name from the registry. If no argument is given, the
+/// current directory is used.
+#[derive(clap::Parser, Debug)]
+pub struct PackageGet {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    /// The package to show.
+    ///
+    /// This can be a path to a package directory or a `.webc` file, or the name
+    /// of a package in the registry (e.g. `wasmer/hello@=0.1.0`).
+    #[clap(default_value = ".")]
+    pub package: String,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for PackageGet {
+    type Output = ();
+
+    async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
+        let (manifest, web_url) = self.load_manifest().await?;
+
+        let print_field = |label: &str, value: &str| {
+            println!("{:<13} {value}", style(format!("{label}:")).bold().dim());
+        };
+
+        if let Some(package) = manifest.package.as_ref() {
+            print_field("Name", package.name.as_deref().unwrap_or("<unnamed>"));
+            print_field(
+                "Version",
+                &package
+                    .version
+                    .as_ref()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "<none>".to_string()),
+            );
+
+            if let Some(description) = &package.description {
+                print_field("Description", description);
+            }
+            if let Some(license) = &package.license {
+                print_field("License", license);
+            }
+            if let Some(homepage) = &package.homepage {
+                print_field("Homepage", homepage);
+            }
+            if let Some(repository) = &package.repository {
+                print_field("Repository", repository);
+            }
+            if let Some(entrypoint) = &package.entrypoint {
+                print_field("Entrypoint", entrypoint);
+            }
+            if package.private {
+                print_field("Private", "true");
+            }
+        } else {
+            println!("{}", style("Package has no metadata.").dim());
+        }
+
+        if !manifest.commands.is_empty() {
+            let commands = manifest
+                .commands
+                .iter()
+                .map(|c| c.get_name())
+                .collect::<Vec<_>>()
+                .join(", ");
+            print_field("Commands", &commands);
+        }
+
+        if !manifest.dependencies.is_empty() {
+            print_field("Dependencies", &manifest.dependencies.len().to_string());
+            for (name, version) in &manifest.dependencies {
+                println!("  {name} = {version}");
+            }
+        }
+
+        if let Some(web_url) = web_url {
+            print_field("URL", &web_url);
+        }
+
+        Ok(())
+    }
+}
+
+impl PackageGet {
+    /// Resolve the `package` argument into a [`Manifest`], whether it points to a
+    /// local package or a package in the registry.
+    ///
+    /// The second tuple element is a link to the package's page on the registry
+    /// web frontend, present only when the package was resolved from a named
+    /// registry lookup (local files and hashes have no such page).
+    async fn load_manifest(&self) -> anyhow::Result<(Manifest, Option<String>)> {
+        // A path on disk (directory with a `wasmer.toml`, or a `.webc` file)
+        // takes precedence over registry resolution.
+        let path = Path::new(&self.package);
+        if path.exists() {
+            let (_, manifest) = get_manifest(path)?;
+            return Ok((manifest, None));
+        }
+
+        let source: PackageSource = self.package.parse().with_context(|| {
+            format!(
+                "'{}' is not a file or directory on disk, or a valid package name",
+                self.package
+            )
+        })?;
+
+        match source {
+            PackageSource::Ident(PackageIdent::Named(id)) => {
+                let client = self.env.client_unauthennticated()?;
+
+                let version = id.version_or_default().to_string();
+                let version = if version == "*" {
+                    String::from("latest")
+                } else {
+                    version
+                };
+                let full_name = id.full_name();
+
+                let package = wasmer_backend_api::query::get_package_version(
+                    &client,
+                    full_name.clone(),
+                    version.clone(),
+                )
+                .await?
+                .with_context(|| {
+                    format!(
+                        "could not retrieve package information for package '{}' from registry '{}'",
+                        full_name,
+                        client.graphql_endpoint(),
+                    )
+                })?;
+
+                let json = package
+                    .pirita_manifest
+                    .as_ref()
+                    .context("the registry did not return a manifest for this package")?;
+                let webc_manifest: webc::metadata::Manifest = serde_json::from_str(&json.0)
+                    .context("could not parse the manifest returned by the registry")?;
+                let mut manifest = manifest_from_webc_metadata(&webc_manifest)?;
+
+                // Link to the package's page on the registry web frontend,
+                // using the concrete version the registry resolved for us.
+                let web_url = package_web_url(&client, &full_name, Some(&package.version));
+
+                // Prefer the authoritative metadata reported by the registry.
+                //
+                // `Package::from_manifest` strips name/version/description from
+                // the WAPM annotation when building the webc, so the manifest
+                // reconstructed from `pirita_manifest` is missing them. The
+                // registry exposes these fields directly, so re-inject them.
+                if let Some(pkg) = manifest.package.as_mut() {
+                    pkg.name = Some(full_name);
+                    pkg.version = Some(package.version.parse().with_context(|| {
+                        format!(
+                            "invalid version returned by the registry: '{}'",
+                            package.version
+                        )
+                    })?);
+                    // Take each registry field when present, otherwise keep
+                    // whatever the webc carried (license/homepage/repository
+                    // survive in the WAPM annotation; description does not).
+                    if !package.description.is_empty() {
+                        pkg.description = Some(package.description);
+                    }
+                    if package.license.is_some() {
+                        pkg.license = package.license;
+                    }
+                    if package.homepage.is_some() {
+                        pkg.homepage = package.homepage;
+                    }
+                    if package.repository.is_some() {
+                        pkg.repository = package.repository;
+                    }
+                }
+
+                Ok((manifest, Some(web_url)))
+            }
+            PackageSource::Ident(PackageIdent::Hash(hash)) => {
+                let client = self.env.client_unauthennticated()?;
+
+                let pkg = wasmer_backend_api::query::get_package_release(
+                    &client,
+                    &hash.to_string(),
+                )
+                .await?
+                .with_context(|| {
+                    format!(
+                        "Package with {hash} does not exist in the registry, or is not accessible"
+                    )
+                })?;
+
+                let image = pkg
+                    .webc_v3
+                    .or(pkg.webc)
+                    .context("the registry did not return a WebC image for this package")?;
+                let webc_manifest: webc::metadata::Manifest =
+                    serde_json::from_str(&image.manifest.0)
+                        .context("could not parse the manifest returned by the registry")?;
+
+                Ok((manifest_from_webc_metadata(&webc_manifest)?, None))
+            }
+            PackageSource::Path(p) => {
+                // Local paths will have already short-circuited at the very
+                // start of the command, so we should never get here,
+                // unless the local path is invalid or inaccessible.
+                bail!("no file or directory found at '{p}'")
+            }
+            PackageSource::Url(url) => {
+                bail!("showing a package directly from a URL is not supported: '{url}'")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cmd_package_get_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("wasmer.toml"),
+            r#"
+[package]
+name = "wasmer/test"
+version = "1.2.3"
+description = "A test package"
+license = "MIT"
+"#,
+        )
+        .unwrap();
+
+        let cmd = PackageGet {
+            env: WasmerEnv::new(
+                crate::config::DEFAULT_WASMER_CACHE_DIR.clone(),
+                crate::config::DEFAULT_WASMER_CACHE_DIR.clone(),
+                None,
+                None,
+            ),
+            package: dir.path().to_str().unwrap().to_owned(),
+        };
+
+        cmd.run_async().await.unwrap();
+    }
+}

--- a/lib/cli/src/commands/package/get.rs
+++ b/lib/cli/src/commands/package/get.rs
@@ -2,9 +2,12 @@ use std::path::Path;
 
 use anyhow::{Context, bail};
 use dialoguer::console::style;
+use wasmer_backend_api::WasmerClient;
 use wasmer_config::package::{Manifest, PackageIdent, PackageSource};
 
-use super::common::{get_manifest, manifest_from_webc_metadata, package_web_url};
+use super::common::{
+    get_manifest, manifest_from_webc_metadata, package_web_url, registry_web_host,
+};
 use crate::commands::AsyncCliCommand;
 use crate::config::WasmerEnv;
 
@@ -130,19 +133,27 @@ impl PackageGet {
                 };
                 let full_name = id.full_name();
 
-                let package = wasmer_backend_api::query::get_package_version(
+                let package = match wasmer_backend_api::query::get_package_version(
                     &client,
                     full_name.clone(),
                     version.clone(),
                 )
                 .await?
-                .with_context(|| {
-                    format!(
-                        "could not retrieve package information for package '{}' from registry '{}'",
-                        full_name,
-                        client.graphql_endpoint(),
-                    )
-                })?;
+                {
+                    Some(package) => package,
+                    None => {
+                        // Echo the version the user actually typed rather than
+                        // the semver requirement it parsed into (`4.4.4` would
+                        // otherwise render as `^4.4.4`). `None` means the user
+                        // gave no version (we resolved `latest`).
+                        let requested = (version != "latest").then(|| {
+                            self.package
+                                .rsplit_once('@')
+                                .map_or(version.as_str(), |(_, v)| v)
+                        });
+                        return Err(version_not_found_error(&client, &full_name, requested).await);
+                    }
+                };
 
                 let json = package
                     .pirita_manifest
@@ -224,6 +235,56 @@ impl PackageGet {
             }
         }
     }
+}
+
+/// Build a helpful error for when [`get_package_version`] returns nothing.
+///
+/// If the package exists but the requested version doesn't, the error lists the
+/// versions that are available; otherwise it reports the package as not found.
+///
+/// [`get_package_version`]: wasmer_backend_api::query::get_package_version
+async fn version_not_found_error(
+    client: &WasmerClient,
+    full_name: &str,
+    requested: Option<&str>,
+) -> anyhow::Error {
+    let registry = registry_web_host(client);
+
+    match wasmer_backend_api::query::get_package_version_numbers(client, full_name.to_string())
+        .await
+    {
+        Ok(Some(mut versions)) if !versions.is_empty() => {
+            sort_versions(&mut versions);
+            let available = versions.join(", ");
+            match requested {
+                Some(version) => anyhow::anyhow!(
+                    "package '{full_name}' has no version matching '{version}' in registry '{registry}'.\nAvailable versions: {available}"
+                ),
+                None => anyhow::anyhow!(
+                    "could not resolve the latest version of package '{full_name}' from registry '{registry}'.\nAvailable versions: {available}"
+                ),
+            }
+        }
+        // The package exists but has no published versions, or doesn't exist.
+        Ok(_) => {
+            anyhow::anyhow!("package '{full_name}' was not found in registry '{registry}'")
+        }
+        // Couldn't list versions; fall back to a generic message.
+        Err(_) => anyhow::anyhow!(
+            "could not retrieve package information for package '{full_name}' from registry '{registry}'"
+        ),
+    }
+}
+
+/// Sort version strings ascending, parsing them as semver where possible and
+/// falling back to lexical order for anything that doesn't parse.
+fn sort_versions(versions: &mut [String]) {
+    versions.sort_by(
+        |a, b| match (semver::Version::parse(a), semver::Version::parse(b)) {
+            (Ok(a), Ok(b)) => a.cmp(&b),
+            _ => a.cmp(b),
+        },
+    );
 }
 
 #[cfg(test)]

--- a/lib/cli/src/commands/package/mod.rs
+++ b/lib/cli/src/commands/package/mod.rs
@@ -1,6 +1,7 @@
 mod build;
 mod common;
 mod download;
+mod get;
 pub mod publish;
 mod push;
 mod search;
@@ -24,4 +25,5 @@ pub enum Package {
     Publish(publish::PackagePublish),
     Unpack(unpack::PackageUnpack),
     Search(search::PackageSearch),
+    Get(get::PackageGet),
 }

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -145,7 +145,7 @@ impl AsyncCliCommand for PackagePublish {
 
         match ident {
             PackageIdent::Named(ref n) => {
-                let url = make_package_url(&client, n);
+                let url = package_web_url_for_ident(&client, n);
                 eprintln!("\n{} Package URL: {url}", "𖥔".yellow().bold());
             }
             PackageIdent::Hash(ref h) => {

--- a/lib/cli/src/commands/package/tag.rs
+++ b/lib/cli/src/commands/package/tag.rs
@@ -657,7 +657,7 @@ impl AsyncCliCommand for PackageTag {
 
         match id {
             PackageIdent::Named(ref n) => {
-                let url = make_package_url(&client, n);
+                let url = package_web_url_for_ident(&client, n);
                 eprintln!("{} Package URL: {url}", "𖥔".yellow().bold());
             }
             PackageIdent::Hash(ref h) => {

--- a/tests/integration/cli/tests/package/get.rs
+++ b/tests/integration/cli/tests/package/get.rs
@@ -1,0 +1,22 @@
+use assert_cmd::prelude::OutputAssertExt;
+use predicates::str::contains;
+use wasmer_integration_tests_cli::wasmer_command;
+
+#[test]
+fn package_get_named() {
+    wasmer_command()
+        .arg("package")
+        .arg("get")
+        .arg("wasmer/cli@=0.1.3")
+        .assert()
+        .success()
+        .stdout(contains("Name:"))
+        .stdout(contains("wasmer/cli"))
+        .stdout(contains("Version:"))
+        .stdout(contains("0.1.3"))
+        .stdout(contains(
+            "Description:  CLI platform - a wrapper package with many common tools, useful for interactive environments.",
+        ))
+        .stdout(contains("URL:"))
+        .stdout(contains("https://wasmer.io/wasmer/cli@0.1.3"));
+}

--- a/tests/integration/cli/tests/package/get.rs
+++ b/tests/integration/cli/tests/package/get.rs
@@ -20,3 +20,18 @@ fn package_get_named() {
         .stdout(contains("URL:"))
         .stdout(contains("https://wasmer.io/wasmer/cli@0.1.3"));
 }
+
+// A missing version reports the request as unmatched and lists what's available
+// (`0.1.3` exists permanently, so the assertion stays stable).
+#[test]
+fn package_get_missing_version() {
+    wasmer_command()
+        .arg("package")
+        .arg("get")
+        .arg("wasmer/cli@9999.0.0")
+        .assert()
+        .failure()
+        .stderr(contains("has no version matching"))
+        .stderr(contains("Available versions:"))
+        .stderr(contains("0.1.3"));
+}

--- a/tests/integration/cli/tests/package/get.rs
+++ b/tests/integration/cli/tests/package/get.rs
@@ -1,37 +1,59 @@
-use assert_cmd::prelude::OutputAssertExt;
-use predicates::str::contains;
+use insta::assert_snapshot;
 use wasmer_integration_tests_cli::wasmer_command;
 
 #[test]
 fn package_get_named() {
-    wasmer_command()
+    let output = wasmer_command()
         .arg("package")
         .arg("get")
         .arg("wasmer/cli@=0.1.3")
-        .assert()
-        .success()
-        .stdout(contains("Name:"))
-        .stdout(contains("wasmer/cli"))
-        .stdout(contains("Version:"))
-        .stdout(contains("0.1.3"))
-        .stdout(contains(
-            "Description:  CLI platform - a wrapper package with many common tools, useful for interactive environments.",
-        ))
-        .stdout(contains("URL:"))
-        .stdout(contains("https://wasmer.io/wasmer/cli@0.1.3"));
+        .env("RUST_LOG", "off")
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout));
 }
 
-// A missing version reports the request as unmatched and lists what's available
-// (`0.1.3` exists permanently, so the assertion stays stable).
 #[test]
 fn package_get_missing_version() {
-    wasmer_command()
+    let output = wasmer_command()
         .arg("package")
         .arg("get")
         .arg("wasmer/cli@9999.0.0")
-        .assert()
-        .failure()
-        .stderr(contains("has no version matching"))
-        .stderr(contains("Available versions:"))
-        .stderr(contains("0.1.3"));
+        .env("RUST_LOG", "off")
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The list of available versions is subject to change,
+    // so in order to avoid snapshot churn we mask it out.
+    // As a sanity check however, we always check for a single known one.
+    assert!(
+        stderr.contains("0.1.3"),
+        "expected available versions to include 0.1.3:\n{stderr}"
+    );
+
+    let masked = stderr
+        .lines()
+        .map(|line| {
+            if line.starts_with("Available versions:") {
+                "Available versions: [masked]"
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_snapshot!(masked);
 }

--- a/tests/integration/cli/tests/package/main.rs
+++ b/tests/integration/cli/tests/package/main.rs
@@ -1,4 +1,4 @@
 //! Integration tests for the `wasmer package` subcommands.
 
-mod search;
 mod get;
+mod search;

--- a/tests/integration/cli/tests/package/main.rs
+++ b/tests/integration/cli/tests/package/main.rs
@@ -1,3 +1,4 @@
 //! Integration tests for the `wasmer package` subcommands.
 
 mod search;
+mod get;

--- a/tests/integration/cli/tests/package/snapshots/package__get__package_get_missing_version.snap
+++ b/tests/integration/cli/tests/package/snapshots/package__get__package_get_missing_version.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration/cli/tests/package/get.rs
+expression: masked
+---
+error: package 'wasmer/cli' has no version matching '9999.0.0' in registry 'wasmer.io'.
+Available versions: [masked]

--- a/tests/integration/cli/tests/package/snapshots/package__get__package_get_named.snap
+++ b/tests/integration/cli/tests/package/snapshots/package__get__package_get_named.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration/cli/tests/package/get.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+Name:         wasmer/cli
+Version:      0.1.3
+Description:  CLI platform - a wrapper package with many common tools, useful for interactive environments.
+Entrypoint:   bash
+URL:          https://wasmer.io/wasmer/cli@0.1.3


### PR DESCRIPTION

# Description

Adds a small command to show basic metadata for packages. Works with local paths as well as registry names.

Example:

```
$ wasmer package show wasmer/bash@=1.0.24
Name:         wasmer/bash
Version:      1.0.24
License:      GNU
Entrypoint:   bash
```

Closes #6723