### PR TITLE
Added test for setsockopt()

### DIFF
--- a/.github/ci-constants.env
+++ b/.github/ci-constants.env
@@ -1,3 +1,3 @@
 # Shared CI constants. Loaded into GITHUB_ENV by workflows that need them.
 # Pinned wasix-libc sysroot (wasix-org/wasix-libc release tag).
-WASIX_LIBC_SYSROOT_TAG=v2026-06-09.1
+WASIX_LIBC_SYSROOT_TAG=v2026-06-18.1

--- a/lib/wasix/tests/wasm_tests/socket/set-socket-opt-bool/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/set-socket-opt-bool/main.c
@@ -1,3 +1,4 @@
+//#MinimalLibc: v2026-06-18.1
 //#ExpectedStdout: boolean socket option used pointed-to value
 
 #include <errno.h>

--- a/lib/wasix/tests/wasm_tests/socket/set-socket-opt-bool/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/set-socket-opt-bool/main.c
@@ -1,0 +1,38 @@
+//#ExpectedStdout: boolean socket option used pointed-to value
+
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = socket(AF_INET6, SOCK_STREAM, 0);
+  if (fd < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  int off = 0;
+  if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &off, sizeof(off)) < 0) {
+    perror("setsockopt(IPV6_V6ONLY=0)");
+    return 1;
+  }
+
+  int value = -1;
+  socklen_t value_len = sizeof(value);
+  if (getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &value, &value_len) < 0) {
+    perror("getsockopt(IPV6_V6ONLY)");
+    return 1;
+  }
+
+  if (value != 0) {
+    fprintf(stderr, "expected IPV6_V6ONLY=0, got %d\n", value);
+    return 1;
+  }
+
+  puts("boolean socket option used pointed-to value");
+  close(fd);
+  return 0;
+}


### PR DESCRIPTION
Test that `setsockopt()` correctly turns off boolean option. 

Fix proposed in https://github.com/wasix-org/wasix-libc/pull/120 solves bug, where pointer wasn't correctly dereferenced, and as a result value of the pointer, which would be non-zero, was casted to bool, and thus never becoming false.