### PR TITLE
Document libpolly installation in LLVM setup instructions

### DIFF
--- a/lib/compiler-llvm/README.md
+++ b/lib/compiler-llvm/README.md
@@ -31,6 +31,7 @@ You can install LLVM easily on your Debian-like system via this command:
 ```bash
 wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
 sudo bash /tmp/llvm.sh 22
+sudo apt install libpolly-22-dev
 ```
 
 Or in macOS:


### PR DESCRIPTION
Fixes #6753. 

# Description

Adds a line to LLVM setup instructions with libpolly that's not installed by default. `llvm.sh all` would have installed it as well, but it's an overkill due to the amount of additional unneeded packages it brings.