### PR TITLE
 fix(wasix): pass through EFD_NONBLOCK 

### DIFF
--- a/lib/wasi-types/src/types.rs
+++ b/lib/wasi-types/src/types.rs
@@ -27,6 +27,7 @@ pub mod file {
     pub const __WASI_STDERR_FILENO: Fd = 2;
 
     pub const EVENT_FD_FLAGS_SEMAPHORE: EventFdFlags = 1;
+    pub const EVENT_FD_FLAGS_NONBLOCK: EventFdFlags = 1 << 2;
 
     pub const __WASI_LOOKUP_SYMLINK_FOLLOW: LookupFlags = 1;
 

--- a/lib/wasix/src/syscalls/wasi/fd_event.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_event.rs
@@ -44,6 +44,13 @@ pub fn fd_event_internal(
         inner: Arc::new(NotificationInner::new(initial_val, is_semaphore)),
     };
 
+    // Forward EFD_NONBLOCK (== O_NONBLOCK == Fdflags::NONBLOCK) onto the fd.
+    let fs_flags = if flags & EVENT_FD_FLAGS_NONBLOCK != 0 {
+        Fdflags::NONBLOCK
+    } else {
+        Fdflags::empty()
+    };
+
     let inode =
         state
             .fs
@@ -55,25 +62,12 @@ pub fn fd_event_internal(
     let fd = wasi_try_ok_ok!(if let Some(fd) = with_fd {
         state
             .fs
-            .with_fd(
-                rights,
-                rights,
-                Fdflags::empty(),
-                Fdflagsext::empty(),
-                0,
-                inode,
-                fd,
-            )
+            .with_fd(rights, rights, fs_flags, Fdflagsext::empty(), 0, inode, fd)
             .map(|_| fd)
     } else {
-        state.fs.create_fd(
-            rights,
-            rights,
-            Fdflags::empty(),
-            Fdflagsext::empty(),
-            0,
-            inode,
-        )
+        state
+            .fs
+            .create_fd(rights, rights, fs_flags, Fdflagsext::empty(), 0, inode)
     });
 
     Ok(Ok(fd))

--- a/lib/wasix/tests/wasm_tests/fd_tests/fd-event-nonblock/main.c
+++ b/lib/wasix/tests/wasm_tests/fd_tests/fd-event-nonblock/main.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+/* EFD_NONBLOCK must be honored on the eventfd returned by eventfd().
+
+   POSIX/Linux eventfd(2): a read() of an eventfd whose counter is 0 fails with
+   EAGAIN when the fd is non-blocking, and blocks otherwise. */
+int main(void) {
+  int efd = eventfd(0, EFD_NONBLOCK);
+  assert(efd >= 0);
+
+  /* The flag must be observable through F_GETFL. Checked before the read so a
+     regressed (blocking) fd fails here instead of hanging on the read below. */
+  int flags = fcntl(efd, F_GETFL, 0);
+  assert(flags >= 0);
+  assert(flags & O_NONBLOCK);
+
+  /* counter == 0 on a non-blocking fd: read must fail with EAGAIN, not block.
+   */
+  uint64_t val = 0;
+  errno = 0;
+  ssize_t n = read(efd, &val, sizeof(val));
+  assert(n == -1);
+  assert(errno == EAGAIN);
+
+  /* Control: once the counter is non-zero the same non-blocking fd reads the
+     value and drains the counter, exactly as a blocking fd would. */
+  uint64_t one = 1;
+  assert(write(efd, &one, sizeof(one)) == sizeof(one));
+  assert(read(efd, &val, sizeof(val)) == sizeof(val));
+  assert(val == 1);
+
+  close(efd);
+}


### PR DESCRIPTION

# Description

Previously, `event_fd` would silently drop `NONBLOCK`, causing hangs in some programs.

Discovered specifically in `curl` when built with the following patch: [fix-wakeup-consumption.patch](https://github.com/NixOS/nixpkgs/blob/ee6ca4145bbd7f48a82110505c7a736b9715cb3e/pkgs/by-name/cu/curlMinimal/fix-wakeup-consumption.patch)