### PR TITLE
Add namespace create CLI command

### DIFF
--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1112,13 +1112,14 @@ mod queries {
     #[derive(cynic::QueryVariables, Debug)]
     pub struct CreateNamespaceVars {
         pub name: String,
+        pub display_name: Option<String>,
         pub description: Option<String>,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(graphql_type = "Mutation", variables = "CreateNamespaceVars")]
     pub struct CreateNamespace {
-        #[arguments(input: {name: $name, description: $description})]
+        #[arguments(input: {name: $name, displayName: $display_name, description: $description})]
         pub create_namespace: Option<CreateNamespacePayload>,
     }
 

--- a/lib/cli/src/commands/namespace/create.rs
+++ b/lib/cli/src/commands/namespace/create.rs
@@ -9,6 +9,10 @@ pub struct CmdNamespaceCreate {
     #[clap(flatten)]
     env: WasmerEnv,
 
+    /// Display name of the namespace.
+    #[clap(long)]
+    display_name: Option<String>,
+
     /// Description of the namespace.
     #[clap(long)]
     description: Option<String>,
@@ -26,6 +30,7 @@ impl AsyncCliCommand for CmdNamespaceCreate {
 
         let vars = wasmer_backend_api::types::CreateNamespaceVars {
             name: self.name.clone(),
+            display_name: self.display_name.clone(),
             description: self.description.clone(),
         };
         let namespace = wasmer_backend_api::query::create_namespace(&client, vars).await?;

--- a/lib/cli/src/commands/namespace/mod.rs
+++ b/lib/cli/src/commands/namespace/mod.rs
@@ -7,6 +7,7 @@ use crate::commands::AsyncCliCommand;
 /// Manage namespaces.
 #[derive(clap::Subcommand, Debug)]
 pub enum CmdNamespace {
+    Create(create::CmdNamespaceCreate),
     Get(get::CmdNamespaceGet),
     List(list::CmdNamespaceList),
 }
@@ -17,6 +18,7 @@ impl AsyncCliCommand for CmdNamespace {
 
     async fn run_async(self) -> Result<(), anyhow::Error> {
         match self {
+            CmdNamespace::Create(cmd) => cmd.run_async().await,
             CmdNamespace::List(cmd) => cmd.run_async().await,
             CmdNamespace::Get(cmd) => cmd.run_async().await,
         }


### PR DESCRIPTION
## Summary
- register the existing `wasmer namespace create` subcommand so it is reachable
- add optional `--display-name` support alongside `--description`
- pass `displayName` through the create namespace GraphQL mutation

Closes #6733

## Verification
- `cargo fmt --all`
- `make lint-formatting`
- `cargo build -p wasmer-backend-api`
- `cargo build -p wasmer-cli`
- `cargo clippy -p wasmer-backend-api -- -D clippy::all`
- `cargo clippy -p wasmer-cli -- -D clippy::all`
- `cargo test -p wasmer-backend-api`
- `cargo test -p wasmer-cli`
- `./target/debug/wasmer namespace create --help`