### PR TITLE
Last socket error

### DIFF
--- a/.github/ci-constants.env
+++ b/.github/ci-constants.env
@@ -1,3 +1,3 @@
 # Shared CI constants. Loaded into GITHUB_ENV by workflows that need them.
 # Pinned wasix-libc sysroot (wasix-org/wasix-libc release tag).
-WASIX_LIBC_SYSROOT_TAG=v2026-06-09.1
+WASIX_LIBC_SYSROOT_TAG=v2026-06-18.1

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -527,6 +527,7 @@ enum ConnectState {
     Unknown,
     Opened,
     Failed(NetworkError),
+    Reset,
 }
 
 #[derive(Debug)]
@@ -764,7 +765,9 @@ impl VirtualSocket for LocalTcpStream {
         let mut connect_state = self.connect_state.lock().unwrap();
         match *connect_state {
             ConnectState::Opened => return Ok(SocketStatus::Opened),
-            ConnectState::Failed(_) => return Ok(SocketStatus::Failed),
+            ConnectState::Failed(_) | ConnectState::Reset => {
+                return Ok(SocketStatus::Failed);
+            }
             ConnectState::Unknown => {}
         }
 
@@ -798,7 +801,7 @@ impl VirtualSocket for LocalTcpStream {
         let mut connect_state = self.connect_state.lock().unwrap();
         Ok(match *connect_state {
             ConnectState::Failed(err) => {
-                *connect_state = ConnectState::Unknown;
+                *connect_state = ConnectState::Reset;
                 Some(err)
             }
             _ => None,

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -526,7 +526,7 @@ impl VirtualTcpBoundSocket for LocalTcpBoundSocket {
 enum ConnectState {
     Unknown,
     Opened,
-    Failed,
+    Failed(NetworkError),
 }
 
 #[derive(Debug)]
@@ -764,16 +764,15 @@ impl VirtualSocket for LocalTcpStream {
         let mut connect_state = self.connect_state.lock().unwrap();
         match *connect_state {
             ConnectState::Opened => return Ok(SocketStatus::Opened),
-            ConnectState::Failed => return Ok(SocketStatus::Failed),
+            ConnectState::Failed(_) => return Ok(SocketStatus::Failed),
             ConnectState::Unknown => {}
         }
 
-        if self
+        if let Some(err) = self
             .with_sock_ref(|sockref| sockref.take_error())
             .map_err(io_err_into_net_error)?
-            .is_some()
         {
-            *connect_state = ConnectState::Failed;
+            *connect_state = ConnectState::Failed(io_err_into_net_error(err));
             return Ok(SocketStatus::Failed); // connect error on the socket
         }
         match self.stream.peer_addr() {
@@ -788,12 +787,19 @@ impl VirtualSocket for LocalTcpStream {
                 ) {
                     Ok(SocketStatus::Opening) // The connect is still in progress
                 } else {
-                    // TODO: Store the concrete err so we can return it later on
-                    *connect_state = ConnectState::Failed;
+                    *connect_state = ConnectState::Failed(io_err_into_net_error(err));
                     Ok(SocketStatus::Failed) // Any other error means the socket is unusable
                 }
             }
         }
+    }
+
+    fn last_error(&self) -> Result<Option<NetworkError>> {
+        let connect_state = self.connect_state.lock().unwrap();
+        Ok(match *connect_state {
+            ConnectState::Failed(err) => Some(err),
+            _ => None,
+        })
     }
 
     fn set_handler(&mut self, mut handler: Box<dyn InterestHandler + Send + Sync>) -> Result<()> {

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -795,9 +795,12 @@ impl VirtualSocket for LocalTcpStream {
     }
 
     fn last_error(&self) -> Result<Option<NetworkError>> {
-        let connect_state = self.connect_state.lock().unwrap();
+        let mut connect_state = self.connect_state.lock().unwrap();
         Ok(match *connect_state {
-            ConnectState::Failed(err) => Some(err),
+            ConnectState::Failed(err) => {
+                *connect_state = ConnectState::Unknown;
+                Some(err)
+            }
             _ => None,
         })
     }

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -319,7 +319,7 @@ pub trait VirtualSocket: VirtualIoSource + fmt::Debug + Send + Sync + 'static {
     /// Returns the status/state of the socket
     fn status(&self) -> Result<SocketStatus>;
 
-    /// Returns the last socket error when the backend can report one.
+    /// Returns and clears the last socket error when the backend can report one.
     fn last_error(&self) -> Result<Option<NetworkError>> {
         Ok(None)
     }

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -319,6 +319,11 @@ pub trait VirtualSocket: VirtualIoSource + fmt::Debug + Send + Sync + 'static {
     /// Returns the status/state of the socket
     fn status(&self) -> Result<SocketStatus>;
 
+    /// Returns the last socket error when the backend can report one.
+    fn last_error(&self) -> Result<Option<NetworkError>> {
+        Ok(None)
+    }
+
     /// Registers a waker for when this connection is ready to receive
     /// more data. Uses a stack machine which means more than one waker
     /// can be registered

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -849,6 +849,20 @@ impl InodeSocket {
         })
     }
 
+    pub fn last_error(&self) -> Result<Errno, Errno> {
+        self.status()?;
+
+        let inner = self.inner.protected.read().unwrap();
+        match &inner.kind {
+            InodeSocketKind::TcpStream { socket, .. } => socket
+                .last_error()
+                .map_err(net_error_into_wasi_err)
+                .map(|err| err.map(net_error_into_wasi_err).unwrap_or(Errno::Success)),
+            InodeSocketKind::RemoteSocket { is_dead, .. } if *is_dead => Ok(Errno::Pipe),
+            _ => Ok(Errno::Success),
+        }
+    }
+
     pub fn addr_local(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
         Ok(match &inner.kind {

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -858,7 +858,7 @@ impl InodeSocket {
                 .last_error()
                 .map_err(net_error_into_wasi_err)
                 .map(|err| err.map(net_error_into_wasi_err).unwrap_or(Errno::Success)),
-            InodeSocketKind::RemoteSocket { is_dead, .. } if *is_dead => Ok(Errno::Pipe),
+            InodeSocketKind::RemoteSocket { is_dead, .. } if *is_dead => Ok(Errno::Connreset),
             _ => Ok(Errno::Success),
         }
     }

--- a/lib/wasix/src/syscalls/wasix/sock_get_opt_size.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_get_opt_size.rs
@@ -24,6 +24,7 @@ pub fn sock_get_opt_size<M: MemorySize>(
             Sockoption::RecvBufSize => socket.recv_buf_size().map(|a| a as Filesize),
             Sockoption::SendBufSize => socket.send_buf_size().map(|a| a as Filesize),
             Sockoption::Ttl => socket.ttl().map(|a| a as Filesize),
+            Sockoption::LastError => socket.last_error().map(|a| u16::from(a) as Filesize),
             Sockoption::MulticastTtlV4 => {
                 socket.multicast_ttl_v4().map(|a| a as Filesize)
             }

--- a/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
@@ -16,7 +16,7 @@ int main(void) {
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   addr.sin_port = htons(9); /* normally closed discard port */
 
-  connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+  connect(fd, (struct sockaddr*)&addr, sizeof(addr));
 
   struct pollfd pfd = {.fd = fd, .events = POLLOUT};
   poll(&pfd, 1, 1000);

--- a/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
@@ -1,0 +1,36 @@
+//#ExpectedStdout: SO_ERROR: Success
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+
+  struct sockaddr_in addr = {0};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = htons(9); /* normally closed discard port */
+
+  connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+
+  struct pollfd pfd = {.fd = fd, .events = POLLOUT};
+  poll(&pfd, 1, 1000);
+
+  int err = 0;
+  socklen_t errlen = sizeof(err);
+  int res = getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen);
+  close(fd);
+
+  if (!res) {
+    fprintf(stderr, "Cannot get socket error\n");
+    return 1;
+  }
+
+  printf("SO_ERROR: %s\n", strerror(err));
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
@@ -1,3 +1,4 @@
+//#MinimalLibc: v2026-06-18.1
 //#ExpectedStdout: SO_ERROR: Connection refused, Success
 
 #include <arpa/inet.h>

--- a/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
@@ -16,7 +16,14 @@ int main(void) {
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   addr.sin_port = htons(9); /* normally closed discard port */
 
-  connect(fd, (struct sockaddr*)&addr, sizeof(addr));
+  errno = 0;
+  int connect_res = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
+  if (connect_res == 0 ||
+      (errno != EINPROGRESS && errno != EWOULDBLOCK && errno != ENOTCONN)) {
+    fprintf(stderr, "connect did not enter async failure path: %s\n",
+            strerror(errno));
+    return 1;
+  }
 
   struct pollfd pfd = {.fd = fd, .events = POLLOUT};
   poll(&pfd, 1, 1000);

--- a/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/get-last-socket-error/main.c
@@ -1,4 +1,4 @@
-//#ExpectedStdout: SO_ERROR: Success
+//#ExpectedStdout: SO_ERROR: Connection refused, Success
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -24,13 +24,25 @@ int main(void) {
   int err = 0;
   socklen_t errlen = sizeof(err);
   int res = getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen);
-  close(fd);
 
-  if (!res) {
+  if (res) {
+    close(fd);
     fprintf(stderr, "Cannot get socket error\n");
     return 1;
   }
 
-  printf("SO_ERROR: %s\n", strerror(err));
+  int err2 = 0;
+  socklen_t errlen2 = sizeof(err);
+  res = getsockopt(fd, SOL_SOCKET, SO_ERROR, &err2, &errlen2);
+
+  if (res) {
+    close(fd);
+    fprintf(stderr, "Cannot get socket error (2)\n");
+    return 1;
+  }
+
+  close(fd);
+  printf("SO_ERROR: %s, %s\n", strerror(err), strerror(err2));
+
   return 0;
 }


### PR DESCRIPTION
- Added `last_error()` to `VirtualSocket` and its implementations.
- Added `last_error()` to `InodeSocket` delegating to impl of virtual socket
- The `sock_get_opt_size()` calls `InodeSocket::last_error()`, which first calls `LocalTcpStream::status()` that sets `connect_state` including new socket error in it, and then `LocalTcpStream::last_error()` returns that as an `Option<NetworkError>`, which is then mapped into `Errno`, converted into `u16`, and eventually returned to libc caller.

In the baseline runtime, the socket operation that actually fails and the later getsockopt(SO_ERROR) call can be disconnected from each other. A nonblocking connect can fail with ECONNREFUSED, but if Wasmer does not record that error on the socket object, the next SO_ERROR read can return success or a generic error.

The visible result is wrong POSIX error reporting. Code that expects ECONNREFUSED may instead see EPIPE, ECONNRESET, or no pending error at all. The fix will store the last socket error in Wasmer socket state and expose that state through the WASIX Sockoption::LastError path used by getsockopt(SO_ERROR).

[Detailed description](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasmer/03_last_socket_error_so_error.md#last-socket-error--so_error)