### PR TITLE
fix(wasix-tests): stop parsing exit codes from error strings

### DIFF
--- a/lib/wasix/tests/runner_exit_code.rs
+++ b/lib/wasix/tests/runner_exit_code.rs
@@ -1,0 +1,38 @@
+#[path = "wasm_tests/error.rs"]
+mod error;
+
+use anyhow::{Result, anyhow};
+use wasmer_wasix::{WasiError, WasiRuntimeError, wasmer_wasix_types::wasi::ExitCode};
+
+#[test]
+fn extracts_exit_code_from_wasi_runtime_error_chain() -> Result<()> {
+    let err = anyhow!(WasiRuntimeError::Wasi(WasiError::Exit(ExitCode::from(42))))
+        .context("outer context");
+
+    assert_eq!(error::exit_code_from_error(&err), Some(42));
+    Ok(())
+}
+
+#[test]
+fn extracts_exit_code_from_direct_wasi_error_chain() -> Result<()> {
+    let err = ErrorWrapper::wrap(anyhow!(WasiError::Exit(ExitCode::from(17))));
+
+    assert_eq!(error::exit_code_from_error(&err), Some(17));
+    Ok(())
+}
+
+#[test]
+fn does_not_treat_free_form_messages_as_exit_codes() -> Result<()> {
+    let err = anyhow!("Spawn failed: ExitCode::1").context("outer context");
+
+    assert_eq!(error::exit_code_from_error(&err), None);
+    Ok(())
+}
+
+struct ErrorWrapper;
+
+impl ErrorWrapper {
+    fn wrap(err: anyhow::Error) -> anyhow::Error {
+        err.context("wrapped")
+    }
+}

--- a/lib/wasix/tests/wasm_tests/error.rs
+++ b/lib/wasix/tests/wasm_tests/error.rs
@@ -1,0 +1,16 @@
+use anyhow::Error;
+use wasmer_wasix::{WasiError, WasiRuntimeError};
+
+pub(crate) fn exit_code_from_error(err: &Error) -> Option<i32> {
+    err.chain()
+        .find_map(|cause| {
+            cause
+                .downcast_ref::<WasiRuntimeError>()
+                .and_then(WasiRuntimeError::as_exit_code)
+                .or_else(|| match cause.downcast_ref::<WasiError>() {
+                    Some(WasiError::Exit(code)) => Some(*code),
+                    _ => None,
+                })
+        })
+        .map(|code| code.raw())
+}

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -92,6 +92,7 @@ use wasmer_wasix::virtual_fs::{
     StaticFile, TmpFileSystem, create_dir_all as create_virtual_dir_all, mem_fs,
 };
 
+mod error;
 mod runner;
 
 const TESTED_LIBC_VERSIONS: &[Option<&str>] = &[None, Some("v2026-05-12.1")];

--- a/lib/wasix/tests/wasm_tests/runner.rs
+++ b/lib/wasix/tests/wasm_tests/runner.rs
@@ -15,6 +15,7 @@ use wasmer_wasix::runtime::module_cache::{HashedModuleData, ModuleCache};
 use wasmer_wasix::virtual_fs::{AsyncRead, AsyncSeek, AsyncWrite};
 
 use crate::Engine;
+use crate::error::exit_code_from_error;
 
 static TRACE_SUBSCRIBER_INIT: OnceLock<()> = OnceLock::new();
 static TRACE_CAPTURE_STATE: OnceLock<TraceCaptureState> = OnceLock::new();
@@ -403,20 +404,7 @@ pub(crate) fn run_wasm_with_runner_config(
     // Extract exit code from result
     let exit_code = match result {
         Ok(_) => 0,
-        Err(e) => {
-            // Try to extract exit code from error message
-            let error_msg = e.to_string();
-            if let Some(code_str) = error_msg.split("ExitCode::").nth(1) {
-                if let Some(code) = code_str.split_whitespace().next() {
-                    code.parse::<i32>()
-                        .unwrap_or_else(|_| panic!("exit code cannot be parsed: `{error_msg}`"))
-                } else {
-                    return Err(e);
-                }
-            } else {
-                return Err(e);
-            }
-        }
+        Err(e) => exit_code_from_error(&e).ok_or(e)?,
     };
 
     Ok(WasmRunResult {


### PR DESCRIPTION
# Description

Tiny WASIX test harness fix.

Right now `lib/wasix/tests/wasm_tests/runner.rs` pulls exit codes out of free form error text by looking for `ExitCode::...`.
If some real runner error contains that text, the harness can treat it like a normal process exit. Kinda cursed, but real.

This patch reads typed `WasiError` and `WasiRuntimeError` values from the error chain instead.
Normal exit handling stays the same. Random strings stop getting treated like exits.

This is not some impossible edge tied to quotas or hard limits. Any error message with `ExitCode::N` can hit it, so the boundary is very reachable.

Repro before this patch:
1. Make `run_wasm_with_runner_config` return `anyhow!("Spawn failed: ExitCode::1")`.
2. The harness reports exit code `1` instead of returning the real error.

Checks:
- `cargo test -p wasmer-wasix --test runner_exit_code -- --nocapture`
- `cargo test -p wasmer-wasix --test runners -- --nocapture`
- `cargo build -p wasmer-wasix --tests`

Related recent harness work: #6599, #6531
