### PR TITLE
UDP Datagram Receive, Readiness, and Backlog

### DIFF
--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -1045,13 +1045,13 @@ impl VirtualIoSource for RemoteSocket {
             let len = self
                 .buffer_recv_with_addr
                 .front()
-                .map(|a| a.data.len())
+                .map(|a| a.data.len().max(1))
                 .unwrap_or_default();
             return Poll::Ready(Ok(len));
         }
         match self.rx_recv_with_addr.poll_recv(cx) {
             Poll::Ready(Some(data)) => {
-                let len = data.data.len();
+                let len = data.data.len().max(1);
                 self.buffer_recv_with_addr.push_back(data);
                 return Poll::Ready(Ok(len));
             }

--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -1042,15 +1042,19 @@ impl VirtualIoSource for RemoteSocket {
             Poll::Pending => {}
         }
         if !self.buffer_recv_with_addr.is_empty() {
-            let total = self
+            let len = self
                 .buffer_recv_with_addr
-                .iter()
+                .front()
                 .map(|a| a.data.len())
-                .sum();
-            return Poll::Ready(Ok(total));
+                .unwrap_or_default();
+            return Poll::Ready(Ok(len));
         }
         match self.rx_recv_with_addr.poll_recv(cx) {
-            Poll::Ready(Some(data)) => self.buffer_recv_with_addr.push_back(data),
+            Poll::Ready(Some(data)) => {
+                let len = data.data.len();
+                self.buffer_recv_with_addr.push_back(data);
+                return Poll::Ready(Ok(len));
+            }
             Poll::Ready(None) => return Poll::Ready(Ok(0)),
             Poll::Pending => {}
         }
@@ -1382,22 +1386,34 @@ impl VirtualConnectionlessSocket for RemoteSocket {
         buf: &mut [std::mem::MaybeUninit<u8>],
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
-        // FIXME: A proper peek implementation would require correct use of a
-        // buffer. We don't use this implementation AFAIK, so I'll skip over it
-        // for the time being.
-        if peek {
-            return Err(NetworkError::Unsupported);
+        if let Some(received) = self.buffer_recv_with_addr.front() {
+            let amt = buf.len().min(received.data.len());
+            let addr = received.addr;
+            let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+            buf[..amt].copy_from_slice(&received.data[..amt]);
+
+            if !peek {
+                self.buffer_recv_with_addr.pop_front();
+            }
+
+            return Ok((amt, addr));
         }
 
-        match self.rx_recv_with_addr.try_recv() {
-            Ok(received) => {
-                let amt = buf.len().min(received.data.len());
-                let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
-                buf[..amt].copy_from_slice(&received.data[..amt]);
-                Ok((amt, received.addr))
-            }
-            Err(TryRecvError::Disconnected) => Err(NetworkError::ConnectionAborted),
-            Err(TryRecvError::Empty) => Err(NetworkError::WouldBlock),
+        let received = self.rx_recv_with_addr.try_recv().map_err(|err| match err {
+            TryRecvError::Disconnected => NetworkError::ConnectionAborted,
+            TryRecvError::Empty => NetworkError::WouldBlock,
+        })?;
+
+        let amt = buf.len().min(received.data.len());
+        let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+        buf[..amt].copy_from_slice(&received.data[..amt]);
+        let addr = received.addr;
+
+        if peek {
+            self.buffer_recv_with_addr.push_back(received);
+            Ok((amt, addr))
+        } else {
+            Ok((amt, addr))
         }
     }
 }

--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -1386,35 +1386,27 @@ impl VirtualConnectionlessSocket for RemoteSocket {
         buf: &mut [std::mem::MaybeUninit<u8>],
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
-        if let Some(received) = self.buffer_recv_with_addr.front() {
-            let amt = buf.len().min(received.data.len());
-            let addr = received.addr;
-            let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
-            buf[..amt].copy_from_slice(&received.data[..amt]);
-
-            if !peek {
-                self.buffer_recv_with_addr.pop_front();
-            }
-
-            return Ok((amt, addr));
+        if self.buffer_recv_with_addr.is_empty() {
+            let received = self.rx_recv_with_addr.try_recv().map_err(|err| match err {
+                TryRecvError::Disconnected => NetworkError::ConnectionAborted,
+                TryRecvError::Empty => NetworkError::WouldBlock,
+            })?;
+            self.buffer_recv_with_addr.push_back(received);
         }
 
-        let received = self.rx_recv_with_addr.try_recv().map_err(|err| match err {
-            TryRecvError::Disconnected => NetworkError::ConnectionAborted,
-            TryRecvError::Empty => NetworkError::WouldBlock,
-        })?;
-
+        let Some(received) = self.buffer_recv_with_addr.front() else {
+            return Err(NetworkError::WouldBlock);
+        };
         let amt = buf.len().min(received.data.len());
+        let addr = received.addr;
         let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
         buf[..amt].copy_from_slice(&received.data[..amt]);
-        let addr = received.addr;
 
-        if peek {
-            self.buffer_recv_with_addr.push_back(received);
-            Ok((amt, addr))
-        } else {
-            Ok((amt, addr))
+        if !peek {
+            self.buffer_recv_with_addr.pop_front();
         }
+
+        Ok((amt, addr))
     }
 }
 

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -1134,6 +1134,15 @@ impl VirtualSocket for LocalUdpSocket {
 }
 
 impl LocalUdpSocket {
+    /// A queued zero-length UDP datagram is readable (Linux `POLLIN`), but
+    /// wasix poll treats `nbytes == 0` as hangup, so report at least 1.
+    fn backlog_read_ready_len(&self) -> usize {
+        self.backlog
+            .front()
+            .map(|(packet, _)| packet.len().max(1))
+            .unwrap_or_default()
+    }
+
     fn recv_into_backlog(&mut self) -> io::Result<()> {
         let mut buffer = BytesMut::default();
         buffer.reserve(10240);
@@ -1176,8 +1185,7 @@ impl VirtualIoSource for LocalUdpSocket {
 
     fn poll_read_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<usize>> {
         if !self.backlog.is_empty() {
-            let len = self.backlog.front().map(|a| a.0.len()).unwrap_or_default();
-            return Poll::Ready(Ok(len));
+            return Poll::Ready(Ok(self.backlog_read_ready_len()));
         }
 
         let (state, selector, socket) = self.split_borrow();
@@ -1186,10 +1194,7 @@ impl VirtualIoSource for LocalUdpSocket {
         map.add(InterestType::Readable, cx.waker());
 
         match self.recv_into_backlog() {
-            Ok(()) => {
-                let len = self.backlog.front().map(|a| a.0.len()).unwrap_or_default();
-                Poll::Ready(Ok(len))
-            }
+            Ok(()) => Poll::Ready(Ok(self.backlog_read_ready_len())),
             Err(err) if err.kind() == io::ErrorKind::ConnectionAborted => Poll::Ready(Ok(0)),
             Err(err) if err.kind() == io::ErrorKind::ConnectionReset => Poll::Ready(Ok(0)),
             Err(err) if err.kind() == io::ErrorKind::WouldBlock => Poll::Pending,

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -1158,7 +1158,7 @@ impl LocalUdpSocket {
 
     fn recv_into_backlog(&mut self) -> io::Result<()> {
         let mut buffer = BytesMut::default();
-        buffer.reserve(10240);
+        buffer.reserve(MAX_SOCKET_PAYLOAD);
         let uninit: &mut [MaybeUninit<u8>] = buffer.spare_capacity_mut();
         let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
 

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -1070,6 +1070,16 @@ impl VirtualConnectionlessSocket for LocalUdpSocket {
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
         let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+        if let Some((packet, addr)) = self.backlog.front() {
+            let amt = buf.len().min(packet.len());
+            let addr = *addr;
+            buf[..amt].copy_from_slice(&packet[..amt]);
+            if !peek {
+                self.backlog.pop_front();
+            }
+            return Ok((amt, addr));
+        }
+
         if peek {
             self.socket.peek_from(buf)
         } else {
@@ -1154,8 +1164,8 @@ impl VirtualIoSource for LocalUdpSocket {
 
     fn poll_read_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<usize>> {
         if !self.backlog.is_empty() {
-            let total = self.backlog.iter().map(|a| a.0.len()).sum();
-            return Poll::Ready(Ok(total));
+            let len = self.backlog.front().map(|a| a.0.len()).unwrap_or_default();
+            return Poll::Ready(Ok(len));
         }
 
         let (state, selector, socket) = self.split_borrow();
@@ -1169,7 +1179,10 @@ impl VirtualIoSource for LocalUdpSocket {
         let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
 
         match self.socket.recv_from(uninit_unsafe) {
-            Ok((0, _)) => Poll::Ready(Ok(0)),
+            Ok((0, peer)) => {
+                self.backlog.push_back((buffer, peer));
+                Poll::Ready(Ok(0))
+            }
             Ok((amt, peer)) => {
                 unsafe {
                     buffer.set_len(amt);

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -2,9 +2,10 @@
 use crate::ruleset::{Direction, Ruleset};
 #[allow(unused_imports)]
 use crate::{
-    IpCidr, IpRoute, NetworkError, Result, SocketStatus, StreamSecurity, VirtualConnectedSocket,
-    VirtualConnectionlessSocket, VirtualIcmpSocket, VirtualNetworking, VirtualRawSocket,
-    VirtualSocket, VirtualTcpBoundSocket, VirtualTcpListener, VirtualTcpSocket, VirtualUdpSocket,
+    IpCidr, IpRoute, MAX_SOCKET_PAYLOAD, NetworkError, Result, SocketStatus, StreamSecurity,
+    VirtualConnectedSocket, VirtualConnectionlessSocket, VirtualIcmpSocket, VirtualNetworking,
+    VirtualRawSocket, VirtualSocket, VirtualTcpBoundSocket, VirtualTcpListener, VirtualTcpSocket,
+    VirtualUdpSocket,
 };
 use crate::{VirtualIoSource, io_err_into_net_error};
 use bytes::{Buf, BytesMut};

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -1069,23 +1069,21 @@ impl VirtualConnectionlessSocket for LocalUdpSocket {
         buf: &mut [MaybeUninit<u8>],
         peek: bool,
     ) -> Result<(usize, SocketAddr)> {
-        let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
-        if let Some((packet, addr)) = self.backlog.front() {
-            let amt = buf.len().min(packet.len());
-            let addr = *addr;
-            buf[..amt].copy_from_slice(&packet[..amt]);
-            if !peek {
-                self.backlog.pop_front();
-            }
-            return Ok((amt, addr));
+        if self.backlog.is_empty() {
+            self.recv_into_backlog().map_err(io_err_into_net_error)?;
         }
 
-        if peek {
-            self.socket.peek_from(buf)
-        } else {
-            self.socket.recv_from(buf)
+        let buf: &mut [u8] = unsafe { std::mem::transmute(buf) };
+        let Some((packet, addr)) = self.backlog.front() else {
+            return Err(NetworkError::WouldBlock);
+        };
+        let amt = buf.len().min(packet.len());
+        let addr = *addr;
+        buf[..amt].copy_from_slice(&packet[..amt]);
+        if !peek {
+            self.backlog.pop_front();
         }
-        .map_err(io_err_into_net_error)
+        Ok((amt, addr))
     }
 }
 
@@ -1136,6 +1134,20 @@ impl VirtualSocket for LocalUdpSocket {
 }
 
 impl LocalUdpSocket {
+    fn recv_into_backlog(&mut self) -> io::Result<()> {
+        let mut buffer = BytesMut::default();
+        buffer.reserve(10240);
+        let uninit: &mut [MaybeUninit<u8>] = buffer.spare_capacity_mut();
+        let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
+
+        let (amt, peer) = self.socket.recv_from(uninit_unsafe)?;
+        unsafe {
+            buffer.set_len(amt);
+        }
+        self.backlog.push_back((buffer, peer));
+        Ok(())
+    }
+
     fn split_borrow(
         &mut self,
     ) -> (
@@ -1173,22 +1185,10 @@ impl VirtualIoSource for LocalUdpSocket {
         map.pop(InterestType::Readable);
         map.add(InterestType::Readable, cx.waker());
 
-        let mut buffer = BytesMut::default();
-        buffer.reserve(10240);
-        let uninit: &mut [MaybeUninit<u8>] = buffer.spare_capacity_mut();
-        let uninit_unsafe: &mut [u8] = unsafe { std::mem::transmute(uninit) };
-
-        match self.socket.recv_from(uninit_unsafe) {
-            Ok((0, peer)) => {
-                self.backlog.push_back((buffer, peer));
-                Poll::Ready(Ok(0))
-            }
-            Ok((amt, peer)) => {
-                unsafe {
-                    buffer.set_len(amt);
-                }
-                self.backlog.push_back((buffer, peer));
-                Poll::Ready(Ok(amt))
+        match self.recv_into_backlog() {
+            Ok(()) => {
+                let len = self.backlog.front().map(|a| a.0.len()).unwrap_or_default();
+                Poll::Ready(Ok(len))
             }
             Err(err) if err.kind() == io::ErrorKind::ConnectionAborted => Poll::Ready(Ok(0)),
             Err(err) if err.kind() == io::ErrorKind::ConnectionReset => Poll::Ready(Ok(0)),

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -53,6 +53,10 @@ pub use virtual_mio::{InterestHandler, handler_into_waker};
 
 pub type Result<T> = std::result::Result<T, NetworkError>;
 
+/// Largest datagram payload (65535 - UDP header).
+/// Caps host allocation across address families; the OS rejects oversize packets.
+pub const MAX_SOCKET_PAYLOAD: usize = 65535 - 8;
+
 /// Represents an IP address and its netmask
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "rkyv", derive(RkyvSerialize, RkyvDeserialize, Archive))]

--- a/lib/wasix/src/net/mod.rs
+++ b/lib/wasix/src/net/mod.rs
@@ -18,9 +18,7 @@ use wasmer_wasix_types::{
 
 pub mod socket;
 
-/// Largest datagram payload we coalesce before send (65535 - UDP header).
-/// Caps host allocation across address families; the OS rejects oversize packets.
-pub const MAX_SOCKET_PAYLOAD: usize = 65535 - 8;
+pub use virtual_net::MAX_SOCKET_PAYLOAD;
 
 #[allow(dead_code)]
 pub(crate) fn read_ip<M: MemorySize>(

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -1516,10 +1516,15 @@ impl InodeSocket {
                         }
                         InodeSocketKind::UdpSocket { socket, peer } => {
                             if let Some(peer) = peer {
-                                match socket.try_recv_from(self.data, peek) {
-                                    Ok((amt, addr)) if addr == *peer => Ok(amt),
-                                    Ok(_) => Err(NetworkError::WouldBlock),
-                                    Err(err) => Err(err),
+                                loop {
+                                    match socket.try_recv_from(self.data, peek) {
+                                        Ok((amt, addr)) if addr == *peer => break Ok(amt),
+                                        Ok(_) if peek => {
+                                            let _ = socket.try_recv_from(self.data, false);
+                                        }
+                                        Ok(_) => continue,
+                                        Err(err) => break Err(err),
+                                    }
                                 }
                             } else {
                                 match socket.try_recv_from(self.data, peek) {

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -1704,9 +1704,11 @@ fn discard_non_matching_udp_datagrams(
     loop {
         match socket.try_recv_from(&mut discard, true) {
             Ok((_, addr)) if addr == *peer => return Ok(()),
-            Ok(_) => {
-                let _ = socket.try_recv_from(&mut discard, false);
-            }
+            Ok(_) => match socket.try_recv_from(&mut discard, false) {
+                Ok(_) => {}
+                Err(NetworkError::WouldBlock) => {}
+                Err(err) => return Err(err),
+            },
             Err(NetworkError::WouldBlock) => return Ok(()),
             Err(err) => return Err(err),
         }
@@ -1723,9 +1725,11 @@ fn try_recv_from_connected_udp(
     loop {
         match socket.try_recv_from(data, peek) {
             Ok((amt, addr)) if addr == *peer => return Ok((amt, addr)),
-            Ok(_) if peek => {
-                let _ = socket.try_recv_from(data, false);
-            }
+            Ok(_) if peek => match socket.try_recv_from(data, false) {
+                Ok(_) => {}
+                Err(NetworkError::WouldBlock) => {}
+                Err(err) => return Err(err),
+            },
             Ok(_) => continue,
             Err(err) => return Err(err),
         }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -888,18 +888,18 @@ impl InodeSocket {
 
     pub fn addr_peer(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
-        Ok(match &inner.kind {
+        match &inner.kind {
             InodeSocketKind::BoundTcp { .. } => return Err(Errno::Notconn),
-            InodeSocketKind::PreSocket { props, .. } => SocketAddr::new(
+            InodeSocketKind::PreSocket { props, .. } => Ok(SocketAddr::new(
                 match props.family {
                     Addressfamily::Inet4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                     Addressfamily::Inet6 => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
                     _ => return Err(Errno::Inval),
                 },
                 0,
-            ),
+            )),
             InodeSocketKind::TcpStream { socket, .. } => {
-                socket.addr_peer().map_err(net_error_into_wasi_err)?
+                socket.addr_peer().map_err(net_error_into_wasi_err)
             }
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -889,7 +889,7 @@ impl InodeSocket {
     pub fn addr_peer(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
         match &inner.kind {
-            InodeSocketKind::BoundTcp { .. } => return Err(Errno::Notconn),
+            InodeSocketKind::BoundTcp { .. } => Err(Errno::Notconn),
             InodeSocketKind::PreSocket { props, .. } => Ok(SocketAddr::new(
                 match props.family {
                     Addressfamily::Inet4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -888,18 +888,18 @@ impl InodeSocket {
 
     pub fn addr_peer(&self) -> Result<SocketAddr, Errno> {
         let inner = self.inner.protected.read().unwrap();
-        match &inner.kind {
-            InodeSocketKind::BoundTcp { .. } => Err(Errno::Notconn),
-            InodeSocketKind::PreSocket { props, .. } => Ok(SocketAddr::new(
+        Ok(match &inner.kind {
+            InodeSocketKind::BoundTcp { .. } => return Err(Errno::Notconn),
+            InodeSocketKind::PreSocket { props, .. } => SocketAddr::new(
                 match props.family {
                     Addressfamily::Inet4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                     Addressfamily::Inet6 => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
                     _ => return Err(Errno::Inval),
                 },
                 0,
-            )),
+            ),
             InodeSocketKind::TcpStream { socket, .. } => {
-                socket.addr_peer().map_err(net_error_into_wasi_err)
+                socket.addr_peer().map_err(net_error_into_wasi_err)?
             }
             InodeSocketKind::UdpSocket { socket, .. } => socket
                 .addr_peer()

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -1514,25 +1514,13 @@ impl InodeSocket {
                         InodeSocketKind::TcpStream { socket, .. } => {
                             socket.try_recv(self.data, peek)
                         }
-                        InodeSocketKind::UdpSocket { socket, peer } => {
-                            if let Some(peer) = peer {
-                                loop {
-                                    match socket.try_recv_from(self.data, peek) {
-                                        Ok((amt, addr)) if addr == *peer => break Ok(amt),
-                                        Ok(_) if peek => {
-                                            let _ = socket.try_recv_from(self.data, false);
-                                        }
-                                        Ok(_) => continue,
-                                        Err(err) => break Err(err),
-                                    }
-                                }
-                            } else {
-                                match socket.try_recv_from(self.data, peek) {
-                                    Ok((amt, _)) => Ok(amt),
-                                    Err(err) => Err(err),
-                                }
+                        InodeSocketKind::UdpSocket { socket, peer } => match peer {
+                            Some(peer) => {
+                                try_recv_from_connected_udp(socket.as_mut(), self.data, peek, peer)
+                                    .map(|(amt, _)| amt)
                             }
-                        }
+                            None => socket.try_recv_from(self.data, peek).map(|(amt, _)| amt),
+                        },
                         InodeSocketKind::RemoteSocket { is_dead, .. } => {
                             return match is_dead {
                                 true => Poll::Ready(Ok(0)),
@@ -1616,9 +1604,12 @@ impl InodeSocket {
                 loop {
                     let res = match &mut inner.kind {
                         InodeSocketKind::Icmp(socket) => socket.try_recv_from(self.data, peek),
-                        InodeSocketKind::UdpSocket { socket, .. } => {
-                            socket.try_recv_from(self.data, peek)
-                        }
+                        InodeSocketKind::UdpSocket { socket, peer } => match peer {
+                            Some(peer) => {
+                                try_recv_from_connected_udp(socket.as_mut(), self.data, peek, peer)
+                            }
+                            None => socket.try_recv_from(self.data, peek),
+                        },
                         InodeSocketKind::RemoteSocket {
                             is_dead, peer_addr, ..
                         } => {
@@ -1699,6 +1690,44 @@ impl InodeSocket {
     }
 }
 
+/// On connected UDP sockets, discard datagrams not from the stored peer.
+/// Linux filters these in the kernel; wasix stores the peer separately.
+fn discard_non_matching_udp_datagrams(
+    socket: &mut dyn VirtualUdpSocket,
+    peer: &SocketAddr,
+) -> Result<(), NetworkError> {
+    let mut discard = [MaybeUninit::<u8>::uninit()];
+    loop {
+        match socket.try_recv_from(&mut discard, true) {
+            Ok((_, addr)) if addr == *peer => return Ok(()),
+            Ok(_) => {
+                let _ = socket.try_recv_from(&mut discard, false);
+            }
+            Err(NetworkError::WouldBlock) => return Ok(()),
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn try_recv_from_connected_udp(
+    socket: &mut dyn VirtualUdpSocket,
+    data: &mut [MaybeUninit<u8>],
+    peek: bool,
+    peer: &SocketAddr,
+) -> Result<(usize, SocketAddr), NetworkError> {
+    discard_non_matching_udp_datagrams(socket, peer)?;
+    loop {
+        match socket.try_recv_from(data, peek) {
+            Ok((amt, addr)) if addr == *peer => return Ok((amt, addr)),
+            Ok(_) if peek => {
+                let _ = socket.try_recv_from(data, false);
+            }
+            Ok(_) => continue,
+            Err(err) => return Err(err),
+        }
+    }
+}
+
 impl InodeSocketProtected {
     pub fn remove_handler(&mut self) {
         match &mut self.kind {
@@ -1723,7 +1752,28 @@ impl InodeSocketProtected {
         match &mut self.kind {
             InodeSocketKind::TcpListener { socket, .. } => socket.poll_read_ready(cx),
             InodeSocketKind::TcpStream { socket, .. } => socket.poll_read_ready(cx),
-            InodeSocketKind::UdpSocket { socket, .. } => socket.poll_read_ready(cx),
+            InodeSocketKind::UdpSocket {
+                socket,
+                peer: Some(peer),
+            } => loop {
+                if let Err(err) = discard_non_matching_udp_datagrams(socket.as_mut(), peer) {
+                    break Poll::Ready(Err(err));
+                }
+                match socket.poll_read_ready(cx) {
+                    Poll::Pending => break Poll::Pending,
+                    Poll::Ready(Err(err)) => break Poll::Ready(Err(err)),
+                    Poll::Ready(Ok(n)) => {
+                        let mut peek_buf = [MaybeUninit::<u8>::uninit()];
+                        match socket.try_recv_from(&mut peek_buf, true) {
+                            Ok((_, addr)) if addr == *peer => break Poll::Ready(Ok(n)),
+                            Ok(_) => continue,
+                            Err(NetworkError::WouldBlock) => break Poll::Pending,
+                            Err(err) => break Poll::Ready(Err(err)),
+                        }
+                    }
+                }
+            },
+            InodeSocketKind::UdpSocket { socket, peer: None } => socket.poll_read_ready(cx),
             InodeSocketKind::Raw(socket) => socket.poll_read_ready(cx),
             InodeSocketKind::Icmp(socket) => socket.poll_read_ready(cx),
             InodeSocketKind::BoundTcp { .. } => Poll::Pending,

--- a/lib/wasix/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_to.rs
@@ -1,10 +1,7 @@
 use std::task::Waker;
 
 use super::*;
-use crate::{
-    net::socket::{InodeSocketKind, TimeType},
-    syscalls::*,
-};
+use crate::{net::socket::TimeType, syscalls::*};
 
 /// ### `sock_send_to()`
 /// Send a message on a socket to a specific address.
@@ -123,39 +120,6 @@ pub(crate) fn sock_send_to_internal<M: MemorySize>(
                     FdWriteSource::Iovs { iovs, iovs_len } => {
                         let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;
                         let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
-
-                        let is_dgram = {
-                            let inner = socket.inner.protected.read().unwrap();
-                            match &inner.kind {
-                                InodeSocketKind::UdpSocket { .. } => true,
-                                InodeSocketKind::RemoteSocket { props, .. } => {
-                                    props.ty == Socktype::Dgram
-                                }
-                                _ => false,
-                            }
-                        };
-
-                        if is_dgram {
-                            let mut data = Vec::new();
-                            for iovs in iovs_arr.iter() {
-                                let buf = WasmPtr::<u8, M>::new(iovs.buf)
-                                    .slice(&memory, iovs.buf_len)
-                                    .map_err(mem_error_to_wasi)?
-                                    .access()
-                                    .map_err(mem_error_to_wasi)?;
-                                data.extend_from_slice(buf.as_ref());
-                            }
-
-                            return socket
-                                .send_to::<M>(
-                                    env.tasks().deref(),
-                                    data.as_ref(),
-                                    addr,
-                                    Some(timeout),
-                                    nonblocking,
-                                )
-                                .await;
-                        }
 
                         let mut sent = 0usize;
                         for iovs in iovs_arr.iter() {

--- a/lib/wasix/src/syscalls/wasix/sock_send_to.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_to.rs
@@ -1,7 +1,10 @@
 use std::task::Waker;
 
 use super::*;
-use crate::{net::socket::TimeType, syscalls::*};
+use crate::{
+    net::socket::{InodeSocketKind, TimeType},
+    syscalls::*,
+};
 
 /// ### `sock_send_to()`
 /// Send a message on a socket to a specific address.
@@ -120,6 +123,39 @@ pub(crate) fn sock_send_to_internal<M: MemorySize>(
                     FdWriteSource::Iovs { iovs, iovs_len } => {
                         let iovs_arr = iovs.slice(&memory, iovs_len).map_err(mem_error_to_wasi)?;
                         let iovs_arr = iovs_arr.access().map_err(mem_error_to_wasi)?;
+
+                        let is_dgram = {
+                            let inner = socket.inner.protected.read().unwrap();
+                            match &inner.kind {
+                                InodeSocketKind::UdpSocket { .. } => true,
+                                InodeSocketKind::RemoteSocket { props, .. } => {
+                                    props.ty == Socktype::Dgram
+                                }
+                                _ => false,
+                            }
+                        };
+
+                        if is_dgram {
+                            let mut data = Vec::new();
+                            for iovs in iovs_arr.iter() {
+                                let buf = WasmPtr::<u8, M>::new(iovs.buf)
+                                    .slice(&memory, iovs.buf_len)
+                                    .map_err(mem_error_to_wasi)?
+                                    .access()
+                                    .map_err(mem_error_to_wasi)?;
+                                data.extend_from_slice(buf.as_ref());
+                            }
+
+                            return socket
+                                .send_to::<M>(
+                                    env.tasks().deref(),
+                                    data.as_ref(),
+                                    addr,
+                                    Some(timeout),
+                                    nonblocking,
+                                )
+                                .await;
+                        }
 
                         let mut sent = 0usize;
                         for iovs in iovs_arr.iter() {

--- a/lib/wasix/tests/wasm_tests/poll/udp-zero-length-poll-oneoff/main.c
+++ b/lib/wasix/tests/wasm_tests/poll/udp-zero-length-poll-oneoff/main.c
@@ -1,0 +1,72 @@
+//#ExpectedStdout: zero-length UDP datagram poll_oneoff is readable
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <wasi/api_wasi.h>
+
+int main(void) {
+  int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+  if (fd < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  struct sockaddr_in addr = {0};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    return 1;
+  }
+
+  socklen_t len = sizeof(addr);
+  if (getsockname(fd, (struct sockaddr*)&addr, &len) != 0) {
+    perror("getsockname");
+    return 1;
+  }
+
+  if (sendto(fd, "", 0, 0, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("sendto zero-length");
+    return 1;
+  }
+
+  __wasi_subscription_t sub = {
+      .userdata = 42,
+      .u = {.tag = __WASI_EVENTTYPE_FD_READ,
+            .u = {.fd_read = {.file_descriptor = fd}}}};
+  __wasi_event_t ev = {0};
+  __wasi_size_t nevents = 0;
+  __wasi_errno_t err = __wasi_poll_oneoff(&sub, &ev, 1, &nevents);
+  if (err != __WASI_ERRNO_SUCCESS) {
+    fprintf(stderr, "poll_oneoff failed: %u\n", err);
+    return 1;
+  }
+  if (nevents != 1 || ev.type != __WASI_EVENTTYPE_FD_READ ||
+      ev.error != __WASI_ERRNO_SUCCESS) {
+    fprintf(stderr,
+            "unexpected poll_oneoff event: nevents=%u type=%u error=%u\n",
+            (unsigned)nevents, ev.type, ev.error);
+    return 1;
+  }
+  if ((ev.fd_readwrite.flags & __WASI_EVENTRWFLAGS_FD_READWRITE_HANGUP) != 0) {
+    fprintf(stderr, "zero-length UDP datagram reported as hangup (flags=%u)\n",
+            ev.fd_readwrite.flags);
+    return 1;
+  }
+
+  char byte;
+  ssize_t n = recvfrom(fd, &byte, sizeof(byte), 0, NULL, NULL);
+  if (n != 0) {
+    fprintf(stderr, "expected zero-length recvfrom, got %zd\n", n);
+    return 1;
+  }
+
+  close(fd);
+  puts("zero-length UDP datagram poll_oneoff is readable");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/udp-connected-wrong-peer/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-connected-wrong-peer/main.c
@@ -1,0 +1,121 @@
+//#ExpectedStdout: connected UDP ignores wrong peer datagrams
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int bind_loopback(int fd, struct sockaddr_in* out) {
+  memset(out, 0, sizeof(*out));
+  out->sin_family = AF_INET;
+  out->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  out->sin_port = 0;
+  if (bind(fd, (struct sockaddr*)out, sizeof(*out)) != 0) {
+    perror("bind");
+    return -1;
+  }
+  socklen_t len = sizeof(*out);
+  if (getsockname(fd, (struct sockaddr*)out, &len) != 0) {
+    perror("getsockname");
+    return -1;
+  }
+  return 0;
+}
+
+int main(void) {
+  int peer_fd = socket(AF_INET, SOCK_DGRAM, 0);
+  int conn_fd = socket(AF_INET, SOCK_DGRAM, 0);
+  int stranger_fd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (peer_fd < 0 || conn_fd < 0 || stranger_fd < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  struct sockaddr_in peer_addr;
+  struct sockaddr_in conn_addr;
+  if (bind_loopback(peer_fd, &peer_addr) != 0 ||
+      bind_loopback(conn_fd, &conn_addr) != 0) {
+    return 1;
+  }
+
+  if (connect(conn_fd, (struct sockaddr*)&peer_addr, sizeof(peer_addr)) != 0) {
+    perror("connect");
+    return 1;
+  }
+
+  if (fcntl(conn_fd, F_SETFL, fcntl(conn_fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
+    perror("fcntl(O_NONBLOCK)");
+    return 1;
+  }
+
+  const char bad[] = "bad";
+  if (sendto(stranger_fd, bad, sizeof(bad) - 1, 0, (struct sockaddr*)&conn_addr,
+             sizeof(conn_addr)) != (ssize_t)(sizeof(bad) - 1)) {
+    perror("sendto(stranger)");
+    return 1;
+  }
+
+  struct pollfd pfd = {.fd = conn_fd, .events = POLLIN};
+  int poll_ret = poll(&pfd, 1, 0);
+  if (poll_ret != 0) {
+    fprintf(stderr, "poll after wrong peer: expected 0, got %d revents=0x%x\n",
+            poll_ret, pfd.revents);
+    return 1;
+  }
+
+  char buf[16];
+  if (recv(conn_fd, buf, sizeof(buf), 0) >= 0 ||
+      (errno != EAGAIN && errno != EWOULDBLOCK)) {
+    fprintf(stderr, "recv after wrong peer: expected EAGAIN, got errno=%d (%s)\n",
+            errno, strerror(errno));
+    return 1;
+  }
+
+  if (recvfrom(conn_fd, buf, sizeof(buf), 0, NULL, NULL) >= 0 ||
+      (errno != EAGAIN && errno != EWOULDBLOCK)) {
+    fprintf(stderr,
+            "recvfrom after wrong peer: expected EAGAIN, got errno=%d (%s)\n",
+            errno, strerror(errno));
+    return 1;
+  }
+
+  const char good[] = "ok";
+  if (sendto(peer_fd, good, sizeof(good) - 1, 0, (struct sockaddr*)&conn_addr,
+             sizeof(conn_addr)) != (ssize_t)(sizeof(good) - 1)) {
+    perror("sendto(peer)");
+    return 1;
+  }
+
+  pfd.revents = 0;
+  if (poll(&pfd, 1, 1000) != 1 || (pfd.revents & POLLIN) == 0) {
+    fprintf(stderr, "poll after good peer: expected POLLIN, revents=0x%x\n",
+            pfd.revents);
+    return 1;
+  }
+
+  struct sockaddr_in from;
+  socklen_t from_len = sizeof(from);
+  ssize_t nread =
+      recvfrom(conn_fd, buf, sizeof(buf), 0, (struct sockaddr*)&from, &from_len);
+  if (nread != (ssize_t)(sizeof(good) - 1) ||
+      memcmp(buf, good, sizeof(good) - 1) != 0) {
+    fprintf(stderr, "expected `%.*s`, got %zd bytes\n", (int)(sizeof(good) - 1),
+            good, nread);
+    return 1;
+  }
+  if (from.sin_port != peer_addr.sin_port ||
+      from.sin_addr.s_addr != peer_addr.sin_addr.s_addr) {
+    fprintf(stderr, "unexpected recvfrom source address\n");
+    return 1;
+  }
+
+  close(stranger_fd);
+  close(conn_fd);
+  close(peer_fd);
+  puts("connected UDP ignores wrong peer datagrams");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/udp-connected-wrong-peer/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-connected-wrong-peer/main.c
@@ -70,7 +70,8 @@ int main(void) {
   char buf[16];
   if (recv(conn_fd, buf, sizeof(buf), 0) >= 0 ||
       (errno != EAGAIN && errno != EWOULDBLOCK)) {
-    fprintf(stderr, "recv after wrong peer: expected EAGAIN, got errno=%d (%s)\n",
+    fprintf(stderr,
+            "recv after wrong peer: expected EAGAIN, got errno=%d (%s)\n",
             errno, strerror(errno));
     return 1;
   }
@@ -99,8 +100,8 @@ int main(void) {
 
   struct sockaddr_in from;
   socklen_t from_len = sizeof(from);
-  ssize_t nread =
-      recvfrom(conn_fd, buf, sizeof(buf), 0, (struct sockaddr*)&from, &from_len);
+  ssize_t nread = recvfrom(conn_fd, buf, sizeof(buf), 0,
+                           (struct sockaddr*)&from, &from_len);
   if (nread != (ssize_t)(sizeof(good) - 1) ||
       memcmp(buf, good, sizeof(good) - 1) != 0) {
     fprintf(stderr, "expected `%.*s`, got %zd bytes\n", (int)(sizeof(good) - 1),

--- a/lib/wasix/tests/wasm_tests/socket/udp-large-recv/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-large-recv/main.c
@@ -1,0 +1,64 @@
+//#ExpectedStdout: large UDP datagram receive works
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define PAYLOAD_SIZE 20480
+
+static uint8_t sendbuf[PAYLOAD_SIZE];
+static uint8_t recvbuf[PAYLOAD_SIZE];
+
+int main(void) {
+  int receiver = socket(AF_INET, SOCK_DGRAM, 0);
+  int sender = socket(AF_INET, SOCK_DGRAM, 0);
+  if (receiver < 0 || sender < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(receiver, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    return 1;
+  }
+
+  socklen_t len = sizeof(addr);
+  if (getsockname(receiver, (struct sockaddr*)&addr, &len) != 0) {
+    perror("getsockname");
+    return 1;
+  }
+
+  for (size_t i = 0; i < PAYLOAD_SIZE; ++i) {
+    sendbuf[i] = (uint8_t)(i & 0xff);
+  }
+
+  if (sendto(sender, sendbuf, PAYLOAD_SIZE, 0, (struct sockaddr*)&addr,
+             sizeof(addr)) != PAYLOAD_SIZE) {
+    perror("sendto");
+    return 1;
+  }
+
+  ssize_t nread = recvfrom(receiver, recvbuf, sizeof(recvbuf), 0, NULL, NULL);
+  if (nread != PAYLOAD_SIZE) {
+    fprintf(stderr, "expected %d-byte datagram, got %zd\n", PAYLOAD_SIZE,
+            nread);
+    return 1;
+  }
+  if (memcmp(sendbuf, recvbuf, PAYLOAD_SIZE) != 0) {
+    fprintf(stderr, "payload mismatch\n");
+    return 1;
+  }
+
+  close(sender);
+  close(receiver);
+  puts("large UDP datagram receive works");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/udp-large-recv/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-large-recv/main.c
@@ -2,6 +2,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>

--- a/lib/wasix/tests/wasm_tests/socket/udp-peek/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-peek/main.c
@@ -41,8 +41,8 @@ int main(void) {
 
   char peek_buf[16] = {0};
   char recv_buf[16] = {0};
-  ssize_t peek_len = recvfrom(receiver, peek_buf, sizeof(peek_buf), MSG_PEEK,
-                              NULL, NULL);
+  ssize_t peek_len =
+      recvfrom(receiver, peek_buf, sizeof(peek_buf), MSG_PEEK, NULL, NULL);
   if (peek_len != (ssize_t)(sizeof(msg) - 1) ||
       memcmp(peek_buf, msg, sizeof(msg) - 1) != 0) {
     fprintf(stderr, "MSG_PEEK: expected `%s`, got %zd bytes `%.*s`\n", msg,
@@ -50,7 +50,8 @@ int main(void) {
     return 1;
   }
 
-  ssize_t first_len = recvfrom(receiver, recv_buf, sizeof(recv_buf), 0, NULL, NULL);
+  ssize_t first_len =
+      recvfrom(receiver, recv_buf, sizeof(recv_buf), 0, NULL, NULL);
   if (first_len != (ssize_t)(sizeof(msg) - 1) ||
       memcmp(recv_buf, msg, sizeof(msg) - 1) != 0) {
     fprintf(stderr, "first recv: expected `%s`, got %zd bytes\n", msg,

--- a/lib/wasix/tests/wasm_tests/socket/udp-peek/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-peek/main.c
@@ -1,0 +1,78 @@
+//#ExpectedStdout: UDP MSG_PEEK leaves datagram queued
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  int receiver = socket(AF_INET, SOCK_DGRAM, 0);
+  int sender = socket(AF_INET, SOCK_DGRAM, 0);
+  if (receiver < 0 || sender < 0) {
+    perror("socket");
+    return 1;
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(receiver, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    return 1;
+  }
+
+  socklen_t len = sizeof(addr);
+  if (getsockname(receiver, (struct sockaddr*)&addr, &len) != 0) {
+    perror("getsockname");
+    return 1;
+  }
+
+  const char msg[] = "hello";
+  if (sendto(sender, msg, sizeof(msg) - 1, 0, (struct sockaddr*)&addr,
+             sizeof(addr)) != (ssize_t)(sizeof(msg) - 1)) {
+    perror("sendto");
+    return 1;
+  }
+
+  char peek_buf[16] = {0};
+  char recv_buf[16] = {0};
+  ssize_t peek_len = recvfrom(receiver, peek_buf, sizeof(peek_buf), MSG_PEEK,
+                              NULL, NULL);
+  if (peek_len != (ssize_t)(sizeof(msg) - 1) ||
+      memcmp(peek_buf, msg, sizeof(msg) - 1) != 0) {
+    fprintf(stderr, "MSG_PEEK: expected `%s`, got %zd bytes `%.*s`\n", msg,
+            peek_len, peek_len > 0 ? (int)peek_len : 0, peek_buf);
+    return 1;
+  }
+
+  ssize_t first_len = recvfrom(receiver, recv_buf, sizeof(recv_buf), 0, NULL, NULL);
+  if (first_len != (ssize_t)(sizeof(msg) - 1) ||
+      memcmp(recv_buf, msg, sizeof(msg) - 1) != 0) {
+    fprintf(stderr, "first recv: expected `%s`, got %zd bytes\n", msg,
+            first_len);
+    return 1;
+  }
+
+  if (fcntl(receiver, F_SETFL, fcntl(receiver, F_GETFL, 0) | O_NONBLOCK) != 0) {
+    perror("fcntl(O_NONBLOCK)");
+    return 1;
+  }
+
+  char drain_buf[16];
+  if (recvfrom(receiver, drain_buf, sizeof(drain_buf), 0, NULL, NULL) >= 0 ||
+      (errno != EAGAIN && errno != EWOULDBLOCK)) {
+    fprintf(stderr,
+            "second recv: expected EAGAIN after draining peeked datagram\n");
+    return 1;
+  }
+
+  close(sender);
+  close(receiver);
+  puts("UDP MSG_PEEK leaves datagram queued");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
@@ -1,3 +1,4 @@
+//#MinimalLibc: v2026-06-18.1
 //#ExpectedStdout: received datagram length: 0
 
 #include <arpa/inet.h>

--- a/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
@@ -11,21 +11,38 @@
 
 int main(void) {
   int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+  if (fd < 0) {
+    perror("socket");
+    return 1;
+  }
 
   struct sockaddr_in addr = {0};
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   addr.sin_port = 0;
-  bind(fd, (struct sockaddr*)&addr, sizeof(addr));
+  if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("bind");
+    close(fd);
+    return 1;
+  }
 
   socklen_t len = sizeof(addr);
-  getsockname(fd, (struct sockaddr*)&addr, &len);
+  if (getsockname(fd, (struct sockaddr*)&addr, &len) != 0) {
+    perror("getsockname");
+    close(fd);
+    return 1;
+  }
 
-  sendto(fd, "", 0, 0, (struct sockaddr*)&addr, sizeof(addr));
+  if (sendto(fd, "", 0, 0, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    perror("sendto");
+    close(fd);
+    return 1;
+  }
 
   struct pollfd pfd = {.fd = fd, .events = POLLIN};
   if (poll(&pfd, 1, 1000) != 1 || (pfd.revents & POLLIN) == 0) {
     fprintf(stderr, "poll: expected POLLIN, got revents=0x%x\n", pfd.revents);
+    close(fd);
     return 1;
   }
 

--- a/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
@@ -1,0 +1,39 @@
+//#ExpectedStdout: received datagram length: 0
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+
+  struct sockaddr_in addr = {0};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  bind(fd, (struct sockaddr*)&addr, sizeof(addr));
+
+  socklen_t len = sizeof(addr);
+  getsockname(fd, (struct sockaddr*)&addr, &len);
+
+  sendto(fd, "", 0, 0, (struct sockaddr*)&addr, sizeof(addr));
+
+  struct pollfd pfd = {.fd = fd, .events = POLLIN};
+  poll(&pfd, 1, 1000);
+
+  char byte;
+  ssize_t n = recvfrom(fd, &byte, sizeof(byte), 0, NULL, NULL);
+  close(fd);
+
+  if (n < 0) {
+    perror("recvfrom after poll");
+    return 1;
+  }
+
+  printf("received datagram length: %zd\n", n);
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-readiness/main.c
@@ -24,7 +24,10 @@ int main(void) {
   sendto(fd, "", 0, 0, (struct sockaddr*)&addr, sizeof(addr));
 
   struct pollfd pfd = {.fd = fd, .events = POLLIN};
-  poll(&pfd, 1, 1000);
+  if (poll(&pfd, 1, 1000) != 1 || (pfd.revents & POLLIN) == 0) {
+    fprintf(stderr, "poll: expected POLLIN, got revents=0x%x\n", pfd.revents);
+    return 1;
+  }
 
   char byte;
   ssize_t n = recvfrom(fd, &byte, sizeof(byte), 0, NULL, NULL);


### PR DESCRIPTION
## Summary

Supersedes #6720.

- Fix UDP receive readiness and backlog handling in `virtual-net`: datagrams are prefetched into a backlog, peek is supported, and zero-length datagrams no longer surface as hangup on poll.
- Apply connected-UDP peer filtering consistently across `recv`, `recvfrom`, and poll readiness in wasix (wrong-peer datagrams are discarded like on Linux).
- Use `MAX_SOCKET_PAYLOAD` for backlog receive buffers so large datagrams are not permanently truncated at the guest boundary.
- Add wasm integration tests covering zero-length poll/poll_oneoff, peek, large receive, and connected-UDP wrong-peer filtering.

## Test plan

- [x] `cargo test -p wasmer-wasix --test wasm_tests udp-readiness`
- [x] `cargo test -p wasmer-wasix --test wasm_tests udp-zero-length-poll-oneoff`
- [x] `cargo test -p wasmer-wasix --test wasm_tests udp-peek`
- [x] `cargo test -p wasmer-wasix --test wasm_tests udp-large-recv`
- [x] `cargo test -p wasmer-wasix --test wasm_tests udp-connected-wrong-peer`