### PR TITLE
feat: associate `.webc` files with metadata via `.webcm` sidecar manifests

### DIFF
--- a/lib/cli/src/commands/package/build.rs
+++ b/lib/cli/src/commands/package/build.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use dialoguer::console::{Emoji, style};
 use indicatif::ProgressBar;
 use sha2::Digest;
-use wasmer_config::package::PackageHash;
+use wasmer_config::package::{NamedPackageId, PackageHash, Webcm};
 use wasmer_package::package::Package;
 
 use crate::utils::load_package_manifest;
@@ -29,6 +29,14 @@ pub struct PackageBuild {
     /// Only checks whether the package could be built successfully
     #[clap(long)]
     check: bool,
+
+    /// Don't write the `.webcm` sidecar manifest next to the built package.
+    ///
+    /// The sidecar records the package's name, version, and hash, which the
+    /// `.webc` itself does not retain. Local tooling (e.g. `wasmer run
+    /// --include-webc`) uses it to identify the package.
+    #[clap(long)]
+    no_webcm: bool,
 }
 
 static READING_MANIFEST_EMOJI: Emoji<'_, '_> = Emoji("📖 ", "");
@@ -43,6 +51,7 @@ impl PackageBuild {
             quiet: true,
             package: Some(package_path),
             check: true,
+            no_webcm: true,
         }
     }
 
