### PR TITLE
UDP Datagram Receive, Readiness, and Backlog

### DIFF
--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -1042,15 +1042,19 @@ impl VirtualIoSource for RemoteSocket {
             Poll::Pending => {}
         }
         if !self.buffer_recv_with_addr.is_empty() {
-            let total = self
+            let len = self
                 .buffer_recv_with_addr
-                .iter()
+                .front()
                 .map(|a| a.data.len())
-                .sum();
-            return Poll::Ready(Ok(total));
+                .unwrap_or_default();
+            return Poll::Ready(Ok(len));
         }
         match self.rx_recv_with_addr.poll_recv(cx) {
-            Poll::Ready(Some(data)) => self.buffer_recv_with_addr.push_back(data),
+            Poll::Ready(Some(data)) => {
+                let len = data.data.len();
+                self.buffer_recv_with_addr.push_back(data);
+                return Poll::Ready(Ok(len));
+            }
             Poll::Ready(None) => return Poll::Ready(Ok(0)),
             Poll::Pending => {}
         }
@@ -1382,22 +1386,34 @@ impl VirtualConnectionlessSocket for RemoteSocket {
         buf: &mut [std::mem::MaybeUninit<u8>],
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
-        // FIXME: A proper peek implementation would require correct use of a
-        // buffer. We don't use this implementation AFAIK, so I'll skip over it
-        // for the time being.
-        if peek {
-            return Err(NetworkError::Unsupported);
+        if let Some(received) = self.buffer_recv_with_addr.front() {
+            let amt = buf.len().min(received.data.len());
+            let addr = received.addr;
+            let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+            buf[..amt].copy_from_slice(&received.data[..amt]);
+
+            if !peek {
+                self.buffer_recv_with_addr.pop_front();
+            }
+
+            return Ok((amt, addr));
         }
 
-        match self.rx_recv_with_addr.try_recv() {
-            Ok(received) => {
-                let amt = buf.len().min(received.data.len());
-                let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
-                buf[..amt].copy_from_slice(&received.data[..amt]);
-                Ok((amt, received.addr))
-            }
-            Err(TryRecvError::Disconnected) => Err(NetworkError::ConnectionAborted),
-            Err(TryRecvError::Empty) => Err(NetworkError::WouldBlock),
+        let received = self.rx_recv_with_addr.try_recv().map_err(|err| match err {
+            TryRecvError::Disconnected => NetworkError::ConnectionAborted,
+            TryRecvError::Empty => NetworkError::WouldBlock,
+        })?;
+
+        let amt = buf.len().min(received.data.len());
+        let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+        buf[..amt].copy_from_slice(&received.data[..amt]);
+        let addr = received.addr;
+
+        if peek {
+            self.buffer_recv_with_addr.push_back(received);
+            Ok((amt, addr))
+        } else {
+            Ok((amt, addr))
         }
     }
 }

--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -1386,35 +1386,27 @@ impl VirtualConnectionlessSocket for RemoteSocket {
         buf: &mut [std::mem::MaybeUninit<u8>],
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
-        if let Some(received) = self.buffer_recv_with_addr.front() {
-            let amt = buf.len().min(received.data.len());
-            let addr = received.addr;
-            let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
-            buf[..amt].copy_from_slice(&received.data[..amt]);
-
-            if !peek {
-                self.buffer_recv_with_addr.pop_front();
-            }
-
-            return Ok((amt, addr));
+        if self.buffer_recv_with_addr.is_empty() {
+            let received = self.rx_recv_with_addr.try_recv().map_err(|err| match err {
+                TryRecvError::Disconnected => NetworkError::ConnectionAborted,
+                TryRecvError::Empty => NetworkError::WouldBlock,
+            })?;
+            self.buffer_recv_with_addr.push_back(received);
         }
 
-        let received = self.rx_recv_with_addr.try_recv().map_err(|err| match err {
-            TryRecvError::Disconnected => NetworkError::ConnectionAborted,
-            TryRecvError::Empty => NetworkError::WouldBlock,
-        })?;
-
+        let Some(received) = self.buffer_recv_with_addr.front() else {
+            return Err(NetworkError::WouldBlock);
+        };
         let amt = buf.len().min(received.data.len());
+        let addr = received.addr;
         let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
         buf[..amt].copy_from_slice(&received.data[..amt]);
-        let addr = received.addr;
 
-        if peek {
-            self.buffer_recv_with_addr.push_back(received);
-            Ok((amt, addr))
-        } else {
-            Ok((amt, addr))
+        if !peek {
+            self.buffer_recv_with_addr.pop_front();
         }
+
+        Ok((amt, addr))
     }
 }
 

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -1070,6 +1070,16 @@ impl VirtualConnectionlessSocket for LocalUdpSocket {
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
         let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+        if let Some((packet, addr)) = self.backlog.front() {
+            let amt = buf.len().min(packet.len());
+            let addr = *addr;
+            buf[..amt].copy_from_slice(&packet[..amt]);
+            if !peek {
+                self.backlog.pop_front();
+            }
+            return Ok((amt, addr));
+        }
+
         if peek {
             self.socket.peek_from(buf)
         } else {
@@ -1154,8 +1164,8 @@ impl VirtualIoSource for LocalUdpSocket {
 
     fn poll_read_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<usize>> {
         if !self.backlog.is_empty() {
-            let total = self.backlog.iter().map(|a| a.0.len()).sum();
-            return Poll::Ready(Ok(total));
+            let len = self.backlog.front().map(|a| a.0.len()).unwrap_or_default();
+            return Poll::Ready(Ok(len));
         }
 
         let (state, selector, socket) = self.split_borrow();
@@ -1169,7 +1179,10 @@ impl VirtualIoSource for LocalUdpSocket {
         let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
 
         match self.socket.recv_from(uninit_unsafe) {
-            Ok((0, _)) => Poll::Ready(Ok(0)),
+            Ok((0, peer)) => {
+                self.backlog.push_back((buffer, peer));
+                Poll::Ready(Ok(0))
+            }
             Ok((amt, peer)) => {
                 unsafe {
                     buffer.set_len(amt);

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -1069,23 +1069,21 @@ impl VirtualConnectionlessSocket for LocalUdpSocket {
         buf: &mut [MaybeUninit<u8>],
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
-        let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
-        if let Some((packet, addr)) = self.backlog.front() {
-            let amt = buf.len().min(packet.len());
-            let addr = *addr;
-            buf[..amt].copy_from_slice(&packet[..amt]);
-            if !peek {
-                self.backlog.pop_front();
-            }
-            return Ok((amt, addr));
+        if self.backlog.is_empty() {
+            self.recv_into_backlog().map_err(io_err_into_net_error)?;
         }
 
-        if peek {
-            self.socket.peek_from(buf)
-        } else {
-            self.socket.recv_from(buf)
+        let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+        let Some((packet, addr)) = self.backlog.front() else {
+            return Err(NetworkError::WouldBlock);
+        };
+        let amt = buf.len().min(packet.len());
+        let addr = *addr;
+        buf[..amt].copy_from_slice(&packet[..amt]);
+        if !peek {
+            self.backlog.pop_front();
         }
-        .map_err(io_err_into_net_error)
+        Ok((amt, addr))
     }
 }
 
@@ -1136,6 +1134,20 @@ impl VirtualSocket for LocalUdpSocket {
 }
 
 impl LocalUdpSocket {
+    fn recv_into_backlog(&mut self) -> io::Result<()> {
+        let mut buffer = BytesMut::default();
+        buffer.reserve(10240);
+        let uninit: &mut [MaybeUninit<u8>] = buffer.spare_capacity_mut();
+        let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
+
+        let (amt, peer) = self.socket.recv_from(uninit_unsafe)?;
+        unsafe {
+            buffer.set_len(amt);
+        }
+        self.backlog.push_back((buffer, peer));
+        Ok(())
+    }
+
     fn split_borrow(
         &mut self,
     ) -> (
@@ -1173,22 +1185,10 @@ impl VirtualIoSource for LocalUdpSocket {
         map.pop(InterestType::Readable);
         map.add(InterestType::Readable, cx.waker());
 
-        let mut buffer = BytesMut::default();
-        buffer.reserve(10240);
-        let uninit: &mut [MaybeUninit<u8>] = buffer.spare_capacity_mut();
-        let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
-
-        match self.socket.recv_from(uninit_unsafe) {
-            Ok((0, peer)) => {
-                self.backlog.push_back((buffer, peer));
-                Poll::Ready(Ok(0))
-            }
-            Ok((amt, peer)) => {
-                unsafe {
-                    buffer.set_len(amt);
-                }
-                self.backlog.push_back((buffer, peer));
-                Poll::Ready(Ok(amt))
+        match self.recv_into_backlog() {
+            Ok(()) => {
+                let len = self.backlog.front().map(|a| a.0.len()).unwrap_or_default();
+                Poll::Ready(Ok(len))
             }
             Err(err) if err.kind() == io::ErrorKind::ConnectionAborted => Poll::Ready(Ok(0)),
             Err(err) if err.kind() == io::ErrorKind::ConnectionReset => Poll::Ready(Ok(0)),

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -1516,10 +1516,15 @@ impl InodeSocket {
                         }
                         InodeSocketKind::UdpSocket { socket, peer } => {
                             if let Some(peer) = peer {
-                                match socket.try_recv_from(self.data, peek) {
-                                    Ok((amt, addr)) if addr == *peer => Ok(amt),
-                                    Ok(_) => Err(NetworkError::WouldBlock),
-                                    Err(err) => Err(err),
+                                loop {
+                                    match socket.try_recv_from(self.data, peek) {
+                                        Ok((amt, addr)) if addr == *peer => break Ok(amt),
+                                        Ok(_) if peek => {
+                                            let _ = socket.try_recv_from(self.data, false);
+                                        }
+                                        Ok(_) => continue,
+                                        Err(err) => break Err(err),
+                                    }
                                 }
                             } else {
                                 match socket.try_recv_from(self.data, peek) {

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -888,18 +888,18 @@ impl InodeSocket {
 
     pub fn addr_peer(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
-        Ok(match &inner.kind {
+        match &inner.kind {
             InodeSocketKind::BoundTcp { .. } => return Err(Errno::Notconn),
-            InodeSocketKind::PreSocket { props, .. } => SocketAddr::new(
+            InodeSocketKind::PreSocket { props, .. } => Ok(SocketAddr::new(
                 match props.family {
                     Addressfamily::Inet4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                     Addressfamily::Inet6 => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
                     _ => return Err(Errno::Inval),
                 },
                 0,
-            ),
+            )),
             InodeSocketKind::TcpStream { socket, .. } => {
-                socket.addr_peer().map_err(net_error_into_wasi_err)?
+                socket.addr_peer().map_err(net_error_into_wasi_err)
             }
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -889,7 +889,7 @@ impl InodeSocket {
     pub fn addr_peer(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
         match &inner.kind {
-            InodeSocketKind::BoundTcp { .. } => return Err(Errno::Notconn),
+            InodeSocketKind::BoundTcp { .. } => Err(Errno::Notconn),
             InodeSocketKind::PreSocket { props, .. } => Ok(SocketAddr::new(
                 match props.family {
                     Addressfamily::Inet4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -888,18 +888,18 @@ impl InodeSocket {
 
     pub fn addr_peer(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
-        match &inner.kind {
-            InodeSocketKind::BoundTcp { .. } => Err(Errno::Notconn),
-            InodeSocketKind::PreSocket { props, .. } => Ok(SocketAddr::new(
+        Ok(match &inner.kind {
+            InodeSocketKind::BoundTcp { .. } => return Err(Errno::Notconn),
+            InodeSocketKind::PreSocket { props, .. } => SocketAddr::new(
                 match props.family {
                     Addressfamily::Inet4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                     Addressfamily::Inet6 => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
                     _ => return Err(Errno::Inval),
                 },
                 0,
-            )),
+            ),
             InodeSocketKind::TcpStream { socket, .. } => {
-                socket.addr_peer().map_err(net_error_into_wasi_err)
+                socket.addr_peer().map_err(net_error_into_wasi_err)?
             }
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()

--- a/lib/wasix/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_to.rs
@@ -1,10 +1,7 @@
 use std::task::Waker;
 
 use super::*;
-use crate::{
-    net::socket::{InodeSocketKind, TimeType},
-    syscalls::*,
-};
+use crate::{net::socket::TimeType, syscalls::*};
 
 /// ### `sock_send_to()`
 /// Send a message on a socket to a specific address.
@@ -123,39 +120,6 @@ pub(crate) fn sock_send_to_internal<M: MemorySize>(
                     FdWriteSource::Iovs { iovs, iovs_len } => {
                         let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;
                         let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
-
-                        let is_dgram = {
-                            let inner = socket.inner.protected.read().unwrap();
-                            match &inner.kind {
-                                InodeSocketKind::UdpSocket { .. } => true,
-                                InodeSocketKind::RemoteSocket { props, .. } => {
-                                    props.ty == Socktype::Dgram
-                                }
-                                _ => false,
-                            }
-                        };
-
-                        if is_dgram {
-                            let mut data = Vec::new();
-                            for iovs in iovs_arr.iter() {
-                                let buf = WasmPtr::<u8, M>::new(iovs.buf)
-                                    .slice(&memory, iovs.buf_len)
-                                    .map_err(mem_error_to_wasi)?
-                                    .access()
-                                    .map_err(mem_error_to_wasi)?;
-                                data.extend_from_slice(buf.as_ref());
-                            }
-
-                            return socket
-                                .send_to::<M>(
-                                    env.tasks().deref(),
-                                    data.as_ref(),
-                                    addr,
-                                    Some(timeout),
-                                    nonblocking,
-                                )
-                                .await;
-                        }
 
                         let mut sent = 0usize;
                         for iovs in iovs_arr.iter() {

--- a/lib/wasix/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_to.rs
@@ -1,7 +1,10 @@
 use std::task::Waker;
 
 use super::*;
-use crate::{net::socket::TimeType, syscalls::*};
+use crate::{
+    net::socket::{InodeSocketKind, TimeType},
+    syscalls::*,
+};
 
 /// ### `sock_send_to()`
 /// Send a message on a socket to a specific address.
@@ -120,6 +123,39 @@ pub(crate) fn sock_send_to_internal<M: MemorySize>(
                     FdWriteSource::Iovs { iovs, iovs_len } => {
                         let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;
                         let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
+
+                        let is_dgram = {
+                            let inner = socket.inner.protected.read().unwrap();
+                            match &inner.kind {
+                                InodeSocketKind::UdpSocket { .. } => true,
+                                InodeSocketKind::RemoteSocket { props, .. } => {
+                                    props.ty == Socktype::Dgram
+                                }
+                                _ => false,
+                            }
+                        };
+
+                        if is_dgram {
+                            let mut data = Vec::new();
+                            for iovs in iovs_arr.iter() {
+                                let buf = WasmPtr::<u8, M>::new(iovs.buf)
+                                    .slice(&memory, iovs.buf_len)
+                                    .map_err(mem_error_to_wasi)?
+                                    .access()
+                                    .map_err(mem_error_to_wasi)?;
+                                data.extend_from_slice(buf.as_ref());
+                            }
+
+                            return socket
+                                .send_to::<M>(
+                                    env.tasks().deref(),
+                                    data.as_ref(),
+                                    addr,
+                                    Some(timeout),
+                                    nonblocking,
+                                )
+                                .await;
+                        }
 
                         let mut sent = 0usize;
                         for iovs in iovs_arr.iter() {

--- a/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
@@ -1,3 +1,4 @@
+//#MinimalLibc: v2026-06-18.1
 //#ExpectedStdout: received datagram length: 0
 
 #include <arpa/inet.h>

--- a/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
@@ -1,0 +1,39 @@
+//#ExpectedStdout: received datagram length: 0
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+
+  struct sockaddr_in addr = {0};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  bind(fd, (struct sockaddr*)&addr, sizeof(addr));
+
+  socklen_t len = sizeof(addr);
+  getsockname(fd, (struct sockaddr*)&addr, &len);
+
+  sendto(fd, "", 0, 0, (struct sockaddr*)&addr, sizeof(addr));
+
+  struct pollfd pfd = {.fd = fd, .events = POLLIN};
+  poll(&pfd, 1, 1000);
+
+  char byte;
+  ssize_t n = recvfrom(fd, &byte, sizeof(byte), 0, NULL, NULL);
+  close(fd);
+
+  if (n < 0) {
+    perror("recvfrom after poll");
+    return 1;
+  }
+
+  printf("received datagram length: %zd\n", n);
+  return 0;
+}


### PR DESCRIPTION
- Fixed implementation of `poll_read_ready()` and `try_recv_from()` so that bytes received into `backlog` are consumed correctly.
- Additionally peek is now supported, and peeks bytes in backlog first.
- Flow is bytes are received from underlying stream, and placed into backlog, and then peeked or drained from that backlog. 
 
This solution guarantees consistency and without this fix packets would be dropped.

[Detailed description](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasmer/01_udp_datagram_receive_readiness_and_backlog.md#udp-datagram-receive-readiness-and-backlog)