### PR TITLE
feat: cronjobs CLI support

### DIFF
--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -415,8 +415,20 @@ pub async fn get_cron_job_invocations_page(
     let cron_job = cron_job.as_ref();
     let owner = owner.into();
     let name = name.into();
-    let start = start.map(types::DateTime::try_from).transpose()?;
-    let end = end.map(types::DateTime::try_from).transpose()?;
+    let (start, end) = match (start, end) {
+        (Some(start), Some(end)) => (start, end),
+        (Some(start), None) => (start, OffsetDateTime::now_utc()),
+        (None, Some(end)) => (end - time::Duration::days(31), end),
+        (None, None) => {
+            let end = OffsetDateTime::now_utc();
+            (end - time::Duration::days(31), end)
+        }
+    };
+    if start > end {
+        bail!("invocation start must not be after end");
+    }
+    let start = types::DateTime::try_from(start)?;
+    let end = types::DateTime::try_from(end)?;
     let mut cron_after = None;
 
     loop {
@@ -425,8 +437,8 @@ pub async fn get_cron_job_invocations_page(
             name: name.clone(),
             cron_after: cron_after.clone(),
             cron_first: Some(100),
-            invocation_start: start.clone(),
-            invocation_end: end.clone(),
+            invocation_start: Some(start.clone()),
+            invocation_end: Some(end.clone()),
             invocation_after: invocation_after.clone(),
             invocation_first,
         };

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -550,6 +550,7 @@ pub async fn get_cron_job_invocations_page_by_id(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn get_cron_job_invocation_logs(
     client: &WasmerClient,
     owner: impl Into<String>,

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -324,6 +324,25 @@ pub async fn get_app_cron_jobs(
     Ok(cron_jobs)
 }
 
+/// Enable or disable a cron job.
+pub async fn toggle_cron_job(
+    client: &WasmerClient,
+    cron_job_id: impl Into<String>,
+    enabled: bool,
+) -> Result<types::CronJob, anyhow::Error> {
+    let res = client
+        .run_graphql_strict(types::ToggleCronJob::build(types::ToggleCronJobVars {
+            cron_job_id: types::Id::from(cron_job_id),
+            enabled,
+        }))
+        .await?;
+
+    Ok(res
+        .toggle_cron_job
+        .context("backend did not return toggled cron job")?
+        .cron_job)
+}
+
 /// Retrieve invocations for a cron job. The cron job can be referenced by id or name.
 pub async fn get_cron_job_invocations(
     client: &WasmerClient,
@@ -376,6 +395,7 @@ pub async fn get_cron_job_invocations(
 }
 
 /// Retrieve one page of invocations for a cron job. The cron job can be referenced by id or name.
+#[allow(clippy::too_many_arguments)]
 pub async fn get_cron_job_invocations_page(
     client: &WasmerClient,
     owner: impl Into<String>,

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -16,6 +16,8 @@ use crate::{
     types::{self, *},
 };
 
+pub const CRON_JOB_PAGE_SIZE: i32 = 100;
+
 /// Rotate the s3 secrets tied to an app given its id.
 pub async fn rotate_s3_secrets(
     client: &WasmerClient,
@@ -304,7 +306,7 @@ pub async fn get_app_cron_jobs(
             owner: owner.clone(),
             name: name.clone(),
             after,
-            first: Some(100),
+            first: Some(CRON_JOB_PAGE_SIZE),
         };
         let res = client
             .run_graphql_strict(types::GetAppCronJobs::build(vars))
@@ -364,7 +366,7 @@ pub async fn get_cron_job_invocations(
             name.clone(),
             &cron_job,
             invocation_after,
-            Some(100),
+            Some(CRON_JOB_PAGE_SIZE),
             None,
             None,
         )
@@ -436,7 +438,7 @@ pub async fn get_cron_job_invocations_page(
             owner: owner.clone(),
             name: name.clone(),
             cron_after: cron_after.clone(),
-            cron_first: Some(100),
+            cron_first: Some(CRON_JOB_PAGE_SIZE),
             invocation_start: Some(start.clone()),
             invocation_end: Some(end.clone()),
             invocation_after: invocation_after.clone(),

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -361,57 +361,6 @@ pub async fn get_cron_job_by_id(
         .with_context(|| format!("cron job '{cron_job_id}' not found"))
 }
 
-/// Retrieve invocations for a cron job. The cron job can be referenced by id or name.
-pub async fn get_cron_job_invocations(
-    client: &WasmerClient,
-    owner: impl Into<String>,
-    name: impl Into<String>,
-    cron_job: impl AsRef<str>,
-) -> Result<(types::CronJobWithInvocations, Vec<types::CronJobInvocation>), anyhow::Error> {
-    let cron_job = cron_job.as_ref().to_string();
-    let owner = owner.into();
-    let name = name.into();
-    let mut invocation_after = None;
-    let mut all_invocations = Vec::new();
-    let mut cron_job_with_invocations: Option<types::CronJobWithInvocations> = None;
-
-    loop {
-        let (mut cron, page) = get_cron_job_invocations_page(
-            client,
-            owner.clone(),
-            name.clone(),
-            &cron_job,
-            invocation_after,
-            Some(CRON_JOB_PAGE_SIZE),
-            None,
-            None,
-        )
-        .await?;
-
-        all_invocations.extend(page.items);
-        invocation_after = page.next_cursor;
-
-        if let Some(existing_cron) = &mut cron_job_with_invocations {
-            existing_cron
-                .invocations
-                .edges
-                .append(&mut cron.invocations.edges);
-            existing_cron.invocations.page_info = cron.invocations.page_info;
-        } else {
-            cron_job_with_invocations = Some(cron);
-        }
-
-        if invocation_after.is_none() {
-            break;
-        }
-    }
-
-    Ok((
-        cron_job_with_invocations.context("cron job missing from invocations response")?,
-        all_invocations,
-    ))
-}
-
 /// Retrieve one page of invocations for a cron job. The cron job can be referenced by id or name.
 #[allow(clippy::too_many_arguments)]
 pub async fn get_cron_job_invocations_page(

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -345,6 +345,22 @@ pub async fn toggle_cron_job(
         .cron_job)
 }
 
+pub async fn get_cron_job_by_id(
+    client: &WasmerClient,
+    cron_job_id: impl Into<String>,
+) -> Result<types::CronJob, anyhow::Error> {
+    let cron_job_id = cron_job_id.into();
+    let res = client
+        .run_graphql_strict(types::GetCronJobById::build(types::GetCronJobByIdVars {
+            id: types::Id::from(cron_job_id.clone()),
+        }))
+        .await?;
+
+    res.cron_job
+        .and_then(types::NodeCronJob::into_cron_job)
+        .with_context(|| format!("cron job '{cron_job_id}' not found"))
+}
+
 /// Retrieve invocations for a cron job. The cron job can be referenced by id or name.
 pub async fn get_cron_job_invocations(
     client: &WasmerClient,
@@ -417,18 +433,7 @@ pub async fn get_cron_job_invocations_page(
     let cron_job = cron_job.as_ref();
     let owner = owner.into();
     let name = name.into();
-    let (start, end) = match (start, end) {
-        (Some(start), Some(end)) => (start, end),
-        (Some(start), None) => (start, OffsetDateTime::now_utc()),
-        (None, Some(end)) => (end - time::Duration::days(31), end),
-        (None, None) => {
-            let end = OffsetDateTime::now_utc();
-            (end - time::Duration::days(31), end)
-        }
-    };
-    if start > end {
-        bail!("invocation start must not be after end");
-    }
+    let (start, end) = default_cron_invocation_window(start, end)?;
     let start = types::DateTime::try_from(start)?;
     let end = types::DateTime::try_from(end)?;
     let mut cron_after = None;
@@ -486,6 +491,224 @@ pub async fn get_cron_job_invocations_page(
     }
 
     bail!("cron job '{cron_job}' not found")
+}
+
+/// Retrieve one page of invocations for a cron job referenced by id.
+pub async fn get_cron_job_invocations_page_by_id(
+    client: &WasmerClient,
+    cron_job_id: impl Into<String>,
+    invocation_after: Option<String>,
+    invocation_first: Option<i32>,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+) -> Result<
+    (
+        types::CronJobWithInvocationsById,
+        Paginated<types::CronJobInvocation>,
+    ),
+    anyhow::Error,
+> {
+    let cron_job_id = cron_job_id.into();
+    let (start, end) = default_cron_invocation_window(start, end)?;
+
+    let res = client
+        .run_graphql_strict(types::GetCronJobInvocationsById::build(
+            types::GetCronJobInvocationsByIdVars {
+                id: types::Id::from(cron_job_id.clone()),
+                invocation_start: Some(types::DateTime::try_from(start)?),
+                invocation_end: Some(types::DateTime::try_from(end)?),
+                invocation_after,
+                invocation_first,
+            },
+        ))
+        .await?;
+
+    let cron = res
+        .cron_job
+        .and_then(types::NodeCronJobWithInvocations::into_cron_job)
+        .with_context(|| format!("cron job '{cron_job_id}' not found"))?;
+    let invocations = cron
+        .invocations
+        .edges
+        .iter()
+        .flatten()
+        .flat_map(|edge| edge.node.clone())
+        .collect::<Vec<_>>();
+    let next_cursor = cron
+        .invocations
+        .page_info
+        .has_next_page
+        .then(|| cron.invocations.page_info.end_cursor.clone())
+        .flatten();
+
+    Ok((
+        cron,
+        Paginated {
+            items: invocations,
+            next_cursor,
+        },
+    ))
+}
+
+pub async fn get_cron_job_invocation_logs(
+    client: &WasmerClient,
+    owner: impl Into<String>,
+    name: impl Into<String>,
+    cron_job: impl AsRef<str>,
+    invocation: impl AsRef<str>,
+    log_first: Option<i32>,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
+    let owner = owner.into();
+    let name = name.into();
+    let cron_job = cron_job.as_ref().to_string();
+    let invocation = invocation.as_ref().to_string();
+    let (start, end) = default_cron_invocation_window(start, end)?;
+    let start = types::DateTime::try_from(start)?;
+    let end = types::DateTime::try_from(end)?;
+    let mut cron_after = None;
+
+    loop {
+        let mut invocation_after = None;
+        loop {
+            let vars = types::GetCronJobInvocationLogsVars {
+                owner: owner.clone(),
+                name: name.clone(),
+                cron_after: cron_after.clone(),
+                cron_first: Some(CRON_JOB_PAGE_SIZE),
+                invocation_start: Some(start.clone()),
+                invocation_end: Some(end.clone()),
+                invocation_after: invocation_after.clone(),
+                invocation_first: Some(1),
+                log_first,
+            };
+            let res = client
+                .run_graphql_strict(types::GetCronJobInvocationLogs::build(vars))
+                .await?;
+            let app = res.get_deploy_app.context("app not found")?;
+            let con = app.cron_jobs;
+            let page_info = con.page_info;
+
+            if let Some(cron) = con
+                .nodes
+                .into_iter()
+                .find(|node| node.id.inner() == cron_job || node.name == cron_job)
+            {
+                if let Some(invocation_logs) = cron
+                    .invocations
+                    .edges
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|edge| edge.node)
+                    .find(|node| node.id.inner() == invocation || node.edge_job_id == invocation)
+                {
+                    return Ok(logs_from_connection(invocation_logs.logs));
+                }
+
+                if !cron.invocations.page_info.has_next_page {
+                    bail!("cron job invocation '{invocation}' not found");
+                }
+                invocation_after = Some(
+                    cron.invocations
+                        .page_info
+                        .end_cursor
+                        .context("cron job invocations cursor missing")?,
+                );
+                continue;
+            }
+
+            if !page_info.has_next_page {
+                bail!("cron job '{cron_job}' not found");
+            }
+            cron_after = Some(page_info.end_cursor.context("cron jobs cursor missing")?);
+            break;
+        }
+    }
+}
+
+pub async fn get_cron_job_invocation_logs_by_id(
+    client: &WasmerClient,
+    cron_job_id: impl Into<String>,
+    invocation: impl AsRef<str>,
+    log_first: Option<i32>,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
+    let cron_job_id = cron_job_id.into();
+    let invocation = invocation.as_ref().to_string();
+    let (start, end) = default_cron_invocation_window(start, end)?;
+    let start = types::DateTime::try_from(start)?;
+    let end = types::DateTime::try_from(end)?;
+    let mut invocation_after = None;
+
+    loop {
+        let res = client
+            .run_graphql_strict(types::GetCronJobInvocationLogsById::build(
+                types::GetCronJobInvocationLogsByIdVars {
+                    id: types::Id::from(cron_job_id.clone()),
+                    invocation_start: Some(start.clone()),
+                    invocation_end: Some(end.clone()),
+                    invocation_after: invocation_after.clone(),
+                    invocation_first: Some(1),
+                    log_first,
+                },
+            ))
+            .await?;
+        let cron = res
+            .cron_job
+            .and_then(types::NodeCronJobWithInvocationLogs::into_cron_job)
+            .with_context(|| format!("cron job '{cron_job_id}' not found"))?;
+
+        if let Some(invocation_logs) = cron
+            .invocations
+            .edges
+            .into_iter()
+            .flatten()
+            .filter_map(|edge| edge.node)
+            .find(|node| node.id.inner() == invocation || node.edge_job_id == invocation)
+        {
+            return Ok(logs_from_connection(invocation_logs.logs));
+        }
+
+        if !cron.invocations.page_info.has_next_page {
+            bail!("cron job invocation '{invocation}' not found");
+        }
+        invocation_after = Some(
+            cron.invocations
+                .page_info
+                .end_cursor
+                .context("cron job invocations cursor missing")?,
+        );
+    }
+}
+
+fn default_cron_invocation_window(
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+) -> Result<(OffsetDateTime, OffsetDateTime), anyhow::Error> {
+    let (start, end) = match (start, end) {
+        (Some(start), Some(end)) => (start, end),
+        (Some(start), None) => (start, OffsetDateTime::now_utc()),
+        (None, Some(end)) => (end - time::Duration::days(31), end),
+        (None, None) => {
+            let end = OffsetDateTime::now_utc();
+            (end - time::Duration::days(31), end)
+        }
+    };
+    if start > end {
+        bail!("invocation start must not be after end");
+    }
+    Ok((start, end))
+}
+
+fn logs_from_connection(connection: types::CronJobLogConnection) -> Vec<types::CronJobLog> {
+    connection
+        .edges
+        .into_iter()
+        .flatten()
+        .filter_map(|edge| edge.node)
+        .collect()
 }
 
 /// Load the S3 credentials.

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -288,6 +288,172 @@ pub async fn get_app_databases(
     Ok(dbs)
 }
 
+/// Retrieve cron jobs for an app.
+pub async fn get_app_cron_jobs(
+    client: &WasmerClient,
+    owner: impl Into<String>,
+    name: impl Into<String>,
+) -> Result<Vec<types::CronJob>, anyhow::Error> {
+    let owner = owner.into();
+    let name = name.into();
+    let mut after = None;
+    let mut cron_jobs = Vec::new();
+
+    loop {
+        let vars = types::GetAppCronJobsVars {
+            owner: owner.clone(),
+            name: name.clone(),
+            after,
+            first: Some(100),
+        };
+        let res = client
+            .run_graphql_strict(types::GetAppCronJobs::build(vars))
+            .await?;
+
+        let app = res.get_deploy_app.context("app not found")?;
+        let con = app.cron_jobs;
+        let page_info = con.page_info;
+        cron_jobs.extend(con.edges.into_iter().flatten().flat_map(|edge| edge.node));
+
+        if !page_info.has_next_page {
+            break;
+        }
+        after = Some(page_info.end_cursor.context("cron jobs cursor missing")?);
+    }
+
+    Ok(cron_jobs)
+}
+
+/// Retrieve invocations for a cron job. The cron job can be referenced by id or name.
+pub async fn get_cron_job_invocations(
+    client: &WasmerClient,
+    owner: impl Into<String>,
+    name: impl Into<String>,
+    cron_job: impl AsRef<str>,
+) -> Result<(types::CronJobWithInvocations, Vec<types::CronJobInvocation>), anyhow::Error> {
+    let cron_job = cron_job.as_ref().to_string();
+    let owner = owner.into();
+    let name = name.into();
+    let mut invocation_after = None;
+    let mut all_invocations = Vec::new();
+    let mut cron_job_with_invocations: Option<types::CronJobWithInvocations> = None;
+
+    loop {
+        let (mut cron, page) = get_cron_job_invocations_page(
+            client,
+            owner.clone(),
+            name.clone(),
+            &cron_job,
+            invocation_after,
+            Some(100),
+            None,
+            None,
+        )
+        .await?;
+
+        all_invocations.extend(page.items);
+        invocation_after = page.next_cursor;
+
+        if let Some(existing_cron) = &mut cron_job_with_invocations {
+            existing_cron
+                .invocations
+                .edges
+                .append(&mut cron.invocations.edges);
+            existing_cron.invocations.page_info = cron.invocations.page_info;
+        } else {
+            cron_job_with_invocations = Some(cron);
+        }
+
+        if invocation_after.is_none() {
+            break;
+        }
+    }
+
+    Ok((
+        cron_job_with_invocations.context("cron job missing from invocations response")?,
+        all_invocations,
+    ))
+}
+
+/// Retrieve one page of invocations for a cron job. The cron job can be referenced by id or name.
+pub async fn get_cron_job_invocations_page(
+    client: &WasmerClient,
+    owner: impl Into<String>,
+    name: impl Into<String>,
+    cron_job: impl AsRef<str>,
+    invocation_after: Option<String>,
+    invocation_first: Option<i32>,
+    start: Option<OffsetDateTime>,
+    end: Option<OffsetDateTime>,
+) -> Result<
+    (
+        types::CronJobWithInvocations,
+        Paginated<types::CronJobInvocation>,
+    ),
+    anyhow::Error,
+> {
+    let cron_job = cron_job.as_ref();
+    let owner = owner.into();
+    let name = name.into();
+    let start = start.map(types::DateTime::try_from).transpose()?;
+    let end = end.map(types::DateTime::try_from).transpose()?;
+    let mut cron_after = None;
+
+    loop {
+        let vars = types::GetCronJobInvocationsVars {
+            owner: owner.clone(),
+            name: name.clone(),
+            cron_after: cron_after.clone(),
+            cron_first: Some(100),
+            invocation_start: start.clone(),
+            invocation_end: end.clone(),
+            invocation_after: invocation_after.clone(),
+            invocation_first,
+        };
+        let res = client
+            .run_graphql_strict(types::GetCronJobInvocations::build(vars))
+            .await?;
+
+        let app = res.get_deploy_app.context("app not found")?;
+        let con = app.cron_jobs;
+        let page_info = con.page_info;
+        if let Some(cron) = con
+            .nodes
+            .into_iter()
+            .find(|node| node.id.inner() == cron_job || node.name == cron_job)
+        {
+            let invocations = cron
+                .invocations
+                .edges
+                .iter()
+                .flatten()
+                .flat_map(|edge| edge.node.clone())
+                .collect::<Vec<_>>();
+            let next_cursor = cron
+                .invocations
+                .page_info
+                .has_next_page
+                .then(|| cron.invocations.page_info.end_cursor.clone())
+                .flatten();
+
+            return Ok((
+                cron,
+                Paginated {
+                    items: invocations,
+                    next_cursor,
+                },
+            ));
+        }
+
+        if !page_info.has_next_page {
+            break;
+        }
+        cron_after = Some(page_info.end_cursor.context("cron jobs cursor missing")?);
+    }
+
+    bail!("cron job '{cron_job}' not found")
+}
+
 /// Load the S3 credentials.
 ///
 /// S3 can be used to get access to an apps volumes.

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1255,6 +1255,24 @@ mod queries {
         pub target: CronJobTarget,
     }
 
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct ToggleCronJobVars {
+        pub cron_job_id: cynic::Id,
+        pub enabled: bool,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Mutation", variables = "ToggleCronJobVars")]
+    pub struct ToggleCronJob {
+        #[arguments(input: { cronJobId: $cron_job_id, enabled: $enabled })]
+        pub toggle_cron_job: Option<ToggleCronJobPayload>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    pub struct ToggleCronJobPayload {
+        pub cron_job: CronJob,
+    }
+
     #[derive(cynic::InlineFragments, Debug, Clone, Serialize)]
     #[cynic(graphql_type = "CronJobTarget")]
     pub enum CronJobTarget {

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1313,6 +1313,95 @@ mod queries {
         pub invocation_first: Option<i32>,
     }
 
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetCronJobInvocationsByIdVars {
+        pub id: cynic::Id,
+        pub invocation_start: Option<DateTime>,
+        pub invocation_end: Option<DateTime>,
+        pub invocation_after: Option<String>,
+        pub invocation_first: Option<i32>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetCronJobInvocationLogsVars {
+        pub owner: String,
+        pub name: String,
+        pub cron_after: Option<String>,
+        pub cron_first: Option<i32>,
+        pub invocation_start: Option<DateTime>,
+        pub invocation_end: Option<DateTime>,
+        pub invocation_after: Option<String>,
+        pub invocation_first: Option<i32>,
+        pub log_first: Option<i32>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetCronJobInvocationLogsByIdVars {
+        pub id: cynic::Id,
+        pub invocation_start: Option<DateTime>,
+        pub invocation_end: Option<DateTime>,
+        pub invocation_after: Option<String>,
+        pub invocation_first: Option<i32>,
+        pub log_first: Option<i32>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationsByIdVars")]
+    pub struct GetCronJobInvocationsById {
+        #[arguments(id: $id)]
+        #[cynic(rename = "node")]
+        pub cron_job: Option<NodeCronJobWithInvocations>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationLogsVars")]
+    pub struct GetCronJobInvocationLogs {
+        #[arguments(owner: $owner, name: $name)]
+        pub get_deploy_app: Option<DeployAppCronJobInvocationLogs>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationLogsByIdVars")]
+    pub struct GetCronJobInvocationLogsById {
+        #[arguments(id: $id)]
+        #[cynic(rename = "node")]
+        pub cron_job: Option<NodeCronJobWithInvocationLogs>,
+    }
+
+    #[derive(cynic::InlineFragments, Debug, Clone)]
+    #[cynic(graphql_type = "Node", variables = "GetCronJobInvocationsByIdVars")]
+    pub enum NodeCronJobWithInvocations {
+        CronJob(CronJobWithInvocationsById),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    impl NodeCronJobWithInvocations {
+        pub fn into_cron_job(self) -> Option<CronJobWithInvocationsById> {
+            match self {
+                Self::CronJob(cron_job) => Some(cron_job),
+                Self::Unknown => None,
+            }
+        }
+    }
+
+    #[derive(cynic::InlineFragments, Debug, Clone)]
+    #[cynic(graphql_type = "Node", variables = "GetCronJobInvocationLogsByIdVars")]
+    pub enum NodeCronJobWithInvocationLogs {
+        CronJob(CronJobWithInvocationLogsById),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    impl NodeCronJobWithInvocationLogs {
+        pub fn into_cron_job(self) -> Option<CronJobWithInvocationLogsById> {
+            match self {
+                Self::CronJob(cron_job) => Some(cron_job),
+                Self::Unknown => None,
+            }
+        }
+    }
+
     #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationsVars")]
     pub struct GetCronJobInvocations {
@@ -1328,6 +1417,13 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "DeployApp", variables = "GetCronJobInvocationLogsVars")]
+    pub struct DeployAppCronJobInvocationLogs {
+        #[arguments(first: $cron_first, after: $cron_after)]
+        pub cron_jobs: CronJobConnectionForInvocationLogs,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(
         graphql_type = "CronJobConnection",
         variables = "GetCronJobInvocationsVars"
@@ -1338,12 +1434,52 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobConnection",
+        variables = "GetCronJobInvocationLogsVars"
+    )]
+    pub struct CronJobConnectionForInvocationLogs {
+        pub page_info: PageInfo,
+        pub nodes: Vec<CronJobWithInvocationLogs>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(graphql_type = "CronJob", variables = "GetCronJobInvocationsVars")]
     pub struct CronJobWithInvocations {
         pub id: cynic::Id,
         pub name: String,
         #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
         pub invocations: CronJobInvocationConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "CronJob", variables = "GetCronJobInvocationsByIdVars")]
+    pub struct CronJobWithInvocationsById {
+        pub id: cynic::Id,
+        pub name: String,
+        #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
+        pub invocations: CronJobInvocationConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "CronJob", variables = "GetCronJobInvocationLogsVars")]
+    pub struct CronJobWithInvocationLogs {
+        pub id: cynic::Id,
+        pub name: String,
+        #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
+        pub invocations: CronJobInvocationLogsConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJob",
+        variables = "GetCronJobInvocationLogsByIdVars"
+    )]
+    pub struct CronJobWithInvocationLogsById {
+        pub id: cynic::Id,
+        pub name: String,
+        #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
+        pub invocations: CronJobInvocationLogsConnectionById,
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
@@ -1370,6 +1506,88 @@ mod queries {
         pub retry_attempts: Option<i32>,
         pub error_summary: Option<String>,
         pub result: Option<CronJobInvocationResult>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocationConnection",
+        variables = "GetCronJobInvocationLogsVars"
+    )]
+    pub struct CronJobInvocationLogsConnection {
+        pub page_info: PageInfo,
+        pub edges: Vec<Option<CronJobInvocationLogsEdge>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocationEdge",
+        variables = "GetCronJobInvocationLogsVars"
+    )]
+    pub struct CronJobInvocationLogsEdge {
+        pub node: Option<CronJobInvocationWithLogs>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocationConnection",
+        variables = "GetCronJobInvocationLogsByIdVars"
+    )]
+    pub struct CronJobInvocationLogsConnectionById {
+        pub page_info: PageInfo,
+        pub edges: Vec<Option<CronJobInvocationLogsEdgeById>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocationEdge",
+        variables = "GetCronJobInvocationLogsByIdVars"
+    )]
+    pub struct CronJobInvocationLogsEdgeById {
+        pub node: Option<CronJobInvocationWithLogsById>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocation",
+        variables = "GetCronJobInvocationLogsVars"
+    )]
+    pub struct CronJobInvocationWithLogs {
+        pub id: cynic::Id,
+        pub edge_job_id: String,
+        #[arguments(first: $log_first)]
+        pub logs: CronJobLogConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocation",
+        variables = "GetCronJobInvocationLogsByIdVars"
+    )]
+    pub struct CronJobInvocationWithLogsById {
+        pub id: cynic::Id,
+        pub edge_job_id: String,
+        #[arguments(first: $log_first)]
+        pub logs: CronJobLogConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    #[cynic(graphql_type = "LogConnection")]
+    pub struct CronJobLogConnection {
+        pub edges: Vec<Option<CronJobLogEdge>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    #[cynic(graphql_type = "LogEdge")]
+    pub struct CronJobLogEdge {
+        pub node: Option<CronJobLog>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize, PartialEq)]
+    #[cynic(graphql_type = "Log")]
+    pub struct CronJobLog {
+        pub message: String,
+        pub datetime: DateTime,
+        pub stream: Option<LogStream>,
     }
 
     #[derive(cynic::InlineFragments, Debug, Clone, Serialize)]
@@ -1906,17 +2124,17 @@ mod queries {
         pub logs: LogConnection,
     }
 
-    #[derive(cynic::QueryFragment, Debug)]
+    #[derive(cynic::QueryFragment, Debug, Clone)]
     pub struct LogConnection {
         pub edges: Vec<Option<LogEdge>>,
     }
 
-    #[derive(cynic::QueryFragment, Debug)]
+    #[derive(cynic::QueryFragment, Debug, Clone)]
     pub struct LogEdge {
         pub node: Option<Log>,
     }
 
-    #[derive(cynic::QueryFragment, Debug, serde::Serialize, PartialEq)]
+    #[derive(cynic::QueryFragment, Debug, Clone, serde::Serialize, PartialEq)]
     pub struct Log {
         pub message: String,
         /// When the message was recorded, in nanoseconds since the Unix epoch.
@@ -2004,6 +2222,36 @@ mod queries {
     pub struct GetNode {
         #[arguments(id: $id)]
         pub node: Option<Node>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetCronJobByIdVars {
+        pub id: cynic::Id,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Query", variables = "GetCronJobByIdVars")]
+    pub struct GetCronJobById {
+        #[arguments(id: $id)]
+        #[cynic(rename = "node")]
+        pub cron_job: Option<NodeCronJob>,
+    }
+
+    #[derive(cynic::InlineFragments, Debug, Clone)]
+    #[cynic(graphql_type = "Node")]
+    pub enum NodeCronJob {
+        CronJob(CronJob),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    impl NodeCronJob {
+        pub fn into_cron_job(self) -> Option<CronJob> {
+            match self {
+                Self::CronJob(cron_job) => Some(cron_job),
+                Self::Unknown => None,
+            }
+        }
     }
 
     #[derive(cynic::QueryVariables, Debug)]

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -39,6 +39,9 @@ mod queries {
     #[derive(cynic::Scalar, Debug, Clone)]
     pub struct JSONString(pub String);
 
+    #[derive(cynic::Scalar, Debug, Clone)]
+    pub struct GenericScalar(pub serde_json::Value);
+
     #[derive(cynic::Enum, Clone, Copy, Debug)]
     pub enum GrapheneRole {
         Owner,
@@ -1169,6 +1172,207 @@ mod queries {
         pub s3_url: Option<Url>,
         pub will_perish_at: Option<DateTime>,
         pub perish_reason: Option<DeployDeployAppPerishReasonChoices>,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+    pub enum CronJobKind {
+        #[cynic(rename = "FETCH")]
+        Fetch,
+        #[cynic(rename = "EXECUTE")]
+        Execute,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    pub enum CronJobSource {
+        #[cynic(rename = "CONFIG")]
+        Config,
+        #[cynic(rename = "API")]
+        Api,
+        #[cynic(rename = "PROVISIONED")]
+        Provisioned,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    pub enum CronJobInvocationStatus {
+        #[cynic(rename = "PENDING")]
+        Pending,
+        #[cynic(rename = "RUNNING")]
+        Running,
+        #[cynic(rename = "SUCCESS")]
+        Success,
+        #[cynic(rename = "FAILURE")]
+        Failure,
+    }
+
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetAppCronJobsVars {
+        pub owner: String,
+        pub name: String,
+        pub after: Option<String>,
+        pub first: Option<i32>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Query", variables = "GetAppCronJobsVars")]
+    pub struct GetAppCronJobs {
+        #[arguments(owner: $owner, name: $name)]
+        pub get_deploy_app: Option<DeployAppCronJobs>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "DeployApp", variables = "GetAppCronJobsVars")]
+    pub struct DeployAppCronJobs {
+        #[arguments(first: $first, after: $after)]
+        pub cron_jobs: CronJobConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct CronJobConnection {
+        pub page_info: PageInfo,
+        pub edges: Vec<Option<CronJobEdge>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct CronJobEdge {
+        pub cursor: String,
+        pub node: Option<CronJob>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct CronJob {
+        pub id: cynic::Id,
+        pub name: String,
+        pub schedule: String,
+        pub kind: CronJobKind,
+        pub source: CronJobSource,
+        pub enabled: bool,
+        pub is_managed: bool,
+        pub timeout: Option<String>,
+        pub max_schedule_drift: Option<String>,
+        pub max_retries: Option<i32>,
+        pub created_at: DateTime,
+        pub updated_at: DateTime,
+        pub target: CronJobTarget,
+    }
+
+    #[derive(cynic::InlineFragments, Debug, Clone, Serialize)]
+    #[cynic(graphql_type = "CronJobTarget")]
+    pub enum CronJobTarget {
+        FetchCronJobTarget(FetchCronJobTarget),
+        ExecuteCronJobTarget(ExecuteCronJobTarget),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct FetchCronJobTarget {
+        pub body: Option<String>,
+        pub headers: GenericScalar,
+        pub method: String,
+        pub path: String,
+        pub expect_body_includes: Option<String>,
+        pub expect_body_regex: Option<String>,
+        pub expect_status_codes: Option<GenericScalar>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct ExecuteCronJobTarget {
+        pub package_name: Option<String>,
+        pub command: Option<String>,
+        pub cli_args: Vec<String>,
+        pub env: GenericScalar,
+    }
+
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetCronJobInvocationsVars {
+        pub owner: String,
+        pub name: String,
+        pub cron_after: Option<String>,
+        pub cron_first: Option<i32>,
+        pub invocation_start: Option<DateTime>,
+        pub invocation_end: Option<DateTime>,
+        pub invocation_after: Option<String>,
+        pub invocation_first: Option<i32>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationsVars")]
+    pub struct GetCronJobInvocations {
+        #[arguments(owner: $owner, name: $name)]
+        pub get_deploy_app: Option<DeployAppCronJobInvocations>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "DeployApp", variables = "GetCronJobInvocationsVars")]
+    pub struct DeployAppCronJobInvocations {
+        #[arguments(first: $cron_first, after: $cron_after)]
+        pub cron_jobs: CronJobConnectionForInvocations,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobConnection",
+        variables = "GetCronJobInvocationsVars"
+    )]
+    pub struct CronJobConnectionForInvocations {
+        pub page_info: PageInfo,
+        pub nodes: Vec<CronJobWithInvocations>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(graphql_type = "CronJob", variables = "GetCronJobInvocationsVars")]
+    pub struct CronJobWithInvocations {
+        pub id: cynic::Id,
+        pub name: String,
+        #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
+        pub invocations: CronJobInvocationConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct CronJobInvocationConnection {
+        pub page_info: PageInfo,
+        pub edges: Vec<Option<CronJobInvocationEdge>>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct CronJobInvocationEdge {
+        pub cursor: String,
+        pub node: Option<CronJobInvocation>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct CronJobInvocation {
+        pub id: String,
+        pub edge_job_id: String,
+        pub status: Option<CronJobInvocationStatus>,
+        pub scheduled_at: Option<DateTime>,
+        pub started_at: Option<DateTime>,
+        pub finished_at: Option<DateTime>,
+        pub duration_ms: Option<i32>,
+        pub retry_attempts: Option<i32>,
+        pub error_summary: Option<String>,
+        pub result: Option<CronJobInvocationResult>,
+    }
+
+    #[derive(cynic::InlineFragments, Debug, Clone, Serialize)]
+    #[cynic(graphql_type = "CronJobInvocationResult")]
+    pub enum CronJobInvocationResult {
+        ExecuteCronJobInvocationResult(ExecuteCronJobInvocationResult),
+        FetchCronJobInvocationResult(FetchCronJobInvocationResult),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct ExecuteCronJobInvocationResult {
+        pub exit_code: Option<i32>,
+        pub instance_id: Option<String>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
+    pub struct FetchCronJobInvocationResult {
+        pub status_code: Option<i32>,
+        pub request_id: Option<String>,
     }
 
     #[derive(cynic::Enum, Clone, Copy, Debug)]

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1297,7 +1297,7 @@ mod queries {
     pub struct ExecuteCronJobTarget {
         pub package_name: Option<String>,
         pub command: Option<String>,
-        pub cli_args: Vec<String>,
+        pub cli_args: GenericScalar,
         pub env: GenericScalar,
     }
 
@@ -1360,7 +1360,7 @@ mod queries {
 
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
     pub struct CronJobInvocation {
-        pub id: String,
+        pub id: cynic::Id,
         pub edge_job_id: String,
         pub status: Option<CronJobInvocationStatus>,
         pub scheduled_at: Option<DateTime>,

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -2240,7 +2240,7 @@ mod queries {
     #[derive(cynic::InlineFragments, Debug, Clone)]
     #[cynic(graphql_type = "Node")]
     pub enum NodeCronJob {
-        CronJob(CronJob),
+        CronJob(Box<CronJob>),
         #[cynic(fallback)]
         Unknown,
     }
@@ -2248,7 +2248,7 @@ mod queries {
     impl NodeCronJob {
         pub fn into_cron_job(self) -> Option<CronJob> {
             match self {
-                Self::CronJob(cron_job) => Some(cron_job),
+                Self::CronJob(cron_job) => Some(*cron_job),
                 Self::Unknown => None,
             }
         }

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -305,7 +305,7 @@ async fn toggle_cron_job(
     let cron_job = cron_jobs
         .into_iter()
         .find(|job| job.id.inner() == cron_job || job.name == cron_job)
-        .with_context(|| format!("cron job '{}' not found", cron_job))?;
+        .with_context(|| format!("cron job '{cron_job}' not found"))?;
 
     let cron_job =
         wasmer_backend_api::query::toggle_cron_job(&client, cron_job.id.inner(), enabled).await?;

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -1,6 +1,9 @@
 //! Cron job commands.
 
-use std::io::{self, IsTerminal, Write};
+use std::{
+    io::{self, IsTerminal, Write},
+    num::NonZeroU32,
+};
 
 use anyhow::{Context, bail};
 use time::OffsetDateTime;
@@ -12,11 +15,17 @@ use crate::{
     utils::{render::ListFormat, timestamp::parse_timestamp_or_relative_time_negative_offset},
 };
 
+const DEFAULT_CRON_JOB_PAGE_SIZE: NonZeroU32 =
+    match NonZeroU32::new(wasmer_backend_api::query::CRON_JOB_PAGE_SIZE as u32) {
+        Some(value) => value,
+        None => panic!("cron job page size must be non-zero"),
+    };
+
 /// Manage cron jobs for Wasmer Edge apps.
 #[derive(clap::Subcommand, Debug)]
 pub enum CmdCron {
     List(CmdCronList),
-    Show(CmdCronShow),
+    Get(CmdCronGet),
     Invocations(CmdCronInvocations),
     Enable(CmdCronEnable),
     Disable(CmdCronDisable),
@@ -29,7 +38,7 @@ impl AsyncCliCommand for CmdCron {
     async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
         match self {
             Self::List(cmd) => cmd.run_async().await,
-            Self::Show(cmd) => cmd.run_async().await,
+            Self::Get(cmd) => cmd.run_async().await,
             Self::Invocations(cmd) => cmd.run_async().await,
             Self::Enable(cmd) => cmd.run_async().await,
             Self::Disable(cmd) => cmd.run_async().await,
@@ -74,9 +83,9 @@ impl AsyncCliCommand for CmdCronList {
     }
 }
 
-/// Show one cron job.
+/// Get one cron job.
 #[derive(clap::Parser, Debug)]
-pub struct CmdCronShow {
+pub struct CmdCronGet {
     #[clap(flatten)]
     fmt: ItemFormatOpts,
 
@@ -91,22 +100,13 @@ pub struct CmdCronShow {
 }
 
 #[async_trait::async_trait]
-impl AsyncCliCommand for CmdCronShow {
+impl AsyncCliCommand for CmdCronGet {
     type Output = ();
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
         let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
-        let cron_jobs = wasmer_backend_api::query::get_app_cron_jobs(
-            &client,
-            &app.owner.global_name,
-            &app.name,
-        )
-        .await?;
-        let cron_job = cron_jobs
-            .into_iter()
-            .find(|job| job.id.inner() == self.cron_job || job.name == self.cron_job)
-            .with_context(|| format!("cron job '{}' not found", self.cron_job))?;
+        let cron_job = find_app_cron_job(&client, &app, &self.cron_job).await?;
 
         println!("{}", self.fmt.get().render(&cron_job));
         Ok(())
@@ -145,8 +145,8 @@ pub struct CmdCronInvocations {
     end: Option<OffsetDateTime>,
 
     /// Number of invocations to fetch per page.
-    #[clap(long, default_value = "100")]
-    page_size: i32,
+    #[clap(long, default_value_t = DEFAULT_CRON_JOB_PAGE_SIZE)]
+    page_size: NonZeroU32,
 
     /// Fetch all invocation pages without prompting.
     #[clap(long)]
@@ -158,9 +158,8 @@ impl AsyncCliCommand for CmdCronInvocations {
     type Output = ();
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
-        if self.page_size <= 0 {
-            bail!("--page-size must be greater than 0");
-        }
+        let invocation_first = invocation_page_size(self.page_size)?;
+
         if let (Some(start), Some(end)) = (self.start, self.end)
             && start > end
         {
@@ -186,7 +185,7 @@ impl AsyncCliCommand for CmdCronInvocations {
                 &app.name,
                 &self.cron_job,
                 invocation_after,
-                Some(self.page_size),
+                Some(invocation_first),
                 self.start,
                 self.end,
             )
@@ -299,13 +298,7 @@ async fn toggle_cron_job(
 ) -> Result<(), anyhow::Error> {
     let client = env.client()?;
     let (_ident, app) = ident.to_opts().load_app(&client).await?;
-    let cron_jobs =
-        wasmer_backend_api::query::get_app_cron_jobs(&client, &app.owner.global_name, &app.name)
-            .await?;
-    let cron_job = cron_jobs
-        .into_iter()
-        .find(|job| job.id.inner() == cron_job || job.name == cron_job)
-        .with_context(|| format!("cron job '{cron_job}' not found"))?;
+    let cron_job = find_app_cron_job(&client, &app, &cron_job).await?;
 
     let cron_job =
         wasmer_backend_api::query::toggle_cron_job(&client, cron_job.id.inner(), enabled).await?;
@@ -317,4 +310,20 @@ async fn toggle_cron_job(
 
     eprintln!("Cron job {} is now {}.", cron_job.name, state);
     Ok(())
+}
+
+async fn find_app_cron_job(
+    client: &wasmer_backend_api::WasmerClient,
+    app: &wasmer_backend_api::types::DeployApp,
+    cron_job: &str,
+) -> Result<wasmer_backend_api::types::CronJob, anyhow::Error> {
+    wasmer_backend_api::query::get_app_cron_jobs(client, &app.owner.global_name, &app.name)
+        .await?
+        .into_iter()
+        .find(|job| job.id.inner() == cron_job || job.name == cron_job)
+        .with_context(|| format!("cron job '{cron_job}' not found"))
+}
+
+fn invocation_page_size(page_size: NonZeroU32) -> Result<i32, anyhow::Error> {
+    i32::try_from(page_size.get()).context("--page-size must be less than or equal to 2147483647")
 }

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -27,6 +27,7 @@ pub enum CmdCron {
     List(CmdCronList),
     Get(CmdCronGet),
     Invocations(CmdCronInvocations),
+    Logs(CmdCronLogs),
     Enable(CmdCronEnable),
     Disable(CmdCronDisable),
 }
@@ -40,6 +41,7 @@ impl AsyncCliCommand for CmdCron {
             Self::List(cmd) => cmd.run_async().await,
             Self::Get(cmd) => cmd.run_async().await,
             Self::Invocations(cmd) => cmd.run_async().await,
+            Self::Logs(cmd) => cmd.run_async().await,
             Self::Enable(cmd) => cmd.run_async().await,
             Self::Disable(cmd) => cmd.run_async().await,
         }
@@ -105,8 +107,7 @@ impl AsyncCliCommand for CmdCronGet {
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
         let client = self.env.client()?;
-        let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
-        let cron_job = find_app_cron_job(&client, &app, &self.cron_job).await?;
+        let cron_job = resolve_cron_job(&client, self.ident, &self.cron_job).await?;
 
         println!("{}", self.fmt.get().render(&cron_job));
         Ok(())
@@ -167,8 +168,13 @@ impl AsyncCliCommand for CmdCronInvocations {
         }
 
         let client = self.env.client()?;
-        let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
         let format = self.fmt.format;
+        let resolve_by_id = should_resolve_cron_job_by_id(&self.ident, &self.cron_job);
+        let app = if resolve_by_id {
+            None
+        } else {
+            Some(self.ident.to_opts().load_app(&client).await?.1)
+        };
         let interactive = io::stdin().is_terminal()
             && matches!(format, ListFormat::Table | ListFormat::ItemTable)
             && !self.all;
@@ -179,17 +185,32 @@ impl AsyncCliCommand for CmdCronInvocations {
         let mut saw_invocations = false;
 
         loop {
-            let (_cron_job, page) = wasmer_backend_api::query::get_cron_job_invocations_page(
-                &client,
-                &app.owner.global_name,
-                &app.name,
-                &self.cron_job,
-                invocation_after,
-                Some(invocation_first),
-                self.start,
-                self.end,
-            )
-            .await?;
+            let page = if resolve_by_id {
+                wasmer_backend_api::query::get_cron_job_invocations_page_by_id(
+                    &client,
+                    &self.cron_job,
+                    invocation_after,
+                    Some(invocation_first),
+                    self.start,
+                    self.end,
+                )
+                .await?
+                .1
+            } else {
+                let app = app.as_ref().expect("app is loaded for name-based lookup");
+                wasmer_backend_api::query::get_cron_job_invocations_page(
+                    &client,
+                    &app.owner.global_name,
+                    &app.name,
+                    &self.cron_job,
+                    invocation_after,
+                    Some(invocation_first),
+                    self.start,
+                    self.end,
+                )
+                .await?
+                .1
+            };
 
             saw_invocations |= !page.items.is_empty();
             invocation_after = page.next_cursor;
@@ -246,6 +267,95 @@ fn prompt_next_invocation_page() -> Result<bool, anyhow::Error> {
     }
 }
 
+/// Show logs for one cron job invocation.
+#[derive(clap::Parser, Debug)]
+pub struct CmdCronLogs {
+    #[clap(flatten)]
+    fmt: ListFormatOpts,
+
+    #[clap(flatten)]
+    env: WasmerEnv,
+
+    #[clap(flatten)]
+    ident: AppIdentArgOpts,
+
+    /// Cron job id or name.
+    cron_job: String,
+
+    /// Cron job invocation id or edge job id.
+    invocation: String,
+
+    /// The earliest invocation timestamp to include.
+    ///
+    /// Defaults to 31 days before --end, or 31 days before now.
+    ///
+    /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
+    #[clap(long = "start", alias = "from", value_parser = parse_timestamp_or_relative_time_negative_offset)]
+    start: Option<OffsetDateTime>,
+
+    /// The latest invocation timestamp to include.
+    ///
+    /// Defaults to now.
+    ///
+    /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
+    #[clap(long = "end", alias = "until", value_parser = parse_timestamp_or_relative_time_negative_offset)]
+    end: Option<OffsetDateTime>,
+
+    /// Maximum log lines to fetch.
+    #[clap(long, default_value = "1000")]
+    max: i32,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCronLogs {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        if self.max < 1 {
+            bail!("--max must be greater than 0");
+        }
+        if let (Some(start), Some(end)) = (self.start, self.end)
+            && start > end
+        {
+            bail!("--start must be before or equal to --end");
+        }
+
+        let client = self.env.client()?;
+        let logs = if should_resolve_cron_job_by_id(&self.ident, &self.cron_job) {
+            wasmer_backend_api::query::get_cron_job_invocation_logs_by_id(
+                &client,
+                &self.cron_job,
+                &self.invocation,
+                Some(self.max),
+                self.start,
+                self.end,
+            )
+            .await?
+        } else {
+            let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
+            wasmer_backend_api::query::get_cron_job_invocation_logs(
+                &client,
+                &app.owner.global_name,
+                &app.name,
+                &self.cron_job,
+                &self.invocation,
+                Some(self.max),
+                self.start,
+                self.end,
+            )
+            .await?
+        };
+
+        if logs.is_empty() {
+            eprintln!("Cron job invocation {} has no logs!", self.invocation);
+        } else {
+            println!("{}", self.fmt.format.render(logs.as_slice()));
+        }
+
+        Ok(())
+    }
+}
+
 /// Enable one cron job.
 #[derive(clap::Parser, Debug)]
 pub struct CmdCronEnable {
@@ -297,8 +407,7 @@ async fn toggle_cron_job(
     enabled: bool,
 ) -> Result<(), anyhow::Error> {
     let client = env.client()?;
-    let (_ident, app) = ident.to_opts().load_app(&client).await?;
-    let cron_job = find_app_cron_job(&client, &app, &cron_job).await?;
+    let cron_job = resolve_cron_job(&client, ident, &cron_job).await?;
 
     let cron_job =
         wasmer_backend_api::query::toggle_cron_job(&client, cron_job.id.inner(), enabled).await?;
@@ -310,6 +419,23 @@ async fn toggle_cron_job(
 
     eprintln!("Cron job {} is now {}.", cron_job.name, state);
     Ok(())
+}
+
+async fn resolve_cron_job(
+    client: &wasmer_backend_api::WasmerClient,
+    ident: AppIdentArgOpts,
+    cron_job: &str,
+) -> Result<wasmer_backend_api::types::CronJob, anyhow::Error> {
+    if should_resolve_cron_job_by_id(&ident, cron_job) {
+        return wasmer_backend_api::query::get_cron_job_by_id(client, cron_job).await;
+    }
+
+    let (_ident, app) = ident.to_opts().load_app(client).await?;
+    find_app_cron_job(client, &app, cron_job).await
+}
+
+fn should_resolve_cron_job_by_id(ident: &AppIdentArgOpts, cron_job: &str) -> bool {
+    ident.app.is_none() && cron_job.starts_with("cron_")
 }
 
 async fn find_app_cron_job(

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -261,8 +261,7 @@ impl AsyncCliCommand for CmdCronEnable {
     type Output = ();
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
-        let _ = (self.env, self.ident, self.cron_job);
-        bail!("enabling cron jobs is not supported by the current backend API yet")
+        toggle_cron_job(self.env, self.ident, self.cron_job, true).await
     }
 }
 
@@ -284,7 +283,34 @@ impl AsyncCliCommand for CmdCronDisable {
     type Output = ();
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
-        let _ = (self.env, self.ident, self.cron_job);
-        bail!("disabling cron jobs is not supported by the current backend API yet")
+        toggle_cron_job(self.env, self.ident, self.cron_job, false).await
     }
+}
+
+async fn toggle_cron_job(
+    env: WasmerEnv,
+    ident: AppIdentArgOpts,
+    cron_job: String,
+    enabled: bool,
+) -> Result<(), anyhow::Error> {
+    let client = env.client()?;
+    let (_ident, app) = ident.to_opts().load_app(&client).await?;
+    let cron_jobs =
+        wasmer_backend_api::query::get_app_cron_jobs(&client, &app.owner.global_name, &app.name)
+            .await?;
+    let cron_job = cron_jobs
+        .into_iter()
+        .find(|job| job.id.inner() == cron_job || job.name == cron_job)
+        .with_context(|| format!("cron job '{}' not found", cron_job))?;
+
+    let cron_job =
+        wasmer_backend_api::query::toggle_cron_job(&client, cron_job.id.inner(), enabled).await?;
+    let state = if cron_job.enabled {
+        "enabled"
+    } else {
+        "disabled"
+    };
+
+    eprintln!("Cron job {} is now {}.", cron_job.name, state);
+    Ok(())
 }

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -1,0 +1,290 @@
+//! Cron job commands.
+
+use std::io::{self, IsTerminal, Write};
+
+use anyhow::{Context, bail};
+use time::OffsetDateTime;
+
+use crate::{
+    commands::{AsyncCliCommand, app::AppIdentArgOpts},
+    config::WasmerEnv,
+    opts::{ItemFormatOpts, ListFormatOpts},
+    utils::{render::ListFormat, timestamp::parse_timestamp_or_relative_time_negative_offset},
+};
+
+/// Manage cron jobs for Wasmer Edge apps.
+#[derive(clap::Subcommand, Debug)]
+pub enum CmdCron {
+    List(CmdCronList),
+    Show(CmdCronShow),
+    Invocations(CmdCronInvocations),
+    Enable(CmdCronEnable),
+    Disable(CmdCronDisable),
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCron {
+    type Output = ();
+
+    async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
+        match self {
+            Self::List(cmd) => cmd.run_async().await,
+            Self::Show(cmd) => cmd.run_async().await,
+            Self::Invocations(cmd) => cmd.run_async().await,
+            Self::Enable(cmd) => cmd.run_async().await,
+            Self::Disable(cmd) => cmd.run_async().await,
+        }
+    }
+}
+
+/// List cron jobs for an app.
+#[derive(clap::Parser, Debug)]
+pub struct CmdCronList {
+    #[clap(flatten)]
+    fmt: ListFormatOpts,
+
+    #[clap(flatten)]
+    env: WasmerEnv,
+
+    #[clap(flatten)]
+    ident: AppIdentArgOpts,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCronList {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        let client = self.env.client()?;
+        let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
+        let cron_jobs = wasmer_backend_api::query::get_app_cron_jobs(
+            &client,
+            &app.owner.global_name,
+            &app.name,
+        )
+        .await?;
+
+        if cron_jobs.is_empty() {
+            eprintln!("App {} has no cron jobs!", app.name);
+        } else {
+            println!("{}", self.fmt.format.render(cron_jobs.as_slice()));
+        }
+
+        Ok(())
+    }
+}
+
+/// Show one cron job.
+#[derive(clap::Parser, Debug)]
+pub struct CmdCronShow {
+    #[clap(flatten)]
+    fmt: ItemFormatOpts,
+
+    #[clap(flatten)]
+    env: WasmerEnv,
+
+    #[clap(flatten)]
+    ident: AppIdentArgOpts,
+
+    /// Cron job id or name.
+    cron_job: String,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCronShow {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        let client = self.env.client()?;
+        let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
+        let cron_jobs = wasmer_backend_api::query::get_app_cron_jobs(
+            &client,
+            &app.owner.global_name,
+            &app.name,
+        )
+        .await?;
+        let cron_job = cron_jobs
+            .into_iter()
+            .find(|job| job.id.inner() == self.cron_job || job.name == self.cron_job)
+            .with_context(|| format!("cron job '{}' not found", self.cron_job))?;
+
+        println!("{}", self.fmt.get().render(&cron_job));
+        Ok(())
+    }
+}
+
+/// List invocations for one cron job.
+#[derive(clap::Parser, Debug)]
+pub struct CmdCronInvocations {
+    #[clap(flatten)]
+    fmt: ListFormatOpts,
+
+    #[clap(flatten)]
+    env: WasmerEnv,
+
+    #[clap(flatten)]
+    ident: AppIdentArgOpts,
+
+    /// Cron job id or name.
+    cron_job: String,
+
+    /// The earliest invocation timestamp to include.
+    ///
+    /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
+    #[clap(long = "start", alias = "from", value_parser = parse_timestamp_or_relative_time_negative_offset)]
+    start: Option<OffsetDateTime>,
+
+    /// The latest invocation timestamp to include.
+    ///
+    /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
+    #[clap(long = "end", alias = "until", value_parser = parse_timestamp_or_relative_time_negative_offset)]
+    end: Option<OffsetDateTime>,
+
+    /// Number of invocations to fetch per page.
+    #[clap(long, default_value = "100")]
+    page_size: i32,
+
+    /// Fetch all invocation pages without prompting.
+    #[clap(long)]
+    all: bool,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCronInvocations {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        if self.page_size <= 0 {
+            bail!("--page-size must be greater than 0");
+        }
+        if let (Some(start), Some(end)) = (self.start, self.end)
+            && start > end
+        {
+            bail!("--start must be before or equal to --end");
+        }
+
+        let client = self.env.client()?;
+        let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
+        let format = self.fmt.format;
+        let interactive = io::stdin().is_terminal()
+            && matches!(format, ListFormat::Table | ListFormat::ItemTable)
+            && !self.all;
+        let render_after_fetching =
+            self.all || !matches!(format, ListFormat::Table | ListFormat::ItemTable);
+        let mut invocation_after = None;
+        let mut all_invocations = Vec::new();
+        let mut saw_invocations = false;
+
+        loop {
+            let (_cron_job, page) = wasmer_backend_api::query::get_cron_job_invocations_page(
+                &client,
+                &app.owner.global_name,
+                &app.name,
+                &self.cron_job,
+                invocation_after,
+                Some(self.page_size),
+                self.start,
+                self.end,
+            )
+            .await?;
+
+            saw_invocations |= !page.items.is_empty();
+            invocation_after = page.next_cursor;
+
+            if render_after_fetching {
+                all_invocations.extend(page.items);
+            } else if !page.items.is_empty() {
+                println!("{}", format.render(page.items.as_slice()));
+            }
+
+            if invocation_after.is_none() {
+                break;
+            }
+
+            if self.all {
+                continue;
+            }
+
+            if !interactive {
+                eprintln!("More invocations are available. Re-run with --all to fetch every page.");
+                break;
+            }
+
+            if !prompt_next_invocation_page()? {
+                break;
+            }
+        }
+
+        if !saw_invocations {
+            eprintln!("Cron job {} has no invocations!", self.cron_job);
+        } else if render_after_fetching {
+            println!("{}", format.render(all_invocations.as_slice()));
+        }
+
+        Ok(())
+    }
+}
+
+fn prompt_next_invocation_page() -> Result<bool, anyhow::Error> {
+    eprint!("Press Enter for the next page, or q to quit: ");
+    io::stderr().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        Ok(true)
+    } else if input.eq_ignore_ascii_case("q") {
+        Ok(false)
+    } else {
+        eprintln!("Unrecognized input; stopping.");
+        Ok(false)
+    }
+}
+
+/// Enable one cron job.
+#[derive(clap::Parser, Debug)]
+pub struct CmdCronEnable {
+    #[clap(flatten)]
+    env: WasmerEnv,
+
+    #[clap(flatten)]
+    ident: AppIdentArgOpts,
+
+    /// Cron job id or name.
+    cron_job: String,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCronEnable {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        let _ = (self.env, self.ident, self.cron_job);
+        bail!("enabling cron jobs is not supported by the current backend API yet")
+    }
+}
+
+/// Disable one cron job.
+#[derive(clap::Parser, Debug)]
+pub struct CmdCronDisable {
+    #[clap(flatten)]
+    env: WasmerEnv,
+
+    #[clap(flatten)]
+    ident: AppIdentArgOpts,
+
+    /// Cron job id or name.
+    cron_job: String,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdCronDisable {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        let _ = (self.env, self.ident, self.cron_job);
+        bail!("disabling cron jobs is not supported by the current backend API yet")
+    }
+}

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -130,11 +130,15 @@ pub struct CmdCronInvocations {
 
     /// The earliest invocation timestamp to include.
     ///
+    /// Defaults to 31 days before --end, or 31 days before now.
+    ///
     /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
     #[clap(long = "start", alias = "from", value_parser = parse_timestamp_or_relative_time_negative_offset)]
     start: Option<OffsetDateTime>,
 
     /// The latest invocation timestamp to include.
+    ///
+    /// Defaults to now.
     ///
     /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
     #[clap(long = "end", alias = "until", value_parser = parse_timestamp_or_relative_time_negative_offset)]

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod container;
 mod create_exe;
 #[cfg(feature = "static-artifact-create")]
 mod create_obj;
+mod cron;
 pub(crate) mod domain;
 #[cfg(feature = "static-artifact-create")]
 mod gen_c_header;
@@ -217,6 +218,7 @@ impl WasmerCmd {
             // Deploy commands.
             Some(Cmd::Deploy(c)) => c.run(),
             Some(Cmd::App(apps)) => apps.run(),
+            Some(Cmd::Cron(cron)) => cron.run(),
             #[cfg(feature = "journal")]
             Some(Cmd::Journal(journal)) => journal.run(),
             Some(Cmd::Ssh(ssh)) => ssh.run(),
@@ -481,6 +483,10 @@ enum Cmd {
     /// Create and manage Wasmer Edge apps
     #[clap(subcommand, alias = "apps")]
     App(crate::commands::app::CmdApp),
+
+    /// Manage cron jobs for Wasmer Edge apps
+    #[clap(subcommand)]
+    Cron(crate::commands::cron::CmdCron),
 
     /// Run commands/packages on Wasmer Edge in an interactive shell session
     Ssh(crate::commands::ssh::CmdSsh),

--- a/lib/cli/src/types.rs
+++ b/lib/cli/src/types.rs
@@ -105,7 +105,7 @@ impl CliRender for CronJobInvocation {
     fn render_item_table(&self) -> String {
         let mut table = Table::new();
         table.add_rows([
-            vec!["Id".to_string(), self.id.clone()],
+            vec!["Id".to_string(), self.id.inner().to_string()],
             vec!["Edge job id".to_string(), self.edge_job_id.clone()],
             vec![
                 "Status".to_string(),
@@ -166,7 +166,7 @@ impl CliRender for CronJobInvocation {
         ]);
         table.add_rows(items.iter().map(|invocation| {
             vec![
-                invocation.id.clone(),
+                invocation.id.inner().to_string(),
                 invocation
                     .status
                     .map(|status| format!("{status:?}"))

--- a/lib/cli/src/types.rs
+++ b/lib/cli/src/types.rs
@@ -1,7 +1,9 @@
+use colored::Colorize;
 use comfy_table::Table;
 use wasmer_backend_api::types::{
-    CronJob, CronJobInvocation, CronJobInvocationResult, CronJobKind, CronJobTarget, DeployApp,
-    DeployAppVersion, Deployment, DnsDomain, DnsDomainWithRecords, Namespace, SearchPackageVersion,
+    CronJob, CronJobInvocation, CronJobInvocationResult, CronJobKind, CronJobLog, CronJobTarget,
+    DeployApp, DeployAppVersion, Deployment, DnsDomain, DnsDomainWithRecords, LogStream, Namespace,
+    SearchPackageVersion,
 };
 
 use crate::utils::render::CliRender;
@@ -188,6 +190,37 @@ impl CliRender for CronJobInvocation {
                 cron_invocation_result_summary(&invocation.result),
             ]
         }));
+        table.to_string()
+    }
+}
+
+impl CliRender for CronJobLog {
+    fn render_item_table(&self) -> String {
+        let mut table = Table::new();
+        table.add_rows([
+            vec!["Timestamp".to_string(), self.datetime.0.clone()],
+            vec!["Message".to_string(), self.message.clone()],
+        ]);
+        table.to_string()
+    }
+
+    fn render_list_table(items: &[Self]) -> String {
+        let mut table = Table::new();
+        table.load_preset(comfy_table::presets::NOTHING);
+        table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+
+        for item in items {
+            let message = match item.stream {
+                Some(LogStream::Stderr) => item.message.clone().yellow(),
+                Some(LogStream::Runtime) => item.message.clone().cyan(),
+                Some(LogStream::Stdout) | None => item.message.clone().bold(),
+            };
+            table.add_row([
+                comfy_table::Cell::new(format!("[{}]", item.datetime.0))
+                    .set_alignment(comfy_table::CellAlignment::Right),
+                comfy_table::Cell::new(message),
+            ]);
+        }
         table.to_string()
     }
 }

--- a/lib/cli/src/types.rs
+++ b/lib/cli/src/types.rs
@@ -1,7 +1,7 @@
 use comfy_table::Table;
 use wasmer_backend_api::types::{
-    DeployApp, DeployAppVersion, Deployment, DnsDomain, DnsDomainWithRecords, Namespace,
-    SearchPackageVersion,
+    CronJob, CronJobInvocation, CronJobInvocationResult, CronJobKind, CronJobTarget, DeployApp,
+    DeployAppVersion, Deployment, DnsDomain, DnsDomainWithRecords, Namespace, SearchPackageVersion,
 };
 
 use crate::utils::render::CliRender;
@@ -11,6 +11,184 @@ fn package_full_name(pv: &SearchPackageVersion) -> String {
     match &pv.package.namespace {
         Some(ns) => format!("{ns}/{}", pv.package.package_name),
         None => pv.package.package_name.clone(),
+    }
+}
+
+fn cron_job_target_summary(target: &CronJobTarget) -> String {
+    match target {
+        CronJobTarget::FetchCronJobTarget(target) => {
+            format!("{} {}", target.method, target.path)
+        }
+        CronJobTarget::ExecuteCronJobTarget(target) => {
+            let package = target.package_name.as_deref().unwrap_or("-");
+            let command = target.command.as_deref().unwrap_or("-");
+            format!("{package} {command}")
+        }
+        CronJobTarget::Unknown => "unknown".to_string(),
+    }
+}
+
+fn cron_job_kind(kind: CronJobKind) -> &'static str {
+    match kind {
+        CronJobKind::Fetch => "fetch",
+        CronJobKind::Execute => "execute",
+    }
+}
+
+fn cron_invocation_result_summary(result: &Option<CronJobInvocationResult>) -> String {
+    match result {
+        Some(CronJobInvocationResult::ExecuteCronJobInvocationResult(result)) => result
+            .exit_code
+            .map(|code| format!("exit_code={code}"))
+            .unwrap_or_else(|| "execute".to_string()),
+        Some(CronJobInvocationResult::FetchCronJobInvocationResult(result)) => result
+            .status_code
+            .map(|code| format!("status_code={code}"))
+            .unwrap_or_else(|| "fetch".to_string()),
+        Some(CronJobInvocationResult::Unknown) => "unknown".to_string(),
+        None => "-".to_string(),
+    }
+}
+
+impl CliRender for CronJob {
+    fn render_item_table(&self) -> String {
+        let mut table = Table::new();
+        table.add_rows([
+            vec!["Name".to_string(), self.name.clone()],
+            vec!["Id".to_string(), self.id.inner().to_string()],
+            vec!["Kind".to_string(), cron_job_kind(self.kind).to_string()],
+            vec!["Schedule".to_string(), self.schedule.clone()],
+            vec!["Enabled".to_string(), self.enabled.to_string()],
+            vec!["Managed".to_string(), self.is_managed.to_string()],
+            vec!["Target".to_string(), cron_job_target_summary(&self.target)],
+            vec![
+                "Max retries".to_string(),
+                self.max_retries
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+            vec![
+                "Timeout".to_string(),
+                self.timeout.clone().unwrap_or_else(|| "-".to_string()),
+            ],
+            vec!["Created".to_string(), self.created_at.0.clone()],
+            vec!["Updated".to_string(), self.updated_at.0.clone()],
+        ]);
+        table.to_string()
+    }
+
+    fn render_list_table(items: &[Self]) -> String {
+        let mut table = Table::new();
+        table.set_header(vec![
+            "Name".to_string(),
+            "Kind".to_string(),
+            "Schedule".to_string(),
+            "Enabled".to_string(),
+            "Target".to_string(),
+            "Id".to_string(),
+        ]);
+        table.add_rows(items.iter().map(|job| {
+            vec![
+                job.name.clone(),
+                cron_job_kind(job.kind).to_string(),
+                job.schedule.clone(),
+                job.enabled.to_string(),
+                cron_job_target_summary(&job.target),
+                job.id.inner().to_string(),
+            ]
+        }));
+        table.to_string()
+    }
+}
+
+impl CliRender for CronJobInvocation {
+    fn render_item_table(&self) -> String {
+        let mut table = Table::new();
+        table.add_rows([
+            vec!["Id".to_string(), self.id.clone()],
+            vec!["Edge job id".to_string(), self.edge_job_id.clone()],
+            vec![
+                "Status".to_string(),
+                self.status
+                    .map(|status| format!("{status:?}"))
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+            vec![
+                "Scheduled".to_string(),
+                self.scheduled_at
+                    .as_ref()
+                    .map(|value| value.0.clone())
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+            vec![
+                "Started".to_string(),
+                self.started_at
+                    .as_ref()
+                    .map(|value| value.0.clone())
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+            vec![
+                "Finished".to_string(),
+                self.finished_at
+                    .as_ref()
+                    .map(|value| value.0.clone())
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+            vec![
+                "Duration ms".to_string(),
+                self.duration_ms
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+            vec![
+                "Result".to_string(),
+                cron_invocation_result_summary(&self.result),
+            ],
+            vec![
+                "Error".to_string(),
+                self.error_summary
+                    .clone()
+                    .unwrap_or_else(|| "-".to_string()),
+            ],
+        ]);
+        table.to_string()
+    }
+
+    fn render_list_table(items: &[Self]) -> String {
+        let mut table = Table::new();
+        table.set_header(vec![
+            "Id".to_string(),
+            "Status".to_string(),
+            "Scheduled".to_string(),
+            "Started".to_string(),
+            "Duration ms".to_string(),
+            "Result".to_string(),
+        ]);
+        table.add_rows(items.iter().map(|invocation| {
+            vec![
+                invocation.id.clone(),
+                invocation
+                    .status
+                    .map(|status| format!("{status:?}"))
+                    .unwrap_or_else(|| "-".to_string()),
+                invocation
+                    .scheduled_at
+                    .as_ref()
+                    .map(|value| value.0.clone())
+                    .unwrap_or_else(|| "-".to_string()),
+                invocation
+                    .started_at
+                    .as_ref()
+                    .map(|value| value.0.clone())
+                    .unwrap_or_else(|| "-".to_string()),
+                invocation
+                    .duration_ms
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                cron_invocation_result_summary(&invocation.result),
+            ]
+        }));
+        table.to_string()
     }
 }
 

--- a/tests/integration/cli/tests/cron.rs
+++ b/tests/integration/cli/tests/cron.rs
@@ -1,0 +1,198 @@
+use assert_cmd::prelude::OutputAssertExt;
+use predicates::str::contains;
+use serde_json::Value;
+use wasmer_integration_tests_cli::wasmer_command;
+
+const USERNAME: &str = "ciuser";
+const REGISTRY: &str = "wasmer.wtf";
+const HOURLY_JOB: &str = "hourly-check";
+const DAILY_JOB: &str = "daily-check";
+
+#[test]
+fn cron_commands_work_against_deployed_app() -> anyhow::Result<()> {
+    if std::env::var("GITHUB_TOKEN").is_err() {
+        return Ok(());
+    }
+
+    let ciuser_token = std::env::var("DEV_BACKEND_CIUSER_TOKEN")
+        .expect("DEV_BACKEND_CIUSER_TOKEN env var not set");
+    if ciuser_token.is_empty() {
+        return Ok(());
+    }
+
+    let app_name = format!("ci-cron-{}", rand::random::<u32>());
+    let app_ident = format!("{USERNAME}/{app_name}");
+    let tempdir = tempfile::tempdir()?;
+    let app_dir = tempdir.path();
+
+    std::fs::write(
+        app_dir.join("app.yaml"),
+        format!(
+            r#"kind: wasmer.io/App.v0
+name: {app_name}
+owner: {USERNAME}
+package: wasmer/hello
+jobs:
+  - name: {HOURLY_JOB}
+    trigger: "@hourly"
+    action:
+      fetch:
+        path: /
+  - name: {DAILY_JOB}
+    trigger: "@daily"
+    action:
+      fetch:
+        path: /
+"#
+        ),
+    )?;
+
+    wasmer_command()
+        .arg("deploy")
+        .arg("--non-interactive")
+        .arg("--quiet")
+        .arg(format!("--dir={}", app_dir.display()))
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .assert()
+        .success();
+
+    let cleanup = AppCleanup {
+        ident: app_ident.clone(),
+        token: ciuser_token.clone(),
+    };
+
+    let list_output = wasmer_command()
+        .arg("cron")
+        .arg("list")
+        .arg(&app_ident)
+        .arg("--format=json")
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let cron_jobs: Value = serde_json::from_slice(&list_output)?;
+    assert!(
+        cron_jobs
+            .as_array()
+            .is_some_and(|jobs| jobs.iter().any(|job| job["name"] == HOURLY_JOB)
+                && jobs.iter().any(|job| job["name"] == DAILY_JOB)),
+        "cron list did not contain expected jobs: {}",
+        String::from_utf8_lossy(&list_output)
+    );
+
+    wasmer_command()
+        .arg("cron")
+        .arg("get")
+        .arg(&app_ident)
+        .arg(HOURLY_JOB)
+        .arg("--format=json")
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .assert()
+        .success()
+        .stdout(contains(format!(r#""name": "{HOURLY_JOB}""#)));
+
+    wasmer_command()
+        .arg("cron")
+        .arg("disable")
+        .arg(&app_ident)
+        .arg(HOURLY_JOB)
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .assert()
+        .success()
+        .stderr(contains(format!("Cron job {HOURLY_JOB} is now disabled.")));
+
+    wasmer_command()
+        .arg("cron")
+        .arg("get")
+        .arg(&app_ident)
+        .arg(HOURLY_JOB)
+        .arg("--format=json")
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .assert()
+        .success()
+        .stdout(contains(r#""enabled": false"#));
+
+    wasmer_command()
+        .arg("cron")
+        .arg("enable")
+        .arg(&app_ident)
+        .arg(HOURLY_JOB)
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .assert()
+        .success()
+        .stderr(contains(format!("Cron job {HOURLY_JOB} is now enabled.")));
+
+    wasmer_command()
+        .arg("cron")
+        .arg("invocations")
+        .arg(&app_ident)
+        .arg(HOURLY_JOB)
+        .arg("--all")
+        .arg("--page-size=1")
+        .arg("--format=json")
+        .arg(format!("--registry={REGISTRY}"))
+        .arg("--token")
+        .arg(&ciuser_token)
+        .output()
+        .map(|output| {
+            assert!(
+                output.status.success(),
+                "cron invocations failed: stdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            if output.stdout.is_empty() {
+                assert!(
+                    String::from_utf8_lossy(&output.stderr)
+                        .contains(&format!("Cron job {HOURLY_JOB} has no invocations!")),
+                    "cron invocations returned no JSON and no empty-invocations message: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            } else {
+                let invocations: Value = serde_json::from_slice(&output.stdout)
+                    .expect("cron invocations output should be valid JSON");
+                assert!(
+                    invocations.is_array(),
+                    "cron invocations JSON should be an array: {}",
+                    String::from_utf8_lossy(&output.stdout)
+                );
+            }
+        })?;
+
+    drop(cleanup);
+    Ok(())
+}
+
+struct AppCleanup {
+    ident: String,
+    token: String,
+}
+
+impl Drop for AppCleanup {
+    fn drop(&mut self) {
+        let _ = wasmer_command()
+            .arg("app")
+            .arg("delete")
+            .arg("--non-interactive")
+            .arg(&self.ident)
+            .arg(format!("--registry={REGISTRY}"))
+            .arg("--token")
+            .arg(&self.token)
+            .output();
+    }
+}

--- a/tests/integration/cli/tests/cron.rs
+++ b/tests/integration/cli/tests/cron.rs
@@ -66,6 +66,7 @@ jobs:
     let list_output = wasmer_command()
         .arg("cron")
         .arg("list")
+        .arg("--app")
         .arg(&app_ident)
         .arg("--format=json")
         .arg(format!("--registry={REGISTRY}"))
@@ -89,8 +90,9 @@ jobs:
     wasmer_command()
         .arg("cron")
         .arg("get")
-        .arg(&app_ident)
         .arg(HOURLY_JOB)
+        .arg("--app")
+        .arg(&app_ident)
         .arg("--format=json")
         .arg(format!("--registry={REGISTRY}"))
         .arg("--token")
@@ -102,8 +104,9 @@ jobs:
     wasmer_command()
         .arg("cron")
         .arg("disable")
-        .arg(&app_ident)
         .arg(HOURLY_JOB)
+        .arg("--app")
+        .arg(&app_ident)
         .arg(format!("--registry={REGISTRY}"))
         .arg("--token")
         .arg(&ciuser_token)
@@ -114,8 +117,9 @@ jobs:
     wasmer_command()
         .arg("cron")
         .arg("get")
-        .arg(&app_ident)
         .arg(HOURLY_JOB)
+        .arg("--app")
+        .arg(&app_ident)
         .arg("--format=json")
         .arg(format!("--registry={REGISTRY}"))
         .arg("--token")
@@ -127,8 +131,9 @@ jobs:
     wasmer_command()
         .arg("cron")
         .arg("enable")
-        .arg(&app_ident)
         .arg(HOURLY_JOB)
+        .arg("--app")
+        .arg(&app_ident)
         .arg(format!("--registry={REGISTRY}"))
         .arg("--token")
         .arg(&ciuser_token)
@@ -136,43 +141,101 @@ jobs:
         .success()
         .stderr(contains(format!("Cron job {HOURLY_JOB} is now enabled.")));
 
-    wasmer_command()
+    let invocations_output = wasmer_command()
         .arg("cron")
         .arg("invocations")
-        .arg(&app_ident)
         .arg(HOURLY_JOB)
+        .arg("--app")
+        .arg(&app_ident)
         .arg("--all")
         .arg("--page-size=1")
         .arg("--format=json")
         .arg(format!("--registry={REGISTRY}"))
         .arg("--token")
         .arg(&ciuser_token)
-        .output()
-        .map(|output| {
+        .output()?;
+
+    assert!(
+        invocations_output.status.success(),
+        "cron invocations failed: stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&invocations_output.stdout),
+        String::from_utf8_lossy(&invocations_output.stderr)
+    );
+
+    if invocations_output.stdout.is_empty() {
+        assert!(
+            String::from_utf8_lossy(&invocations_output.stderr)
+                .contains(&format!("Cron job {HOURLY_JOB} has no invocations!")),
+            "cron invocations returned no JSON and no empty-invocations message: {}",
+            String::from_utf8_lossy(&invocations_output.stderr)
+        );
+    } else {
+        let invocations: Value = serde_json::from_slice(&invocations_output.stdout)
+            .expect("cron invocations output should be valid JSON");
+        let invocations = invocations.as_array().unwrap_or_else(|| {
+            panic!(
+                "cron invocations JSON should be an array: {}",
+                String::from_utf8_lossy(&invocations_output.stdout)
+            )
+        });
+
+        if let Some(invocation) = invocations.first() {
+            let invocation_id = invocation["id"]
+                .as_str()
+                .or_else(|| invocation["edge_job_id"].as_str())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "cron invocation should include id or edge_job_id: {}",
+                        serde_json::to_string(invocation).unwrap()
+                    )
+                });
+
+            let logs_output = wasmer_command()
+                .arg("cron")
+                .arg("logs")
+                .arg(HOURLY_JOB)
+                .arg(invocation_id)
+                .arg("--app")
+                .arg(&app_ident)
+                .arg("--max=1")
+                .arg("--format=json")
+                .arg(format!("--registry={REGISTRY}"))
+                .arg("--token")
+                .arg(&ciuser_token)
+                .output()?;
+
             assert!(
-                output.status.success(),
-                "cron invocations failed: stdout: {}\nstderr: {}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
+                logs_output.status.success(),
+                "cron logs failed: stdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&logs_output.stdout),
+                String::from_utf8_lossy(&logs_output.stderr)
             );
 
-            if output.stdout.is_empty() {
+            if logs_output.stdout.is_empty() {
                 assert!(
-                    String::from_utf8_lossy(&output.stderr)
-                        .contains(&format!("Cron job {HOURLY_JOB} has no invocations!")),
-                    "cron invocations returned no JSON and no empty-invocations message: {}",
-                    String::from_utf8_lossy(&output.stderr)
+                    String::from_utf8_lossy(&logs_output.stderr)
+                        .contains(&format!("Cron job invocation {invocation_id} has no logs!")),
+                    "cron logs returned no JSON and no empty-logs message: {}",
+                    String::from_utf8_lossy(&logs_output.stderr)
                 );
             } else {
-                let invocations: Value = serde_json::from_slice(&output.stdout)
-                    .expect("cron invocations output should be valid JSON");
+                let logs: Value = serde_json::from_slice(&logs_output.stdout)
+                    .expect("cron logs output should be valid JSON");
+                let logs = logs.as_array().unwrap_or_else(|| {
+                    panic!(
+                        "cron logs JSON should be an array: {}",
+                        String::from_utf8_lossy(&logs_output.stdout)
+                    )
+                });
                 assert!(
-                    invocations.is_array(),
-                    "cron invocations JSON should be an array: {}",
-                    String::from_utf8_lossy(&output.stdout)
+                    logs.iter()
+                        .all(|log| log["message"].is_string() && log["datetime"].is_string()),
+                    "cron logs should include message and datetime fields: {}",
+                    String::from_utf8_lossy(&logs_output.stdout)
                 );
             }
-        })?;
+        }
+    }
 
     drop(cleanup);
     Ok(())


### PR DESCRIPTION
# Changes
- added CLI support for `cronjobs`
- list cronjobs for an app `wasmer cron list --app <app_id>`
- list cronjob invocations `wasmer cron invocations <cronjob_id> --app <app_id>`
- enable/disable cronjobs `wasmer cron enable/disable <cronjob_id> --app <app_id>`

Cronjobs currently only exist in association with an app, but in future standalone cronjobs are a possibility. Hence why `cron` is not a subcommand under `app`.	