### PR TITLE
fix: allow seek on readonly mem_fs files

### DIFF
--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -1317,6 +1317,7 @@ impl AsyncWrite for FileHandle {
 
 #[cfg(test)]
 mod test_read_write_seek {
+    use shared_buffer::OwnedBuffer;
     use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
     use crate::{FileSystem as FS, mem_fs::*};
@@ -1598,6 +1599,39 @@ mod test_read_write_seek {
             "failing to read an exact buffer",
         );
     }
+
+    #[tokio::test]
+    async fn test_readonly_file_seek_and_reading_at_eof_returns_zero() {
+        let fs = FileSystem::default();
+        fs.insert_ro_file(path!("/foo.txt"), OwnedBuffer::from_static(b"foo"))
+            .expect("failed to insert readonly file");
+
+        let mut file = fs
+            .new_open_options()
+            .read(true)
+            .open(path!("/foo.txt"))
+            .expect("failed to open readonly file");
+
+        assert!(
+            matches!(file.seek(io::SeekFrom::End(0)).await, Ok(3)),
+            "seeking to EOF",
+        );
+
+        let mut buf = [0; 8];
+        assert!(
+            matches!(file.read(&mut buf).await, Ok(0)),
+            "reading at EOF should return zero bytes",
+        );
+
+        assert!(
+            matches!(file.seek(io::SeekFrom::Start(10)).await, Ok(10)),
+            "seeking past EOF",
+        );
+        assert!(
+            matches!(file.read(&mut buf).await, Ok(0)),
+            "reading past EOF should return zero bytes",
+        );
+    }
 }
 
 impl fmt::Debug for FileHandle {
@@ -1771,6 +1805,11 @@ impl ReadOnlyFile {
 impl ReadOnlyFile {
     pub fn read(&self, buf: &mut [u8], cursor: &mut u64) -> io::Result<usize> {
         let cur_pos = *cursor as usize;
+
+        if cur_pos >= self.buffer.len() {
+            return Ok(0);
+        }
+
         let max_to_read = cmp::min(self.buffer.len() - cur_pos, buf.len());
         let data_to_copy = &self.buffer[cur_pos..][..max_to_read];
 
@@ -1785,11 +1824,28 @@ impl ReadOnlyFile {
 }
 
 impl ReadOnlyFile {
-    pub fn seek(&self, _position: io::SeekFrom, _cursor: &mut u64) -> io::Result<u64> {
-        Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "file is read-only",
-        ))
+    pub fn seek(&self, position: io::SeekFrom, cursor: &mut u64) -> io::Result<u64> {
+        let to_err = |_| io::ErrorKind::InvalidInput;
+
+        let next_cursor: i64 = match position {
+            io::SeekFrom::Start(offset) => offset.try_into().map_err(to_err)?,
+            io::SeekFrom::End(offset) => {
+                TryInto::<i64>::try_into(self.buffer.len()).map_err(to_err)? + offset
+            }
+            io::SeekFrom::Current(offset) => {
+                TryInto::<i64>::try_into(*cursor).map_err(to_err)? + offset
+            }
+        };
+
+        if next_cursor < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "seeking before the byte 0",
+            ));
+        }
+
+        *cursor = next_cursor.try_into().map_err(to_err)?;
+        Ok(*cursor)
     }
 }
 


### PR DESCRIPTION
`mem_fs` readonly files reject `seek()` with `PermissionDenied`. That is a bit off for regular file semantics. Once seek is allowed, reads at or past EOF also need to return `0`, or the readonly path can underflow. Pretty weird little footgun tbh.

This keeps writes blocked, but makes readonly files seekable and makes EOF reads behave normally.

Repro:
1. call `insert_ro_file("/foo.txt", OwnedBuffer::from_static(b"foo"))`
2. open it with `.read(true)`
3. call `file.seek(SeekFrom::End(0)).await`
4. before this PR it fails with `PermissionDenied`
5. after this PR seek works, and `read()` at or past EOF returns `0`

Added a regression test in `mem_fs/file.rs`.