### PR TITLE
fix(RUSTSEC-2026-0186): update memmap2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,7 +1794,7 @@ dependencies = [
  "byteorder",
  "dynasm",
  "fnv",
- "memmap2 0.9.10",
+ "memmap2 0.9.11",
 ]
 
 [[package]]
@@ -3418,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -5322,7 +5322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c30da69ccd7ab2780ce5309791f3cd2ef9716262c07a0a29096226d4235a979"
 dependencies = [
  "debugid",
- "memmap2 0.9.10",
+ "memmap2 0.9.11",
  "stable_deref_trait",
  "uuid",
 ]
@@ -7204,7 +7204,7 @@ dependencies = [
  "libc",
  "loupe",
  "macho-unwind-info",
- "memmap2 0.9.10",
+ "memmap2 0.9.11",
  "more-asserts",
  "object 0.39.1",
  "rangemap",


### PR DESCRIPTION
Fixes:  https://rustsec.org/advisories/RUSTSEC-2026-0186