### PR TITLE
feat(vm): heap-based `Mmap` for environments without `mmap` syscall

### DIFF
--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -172,10 +172,9 @@ enable-serde = [
 # AddressSanitizer support
 sanitizer = ["wasmer-vm/sanitizer"]
 
-# Use the signal-free trap-handler backend (no OS signal infrastructure required).
-# Enable when targeting ZK virtual machines, embedded RTOSes, or similar
-# environments that provide std but lack Unix/Windows signal delivery.
-# Does NOT imply no_std support.
+# Enable when targeting environments without standard OS support: no Unix/Windows
+# signal delivery (uses signal-free trap handler) and no mmap syscall (uses
+# heap-based memory allocation). std is still required; this does NOT imply no_std.
 baremetal = ["wasmer-vm/baremetal"]
 
 wasmer-artifact-load = ["wasmer-compiler/wasmer-artifact-load"]

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -75,7 +75,7 @@ std = ["wasmer-types/std"]
 core = ["hashbrown", "wasmer-types/core"]
 enable-serde = ["serde", "serde_bytes", "wasmer-types/enable-serde"]
 artifact-size = ["dep:loupe"]
-# Signal-free trap-handler backend; see wasmer-vm's baremetal feature for details.
+# Enable when targeting environments without standard OS support; see wasmer-vm's baremetal feature for details.
 baremetal = ["wasmer-vm/baremetal"]
 
 [badges]

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -66,10 +66,9 @@ sanitizer = ["corosensei/sanitizer"]
 
 experimental-host-interrupt = []
 
-# Compile the signal-free trap-handler backend instead of the OS signal-based one.
-# Enable when targeting platforms that lack OS signal infrastructure (ZK virtual
-# machines, embedded RTOSes, …) but still provide a Rust std environment.
-# This does NOT imply no_std support.
+# Enable when targeting environments without standard OS support: no Unix/Windows
+# signal delivery (uses signal-free trap handler) and no mmap syscall (uses
+# heap-based memory allocation). std is still required; this does NOT imply no_std.
 baremetal = []
 
 [package.metadata.docs.rs]

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -80,6 +80,9 @@ impl Mmap {
         // mmap requires alignment to pages, we follow the same behavior
         let layout = Layout::from_size_align(mapping_size, page_size).unwrap();
         let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            return Err("memory allocation failed".to_string());
+        }
 
         if accessible_size < mapping_size {
             unsafe {

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -78,8 +78,7 @@ impl Mmap {
         assert!(backing_file.is_none());
 
         // mmap requires alignment to pages, we follow the same behavior
-        let layout = Layout::from_size_align(mapping_size, page_size)
-            .map_err(|e| e.to_string())?;
+        let layout = Layout::from_size_align(mapping_size, page_size).map_err(|e| e.to_string())?;
         let ptr = unsafe { alloc(layout) };
         if ptr.is_null() {
             return Err("memory allocation failed".to_string());
@@ -319,7 +318,9 @@ impl Mmap {
 
         // mmap(MAP_ANONYMOUS) returns zeroed pages; heap alloc does not.
         #[cfg(feature = "baremetal")]
-        unsafe { ptr::write_bytes(ptr_start, 0, len) };
+        unsafe {
+            ptr::write_bytes(ptr_start, 0, len)
+        };
 
         Ok(())
     }

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -81,7 +81,10 @@ impl Mmap {
         let layout = Layout::from_size_align(mapping_size, page_size).map_err(|e| e.to_string())?;
         let ptr = unsafe { alloc(layout) };
         if ptr.is_null() {
-            return Err("memory allocation failed".to_string());
+            return Err(format!(
+                "memory allocation failed: requested {mapping_size} bytes \
+                 (accessible: {accessible_size}, alignment: {page_size})"
+            ));
         }
 
         if accessible_size < mapping_size {

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -304,7 +304,7 @@ impl Mmap {
     /// Make the memory starting at `start` and extending for `len` bytes accessible.
     /// `start` and `len` must be native page-size multiples and describe a range within
     /// `self`'s reserved memory.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(any(feature = "baremetal", not(target_os = "windows")))]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -5,6 +5,8 @@
 //! of memory.
 
 use more_asserts::assert_le;
+#[cfg(feature = "baremetal")]
+use std::alloc::{Layout, alloc, dealloc};
 use std::io;
 use std::ptr;
 use std::slice;
@@ -74,8 +76,6 @@ impl Mmap {
         }
 
         assert!(backing_file.is_none());
-
-        use std::alloc::{Layout, alloc};
 
         // mmap requires alignment to pages, we follow the same behavior
         let layout = Layout::from_size_align(mapping_size, page_size).unwrap();
@@ -437,8 +437,6 @@ impl Drop for Mmap {
                 )
             }
             .expect("restore memory as accessible again");
-
-            use std::alloc::{Layout, dealloc};
 
             let layout =
                 Layout::from_size_align(self.total_size, region::page::size()).unwrap();

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -64,7 +64,7 @@ impl Mmap {
         accessible_size: usize,
         mapping_size: usize,
         backing_file: Option<std::path::PathBuf>,
-        _memory_type: MmapType,
+        memory_type: MmapType,
     ) -> Result<Self, String> {
         let page_size = region::page::size();
         assert_le!(accessible_size, mapping_size);
@@ -75,7 +75,12 @@ impl Mmap {
             return Ok(Self::new());
         }
 
-        assert!(backing_file.is_none());
+        if backing_file.is_some() {
+            return Err("baremetal Mmap does not support file-backed mappings".to_string());
+        }
+        if memory_type == MmapType::Shared {
+            return Err("baremetal Mmap does not support shared mappings".to_string());
+        }
 
         // mmap requires alignment to pages, we follow the same behavior
         let layout = Layout::from_size_align(mapping_size, page_size).map_err(|e| e.to_string())?;

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -20,7 +20,7 @@ pub struct Mmap {
     ptr: usize,
     total_size: usize,
     accessible_size: usize,
-    #[cfg_attr(target_os = "windows", allow(dead_code))]
+    #[cfg_attr(any(target_os = "windows", feature = "baremetal"), allow(dead_code))]
     sync_on_drop: bool,
 }
 
@@ -56,10 +56,60 @@ impl Mmap {
         Self::accessible_reserved(rounded_size, rounded_size, None, MmapType::Private)
     }
 
+    /// Allocates bytes from heap; used on platforms without mmap syscall.
+    #[cfg(feature = "baremetal")]
+    pub fn accessible_reserved(
+        accessible_size: usize,
+        mapping_size: usize,
+        backing_file: Option<std::path::PathBuf>,
+        _memory_type: MmapType,
+    ) -> Result<Self, String> {
+        let page_size = region::page::size();
+        assert_le!(accessible_size, mapping_size);
+        assert_eq!(mapping_size & (page_size - 1), 0);
+        assert_eq!(accessible_size & (page_size - 1), 0);
+
+        if mapping_size == 0 {
+            return Ok(Self::new());
+        }
+
+        assert!(backing_file.is_none());
+
+        use std::alloc::{Layout, alloc};
+
+        // mmap requires alignment to pages, we follow the same behavior
+        let layout = Layout::from_size_align(mapping_size, page_size).unwrap();
+        let ptr = unsafe { alloc(layout) } as *const u8;
+
+        if accessible_size < mapping_size {
+            unsafe {
+                region::protect(
+                    ptr.add(accessible_size),
+                    mapping_size - accessible_size,
+                    region::Protection::NONE,
+                )
+            }
+            .map_err(|e| e.to_string())?;
+        }
+
+        let mut result = Self {
+            ptr: ptr as usize,
+            total_size: mapping_size,
+            accessible_size,
+            sync_on_drop: false,
+        };
+
+        if accessible_size != 0 {
+            result.make_accessible(0, accessible_size)?;
+        }
+
+        Ok(result)
+    }
+
     /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned accessible memory,
     /// within a reserved mapping of `mapping_size` bytes. `accessible_size` and `mapping_size`
     /// must be native page-size multiples.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(feature = "baremetal"), not(target_os = "windows")))]
     pub fn accessible_reserved(
         mut accessible_size: usize,
         mapping_size: usize,
@@ -247,10 +297,29 @@ impl Mmap {
         })
     }
 
+    /// Make the memory accessible; used on platforms without mmap syscall.
+    /// Explicitly zeroes the region since heap memory is not guaranteed to be zeroed.
+    #[cfg(feature = "baremetal")]
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
+        let page_size = region::page::size();
+        assert_eq!(start & (page_size - 1), 0);
+        assert_eq!(len & (page_size - 1), 0);
+        assert_le!(len, self.total_size);
+        assert_le!(start, self.total_size - len);
+
+        unsafe {
+            let ptr_start = (self.ptr as *mut u8).add(start);
+            region::protect(ptr_start, len, region::Protection::READ_WRITE)
+                .map_err(|e| e.to_string())?;
+            ptr::write_bytes(ptr_start, 0, len);
+        }
+        Ok(())
+    }
+
     /// Make the memory starting at `start` and extending for `len` bytes accessible.
     /// `start` and `len` must be native page-size multiples and describe a range within
     /// `self`'s reserved memory.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(feature = "baremetal"), not(target_os = "windows")))]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);
@@ -371,7 +440,27 @@ impl Mmap {
 }
 
 impl Drop for Mmap {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(feature = "baremetal")]
+    fn drop(&mut self) {
+        if self.total_size != 0 {
+            unsafe {
+                region::protect(
+                    self.ptr as *const u8,
+                    self.total_size,
+                    region::Protection::READ_WRITE,
+                )
+            }
+            .expect("restore memory as accessible again");
+
+            use std::alloc::{Layout, dealloc};
+
+            let layout =
+                Layout::from_size_align(self.total_size, region::page::size()).unwrap();
+            unsafe { dealloc(self.ptr as *mut u8, layout) }
+        }
+    }
+
+    #[cfg(all(not(feature = "baremetal"), not(target_os = "windows")))]
     fn drop(&mut self) {
         if self.total_size != 0 {
             if self.sync_on_drop {

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -85,14 +85,16 @@ impl Mmap {
         }
 
         if accessible_size < mapping_size {
-            unsafe {
+            if let Err(e) = unsafe {
                 region::protect(
                     ptr.add(accessible_size),
                     mapping_size - accessible_size,
                     region::Protection::NONE,
                 )
+            } {
+                unsafe { dealloc(ptr, layout) };
+                return Err(e.to_string());
             }
-            .map_err(|e| e.to_string())?;
         }
 
         // alloc does not guarantee zeroed memory unlike mmap(MAP_ANONYMOUS).

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -78,7 +78,8 @@ impl Mmap {
         assert!(backing_file.is_none());
 
         // mmap requires alignment to pages, we follow the same behavior
-        let layout = Layout::from_size_align(mapping_size, page_size).unwrap();
+        let layout = Layout::from_size_align(mapping_size, page_size)
+            .map_err(|e| e.to_string())?;
         let ptr = unsafe { alloc(layout) };
         if ptr.is_null() {
             return Err("memory allocation failed".to_string());
@@ -433,9 +434,9 @@ impl Drop for Mmap {
     #[cfg(feature = "baremetal")]
     fn drop(&mut self) {
         if self.total_size != 0 {
-            let layout =
-                Layout::from_size_align(self.total_size, region::page::size()).unwrap();
-            unsafe { dealloc(self.ptr as *mut u8, layout) }
+            if let Ok(layout) = Layout::from_size_align(self.total_size, region::page::size()) {
+                unsafe { dealloc(self.ptr as *mut u8, layout) }
+            }
         }
     }
 

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -231,7 +231,7 @@ impl Mmap {
     /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned accessible memory,
     /// within a reserved mapping of `mapping_size` bytes. `accessible_size` and `mapping_size`
     /// must be native page-size multiples.
-    #[cfg(target_os = "windows")]
+    #[cfg(all(not(feature = "baremetal"), target_os = "windows"))]
     pub fn accessible_reserved(
         accessible_size: usize,
         mapping_size: usize,
@@ -322,7 +322,7 @@ impl Mmap {
     /// Make the memory starting at `start` and extending for `len` bytes accessible.
     /// `start` and `len` must be native page-size multiples and describe a range within
     /// `self`'s reserved memory.
-    #[cfg(target_os = "windows")]
+    #[cfg(all(not(feature = "baremetal"), target_os = "windows"))]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
         use std::ffi::c_void;
         use windows_sys::Win32::System::Memory::{MEM_COMMIT, PAGE_READWRITE, VirtualAlloc};
@@ -464,7 +464,7 @@ impl Drop for Mmap {
         }
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(all(not(feature = "baremetal"), target_os = "windows"))]
     fn drop(&mut self) {
         if !self.is_empty() {
             use std::ffi::c_void;

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -79,7 +79,7 @@ impl Mmap {
 
         // mmap requires alignment to pages, we follow the same behavior
         let layout = Layout::from_size_align(mapping_size, page_size).unwrap();
-        let ptr = unsafe { alloc(layout) } as *const u8;
+        let ptr = unsafe { alloc(layout) };
 
         if accessible_size < mapping_size {
             unsafe {
@@ -92,18 +92,17 @@ impl Mmap {
             .map_err(|e| e.to_string())?;
         }
 
-        let mut result = Self {
+        // alloc does not guarantee zeroed memory unlike mmap(MAP_ANONYMOUS).
+        if accessible_size != 0 {
+            unsafe { ptr::write_bytes(ptr, 0, accessible_size) };
+        }
+
+        Ok(Self {
             ptr: ptr as usize,
             total_size: mapping_size,
             accessible_size,
             sync_on_drop: false,
-        };
-
-        if accessible_size != 0 {
-            result.make_accessible(0, accessible_size)?;
-        }
-
-        Ok(result)
+        })
     }
 
     /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned accessible memory,

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -297,29 +297,10 @@ impl Mmap {
         })
     }
 
-    /// Make the memory accessible; used on platforms without mmap syscall.
-    /// Explicitly zeroes the region since heap memory is not guaranteed to be zeroed.
-    #[cfg(feature = "baremetal")]
-    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
-        let page_size = region::page::size();
-        assert_eq!(start & (page_size - 1), 0);
-        assert_eq!(len & (page_size - 1), 0);
-        assert_le!(len, self.total_size);
-        assert_le!(start, self.total_size - len);
-
-        unsafe {
-            let ptr_start = (self.ptr as *mut u8).add(start);
-            region::protect(ptr_start, len, region::Protection::READ_WRITE)
-                .map_err(|e| e.to_string())?;
-            ptr::write_bytes(ptr_start, 0, len);
-        }
-        Ok(())
-    }
-
     /// Make the memory starting at `start` and extending for `len` bytes accessible.
     /// `start` and `len` must be native page-size multiples and describe a range within
     /// `self`'s reserved memory.
-    #[cfg(all(not(feature = "baremetal"), not(target_os = "windows")))]
+    #[cfg(not(target_os = "windows"))]
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<(), String> {
         let page_size = region::page::size();
         assert_eq!(start & (page_size - 1), 0);
@@ -327,10 +308,15 @@ impl Mmap {
         assert_le!(len, self.total_size);
         assert_le!(start, self.total_size - len);
 
-        // Commit the accessible size.
-        let ptr = self.ptr as *const u8;
-        unsafe { region::protect(ptr.add(start), len, region::Protection::READ_WRITE) }
-            .map_err(|e| e.to_string())
+        let ptr_start = unsafe { (self.ptr as *mut u8).add(start) };
+        unsafe { region::protect(ptr_start, len, region::Protection::READ_WRITE) }
+            .map_err(|e| e.to_string())?;
+
+        // mmap(MAP_ANONYMOUS) returns zeroed pages; heap alloc does not.
+        #[cfg(feature = "baremetal")]
+        unsafe { ptr::write_bytes(ptr_start, 0, len) };
+
+        Ok(())
     }
 
     /// Make the memory starting at `start` and extending for `len` bytes accessible.

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -429,15 +429,6 @@ impl Drop for Mmap {
     #[cfg(feature = "baremetal")]
     fn drop(&mut self) {
         if self.total_size != 0 {
-            unsafe {
-                region::protect(
-                    self.ptr as *const u8,
-                    self.total_size,
-                    region::Protection::READ_WRITE,
-                )
-            }
-            .expect("restore memory as accessible again");
-
             let layout =
                 Layout::from_size_align(self.total_size, region::page::size()).unwrap();
             unsafe { dealloc(self.ptr as *mut u8, layout) }

--- a/lib/vm/src/mmap.rs
+++ b/lib/vm/src/mmap.rs
@@ -434,6 +434,16 @@ impl Drop for Mmap {
     #[cfg(feature = "baremetal")]
     fn drop(&mut self) {
         if self.total_size != 0 {
+            // Restore the full range before handing back to the allocator.
+            // Some allocators write freelist metadata into freed blocks; a
+            // PROT_NONE tail would cause a segfault inside dealloc.
+            let _ = unsafe {
+                region::protect(
+                    self.ptr as *mut u8,
+                    self.total_size,
+                    region::Protection::READ_WRITE,
+                )
+            };
             if let Ok(layout) = Layout::from_size_align(self.total_size, region::page::size()) {
                 unsafe { dealloc(self.ptr as *mut u8, layout) }
             }


### PR DESCRIPTION
Extends `Mmap` to support platforms that lack `mmap`/`munmap` syscalls (e.g. SP1's zkvm), activated via the existing `baremetal` feature flag already used for the signal-free trap handler.

### What changes:
  - `accessible_reserved` - allocates via `std::alloc` with page alignment, protects the reserved-but-inaccessible tail with `PROT_NONE`, and zeroes the accessible portion explicitly (heap alloc doesn't guarantee zeroed memory unlike `mmap(MAP_ANONYMOUS)`)
  - `make_accessible` - unified with the Unix implementation; zeroing is added under `#[cfg(feature = "baremetal")]` since pages promoted from `PROT_NONE` come from heap and are not zeroed by the OS
  - `drop` - restores the full range to `READ_WRITE` before calling `dealloc` to avoid segfaulting allocators that write freelist metadata into freed blocks

**Why baremetal rather than a new feature**: platforms already enabling `baremetal` for signal-free trapping (no OS signals) are usually those that also lack `mmap`. Reusing the flag avoids a separate opt-in.
