### PR TITLE
Added loopback reverse lookup test

### DIFF
--- a/.github/ci-constants.env
+++ b/.github/ci-constants.env
@@ -1,3 +1,3 @@
 # Shared CI constants. Loaded into GITHUB_ENV by workflows that need them.
 # Pinned wasix-libc sysroot (wasix-org/wasix-libc release tag).
-WASIX_LIBC_SYSROOT_TAG=v2026-06-09.1
+WASIX_LIBC_SYSROOT_TAG=v2026-06-18.1

--- a/lib/wasix/tests/wasm_tests/socket/getnameinfo-loopback/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/getnameinfo-loopback/main.c
@@ -1,0 +1,86 @@
+//#ExpectedStdout: getnameinfo loopback returns localhost
+//#MinimalLibc: v2026-06-03.1
+
+/*
+ * Regression test for WASIX loopback reverse lookup.
+ *
+ * getnameinfo() should be able to resolve the canonical loopback addresses to
+ * localhost even when /etc/hosts is unavailable. IPv6 scope ids are not
+ * meaningful for ::1, and IPv4-mapped 127.0.0.1 should follow the same
+ * loopback fallback as plain IPv4.
+ */
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+
+static int expect_host(const struct sockaddr* addr, socklen_t addrlen,
+                       const char* label) {
+  char host[NI_MAXHOST];
+  int err = getnameinfo(addr, addrlen, host, sizeof(host), NULL, 0,
+                        NI_NAMEREQD);
+  if (err != 0) {
+    fprintf(stderr, "%s: getnameinfo failed: %s\n", label, gai_strerror(err));
+    return 1;
+  }
+
+  if (strcmp(host, "localhost") != 0) {
+    fprintf(stderr, "%s: expected localhost, got %s\n", label, host);
+    return 1;
+  }
+
+  return 0;
+}
+
+static int expect_ipv4_loopback(void) {
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(80);
+  if (inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr) != 1) {
+    fprintf(stderr, "inet_pton(AF_INET) failed\n");
+    return 1;
+  }
+
+  return expect_host((const struct sockaddr*)&addr, sizeof(addr),
+                     "127.0.0.1");
+}
+
+static int expect_ipv6_loopback_with_scope(void) {
+  struct sockaddr_in6 addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(80);
+  addr.sin6_scope_id = 7;
+  if (inet_pton(AF_INET6, "::1", &addr.sin6_addr) != 1) {
+    fprintf(stderr, "inet_pton(AF_INET6 ::1) failed\n");
+    return 1;
+  }
+
+  return expect_host((const struct sockaddr*)&addr, sizeof(addr),
+                     "::1%7");
+}
+
+static int expect_ipv4_mapped_loopback(void) {
+  struct sockaddr_in6 addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(80);
+  if (inet_pton(AF_INET6, "::ffff:127.0.0.1", &addr.sin6_addr) != 1) {
+    fprintf(stderr, "inet_pton(AF_INET6 ::ffff:127.0.0.1) failed\n");
+    return 1;
+  }
+
+  return expect_host((const struct sockaddr*)&addr, sizeof(addr),
+                     "::ffff:127.0.0.1");
+}
+
+int main(void) {
+  if (expect_ipv4_loopback() != 0) return 1;
+  if (expect_ipv6_loopback_with_scope() != 0) return 1;
+  if (expect_ipv4_mapped_loopback() != 0) return 1;
+
+  puts("getnameinfo loopback returns localhost");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/getnameinfo-loopback/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/getnameinfo-loopback/main.c
@@ -1,5 +1,5 @@
 //#ExpectedStdout: getnameinfo loopback returns localhost
-//#MinimalLibc: v2026-06-03.1
+//#MinimalLibc: v2026-06-18.1
 
 /*
  * Regression test for WASIX loopback reverse lookup.

--- a/lib/wasix/tests/wasm_tests/socket/getnameinfo-loopback/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/getnameinfo-loopback/main.c
@@ -18,8 +18,8 @@
 static int expect_host(const struct sockaddr* addr, socklen_t addrlen,
                        const char* label) {
   char host[NI_MAXHOST];
-  int err = getnameinfo(addr, addrlen, host, sizeof(host), NULL, 0,
-                        NI_NAMEREQD);
+  int err =
+      getnameinfo(addr, addrlen, host, sizeof(host), NULL, 0, NI_NAMEREQD);
   if (err != 0) {
     fprintf(stderr, "%s: getnameinfo failed: %s\n", label, gai_strerror(err));
     return 1;
@@ -43,8 +43,7 @@ static int expect_ipv4_loopback(void) {
     return 1;
   }
 
-  return expect_host((const struct sockaddr*)&addr, sizeof(addr),
-                     "127.0.0.1");
+  return expect_host((const struct sockaddr*)&addr, sizeof(addr), "127.0.0.1");
 }
 
 static int expect_ipv6_loopback_with_scope(void) {
@@ -58,8 +57,7 @@ static int expect_ipv6_loopback_with_scope(void) {
     return 1;
   }
 
-  return expect_host((const struct sockaddr*)&addr, sizeof(addr),
-                     "::1%7");
+  return expect_host((const struct sockaddr*)&addr, sizeof(addr), "::1%7");
 }
 
 static int expect_ipv4_mapped_loopback(void) {


### PR DESCRIPTION
Test that `getnameinfo()` can resolve `localhost` for IP v4, v6, and mapped v4 addreses.