@@ -62,16 +71,22 @@ impl PackageBuild {
         let hash = sha2::Sha256::digest(&data).into();
         let pkg_hash = PackageHash::from_sha256_bytes(hash);
 
-        let name = if let Some(manifest_pkg) = manifest.package {
-            if let Some(name) = manifest_pkg.name {
-                if let Some(version) = manifest_pkg.version {
-                    format!("{}-{}.webc", name.replace('/', "-"), version)
-                } else {
-                    format!("{}-{}.webc", name.replace('/', "-"), pkg_hash)
-                }
-            } else {
-                format!("{pkg_hash}.webc")
-            }
+        let manifest_pkg = manifest.package.as_ref();
+        let ident = manifest_pkg.and_then(|p| {
+            Some(NamedPackageId {
+                full_name: p.name.clone()?,
+                version: p.version.clone()?,
+            })
+        });
+
+        let name = if let Some(ident) = &ident {
+            format!(
+                "{}-{}.webc",
+                ident.full_name.replace('/', "-"),
+                ident.version
+            )
+        } else if let Some(name) = manifest_pkg.and_then(|p| p.name.as_deref()) {
+            format!("{}-{}.webc", name.replace('/', "-"), pkg_hash)
         } else {
             format!("{pkg_hash}.webc")
         };
@@ -132,6 +147,19 @@ impl PackageBuild {
 
         std::fs::write(&out_path, &data)
             .with_context(|| format!("could not write contents to '{}'", out_path.display()))?;
+
+        // Only named packages have an identity worth recording in a sidecar.
+        if let Some(ident) = ident.filter(|_| !self.no_webcm) {
+            let webcm_path = Webcm::path_for_webc(&out_path);
+            let webcm = Webcm::new(ident, Some(pkg_hash.clone()));
+            std::fs::write(&webcm_path, webcm.to_toml()?)
+                .with_context(|| format!("could not write '{}'", webcm_path.display()))?;
+
+            pb.println(format!(
+                "{WRITING_PACKAGE_EMOJI}Sidecar manifest written to '{}'",
+                webcm_path.display()
+            ));
+        }
 
         pb.finish_with_message(format!(
             "{} Package written to '{}'",
@@ -211,10 +239,21 @@ description = "hello"
             out: Some(path.to_owned()),
             quiet: true,
             check: false,
+            no_webcm: false,
         };
 
-        cmd.execute().unwrap();
+        let (_, pkg_hash) = cmd.execute().unwrap();
 
         from_disk(path.join("wasmer-hello-0.1.0.webc")).unwrap();
+
+        let webcm: Webcm = std::fs::read_to_string(path.join("wasmer-hello-0.1.0.webcm"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(
+            webcm.id(),
+            NamedPackageId::try_new("wasmer/hello", "0.1.0").unwrap()
+        );
+        assert_eq!(webcm.package.hash, Some(pkg_hash));
     }
 }

--- a/lib/cli/src/commands/package/build.rs
+++ b/lib/cli/src/commands/package/build.rs
@@ -80,11 +80,7 @@ impl PackageBuild {
         });
 
         let name = if let Some(ident) = &ident {
-            format!(
-                "{}-{}.webc",
-                ident.full_name.replace('/', "-"),
-                ident.version
-            )
+            ident.webc_file_name()
         } else if let Some(name) = manifest_pkg.and_then(|p| p.name.as_deref()) {
             format!("{}-{}.webc", name.replace('/', "-"), pkg_hash)
         } else {
@@ -149,7 +145,9 @@ impl PackageBuild {
             .with_context(|| format!("could not write contents to '{}'", out_path.display()))?;
 
         // Only named packages have an identity worth recording in a sidecar.
-        if let Some(ident) = ident.filter(|_| !self.no_webcm) {
+        if !self.no_webcm
+            && let Some(ident) = ident
+        {
             let webcm_path = Webcm::path_for_webc(&out_path);
             let webcm = Webcm::new(ident, Some(pkg_hash.clone()));
             std::fs::write(&webcm_path, webcm.to_toml()?)

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     config::WasmerEnv,
     utils::load_package_manifest,
 };
+use anyhow::Context;
 use bytes::Bytes;
 use colored::Colorize;
 use dialoguer::Confirm;
@@ -10,7 +11,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Body;
 use std::path::{Path, PathBuf};
 use wasmer_backend_api::{WasmerClient, query::UploadMethod};
-use wasmer_config::package::{Manifest, NamedPackageIdent, PackageHash};
+use wasmer_config::package::{Manifest, NamedPackageIdent, PackageHash, Webcm};
 
 pub mod macros;
 pub mod wait;
@@ -131,12 +132,33 @@ pub(super) async fn upload(
 
 /// Read and return a manifest given a path.
 ///
+/// For a prebuilt package (a `.webc`, or the `.webcm` sidecar naming one) the
+/// returned path is the `.webc` and the manifest is reconstructed from its
+/// metadata, with the sidecar (when present) as the authoritative source of
+/// the package's name and version.
+///
 // The difference with the `load_package_manifest` is that
 // this function returns an error if no manifest is found.
 pub(super) fn get_manifest(path: &Path) -> anyhow::Result<(PathBuf, Manifest)> {
-    // Check if the path is a .webc file
-    if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("webc") {
-        return Ok((path.to_path_buf(), get_manifest_from_webc_file(path)?));
+    if path.is_file() {
+        let extension = path.extension().and_then(|s| s.to_str());
+        if extension == Some(Webcm::EXTENSION) {
+            let webc = Webcm::webc_path(path);
+            anyhow::ensure!(
+                webc.is_file(),
+                "the webcm '{}' has no paired webc '{}'",
+                path.display(),
+                webc.display()
+            );
+            let manifest = get_manifest_from_webc_file(&webc, Some(path))?;
+            return Ok((webc, manifest));
+        }
+        if extension == Some("webc") {
+            let sidecar = Webcm::path_for_webc(path);
+            let sidecar = sidecar.is_file().then_some(sidecar);
+            let manifest = get_manifest_from_webc_file(path, sidecar.as_deref())?;
+            return Ok((path.to_path_buf(), manifest));
+        }
     }
 
     load_package_manifest(path).and_then(|j| {
@@ -144,14 +166,52 @@ pub(super) fn get_manifest(path: &Path) -> anyhow::Result<(PathBuf, Manifest)> {
     })
 }
 
-/// Load a manifest from a .webc file
-fn get_manifest_from_webc_file(path: &Path) -> anyhow::Result<Manifest> {
-    use wasmer_package::utils::from_disk;
+/// Load a manifest from a .webc file, with the package identity taken from
+/// `webcm_path` when given. The webc is verified against the hash the sidecar
+/// records, if any.
+fn get_manifest_from_webc_file(path: &Path, webcm_path: Option<&Path>) -> anyhow::Result<Manifest> {
+    use sha2::Digest;
+    use wasmer_package::utils::{from_bytes, from_disk};
 
-    let container = from_disk(path)
-        .map_err(|e| anyhow::anyhow!("Failed to load webc file '{}': {}", path.display(), e))?;
+    let webcm = webcm_path
+        .map(|webcm_path| -> anyhow::Result<Webcm> {
+            let contents = std::fs::read_to_string(webcm_path)
+                .with_context(|| format!("Failed to read '{}'", webcm_path.display()))?;
+            contents
+                .parse()
+                .with_context(|| format!("Invalid webcm '{}'", webcm_path.display()))
+        })
+        .transpose()?;
 
-    manifest_from_webc_metadata(container.manifest())
+    // When the sidecar records a hash, read the bytes once to both verify and
+    // parse; otherwise let `from_disk` load the manifest without a full read.
+    let container = match webcm.as_ref().and_then(|w| w.package.hash.as_ref()) {
+        Some(expected) => {
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("Failed to read webc file '{}'", path.display()))?;
+            let actual = PackageHash::from_sha256_bytes(sha2::Sha256::digest(&bytes).into());
+            anyhow::ensure!(
+                *expected == actual,
+                "hash mismatch for '{}': the webcm records {expected}, the file hashes to {actual}",
+                path.display()
+            );
+            from_bytes(bytes)
+        }
+        None => from_disk(path),
+    }
+    .map_err(|e| anyhow::anyhow!("Failed to load webc file '{}': {}", path.display(), e))?;
+
+    let mut manifest = manifest_from_webc_metadata(container.manifest())?;
+
+    if let Some(webcm) = webcm {
+        let package = manifest
+            .package
+            .get_or_insert_with(wasmer_config::package::Package::new_empty);
+        package.name = Some(webcm.package.name);
+        package.version = Some(webcm.package.version);
+    }
+
+    Ok(manifest)
 }
 
 /// Convert a webc manifest into a [`Manifest`], extracting the package metadata.
@@ -385,6 +445,96 @@ data = "data"
             package.description, None,
             "Package description should be None in webc (stripped by Package::from_manifest)"
         );
+
+        Ok(())
+    }
+
+    /// Build a stripped webc in `dir` and return its path and package hash.
+    fn build_test_webc(dir: &Path) -> anyhow::Result<(PathBuf, PackageHash)> {
+        use wasmer_package::package::Package;
+
+        std::fs::write(
+            dir.join("wasmer.toml"),
+            r#"
+[package]
+name = "test/mypackage"
+version = "0.1.0"
+
+[fs]
+data = "data"
+"#,
+        )?;
+        std::fs::create_dir(dir.join("data"))?;
+        std::fs::write(dir.join("data/test.txt"), "Hello World")?;
+
+        let pkg = Package::from_manifest(dir.join("wasmer.toml"))?;
+        let webc_bytes = pkg.serialize()?;
+        let hash_bytes: [u8; 32] = Sha256::digest(&webc_bytes).into();
+
+        let webc_path = dir.join("test.webc");
+        std::fs::write(&webc_path, &webc_bytes)?;
+
+        Ok((webc_path, PackageHash::from_sha256_bytes(hash_bytes)))
+    }
+
+    #[test]
+    fn test_get_manifest_takes_identity_from_webcm() -> anyhow::Result<()> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let (webc_path, hash) = build_test_webc(temp_dir.path())?;
+
+        // The name intentionally differs from the wasmer.toml the webc was
+        // built from: the sidecar is authoritative (and the webc is stripped
+        // of its identity anyway).
+        let webcm = Webcm::new(
+            wasmer_config::package::NamedPackageId::try_new("acme/published", "9.9.9")?,
+            Some(hash),
+        );
+        std::fs::write(Webcm::path_for_webc(&webc_path), webcm.to_toml()?)?;
+
+        // Both the webc and its sidecar are accepted as the input path.
+        for input in [webc_path.clone(), Webcm::path_for_webc(&webc_path)] {
+            let (path, manifest) = get_manifest(&input)?;
+
+            assert_eq!(path, webc_path, "input: {}", input.display());
+            let package = manifest.package.unwrap();
+            assert_eq!(package.name.as_deref(), Some("acme/published"));
+            assert_eq!(
+                package.version.map(|v| v.to_string()).as_deref(),
+                Some("9.9.9")
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_manifest_rejects_webcm_hash_mismatch() -> anyhow::Result<()> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let (webc_path, _) = build_test_webc(temp_dir.path())?;
+
+        let webcm = Webcm::new(
+            wasmer_config::package::NamedPackageId::try_new("acme/published", "9.9.9")?,
+            Some(format!("sha256:{}", "a".repeat(64)).parse()?),
+        );
+        std::fs::write(Webcm::path_for_webc(&webc_path), webcm.to_toml()?)?;
+
+        let err = get_manifest(&webc_path).unwrap_err();
+        assert!(format!("{err:#}").contains("hash mismatch"), "{err:#}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_manifest_rejects_orphaned_webcm() -> anyhow::Result<()> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let webcm_path = temp_dir.path().join("test.webcm");
+        std::fs::write(
+            &webcm_path,
+            "[package]\nname = \"acme/published\"\nversion = \"9.9.9\"\n",
+        )?;
+
+        let err = get_manifest(&webcm_path).unwrap_err();
+        assert!(format!("{err:#}").contains("no paired webc"), "{err:#}");
 
         Ok(())
     }

--- a/lib/cli/src/commands/package/common/mod.rs
+++ b/lib/cli/src/commands/package/common/mod.rs
@@ -9,9 +9,11 @@ use colored::Colorize;
 use dialoguer::Confirm;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Body;
+use sha2::Digest;
 use std::path::{Path, PathBuf};
 use wasmer_backend_api::{WasmerClient, query::UploadMethod};
 use wasmer_config::package::{Manifest, NamedPackageIdent, PackageHash, Webcm};
+use wasmer_package::utils::{from_bytes, from_disk};
 
 pub mod macros;
 pub mod wait;
@@ -142,22 +144,19 @@ pub(super) async fn upload(
 pub(super) fn get_manifest(path: &Path) -> anyhow::Result<(PathBuf, Manifest)> {
     if path.is_file() {
         let extension = path.extension().and_then(|s| s.to_str());
-        if extension == Some(Webcm::EXTENSION) {
-            let webc = Webcm::webc_path(path);
-            anyhow::ensure!(
-                webc.is_file(),
-                "the webcm '{}' has no paired webc '{}'",
-                path.display(),
-                webc.display()
-            );
-            let manifest = get_manifest_from_webc_file(&webc, Some(path))?;
-            return Ok((webc, manifest));
-        }
-        if extension == Some("webc") {
-            let sidecar = Webcm::path_for_webc(path);
-            let sidecar = sidecar.is_file().then_some(sidecar);
-            let manifest = get_manifest_from_webc_file(path, sidecar.as_deref())?;
-            return Ok((path.to_path_buf(), manifest));
+        match extension {
+            Some(Webcm::EXTENSION) => {
+                let webc = Webcm::require_paired_webc(path)?;
+                let manifest = get_manifest_from_webc_file(&webc, Some(path))?;
+                return Ok((webc, manifest));
+            }
+            Some(Webcm::WEBC_EXTENSION) => {
+                let sidecar = Webcm::path_for_webc(path);
+                let sidecar = sidecar.is_file().then_some(sidecar);
+                let manifest = get_manifest_from_webc_file(path, sidecar.as_deref())?;
+                return Ok((path.to_path_buf(), manifest));
+            }
+            _ => {}
         }
     }
 
@@ -170,9 +169,6 @@ pub(super) fn get_manifest(path: &Path) -> anyhow::Result<(PathBuf, Manifest)> {
 /// `webcm_path` when given. The webc is verified against the hash the sidecar
 /// records, if any.
 fn get_manifest_from_webc_file(path: &Path, webcm_path: Option<&Path>) -> anyhow::Result<Manifest> {
-    use sha2::Digest;
-    use wasmer_package::utils::{from_bytes, from_disk};
-
     let webcm = webcm_path
         .map(|webcm_path| -> anyhow::Result<Webcm> {
             let contents = std::fs::read_to_string(webcm_path)
@@ -190,11 +186,9 @@ fn get_manifest_from_webc_file(path: &Path, webcm_path: Option<&Path>) -> anyhow
             let bytes = std::fs::read(path)
                 .with_context(|| format!("Failed to read webc file '{}'", path.display()))?;
             let actual = PackageHash::from_sha256_bytes(sha2::Sha256::digest(&bytes).into());
-            anyhow::ensure!(
-                *expected == actual,
-                "hash mismatch for '{}': the webcm records {expected}, the file hashes to {actual}",
-                path.display()
-            );
+            expected
+                .ensure_matches(&actual)
+                .with_context(|| format!("for webc '{}'", path.display()))?;
             from_bytes(bytes)
         }
         None => from_disk(path),

--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -190,7 +190,7 @@ impl PackageDownload {
                 let webcm_hash = package
                     .distribution_v3
                     .pirita_sha256_hash
-                    .map(|hex| format!("sha256:{hex}").parse::<PackageHash>())
+                    .map(|hex| PackageHash::from_sha256_hex(&hex))
                     .transpose()
                     .context("registry returned an invalid container hash")?;
 
@@ -310,7 +310,9 @@ impl PackageDownload {
 
         // Record the registry's hash, not one we compute: if the download was
         // corrupted, the pair fails verification instead of blessing bad bytes.
-        if let Some((id, hash)) = webcm_id.filter(|_| !self.no_webcm) {
+        if !self.no_webcm
+            && let Some((id, hash)) = webcm_id
+        {
             if hash.is_none() {
                 pb.println(
                     "Warning: the registry did not provide a container hash; \

--- a/lib/cli/src/commands/package/download.rs
+++ b/lib/cli/src/commands/package/download.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, bail};
 use dialoguer::console::{Emoji, style};
 use indicatif::{ProgressBar, ProgressStyle};
 use tempfile::NamedTempFile;
-use wasmer_config::package::{PackageIdent, PackageSource};
+use wasmer_config::package::{NamedPackageId, PackageHash, PackageIdent, PackageSource, Webcm};
 use wasmer_package::utils::from_disk;
 
 use crate::config::WasmerEnv;
@@ -43,6 +43,15 @@ pub struct PackageDownload {
     /// Note: unpacking can also be done manually with the `wasmer package unpack` command.
     #[clap(short, long)]
     unpack: bool,
+
+    /// Don't write the `.webcm` sidecar manifest next to the downloaded package.
+    ///
+    /// The sidecar records the package's name, version, and hash, which the
+    /// `.webc` itself does not retain. Local tooling (e.g. `wasmer run
+    /// --include-webc`) uses it to identify the package. It is only written
+    /// when downloading a package by name.
+    #[clap(long)]
+    no_webcm: bool,
 
     /// The package to download.
     package: PackageSource,
@@ -126,7 +135,7 @@ impl PackageDownload {
 
         step_num += 1;
 
-        let (download_url, ident, filename) = match &self.package {
+        let (download_url, ident, filename, webcm_id) = match &self.package {
             PackageSource::Ident(PackageIdent::Named(id)) => {
                 // caveat: client_unauthennticated will use a token if provided, it
                 // just won't fail if none is present. So, _unauthenticated() can actually
@@ -172,7 +181,20 @@ impl PackageDownload {
                     format!("{}@{}.webc", package.package.package_name, package.version)
                 };
 
-                (download_url, ident, filename)
+                let webcm_id = NamedPackageId {
+                    full_name,
+                    version: package.version.parse().with_context(|| {
+                        format!("registry returned invalid version '{}'", package.version)
+                    })?,
+                };
+                let webcm_hash = package
+                    .distribution_v3
+                    .pirita_sha256_hash
+                    .map(|hex| format!("sha256:{hex}").parse::<PackageHash>())
+                    .transpose()
+                    .context("registry returned an invalid container hash")?;
+
+                (download_url, ident, filename, Some((webcm_id, webcm_hash)))
             }
             PackageSource::Ident(PackageIdent::Hash(hash)) => {
                 // caveat: client_unauthennticated will use a token if provided, it
@@ -187,7 +209,7 @@ impl PackageDownload {
                 let ident = hash.to_string();
                 let filename = format!("{hash}.webc");
 
-                (pkg.webc_url, ident, filename)
+                (pkg.webc_url, ident, filename, None)
             }
             PackageSource::Path(p) => bail!("cannot download a package from a local path: '{p}'"),
             PackageSource::Url(url) => bail!("cannot download a package from a URL: '{url}'"),
@@ -286,6 +308,26 @@ impl PackageDownload {
             )
         })?;
 
+        // Record the registry's hash, not one we compute: if the download was
+        // corrupted, the pair fails verification instead of blessing bad bytes.
+        if let Some((id, hash)) = webcm_id.filter(|_| !self.no_webcm) {
+            if hash.is_none() {
+                pb.println(
+                    "Warning: the registry did not provide a container hash; \
+                     writing the sidecar manifest without one",
+                );
+            }
+
+            let webcm_path = Webcm::path_for_webc(&out_path);
+            std::fs::write(&webcm_path, Webcm::new(id, hash).to_toml()?)
+                .with_context(|| format!("could not write '{}'", webcm_path.display()))?;
+
+            pb.println(format!(
+                "{WRITING_PACKAGE_EMOJI}Sidecar manifest written to '{}'",
+                webcm_path.display()
+            ));
+        }
+
         pb.println(format!(
             "{} {WRITING_PACKAGE_EMOJI}Package downloaded to '{}'",
             style(format!("[{step_num}/{total_steps}]")).bold().dim(),
@@ -319,6 +361,7 @@ impl PackageDownload {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::Digest;
 
     /// Download a package from the dev registry.
     #[test]
@@ -336,15 +379,29 @@ mod tests {
             ),
             validate: true,
             out_path: Some(out_path.clone()),
-            package: "wasmer/hello@0.1.0".parse().unwrap(),
+            package: "wasmer/hello@=0.1.0".parse().unwrap(),
             unpack: true,
             quiet: true,
+            no_webcm: false,
         };
 
         cmd.execute().unwrap();
 
-        from_disk(out_path).unwrap();
+        from_disk(&out_path).unwrap();
 
         assert!(dir.path().join("hello/wasmer.toml").is_file());
+
+        let webcm: Webcm = std::fs::read_to_string(dir.path().join("hello.webcm"))
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(
+            webcm.id(),
+            NamedPackageId::try_new("wasmer/hello", "0.1.0").unwrap()
+        );
+        // The recorded hash is the registry's; it must match the actual bytes.
+        let bytes = std::fs::read(&out_path).unwrap();
+        let actual = PackageHash::from_sha256_bytes(sha2::Sha256::digest(&bytes).into());
+        assert_eq!(webcm.package.hash.unwrap(), actual);
     }
 }

--- a/lib/cli/src/commands/package/publish.rs
+++ b/lib/cli/src/commands/package/publish.rs
@@ -45,7 +45,12 @@ pub struct PackagePublish {
     #[clap(long)]
     pub no_validate: bool,
 
-    /// Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
+    /// Path to a package source:
+    /// - a directory containing `wasmer.toml`
+    /// - a custom `*.toml` manifest file
+    /// - a pre-built raw `*.webc` file (a `*.webcm` sidecar next to it, when
+    ///   present, provides the package's name and version)
+    /// - a `*.webcm` sidecar manifest naming the pre-built `*.webc` beside it
     ///
     /// Defaults to current working directory.
     #[clap(name = "path", default_value = ".")]
@@ -132,12 +137,14 @@ impl AsyncCliCommand for PackagePublish {
     type Output = PackageIdent;
 
     async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
-        tracing::info!("Checking if user is logged in");
-        let client = login_user(&self.env, !self.non_interactive, "publish a package").await?;
-
+        // Load and validate the package before prompting for login, so bad
+        // input (e.g. a webcm hash mismatch) fails fast without auth.
         tracing::info!("Loading manifest");
         let (manifest_path, manifest) = get_manifest(&self.package_path)?;
         tracing::info!("Got manifest at path {}", manifest_path.display());
+
+        tracing::info!("Checking if user is logged in");
+        let client = login_user(&self.env, !self.non_interactive, "publish a package").await?;
 
         let ident = self
             .publish(&client, &manifest_path, &manifest, false)

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -10,7 +10,7 @@ use sha2::Digest;
 use std::io::IsTerminal as _;
 use std::path::{Path, PathBuf};
 use wasmer_backend_api::WasmerClient;
-use wasmer_config::package::{Manifest, PackageHash};
+use wasmer_config::package::{Manifest, PackageHash, Webcm};
 
 /// Push a package to the registry from a `wasmer.toml` project or a raw `.webc` file.
 ///
@@ -179,7 +179,7 @@ impl PackagePush {
     ) -> anyhow::Result<(String, PackageHash)> {
         // Check if manifest_path is a .webc file
         let is_webc = manifest_path.is_file()
-            && manifest_path.extension().and_then(|s| s.to_str()) == Some("webc");
+            && manifest_path.extension().and_then(|s| s.to_str()) == Some(Webcm::WEBC_EXTENSION);
 
         let (hash, package_bytes) = if is_webc {
             tracing::info!("Loading pre-built package from webc");

--- a/lib/cli/src/commands/package/push.rs
+++ b/lib/cli/src/commands/package/push.rs
@@ -52,7 +52,9 @@ pub struct PackagePush {
     /// Path to a package source:
     /// - a directory containing `wasmer.toml`
     /// - a custom `*.toml` manifest file
-    /// - a pre-built raw `*.webc` file
+    /// - a pre-built raw `*.webc` file (a `*.webcm` sidecar next to it, when
+    ///   present, provides the package's name and version)
+    /// - a `*.webcm` sidecar manifest naming the pre-built `*.webc` beside it
     ///
     /// Defaults to current working directory.
     #[clap(name = "path", default_value = ".")]
@@ -268,12 +270,14 @@ impl AsyncCliCommand for PackagePush {
     type Output = ();
 
     async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
-        tracing::info!("Checking if user is logged in");
-        let client = login_user(&self.env, !self.non_interactive, "push a package").await?;
-
+        // Load and validate the package before prompting for login, so bad
+        // input (e.g. a webcm hash mismatch) fails fast without auth.
         tracing::info!("Loading manifest");
         let (manifest_path, manifest) = get_manifest(&self.package_path)?;
         tracing::info!("Got manifest at path {}", manifest_path.display());
+
+        tracing::info!("Checking if user is logged in");
+        let client = login_user(&self.env, !self.non_interactive, "push a package").await?;
 
         let (_, hash) = self.push(&client, &manifest, &manifest_path).await?;
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -106,9 +106,11 @@ pub struct Wasi {
     #[clap(long = "use", name = "USE")]
     pub(crate) uses: Vec<String>,
 
-    /// Webc packages to use instead of the registry ones: a `*.webc` file, or a
-    /// directory tree of them resolved by location. Resolves named dependencies
-    /// from local files, offline.
+    /// Webc packages to use instead of the registry ones: a `*.webc` or
+    /// `*.webcm` file, or a directory tree of them. A `.webcm` sidecar manifest
+    /// (as written by `wasmer package build`) names the anonymous `.webc` next
+    /// to it; webcs without one keep the id from their own manifest. Resolves
+    /// named dependencies from local files, offline.
     #[clap(long = "include-webc", name = "WEBC")]
     pub(super) include_webcs: Vec<PathBuf>,
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -106,10 +106,16 @@ pub struct Wasi {
     #[clap(long = "use", name = "USE")]
     pub(crate) uses: Vec<String>,
 
-    /// List of webc packages that are explicitly included for execution
-    /// Note: these packages will be used instead of those in the registry
+    /// Webc packages to use instead of the registry ones: a `*.webc` file, or a
+    /// directory tree of them resolved by location. Resolves named dependencies
+    /// from local files, offline.
     #[clap(long = "include-webc", name = "WEBC")]
     pub(super) include_webcs: Vec<PathBuf>,
+
+    /// Resolve only from local sources (`--include-webc`, filesystem paths), never
+    /// the registry. Needed offline, where a registry query would fail resolution.
+    #[clap(long = "offline")]
+    pub(super) offline: bool,
 
     /// List of injected atoms
     #[clap(long = "map-command", name = "MAPCMD")]
@@ -709,32 +715,36 @@ impl Wasi {
     ) -> Result<MultiSource> {
         let mut source = MultiSource::default();
 
-        // Note: This should be first so our "preloaded" sources get a chance to
-        // override the main registry.
+        // Local packages go first so they override the registry.
         let mut preloaded = InMemorySource::new();
         for path in &self.include_webcs {
             preloaded
-                .add_webc(path)
-                .with_context(|| format!("Unable to load \"{}\"", path.display()))?;
+                .add_packages(path)
+                .with_context(|| format!("Unable to load packages from \"{}\"", path.display()))?;
         }
         source.add_source(preloaded);
 
-        let graphql_endpoint = self.graphql_endpoint(env)?;
-        let cache_dir = registry_query_cache_dir(env.cache_dir(), &graphql_endpoint);
-        let mut wapm_source = BackendSource::new(graphql_endpoint, Arc::clone(&client))
-            .with_local_cache(cache_dir, WAPM_SOURCE_CACHE_TIMEOUT)
-            .with_preferred_webc_version(preferred_webc_version);
-        if let Some(token) = env
-            .config()?
-            .registry
-            .get_login_token_for_registry(wapm_source.registry_endpoint().as_str())
-        {
-            wapm_source = wapm_source.with_auth_token(token);
-        }
-        source.add_source(wapm_source);
+        // Drop the registry/web sources offline. Their network errors bubble out
+        // of the merging MultiSource and abort resolution even when a local
+        // source already matched.
+        if !self.offline {
+            let graphql_endpoint = self.graphql_endpoint(env)?;
+            let cache_dir = registry_query_cache_dir(env.cache_dir(), &graphql_endpoint);
+            let mut wapm_source = BackendSource::new(graphql_endpoint, Arc::clone(&client))
+                .with_local_cache(cache_dir, WAPM_SOURCE_CACHE_TIMEOUT)
+                .with_preferred_webc_version(preferred_webc_version);
+            if let Some(token) = env
+                .config()?
+                .registry
+                .get_login_token_for_registry(wapm_source.registry_endpoint().as_str())
+            {
+                wapm_source = wapm_source.with_auth_token(token);
+            }
+            source.add_source(wapm_source);
 
-        let cache_dir = env.cache_dir().join("downloads");
-        source.add_source(WebSource::new(cache_dir, client));
+            let cache_dir = env.cache_dir().join("downloads");
+            source.add_source(WebSource::new(cache_dir, client));
+        }
 
         source.add_source(FileSystemSource::default());
 

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -10,6 +10,7 @@ mod package_hash;
 mod package_id;
 mod package_ident;
 mod package_source;
+mod webcm;
 
 pub use self::{
     error::PackageParseError,
@@ -18,6 +19,7 @@ pub use self::{
     package_id::{NamedPackageId, PackageId},
     package_ident::PackageIdent,
     package_source::PackageSource,
+    webcm::{Webcm, WebcmError, WebcmPackage},
 };
 
 use std::{

--- a/lib/config/src/package/mod.rs
+++ b/lib/config/src/package/mod.rs
@@ -15,7 +15,7 @@ mod webcm;
 pub use self::{
     error::PackageParseError,
     named_package_ident::{NamedPackageIdent, Tag},
-    package_hash::PackageHash,
+    package_hash::{PackageHash, PackageHashMismatch},
     package_id::{NamedPackageId, PackageId},
     package_ident::PackageIdent,
     package_source::PackageSource,

--- a/lib/config/src/package/package_hash.rs
+++ b/lib/config/src/package/package_hash.rs
@@ -23,6 +23,34 @@ impl PackageHash {
     pub fn from_sha256_bytes(bytes: [u8; 32]) -> Self {
         Self::Sha256(Sha256Hash(bytes))
     }
+
+    /// Parse a bare (un-prefixed) sha256 hex digest, e.g. one straight from the
+    /// registry, into a [`PackageHash`].
+    pub fn from_sha256_hex(hex: &str) -> Result<Self, PackageParseError> {
+        hex.parse::<Sha256Hash>()
+            .map(Self::Sha256)
+            .map_err(|e| PackageParseError::new(hex, e.to_string()))
+    }
+
+    /// Error if this (expected) hash does not match `actual`.
+    pub fn ensure_matches(&self, actual: &PackageHash) -> Result<(), PackageHashMismatch> {
+        if self == actual {
+            Ok(())
+        } else {
+            Err(PackageHashMismatch {
+                expected: self.clone(),
+                actual: actual.clone(),
+            })
+        }
+    }
+}
+
+/// A package's hash did not match the expected one.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("hash mismatch: expected {expected}, found {actual}")]
+pub struct PackageHashMismatch {
+    pub expected: PackageHash,
+    pub actual: PackageHash,
 }
 
 impl From<Sha256Hash> for PackageHash {

--- a/lib/config/src/package/package_id.rs
+++ b/lib/config/src/package/package_id.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::PackageHash;
+use super::{PackageHash, Webcm};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NamedPackageId {
@@ -17,6 +17,18 @@ impl NamedPackageId {
             full_name: name.into(),
             version: version.as_ref().parse()?,
         })
+    }
+
+    /// The default `.webc` file name for this package, e.g.
+    /// `wasmer-hello-0.1.0.webc`. Slashes in the name become dashes to keep
+    /// the result a single path component.
+    pub fn webc_file_name(&self) -> String {
+        format!(
+            "{}-{}.{}",
+            self.full_name.replace('/', "-"),
+            self.version,
+            Webcm::WEBC_EXTENSION,
+        )
     }
 }
 

--- a/lib/config/src/package/webcm.rs
+++ b/lib/config/src/package/webcm.rs
@@ -1,0 +1,210 @@
+//! The `.webcm` sidecar manifest format.
+//!
+//! A built `.webc` is stripped of its package identity. A `.webcm` is a small
+//! TOML file next to it (same basename, e.g. `phpix.webcm` beside `phpix.webc`)
+//! that records that identity, making it the canonical metadata source for
+//! local `.webc` artifacts:
+//!
+//! ```toml
+//! format_version = 1
+//!
+//! [package]
+//! name = "wasmer/phpix"
+//! version = "0.1.2"
+//! hash = "sha256:c355cd53795b9b481f7eb2b5f4f6c8cf73631bdc343723a579d671e32db70b3c"
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use super::{NamedPackageId, PackageHash};
+
+/// A parsed `.webcm` sidecar manifest describing the identity of a `.webc`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Webcm {
+    /// The version of the `.webcm` format itself, bumped only on breaking
+    /// changes (unknown fields are ignored, so additive changes need no
+    /// bump). Written as [`Webcm::FORMAT_VERSION`]; missing is read as `1`.
+    #[serde(default = "default_format_version")]
+    pub format_version: u32,
+    pub package: WebcmPackage,
+}
+
+/// The identity of the `.webc` a [`Webcm`] pairs with.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebcmPackage {
+    /// The full package name, e.g. `wasmer/phpix`.
+    pub name: String,
+    pub version: Version,
+    /// The package hash of the paired `.webc`. Optional so identity-only
+    /// manifests can be written by hand; when present, tooling must reject a
+    /// paired `.webc` that hashes differently.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<PackageHash>,
+}
+
+fn default_format_version() -> u32 {
+    Webcm::FORMAT_VERSION
+}
+
+impl Webcm {
+    /// The current `.webcm` format version.
+    pub const FORMAT_VERSION: u32 = 1;
+
+    /// The file extension of sidecar manifests, without the dot.
+    pub const EXTENSION: &'static str = "webcm";
+
+    pub fn new(id: NamedPackageId, hash: Option<PackageHash>) -> Self {
+        Webcm {
+            format_version: Self::FORMAT_VERSION,
+            package: WebcmPackage {
+                name: id.full_name,
+                version: id.version,
+                hash,
+            },
+        }
+    }
+
+    /// The package id recorded in this manifest.
+    pub fn id(&self) -> NamedPackageId {
+        NamedPackageId {
+            full_name: self.package.name.clone(),
+            version: self.package.version.clone(),
+        }
+    }
+
+    /// The path of the `.webcm` pairing with `webc` (same basename, swapped
+    /// extension).
+    pub fn path_for_webc(webc: impl AsRef<Path>) -> PathBuf {
+        webc.as_ref().with_extension(Self::EXTENSION)
+    }
+
+    /// The path of the `.webc` pairing with `webcm` (same basename, swapped
+    /// extension).
+    pub fn webc_path(webcm: impl AsRef<Path>) -> PathBuf {
+        webcm.as_ref().with_extension("webc")
+    }
+
+    pub fn to_toml(&self) -> Result<String, toml::ser::Error> {
+        toml::to_string_pretty(self)
+    }
+}
+
+impl std::str::FromStr for Webcm {
+    type Err = WebcmError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let webcm: Webcm = toml::from_str(s)?;
+        if webcm.format_version != Self::FORMAT_VERSION {
+            return Err(WebcmError::UnsupportedFormatVersion {
+                found: webcm.format_version,
+            });
+        }
+        Ok(webcm)
+    }
+}
+
+/// An error parsing a [`Webcm`].
+#[derive(Debug, thiserror::Error)]
+pub enum WebcmError {
+    #[error("invalid webcm")]
+    Toml(#[from] toml::de::Error),
+    #[error(
+        "unsupported webcm format version {found} (supported: {})",
+        Webcm::FORMAT_VERSION
+    )]
+    UnsupportedFormatVersion { found: u32 },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn parse_full_webcm() {
+        let webcm = Webcm::from_str(
+            r#"
+format_version = 1
+
+[package]
+name = "wasmer/phpix"
+version = "0.1.2"
+hash = "sha256:c355cd53795b9b481f7eb2b5f4f6c8cf73631bdc343723a579d671e32db70b3c"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            webcm.id(),
+            NamedPackageId::try_new("wasmer/phpix", "0.1.2").unwrap()
+        );
+        assert_eq!(
+            webcm.package.hash.unwrap().to_string(),
+            "sha256:c355cd53795b9b481f7eb2b5f4f6c8cf73631bdc343723a579d671e32db70b3c"
+        );
+    }
+
+    #[test]
+    fn format_version_and_hash_are_optional() {
+        let webcm = Webcm::from_str("[package]\nname = \"phpix\"\nversion = \"0.1.2\"").unwrap();
+
+        assert_eq!(webcm.format_version, Webcm::FORMAT_VERSION);
+        assert_eq!(webcm.package.hash, None);
+    }
+
+    #[test]
+    fn reject_unsupported_format_version() {
+        let err = Webcm::from_str(
+            "format_version = 99\n[package]\nname = \"phpix\"\nversion = \"0.1.2\"",
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            WebcmError::UnsupportedFormatVersion { found: 99 }
+        ));
+    }
+
+    #[test]
+    fn reject_malformed_webcm() {
+        // Identity is the whole point; a manifest without it is invalid.
+        assert!(Webcm::from_str("[package]\nname = \"phpix\"").is_err());
+        assert!(Webcm::from_str("[package]\nname = \"phpix\"\nversion = \"not.semver\"").is_err());
+        assert!(
+            Webcm::from_str("[package]\nname = \"p\"\nversion = \"1.0.0\"\nhash = \"deadbeef\"")
+                .is_err(),
+            "hashes must carry the sha256: prefix"
+        );
+    }
+
+    #[test]
+    fn toml_roundtrip() {
+        let webcm = Webcm::new(
+            NamedPackageId::try_new("wasmer/phpix", "0.1.2").unwrap(),
+            Some(
+                "sha256:c355cd53795b9b481f7eb2b5f4f6c8cf73631bdc343723a579d671e32db70b3c"
+                    .parse()
+                    .unwrap(),
+            ),
+        );
+
+        let toml = webcm.to_toml().unwrap();
+        assert_eq!(Webcm::from_str(&toml).unwrap(), webcm);
+    }
+
+    #[test]
+    fn path_pairing() {
+        assert_eq!(
+            Webcm::path_for_webc("pkgs/phpix.webc"),
+            Path::new("pkgs/phpix.webcm")
+        );
+        assert_eq!(
+            Webcm::webc_path("pkgs/phpix.webcm"),
+            Path::new("pkgs/phpix.webc")
+        );
+    }
+}

--- a/lib/config/src/package/webcm.rs
+++ b/lib/config/src/package/webcm.rs
@@ -56,6 +56,9 @@ impl Webcm {
     /// The file extension of sidecar manifests, without the dot.
     pub const EXTENSION: &'static str = "webcm";
 
+    /// The file extension of the packages a sidecar pairs with, without the dot.
+    pub const WEBC_EXTENSION: &'static str = "webc";
+
     pub fn new(id: NamedPackageId, hash: Option<PackageHash>) -> Self {
         Webcm {
             format_version: Self::FORMAT_VERSION,
@@ -84,7 +87,22 @@ impl Webcm {
     /// The path of the `.webc` pairing with `webcm` (same basename, swapped
     /// extension).
     pub fn webc_path(webcm: impl AsRef<Path>) -> PathBuf {
-        webcm.as_ref().with_extension("webc")
+        webcm.as_ref().with_extension(Self::WEBC_EXTENSION)
+    }
+
+    /// The paired `.webc` for the `.webcm` at `webcm_path`, erroring if no such
+    /// file exists beside it.
+    pub fn require_paired_webc(webcm_path: impl AsRef<Path>) -> Result<PathBuf, WebcmError> {
+        let webcm_path = webcm_path.as_ref();
+        let webc = Self::webc_path(webcm_path);
+        if webc.is_file() {
+            Ok(webc)
+        } else {
+            Err(WebcmError::MissingPairedWebc {
+                webcm: webcm_path.to_path_buf(),
+                webc,
+            })
+        }
     }
 
     pub fn to_toml(&self) -> Result<String, toml::ser::Error> {
@@ -106,7 +124,7 @@ impl std::str::FromStr for Webcm {
     }
 }
 
-/// An error parsing a [`Webcm`].
+/// An error working with a [`Webcm`].
 #[derive(Debug, thiserror::Error)]
 pub enum WebcmError {
     #[error("invalid webcm")]
@@ -116,6 +134,8 @@ pub enum WebcmError {
         Webcm::FORMAT_VERSION
     )]
     UnsupportedFormatVersion { found: u32 },
+    #[error("the webcm \"{}\" has no paired webc \"{}\"", webcm.display(), webc.display())]
+    MissingPairedWebc { webcm: PathBuf, webc: PathBuf },
 }
 
 #[cfg(test)]

--- a/lib/wasix/src/runtime/resolver/in_memory_source.rs
+++ b/lib/wasix/src/runtime/resolver/in_memory_source.rs
@@ -8,7 +8,7 @@ use wasmer_config::package::{
     NamedPackageId, PackageHash, PackageId, PackageIdent, PackageSource, Webcm,
 };
 
-use crate::runtime::resolver::{PackageSummary, QueryError, Source, WebcHash};
+use crate::runtime::resolver::{PackageSummary, QueryError, Source};
 
 /// A [`Source`] that tracks packages in memory.
 ///
@@ -90,7 +90,7 @@ impl InMemorySource {
                 }
             } else if current.extension().and_then(|e| e.to_str()) == Some(Webcm::EXTENSION) {
                 self.add_from_webcm(&current)?;
-            } else if current.extension().and_then(|e| e.to_str()) == Some("webc") {
+            } else if current.extension().and_then(|e| e.to_str()) == Some(Webcm::WEBC_EXTENSION) {
                 let sidecar = Webcm::path_for_webc(&current);
                 if !sidecar.is_file() {
                     self.add_bare_webc(root, &current)?;
@@ -113,18 +113,15 @@ impl InMemorySource {
             .parse()
             .with_context(|| format!("Invalid webcm \"{}\"", webcm_path.display()))?;
 
-        let webc = Webcm::webc_path(webcm_path);
-        anyhow::ensure!(
-            webc.is_file(),
-            "the webcm \"{}\" has no paired webc \"{}\"",
-            webcm_path.display(),
-            webc.display(),
-        );
+        let webc = Webcm::require_paired_webc(webcm_path)?;
         let mut summary = PackageSummary::from_webc_file(&webc)
             .with_context(|| format!("Unable to load \"{}\"", webc.display()))?;
 
         if let Some(expected) = &webcm.package.hash {
-            verify_hash(&webc, &summary.dist.webc_sha256, expected)?;
+            let actual = PackageHash::from_sha256_bytes(summary.dist.webc_sha256.as_bytes());
+            expected
+                .ensure_matches(&actual)
+                .with_context(|| format!("for webc \"{}\"", webc.display()))?;
         }
         summary.pkg.id = PackageId::Named(webcm.id());
         self.add(summary);
@@ -172,21 +169,6 @@ impl InMemorySource {
         // as the named packages are also always added as hashed.
         self.hash_packages.len()
     }
-}
-
-/// Error if the webc's `actual` hash doesn't match the one its webcm records.
-fn verify_hash(webc: &Path, actual: &WebcHash, expected: &PackageHash) -> Result<(), Error> {
-    let matches = match expected.as_sha256() {
-        Some(expected) => *expected.as_bytes() == actual.as_bytes(),
-        None => anyhow::bail!("unsupported hash algorithm in webcm: {expected}"),
-    };
-    anyhow::ensure!(
-        matches,
-        "hash mismatch for \"{}\": the webcm records {expected}, the file hashes to sha256:{}",
-        webc.display(),
-        actual.as_hex(),
-    );
-    Ok(())
 }
 
 #[async_trait::async_trait]

--- a/lib/wasix/src/runtime/resolver/in_memory_source.rs
+++ b/lib/wasix/src/runtime/resolver/in_memory_source.rs
@@ -1,13 +1,12 @@
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
-    fs::File,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Error};
 use wasmer_config::package::{NamedPackageId, PackageHash, PackageId, PackageIdent, PackageSource};
 
-use crate::runtime::resolver::{PackageSummary, QueryError, Source};
+use crate::runtime::resolver::{PackageSummary, QueryError, Source, WebcHash};
 
 /// A [`Source`] that tracks packages in memory.
 ///
@@ -29,41 +28,10 @@ impl InMemorySource {
         InMemorySource::default()
     }
 
-    /// Recursively walk a directory, adding all valid WEBC files to the source.
+    /// Constructor wrapper over [`Self::add_packages`].
     pub fn from_directory_tree(dir: impl Into<PathBuf>) -> Result<Self, Error> {
         let mut source = InMemorySource::default();
-
-        let mut to_check: VecDeque<PathBuf> = VecDeque::new();
-        to_check.push_back(dir.into());
-
-        fn process_entry(
-            path: &Path,
-            source: &mut InMemorySource,
-            to_check: &mut VecDeque<PathBuf>,
-        ) -> Result<(), Error> {
-            let metadata = std::fs::metadata(path).context("Unable to get filesystem metadata")?;
-
-            if metadata.is_dir() {
-                for entry in path.read_dir().context("Unable to read the directory")? {
-                    to_check.push_back(entry?.path());
-                }
-            } else if metadata.is_file() {
-                let f = File::open(path).context("Unable to open the file")?;
-                if webc::detect(f).is_ok() {
-                    source
-                        .add_webc(path)
-                        .with_context(|| format!("Unable to load \"{}\"", path.display()))?;
-                }
-            }
-
-            Ok(())
-        }
-
-        while let Some(path) = to_check.pop_front() {
-            process_entry(&path, &mut source, &mut to_check)
-                .with_context(|| format!("Unable to add entries from \"{}\"", path.display()))?;
-        }
-
+        source.add_packages(dir.into())?;
         Ok(source)
     }
 
@@ -103,6 +71,55 @@ impl InMemorySource {
         Ok(())
     }
 
+    /// Load every webc under `path` (a single file or a directory tree). `path`
+    /// is the location-scheme root passed to [`Self::add_one`].
+    pub fn add_packages(&mut self, path: impl AsRef<Path>) -> Result<(), Error> {
+        let root = path.as_ref();
+        // Error on a missing path instead of silently loading nothing.
+        anyhow::ensure!(
+            root.exists(),
+            "package path does not exist: \"{}\"",
+            root.display()
+        );
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(current) = stack.pop() {
+            if current.is_dir() {
+                for entry in std::fs::read_dir(&current)
+                    .with_context(|| format!("Unable to read \"{}\"", current.display()))?
+                {
+                    stack.push(entry?.path());
+                }
+            } else if current.extension().and_then(|e| e.to_str()) == Some("webc") {
+                self.add_one(root, &current)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Load one webc. Its id comes from `id_from_path(root, webc)` (swap that call
+    /// for `id_from_filename`/`id_from_sidecar` to change scheme), else the
+    /// manifest id. Checks an optional sha256. Unreadable webcs are skipped.
+    fn add_one(&mut self, root: &Path, webc: &Path) -> Result<(), Error> {
+        let mut summary = match PackageSummary::from_webc_file(webc) {
+            Ok(summary) => summary,
+            Err(e) if webc == root => {
+                return Err(e).with_context(|| format!("Unable to load \"{}\"", webc.display()));
+            }
+            Err(e) => {
+                tracing::warn!(path=%webc.display(), error=&*e, "Skipping unreadable webc");
+                return Ok(());
+            }
+        };
+        if let Some(identity) = id_from_path(root, webc)? {
+            if let Some(expected) = &identity.expected_sha256 {
+                verify_sha256(webc, &summary.dist.webc_sha256, expected)?;
+            }
+            summary.pkg.id = identity.id;
+        }
+        self.add(summary);
+        Ok(())
+    }
+
     pub fn get(&self, id: &PackageId) -> Option<&PackageSummary> {
         match id {
             PackageId::Named(ident) => {
@@ -129,6 +146,118 @@ impl InMemorySource {
         // as the named packages are also always added as hashed.
         self.hash_packages.len()
     }
+}
+
+// Identity schemes. A built webc is anonymous (name stripped on build), so its id
+// comes from the file location or a sidecar. `add_one` calls one of these; switch
+// scheme by switching which. Each returns the id and an optional sha256 to verify,
+// or `None` to fall back to the manifest id.
+
+/// A package id and an optional sha256 (hex) to verify the webc against.
+struct ResolvedIdentity {
+    id: PackageId,
+    expected_sha256: Option<String>,
+}
+
+/// christoph's scheme (Edge convention): `<namespace>--<name>@<version>.webc`, or
+/// unnamespaced `<name>@<version>.webc`. `root` is unused.
+#[allow(dead_code)] // inactive scheme; swap into `add_one` to use.
+fn id_from_filename(_root: &Path, webc: &Path) -> Result<Option<ResolvedIdentity>, Error> {
+    let Some((name, version)) = webc
+        .file_name()
+        .and_then(|f| f.to_str())
+        .and_then(|f| f.strip_suffix(".webc"))
+        .and_then(|stem| stem.rsplit_once('@'))
+    else {
+        return Ok(None);
+    };
+    let full_name = match name.split_once("--") {
+        Some((namespace, name)) => format!("{namespace}/{name}"),
+        None => name.to_string(),
+    };
+    let Ok(version) = version.parse() else {
+        return Ok(None);
+    };
+    Ok(Some(ResolvedIdentity {
+        id: PackageId::Named(NamedPackageId { full_name, version }),
+        expected_sha256: read_sha256_sibling(webc),
+    }))
+}
+
+/// nikolas's scheme: `<namespace>/<name>/<version>.webc` (or `<name>/<version>
+/// .webc`) relative to `root`. Each field is a path component, nothing to escape.
+fn id_from_path(root: &Path, webc: &Path) -> Result<Option<ResolvedIdentity>, Error> {
+    let Some(parts) = webc
+        .strip_prefix(root)
+        .ok()
+        .and_then(|rel| rel.iter().map(|p| p.to_str()).collect::<Option<Vec<_>>>())
+    else {
+        return Ok(None);
+    };
+    let (full_name, file) = match parts.as_slice() {
+        [namespace, name, file] => (format!("{namespace}/{name}"), *file),
+        [name, file] => (name.to_string(), *file),
+        _ => return Ok(None),
+    };
+    let Some(Ok(version)) = file.strip_suffix(".webc").map(str::parse) else {
+        return Ok(None);
+    };
+    Ok(Some(ResolvedIdentity {
+        id: PackageId::Named(NamedPackageId { full_name, version }),
+        expected_sha256: read_sha256_sibling(webc),
+    }))
+}
+
+/// The `<stem>.webcm` sidecar's metadata.
+#[allow(dead_code)] // inactive scheme; swap into `add_one` to use.
+#[derive(serde::Deserialize)]
+struct Webcm {
+    name: String,
+    version: String,
+    #[serde(rename = "package-hash")]
+    package_hash: Option<String>,
+}
+
+/// arshia's scheme: a `<stem>.webcm` TOML sidecar (name/version/hash) beside the
+/// webc. `root` is unused. Absent gives `None`; malformed is an error.
+#[allow(dead_code)] // inactive scheme; swap into `add_one` to use.
+fn id_from_sidecar(_root: &Path, webc: &Path) -> Result<Option<ResolvedIdentity>, Error> {
+    let sidecar = webc.with_extension("webcm");
+    if !sidecar.is_file() {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(&sidecar)
+        .with_context(|| format!("Unable to read \"{}\"", sidecar.display()))?;
+    let webcm: Webcm = toml::from_str(&contents)
+        .with_context(|| format!("Invalid webcm \"{}\"", sidecar.display()))?;
+    Ok(Some(ResolvedIdentity {
+        id: PackageId::Named(NamedPackageId {
+            full_name: webcm.name,
+            version: webcm.version.parse().context("Invalid webcm version")?,
+        }),
+        expected_sha256: webcm.package_hash,
+    }))
+}
+
+/// The trimmed digest of an optional `<stem>.sha256` sibling, if present.
+fn read_sha256_sibling(webc: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(webc.with_extension("sha256")).ok()?;
+    Some(contents.trim().to_string())
+}
+
+/// Error if `actual` doesn't match `expected` (hex, an optional `sha256:` prefix
+/// allowed).
+fn verify_sha256(webc: &Path, actual: &WebcHash, expected: &str) -> Result<(), Error> {
+    let expected = expected.trim();
+    let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+    if !expected.eq_ignore_ascii_case(&actual.as_hex()) {
+        anyhow::bail!(
+            "sha256 mismatch for \"{}\": expected {expected}, file hashes to {}",
+            webc.display(),
+            actual.as_hex(),
+        );
+    }
+    Ok(())
 }
 
 #[async_trait::async_trait]
@@ -211,6 +340,125 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../wasmer-test-files/integration/webc/bash-1.0.16-f097441a-a80b-4e0d-87d7-684918ef4bb6.webc"
     ));
+
+    #[test]
+    fn parse_path_ids() {
+        let root = Path::new("/pkgs");
+        let id = |p: &str| {
+            id_from_path(root, &root.join(p))
+                .unwrap()
+                .map(|ri| ri.id.to_string())
+        };
+
+        assert_eq!(id("ns/name/1.2.3.webc").as_deref(), Some("ns/name@1.2.3"));
+        assert_eq!(id("name/1.2.3.webc").as_deref(), Some("name@1.2.3"));
+        assert_eq!(
+            id("ns/name/1.0.0-rc.1.webc").as_deref(),
+            Some("ns/name@1.0.0-rc.1")
+        );
+        // doesn't fit the layout -> None, so the caller keeps the manifest id.
+        assert_eq!(id("ns/name/notaversion.webc"), None); // bad semver
+        assert_eq!(id("too/deep/ns/name/1.0.0.webc"), None); // wrong depth
+        assert_eq!(id("flat.webc"), None); // no version directory
+    }
+
+    #[test]
+    fn parse_filename_ids() {
+        let id = |s: &str| {
+            id_from_filename(Path::new(""), Path::new(s))
+                .unwrap()
+                .map(|ri| ri.id.to_string())
+        };
+
+        assert_eq!(id("ns--name@1.2.3.webc").as_deref(), Some("ns/name@1.2.3"));
+        assert_eq!(id("name@1.2.3.webc").as_deref(), Some("name@1.2.3"));
+        assert_eq!(id("ns--name@notaversion.webc"), None); // bad semver
+        assert_eq!(id(&format!("{}.webc", "a".repeat(64))), None); // hash-named
+    }
+
+    #[test]
+    fn add_packages_names_from_layout() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("acme").join("cutils");
+        std::fs::create_dir_all(&dir).unwrap();
+        // COREUTILS_16's manifest is "sharrattj/coreutils@1.0.16"; the layout
+        // must win, proving resolution keys off the path, not the artifact.
+        std::fs::write(dir.join("9.9.9.webc"), COREUTILS_16).unwrap();
+
+        let mut source = InMemorySource::new();
+        source.add_packages(temp.path()).unwrap();
+
+        assert_eq!(
+            source
+                .named_packages
+                .keys()
+                .map(|k| k.as_str())
+                .collect::<Vec<_>>(),
+            ["acme/cutils"]
+        );
+        assert_eq!(
+            source.named_packages["acme/cutils"][0].ident,
+            NamedPackageId::try_new("acme/cutils", "9.9.9").unwrap()
+        );
+    }
+
+    #[test]
+    fn add_packages_single_file_falls_back_to_manifest() {
+        // A lone file has no layout, so the path scheme keeps its manifest id.
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("anything.webc");
+        std::fs::write(&file, COREUTILS_16).unwrap();
+
+        let mut source = InMemorySource::new();
+        source.add_packages(&file).unwrap();
+
+        assert_eq!(
+            source.named_packages["sharrattj/coreutils"][0].ident,
+            NamedPackageId::try_new("sharrattj/coreutils", "1.0.16").unwrap()
+        );
+    }
+
+    #[test]
+    fn add_packages_errors_on_missing_path() {
+        let temp = TempDir::new().unwrap();
+        let missing = temp.path().join("does-not-exist");
+
+        let mut source = InMemorySource::new();
+        assert!(source.add_packages(&missing).is_err());
+    }
+
+    #[test]
+    fn add_packages_rejects_bad_sha256_sidecar() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("acme").join("cutils");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("9.9.9.webc"), COREUTILS_16).unwrap();
+        std::fs::write(dir.join("9.9.9.sha256"), "deadbeef").unwrap();
+
+        let mut source = InMemorySource::new();
+        assert!(source.add_packages(temp.path()).is_err());
+    }
+
+    #[test]
+    fn sidecar_identity() {
+        // add_one uses the path scheme, so test the sidecar scheme directly.
+        let temp = TempDir::new().unwrap();
+        let webc = temp.path().join("pkg.webc");
+        std::fs::write(&webc, COREUTILS_16).unwrap();
+        let hash = WebcHash::sha256(COREUTILS_16).as_hex();
+        std::fs::write(
+            temp.path().join("pkg.webcm"),
+            format!("name = \"acme/cutils\"\nversion = \"9.9.9\"\npackage-hash = \"{hash}\"\n"),
+        )
+        .unwrap();
+
+        let identity = id_from_sidecar(temp.path(), &webc).unwrap().unwrap();
+        assert_eq!(identity.id.to_string(), "acme/cutils@9.9.9");
+
+        let actual = WebcHash::sha256(COREUTILS_16);
+        verify_sha256(&webc, &actual, identity.expected_sha256.as_deref().unwrap()).unwrap();
+        assert!(verify_sha256(&webc, &actual, "deadbeef").is_err());
+    }
 
     #[test]
     fn load_a_directory_tree() {

--- a/lib/wasix/src/runtime/resolver/in_memory_source.rs
+++ b/lib/wasix/src/runtime/resolver/in_memory_source.rs
@@ -1,10 +1,12 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use anyhow::{Context, Error};
-use wasmer_config::package::{NamedPackageId, PackageHash, PackageId, PackageIdent, PackageSource};
+use wasmer_config::package::{
+    NamedPackageId, PackageHash, PackageId, PackageIdent, PackageSource, Webcm,
+};
 
 use crate::runtime::resolver::{PackageSummary, QueryError, Source, WebcHash};
 
@@ -26,13 +28,6 @@ struct NamedPackageSummary {
 impl InMemorySource {
     pub fn new() -> Self {
         InMemorySource::default()
-    }
-
-    /// Constructor wrapper over [`Self::add_packages`].
-    pub fn from_directory_tree(dir: impl Into<PathBuf>) -> Result<Self, Error> {
-        let mut source = InMemorySource::default();
-        source.add_packages(dir.into())?;
-        Ok(source)
     }
 
     /// Add a new [`PackageSummary`] to the [`InMemorySource`].
@@ -71,8 +66,12 @@ impl InMemorySource {
         Ok(())
     }
 
-    /// Load every webc under `path` (a single file or a directory tree). `path`
-    /// is the location-scheme root passed to [`Self::add_one`].
+    /// Load every package under `path` (a `.webc`, a `.webcm`, or a directory
+    /// tree of them), keying each by the identity in its [`Webcm`] sidecar, or
+    /// by its own manifest when it has none.
+    ///
+    /// An invalid sidecar (unparsable, missing its paired `.webc`, or a hash
+    /// mismatch) is an error, never silently skipped.
     pub fn add_packages(&mut self, path: impl AsRef<Path>) -> Result<(), Error> {
         let root = path.as_ref();
         // Error on a missing path instead of silently loading nothing.
@@ -89,34 +88,61 @@ impl InMemorySource {
                 {
                     stack.push(entry?.path());
                 }
+            } else if current.extension().and_then(|e| e.to_str()) == Some(Webcm::EXTENSION) {
+                self.add_from_webcm(&current)?;
             } else if current.extension().and_then(|e| e.to_str()) == Some("webc") {
-                self.add_one(root, &current)?;
+                let sidecar = Webcm::path_for_webc(&current);
+                if !sidecar.is_file() {
+                    self.add_bare_webc(root, &current)?;
+                } else if current == root {
+                    // The sidecar drives loading. During a directory walk it
+                    // is its own entry; for a file root, chase it explicitly.
+                    self.add_from_webcm(&sidecar)?;
+                }
             }
         }
         Ok(())
     }
 
-    /// Load one webc. Its id comes from `id_from_path(root, webc)` (swap that call
-    /// for `id_from_filename`/`id_from_sidecar` to change scheme), else the
-    /// manifest id. Checks an optional sha256. Unreadable webcs are skipped.
-    fn add_one(&mut self, root: &Path, webc: &Path) -> Result<(), Error> {
-        let mut summary = match PackageSummary::from_webc_file(webc) {
-            Ok(summary) => summary,
+    /// Load the webc paired with the `.webcm` at `webcm_path` under the
+    /// sidecar's identity, verifying its hash when the sidecar records one.
+    fn add_from_webcm(&mut self, webcm_path: &Path) -> Result<(), Error> {
+        let contents = std::fs::read_to_string(webcm_path)
+            .with_context(|| format!("Unable to read \"{}\"", webcm_path.display()))?;
+        let webcm: Webcm = contents
+            .parse()
+            .with_context(|| format!("Invalid webcm \"{}\"", webcm_path.display()))?;
+
+        let webc = Webcm::webc_path(webcm_path);
+        anyhow::ensure!(
+            webc.is_file(),
+            "the webcm \"{}\" has no paired webc \"{}\"",
+            webcm_path.display(),
+            webc.display(),
+        );
+        let mut summary = PackageSummary::from_webc_file(&webc)
+            .with_context(|| format!("Unable to load \"{}\"", webc.display()))?;
+
+        if let Some(expected) = &webcm.package.hash {
+            verify_hash(&webc, &summary.dist.webc_sha256, expected)?;
+        }
+        summary.pkg.id = PackageId::Named(webcm.id());
+        self.add(summary);
+        Ok(())
+    }
+
+    /// Load a webc that has no sidecar, keeping its manifest id. Unreadable
+    /// webcs found during a directory walk are skipped.
+    fn add_bare_webc(&mut self, root: &Path, webc: &Path) -> Result<(), Error> {
+        match PackageSummary::from_webc_file(webc) {
+            Ok(summary) => self.add(summary),
             Err(e) if webc == root => {
                 return Err(e).with_context(|| format!("Unable to load \"{}\"", webc.display()));
             }
             Err(e) => {
                 tracing::warn!(path=%webc.display(), error=&*e, "Skipping unreadable webc");
-                return Ok(());
             }
-        };
-        if let Some(identity) = id_from_path(root, webc)? {
-            if let Some(expected) = &identity.expected_sha256 {
-                verify_sha256(webc, &summary.dist.webc_sha256, expected)?;
-            }
-            summary.pkg.id = identity.id;
         }
-        self.add(summary);
         Ok(())
     }
 
@@ -148,115 +174,18 @@ impl InMemorySource {
     }
 }
 
-// Identity schemes. A built webc is anonymous (name stripped on build), so its id
-// comes from the file location or a sidecar. `add_one` calls one of these; switch
-// scheme by switching which. Each returns the id and an optional sha256 to verify,
-// or `None` to fall back to the manifest id.
-
-/// A package id and an optional sha256 (hex) to verify the webc against.
-struct ResolvedIdentity {
-    id: PackageId,
-    expected_sha256: Option<String>,
-}
-
-/// christoph's scheme (Edge convention): `<namespace>--<name>@<version>.webc`, or
-/// unnamespaced `<name>@<version>.webc`. `root` is unused.
-#[allow(dead_code)] // inactive scheme; swap into `add_one` to use.
-fn id_from_filename(_root: &Path, webc: &Path) -> Result<Option<ResolvedIdentity>, Error> {
-    let Some((name, version)) = webc
-        .file_name()
-        .and_then(|f| f.to_str())
-        .and_then(|f| f.strip_suffix(".webc"))
-        .and_then(|stem| stem.rsplit_once('@'))
-    else {
-        return Ok(None);
+/// Error if the webc's `actual` hash doesn't match the one its webcm records.
+fn verify_hash(webc: &Path, actual: &WebcHash, expected: &PackageHash) -> Result<(), Error> {
+    let matches = match expected.as_sha256() {
+        Some(expected) => *expected.as_bytes() == actual.as_bytes(),
+        None => anyhow::bail!("unsupported hash algorithm in webcm: {expected}"),
     };
-    let full_name = match name.split_once("--") {
-        Some((namespace, name)) => format!("{namespace}/{name}"),
-        None => name.to_string(),
-    };
-    let Ok(version) = version.parse() else {
-        return Ok(None);
-    };
-    Ok(Some(ResolvedIdentity {
-        id: PackageId::Named(NamedPackageId { full_name, version }),
-        expected_sha256: read_sha256_sibling(webc),
-    }))
-}
-
-/// nikolas's scheme: `<namespace>/<name>/<version>.webc` (or `<name>/<version>
-/// .webc`) relative to `root`. Each field is a path component, nothing to escape.
-fn id_from_path(root: &Path, webc: &Path) -> Result<Option<ResolvedIdentity>, Error> {
-    let Some(parts) = webc
-        .strip_prefix(root)
-        .ok()
-        .and_then(|rel| rel.iter().map(|p| p.to_str()).collect::<Option<Vec<_>>>())
-    else {
-        return Ok(None);
-    };
-    let (full_name, file) = match parts.as_slice() {
-        [namespace, name, file] => (format!("{namespace}/{name}"), *file),
-        [name, file] => (name.to_string(), *file),
-        _ => return Ok(None),
-    };
-    let Some(Ok(version)) = file.strip_suffix(".webc").map(str::parse) else {
-        return Ok(None);
-    };
-    Ok(Some(ResolvedIdentity {
-        id: PackageId::Named(NamedPackageId { full_name, version }),
-        expected_sha256: read_sha256_sibling(webc),
-    }))
-}
-
-/// The `<stem>.webcm` sidecar's metadata.
-#[allow(dead_code)] // inactive scheme; swap into `add_one` to use.
-#[derive(serde::Deserialize)]
-struct Webcm {
-    name: String,
-    version: String,
-    #[serde(rename = "package-hash")]
-    package_hash: Option<String>,
-}
-
-/// arshia's scheme: a `<stem>.webcm` TOML sidecar (name/version/hash) beside the
-/// webc. `root` is unused. Absent gives `None`; malformed is an error.
-#[allow(dead_code)] // inactive scheme; swap into `add_one` to use.
-fn id_from_sidecar(_root: &Path, webc: &Path) -> Result<Option<ResolvedIdentity>, Error> {
-    let sidecar = webc.with_extension("webcm");
-    if !sidecar.is_file() {
-        return Ok(None);
-    }
-    let contents = std::fs::read_to_string(&sidecar)
-        .with_context(|| format!("Unable to read \"{}\"", sidecar.display()))?;
-    let webcm: Webcm = toml::from_str(&contents)
-        .with_context(|| format!("Invalid webcm \"{}\"", sidecar.display()))?;
-    Ok(Some(ResolvedIdentity {
-        id: PackageId::Named(NamedPackageId {
-            full_name: webcm.name,
-            version: webcm.version.parse().context("Invalid webcm version")?,
-        }),
-        expected_sha256: webcm.package_hash,
-    }))
-}
-
-/// The trimmed digest of an optional `<stem>.sha256` sibling, if present.
-fn read_sha256_sibling(webc: &Path) -> Option<String> {
-    let contents = std::fs::read_to_string(webc.with_extension("sha256")).ok()?;
-    Some(contents.trim().to_string())
-}
-
-/// Error if `actual` doesn't match `expected` (hex, an optional `sha256:` prefix
-/// allowed).
-fn verify_sha256(webc: &Path, actual: &WebcHash, expected: &str) -> Result<(), Error> {
-    let expected = expected.trim();
-    let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
-    if !expected.eq_ignore_ascii_case(&actual.as_hex()) {
-        anyhow::bail!(
-            "sha256 mismatch for \"{}\": expected {expected}, file hashes to {}",
-            webc.display(),
-            actual.as_hex(),
-        );
-    }
+    anyhow::ensure!(
+        matches,
+        "hash mismatch for \"{}\": the webcm records {expected}, the file hashes to sha256:{}",
+        webc.display(),
+        actual.as_hex(),
+    );
     Ok(())
 }
 
@@ -341,49 +270,28 @@ mod tests {
         "/../../wasmer-test-files/integration/webc/bash-1.0.16-f097441a-a80b-4e0d-87d7-684918ef4bb6.webc"
     ));
 
-    #[test]
-    fn parse_path_ids() {
-        let root = Path::new("/pkgs");
-        let id = |p: &str| {
-            id_from_path(root, &root.join(p))
-                .unwrap()
-                .map(|ri| ri.id.to_string())
+    /// Write a `.webcm` pairing with `webc`, recording COREUTILS_16's real
+    /// hash unless `hash` overrides it.
+    fn write_webcm(webc: &Path, name: &str, version: &str, hash: Option<&str>) {
+        let hash = match hash {
+            Some(hash) => hash.to_string(),
+            None => format!("sha256:{}", WebcHash::sha256(COREUTILS_16).as_hex()),
         };
-
-        assert_eq!(id("ns/name/1.2.3.webc").as_deref(), Some("ns/name@1.2.3"));
-        assert_eq!(id("name/1.2.3.webc").as_deref(), Some("name@1.2.3"));
-        assert_eq!(
-            id("ns/name/1.0.0-rc.1.webc").as_deref(),
-            Some("ns/name@1.0.0-rc.1")
-        );
-        // doesn't fit the layout -> None, so the caller keeps the manifest id.
-        assert_eq!(id("ns/name/notaversion.webc"), None); // bad semver
-        assert_eq!(id("too/deep/ns/name/1.0.0.webc"), None); // wrong depth
-        assert_eq!(id("flat.webc"), None); // no version directory
+        std::fs::write(
+            Webcm::path_for_webc(webc),
+            format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\nhash = \"{hash}\"\n"),
+        )
+        .unwrap();
     }
 
     #[test]
-    fn parse_filename_ids() {
-        let id = |s: &str| {
-            id_from_filename(Path::new(""), Path::new(s))
-                .unwrap()
-                .map(|ri| ri.id.to_string())
-        };
-
-        assert_eq!(id("ns--name@1.2.3.webc").as_deref(), Some("ns/name@1.2.3"));
-        assert_eq!(id("name@1.2.3.webc").as_deref(), Some("name@1.2.3"));
-        assert_eq!(id("ns--name@notaversion.webc"), None); // bad semver
-        assert_eq!(id(&format!("{}.webc", "a".repeat(64))), None); // hash-named
-    }
-
-    #[test]
-    fn add_packages_names_from_layout() {
+    fn add_packages_names_from_webcm() {
         let temp = TempDir::new().unwrap();
-        let dir = temp.path().join("acme").join("cutils");
-        std::fs::create_dir_all(&dir).unwrap();
-        // COREUTILS_16's manifest is "sharrattj/coreutils@1.0.16"; the layout
-        // must win, proving resolution keys off the path, not the artifact.
-        std::fs::write(dir.join("9.9.9.webc"), COREUTILS_16).unwrap();
+        let webc = temp.path().join("cutils.webc");
+        // COREUTILS_16's own manifest is "sharrattj/coreutils@1.0.16"; the
+        // sidecar must win, proving it is the authoritative identity.
+        std::fs::write(&webc, COREUTILS_16).unwrap();
+        write_webcm(&webc, "acme/cutils", "9.9.9", None);
 
         let mut source = InMemorySource::new();
         source.add_packages(temp.path()).unwrap();
@@ -400,11 +308,91 @@ mod tests {
             source.named_packages["acme/cutils"][0].ident,
             NamedPackageId::try_new("acme/cutils", "9.9.9").unwrap()
         );
+        // Not double-added under its manifest id by the directory walk.
+        assert_eq!(source.len(), 1);
+    }
+
+    #[test]
+    fn add_packages_accepts_webc_or_webcm_file_roots() {
+        let temp = TempDir::new().unwrap();
+        let webc = temp.path().join("cutils.webc");
+        std::fs::write(&webc, COREUTILS_16).unwrap();
+        write_webcm(&webc, "acme/cutils", "9.9.9", None);
+
+        for root in [webc.clone(), Webcm::path_for_webc(&webc)] {
+            let mut source = InMemorySource::new();
+            source.add_packages(&root).unwrap();
+            assert_eq!(
+                source.named_packages["acme/cutils"][0].ident,
+                NamedPackageId::try_new("acme/cutils", "9.9.9").unwrap(),
+                "root: {}",
+                root.display()
+            );
+        }
+    }
+
+    #[test]
+    fn webcm_hash_is_optional() {
+        let temp = TempDir::new().unwrap();
+        let webc = temp.path().join("cutils.webc");
+        std::fs::write(&webc, COREUTILS_16).unwrap();
+        std::fs::write(
+            Webcm::path_for_webc(&webc),
+            "[package]\nname = \"acme/cutils\"\nversion = \"9.9.9\"\n",
+        )
+        .unwrap();
+
+        let mut source = InMemorySource::new();
+        source.add_packages(temp.path()).unwrap();
+
+        assert!(source.named_packages.contains_key("acme/cutils"));
+    }
+
+    #[test]
+    fn webcm_hash_mismatch_is_an_error() {
+        let temp = TempDir::new().unwrap();
+        let webc = temp.path().join("cutils.webc");
+        std::fs::write(&webc, COREUTILS_16).unwrap();
+        write_webcm(
+            &webc,
+            "acme/cutils",
+            "9.9.9",
+            Some(&format!("sha256:{}", "a".repeat(64))),
+        );
+
+        let mut source = InMemorySource::new();
+        let err = source.add_packages(temp.path()).unwrap_err();
+        assert!(format!("{err:#}").contains("hash mismatch"), "{err:#}");
+    }
+
+    #[test]
+    fn orphaned_webcm_is_an_error() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("cutils.webcm"),
+            "[package]\nname = \"acme/cutils\"\nversion = \"9.9.9\"\n",
+        )
+        .unwrap();
+
+        let mut source = InMemorySource::new();
+        let err = source.add_packages(temp.path()).unwrap_err();
+        assert!(format!("{err:#}").contains("no paired webc"), "{err:#}");
+    }
+
+    #[test]
+    fn malformed_webcm_is_an_error() {
+        let temp = TempDir::new().unwrap();
+        let webc = temp.path().join("cutils.webc");
+        std::fs::write(&webc, COREUTILS_16).unwrap();
+        std::fs::write(Webcm::path_for_webc(&webc), "not webcm").unwrap();
+
+        let mut source = InMemorySource::new();
+        assert!(source.add_packages(temp.path()).is_err());
     }
 
     #[test]
     fn add_packages_single_file_falls_back_to_manifest() {
-        // A lone file has no layout, so the path scheme keeps its manifest id.
+        // Without a sidecar, a webc keeps its manifest id.
         let temp = TempDir::new().unwrap();
         let file = temp.path().join("anything.webc");
         std::fs::write(&file, COREUTILS_16).unwrap();
@@ -428,39 +416,6 @@ mod tests {
     }
 
     #[test]
-    fn add_packages_rejects_bad_sha256_sidecar() {
-        let temp = TempDir::new().unwrap();
-        let dir = temp.path().join("acme").join("cutils");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("9.9.9.webc"), COREUTILS_16).unwrap();
-        std::fs::write(dir.join("9.9.9.sha256"), "deadbeef").unwrap();
-
-        let mut source = InMemorySource::new();
-        assert!(source.add_packages(temp.path()).is_err());
-    }
-
-    #[test]
-    fn sidecar_identity() {
-        // add_one uses the path scheme, so test the sidecar scheme directly.
-        let temp = TempDir::new().unwrap();
-        let webc = temp.path().join("pkg.webc");
-        std::fs::write(&webc, COREUTILS_16).unwrap();
-        let hash = WebcHash::sha256(COREUTILS_16).as_hex();
-        std::fs::write(
-            temp.path().join("pkg.webcm"),
-            format!("name = \"acme/cutils\"\nversion = \"9.9.9\"\npackage-hash = \"{hash}\"\n"),
-        )
-        .unwrap();
-
-        let identity = id_from_sidecar(temp.path(), &webc).unwrap().unwrap();
-        assert_eq!(identity.id.to_string(), "acme/cutils@9.9.9");
-
-        let actual = WebcHash::sha256(COREUTILS_16);
-        verify_sha256(&webc, &actual, identity.expected_sha256.as_deref().unwrap()).unwrap();
-        assert!(verify_sha256(&webc, &actual, "deadbeef").is_err());
-    }
-
-    #[test]
     fn load_a_directory_tree() {
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join("python-0.1.0.webc"), PYTHON).unwrap();
@@ -471,7 +426,8 @@ mod tests {
         let bash = nested.join("bash-1.0.12.webc");
         std::fs::write(&bash, BASH).unwrap();
 
-        let source = InMemorySource::from_directory_tree(temp.path()).unwrap();
+        let mut source = InMemorySource::new();
+        source.add_packages(temp.path()).unwrap();
 
         assert_eq!(
             source

--- a/tests/integration/cli/tests/publish.rs
+++ b/tests/integration/cli/tests/publish.rs
@@ -90,3 +90,69 @@ fn wasmer_publish() {
             "wasmer.wtf/{username}/largewasmfile@{random1}.{random2}.{random3}"
         )));
 }
+
+/// Building a package emits a `.webcm` sidecar, and publishing that sidecar
+/// alone reproduces the package identity from it: the CI-from-a-webc workflow
+/// (WARP-68), where publish takes name/version from the sidecar, not a
+/// `wasmer.toml`.
+#[test]
+fn wasmer_publish_webcm_sidecar() {
+    let ciuser_token = std::env::var("DEV_BACKEND_CIUSER_TOKEN").ok();
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path();
+    let username = "ciuser";
+
+    let random1 = format!("{}", rand::random::<u32>());
+    let random2 = format!("{}", rand::random::<u32>());
+    let random3 = format!("{}", rand::random::<u32>());
+    let version = format!("{random1}.{random2}.{random3}");
+
+    std::fs::copy(fixtures::qjs(), path.join("largewasmfile.wasm")).unwrap();
+    std::fs::write(
+        path.join("wasmer.toml"),
+        include_str!("./fixtures/init6.toml")
+            .replace("WAPMUSERNAME", username)
+            .replace("RANDOMVERSION1", &random1)
+            .replace("RANDOMVERSION2", &random2)
+            .replace("RANDOMVERSION3", &random3),
+    )
+    .unwrap();
+
+    // Build the package. This emits the `.webc` and its `.webcm` sidecar, and
+    // needs no registry, so this half runs everywhere, covering the default
+    // sidecar emission on its own.
+    let webc = path.join("pkg.webc");
+    let webcm = webc.with_extension("webcm");
+    wasmer_command()
+        .arg("package")
+        .arg("build")
+        .arg("--quiet")
+        .arg("-o")
+        .arg(&webc)
+        .arg(path)
+        .assert()
+        .success();
+    assert!(webc.is_file(), "build did not emit the .webc");
+    assert!(webcm.is_file(), "build did not emit the .webcm sidecar");
+
+    // Publishing needs the registry; without a token, the sidecar-emission
+    // assertions above are all this test can cover.
+    let token = match ciuser_token {
+        // Special case: GitHub secrets aren't visible to outside collaborators.
+        Some(token) if !token.is_empty() => token,
+        _ => return,
+    };
+
+    wasmer_command()
+        .arg("publish")
+        .arg("--quiet")
+        .arg("--registry=wasmer.wtf")
+        .arg("--token")
+        .arg(token)
+        .arg(&webcm)
+        .assert()
+        .success()
+        .stderr(predicates::str::contains(format!(
+            "wasmer.wtf/{username}/largewasmfile@{version}"
+        )));
+}


### PR DESCRIPTION
Implements [WARP-68](https://linear.app/wasmer/issue/WARP-68).

Built `.webc`s are stripped of their package identity, which makes them hard to use locally (offline resolution) and awkward to publish from CI. This PR introduces the `.webcm` sidecar: a small TOML manifest with the same basename as its `.webc` (`phpix.webcm` ↔ `phpix.webc`) that acts as the canonical source of package identity for local artifacts:

```toml
format_version = 1

[package]
name = "wasmer/phpix"
version = "0.1.2"
hash = "sha256:..."
```

`format_version` is a breaking-changes-only integer (unknown fields are ignored, so additive changes need no bump). On read, `format_version` and `hash` are optional (the hash is only verified when present) but both are always written.

### Changes

- **`wasmer-config`**: new `Webcm` type defining the format, with parsing, serialization, and path-pairing helpers.
- **Resolver** (`InMemorySource`): directory scans and `--include-webc` treat sidecars as authoritative, such that packages are indexed by name/version and hash, and an invalid sidecar (orphaned, hash mismatch, unparseable) is a hard error. Webcs without a sidecar keep their embedded manifest id. The filename/path-based schemes from the RUN-1056 draft are dropped per the WARP (possible later as optional hints).
- **`wasmer package build`**: writes the sidecar next to the built `.webc` by default (`--no-webcm` to opt out).
- **`wasmer package publish` / `push` / `tag`**: accept a `.webcm` path (or a `.webc` with a sidecar) and take identity from it, verifying the hash first, such that CI can publish a prebuilt artifact with `wasmer publish pkg.webcm`
- **`wasmer package download`**: writes the sidecar by default for named downloads (`--no-webcm` to opt out), recording the registry's hash — without it, downloaded packages can't be resolved by name offline.

Supersedes https://github.com/wasmerio/wasmer/pull/6768
Closes https://github.com/wasmerio/wasmer/issues/6766
