### PR TITLE
fix(wasix): report SocketStream filetype for sock_pair fds

### DIFF
--- a/lib/wasix/src/syscalls/wasix/sock_pair.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_pair.rs
@@ -83,17 +83,26 @@ pub(crate) fn sock_pair_internal(
     let (memory, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
     let (end1, end2) = Pipe::channel();
 
-    let inode1 = state.fs.create_inode_with_default_stat(
+    // Report a proper socket filetype: callers (e.g. libuv's uv_guess_handle)
+    // fstat socketpair fds to classify them, and the default filestat's
+    // Unknown filetype makes them unusable as streams.
+    let stat = Filestat {
+        st_filetype: Filetype::SocketStream,
+        ..Filestat::default()
+    };
+    let inode1 = state.fs.create_inode_with_stat(
         inodes,
         Kind::DuplexPipe { pipe: end1 },
         false,
         "socketpair".into(),
+        stat,
     );
-    let inode2 = state.fs.create_inode_with_default_stat(
+    let inode2 = state.fs.create_inode_with_stat(
         inodes,
         Kind::DuplexPipe { pipe: end2 },
         false,
         "socketpair".into(),
+        stat,
     );
 
     let rights = Rights::all_socket();


### PR DESCRIPTION
## Problem

`sock_pair` creates its `DuplexPipe` inodes with `create_inode_with_default_stat`, so `fd_filestat_get` on a socketpair fd returns filetype **Unknown** — guest `fstat` sees `st_mode == 0`. Anything that classifies fds by fstat then breaks:

- libuv's `uv_guess_handle` returns `UV_UNKNOWN_HANDLE`
- Node's `net.Socket({ fd })` throws `ERR_INVALID_FD_TYPE: Unsupported fd type: UNKNOWN`

for perfectly usable socketpair fds — including ones inherited through `proc_spawn`, which is how this surfaced while debugging Node `cluster`/`child_process.fork` IPC channels under WASIX (EdgeJS).

## Fix

Give the socketpair inodes a filestat with `Filetype::SocketStream` so guest `fstat` reports `S_IFSOCK`, matching how the fd actually behaves.

## Verification

With an EdgeJS guest under this build, `fstat` on a forked child's inherited IPC channel fd now reports `isSocket=true`, `st_mode=0160000` (previously `false` / `0`). `cargo check -p wasmer-wasix` clean.

## Known remaining gap (out of scope)

`getsockname`/`getsockopt(SO_TYPE)` still fail on these fds because the underlying kind is `DuplexPipe`, not a real socket (the existing FIXME in `sock_pair.rs`), so `uv_guess_handle`'s full classification chain still ends at unknown. Fixing that needs the socketpair-as-real-socket rework the FIXME describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)