### PR TITLE
Add app CDN cache CLI commands

### DIFF
--- a/docs/schema/generated/jsonschema/types/AppConfigV1.schema.json
+++ b/docs/schema/generated/jsonschema/types/AppConfigV1.schema.json
@@ -146,6 +146,20 @@
     "package"
   ],
   "$defs": {
+    "AppConfigCapabilityCdnCacheV1": {
+      "description": "CDN cache capability settings.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable CDN caching for the app.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
     "AppConfigCapabilityInstaBootV1": {
       "description": "Enables accelerated instance boot times with startup snapshots.\n\nHow it works:\nThe Edge runtime will create a pre-initialized snapshot of apps that is\nready to serve requests\nYour app will then restore from the generated snapshot, which has the\npotential to significantly speed up cold starts.\n\nTo drive the initialization, multiple http requests can be specified.\nAll the specified requests will be sent to the app before the snapshot is\ncreated, allowing the app to pre-load files, pre initialize caches, ...",
       "type": "object",
@@ -186,6 +200,17 @@
       "description": "Restricted version of the internal `CapabilityMapV1`, with only a select\nsubset of settings.",
       "type": "object",
       "properties": {
+        "cdn_cache": {
+          "description": "CDN cache settings.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AppConfigCapabilityCdnCacheV1"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "instaboot": {
           "description": "Enables app bootstrapping with startup snapshots.",
           "anyOf": [

--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -1,119 +1,2050 @@
+type AAAARecord implements Node & DNSRecordInterface {
+	address: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type APIKey implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	namespace: Namespace!
+	createdBy: User!
+	createdAt: DateTime!
+	deletedAt: DateTime
+	name: String!
+	note: String
+	lastUsedAt: DateTime
+	maskedKey: String!
+}
+
+type APIKeyConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [APIKeyEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
 """
-Directs the executor to include this field or fragment only when the user is not logged in.
+A Relay edge containing a `APIKey` and its cursor.
 """
-directive @includeIfLoggedIn on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+type APIKeyEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: APIKey!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type APIToken implements Node {
+	user: User!
+	identifier: String
+	createdAt: DateTime!
+	revokedAt: DateTime
+	lastUsedAt: DateTime
+	nonceSet(offset: Int, before: String, after: String, first: Int, last: Int): NonceConnection!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+}
+
+type APITokenConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [APITokenEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int!
+}
 
 """
-Directs the executor to skip this field or fragment when the user is not logged in.
+A Relay edge containing a `APIToken` and its cursor.
 """
-directive @skipIfLoggedIn on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-
-interface Node {
-  """The ID of the object"""
-  id: ID!
+type APITokenEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: APIToken!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type PublicKey implements Node {
-  """The ID of the object"""
-  id: ID!
-  owner: User!
-  keyId: String!
-  key: String!
-  revokedAt: DateTime
-  uploadedAt: DateTime!
-  verifyingSignature: Signature
-  revoked: Boolean!
+type ARecord implements Node & DNSRecordInterface {
+	address: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
 }
 
-type User implements Node & PackageOwner & Owner {
-  firstName: String!
-  lastName: String!
-  email: String!
-  dateJoined: DateTime!
-  probationStartedAt: DateTime
-
-  """Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."""
-  username: String!
-  registerIntent: String
-  isEmailValidated: Boolean!
-  bio: String
-  location: String
-  websiteUrl: String
-  wasmerInternal: Boolean!
-
-  """The ID of the object"""
-  id: ID!
-  globalName: String!
-  globalId: ID!
-  viewerCan(action: OwnerAction!): Boolean!
-  isPro: Boolean!
-  avatar(size: Int = 80): String!
-  limitState: LimitState!
-  isViewer: Boolean!
-  hasUsablePassword: Boolean
-  fullName: String!
-  githubUrl: String
-  twitterUrl: String
-  companyRole: String
-  companyDescription: String
-  publicActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
-  billing: Billing
-  waitlist(name: String!): WaitlistMember
-  namespaces(role: GrapheneRole, offset: Int, before: String, after: String, first: Int, last: Int): NamespaceConnection!
-  packages(collaborating: Boolean = false, offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
-  apps(collaborating: Boolean = false, sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
-  usageMetrics(
-    variant: MetricType!
-    grouping: MetricGrouping
-
-    """List of app IDs. Metrics gets filtered for the specific apps."""
-    appIds: [ID]
-
-    """Optional time range filter."""
-    timeRange: TimeRangeInput
-  ): [UsageMetric]!
-  domains(offset: Int, before: String, after: String, first: Int, last: Int): DNSDomainConnection!
-  isStaff: Boolean
-  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
-  packageTransfersIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
-  packageInvitesIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
-  namespaceInvitesIncoming(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
-  apiTokens(offset: Int, before: String, after: String, first: Int, last: Int): APITokenConnection!
-  notifications(offset: Int, before: String, after: String, first: Int, last: Int): UserNotificationConnection!
-  dashboardActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
-  loginMethods: [LoginMethod!]!
-  pendingVerifications: [PendingVerification!]!
-  githubUser: SocialAuth
-  githubScopes: [String]! @deprecated(reason: "Please use github installations instead.")
-  githubRepositories: [GithubInstallationRepository]! @deprecated(reason: "Please use github installations instead.")
-  githubInstallationExists: Boolean! @deprecated(reason: "Please use github installations instead.")
-  githubInstallations: [GithubAppInstallation!]
-  currentUsage(
-    """List of app IDs. Usage gets filtered for the specific apps."""
-    appIds: [ID]
-
-    """Optional time range filter."""
-    timeRange: TimeRangeInput
-  ): OwnerUsageSummary
+input AcceptAppTransferRequestInput {
+	appTransferRequestId: ID!
+	clientMutationId: String
 }
 
-"""Setup for backwards compatibility with existing frontends."""
-interface PackageOwner {
-  globalName: String!
-  globalId: ID!
-  viewerCan(action: OwnerAction!): Boolean!
+type AcceptAppTransferRequestPayload {
+	clientMutationId: String
+	app: DeployApp!
+	appTransferRequest: AppTransferRequest!
 }
 
-enum OwnerAction {
-  DEPLOY_APP
-  PUBLISH_PACKAGE
+input AcceptNamespaceCollaboratorInviteInput {
+	inviteId: ID!
+	clientMutationId: String
 }
 
-interface Owner {
-  globalName: String!
-  globalId: ID!
-  viewerCan(action: OwnerAction!): Boolean!
-  isPro: Boolean!
+type AcceptNamespaceCollaboratorInvitePayload {
+	namespaceCollaboratorInvite: NamespaceCollaboratorInvite!
+	clientMutationId: String
+}
+
+input AcceptPackageCollaboratorInviteInput {
+	inviteId: ID!
+	clientMutationId: String
+}
+
+type AcceptPackageCollaboratorInvitePayload {
+	clientMutationId: String
+	packageCollaboratorInvite: PackageCollaboratorInvite!
+}
+
+input AcceptPackageTransferRequestInput {
+	packageTransferRequestId: ID!
+	clientMutationId: String
+}
+
+type AcceptPackageTransferRequestPayload {
+	clientMutationId: String
+	package: Package!
+	packageTransferRequest: PackageTransferRequest!
+}
+
+input AcceptTOSInput {
+	clientMutationId: String
+}
+
+"""
+Viewer accepts the latest ToS.
+"""
+type AcceptTOSPayload {
+	clientMutationId: String
+	TOS: TermsOfService!
+}
+
+type ActivityEvent implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	body: EventBody!
+	actorIcon: String!
+	createdAt: DateTime!
+}
+
+type ActivityEventConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [ActivityEventEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `ActivityEvent` and its cursor.
+"""
+type ActivityEventEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ActivityEvent!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input AddPaymentInput {
+	clientMutationId: String
+}
+
+"""
+Add stripe payment to the user
+"""
+type AddPaymentPayload {
+	clientMutationId: String
+	customerSecret: String!
+}
+
+input AddSshAuthorizedKeyInput {
+	"""
+	SSH User ID
+	"""
+	sshUserId: ID!
+	publicKey: String!
+	name: String
+	clientMutationId: String
+}
+
+"""
+Add an SSH authorized key to an SSH user.
+"""
+type AddSshAuthorizedKeyPayload {
+	authorizedKey: SshAuthorizedKey!
+	clientMutationId: String
+}
+
+type AggregateMetrics {
+	cpuTime: String!
+	memoryTime: String!
+	ingress: String!
+	egress: String!
+	noRequests: String!
+	noFailedRequests: String!
+	monthlyCost: String!
+}
+
+type AppAlias implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	lastCheckedAt: DateTime
+	firstCheckedAt: DateTime
+	name: String!
+	app: DeployApp!
+	isDefault: Boolean!
+	hostname: String!
+	text: String!
+	kind: DeployAppAliasKindChoices!
+	redirectsTo: AppAlias
+	url: String!
+	state: AppAliasVerificationStates!
+	"""
+	List of records backend expects to move forward with domain verification
+	"""
+	expectedDnsRecords: [AppAliasDNSRecord!]!
+	"""
+	HTTP code for redirection
+	"""
+	redirectionHttpCode: HTTPRedirectType
+	"""
+	list of AppAlias objects that redirect to this one.
+	"""
+	redirectsFrom: [AppAlias!]!
+}
+
+type AppAliasConnection {
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [AppAliasEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int!
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+}
+
+type AppAliasDNSRecord {
+	recordType: String!
+	host: String!
+	value: String!
+}
+
+"""
+A Relay edge containing a `AppAlias` and its cursor.
+"""
+type AppAliasEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AppAlias!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
+An enumeration.
+"""
+enum AppAliasSortBy {
+	NEWEST
+	OLDEST
+}
+
+"""
+An enumeration.
+"""
+enum AppAliasVerificationStates {
+	UNVERIFIED
+	VERIFIED
+	APEX_WITHOUT_REDIRECTION
+}
+
+input AppCdnCacheConfigUpdate {
+	enabled: Boolean
+}
+
+type AppCdnCacheMutationPayload {
+	success: Boolean!
+}
+
+input AppConfigV1 {
+	kind: String = "wasmer.io/App.v0"
+	appId: ID
+	name: String!
+	description: String
+	package: String!
+}
+
+type AppDatabase implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	username: String!
+	app: DeployApp!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	host: String!
+	port: String!
+	password: String
+	phpmyadminUrl: String
+	dbExplorerUrl: String
+}
+
+type AppDatabaseConfig implements Node {
+	id: ID!
+}
+
+type AppDatabaseConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [AppDatabaseEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int!
+}
+
+"""
+A Relay edge containing a `AppDatabase` and its cursor.
+"""
+type AppDatabaseEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AppDatabase!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input AppDomainRedirectRules {
+	"""
+	Domain to redirect to.
+	"""
+	to: String!
+	"""
+	Type of redirection; sets the http code appropriately.
+	"""
+	httpCode: HTTPRedirectType!
+}
+
+input AppFilter {
+	count: Int = 1000
+	sortBy: SearchOrderSort = DESC
+	"""
+	Filter apps by deployed by.
+	"""
+	deployedBy: String
+	"""
+	Filter apps last deployed after this date.
+	"""
+	lastDeployedAfter: DateTime
+	"""
+	Filter apps last deployed before this date.
+	"""
+	lastDeployedBefore: DateTime
+	"""
+	Filter apps by owner.
+	"""
+	owner: String
+	"""
+	Order apps by field.
+	"""
+	orderBy: AppOrderBy = CREATED_DATE
+	"""
+	Filter apps by client name.
+	"""
+	clientName: String
+}
+
+type AppLimit implements Node {
+	id: ID!
+}
+
+type AppMail implements Node {
+	emailAddr: String!
+	login: String!
+	passwordSecret: Secret!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+}
+
+enum AppOrderBy {
+	PUBLISHED_DATE
+	CREATED_DATE
+}
+
+type AppRegion implements Node {
+	name: String!
+	country: String!
+	city: String!
+	supportsVolumes: Boolean!
+	supportsDbs: Boolean!
+	active: Boolean!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+}
+
+type AppRegionConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [AppRegionEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int!
+}
+
+"""
+A Relay edge containing a `AppRegion` and its cursor.
+"""
+type AppRegionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AppRegion!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type AppScreenshot implements Node {
+	id: ID!
+}
+
+"""
+An enumeration.
+"""
+enum AppScreenshotAppearance {
+	LIGHT
+	DARK
+}
+
+"""
+An enumeration.
+"""
+enum AppScreenshotViewportSize {
+	MOBILE
+	DESKTOP
+}
+
+type AppSshServer implements Node {
+	enabled: Boolean!
+	users(offset: Int, before: String, after: String, first: Int, last: Int): SshUserConnection!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+}
+
+type AppTemplate implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	slug: String!
+	description: String!
+	demoUrl: String!
+	repoUrl: String!
+	rootDir: String
+	branch: String
+	category: String!
+	isPublic: Boolean!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	readme: String!
+	useCases: JSONString!
+	repoLicense: String!
+	usingPackage: Package
+	canDeployWithoutRepo: Boolean!
+	completionTimeInSeconds: Int!
+	highlighted: Boolean!
+	defaultImage: String
+	defaultRepositoryCloneName: String
+	framework: String!
+	templateFramework: TemplateFramework
+	language: String
+	templateLanguage: TemplateLanguage
+}
+
+type AppTemplateCategory implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	slug: String!
+	description: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	appTemplates(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection!
+}
+
+type AppTemplateCategoryConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [AppTemplateCategoryEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `AppTemplateCategory` and its cursor.
+"""
+type AppTemplateCategoryEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AppTemplateCategory!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type AppTemplateConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [AppTemplateEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `AppTemplate` and its cursor.
+"""
+type AppTemplateEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AppTemplate!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input AppTemplateFilter {
+	count: Int = 1000
+	sortBy: SearchOrderSort = DESC
+	"""
+	Order app templates by field.
+	"""
+	orderBy: AppTemplateOrderBy = HIGHLIGHTED
+	"""
+	Filter by app template framework
+	"""
+	framework: String
+	"""
+	Filter by app template language
+	"""
+	language: String
+	"""
+	Filter by one or more of the use-cases for the app template
+	"""
+	useCases: [String]
+}
+
+enum AppTemplateOrderBy {
+	CREATED_DATE
+	HIGHLIGHTED
+}
+
+"""
+An enumeration.
+"""
+enum AppTemplatesSortBy {
+	NEWEST
+	OLDEST
+	POPULAR
+}
+
+type AppTransferRequest implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	requestedBy: User!
+	previousOwnerObjectId: Int!
+	newOwnerObjectId: Int!
+	app: DeployApp!
+	approvedBy: User
+	declinedBy: User
+	createdAt: DateTime!
+	expiresAt: DateTime!
+	closedAt: DateTime
+	previousOwner: Owner!
+	newOwner: Owner!
+}
+
+input AppV1Spec {
+	aliases: [String] = []
+	workload: WorkloadV2!
+}
+
+type AppVersionVolume {
+	id: ID!
+	name: String!
+	s3Url: String
+	mountPaths: [AppVersionVolumeMountPath!]!
+	size: BigInt
+	usedSize: BigInt
+	explorerUrl: String
+}
+
+type AppVersionVolumeMountPath {
+	path: String!
+	subpath: String
+}
+
+type AppVolume implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	app: DeployApp
+	region: AppRegion!
+	volumeId: String!
+	mountPath: String!
+	maxSizeBytes: BigInt!
+	isAddedByUi: Boolean!
+	s3Enabled: Boolean!
+	s3: S3
+	s3Url: URL
+	explorerUrl: URL
+}
+
+type AppVolumeConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [AppVolumeEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int!
+}
+
+"""
+A Relay edge containing a `AppVolume` and its cursor.
+"""
+type AppVolumeEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: AppVolume!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input ArchivePackageInput {
+	packageId: ID!
+	clientMutationId: String
+}
+
+type ArchivePackagePayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input AttachVaultInput {
+	"""
+	ID of app to which the vault will be attached.
+	"""
+	appId: ID!
+	"""
+	ID of vault to attach.
+	"""
+	vaultId: ID!
+	clientMutationId: String
+}
+
+"""
+Attach vault to an app
+"""
+type AttachVaultPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+enum AutoBuildDeployAppLogKind {
+	LOG
+	PREPARING_TO_DEPLOY_STATUS
+	FETCHING_PLAN_STATUS
+	BUILD_STATUS
+	DEPLOY_STATUS
+	COMPLETE
+	FAILED
+}
+
+input AutobuildConfigForRepoInput {
+	"""
+	The repo URL
+	"""
+	repoUrl: String!
+	"""
+	The path to build from
+	"""
+	basePath: String @deprecated(reason: "Please use root_dir instead")
+	"""
+	The preset to use
+	"""
+	presetName: String
+	"""
+	The root directory to build from
+	"""
+	rootDir: String
+	"""
+	The branch to use
+	"""
+	branch: String
+	clientMutationId: String
+}
+
+"""
+Get the autobuild config for a given repo
+"""
+type AutobuildConfigForRepoPayload {
+	clientMutationId: String
+	"""
+	The build configuration
+	"""
+	buildConfig: BuildConfig
+	"""
+	List of apps deployed with this repo.
+	"""
+	deployedApps: DeployAppConnection @deprecated(reason: "This field is not used anymore")
+}
+
+input AutobuildConfigForZipUploadInput {
+	"""
+	The Zip upload URL
+	"""
+	uploadUrl: String!
+	"""
+	The preset to use
+	"""
+	presetName: String
+	clientMutationId: String
+}
+
+"""
+Get the autobuild config for a given zip upload URL
+"""
+type AutobuildConfigForZipUploadPayload {
+	clientMutationId: String
+	"""
+	The build configuration
+	"""
+	buildConfig: BuildConfig
+	"""
+	List of apps deployed with this repo.
+	"""
+	deployedApps: DeployAppConnection @deprecated(reason: "This field is not used anymore")
+}
+
+input AutobuildDeploymentExtraData {
+	wordpress: WordpressDeploymentExtraData = null
+}
+
+type AutobuildDeploymentStatus {
+	buildId: UUID!
+	status: StatusEnum!
+	appVersion: DeployAppVersion
+}
+
+"""
+Log entry for Deploying app from github repo
+"""
+type AutobuildLog {
+	"""
+	Kind of log message.
+	"""
+	kind: AutoBuildDeployAppLogKind!
+	"""
+	Log message
+	"""
+	message: String
+	appVersion: DeployAppVersion
+	"""
+	Timestamp in nanoseconds
+	"""
+	timestamp: String!
+	"""
+	ISO 8601 string in UTC
+	"""
+	datetime: DateTime!
+	"""
+	Log stream
+	"""
+	stream: LogStream
+}
+
+type AutobuildRepository implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	appVersion: DeployAppVersion
+	buildId: UUID!
+	buildCmd: String
+	installCmd: String
+	user: User!
+	name: String!
+	namespace: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	appName: String
+	repoUrl: String!
+	prevCommitHash: String
+	commitHash: String!
+	commitMessage: String!
+	commitAuthorUsername: String!
+	reference: String
+	status: StatusEnum!
+	logUrl: String
+	commitUrl: String
+	buildConfiguration: BuildConfiguration
+	logs(startingFrom: Float, startingFromIso: DateTime, until: Float, streams: [LogStream], instanceIds: [String], requestId: String, before: String, after: String, first: Int, last: Int): LogConnection!
+}
+
+type AutobuildZipUpload implements Node {
+	id: ID!
+}
+
+input BanAppInput {
+	"""
+	ID of app to disable
+	"""
+	appId: ID!
+	"""
+	Disable with this reason
+	"""
+	reason: String!
+	"""
+	Blackhole the app (no network access)
+	"""
+	blackholed: Boolean = false
+	clientMutationId: String
+}
+
+"""
+Ban app with a reason.
+"""
+type BanAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+"""
+The `BigInt` scalar type represents non-fractional whole numeric values.
+`BigInt` is not constrained to 32-bit like the `Int` type and thus is a less
+compatible type.
+"""
+scalar BigInt
+
+type Billing {
+	stripeCustomer: StripeCustomer!
+	payments: [PaymentIntent!]! @deprecated(reason: "Use `payment_connection` instead")
+	subscriptions: [WasmerSubscription!]!
+	paymentMethods: [PaymentMethod!]! @deprecated(reason: "Use `payment_connection` instead")
+	paymentConnection(offset: Int, before: String, after: String, first: Int, last: Int): PaymentIntentConnection!
+	paymentMethodConnection(offset: Int, before: String, after: String, first: Int, last: Int): CardPaymentMethodConnection!
+}
+
+type BillingPlan implements Node {
+	id: ID!
+}
+
+type BillingPlanResource implements Node {
+	id: ID!
+}
+
+type BindingsGenerator implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	packageVersion: PackageVersion!
+	active: Boolean!
+	commandName: String!
+	registryJavascriptlanguagebindings(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
+	registryPythonlanguagebindings(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
+}
+
+type BindingsGeneratorConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [BindingsGeneratorEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `BindingsGenerator` and its cursor.
+"""
+type BindingsGeneratorEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: BindingsGenerator!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
+An enumeration.
+"""
+enum BlogBlogPostThemeChoices {
+	"""
+	Green
+	"""
+	GREEN
+	"""
+	Purple
+	"""
+	PURPLE
+	"""
+	Orange
+	"""
+	ORANGE
+	"""
+	Blue
+	"""
+	BLUE
+}
+
+type BlogPost implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	live: Boolean!
+	"""
+	The page title as you'd like it to be seen by the public
+	"""
+	title: String!
+	"""
+	The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/
+	"""
+	slug: String!
+	owner: User
+	body: String!
+	publishDate: DateTime
+	theme: BlogBlogPostThemeChoices!
+	url: String!
+	coverImageUrl: String
+	opengraphImageUrl: String
+	tagline: String!
+	relatedArticles: [BlogPost!]
+	updatedAt: DateTime!
+	tags: [BlogPostTag!]
+	editUrl: String
+}
+
+type BlogPostConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [BlogPostEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `BlogPost` and its cursor.
+"""
+type BlogPostEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: BlogPost!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type BlogPostTag implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	slug: String!
+}
+
+type BlogPostTagConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [BlogPostTagEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `BlogPostTag` and its cursor.
+"""
+type BlogPostTagEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: BlogPostTag!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input BlogPostsFilter {
+	count: Int! = 1000
+	sortBy: SearchOrderSort = DESC
+	"""
+	Filter blog posts by tag.
+	"""
+	tags: [String!]
+}
+
+"""
+The Build Configuration for a given repo
+"""
+type BuildConfig {
+	startCmd: String
+	buildCmd: String
+	installCmd: String
+	afterDeployCmd: String
+	setupDb: Boolean!
+	presetName: String!
+	appName: String!
+	completionTimeInSeconds: Int!
+	branch: String
+	canDeployWithoutRepo: Boolean! @deprecated(reason: "This field is not used anymore")
+}
+
+type BuildConfiguration implements Node {
+	kind: BuildKind
+	startCmd: String
+	buildCmd: String
+	installCmd: String
+	rootDir: String
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String
+	repo: String @deprecated(reason: "This field is deprecated and return null always.")
+	repoName: String @deprecated(reason: "This field is deprecated and return null always.")
+	repoNamespace: String @deprecated(reason: "This field is deprecated and return null always.")
+	completionTimeInSeconds: Int! @deprecated(reason: "This field is deprecated and return null always.")
+	setupDb: Boolean! @deprecated(reason: "This field is deprecated and return null always.")
+}
+
+type BuildKind implements Node {
+	name: String!
+	provider: String!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	config: JSONString!
+	setupDb: Boolean @deprecated(reason: "This field is deprecated and return null always.")
+	buildCmd: String @deprecated(reason: "This field is deprecated and return null always.")
+	installCmd: String @deprecated(reason: "This field is deprecated and return null always.")
+	startCmd: String @deprecated(reason: "This field is deprecated and return null always.")
+}
+
+type BuildKindConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [BuildKindEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `BuildKind` and its cursor.
+"""
+type BuildKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: BuildKind
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type CAARecord implements Node & DNSRecordInterface {
+	flags: Int!
+	tag: DnsmanagerCertificationAuthorityAuthorizationRecordTagChoices!
+	value: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type CNAMERecord implements Node & DNSRecordInterface {
+	"""
+	This domain name will alias to this canonical name.
+	"""
+	cName: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+input CancelSubscriptionInput {
+	"""
+	ID of owner whose subscription to cancel.
+	"""
+	forOwnerId: ID!
+	"""
+	ID of the subscription to cancel
+	"""
+	subscriptionId: ID!
+	clientMutationId: String
+}
+
+type CancelSubscriptionPayload {
+	clientMutationId: String
+	ok: Boolean!
+}
+
+input CapabilityCpuV1 {
+	maximumThreads: Int
+	maximumUsage: Int
+}
+
+input CapabilityFileSystemV1 {
+	volumes: [FileSystemVolumeConfigV1]!
+}
+
+input CapabilityMapV1 {
+	memorySwap: CapabilityCpuV1
+}
+
+input CapabilityMemorySwapV1 {
+	maximumSize: String
+	memoryId: String
+}
+
+input CapabilityNetworkDnsV1 {
+	enabled: Boolean
+	servers: [String]
+	allowedHosts: NetworkDnsAllowedHostsV1
+}
+
+input CapabilityNetworkGatewayV1 {
+	domains: [String]
+	enforceHttps: Boolean
+}
+
+input CapabilityNetworkV1 {
+	egress: NetworkEgressV1
+}
+
+input CapabilityPersistentMemoryV1 {
+	volumes: [String]
+}
+
+"""
+Card brand.
+
+Can be amex, diners, discover, jcb, mastercard, unionpay, visa, or unknown.
+"""
+enum CardBrand {
+	AMEX
+	DINERS
+	DISCOVER
+	JCB
+	MASTERCARD
+	UNIONPAY
+	VISA
+	UNKNOWN
+}
+
+"""
+Card funding type.
+
+Can be credit, debit, prepaid, or unknown.
+"""
+enum CardFunding {
+	CREDIT
+	DEBIT
+	PREPAID
+	UNKNOWN
+}
+
+type CardPaymentMethod implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	brand: CardBrand!
+	country: String!
+	expMonth: Int!
+	expYear: Int!
+	funding: CardFunding!
+	last4: String!
+	isDefault: Boolean!
+}
+
+type CardPaymentMethodConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [CardPaymentMethodEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `CardPaymentMethod` and its cursor.
+"""
+type CardPaymentMethodEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: CardPaymentMethod!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
+The `CaseInsensitiveString` scalar type represents textual data, represented as UTF-8
+character sequences. The String type is most often used by GraphQL to
+represent free-form human-readable text.
+"""
+scalar CaseInsensitiveString
+
+type Category implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	"""
+	A category is a label that can be attached to a package.
+	"""
+	name: String!
+	packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+}
+
+type CategoryConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [CategoryEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int!
+}
+
+"""
+A Relay edge containing a `Category` and its cursor.
+"""
+type CategoryEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Category!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input ChangePackageVersionArchivedStatusInput {
+	packageVersionId: ID!
+	isArchived: Boolean
+	clientMutationId: String
+}
+
+type ChangePackageVersionArchivedStatusPayload {
+	clientMutationId: String
+	packageVersion: PackageVersion!
+}
+
+input ChangeUserEmailInput {
+	newEmail: String!
+	clientMutationId: String
+}
+
+type ChangeUserEmailPayload {
+	clientMutationId: String
+	user: User!
+}
+
+input ChangeUserPasswordInput {
+	"""
+	The token associated to change the password. If not existing it will use the request user by default
+	"""
+	token: String
+	oldPassword: String
+	password: String!
+	clientMutationId: String
+}
+
+type ChangeUserPasswordPayload {
+	token: String
+	clientMutationId: String
+}
+
+input ChangeUserUsernameInput {
+	"""
+	The new user username
+	"""
+	username: CaseInsensitiveString!
+	clientMutationId: String
+}
+
+type ChangeUserUsernamePayload {
+	clientMutationId: String
+	user: User!
+	token: String
+}
+
+input CheckUserExistsInput {
+	"""
+	The user
+	"""
+	user: String!
+	clientMutationId: String
+}
+
+type CheckUserExistsPayload {
+	exists: Boolean!
+	"""
+	The user is only returned if the user input was the username
+	"""
+	user: User
+	clientMutationId: String
+}
+
+input ClaimPerishableAppInput {
+	"""
+	ID of app to disable
+	"""
+	appId: ID!
+	clientMutationId: String
+}
+
+"""
+Claim a perishable app as their own.
+"""
+type ClaimPerishableAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+type Collection {
+	slug: String!
+	displayName: String!
+	description: String!
+	createdAt: DateTime!
+	banner: String!
+	packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+}
+
+type CollectionConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [CollectionEdge!]!
+}
+
+"""
+A Relay edge containing a `Collection` and its cursor.
+"""
+type CollectionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Collection!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type Command {
+	command: String!
+	packageVersion: PackageVersion!
+	module: PackageVersionModule
+}
+
+input Configuration {
+	deployment: AppConfigV1
+	yamlConfig: String
+}
+
+input ConnectGithubRepoToAppInput {
+	"""
+	The ID of the App
+	"""
+	appId: ID!
+	"""
+	The ID of the Github app repository installation
+	"""
+	installationRepoId: ID!
+	"""
+	The branch to deploy from
+	"""
+	deployBranch: String
+	clientMutationId: String
+}
+
+"""
+Connect a github repo to an app.
+"""
+type ConnectGithubRepoToAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+	githubRepoConnection: GithubRepoConnection!
+	success: Boolean!
+}
+
+enum CountComparison {
+	EQUAL
+	GREATER_THAN
+	LESS_THAN
+	GREATER_THAN_OR_EQUAL
+	LESS_THAN_OR_EQUAL
+}
+
+input CountFilter {
+	count: Int = 0
+	comparison: CountComparison = GREATER_THAN_OR_EQUAL
+}
+
+input CreateAppDBInput {
+	"""
+	App ID
+	"""
+	id: ID!
+	"""
+	Database name
+	"""
+	name: String
+	clientMutationId: String
+}
+
+"""
+Create a new database for an app.
+"""
+type CreateAppDBPayload {
+	clientMutationId: String
+	database: AppDatabase!
+	password: String!
+}
+
+input CreateAppDatabaseInput {
+	"""
+	App ID.
+	"""
+	appId: ID!
+	"""
+	Database engine to provision and link to the app.
+	"""
+	dbEngine: DatabaseEngine!
+	"""
+	Database name.
+	"""
+	name: String
+	clientMutationId: String
+}
+
+input CreateAppTemplateInput {
+	name: String!
+	slug: String!
+	description: String
+	demoUrl: String!
+	repoUrl: String!
+	rootDir: String
+	branch: String
+	category: String!
+	framework: String!
+	language: String
+	isPublic: Boolean!
+	highlighted: Boolean!
+	canDeployWithoutRepo: Boolean!
+	completionTimeInSeconds: String!
+	repoLicense: String!
+	useCases: [String!]
+	readme: String!
+	defaultImageUpload: Upload
+	clientMutationId: String
+}
+
+type CreateAppTemplatePayload {
+	appTemplate: AppTemplate!
+	clientMutationId: String
+}
+
+input CreateAppVolumeInput {
+	"""
+	App ID
+	"""
+	appId: ID!
+	"""
+	Volume mount path
+	"""
+	mountPath: String!
+	"""
+	Volume max size in bytes
+	"""
+	maxSizeBytes: BigInt
+	clientMutationId: String
+}
+
+"""
+Create a UI-managed volume for an app.
+"""
+type CreateAppVolumePayload {
+	clientMutationId: String
+	volume: AppVolume!
+	success: Boolean!
+}
+
+input CreateCheckoutSessionInput {
+	"""
+	URL to redirect.
+	"""
+	returnUrl: String!
+	"""
+	ID of price (product) to charge the user.
+	"""
+	priceId: ID!
+	"""
+	Locale of the customer.
+	"""
+	locale: String!
+	"""
+	ID of owner to create subscription on. Defaults to current user.
+	"""
+	forOwnerId: ID
+	"""
+	Whether to apply a trial period if available.
+	"""
+	isTrial: Boolean = false
+	clientMutationId: String
+}
+
+type CreateCheckoutSessionPayload {
+	clientMutationId: String
+	clientSecret: String!
+}
+
+input CreateNamespaceAPIKeyInput {
+	namespaceId: ID!
+	name: String
+	note: String
+	clientMutationId: String
+}
+
+type CreateNamespaceAPIKeyPayload {
+	apiKey: APIKey!
+	keyRaw: String!
+	clientMutationId: String
+}
+
+input CreateNamespaceInput {
+	name: String!
+	"""
+	The namespace display name
+	"""
+	displayName: String
+	"""
+	The namespace description
+	"""
+	description: String
+	"""
+	The namespace avatar
+	"""
+	avatar: String @deprecated(reason: "Use `avatarUpload` instead")
+	"""
+	The namespace avatar
+	"""
+	avatarUpload: Upload
+	clientMutationId: String
+}
+
+type CreateNamespacePayload {
+	namespace: Namespace!
+	user: User!
+	clientMutationId: String
+}
+
+input CreateRepoForAppTemplateInput {
+	templateId: ID!
+	name: String!
+	namespace: String!
+	private: Boolean = false
+	domains: [String] = null
+	clientMutationId: String
+}
+
+type CreateRepoForAppTemplatePayload {
+	clientMutationId: String
+	success: Boolean!
+	repoId: ID!
+}
+
+type CronJob implements Node {
+	id: ID!
+	name: String!
+	schedule: String!
+	kind: CronJobKind!
+	source: CronJobSource!
+	isManaged: Boolean!
+	enabled: Boolean!
+	timeout: String
+	maxScheduleDrift: String
+	maxRetries: Int
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	owner: Owner
+	target: CronJobTarget!
+	invocations(start: DateTime, end: DateTime, after: String, first: Int): CronJobInvocationConnection!
+}
+
+type CronJobConnection {
+	totalCount: Int
+	pageInfo: PageInfo!
+	edges: [CronJobEdge!]!
+	nodes: [CronJob!]!
+}
+
+type CronJobEdge {
+	cursor: String!
+	node: CronJob!
+}
+
+type CronJobInvocation {
+	id: ID!
+	edgeJobId: String!
+	status: CronJobInvocationStatus
+	scheduledAt: DateTime
+	startedAt: DateTime
+	finishedAt: DateTime
+	durationMs: Int
+	retryAttempts: Int
+	errorSummary: String
+	result: CronJobInvocationResult
+	logs(before: String, after: String, first: Int, last: Int): LogConnection!
+}
+
+type CronJobInvocationConnection {
+	pageInfo: PageInfo!
+	edges: [CronJobInvocationEdge!]!
+	nodes: [CronJobInvocation!]!
+}
+
+type CronJobInvocationEdge {
+	cursor: String!
+	node: CronJobInvocation!
+}
+
+union CronJobInvocationResult = ExecuteCronJobInvocationResult | FetchCronJobInvocationResult
+
+enum CronJobInvocationStatus {
+	PENDING
+	RUNNING
+	SUCCESS
+	FAILURE
+}
+
+enum CronJobKind {
+	FETCH
+	EXECUTE
+}
+
+enum CronJobSource {
+	CONFIG
+	API
+	PROVISIONED
+}
+
+union CronJobTarget = FetchCronJobTarget | ExecuteCronJobTarget
+
+enum CronJobsSortBy {
+	OLDEST
+	NEWEST
+}
+
+type DNAMERecord implements Node & DNSRecordInterface {
+	"""
+	This domain name will alias to the entire subtree of that delegation domain.
+	"""
+	dName: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+input DNSCAAExtraInput {
+	flags: Int!
+	tag: String!
+}
+
+enum DNSDelegationStatus {
+	UNKNOWN
+	PENDING
+	VERIFIED
+	MISCONFIGURED
+}
+
+type DNSDomain implements Node {
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	name: String!
+	"""
+	This zone will be accessible at /dns/{slug}/.
+	"""
+	slug: String!
+	zoneFile: String!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	records: [DNSRecord]
+	recordsConnection(first: Int, after: String, last: Int, before: String, sortBy: DNSRecordsSortBy): DNSRecordConnection!
+	nameservers: [String!]!
+	delegationStatus: DNSDelegationStatus!
+	verifiedAt: DateTime
+	lastCheckedAt: DateTime
+	owner: Owner!
+}
+
+type DNSDomainConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [DNSDomainEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `DNSDomain` and its cursor.
+"""
+type DNSDomainEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DNSDomain!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input DNSMXExtraInput {
+	preference: Int!
+}
+
+union DNSRecord = ARecord | AAAARecord | CNAMERecord | TXTRecord | MXRecord | NSRecord | CAARecord | DNAMERecord | PTRRecord | SOARecord | SRVRecord | SSHFPRecord
+
+type DNSRecordConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [DNSRecordEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `DNSRecord` and its cursor.
+"""
+type DNSRecordEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DNSRecord!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+interface DNSRecordInterface {
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+}
+
+input DNSRecordUpdate {
+	"""
+	ID of the DNS record to update or delete.
+	"""
+	id: ID
+	"""
+	Record owner/name within the DNS domain.
+	"""
+	name: String
+	"""
+	Record kind. Required when creating/upserting by name or deleting by natural key.
+	"""
+	kind: RecordKind
+	"""
+	Record value. Required when creating/upserting by name.
+	"""
+	value: String
+	"""
+	Time to live in seconds.
+	"""
+	ttl: Int
+	mx: DNSMXExtraInput
+	soa: DNSSOAExtraInput
+	srv: DNSSRVExtraInput
+	caa: DNSCAAExtraInput
+	sshfp: DNSSSHFPExtraInput
+	"""
+	Whether the DNS record should be deleted instead of upserted.
+	"""
+	delete: Boolean = false
+}
+
+enum DNSRecordsSortBy {
+	NEWEST
+	OLDEST
+}
+
+input DNSSOAExtraInput {
+	mname: String!
+	rname: String!
+	serial: Int!
+	refresh: Int!
+	retry: Int!
+	expire: Int!
+	minimum: Int!
+}
+
+input DNSSRVExtraInput {
+	service: String!
+	protocol: String!
+	priority: Int!
+	weight: Int!
+	port: Int!
+}
+
+input DNSSSHFPExtraInput {
+	algorithm: Int!
+	type: Int!
+}
+
+enum DatabaseEngine {
+	MYSQL
+	POSTGRES
+	SQLITE
 }
 
 """
@@ -123,442 +2054,1385 @@ value as specified by
 """
 scalar DateTime
 
-"""An enumeration."""
-enum LimitState {
-  not_limited
-  nearing_limits
-  under_probation
-  limit_exceeded
-}
-
-type ActivityEventConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [ActivityEventEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+input DeleteAppDBInput {
+	"""
+	App Database ID
+	"""
+	id: ID!
+	clientMutationId: String
 }
 
 """
-The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+Delete a database for an app.
 """
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
+type DeleteAppDBPayload {
+	success: Boolean!
+	clientMutationId: String
 }
 
-"""A Relay edge containing a `ActivityEvent` and its cursor."""
-type ActivityEventEdge {
-  """The item at the end of the edge"""
-  node: ActivityEvent
-
-  """A cursor for use in pagination"""
-  cursor: String!
+input DeleteAppDomainInput {
+	"""
+	ID of the domain to delete.
+	"""
+	id: ID!
+	clientMutationId: String
 }
 
-type ActivityEvent implements Node {
-  """The ID of the object"""
-  id: ID!
-  body: EventBody!
-  actorIcon: String!
-  createdAt: DateTime!
+"""
+Delete domain with given ID
+"""
+type DeleteAppDomainPayload {
+	success: Boolean!
+	clientMutationId: String
+	"""
+	ID of the deleted domain.
+	"""
+	id: ID!
+}
+
+input DeleteAppInput {
+	"""
+	App ID to delete.
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+type DeleteAppPayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteAppSecretInput {
+	"""
+	ID of the secret to delete.
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Deprecated: use UpdateEnvVars.
+"""
+type DeleteAppSecretPayload {
+	clientMutationId: String
+	success: Boolean!
+	"""
+	ID of the deleted secret.
+	"""
+	id: ID!
+}
+
+input DeleteAppTemplateInput {
+	templateId: ID!
+	clientMutationId: String
+}
+
+type DeleteAppTemplatePayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteAppVolumeInput {
+	"""
+	App Volume ID
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Soft-delete an app volume.
+"""
+type DeleteAppVolumePayload {
+	clientMutationId: String
+	"""
+	ID of the deleted volume
+	"""
+	id: ID!
+	success: Boolean!
+}
+
+input DeleteDNSRecordInput {
+	recordId: ID!
+	clientMutationId: String
+}
+
+type DeleteDNSRecordPayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteDomainInput {
+	domainId: ID!
+	clientMutationId: String
+}
+
+type DeleteDomainPayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteNamespaceAPIKeyInput {
+	apiKeyId: ID!
+	clientMutationId: String
+}
+
+type DeleteNamespaceAPIKeyPayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteNamespaceInput {
+	namespaceId: ID!
+	clientMutationId: String
+}
+
+type DeleteNamespacePayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteSshAuthorizedKeyByIdInput {
+	"""
+	SSH authorized key ID.
+	"""
+	authorizedKeyId: ID!
+	clientMutationId: String
+}
+
+input DeleteSshAuthorizedKeyInput {
+	"""
+	SSH User ID
+	"""
+	sshUserId: ID!
+	name: String
+	clientMutationId: String
+}
+
+"""
+Edit an SSH user.
+"""
+type DeleteSshAuthorizedKeyPayload {
+	success: Boolean!
+	clientMutationId: String
+}
+
+input DeleteUserInput {
+	"""
+	ID of user to delete
+	"""
+	userId: ID!
+	clientMutationId: String
+}
+
+"""
+Delete a user with some reason. The deletion will be soft, so the
+underlying data will remain and be anonymized following GDPR.
+"""
+type DeleteUserPayload {
+	clientMutationId: String
+	deleted: Boolean!
+	"""
+	ID of user to delete
+	"""
+	userId: ID!
+}
+
+type DeployApp implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	state: String!
+	forceHttps: Boolean!
+	cdnCacheEnabled: Boolean!
+	cdnCachePurgedAt: DateTime
+	createdBy: User!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	activeVersion: DeployAppVersion
+	region: AppRegion
+	managed: Boolean!
+	willPerishAt: DateTime
+	globalName: String!
+	globalId: ID!
+	viewerCan(action: OwnerAction!): Boolean!
+	isPro: Boolean!
+	url: String!
+	adminUrl: String!
+	permalink: String!
+	urls: [String!]!
+	description: String
+	name: String!
+	owner: Owner!
+	versions(sortBy: DeployAppVersionsSortBy, createdAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
+	aggregateMetrics: AggregateMetrics!
+	aliases(offset: Int, before: String, after: String, first: Int, last: Int): AppAliasConnection!
+	domains(sortBy: AppAliasSortBy! = NEWEST, offset: Int, before: String, after: String, first: Int, last: Int): AppAliasConnection!
+	secrets(names: [String], nameRegex: String, offset: Int, before: String, after: String, first: Int, last: Int): SecretConnection! @deprecated(reason: "Use `envVars` instead.")
+	envVars(names: [String], nameRegex: String, offset: Int, before: String, after: String, first: Int, last: Int): EnvVarConnection!
+	databases(offset: Int, before: String, after: String, first: Int, last: Int): AppDatabaseConnection!
+	volumes(offset: Int, before: String, after: String, first: Int, last: Int): AppVolumeConnection!
+	cronJobs(kind: CronJobKind, sortBy: CronJobsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): CronJobConnection!
+	usageMetrics(		variant: MetricType!,		grouping: MetricGrouping,
+		"""
+		Optional time range filter.
+		"""
+		timeRange: TimeRangeInput
+	): [UsageMetric]!
+	groupedMetrics(startAt: DateTime!, endAt: DateTime!, groupedBy: MetricGrouping!): UsageMetrics!
+	emailUsage: EmailUsageSummary
+	logs(
+		"""
+		Filter for this instance id in logs
+		"""
+		instanceId: String,
+		"""
+		Search logs for this text.
+		"""
+		textSearch: String,		before: String,		after: String,		first: Int,		last: Int
+	): LogConnection!
+	s3Url: URL
+	s3Credentials: S3Credentials
+	deleted: Boolean!
+	favicon: URL
+	screenshot(viewportSize: AppScreenshotViewportSize, appearance: AppScreenshotAppearance): URL
+	deployments(before: String, after: String, first: Int, last: Int): DeploymentConnection @deprecated(reason: "Use rollouts instead")
+	rollouts(before: String, after: String, first: Int, last: Int): RolloutConnection
+	githubPrPreviews(prNumber: Int): [GithubPrPreviewDeployment!]!
+	buildConfiguration: BuildConfiguration
+	sshServer: AppSshServer
+	mails: [AppMail]
+	sentEmails(first: Int, after: String, last: Int, before: String): EmailMessageConnection!
+	receivedEmails(first: Int, after: String, last: Int, before: String): EmailMessageConnection!
+	kind: Kind
+	githubRepoConnection: GithubRepoConnection
+	perishReason: DeployDeployAppPerishReasonChoices
+}
+
+"""
+An enumeration.
+"""
+enum DeployAppAliasKindChoices {
+	"""
+	Deployment
+	"""
+	DEPLOYMENT
+	"""
+	Domain
+	"""
+	DOMAIN
+}
+
+type DeployAppConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [DeployAppEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `DeployApp` and its cursor.
+"""
+type DeployAppEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DeployApp!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type DeployAppVersion implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	app: DeployApp!
+	yamlConfig: String!
+	userYamlConfig: String!
+	clientName: String!
+	signature: String
+	description: String
+	publishedBy: User!
+	disabledAt: DateTime
+	disabledBy: User
+	disabledReason: String
+	disabledPermanently: Boolean!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	configWebc: String @deprecated(reason: "webc support has been deprecated for apps")
+	config: String! @deprecated(reason: "Please use jsonConfig instead")
+	jsonConfig: String!
+	url: String!
+	permalink: String!
+	urls: [String]!
+	version: String!
+	isActive: Boolean!
+	manifest: String!
+	usageMetrics(		variant: MetricType!,		grouping: MetricGrouping,
+		"""
+		Optional time range filter.
+		"""
+		timeRange: TimeRangeInput
+	): [UsageMetric]!
+	logs(
+		"""
+		Get logs starting from this timestamp. Takes ISO timestamp.
+		"""
+		start: DateTime,
+		"""
+		Fetch logs until this timestamp. Takes ISO timestamp.
+		"""
+		end: DateTime,
+		"""
+		Search logs for this text.
+		"""
+		textSearch: String,
+		"""
+		Get logs starting from this timestamp. Takes EPOCH timestamp in seconds.
+		"""
+		startingFrom: Float,
+		"""
+		Get logs starting from this timestamp. Takes ISO timestamp.
+		"""
+		startingFromISO: DateTime,
+		"""
+		Fetch logs until this timestamp. Takes EPOCH timestamp in seconds.
+		"""
+		until: Float,
+		"""
+		List of streams to fetch logs from. e.g. stdout, stderr.
+		"""
+		streams: [LogStream],
+		"""
+		List of instance ids to fetch logs from.
+		"""
+		instanceIds: [String] @deprecated(reason: "Use instance_id instead"),
+		"""
+		Filter for this instance id in logs
+		"""
+		instanceId: String,
+		"""
+		Filter for this request id in logs
+		"""
+		requestId: String,		before: String,		after: String,		first: Int,		last: Int
+	): LogConnection!
+	sourcePackageVersion: PackageVersion
+	sourcePackageRelease: PackageWebc
+	sourcePackage: Package!
+	aggregateMetrics: AggregateMetrics!
+	volumes: [AppVersionVolume]
+	gitSource: AutobuildRepository @deprecated(reason: "This field is deprecated and return null always.")
+	rolloutSource: Rollout
+	favicon: URL
+	screenshot(viewportSize: AppScreenshotViewportSize, appearance: AppScreenshotAppearance): URL
+	isUploaded: Boolean!
+}
+
+type DeployAppVersionConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [DeployAppVersionEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `DeployAppVersion` and its cursor.
+"""
+type DeployAppVersionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: DeployAppVersion!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
+An enumeration.
+"""
+enum DeployAppVersionsSortBy {
+	NEWEST
+	OLDEST
+}
+
+"""
+An enumeration.
+"""
+enum DeployAppsSortBy {
+	NEWEST
+	OLDEST
+	MOST_ACTIVE
+}
+
+"""
+An enumeration.
+"""
+enum DeployDeployAppPerishReasonChoices {
+	"""
+	User Pending Verification
+	"""
+	USER_PENDING_VERIFICATION
+	"""
+	User Requested
+	"""
+	USER_REQUESTED
+	"""
+	App Unclaimed
+	"""
+	APP_UNCLAIMED
+}
+
+"""
+An enumeration.
+"""
+enum DeploySecretLogActionChoices {
+	"""
+	Access
+	"""
+	ACCESS
+	"""
+	Modification
+	"""
+	MODIFICATION
+	"""
+	Create
+	"""
+	CREATE
+	"""
+	DELETE
+	"""
+	DELETE
+}
+
+input DeployViaAutobuildInput {
+	repoUrl: String
+	uploadUrl: String
+	appName: String
+	appId: ID
+	owner: String
+	presetName: String
+	buildCmd: String
+	installCmd: String
+	startCmd: String
+	afterDeployCmd: String
+	enableDatabase: Boolean
+	secrets: [SecretInput] @deprecated(reason: "Use envVars instead")
+	envVars: [EnvVarInput]
+	extraData: AutobuildDeploymentExtraData
+	params: AutobuildDeploymentExtraData
+	"""
+	If set, the app is managed by wasmer.
+	"""
+	managed: Boolean = false
+	kind: String
+	"""
+	If set, the screenshot is waited for.
+	"""
+	waitForScreenshotGeneration: Boolean = false
+	"""
+	Region to deploy the app
+	"""
+	region: String
+	"""
+	The path to build from (defaults to /)
+	"""
+	basePath: String @deprecated(reason: "Please use root_dir instead")
+	"""
+	The root directory to build from (defaults to /)
+	"""
+	rootDir: String
+	"""
+	Branch to deploy from. If no branch is specified, the default branch is used.
+	"""
+	branch: String
+	"""
+	If set, allows deploying a new version of an existing app.
+	"""
+	allowExistingApp: Boolean = false
+	"""
+	Additional jobs to run in the deployment.
+	"""
+	jobs: [JobDefinitionInput]
+	"""
+	Domains for this app
+	"""
+	domains: [String]
+	"""
+	When the app should be perished
+	"""
+	perishAt: String
+	clientMutationId: String
+}
+
+type DeployViaAutobuildPayload {
+	clientMutationId: String
+	success: Boolean!
+	buildId: UUID!
+}
+
+input DeployWordpressInput {
+	"""
+	Wordpress site name.
+	"""
+	siteName: String!
+	"""
+	Name of app to create.
+	"""
+	appName: String!
+	"""
+	Owner of this app.
+	"""
+	appOwner: String!
+	"""
+	Region for this app.
+	"""
+	region: String!
+	"""
+	Username of admin for the wordpress site.
+	"""
+	adminUsername: String!
+	"""
+	Admin password for the wordpress site.
+	"""
+	adminPassword: String!
+	"""
+	Email of admin of the wordpress site.
+	"""
+	adminEmail: String!
+	"""
+	Email of admin of the wordpress site.
+	"""
+	language: String
+	"""
+	If set, the app is managed by wasmer.
+	"""
+	managed: Boolean
+	clientMutationId: String
+}
+
+"""
+Deploy a wordpress site.
+"""
+type DeployWordpressPayload {
+	clientMutationId: String
+	appVersion: DeployAppVersion!
+}
+
+union Deployment = NakedDeployment | AutobuildRepository
+
+type DeploymentConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [DeploymentEdge]!
+}
+
+"""
+A Relay edge containing a `Deployment` and its cursor.
+"""
+type DeploymentEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Deployment
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input DeploymentV1 {
+	name: String!
+	workload: WorkloadV1!
+}
+
+input DetachAppFromAutobuildInput {
+	"""
+	The ID of the App
+	"""
+	appId: ID!
+	clientMutationId: String
+}
+
+"""
+Detach autobuild from app.
+"""
+type DetachAppFromAutobuildPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+input DetachPaymentMethodInput {
+	paymentMethod: ID!
+	clientMutationId: String
+}
+
+"""
+Try to detach a payment method from customer.
+Fails if trying to detach a default method,
+or if it's the only payment method.
+"""
+type DetachPaymentMethodPayload {
+	success: Boolean!
+	billing: Billing!
+	clientMutationId: String
+}
+
+input DisableAppInput {
+	"""
+	ID of app to disable
+	"""
+	appId: ID!
+	"""
+	Disable with this reason
+	"""
+	reason: String!
+	clientMutationId: String
+}
+
+"""
+Disable app with a reason.
+"""
+type DisableAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+input DisconnectGithubRepoFromAppInput {
+	"""
+	The ID of the App
+	"""
+	appId: ID!
+	clientMutationId: String
+}
+
+"""
+Disconnect a github repo from an app.
+"""
+type DisconnectGithubRepoFromAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+	success: Boolean!
+}
+
+"""
+An enumeration.
+"""
+enum DnsmanagerCertificationAuthorityAuthorizationRecordTagChoices {
+	"""
+	issue
+	"""
+	ISSUE
+	"""
+	issue wildcard
+	"""
+	ISSUEWILD
+	"""
+	Incident object description exchange format
+	"""
+	IODEF
+}
+
+"""
+An enumeration.
+"""
+enum DnsmanagerSshFingerprintRecordAlgorithmChoices {
+	"""
+	RSA
+	"""
+	A_1
+	"""
+	DSA
+	"""
+	A_2
+	"""
+	ECDSA
+	"""
+	A_3
+	"""
+	Ed25519
+	"""
+	A_4
+}
+
+"""
+An enumeration.
+"""
+enum DnsmanagerSshFingerprintRecordTypeChoices {
+	"""
+	SHA-1
+	"""
+	A_1
+	"""
+	SHA-256
+	"""
+	A_2
+}
+
+input EditSshUserInput {
+	"""
+	SSH User ID
+	"""
+	id: ID!
+	username: String
+	authenticationMethods: [SshAuthenticationMethod] = null
+	sftpRootFolder: String
+	clientMutationId: String
+}
+
+"""
+Edit an SSH user.
+"""
+type EditSshUserPayload {
+	sshUser: SshUser!
+	clientMutationId: String
+}
+
+type EmailMessage implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	direction: EmailMessageDirection!
+	status: EmailMessageStatus!
+	from: String!
+	to: [String!]!
+	cc: [String!]!
+	bcc: [String!]!
+	replyTo: String
+	subject: String!
+	textBody: String
+	htmlBody: String
+	app: DeployApp
+	owner: Owner
+	createdAt: DateTime!
+	sentAt: DateTime
+	receivedAt: DateTime
+}
+
+type EmailMessageConnection {
+	pageInfo: PageInfo!
+	edges: [EmailMessageEdge!]!
+	totalCount: Int
+}
+
+enum EmailMessageDirection {
+	SENT
+	RECEIVED
+}
+
+type EmailMessageEdge {
+	node: EmailMessage!
+	cursor: String!
+}
+
+enum EmailMessageStatus {
+	QUEUED
+	SENT
+	DELIVERED
+	FAILED
+	RECEIVED
+}
+
+type EmailUsageSummary {
+	startDate: DateTime!
+	endDate: DateTime!
+	currentUsage: Int!
+}
+
+input EnableAppInput {
+	"""
+	ID of app to disable
+	"""
+	appId: ID!
+	clientMutationId: String
+}
+
+"""
+Enable app that was previously disabled.
+"""
+type EnableAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+type EnvVar implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	sensitive: Boolean!
+	value: String
+}
+
+type EnvVarConnection {
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [EnvVarEdge!]!
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `EnvVar` and its cursor.
+"""
+type EnvVarEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EnvVar!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input EnvVarInput {
+	"""
+	Name of the environment variable.
+	"""
+	name: String!
+	"""
+	Value of the environment variable.
+	"""
+	value: String!
+	"""
+	Whether the environment variable value should be hidden from GraphQL.
+	"""
+	sensitive: Boolean = false
+}
+
+type EnvVarLog implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	action: DeploySecretLogActionChoices!
+	envVarName: String!
+}
+
+type EnvVarLogConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [EnvVarLogEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `EnvVarLog` and its cursor.
+"""
+type EnvVarLogEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EnvVarLog!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+input EnvVarUpdate {
+	"""
+	ID of the environment variable.
+	"""
+	id: ID
+	"""
+	Name of the environment variable.
+	"""
+	name: String
+	"""
+	Value of the environment variable.
+	"""
+	value: String
+	"""
+	Whether the environment variable value should be hidden from GraphQL.
+	"""
+	sensitive: Boolean = false
+	"""
+	Whether the environment variable should be deleted by name instead of upserted.
+	"""
+	delete: Boolean = false
+}
+
+type ErrorType {
+	field: String!
+	messages: [String!]!
 }
 
 type EventBody {
-  text: String!
-  ranges: [NodeBodyRange!]!
+	text: String!
+	ranges: [NodeBodyRange!]!
 }
 
-type NodeBodyRange {
-  entity: Node!
-  offset: Int!
-  length: Int!
+type ExecutableCronJob implements Node {
+	id: ID!
 }
 
-type WaitlistMember implements Node {
-  waitlist: Waitlist!
-  joinedAt: DateTime!
-  approvedAt: DateTime
-
-  """The ID of the object"""
-  id: ID!
-  member: Owner!
-  approved: Boolean!
+type ExecuteCronJobInvocationResult {
+	exitCode: Int
+	instanceId: String
 }
 
-type Waitlist implements Node {
-  name: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-
-  """The ID of the object"""
-  id: ID!
+type ExecuteCronJobTarget {
+	packageName: String
+	command: String
+	cliArgs: GenericScalar!
+	env: GenericScalar!
 }
 
-type NamespaceConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [NamespaceEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type FetchCronJob implements Node {
+	id: ID!
 }
 
-"""A Relay edge containing a `Namespace` and its cursor."""
-type NamespaceEdge {
-  """The item at the end of the edge"""
-  node: Namespace
-
-  """A cursor for use in pagination"""
-  cursor: String!
+type FetchCronJobInvocationResult {
+	statusCode: Int
+	responseBody: String
+	requestId: String
 }
 
-type Namespace implements Node & PackageOwner & Owner {
-  """The ID of the object"""
-  id: ID!
-  probationStartedAt: DateTime
-  name: String!
-  displayName: String
-  description: String!
-  avatarUpdatedAt: DateTime
-  twitterHandle: String
-  githubHandle: String
-  websiteUrl: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  wasmerInternal: Boolean!
-  maintainerInvites(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
-  userSet(offset: Int, before: String, after: String, first: Int, last: Int): UserConnection!
-  globalName: String!
-  globalId: ID!
-  viewerCan(action: OwnerAction!): Boolean!
-  isPro: Boolean!
-  limitState: LimitState!
-  avatar: String!
-  packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
-  apps(sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
-  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
-  collaborators(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorConnection!
-  publicActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
-  pendingInvites(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
-  viewerHasRole(role: GrapheneRole!): Boolean!
-  viewerAsCollaborator(role: GrapheneRole): NamespaceCollaborator
-
-  """Whether the current user is invited to the namespace"""
-  viewerIsInvited: Boolean!
-
-  """The invitation for the current user to the namespace"""
-  viewerInvitation: NamespaceCollaboratorInvite
-  packageTransfersIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
-  usageMetrics(
-    variant: MetricType!
-    grouping: MetricGrouping
-
-    """List of app IDs. Metrics gets filtered for the specific apps."""
-    appIds: [ID]
-
-    """Optional time range filter."""
-    timeRange: TimeRangeInput
-  ): [UsageMetric]!
-  domains(offset: Int, before: String, after: String, first: Int, last: Int): DNSDomainConnection!
-  billing: Billing
-  currentUsage(
-    """List of app IDs. Usage gets filtered for the specific apps."""
-    appIds: [ID]
-
-    """Optional time range filter."""
-    timeRange: TimeRangeInput
-  ): OwnerUsageSummary
+type FetchCronJobTarget {
+	body: String
+	headers: GenericScalar!
+	method: String!
+	path: String!
+	expectBodyIncludes: String
+	expectBodyRegex: String
+	expectStatusCodes: GenericScalar
 }
 
-type NamespaceCollaboratorInviteConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
+input FileSystemPermissionsV1 {
+	delete: Boolean
+	read: Boolean
+	write: Boolean
+}
 
-  """Contains the nodes in this connection."""
-  edges: [NamespaceCollaboratorInviteEdge]!
+input FileSystemVolumeConfigV1 {
+	mounts: [FileSystemVolumeMountV1]!
+	name: String!
+	source: FileSystemVolumeSourceV1!
+}
 
-  """Total number of items in the connection."""
-  totalCount: Int
+input FileSystemVolumeMountV1 {
+	path: String!
+	permissions: [FileSystemPermissionsV1]
+}
+
+input FileSystemVolumeSourceLocalV1 {
+	maximumSize: String!
+}
+
+input FileSystemVolumeSourceV1 {
+	local: FileSystemVolumeSourceLocalV1!
+}
+
+input GenerateAPITokenInput {
+	identifier: String
+	clientMutationId: String
+}
+
+type GenerateAPITokenPayload {
+	clientMutationId: String
+	token: APIToken
+	tokenRaw: String
+	user: User
+}
+
+input GenerateBindingsForAllPackagesInput {
+	bindingsGeneratorId: ID
+	bindingsGeneratorCommand: String
+	clientMutationId: String
+}
+
+type GenerateBindingsForAllPackagesPayload {
+	clientMutationId: String
+	message: String!
+}
+
+input GenerateCheckoutUrlInput {
+	"""
+	URL to redirect to on success.
+	"""
+	successUrl: String!
+	"""
+	URL to redirect to on cancellation.
+	"""
+	cancelUrl: String!
+	"""
+	ID of price (product) to charge the user.
+	"""
+	priceId: ID!
+	"""
+	Locale of the customer.
+	"""
+	locale: String!
+	"""
+	ID of owner to create subscription on. Defaults to current user.
+	"""
+	forOwnerId: ID
+	clientMutationId: String
+}
+
+type GenerateCheckoutUrlPayload {
+	clientMutationId: String
+	checkout: StripeCheckout!
+}
+
+input GenerateDeployConfigTokenInput {
+	config: String!
+	clientMutationId: String
+}
+
+type GenerateDeployConfigTokenPayload {
+	token: String!
+	config: String!
+	clientMutationId: String
+}
+
+input GenerateDeployTokenInput {
+	deployConfigVersionId: String!
+	clientMutationId: String
+}
+
+type GenerateDeployTokenPayload {
+	clientMutationId: String
+	token: String!
+	deployConfigVersion: DeployAppVersion!
+}
+
+input GenerateSshTokenInput {
+	appId: ID
+	clientMutationId: String
+}
+
+type GenerateSshTokenPayload {
+	token: String!
+	clientMutationId: String
+}
+
+input GenerateUploadUrlInput {
+	name: String
+	version: String = "latest"
+	filename: String
+	expiresAfterSeconds: Int = 900
+	method: String
+	clientMutationId: String
+}
+
+type GenerateUploadUrlPayload {
+	clientMutationId: String
+	signedUrl: SignedUrl!
+	method: String!
+}
+
+input GenerateWordPressMagicLoginUrlInput {
+	appId: ID!
+	clientMutationId: String
+}
+
+type GenerateWordPressMagicLoginUrlPayload {
+	clientMutationId: String
+	magicLoginUrl: String!
 }
 
 """
-A Relay edge containing a `NamespaceCollaboratorInvite` and its cursor.
+The `GenericScalar` scalar type represents a generic
+GraphQL scalar value that could be:
+String, Boolean, Int, Float, List or Object.
 """
-type NamespaceCollaboratorInviteEdge {
-  """The item at the end of the edge"""
-  node: NamespaceCollaboratorInvite
+scalar GenericScalar
 
-  """A cursor for use in pagination"""
-  cursor: String!
+type GetPasswordResetToken {
+	valid: Boolean!
+	user: User
 }
 
-type NamespaceCollaboratorInvite implements Node {
-  """The ID of the object"""
-  id: ID!
-  requestedBy: User!
-  user: User
-  inviteEmail: String
-  namespace: Namespace!
-  role: RegistryNamespaceMaintainerInviteRoleChoices!
-  accepted: NamespaceCollaborator
-  approvedBy: User
-  declinedBy: User
-  createdAt: DateTime!
-  expiresAt: DateTime!
-  closedAt: DateTime
+type GitHubRollout implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	externalId: String
+	rollout: Rollout!
+	branch: String
+	commitHash: String
+	prevCommitHash: String
+	commitMessage: String
+	authorEmail: String
+	authorName: String
+	authorLogin: String
+	repoUrl: String!
+	commitUrl: String
 }
 
-"""An enumeration."""
-enum RegistryNamespaceMaintainerInviteRoleChoices {
-  """Owner"""
-  OWNER
-
-  """Admin"""
-  ADMIN
-
-  """Editor"""
-  EDITOR
-
-  """Viewer"""
-  VIEWER
+type GithubAppInstallation implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	slug: String!
+	githubConfigureUrl: String!
+	repositories(filterByName: String): [GithubInstallationRepository!]!
 }
 
-type NamespaceCollaborator implements Node {
-  """The ID of the object"""
-  id: ID!
-  user: User!
-  role: RegistryNamespaceMaintainerRoleChoices!
-  namespace: Namespace!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  invite: NamespaceCollaboratorInvite
+type GithubInstallationRepository implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	repoUrl: String!
+	installation: GithubAppInstallation!
+	url: String!
+	name: String!
+	namespace: String!
 }
 
-"""An enumeration."""
-enum RegistryNamespaceMaintainerRoleChoices {
-  """Owner"""
-  OWNER
-
-  """Admin"""
-  ADMIN
-
-  """Editor"""
-  EDITOR
-
-  """Viewer"""
-  VIEWER
+type GithubPrPreviewDeployment {
+	databaseId: Int!
+	prNumber: Int!
+	baseRef: String!
+	headRef: String!
+	headSha: String!
+	previewUrl: String!
+	status: String!
+	buildId: String!
+	rolloutId: ID
+	githubCommentId: Int
+	createdAt: DateTime!
+	updatedAt: DateTime!
 }
 
-type UserConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [UserEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type GithubRepoConnection implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	githubRepoInstallation: GithubInstallationRepository!
+	connectedBy: User!
+	deployBranch: String!
+	app: DeployApp!
+	pullRequestComments: Boolean!
+	connectedAt: DateTime!
+	deploymentStatusEvents: Boolean!
 }
 
-"""A Relay edge containing a `User` and its cursor."""
-type UserEdge {
-  """The item at the end of the edge"""
-  node: User
+union GlobalObject = User | Namespace
 
-  """A cursor for use in pagination"""
-  cursor: String!
+enum GrapheneRole {
+	OWNER
+	ADMIN
+	EDITOR
+	VIEWER
 }
 
-type PackageConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type GroupedUsageMetrics {
+	groupedAt: DateTime!
+	requests: RequestMetrics!
+	workloads: WorkloadMetrics!
 }
 
-"""A Relay edge containing a `Package` and its cursor."""
-type PackageEdge {
-  """The item at the end of the edge"""
-  node: Package
-
-  """A cursor for use in pagination"""
-  cursor: String!
+enum HTTPRedirectType {
+	TEMPORARY_REDIRECT
+	TEMPORARY_FOUND
+	PERMANENT_REDIRECT
+	PERMANENT_MOVED
 }
 
-type Package implements Likeable & Node & PackageOwner {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  namespace: String!
-  private: Boolean!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  maintainers: [User]! @deprecated(reason: "Please use collaborators instead")
-  curated: Boolean!
-  ownerObjectId: Int!
-  lastVersion: PackageVersion
-
-  """The app icon. It should be formatted in the same way as Apple icons"""
-  icon: String!
-  totalDownloads: Int!
-  iconUpdatedAt: DateTime
-  likersCount: Int!
-  watchersCount: Int!
-  webcs(offset: Int, before: String, after: String, first: Int, last: Int): WebcImageConnection!
-  packagewebcSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageWebcConnection!
-  versions: [PackageVersion]
-  collectionSet: [Collection!]!
-
-  """List of app templates for this package"""
-  appTemplates(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection!
-  categories(offset: Int, before: String, after: String, first: Int, last: Int): CategoryConnection!
-  keywords(offset: Int, before: String, after: String, first: Int, last: Int): PackageKeywordConnection!
-  viewerHasLiked: Boolean!
-  globalName: String!
-  globalId: ID!
-  viewerCan(action: OwnerAction!): Boolean!
-  alias: String
-  displayName: String!
-
-  """The name of the package without the owner"""
-  packageName: String!
-
-  """The app icon. It should be formatted in the same way as Apple icons"""
-  appIcon: String! @deprecated(reason: "Please use icon instead")
-
-  """The total number of downloads of the package"""
-  downloadsCount: Int
-
-  """The public keys for all the published versions"""
-  publicKeys: [PublicKey!]!
-  collaborators(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorConnection!
-  pendingInvites(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
-  viewerHasRole(role: GrapheneRole!): Boolean!
-  viewerAsCollaborator(role: GrapheneRole): PackageCollaborator
-  owner: PackageOwner!
-  isTransferring: Boolean!
-  activeTransferRequest: PackageTransferRequest
-  isArchived: Boolean!
-  viewerIsWatching: Boolean!
-  showDeployButton: Boolean!
-  similarPackageVersions(before: String, after: String, first: Int, last: Int): PackageSearchConnection!
-
-  """Whether the current user is invited to the package"""
-  viewerIsInvited: Boolean!
-
-  """The invitation for the current user to the package"""
-  viewerInvitation: PackageCollaboratorInvite
+input InputSignature {
+	publicKeyKeyId: String!
+	data: String!
 }
 
-interface Likeable {
-  id: ID!
-  likersCount: Int!
-  viewerHasLiked: Boolean!
+input InstallGithubAppInput {
+	"""
+	Github app Installation ID
+	"""
+	installationId: ID!
+	"""
+	Github App Account ID
+	"""
+	githubAccountId: ID
+	"""
+	Github App Account Login
+	"""
+	githubAccountLogin: String
+	clientMutationId: String
 }
 
-type PackageVersion implements Node & PackageReleaseInterface & PackageInstance {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  package: Package!
-  webc: WebcImage
-  webcV3: WebcImage
-
-  """List of direct dependencies of this package version"""
-  dependencies(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
-  publishedBy: User!
-  tag: String!
-  clientName: String
-  webcGenerationErrors: String
-  version: String!
-  description: String!
-  manifest: String!
-  license: String
-  licenseFile: String
-  readme: String
-  witMd: String
-  repository: String
-  homepage: String
-  staticObjectsCompiled: Boolean!
-  nativeExecutablesCompiled: Boolean!
-  signature: Signature
-  isArchived: Boolean!
-  file: String!
-
-  """"""
-  fileSize: BigInt!
-  totalDownloads: Int!
-  bindingsState: RegistryPackageVersionBindingsStateChoices!
-  nativeExecutablesState: RegistryPackageVersionNativeExecutablesStateChoices!
-  packagewebcSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageWebcConnection!
-  lastversionPackage(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
-  commands: [Command!]!
-  nativeexecutableSet(offset: Int, before: String, after: String, first: Int, last: Int): NativeExecutableConnection!
-  bindingsgeneratorSet(offset: Int, before: String, after: String, first: Int, last: Int): BindingsGeneratorConnection!
-  javascriptlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
-  pythonlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
-  deployappversionSet(offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
-  packagerolloutSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageRolloutConnection!
-  piritaManifest: JSONString
-  piritaOffsets: JSONString
-  piritaVolumes: JSONString
-  piritaFile: String @deprecated(reason: "Please use distribution.piritaDownloadUrl instead.")
-  piritaFileSize: Int @deprecated(reason: "Please use distribution.piritaSize instead.")
-  pirita256hash: String @deprecated(reason: "Please use distribution.piritaSha256Hash instead.")
-  distribution(version: WebcVersion): PackageDistribution!
-  filesystem: [PackageVersionFilesystem]!
-  isLastVersion: Boolean!
-  witFile: String
-  isSigned: Boolean!
-  moduleInterfaces: [InterfaceVersion!]!
-  modules: [PackageVersionModule!]!
-  getPiritaContents(volume: String! = "atom", base: String! = ""): [PiritaFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly from the webc")
-  getWebcContents(volume: String! = "atom", base: String! = "/"): [WEBCFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly from the webc")
-  nativeExecutables(triple: String, wasmerCompilerVersion: String): [NativeExecutable]
-  bindings: [PackageVersionLanguageBinding]!
-  npmBindings: PackageVersionNPMBinding
-  pythonBindings: PackageVersionPythonBinding
-  bindingsSet(before: String, after: String, first: Int, last: Int): PackageVersionBindingConnection
-  hasBindings: Boolean!
-  hasCommands: Boolean!
-  showDeployButton: Boolean!
-  isCorrupt: Boolean!
+"""
+Add a new github app installation
+"""
+type InstallGithubAppPayload {
+	clientMutationId: String
+	success: Boolean!
+	user: User!
+	installation: GithubAppInstallation
 }
 
-interface PackageReleaseInterface {
-  piritaManifest: JSONString
-  piritaOffsets: JSONString
-  piritaVolumes: JSONString
-  isArchived: Boolean!
-  clientName: String
-  publishedBy: User!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  package: Package!
-  webc: WebcImage
-  webcV3: WebcImage
-  tag: String!
+input InstallWasmerWpPluginInput {
+	appId: ID!
+	clientMutationId: String
+}
+
+type InstallWasmerWpPluginPayload {
+	clientMutationId: String
+	app: DeployApp!
+	liveConfig: WordpressLiveConfig
+}
+
+type Interface implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	displayName: String!
+	description: String!
+	homepage: String
+	icon: String
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	versions(offset: Int, before: String, after: String, first: Int, last: Int): InterfaceVersionConnection!
+	lastVersion: InterfaceVersion
+}
+
+type InterfaceVersion implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	interface: Interface!
+	version: String!
+	content: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	publishedBy: User!
+	packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+}
+
+type InterfaceVersionConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [InterfaceVersionEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `InterfaceVersion` and its cursor.
+"""
+type InterfaceVersionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: InterfaceVersion!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type InternalTask {
+	id: ID!
+	status: String!
+	result: JSONString
+	dateDone: DateTime
+	traceback: String
+}
+
+input InvalidateNonceInput {
+	id: ID!
+	secret: String!
+	clientMutationId: String
+}
+
+type InvalidateNoncePayload {
+	nonce: Nonce!
+	clientMutationId: String
+}
+
+input InviteNamespaceCollaboratorInput {
+	namespaceId: ID!
+	username: String
+	email: String
+	role: GrapheneRole!
+	clientMutationId: String
+}
+
+type InviteNamespaceCollaboratorPayload {
+	invite: NamespaceCollaboratorInvite!
+	namespace: Namespace!
+	clientMutationId: String
+}
+
+input InvitePackageCollaboratorInput {
+	packageName: String!
+	role: GrapheneRole!
+	username: String
+	email: String
+	clientMutationId: String
+}
+
+type InvitePackageCollaboratorPayload {
+	clientMutationId: String
+	invite: PackageCollaboratorInvite!
+	package: Package!
 }
 
 """
@@ -569,720 +3443,3795 @@ schema (one of the key benefits of GraphQL).
 """
 scalar JSONString
 
-type WebcImage implements Node {
-  """The ID of the object"""
-  id: ID!
-
-  """The version of the webc image, defaults to v2."""
-  version: WebcVersion!
-
-  """"""
-  fileSize: BigInt!
-  manifest: JSONString!
-  webcSha256: String!
-  targzSha256: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  webcUrl: String!
-  volumes: JSONString! @deprecated(reason: "Deprecated, use the webc_url to explore the webc file")
-  offsets: JSONString! @deprecated(reason: "Deprecated, use the webc_url to explore the webc file")
+input JobDefinitionInput {
+	name: String
+	package: String
+	"""
+	Command to run the job
+	"""
+	command: String!
+	cliArgs: [String]
+	env: [String]
+	"""
+	Humanfriendly timeout definition. e.g. 10m, 1h
+	"""
+	timeout: String = "10m"
 }
 
-enum WebcVersion {
-  V2
-  V3
+input JoinWaitlistInput {
+	name: String!
+	clientMutationId: String
 }
 
 """
-The `BigInt` scalar type represents non-fractional whole numeric values.
-`BigInt` is not constrained to 32-bit like the `Int` type and thus is a less
-compatible type.
+Add current user to the waitlist.
 """
-scalar BigInt
-
-type PackageVersionConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageVersionEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type JoinWaitlistPayload {
+	clientMutationId: String
+	waitlistMember: WaitlistMember!
 }
 
-"""A Relay edge containing a `PackageVersion` and its cursor."""
-type PackageVersionEdge {
-  """The item at the end of the edge"""
-  node: PackageVersion
+union Kind = WordpressAppKind | MCPServerAppKind
 
-  """A cursor for use in pagination"""
-  cursor: String!
+input LikePackageInput {
+	packageId: ID!
+	clientMutationId: String
 }
 
-"""An enumeration."""
-enum RegistryPackageVersionBindingsStateChoices {
-  """Bindings are not detected"""
-  NOT_PRESENT
-
-  """Bindings are being built"""
-  GENERATING
-
-  """Bindings generation has failed"""
-  ERROR
-
-  """Bindings are built and present"""
-  GENERATED_AND_PRESENT
+type LikePackagePayload {
+	clientMutationId: String
+	package: Package!
 }
 
-"""An enumeration."""
-enum RegistryPackageVersionNativeExecutablesStateChoices {
-  """Native Executables are not detected"""
-  NOT_PRESENT
-
-  """Native Executables are being built"""
-  GENERATING
-
-  """Native Executables generation has failed"""
-  ERROR
-
-  """Native Executables are built and present"""
-  GENERATED_AND_PRESENT
+interface Likeable {
+	id: ID!
+	likersCount: Int!
+	viewerHasLiked: Boolean!
 }
 
-type PackageWebcConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageWebcEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+"""
+An enumeration.
+"""
+enum LimitState {
+	not_limited
+	nearing_limits
+	under_probation
+	limit_exceeded
 }
 
-"""A Relay edge containing a `PackageWebc` and its cursor."""
-type PackageWebcEdge {
-  """The item at the end of the edge"""
-  node: PackageWebc
-
-  """A cursor for use in pagination"""
-  cursor: String!
+"""
+Log entry for deploy app.
+"""
+type Log {
+	"""
+	Timestamp in nanoseconds
+	"""
+	timestamp: Float!
+	"""
+	ISO 8601 string in UTC
+	"""
+	datetime: DateTime!
+	"""
+	Log message
+	"""
+	message: String!
+	"""
+	Log stream
+	"""
+	stream: LogStream
+	"""
+	ID of instance from which the log was generated
+	"""
+	instanceId: String!
+	labels: [LogLabel]!
 }
 
-type PackageWebc implements Node & PackageReleaseInterface & PackageInstance {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  package: Package!
-  webc: WebcImage
-  piritaManifest: JSONString
-  piritaOffsets: JSONString
-  piritaVolumes: JSONString
-  isArchived: Boolean!
-  clientName: String
-  publishedBy: User!
-  webcV3: WebcImage
-  tag: String!
-  webcUrl: String!
+type LogConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [LogEdge]!
 }
 
-type Command {
-  command: String!
-  packageVersion: PackageVersion!
-  module: PackageVersionModule
+"""
+A Relay edge containing a `Log` and its cursor.
+"""
+type LogEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Log
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type PackageVersionModule {
-  name: String!
-  source: String!
-  abi: String
-  publicUrl: String!
-  atom: PiritaFilesystemFile!
-  rangeHeader: String!
+type LogLabel {
+	label: String!
+	value: String!
 }
 
-type PiritaFilesystemFile {
-  name(display: PiritaFilesystemNameDisplay): String!
-  size: Int!
-  offset: Int!
+"""
+An enumeration.
+"""
+enum LogStream {
+	STDOUT
+	STDERR
+	RUNTIME
 }
 
-enum PiritaFilesystemNameDisplay {
-  RELATIVE
-  ABSOLUTE
+enum LoginMethod {
+	GOOGLE
+	GITHUB
+	PASSWORD
 }
 
-type NativeExecutableConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [NativeExecutableEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type MCPServerAppKind {
+	url: String!
+	transport: MCPServerTransportEnum
 }
 
-"""A Relay edge containing a `NativeExecutable` and its cursor."""
-type NativeExecutableEdge {
-  """The item at the end of the edge"""
-  node: NativeExecutable
+"""
+An enumeration.
+"""
+enum MCPServerTransportEnum {
+	STDIO
+	STREAMABLE_HTTP
+	SSE
+}
 
-  """A cursor for use in pagination"""
-  cursor: String!
+"""
+Response object for MFAAuth mutation.
+"""
+type MFAAuthResponse {
+	success: Boolean!
+	token: String
+	refreshToken: String
+	username: String
+	refreshTokenExpiresIn: Int
+}
+
+input MFAEmailAuthInput {
+	username: String!
+	otp: String!
+	clientMutationId: String
+}
+
+type MFAEmailGenerationResponse {
+	success: Boolean!
+}
+
+input MFAGenerateEmailOTPInput {
+	clientMutationId: String
+}
+
+input MFAGenerateRecoveryTokenInput {
+	clientMutationId: String
+}
+
+input MFARecoveryAuthInput {
+	username: String!
+	otp: String!
+	clientMutationId: String
+}
+
+type MFARecoveryCodes {
+	codes: [String!]!
+}
+
+input MFATOTPAuthInput {
+	username: String!
+	otp: String!
+	clientMutationId: String
+}
+
+input MFATOTPGetTokenInput {
+	clientMutationId: String
+}
+
+type MFATOTPTokenType {
+	qr: String
+	secretKey: String
+}
+
+input MFATOTPVerifyInput {
+	answer: String!
+	secretKey: String!
+	clientMutationId: String
+}
+
+type MFATOTPVerifyPayload {
+	status: MFATOTPVerifyStatus
+	clientMutationId: String
+}
+
+enum MFATOTPVerifyStatus {
+	SUCCESS
+	RECOVERY
+}
+
+type MXRecord implements Node & DNSRecordInterface {
+	preference: Int!
+	exchange: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+input MakePackagePublicInput {
+	"""
+	The ID of the package to make public
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+type MakePackagePublicPayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input MarkAppVersionAsActiveInput {
+	"""
+	The ID of the DeployAppVersion to set as the new active version.
+	"""
+	appVersion: ID!
+	clientMutationId: String
+}
+
+"""
+Mutation to change the active version of a DeployApp to another DeployAppVersion.
+"""
+type MarkAppVersionAsActivePayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+"""
+Groupings for metrics
+"""
+enum MetricGrouping {
+	BY_15_MINUTES
+	BY_5_MINUTES
+	BY_HOUR
+	BY_DAY
+	BY_WEEK
+}
+
+"""
+An enumeration.
+"""
+enum MetricType {
+	cpu_time
+	memory_time
+	network_egress
+	network_ingress
+	no_of_requests
+	no_of_failed_requests
+	cost
+}
+
+"""
+Units for metrics
+"""
+enum MetricUnit {
+	"""
+	represents the unit of "seconds".
+	"""
+	SEC
+	"""
+	represents the unit of "milliseconds".
+	"""
+	MS
+	"""
+	represents the unit of "hours".
+	"""
+	hours
+	"""
+	represents the unit of "kilobytes".
+	"""
+	KB
+	"""
+	represents the unit of "bytes".
+	"""
+	Bytes
+	"""
+	represents the unit of "kilobytes per second".
+	"""
+	KBS
+	"""
+	represents the unit of "number of requests".
+	"""
+	NO_REQUESTS
+	"""
+	represents the unit of "cost" in USD.
+	"""
+	DOLLARS
+}
+
+type MetricsTotals {
+	requests: RequestMetrics!
+	workloads: WorkloadMetrics!
+}
+
+input MigrateAppRegionInput {
+	"""
+	ID of the app to migrate
+	"""
+	appId: ID!
+	"""
+	Target region name
+	"""
+	regionName: String!
+	clientMutationId: String
+}
+
+"""
+Migrate an app to a different region.
+"""
+type MigrateAppRegionPayload {
+	clientMutationId: String
+	app: DeployApp!
+	"""
+	ID of the internal task for app migration
+	"""
+	taskId: ID!
+}
+
+type MoneyType {
+	amount: String
+	currency: String
+}
+
+type Mutation {
+	"""
+	Sync all blog posts from Notion to the database.
+	"""
+	syncNotionBlogPosts(input: SyncNotionBlogPostsInput!): SyncNotionBlogPostsPayload
+	tokenAuth(input: ObtainJSONWebTokenInput!): ObtainJSONWebTokenPayload!
+	verifyAccessToken(token: String!): Verify!
+	refreshAccessToken(refreshToken: String!): Refresh!
+	revokeAccessToken(refreshToken: String!): Revoke!
+	registerUser(input: RegisterUserInput!): RegisterUserPayload!
+	socialAuth(input: SocialAuthJWTInput!): SocialAuthJWTPayload!
+	requestPasswordReset(input: RequestPasswordResetInput!): RequestPasswordResetPayload
+	requestValidationEmail(input: RequestValidationEmailInput!): RequestValidationEmailPayload
+	validateUserEmail(input: ValidateUserEmailInput!): ValidateUserEmailPayload
+	validateUserFingerprint(input: ValidateUserFingerprintInput!): ValidateUserFingerprintPayload
+	changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordPayload
+	changeUserUsername(input: ChangeUserUsernameInput!): ChangeUserUsernamePayload
+	changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload
+	createNamespace(input: CreateNamespaceInput!): CreateNamespacePayload!
+	updateNamespace(input: UpdateNamespaceInput!): UpdateNamespacePayload
+	deleteNamespace(input: DeleteNamespaceInput!): DeleteNamespacePayload
+	inviteNamespaceCollaborator(input: InviteNamespaceCollaboratorInput!): InviteNamespaceCollaboratorPayload!
+	acceptNamespaceCollaboratorInvite(input: AcceptNamespaceCollaboratorInviteInput!): AcceptNamespaceCollaboratorInvitePayload!
+	removeNamespaceCollaborator(input: RemoveNamespaceCollaboratorInput!): RemoveNamespaceCollaboratorPayload
+	removeNamespaceCollaboratorInvite(input: RemoveNamespaceCollaboratorInviteInput!): RemoveNamespaceCollaboratorInvitePayload
+	updateNamespaceCollaboratorRole(input: UpdateNamespaceCollaboratorRoleInput!): UpdateNamespaceCollaboratorRolePayload!
+	updateNamespaceCollaboratorInviteRole(input: UpdateNamespaceCollaboratorInviteRoleInput!): UpdateNamespaceCollaboratorInviteRolePayload!
+	createNamespaceApiKey(input: CreateNamespaceAPIKeyInput!): CreateNamespaceAPIKeyPayload
+	updateApiKey(input: UpdateAPIKeyInput!): UpdateAPIKeyPayload
+	rotateApiKey(input: RotateAPIKeyInput!): RotateAPIKeyPayload
+	deleteNamespaceApiKey(input: DeleteNamespaceAPIKeyInput!): DeleteNamespaceAPIKeyPayload
+	updateUserInfo(input: UpdateUserInfoInput!): UpdateUserInfoPayload
+	validateUserPassword(input: ValidateUserPasswordInput!): ValidateUserPasswordPayload
+	generateApiToken(input: GenerateAPITokenInput!): GenerateAPITokenPayload
+	"""
+	Request To revoke an API token; these start with 'wap_'.
+	"""
+	revokeApiToken(input: RevokeAPITokenInput!): RevokeAPITokenPayload
+	checkUserExists(input: CheckUserExistsInput!): CheckUserExistsPayload
+	newNonce(input: NewNonceInput!): NewNoncePayload!
+	validateNonce(input: ValidateNonceInput!): ValidateNoncePayload!
+	invalidateNonce(input: InvalidateNonceInput!): InvalidateNoncePayload!
+	mfa2totpGetToken(input: MFATOTPGetTokenInput!): MFATOTPTokenType!
+	mfa2totpVerify(input: MFATOTPVerifyInput!): MFATOTPVerifyPayload!
+	mfa2totpAuth(input: MFATOTPAuthInput!): MFAAuthResponse!
+	mfa2RecoveryGetToken(input: MFAGenerateRecoveryTokenInput!): MFARecoveryCodes!
+	mfa2RecoveryAuth(input: MFARecoveryAuthInput!): MFAAuthResponse!
+	mfa2EmailAuth(input: MFAEmailAuthInput!): MFAAuthResponse!
+	mfa2EmailGetToken(input: MFAGenerateEmailOTPInput!): MFAEmailGenerationResponse!
+	"""
+	Viewer accepts the latest ToS.
+	"""
+	acceptTOS(input: AcceptTOSInput!): AcceptTOSPayload!
+	"""
+	Delete domain with given ID
+	"""
+	deleteAppDomain(input: DeleteAppDomainInput!): DeleteAppDomainPayload
+	"""
+	Enable or disable the SSH server capability on an app.
+	"""
+	toggleSshServer(input: ToggleSshServerInput!): ToggleSshServerPayload
+	"""
+	Enable or disable a cronjob on an app.
+	"""
+	toggleCronJob(input: ToggleCronJobInput!): ToggleCronJobPayload
+	"""
+	Reveal the password for an SSH user.
+	"""
+	revealSshUserPassword(input: RevealSshUserPasswordInput!): RevealSshUserPasswordPayload
+	"""
+	Rotate the password for an SSH user.
+	"""
+	rotateSshUserPassword(input: RotateSshUserPasswordInput!): RotateSshUserPasswordPayload
+	"""
+	Add an SSH authorized key to an SSH user.
+	"""
+	addSshAuthorizedKey(input: AddSshAuthorizedKeyInput!): AddSshAuthorizedKeyPayload
+	"""
+	Edit an SSH user.
+	"""
+	deleteSshAuthorizedKey(input: DeleteSshAuthorizedKeyInput!): DeleteSshAuthorizedKeyPayload
+	"""
+	Delete an SSH authorized key by its node ID.
+	"""
+	deleteSshAuthorizedKeyById(input: DeleteSshAuthorizedKeyByIdInput!): DeleteSshAuthorizedKeyPayload
+	"""
+	Edit an SSH user.
+	"""
+	editSshUser(input: EditSshUserInput!): EditSshUserPayload
+	"""
+	Detach autobuild from app.
+	"""
+	verifyAppDomain(input: VerifyAppDomainInput!): VerifyAppDomainPayload
+	"""
+	Set the requested default domain for an app.
+	"""
+	setAppDefaultAlias(input: SetAppDefaultAliasInput!): SetAppDefaultAliasPayload
+	"""
+	Create or update an app domain on an app with given ID
+	"""
+	upsertAppDomain(input: UpsertAppDomainInput!): UpsertAppDomainPayload
+	publishDeployApp(input: PublishDeployAppInput!): PublishDeployAppPayload
+	deleteApp(input: DeleteAppInput!): DeleteAppPayload
+	"""
+	Add current user to the waitlist.
+	"""
+	joinWaitlist(input: JoinWaitlistInput!): JoinWaitlistPayload!
+	"""
+	Add stripe payment to the user
+	"""
+	addPayment(input: AddPaymentInput!): AddPaymentPayload!
+	"""
+	Mutation to change the active version of a DeployApp to another DeployAppVersion.
+	"""
+	markAppVersionAsActive(input: MarkAppVersionAsActiveInput!): MarkAppVersionAsActivePayload
+	"""
+	Set a payment method as default for the user.
+	"""
+	makePaymentDefault(input: SetDefaultPaymentMethodInput!): SetDefaultPaymentMethodPayload!
+	"""
+	Try to detach a payment method from customer.
+	Fails if trying to detach a default method,
+	or if it's the only payment method.
+	"""
+	detachPaymentMethod(input: DetachPaymentMethodInput!): DetachPaymentMethodPayload!
+	generateDeployConfigToken(input: GenerateDeployConfigTokenInput!): GenerateDeployConfigTokenPayload
+	generateSshToken(input: GenerateSshTokenInput!): GenerateSshTokenPayload
+	runEdgeCommand(input: RunEdgeCommandInput!): RunEdgeCommandPayload
+	renameApp(input: RenameAppInput!): RenameAppPayload
+	renameAppAlias(input: RenameAppAliasInput!): RenameAppAliasPayload
+	"""
+	Purges all cache for this app version
+	"""
+	purgeCacheForAppVersion(input: PurgeCacheForAppVersionInput!): PurgeCacheForAppVersionPayload
+	"""
+	Purges all cache for this app version by app version ID.
+	"""
+	purgeCacheForAppVersionById(input: PurgeCacheForAppVersionByIdInput!): PurgeCacheForAppVersionPayload
+	configureAppCdnCache(app: ID!, config: AppCdnCacheConfigUpdate!): AppCdnCacheMutationPayload!
+	purgeAppCdnCache(app: ID!): AppCdnCacheMutationPayload!
+	requestAppTransfer(input: RequestAppTransferInput!): RequestAppTransferPayload
+	acceptAppTransferRequest(input: AcceptAppTransferRequestInput!): AcceptAppTransferRequestPayload
+	removeAppTransferRequest(input: RemoveAppTransferRequestInput!): RemoveAppTransferRequestPayload
+	createRepoForAppTemplate(input: CreateRepoForAppTemplateInput!): CreateRepoForAppTemplatePayload
+	createAppTemplate(input: CreateAppTemplateInput!): CreateAppTemplatePayload
+	updateAppTemplate(input: UpdateAppTemplateInput!): UpdateAppTemplatePayload
+	deleteAppTemplate(input: DeleteAppTemplateInput!): DeleteAppTemplatePayload
+	registerDomain(input: RegisterDomainInput!): RegisterDomainPayload
+	upsertDNSRecord(input: UpsertDNSRecordInput!): UpsertDNSRecordPayload
+	updateDNSRecords(input: UpdateDNSRecordsInput!): UpdateDNSRecordsPayload
+	deleteDNSRecord(input: DeleteDNSRecordInput!): DeleteDNSRecordPayload
+	upsertDomainFromZoneFile(input: UpsertDomainFromZoneFileInput!): UpsertDomainFromZoneFilePayload
+	deleteDomain(input: DeleteDomainInput!): DeleteDomainPayload
+	"""
+	Deprecated: use UpdateEnvVars.
+	"""
+	upsertAppSecret(input: UpsertAppSecretInput!): UpsertAppSecretPayload @deprecated(reason: "Use `updateEnvVars` instead.")
+	"""
+	Deprecated: use UpdateEnvVars.
+	"""
+	upsertAppSecrets(input: UpsertAppSecretsInput!): UpsertAppSecretsPayload @deprecated(reason: "Use `updateEnvVars` instead.")
+	"""
+	Create, update, or delete app environment variables on an app with given ID
+	"""
+	updateEnvVars(input: UpdateEnvVarsInput!): UpdateEnvVarsPayload
+	"""
+	Deprecated: use UpdateEnvVars.
+	"""
+	deleteAppSecret(input: DeleteAppSecretInput!): DeleteAppSecretPayload @deprecated(reason: "Use `updateEnvVars` instead.")
+	"""
+	Redeploy the active version of an app.
+	"""
+	redeployActiveVersion(input: RedeployActiveVersionInput!): RedeployActiveVersionPayload
+	"""
+	Redeploy the active version of an app by app ID.
+	"""
+	redeployActiveAppVersion(input: RedeployActiveAppVersionInput!): RedeployActiveVersionPayload
+	"""
+	Toggle HTTP redirect for the active version of app
+	"""
+	toggleForceHttps(input: ToggleForceHTTPSInput!): ToggleForceHTTPSPayload
+	"""
+	Deprecated. Use rotateS3Credentials with an AppVolume ID.
+	"""
+	rotateS3SecretsForApp(input: RotateS3SecretsForAppInput!): RotateS3SecretsForAppPayload @deprecated(reason: "Use rotateS3Credentials with an AppVolume ID.")
+	"""
+	Rotate S3 credentials for an app volume.
+	"""
+	rotateS3Credentials(input: RotateS3CredentialsInput!): RotateS3CredentialsPayload!
+	"""
+	Delete a database for an app.
+	"""
+	rotateCredentialsForAppDb(input: RotateCredentialsForAppDBInput!): RotateCredentialsForAppDBPayload
+	"""
+	Create a new database for an app.
+	"""
+	createAppDb(input: CreateAppDBInput!): CreateAppDBPayload
+	"""
+	Create a new database and link it to an app.
+	"""
+	createDatabaseAndLinkToApp(input: CreateAppDatabaseInput!): CreateAppDBPayload
+	sendAppEmail(input: SendAppEmailInput!): SendAppEmailPayload!
+	"""
+	Delete a database for an app.
+	"""
+	deleteAppDb(input: DeleteAppDBInput!): DeleteAppDBPayload
+	"""
+	Create a UI-managed volume for an app.
+	"""
+	createAppVolume(input: CreateAppVolumeInput!): CreateAppVolumePayload!
+	"""
+	Soft-delete an app volume.
+	"""
+	deleteAppVolume(input: DeleteAppVolumeInput!): DeleteAppVolumePayload!
+	"""
+	Update an app volume.
+	"""
+	updateVolume(input: UpdateVolumeInput!): UpdateVolumePayload!
+	updateBuildConfig(input: UpdateBuildConfigInput!): UpdateBuildConfigPayload
+	"""
+	Get the autobuild config for a given repo
+	"""
+	autobuildConfigForRepo(input: AutobuildConfigForRepoInput!): AutobuildConfigForRepoPayload!
+	"""
+	Get the autobuild config for a given zip upload URL
+	"""
+	autobuildConfigForZipUpload(input: AutobuildConfigForZipUploadInput!): AutobuildConfigForZipUploadPayload!
+	"""
+	Add a new github app installation
+	"""
+	installGithubApp(input: InstallGithubAppInput!): InstallGithubAppPayload!
+	"""
+	Detach autobuild from app.
+	"""
+	detachAppFromAutobuild(input: DetachAppFromAutobuildInput!): DetachAppFromAutobuildPayload!
+	"""
+	Update autobuild config for an app.
+	"""
+	updateAutobuildConfigForApp(input: UpdateAutobuildConfigForAppInput!): UpdateAutobuildConfigForAppPayload!
+	"""
+	Connect a github repo to an app.
+	"""
+	connectGithubRepoToApp(input: ConnectGithubRepoToAppInput!): ConnectGithubRepoToAppPayload!
+	"""
+	Disconnect a github repo from an app.
+	"""
+	disconnectGithubRepoFromApp(input: DisconnectGithubRepoFromAppInput!): DisconnectGithubRepoFromAppPayload!
+	updateGithubRepoConnection(input: UpdateGithubRepoAppConnectionInput!): UpdateGithubRepoAppConnectionPayload!
+	"""
+	Deploy a wordpress site.
+	"""
+	deployWordpress(input: DeployWordpressInput!): DeployWordpressPayload @deprecated(reason: "Use `publishAppFromRepoAutobuild` subscription instead.")
+	installWasmerWpPlugin(input: InstallWasmerWpPluginInput!): InstallWasmerWpPluginPayload
+	generateWordPressMagicLoginUrl(input: GenerateWordPressMagicLoginUrlInput!): GenerateWordPressMagicLoginUrlPayload
+	"""
+	Enable app that was previously disabled.
+	"""
+	enableApp(input: EnableAppInput!): EnableAppPayload
+	"""
+	Disable app with a reason.
+	"""
+	disableApp(input: DisableAppInput!): DisableAppPayload
+	"""
+	Ban app with a reason.
+	"""
+	banApp(input: BanAppInput!): BanAppPayload
+	"""
+	Un-ban app with a reason.
+	"""
+	unbanApp(input: UnbanAppInput!): UnbanAppPayload
+	"""
+	Claim a perishable app as their own.
+	"""
+	claimPerishableApp(input: ClaimPerishableAppInput!): ClaimPerishableAppPayload
+	deployViaAutobuild(input: DeployViaAutobuildInput!): DeployViaAutobuildPayload
+	"""
+	Delete a user with some reason. The deletion will be soft, so the
+	underlying data will remain and be anonymized following GDPR.
+	"""
+	deleteUser(input: DeleteUserInput!): DeleteUserPayload
+	"""
+	Create a new vault from yaml config
+	"""
+	upsertVault(input: UpsertVaultInput!): UpsertVaultPayload
+	"""
+	Attach vault to an app
+	"""
+	attachVault(input: AttachVaultInput!): AttachVaultPayload
+	"""
+	Migrate an app to a different region.
+	"""
+	migrateAppRegion(input: MigrateAppRegionInput!): MigrateAppRegionPayload
+	generateDeployToken(input: GenerateDeployTokenInput!): GenerateDeployTokenPayload
+	readNotification(input: ReadNotificationInput!): ReadNotificationPayload
+	seePendingNotifications(input: SeePendingNotificationsInput!): SeePendingNotificationsPayload
+	generateCheckoutUrl(input: GenerateCheckoutUrlInput!): GenerateCheckoutUrlPayload!
+	createCheckoutSession(input: CreateCheckoutSessionInput!): CreateCheckoutSessionPayload!
+	cancelSubscription(input: CancelSubscriptionInput!): CancelSubscriptionPayload!
+	renewCanceledSubscription(input: RenewCanceledSubscriptionInput!): RenewCanceledSubscriptionPayload!
+	publishPublicKey(input: PublishPublicKeyInput!): PublishPublicKeyPayload
+	publishPackage(input: PublishPackageInput!): PublishPackagePayload
+	pushPackageRelease(input: PushPackageReleaseInput!): PushPackageReleasePayload
+	tagPackageRelease(input: TagPackageReleaseInput!): TagPackageReleasePayload
+	updatePackage(input: UpdatePackageInput!): UpdatePackagePayload
+	likePackage(input: LikePackageInput!): LikePackagePayload
+	unlikePackage(input: UnlikePackageInput!): UnlikePackagePayload
+	watchPackage(input: WatchPackageInput!): WatchPackagePayload
+	unwatchPackage(input: UnwatchPackageInput!): UnwatchPackagePayload
+	archivePackage(input: ArchivePackageInput!): ArchivePackagePayload
+	renamePackage(input: RenamePackageInput!): RenamePackagePayload
+	changePackageVersionArchivedStatus(input: ChangePackageVersionArchivedStatusInput!): ChangePackageVersionArchivedStatusPayload
+	invitePackageCollaborator(input: InvitePackageCollaboratorInput!): InvitePackageCollaboratorPayload
+	acceptPackageCollaboratorInvite(input: AcceptPackageCollaboratorInviteInput!): AcceptPackageCollaboratorInvitePayload
+	removePackageCollaboratorInvite(input: RemovePackageCollaboratorInviteInput!): RemovePackageCollaboratorInvitePayload
+	updatePackageCollaboratorRole(input: UpdatePackageCollaboratorRoleInput!): UpdatePackageCollaboratorRolePayload
+	updatePackageCollaboratorInviteRole(input: UpdatePackageCollaboratorInviteRoleInput!): UpdatePackageCollaboratorInviteRolePayload
+	removePackageCollaborator(input: RemovePackageCollaboratorInput!): RemovePackageCollaboratorPayload
+	requestPackageTransfer(input: RequestPackageTransferInput!): RequestPackageTransferPayload
+	acceptPackageTransferRequest(input: AcceptPackageTransferRequestInput!): AcceptPackageTransferRequestPayload
+	removePackageTransferRequest(input: RemovePackageTransferRequestInput!): RemovePackageTransferRequestPayload
+	generateBindingsForAllPackages(input: GenerateBindingsForAllPackagesInput!): GenerateBindingsForAllPackagesPayload
+	makePackagePublic(input: MakePackagePublicInput!): MakePackagePublicPayload
+	generateUploadUrl(input: GenerateUploadUrlInput!): GenerateUploadUrlPayload
+}
+
+type NSRecord implements Node & DNSRecordInterface {
+	nsdname: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type NakedDeployment implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	appVersion: DeployAppVersion
+}
+
+type Namespace implements PackageOwner & Owner & Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	probationStartedAt: DateTime
+	name: String!
+	displayName: String
+	description: String!
+	avatarUpdatedAt: DateTime
+	twitterHandle: String
+	githubHandle: String
+	websiteUrl: String
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	wasmerInternal: Boolean!
+	globalName: String!
+	globalId: ID!
+	maintainerInvites(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+	userSet(offset: Int, before: String, after: String, first: Int, last: Int): UserConnection!
+	viewerCan(action: OwnerAction!): Boolean!
+	isPro: Boolean!
+	limitState: LimitState!
+	avatar: String!
+	packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+	apps(sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
+	packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+	collaborators(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorConnection!
+	apiKeys(offset: Int, before: String, after: String, first: Int, last: Int): APIKeyConnection!
+	publicActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+	pendingInvites(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+	viewerHasRole(role: GrapheneRole!): Boolean!
+	viewerAsCollaborator(role: GrapheneRole): NamespaceCollaborator
+	"""
+	Whether the current user is invited to the namespace
+	"""
+	viewerIsInvited: Boolean!
+	"""
+	The invitation for the current user to the namespace
+	"""
+	viewerInvitation: NamespaceCollaboratorInvite
+	packageTransfersIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
+	usageMetrics(		variant: MetricType!,		grouping: MetricGrouping,
+		"""
+		List of app IDs. Metrics gets filtered for the specific apps.
+		"""
+		appIds: [ID],
+		"""
+		Optional time range filter.
+		"""
+		timeRange: TimeRangeInput
+	): [UsageMetric]!
+	groupedMetrics(startAt: DateTime!, endAt: DateTime!, groupedBy: MetricGrouping!): UsageMetrics!
+	domains(offset: Int, before: String, after: String, first: Int, last: Int): DNSDomainConnection!
+	sentEmails(first: Int, after: String, last: Int, before: String): EmailMessageConnection!
+	receivedEmails(first: Int, after: String, last: Int, before: String): EmailMessageConnection!
+	billing: Billing
+	currentUsage(
+		"""
+		List of app IDs. Usage gets filtered for the specific apps.
+		"""
+		appIds: [ID],
+		"""
+		Optional time range filter.
+		"""
+		timeRange: TimeRangeInput
+	): OwnerUsageSummary
+	emailUsage: EmailUsageSummary
+}
+
+type NamespaceCollaborator implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	user: User!
+	role: RegistryNamespaceMaintainerRoleChoices!
+	namespace: Namespace!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	invite: NamespaceCollaboratorInvite
+}
+
+type NamespaceCollaboratorConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [NamespaceCollaboratorEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `NamespaceCollaborator` and its cursor.
+"""
+type NamespaceCollaboratorEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: NamespaceCollaborator!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type NamespaceCollaboratorInvite implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	requestedBy: User!
+	user: User
+	inviteEmail: String
+	namespace: Namespace!
+	role: RegistryNamespaceMaintainerInviteRoleChoices!
+	accepted: NamespaceCollaborator
+	approvedBy: User
+	declinedBy: User
+	createdAt: DateTime!
+	expiresAt: DateTime!
+	closedAt: DateTime
+}
+
+type NamespaceCollaboratorInviteConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [NamespaceCollaboratorInviteEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `NamespaceCollaboratorInvite` and its cursor.
+"""
+type NamespaceCollaboratorInviteEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: NamespaceCollaboratorInvite!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type NamespaceConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [NamespaceEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `Namespace` and its cursor.
+"""
+type NamespaceEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Namespace!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+enum NamespaceOrderBy {
+	PACKAGE_COUNT
+	COLLABORATOR_COUNT
+	APP_COUNT
+	CREATED_DATE
+}
+
+input NamespacesFilter {
+	count: Int = 1000
+	sortBy: SearchOrderSort = DESC
+	"""
+	Filter namespaces by package count.
+	"""
+	packageCount: CountFilter
+	"""
+	Filter namespaces created after this date.
+	"""
+	createdAfter: DateTime
+	"""
+	Filter namespaces created before this date.
+	"""
+	createdBefore: DateTime
+	"""
+	Filter namespaces by user count.
+	"""
+	userCount: CountFilter
+	"""
+	Filter namespaces by collaborator.
+	"""
+	collaborator: String
+	"""
+	Order namespaces by field.
+	"""
+	orderBy: NamespaceOrderBy = CREATED_DATE
 }
 
 type NativeExecutable implements Node {
-  """The ID of the object"""
-  id: ID!
-  module: String! @deprecated(reason: "Use filename instead")
-  filename: String!
-  filesize: Int!
-  targetTriple: String!
-  downloadUrl: String!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	module: String! @deprecated(reason: "Use filename instead")
+	filename: String!
+	filesize: Int!
+	targetTriple: String!
+	downloadUrl: String!
 }
 
-type BindingsGeneratorConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [BindingsGeneratorEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type NativeExecutableConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [NativeExecutableEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-"""A Relay edge containing a `BindingsGenerator` and its cursor."""
-type BindingsGeneratorEdge {
-  """The item at the end of the edge"""
-  node: BindingsGenerator
-
-  """A cursor for use in pagination"""
-  cursor: String!
+"""
+A Relay edge containing a `NativeExecutable` and its cursor.
+"""
+type NativeExecutableEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: NativeExecutable!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type BindingsGenerator implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  packageVersion: PackageVersion!
-  active: Boolean!
-  commandName: String!
-  registryJavascriptlanguagebindings(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
-  registryPythonlanguagebindings(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
+input NetworkDnsAllowedHostsV1 {
+	allowAllHosts: Boolean
+	hosts: [String]
+	regexPatterns: [String]
+	wildcardPatterns: [String]
 }
 
-type PackageVersionNPMBindingConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageVersionNPMBindingEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+input NetworkEgressV1 {
+	enabled: Boolean
 }
 
-"""A Relay edge containing a `PackageVersionNPMBinding` and its cursor."""
-type PackageVersionNPMBindingEdge {
-  """The item at the end of the edge"""
-  node: PackageVersionNPMBinding
-
-  """A cursor for use in pagination"""
-  cursor: String!
+input NewNonceInput {
+	name: String!
+	callbackUrl: String!
+	clientMutationId: String
 }
 
-type PackageVersionNPMBinding implements PackageVersionLanguageBinding & Node {
-  """The ID of the object"""
-  id: ID!
-  language: ProgrammingLanguage!
+type NewNoncePayload {
+	nonce: Nonce!
+	clientMutationId: String
+}
 
-  """The URL of the generated artifacts on Wasmer CDN."""
-  url: String!
+interface Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+}
 
-  """When the binding was generated"""
-  createdAt: DateTime!
+type NodeBodyRange {
+	entity: Node!
+	offset: Int!
+	length: Int!
+}
 
-  """Package version used to generate this binding"""
-  generator: BindingsGenerator!
-  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+type Nonce implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	callbackUrl: String!
+	createdAt: DateTime!
+	isValidated: Boolean!
+	secret: String!
+	token: String!
+	expired: Boolean!
+	authUrl: String!
+}
 
-  """Name of package source"""
-  packageName: String!
+type NonceConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [NonceEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
 
-  """Name of the package to import"""
-  importablePackageName: String!
+"""
+A Relay edge containing a `Nonce` and its cursor.
+"""
+type NonceEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Nonce!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
 
-  """Code snippet example to use the package"""
-  codeSnippetExample: String!
-  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-  npmDefaultInstallPackageName(url: String): String! @deprecated(reason: "Please use packageName instead")
+input ObtainJSONWebTokenInput {
+	username: String!
+	password: String!
+	clientMutationId: String
+}
+
+type ObtainJSONWebTokenPayload {
+	payload: GenericScalar!
+	refreshExpiresIn: Int!
+	username: CaseInsensitiveString!
+	token: String!
+	refreshToken: String!
+	clientMutationId: String
+}
+
+interface Owner {
+	globalName: String!
+	globalId: ID!
+	viewerCan(action: OwnerAction!): Boolean!
+	isPro: Boolean!
+	emailUsage: EmailUsageSummary
+}
+
+enum OwnerAction {
+	DEPLOY_APP
+	PUBLISH_PACKAGE
+}
+
+"""
+Usage summary for a specific owner.
+"""
+type OwnerUsageSummary {
+	since: DateTime!
+	cpuTime: Usage!
+	noRequests: Usage!
+	ingress: Usage!
+	egress: Usage!
+	appCount: Usage!
+	buildMinutes: Usage!
+}
+
+type PTRRecord implements Node & DNSRecordInterface {
+	ptrdname: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type Package implements PackageOwner & Node & Likeable {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	namespace: String!
+	private: Boolean!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	maintainers: [User]! @deprecated(reason: "Please use collaborators instead")
+	curated: Boolean!
+	ownerObjectId: Int!
+	lastVersion: PackageVersion
+	"""
+	The app icon. It should be formatted in the same way as Apple icons
+	"""
+	icon: String!
+	totalDownloads: Int!
+	iconUpdatedAt: DateTime
+	likersCount: Int!
+	watchersCount: Int!
+	webcs(offset: Int, before: String, after: String, first: Int, last: Int): WebcImageConnection!
+	packagewebcSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageWebcConnection!
+	versions: [PackageVersion]
+	collectionSet: [Collection!]!
+	"""
+	List of app templates for this package
+	"""
+	appTemplates(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection!
+	categories(offset: Int, before: String, after: String, first: Int, last: Int): CategoryConnection!
+	keywords(offset: Int, before: String, after: String, first: Int, last: Int): PackageKeywordConnection!
+	viewerHasLiked: Boolean!
+	globalName: String!
+	globalId: ID!
+	viewerCan(action: OwnerAction!): Boolean!
+	alias: String
+	displayName: String!
+	"""
+	The name of the package without the owner
+	"""
+	packageName: String!
+	"""
+	The app icon. It should be formatted in the same way as Apple icons
+	"""
+	appIcon: String! @deprecated(reason: "Please use icon instead")
+	"""
+	The total number of downloads of the package
+	"""
+	downloadsCount: Int
+	"""
+	The public keys for all the published versions
+	"""
+	publicKeys: [PublicKey!]!
+	collaborators(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorConnection!
+	pendingInvites(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
+	viewerHasRole(role: GrapheneRole!): Boolean!
+	viewerAsCollaborator(role: GrapheneRole): PackageCollaborator
+	owner: PackageOwner!
+	isTransferring: Boolean!
+	activeTransferRequest: PackageTransferRequest
+	isArchived: Boolean!
+	viewerIsWatching: Boolean!
+	showDeployButton: Boolean!
+	similarPackageVersions(before: String, after: String, first: Int, last: Int): PackageSearchConnection!
+	"""
+	Whether the current user is invited to the package
+	"""
+	viewerIsInvited: Boolean!
+	"""
+	The invitation for the current user to the package
+	"""
+	viewerInvitation: PackageCollaboratorInvite
+}
+
+type PackageCategory implements Node {
+	id: ID!
+	package: Package
+	category: Category
+}
+
+type PackageCollaborator implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	user: User!
+	role: RegistryPackageMaintainerRoleChoices!
+	package: Package!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	invite: PackageCollaboratorInvite
+}
+
+type PackageCollaboratorConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageCollaboratorEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageCollaborator` and its cursor.
+"""
+type PackageCollaboratorEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageCollaborator!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageCollaboratorInvite implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	requestedBy: User!
+	user: User
+	inviteEmail: String
+	package: Package!
+	role: RegistryPackageMaintainerInviteRoleChoices!
+	accepted: PackageCollaborator
+	approvedBy: User
+	declinedBy: User
+	createdAt: DateTime!
+	expiresAt: DateTime!
+	closedAt: DateTime
+}
+
+type PackageCollaboratorInviteConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageCollaboratorInviteEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageCollaboratorInvite` and its cursor.
+"""
+type PackageCollaboratorInviteEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageCollaboratorInvite!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+type PackageDistribution {
+	"""
+	Download URL of the tar.gz file.
+	If the package was published with webc only,this will contain download URL for webc file instead.
+	"""
+	downloadUrl: String!
+	expiresInSeconds: Int
+	size: Int
+	piritaDownloadUrl: String
+	piritaExpiresInSeconds: Int
+	piritaSize: Int
+	piritaSha256Hash: String
+	webcDownloadUrl: String
+	webcExpiresInSeconds: Int
+	webcSize: Int
+	webcSha256Hash: String
+	webcVersion: WebcVersion
+	webcManifest: JSONString
+}
+
+"""
+A Relay edge containing a `Package` and its cursor.
+"""
+type PackageEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Package!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageInfo {
+	"""
+	Number of package versions published this month
+	"""
+	versionsPublishedThisMonth: Int!
+	"""
+	Number of new packages published this month
+	"""
+	newPackagesThisMonth: Int!
+	"""
+	Number of package downloads this month
+	"""
+	packageDownloadsThisMonth: Int!
+}
+
+"""
+This is for backwards compatibility with the old PackageInstance type.
+"""
+interface PackageInstance {
+	piritaManifest: JSONString
+	piritaOffsets: JSONString
+	piritaVolumes: JSONString
+	isArchived: Boolean!
+	clientName: String
+	publishedBy: User!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	package: Package!
+	webc: WebcImage
+	webcV3: WebcImage
+	tag: String!
+}
+
+type PackageKeyword implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+}
+
+type PackageKeywordConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageKeywordEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageKeyword` and its cursor.
+"""
+type PackageKeywordEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageKeyword!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+enum PackageOrderBy {
+	ALPHABETICALLY
+	SIZE
+	TOTAL_DOWNLOADS
+	PUBLISHED_DATE
+	CREATED_DATE
+	TOTAL_LIKES
+}
+
+"""
+Setup for backwards compatibility with existing frontends.
+"""
+interface PackageOwner {
+	globalName: String!
+	globalId: ID!
+	viewerCan(action: OwnerAction!): Boolean!
+}
+
+interface PackageReleaseInterface {
+	piritaManifest: JSONString
+	piritaOffsets: JSONString
+	piritaVolumes: JSONString
+	isArchived: Boolean!
+	clientName: String
+	publishedBy: User!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	package: Package!
+	webc: WebcImage
+	webcV3: WebcImage
+	tag: String!
+}
+
+type PackageRollout implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	externalId: String
+	rollout: Rollout!
+	sourcePackageVersion: PackageVersion
+	sourcePackageRelease: PackageWebc
+}
+
+type PackageRolloutConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageRolloutEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageRollout` and its cursor.
+"""
+type PackageRolloutEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageRollout!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageSearchConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageSearchEdge]!
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageSearch` and its cursor.
+"""
+type PackageSearchEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageVersion!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageTransferRequest implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	requestedBy: User!
+	previousOwnerObjectId: Int!
+	newOwnerObjectId: Int!
+	package: Package!
+	approvedBy: User
+	declinedBy: User
+	createdAt: DateTime!
+	expiresAt: DateTime!
+	closedAt: DateTime
+	previousOwner: PackageOwner!
+	newOwner: PackageOwner!
+}
+
+type PackageTransferRequestConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageTransferRequestEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageTransferRequest` and its cursor.
+"""
+type PackageTransferRequestEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageTransferRequest!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageVersion implements Node & PackageInstance & PackageReleaseInterface {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	package: Package!
+	webc: WebcImage
+	webcV3: WebcImage
+	"""
+	List of direct dependencies of this package version
+	"""
+	dependencies(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+	publishedBy: User!
+	tag: String!
+	clientName: String
+	webcGenerationErrors: String
+	version: String!
+	description: String!
+	manifest: String!
+	license: String
+	licenseFile: String
+	readme: String
+	witMd: String
+	repository: String
+	homepage: String
+	staticObjectsCompiled: Boolean!
+	nativeExecutablesCompiled: Boolean!
+	signature: Signature
+	isArchived: Boolean!
+	file: String!
+	fileSize: BigInt!
+	totalDownloads: Int!
+	bindingsState: RegistryPackageVersionBindingsStateChoices!
+	nativeExecutablesState: RegistryPackageVersionNativeExecutablesStateChoices!
+	packagewebcSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageWebcConnection!
+	lastversionPackage(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+	commands: [Command!]!
+	nativeexecutableSet(offset: Int, before: String, after: String, first: Int, last: Int): NativeExecutableConnection!
+	bindingsgeneratorSet(offset: Int, before: String, after: String, first: Int, last: Int): BindingsGeneratorConnection!
+	javascriptlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionNPMBindingConnection!
+	pythonlanguagebindingSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionPythonBindingConnection!
+	deployappversionSet(offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
+	packagerolloutSet(offset: Int, before: String, after: String, first: Int, last: Int): PackageRolloutConnection!
+	piritaManifest: JSONString
+	piritaOffsets: JSONString
+	piritaVolumes: JSONString
+	piritaFile: String @deprecated(reason: "Please use distribution.piritaDownloadUrl instead.")
+	piritaFileSize: Int @deprecated(reason: "Please use distribution.piritaSize instead.")
+	pirita256hash: String @deprecated(reason: "Please use distribution.piritaSha256Hash instead.")
+	distribution(version: WebcVersion): PackageDistribution!
+	filesystem: [PackageVersionFilesystem]!
+	isLastVersion: Boolean!
+	witFile: String
+	isSigned: Boolean!
+	moduleInterfaces: [InterfaceVersion!]!
+	modules: [PackageVersionModule!]!
+	getPiritaContents(volume: String! = "atom", base: String! = ""): [PiritaFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly fromt he webc")
+	getWebcContents(volume: String! = "atom", base: String! = "/"): [WEBCFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly fromt he webc")
+	nativeExecutables(triple: String, wasmerCompilerVersion: String): [NativeExecutable]
+	bindings: [PackageVersionLanguageBinding]!
+	npmBindings: PackageVersionNPMBinding
+	pythonBindings: PackageVersionPythonBinding
+	bindingsSet(before: String, after: String, first: Int, last: Int): PackageVersionBindingConnection
+	hasBindings: Boolean!
+	hasCommands: Boolean!
+	showDeployButton: Boolean!
+	isCorrupt: Boolean!
+}
+
+union PackageVersionBinding = PackageVersionNPMBinding | PackageVersionPythonBinding
+
+type PackageVersionBindingConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageVersionBindingEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageVersionBinding` and its cursor.
+"""
+type PackageVersionBindingEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageVersionBinding!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageVersionConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageVersionEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageVersion` and its cursor.
+"""
+type PackageVersionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageVersion!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageVersionFilesystem {
+	wasm: String!
+	host: String!
 }
 
 interface PackageVersionLanguageBinding {
-  id: ID!
-  language: ProgrammingLanguage!
-
-  """The URL of the generated artifacts on Wasmer CDN."""
-  url: String!
-
-  """When the binding was generated"""
-  createdAt: DateTime!
-
-  """Package version used to generate this binding"""
-  generator: BindingsGenerator!
-  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-
-  """Name of package source"""
-  packageName: String!
-
-  """Name of the package to import"""
-  importablePackageName: String!
-
-  """Code snippet example to use the package"""
-  codeSnippetExample: String!
-  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	id: ID!
+	language: ProgrammingLanguage!
+	"""
+	The URL of the generated artifacts on Wasmer CDN.
+	"""
+	url: String!
+	"""
+	When the binding was generated
+	"""
+	createdAt: DateTime!
+	"""
+	Package version used to generate this binding
+	"""
+	generator: BindingsGenerator!
+	name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	"""
+	Name of package source
+	"""
+	packageName: String!
+	"""
+	Name of the package to import
+	"""
+	importablePackageName: String!
+	"""
+	Code snippet example to use the package
+	"""
+	codeSnippetExample: String!
+	module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
 }
 
-enum ProgrammingLanguage {
-  PYTHON
-  JAVASCRIPT
+type PackageVersionModule {
+	name: String!
+	source: String!
+	abi: String
+	publicUrl: String!
+	atom: PiritaFilesystemFile!
+	rangeHeader: String!
+}
+
+type PackageVersionNPMBinding implements PackageVersionLanguageBinding & Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	language: ProgrammingLanguage!
+	"""
+	The URL of the generated artifacts on Wasmer CDN.
+	"""
+	url: String!
+	"""
+	When the binding was generated
+	"""
+	createdAt: DateTime!
+	"""
+	Package version used to generate this binding
+	"""
+	generator: BindingsGenerator!
+	name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	"""
+	Name of package source
+	"""
+	packageName: String!
+	"""
+	Name of the package to import
+	"""
+	importablePackageName: String!
+	"""
+	Code snippet example to use the package
+	"""
+	codeSnippetExample: String!
+	module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	npmDefaultInstallPackageName(url: String): String! @deprecated(reason: "Please use packageName instead")
+}
+
+type PackageVersionNPMBindingConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageVersionNPMBindingEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `PackageVersionNPMBinding` and its cursor.
+"""
+type PackageVersionNPMBindingEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageVersionNPMBinding!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type PackageVersionPythonBinding implements PackageVersionLanguageBinding & Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	language: ProgrammingLanguage!
+	"""
+	The URL of the generated artifacts on Wasmer CDN.
+	"""
+	url: String!
+	"""
+	When the binding was generated
+	"""
+	createdAt: DateTime!
+	"""
+	Package version used to generate this binding
+	"""
+	generator: BindingsGenerator!
+	name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	"""
+	Name of package source
+	"""
+	packageName: String!
+	"""
+	Name of the package to import
+	"""
+	importablePackageName: String!
+	"""
+	Code snippet example to use the package
+	"""
+	codeSnippetExample: String!
+	module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
+	pythonDefaultInstallPackageName(url: String): String!
 }
 
 type PackageVersionPythonBindingConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageVersionPythonBindingEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageVersionPythonBindingEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
 """
 A Relay edge containing a `PackageVersionPythonBinding` and its cursor.
 """
 type PackageVersionPythonBindingEdge {
-  """The item at the end of the edge"""
-  node: PackageVersionPythonBinding
-
-  """A cursor for use in pagination"""
-  cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageVersionPythonBinding!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type PackageVersionPythonBinding implements PackageVersionLanguageBinding & Node {
-  """The ID of the object"""
-  id: ID!
-  language: ProgrammingLanguage!
-
-  """The URL of the generated artifacts on Wasmer CDN."""
-  url: String!
-
-  """When the binding was generated"""
-  createdAt: DateTime!
-
-  """Package version used to generate this binding"""
-  generator: BindingsGenerator!
-  name: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-  kind: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-
-  """Name of package source"""
-  packageName: String!
-
-  """Name of the package to import"""
-  importablePackageName: String!
-
-  """Code snippet example to use the package"""
-  codeSnippetExample: String!
-  module: String! @deprecated(reason: "Do not use this field, since bindings for all modules are generated at once now.")
-  pythonDefaultInstallPackageName(url: String): String!
+type PackageVersionReadyResponse {
+	state: PackageVersionState!
+	packageVersion: PackageVersion!
+	success: Boolean!
 }
 
-type DeployAppVersionConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [DeployAppVersionEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+"""
+An enumeration.
+"""
+enum PackageVersionSortBy {
+	NEWEST
+	OLDEST
 }
 
-"""A Relay edge containing a `DeployAppVersion` and its cursor."""
-type DeployAppVersionEdge {
-  """The item at the end of the edge"""
-  node: DeployAppVersion
-
-  """A cursor for use in pagination"""
-  cursor: String!
+enum PackageVersionState {
+	WEBC_GENERATED
+	BINDINGS_GENERATED
+	NATIVE_EXES_GENERATED
 }
 
-type DeployAppVersion implements Node {
-  """The ID of the object"""
-  id: ID!
-  app: DeployApp!
-  yamlConfig: String!
-  userYamlConfig: String!
-  clientName: String!
-  signature: String
-  description: String
-  publishedBy: User!
-  disabledAt: DateTime
-  disabledBy: User
-  disabledReason: String
-  disabledPermanently: Boolean!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  configWebc: String @deprecated(reason: "webc support has been deprecated for apps")
-  config: String! @deprecated(reason: "Please use jsonConfig instead")
-  jsonConfig: String!
-  url: String!
-  permalink: String!
-  urls: [String]!
-  version: String!
-  isActive: Boolean!
-  manifest: String!
-  logs(
-    """
-    Get logs starting from this timestamp. Takes EPOCH timestamp in seconds.
-    """
-    startingFrom: Float
-
-    """Get logs starting from this timestamp. Takes ISO timestamp."""
-    startingFromISO: DateTime
-
-    """Fetch logs until this timestamp. Takes EPOCH timestamp in seconds."""
-    until: Float
-
-    """List of streams to fetch logs from. e.g. stdout, stderr."""
-    streams: [LogStream]
-
-    """List of instance ids to fetch logs from."""
-    instanceIds: [String]
-
-    """Filter for this request id in logs"""
-    requestId: String
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): LogConnection!
-  usageMetrics(
-    variant: MetricType!
-    grouping: MetricGrouping
-
-    """Optional time range filter."""
-    timeRange: TimeRangeInput
-  ): [UsageMetric]!
-  sourcePackageVersion: PackageVersion
-  sourcePackageRelease: PackageWebc
-  sourcePackage: Package!
-  aggregateMetrics: AggregateMetrics!
-  volumes: [AppVersionVolume]
-  gitSource: AutobuildRepository @deprecated(reason: "This field is deprecated and return null always.")
-  rolloutSource: Rollout
-  favicon: URL
-  screenshot(viewportSize: AppScreenshotViewportSize, appearance: AppScreenshotAppearance): URL
-  isUploaded: Boolean!
+type PackageWebc implements Node & PackageInstance & PackageReleaseInterface {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	package: Package!
+	webc: WebcImage
+	piritaManifest: JSONString
+	piritaOffsets: JSONString
+	piritaVolumes: JSONString
+	isArchived: Boolean!
+	clientName: String
+	publishedBy: User!
+	webcV3: WebcImage
+	tag: String!
+	webcUrl: String!
 }
 
-type DeployApp implements Node & Owner {
-  """The ID of the object"""
-  id: ID!
-  state: String!
-  forceHttps: Boolean!
-  createdBy: User!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  activeVersion: DeployAppVersion
-  managed: Boolean!
-  willPerishAt: DateTime
-  perishReason: DeployDeployAppPerishReasonChoices
-  globalName: String!
-  globalId: ID!
-  viewerCan(action: OwnerAction!): Boolean!
-  isPro: Boolean!
-  url: String!
-  adminUrl: String!
-  permalink: String!
-  urls: [String]!
-  description: String
-  name: String!
-  owner: Owner!
-  versions(sortBy: DeployAppVersionsSortBy, createdAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
-  aggregateMetrics: AggregateMetrics!
-  aliases(offset: Int, before: String, after: String, first: Int, last: Int): AppAliasConnection!
-  domains(sortBy: AppAliasSortBy! = NEWEST, offset: Int, before: String, after: String, first: Int, last: Int): AppAliasConnection!
-  secrets(offset: Int, before: String, after: String, first: Int, last: Int): SecretConnection!
-  databases(offset: Int, before: String, after: String, first: Int, last: Int): AppDatabaseConnection!
-  usageMetrics(
-    variant: MetricType!
-    grouping: MetricGrouping
-
-    """Optional time range filter."""
-    timeRange: TimeRangeInput
-  ): [UsageMetric]!
-  s3Url: URL
-  s3Credentials: S3Credentials
-  deleted: Boolean!
-  favicon: URL
-  screenshot(viewportSize: AppScreenshotViewportSize, appearance: AppScreenshotAppearance): URL
-  deployments(before: String, after: String, first: Int, last: Int): DeploymentConnection @deprecated(reason: "Use rollouts instead")
-  rollouts(before: String, after: String, first: Int, last: Int): RolloutConnection
-  buildConfiguration: BuildConfiguration
-  sshServer: AppSshServer
-  mails: [AppMail]
-  kind: Kind
-  githubRepoConnection: GithubRepoConnection
+type PackageWebcConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PackageWebcEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-"""An enumeration."""
-enum DeployDeployAppPerishReasonChoices {
-  """User Pending Verification"""
-  USER_PENDING_VERIFICATION
-
-  """User Requested"""
-  USER_REQUESTED
-
-  """App Unclaimed"""
-  APP_UNCLAIMED
+"""
+A Relay edge containing a `PackageWebc` and its cursor.
+"""
+type PackageWebcEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PackageWebc!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-"""An enumeration."""
-enum DeployAppVersionsSortBy {
-  NEWEST
-  OLDEST
+input PackagesFilter {
+	count: Int = 1000
+	sortBy: SearchOrderSort = DESC
+	"""
+	Filter packages by being curated.
+	"""
+	curated: Boolean
+	"""
+	Filter packages by publish date.
+	"""
+	publishDate: SearchPublishDate
+	"""
+	Filter packages by having bindings.
+	"""
+	hasBindings: Boolean = false
+	"""
+	Filter packages by being standalone.
+	"""
+	isStandalone: Boolean = false
+	"""
+	Filter packages by having commands.
+	"""
+	hasCommands: Boolean = false
+	"""
+	Filter packages by interface.
+	"""
+	withInterfaces: [String]
+	"""
+	Filter packages by deployable status.
+	"""
+	deployable: Boolean
+	"""
+	Filter packages by license.
+	"""
+	license: String
+	"""
+	Filter packages created after this date.
+	"""
+	createdAfter: DateTime
+	"""
+	Filter packages created before this date.
+	"""
+	createdBefore: DateTime
+	"""
+	Filter packages with version published after this date.
+	"""
+	lastPublishedAfter: DateTime
+	"""
+	Filter packages with version published before this date.
+	"""
+	lastPublishedBefore: DateTime
+	"""
+	Filter packages by size.
+	"""
+	size: CountFilter
+	"""
+	Filter packages by download count.
+	"""
+	downloads: CountFilter
+	"""
+	Filter packages by like count.
+	"""
+	likes: CountFilter
+	"""
+	Filter packages by owner.
+	"""
+	owner: String
+	"""
+	Filter packages by published by.
+	"""
+	publishedBy: String
+	"""
+	Order packages by field.
+	"""
+	orderBy: PackageOrderBy = PUBLISHED_DATE
 }
 
-type AggregateMetrics {
-  cpuTime: String!
-  memoryTime: String!
-  ingress: String!
-  egress: String!
-  noRequests: String!
-  noFailedRequests: String!
-  monthlyCost: String!
+"""
+The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+"""
+type PageInfo {
+	"""
+	When paginating forwards, are there more items?
+	"""
+	hasNextPage: Boolean!
+	"""
+	When paginating backwards, are there more items?
+	"""
+	hasPreviousPage: Boolean!
+	"""
+	When paginating backwards, the cursor to continue.
+	"""
+	startCursor: String
+	"""
+	When paginating forwards, the cursor to continue.
+	"""
+	endCursor: String
 }
 
-type AppAliasConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [AppAliasEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type Payment {
+	id: ID
+	amount: String
+	paidOn: DateTime
 }
 
-"""A Relay edge containing a `AppAlias` and its cursor."""
-type AppAliasEdge {
-  """The item at the end of the edge"""
-  node: AppAlias
-
-  """A cursor for use in pagination"""
-  cursor: String!
+type PaymentIntent implements Node {
+	"""
+	The datetime this object was created in stripe.
+	"""
+	created: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	amount: String!
+	currency: String!
+	status: String!
+	invoicePdfUrl: String
 }
 
-type AppAlias implements Node {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  lastCheckedAt: DateTime
-  firstCheckedAt: DateTime
-  name: String!
-  app: DeployApp!
-  isDefault: Boolean!
-  hostname: String!
-  text: String!
-  kind: DeployAppAliasKindChoices!
-  redirectsTo: AppAlias
-
-  """The ID of the object"""
-  id: ID!
-  url: String!
-  state: AppAliasVerificationStates!
-
-  """
-  List of records backend expects to move forward with domain verification
-  """
-  expectedDnsRecords: [AppAliasDNSRecord]
-
-  """HTTP code for redirection"""
-  redirectionHttpCode: HTTPRedirectType
-
-  """list of AppAlias objects that redirect to this one."""
-  redirectsFrom: [AppAlias]
+type PaymentIntentConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [PaymentIntentEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-"""An enumeration."""
-enum DeployAppAliasKindChoices {
-  """Deployment"""
-  DEPLOYMENT
-
-  """Domain"""
-  DOMAIN
+"""
+A Relay edge containing a `PaymentIntent` and its cursor.
+"""
+type PaymentIntentEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: PaymentIntent!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-"""An enumeration."""
-enum AppAliasVerificationStates {
-  UNVERIFIED
-  VERIFIED
-  APEX_WITHOUT_REDIRECTION
+union PaymentMethod = CardPaymentMethod
+
+"""
+An enumeration.
+"""
+enum PendingVerification {
+	VALIDATE_EMAIL
+	FINGERPRINT
+	SUBMIT_ACCEPTABLE_EMAIL
 }
 
-type AppAliasDNSRecord {
-  recordType: String!
-  host: String!
-  value: String!
+type PiritaFilesystemDir {
+	name(display: PiritaFilesystemNameDisplay): String!
 }
 
-enum HTTPRedirectType {
-  TEMPORARY_REDIRECT
-  TEMPORARY_FOUND
-  PERMANENT_REDIRECT
-  PERMANENT_MOVED
+type PiritaFilesystemFile {
+	name(display: PiritaFilesystemNameDisplay): String!
+	size: Int!
+	offset: Int!
 }
 
-"""An enumeration."""
-enum AppAliasSortBy {
-  NEWEST
-  OLDEST
+union PiritaFilesystemItem = PiritaFilesystemFile | PiritaFilesystemDir
+
+enum PiritaFilesystemNameDisplay {
+	RELATIVE
+	ABSOLUTE
+}
+
+enum ProgrammingLanguage {
+	PYTHON
+	JAVASCRIPT
+}
+
+type PublicKey implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	owner: User!
+	keyId: String!
+	key: String!
+	revokedAt: DateTime
+	uploadedAt: DateTime!
+	verifyingSignature: Signature
+	revoked: Boolean!
+}
+
+input PublishDeployAppInput {
+	"""
+	The configuration of the app.
+	"""
+	config: Configuration!
+	"""
+	The name of the app.
+	"""
+	name: ID
+	"""
+	The owner of the app.
+	"""
+	owner: ID
+	"""
+	The description of the app.
+	"""
+	description: String
+	"""
+	If true, the new version will be set as the default version.
+	"""
+	makeDefault: Boolean = true
+	"""
+	If true, Publishing will fail if the source package does not have a valid webc.
+	"""
+	strict: Boolean = false
+	"""
+	If true, the mutation will wait for all deployment jobs to finish before returning.
+	"""
+	waitForJobs: Boolean = false
+	"""
+	If true, the mutation will trigger a screenshot generation job.
+	"""
+	generateScreenshot: Boolean = true
+	"""
+	Wait for smaller of n seconds or till the published app version is live.
+	"""
+	waitTillLive: Int = null
+	clientMutationId: String
+}
+
+type PublishDeployAppPayload {
+	clientMutationId: String
+	deployAppVersion: DeployAppVersion!
+}
+
+input PublishPackageInput {
+	manifest: String!
+	name: String
+	namespace: String
+	version: String
+	description: String
+	license: String
+	licenseFile: String
+	readme: String
+	repository: String
+	homepage: String
+	"""
+	The package file
+	"""
+	file: String @deprecated(reason: "Use `fileUpload` instead")
+	"""
+	The package file
+	"""
+	fileUpload: Upload
+	signedUrl: String
+	signature: InputSignature
+	"""
+	The package icon
+	"""
+	icon: String @deprecated(reason: "Use `iconUpload` instead")
+	"""
+	The package icon
+	"""
+	iconUpload: Upload
+	"""
+	Whether the package is private
+	"""
+	private: Boolean = false
+	"""
+	The upload format of the package
+	"""
+	uploadFormat: UploadFormat = targz
+	"""
+	Whether to wait for webc generation to finish
+	"""
+	wait: Boolean = false
+	clientMutationId: String
+}
+
+type PublishPackagePayload {
+	success: Boolean!
+	clientMutationId: String
+	packageVersion: PackageVersion
+	packageWebc: PackageWebc
+}
+
+input PublishPublicKeyInput {
+	keyId: String!
+	key: String!
+	verifyingSignatureId: String
+	clientMutationId: String
+}
+
+type PublishPublicKeyPayload {
+	clientMutationId: String
+	success: Boolean!
+	publicKey: PublicKey!
+}
+
+input PurgeCacheForAppVersionByIdInput {
+	"""
+	App version ID to purge cache for.
+	"""
+	appVersionId: ID!
+	clientMutationId: String
+}
+
+input PurgeCacheForAppVersionInput {
+	"""
+	ID of the app version to purge cache for.
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Purges all cache for this app version
+"""
+type PurgeCacheForAppVersionPayload {
+	clientMutationId: String
+	appVersion: DeployAppVersion!
+	success: Boolean!
+}
+
+input PushPackageReleaseInput {
+	namespace: String!
+	signedUrl: String!
+	name: String
+	"""
+	Whether the package is private
+	"""
+	private: Boolean = false
+	clientMutationId: String
+}
+
+type PushPackageReleasePayload {
+	success: Boolean!
+	clientMutationId: String
+	packageWebc: PackageWebc
+}
+
+type Query {
+	getPasswordResetToken(token: String!): GetPasswordResetToken!
+	getAuthNonce(name: String!): Nonce!
+	"""
+	Can the logged in user create app templates?
+	"""
+	canDeployAppToGithub: Boolean!
+	"""
+	Check if a repo exists in the logged in user's github account.
+	"""
+	checkRepoExists(
+		"""
+		The namespace of the repo to check.
+		"""
+		namespace: String!,
+		"""
+		The name of the repo to check.
+		"""
+		name: String!
+	): Boolean!
+	latestTOS: TermsOfService!
+	getAppRegions(active: Boolean, supportsVolumes: Boolean, supportsDatabases: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): AppRegionConnection!
+	getDeployAppVersion(name: String!, owner: String, version: String): DeployAppVersion
+	getAllDomains(namespace: String, ownerId: ID, offset: Int, before: String, after: String, first: Int, last: Int): DNSDomainConnection!
+	getAllDNSRecords(sortBy: DNSRecordsSortBy, updatedAfter: DateTime, before: String, after: String, first: Int, last: Int): DNSRecordConnection!
+	getDomain(name: String!): DNSDomain
+	getDeployApp(		name: String!,
+		"""
+		Owner of the app. Defaults to logged in user.
+		"""
+		owner: String
+	): DeployApp
+	getAppByGlobalAlias(alias: String!): DeployApp
+	autobuildDeploymentStatus(buildId: UUID!): AutobuildDeploymentStatus
+	getDeployApps(ownerId: ID, sortBy: DeployAppsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
+	getAppVersions(sortBy: DeployAppVersionsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
+	getTemplateFrameworks(offset: Int, before: String, after: String, first: Int, last: Int): TemplateFrameworkConnection!
+	getTemplateLanguages(offset: Int, before: String, after: String, first: Int, last: Int): TemplateLanguageConnection!
+	getAppTemplates(categorySlug: String, frameworkSlug: String, languageSlug: String, sortBy: AppTemplatesSortBy, highlighted: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection!
+	getAppSecrets(appId: ID!, names: [String], nameRegex: String, offset: Int, before: String, after: String, first: Int, last: Int): SecretConnection @deprecated(reason: "Use `DeployApp.envVars` instead.")
+	getAppSecret(appId: ID!, secretName: String!): Secret @deprecated(reason: "Use `DeployApp.envVars` instead.")
+	getAppSecretLog(appId: ID!, offset: Int, before: String, after: String, first: Int, last: Int): SecretLogConnection @deprecated(reason: "Use `getAppEnvVarLog` instead.")
+	getAppEnvVarLog(appId: ID!, offset: Int, before: String, after: String, first: Int, last: Int): EnvVarLogConnection
+	getSecretValue(id: ID!): String @deprecated(reason: "Use `EnvVar.value` for non-sensitive environment variables.")
+	getAppTemplate(slug: String!): AppTemplate
+	getAppTemplateCategories(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateCategoryConnection!
+	getBuildKinds(offset: Int, before: String, after: String, first: Int, last: Int): BuildKindConnection!
+	"""
+	Specify if the database name is valid or not.
+	"""
+	canDeployDbWithName(
+		"""
+		Name of the database
+		"""
+		name: String!
+	): Boolean!
+	wordpressDeploymentDefaults: WordpressDeploymentDefaults!
+	wordpressVersions: [WordpressVersion!]!
+	rollout(id: ID!): Rollout
+	githubRollout(id: ID!): GitHubRollout
+	viewer: User
+	getUser(username: String!): User
+	"""
+	Generate a unique repo name in the logged in user's github account.
+	"""
+	newRepoName(
+		"""
+		The github namespace of the repo to create the repo in.
+		"""
+		namespace: String!,
+		"""
+		The template to use.
+		"""
+		templateSlug: String!
+	): String!
+	packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+	recentPackageVersions(curated: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+	allPackageVersions(sortBy: PackageVersionSortBy, createdAfter: DateTime, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+	allPackageReleases(sortBy: PackageVersionSortBy, createdAfter: DateTime, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): PackageWebcConnection!
+	getWebcImage(hash: String!): WebcImage
+	getNamespace(name: String!): Namespace
+	getPackage(name: String!): Package
+	getPackages(names: [String!]!): [Package]!
+	getPackageVersion(name: String!, version: String = "latest"): PackageVersion
+	getPackageVersions(names: [String!]!): [PackageVersion]!
+	getPackageVersionByHash(name: String!, hash: String!): PackageVersion
+	getInterface(name: String!): Interface
+	getInterfaces(names: [String!]!): [Interface]!
+	getInterfaceVersion(name: String!, version: String = "latest"): InterfaceVersion
+	getContract(name: String!): Interface @deprecated(reason: "Please use getInterface instead")
+	getContracts(names: [String!]!): [Interface]! @deprecated(reason: "Please use getInterfaces instead")
+	getContractVersion(name: String!, version: String): InterfaceVersion @deprecated(reason: "Please use getInterfaceVersion instead")
+	getCommand(name: String!): Command
+	getCommands(names: [String!]!): [Command]
+	getCollections(before: String, after: String, first: Int, last: Int): CollectionConnection!
+	getSignedUrlForPackageUpload(name: String, version: String = "latest", filename: String, expiresAfterSeconds: Int = 900, method: String): SignedUrl
+	getSignedUrl(filename: String, expiresAfterSeconds: Int = 900, method: String): SignedUrl
+	getPackageHash(name: String, hash: String!): PackageWebc
+	getPackageRelease(hash: String): PackageWebc
+	getPackageInstanceByVersionOrHash(name: String!, version: String, hash: String): PackageInstance
+	categories(offset: Int, before: String, after: String, first: Int, last: Int): CategoryConnection!
+	logs(appId: ID, appVersionId: ID, instanceId: ID, textSearch: String, before: String, after: String, first: Int, last: Int): LogConnection!
+	logValues(		appId: ID,		appVersionId: ID,
+		"""
+		Label to get the values for
+		"""
+		label: String!,		before: String,		after: String
+	): [String]!
+	viewerCan(action: OwnerAction!, ownerName: String!): Boolean!
+	blogposts(tags: [String!], offset: Int, before: String, after: String, first: Int, last: Int): BlogPostConnection!
+	getBlogpost(slug: String, featured: Boolean): BlogPost
+	allBlogpostTags(offset: Int, before: String, after: String, first: Int, last: Int): BlogPostTagConnection
+	search(query: String!, packages: PackagesFilter, namespaces: NamespacesFilter, users: UsersFilter, apps: AppFilter, blogposts: BlogPostsFilter, appTemplates: AppTemplateFilter, before: String, after: String, first: Int, last: Int): SearchConnection!
+	searchAutocomplete(kind: [SearchKind!], query: String!, before: String, after: String, first: Int, last: Int): SearchConnection!
+	getGlobalObject(slug: String!): GlobalObject
+	internalTask(id: ID!): InternalTask
+	node(
+		"""
+		The ID of the object
+		"""
+		id: ID!
+	): Node
+	nodes(ids: [ID!]!): [Node]!
+	info: RegistryInfo!
+}
+
+input ReadNotificationInput {
+	notificationId: ID!
+	clientMutationId: String
+}
+
+type ReadNotificationPayload {
+	clientMutationId: String
+	notification: UserNotification
+}
+
+"""
+An enumeration.
+"""
+enum RecordKind {
+	A
+	AAAA
+	CNAME
+	MX
+	NS
+	TXT
+	DNAME
+	PTR
+	SOA
+	SRV
+	CAA
+	SSHFP
+}
+
+input RedeployActiveAppVersionInput {
+	"""
+	App ID to redeploy.
+	"""
+	appId: ID!
+	clientMutationId: String
+}
+
+input RedeployActiveVersionInput {
+	"""
+	ID of the app to redeploy.
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Redeploy the active version of an app.
+"""
+type RedeployActiveVersionPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+type Refresh {
+	payload: GenericScalar!
+	refreshExpiresIn: Int!
+	token: String!
+	refreshToken: String!
+}
+
+input RegisterDomainInput {
+	name: String!
+	namespace: String
+	ownerId: ID
+	importRecords: Boolean = true
+	clientMutationId: String
+}
+
+type RegisterDomainPayload {
+	clientMutationId: String
+	success: Boolean!
+	domain: DNSDomain
+}
+
+input RegisterUserInput {
+	fullName: String
+	email: String!
+	username: CaseInsensitiveString!
+	password: String!
+	acceptedTos: Boolean
+	intent: String
+	fingerprintVisitorId: String
+	enterProTrial: Boolean
+	clientMutationId: String
+}
+
+type RegisterUserPayload {
+	token: String
+	clientMutationId: String
+}
+
+type RegistryInfo {
+	"""
+	Base URL for this registry
+	"""
+	baseUrl: String!
+	"""
+	Base URL for the default frontend
+	"""
+	defaultFrontend: String!
+	"""
+	URL to the graphql endpoint
+	"""
+	graphqlUrl: String!
+	"""
+	URL for app domains
+	"""
+	appDomain: String!
+	"""
+	URL to the graphql endpoint
+	"""
+	createBlogpostUrl: String
+	"""
+	Public metadata about packages
+	"""
+	packages: PackageInfo!
+	"""
+	Public metadata about the graphql schema
+	"""
+	schema: SchemaInfo!
+}
+
+"""
+An enumeration.
+"""
+enum RegistryNamespaceMaintainerInviteRoleChoices {
+	"""
+	Owner
+	"""
+	OWNER
+	"""
+	Admin
+	"""
+	ADMIN
+	"""
+	Editor
+	"""
+	EDITOR
+	"""
+	Viewer
+	"""
+	VIEWER
+}
+
+"""
+An enumeration.
+"""
+enum RegistryNamespaceMaintainerRoleChoices {
+	"""
+	Owner
+	"""
+	OWNER
+	"""
+	Admin
+	"""
+	ADMIN
+	"""
+	Editor
+	"""
+	EDITOR
+	"""
+	Viewer
+	"""
+	VIEWER
+}
+
+"""
+An enumeration.
+"""
+enum RegistryPackageMaintainerInviteRoleChoices {
+	"""
+	Owner
+	"""
+	OWNER
+	"""
+	Admin
+	"""
+	ADMIN
+	"""
+	Editor
+	"""
+	EDITOR
+	"""
+	Viewer
+	"""
+	VIEWER
+}
+
+"""
+An enumeration.
+"""
+enum RegistryPackageMaintainerRoleChoices {
+	"""
+	Owner
+	"""
+	OWNER
+	"""
+	Admin
+	"""
+	ADMIN
+	"""
+	Editor
+	"""
+	EDITOR
+	"""
+	Viewer
+	"""
+	VIEWER
+}
+
+"""
+An enumeration.
+"""
+enum RegistryPackageVersionBindingsStateChoices {
+	"""
+	Bindings are not detected
+	"""
+	NOT_PRESENT
+	"""
+	Bindings are being built
+	"""
+	GENERATING
+	"""
+	Bindings generation has failed
+	"""
+	ERROR
+	"""
+	Bindings are built and present
+	"""
+	GENERATED_AND_PRESENT
+}
+
+"""
+An enumeration.
+"""
+enum RegistryPackageVersionNativeExecutablesStateChoices {
+	"""
+	Native Executables are not detected
+	"""
+	NOT_PRESENT
+	"""
+	Native Executables are being built
+	"""
+	GENERATING
+	"""
+	Native Executables generation has failed
+	"""
+	ERROR
+	"""
+	Native Executables are built and present
+	"""
+	GENERATED_AND_PRESENT
+}
+
+input RemoveAppTransferRequestInput {
+	appTransferRequestId: ID!
+	clientMutationId: String
+}
+
+type RemoveAppTransferRequestPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+input RemoveNamespaceCollaboratorInput {
+	namespaceCollaboratorId: ID!
+	clientMutationId: String
+}
+
+input RemoveNamespaceCollaboratorInviteInput {
+	inviteId: ID!
+	clientMutationId: String
+}
+
+type RemoveNamespaceCollaboratorInvitePayload {
+	namespace: Namespace!
+	clientMutationId: String
+}
+
+type RemoveNamespaceCollaboratorPayload {
+	namespace: Namespace!
+	clientMutationId: String
+}
+
+input RemovePackageCollaboratorInput {
+	packageCollaboratorId: ID!
+	clientMutationId: String
+}
+
+input RemovePackageCollaboratorInviteInput {
+	inviteId: ID!
+	clientMutationId: String
+}
+
+type RemovePackageCollaboratorInvitePayload {
+	clientMutationId: String
+	package: Package!
+}
+
+type RemovePackageCollaboratorPayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input RemovePackageTransferRequestInput {
+	packageTransferRequestId: ID!
+	clientMutationId: String
+}
+
+type RemovePackageTransferRequestPayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input RenameAppAliasInput {
+	"""
+	App alias ID to delete.
+	"""
+	id: ID!
+	"""
+	New name for the alias.
+	"""
+	name: String!
+	clientMutationId: String
+}
+
+type RenameAppAliasPayload {
+	clientMutationId: String
+	success: Boolean!
+	alias: AppAlias!
+}
+
+input RenameAppInput {
+	"""
+	App ID to rename.
+	"""
+	id: ID!
+	"""
+	New name for the app.
+	"""
+	name: String!
+	clientMutationId: String
+}
+
+type RenameAppPayload {
+	clientMutationId: String
+	success: Boolean!
+	app: DeployApp!
+}
+
+input RenamePackageInput {
+	packageId: ID!
+	newName: String!
+	clientMutationId: String
+}
+
+type RenamePackagePayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input RenewCanceledSubscriptionInput {
+	"""
+	ID of owner whose subscription to renew.
+	"""
+	forOwnerId: ID!
+	"""
+	ID of the subscription to renew
+	"""
+	subscriptionId: ID!
+	clientMutationId: String
+}
+
+type RenewCanceledSubscriptionPayload {
+	clientMutationId: String
+	ok: Boolean!
+}
+
+input RequestAppTransferInput {
+	appId: ID!
+	newOwnerId: ID!
+	clientMutationId: String
+}
+
+type RequestAppTransferPayload {
+	clientMutationId: String
+	appTransferRequest: AppTransferRequest
+	wasInstantlyTransferred: Boolean!
+}
+
+type RequestMetrics {
+	totalRequests: BigInt!
+	cachedRequests: BigInt!
+	percentageCached: Float!
+	http2xx: BigInt!
+	http3xx: BigInt!
+	http4xx: BigInt!
+	http5xx: BigInt!
+	httpOther: BigInt!
+	requestDurationMillis: BigInt!
+	uniqueUsers: Int!
+	dataServedBytes: BigInt!
+	dataCachedBytes: BigInt!
+}
+
+input RequestPackageTransferInput {
+	packageId: ID!
+	newOwnerId: ID!
+	clientMutationId: String
+}
+
+type RequestPackageTransferPayload {
+	clientMutationId: String
+	package: Package!
+	wasInstantlyTransferred: Boolean!
+	packageTransferRequest: PackageTransferRequest
+}
+
+input RequestPasswordResetInput {
+	email: String!
+	clientMutationId: String
+}
+
+type RequestPasswordResetPayload {
+	email: String!
+	errors: [ErrorType!]
+	clientMutationId: String
+}
+
+input RequestValidationEmailInput {
+	"""
+	The user id
+	"""
+	userId: ID @deprecated(reason: "This field is deprecated. The user can only request a validation email for themselves.")
+	clientMutationId: String
+}
+
+type RequestValidationEmailPayload {
+	clientMutationId: String
+	user: User
+	success: Boolean!
+}
+
+input RevealSshUserPasswordInput {
+	"""
+	SSH User ID
+	"""
+	sshUserId: ID!
+	clientMutationId: String
+}
+
+"""
+Reveal the password for an SSH user.
+"""
+type RevealSshUserPasswordPayload {
+	clientMutationId: String
+	sshUser: SshUser!
+	password: String
+}
+
+type Revoke {
+	revoked: Int!
+}
+
+input RevokeAPITokenInput {
+	"""
+	The API token ID
+	"""
+	tokenId: String
+	"""
+	The raw API token
+	"""
+	token: String
+	clientMutationId: String
+}
+
+"""
+Request To revoke an API token; these start with 'wap_'.
+"""
+type RevokeAPITokenPayload {
+	clientMutationId: String
+	token: APIToken
+	success: Boolean
+}
+
+type Rollout implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deployappVersion: DeployAppVersion
+	startCommand: String
+	afterDeployCommand: String
+	buildCommand: String
+	installCommand: String
+	buildId: String
+	status: StatusEnum!
+	logUrl: String @deprecated(reason: "Use fetchBuildLogsSubscription instead")
+	buildConfiguration: BuildConfiguration
+	rolloutDetails: RolloutType
+}
+
+type RolloutConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [RolloutEdge!]!
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `Rollout` and its cursor.
+"""
+type RolloutEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Rollout!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+union RolloutType = GitHubRollout | ZipRollout | PackageRollout
+
+input RotateAPIKeyInput {
+	apiKeyId: ID!
+	clientMutationId: String
+}
+
+type RotateAPIKeyPayload {
+	apiKey: APIKey!
+	keyRaw: String!
+	clientMutationId: String
+}
+
+input RotateCredentialsForAppDBInput {
+	"""
+	App Database ID
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Delete a database for an app.
+"""
+type RotateCredentialsForAppDBPayload {
+	clientMutationId: String
+	database: AppDatabase!
+	password: String!
+}
+
+input RotateS3CredentialsInput {
+	"""
+	App Volume ID
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Rotate S3 credentials for an app volume.
+"""
+type RotateS3CredentialsPayload {
+	clientMutationId: String
+	volume: AppVolume!
+	accessKey: String!
+	secretKey: String!
+	endpoint: String!
+	success: Boolean!
+}
+
+input RotateS3SecretsForAppInput {
+	"""
+	ID of the app.
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Deprecated. Use rotateS3Credentials with an AppVolume ID.
+"""
+type RotateS3SecretsForAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+input RotateSshUserPasswordInput {
+	"""
+	SSH User ID
+	"""
+	sshUserId: ID!
+	clientMutationId: String
+}
+
+"""
+Rotate the password for an SSH user.
+"""
+type RotateSshUserPasswordPayload {
+	clientMutationId: String
+	sshUser: SshUser!
+	password: String!
+}
+
+input RunEdgeCommandInput {
+	appId: ID!
+	command: String!
+	timeoutSeconds: Int
+	clientMutationId: String
+}
+
+type RunEdgeCommandPayload {
+	clientMutationId: String
+	app: DeployApp!
+	stdout: String!
+	stderr: String!
+	exitCode: Int!
+}
+
+"""
+Run a webassembly file.
+"""
+input RunnerWCGIV1 {
+	source: WorkloadRunnerWasmSourceV1!
+	dialect: String
+}
+
+input RunnerWebProxyV1 {
+	source: WorkloadRunnerWasmSourceV1!
+}
+
+type S3 {
+	accessKey: String!
+	secretKey: String!
+	endpoint: String!
+}
+
+type S3Credentials {
+	accessKey: String!
+	secretKey: String!
+	endpoint: String!
+}
+
+type SOARecord implements Node & DNSRecordInterface {
+	"""
+	Primary master name server for this zone.
+	"""
+	mname: String!
+	"""
+	Email address of the administrator responsible for this zone.
+	"""
+	rname: String!
+	"""
+	A slave name server will initiate a zone transfer if this serial is incremented.
+	"""
+	serial: BigInt!
+	"""
+	Number of seconds after which secondary name servers should query the master to detect zone changes.
+	"""
+	refresh: BigInt!
+	"""
+	Number of seconds after which secondary name servers should retry to request the serial number from the master if the master does not respond.
+	"""
+	retry: BigInt!
+	"""
+	Number of seconds after which secondary name servers should stop answering request for this zone if the master does not respond.
+	"""
+	expire: BigInt!
+	"""
+	Time to live for purposes of negative caching.
+	"""
+	minimum: BigInt!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type SRVRecord implements Node & DNSRecordInterface {
+	"""
+	The symbolic name of the desired service.
+	"""
+	service: String!
+	"""
+	The transport protocol of the desired service, usually either TCP or UDP.
+	"""
+	protocol: String!
+	"""
+	The priority of the target host, lower value means more preferred.
+	"""
+	priority: Int!
+	"""
+	A relative weight for records with the same priority, higher value means higher chance of getting picked.
+	"""
+	weight: Int!
+	port: Int!
+	"""
+	The canonical hostname of the machine providing the service, ending in a dot.
+	"""
+	target: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type SSHFPRecord implements Node & DNSRecordInterface {
+	algorithm: DnsmanagerSshFingerprintRecordAlgorithmChoices!
+	type: DnsmanagerSshFingerprintRecordTypeChoices!
+	fingerprint: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+type SchemaInfo {
+	"""
+	Download link for graphql schema
+	"""
+	downloadUrl: String!
+	"""
+	SHA256 hash of the schema data
+	"""
+	SHA256Hash: String!
+	"""
+	Timestamp when the schema was last updated
+	"""
+	lastUpdated: DateTime!
+}
+
+type SearchConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [SearchEdge!]!
+	totalCount: Int!
+}
+
+"""
+A Relay edge containing a `Search` and its cursor.
+"""
+type SearchEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: SearchResult!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+enum SearchKind {
+	PACKAGE
+	NAMESPACE
+	USER
+}
+
+enum SearchOrderSort {
+	ASC
+	DESC
+}
+
+enum SearchPublishDate {
+	LAST_DAY
+	LAST_WEEK
+	LAST_MONTH
+	LAST_YEAR
+}
+
+union SearchResult = PackageVersion | User | Namespace | DeployApp | BlogPost | AppTemplate
+
+"""
+Deprecated: use EnvVar for persisted app environment variables.
+"""
+type Secret implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	sensitive: Boolean!
+	value: String
 }
 
 type SecretConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [SecretEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [SecretEdge!]!
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-"""A Relay edge containing a `Secret` and its cursor."""
+"""
+A Relay edge containing a `Secret` and its cursor.
+"""
 type SecretEdge {
-  """The item at the end of the edge"""
-  node: Secret
-
-  """A cursor for use in pagination"""
-  cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: Secret!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type Secret implements Node {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  name: String!
-
-  """The ID of the object"""
-  id: ID!
+"""
+Deprecated for persisted app environment variables; use EnvVarUpdate.
+"""
+input SecretInput {
+	"""
+	Name of the secret.
+	"""
+	name: String!
+	"""
+	Value of the secret.
+	"""
+	value: String!
+	"""
+	Whether the secret value should be hidden from GraphQL.
+	"""
+	sensitive: Boolean = false
 }
 
-type AppDatabaseConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [AppDatabaseEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+"""
+Deprecated: use EnvVarLog for persisted app environment variable logs.
+"""
+type SecretLog implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	action: DeploySecretLogActionChoices!
+	secretName: String!
 }
 
-"""A Relay edge containing a `AppDatabase` and its cursor."""
-type AppDatabaseEdge {
-  """The item at the end of the edge"""
-  node: AppDatabase
-
-  """A cursor for use in pagination"""
-  cursor: String!
+type SecretLogConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [SecretLogEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-type AppDatabase implements Node {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  name: String!
-  username: String!
-  app: DeployApp!
-
-  """The ID of the object"""
-  id: ID!
-  host: String!
-  port: String!
-  phpmyadminUrl: String
-  dbExplorerUrl: String
-  password: String
+"""
+A Relay edge containing a `SecretLog` and its cursor.
+"""
+type SecretLogEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: SecretLog!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type UsageMetric {
-  variant: MetricType!
-  value: Float!
-  unit: MetricUnit!
-  timestamp: DateTime!
+input SeePendingNotificationsInput {
+	clientMutationId: String
 }
 
-"""An enumeration."""
-enum MetricType {
-  cpu_time
-  memory_time
-  network_egress
-  network_ingress
-  no_of_requests
-  no_of_failed_requests
-  cost
+type SeePendingNotificationsPayload {
+	clientMutationId: String
+	success: Boolean
 }
 
-"""Units for metrics"""
-enum MetricUnit {
-  """represents the unit of "seconds"."""
-  SEC
-
-  """represents the unit of "milliseconds"."""
-  MS
-
-  """represents the unit of "hours"."""
-  hours
-
-  """represents the unit of "kilobytes"."""
-  KB
-
-  """represents the unit of "bytes"."""
-  Bytes
-
-  """represents the unit of "kilobytes per second"."""
-  KBS
-
-  """represents the unit of "number of requests"."""
-  NO_REQUESTS
-
-  """represents the unit of "cost" in USD."""
-  DOLLARS
+input SendAppEmailInput {
+	appId: ID!
+	fromEmailId: ID
+	fromAddress: String
+	to: [String!]!
+	cc: [String!]
+	bcc: [String!]
+	replyTo: String
+	subject: String!
+	textBody: String
+	htmlBody: String
+	rawMessage: Upload
+	clientMutationId: String
 }
 
-"""Groupings for metrics"""
-enum MetricGrouping {
-  BY_15_MINUTES
-  BY_5_MINUTES
-  BY_HOUR
-  BY_DAY
-  BY_WEEK
+type SendAppEmailPayload {
+	clientMutationId: String
+	success: Boolean!
+	message: EmailMessage!
+}
+
+input SetAppDefaultAliasInput {
+	"""
+	ID of the domain to set as the default.
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Set the requested default domain for an app.
+"""
+type SetAppDefaultAliasPayload {
+	clientMutationId: String
+	domain: AppAlias!
+	success: Boolean!
+}
+
+input SetDefaultPaymentMethodInput {
+	paymentMethod: ID!
+	clientMutationId: String
+}
+
+"""
+Set a payment method as default for the user.
+"""
+type SetDefaultPaymentMethodPayload {
+	clientMutationId: String
+	success: Boolean!
+	billing: Billing!
+}
+
+type Signature {
+	id: ID!
+	publicKey: PublicKey!
+	data: String!
+	createdAt: DateTime!
+}
+
+type SignedUrl {
+	url: String!
+}
+
+type SocialAuth implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	user: User!
+	provider: String!
+	uid: String!
+	extraData: JSONString!
+	created: DateTime!
+	modified: DateTime!
+	username: String!
+}
+
+input SocialAuthJWTInput {
+	provider: String!
+	accessToken: String!
+	register: Boolean = false
+	registerIntent: String
+	fingerprintVisitorId: String
+	enterProTrial: Boolean
+	response: JSONString
+	clientMutationId: String
+}
+
+type SocialAuthJWTPayload {
+	social: SocialAuth
+	token: String
+	clientMutationId: String
+}
+
+enum SshAuthenticationMethod {
+	PASSWORD
+	PUBLIC_KEY
+}
+
+"""
+A public key authorised for a specific SSH user.
+"""
+type SshAuthorizedKey implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	sshUser: SshUser!
+	name: String
+	publicKey: String!
+	createdBy: User!
+}
+
+type SshAuthorizedKeyConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [SshAuthorizedKeyEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `SshAuthorizedKey` and its cursor.
+"""
+type SshAuthorizedKeyEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: SshAuthorizedKey
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type SshUser implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	username: String!
+	sftpRootFolder: String!
+	authorizedKeys(offset: Int, before: String, after: String, first: Int, last: Int): SshAuthorizedKeyConnection!
+	port: Int!
+	serverHost: String!
+	authenticationMethods: [SshAuthenticationMethod]!
+}
+
+type SshUserConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [SshUserEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `SshUser` and its cursor.
+"""
+type SshUserEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: SshUser
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+enum StatusEnum {
+	SUCCESS
+	WORKING
+	RUNNING
+	FAILED
+	QUEUED
+	TIMEOUT
+	INTERNAL_ERROR
+	CANCELLED
+}
+
+type StripeCheckout {
+	url: String!
+	expiresAt: DateTime!
+	clientSecret: String!
+}
+
+type StripeCustomer {
+	id: ID!
+}
+
+type Subscription {
+	logAdded(appId: ID, appVersionId: ID, instanceId: ID, textSearch: String): Log!
+	autobuildDeployment(buildId: UUID!): AutobuildLog
+	generateScreenshot(
+		"""
+		App version ID
+		"""
+		appVersionId: ID!,
+		"""
+		Force generation
+		"""
+		forceGeneration: Boolean = false
+	): DeployAppVersion!
+	streamLogs(
+		"""
+		Specify the app to show logs for. Alternatively, you can also just specify the app version if you want. If both app and app-version are specified, then the app-version must be associated with specified app.
+		"""
+		appId: ID,
+		"""
+		Filter logs for app to a certain app version.
+		"""
+		appVersionId: ID,
+		"""
+		Get logs starting from this timestamp. Takes ISO timestamp in UTC timezone.
+		"""
+		startingFromISO: DateTime,
+		"""
+		Fetch logs until this timestamp. Takes ISO timestamp in UTC timezone. If specified, the subscription will at this time.
+		"""
+		untilISO: DateTime,
+		"""
+		Filter logs by stream
+		"""
+		streams: [LogStream],
+		"""
+		Filter logs by instance ids
+		"""
+		instanceIds: [String],
+		"""
+		Filter logs by request ID
+		"""
+		requestId: String,
+		"""
+		Search logs for this term
+		"""
+		searchTerm: String
+	): Log!
+	waitOnRepoCreation(repoId: ID!): Boolean!
+	appIsPublishedFromRepo(repoId: ID!): DeployAppVersion!
+	runEdgeJob(command: String!, appVersionId: ID!, envVars: [SecretInput], source: String, cliArgs: [String]): Boolean
+	fetchBuildLogs(buildId: String!): String!
+	timeout: Int
+	packageVersionCreated(publishedBy: ID, ownerId: ID): PackageVersion!
+	"""
+	Subscribe to package version ready
+	"""
+	packageVersionReady(packageVersionId: ID!): PackageVersionReadyResponse!
+	userNotificationCreated(userId: ID!): UserNotificationCreated!
+}
+
+input SyncNotionBlogPostsInput {
+	clientMutationId: String
+	force: Boolean
+}
+
+"""
+Sync all blog posts from Notion to the database.
+"""
+type SyncNotionBlogPostsPayload {
+	syncedCount: Int!
+	createdCount: Int!
+	updatedCount: Int!
+	errors: [String!]
+	clientMutationId: String
+}
+
+type TXTRecord implements Node & DNSRecordInterface {
+	data: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	ttl: Int!
+	dnsClass: String
+	text: String!
+	domain: DNSDomain!
+}
+
+input TagPackageReleaseInput {
+	packageReleaseId: ID!
+	version: String!
+	name: String
+	manifest: String
+	namespace: String
+	description: String
+	license: String
+	licenseFile: String
+	readme: String
+	repository: String
+	homepage: String
+	signature: InputSignature
+	"""
+	The package icon
+	"""
+	icon: String
+	private: Boolean = false
+	clientMutationId: String
+}
+
+type TagPackageReleasePayload {
+	success: Boolean!
+	clientMutationId: String
+	packageVersion: PackageVersion
+}
+
+type TemplateFramework implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	slug: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+}
+
+type TemplateFrameworkConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [TemplateFrameworkEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `TemplateFramework` and its cursor.
+"""
+type TemplateFrameworkEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TemplateFramework!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type TemplateLanguage implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	name: String!
+	slug: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+}
+
+type TemplateLanguageConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [TemplateLanguageEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+}
+
+"""
+A Relay edge containing a `TemplateLanguage` and its cursor.
+"""
+type TemplateLanguageEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TemplateLanguage!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+type TermsOfService implements Node {
+	content: String!
+	createdAt: DateTime!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	viewerHasAccepted: Boolean!
 }
 
 input TimeRangeInput {
-  """Start of the time range."""
-  fromDt: DateTime!
+	"""
+	Start of the time range.
+	"""
+	fromDt: DateTime!
+	"""
+	End of the time range.
+	"""
+	toDt: DateTime
+}
 
-  """End of the time range."""
-  toDt: DateTime
+input ToggleCronJobInput {
+	"""
+	CronJob ID
+	"""
+	cronJobId: ID!
+	enabled: Boolean!
+	clientMutationId: String
+}
+
+type ToggleCronJobPayload {
+	clientMutationId: String
+	app: DeployApp!
+	cronJob: CronJob!
+}
+
+input ToggleForceHTTPSInput {
+	"""
+	App ID
+	"""
+	id: ID!
+	clientMutationId: String
+}
+
+"""
+Toggle HTTP redirect for the active version of app
+"""
+type ToggleForceHTTPSPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+input ToggleSshServerInput {
+	"""
+	App ID
+	"""
+	appId: ID!
+	enabled: Boolean!
+	clientMutationId: String
+}
+
+"""
+Enable or disable the SSH server capability on an app.
+"""
+type ToggleSshServerPayload {
+	clientMutationId: String
+	app: DeployApp!
+	sshServer: AppSshServer!
 }
 
 """
@@ -1291,4772 +7240,1145 @@ character sequences.
 """
 scalar URL
 
-type S3Credentials {
-  accessKey: String!
-  secretKey: String!
-  endpoint: String!
-}
-
-"""An enumeration."""
-enum AppScreenshotViewportSize {
-  MOBILE
-  DESKTOP
-}
-
-"""An enumeration."""
-enum AppScreenshotAppearance {
-  LIGHT
-  DARK
-}
-
-type DeploymentConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [DeploymentEdge]!
-}
-
-"""A Relay edge containing a `Deployment` and its cursor."""
-type DeploymentEdge {
-  """The item at the end of the edge"""
-  node: Deployment
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-union Deployment = NakedDeployment | AutobuildRepository
-
-type NakedDeployment implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  appVersion: DeployAppVersion
-}
-
-type AutobuildRepository implements Node {
-  """The ID of the object"""
-  id: ID!
-  appVersion: DeployAppVersion
-  buildId: UUID!
-  buildCmd: String
-  installCmd: String
-  user: User!
-  name: String!
-  namespace: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  appName: String
-  repoUrl: String!
-  prevCommitHash: String
-  commitHash: String!
-  commitMessage: String!
-  commitAuthorUsername: String!
-  reference: String
-  status: StatusEnum!
-  logUrl: String
-  commitUrl: String
-  buildConfiguration: BuildConfiguration
-}
-
 """
 Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
 in fields, resolvers and input.
 """
 scalar UUID
 
-enum StatusEnum {
-  SUCCESS
-  WORKING
-  RUNNING
-  FAILED
-  QUEUED
-  TIMEOUT
-  INTERNAL_ERROR
-  CANCELLED
-}
-
-type BuildConfiguration implements Node {
-  kind: BuildKind
-  startCmd: String
-  buildCmd: String
-  installCmd: String
-
-  """The ID of the object"""
-  id: ID!
-  name: String
-  repo: String @deprecated(reason: "This field is deprecated and return null always.")
-  repoName: String @deprecated(reason: "This field is deprecated and return null always.")
-  repoNamespace: String @deprecated(reason: "This field is deprecated and return null always.")
-  completionTimeInSeconds: Int! @deprecated(reason: "This field is deprecated and return null always.")
-  setupDb: Boolean! @deprecated(reason: "This field is deprecated and return null always.")
-}
-
-type BuildKind implements Node {
-  name: String!
-  provider: String!
-  config: JSONString!
-
-  """The ID of the object"""
-  id: ID!
-  setupDb: Boolean @deprecated(reason: "This field is deprecated and return null always.")
-  buildCmd: String @deprecated(reason: "This field is deprecated and return null always.")
-  installCmd: String @deprecated(reason: "This field is deprecated and return null always.")
-  startCmd: String @deprecated(reason: "This field is deprecated and return null always.")
-}
-
-type RolloutConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [RolloutEdge]!
-}
-
-"""A Relay edge containing a `Rollout` and its cursor."""
-type RolloutEdge {
-  """The item at the end of the edge"""
-  node: Rollout
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type Rollout implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deployappVersion: DeployAppVersion
-  startCommand: String
-  afterDeployCommand: String
-  buildCommand: String
-  installCommand: String
-  buildId: String
-  status: StatusEnum!
-  logUrl: String
-  buildConfiguration: BuildConfiguration
-  rolloutDetails: RolloutType
-}
-
-union RolloutType = GitHubRollout | ZipRollout | PackageRollout
-
-type GitHubRollout implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  externalId: String
-  rollout: Rollout!
-  branch: String
-  commitHash: String
-  prevCommitHash: String
-  commitMessage: String
-  authorEmail: String
-  authorName: String
-  authorLogin: String
-  repoUrl: String!
-  commitUrl: String
-}
-
-type ZipRollout implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  externalId: String
-  rollout: Rollout
-  zipFileUrl: String!
-  zipFileHash: String
+input UnbanAppInput {
+	"""
+	ID of app to disable
+	"""
+	appId: ID!
+	clientMutationId: String
+}
+
+"""
+Un-ban app with a reason.
+"""
+type UnbanAppPayload {
+	clientMutationId: String
+	app: DeployApp!
+}
+
+input UnlikePackageInput {
+	packageId: ID!
+	clientMutationId: String
+}
+
+type UnlikePackagePayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input UnwatchPackageInput {
+	packageId: ID!
+	clientMutationId: String
+}
+
+type UnwatchPackagePayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input UpdateAPIKeyInput {
+	apiKeyId: ID!
+	name: String
+	note: String
+	clientMutationId: String
+}
+
+type UpdateAPIKeyPayload {
+	apiKey: APIKey!
+	clientMutationId: String
+}
+
+input UpdateAppTemplateInput {
+	templateId: ID!
+	name: String!
+	slug: String!
+	description: String
+	demoUrl: String!
+	repoUrl: String!
+	rootDir: String
+	branch: String
+	category: String!
+	framework: String!
+	language: String
+	isPublic: Boolean!
+	highlighted: Boolean!
+	canDeployWithoutRepo: Boolean!
+	completionTimeInSeconds: String!
+	repoLicense: String!
+	useCases: [String!]
+	readme: String!
+	defaultImageUpload: Upload
+	clientMutationId: String
+}
+
+type UpdateAppTemplatePayload {
+	appTemplate: AppTemplate!
+	clientMutationId: String
+}
+
+input UpdateAutobuildConfigForAppInput {
+	"""
+	The ID of the App
+	"""
+	appId: ID!
+	"""
+	Preset name of the build kind
+	"""
+	presetName: String
+	"""
+	Build command for the app
+	"""
+	buildCmd: String
+	"""
+	Install command for the app
+	"""
+	installCmd: String
+	"""
+	Start command for the app
+	"""
+	startCmd: String
+	"""
+	After deploy command for the app
+	"""
+	afterDeployCmd: String
+	"""
+	Root directory for the app build
+	"""
+	rootDir: String
+	clientMutationId: String
+}
+
+"""
+Update autobuild config for an app.
+"""
+type UpdateAutobuildConfigForAppPayload {
+	clientMutationId: String
+	app: DeployApp!
 }
 
-type PackageRollout implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  externalId: String
-  rollout: Rollout!
-  sourcePackageVersion: PackageVersion
-  sourcePackageRelease: PackageWebc
-}
-
-type AppSshServer implements Node {
-  enabled: Boolean!
-  users(offset: Int, before: String, after: String, first: Int, last: Int): SshUserConnection!
-
-  """The ID of the object"""
-  id: ID!
-}
-
-type SshUserConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [SshUserEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `SshUser` and its cursor."""
-type SshUserEdge {
-  """The item at the end of the edge"""
-  node: SshUser
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type SshUser implements Node {
-  """The ID of the object"""
-  id: ID!
-  username: String!
-  sftpRootFolder: String!
-  authorizedKeys(offset: Int, before: String, after: String, first: Int, last: Int): SshAuthorizedKeyConnection!
-  port: Int!
-  serverHost: String!
-  authenticationMethods: [SshAuthenticationMethod]
-}
-
-type SshAuthorizedKeyConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [SshAuthorizedKeyEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `SshAuthorizedKey` and its cursor."""
-type SshAuthorizedKeyEdge {
-  """The item at the end of the edge"""
-  node: SshAuthorizedKey
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-"""A public key authorised for a specific SSH user."""
-type SshAuthorizedKey implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  sshUser: SshUser!
-  name: String
-  publicKey: String!
-  createdBy: User!
-}
-
-enum SshAuthenticationMethod {
-  PASSWORD
-  PUBLIC_KEY
-}
-
-type AppMail implements Node {
-  emailAddr: String!
-  login: String!
-  passwordSecret: Secret!
-
-  """The ID of the object"""
-  id: ID!
-}
-
-union Kind = WordpressAppKind | MCPServerAppKind
-
-type WordpressAppKind {
-  adminUrl: String!
-  liveConfig(forceFetch: Boolean): WordpressLiveConfig
-  wordpressCronjobEnabled: Boolean!
-}
-
-type WordpressLiveConfig {
-  checkedAt: DateTime!
-  wordpressVersion: String!
-  phpVersion: String!
-  phpArchitecture: String!
-  mysqlServer: String!
-  plugins: [WordPressPlugin]!
-  themes: [WordPressTheme]!
-  isLive: Boolean!
-  usersCount: Int!
-  publishedPostsCount: Int!
-  publishedPagesCount: Int!
-}
-
-type WordPressPlugin {
-  slug: String!
-  name: String!
-  icon: String
-  version: String!
-  latestVersion: String
-  active: Boolean!
-  description: String
-}
-
-type WordPressTheme {
-  slug: String!
-  name: String!
-  version: String!
-  latestVersion: String
-  active: Boolean!
-  description: String
-}
-
-type MCPServerAppKind {
-  url: String!
-  transport: MCPServerTransportEnum
-}
-
-"""An enumeration."""
-enum MCPServerTransportEnum {
-  STDIO
-  STREAMABLE_HTTP
-  SSE
-}
-
-type LogConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [LogEdge]!
-}
-
-"""A Relay edge containing a `Log` and its cursor."""
-type LogEdge {
-  """The item at the end of the edge"""
-  node: Log
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-"""An enumeration."""
-enum LogStream {
-  STDOUT
-  STDERR
-  RUNTIME
-}
-
-type AppVersionVolume {
-  id: ID!
-  name: String!
-  s3Url: String!
-  mountPaths: [AppVersionVolumeMountPath]!
-  size: BigInt
-  usedSize: BigInt
-  explorerUrl: String
-}
-
-type AppVersionVolumeMountPath {
-  path: String!
-  subpath: String
-}
-
-type PackageRolloutConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageRolloutEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageRollout` and its cursor."""
-type PackageRolloutEdge {
-  """The item at the end of the edge"""
-  node: PackageRollout
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type PackageDistribution {
-  """
-  Download URL of the tar.gz file.
-  If the package was published with webc only,this will contain download URL for webc file instead.
-  """
-  downloadUrl: String!
-  expiresInSeconds: Int
-  size: Int
-  piritaDownloadUrl: String
-  piritaExpiresInSeconds: Int
-  piritaSize: Int
-  piritaSha256Hash: String
-  webcDownloadUrl: String
-  webcExpiresInSeconds: Int
-  webcSize: Int
-  webcSha256Hash: String
-  webcVersion: WebcVersion
-  webcManifest: JSONString
-}
-
-type PackageVersionFilesystem {
-  wasm: String!
-  host: String!
-}
-
-type InterfaceVersion implements Node {
-  """The ID of the object"""
-  id: ID!
-  interface: Interface!
-  version: String!
-  content: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  publishedBy: User!
-  packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
-}
-
-type Interface implements Node {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  displayName: String!
-  description: String!
-  homepage: String
-  icon: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  versions(offset: Int, before: String, after: String, first: Int, last: Int): InterfaceVersionConnection!
-  lastVersion: InterfaceVersion
-}
-
-type InterfaceVersionConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [InterfaceVersionEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `InterfaceVersion` and its cursor."""
-type InterfaceVersionEdge {
-  """The item at the end of the edge"""
-  node: InterfaceVersion
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-union PiritaFilesystemItem = PiritaFilesystemFile | PiritaFilesystemDir
-
-type PiritaFilesystemDir {
-  name(display: PiritaFilesystemNameDisplay): String!
-}
-
-type WEBCFilesystemItem {
-  name: String!
-  checksum: String!
-  size: Int!
-  offset: Int!
-}
-
-type PackageVersionBindingConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageVersionBindingEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageVersionBinding` and its cursor."""
-type PackageVersionBindingEdge {
-  """The item at the end of the edge"""
-  node: PackageVersionBinding
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-union PackageVersionBinding = PackageVersionNPMBinding | PackageVersionPythonBinding
-
-type WebcImageConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [WebcImageEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `WebcImage` and its cursor."""
-type WebcImageEdge {
-  """The item at the end of the edge"""
-  node: WebcImage
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type Collection {
-  slug: String!
-  displayName: String!
-  description: String!
-  createdAt: DateTime!
-  banner: String!
-  packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
-}
-
-type AppTemplateConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [AppTemplateEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `AppTemplate` and its cursor."""
-type AppTemplateEdge {
-  """The item at the end of the edge"""
-  node: AppTemplate
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type AppTemplate implements Node {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  slug: String!
-  description: String!
-  demoUrl: String!
-  repoUrl: String!
-  rootDir: String
-  branch: String
-  category: AppTemplateCategory!
-  isPublic: Boolean!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  readme: String!
-  useCases: JSONString!
-  repoLicense: String!
-  usingPackage: Package
-  canDeployWithoutRepo: Boolean!
-  completionTimeInSeconds: Int!
-  highlighted: Boolean!
-  defaultImage: String
-  defaultRepositoryCloneName: String
-  framework: String!
-  templateFramework: TemplateFramework
-  language: String!
-  templateLanguage: TemplateLanguage
-}
-
-type AppTemplateCategory implements Node {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  slug: String!
-  description: String!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  appTemplates(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection!
-}
-
-type TemplateFramework implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  name: String!
-  slug: String!
-}
-
-type TemplateLanguage implements Node {
-  """The ID of the object"""
-  id: ID!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  name: String!
-  slug: String!
-}
-
-type CategoryConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [CategoryEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `Category` and its cursor."""
-type CategoryEdge {
-  """The item at the end of the edge"""
-  node: Category
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type Category implements Node {
-  """The ID of the object"""
-  id: ID!
-
-  """A category is a label that can be attached to a package."""
-  name: String!
-  packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection
-}
-
-type PackageKeywordConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageKeywordEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageKeyword` and its cursor."""
-type PackageKeywordEdge {
-  """The item at the end of the edge"""
-  node: PackageKeyword
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type PackageKeyword implements Node {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-}
-
-type PackageCollaboratorConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageCollaboratorEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageCollaborator` and its cursor."""
-type PackageCollaboratorEdge {
-  """The item at the end of the edge"""
-  node: PackageCollaborator
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type PackageCollaborator implements Node {
-  """The ID of the object"""
-  id: ID!
-  user: User!
-  role: RegistryPackageMaintainerRoleChoices!
-  package: Package!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  invite: PackageCollaboratorInvite
-}
-
-"""An enumeration."""
-enum RegistryPackageMaintainerRoleChoices {
-  """Owner"""
-  OWNER
-
-  """Admin"""
-  ADMIN
-
-  """Editor"""
-  EDITOR
-
-  """Viewer"""
-  VIEWER
-}
-
-type PackageCollaboratorInvite implements Node {
-  """The ID of the object"""
-  id: ID!
-  requestedBy: User!
-  user: User
-  inviteEmail: String
-  package: Package!
-  role: RegistryPackageMaintainerInviteRoleChoices!
-  accepted: PackageCollaborator
-  approvedBy: User
-  declinedBy: User
-  createdAt: DateTime!
-  expiresAt: DateTime!
-  closedAt: DateTime
-}
-
-"""An enumeration."""
-enum RegistryPackageMaintainerInviteRoleChoices {
-  """Owner"""
-  OWNER
-
-  """Admin"""
-  ADMIN
-
-  """Editor"""
-  EDITOR
-
-  """Viewer"""
-  VIEWER
-}
-
-type PackageCollaboratorInviteConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageCollaboratorInviteEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageCollaboratorInvite` and its cursor."""
-type PackageCollaboratorInviteEdge {
-  """The item at the end of the edge"""
-  node: PackageCollaboratorInvite
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-enum GrapheneRole {
-  OWNER
-  ADMIN
-  EDITOR
-  VIEWER
-}
-
-type PackageTransferRequest implements Node {
-  """The ID of the object"""
-  id: ID!
-  requestedBy: User!
-  previousOwnerObjectId: Int!
-  newOwnerObjectId: Int!
-  package: Package!
-  approvedBy: User
-  declinedBy: User
-  createdAt: DateTime!
-  expiresAt: DateTime!
-  closedAt: DateTime
-  previousOwner: PackageOwner!
-  newOwner: PackageOwner!
-}
-
-type PackageSearchConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageSearchEdge]!
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageSearch` and its cursor."""
-type PackageSearchEdge {
-  """The item at the end of the edge"""
-  node: PackageVersion
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type DeployAppConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [DeployAppEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `DeployApp` and its cursor."""
-type DeployAppEdge {
-  """The item at the end of the edge"""
-  node: DeployApp
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-"""An enumeration."""
-enum DeployAppsSortBy {
-  NEWEST
-  OLDEST
-  MOST_ACTIVE
-}
-
-type NamespaceCollaboratorConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [NamespaceCollaboratorEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `NamespaceCollaborator` and its cursor."""
-type NamespaceCollaboratorEdge {
-  """The item at the end of the edge"""
-  node: NamespaceCollaborator
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type PackageTransferRequestConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PackageTransferRequestEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PackageTransferRequest` and its cursor."""
-type PackageTransferRequestEdge {
-  """The item at the end of the edge"""
-  node: PackageTransferRequest
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type DNSDomainConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [DNSDomainEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `DNSDomain` and its cursor."""
-type DNSDomainEdge {
-  """The item at the end of the edge"""
-  node: DNSDomain
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type DNSDomain implements Node {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  name: String!
-
-  """This zone will be accessible at /dns/{slug}/."""
-  slug: String!
-  zoneFile: String!
-
-  """The ID of the object"""
-  id: ID!
-  records: [DNSRecord]
-  owner: Owner!
-}
-
-union DNSRecord = ARecord | AAAARecord | CNAMERecord | TXTRecord | MXRecord | NSRecord | CAARecord | DNAMERecord | PTRRecord | SOARecord | SRVRecord | SSHFPRecord
-
-type ARecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  address: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-interface DNSRecordInterface {
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-}
-
-type AAAARecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  address: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type CNAMERecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-
-  """This domain name will alias to this canonical name."""
-  cName: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type TXTRecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  data: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type MXRecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  preference: Int!
-  exchange: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type NSRecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  nsdname: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type CAARecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  flags: Int!
-  tag: DnsmanagerCertificationAuthorityAuthorizationRecordTagChoices!
-  value: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-"""An enumeration."""
-enum DnsmanagerCertificationAuthorityAuthorizationRecordTagChoices {
-  """issue"""
-  ISSUE
-
-  """issue wildcard"""
-  ISSUEWILD
-
-  """Incident object description exchange format"""
-  IODEF
-}
-
-type DNAMERecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-
-  """
-  This domain name will alias to the entire subtree of that delegation domain.
-  """
-  dName: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type PTRRecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  ptrdname: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type SOARecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-
-  """Primary master name server for this zone."""
-  mname: String!
-
-  """Email address of the administrator responsible for this zone."""
-  rname: String!
-
-  """
-  A slave name server will initiate a zone transfer if this serial is incremented.
-  """
-  serial: BigInt!
-
-  """
-  Number of seconds after which secondary name servers should query the master to detect zone changes.
-  """
-  refresh: BigInt!
-
-  """
-  Number of seconds after which secondary name servers should retry to request the serial number from the master if the master does not respond.
-  """
-  retry: BigInt!
-
-  """
-  Number of seconds after which secondary name servers should stop answering request for this zone if the master does not respond.
-  """
-  expire: BigInt!
-
-  """Time to live for purposes of negative caching."""
-  minimum: BigInt!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type SRVRecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-
-  """The symbolic name of the desired service."""
-  service: String!
-
-  """
-  The transport protocol of the desired service, usually either TCP or UDP.
-  """
-  protocol: String!
-
-  """The priority of the target host, lower value means more preferred."""
-  priority: Int!
-
-  """
-  A relative weight for records with the same priority, higher value means higher chance of getting picked.
-  """
-  weight: Int!
-  port: Int!
-
-  """
-  The canonical hostname of the machine providing the service, ending in a dot.
-  """
-  target: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-type SSHFPRecord implements Node & DNSRecordInterface {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  deletedAt: DateTime
-  algorithm: DnsmanagerSshFingerprintRecordAlgorithmChoices!
-  type: DnsmanagerSshFingerprintRecordTypeChoices!
-  fingerprint: String!
-
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  ttl: Int!
-  dnsClass: String
-  text: String!
-  domain: DNSDomain!
-}
-
-"""An enumeration."""
-enum DnsmanagerSshFingerprintRecordAlgorithmChoices {
-  """RSA"""
-  A_1
-
-  """DSA"""
-  A_2
-
-  """ECDSA"""
-  A_3
-
-  """Ed25519"""
-  A_4
-}
-
-"""An enumeration."""
-enum DnsmanagerSshFingerprintRecordTypeChoices {
-  """SHA-1"""
-  A_1
-
-  """SHA-256"""
-  A_2
-}
-
-"""Usage summary for a specific owner."""
-type OwnerUsageSummary {
-  since: DateTime!
-  cpuTime: Usage!
-  noRequests: Usage!
-  ingress: Usage!
-  egress: Usage!
-  appCount: Usage!
-  buildMinutes: Usage!
-}
-
-"""Individual usage metrics for a specific app."""
+input UpdateBuildConfigInput {
+	appId: ID!
+	presetName: String
+	startCmd: String
+	buildCmd: String
+	installCmd: String
+	afterDeployCmd: String
+	rootDir: String
+	clientMutationId: String
+}
+
+type UpdateBuildConfigPayload {
+	clientMutationId: String
+	buildConfig: BuildConfiguration!
+	success: Boolean!
+}
+
+input UpdateDNSRecordsInput {
+	"""
+	ID of the DNS domain whose records should be changed.
+	"""
+	domainId: ID!
+	records: [DNSRecordUpdate]
+	clientMutationId: String
+}
+
+type UpdateDNSRecordsPayload {
+	clientMutationId: String
+	success: Boolean!
+	records: [DNSRecord!]!
+}
+
+input UpdateEnvVarsInput {
+	"""
+	ID of the app onto which to add environment variables.
+	"""
+	appId: ID!
+	envVars: [EnvVarUpdate]
+	clientMutationId: String
+}
+
+"""
+Create, update, or delete app environment variables on an app with given ID
+"""
+type UpdateEnvVarsPayload {
+	success: Boolean!
+	envVars: [EnvVar!]!
+	clientMutationId: String
+}
+
+input UpdateGithubRepoAppConnectionInput {
+	"""
+	The ID of the GithubRepoConnection.
+
+	Deprecated for app-scoped SDK usage; use `appId` instead.
+	"""
+	connectionId: ID
+	"""
+	The app whose GitHub repo connection should be updated.
+	"""
+	appId: ID
+	deploymentStatusEvents: Boolean
+	pullRequestComments: Boolean
+	"""
+	Optional deploy branch for the app-scoped GitHub repo connection.
+	"""
+	deployBranch: String
+	clientMutationId: String
+}
+
+type UpdateGithubRepoAppConnectionPayload {
+	clientMutationId: String
+	githubRepoConnection: GithubRepoConnection!
+	success: Boolean!
+}
+
+input UpdateNamespaceCollaboratorInviteRoleInput {
+	namespaceCollaboratorInviteId: ID!
+	role: GrapheneRole!
+	clientMutationId: String
+}
+
+type UpdateNamespaceCollaboratorInviteRolePayload {
+	collaboratorInvite: NamespaceCollaboratorInvite!
+	clientMutationId: String
+}
+
+input UpdateNamespaceCollaboratorRoleInput {
+	namespaceCollaboratorId: ID!
+	role: GrapheneRole!
+	clientMutationId: String
+}
+
+type UpdateNamespaceCollaboratorRolePayload {
+	collaborator: NamespaceCollaborator!
+	clientMutationId: String
+}
+
+input UpdateNamespaceInput {
+	namespaceId: ID!
+	"""
+	The namespace slug name
+	"""
+	name: String
+	"""
+	The namespace display name
+	"""
+	displayName: String
+	"""
+	The namespace description
+	"""
+	description: String
+	"""
+	The namespace avatar
+	"""
+	avatar: String @deprecated(reason: "Use `avatarUpload` instead")
+	"""
+	The namespace avatar
+	"""
+	avatarUpload: Upload
+	"""
+	The user Twitter (it can be the url, or the handle with or without the @)
+	"""
+	twitter: String
+	"""
+	The user Github (it can be the url, or the handle with or without the @)
+	"""
+	github: String
+	"""
+	The user website (it must be a valid url)
+	"""
+	websiteUrl: String
+	clientMutationId: String
+}
+
+type UpdateNamespacePayload {
+	namespace: Namespace!
+	clientMutationId: String
+}
+
+input UpdatePackageCollaboratorInviteRoleInput {
+	packageCollaboratorInviteId: ID!
+	role: GrapheneRole!
+	clientMutationId: String
+}
+
+type UpdatePackageCollaboratorInviteRolePayload {
+	clientMutationId: String
+	collaboratorInvite: PackageCollaboratorInvite!
+}
+
+input UpdatePackageCollaboratorRoleInput {
+	packageCollaboratorId: ID!
+	role: GrapheneRole!
+	clientMutationId: String
+}
+
+type UpdatePackageCollaboratorRolePayload {
+	clientMutationId: String
+	collaborator: PackageCollaborator!
+}
+
+input UpdatePackageInput {
+	packageId: ID!
+	"""
+	The package icon
+	"""
+	icon: String @deprecated(reason: "Use `iconUpload` instead")
+	"""
+	The package icon
+	"""
+	iconUpload: Upload
+	clientMutationId: String
+}
+
+type UpdatePackagePayload {
+	clientMutationId: String
+	package: Package!
+}
+
+input UpdateUserInfoInput {
+	"""
+	The user id
+	"""
+	userId: ID
+	"""
+	The user full name
+	"""
+	fullName: String
+	"""
+	The user bio
+	"""
+	bio: String
+	"""
+	The user avatar
+	"""
+	avatar: String @deprecated(reason: "Use `avatarUpload` instead")
+	"""
+	The user avatar
+	"""
+	avatarUpload: Upload
+	"""
+	The user Twitter (it can be the url, or the handle with or without the @)
+	"""
+	twitter: String
+	"""
+	The user Github (it can be the url, or the handle with or without the @)
+	"""
+	github: String
+	"""
+	The user website (it must be a valid url)
+	"""
+	websiteUrl: String
+	"""
+	The user location
+	"""
+	location: String
+	clientMutationId: String
+}
+
+type UpdateUserInfoPayload {
+	clientMutationId: String
+	user: User
+}
+
+input UpdateVolumeInput {
+	"""
+	App Volume ID
+	"""
+	id: ID!
+	"""
+	Volume mount path
+	"""
+	mountPath: String
+	"""
+	Volume max size in bytes
+	"""
+	maxSizeBytes: BigInt
+	"""
+	Whether the S3 endpoint is enabled
+	"""
+	s3Enabled: Boolean
+	"""
+	Whether to redeploy the active app version after workload changes
+	"""
+	redeployApp: Boolean
+	clientMutationId: String
+}
+
+"""
+Update an app volume.
+"""
+type UpdateVolumePayload {
+	clientMutationId: String
+	volume: AppVolume!
+	success: Boolean!
+	redeployedApp: Boolean!
+}
+
+"""
+A multipart file upload
+"""
+scalar Upload
+
+"""
+An enumeration.
+"""
+enum UploadFormat {
+	targz
+	webcv2
+	webcv3
+}
+
+input UpsertAppDomainInput {
+	"""
+	ID of the app onto which to add secrets.
+	"""
+	appId: ID!
+	"""
+	ID of the domain to upsert.
+	"""
+	id: ID
+	"""
+	Name of the secret.
+	"""
+	name: String!
+	"""
+	Whether this domain should become the app's selected default domain.
+	"""
+	isDefault: Boolean = false
+	"""
+	Redirection rules for this domain
+	"""
+	redirection: AppDomainRedirectRules = null
+	"""
+	Wait for the domain to become available before returning.
+	"""
+	wait: Boolean = true
+	clientMutationId: String
+}
+
+"""
+Create or update an app domain on an app with given ID
+"""
+type UpsertAppDomainPayload {
+	clientMutationId: String
+	"""
+	List of domains generated by the mutation
+	"""
+	domains: [AppAlias!]!
+	success: Boolean!
+}
+
+input UpsertAppSecretInput {
+	"""
+	ID of the app onto which to add secrets.
+	"""
+	appId: ID!
+	"""
+	Name of the secret.
+	"""
+	name: String!
+	"""
+	Value of the secret.
+	"""
+	value: String!
+	"""
+	Whether the secret value should be hidden from GraphQL.
+	"""
+	sensitive: Boolean = false
+	clientMutationId: String
+}
+
+"""
+Deprecated: use UpdateEnvVars.
+"""
+type UpsertAppSecretPayload {
+	secret: Secret!
+	success: Boolean!
+	clientMutationId: String
+}
+
+input UpsertAppSecretsInput {
+	"""
+	ID of the app onto which to add secrets.
+	"""
+	appId: ID!
+	secrets: [SecretInput]
+	clientMutationId: String
+}
+
+"""
+Deprecated: use UpdateEnvVars.
+"""
+type UpsertAppSecretsPayload {
+	success: Boolean!
+	secrets: [Secret!]!
+	clientMutationId: String
+}
+
+input UpsertDNSRecordInput {
+	kind: RecordKind!
+	domainId: String!
+	name: String!
+	value: String!
+	ttl: Int
+	recordId: String
+	mx: DNSMXExtraInput
+	soa: DNSSOAExtraInput
+	srv: DNSSRVExtraInput
+	caa: DNSCAAExtraInput
+	sshfp: DNSSSHFPExtraInput
+	clientMutationId: String
+}
+
+type UpsertDNSRecordPayload {
+	clientMutationId: String
+	success: Boolean!
+	record: DNSRecord!
+}
+
+input UpsertDomainFromZoneFileInput {
+	zoneFile: String!
+	deleteMissingRecords: Boolean
+	clientMutationId: String
+}
+
+type UpsertDomainFromZoneFilePayload {
+	success: Boolean!
+	clientMutationId: String
+	domain: DNSDomain!
+}
+
+input UpsertVaultInput {
+	"""
+	YAML Configuration for vault
+	"""
+	config: String!
+	clientMutationId: String
+}
+
+"""
+Create a new vault from yaml config
+"""
+type UpsertVaultPayload {
+	vault: Vault!
+	clientMutationId: String
+}
+
+"""
+Individual usage metrics for a specific app.
+"""
 type Usage {
-  used: Int!
-  max: Int
-  charge: MoneyType!
-  usedPercent: Float!
-  unit: String
-  nearingLimits: Boolean!
+	used: Int!
+	max: Int
+	charge: MoneyType!
+	usedPercent: Float!
+	unit: String
+	nearingLimits: Boolean!
 }
 
-type MoneyType {
-  amount: String
-  currency: String
+type UsageMetric {
+	variant: MetricType!
+	value: Float!
+	unit: MetricUnit!
+	timestamp: DateTime!
 }
 
-type APITokenConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [APITokenEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
+type UsageMetrics {
+	startAt: DateTime!
+	endAt: DateTime!
+	totals: MetricsTotals!
+	grouped: [GroupedUsageMetrics!]!
 }
 
-"""A Relay edge containing a `APIToken` and its cursor."""
-type APITokenEdge {
-  """The item at the end of the edge"""
-  node: APIToken
-
-  """A cursor for use in pagination"""
-  cursor: String!
+type User implements PackageOwner & Owner & Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	firstName: String!
+	lastName: String!
+	email: String!
+	dateJoined: DateTime!
+	probationStartedAt: DateTime
+	"""
+	Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
+	"""
+	username: String!
+	registerIntent: String
+	isEmailValidated: Boolean!
+	isEmailAcceptable: Boolean!
+	pendingVerifications: [PendingVerification!]!
+	bio: String
+	location: String
+	websiteUrl: String
+	wasmerInternal: Boolean!
+	globalName: String!
+	globalId: ID!
+	viewerCan(action: OwnerAction!): Boolean!
+	isPro: Boolean!
+	avatar(size: Int = 80): String!
+	limitState: LimitState!
+	isViewer: Boolean!
+	hasUsablePassword: Boolean
+	fullName: String!
+	githubUrl: String
+	twitterUrl: String
+	companyRole: String
+	companyDescription: String
+	publicActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+	billing: Billing
+	waitlist(name: String!): WaitlistMember
+	namespaces(role: GrapheneRole, offset: Int, before: String, after: String, first: Int, last: Int): NamespaceConnection!
+	packages(collaborating: Boolean = false, offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection!
+	apps(collaborating: Boolean = false, sortBy: DeployAppsSortBy, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
+	usageMetrics(		variant: MetricType!,		grouping: MetricGrouping,
+		"""
+		List of app IDs. Metrics gets filtered for the specific apps.
+		"""
+		appIds: [ID],
+		"""
+		Optional time range filter.
+		"""
+		timeRange: TimeRangeInput
+	): [UsageMetric]!
+	groupedMetrics(startAt: DateTime!, endAt: DateTime!, groupedBy: MetricGrouping!): UsageMetrics!
+	domains(offset: Int, before: String, after: String, first: Int, last: Int): DNSDomainConnection!
+	sentEmails(first: Int, after: String, last: Int, before: String): EmailMessageConnection!
+	receivedEmails(first: Int, after: String, last: Int, before: String): EmailMessageConnection!
+	isStaff: Boolean
+	packageVersions(offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
+	packageTransfersIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageTransferRequestConnection!
+	packageInvitesIncoming(offset: Int, before: String, after: String, first: Int, last: Int): PackageCollaboratorInviteConnection!
+	namespaceInvitesIncoming(offset: Int, before: String, after: String, first: Int, last: Int): NamespaceCollaboratorInviteConnection!
+	apiTokens(offset: Int, before: String, after: String, first: Int, last: Int): APITokenConnection!
+	notifications(offset: Int, before: String, after: String, first: Int, last: Int): UserNotificationConnection!
+	dashboardActivity(offset: Int, before: String, after: String, first: Int, last: Int): ActivityEventConnection!
+	loginMethods: [LoginMethod!]!
+	githubUser: SocialAuth
+	githubScopes: [String]! @deprecated(reason: "Please use github installations instead.")
+	githubRepositories: [GithubInstallationRepository]! @deprecated(reason: "Please use github installations instead.")
+	githubInstallationExists: Boolean! @deprecated(reason: "Please use github installations instead.")
+	githubInstallations: [GithubAppInstallation!]
+	currentUsage(
+		"""
+		List of app IDs. Usage gets filtered for the specific apps.
+		"""
+		appIds: [ID],
+		"""
+		Optional time range filter.
+		"""
+		timeRange: TimeRangeInput
+	): OwnerUsageSummary
+	emailUsage: EmailUsageSummary
 }
 
-type APIToken implements Node {
-  user: User!
-  identifier: String
-  createdAt: DateTime!
-  revokedAt: DateTime
-  lastUsedAt: DateTime
-  nonceSet(offset: Int, before: String, after: String, first: Int, last: Int): NonceConnection!
-
-  """The ID of the object"""
-  id: ID!
+type UserConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [UserEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-type NonceConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [NonceEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `Nonce` and its cursor."""
-type NonceEdge {
-  """The item at the end of the edge"""
-  node: Nonce
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type Nonce implements Node {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  callbackUrl: String!
-  createdAt: DateTime!
-  isValidated: Boolean!
-  secret: String!
-  token: String!
-  expired: Boolean!
-  authUrl: String!
-}
-
-type UserNotificationConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [UserNotificationEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-  hasPendingNotifications: Boolean!
-  pendingNotificationsCount: Int!
-}
-
-"""A Relay edge containing a `UserNotification` and its cursor."""
-type UserNotificationEdge {
-  """The item at the end of the edge"""
-  node: UserNotification
-
-  """A cursor for use in pagination"""
-  cursor: String!
+"""
+A Relay edge containing a `User` and its cursor.
+"""
+type UserEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: User!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 type UserNotification implements Node {
-  """The ID of the object"""
-  id: ID!
-  icon: String
-  body: EventBody!
-  seenState: UserNotificationSeenState!
-  kind: UserNotificationKind
-  createdAt: DateTime!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	icon: String
+	body: EventBody!
+	seenState: UserNotificationSeenState!
+	kind: UserNotificationKind
+	createdAt: DateTime!
 }
 
-enum UserNotificationSeenState {
-  UNSEEN
-  SEEN
-  SEEN_AND_READ
+type UserNotificationConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [UserNotificationEdge!]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
+	hasPendingNotifications: Boolean!
+	pendingNotificationsCount: Int!
+}
+
+type UserNotificationCreated {
+	notification: UserNotification
+	notificationDeletedId: ID
+}
+
+"""
+A Relay edge containing a `UserNotification` and its cursor.
+"""
+type UserNotificationEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: UserNotification!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
 union UserNotificationKind = UserNotificationKindPublishedPackageVersion | UserNotificationKindIncomingPackageTransfer | UserNotificationKindIncomingPackageInvite | UserNotificationKindIncomingNamespaceInvite | UserNotificationKindValidateEmail
 
-type UserNotificationKindPublishedPackageVersion {
-  packageVersion: PackageVersion!
-}
-
 type UserNotificationKindIncomingNamespaceInvite {
-  namespaceInvite: NamespaceCollaboratorInvite!
-}
-
-type UserNotificationKindValidateEmail {
-  user: User!
-}
-
-"\n    Enum of ways a user can login. One user can have many login methods\n    associated with their account.\n    "
-enum LoginMethod {
-  GOOGLE
-  GITHUB
-  PASSWORD
-}
-
-"""An enumeration."""
-enum PendingVerification {
-  VALIDATE_EMAIL
-  FINGERPRINT
-}
-
-type SocialAuth implements Node {
-  """The ID of the object"""
-  id: ID!
-  user: User!
-  provider: String!
-  uid: String!
-  extraData: JSONString!
-  created: DateTime!
-  modified: DateTime!
-  username: String!
-}
-
-type Signature {
-  id: ID!
-  publicKey: PublicKey!
-  data: String!
-  createdAt: DateTime!
-}
-
-type StripeCustomer {
-  id: ID!
-}
-
-type Billing {
-  stripeCustomer: StripeCustomer!
-  payments: [PaymentIntent]! @deprecated(reason: "Use `payment_connection` instead")
-  subscriptions: [WasmerSubscription]!
-  paymentMethods: [PaymentMethod]! @deprecated(reason: "Use `payment_connection` instead")
-  paymentConnection(offset: Int, before: String, after: String, first: Int, last: Int): PaymentIntentConnection!
-  paymentMethodConnection(offset: Int, before: String, after: String, first: Int, last: Int): CardPaymentMethodConnection!
-}
-
-type PaymentIntent implements Node {
-  """The datetime this object was created in stripe."""
-  created: DateTime
-
-  """The ID of the object"""
-  id: ID!
-  amount: String!
-  currency: String!
-  status: String!
-  invoicePdfUrl: String
-}
-
-type WasmerSubscription implements Node {
-  """The datetime this object was created in stripe."""
-  created: DateTime
-
-  """The ID of the object"""
-  id: ID!
-  cancelAt: DateTime
-  canceledAt: DateTime
-  currentPeriodEnd: DateTime
-  currentPeriodStart: DateTime
-  daysUntilDue: Int
-  endedAt: DateTime
-  startDate: DateTime
-  status: String
-  trialEnd: DateTime
-  trialStart: DateTime
-  description: String
-  cancelAtPeriodEnd: Boolean
-}
-
-union PaymentMethod = CardPaymentMethod
-
-type CardPaymentMethod implements Node {
-  """The ID of the object"""
-  id: ID!
-  brand: CardBrand!
-  country: String!
-  expMonth: Int!
-  expYear: Int!
-  funding: CardFunding!
-  last4: String!
-  isDefault: Boolean!
-}
-
-"""
-Card brand.
-
-Can be amex, diners, discover, jcb, mastercard, unionpay, visa, or unknown.
-"""
-enum CardBrand {
-  AMEX
-  DINERS
-  DISCOVER
-  JCB
-  MASTERCARD
-  UNIONPAY
-  VISA
-  UNKNOWN
-}
-
-"""
-Card funding type.
-
-Can be credit, debit, prepaid, or unknown.
-"""
-enum CardFunding {
-  CREDIT
-  DEBIT
-  PREPAID
-  UNKNOWN
-}
-
-type PaymentIntentConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [PaymentIntentEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `PaymentIntent` and its cursor."""
-type PaymentIntentEdge {
-  """The item at the end of the edge"""
-  node: PaymentIntent
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type CardPaymentMethodConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [CardPaymentMethodEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `CardPaymentMethod` and its cursor."""
-type CardPaymentMethodEdge {
-  """The item at the end of the edge"""
-  node: CardPaymentMethod
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type Payment {
-  id: ID
-  amount: String
-  paidOn: DateTime
-}
-
-"""Log entry for deploy app."""
-type Log {
-  """Timestamp in nanoseconds"""
-  timestamp: Float!
-
-  """ISO 8601 string in UTC"""
-  datetime: DateTime!
-
-  """Log message"""
-  message: String!
-
-  """Log stream"""
-  stream: LogStream
-
-  """ID of instance from which the log was generated"""
-  instanceId: String!
-}
-
-"""This is for backwards compatibility with the old PackageInstance type."""
-interface PackageInstance {
-  piritaManifest: JSONString
-  piritaOffsets: JSONString
-  piritaVolumes: JSONString
-  isArchived: Boolean!
-  clientName: String
-  publishedBy: User!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  package: Package!
-  webc: WebcImage
-  webcV3: WebcImage
-  tag: String!
-}
-
-type UserNotificationKindIncomingPackageTransfer {
-  packageTransferRequest: PackageTransferRequest!
+	namespaceInvite: NamespaceCollaboratorInvite!
 }
 
 type UserNotificationKindIncomingPackageInvite {
-  packageInvite: PackageCollaboratorInvite!
+	packageInvite: PackageCollaboratorInvite!
 }
 
-input DeploymentV1 {
-  name: String!
-  workload: WorkloadV1!
+type UserNotificationKindIncomingPackageTransfer {
+	packageTransferRequest: PackageTransferRequest!
 }
 
-input WorkloadV1 {
-  capability: CapabilityMapV1
-  name: String = null
-  runner: WorkloadRunnerV1!
+type UserNotificationKindPublishedPackageVersion {
+	packageVersion: PackageVersion!
 }
 
-input AppV1Spec {
-  aliases: [String] = []
-  workload: WorkloadV2!
+type UserNotificationKindValidateEmail {
+	user: User!
 }
 
-input WorkloadV2 {
-  source: String!
-}
-
-input CapabilityCpuV1 {
-  maximumThreads: Int
-  maximumUsage: Int
-}
-
-input FileSystemPermissionsV1 {
-  delete: Boolean
-  read: Boolean
-  write: Boolean
-}
-
-input FileSystemVolumeMountV1 {
-  path: String!
-  permissions: [FileSystemPermissionsV1]
-}
-
-input FileSystemVolumeSourceLocalV1 {
-  maximumSize: String!
-}
-
-input FileSystemVolumeSourceV1 {
-  local: FileSystemVolumeSourceLocalV1!
-}
-
-input FileSystemVolumeConfigV1 {
-  mounts: [FileSystemVolumeMountV1]!
-  name: String!
-  source: FileSystemVolumeSourceV1!
-}
-
-input CapabilityFileSystemV1 {
-  volumes: [FileSystemVolumeConfigV1]!
-}
-
-input CapabilityPersistentMemoryV1 {
-  volumes: [String]
-}
-
-input CapabilityMemorySwapV1 {
-  maximumSize: String
-  memoryId: String
-}
-
-input CapabilityNetworkV1 {
-  egress: NetworkEgressV1
-}
-
-input NetworkEgressV1 {
-  enabled: Boolean
-}
-
-input CapabilityNetworkDnsV1 {
-  enabled: Boolean
-  servers: [String]
-  allowedHosts: NetworkDnsAllowedHostsV1
-}
-
-input NetworkDnsAllowedHostsV1 {
-  allowAllHosts: Boolean
-  hosts: [String]
-  regexPatterns: [String]
-  wildcardPatterns: [String]
-}
-
-input CapabilityNetworkGatewayV1 {
-  domains: [String]
-  enforceHttps: Boolean
-}
-
-input CapabilityMapV1 {
-  memorySwap: CapabilityCpuV1
-}
-
-input WebcSourceV1 {
-  name: String!
-  namespace: String!
-  repository: String! = "https://registry.wasmer.wtf"
-  tag: String
-  authToken: String
-}
-
-input WorkloadRunnerV1 {
-  webProxy: RunnerWebProxyV1
-  wcgi: RunnerWCGIV1
-}
-
-"""Run a webassembly file."""
-input RunnerWCGIV1 {
-  source: WorkloadRunnerWasmSourceV1!
-  dialect: String
-}
-
-input RunnerWebProxyV1 {
-  source: WorkloadRunnerWasmSourceV1!
-}
-
-input WorkloadRunnerWasmSourceV1 {
-  webc: WebcSourceV1!
-}
-
-type GithubAppInstallation implements Node {
-  """The ID of the object"""
-  id: ID!
-  slug: String!
-  githubConfigureUrl: String!
-  repositories(filterByName: String): [GithubInstallationRepository]!
-}
-
-type GithubInstallationRepository implements Node {
-  """The ID of the object"""
-  id: ID!
-  repoUrl: String!
-  installation: GithubAppInstallation!
-  url: String!
-  name: String!
-  namespace: String!
-}
-
-type GithubRepoConnection implements Node {
-  """The ID of the object"""
-  id: ID!
-  githubRepoInstallation: GithubInstallationRepository!
-  connectedBy: User!
-  deployBranch: String!
-  app: DeployApp!
-  pullRequestComments: Boolean!
-  connectedAt: DateTime!
-  deploymentStatusEvents: Boolean!
-}
-
-type Query {
-  latestTOS: TermsOfService!
-  getAppRegions(active: Boolean, supportsVolumes: Boolean, supportsDatabases: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): AppRegionConnection!
-  getDeployAppVersion(name: String!, owner: String, version: String): DeployAppVersion
-  getAllDomains(namespace: String, offset: Int, before: String, after: String, first: Int, last: Int): DNSDomainConnection!
-  getAllDNSRecords(sortBy: DNSRecordsSortBy, updatedAfter: DateTime, before: String, after: String, first: Int, last: Int): DNSRecordConnection!
-  getDomain(name: String!): DNSDomain
-  getDeployApp(
-    name: String!
-
-    """Owner of the app. Defaults to logged in user."""
-    owner: String
-  ): DeployApp
-  getAppByGlobalAlias(alias: String!): DeployApp
-  autobuildDeploymentStatus(buildId: UUID!): AutobuildDeploymentStatus
-  getDeployApps(sortBy: DeployAppsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppConnection!
-  getAppVersions(sortBy: DeployAppVersionsSortBy, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): DeployAppVersionConnection!
-  getTemplateFrameworks(offset: Int, before: String, after: String, first: Int, last: Int): TemplateFrameworkConnection
-  getTemplateLanguages(offset: Int, before: String, after: String, first: Int, last: Int): TemplateLanguageConnection
-  getAppTemplates(categorySlug: String, frameworkSlug: String, languageSlug: String, sortBy: AppTemplatesSortBy, highlighted: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateConnection
-  getAppSecrets(appId: ID!, names: [String], offset: Int, before: String, after: String, first: Int, last: Int): SecretConnection
-  getAppSecret(appId: ID!, secretName: String!): Secret
-  getAppSecretLog(appId: ID!, offset: Int, before: String, after: String, first: Int, last: Int): SecretLogConnection
-  getSecretValue(id: ID!): String
-  getAppTemplate(slug: String!): AppTemplate
-  getAppTemplateCategories(offset: Int, before: String, after: String, first: Int, last: Int): AppTemplateCategoryConnection
-  getBuildKinds(offset: Int, before: String, after: String, first: Int, last: Int): BuildKindConnection!
-
-  """Specify if the database name is valid or not."""
-  canDeployDbWithName(
-    """Name of the database"""
-    name: String!
-  ): Boolean!
-  wordpressDeploymentDefaults: WordpressDeploymentDefaults!
-  rollout(id: ID!): Rollout
-  githubRollout(id: ID!): GitHubRollout
-  viewer: User
-  getUser(username: String!): User
-  getPasswordResetToken(token: String!): GetPasswordResetToken
-  getAuthNonce(name: String!): Nonce
-
-  """Can the logged in user create app templates?"""
-  canDeployAppToGithub: Boolean!
-
-  """Check if a repo exists in the logged in user's github account."""
-  checkRepoExists(
-    """The namespace of the repo to check."""
-    namespace: String!
-
-    """The name of the repo to check."""
-    name: String!
-  ): Boolean!
-
-  """Generate a unique repo name in the logged in user's github account."""
-  newRepoName(
-    """The github namespace of the repo to create the repo in."""
-    namespace: String!
-
-    """The template to use."""
-    templateSlug: String!
-  ): String!
-  packages(offset: Int, before: String, after: String, first: Int, last: Int): PackageConnection
-  recentPackageVersions(curated: Boolean, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
-  allPackageVersions(sortBy: PackageVersionSortBy, createdAfter: DateTime, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): PackageVersionConnection!
-  allPackageReleases(sortBy: PackageVersionSortBy, createdAfter: DateTime, updatedAfter: DateTime, offset: Int, before: String, after: String, first: Int, last: Int): PackageWebcConnection!
-  getWebcImage(hash: String!): WebcImage
-  getNamespace(name: String!): Namespace
-  getPackage(name: String!): Package
-  getPackages(names: [String!]!): [Package]!
-  getPackageVersion(name: String!, version: String = "latest"): PackageVersion
-  getPackageVersions(names: [String!]!): [PackageVersion]
-  getPackageVersionByHash(name: String!, hash: String!): PackageVersion
-  getInterface(name: String!): Interface
-  getInterfaces(names: [String!]!): [Interface]!
-  getInterfaceVersion(name: String!, version: String = "latest"): InterfaceVersion
-  getContract(name: String!): Interface @deprecated(reason: "Please use getInterface instead")
-  getContracts(names: [String!]!): [Interface]! @deprecated(reason: "Please use getInterfaces instead")
-  getContractVersion(name: String!, version: String): InterfaceVersion @deprecated(reason: "Please use getInterfaceVersion instead")
-  getCommand(name: String!): Command
-  getCommands(names: [String!]!): [Command]
-  getCollections(before: String, after: String, first: Int, last: Int): CollectionConnection
-  getSignedUrlForPackageUpload(name: String, version: String = "latest", filename: String, expiresAfterSeconds: Int = 60, method: String): SignedUrl
-  getSignedUrl(filename: String, expiresAfterSeconds: Int = 60, method: String): SignedUrl
-  getPackageHash(name: String, hash: String!): PackageWebc
-  getPackageRelease(hash: String): PackageWebc
-  getPackageInstanceByVersionOrHash(name: String!, version: String, hash: String): PackageInstance
-  categories(offset: Int, before: String, after: String, first: Int, last: Int): CategoryConnection!
-  viewerCan(action: OwnerAction!, ownerName: String!): Boolean!
-  blogposts(tags: [String!], offset: Int, before: String, after: String, first: Int, last: Int): BlogPostConnection!
-  getBlogpost(slug: String, featured: Boolean): BlogPost
-  allBlogpostTags(offset: Int, before: String, after: String, first: Int, last: Int): BlogPostTagConnection
-  search(query: String!, packages: PackagesFilter, namespaces: NamespacesFilter, users: UsersFilter, apps: AppFilter, blogposts: BlogPostsFilter, appTemplates: AppTemplateFilter, before: String, after: String, first: Int, last: Int): SearchConnection!
-  searchAutocomplete(kind: [SearchKind!], query: String!, before: String, after: String, first: Int, last: Int): SearchConnection!
-  getGlobalObject(slug: String!): GlobalObject
-  internalTask(id: ID!): InternalTask
-  node(
-    """The ID of the object"""
-    id: ID!
-  ): Node
-  nodes(ids: [ID!]!): [Node]
-  info: RegistryInfo
-}
-
-type TermsOfService implements Node {
-  """The ID of the object"""
-  id: ID!
-  content: String!
-  createdAt: DateTime!
-  viewerHasAccepted: Boolean!
-}
-
-type AppRegionConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [AppRegionEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `AppRegion` and its cursor."""
-type AppRegionEdge {
-  """The item at the end of the edge"""
-  node: AppRegion
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type AppRegion implements Node {
-  name: String!
-  country: String!
-  city: String!
-  supportsVolumes: Boolean!
-  supportsDbs: Boolean!
-  active: Boolean!
-
-  """The ID of the object"""
-  id: ID!
-}
-
-type DNSRecordConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [DNSRecordEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `DNSRecord` and its cursor."""
-type DNSRecordEdge {
-  """The item at the end of the edge"""
-  node: DNSRecord
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-enum DNSRecordsSortBy {
-  NEWEST
-  OLDEST
-}
-
-type AutobuildDeploymentStatus {
-  buildId: UUID!
-  status: StatusEnum!
-  appVersion: DeployAppVersion
-}
-
-type TemplateFrameworkConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [TemplateFrameworkEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `TemplateFramework` and its cursor."""
-type TemplateFrameworkEdge {
-  """The item at the end of the edge"""
-  node: TemplateFramework
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type TemplateLanguageConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [TemplateLanguageEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `TemplateLanguage` and its cursor."""
-type TemplateLanguageEdge {
-  """The item at the end of the edge"""
-  node: TemplateLanguage
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-"""An enumeration."""
-enum AppTemplatesSortBy {
-  NEWEST
-  OLDEST
-  POPULAR
-}
-
-type SecretLogConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [SecretLogEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `SecretLog` and its cursor."""
-type SecretLogEdge {
-  """The item at the end of the edge"""
-  node: SecretLog
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type SecretLog implements Node {
-  createdAt: DateTime!
-  action: DeploySecretLogActionChoices!
-
-  """The ID of the object"""
-  id: ID!
-  secretName: String!
-}
-
-"""An enumeration."""
-enum DeploySecretLogActionChoices {
-  """Access"""
-  ACCESS
-
-  """Modification"""
-  MODIFICATION
-
-  """Create"""
-  CREATE
-
-  """DELETE"""
-  DELETE
-}
-
-type AppTemplateCategoryConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [AppTemplateCategoryEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `AppTemplateCategory` and its cursor."""
-type AppTemplateCategoryEdge {
-  """The item at the end of the edge"""
-  node: AppTemplateCategory
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type BuildKindConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [BuildKindEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `BuildKind` and its cursor."""
-type BuildKindEdge {
-  """The item at the end of the edge"""
-  node: BuildKind
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type WordpressDeploymentDefaults {
-  siteTitle: String!
-  appName: String!
-  adminUsername: String!
-  adminPassword: String!
-  adminEmail: String!
-}
-
-type GetPasswordResetToken {
-  valid: Boolean!
-  user: User
-}
-
-"""An enumeration."""
-enum PackageVersionSortBy {
-  NEWEST
-  OLDEST
-}
-
-type CollectionConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [CollectionEdge]!
-}
-
-"""A Relay edge containing a `Collection` and its cursor."""
-type CollectionEdge {
-  """The item at the end of the edge"""
-  node: Collection
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type SignedUrl {
-  url: String!
-}
-
-type BlogPostConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [BlogPostEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `BlogPost` and its cursor."""
-type BlogPostEdge {
-  """The item at the end of the edge"""
-  node: BlogPost
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type BlogPost implements Node {
-  """The ID of the object"""
-  id: ID!
-  live: Boolean!
-
-  """The page title as you'd like it to be seen by the public"""
-  title: String!
-
-  """
-  The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/
-  """
-  slug: String!
-  owner: User
-  body: String!
-  publishDate: DateTime
-  theme: BlogBlogPostThemeChoices!
-  url: String!
-  coverImageUrl: String
-  opengraphImageUrl: String
-  tagline: String!
-  relatedArticles: [BlogPost!]
-  updatedAt: DateTime!
-  tags: [BlogPostTag!]
-  editUrl: String
-}
-
-"""An enumeration."""
-enum BlogBlogPostThemeChoices {
-  """Green"""
-  GREEN
-
-  """Purple"""
-  PURPLE
-
-  """Orange"""
-  ORANGE
-
-  """Blue"""
-  BLUE
-}
-
-type BlogPostTag implements Node {
-  """The ID of the object"""
-  id: ID!
-  name: String!
-  slug: String!
-}
-
-type BlogPostTagConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [BlogPostTagEdge]!
-
-  """Total number of items in the connection."""
-  totalCount: Int
-}
-
-"""A Relay edge containing a `BlogPostTag` and its cursor."""
-type BlogPostTagEdge {
-  """The item at the end of the edge"""
-  node: BlogPostTag
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-type SearchConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [SearchEdge]!
-  totalCount: Int
-}
-
-"""A Relay edge containing a `Search` and its cursor."""
-type SearchEdge {
-  """The item at the end of the edge"""
-  node: SearchResult
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-union SearchResult = PackageVersion | User | Namespace | DeployApp | BlogPost | AppTemplate
-
-input PackagesFilter {
-  count: Int = 1000
-  sortBy: SearchOrderSort = DESC
-
-  """Filter packages by being curated."""
-  curated: Boolean
-
-  """Filter packages by publish date."""
-  publishDate: SearchPublishDate
-
-  """Filter packages by having bindings."""
-  hasBindings: Boolean = false
-
-  """Filter packages by being standalone."""
-  isStandalone: Boolean = false
-
-  """Filter packages by having commands."""
-  hasCommands: Boolean = false
-
-  """Filter packages by interface."""
-  withInterfaces: [String]
-
-  """Filter packages by deployable status."""
-  deployable: Boolean
-
-  """Filter packages by license."""
-  license: String
-
-  """Filter packages created after this date."""
-  createdAfter: DateTime
-
-  """Filter packages created before this date."""
-  createdBefore: DateTime
-
-  """Filter packages with version published after this date."""
-  lastPublishedAfter: DateTime
-
-  """Filter packages with version published before this date."""
-  lastPublishedBefore: DateTime
-
-  """Filter packages by size."""
-  size: CountFilter
-
-  """Filter packages by download count."""
-  downloads: CountFilter
-
-  """Filter packages by like count."""
-  likes: CountFilter
-
-  """Filter packages by owner."""
-  owner: String
-
-  """Filter packages by published by."""
-  publishedBy: String
-
-  """Order packages by field."""
-  orderBy: PackageOrderBy = PUBLISHED_DATE
-}
-
-enum SearchOrderSort {
-  ASC
-  DESC
-}
-
-enum SearchPublishDate {
-  LAST_DAY
-  LAST_WEEK
-  LAST_MONTH
-  LAST_YEAR
-}
-
-input CountFilter {
-  count: Int = 0
-  comparison: CountComparison = GREATER_THAN_OR_EQUAL
-}
-
-enum CountComparison {
-  EQUAL
-  GREATER_THAN
-  LESS_THAN
-  GREATER_THAN_OR_EQUAL
-  LESS_THAN_OR_EQUAL
-}
-
-enum PackageOrderBy {
-  ALPHABETICALLY
-  SIZE
-  TOTAL_DOWNLOADS
-  PUBLISHED_DATE
-  CREATED_DATE
-  TOTAL_LIKES
-}
-
-input NamespacesFilter {
-  count: Int = 1000
-  sortBy: SearchOrderSort = DESC
-
-  """Filter namespaces by package count."""
-  packageCount: CountFilter
-
-  """Filter namespaces created after this date."""
-  createdAfter: DateTime
-
-  """Filter namespaces created before this date."""
-  createdBefore: DateTime
-
-  """Filter namespaces by user count."""
-  userCount: CountFilter
-
-  """Filter namespaces by collaborator."""
-  collaborator: String
-
-  """Order namespaces by field."""
-  orderBy: NamespaceOrderBy = CREATED_DATE
-}
-
-enum NamespaceOrderBy {
-  PACKAGE_COUNT
-  COLLABORATOR_COUNT
-  APP_COUNT
-  CREATED_DATE
-}
-
-input UsersFilter {
-  count: Int = 1000
-  sortBy: SearchOrderSort = DESC
-
-  """Filter users by package count."""
-  packageCount: CountFilter
-
-  """Filter users by namespace count."""
-  namespaceCount: CountFilter
-
-  """Filter users joined after this date."""
-  joinedAfter: DateTime
-
-  """Filter users joined before this date."""
-  joinedBefore: DateTime
-
-  """Order users by field."""
-  orderBy: UserOrderBy = CREATED_DATE
+enum UserNotificationSeenState {
+	UNSEEN
+	SEEN
+	SEEN_AND_READ
 }
 
 enum UserOrderBy {
-  PACKAGE_COUNT
-  APP_COUNT
-  CREATED_DATE
-}
-
-input AppFilter {
-  count: Int = 1000
-  sortBy: SearchOrderSort = DESC
-
-  """Filter apps by deployed by."""
-  deployedBy: String
-
-  """Filter apps last deployed after this date."""
-  lastDeployedAfter: DateTime
-
-  """Filter apps last deployed before this date."""
-  lastDeployedBefore: DateTime
-
-  """Filter apps by owner."""
-  owner: String
-
-  """Order apps by field."""
-  orderBy: AppOrderBy = CREATED_DATE
-
-  """Filter apps by client name."""
-  clientName: String
-}
-
-enum AppOrderBy {
-  PUBLISHED_DATE
-  CREATED_DATE
-}
-
-input BlogPostsFilter {
-  count: Int = 1000
-  sortBy: SearchOrderSort = DESC
-
-  """Filter blog posts by tag."""
-  tags: [String]
-}
-
-input AppTemplateFilter {
-  count: Int = 1000
-  sortBy: SearchOrderSort = DESC
-
-  """Order app templates by field."""
-  orderBy: AppTemplateOrderBy = HIGHLIGHTED
-
-  """Filter by app template framework"""
-  framework: String
-
-  """Filter by app template language"""
-  language: String
-
-  """Filter by one or more of the use-cases for the app template"""
-  useCases: [String]
-}
-
-enum AppTemplateOrderBy {
-  CREATED_DATE
-  HIGHLIGHTED
-}
-
-enum SearchKind {
-  PACKAGE
-  NAMESPACE
-  USER
-}
-
-union GlobalObject = User | Namespace
-
-type InternalTask {
-  id: ID!
-  status: String!
-  result: JSONString
-  dateDone: DateTime
-  traceback: String
-}
-
-type RegistryInfo {
-  """Base URL for this registry"""
-  baseUrl: String!
-
-  """Base URL for the default frontend"""
-  defaultFrontend: String!
-
-  """URL to the graphql endpoint"""
-  graphqlUrl: String!
-
-  """URL for app domains"""
-  appDomain: String!
-
-  """URL to the graphql endpoint"""
-  createBlogpostUrl: String
-
-  """Public metadata about packages"""
-  packages: PackageInfo!
-
-  """Public metadata about the graphql schema"""
-  schema: SchemaInfo!
-}
-
-type PackageInfo {
-  """Number of package versions published this month"""
-  versionsPublishedThisMonth: Int!
-
-  """Number of new packages published this month"""
-  newPackagesThisMonth: Int!
-
-  """Number of package downloads this month"""
-  packageDownloadsThisMonth: Int!
-}
-
-type SchemaInfo {
-  """Download link for graphql schema"""
-  downloadUrl: String!
-
-  """SHA256 hash of the schema data"""
-  SHA256Hash: String!
-
-  """Timestamp when the schema was last updated"""
-  lastUpdated: DateTime!
-}
-
-type Mutation {
-  """Sync all blog posts from Notion to the database."""
-  syncNotionBlogPosts(input: SyncNotionBlogPostsInput!): SyncNotionBlogPostsPayload
-
-  """Viewer accepts the latest ToS."""
-  acceptTOS(input: AcceptTOSInput!): AcceptTOSPayload
-
-  """Delete domain with given ID"""
-  deleteAppDomain(input: DeleteAppDomainInput!): DeleteAppDomainPayload
-
-  """Enable or disable the SSH server capability on an app."""
-  toggleSshServer(input: ToggleSshServerInput!): ToggleSshServerPayload
-
-  """Reveal the password for an SSH user."""
-  revealSshUserPassword(input: RevealSshUserPasswordInput!): RevealSshUserPasswordPayload
-
-  """Rotate the password for an SSH user."""
-  rotateSshUserPassword(input: RotateSshUserPasswordInput!): RotateSshUserPasswordPayload
-
-  """Add an SSH authorized key to an SSH user."""
-  addSshAuthorizedKey(input: AddSshAuthorizedKeyInput!): AddSshAuthorizedKeyPayload
-
-  """Edit an SSH user."""
-  deleteSshAuthorizedKey(input: DeleteSshAuthorizedKeyInput!): DeleteSshAuthorizedKeyPayload
-
-  """Edit an SSH user."""
-  editSshUser(input: EditSshUserInput!): EditSshUserPayload
-
-  """Detach autobuild from app."""
-  verifyAppDomain(input: VerifyAppDomainInput!): VerifyAppDomainPayload
-
-  """Create or update an app domain on an app with given ID"""
-  upsertAppDomain(input: UpsertAppDomainInput!): UpsertAppDomainPayload
-  publishDeployApp(input: PublishDeployAppInput!): PublishDeployAppPayload
-  deleteApp(input: DeleteAppInput!): DeleteAppPayload
-
-  """Add current user to the waitlist."""
-  joinWaitlist(input: JoinWaitlistInput!): JoinWaitlistPayload
-
-  """Add stripe payment to the user"""
-  addPayment(input: AddPaymentInput!): AddPaymentPayload
-
-  """
-  Mutation to change the active version of a DeployApp to another DeployAppVersion.
-  """
-  markAppVersionAsActive(input: MarkAppVersionAsActiveInput!): MarkAppVersionAsActivePayload
-
-  """Set a payment method as default for the user."""
-  makePaymentDefault(input: SetDefaultPaymentMethodInput!): SetDefaultPaymentMethodPayload
-
-  """
-  Try to detach a payment method from customer.
-  Fails if trying to detach a default method,
-  or if it's the only payment method.
-  """
-  detachPaymentMethod(input: DetachPaymentMethodInput!): DetachPaymentMethodPayload
-  generateDeployConfigToken(input: GenerateDeployConfigTokenInput!): GenerateDeployConfigTokenPayload
-  generateSshToken(input: GenerateSshTokenInput!): GenerateSshTokenPayload
-  renameApp(input: RenameAppInput!): RenameAppPayload
-  renameAppAlias(input: RenameAppAliasInput!): RenameAppAliasPayload
-
-  """Purges all cache for this app version"""
-  purgeCacheForAppVersion(input: PurgeCacheForAppVersionInput!): PurgeCacheForAppVersionPayload
-  requestAppTransfer(input: RequestAppTransferInput!): RequestAppTransferPayload
-  acceptAppTransferRequest(input: AcceptAppTransferRequestInput!): AcceptAppTransferRequestPayload
-  removeAppTransferRequest(input: RemoveAppTransferRequestInput!): RemoveAppTransferRequestPayload
-  createRepoForAppTemplate(input: CreateRepoForAppTemplateInput!): CreateRepoForAppTemplatePayload
-  registerDomain(input: RegisterDomainInput!): RegisterDomainPayload
-  upsertDNSRecord(input: UpsertDNSRecordInput!): UpsertDNSRecordPayload
-  deleteDNSRecord(input: DeleteDNSRecordInput!): DeleteDNSRecordPayload
-  upsertDomainFromZoneFile(input: UpsertDomainFromZoneFileInput!): UpsertDomainFromZoneFilePayload
-  deleteDomain(input: DeleteDomainInput!): DeleteDomainPayload
-
-  """Create or update an app secret on an app with given ID"""
-  upsertAppSecret(input: UpsertAppSecretInput!): UpsertAppSecretPayload
-
-  """Create or update app secrets on an app with given ID"""
-  upsertAppSecrets(input: UpsertAppSecretsInput!): UpsertAppSecretsPayload
-
-  """Delete secret with given ID"""
-  deleteAppSecret(input: DeleteAppSecretInput!): DeleteAppSecretPayload
-
-  """Redeploy the active version of an app."""
-  redeployActiveVersion(input: RedeployActiveVersionInput!): RedeployActiveVersionPayload
-
-  """Toggle HTTP redirect for the active version of app"""
-  toggleForceHttps(input: ToggleForceHTTPSInput!): ToggleForceHTTPSPayload
-
-  """Redeploy the active version of an app."""
-  rotateS3SecretsForApp(input: RotateS3SecretsForAppInput!): RotateS3SecretsForAppPayload
-
-  """Delete a database for an app."""
-  rotateCredentialsForAppDb(input: RotateCredentialsForAppDBInput!): RotateCredentialsForAppDBPayload
-
-  """Create a new database for an app."""
-  createAppDb(input: CreateAppDBInput!): CreateAppDBPayload
-
-  """Delete a database for an app."""
-  deleteAppDb(input: DeleteAppDBInput!): DeleteAppDBPayload
-  updateBuildConfig(input: UpdateBuildConfigInput!): UpdateBuildConfigPayload
-
-  """Get the autobuild config for a given repo"""
-  autobuildConfigForRepo(input: AutobuildConfigForRepoInput!): AutobuildConfigForRepoPayload
-
-  """Get the autobuild config for a given zip upload URL"""
-  autobuildConfigForZipUpload(input: AutobuildConfigForZipUploadInput!): AutobuildConfigForZipUploadPayload
-
-  """Add a new github app installation"""
-  installGithubApp(input: InstallGithubAppInput!): InstallGithubAppPayload
-
-  """Detach autobuild from app."""
-  detachAppFromAutobuild(input: DetachAppFromAutobuildInput!): DetachAppFromAutobuildPayload
-
-  """Update autobuild config for an app."""
-  updateAutobuildConfigForApp(input: UpdateAutobuildConfigForAppInput!): UpdateAutobuildConfigForAppPayload
-
-  """Connect a github repo to an app."""
-  connectGithubRepoToApp(input: ConnectGithubRepoToAppInput!): ConnectGithubRepoToAppPayload
-
-  """Disconnect a github repo from an app."""
-  disconnectGithubRepoFromApp(input: DisconnectGithubRepoFromAppInput!): DisconnectGithubRepoFromAppPayload
-  updateGithubRepoConnection(input: UpdateGithubRepoAppConnectionInput!): UpdateGithubRepoAppConnectionPayload
-
-  """Deploy a wordpress site."""
-  deployWordpress(input: DeployWordpressInput!): DeployWordpressPayload @deprecated(reason: "Use `publishAppFromRepoAutobuild` subscription instead.")
-
-  """Enable app that was previously disabled."""
-  enableApp(input: EnableAppInput!): EnableAppPayload
-
-  """Disable app with a reason."""
-  disableApp(input: DisableAppInput!): DisableAppPayload
-
-  """Ban app with a reason."""
-  banApp(input: BanAppInput!): BanAppPayload
-
-  """Un-ban app with a reason."""
-  unbanApp(input: UnbanAppInput!): UnbanAppPayload
-
-  """Claim a perishable app as their own."""
-  claimPerishableApp(input: ClaimPerishableAppInput!): ClaimPerishableAppPayload
-  deployViaAutobuild(input: DeployViaAutobuildInput!): DeployViaAutobuildPayload
-
-  """
-  Delete a user with some reason. The deletion will be soft, so the
-  underlying data will remain and be anonymized following GDPR.
-  """
-  deleteUser(input: DeleteUserInput!): DeleteUserPayload
-
-  """Create a new vault from yaml config"""
-  upsertVault(input: UpsertVaultInput!): UpsertVaultPayload
-
-  """Attach vault to an app"""
-  attachVault(input: AttachVaultInput!): AttachVaultPayload
-
-  """Migrate an app to a different region."""
-  migrateAppRegion(input: MigrateAppRegionInput!): MigrateAppRegionPayload
-  tokenAuth(input: ObtainJSONWebTokenInput!): ObtainJSONWebTokenPayload
-  generateDeployToken(input: GenerateDeployTokenInput!): GenerateDeployTokenPayload
-  verifyAccessToken(token: String): Verify
-  refreshAccessToken(refreshToken: String): Refresh
-  revokeAccessToken(refreshToken: String): Revoke
-  registerUser(input: RegisterUserInput!): RegisterUserPayload
-  socialAuth(input: SocialAuthJWTInput!): SocialAuthJWTPayload
-  validateUserEmail(input: ValidateUserEmailInput!): ValidateUserEmailPayload
-  validateUserFingerprint(input: ValidateUserFingerprintInput!): ValidateUserFingerprintPayload
-  requestPasswordReset(input: RequestPasswordResetInput!): RequestPasswordResetPayload
-  requestValidationEmail(input: RequestValidationEmailInput!): RequestValidationEmailPayload
-  changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordPayload
-  changeUserUsername(input: ChangeUserUsernameInput!): ChangeUserUsernamePayload
-  changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload
-  updateUserInfo(input: UpdateUserInfoInput!): UpdateUserInfoPayload
-  validateUserPassword(input: ValidateUserPasswordInput!): ValidateUserPasswordPayload
-  generateApiToken(input: GenerateAPITokenInput!): GenerateAPITokenPayload
-
-  """Request To revoke an API token; these start with 'wap_'."""
-  revokeApiToken(input: RevokeAPITokenInput!): RevokeAPITokenPayload
-  checkUserExists(input: CheckUserExistsInput!): CheckUserExistsPayload
-  readNotification(input: ReadNotificationInput!): ReadNotificationPayload
-  seePendingNotifications(input: SeePendingNotificationsInput!): SeePendingNotificationsPayload
-  newNonce(input: NewNonceInput!): NewNoncePayload
-  validateNonce(input: ValidateNonceInput!): ValidateNoncePayload
-  invalidateNonce(input: InvalidateNonceInput!): InvalidateNoncePayload
-  mfa2totpGetToken(input: MFATOTPGetTokenInput!): MFATOTPTokenType
-  mfa2totpVerify(input: MFATOTPVerifyInput!): MFATOTPVerifyPayload
-  mfa2totpAuth(input: MFATOTPAuthInput!): MFAAuthResponse
-  mfa2RecoveryGetToken(input: MFAGenerateRecoveryTokenInput!): MFARecoveryCodes
-  mfa2RecoveryAuth(input: MFARecoveryAuthInput!): MFAAuthResponse
-  mfa2EmailAuth(input: MFAEmailAuthInput!): MFAAuthResponse
-  mfa2EmailGetToken(input: MFAGenerateEmailOTPInput!): MFAEmailGenerationResponse
-  generateCheckoutUrl(input: GenerateCheckoutUrlInput!): GenerateCheckoutUrlPayload
-  createCheckoutSession(input: CreateCheckoutSessionInput!): CreateCheckoutSessionPayload
-  cancelSubscription(input: CancelSubscriptionInput!): CancelSubscriptionPayload
-  renewCanceledSubscription(input: RenewCanceledSubscriptionInput!): RenewCanceledSubscriptionPayload
-  publishPublicKey(input: PublishPublicKeyInput!): PublishPublicKeyPayload
-  publishPackage(input: PublishPackageInput!): PublishPackagePayload
-  pushPackageRelease(input: PushPackageReleaseInput!): PushPackageReleasePayload
-  tagPackageRelease(input: TagPackageReleaseInput!): TagPackageReleasePayload
-  updatePackage(input: UpdatePackageInput!): UpdatePackagePayload
-  likePackage(input: LikePackageInput!): LikePackagePayload
-  unlikePackage(input: UnlikePackageInput!): UnlikePackagePayload
-  watchPackage(input: WatchPackageInput!): WatchPackagePayload
-  unwatchPackage(input: UnwatchPackageInput!): UnwatchPackagePayload
-  archivePackage(input: ArchivePackageInput!): ArchivePackagePayload
-  renamePackage(input: RenamePackageInput!): RenamePackagePayload
-  changePackageVersionArchivedStatus(input: ChangePackageVersionArchivedStatusInput!): ChangePackageVersionArchivedStatusPayload
-  createNamespace(input: CreateNamespaceInput!): CreateNamespacePayload
-  updateNamespace(input: UpdateNamespaceInput!): UpdateNamespacePayload
-  deleteNamespace(input: DeleteNamespaceInput!): DeleteNamespacePayload
-  inviteNamespaceCollaborator(input: InviteNamespaceCollaboratorInput!): InviteNamespaceCollaboratorPayload
-  acceptNamespaceCollaboratorInvite(input: AcceptNamespaceCollaboratorInviteInput!): AcceptNamespaceCollaboratorInvitePayload
-  removeNamespaceCollaboratorInvite(input: RemoveNamespaceCollaboratorInviteInput!): RemoveNamespaceCollaboratorInvitePayload
-  removeNamespaceCollaborator(input: RemoveNamespaceCollaboratorInput!): RemoveNamespaceCollaboratorPayload
-  updateNamespaceCollaboratorRole(input: UpdateNamespaceCollaboratorRoleInput!): UpdateNamespaceCollaboratorRolePayload
-  updateNamespaceCollaboratorInviteRole(input: UpdateNamespaceCollaboratorInviteRoleInput!): UpdateNamespaceCollaboratorInviteRolePayload
-  invitePackageCollaborator(input: InvitePackageCollaboratorInput!): InvitePackageCollaboratorPayload
-  acceptPackageCollaboratorInvite(input: AcceptPackageCollaboratorInviteInput!): AcceptPackageCollaboratorInvitePayload
-  removePackageCollaboratorInvite(input: RemovePackageCollaboratorInviteInput!): RemovePackageCollaboratorInvitePayload
-  updatePackageCollaboratorRole(input: UpdatePackageCollaboratorRoleInput!): UpdatePackageCollaboratorRolePayload
-  updatePackageCollaboratorInviteRole(input: UpdatePackageCollaboratorInviteRoleInput!): UpdatePackageCollaboratorInviteRolePayload
-  removePackageCollaborator(input: RemovePackageCollaboratorInput!): RemovePackageCollaboratorPayload
-  requestPackageTransfer(input: RequestPackageTransferInput!): RequestPackageTransferPayload
-  acceptPackageTransferRequest(input: AcceptPackageTransferRequestInput!): AcceptPackageTransferRequestPayload
-  removePackageTransferRequest(input: RemovePackageTransferRequestInput!): RemovePackageTransferRequestPayload
-  generateBindingsForAllPackages(input: GenerateBindingsForAllPackagesInput!): GenerateBindingsForAllPackagesPayload
-  makePackagePublic(input: MakePackagePublicInput!): MakePackagePublicPayload
-  generateUploadUrl(input: GenerateUploadUrlInput!): GenerateUploadUrlPayload
-}
-
-"""Sync all blog posts from Notion to the database."""
-type SyncNotionBlogPostsPayload {
-  syncedCount: Int!
-  createdCount: Int!
-  updatedCount: Int!
-  errors: [String]
-  clientMutationId: String
-}
-
-input SyncNotionBlogPostsInput {
-  clientMutationId: String
-}
-
-"""Viewer accepts the latest ToS."""
-type AcceptTOSPayload {
-  TOS: TermsOfService!
-  clientMutationId: String
-}
-
-input AcceptTOSInput {
-  clientMutationId: String
-}
-
-"""Delete domain with given ID"""
-type DeleteAppDomainPayload {
-  success: Boolean!
-
-  """ID of the deleted domain."""
-  id: ID!
-  clientMutationId: String
-}
-
-input DeleteAppDomainInput {
-  """ID of the domain to delete."""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Enable or disable the SSH server capability on an app."""
-type ToggleSshServerPayload {
-  sshServer: AppSshServer!
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input ToggleSshServerInput {
-  """App ID"""
-  appId: ID!
-  enabled: Boolean!
-  clientMutationId: String
-}
-
-"""Reveal the password for an SSH user."""
-type RevealSshUserPasswordPayload {
-  sshUser: SshUser!
-  password: String
-  clientMutationId: String
-}
-
-input RevealSshUserPasswordInput {
-  """SSH User ID"""
-  sshUserId: ID!
-  clientMutationId: String
-}
-
-"""Rotate the password for an SSH user."""
-type RotateSshUserPasswordPayload {
-  sshUser: SshUser!
-  password: String!
-  clientMutationId: String
-}
-
-input RotateSshUserPasswordInput {
-  """SSH User ID"""
-  sshUserId: ID!
-  clientMutationId: String
-}
-
-"""Add an SSH authorized key to an SSH user."""
-type AddSshAuthorizedKeyPayload {
-  authorizedKey: SshAuthorizedKey!
-  clientMutationId: String
-}
-
-input AddSshAuthorizedKeyInput {
-  """SSH User ID"""
-  sshUserId: ID!
-  publicKey: String!
-  name: String
-  clientMutationId: String
-}
-
-"""Edit an SSH user."""
-type DeleteSshAuthorizedKeyPayload {
-  success: Boolean!
-  clientMutationId: String
-}
-
-input DeleteSshAuthorizedKeyInput {
-  """SSH User ID"""
-  sshUserId: ID!
-  name: String
-  clientMutationId: String
-}
-
-"""Edit an SSH user."""
-type EditSshUserPayload {
-  sshUser: SshUser!
-  clientMutationId: String
-}
-
-input EditSshUserInput {
-  """SSH User ID"""
-  id: ID!
-  username: String
-  authenticationMethods: [SshAuthenticationMethod] = null
-  sftpRootFolder: String
-  clientMutationId: String
-}
-
-"""Detach autobuild from app."""
-type VerifyAppDomainPayload {
-  verified: Boolean!
-  clientMutationId: String
-}
-
-input VerifyAppDomainInput {
-  """The ID of the domain to verify"""
-  domainId: ID!
-
-  """Specify how to verify the domain"""
-  kind: VerificationKind = QUICK
-  clientMutationId: String
-}
-
-enum VerificationKind {
-  QUICK
-  DEEP
-}
-
-"""Create or update an app domain on an app with given ID"""
-type UpsertAppDomainPayload {
-  """List of domains generated by the mutation"""
-  domains: [AppAlias]
-  success: Boolean!
-  clientMutationId: String
-}
-
-input UpsertAppDomainInput {
-  """ID of the app onto which to add secrets."""
-  appId: ID!
-
-  """ID of the domain to upsert."""
-  id: ID
-
-  """Name of the secret."""
-  name: String!
-
-  """Redirection rules for this domain"""
-  redirection: AppDomainRedirectRules = null
-
-  """Wait for the domain to become available before returning."""
-  wait: Boolean = true
-  clientMutationId: String
-}
-
-input AppDomainRedirectRules {
-  """Domain to redirect to."""
-  to: String!
-
-  """Type of redirection; sets the http code appropriately."""
-  httpCode: HTTPRedirectType!
-}
-
-type PublishDeployAppPayload {
-  deployAppVersion: DeployAppVersion!
-  clientMutationId: String
-}
-
-input PublishDeployAppInput {
-  """The configuration of the app."""
-  config: Configuration!
-
-  """The name of the app."""
-  name: ID
-
-  """The owner of the app."""
-  owner: ID
-
-  """The description of the app."""
-  description: String
-
-  """If true, the new version will be set as the default version."""
-  makeDefault: Boolean = true
-
-  """
-  If true, Publishing will fail if the source package does not have a valid webc.
-  """
-  strict: Boolean = false
-
-  """
-  If true, the mutation will wait for all deployment jobs to finish before returning.
-  """
-  waitForJobs: Boolean = false
-
-  """If true, the mutation will trigger a screenshot generation job."""
-  generateScreenshot: Boolean = true
-
-  """
-  Wait for smaller of n seconds or till the published app version is live.
-  """
-  waitTillLive: Int = null
-  clientMutationId: String
-}
-
-input Configuration {
-  deployment: AppConfigV1
-  yamlConfig: String
-}
-
-input AppConfigV1 {
-  kind: String = "wasmer.io/App.v0"
-  appId: ID
-  name: String!
-  description: String
-  package: String!
-}
-
-type DeleteAppPayload {
-  success: Boolean!
-  clientMutationId: String
-}
-
-input DeleteAppInput {
-  """App ID to delete."""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Add current user to the waitlist."""
-type JoinWaitlistPayload {
-  waitlistMember: WaitlistMember!
-  clientMutationId: String
-}
-
-input JoinWaitlistInput {
-  name: String!
-  clientMutationId: String
-}
-
-"""Add stripe payment to the user"""
-type AddPaymentPayload {
-  customerSecret: String!
-  clientMutationId: String
-}
-
-input AddPaymentInput {
-  clientMutationId: String
-}
-
-"""
-Mutation to change the active version of a DeployApp to another DeployAppVersion.
-"""
-type MarkAppVersionAsActivePayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input MarkAppVersionAsActiveInput {
-  """The ID of the DeployAppVersion to set as the new active version."""
-  appVersion: ID!
-  clientMutationId: String
-}
-
-"""Set a payment method as default for the user."""
-type SetDefaultPaymentMethodPayload {
-  success: Boolean!
-  billing: Billing!
-  clientMutationId: String
-}
-
-input SetDefaultPaymentMethodInput {
-  paymentMethod: ID!
-  clientMutationId: String
-}
-
-"""
-Try to detach a payment method from customer.
-Fails if trying to detach a default method,
-or if it's the only payment method.
-"""
-type DetachPaymentMethodPayload {
-  success: Boolean!
-  billing: Billing!
-  clientMutationId: String
-}
-
-input DetachPaymentMethodInput {
-  paymentMethod: ID!
-  clientMutationId: String
-}
-
-type GenerateDeployConfigTokenPayload {
-  token: String!
-  config: String!
-  clientMutationId: String
-}
-
-input GenerateDeployConfigTokenInput {
-  config: String!
-  clientMutationId: String
-}
-
-type GenerateSshTokenPayload {
-  token: String!
-  clientMutationId: String
-}
-
-input GenerateSshTokenInput {
-  appId: ID
-  clientMutationId: String
-}
-
-type RenameAppPayload {
-  success: Boolean!
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input RenameAppInput {
-  """App ID to delete."""
-  id: ID!
-
-  """New name for the app."""
-  name: String!
-  clientMutationId: String
-}
-
-type RenameAppAliasPayload {
-  success: Boolean!
-  alias: AppAlias!
-  clientMutationId: String
-}
-
-input RenameAppAliasInput {
-  """App alias ID to delete."""
-  id: ID!
-
-  """New name for the alias."""
-  name: String!
-  clientMutationId: String
-}
-
-"""Purges all cache for this app version"""
-type PurgeCacheForAppVersionPayload {
-  appVersion: DeployAppVersion!
-  success: Boolean!
-  clientMutationId: String
-}
-
-input PurgeCacheForAppVersionInput {
-  """ID of the app version to purge cache for."""
-  id: ID!
-  clientMutationId: String
-}
-
-type RequestAppTransferPayload {
-  appTransferRequest: AppTransferRequest
-  wasInstantlyTransferred: Boolean!
-  clientMutationId: String
-}
-
-type AppTransferRequest implements Node {
-  """The ID of the object"""
-  id: ID!
-  requestedBy: User!
-  previousOwnerObjectId: Int!
-  newOwnerObjectId: Int!
-  app: DeployApp!
-  approvedBy: User
-  declinedBy: User
-  createdAt: DateTime!
-  expiresAt: DateTime!
-  closedAt: DateTime
-  previousOwner: Owner!
-  newOwner: Owner!
-}
-
-input RequestAppTransferInput {
-  appId: ID!
-  newOwnerId: ID!
-  clientMutationId: String
-}
-
-type AcceptAppTransferRequestPayload {
-  app: DeployApp!
-  appTransferRequest: AppTransferRequest!
-  clientMutationId: String
-}
-
-input AcceptAppTransferRequestInput {
-  appTransferRequestId: ID!
-  clientMutationId: String
-}
-
-type RemoveAppTransferRequestPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input RemoveAppTransferRequestInput {
-  appTransferRequestId: ID!
-  clientMutationId: String
-}
-
-type CreateRepoForAppTemplatePayload {
-  success: Boolean!
-  repoId: ID!
-  clientMutationId: String
-}
-
-input CreateRepoForAppTemplateInput {
-  templateId: ID!
-  name: String!
-  namespace: String!
-  private: Boolean = false
-  domains: [String] = null
-  clientMutationId: String
-}
-
-type RegisterDomainPayload {
-  success: Boolean!
-  domain: DNSDomain
-  clientMutationId: String
-}
-
-input RegisterDomainInput {
-  name: String!
-  namespace: String
-  importRecords: Boolean = true
-  clientMutationId: String
-}
-
-type UpsertDNSRecordPayload {
-  success: Boolean!
-  record: DNSRecord!
-  clientMutationId: String
-}
-
-input UpsertDNSRecordInput {
-  kind: RecordKind!
-  domainId: String!
-  name: String!
-  value: String!
-  ttl: Int
-  recordId: String
-  mx: DNSMXExtraInput
-  clientMutationId: String
-}
-
-"""An enumeration."""
-enum RecordKind {
-  A
-  AAAA
-  CNAME
-  MX
-  NS
-  TXT
-  DNAME
-  PTR
-  SOA
-  SRV
-  CAA
-  SSHFP
-}
-
-input DNSMXExtraInput {
-  preference: Int!
-}
-
-type DeleteDNSRecordPayload {
-  success: Boolean!
-  clientMutationId: String
-}
-
-input DeleteDNSRecordInput {
-  recordId: ID!
-  clientMutationId: String
-}
-
-type UpsertDomainFromZoneFilePayload {
-  success: Boolean!
-  domain: DNSDomain!
-  clientMutationId: String
-}
-
-input UpsertDomainFromZoneFileInput {
-  zoneFile: String!
-  deleteMissingRecords: Boolean
-  clientMutationId: String
-}
-
-type DeleteDomainPayload {
-  success: Boolean!
-  clientMutationId: String
-}
-
-input DeleteDomainInput {
-  domainId: ID!
-  clientMutationId: String
-}
-
-"""Create or update an app secret on an app with given ID"""
-type UpsertAppSecretPayload {
-  secret: Secret!
-  success: Boolean!
-  clientMutationId: String
-}
-
-input UpsertAppSecretInput {
-  """ID of the app onto which to add secrets."""
-  appId: ID!
-
-  """Name of the secret."""
-  name: String!
-
-  """Value of the secret."""
-  value: String!
-  clientMutationId: String
-}
-
-"""Create or update app secrets on an app with given ID"""
-type UpsertAppSecretsPayload {
-  success: Boolean!
-  secrets: [Secret]!
-  clientMutationId: String
-}
-
-input UpsertAppSecretsInput {
-  """ID of the app onto which to add secrets."""
-  appId: ID!
-  secrets: [SecretInput]
-  clientMutationId: String
-}
-
-input SecretInput {
-  """Name of the secret."""
-  name: String!
-
-  """Value of the secret."""
-  value: String!
-}
-
-"""Delete secret with given ID"""
-type DeleteAppSecretPayload {
-  success: Boolean!
-
-  """ID of the deleted secret."""
-  id: ID!
-  clientMutationId: String
-}
-
-input DeleteAppSecretInput {
-  """ID of the secret to delete."""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Redeploy the active version of an app."""
-type RedeployActiveVersionPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input RedeployActiveVersionInput {
-  """ID of the app to redeploy."""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Toggle HTTP redirect for the active version of app"""
-type ToggleForceHTTPSPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input ToggleForceHTTPSInput {
-  """App ID"""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Redeploy the active version of an app."""
-type RotateS3SecretsForAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input RotateS3SecretsForAppInput {
-  """ID of the app."""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Delete a database for an app."""
-type RotateCredentialsForAppDBPayload {
-  database: AppDatabase!
-  password: String!
-  clientMutationId: String
-}
-
-input RotateCredentialsForAppDBInput {
-  """App Database ID"""
-  id: ID!
-  clientMutationId: String
-}
-
-"""Create a new database for an app."""
-type CreateAppDBPayload {
-  database: AppDatabase!
-  password: String!
-  clientMutationId: String
-}
-
-input CreateAppDBInput {
-  """App ID"""
-  id: ID!
-
-  """Database name"""
-  name: String
-  clientMutationId: String
-}
-
-"""Delete a database for an app."""
-type DeleteAppDBPayload {
-  success: Boolean!
-  clientMutationId: String
-}
-
-input DeleteAppDBInput {
-  """App Database ID"""
-  id: ID!
-  clientMutationId: String
-}
-
-type UpdateBuildConfigPayload {
-  buildConfig: BuildConfiguration!
-  success: Boolean!
-  clientMutationId: String
-}
-
-input UpdateBuildConfigInput {
-  appId: ID!
-  presetName: String
-  startCmd: String
-  buildCmd: String
-  installCmd: String
-  afterDeployCmd: String
-  clientMutationId: String
-}
-
-"""Get the autobuild config for a given repo"""
-type AutobuildConfigForRepoPayload {
-  """The build configuration"""
-  buildConfig: BuildConfig
-
-  """List of apps deployed with this repo."""
-  deployedApps: [DeployApp] @deprecated(reason: "This field is not used anymore")
-  clientMutationId: String
-}
-
-"""The Build Configuration for a given repo"""
-type BuildConfig {
-  startCmd: String
-  buildCmd: String
-  installCmd: String
-  afterDeployCmd: String
-  setupDb: Boolean!
-  presetName: String!
-  appName: String!
-  completionTimeInSeconds: Int!
-  branch: String
-  canDeployWithoutRepo: Boolean! @deprecated(reason: "This field is not used anymore")
-}
-
-input AutobuildConfigForRepoInput {
-  """The repo URL"""
-  repoUrl: String!
-
-  """The path to build from"""
-  basePath: String @deprecated(reason: "Please use root_dir instead")
-
-  """The preset to use"""
-  presetName: String
-
-  """The root directory to build from"""
-  rootDir: String
-
-  """The branch to use"""
-  branch: String
-  clientMutationId: String
-}
-
-"""Get the autobuild config for a given zip upload URL"""
-type AutobuildConfigForZipUploadPayload {
-  """The build configuration"""
-  buildConfig: BuildConfig
-
-  """List of apps deployed with this repo."""
-  deployedApps: [DeployApp] @deprecated(reason: "This field is not used anymore")
-  clientMutationId: String
-}
-
-input AutobuildConfigForZipUploadInput {
-  """The Zip upload URL"""
-  uploadUrl: String!
-
-  """The preset to use"""
-  presetName: String
-  clientMutationId: String
-}
-
-"""Add a new github app installation"""
-type InstallGithubAppPayload {
-  success: Boolean!
-  user: User!
-  installation: GithubAppInstallation
-  clientMutationId: String
-}
-
-input InstallGithubAppInput {
-  """Github app Installation ID"""
-  installationId: ID!
-
-  """Github App Account ID"""
-  githubAccountId: ID
-
-  """Github App Account Login"""
-  githubAccountLogin: String
-  clientMutationId: String
-}
-
-"""Detach autobuild from app."""
-type DetachAppFromAutobuildPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input DetachAppFromAutobuildInput {
-  """The ID of the App"""
-  appId: ID!
-  clientMutationId: String
-}
-
-"""Update autobuild config for an app."""
-type UpdateAutobuildConfigForAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input UpdateAutobuildConfigForAppInput {
-  """The ID of the App"""
-  appId: ID!
-
-  """Preset name of the build kind"""
-  presetName: String
-
-  """Build command for the app"""
-  buildCmd: String
-
-  """Install command for the app"""
-  installCmd: String
-
-  """Start command for the app"""
-  startCmd: String
-
-  """After deploy command for the app"""
-  afterDeployCmd: String
-  clientMutationId: String
-}
-
-"""Connect a github repo to an app."""
-type ConnectGithubRepoToAppPayload {
-  app: DeployApp!
-  githubRepoConnection: GithubRepoConnection!
-  success: Boolean!
-  clientMutationId: String
-}
-
-input ConnectGithubRepoToAppInput {
-  """The ID of the App"""
-  appId: ID!
-
-  """The ID of the Github app repository installation"""
-  installationRepoId: ID!
-
-  """The branch to deploy from"""
-  deployBranch: String
-  clientMutationId: String
-}
-
-"""Disconnect a github repo from an app."""
-type DisconnectGithubRepoFromAppPayload {
-  app: DeployApp!
-  success: Boolean!
-  clientMutationId: String
-}
-
-input DisconnectGithubRepoFromAppInput {
-  """The ID of the App"""
-  appId: ID!
-  clientMutationId: String
-}
-
-type UpdateGithubRepoAppConnectionPayload {
-  githubRepoConnection: GithubRepoConnection!
-  success: Boolean!
-  clientMutationId: String
-}
-
-input UpdateGithubRepoAppConnectionInput {
-  """The ID of the GithubRepoConnection"""
-  connectionId: ID!
-  deploymentStatusEvents: Boolean
-  pullRequestComments: Boolean
-  clientMutationId: String
-}
-
-"""Deploy a wordpress site."""
-type DeployWordpressPayload {
-  appVersion: DeployAppVersion!
-  clientMutationId: String
-}
-
-input DeployWordpressInput {
-  """Wordpress site name."""
-  siteName: String!
-
-  """Name of app to create."""
-  appName: String!
-
-  """Owner of this app."""
-  appOwner: String!
-
-  """Region for this app."""
-  region: String!
-
-  """Username of admin for the wordpress site."""
-  adminUsername: String!
-
-  """Admin password for the wordpress site."""
-  adminPassword: String!
-
-  """Email of admin of the wordpress site."""
-  adminEmail: String!
-
-  """Email of admin of the wordpress site."""
-  language: String
-
-  """If set, the app is managed by wasmer."""
-  managed: Boolean
-  clientMutationId: String
-}
-
-"""Enable app that was previously disabled."""
-type EnableAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input EnableAppInput {
-  """ID of app to disable"""
-  appId: ID!
-  clientMutationId: String
-}
-
-"""Disable app with a reason."""
-type DisableAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input DisableAppInput {
-  """ID of app to disable"""
-  appId: ID!
-
-  """Disable with this reason"""
-  reason: String!
-  clientMutationId: String
-}
-
-"""Ban app with a reason."""
-type BanAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input BanAppInput {
-  """ID of app to disable"""
-  appId: ID!
-
-  """Disable with this reason"""
-  reason: String!
-
-  """Blackhole the app (no network access)"""
-  blackholed: Boolean = false
-  clientMutationId: String
-}
-
-"""Un-ban app with a reason."""
-type UnbanAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input UnbanAppInput {
-  """ID of app to disable"""
-  appId: ID!
-  clientMutationId: String
-}
-
-"""Claim a perishable app as their own."""
-type ClaimPerishableAppPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input ClaimPerishableAppInput {
-  """ID of app to disable"""
-  appId: ID!
-  clientMutationId: String
-}
-
-type DeployViaAutobuildPayload {
-  success: Boolean!
-  buildId: UUID!
-  clientMutationId: String
-}
-
-input DeployViaAutobuildInput {
-  repoUrl: String
-  uploadUrl: String
-  appName: String
-  appId: ID
-  owner: String
-  presetName: String
-  buildCmd: String
-  installCmd: String
-  startCmd: String
-  afterDeployCmd: String
-  enableDatabase: Boolean
-  secrets: [SecretInput]
-  extraData: AutobuildDeploymentExtraData
-  params: AutobuildDeploymentExtraData
-
-  """If set, the app is managed by wasmer."""
-  managed: Boolean = false
-  kind: String
-
-  """If set, the screenshot is waited for."""
-  waitForScreenshotGeneration: Boolean = false
-
-  """Region to deploy the app"""
-  region: String
-
-  """The path to build from (defaults to /)"""
-  basePath: String @deprecated(reason: "Please use root_dir instead")
-
-  """The root directory to build from (defaults to /)"""
-  rootDir: String
-
-  """
-  Branch to deploy from. If no branch is specified, the default branch is used.
-  """
-  branch: String
-
-  """If set, allows deploying a new version of an existing app."""
-  allowExistingApp: Boolean = false
-
-  """Additional jobs to run in the deployment."""
-  jobs: [JobDefinitionInput]
-
-  """Domains for this app"""
-  domains: [String]
-
-  """When the app should be perished"""
-  perishAt: String
-  clientMutationId: String
-}
-
-input AutobuildDeploymentExtraData {
-  wordpress: WordpressDeploymentExtraData = null
-}
-
-input WordpressDeploymentExtraData {
-  siteName: String!
-  adminUsername: String!
-  adminPassword: String!
-  adminEmail: String!
-  language: String = "en_US"
-}
-
-input JobDefinitionInput {
-  name: String
-  package: String
-
-  """Command to run the job"""
-  command: String!
-  cliArgs: [String]
-  env: [String]
-
-  """Humanfriendly timeout definition. e.g. 10m, 1h"""
-  timeout: String = "10m"
-}
-
-"""
-Delete a user with some reason. The deletion will be soft, so the
-underlying data will remain and be anonymized following GDPR.
-"""
-type DeleteUserPayload {
-  deleted: Boolean!
-
-  """ID of user to delete"""
-  userId: ID!
-  clientMutationId: String
-}
-
-input DeleteUserInput {
-  """ID of user to delete"""
-  userId: ID!
-  clientMutationId: String
-}
-
-"""Create a new vault from yaml config"""
-type UpsertVaultPayload {
-  vault: Vault!
-  clientMutationId: String
-}
-
-type Vault implements Node {
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  name: String!
-  app: DeployApp
-
-  """The ID of the object"""
-  id: ID!
-}
-
-input UpsertVaultInput {
-  """YAML Configuration for vault"""
-  config: String!
-  clientMutationId: String
-}
-
-"""Attach vault to an app"""
-type AttachVaultPayload {
-  app: DeployApp!
-  clientMutationId: String
-}
-
-input AttachVaultInput {
-  """ID of app to which the vault will be attached."""
-  appId: ID!
-
-  """ID of vault to attach."""
-  vaultId: ID!
-  clientMutationId: String
-}
-
-"""Migrate an app to a different region."""
-type MigrateAppRegionPayload {
-  app: DeployApp!
-
-  """ID of the internal task for app migration"""
-  taskId: ID!
-  clientMutationId: String
-}
-
-input MigrateAppRegionInput {
-  """ID of the app to migrate"""
-  appId: ID!
-
-  """Target region name"""
-  regionName: String!
-  clientMutationId: String
-}
-
-type ObtainJSONWebTokenPayload {
-  payload: GenericScalar!
-  refreshExpiresIn: Int!
-  username: CaseInsensitiveString!
-  clientMutationId: String
-  token: String!
-  refreshToken: String!
-}
-
-"""
-The `GenericScalar` scalar type represents a generic
-GraphQL scalar value that could be:
-String, Boolean, Int, Float, List or Object.
-"""
-scalar GenericScalar
-
-"""
-The `CaseInsensitiveString` scalar type represents textual data, represented as UTF-8
-character sequences. The String type is most often used by GraphQL to
-represent free-form human-readable text.
-"""
-scalar CaseInsensitiveString
-
-input ObtainJSONWebTokenInput {
-  clientMutationId: String
-  username: String!
-  password: String!
-}
-
-type GenerateDeployTokenPayload {
-  token: String!
-  deployConfigVersion: DeployAppVersion!
-  clientMutationId: String
-}
-
-input GenerateDeployTokenInput {
-  deployConfigVersionId: String!
-  clientMutationId: String
-}
-
-type Verify {
-  payload: GenericScalar!
-}
-
-type Refresh {
-  payload: GenericScalar!
-  refreshExpiresIn: Int!
-  token: String!
-  refreshToken: String!
-}
-
-type Revoke {
-  revoked: Int!
-}
-
-type RegisterUserPayload {
-  token: String
-  clientMutationId: String
-}
-
-input RegisterUserInput {
-  fullName: String
-  email: String!
-  username: CaseInsensitiveString!
-  password: String!
-  acceptedTos: Boolean
-  intent: String
-  fingerprintVisitorId: String
-  enterProTrial: Boolean
-  clientMutationId: String
-}
-
-type SocialAuthJWTPayload {
-  social: SocialAuth
-  token: String
-  clientMutationId: String
-}
-
-input SocialAuthJWTInput {
-  provider: String!
-  accessToken: String!
-  register: Boolean = false
-  registerIntent: String
-  fingerprintVisitorId: String
-  enterProTrial: Boolean
-  response: JSONString
-  clientMutationId: String
-}
-
-type ValidateUserEmailPayload {
-  user: User
-  clientMutationId: String
-}
-
-input ValidateUserEmailInput {
-  """The user id"""
-  userId: ID
-  challenge: String!
-  clientMutationId: String
-}
-
-type ValidateUserFingerprintPayload {
-  user: User
-  clientMutationId: String
-}
-
-input ValidateUserFingerprintInput {
-  fingerprintVisitorId: String!
-  clientMutationId: String
-}
-
-type RequestPasswordResetPayload {
-  email: String!
-  errors: [ErrorType]
-  clientMutationId: String
-}
-
-type ErrorType {
-  field: String!
-  messages: [String!]!
-}
-
-input RequestPasswordResetInput {
-  email: String!
-  clientMutationId: String
-}
-
-type RequestValidationEmailPayload {
-  user: User
-  success: Boolean!
-  clientMutationId: String
-}
-
-input RequestValidationEmailInput {
-  """The user id"""
-  userId: ID @deprecated(reason: "This field is deprecated. The user can only request a validation email for themselves.")
-  clientMutationId: String
-}
-
-type ChangeUserPasswordPayload {
-  token: String
-  clientMutationId: String
-}
-
-input ChangeUserPasswordInput {
-  """
-  The token associated to change the password. If not existing it will use the request user by default
-  """
-  token: String
-  oldPassword: String
-  password: String!
-  clientMutationId: String
-}
-
-type ChangeUserUsernamePayload {
-  user: User
-  token: String
-  clientMutationId: String
-}
-
-input ChangeUserUsernameInput {
-  """The new user username"""
-  username: CaseInsensitiveString!
-  clientMutationId: String
-}
-
-type ChangeUserEmailPayload {
-  user: User!
-  clientMutationId: String
-}
-
-input ChangeUserEmailInput {
-  newEmail: String!
-  clientMutationId: String
-}
-
-type UpdateUserInfoPayload {
-  user: User
-  clientMutationId: String
-}
-
-input UpdateUserInfoInput {
-  """The user id"""
-  userId: ID
-
-  """The user full name"""
-  fullName: String
-
-  """The user bio"""
-  bio: String
-
-  """The user avatar"""
-  avatar: String @deprecated(reason: "Use `avatarUpload` instead")
-
-  """The user avatar"""
-  avatarUpload: Upload
-
-  """
-  The user Twitter (it can be the url, or the handle with or without the @)
-  """
-  twitter: String
-
-  """
-  The user Github (it can be the url, or the handle with or without the @)
-  """
-  github: String
-
-  """The user website (it must be a valid url)"""
-  websiteUrl: String
-
-  """The user location"""
-  location: String
-  clientMutationId: String
-}
-
-"""
-Create scalar that ignores normal serialization/deserialization, since
-that will be handled by the multipart request spec
-"""
-scalar Upload
-
-type ValidateUserPasswordPayload {
-  success: Boolean
-  clientMutationId: String
-}
-
-input ValidateUserPasswordInput {
-  password: String!
-  clientMutationId: String
-}
-
-type GenerateAPITokenPayload {
-  token: APIToken
-  tokenRaw: String
-  user: User
-  clientMutationId: String
-}
-
-input GenerateAPITokenInput {
-  identifier: String
-  clientMutationId: String
-}
-
-"""Request To revoke an API token; these start with 'wap_'."""
-type RevokeAPITokenPayload {
-  token: APIToken
-  success: Boolean
-  clientMutationId: String
-}
-
-input RevokeAPITokenInput {
-  """The API token ID"""
-  tokenId: String
-
-  """The raw API token"""
-  token: String
-  clientMutationId: String
-}
-
-type CheckUserExistsPayload {
-  exists: Boolean!
-
-  """The user is only returned if the user input was the username"""
-  user: User
-  clientMutationId: String
-}
-
-input CheckUserExistsInput {
-  """The user"""
-  user: String!
-  clientMutationId: String
-}
-
-type ReadNotificationPayload {
-  notification: UserNotification
-  clientMutationId: String
-}
-
-input ReadNotificationInput {
-  notificationId: ID!
-  clientMutationId: String
-}
-
-type SeePendingNotificationsPayload {
-  success: Boolean
-  clientMutationId: String
-}
-
-input SeePendingNotificationsInput {
-  clientMutationId: String
-}
-
-type NewNoncePayload {
-  nonce: Nonce!
-  clientMutationId: String
-}
-
-input NewNonceInput {
-  name: String!
-  callbackUrl: String!
-  clientMutationId: String
-}
-
-type ValidateNoncePayload {
-  nonce: Nonce!
-  clientMutationId: String
+	PACKAGE_COUNT
+	APP_COUNT
+	CREATED_DATE
+}
+
+input UsersFilter {
+	count: Int = 1000
+	sortBy: SearchOrderSort = DESC
+	"""
+	Filter users by package count.
+	"""
+	packageCount: CountFilter
+	"""
+	Filter users by namespace count.
+	"""
+	namespaceCount: CountFilter
+	"""
+	Filter users joined after this date.
+	"""
+	joinedAfter: DateTime
+	"""
+	Filter users joined before this date.
+	"""
+	joinedBefore: DateTime
+	"""
+	Order users by field.
+	"""
+	orderBy: UserOrderBy = CREATED_DATE
 }
 
 input ValidateNonceInput {
-  id: ID!
-  secret: String!
-  clientMutationId: String
+	id: ID!
+	secret: String!
+	clientMutationId: String
 }
 
-type InvalidateNoncePayload {
-  nonce: Nonce!
-  clientMutationId: String
+type ValidateNoncePayload {
+	nonce: Nonce!
+	clientMutationId: String
 }
 
-input InvalidateNonceInput {
-  id: ID!
-  secret: String!
-  clientMutationId: String
+input ValidateUserEmailInput {
+	"""
+	The user id
+	"""
+	userId: ID
+	challenge: String!
+	clientMutationId: String
 }
 
-type MFATOTPTokenType {
-  qr: String
-  secretKey: String
+type ValidateUserEmailPayload {
+	clientMutationId: String
+	user: User
 }
 
-input MFATOTPGetTokenInput {
-  clientMutationId: String
+input ValidateUserFingerprintInput {
+	fingerprintVisitorId: String!
+	clientMutationId: String
 }
 
-type MFATOTPVerifyPayload {
-  status: MFATOTPVerifyStatus
-  clientMutationId: String
+type ValidateUserFingerprintPayload {
+	clientMutationId: String
+	user: User
 }
 
-enum MFATOTPVerifyStatus {
-  SUCCESS
-  RECOVERY
+input ValidateUserPasswordInput {
+	password: String!
+	clientMutationId: String
 }
 
-input MFATOTPVerifyInput {
-  answer: String!
-  secretKey: String!
-  clientMutationId: String
+type ValidateUserPasswordPayload {
+	success: Boolean
+	clientMutationId: String
 }
 
-"""Response object for MFAAuth mutation."""
-type MFAAuthResponse {
-  success: Boolean!
-  token: String
-  refreshToken: String
-  username: String
-  refreshTokenExpiresIn: Int
+type Vault implements Node {
+	name: String!
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	app: DeployApp
 }
 
-input MFATOTPAuthInput {
-  username: String!
-  otp: String!
-  clientMutationId: String
+enum VerificationKind {
+	QUICK
+	DEEP
 }
 
-type MFARecoveryCodes {
-  codes: [String]!
+type Verify {
+	payload: GenericScalar!
 }
 
-input MFAGenerateRecoveryTokenInput {
-  clientMutationId: String
+input VerifyAppDomainInput {
+	"""
+	The ID of the domain to verify
+	"""
+	domainId: ID!
+	"""
+	Specify how to verify the domain
+	"""
+	kind: VerificationKind = QUICK
+	clientMutationId: String
 }
 
-input MFARecoveryAuthInput {
-  username: String!
-  otp: String!
-  clientMutationId: String
+"""
+Detach autobuild from app.
+"""
+type VerifyAppDomainPayload {
+	verified: Boolean!
+	clientMutationId: String
 }
 
-input MFAEmailAuthInput {
-  username: String!
-  otp: String!
-  clientMutationId: String
+type WEBCFilesystemItem {
+	name: String!
+	checksum: String!
+	size: Int!
+	offset: Int!
 }
 
-type MFAEmailGenerationResponse {
-  success: Boolean!
+type Waitlist implements Node {
+	name: String!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	"""
+	The ID of the object
+	"""
+	id: ID!
 }
 
-input MFAGenerateEmailOTPInput {
-  clientMutationId: String
+type WaitlistMember implements Node {
+	waitlist: Waitlist!
+	joinedAt: DateTime!
+	approvedAt: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	member: Owner!
+	approved: Boolean!
 }
 
-type GenerateCheckoutUrlPayload {
-  checkout: StripeCheckout!
-  clientMutationId: String
-}
-
-type StripeCheckout {
-  url: String!
-  expiresAt: DateTime!
-  clientSecret: String!
-}
-
-input GenerateCheckoutUrlInput {
-  """URL to redirect to on success."""
-  successUrl: String!
-
-  """URL to redirect to on cancellation."""
-  cancelUrl: String!
-
-  """ID of price (product) to charge the user."""
-  priceId: ID!
-
-  """Locale of the customer."""
-  locale: String!
-
-  """ID of owner to create subscription on. Defaults to current user."""
-  forOwnerId: ID
-  clientMutationId: String
-}
-
-type CreateCheckoutSessionPayload {
-  clientSecret: String!
-  clientMutationId: String
-}
-
-input CreateCheckoutSessionInput {
-  """URL to redirect."""
-  returnUrl: String!
-
-  """ID of price (product) to charge the user."""
-  priceId: ID!
-
-  """Locale of the customer."""
-  locale: String!
-
-  """ID of owner to create subscription on. Defaults to current user."""
-  forOwnerId: ID
-
-  """Whether to apply a trial period if available."""
-  isTrial: Boolean = false
-  clientMutationId: String
-}
-
-type CancelSubscriptionPayload {
-  ok: Boolean!
-  clientMutationId: String
-}
-
-input CancelSubscriptionInput {
-  """ID of owner whose subscription to cancel."""
-  forOwnerId: ID!
-
-  """ID of the subscription to cancel"""
-  subscriptionId: ID!
-  clientMutationId: String
-}
-
-type RenewCanceledSubscriptionPayload {
-  ok: Boolean!
-  clientMutationId: String
-}
-
-input RenewCanceledSubscriptionInput {
-  """ID of owner whose subscription to renew."""
-  forOwnerId: ID!
-
-  """ID of the subscription to renew"""
-  subscriptionId: ID!
-  clientMutationId: String
-}
-
-type PublishPublicKeyPayload {
-  success: Boolean!
-  publicKey: PublicKey!
-  clientMutationId: String
-}
-
-input PublishPublicKeyInput {
-  keyId: String!
-  key: String!
-  verifyingSignatureId: String
-  clientMutationId: String
-}
-
-type PublishPackagePayload {
-  success: Boolean!
-  packageVersion: PackageVersion
-  packageWebc: PackageWebc
-  clientMutationId: String
-}
-
-input PublishPackageInput {
-  manifest: String!
-  name: String
-  namespace: String
-  version: String
-  description: String
-  license: String
-  licenseFile: String
-  readme: String
-  repository: String
-  homepage: String
-
-  """The package file"""
-  file: String @deprecated(reason: "Use `fileUpload` instead")
-
-  """The package file"""
-  fileUpload: Upload
-  signedUrl: String
-  signature: InputSignature
-
-  """The package icon"""
-  icon: String @deprecated(reason: "Use `iconUpload` instead")
-
-  """The package icon"""
-  iconUpload: Upload
-
-  """Whether the package is private"""
-  private: Boolean = false
-
-  """The upload format of the package"""
-  uploadFormat: UploadFormat = targz
-
-  """Whether to wait for webc generation to finish"""
-  wait: Boolean = false
-  clientMutationId: String
-}
-
-input InputSignature {
-  publicKeyKeyId: String!
-  data: String!
-}
-
-"""An enumeration."""
-enum UploadFormat {
-  targz
-  webcv2
-  webcv3
-}
-
-type PushPackageReleasePayload {
-  success: Boolean!
-  packageWebc: PackageWebc
-  clientMutationId: String
-}
-
-input PushPackageReleaseInput {
-  namespace: String!
-  signedUrl: String!
-  name: String
-
-  """Whether the package is private"""
-  private: Boolean = false
-  clientMutationId: String
-}
-
-type TagPackageReleasePayload {
-  success: Boolean!
-  packageVersion: PackageVersion
-  clientMutationId: String
-}
-
-input TagPackageReleaseInput {
-  packageReleaseId: ID!
-  version: String!
-  name: String
-  manifest: String
-  namespace: String
-  description: String
-  license: String
-  licenseFile: String
-  readme: String
-  repository: String
-  homepage: String
-  signature: InputSignature
-
-  """The package icon"""
-  icon: String
-  private: Boolean = false
-  clientMutationId: String
-}
-
-type UpdatePackagePayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input UpdatePackageInput {
-  packageId: ID!
-
-  """The package icon"""
-  icon: String @deprecated(reason: "Use `iconUpload` instead")
-
-  """The package icon"""
-  iconUpload: Upload
-  clientMutationId: String
-}
-
-type LikePackagePayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input LikePackageInput {
-  packageId: ID!
-  clientMutationId: String
-}
-
-type UnlikePackagePayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input UnlikePackageInput {
-  packageId: ID!
-  clientMutationId: String
-}
-
-type WatchPackagePayload {
-  package: Package!
-  clientMutationId: String
+type WasmerSubscription implements Node {
+	"""
+	The datetime this object was created in stripe.
+	"""
+	created: DateTime
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	cancelAt: DateTime
+	canceledAt: DateTime
+	currentPeriodEnd: DateTime
+	currentPeriodStart: DateTime
+	daysUntilDue: Int
+	endedAt: DateTime
+	startDate: DateTime
+	status: String
+	trialEnd: DateTime
+	trialStart: DateTime
+	description: String
+	cancelAtPeriodEnd: Boolean
 }
 
 input WatchPackageInput {
-  packageId: ID!
-  clientMutationId: String
+	packageId: ID!
+	clientMutationId: String
 }
 
-type UnwatchPackagePayload {
-  package: Package!
-  clientMutationId: String
+type WatchPackagePayload {
+	clientMutationId: String
+	package: Package!
 }
 
-input UnwatchPackageInput {
-  packageId: ID!
-  clientMutationId: String
+type WebcImage implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	"""
+	The version of the webc image, defaults to v2.
+	"""
+	version: WebcVersion!
+	fileSize: BigInt!
+	manifest: JSONString!
+	webcSha256: String!
+	targzSha256: String
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	webcUrl: String!
+	volumes: JSONString! @deprecated(reason: "Deprecated, use the webc_url to explore the webc file")
+	offsets: JSONString! @deprecated(reason: "Deprecated, use the webc_url to explore the webc file")
 }
 
-type ArchivePackagePayload {
-  package: Package!
-  clientMutationId: String
+type WebcImageConnection {
+	"""
+	Pagination data for this connection.
+	"""
+	pageInfo: PageInfo!
+	"""
+	Contains the nodes in this connection.
+	"""
+	edges: [WebcImageEdge]!
+	"""
+	Total number of items in the connection.
+	"""
+	totalCount: Int
 }
 
-input ArchivePackageInput {
-  packageId: ID!
-  clientMutationId: String
+"""
+A Relay edge containing a `WebcImage` and its cursor.
+"""
+type WebcImageEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: WebcImage!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
 }
 
-type RenamePackagePayload {
-  package: Package!
-  clientMutationId: String
+input WebcSourceV1 {
+	name: String!
+	namespace: String!
+	repository: String! = "https://registry.wasmer.wtf"
+	tag: String
+	authToken: String
 }
 
-input RenamePackageInput {
-  packageId: ID!
-  newName: String!
-  clientMutationId: String
+enum WebcVersion {
+	V2
+	V3
 }
 
-type ChangePackageVersionArchivedStatusPayload {
-  packageVersion: PackageVersion!
-  clientMutationId: String
+type WordPressPlugin {
+	slug: String!
+	name: String!
+	title: String
+	version: String!
+	latestVersion: String
+	active: Boolean!
+	description: String
+	icon: String
+	url: String
+	status: String
+	autoUpdate: Boolean
 }
 
-input ChangePackageVersionArchivedStatusInput {
-  packageVersionId: ID!
-  isArchived: Boolean
-  clientMutationId: String
+type WordPressTheme {
+	slug: String!
+	name: String!
+	title: String
+	version: String!
+	latestVersion: String
+	active: Boolean!
+	description: String
+	status: String
+	autoUpdate: Boolean
 }
 
-type CreateNamespacePayload {
-  namespace: Namespace!
-  user: User!
-  clientMutationId: String
+type WordpressAppKind {
+	adminUrl: String! @deprecated(reason: "Use generateWordPressMagicLoginUrl mutation instead.")
+	liveConfig(forceFetch: Boolean): WordpressLiveConfig
+	wordpressCronjobEnabled: Boolean!
+	wordpressVersion: WordpressVersion
 }
 
-input CreateNamespaceInput {
-  name: String!
-
-  """The namespace display name"""
-  displayName: String
-
-  """The namespace description"""
-  description: String
-
-  """The namespace avatar"""
-  avatar: String @deprecated(reason: "Use `avatarUpload` instead")
-
-  """The namespace avatar"""
-  avatarUpload: Upload
-  clientMutationId: String
+type WordpressDeploymentDefaults {
+	siteTitle: String!
+	appName: String!
+	adminUsername: String!
+	adminPassword: String!
+	adminEmail: String!
 }
 
-type UpdateNamespacePayload {
-  namespace: Namespace!
-  clientMutationId: String
+input WordpressDeploymentExtraData {
+	siteName: String!
+	adminUsername: String!
+	adminPassword: String!
+	adminEmail: String!
+	language: String = "en_US"
+	theme: String
 }
 
-input UpdateNamespaceInput {
-  namespaceId: ID!
-
-  """The namespace slug name"""
-  name: String
-
-  """The namespace display name"""
-  displayName: String
-
-  """The namespace description"""
-  description: String
-
-  """The namespace avatar"""
-  avatar: String @deprecated(reason: "Use `avatarUpload` instead")
-
-  """The namespace avatar"""
-  avatarUpload: Upload
-
-  """
-  The user Twitter (it can be the url, or the handle with or without the @)
-  """
-  twitter: String
-
-  """
-  The user Github (it can be the url, or the handle with or without the @)
-  """
-  github: String
-
-  """The user website (it must be a valid url)"""
-  websiteUrl: String
-  clientMutationId: String
+type WordpressLiveConfig {
+	checkedAt: DateTime!
+	wordpressVersion: String!
+	phpVersion: String!
+	phpArchitecture: String!
+	mysqlServer: String!
+	plugins: [WordPressPlugin]!
+	wasmerPlugin: WordPressPlugin
+	themes: [WordPressTheme]!
+	isLive: Boolean!
+	usersCount: Int!
+	mainAdminId: String
+	publishedPostsCount: Int!
+	publishedPagesCount: Int!
 }
 
-type DeleteNamespacePayload {
-  success: Boolean!
-  clientMutationId: String
+type WordpressVersion implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	version: String!
+	downloadUrl: String! @deprecated(reason: "Use zip.downloadUrl instead.")
+	minPhpVersion: String!
+	mysqlVersion: String!
+	githubRepo: String!
+	githubTag: String!
+	defaultTheme: String!
+	isLatest: Boolean!
+	zip: WordpressVersionZip!
 }
 
-input DeleteNamespaceInput {
-  namespaceId: ID!
-  clientMutationId: String
+type WordpressVersionZip {
+	downloadUrl: String!
+	hash: String!
 }
 
-type InviteNamespaceCollaboratorPayload {
-  invite: NamespaceCollaboratorInvite!
-  namespace: Namespace!
-  clientMutationId: String
+type WorkloadMetrics {
+	workloads: Int!
+	wallCpuTimeMillis: BigInt!
+	realCpuTimeMillis: BigInt!
+	memoryBytes: BigInt!
+	networkIngressBytes: BigInt!
+	networkEgressBytes: BigInt!
 }
 
-input InviteNamespaceCollaboratorInput {
-  namespaceId: ID!
-  role: GrapheneRole!
-  username: String
-  email: String
-  clientMutationId: String
+input WorkloadRunnerV1 {
+	webProxy: RunnerWebProxyV1
+	wcgi: RunnerWCGIV1
 }
 
-type AcceptNamespaceCollaboratorInvitePayload {
-  namespaceCollaboratorInvite: NamespaceCollaboratorInvite!
-  clientMutationId: String
+input WorkloadRunnerWasmSourceV1 {
+	webc: WebcSourceV1!
 }
 
-input AcceptNamespaceCollaboratorInviteInput {
-  inviteId: ID!
-  clientMutationId: String
+input WorkloadV1 {
+	capability: CapabilityMapV1
+	name: String = null
+	runner: WorkloadRunnerV1!
 }
 
-type RemoveNamespaceCollaboratorInvitePayload {
-  namespace: Namespace!
-  clientMutationId: String
+input WorkloadV2 {
+	source: String!
 }
 
-input RemoveNamespaceCollaboratorInviteInput {
-  inviteId: ID!
-  clientMutationId: String
+type ZipRollout implements Node {
+	"""
+	The ID of the object
+	"""
+	id: ID!
+	createdAt: DateTime!
+	updatedAt: DateTime!
+	deletedAt: DateTime
+	externalId: String
+	rollout: Rollout
+	zipFileUrl: String!
+	zipFileHash: String
 }
 
-type RemoveNamespaceCollaboratorPayload {
-  namespace: Namespace!
-  clientMutationId: String
-}
-
-input RemoveNamespaceCollaboratorInput {
-  namespaceCollaboratorId: ID!
-  clientMutationId: String
-}
-
-type UpdateNamespaceCollaboratorRolePayload {
-  collaborator: NamespaceCollaborator!
-  clientMutationId: String
-}
-
-input UpdateNamespaceCollaboratorRoleInput {
-  namespaceCollaboratorId: ID!
-  role: GrapheneRole!
-  clientMutationId: String
-}
-
-type UpdateNamespaceCollaboratorInviteRolePayload {
-  collaboratorInvite: NamespaceCollaboratorInvite!
-  clientMutationId: String
-}
-
-input UpdateNamespaceCollaboratorInviteRoleInput {
-  namespaceCollaboratorInviteId: ID!
-  role: GrapheneRole!
-  clientMutationId: String
-}
-
-type InvitePackageCollaboratorPayload {
-  invite: PackageCollaboratorInvite!
-  package: Package!
-  clientMutationId: String
-}
-
-input InvitePackageCollaboratorInput {
-  packageName: String!
-  role: GrapheneRole!
-  username: String
-  email: String
-  clientMutationId: String
-}
-
-type AcceptPackageCollaboratorInvitePayload {
-  packageCollaboratorInvite: PackageCollaboratorInvite!
-  clientMutationId: String
-}
-
-input AcceptPackageCollaboratorInviteInput {
-  inviteId: ID!
-  clientMutationId: String
-}
-
-type RemovePackageCollaboratorInvitePayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input RemovePackageCollaboratorInviteInput {
-  inviteId: ID!
-  clientMutationId: String
-}
-
-type UpdatePackageCollaboratorRolePayload {
-  collaborator: PackageCollaborator!
-  clientMutationId: String
-}
-
-input UpdatePackageCollaboratorRoleInput {
-  packageCollaboratorId: ID!
-  role: GrapheneRole!
-  clientMutationId: String
-}
-
-type UpdatePackageCollaboratorInviteRolePayload {
-  collaboratorInvite: PackageCollaboratorInvite!
-  clientMutationId: String
-}
-
-input UpdatePackageCollaboratorInviteRoleInput {
-  packageCollaboratorInviteId: ID!
-  role: GrapheneRole!
-  clientMutationId: String
-}
-
-type RemovePackageCollaboratorPayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input RemovePackageCollaboratorInput {
-  packageCollaboratorId: ID!
-  clientMutationId: String
-}
-
-type RequestPackageTransferPayload {
-  package: Package!
-  wasInstantlyTransferred: Boolean!
-  packageTransferRequest: PackageTransferRequest
-  clientMutationId: String
-}
-
-input RequestPackageTransferInput {
-  packageId: ID!
-  newOwnerId: ID!
-  clientMutationId: String
-}
-
-type AcceptPackageTransferRequestPayload {
-  package: Package!
-  packageTransferRequest: PackageTransferRequest!
-  clientMutationId: String
-}
-
-input AcceptPackageTransferRequestInput {
-  packageTransferRequestId: ID!
-  clientMutationId: String
-}
-
-type RemovePackageTransferRequestPayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input RemovePackageTransferRequestInput {
-  packageTransferRequestId: ID!
-  clientMutationId: String
-}
-
-type GenerateBindingsForAllPackagesPayload {
-  message: String!
-  clientMutationId: String
-}
-
-input GenerateBindingsForAllPackagesInput {
-  bindingsGeneratorId: ID
-  bindingsGeneratorCommand: String
-  clientMutationId: String
-}
-
-type MakePackagePublicPayload {
-  package: Package!
-  clientMutationId: String
-}
-
-input MakePackagePublicInput {
-  """The ID of the package to make public"""
-  id: ID!
-  clientMutationId: String
-}
-
-type GenerateUploadUrlPayload {
-  signedUrl: SignedUrl!
-  method: String!
-  clientMutationId: String
-}
-
-input GenerateUploadUrlInput {
-  name: String
-  version: String = "latest"
-  filename: String
-  expiresAfterSeconds: Int = 60
-  method: String
-  clientMutationId: String
-}
-
-type Subscription {
-  autobuildDeployment(buildId: UUID!): AutobuildLog
-  generateScreenshot(
-    """App version ID"""
-    appVersionId: ID!
-
-    """Force generation"""
-    forceGeneration: Boolean = false
-  ): DeployAppVersion!
-  streamLogs(
-    """
-    Specify the app to show logs for. Alternatively, you can also just specify the app version if you want. If both app and app-version are specified, then the app-version must be associated with specified app.
-    """
-    appId: ID
-
-    """Filter logs for app to a certain app version."""
-    appVersionId: ID
-
-    """
-    Get logs starting from this timestamp. Takes ISO timestamp in UTC timezone.
-    """
-    startingFromISO: DateTime
-
-    """
-    Fetch logs until this timestamp. Takes ISO timestamp in UTC timezone. If specified, the subscription will at this time.
-    """
-    untilISO: DateTime
-
-    """Filter logs by stream"""
-    streams: [LogStream]
-
-    """Filter logs by instance ids"""
-    instanceIds: [String]
-
-    """Filter logs by request ID"""
-    requestId: String
-
-    """Search logs for this term"""
-    searchTerm: String
-  ): Log!
-  waitOnRepoCreation(repoId: ID!): Boolean!
-  appIsPublishedFromRepo(repoId: ID!): DeployAppVersion!
-  runEdgeJob(command: String!, appVersionId: ID!, envVars: [SecretInput], source: String, cliArgs: [String]): Boolean
-  fetchBuildLogs(buildId: String!): String
-  timeout: Int
-  packageVersionCreated(publishedBy: ID, ownerId: ID): PackageVersion!
-
-  """Subscribe to package version ready"""
-  packageVersionReady(packageVersionId: ID!): PackageVersionReadyResponse!
-  userNotificationCreated(userId: ID!): UserNotificationCreated!
-}
-
-"""Log entry for Deploying app from github repo"""
-type AutobuildLog {
-  """Kind of log message."""
-  kind: AutoBuildDeployAppLogKind!
-
-  """Log message"""
-  message: String
-  appVersion: DeployAppVersion
-
-  """Timestamp in nanoseconds"""
-  timestamp: String!
-
-  """ISO 8601 string in UTC"""
-  datetime: DateTime!
-
-  """Log stream"""
-  stream: LogStream
-}
-
-enum AutoBuildDeployAppLogKind {
-  LOG
-  PREPARING_TO_DEPLOY_STATUS
-  FETCHING_PLAN_STATUS
-  BUILD_STATUS
-  DEPLOY_STATUS
-  COMPLETE
-  FAILED
-}
-
-type PackageVersionReadyResponse {
-  state: PackageVersionState!
-  packageVersion: PackageVersion!
-  success: Boolean!
-}
-
-enum PackageVersionState {
-  WEBC_GENERATED
-  BINDINGS_GENERATED
-  NATIVE_EXES_GENERATED
-}
-
-type UserNotificationCreated {
-  notification: UserNotification
-  notificationDeletedId: ID
+"""
+Marks an element of a GraphQL schema as no longer supported.
+"""
+directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to include this field or fragment only when the user is not logged in.
+"""
+directive @includeIfLoggedIn on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the user is not logged in.
+"""
+directive @skipIfLoggedIn on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Provides a scalar specification URL for specifying the behavior of custom scalar types.
+"""
+directive @specifiedBy(url: String!) on SCALAR
+schema {
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
 }

--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -5046,8 +5046,8 @@ type PackageVersion implements Node & PackageInstance & PackageReleaseInterface 
 	isSigned: Boolean!
 	moduleInterfaces: [InterfaceVersion!]!
 	modules: [PackageVersionModule!]!
-	getPiritaContents(volume: String! = "atom", base: String! = ""): [PiritaFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly fromt he webc")
-	getWebcContents(volume: String! = "atom", base: String! = "/"): [WEBCFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly fromt he webc")
+	getPiritaContents(volume: String! = "atom", base: String! = ""): [PiritaFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly from the webc")
+	getWebcContents(volume: String! = "atom", base: String! = "/"): [WEBCFilesystemItem!]! @deprecated(reason: "File exploration is of the webc is not supported anymore, please get the files directly from the webc")
 	nativeExecutables(triple: String, wasmerCompilerVersion: String): [NativeExecutable]
 	bindings: [PackageVersionLanguageBinding]!
 	npmBindings: PackageVersionNPMBinding

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -2341,6 +2341,52 @@ pub async fn purge_cache_for_app_version(
     Ok(())
 }
 
+pub async fn configure_app_cdn_cache(
+    client: &WasmerClient,
+    vars: types::ConfigureAppCdnCacheVars,
+) -> Result<types::AppCdnCacheMutationPayload, anyhow::Error> {
+    client
+        .run_graphql_strict(types::ConfigureAppCdnCache::build(vars))
+        .await
+        .map(|x| x.configure_app_cdn_cache)
+}
+
+pub async fn purge_app_cdn_cache(
+    client: &WasmerClient,
+    vars: types::PurgeAppCdnCacheVars,
+) -> Result<types::AppCdnCacheMutationPayload, anyhow::Error> {
+    client
+        .run_graphql_strict(types::PurgeAppCdnCache::build(vars))
+        .await
+        .map(|x| x.purge_app_cdn_cache)
+}
+
+pub async fn app_cdn_cache_status(
+    client: &WasmerClient,
+    vars: types::GetAppCdnCacheStatusVars,
+) -> Result<types::AppCdnCacheStatus, anyhow::Error> {
+    client
+        .run_graphql_strict(types::GetAppCdnCacheStatus::build(vars))
+        .await?
+        .app
+        .context("app not found")?
+        .into_app()
+        .context("invalid node type returned")
+}
+
+pub async fn app_cdn_cache_metrics(
+    client: &WasmerClient,
+    vars: types::GetAppCdnCacheMetricsVars,
+) -> Result<types::AppCdnCacheMetrics, anyhow::Error> {
+    client
+        .run_graphql_strict(types::GetAppCdnCacheMetrics::build(vars))
+        .await?
+        .app
+        .context("app not found")?
+        .into_app()
+        .context("invalid node type returned")
+}
+
 /// Convert a [`OffsetDateTime`] to a unix timestamp that the WAPM backend
 /// understands.
 fn unix_timestamp(ts: OffsetDateTime) -> f64 {

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -311,7 +311,7 @@ mod queries {
     pub struct AppTemplate {
         #[serde(rename = "demoUrl")]
         pub demo_url: String,
-        pub language: String,
+        pub language: Option<String>,
         pub name: String,
         pub framework: String,
         #[serde(rename = "createdAt")]
@@ -2541,6 +2541,145 @@ mod queries {
     pub struct PurgeCacheForAppVersion {
         #[arguments(input: {id: $id})]
         pub purge_cache_for_app_version: Option<PurgeCacheForAppVersionPayload>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    pub struct ConfigureAppCdnCacheVars {
+        pub app: cynic::Id,
+        pub enabled: Option<bool>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    pub struct PurgeAppCdnCacheVars {
+        pub app: cynic::Id,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct AppCdnCacheMutationPayload {
+        pub success: bool,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Mutation", variables = "ConfigureAppCdnCacheVars")]
+    pub struct ConfigureAppCdnCache {
+        #[arguments(app: $app, config: {enabled: $enabled})]
+        pub configure_app_cdn_cache: AppCdnCacheMutationPayload,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Mutation", variables = "PurgeAppCdnCacheVars")]
+    pub struct PurgeAppCdnCache {
+        #[arguments(app: $app)]
+        pub purge_app_cdn_cache: AppCdnCacheMutationPayload,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    pub struct GetAppCdnCacheStatusVars {
+        pub app: cynic::Id,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", variables = "GetAppCdnCacheStatusVars")]
+    pub struct GetAppCdnCacheStatus {
+        #[arguments(id: $app)]
+        #[cynic(rename = "node")]
+        pub app: Option<NodeAppCdnCacheStatus>,
+    }
+
+    #[derive(cynic::InlineFragments, Debug)]
+    #[cynic(graphql_type = "Node")]
+    pub enum NodeAppCdnCacheStatus {
+        DeployApp(Box<AppCdnCacheStatus>),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    impl NodeAppCdnCacheStatus {
+        pub fn into_app(self) -> Option<AppCdnCacheStatus> {
+            match self {
+                Self::DeployApp(app) => Some(*app),
+                Self::Unknown => None,
+            }
+        }
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "DeployApp")]
+    pub struct AppCdnCacheStatus {
+        pub cdn_cache_enabled: bool,
+        pub cdn_cache_purged_at: Option<DateTime>,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    pub struct GetAppCdnCacheMetricsVars {
+        pub app: cynic::Id,
+        pub start_at: DateTime,
+        pub end_at: DateTime,
+        pub grouped_by: MetricGrouping,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", variables = "GetAppCdnCacheMetricsVars")]
+    pub struct GetAppCdnCacheMetrics {
+        #[arguments(id: $app)]
+        #[cynic(rename = "node")]
+        pub app: Option<NodeAppCdnCacheMetrics>,
+    }
+
+    #[derive(cynic::InlineFragments, Debug)]
+    #[cynic(graphql_type = "Node", variables = "GetAppCdnCacheMetricsVars")]
+    pub enum NodeAppCdnCacheMetrics {
+        DeployApp(Box<AppCdnCacheMetrics>),
+        #[cynic(fallback)]
+        Unknown,
+    }
+
+    impl NodeAppCdnCacheMetrics {
+        pub fn into_app(self) -> Option<AppCdnCacheMetrics> {
+            match self {
+                Self::DeployApp(app) => Some(*app),
+                Self::Unknown => None,
+            }
+        }
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "DeployApp", variables = "GetAppCdnCacheMetricsVars")]
+    pub struct AppCdnCacheMetrics {
+        #[arguments(startAt: $start_at, endAt: $end_at, groupedBy: $grouped_by)]
+        pub grouped_metrics: UsageMetrics,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct UsageMetrics {
+        pub totals: MetricsTotals,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct MetricsTotals {
+        pub requests: RequestMetrics,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct RequestMetrics {
+        pub total_requests: BigInt,
+        pub cached_requests: BigInt,
+        pub data_served_bytes: BigInt,
+        pub data_cached_bytes: BigInt,
+    }
+
+    #[derive(cynic::Enum, Clone, Copy, Debug)]
+    pub enum MetricGrouping {
+        #[cynic(rename = "BY_15_MINUTES")]
+        By15Minutes,
+        #[cynic(rename = "BY_5_MINUTES")]
+        By5Minutes,
+        #[cynic(rename = "BY_HOUR")]
+        ByHour,
+        #[cynic(rename = "BY_DAY")]
+        ByDay,
+        #[cynic(rename = "BY_WEEK")]
+        ByWeek,
     }
 
     #[derive(cynic::Scalar, Debug, Clone)]

--- a/lib/cli/src/commands/app/cdn/disable.rs
+++ b/lib/cli/src/commands/app/cdn/disable.rs
@@ -1,0 +1,21 @@
+use super::{AppIdentOpts, WasmerEnv, configure_cdn_cache};
+use crate::commands::AsyncCliCommand;
+
+/// Disable CDN cache for an app.
+#[derive(clap::Parser, Debug)]
+pub struct CmdAppCdnDisable {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    #[clap(flatten)]
+    pub ident: AppIdentOpts,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdAppCdnDisable {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        configure_cdn_cache(self.env, self.ident, false).await
+    }
+}

--- a/lib/cli/src/commands/app/cdn/enable.rs
+++ b/lib/cli/src/commands/app/cdn/enable.rs
@@ -1,0 +1,21 @@
+use super::{AppIdentOpts, WasmerEnv, configure_cdn_cache};
+use crate::commands::AsyncCliCommand;
+
+/// Enable CDN cache for an app.
+#[derive(clap::Parser, Debug)]
+pub struct CmdAppCdnEnable {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    #[clap(flatten)]
+    pub ident: AppIdentOpts,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdAppCdnEnable {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        configure_cdn_cache(self.env, self.ident, true).await
+    }
+}

--- a/lib/cli/src/commands/app/cdn/mod.rs
+++ b/lib/cli/src/commands/app/cdn/mod.rs
@@ -1,0 +1,62 @@
+//! Manage app CDN cache.
+
+use super::util::AppIdentOpts;
+use crate::{commands::AsyncCliCommand, config::WasmerEnv};
+
+pub mod disable;
+pub mod enable;
+pub mod purge;
+pub mod status;
+
+/// Manage CDN cache for an app.
+#[derive(clap::Subcommand, Debug)]
+pub enum CmdAppCdn {
+    Enable(enable::CmdAppCdnEnable),
+    Disable(disable::CmdAppCdnDisable),
+    Status(status::CmdAppCdnStatus),
+    Purge(purge::CmdAppCdnPurge),
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdAppCdn {
+    type Output = ();
+
+    async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
+        match self {
+            Self::Enable(cmd) => cmd.run_async().await,
+            Self::Disable(cmd) => cmd.run_async().await,
+            Self::Status(cmd) => cmd.run_async().await,
+            Self::Purge(cmd) => cmd.run_async().await,
+        }
+    }
+}
+
+async fn configure_cdn_cache(
+    env: WasmerEnv,
+    ident: AppIdentOpts,
+    enabled: bool,
+) -> Result<(), anyhow::Error> {
+    let client = env.client()?;
+    let (_ident, app) = ident.load_app(&client).await?;
+
+    let payload = wasmer_backend_api::query::configure_app_cdn_cache(
+        &client,
+        wasmer_backend_api::types::ConfigureAppCdnCacheVars {
+            app: app.id,
+            enabled: Some(enabled),
+        },
+    )
+    .await?;
+
+    anyhow::ensure!(
+        payload.success,
+        "CDN cache configuration update was not successful"
+    );
+
+    println!(
+        "CDN cache {}.",
+        if enabled { "enabled" } else { "disabled" }
+    );
+
+    Ok(())
+}

--- a/lib/cli/src/commands/app/cdn/purge.rs
+++ b/lib/cli/src/commands/app/cdn/purge.rs
@@ -1,0 +1,33 @@
+use super::{AppIdentOpts, WasmerEnv};
+use crate::commands::AsyncCliCommand;
+
+/// Purge CDN cache for an app.
+#[derive(clap::Parser, Debug)]
+pub struct CmdAppCdnPurge {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    #[clap(flatten)]
+    pub ident: AppIdentOpts,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdAppCdnPurge {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        let client = self.env.client()?;
+        let (_ident, app) = self.ident.load_app(&client).await?;
+
+        let payload = wasmer_backend_api::query::purge_app_cdn_cache(
+            &client,
+            wasmer_backend_api::types::PurgeAppCdnCacheVars { app: app.id },
+        )
+        .await?;
+
+        anyhow::ensure!(payload.success, "CDN cache purge was not successful");
+        println!("CDN cache purged.");
+
+        Ok(())
+    }
+}

--- a/lib/cli/src/commands/app/cdn/status.rs
+++ b/lib/cli/src/commands/app/cdn/status.rs
@@ -1,0 +1,155 @@
+use bytesize::ByteSize;
+use comfy_table::{Cell, Table};
+use time::{Duration, OffsetDateTime};
+
+use super::{AppIdentOpts, WasmerEnv};
+use crate::{
+    commands::AsyncCliCommand,
+    opts::ItemFormatOpts,
+    utils::render::{CliRender, ListFormat},
+};
+
+/// Show CDN cache status for an app.
+#[derive(clap::Parser, Debug)]
+pub struct CmdAppCdnStatus {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    #[clap(flatten)]
+    pub fmt: ItemFormatOpts,
+
+    #[clap(flatten)]
+    pub ident: AppIdentOpts,
+
+    /// Include CDN cache metrics for the last 30 days.
+    #[clap(long)]
+    pub with_metrics: bool,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdAppCdnStatus {
+    type Output = ();
+
+    async fn run_async(self) -> Result<(), anyhow::Error> {
+        let client = self.env.client()?;
+        let (_ident, app) = self.ident.load_app(&client).await?;
+        let cdn_status = wasmer_backend_api::query::app_cdn_cache_status(
+            &client,
+            wasmer_backend_api::types::GetAppCdnCacheStatusVars {
+                app: app.id.clone(),
+            },
+        )
+        .await?;
+
+        let metrics = if self.with_metrics {
+            let end_at = OffsetDateTime::now_utc();
+            let start_at = end_at - Duration::days(30);
+            let metrics = wasmer_backend_api::query::app_cdn_cache_metrics(
+                &client,
+                wasmer_backend_api::types::GetAppCdnCacheMetricsVars {
+                    app: app.id.clone(),
+                    start_at: start_at.try_into()?,
+                    end_at: end_at.try_into()?,
+                    grouped_by: wasmer_backend_api::types::MetricGrouping::ByDay,
+                },
+            )
+            .await?;
+            Some(CdnCacheMetricsStatus::from(metrics))
+        } else {
+            None
+        };
+
+        let status = CdnCacheStatus {
+            app: app.name,
+            owner: app.owner.global_name,
+            enabled: cdn_status.cdn_cache_enabled,
+            last_purged_at: cdn_status.cdn_cache_purged_at.map(|dt| dt.0),
+            metrics,
+        };
+
+        println!("{}", self.fmt.get().render(&status));
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct CdnCacheStatus {
+    app: String,
+    owner: String,
+    enabled: bool,
+    last_purged_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metrics: Option<CdnCacheMetricsStatus>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct CdnCacheMetricsStatus {
+    cached_requests: i64,
+    total_requests: i64,
+    cached_network_egress_bytes: i64,
+    total_network_egress_bytes: i64,
+}
+
+impl From<wasmer_backend_api::types::AppCdnCacheMetrics> for CdnCacheMetricsStatus {
+    fn from(value: wasmer_backend_api::types::AppCdnCacheMetrics) -> Self {
+        let requests = value.grouped_metrics.totals.requests;
+        Self {
+            cached_requests: requests.cached_requests.0,
+            total_requests: requests.total_requests.0,
+            cached_network_egress_bytes: requests.data_cached_bytes.0,
+            total_network_egress_bytes: requests.data_served_bytes.0,
+        }
+    }
+}
+
+impl CliRender for CdnCacheStatus {
+    fn render_item_table(&self) -> String {
+        let mut table = Table::new();
+        table.load_preset(comfy_table::presets::NOTHING);
+        table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+        table.set_header(vec![
+            Cell::new("App"),
+            Cell::new("Owner"),
+            Cell::new("Status"),
+            Cell::new("Last purge"),
+            Cell::new("Cached requests"),
+            Cell::new("Cached egress"),
+        ]);
+
+        let (cached_requests, cached_egress) = match &self.metrics {
+            Some(metrics) => (
+                format!("{} / {}", metrics.cached_requests, metrics.total_requests),
+                format!(
+                    "{} / {}",
+                    ByteSize(metrics.cached_network_egress_bytes as u64),
+                    ByteSize(metrics.total_network_egress_bytes as u64)
+                ),
+            ),
+            None => ("-".to_string(), "-".to_string()),
+        };
+
+        table.add_row(vec![
+            Cell::new(&self.app),
+            Cell::new(&self.owner),
+            Cell::new(if self.enabled { "enabled" } else { "disabled" }),
+            Cell::new(self.last_purged_at.as_deref().unwrap_or("-")),
+            Cell::new(cached_requests),
+            Cell::new(cached_egress),
+        ]);
+
+        table.to_string()
+    }
+
+    fn render_list(_items: &[Self], _format: ListFormat) -> String {
+        unreachable!("CDN cache status is rendered as a single item")
+    }
+
+    fn render_list_table(items: &[Self]) -> String {
+        items
+            .iter()
+            .map(Self::render_item_table)
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+}

--- a/lib/cli/src/commands/app/mod.rs
+++ b/lib/cli/src/commands/app/mod.rs
@@ -1,5 +1,6 @@
 //! Edge app commands.
 
+pub mod cdn;
 pub mod create;
 pub mod database;
 pub mod delete;
@@ -29,6 +30,8 @@ pub enum CmdApp {
     Info(info::CmdAppInfo),
     List(list::CmdAppList),
     Logs(logs::CmdAppLogs),
+    #[clap(subcommand)]
+    Cdn(cdn::CmdAppCdn),
     PurgeCache(purge_cache::CmdAppPurgeCache),
     Delete(delete::CmdAppDelete),
     #[clap(subcommand)]
@@ -65,6 +68,7 @@ impl AsyncCliCommand for CmdApp {
             }
             Self::List(cmd) => cmd.run_async().await,
             Self::Logs(cmd) => cmd.run_async().await,
+            Self::Cdn(cmd) => cmd.run_async().await,
             Self::Delete(cmd) => cmd.run_async().await,
             Self::Version(cmd) => cmd.run_async().await,
             Self::Deploy(cmd) => cmd.run_async().await,

--- a/lib/config/src/app/mod.rs
+++ b/lib/config/src/app/mod.rs
@@ -209,6 +209,10 @@ pub struct AppConfigCapabilityMapV1 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssh: Option<CapabilitySshServerV1>,
 
+    /// CDN cache settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cdn_cache: Option<AppConfigCapabilityCdnCacheV1>,
+
     /// Additional unknown capabilities.
     ///
     /// This provides a small bit of forwards compatibility for newly added
@@ -281,6 +285,21 @@ pub struct AppConfigCapabilityInstaBootV1 {
     /// ones discarded.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_age: Option<PrettyDuration>,
+}
+
+/// CDN cache capability settings.
+#[derive(
+    serde::Serialize, serde::Deserialize, schemars::JsonSchema, Clone, Debug, PartialEq, Eq,
+)]
+pub struct AppConfigCapabilityCdnCacheV1 {
+    /// Enable CDN caching for the app.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    /// Additional unknown fields.
+    /// This provides a small bit of forwards compatibility.
+    #[serde(flatten)]
+    pub other: IndexMap<String, serde_json::Value>,
 }
 
 /// How will an instance be bootstrapped?


### PR DESCRIPTION
## Summary

* add `wasmer app cdn enable|disable|status|purge` commands
* add backend API support for CDN cache status, configure, purge, and 30-day metrics
* add `capabilities.cdn_cache` to app config and refresh generated schemas
* refresh backend GraphQL schema from the [wasmer.wtf](<http://wasmer.wtf>) registry

## Verification

* `cargo test -p wasmer-config test_generated_schemas_up_to_date`
* `git diff --check`
* `cargo check -p wasmer-cli`
* `cargo build -p wasmer-cli --bin wasmer`
* live checked `wasmer app cdn` status/enable/disable/purge against `--registry wasmer.wtf ` and a live app

Closes wasmerio/wasmer#4573