### PR TITLE
Connected UDP Send, Peer State, and EMSGSIZE

### DIFF
--- a/.github/ci-constants.env
+++ b/.github/ci-constants.env
@@ -1,3 +1,3 @@
 # Shared CI constants. Loaded into GITHUB_ENV by workflows that need them.
 # Pinned wasix-libc sysroot (wasix-org/wasix-libc release tag).
-WASIX_LIBC_SYSROOT_TAG=v2026-06-09.1
+WASIX_LIBC_SYSROOT_TAG=v2026-06-18.1

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -953,7 +953,6 @@ pub fn net_error_into_io_err(net_error: NetworkError) -> std::io::Error {
         NetworkError::Interrupted => ErrorKind::Interrupted.into(),
         NetworkError::InvalidData => ErrorKind::InvalidData.into(),
         NetworkError::InvalidInput => ErrorKind::InvalidInput.into(),
-        NetworkError::MessageSize => ErrorKind::InvalidInput.into(),
         NetworkError::NotConnected => ErrorKind::NotConnected.into(),
         NetworkError::NoDevice => ErrorKind::BrokenPipe.into(),
         NetworkError::PermissionDenied => ErrorKind::PermissionDenied.into(),
@@ -964,6 +963,16 @@ pub fn net_error_into_io_err(net_error: NetworkError) -> std::io::Error {
         NetworkError::Unsupported => ErrorKind::Unsupported.into(),
         NetworkError::UnknownError => ErrorKind::BrokenPipe.into(),
         NetworkError::InsufficientMemory => ErrorKind::OutOfMemory.into(),
+        NetworkError::MessageSize => {
+            #[cfg(all(target_family = "unix", feature = "libc"))]
+            {
+                std::io::Error::from_raw_os_error(libc::EMSGSIZE)
+            }
+            #[cfg(not(all(target_family = "unix", feature = "libc")))]
+            {
+                ErrorKind::Other.into()
+            }
+        }
         NetworkError::TooManyOpenFiles => {
             #[cfg(all(target_family = "unix", feature = "libc"))]
             {

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -849,6 +849,9 @@ pub enum NetworkError {
     /// The provided data is invalid
     #[error("invalid input")]
     InvalidInput,
+    /// The message is too large to send as one packet
+    #[error("message too large")]
+    MessageSize,
     /// Could not perform the operation because there was not an open connection
     #[error("connection is not open")]
     NotConnected,
@@ -918,6 +921,7 @@ pub fn io_err_into_net_error(net_error: std::io::Error) -> NetworkError {
                     libc::EACCES => NetworkError::PermissionDenied,
                     libc::ENODEV => NetworkError::NoDevice,
                     libc::EINVAL => NetworkError::InvalidInput,
+                    libc::EMSGSIZE => NetworkError::MessageSize,
                     libc::EPIPE => NetworkError::BrokenPipe,
                     err => {
                         tracing::trace!("unknown os error {}", err);
@@ -949,6 +953,7 @@ pub fn net_error_into_io_err(net_error: NetworkError) -> std::io::Error {
         NetworkError::Interrupted => ErrorKind::Interrupted.into(),
         NetworkError::InvalidData => ErrorKind::InvalidData.into(),
         NetworkError::InvalidInput => ErrorKind::InvalidInput.into(),
+        NetworkError::MessageSize => ErrorKind::InvalidInput.into(),
         NetworkError::NotConnected => ErrorKind::NotConnected.into(),
         NetworkError::NoDevice => ErrorKind::BrokenPipe.into(),
         NetworkError::PermissionDenied => ErrorKind::PermissionDenied.into(),

--- a/lib/wasix/src/net/mod.rs
+++ b/lib/wasix/src/net/mod.rs
@@ -387,6 +387,7 @@ pub fn net_error_into_wasi_err(net_error: NetworkError) -> Errno {
         NetworkError::Interrupted => Errno::Intr,
         NetworkError::InvalidData => Errno::Io,
         NetworkError::InvalidInput => Errno::Inval,
+        NetworkError::MessageSize => Errno::Msgsize,
         NetworkError::NotConnected => Errno::Notconn,
         NetworkError::NoDevice => Errno::Nodev,
         NetworkError::PermissionDenied => Errno::Perm,

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -907,7 +907,7 @@ impl InodeSocket {
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()
                 .map_err(net_error_into_wasi_err)?
-                .map_or_else(|| Err(Errno::Notconn), |addr| Ok(addr)),
+                .map_or(Err(Errno::Notconn), Ok),
             InodeSocketKind::RemoteSocket { peer_addr, .. } => Ok(*peer_addr),
             _ => Err(Errno::Notsup),
         }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -907,7 +907,7 @@ impl InodeSocket {
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()
                 .map_err(net_error_into_wasi_err)?
-                .map_or(Err(Errno::Notconn), Ok),
+                .ok_or(Errno::Notconn),
             InodeSocketKind::RemoteSocket { peer_addr, .. } => Ok(*peer_addr),
             _ => Err(Errno::Notsup),
         }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -901,6 +901,9 @@ impl InodeSocket {
             InodeSocketKind::TcpStream { socket, .. } => {
                 socket.addr_peer().map_err(net_error_into_wasi_err)
             }
+            InodeSocketKind::UdpSocket {
+                peer: Some(peer), ..
+            } => Ok(*peer),
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()
                 .map_err(net_error_into_wasi_err)?

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -907,21 +907,7 @@ impl InodeSocket {
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()
                 .map_err(net_error_into_wasi_err)?
-                .map(Ok)
-                .unwrap_or_else(|| {
-                    socket
-                        .addr_local()
-                        .map_err(net_error_into_wasi_err)
-                        .map(|addr| {
-                            SocketAddr::new(
-                                match addr {
-                                    SocketAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                                    SocketAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-                                },
-                                0,
-                            )
-                        })
-                }),
+                .map_or_else(|| Err(Errno::Notconn), |addr| Ok(addr)),
             InodeSocketKind::RemoteSocket { peer_addr, .. } => Ok(*peer_addr),
             _ => Err(Errno::Notsup),
         }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -1695,6 +1695,18 @@ impl InodeSocket {
             false
         }
     }
+
+    pub fn is_dgram(&self) -> bool {
+        if let Ok(guard) = self.inner.protected.try_read() {
+            match &guard.kind {
+                InodeSocketKind::UdpSocket { .. } => true,
+                InodeSocketKind::RemoteSocket { props, .. } => props.ty == Socktype::Dgram,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
 }
 
 impl InodeSocketProtected {

--- a/lib/wasix/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_write.rs
@@ -136,7 +136,7 @@ impl<'a, M: MemorySize> FdWriteSource<'a, M> {
 
                 for iov in iovs_arr.iter() {
                     let buf = WasmPtr::<u8, M>::new(iov.buf)
-                        .slice(&memory, iov.buf_len)
+                        .slice(memory, iov.buf_len)
                         .map_err(mem_error_to_wasi)?
                         .access()
                         .map_err(mem_error_to_wasi)?;

--- a/lib/wasix/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_write.rs
@@ -124,6 +124,32 @@ pub(crate) enum FdWriteSource<'a, M: MemorySize> {
     Buffer(Cow<'a, [u8]>),
 }
 
+impl<'a, M: MemorySize> FdWriteSource<'a, M> {
+    pub(crate) fn coalesce(&self, memory: &MemoryView) -> Result<Cow<'a, [u8]>, Errno> {
+        match self {
+            FdWriteSource::Iovs { iovs, iovs_len } => {
+                let iovs_arr = iovs.slice(memory, *iovs_len).map_err(mem_error_to_wasi)?;
+                let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
+
+                let total_len: usize = iovs_arr.iter().map(|iov| iov.buf_len.into() as usize).sum();
+                let mut coalesced = Vec::with_capacity(total_len);
+
+                for iov in iovs_arr.iter() {
+                    let buf = WasmPtr::<u8, M>::new(iov.buf)
+                        .slice(&memory, iov.buf_len)
+                        .map_err(mem_error_to_wasi)?
+                        .access()
+                        .map_err(mem_error_to_wasi)?;
+                    coalesced.extend_from_slice(buf.as_ref());
+                }
+
+                Ok(Cow::Owned(coalesced))
+            }
+            FdWriteSource::Buffer(cow) => Ok(cow.clone()),
+        }
+    }
+}
+
 #[allow(clippy::await_holding_lock)]
 pub(crate) fn fd_write_internal<M: MemorySize>(
     mut ctx: &mut FunctionEnvMut<'_, WasiEnv>,
@@ -242,6 +268,14 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
 
                     let res = __asyncify_light(env, None, async {
                         let mut sent = 0usize;
+
+                        if socket.is_dgram() {
+                            let data = data.coalesce(&memory)?;
+                            sent += socket
+                                .send(tasks.deref(), data.as_ref(), Some(timeout), nonblocking)
+                                .await?;
+                            return Ok(sent)
+                        }
 
                         match &data {
                             FdWriteSource::Iovs { iovs, iovs_len } => {

--- a/lib/wasix/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_write.rs
@@ -274,7 +274,7 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                             sent += socket
                                 .send(tasks.deref(), data.as_ref(), Some(timeout), nonblocking)
                                 .await?;
-                            return Ok(sent)
+                            return Ok(sent);
                         }
 
                         match &data {

--- a/lib/wasix/src/syscalls/wasix/sock_connect.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_connect.rs
@@ -75,11 +75,9 @@ pub(crate) fn sock_connect_internal(
         Rights::SOCK_CONNECT,
         move |mut socket, flags| async move {
             // Auto-bind UDP
-            socket = socket
-                .auto_bind_udp(tasks.deref(), net.deref())
-                .await?
-                .unwrap_or(socket);
-            socket
+            let bound_socket = socket.auto_bind_udp(tasks.deref(), net.deref()).await?;
+            socket = bound_socket.clone().unwrap_or(socket);
+            let connected_socket = socket
                 .connect(
                     tasks.deref(),
                     net.deref(),
@@ -87,7 +85,8 @@ pub(crate) fn sock_connect_internal(
                     None,
                     flags.contains(Fdflags::NONBLOCK),
                 )
-                .await
+                .await?;
+            Ok(connected_socket.or(bound_socket))
         }
     ));
 

--- a/lib/wasix/src/syscalls/wasix/sock_send.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send.rs
@@ -109,42 +109,22 @@ pub(crate) fn sock_send_internal<M: MemorySize>(
                 .flatten()
                 .unwrap_or(Duration::from_secs(30));
 
+            if socket.is_dgram() {
+                let data = si_data.coalesce(&memory)?;
+                return socket
+                    .send(
+                        env.tasks().deref(),
+                        data.as_ref(),
+                        Some(timeout),
+                        nonblocking,
+                    )
+                    .await;
+            }
+
             match si_data {
                 FdWriteSource::Iovs { iovs, iovs_len } => {
                     let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;
                     let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
-
-                    let is_dgram = {
-                        let inner = socket.inner.protected.read().unwrap();
-                        match &inner.kind {
-                            InodeSocketKind::UdpSocket { .. } => true,
-                            InodeSocketKind::RemoteSocket { props, .. } => {
-                                props.ty == Socktype::Dgram
-                            }
-                            _ => false,
-                        }
-                    };
-
-                    if is_dgram {
-                        let mut data = Vec::new();
-                        for iovs in iovs_arr.iter() {
-                            let buf = WasmPtr::<u8, M>::new(iovs.buf)
-                                .slice(&memory, iovs.buf_len)
-                                .map_err(mem_error_to_wasi)?
-                                .access()
-                                .map_err(mem_error_to_wasi)?;
-                            data.extend_from_slice(buf.as_ref());
-                        }
-
-                        return socket
-                            .send(
-                                env.tasks().deref(),
-                                data.as_ref(),
-                                Some(timeout),
-                                nonblocking,
-                            )
-                            .await;
-                    }
 
                     let mut sent = 0usize;
                     for iovs in iovs_arr.iter() {

--- a/lib/wasix/src/syscalls/wasix/sock_send.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send.rs
@@ -1,7 +1,10 @@
 use std::{mem::MaybeUninit, task::Waker};
 
 use super::*;
-use crate::{net::socket::TimeType, syscalls::*};
+use crate::{
+    net::socket::{InodeSocketKind, TimeType},
+    syscalls::*,
+};
 
 /// ### `sock_send()`
 /// Send a message on a socket.
@@ -110,6 +113,38 @@ pub(crate) fn sock_send_internal<M: MemorySize>(
                 FdWriteSource::Iovs { iovs, iovs_len } => {
                     let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;
                     let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
+
+                    let is_dgram = {
+                        let inner = socket.inner.protected.read().unwrap();
+                        match &inner.kind {
+                            InodeSocketKind::UdpSocket { .. } => true,
+                            InodeSocketKind::RemoteSocket { props, .. } => {
+                                props.ty == Socktype::Dgram
+                            }
+                            _ => false,
+                        }
+                    };
+
+                    if is_dgram {
+                        let mut data = Vec::new();
+                        for iovs in iovs_arr.iter() {
+                            let buf = WasmPtr::<u8, M>::new(iovs.buf)
+                                .slice(&memory, iovs.buf_len)
+                                .map_err(mem_error_to_wasi)?
+                                .access()
+                                .map_err(mem_error_to_wasi)?;
+                            data.extend_from_slice(buf.as_ref());
+                        }
+
+                        return socket
+                            .send(
+                                env.tasks().deref(),
+                                data.as_ref(),
+                                Some(timeout),
+                                nonblocking,
+                            )
+                            .await;
+                    }
 
                     let mut sent = 0usize;
                     for iovs in iovs_arr.iter() {

--- a/lib/wasix/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_to.rs
@@ -116,6 +116,19 @@ pub(crate) fn sock_send_to_internal<M: MemorySize>(
                     .flatten()
                     .unwrap_or(Duration::from_secs(30));
 
+                if socket.is_dgram() {
+                    let data = si_data.coalesce(&memory)?;
+                    return socket
+                        .send_to::<M>(
+                            env.tasks().deref(),
+                            data.as_ref(),
+                            addr,
+                            Some(timeout),
+                            nonblocking,
+                        )
+                        .await;
+                }
+
                 match si_data {
                     FdWriteSource::Iovs { iovs, iovs_len } => {
                         let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;

--- a/lib/wasix/tests/wasm_tests/socket/connected-udp-peer/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/connected-udp-peer/main.c
@@ -1,3 +1,4 @@
+//#MinimalLibc: v2026-06-18.1
 //#ExpectedStdout: connected UDP peer and sendto work
 
 #include <arpa/inet.h>

--- a/lib/wasix/tests/wasm_tests/socket/connected-udp-peer/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/connected-udp-peer/main.c
@@ -1,0 +1,125 @@
+//#ExpectedStdout: connected UDP peer and sendto work
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  int receiver = socket(AF_INET, SOCK_DGRAM, 0);
+  if (receiver < 0) {
+    perror("socket(receiver)");
+    return 1;
+  }
+
+  int sender = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sender < 0) {
+    perror("socket(sender)");
+    close(receiver);
+    return 1;
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(receiver, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind(receiver)");
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  socklen_t len = sizeof(addr);
+  if (getsockname(receiver, (struct sockaddr*)&addr, &len) != 0) {
+    perror("getsockname(receiver)");
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  if (connect(sender, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("connect(sender)");
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  struct sockaddr_in peer;
+  memset(&peer, 0, sizeof(peer));
+  socklen_t peer_len = sizeof(peer);
+  if (getpeername(sender, (struct sockaddr*)&peer, &peer_len) != 0) {
+    perror("getpeername(sender)");
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  if (peer.sin_family != AF_INET || peer.sin_port != addr.sin_port ||
+      peer.sin_addr.s_addr != addr.sin_addr.s_addr) {
+    fprintf(stderr, "unexpected peer: family=%d port=%u addr=%08x\n",
+            peer.sin_family, ntohs(peer.sin_port), ntohl(peer.sin_addr.s_addr));
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  struct sockaddr_in sender_addr;
+  memset(&sender_addr, 0, sizeof(sender_addr));
+  socklen_t sender_addr_len = sizeof(sender_addr);
+  if (getsockname(sender, (struct sockaddr*)&sender_addr, &sender_addr_len) !=
+      0) {
+    perror("getsockname(sender)");
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  ssize_t written = send(sender, "hello", 5, 0);
+  if (written != 5) {
+    fprintf(stderr, "expected sendto to write 5 bytes, got %zd errno=%d (%s)\n",
+            written, errno, strerror(errno));
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  char buf[16] = {0};
+  struct sockaddr_in peer_from;
+  socklen_t peer_from_len = sizeof(peer_from);
+  memset(&peer_from, 0, sizeof(peer_from));
+  ssize_t nread =
+      recvfrom(receiver, buf, sizeof(buf), 0, &peer_from, &peer_from_len);
+  if (nread != 5 || memcmp(buf, "hello", 5) != 0) {
+    fprintf(stderr,
+            "expected one 5-byte datagram `hello`, got %zd bytes: %.*s\n",
+            nread, nread > 0 ? (int)nread : 0, buf);
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  if (peer_from_len != sizeof(peer_from) || peer_from.sin_family != AF_INET ||
+      peer_from.sin_port != sender_addr.sin_port ||
+      // sender has 0.0.0.0 and recvfrom() reports 127.0.0.1
+      peer_from.sin_addr.s_addr != htonl(INADDR_LOOPBACK) ||
+      sender_addr.sin_addr.s_addr != htonl(INADDR_ANY)) {
+    fprintf(stderr,
+            "unexpected recvfrom/source state: peer_from family=%d port=%u "
+            "addr=%08x, sender family=%d port=%u addr=%08x\n",
+            peer_from.sin_family, ntohs(peer_from.sin_port),
+            ntohl(peer_from.sin_addr.s_addr), sender_addr.sin_family,
+            ntohs(sender_addr.sin_port), ntohl(sender_addr.sin_addr.s_addr));
+    close(sender);
+    close(receiver);
+    return 1;
+  }
+
+  close(sender);
+  close(receiver);
+  puts("connected UDP peer and sendto work");
+  return 0;
+}


### PR DESCRIPTION
- Connected UDP must send single batch of iovecs as a single datagram and not multiple.
- MessageSize error will occur when total size of the data gathered from all iovecs buffers exceeds maximum.
- Original connected peer address is preserved across sends.

The `InodeSocket` stores `inner: InodeSocketKind`, and initially it's `InodeSocketKind::PreSocket`. When `sock_connect_internal()` is called, it uses `__sock_upgrade()` to potentially upgrade `WasiFd` with new socket.

The reason `WasiFd` needs to be rebound to new `InodeSocket` is because `InodeSocket::bind_internal()` creates new instance of `InodeSocket` instead of modifying `self.inner.protected`.

```rust
Ok(Some(InodeSocket::new(InodeSocketKind::UdpSocket {
                                socket,
                                peer: None,
                            })))
```

Then `InodeSocket::connect()` sets peer address:

```rust
               InodeSocketKind::UdpSocket {
                    peer: target_peer, ..
                } => {
                    target_peer.replace(peer);
                    return Ok(None);
                }
```


[Detailed information](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasmer/02_connected_udp_send_peer_state_and_emsgsize.md#connected-udp-send-peer-state-and-emsgsize)