### PR TITLE
Make virtual-fs filesystem operations async

### DIFF
--- a/.github/cross-linux-riscv64/Dockerfile
+++ b/.github/cross-linux-riscv64/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update  && \
 # install rust tools
 RUN curl --proto "=https" --tlsv1.2 --retry 3 -sSfL https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup -v toolchain install 1.94
+RUN rustup -v toolchain install 1.93
 # add docker the manual way
 COPY install_docker.sh /
 RUN /install_docker.sh
@@ -61,7 +61,7 @@ ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc
     RUST_TEST_THREADS=1 \
     PKG_CONFIG_PATH="/usr/lib/riscv64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
 
-RUN rustup target add riscv64gc-unknown-linux-gnu --toolchain 1.94-x86_64-unknown-linux-gnu
+RUN rustup target add riscv64gc-unknown-linux-gnu --toolchain 1.93-x86_64-unknown-linux-gnu
 
 # quickly install cargo nextest by using pre-built binary
 RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin

--- a/.github/cross-linux-riscv64/Dockerfile
+++ b/.github/cross-linux-riscv64/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update  && \
 # install rust tools
 RUN curl --proto "=https" --tlsv1.2 --retry 3 -sSfL https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup -v toolchain install 1.93
+RUN rustup -v toolchain install 1.94
 # add docker the manual way
 COPY install_docker.sh /
 RUN /install_docker.sh
@@ -61,7 +61,7 @@ ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc
     RUST_TEST_THREADS=1 \
     PKG_CONFIG_PATH="/usr/lib/riscv64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
 
-RUN rustup target add riscv64gc-unknown-linux-gnu --toolchain 1.93-x86_64-unknown-linux-gnu
+RUN rustup target add riscv64gc-unknown-linux-gnu --toolchain 1.94-x86_64-unknown-linux-gnu
 
 # quickly install cargo nextest by using pre-built binary
 RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ edition = "2024"
 homepage = "https://wasmer.io/"
 license = "MIT"
 repository = "https://github.com/wasmerio/wasmer"
-rust-version = "1.93"
+rust-version = "1.94"
 version = "7.2.0"
 
 [workspace.dependencies]

--- a/lib/virtual-fs/src/arc_box_file.rs
+++ b/lib/virtual-fs/src/arc_box_file.rs
@@ -4,10 +4,11 @@
 use std::{
     io::{self, *},
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
 };
 
+use futures::lock::Mutex;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
 use crate::VirtualFile;
@@ -27,14 +28,12 @@ impl ArcBoxFile {
 
 impl AsyncSeek for ArcBoxFile {
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.try_lock().ok_or_else(lock_would_block)?;
         let file = Pin::new(guard.as_mut());
         file.start_seek(position)
     }
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_complete(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_complete(cx))
     }
 }
 
@@ -44,31 +43,28 @@ impl AsyncWrite for ArcBoxFile {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_write(cx, buf)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_write(cx, buf))
     }
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_flush(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_flush(cx))
     }
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_shutdown(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_shutdown(cx))
     }
     fn poll_write_vectored(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_write_vectored(cx, bufs)
+        poll_with_inner(&self.inner, cx, |file, cx| {
+            file.poll_write_vectored(cx, bufs)
+        })
     }
     fn is_write_vectored(&self) -> bool {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = match self.inner.try_lock() {
+            Some(guard) => guard,
+            None => return false,
+        };
         let file = Pin::new(guard.as_mut());
         file.is_write_vectored()
     }
@@ -80,59 +76,73 @@ impl AsyncRead for ArcBoxFile {
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_read(cx, buf)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_read(cx, buf))
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for ArcBoxFile {
-    fn last_accessed(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.last_accessed().await
     }
-    fn last_modified(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.last_modified()
+    async fn last_modified(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.last_modified().await
     }
-    fn created_time(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.created_time()
+    async fn created_time(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.created_time().await
     }
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.set_times(atime, mtime)
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.set_times(atime, mtime).await
     }
-    fn size(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.size()
+    async fn size(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.size().await
     }
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.set_len(new_size).await
     }
-    fn unlink(&mut self) -> crate::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.unlink()
+    async fn unlink(&mut self) -> crate::Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.unlink().await
     }
-    fn is_open(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.is_open()
+    async fn is_open(&self) -> bool {
+        let inner = self.inner.lock().await;
+        inner.is_open().await
     }
-    fn get_special_fd(&self) -> Option<u32> {
-        let inner = self.inner.lock().unwrap();
-        inner.get_special_fd()
+    async fn get_special_fd(&self) -> Option<u32> {
+        let inner = self.inner.lock().await;
+        inner.get_special_fd().await
     }
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        let mut inner = self.inner.lock().unwrap();
-        let inner = Pin::new(inner.as_mut());
-        inner.poll_read_ready(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_read_ready(cx))
     }
     fn poll_write_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        let mut inner = self.inner.lock().unwrap();
-        let inner = Pin::new(inner.as_mut());
-        inner.poll_write_ready(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_write_ready(cx))
     }
+}
+
+fn lock_would_block() -> io::Error {
+    io::Error::new(io::ErrorKind::WouldBlock, "shared file is locked")
+}
+
+fn poll_with_inner<R>(
+    inner: &Mutex<Box<dyn VirtualFile + Send + Sync + 'static>>,
+    cx: &mut Context<'_>,
+    f: impl FnOnce(
+        Pin<&mut (dyn VirtualFile + Send + Sync + 'static)>,
+        &mut Context<'_>,
+    ) -> Poll<io::Result<R>>,
+) -> Poll<io::Result<R>> {
+    let Some(mut guard) = inner.try_lock() else {
+        cx.waker().wake_by_ref();
+        return Poll::Pending;
+    };
+    f(Pin::new(guard.as_mut()), cx)
 }
 
 impl From<Box<dyn VirtualFile + Send + Sync + 'static>> for ArcBoxFile {

--- a/lib/virtual-fs/src/arc_file.rs
+++ b/lib/virtual-fs/src/arc_file.rs
@@ -2,11 +2,12 @@
 //! effectively this is a symbolic link without all the complex path redirection
 
 use crate::{CloneableVirtualFile, VirtualFile};
+use futures::lock::Mutex;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{
     io::{self, *},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
@@ -34,14 +35,12 @@ where
     T: VirtualFile + Send + Sync + 'static,
 {
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.try_lock().ok_or_else(lock_would_block)?;
         let file = Pin::new(guard.as_mut());
         file.start_seek(position)
     }
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_complete(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_complete(cx))
     }
 }
 
@@ -54,31 +53,28 @@ where
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_write(cx, buf)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_write(cx, buf))
     }
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_flush(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_flush(cx))
     }
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_shutdown(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_shutdown(cx))
     }
     fn poll_write_vectored(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_write_vectored(cx, bufs)
+        poll_with_inner(&self.inner, cx, |file, cx| {
+            file.poll_write_vectored(cx, bufs)
+        })
     }
     fn is_write_vectored(&self) -> bool {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = match self.inner.try_lock() {
+            Some(guard) => guard,
+            None => return false,
+        };
         let file = Pin::new(guard.as_mut());
         file.is_write_vectored()
     }
@@ -93,62 +89,76 @@ where
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        let mut guard = self.inner.lock().unwrap();
-        let file = Pin::new(guard.as_mut());
-        file.poll_read(cx, buf)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_read(cx, buf))
     }
 }
 
+#[async_trait::async_trait]
 impl<T> VirtualFile for ArcFile<T>
 where
     T: VirtualFile + Send + Sync + 'static,
 {
-    fn last_accessed(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.last_accessed().await
     }
-    fn last_modified(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.last_modified()
+    async fn last_modified(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.last_modified().await
     }
-    fn created_time(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.created_time()
+    async fn created_time(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.created_time().await
     }
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.set_times(atime, mtime)
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.set_times(atime, mtime).await
     }
-    fn size(&self) -> u64 {
-        let inner = self.inner.lock().unwrap();
-        inner.size()
+    async fn size(&self) -> u64 {
+        let inner = self.inner.lock().await;
+        inner.size().await
     }
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.set_len(new_size).await
     }
-    fn unlink(&mut self) -> crate::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
-        inner.unlink()
+    async fn unlink(&mut self) -> crate::Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.unlink().await
     }
-    fn is_open(&self) -> bool {
-        let inner = self.inner.lock().unwrap();
-        inner.is_open()
+    async fn is_open(&self) -> bool {
+        let inner = self.inner.lock().await;
+        inner.is_open().await
     }
-    fn get_special_fd(&self) -> Option<u32> {
-        let inner = self.inner.lock().unwrap();
-        inner.get_special_fd()
+    async fn get_special_fd(&self) -> Option<u32> {
+        let inner = self.inner.lock().await;
+        inner.get_special_fd().await
     }
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        let mut inner = self.inner.lock().unwrap();
-        let inner = Pin::new(inner.as_mut());
-        inner.poll_read_ready(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_read_ready(cx))
     }
     fn poll_write_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        let mut inner = self.inner.lock().unwrap();
-        let inner = Pin::new(inner.as_mut());
-        inner.poll_write_ready(cx)
+        poll_with_inner(&self.inner, cx, |file, cx| file.poll_write_ready(cx))
     }
+}
+
+fn lock_would_block() -> io::Error {
+    io::Error::new(io::ErrorKind::WouldBlock, "shared file is locked")
+}
+
+fn poll_with_inner<T, R>(
+    inner: &Mutex<Box<T>>,
+    cx: &mut Context<'_>,
+    f: impl FnOnce(Pin<&mut T>, &mut Context<'_>) -> Poll<io::Result<R>>,
+) -> Poll<io::Result<R>>
+where
+    T: VirtualFile + Send + Sync + 'static,
+{
+    let Some(mut guard) = inner.try_lock() else {
+        cx.waker().wake_by_ref();
+        return Poll::Pending;
+    };
+    f(Pin::new(guard.as_mut()), cx)
 }
 
 impl<T> Clone for ArcFile<T>

--- a/lib/virtual-fs/src/arc_fs.rs
+++ b/lib/virtual-fs/src/arc_fs.rs
@@ -21,45 +21,54 @@ impl ArcFileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl FileSystem for ArcFileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
-        self.fs.readlink(path)
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
+        self.fs.readlink(path).await
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
-        self.fs.read_dir(path)
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+        self.fs.read_dir(path).await
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
-        self.fs.create_dir(path)
+    async fn create_dir(&self, path: &Path) -> Result<()> {
+        self.fs.create_dir(path).await
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
-        self.fs.create_symlink(source, target)
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+        self.fs.create_symlink(source, target).await
     }
 
-    fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
-        self.fs.hard_link(source, target)
+    async fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+        self.fs.hard_link(source, target).await
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
-        self.fs.remove_dir(path)
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
+        self.fs.remove_dir(path).await
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async { self.fs.rename(from, to).await })
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.fs.rename(from, to).await
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
-        self.fs.metadata(path)
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
+        self.fs.metadata(path).await
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
-        self.fs.symlink_metadata(path)
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+        self.fs.symlink_metadata(path).await
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
-        self.fs.remove_file(path)
+    async fn remove_file(&self, path: &Path) -> Result<()> {
+        self.fs.remove_file(path).await
+    }
+
+    async fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        self.fs.open(path, conf).await
     }
 
     fn new_open_options(&self) -> OpenOptions<'_> {

--- a/lib/virtual-fs/src/buffer_file.rs
+++ b/lib/virtual-fs/src/buffer_file.rs
@@ -67,24 +67,25 @@ impl AsyncRead for BufferFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for BufferFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         1_000_000_000 // 1 second after epoch, since zero times are bad!
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         1_000_000_000
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         1_000_000_000
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         self.data.get_ref().len() as u64
     }
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
         self.data.get_mut().resize(new_size as usize, 0);
         Ok(())
     }
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         Ok(())
     }
     fn poll_read_ready(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/virtual-fs/src/builder.rs
+++ b/lib/virtual-fs/src/builder.rs
@@ -107,7 +107,7 @@ impl RootFileSystemBuilder {
                 .collect::<Vec<_>>();
 
             for root_dir in &default_dirs {
-                if let Err(err) = tmp.create_dir(Path::new(root_dir)) {
+                if let Err(err) = futures::executor::block_on(tmp.create_dir(Path::new(root_dir))) {
                     debug!("failed to create dir [{}] - {}", root_dir, err);
                 }
             }
@@ -147,7 +147,7 @@ impl RootFileSystemBuilder {
                 self.tty.unwrap_or_else(|| Box::<NullFile>::default()),
             );
 
-            let _ = tmp.create_dir(Path::new("/dev/shm"));
+            let _ = futures::executor::block_on(tmp.create_dir(Path::new("/dev/shm")));
         }
         tmp
     }
@@ -167,41 +167,45 @@ mod test_builder {
             .read(true)
             .write(true)
             .open("/dev/null")
+            .await
             .unwrap();
         assert_eq!(dev_null.write(b"hello").await.unwrap(), 5);
         let mut buf = Vec::new();
         dev_null.read_to_end(&mut buf).await.unwrap();
         assert!(buf.is_empty());
-        assert!(dev_null.get_special_fd().is_none());
+        assert!(dev_null.get_special_fd().await.is_none());
 
         let mut dev_zero = root_fs
             .new_open_options()
             .read(true)
             .write(true)
             .open("/dev/zero")
+            .await
             .unwrap();
         assert_eq!(dev_zero.write(b"hello").await.unwrap(), 5);
         let mut buf = vec![1; 10];
         dev_zero.read_exact(&mut buf[..]).await.unwrap();
         assert_eq!(buf, vec![0; 10]);
-        assert!(dev_zero.get_special_fd().is_none());
+        assert!(dev_zero.get_special_fd().await.is_none());
 
         let mut dev_tty = root_fs
             .new_open_options()
             .read(true)
             .write(true)
             .open("/dev/tty")
+            .await
             .unwrap();
         assert_eq!(dev_tty.write(b"hello").await.unwrap(), 5);
         let mut buf = Vec::new();
         dev_tty.read_to_end(&mut buf).await.unwrap();
         assert!(buf.is_empty());
-        assert!(dev_tty.get_special_fd().is_none());
+        assert!(dev_tty.get_special_fd().await.is_none());
 
         root_fs
             .new_open_options()
             .read(true)
             .open("/bin/wasmer")
+            .await
             .unwrap();
 
         let dev_stdin = root_fs
@@ -209,24 +213,27 @@ mod test_builder {
             .read(true)
             .write(true)
             .open("/dev/stdin")
+            .await
             .unwrap();
-        assert_eq!(dev_stdin.get_special_fd().unwrap(), 0);
+        assert_eq!(dev_stdin.get_special_fd().await.unwrap(), 0);
         let dev_stdout = root_fs
             .new_open_options()
             .read(true)
             .write(true)
             .open("/dev/stdout")
+            .await
             .unwrap();
-        assert_eq!(dev_stdout.get_special_fd().unwrap(), 1);
+        assert_eq!(dev_stdout.get_special_fd().await.unwrap(), 1);
         let dev_stderr = root_fs
             .new_open_options()
             .read(true)
             .write(true)
             .open("/dev/stderr")
+            .await
             .unwrap();
-        assert_eq!(dev_stderr.get_special_fd().unwrap(), 2);
+        assert_eq!(dev_stderr.get_special_fd().await.unwrap(), 2);
 
-        let dev_shm_metadata = root_fs.metadata(Path::new("/dev/shm")).unwrap();
+        let dev_shm_metadata = root_fs.metadata(Path::new("/dev/shm")).await.unwrap();
         assert!(dev_shm_metadata.is_dir());
     }
 }

--- a/lib/virtual-fs/src/combine_file.rs
+++ b/lib/virtual-fs/src/combine_file.rs
@@ -17,33 +17,34 @@ impl CombineFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for CombineFile {
-    fn last_accessed(&self) -> u64 {
-        self.rx.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        self.rx.last_accessed().await
     }
 
-    fn last_modified(&self) -> u64 {
-        self.tx.last_modified()
+    async fn last_modified(&self) -> u64 {
+        self.tx.last_modified().await
     }
 
-    fn created_time(&self) -> u64 {
-        self.tx.created_time()
+    async fn created_time(&self) -> u64 {
+        self.tx.created_time().await
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
-        self.tx.set_times(atime, mtime)
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        self.tx.set_times(atime, mtime).await
     }
 
-    fn size(&self) -> u64 {
-        self.rx.size()
+    async fn size(&self) -> u64 {
+        self.rx.size().await
     }
 
-    fn set_len(&mut self, new_size: u64) -> Result<()> {
-        self.tx.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> Result<()> {
+        self.tx.set_len(new_size).await
     }
 
-    fn unlink(&mut self) -> Result<()> {
-        self.tx.unlink()
+    async fn unlink(&mut self) -> Result<()> {
+        self.tx.unlink().await
     }
 
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/virtual-fs/src/cow_file.rs
+++ b/lib/virtual-fs/src/cow_file.rs
@@ -48,9 +48,9 @@ pub struct CopyOnWriteFile {
 impl CopyOnWriteFile {
     pub fn new(inner: Box<dyn VirtualFile + Send + Sync>) -> Self {
         Self {
-            last_accessed: inner.last_accessed(),
-            last_modified: inner.last_modified(),
-            created_time: inner.created_time(),
+            last_accessed: futures::executor::block_on(inner.last_accessed()),
+            last_modified: futures::executor::block_on(inner.last_modified()),
+            created_time: futures::executor::block_on(inner.created_time()),
             state: CowState::ReadOnly(inner),
         }
     }
@@ -84,7 +84,7 @@ impl CopyOnWriteFile {
             } => match future.as_mut().poll(cx) {
                 Poll::Ready(Ok(mut buf)) => {
                     if let Some(requested_size) = requested_size {
-                        buf.set_len(requested_size)?;
+                        futures::executor::block_on(buf.set_len(requested_size))?;
                     }
                     if let Some(requested_position) = requested_position {
                         Pin::new(&mut buf).start_seek(requested_position)?;
@@ -102,7 +102,7 @@ impl CopyOnWriteFile {
     fn start_copy(&mut self) {
         replace_with_or_abort(&mut self.state, |state| match state {
             CowState::ReadOnly(inner) => CowState::Copying {
-                cached_size: inner.size(),
+                cached_size: futures::executor::block_on(inner.size()),
                 requested_size: None,
                 requested_position: None,
                 future: Box::pin(Self::copy(inner)),
@@ -201,20 +201,21 @@ impl AsyncRead for CopyOnWriteFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for CopyOnWriteFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         self.last_accessed
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         self.last_modified
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         self.created_time
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         if let Some(atime) = atime {
             self.last_accessed = atime;
         }
@@ -225,19 +226,19 @@ impl VirtualFile for CopyOnWriteFile {
         Ok(())
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         match &self.state {
-            CowState::ReadOnly(inner) => inner.size(),
+            CowState::ReadOnly(inner) => inner.size().await,
             CowState::Copying {
                 requested_size: Some(size),
                 ..
             } => *size,
             CowState::Copying { cached_size, .. } => *cached_size,
-            CowState::Copied(buffer_file) => buffer_file.size(),
+            CowState::Copied(buffer_file) => buffer_file.size().await,
         }
     }
 
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
         match self.state {
             CowState::ReadOnly(_) => {
                 self.start_copy();
@@ -259,16 +260,16 @@ impl VirtualFile for CopyOnWriteFile {
             }
 
             CowState::Copied(ref mut buf) => {
-                buf.set_len(new_size)?;
+                buf.set_len(new_size).await?;
             }
         }
 
         Ok(())
     }
 
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         // TODO: one can imagine interrupting an in-progress copy here
-        self.set_len(0)
+        self.set_len(0).await
     }
 
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
@@ -303,10 +304,10 @@ mod tests {
         let mut file = CopyOnWriteFile::new(Box::new(inner));
 
         assert!(matches!(file.state, CowState::ReadOnly(_)));
-        assert_eq!(file.size(), 16385);
-        assert_ne!(file.created_time(), 0);
-        assert_ne!(file.last_accessed(), 0);
-        assert_ne!(file.last_modified(), 0);
+        assert_eq!(file.size().await, 16385);
+        assert_ne!(file.created_time().await, 0);
+        assert_ne!(file.last_accessed().await, 0);
+        assert_ne!(file.last_modified().await, 0);
 
         let mut buf = [0u8; 4];
         let read = file.read_exact(buf.as_mut()).await.unwrap();
@@ -319,12 +320,12 @@ mod tests {
         // future won't be polled until we try to read or write.
         file.start_copy();
         assert!(matches!(file.state, CowState::Copying { .. }));
-        assert_eq!(file.size(), 16385);
+        assert_eq!(file.size().await, 16385);
 
         // The cached length should be returned while copying
-        file.set_len(16400).unwrap();
+        file.set_len(16400).await.unwrap();
         assert!(matches!(file.state, CowState::Copying { .. }));
-        assert_eq!(file.size(), 16400);
+        assert_eq!(file.size().await, 16400);
 
         // Now try to read from the file, which will trigger the copy
         let read = file.read_exact(buf.as_mut()).await.unwrap();
@@ -332,7 +333,7 @@ mod tests {
         assert_eq!(read, 4);
         assert_eq!(buf, [4, 5, 6, 7]);
         assert_eq!(file.seek(SeekFrom::Current(0)).await.unwrap(), 8);
-        assert_eq!(file.size(), 16400);
+        assert_eq!(file.size().await, 16400);
 
         file.seek(SeekFrom::Start(16383)).await.unwrap();
         let read = file.read_exact(buf.as_mut()).await.unwrap();

--- a/lib/virtual-fs/src/dual_write_file.rs
+++ b/lib/virtual-fs/src/dual_write_file.rs
@@ -25,33 +25,34 @@ impl DualWriteFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for DualWriteFile {
-    fn last_accessed(&self) -> u64 {
-        self.inner.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        self.inner.last_accessed().await
     }
 
-    fn last_modified(&self) -> u64 {
-        self.inner.last_modified()
+    async fn last_modified(&self) -> u64 {
+        self.inner.last_modified().await
     }
 
-    fn created_time(&self) -> u64 {
-        self.inner.created_time()
+    async fn created_time(&self) -> u64 {
+        self.inner.created_time().await
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
-        self.inner.set_times(atime, mtime)
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        self.inner.set_times(atime, mtime).await
     }
 
-    fn size(&self) -> u64 {
-        self.inner.size()
+    async fn size(&self) -> u64 {
+        self.inner.size().await
     }
 
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
-        self.inner.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+        self.inner.set_len(new_size).await
     }
 
-    fn unlink(&mut self) -> Result<()> {
-        self.inner.unlink()
+    async fn unlink(&mut self) -> Result<()> {
+        self.inner.unlink().await
     }
 
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/virtual-fs/src/empty_fs.rs
+++ b/lib/virtual-fs/src/empty_fs.rs
@@ -11,12 +11,13 @@ use crate::*;
 pub struct EmptyFileSystem {}
 
 #[allow(unused_variables)]
+#[async_trait::async_trait]
 impl FileSystem for EmptyFileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
         Err(FsError::EntryNotFound)
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
         // Special-case the root path by returning an empty iterator.
         // An empty file system should still be readable, just not contain
         // any entries.
@@ -27,19 +28,20 @@ impl FileSystem for EmptyFileSystem {
         }
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    async fn create_dir(&self, path: &Path) -> Result<()> {
         Err(FsError::EntryNotFound)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
         Err(FsError::EntryNotFound)
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async { Err(FsError::EntryNotFound) })
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        let _ = (from, to);
+        Err(FsError::EntryNotFound)
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
         // Special-case the root path by returning an stub value.
         // An empty file system should still be readable, just not contain
         // any entries.
@@ -56,26 +58,23 @@ impl FileSystem for EmptyFileSystem {
         }
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
         Err(FsError::EntryNotFound)
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
+    async fn remove_file(&self, path: &Path) -> Result<()> {
         Err(FsError::EntryNotFound)
     }
 
     fn new_open_options(&self) -> OpenOptions<'_> {
         OpenOptions::new(self)
     }
-}
-
-impl FileOpener for EmptyFileSystem {
-    #[allow(unused_variables)]
-    fn open(
+    async fn open(
         &self,
         path: &Path,
         conf: &OpenOptionsConfig,
     ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        let _ = (path, conf);
         Err(FsError::EntryNotFound)
     }
 }

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -189,55 +189,55 @@ impl crate::FileSystem for FileSystem {
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
-            use filetime::{FileTime, set_file_mtime};
-            let norm_from = normalize_path(from);
-            let norm_to = normalize_path(to);
+        use filetime::{FileTime, set_file_mtime};
+        let norm_from = normalize_path(from);
+        let norm_to = normalize_path(to);
 
-            if norm_from.parent().is_none() {
-                return Err(FsError::BaseNotDirectory);
-            }
-            if norm_to.parent().is_none() {
-                return Err(FsError::BaseNotDirectory);
-            }
+        if norm_from.parent().is_none() {
+            return Err(FsError::BaseNotDirectory);
+        }
+        if norm_to.parent().is_none() {
+            return Err(FsError::BaseNotDirectory);
+        }
 
-            let from = self.prepare_path(from)?;
-            let to = self.prepare_path(to)?;
+        let from = self.prepare_path(from)?;
+        let to = self.prepare_path(to)?;
 
-            if !from.exists() {
-                return Err(FsError::EntryNotFound);
-            }
-            let from_parent = from.parent().unwrap();
-            let to_parent = to.parent().unwrap();
-            if !from_parent.exists() {
-                return Err(FsError::EntryNotFound);
-            }
-            if !to_parent.exists() {
-                return Err(FsError::EntryNotFound);
-            }
-            let result = if from_parent != to_parent {
-                let _ = std::fs::create_dir_all(to_parent);
-                if from.is_dir() {
-                    fs_extra::move_items(
-                        &[&from],
-                        &to,
-                        &fs_extra::dir::CopyOptions {
-                            copy_inside: true,
-                            ..Default::default()
-                        },
-                    )
-                    .map(|_| ())
-                    .map_err(|_| FsError::UnknownError)?;
-                    let _ = fs_extra::remove_items(&[&from]);
-                    Ok(())
-                } else {
-                    fs::copy(&from, &to).map(|_| ()).map_err(FsError::from)?;
-                    fs::remove_file(&from).map(|_| ()).map_err(Into::into)
-                }
+        if !from.exists() {
+            return Err(FsError::EntryNotFound);
+        }
+        let from_parent = from.parent().unwrap();
+        let to_parent = to.parent().unwrap();
+        if !from_parent.exists() {
+            return Err(FsError::EntryNotFound);
+        }
+        if !to_parent.exists() {
+            return Err(FsError::EntryNotFound);
+        }
+        let result = if from_parent != to_parent {
+            let _ = std::fs::create_dir_all(to_parent);
+            if from.is_dir() {
+                fs_extra::move_items(
+                    &[&from],
+                    &to,
+                    &fs_extra::dir::CopyOptions {
+                        copy_inside: true,
+                        ..Default::default()
+                    },
+                )
+                .map(|_| ())
+                .map_err(|_| FsError::UnknownError)?;
+                let _ = fs_extra::remove_items(&[&from]);
+                Ok(())
             } else {
-                fs::rename(&from, &to).map_err(Into::into)
-            };
-            let _ = set_file_mtime(&to, FileTime::now()).map(|_| ());
-            result
+                fs::copy(&from, &to).map(|_| ()).map_err(FsError::from)?;
+                fs::remove_file(&from).map(|_| ()).map_err(Into::into)
+            }
+        } else {
+            fs::rename(&from, &to).map_err(Into::into)
+        };
+        let _ = set_file_mtime(&to, FileTime::now()).map(|_| ());
+        result
     }
 
     async fn remove_file(&self, path: &Path) -> Result<()> {
@@ -1311,9 +1311,11 @@ mod tests {
             "creating a new file",
         );
 
-        assert!(read_dir_names(&fs, Path::new("/"))
-            .await
-            .contains(&"foo.txt".to_string()));
+        assert!(
+            read_dir_names(&fs, Path::new("/"))
+                .await
+                .contains(&"foo.txt".to_string())
+        );
 
         assert!(temp.path().join("foo.txt").is_file());
 
@@ -1337,14 +1339,26 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let fs = FileSystem::new(Handle::current(), temp.path()).expect("get filesystem");
 
-        assert_eq!(fs.create_dir(Path::new("foo")).await, Ok(()), "creating `foo`");
+        assert_eq!(
+            fs.create_dir(Path::new("foo")).await,
+            Ok(()),
+            "creating `foo`"
+        );
         assert_eq!(
             fs.create_dir(Path::new("foo/sub")).await,
             Ok(()),
             "creating `sub`"
         );
-        assert_eq!(fs.create_dir(Path::new("bar")).await, Ok(()), "creating `bar`");
-        assert_eq!(fs.create_dir(Path::new("baz")).await, Ok(()), "creating `bar`");
+        assert_eq!(
+            fs.create_dir(Path::new("bar")).await,
+            Ok(()),
+            "creating `bar`"
+        );
+        assert_eq!(
+            fs.create_dir(Path::new("baz")).await,
+            Ok(()),
+            "creating `bar`"
+        );
         assert!(
             fs.new_open_options()
                 .write(true)

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -288,16 +288,27 @@ impl crate::FileSystem for FileSystem {
         // truncate is going to be applied first and append is going to be ignored anyway.
         let append = if conf.truncate { false } else { conf.append() };
 
-        let mut oo = fs::OpenOptions::new();
-        let file = oo
-            .read(conf.read())
-            .write(conf.write())
-            .create_new(conf.create_new())
-            .create(conf.create())
-            .append(append)
-            .truncate(conf.truncate())
-            .open(&path)
-            .map_err(FsError::from)?;
+        let create_new = conf.create_new();
+        let create = conf.create();
+        let truncate = conf.truncate();
+        let path_for_open = path.clone();
+        let file = self
+            .handle
+            .spawn(async move {
+                let file = tfs::OpenOptions::new()
+                    .read(read)
+                    .write(write)
+                    .create_new(create_new)
+                    .create(create)
+                    .append(append)
+                    .truncate(truncate)
+                    .open(path_for_open)
+                    .await
+                    .map_err(FsError::from)?;
+                Ok::<_, FsError>(file.into_std().await)
+            })
+            .await
+            .map_err(|_| FsError::IOError)??;
 
         Ok(Box::new(File::new(
             self.handle.clone(),

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -114,8 +114,21 @@ impl FileSystem {
             return Err(FsError::InvalidInput);
         }
 
-        let path = path.strip_prefix("/").unwrap_or(&path);
-        let path = self.root.join(path);
+        let mut relative = PathBuf::new();
+        for component in path.components() {
+            match component {
+                Component::Prefix(..) => return Err(FsError::InvalidInput),
+                Component::RootDir | Component::CurDir => {}
+                Component::ParentDir => {
+                    if !relative.pop() {
+                        return Err(FsError::InvalidInput);
+                    }
+                }
+                Component::Normal(part) => relative.push(part),
+            }
+        }
+
+        let path = self.root.join(relative);
 
         debug_assert!(path.starts_with(&self.root));
         Ok(path)
@@ -133,28 +146,32 @@ impl crate::FileSystem for FileSystem {
 
     async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
         let path = self.prepare_path(path)?;
+        let root = self.root.clone();
 
-        let read_dir = fs::read_dir(path)?;
-        let mut data = read_dir
-            .map(|entry| {
-                let entry = entry?;
+        let mut data = self
+            .handle
+            .spawn(async move {
+                let mut read_dir = tfs::read_dir(path).await?;
+                let mut data = Vec::new();
+                while let Some(entry) = read_dir.next_entry().await? {
+                    let path = entry
+                        .path()
+                        .strip_prefix(&root)
+                        .map_err(|_| FsError::InvalidData)?
+                        .to_owned();
+                    let path = Path::new("/").join(path);
 
-                let path = entry
-                    .path()
-                    .strip_prefix(&self.root)
-                    .map_err(|_| FsError::InvalidData)?
-                    .to_owned();
-                let path = Path::new("/").join(path);
+                    let metadata = tfs::symlink_metadata(entry.path()).await?;
 
-                let metadata = fs::symlink_metadata(entry.path())?;
-
-                Ok(DirEntry {
-                    path,
-                    metadata: Ok(metadata.try_into()?),
-                })
+                    data.push(DirEntry {
+                        path,
+                        metadata: Ok(metadata.try_into()?),
+                    });
+                }
+                Ok::<_, FsError>(data)
             })
-            .collect::<std::result::Result<Vec<DirEntry>, io::Error>>()
-            .map_err::<FsError, _>(Into::into)?;
+            .await
+            .map_err(|_| FsError::IOError)??;
         data.sort_by(|a, b| a.path.file_name().cmp(&b.path.file_name()));
         Ok(ReadDir::new(data))
     }

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -3,7 +3,6 @@ use crate::{
     VirtualFile,
 };
 use bytes::{Buf, Bytes};
-use futures::future::BoxFuture;
 use std::convert::TryInto;
 use std::fs;
 use std::io::{self, Seek};
@@ -123,15 +122,16 @@ impl FileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl crate::FileSystem for FileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
         let path = self.prepare_path(path)?;
 
         let target = fs::read_link(path)?;
         Ok(host_root_relative_target(&self.root, target))
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
         let path = self.prepare_path(path)?;
 
         let read_dir = fs::read_dir(path)?;
@@ -159,7 +159,7 @@ impl crate::FileSystem for FileSystem {
         Ok(ReadDir::new(data))
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    async fn create_dir(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 
         if path.parent().is_none() {
@@ -169,7 +169,7 @@ impl crate::FileSystem for FileSystem {
         fs::create_dir(path).map_err(Into::into)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 
         if path.parent().is_none() {
@@ -188,8 +188,7 @@ impl crate::FileSystem for FileSystem {
         fs::remove_dir(path).map_err(Into::into)
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async move {
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
             use filetime::{FileTime, set_file_mtime};
             let norm_from = normalize_path(from);
             let norm_to = normalize_path(to);
@@ -239,10 +238,9 @@ impl crate::FileSystem for FileSystem {
             };
             let _ = set_file_mtime(&to, FileTime::now()).map(|_| ());
             result
-        })
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
+    async fn remove_file(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 
         if path.parent().is_none() {
@@ -256,7 +254,7 @@ impl crate::FileSystem for FileSystem {
         OpenOptions::new(self)
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
         let path = self.prepare_path(path)?;
 
         fs::metadata(path)
@@ -264,12 +262,54 @@ impl crate::FileSystem for FileSystem {
             .map_err(Into::into)
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
         let path = self.prepare_path(path)?;
 
         fs::symlink_metadata(path)
             .and_then(TryInto::try_into)
             .map_err(Into::into)
+    }
+
+    async fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        let path = self.prepare_path(path)?;
+
+        // TODO: handle create implying write, etc.
+        let read = conf.read();
+        let write = conf.write();
+
+        // according to Rust's stdlib, specifying both truncate and append is nonsensical,
+        // and it will return an error if we try to open a file with both flags set.
+        // in order to prevent this, and stay compatible with native binaries, we just ignore
+        // the append flag if truncate is set. the rationale behind this decision is that
+        // truncate is going to be applied first and append is going to be ignored anyway.
+        let append = if conf.truncate { false } else { conf.append() };
+
+        let mut oo = tfs::OpenOptions::new();
+        let file = oo
+            .read(conf.read())
+            .write(conf.write())
+            .create_new(conf.create_new())
+            .create(conf.create())
+            .append(append)
+            .truncate(conf.truncate())
+            .open(&path)
+            .await
+            .map_err(FsError::from)?
+            .into_std()
+            .await;
+
+        Ok(Box::new(File::new(
+            self.handle.clone(),
+            file,
+            path.to_owned(),
+            read,
+            write,
+            append,
+        )) as Box<dyn VirtualFile + Send + Sync + 'static>)
     }
 }
 
@@ -322,47 +362,6 @@ impl TryInto<Metadata> for std::fs::Metadata {
     }
 }
 
-impl crate::FileOpener for FileSystem {
-    fn open(
-        &self,
-        path: &Path,
-        conf: &OpenOptionsConfig,
-    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
-        let path = self.prepare_path(path)?;
-
-        // TODO: handle create implying write, etc.
-        let read = conf.read();
-        let write = conf.write();
-
-        // according to Rust's stdlib, specifying both truncate and append is nonsensical,
-        // and it will return an error if we try to open a file with both flags set.
-        // in order to prevent this, and stay compatible with native binaries, we just ignore
-        // the append flag if truncate is set. the rationale behind this decision is that
-        // truncate is going to be applied first and append is going to be ignored anyway.
-        let append = if conf.truncate { false } else { conf.append() };
-
-        let mut oo = fs::OpenOptions::new();
-        oo.read(conf.read())
-            .write(conf.write())
-            .create_new(conf.create_new())
-            .create(conf.create())
-            .append(append)
-            .truncate(conf.truncate())
-            .open(&path)
-            .map_err(Into::into)
-            .map(|file| {
-                Box::new(File::new(
-                    self.handle.clone(),
-                    file,
-                    path.to_owned(),
-                    read,
-                    write,
-                    append,
-                )) as Box<dyn VirtualFile + Send + Sync + 'static>
-            })
-    }
-}
-
 /// A thin wrapper around `std::fs::File`
 #[derive(Debug)]
 pub struct File {
@@ -409,7 +408,7 @@ impl File {
         }
     }
 
-    fn metadata(&self) -> std::fs::Metadata {
+    async fn metadata(&self) -> std::fs::Metadata {
         // FIXME: no unwrap!
         self.inner_std.metadata().unwrap()
     }
@@ -417,8 +416,9 @@ impl File {
 
 #[async_trait::async_trait]
 impl VirtualFile for File {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         self.metadata()
+            .await
             .accessed()
             .ok()
             .and_then(|ct| ct.duration_since(SystemTime::UNIX_EPOCH).ok())
@@ -426,8 +426,9 @@ impl VirtualFile for File {
             .unwrap_or(0)
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         self.metadata()
+            .await
             .modified()
             .ok()
             .and_then(|ct| ct.duration_since(SystemTime::UNIX_EPOCH).ok())
@@ -435,8 +436,9 @@ impl VirtualFile for File {
             .unwrap_or(0)
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         self.metadata()
+            .await
             .created()
             .ok()
             .and_then(|ct| ct.duration_since(SystemTime::UNIX_EPOCH).ok())
@@ -444,7 +446,7 @@ impl VirtualFile for File {
             .unwrap_or(0)
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         let atime = atime.map(|t| filetime::FileTime::from_unix_time(t as i64, 0));
         let mtime = mtime.map(|t| filetime::FileTime::from_unix_time(t as i64, 0));
 
@@ -452,19 +454,19 @@ impl VirtualFile for File {
             .map_err(|_| crate::FsError::IOError)
     }
 
-    fn size(&self) -> u64 {
-        self.metadata().len()
+    async fn size(&self) -> u64 {
+        self.metadata().await.len()
     }
 
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
         fs::File::set_len(&self.inner_std, new_size).map_err(Into::into)
     }
 
-    fn unlink(&mut self) -> Result<()> {
+    async fn unlink(&mut self) -> Result<()> {
         fs::remove_file(&self.host_path).map_err(Into::into)
     }
 
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         None
     }
 
@@ -588,31 +590,31 @@ const DEFAULT_BUF_SIZE_HINT: usize = 8 * 1024;
 
 #[async_trait::async_trait]
 impl VirtualFile for Stdout {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
 
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
 
-    fn unlink(&mut self) -> Result<()> {
+    async fn unlink(&mut self) -> Result<()> {
         Ok(())
     }
 
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         Some(1)
     }
 
@@ -762,31 +764,31 @@ impl AsyncSeek for Stderr {
 
 #[async_trait::async_trait]
 impl VirtualFile for Stderr {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
 
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
 
-    fn unlink(&mut self) -> Result<()> {
+    async fn unlink(&mut self) -> Result<()> {
         Ok(())
     }
 
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         Some(2)
     }
 
@@ -884,25 +886,25 @@ impl AsyncSeek for Stdin {
 
 #[async_trait::async_trait]
 impl VirtualFile for Stdin {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
-    fn unlink(&mut self) -> Result<()> {
+    async fn unlink(&mut self) -> Result<()> {
         Ok(())
     }
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         Some(0)
     }
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
@@ -956,13 +958,14 @@ mod tests {
 
         let fs = FileSystem::new(Handle::current(), temp.path()).expect("get filesystem");
         assert!(
-            fs.read_dir(Path::new("/")).is_ok(),
+            fs.read_dir(Path::new("/")).await.is_ok(),
             "NativeFS can read root"
         );
         assert!(
             fs.new_open_options()
                 .read(true)
                 .open(Path::new("/foo2.txt"))
+                .await
                 .is_ok(),
             "created foo2.txt"
         );
@@ -974,13 +977,13 @@ mod tests {
         let fs = FileSystem::new(Handle::current(), temp.path()).expect("get filesystem");
 
         assert_eq!(
-            fs.create_dir(Path::new("../")),
+            fs.create_dir(Path::new("../")).await,
             Err(FsError::AlreadyExists),
             "creating a directory out of bounds",
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("/foo")),
+            fs.create_dir(Path::new("/foo")).await,
             Ok(()),
             "creating a directory",
         );
@@ -990,7 +993,7 @@ mod tests {
             "foo dir exists in host_fs"
         );
 
-        let cur_dir = read_dir_names(&fs, "/");
+        let cur_dir = read_dir_names(&fs, "/").await;
 
         if !cur_dir.contains(&"foo".to_string()) {
             panic!("cur_dir does not contain foo: {cur_dir:#?}");
@@ -1002,7 +1005,7 @@ mod tests {
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("foo/bar")),
+            fs.create_dir(Path::new("foo/bar")).await,
             Ok(()),
             "creating a sub-directory",
         );
@@ -1012,14 +1015,14 @@ mod tests {
             "foo dir exists in host_fs"
         );
 
-        let foo_dir = read_dir_names(&fs, Path::new("/foo"));
+        let foo_dir = read_dir_names(&fs, Path::new("/foo")).await;
 
         assert!(
             foo_dir.contains(&"bar".to_string()),
             "the foo directory is updated and well-defined"
         );
 
-        let bar_dir = read_dir_names(&fs, Path::new("/foo/bar"));
+        let bar_dir = read_dir_names(&fs, Path::new("/foo/bar")).await;
 
         assert!(
             bar_dir.is_empty(),
@@ -1033,19 +1036,19 @@ mod tests {
         let fs = FileSystem::new(Handle::current(), temp.path()).expect("get filesystem");
 
         assert_eq!(
-            fs.remove_dir(Path::new("/foo")),
+            fs.remove_dir(Path::new("/foo")).await,
             Err(FsError::EntryNotFound),
             "cannot remove a directory that doesn't exist",
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("foo")),
+            fs.create_dir(Path::new("foo")).await,
             Ok(()),
             "creating a directory",
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("foo/bar")),
+            fs.create_dir(Path::new("foo/bar")).await,
             Ok(()),
             "creating a sub-directory",
         );
@@ -1053,24 +1056,24 @@ mod tests {
         assert!(temp.path().join("foo/bar").exists(), "./foo/bar exists");
 
         assert_eq!(
-            fs.remove_dir(Path::new("foo")),
+            fs.remove_dir(Path::new("foo")).await,
             Err(FsError::DirectoryNotEmpty),
             "removing a directory that has children",
         );
 
         assert_eq!(
-            fs.remove_dir(Path::new("foo/bar")),
+            fs.remove_dir(Path::new("foo/bar")).await,
             Ok(()),
             "removing a sub-directory",
         );
 
         assert_eq!(
-            fs.remove_dir(Path::new("foo")),
+            fs.remove_dir(Path::new("foo")).await,
             Ok(()),
             "removing a directory",
         );
 
-        let cur_dir = read_dir_names(&fs, "/");
+        let cur_dir = read_dir_names(&fs, "/").await;
 
         assert!(
             !cur_dir.contains(&"foo".to_string()),
@@ -1078,8 +1081,9 @@ mod tests {
         );
     }
 
-    fn read_dir_names(fs: &FileSystem, path: impl AsRef<Path>) -> Vec<String> {
+    async fn read_dir_names(fs: &FileSystem, path: impl AsRef<Path>) -> Vec<String> {
         fs.read_dir(path.as_ref())
+            .await
             .unwrap()
             .filter_map(|entry| Some(entry.ok()?.file_name().to_str()?.to_string()))
             .collect::<Vec<_>>()
@@ -1114,7 +1118,7 @@ mod tests {
 
         // On Windows, rename "to" must not be an existing directory
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(fs.create_dir(bar), Ok(()));
+        assert_eq!(fs.create_dir(bar).await, Ok(()));
 
         assert_eq!(
             fs.rename(foo, bar).await,
@@ -1127,6 +1131,7 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(bar.join("hello1.txt"))
+                .await
                 .is_ok(),
             "creating a new file (`hello1.txt`)",
         );
@@ -1135,11 +1140,12 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(bar.join("hello2.txt"))
+                .await
                 .is_ok(),
             "creating a new file (`hello2.txt`)",
         );
 
-        let cur_dir = read_dir_names(&fs, Path::new("/"));
+        let cur_dir = read_dir_names(&fs, Path::new("/")).await;
 
         assert!(
             !cur_dir.contains(&"foo".to_string()),
@@ -1151,13 +1157,13 @@ mod tests {
             "the bar directory still exists"
         );
 
-        let bar_dir = read_dir_names(&fs, bar);
+        let bar_dir = read_dir_names(&fs, bar).await;
 
         if !bar_dir.contains(&"qux".to_string()) {
             println!("qux does not exist: {bar_dir:?}")
         }
 
-        let qux_dir = read_dir_names(&fs, bar.join("qux"));
+        let qux_dir = read_dir_names(&fs, bar.join("qux")).await;
 
         assert!(qux_dir.is_empty(), "the qux directory is empty");
 
@@ -1171,7 +1177,7 @@ mod tests {
             "the /bar/hello2.txt file exists"
         );
 
-        assert_eq!(fs.create_dir(foo), Ok(()), "create ./foo again");
+        assert_eq!(fs.create_dir(foo).await, Ok(()), "create ./foo again");
 
         assert_eq!(
             fs.rename(&bar.join("hello2.txt"), &foo.join("world2.txt"))
@@ -1227,7 +1233,7 @@ mod tests {
 
         let fs = FileSystem::new(Handle::current(), temp.path()).expect("get filesystem");
 
-        let root_metadata = fs.metadata(Path::new("/")).unwrap();
+        let root_metadata = fs.metadata(Path::new("/")).await.unwrap();
 
         assert!(root_metadata.ft.dir);
         // it seems created is not available on musl, at least on CI testing.
@@ -1239,9 +1245,9 @@ mod tests {
 
         let foo = Path::new("foo");
 
-        assert_eq!(fs.create_dir(foo), Ok(()));
+        assert_eq!(fs.create_dir(foo).await, Ok(()));
 
-        let foo_metadata = fs.metadata(foo);
+        let foo_metadata = fs.metadata(foo).await;
         assert!(foo_metadata.is_ok());
         let foo_metadata = foo_metadata.unwrap();
 
@@ -1258,13 +1264,13 @@ mod tests {
 
         assert_eq!(fs.rename(foo, bar).await, Ok(()));
 
-        let bar_metadata = fs.metadata(bar).unwrap();
+        let bar_metadata = fs.metadata(bar).await.unwrap();
         assert!(bar_metadata.ft.dir);
         assert!(bar_metadata.accessed >= foo_metadata.accessed);
         assert_eq!(bar_metadata.created, foo_metadata.created);
         assert!(bar_metadata.modified > foo_metadata.modified);
 
-        let root_metadata = fs.metadata(bar).unwrap();
+        let root_metadata = fs.metadata(bar).await.unwrap();
         assert!(
             root_metadata.modified > foo_metadata.modified,
             "the parent modified time was updated"
@@ -1283,9 +1289,9 @@ mod tests {
 
         let fs = FileSystem::new(Handle::current(), &temp_canon).expect("get filesystem");
 
-        assert_eq!(fs.metadata(&file_path), Err(FsError::InvalidInput));
+        assert_eq!(fs.metadata(&file_path).await, Err(FsError::InvalidInput));
         assert!(matches!(
-            fs.new_open_options().read(true).open(&file_path),
+            fs.new_open_options().read(true).open(&file_path).await,
             Err(FsError::InvalidInput)
         ));
     }
@@ -1300,16 +1306,19 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("foo.txt"))
+                .await
                 .is_ok(),
             "creating a new file",
         );
 
-        assert!(read_dir_names(&fs, Path::new("/")).contains(&"foo.txt".to_string()));
+        assert!(read_dir_names(&fs, Path::new("/"))
+            .await
+            .contains(&"foo.txt".to_string()));
 
         assert!(temp.path().join("foo.txt").is_file());
 
         assert_eq!(
-            fs.remove_file(Path::new("foo.txt")),
+            fs.remove_file(Path::new("foo.txt")).await,
             Ok(()),
             "removing a file that exists",
         );
@@ -1317,7 +1326,7 @@ mod tests {
         assert!(!temp.path().join("foo.txt").exists());
 
         assert_eq!(
-            fs.remove_file(Path::new("foo.txt")),
+            fs.remove_file(Path::new("foo.txt")).await,
             Err(FsError::EntryNotFound),
             "removing a file that doesn't exists",
         );
@@ -1328,19 +1337,20 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let fs = FileSystem::new(Handle::current(), temp.path()).expect("get filesystem");
 
-        assert_eq!(fs.create_dir(Path::new("foo")), Ok(()), "creating `foo`");
+        assert_eq!(fs.create_dir(Path::new("foo")).await, Ok(()), "creating `foo`");
         assert_eq!(
-            fs.create_dir(Path::new("foo/sub")),
+            fs.create_dir(Path::new("foo/sub")).await,
             Ok(()),
             "creating `sub`"
         );
-        assert_eq!(fs.create_dir(Path::new("bar")), Ok(()), "creating `bar`");
-        assert_eq!(fs.create_dir(Path::new("baz")), Ok(()), "creating `bar`");
+        assert_eq!(fs.create_dir(Path::new("bar")).await, Ok(()), "creating `bar`");
+        assert_eq!(fs.create_dir(Path::new("baz")).await, Ok(()), "creating `bar`");
         assert!(
             fs.new_open_options()
                 .write(true)
                 .create_new(true)
                 .open(Path::new("a.txt"))
+                .await
                 .is_ok(),
             "creating `a.txt`",
         );
@@ -1349,11 +1359,12 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("b.txt"))
+                .await
                 .is_ok(),
             "creating `b.txt`",
         );
 
-        let readdir = fs.read_dir(Path::new("/"));
+        let readdir = fs.read_dir(Path::new("/")).await;
 
         assert!(
             readdir.is_ok(),

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -288,7 +288,7 @@ impl crate::FileSystem for FileSystem {
         // truncate is going to be applied first and append is going to be ignored anyway.
         let append = if conf.truncate { false } else { conf.append() };
 
-        let mut oo = tfs::OpenOptions::new();
+        let mut oo = fs::OpenOptions::new();
         let file = oo
             .read(conf.read())
             .write(conf.write())
@@ -297,10 +297,7 @@ impl crate::FileSystem for FileSystem {
             .append(append)
             .truncate(conf.truncate())
             .open(&path)
-            .await
-            .map_err(FsError::from)?
-            .into_std()
-            .await;
+            .map_err(FsError::from)?;
 
         Ok(Box::new(File::new(
             self.handle.clone(),

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -159,7 +159,7 @@ impl crate::FileSystem for FileSystem {
                         .strip_prefix(&root)
                         .map_err(|_| FsError::InvalidData)?
                         .to_owned();
-                    let path = Path::new("/").join(path);
+                    let path = path_suffix_to_guest_absolute(&path);
 
                     let metadata = tfs::symlink_metadata(entry.path()).await?;
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -429,7 +429,8 @@ pub trait VirtualFile:
         &mut self,
         src: Box<dyn VirtualFile + Send + Sync + 'static>,
     ) -> std::io::Result<()> {
-        tokio::io::copy(&mut tokio::io::BufReader::new(src), self).await?;
+        let mut src = tokio::io::BufReader::new(src);
+        tokio::io::copy(&mut src, self).await?;
         Ok(())
     }
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -13,7 +13,6 @@ const _: () = {
 #[macro_use]
 extern crate pretty_assertions;
 
-use futures::future::BoxFuture;
 use shared_buffer::OwnedBuffer;
 use std::any::Any;
 use std::ffi::OsString;
@@ -94,26 +93,45 @@ pub trait CloneableVirtualFile: VirtualFile + Clone {}
 
 pub use ops::{copy_reference, copy_reference_ext, create_dir_all, walk};
 
+#[async_trait::async_trait]
 pub trait FileSystem: fmt::Debug + Send + Sync + 'static + Upcastable {
-    fn readlink(&self, path: &Path) -> Result<PathBuf>;
-    fn read_dir(&self, path: &Path) -> Result<ReadDir>;
-    fn create_dir(&self, path: &Path) -> Result<()>;
-    fn create_symlink(&self, _source: &Path, _target: &Path) -> Result<()> {
+    async fn readlink(&self, path: &Path) -> Result<PathBuf>;
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir>;
+    async fn create_dir(&self, path: &Path) -> Result<()>;
+    async fn create_symlink(&self, _source: &Path, _target: &Path) -> Result<()> {
         Err(FsError::Unsupported)
     }
-    fn hard_link(&self, _source: &Path, _target: &Path) -> Result<()> {
+    async fn hard_link(&self, _source: &Path, _target: &Path) -> Result<()> {
         Err(FsError::Unsupported)
     }
-    fn remove_dir(&self, path: &Path) -> Result<()>;
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>>;
-    fn metadata(&self, path: &Path) -> Result<Metadata>;
+    async fn remove_dir(&self, path: &Path) -> Result<()>;
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()>;
+    async fn metadata(&self, path: &Path) -> Result<Metadata>;
     /// This method gets metadata without following symlinks in the path.
     /// Currently identical to `metadata` because symlinks aren't implemented
     /// yet.
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata>;
-    fn remove_file(&self, path: &Path) -> Result<()>;
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata>;
+    async fn remove_file(&self, path: &Path) -> Result<()>;
+
+    async fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        let _ = (path, conf);
+        Err(FsError::Unsupported)
+    }
 
     fn new_open_options(&self) -> OpenOptions<'_>;
+}
+
+#[deprecated(note = "Use async FileSystem::open instead")]
+pub trait FileOpener {
+    fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>>;
 }
 
 impl dyn FileSystem + 'static {
@@ -133,53 +151,57 @@ where
     D: Deref<Target = F> + std::fmt::Debug + Send + Sync + 'static,
     F: FileSystem + ?Sized,
 {
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
-        (**self).read_dir(path)
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+        (**self).read_dir(path).await
     }
 
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
-        (**self).readlink(path)
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
+        (**self).readlink(path).await
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
-        (**self).create_dir(path)
+    async fn create_dir(&self, path: &Path) -> Result<()> {
+        (**self).create_dir(path).await
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
-        (**self).create_symlink(source, target)
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+        (**self).create_symlink(source, target).await
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
-        (**self).remove_dir(path)
+    async fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+        (**self).hard_link(source, target).await
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async { (**self).rename(from, to).await })
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
+        (**self).remove_dir(path).await
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
-        (**self).metadata(path)
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        (**self).rename(from, to).await
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
-        (**self).symlink_metadata(path)
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
+        (**self).metadata(path).await
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
-        (**self).remove_file(path)
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+        (**self).symlink_metadata(path).await
     }
 
-    fn new_open_options(&self) -> OpenOptions<'_> {
-        (**self).new_open_options()
+    async fn remove_file(&self, path: &Path) -> Result<()> {
+        (**self).remove_file(path).await
     }
-}
 
-pub trait FileOpener {
-    fn open(
+    async fn open(
         &self,
         path: &Path,
         conf: &OpenOptionsConfig,
-    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>>;
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        (**self).open(path, conf).await
+    }
+
+    fn new_open_options(&self) -> OpenOptions<'_> {
+        OpenOptions::new(self)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -251,14 +273,14 @@ impl fmt::Debug for OpenOptions<'_> {
 }
 
 pub struct OpenOptions<'a> {
-    opener: &'a dyn FileOpener,
+    fs: &'a dyn FileSystem,
     conf: OpenOptionsConfig,
 }
 
 impl<'a> OpenOptions<'a> {
-    pub fn new(opener: &'a dyn FileOpener) -> Self {
+    pub fn new(fs: &'a dyn FileSystem) -> Self {
         Self {
-            opener,
+            fs,
             conf: OpenOptionsConfig {
                 read: false,
                 write: false,
@@ -335,91 +357,87 @@ impl<'a> OpenOptions<'a> {
         self
     }
 
-    pub fn open<P: AsRef<Path>>(
-        &mut self,
+    pub async fn open<P: AsRef<Path> + Send>(
+        &self,
         path: P,
     ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
-        self.opener.open(path.as_ref(), &self.conf)
+        self.fs.open(path.as_ref(), &self.conf).await
     }
 }
 
+pub fn open_options(fs: &dyn FileSystem) -> OpenOptions<'_> {
+    OpenOptions::new(fs)
+}
+
 /// This trait relies on your file closing when it goes out of scope via `Drop`
+#[async_trait::async_trait]
 pub trait VirtualFile:
-    fmt::Debug + AsyncRead + AsyncWrite + AsyncSeek + Unpin + Upcastable + Send
+    fmt::Debug + AsyncRead + AsyncWrite + AsyncSeek + Unpin + Upcastable + Send + Sync
 {
     /// the last time the file was accessed in nanoseconds as a UNIX timestamp
-    fn last_accessed(&self) -> u64;
+    async fn last_accessed(&self) -> u64;
 
     /// the last time the file was modified in nanoseconds as a UNIX timestamp
-    fn last_modified(&self) -> u64;
+    async fn last_modified(&self) -> u64;
 
     /// the time at which the file was created in nanoseconds as a UNIX timestamp
-    fn created_time(&self) -> u64;
+    async fn created_time(&self) -> u64;
 
     #[allow(unused_variables)]
     /// sets accessed and modified time
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         Ok(())
     }
 
     /// the size of the file in bytes
-    fn size(&self) -> u64;
+    async fn size(&self) -> u64;
 
     /// Change the size of the file, if the `new_size` is greater than the current size
     /// the extra bytes will be allocated and zeroed
-    fn set_len(&mut self, new_size: u64) -> Result<()>;
+    async fn set_len(&mut self, new_size: u64) -> Result<()>;
 
     /// Remove the file from the filesystem namespace.
     ///
     /// Existing open handles may continue to operate after this call.
     /// Backends may defer final storage reclamation until the last open
     /// handle is dropped.
-    fn unlink(&mut self) -> Result<()>;
+    async fn unlink(&mut self) -> Result<()>;
 
     /// Indicates if the file is opened or closed. This function must not block
     /// Defaults to a status of being constantly open
-    fn is_open(&self) -> bool {
+    async fn is_open(&self) -> bool {
         true
     }
 
     /// Used for "special" files such as `stdin`, `stdout` and `stderr`.
     /// Always returns the same file descriptor (0, 1 or 2). Returns `None`
     /// on normal files
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         None
     }
 
     /// Writes to this file using an mmap offset and reference
     /// (this method only works for mmap optimized file systems)
-    fn write_from_mmap(&mut self, _offset: u64, _len: u64) -> std::io::Result<()> {
-        Err(std::io::ErrorKind::Unsupported.into())
+    async fn write_from_mmap(&mut self, _offset: u64, _len: u64) -> std::io::Result<()> {
+        Err(std::io::Error::other(FsError::Unsupported))
     }
 
     /// This method will copy a file from a source to this destination where
     /// the default is to do a straight byte copy however file system implementors
     /// may optimize this to do a zero copy
-    fn copy_reference(
+    async fn copy_reference(
         &mut self,
-        mut src: Box<dyn VirtualFile + Send + Sync + 'static>,
-    ) -> BoxFuture<'_, std::io::Result<()>> {
-        Box::pin(async move {
-            let bytes_written = tokio::io::copy(&mut src, self).await?;
-            tracing::trace!(bytes_written, "Copying file into host filesystem");
-            Ok(())
-        })
+        src: Box<dyn VirtualFile + Send + Sync + 'static>,
+    ) -> std::io::Result<()> {
+        tokio::io::copy(&mut tokio::io::BufReader::new(src), self).await?;
+        Ok(())
     }
 
     /// This method will copy a file from a source to this destination where
     /// the default is to do a straight byte copy however file system implementors
     /// may optimize this to cheaply clone and store the OwnedBuffer directly
-    fn copy_from_owned_buffer(&mut self, src: &OwnedBuffer) -> BoxFuture<'_, std::io::Result<()>> {
-        let src = src.clone();
-        Box::pin(async move {
-            let mut bytes = src.as_slice();
-            let bytes_written = tokio::io::copy(&mut bytes, self).await?;
-            tracing::trace!(bytes_written, "Copying file into host filesystem");
-            Ok(())
-        })
+    async fn copy_from_owned_buffer(&mut self, src: &OwnedBuffer) -> std::io::Result<()> {
+        self.copy_reference(Box::new(StaticFile::new(src.clone()))).await
     }
 
     /// Get the full contents of this file as an [`OwnedBuffer`].
@@ -428,7 +446,7 @@ pub trait VirtualFile:
     /// and can be cloned cheaply!
     ///
     /// Allows consumers to do zero-copy cloning of the underlying data.
-    fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
+    async fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
         None
     }
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -438,7 +438,8 @@ pub trait VirtualFile:
     /// the default is to do a straight byte copy however file system implementors
     /// may optimize this to cheaply clone and store the OwnedBuffer directly
     async fn copy_from_owned_buffer(&mut self, src: &OwnedBuffer) -> std::io::Result<()> {
-        self.copy_reference(Box::new(StaticFile::new(src.clone()))).await
+        self.copy_reference(Box::new(StaticFile::new(src.clone())))
+            .await
     }
 
     /// Get the full contents of this file as an [`OwnedBuffer`].

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -33,7 +33,7 @@ pub(super) struct FileHandle {
     writable: bool,
     append_mode: bool,
     cursor: u64,
-    arc_file: Option<Result<Box<dyn VirtualFile + Send + Sync + 'static>>>,
+    arc_file: Option<Box<dyn VirtualFile + Send + Sync + 'static>>,
 }
 
 impl Clone for FileHandle {
@@ -61,6 +61,7 @@ impl FileHandle {
         writable: bool,
         append_mode: bool,
         cursor: u64,
+        arc_file: Option<Box<dyn VirtualFile + Send + Sync + 'static>>,
     ) -> Self {
         Self {
             inode,
@@ -70,40 +71,15 @@ impl FileHandle {
             writable,
             append_mode,
             cursor,
-            arc_file: None,
+            arc_file,
         }
     }
 
     fn lazy_load_arc_file_mut(&mut self) -> Result<&mut dyn VirtualFile> {
-        if self.arc_file.is_none() {
-            let (node_fs, node_path) = {
-                let fs = match self.filesystem.inner.read() {
-                    Ok(fs) => fs,
-                    _ => return Err(FsError::EntryNotFound),
-                };
-
-                let inode = fs.storage.get(self.inode);
-                match inode {
-                    Some(Node::ArcFile(node)) => (node.fs.clone(), node.path.clone()),
-                    _ => return Err(FsError::EntryNotFound),
-                }
-            };
-
-            self.arc_file.replace(futures::executor::block_on(
-                node_fs
-                    .new_open_options()
-                    .read(self.readable)
-                    .write(self.writable)
-                    .append(self.append_mode)
-                    .open(node_path.as_path()),
-            ));
-        }
         Ok(self
             .arc_file
             .as_mut()
-            .unwrap()
-            .as_mut()
-            .map_err(|err| *err)?
+            .ok_or(FsError::EntryNotFound)?
             .as_mut())
     }
 
@@ -181,41 +157,29 @@ impl VirtualFile for FileHandle {
     }
 
     async fn size(&self) -> u64 {
-        let fs = match self.filesystem.inner.read() {
-            Ok(fs) => fs,
-            _ => return 0,
+        let size = {
+            let fs = match self.filesystem.inner.read() {
+                Ok(fs) => fs,
+                _ => return 0,
+            };
+
+            let inode = fs.storage.get(self.inode);
+            match inode {
+                Some(Node::File(node)) => return node.file.len().try_into().unwrap_or(0),
+                Some(Node::OffloadedFile(node)) => return node.file.len(),
+                Some(Node::ReadOnlyFile(node)) => return node.file.len().try_into().unwrap_or(0),
+                Some(Node::CustomFile(node)) => {
+                    let file = node.file.lock().unwrap();
+                    return futures::executor::block_on(file.size());
+                }
+                Some(Node::ArcFile(_)) => self.arc_file.as_ref().map(|file| file.as_ref()),
+                _ => return 0,
+            }
         };
 
-        let inode = fs.storage.get(self.inode);
-        match inode {
-            Some(Node::File(node)) => node.file.len().try_into().unwrap_or(0),
-            Some(Node::OffloadedFile(node)) => node.file.len(),
-            Some(Node::ReadOnlyFile(node)) => node.file.len().try_into().unwrap_or(0),
-            Some(Node::CustomFile(node)) => {
-                let file = node.file.lock().unwrap();
-                futures::executor::block_on(file.size())
-            }
-            Some(Node::ArcFile(node)) => match self.arc_file.as_ref() {
-                Some(file) => file
-                    .as_ref()
-                    .map(|file| futures::executor::block_on(file.size()))
-                    .unwrap_or(0),
-                None => {
-                    let file = futures::executor::block_on(
-                        node.fs
-                            .new_open_options()
-                            .read(self.readable)
-                            .write(self.writable)
-                            .append(self.append_mode)
-                            .open(node.path.as_path()),
-                    );
-                    match file {
-                        Ok(file) => futures::executor::block_on(file.size()),
-                        Err(_) => 0,
-                    }
-                }
-            },
-            _ => 0,
+        match size {
+            Some(file) => file.size().await,
+            None => 0,
         }
     }
 
@@ -309,25 +273,9 @@ impl VirtualFile for FileHandle {
                 let file = node.file.lock().unwrap();
                 futures::executor::block_on(file.get_special_fd())
             }
-            Some(Node::ArcFile(node)) => match self.arc_file.as_ref() {
-                Some(file) => file
-                    .as_ref()
-                    .map(|file| futures::executor::block_on(file.get_special_fd()))
-                    .unwrap_or(None),
-                None => {
-                    let file = futures::executor::block_on(
-                        node.fs
-                            .new_open_options()
-                            .read(self.readable)
-                            .write(self.writable)
-                            .append(self.append_mode)
-                            .open(node.path.as_path()),
-                    );
-                    match file {
-                        Ok(file) => futures::executor::block_on(file.get_special_fd()),
-                        Err(_) => None,
-                    }
-                }
+            Some(Node::ArcFile(_)) => match self.arc_file.as_ref() {
+                Some(file) => futures::executor::block_on(file.get_special_fd()),
+                None => None,
             },
             _ => None,
         }
@@ -1128,7 +1076,7 @@ impl AsyncWrite for FileHandle {
                 }
                 Some(Node::CustomFile(node)) => {
                     let mut guard = node.file.lock().unwrap();
-                    cursor = self.write_cursor(futures::executor::block_on(guard.size()));
+                    cursor = self.write_cursor(node.metadata.len);
 
                     let file = Pin::new(guard.as_mut());
                     if let Err(err) = file.start_seek(io::SeekFrom::Start(cursor)) {
@@ -1145,7 +1093,7 @@ impl AsyncWrite for FileHandle {
                         Poll::Pending => return Poll::Pending,
                     };
                     cursor += bytes_written as u64;
-                    node.metadata.len = futures::executor::block_on(guard.size());
+                    node.metadata.len = node.metadata.len.max(cursor);
                     bytes_written
                 }
                 Some(Node::ArcFile(_)) => {
@@ -1340,7 +1288,7 @@ impl AsyncWrite for FileHandle {
             Some(Node::ArcFile { .. }) => {
                 drop(fs);
                 match self.arc_file.as_ref() {
-                    Some(Ok(file)) => file.is_write_vectored(),
+                    Some(file) => file.is_write_vectored(),
                     _ => false,
                 }
             }

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -53,6 +53,7 @@ impl Clone for FileHandle {
 }
 
 impl FileHandle {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new_opened(
         inode: Inode,
         filesystem: FileSystem,
@@ -493,7 +494,9 @@ impl VirtualFile for FileHandle {
         let inode = fs.storage.get(self.inode)?;
         match inode {
             Node::ReadOnlyFile(f) => Some(f.file.buffer.clone()),
-            Node::CustomFile(f) => futures::executor::block_on(f.file.lock().ok()?.as_owned_buffer()),
+            Node::CustomFile(f) => {
+                futures::executor::block_on(f.file.lock().ok()?.as_owned_buffer())
+            }
             _ => None,
         }
     }
@@ -558,7 +561,10 @@ mod test_virtual_file {
             .await
             .expect("failed to create a new file");
 
-        assert!(file.last_modified().await > 0, "last modified time is not zero");
+        assert!(
+            file.last_modified().await > 0,
+            "last modified time is not zero"
+        );
     }
 
     #[tokio::test]
@@ -617,7 +623,10 @@ mod test_virtual_file {
             .await
             .expect("failed to create a new file");
 
-        assert!(matches!(file.set_len(7).await, Ok(())), "setting a new length");
+        assert!(
+            matches!(file.set_len(7).await, Ok(())),
+            "setting a new length"
+        );
         assert_eq!(file.size().await, 7, "file has a new length");
     }
 

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -2,7 +2,6 @@
 //! implementations. They aren't exposed to the public API. Only
 //! `FileHandle` can be used through the `VirtualFile` trait object.
 
-use futures::future::BoxFuture;
 use shared_buffer::OwnedBuffer;
 use tokio::io::AsyncRead;
 use tokio::io::{AsyncSeek, AsyncWrite};
@@ -77,25 +76,27 @@ impl FileHandle {
 
     fn lazy_load_arc_file_mut(&mut self) -> Result<&mut dyn VirtualFile> {
         if self.arc_file.is_none() {
-            let fs = match self.filesystem.inner.read() {
-                Ok(fs) => fs,
-                _ => return Err(FsError::EntryNotFound),
+            let (node_fs, node_path) = {
+                let fs = match self.filesystem.inner.read() {
+                    Ok(fs) => fs,
+                    _ => return Err(FsError::EntryNotFound),
+                };
+
+                let inode = fs.storage.get(self.inode);
+                match inode {
+                    Some(Node::ArcFile(node)) => (node.fs.clone(), node.path.clone()),
+                    _ => return Err(FsError::EntryNotFound),
+                }
             };
 
-            let inode = fs.storage.get(self.inode);
-            match inode {
-                Some(Node::ArcFile(node)) => {
-                    self.arc_file.replace(
-                        node.fs
-                            .new_open_options()
-                            .read(self.readable)
-                            .write(self.writable)
-                            .append(self.append_mode)
-                            .open(node.path.as_path()),
-                    );
-                }
-                _ => return Err(FsError::EntryNotFound),
-            }
+            self.arc_file.replace(futures::executor::block_on(
+                node_fs
+                    .new_open_options()
+                    .read(self.readable)
+                    .write(self.writable)
+                    .append(self.append_mode)
+                    .open(node_path.as_path()),
+            ));
         }
         Ok(self
             .arc_file
@@ -115,8 +116,9 @@ impl FileHandle {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for FileHandle {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         let fs = match self.filesystem.inner.read() {
             Ok(fs) => fs,
             _ => return 0,
@@ -129,7 +131,7 @@ impl VirtualFile for FileHandle {
         }
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         let fs = match self.filesystem.inner.read() {
             Ok(fs) => fs,
             _ => return 0,
@@ -142,7 +144,7 @@ impl VirtualFile for FileHandle {
         }
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         let fs = match self.filesystem.inner.read() {
             Ok(fs) => fs,
             _ => return 0,
@@ -157,7 +159,7 @@ impl VirtualFile for FileHandle {
         node.metadata().created
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
         let mut fs = match self.filesystem.inner.write() {
             Ok(fs) => fs,
             _ => return Err(crate::FsError::Lock),
@@ -178,7 +180,7 @@ impl VirtualFile for FileHandle {
         Err(crate::FsError::UnknownError)
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         let fs = match self.filesystem.inner.read() {
             Ok(fs) => fs,
             _ => return 0,
@@ -191,25 +193,33 @@ impl VirtualFile for FileHandle {
             Some(Node::ReadOnlyFile(node)) => node.file.len().try_into().unwrap_or(0),
             Some(Node::CustomFile(node)) => {
                 let file = node.file.lock().unwrap();
-                file.size()
+                futures::executor::block_on(file.size())
             }
             Some(Node::ArcFile(node)) => match self.arc_file.as_ref() {
-                Some(file) => file.as_ref().map(|file| file.size()).unwrap_or(0),
-                None => node
-                    .fs
-                    .new_open_options()
-                    .read(self.readable)
-                    .write(self.writable)
-                    .append(self.append_mode)
-                    .open(node.path.as_path())
-                    .map(|file| file.size())
+                Some(file) => file
+                    .as_ref()
+                    .map(|file| futures::executor::block_on(file.size()))
                     .unwrap_or(0),
+                None => {
+                    let file = futures::executor::block_on(
+                        node.fs
+                            .new_open_options()
+                            .read(self.readable)
+                            .write(self.writable)
+                            .append(self.append_mode)
+                            .open(node.path.as_path()),
+                    );
+                    match file {
+                        Ok(file) => futures::executor::block_on(file.size()),
+                        Err(_) => 0,
+                    }
+                }
             },
             _ => 0,
         }
     }
 
-    fn set_len(&mut self, new_size: u64) -> Result<()> {
+    async fn set_len(&mut self, new_size: u64) -> Result<()> {
         let mut fs = self.filesystem.inner.write().map_err(|_| FsError::Lock)?;
 
         let inode = fs.storage.get_mut(self.inode);
@@ -225,14 +235,14 @@ impl VirtualFile for FileHandle {
             }
             Some(Node::CustomFile(node)) => {
                 let mut file = node.file.lock().unwrap();
-                file.set_len(new_size)?;
+                futures::executor::block_on(file.set_len(new_size))?;
                 node.metadata.len = new_size;
             }
             Some(Node::ReadOnlyFile { .. }) => return Err(FsError::PermissionDenied),
             Some(Node::ArcFile { .. }) => {
                 drop(fs);
                 let file = self.lazy_load_arc_file_mut()?;
-                file.set_len(new_size)?;
+                futures::executor::block_on(file.set_len(new_size))?;
             }
             _ => return Err(FsError::NotAFile),
         }
@@ -242,7 +252,7 @@ impl VirtualFile for FileHandle {
         Ok(())
     }
 
-    fn unlink(&mut self) -> Result<()> {
+    async fn unlink(&mut self) -> Result<()> {
         let filesystem = self.filesystem.clone();
         let inode = self.inode;
 
@@ -285,7 +295,7 @@ impl VirtualFile for FileHandle {
         Ok(())
     }
 
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         let fs = match self.filesystem.inner.read() {
             Ok(a) => a,
             Err(_) => {
@@ -297,93 +307,98 @@ impl VirtualFile for FileHandle {
         match inode {
             Some(Node::CustomFile(node)) => {
                 let file = node.file.lock().unwrap();
-                file.get_special_fd()
+                futures::executor::block_on(file.get_special_fd())
             }
             Some(Node::ArcFile(node)) => match self.arc_file.as_ref() {
                 Some(file) => file
                     .as_ref()
-                    .map(|file| file.get_special_fd())
+                    .map(|file| futures::executor::block_on(file.get_special_fd()))
                     .unwrap_or(None),
-                None => node
-                    .fs
-                    .new_open_options()
-                    .read(self.readable)
-                    .write(self.writable)
-                    .append(self.append_mode)
-                    .open(node.path.as_path())
-                    .map(|file| file.get_special_fd())
-                    .unwrap_or(None),
+                None => {
+                    let file = futures::executor::block_on(
+                        node.fs
+                            .new_open_options()
+                            .read(self.readable)
+                            .write(self.writable)
+                            .append(self.append_mode)
+                            .open(node.path.as_path()),
+                    );
+                    match file {
+                        Ok(file) => futures::executor::block_on(file.get_special_fd()),
+                        Err(_) => None,
+                    }
+                }
             },
             _ => None,
         }
     }
 
-    fn copy_reference(
+    async fn copy_reference(
         &mut self,
         src: Box<dyn VirtualFile + Send + Sync + 'static>,
-    ) -> BoxFuture<'_, std::io::Result<()>> {
+    ) -> std::io::Result<()> {
+        let accessed = src.last_accessed().await;
+        let created = src.created_time().await;
+        let modified = src.last_modified().await;
+        let len = src.size().await;
         let inner = self.filesystem.inner.clone();
-        Box::pin(async move {
-            let mut fs = inner.write().unwrap();
-            let inode = fs.storage.get_mut(self.inode);
-            match inode {
-                Some(inode) => {
-                    let metadata = Metadata {
-                        ft: crate::FileType {
-                            file: true,
-                            ..Default::default()
-                        },
-                        accessed: src.last_accessed(),
-                        created: src.created_time(),
-                        modified: src.last_modified(),
-                        len: src.size(),
-                    };
+        let mut fs = inner.write().unwrap();
+        let inode = fs.storage.get_mut(self.inode);
+        match inode {
+            Some(inode) => {
+                let metadata = Metadata {
+                    ft: crate::FileType {
+                        file: true,
+                        ..Default::default()
+                    },
+                    accessed,
+                    created,
+                    modified,
+                    len,
+                };
 
-                    *inode = Node::CustomFile(CustomFileNode {
-                        inode: inode.inode(),
-                        name: inode.name().to_string_lossy().to_string().into(),
-                        file: Mutex::new(Box::new(CopyOnWriteFile::new(src))),
-                        metadata,
-                        lifecycle: inode.file_lifecycle().cloned().unwrap_or_else(Arc::default),
-                    });
-                    Ok(())
-                }
-                None => Err(std::io::ErrorKind::InvalidInput.into()),
+                *inode = Node::CustomFile(CustomFileNode {
+                    inode: inode.inode(),
+                    name: inode.name().to_string_lossy().to_string().into(),
+                    file: Mutex::new(Box::new(CopyOnWriteFile::new(src))),
+                    metadata,
+                    lifecycle: inode.file_lifecycle().cloned().unwrap_or_else(Arc::default),
+                });
+                Ok(())
             }
-        })
+            None => Err(std::io::ErrorKind::InvalidInput.into()),
+        }
     }
 
-    fn copy_from_owned_buffer(&mut self, src: &OwnedBuffer) -> BoxFuture<'_, std::io::Result<()>> {
+    async fn copy_from_owned_buffer(&mut self, src: &OwnedBuffer) -> std::io::Result<()> {
         let inner = self.filesystem.inner.clone();
         let src = src.clone();
-        Box::pin(async move {
-            let mut fs = inner.write().unwrap();
-            let inode = fs.storage.get_mut(self.inode);
-            match inode {
-                Some(inode) => {
-                    let metadata = Metadata {
-                        ft: crate::FileType {
-                            file: true,
-                            ..Default::default()
-                        },
-                        accessed: 1,
-                        created: 1,
-                        modified: 1,
-                        len: src.len() as u64,
-                    };
+        let mut fs = inner.write().unwrap();
+        let inode = fs.storage.get_mut(self.inode);
+        match inode {
+            Some(inode) => {
+                let metadata = Metadata {
+                    ft: crate::FileType {
+                        file: true,
+                        ..Default::default()
+                    },
+                    accessed: 1,
+                    created: 1,
+                    modified: 1,
+                    len: src.len() as u64,
+                };
 
-                    *inode = Node::ReadOnlyFile(ReadOnlyFileNode {
-                        inode: inode.inode(),
-                        name: inode.name().to_string_lossy().to_string().into(),
-                        file: ReadOnlyFile { buffer: src },
-                        metadata,
-                        lifecycle: inode.file_lifecycle().cloned().unwrap_or_else(Arc::default),
-                    });
-                    Ok(())
-                }
-                None => Err(std::io::ErrorKind::InvalidInput.into()),
+                *inode = Node::ReadOnlyFile(ReadOnlyFileNode {
+                    inode: inode.inode(),
+                    name: inode.name().to_string_lossy().to_string().into(),
+                    file: ReadOnlyFile { buffer: src },
+                    metadata,
+                    lifecycle: inode.file_lifecycle().cloned().unwrap_or_else(Arc::default),
+                });
+                Ok(())
             }
-        })
+            None => Err(std::io::ErrorKind::InvalidInput.into()),
+        }
     }
 
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
@@ -489,7 +504,7 @@ impl VirtualFile for FileHandle {
         }
     }
 
-    fn write_from_mmap(&mut self, offset: u64, size: u64) -> std::io::Result<()> {
+    async fn write_from_mmap(&mut self, offset: u64, size: u64) -> std::io::Result<()> {
         if !self.writable {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
@@ -524,13 +539,13 @@ impl VirtualFile for FileHandle {
         Ok(())
     }
 
-    fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
+    async fn as_owned_buffer(&self) -> Option<OwnedBuffer> {
         let fs = self.filesystem.inner.read().ok()?;
 
         let inode = fs.storage.get(self.inode)?;
         match inode {
             Node::ReadOnlyFile(f) => Some(f.file.buffer.clone()),
-            Node::CustomFile(f) => f.file.lock().ok()?.as_owned_buffer(),
+            Node::CustomFile(f) => futures::executor::block_on(f.file.lock().ok()?.as_owned_buffer()),
             _ => None,
         }
     }
@@ -561,8 +576,9 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
-        let last_accessed_time = file.last_accessed();
+        let last_accessed_time = file.last_accessed().await;
 
         assert!(last_accessed_time > 0, "last accessed time is not zero");
 
@@ -572,8 +588,9 @@ mod test_virtual_file {
             .new_open_options()
             .read(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to open a file");
-        let next_last_accessed_time = file.last_accessed();
+        let next_last_accessed_time = file.last_accessed().await;
 
         assert!(
             next_last_accessed_time > last_accessed_time,
@@ -590,9 +607,10 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
-        assert!(file.last_modified() > 0, "last modified time is not zero");
+        assert!(file.last_modified().await > 0, "last modified time is not zero");
     }
 
     #[tokio::test]
@@ -604,8 +622,9 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
-        let created_time = file.created_time();
+        let created_time = file.created_time().await;
 
         assert!(created_time > 0, "created time is not zero");
 
@@ -613,8 +632,9 @@ mod test_virtual_file {
             .new_open_options()
             .read(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
-        let next_created_time = file.created_time();
+        let next_created_time = file.created_time().await;
 
         assert_eq!(
             next_created_time, created_time,
@@ -631,9 +651,10 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
-        assert_eq!(file.size(), 0, "new file is empty");
+        assert_eq!(file.size().await, 0, "new file is empty");
     }
 
     #[tokio::test]
@@ -645,10 +666,11 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
-        assert!(matches!(file.set_len(7), Ok(())), "setting a new length");
-        assert_eq!(file.size(), 7, "file has a new length");
+        assert!(matches!(file.set_len(7).await, Ok(())), "setting a new length");
+        assert_eq!(file.size().await, 7, "file has a new length");
     }
 
     #[tokio::test]
@@ -661,6 +683,7 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         file.write_all(b"foo").await.expect("write before unlink");
@@ -694,10 +717,13 @@ mod test_virtual_file {
             );
         }
 
-        assert_eq!(file.unlink(), Ok(()), "unlinking the file");
+        assert_eq!(file.unlink().await, Ok(()), "unlinking the file");
         assert!(
             matches!(
-                fs.new_open_options().read(true).open(path!("/foo.txt")),
+                fs.new_open_options()
+                    .read(true)
+                    .open(path!("/foo.txt"))
+                    .await,
                 Err(FsError::EntryNotFound)
             ),
             "the path disappears immediately after unlink",
@@ -758,6 +784,7 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
         first.write_all(b"foo").await.expect("seed contents");
 
@@ -766,9 +793,14 @@ mod test_virtual_file {
             .read(true)
             .write(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to open the same file a second time");
 
-        assert_eq!(first.unlink(), Ok(()), "unlinking through the first handle");
+        assert_eq!(
+            first.unlink().await,
+            Ok(()),
+            "unlinking through the first handle"
+        );
 
         second
             .seek(io::SeekFrom::End(0))
@@ -819,6 +851,7 @@ mod test_virtual_file {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -839,6 +872,7 @@ mod test_virtual_file {
             .new_open_options()
             .write(true)
             .open(path!("/dev"))
+            .await
             .expect("failed to open device file");
         let waker = Waker::noop();
         let mut cx = Context::from_waker(waker);
@@ -1094,7 +1128,7 @@ impl AsyncWrite for FileHandle {
                 }
                 Some(Node::CustomFile(node)) => {
                     let mut guard = node.file.lock().unwrap();
-                    cursor = self.write_cursor(guard.size());
+                    cursor = self.write_cursor(futures::executor::block_on(guard.size()));
 
                     let file = Pin::new(guard.as_mut());
                     if let Err(err) = file.start_seek(io::SeekFrom::Start(cursor)) {
@@ -1111,7 +1145,7 @@ impl AsyncWrite for FileHandle {
                         Poll::Pending => return Poll::Pending,
                     };
                     cursor += bytes_written as u64;
-                    node.metadata.len = guard.size();
+                    node.metadata.len = futures::executor::block_on(guard.size());
                     bytes_written
                 }
                 Some(Node::ArcFile(_)) => {
@@ -1338,19 +1372,20 @@ mod test_read_write_seek {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(
             matches!(file.write(b"foo").await, Ok(3)),
             "writing `foo` at the end of the file",
         );
-        assert_eq!(file.size(), 3, "checking the size of the file");
+        assert_eq!(file.size().await, 3, "checking the size of the file");
 
         assert!(
             matches!(file.write(b"bar").await, Ok(3)),
             "writing `bar` at the end of the file",
         );
-        assert_eq!(file.size(), 6, "checking the size of the file");
+        assert_eq!(file.size().await, 6, "checking the size of the file");
 
         assert!(
             matches!(file.seek(io::SeekFrom::Start(0)).await, Ok(0)),
@@ -1361,13 +1396,13 @@ mod test_read_write_seek {
             matches!(file.write(b"baz").await, Ok(3)),
             "writing `baz` at the beginning of the file",
         );
-        assert_eq!(file.size(), 6, "checking the size of the file");
+        assert_eq!(file.size().await, 6, "checking the size of the file");
 
         assert!(
             matches!(file.write(b"qux").await, Ok(3)),
             "writing `qux` in the middle of the file",
         );
-        assert_eq!(file.size(), 6, "checking the size of the file");
+        assert_eq!(file.size().await, 6, "checking the size of the file");
 
         assert!(
             matches!(file.seek(io::SeekFrom::Start(0)).await, Ok(0)),
@@ -1459,10 +1494,14 @@ mod test_read_write_seek {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(
-            matches!(fs.metadata(path!("/foo.txt")), Ok(Metadata { len: 0, .. })),
+            matches!(
+                fs.metadata(path!("/foo.txt")).await,
+                Ok(Metadata { len: 0, .. })
+            ),
             "checking the `metadata.len` is 0",
         );
         assert!(
@@ -1494,7 +1533,10 @@ mod test_read_write_seek {
         );
         assert_eq!(buffer[..12], b"foobarbazqux"[..], "checking the 12 bytes");
         assert!(
-            matches!(fs.metadata(path!("/foo.txt")), Ok(Metadata { len: 12, .. })),
+            matches!(
+                fs.metadata(path!("/foo.txt")).await,
+                Ok(Metadata { len: 12, .. })
+            ),
             "checking the `metadata.len` is 0",
         );
     }
@@ -1509,6 +1551,7 @@ mod test_read_write_seek {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(
@@ -1539,6 +1582,7 @@ mod test_read_write_seek {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(
@@ -1569,6 +1613,7 @@ mod test_read_write_seek {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -97,7 +97,7 @@ impl FileSystem {
                 let mut fs_lock = self.inner.write().map_err(|_| FsError::Lock)?;
 
                 // Read the metadata or generate a dummy one
-                let meta = match fs.metadata(&target_path) {
+                let meta = match futures::executor::block_on(fs.metadata(&target_path)) {
                     Ok(meta) => meta,
                     _ => {
                         let time = time();
@@ -324,8 +324,8 @@ impl FileSystem {
     }
 }
 
-impl crate::FileOpener for FileSystem {
-    fn open(
+impl FileSystem {
+    pub(crate) async fn open_internal(
         &self,
         path: &Path,
         conf: &OpenOptionsConfig,
@@ -365,13 +365,14 @@ impl crate::FileOpener for FileSystem {
                 return fs
                     .new_open_options()
                     .options(conf.clone())
-                    .open(parent_path);
+                    .open(parent_path)
+                    .await;
             }
         };
         let maybe_inode_of_file = match maybe_inode_of_file {
             Some(InodeResolution::Found(inode)) => Some(inode),
             Some(InodeResolution::Redirect(fs, path)) => {
-                return fs.new_open_options().options(conf.clone()).open(path);
+                return fs.new_open_options().options(conf.clone()).open(path).await;
             }
             None => None,
         };
@@ -443,7 +444,7 @@ impl crate::FileOpener for FileSystem {
                         // Truncate if needed.
                         let mut file = node.file.lock().unwrap();
                         if truncate {
-                            file.set_len(0)?;
+                            futures::executor::block_on(file.set_len(0))?;
                             node.metadata.len = 0;
                         }
 
@@ -454,20 +455,21 @@ impl crate::FileOpener for FileSystem {
                         // Update the accessed time.
                         node.metadata.accessed = time();
 
-                        let mut file = node
-                            .fs
-                            .new_open_options()
-                            .read(read)
-                            .write(write)
-                            .append(append)
-                            .truncate(truncate)
-                            .create(create)
-                            .create_new(create_new)
-                            .open(node.path.as_path())?;
+                        let mut file = futures::executor::block_on(
+                            node.fs
+                                .new_open_options()
+                                .read(read)
+                                .write(write)
+                                .append(append)
+                                .truncate(truncate)
+                                .create(create)
+                                .create_new(create_new)
+                                .open(node.path.as_path()),
+                        )?;
 
                         // Truncate if needed.
                         if truncate {
-                            file.set_len(0)?;
+                            futures::executor::block_on(file.set_len(0))?;
                             node.metadata.len = 0;
                         }
 
@@ -627,6 +629,7 @@ mod test_file_opener {
                 .write(true)
                 .create_new(true)
                 .open(path!("/foo.txt"))
+                .await
                 .is_ok(),
             "creating a new file",
         );
@@ -665,7 +668,8 @@ mod test_file_opener {
                 fs.new_open_options()
                     .write(true)
                     .create_new(true)
-                    .open(path!("/foo.txt")),
+                    .open(path!("/foo.txt"))
+                    .await,
                 Err(FsError::AlreadyExists)
             ),
             "creating a new file that already exist",
@@ -676,18 +680,24 @@ mod test_file_opener {
                 .write(true)
                 .create_new(true)
                 .open(path!("/foo/bar.txt"))
+                .await
                 .map(|_| ()),
             Err(FsError::EntryNotFound),
             "creating a file in a directory that doesn't exist",
         );
 
-        assert_eq!(fs.remove_file(path!("/foo.txt")), Ok(()), "removing a file");
+        assert_eq!(
+            fs.remove_file(path!("/foo.txt")).await,
+            Ok(()),
+            "removing a file"
+        );
 
         assert!(
             fs.new_open_options()
                 .write(false)
                 .create_new(true)
                 .open(path!("/foo.txt"))
+                .await
                 .is_ok(),
             "creating a file without the `write` option",
         );
@@ -702,7 +712,8 @@ mod test_file_opener {
                 fs.new_open_options()
                     .write(false)
                     .truncate(true)
-                    .open(path!("/foo.txt")),
+                    .open(path!("/foo.txt"))
+                    .await,
                 Err(FsError::PermissionDenied),
             ),
             "truncating a read-only file",
@@ -718,6 +729,7 @@ mod test_file_opener {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(
@@ -739,6 +751,7 @@ mod test_file_opener {
             .write(true)
             .truncate(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to open + truncate `foo.txt`");
 
         assert!(
@@ -760,6 +773,7 @@ mod test_file_opener {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to create a new file");
 
         assert!(
@@ -780,6 +794,7 @@ mod test_file_opener {
             .new_open_options()
             .append(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to open `foo.txt`");
 
         assert!(
@@ -796,6 +811,7 @@ mod test_file_opener {
             .new_open_options()
             .read(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("failed to open `foo.txt");
 
         assert!(
@@ -823,6 +839,7 @@ mod test_file_opener {
                 .write(true)
                 .create_new(true)
                 .open(path!("/foo.txt"))
+                .await
                 .is_ok(),
             "creating a _new_ file",
         );
@@ -831,7 +848,8 @@ mod test_file_opener {
             matches!(
                 fs.new_open_options()
                     .create_new(true)
-                    .open(path!("/foo.txt")),
+                    .open(path!("/foo.txt"))
+                    .await,
                 Err(FsError::AlreadyExists),
             ),
             "creating a _new_ file that already exists",
@@ -841,6 +859,7 @@ mod test_file_opener {
             fs.new_open_options()
                 .read(true)
                 .open(path!("/foo.txt"))
+                .await
                 .is_ok(),
             "opening a file that already exists",
         );
@@ -857,6 +876,7 @@ mod test_file_opener {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("create file in backing fs");
 
         fs.insert_arc_directory_at(
@@ -870,6 +890,7 @@ mod test_file_opener {
             .new_open_options()
             .read(true)
             .open(path!("/mnt/foo.txt"))
+            .await
             .expect("open should redirect to the backing fs");
 
         let mut contents = String::new();
@@ -882,7 +903,8 @@ mod test_file_opener {
             matches!(
                 fs.new_open_options()
                     .create_new(true)
-                    .open(path!("/mnt/foo.txt")),
+                    .open(path!("/mnt/foo.txt"))
+                    .await,
                 Err(FsError::AlreadyExists),
             ),
             "create_new on a redirected existing file follows the backing fs result",
@@ -897,13 +919,14 @@ mod test_file_opener {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("create /foo.txt");
 
         let _hook = OpenBeforeHandleHookGuard::install(Box::new({
             let fs = fs.clone();
             move || {
                 assert_eq!(
-                    fs.remove_file(path!("/foo.txt")),
+                    futures::executor::block_on(fs.remove_file(path!("/foo.txt"))),
                     Ok(()),
                     "unlink during the open-return window",
                 );
@@ -915,12 +938,13 @@ mod test_file_opener {
             .read(true)
             .write(true)
             .open(path!("/foo.txt"))
+            .await
             .expect(
                 "open should succeed even if the path is unlinked before the handle is returned",
             );
 
         assert_eq!(
-            fs.metadata(path!("/foo.txt")),
+            fs.metadata(path!("/foo.txt")).await,
             Err(FsError::EntryNotFound),
             "the path is gone immediately after unlink",
         );

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -378,6 +378,7 @@ impl FileSystem {
         };
 
         let cursor = 0u64;
+        let mut arc_file = None;
         let (inode_of_file, handle_lifecycle) = match maybe_inode_of_file {
             // The file already exists, and a _new_ one _must_ be
             // created; it's not OK.
@@ -385,99 +386,128 @@ impl FileSystem {
 
             // The file already exists; it's OK.
             Some(inode_of_file) => {
-                // Write lock.
-                let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+                enum OpenedNode {
+                    Other(Arc<FileLifecycle>),
+                    ArcFile {
+                        lifecycle: Arc<FileLifecycle>,
+                        fs: Arc<dyn crate::FileSystem + Send + Sync>,
+                        path: std::path::PathBuf,
+                    },
+                }
 
-                let handle_lifecycle = match fs.storage.get_mut(inode_of_file) {
-                    Some(Node::File(FileNode {
-                        metadata,
-                        file,
+                let opened_node = {
+                    // Write lock.
+                    let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+
+                    match fs.storage.get_mut(inode_of_file) {
+                        Some(Node::File(FileNode {
+                            metadata,
+                            file,
+                            lifecycle,
+                            ..
+                        })) => {
+                            // Update the accessed time.
+                            metadata.accessed = time();
+
+                            // Truncate if needed.
+                            if truncate {
+                                file.truncate();
+                                metadata.len = 0;
+                            }
+
+                            OpenedNode::Other(lifecycle.clone())
+                        }
+
+                        Some(Node::OffloadedFile(OffloadedFileNode {
+                            metadata,
+                            file,
+                            lifecycle,
+                            ..
+                        })) => {
+                            // Update the accessed time.
+                            metadata.accessed = time();
+
+                            // Truncate if needed.
+                            if truncate {
+                                file.truncate();
+                                metadata.len = 0;
+                            }
+
+                            OpenedNode::Other(lifecycle.clone())
+                        }
+
+                        Some(Node::ReadOnlyFile(node)) => {
+                            // Update the accessed time.
+                            node.metadata.accessed = time();
+
+                            // Truncate if needed.
+                            if truncate || append {
+                                return Err(FsError::PermissionDenied);
+                            }
+
+                            OpenedNode::Other(node.lifecycle.clone())
+                        }
+
+                        Some(Node::CustomFile(node)) => {
+                            // Update the accessed time.
+                            node.metadata.accessed = time();
+
+                            // Truncate if needed.
+                            let mut file = node.file.lock().unwrap();
+                            if truncate {
+                                futures::executor::block_on(file.set_len(0))?;
+                                node.metadata.len = 0;
+                            }
+
+                            OpenedNode::Other(node.lifecycle.clone())
+                        }
+
+                        Some(Node::ArcFile(node)) => {
+                            // Update the accessed time.
+                            node.metadata.accessed = time();
+
+                            OpenedNode::ArcFile {
+                                lifecycle: node.lifecycle.clone(),
+                                fs: node.fs.clone(),
+                                path: node.path.clone(),
+                            }
+                        }
+
+                        None => return Err(FsError::EntryNotFound),
+                        _ => return Err(FsError::NotAFile),
+                    }
+                };
+
+                let handle_lifecycle = match opened_node {
+                    OpenedNode::Other(lifecycle) => lifecycle,
+                    OpenedNode::ArcFile {
                         lifecycle,
-                        ..
-                    })) => {
-                        // Update the accessed time.
-                        metadata.accessed = time();
+                        fs: node_fs,
+                        path: node_path,
+                    } => {
+                        let mut file = node_fs
+                            .new_open_options()
+                            .read(read)
+                            .write(write)
+                            .append(append)
+                            .truncate(truncate)
+                            .create(create)
+                            .create_new(create_new)
+                            .open(node_path.as_path())
+                            .await?;
 
                         // Truncate if needed.
                         if truncate {
-                            file.truncate();
-                            metadata.len = 0;
+                            file.set_len(0).await?;
+                            let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+                            if let Some(Node::ArcFile(node)) = fs.storage.get_mut(inode_of_file) {
+                                node.metadata.len = 0;
+                            }
                         }
 
-                        lifecycle.clone()
+                        arc_file = Some(file);
+                        lifecycle
                     }
-
-                    Some(Node::OffloadedFile(OffloadedFileNode {
-                        metadata,
-                        file,
-                        lifecycle,
-                        ..
-                    })) => {
-                        // Update the accessed time.
-                        metadata.accessed = time();
-
-                        // Truncate if needed.
-                        if truncate {
-                            file.truncate();
-                            metadata.len = 0;
-                        }
-
-                        lifecycle.clone()
-                    }
-
-                    Some(Node::ReadOnlyFile(node)) => {
-                        // Update the accessed time.
-                        node.metadata.accessed = time();
-
-                        // Truncate if needed.
-                        if truncate || append {
-                            return Err(FsError::PermissionDenied);
-                        }
-
-                        node.lifecycle.clone()
-                    }
-
-                    Some(Node::CustomFile(node)) => {
-                        // Update the accessed time.
-                        node.metadata.accessed = time();
-
-                        // Truncate if needed.
-                        let mut file = node.file.lock().unwrap();
-                        if truncate {
-                            futures::executor::block_on(file.set_len(0))?;
-                            node.metadata.len = 0;
-                        }
-
-                        node.lifecycle.clone()
-                    }
-
-                    Some(Node::ArcFile(node)) => {
-                        // Update the accessed time.
-                        node.metadata.accessed = time();
-
-                        let mut file = futures::executor::block_on(
-                            node.fs
-                                .new_open_options()
-                                .read(read)
-                                .write(write)
-                                .append(append)
-                                .truncate(truncate)
-                                .create(create)
-                                .create_new(create_new)
-                                .open(node.path.as_path()),
-                        )?;
-
-                        // Truncate if needed.
-                        if truncate {
-                            futures::executor::block_on(file.set_len(0))?;
-                            node.metadata.len = 0;
-                        }
-
-                        node.lifecycle.clone()
-                    }
-
-                    None => return Err(FsError::EntryNotFound),
-                    _ => return Err(FsError::NotAFile),
                 };
 
                 handle_lifecycle.opened();
@@ -562,6 +592,7 @@ impl FileSystem {
             write || append || truncate,
             append,
             cursor,
+            arc_file,
         )))
     }
 }

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -3,7 +3,22 @@ use super::*;
 use crate::{FileType, FsError, Metadata, OpenOptionsConfig, Result, VirtualFile};
 use shared_buffer::OwnedBuffer;
 use std::path::Path;
+use std::task::{Context, Poll};
 use tracing::*;
+
+fn poll_custom_file_set_len(
+    file: &mut (dyn VirtualFile + Send + Sync),
+    new_size: u64,
+) -> Result<()> {
+    let mut future = file.set_len(new_size);
+    let waker = futures::task::noop_waker_ref();
+    let mut context = Context::from_waker(waker);
+
+    match future.as_mut().poll(&mut context) {
+        Poll::Ready(result) => result,
+        Poll::Pending => Err(FsError::Unsupported),
+    }
+}
 
 impl FileSystem {
     /// Inserts a readonly file into the file system that uses copy-on-write
@@ -457,7 +472,7 @@ impl FileSystem {
                             // Truncate if needed.
                             let mut file = node.file.lock().unwrap();
                             if truncate {
-                                futures::executor::block_on(file.set_len(0))?;
+                                poll_custom_file_set_len(file.as_mut(), 0)?;
                                 node.metadata.len = 0;
                             }
 

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -9,7 +9,7 @@ impl FileSystem {
     /// Inserts a readonly file into the file system that uses copy-on-write
     /// (this is required for zero-copy creation of the same file)
     pub fn insert_ro_file(&self, path: &Path, contents: OwnedBuffer) -> Result<()> {
-        let _ = crate::FileSystem::remove_file(self, path);
+        futures::executor::block_on(crate::FileSystem::remove_file(self, path)).ok();
         let (inode_of_parent, maybe_inode_of_file, name_of_file) = self.insert_inode(path)?;
 
         let inode_of_parent = match inode_of_parent {
@@ -76,7 +76,8 @@ impl FileSystem {
         fs: Arc<dyn crate::FileSystem + Send + Sync>,
         source_path: PathBuf,
     ) -> Result<()> {
-        let _ = crate::FileSystem::remove_file(self, target_path.as_path());
+        futures::executor::block_on(crate::FileSystem::remove_file(self, target_path.as_path()))
+            .ok();
         let (inode_of_parent, maybe_inode_of_file, name_of_file) =
             self.insert_inode(target_path.as_path())?;
 
@@ -157,7 +158,8 @@ impl FileSystem {
         other: Arc<dyn crate::FileSystem + Send + Sync>,
         source_path: PathBuf,
     ) -> Result<()> {
-        let _ = crate::FileSystem::remove_dir(self, target_path.as_path());
+        futures::executor::block_on(crate::FileSystem::remove_dir(self, target_path.as_path()))
+            .ok();
         let (inode_of_parent, maybe_inode_of_file, name_of_file) =
             self.insert_inode(target_path.as_path())?;
 
@@ -231,7 +233,7 @@ impl FileSystem {
         path: PathBuf,
         file: Box<dyn crate::VirtualFile + Send + Sync>,
     ) -> Result<()> {
-        let _ = crate::FileSystem::remove_file(self, path.as_path());
+        futures::executor::block_on(crate::FileSystem::remove_file(self, path.as_path())).ok();
         let (inode_of_parent, maybe_inode_of_file, name_of_file) =
             self.insert_inode(path.as_path())?;
 

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -132,20 +132,14 @@ impl FileSystem {
                 let rm = next.to_string_lossy();
                 let rm = &rm[".wh.".len()..];
                 let rm = PathBuf::from(rm);
-                let _ = futures::executor::block_on(crate::FileSystem::remove_dir(
-                    self,
-                    rm.as_path(),
-                ));
-                let _ = futures::executor::block_on(crate::FileSystem::remove_file(
-                    self,
-                    rm.as_path(),
-                ));
+                let _ =
+                    futures::executor::block_on(crate::FileSystem::remove_dir(self, rm.as_path()));
+                let _ =
+                    futures::executor::block_on(crate::FileSystem::remove_file(self, rm.as_path()));
                 continue;
             }
-            let _ = futures::executor::block_on(crate::FileSystem::create_dir(
-                self,
-                next.as_path(),
-            ));
+            let _ =
+                futures::executor::block_on(crate::FileSystem::create_dir(self, next.as_path()));
 
             let dir = match futures::executor::block_on(other.read_dir(next.as_path())) {
                 Ok(dir) => dir,
@@ -546,143 +540,140 @@ impl crate::FileSystem for FileSystem {
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
-            let name_of_to;
+        let name_of_to;
 
-            // Read lock.
-            let (name_of_from, inode_of_from_parent, name_of_to, inode_of_to_parent) = {
-                let fs = self.inner.read().map_err(|_| FsError::Lock)?;
+        // Read lock.
+        let (name_of_from, inode_of_from_parent, name_of_to, inode_of_to_parent) = {
+            let fs = self.inner.read().map_err(|_| FsError::Lock)?;
 
-                let from = fs.canonicalize_without_inode(from)?;
-                let to = fs.canonicalize_without_inode(to)?;
+            let from = fs.canonicalize_without_inode(from)?;
+            let to = fs.canonicalize_without_inode(to)?;
 
-                // Check the paths have parents.
-                let parent_of_from = from.parent().ok_or(FsError::BaseNotDirectory)?;
-                let parent_of_to = to.parent().ok_or(FsError::BaseNotDirectory)?;
+            // Check the paths have parents.
+            let parent_of_from = from.parent().ok_or(FsError::BaseNotDirectory)?;
+            let parent_of_to = to.parent().ok_or(FsError::BaseNotDirectory)?;
 
-                // Check the names.
-                let name_of_from = from
-                    .file_name()
-                    .ok_or(FsError::InvalidInput)?
-                    .to_os_string();
-                name_of_to = to.file_name().ok_or(FsError::InvalidInput)?.to_os_string();
+            // Check the names.
+            let name_of_from = from
+                .file_name()
+                .ok_or(FsError::InvalidInput)?
+                .to_os_string();
+            name_of_to = to.file_name().ok_or(FsError::InvalidInput)?.to_os_string();
 
-                // Find the parent inodes.
-                let inode_of_from_parent = match fs.inode_of_parent(parent_of_from)? {
-                    InodeResolution::Found(a) => Either::Left(a),
-                    InodeResolution::Redirect(fs, mut path) => {
-                        path.push(&name_of_from);
-                        Either::Right((fs, path))
-                    }
-                };
-                let inode_of_to_parent = match fs.inode_of_parent(parent_of_to)? {
-                    InodeResolution::Found(a) => Either::Left(a),
-                    InodeResolution::Redirect(fs, mut path) => {
-                        path.push(&name_of_to);
-                        Either::Right((fs, path))
-                    }
-                };
-
-                (
-                    name_of_from,
-                    inode_of_from_parent,
-                    name_of_to,
-                    inode_of_to_parent,
-                )
+            // Find the parent inodes.
+            let inode_of_from_parent = match fs.inode_of_parent(parent_of_from)? {
+                InodeResolution::Found(a) => Either::Left(a),
+                InodeResolution::Redirect(fs, mut path) => {
+                    path.push(&name_of_from);
+                    Either::Right((fs, path))
+                }
+            };
+            let inode_of_to_parent = match fs.inode_of_parent(parent_of_to)? {
+                InodeResolution::Found(a) => Either::Left(a),
+                InodeResolution::Redirect(fs, mut path) => {
+                    path.push(&name_of_to);
+                    Either::Right((fs, path))
+                }
             };
 
-            match (inode_of_from_parent, inode_of_to_parent) {
-                // Rename within this MemFS instance
-                (Either::Left(inode_of_from_parent), Either::Left(inode_of_to_parent)) => {
-                    let fs = self.inner.read().map_err(|_| FsError::Lock)?;
+            (
+                name_of_from,
+                inode_of_from_parent,
+                name_of_to,
+                inode_of_to_parent,
+            )
+        };
 
-                    // Find the inode of the dest file if it exists
-                    let maybe_position_and_inode_of_file = fs
-                        .as_parent_get_position_and_inode_of_file(
-                            inode_of_to_parent,
-                            &name_of_to,
-                        )?;
+        match (inode_of_from_parent, inode_of_to_parent) {
+            // Rename within this MemFS instance
+            (Either::Left(inode_of_from_parent), Either::Left(inode_of_to_parent)) => {
+                let fs = self.inner.read().map_err(|_| FsError::Lock)?;
 
-                    // Get the child indexes to update in the parent nodes, in
-                    // addition to the inode of the directory to update.
-                    let (position_of_from, inode) = fs
-                        .as_parent_get_position_and_inode(inode_of_from_parent, &name_of_from)?
-                        .ok_or(FsError::EntryNotFound)?;
+                // Find the inode of the dest file if it exists
+                let maybe_position_and_inode_of_file =
+                    fs.as_parent_get_position_and_inode_of_file(inode_of_to_parent, &name_of_to)?;
 
-                    let (
-                        (position_of_from, inode, inode_of_from_parent),
-                        (inode_of_to_parent, name_of_to),
-                        inode_dest,
-                    ) = (
-                        (position_of_from, inode, inode_of_from_parent),
-                        (inode_of_to_parent, name_of_to),
-                        maybe_position_and_inode_of_file,
-                    );
+                // Get the child indexes to update in the parent nodes, in
+                // addition to the inode of the directory to update.
+                let (position_of_from, inode) = fs
+                    .as_parent_get_position_and_inode(inode_of_from_parent, &name_of_from)?
+                    .ok_or(FsError::EntryNotFound)?;
 
-                    let inode = match inode {
-                        InodeResolution::Found(a) => a,
-                        InodeResolution::Redirect(..) => {
-                            return Err(FsError::InvalidInput);
-                        }
-                    };
+                let (
+                    (position_of_from, inode, inode_of_from_parent),
+                    (inode_of_to_parent, name_of_to),
+                    inode_dest,
+                ) = (
+                    (position_of_from, inode, inode_of_from_parent),
+                    (inode_of_to_parent, name_of_to),
+                    maybe_position_and_inode_of_file,
+                );
 
-                    drop(fs);
+                let inode = match inode {
+                    InodeResolution::Found(a) => a,
+                    InodeResolution::Redirect(..) => {
+                        return Err(FsError::InvalidInput);
+                    }
+                };
 
-                    {
-                        // Write lock.
-                        let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+                drop(fs);
 
-                        if let Some((position, inode_of_file)) = inode_dest {
-                            // Remove the file from the storage.
-                            match inode_of_file {
-                                InodeResolution::Found(inode_of_file) => {
-                                    fs.storage.remove(inode_of_file);
-                                }
-                                InodeResolution::Redirect(..) => {
-                                    return Err(FsError::InvalidInput);
-                                }
+                {
+                    // Write lock.
+                    let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+
+                    if let Some((position, inode_of_file)) = inode_dest {
+                        // Remove the file from the storage.
+                        match inode_of_file {
+                            InodeResolution::Found(inode_of_file) => {
+                                fs.storage.remove(inode_of_file);
                             }
-
-                            fs.remove_child_from_node(inode_of_to_parent, position)?;
-                        }
-
-                        // Update the file name, and update the modified time.
-                        fs.update_node_name(inode, name_of_to)?;
-
-                        // The parents are different. Let's update them.
-                        if inode_of_from_parent != inode_of_to_parent {
-                            // Remove the file from its parent, and update the
-                            // modified time.
-                            fs.remove_child_from_node(inode_of_from_parent, position_of_from)?;
-
-                            // Add the file to its new parent, and update the modified
-                            // time.
-                            fs.add_child_to_node(inode_of_to_parent, inode)?;
-                        }
-                        // Otherwise, we need to at least update the modified time of the parent.
-                        else {
-                            let mut inode = fs.storage.get_mut(inode_of_from_parent);
-                            match inode.as_mut() {
-                                Some(Node::Directory(node)) => node.metadata.modified = time(),
-                                Some(Node::ArcDirectory(node)) => node.metadata.modified = time(),
-                                _ => return Err(FsError::UnknownError),
+                            InodeResolution::Redirect(..) => {
+                                return Err(FsError::InvalidInput);
                             }
                         }
+
+                        fs.remove_child_from_node(inode_of_to_parent, position)?;
                     }
 
-                    Ok(())
+                    // Update the file name, and update the modified time.
+                    fs.update_node_name(inode, name_of_to)?;
+
+                    // The parents are different. Let's update them.
+                    if inode_of_from_parent != inode_of_to_parent {
+                        // Remove the file from its parent, and update the
+                        // modified time.
+                        fs.remove_child_from_node(inode_of_from_parent, position_of_from)?;
+
+                        // Add the file to its new parent, and update the modified
+                        // time.
+                        fs.add_child_to_node(inode_of_to_parent, inode)?;
+                    }
+                    // Otherwise, we need to at least update the modified time of the parent.
+                    else {
+                        let mut inode = fs.storage.get_mut(inode_of_from_parent);
+                        match inode.as_mut() {
+                            Some(Node::Directory(node)) => node.metadata.modified = time(),
+                            Some(Node::ArcDirectory(node)) => node.metadata.modified = time(),
+                            _ => return Err(FsError::UnknownError),
+                        }
+                    }
                 }
 
-                // Rename within the same mounted FS instance
-                (Either::Right((from_fs, from_path)), Either::Right((to_fs, to_path)))
-                    if Arc::ptr_eq(&from_fs, &to_fs) =>
-                {
-                    let same_fs = from_fs;
-                    same_fs.rename(&from_path, &to_path).await
-                }
-
-                // Rename across file systems; we need to do a create and a delete
-                _ => crate::ops::move_across_filesystems(self, self, from, to).await,
+                Ok(())
             }
+
+            // Rename within the same mounted FS instance
+            (Either::Right((from_fs, from_path)), Either::Right((to_fs, to_path)))
+                if Arc::ptr_eq(&from_fs, &to_fs) =>
+            {
+                let same_fs = from_fs;
+                same_fs.rename(&from_path, &to_path).await
+            }
+
+            // Rename across file systems; we need to do a create and a delete
+            _ => crate::ops::move_across_filesystems(self, self, from, to).await,
+        }
     }
 
     async fn metadata(&self, path: &Path) -> Result<Metadata> {
@@ -1300,7 +1291,11 @@ mod test_filesystem {
             "creating the root which already exists",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating a directory");
+        assert_eq!(
+            fs.create_dir(path!("/foo")).await,
+            Ok(()),
+            "creating a directory"
+        );
 
         {
             let fs_inner = fs.inner.read().unwrap();
@@ -1403,7 +1398,11 @@ mod test_filesystem {
             "cannot remove a directory that doesn't exist",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating a directory");
+        assert_eq!(
+            fs.create_dir(path!("/foo")).await,
+            Ok(()),
+            "creating a directory"
+        );
 
         assert_eq!(
             fs.create_dir(path!("/foo/bar")).await,
@@ -1432,7 +1431,11 @@ mod test_filesystem {
             "removing a sub-directory",
         );
 
-        assert_eq!(fs.remove_dir(path!("/foo")).await, Ok(()), "removing a directory");
+        assert_eq!(
+            fs.remove_dir(path!("/foo")).await,
+            Ok(()),
+            "removing a directory"
+        );
 
         {
             let fs_inner = fs.inner.read().unwrap();
@@ -1859,12 +1862,14 @@ mod test_filesystem {
 
         drop(file);
 
-        let fs_inner = fs.inner.read().unwrap();
-        assert_eq!(
-            fs_inner.storage.len(),
-            1,
-            "storage drops the file once the last open handle closes"
-        );
+        {
+            let fs_inner = fs.inner.read().unwrap();
+            assert_eq!(
+                fs_inner.storage.len(),
+                1,
+                "storage drops the file once the last open handle closes"
+            );
+        }
 
         assert_eq!(
             fs.remove_file(path!("/foo.txt")).await,
@@ -1878,7 +1883,11 @@ mod test_filesystem {
         let fs = FileSystem::default();
 
         assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating `foo`");
-        assert_eq!(fs.create_dir(path!("/foo/sub")).await, Ok(()), "creating `sub`");
+        assert_eq!(
+            fs.create_dir(path!("/foo/sub")).await,
+            Ok(()),
+            "creating `sub`"
+        );
         assert_eq!(fs.create_dir(path!("/bar")).await, Ok(()), "creating `bar`");
         assert_eq!(fs.create_dir(path!("/baz")).await, Ok(()), "creating `bar`");
         assert!(
@@ -1969,7 +1978,11 @@ mod test_filesystem {
         let fs = FileSystem::default();
 
         assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating `foo`");
-        assert_eq!(fs.create_dir(path!("/foo/bar")).await, Ok(()), "creating `bar`");
+        assert_eq!(
+            fs.create_dir(path!("/foo/bar")).await,
+            Ok(()),
+            "creating `bar`"
+        );
         assert_eq!(
             fs.create_dir(path!("/foo/bar/baz")).await,
             Ok(()),

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -4,7 +4,7 @@ use self::offloaded_file::OffloadBackingStore;
 
 use super::*;
 use crate::{DirEntry, FileType, FsError, Metadata, OpenOptions, ReadDir, Result};
-use futures::future::{BoxFuture, Either};
+use futures::future::Either;
 use slab::Slab;
 use std::collections::VecDeque;
 use std::convert::identity;
@@ -102,7 +102,7 @@ impl FileSystem {
 
         std::mem::drop(fs_lock);
 
-        let source = other.read_dir(&source_path)?;
+        let source = futures::executor::block_on(other.read_dir(&source_path))?;
         for entry in source.data {
             let meta = entry.metadata?;
 
@@ -132,13 +132,22 @@ impl FileSystem {
                 let rm = next.to_string_lossy();
                 let rm = &rm[".wh.".len()..];
                 let rm = PathBuf::from(rm);
-                let _ = crate::FileSystem::remove_dir(self, rm.as_path());
-                let _ = crate::FileSystem::remove_file(self, rm.as_path());
+                let _ = futures::executor::block_on(crate::FileSystem::remove_dir(
+                    self,
+                    rm.as_path(),
+                ));
+                let _ = futures::executor::block_on(crate::FileSystem::remove_file(
+                    self,
+                    rm.as_path(),
+                ));
                 continue;
             }
-            let _ = crate::FileSystem::create_dir(self, next.as_path());
+            let _ = futures::executor::block_on(crate::FileSystem::create_dir(
+                self,
+                next.as_path(),
+            ));
 
-            let dir = match other.read_dir(next.as_path()) {
+            let dir = match futures::executor::block_on(other.read_dir(next.as_path())) {
                 Ok(dir) => dir,
                 Err(_) => {
                     // TODO: propagate errors (except NotFound)
@@ -164,8 +173,14 @@ impl FileSystem {
                             let rm = next.to_string_lossy();
                             let rm = &rm[".wh.".len()..];
                             let rm = PathBuf::from(rm);
-                            let _ = crate::FileSystem::remove_dir(self, rm.as_path());
-                            let _ = crate::FileSystem::remove_file(self, rm.as_path());
+                            let _ = futures::executor::block_on(crate::FileSystem::remove_dir(
+                                self,
+                                rm.as_path(),
+                            ));
+                            let _ = futures::executor::block_on(crate::FileSystem::remove_file(
+                                self,
+                                rm.as_path(),
+                            ));
                             continue;
                         }
                         let _ = self
@@ -184,7 +199,9 @@ impl FileSystem {
         other: &Arc<dyn crate::FileSystem + Send + Sync>,
         source_path: PathBuf,
     ) -> Result<()> {
-        if crate::FileSystem::read_dir(self, target_path.as_path()).is_ok() {
+        if futures::executor::block_on(crate::FileSystem::read_dir(self, target_path.as_path()))
+            .is_ok()
+        {
             return Err(FsError::AlreadyExists);
         }
 
@@ -314,8 +331,9 @@ impl FileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl crate::FileSystem for FileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
         // Read lock.
         let guard = self.inner.read().map_err(|_| FsError::Lock)?;
 
@@ -326,11 +344,13 @@ impl crate::FileSystem for FileSystem {
                 Some(Node::Symlink(SymlinkNode { target, .. })) => Ok(target.clone()),
                 _ => Err(FsError::InvalidInput),
             },
-            InodeResolution::Redirect(fs, path) => fs.readlink(path.as_path()),
+            InodeResolution::Redirect(fs, path) => {
+                futures::executor::block_on(fs.readlink(path.as_path()))
+            }
         }
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
         // Read lock.
         let guard = self.inner.read().map_err(|_| FsError::Lock)?;
 
@@ -346,7 +366,8 @@ impl crate::FileSystem for FileSystem {
         let inode_of_directory = match inode_of_directory {
             InodeResolution::Found(a) => a,
             InodeResolution::Redirect(fs, redirect_path) => {
-                let mut entries = fs.read_dir(redirect_path.as_path())?;
+                let mut entries =
+                    futures::executor::block_on(fs.read_dir(redirect_path.as_path()))?;
                 rebase_entries(&mut entries, &guest_path);
                 return Ok(entries);
             }
@@ -372,7 +393,7 @@ impl crate::FileSystem for FileSystem {
             Some(Node::ArcDirectory(ArcDirectoryNode {
                 fs, path: fs_path, ..
             })) => {
-                let mut entries = fs.read_dir(fs_path.as_path())?;
+                let mut entries = futures::executor::block_on(fs.read_dir(fs_path.as_path()))?;
                 rebase_entries(&mut entries, &guest_path);
                 return Ok(entries);
             }
@@ -383,8 +404,8 @@ impl crate::FileSystem for FileSystem {
         Ok(ReadDir::new(children))
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
-        if self.read_dir(path).is_ok() {
+    async fn create_dir(&self, path: &Path) -> Result<()> {
+        if self.read_dir(path).await.is_ok() {
             return Err(FsError::AlreadyExists);
         }
 
@@ -411,14 +432,14 @@ impl crate::FileSystem for FileSystem {
                 InodeResolution::Redirect(fs, mut path) => {
                     drop(guard);
                     path.push(name_of_directory);
-                    return fs.create_dir(path.as_path());
+                    return futures::executor::block_on(fs.create_dir(path.as_path()));
                 }
             };
 
             (inode_of_parent, name_of_directory)
         };
 
-        if self.read_dir(path).is_ok() {
+        if self.read_dir(path).await.is_ok() {
             return Err(FsError::AlreadyExists);
         }
 
@@ -460,11 +481,11 @@ impl crate::FileSystem for FileSystem {
         Ok(())
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
         self.create_symlink(source, target)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
         let (inode_of_parent, position, inode_of_directory) = {
             // Read lock.
             let guard = self.inner.read().map_err(|_| FsError::Lock)?;
@@ -487,7 +508,7 @@ impl crate::FileSystem for FileSystem {
                 InodeResolution::Redirect(fs, mut parent_path) => {
                     drop(guard);
                     parent_path.push(name_of_directory);
-                    return fs.remove_dir(parent_path.as_path());
+                    return futures::executor::block_on(fs.remove_dir(parent_path.as_path()));
                 }
             };
 
@@ -506,7 +527,7 @@ impl crate::FileSystem for FileSystem {
         let inode_of_directory = match inode_of_directory {
             InodeResolution::Found(a) => a,
             InodeResolution::Redirect(fs, path) => {
-                return fs.remove_dir(path.as_path());
+                return fs.remove_dir(path.as_path()).await;
             }
         };
 
@@ -524,8 +545,7 @@ impl crate::FileSystem for FileSystem {
         Ok(())
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async move {
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
             let name_of_to;
 
             // Read lock.
@@ -663,44 +683,45 @@ impl crate::FileSystem for FileSystem {
                 // Rename across file systems; we need to do a create and a delete
                 _ => crate::ops::move_across_filesystems(self, self, from, to).await,
             }
-        })
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
-        // Read lock.
-        let guard = self.inner.read().map_err(|_| FsError::Lock)?;
-        match guard.inode_of(path)? {
-            InodeResolution::Found(inode) => Ok(guard
-                .storage
-                .get(inode)
-                .ok_or(FsError::UnknownError)?
-                .metadata()
-                .clone()),
-            InodeResolution::Redirect(fs, path) => {
-                drop(guard);
-                fs.metadata(path.as_path())
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
+        let redirected = {
+            let guard = self.inner.read().map_err(|_| FsError::Lock)?;
+            match guard.inode_of(path)? {
+                InodeResolution::Found(inode) => {
+                    return Ok(guard
+                        .storage
+                        .get(inode)
+                        .ok_or(FsError::UnknownError)?
+                        .metadata()
+                        .clone());
+                }
+                InodeResolution::Redirect(fs, path) => (fs, path),
             }
-        }
+        };
+        redirected.0.metadata(redirected.1.as_path()).await
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
-        // Read lock.
-        let guard = self.inner.read().map_err(|_| FsError::Lock)?;
-        match guard.inode_of(path)? {
-            InodeResolution::Found(inode) => Ok(guard
-                .storage
-                .get(inode)
-                .ok_or(FsError::UnknownError)?
-                .metadata()
-                .clone()),
-            InodeResolution::Redirect(fs, path) => {
-                drop(guard);
-                fs.symlink_metadata(path.as_path())
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+        let redirected = {
+            let guard = self.inner.read().map_err(|_| FsError::Lock)?;
+            match guard.inode_of(path)? {
+                InodeResolution::Found(inode) => {
+                    return Ok(guard
+                        .storage
+                        .get(inode)
+                        .ok_or(FsError::UnknownError)?
+                        .metadata()
+                        .clone());
+                }
+                InodeResolution::Redirect(fs, path) => (fs, path),
             }
-        }
+        };
+        redirected.0.symlink_metadata(redirected.1.as_path()).await
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
+    async fn remove_file(&self, path: &Path) -> Result<()> {
         let (inode_of_parent, position, inode_of_file) = {
             // Read lock.
             let guard = self.inner.read().map_err(|_| FsError::Lock)?;
@@ -722,7 +743,7 @@ impl crate::FileSystem for FileSystem {
                 InodeResolution::Found(a) => a,
                 InodeResolution::Redirect(fs, mut parent_path) => {
                     parent_path.push(name_of_file);
-                    return fs.remove_file(parent_path.as_path());
+                    return futures::executor::block_on(fs.remove_file(parent_path.as_path()));
                 }
             };
 
@@ -739,7 +760,7 @@ impl crate::FileSystem for FileSystem {
         let inode_of_file = match inode_of_file {
             InodeResolution::Found(a) => a,
             InodeResolution::Redirect(fs, path) => {
-                return fs.remove_file(path.as_path());
+                return futures::executor::block_on(fs.remove_file(path.as_path()));
             }
         };
 
@@ -754,6 +775,14 @@ impl crate::FileSystem for FileSystem {
 
     fn new_open_options(&self) -> OpenOptions<'_> {
         OpenOptions::new(self)
+    }
+
+    async fn open(
+        &self,
+        path: &Path,
+        conf: &crate::OpenOptionsConfig,
+    ) -> Result<Box<dyn crate::VirtualFile + Send + Sync + 'static>> {
+        self.open_internal(path, conf).await
     }
 }
 
@@ -1266,12 +1295,12 @@ mod test_filesystem {
         let fs = FileSystem::default();
 
         assert_eq!(
-            fs.create_dir(path!("/")),
+            fs.create_dir(path!("/")).await,
             Err(FsError::AlreadyExists),
             "creating the root which already exists",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating a directory");
+        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating a directory");
 
         {
             let fs_inner = fs.inner.read().unwrap();
@@ -1307,7 +1336,7 @@ mod test_filesystem {
         }
 
         assert_eq!(
-            fs.create_dir(path!("/foo/bar")),
+            fs.create_dir(path!("/foo/bar")).await,
             Ok(()),
             "creating a sub-directory",
         );
@@ -1363,21 +1392,21 @@ mod test_filesystem {
         let fs = FileSystem::default();
 
         assert_eq!(
-            fs.remove_dir(path!("/")),
+            fs.remove_dir(path!("/")).await,
             Err(FsError::BaseNotDirectory),
             "removing a directory that has no parent",
         );
 
         assert_eq!(
-            fs.remove_dir(path!("/foo")),
+            fs.remove_dir(path!("/foo")).await,
             Err(FsError::EntryNotFound),
             "cannot remove a directory that doesn't exist",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating a directory");
+        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating a directory");
 
         assert_eq!(
-            fs.create_dir(path!("/foo/bar")),
+            fs.create_dir(path!("/foo/bar")).await,
             Ok(()),
             "creating a sub-directory",
         );
@@ -1392,18 +1421,18 @@ mod test_filesystem {
         }
 
         assert_eq!(
-            fs.remove_dir(path!("/foo")),
+            fs.remove_dir(path!("/foo")).await,
             Err(FsError::DirectoryNotEmpty),
             "removing a directory that has children",
         );
 
         assert_eq!(
-            fs.remove_dir(path!("/foo/bar")),
+            fs.remove_dir(path!("/foo/bar")).await,
             Ok(()),
             "removing a sub-directory",
         );
 
-        assert_eq!(fs.remove_dir(path!("/foo")), Ok(()), "removing a directory");
+        assert_eq!(fs.remove_dir(path!("/foo")).await, Ok(()), "removing a directory");
 
         {
             let fs_inner = fs.inner.read().unwrap();
@@ -1420,7 +1449,7 @@ mod test_filesystem {
         let fs = FileSystem::default();
 
         let fs2 = FileSystem::default();
-        fs2.create_dir(path!("/boz")).unwrap();
+        fs2.create_dir(path!("/boz")).await.unwrap();
         let arc_fs2: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(fs2);
 
         assert_eq!(
@@ -1434,8 +1463,8 @@ mod test_filesystem {
             "renaming to a directory that has no parent",
         );
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()));
-        assert_eq!(fs.create_dir(path!("/foo/qux")), Ok(()));
+        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()));
+        assert_eq!(fs.create_dir(path!("/foo/qux")).await, Ok(()));
 
         assert_eq!(
             fs.rename(path!("/foo"), path!("/bar/baz")).await,
@@ -1443,13 +1472,14 @@ mod test_filesystem {
             "renaming to a directory that has parent that doesn't exist",
         );
 
-        assert_eq!(fs.create_dir(path!("/bar")), Ok(()));
+        assert_eq!(fs.create_dir(path!("/bar")).await, Ok(()));
 
         assert!(
             fs.new_open_options()
                 .write(true)
                 .create_new(true)
                 .open(path!("/bar/hello1.txt"))
+                .await
                 .is_ok(),
             "creating a new file (`hello1.txt`)",
         );
@@ -1458,6 +1488,7 @@ mod test_filesystem {
                 .write(true)
                 .create_new(true)
                 .open(path!("/bar/hello2.txt"))
+                .await
                 .is_ok(),
             "creating a new file (`hello2.txt`)",
         );
@@ -1561,7 +1592,7 @@ mod test_filesystem {
         );
 
         assert!(
-            arc_fs2.read_dir(path!("/cat")).is_ok(),
+            arc_fs2.read_dir(path!("/cat")).await.is_ok(),
             "The directory was renamed in the inner FS"
         );
 
@@ -1661,7 +1692,7 @@ mod test_filesystem {
         use std::time::Duration;
 
         let fs = FileSystem::default();
-        let root_metadata = fs.metadata(path!("/"));
+        let root_metadata = fs.metadata(path!("/")).await;
 
         assert!(matches!(
             root_metadata,
@@ -1674,9 +1705,9 @@ mod test_filesystem {
             }) if accessed == created && created == modified && modified > 0
         ));
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()));
+        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()));
 
-        let foo_metadata = fs.metadata(path!("/foo"));
+        let foo_metadata = fs.metadata(path!("/foo")).await;
         assert!(foo_metadata.is_ok());
         let foo_metadata = foo_metadata.unwrap();
 
@@ -1697,7 +1728,7 @@ mod test_filesystem {
 
         assert!(
             matches!(
-                fs.metadata(path!("/bar")),
+                fs.metadata(path!("/bar")).await,
                 Ok(Metadata {
                     ft: FileType { dir: true, .. },
                     accessed,
@@ -1713,7 +1744,7 @@ mod test_filesystem {
         );
         assert!(
             matches!(
-                fs.metadata(path!("/")),
+                fs.metadata(path!("/")).await,
                 Ok(Metadata {
                     ft: FileType { dir: true, .. },
                     accessed,
@@ -1726,7 +1757,7 @@ mod test_filesystem {
                     modified > foo_metadata.modified
             ),
             "the modified time of the parent is updated when file is renamed \n{:?}\n{:?}",
-            fs.metadata(path!("/")),
+            fs.metadata(path!("/")).await,
             foo_metadata,
         );
     }
@@ -1741,6 +1772,7 @@ mod test_filesystem {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
+            .await
             .expect("creating a new file");
         use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
         file.write_all(b"foo").await.expect("write before remove");
@@ -1775,7 +1807,7 @@ mod test_filesystem {
         }
 
         assert_eq!(
-            fs.remove_file(path!("/foo.txt")),
+            fs.remove_file(path!("/foo.txt")).await,
             Ok(()),
             "removing a file that exists",
         );
@@ -1804,7 +1836,10 @@ mod test_filesystem {
 
         assert!(
             matches!(
-                fs.new_open_options().read(true).open(path!("/foo.txt")),
+                fs.new_open_options()
+                    .read(true)
+                    .open(path!("/foo.txt"))
+                    .await,
                 Err(FsError::EntryNotFound)
             ),
             "the removed path can no longer be reopened",
@@ -1832,7 +1867,7 @@ mod test_filesystem {
         );
 
         assert_eq!(
-            fs.remove_file(path!("/foo.txt")),
+            fs.remove_file(path!("/foo.txt")).await,
             Err(FsError::EntryNotFound),
             "removing a file that exists",
         );
@@ -1842,15 +1877,16 @@ mod test_filesystem {
     async fn test_readdir() {
         let fs = FileSystem::default();
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating `foo`");
-        assert_eq!(fs.create_dir(path!("/foo/sub")), Ok(()), "creating `sub`");
-        assert_eq!(fs.create_dir(path!("/bar")), Ok(()), "creating `bar`");
-        assert_eq!(fs.create_dir(path!("/baz")), Ok(()), "creating `bar`");
+        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating `foo`");
+        assert_eq!(fs.create_dir(path!("/foo/sub")).await, Ok(()), "creating `sub`");
+        assert_eq!(fs.create_dir(path!("/bar")).await, Ok(()), "creating `bar`");
+        assert_eq!(fs.create_dir(path!("/baz")).await, Ok(()), "creating `bar`");
         assert!(
             fs.new_open_options()
                 .write(true)
                 .create_new(true)
                 .open(path!("/a.txt"))
+                .await
                 .is_ok(),
             "creating `a.txt`",
         );
@@ -1859,11 +1895,12 @@ mod test_filesystem {
                 .write(true)
                 .create_new(true)
                 .open(path!("/b.txt"))
+                .await
                 .is_ok(),
             "creating `b.txt`",
         );
 
-        let readdir = fs.read_dir(path!("/"));
+        let readdir = fs.read_dir(path!("/")).await;
 
         assert!(readdir.is_ok(), "reading the directory `/`");
 
@@ -1931,15 +1968,15 @@ mod test_filesystem {
     async fn test_canonicalize() {
         let fs = FileSystem::default();
 
-        assert_eq!(fs.create_dir(path!("/foo")), Ok(()), "creating `foo`");
-        assert_eq!(fs.create_dir(path!("/foo/bar")), Ok(()), "creating `bar`");
+        assert_eq!(fs.create_dir(path!("/foo")).await, Ok(()), "creating `foo`");
+        assert_eq!(fs.create_dir(path!("/foo/bar")).await, Ok(()), "creating `bar`");
         assert_eq!(
-            fs.create_dir(path!("/foo/bar/baz")),
+            fs.create_dir(path!("/foo/bar/baz")).await,
             Ok(()),
             "creating `baz`",
         );
         assert_eq!(
-            fs.create_dir(path!("/foo/bar/baz/qux")),
+            fs.create_dir(path!("/foo/bar/baz/qux")).await,
             Ok(()),
             "creating `qux`",
         );
@@ -1948,6 +1985,7 @@ mod test_filesystem {
                 .write(true)
                 .create_new(true)
                 .open(path!("/foo/bar/baz/qux/hello.txt"))
+                .await
                 .is_ok(),
             "creating `hello.txt`",
         );
@@ -2025,9 +2063,9 @@ mod test_filesystem {
     #[ignore = "Not yet supported. See https://github.com/wasmerio/wasmer/issues/3678"]
     async fn mount_to_overlapping_directories() {
         let top_level = FileSystem::default();
-        ops::touch(&top_level, "/file.txt").unwrap();
+        ops::touch(&top_level, "/file.txt").await.unwrap();
         let nested = FileSystem::default();
-        ops::touch(&nested, "/another-file.txt").unwrap();
+        ops::touch(&nested, "/another-file.txt").await.unwrap();
         let top_level: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(top_level);
         let nested: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(nested);
 
@@ -2037,16 +2075,16 @@ mod test_filesystem {
         fs.mount("/top-level/nested".into(), &nested, "/".into())
             .unwrap();
 
-        assert!(ops::is_dir(&fs, "/top-level"));
-        assert!(ops::is_file(&fs, "/top-level/file.txt"));
-        assert!(ops::is_dir(&fs, "/top-level/nested"));
-        assert!(ops::is_file(&fs, "/top-level/nested/another-file.txt"));
+        assert!(ops::is_dir(&fs, "/top-level").await);
+        assert!(ops::is_file(&fs, "/top-level/file.txt").await);
+        assert!(ops::is_dir(&fs, "/top-level/nested").await);
+        assert!(ops::is_file(&fs, "/top-level/nested/another-file.txt").await);
     }
 
     #[tokio::test]
     async fn read_dir_rebases_mount_paths() {
         let mounted = FileSystem::default();
-        ops::touch(&mounted, "/file.txt").unwrap();
+        ops::touch(&mounted, "/file.txt").await.unwrap();
         let mounted: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(mounted);
 
         let fs = FileSystem::default();
@@ -2054,6 +2092,7 @@ mod test_filesystem {
 
         let entries: Vec<_> = fs
             .read_dir(Path::new("/mnt"))
+            .await
             .unwrap()
             .map(|e| e.unwrap().path)
             .collect();
@@ -2066,7 +2105,7 @@ mod test_filesystem {
         let main = FileSystem::default();
 
         let other = FileSystem::default();
-        crate::ops::create_dir_all(&other, "/a/x").unwrap();
+        crate::ops::create_dir_all(&other, "/a/x").await.unwrap();
         other
             .insert_ro_file(Path::new("/a/x/a.txt"), OwnedBuffer::from_static(b"a"))
             .unwrap();
@@ -2077,7 +2116,7 @@ mod test_filesystem {
             .insert_ro_file(Path::new("/a/x/c.txt"), OwnedBuffer::from_static(b"c"))
             .unwrap();
 
-        let out = other.read_dir(Path::new("/")).unwrap();
+        let out = other.read_dir(Path::new("/")).await.unwrap();
         dbg!(&out);
 
         let other: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(other);
@@ -2091,6 +2130,7 @@ mod test_filesystem {
             .new_open_options()
             .read(true)
             .open(Path::new("/x/a.txt"))
+            .await
             .unwrap();
         f.read_to_end(&mut buf).await.unwrap();
 

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -328,26 +328,27 @@ impl FileSystem {
 #[async_trait::async_trait]
 impl crate::FileSystem for FileSystem {
     async fn readlink(&self, path: &Path) -> Result<PathBuf> {
-        // Read lock.
-        let guard = self.inner.read().map_err(|_| FsError::Lock)?;
+        let redirected = {
+            // Read lock.
+            let guard = self.inner.read().map_err(|_| FsError::Lock)?;
 
-        // Canonicalize the path.
-        let (_, inode_of_directory) = guard.canonicalize(path)?;
-        match inode_of_directory {
-            InodeResolution::Found(inode) => match guard.storage.get(inode) {
-                Some(Node::Symlink(SymlinkNode { target, .. })) => Ok(target.clone()),
-                _ => Err(FsError::InvalidInput),
-            },
-            InodeResolution::Redirect(fs, path) => {
-                futures::executor::block_on(fs.readlink(path.as_path()))
+            // Canonicalize the path.
+            let (_, inode_of_directory) = guard.canonicalize(path)?;
+            match inode_of_directory {
+                InodeResolution::Found(inode) => {
+                    return match guard.storage.get(inode) {
+                        Some(Node::Symlink(SymlinkNode { target, .. })) => Ok(target.clone()),
+                        _ => Err(FsError::InvalidInput),
+                    };
+                }
+                InodeResolution::Redirect(fs, path) => (fs, path),
             }
-        }
+        };
+
+        redirected.0.readlink(redirected.1.as_path()).await
     }
 
     async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
-        // Read lock.
-        let guard = self.inner.read().map_err(|_| FsError::Lock)?;
-
         fn rebase_entries(entries: &mut ReadDir, base: &Path) {
             for entry in &mut entries.data {
                 let name = entry.file_name();
@@ -355,44 +356,102 @@ impl crate::FileSystem for FileSystem {
             }
         }
 
-        // Canonicalize the path.
-        let (guest_path, inode_of_directory) = guard.canonicalize(path)?;
-        let inode_of_directory = match inode_of_directory {
-            InodeResolution::Found(a) => a,
-            InodeResolution::Redirect(fs, redirect_path) => {
-                let mut entries =
-                    futures::executor::block_on(fs.read_dir(redirect_path.as_path()))?;
-                rebase_entries(&mut entries, &guest_path);
-                return Ok(entries);
+        enum ReadDirTarget {
+            Local {
+                guest_path: PathBuf,
+                inode: Inode,
+            },
+            Redirect {
+                fs: Arc<dyn crate::FileSystem + Send + Sync>,
+                source_path: PathBuf,
+                guest_path: PathBuf,
+            },
+        }
+
+        enum ReadDirResolved {
+            Ready(Vec<DirEntry>),
+            Redirect {
+                fs: Arc<dyn crate::FileSystem + Send + Sync>,
+                source_path: PathBuf,
+                guest_path: PathBuf,
+            },
+        }
+
+        let resolved = {
+            // Read lock.
+            let guard = self.inner.read().map_err(|_| FsError::Lock)?;
+
+            // Canonicalize the path.
+            let (guest_path, inode_of_directory) = guard.canonicalize(path)?;
+            let target = match inode_of_directory {
+                InodeResolution::Found(inode) => ReadDirTarget::Local { guest_path, inode },
+                InodeResolution::Redirect(fs, source_path) => ReadDirTarget::Redirect {
+                    fs,
+                    source_path,
+                    guest_path,
+                },
+            };
+
+            // Check it's a directory and fetch the immediate children as `DirEntry`.
+            match target {
+                ReadDirTarget::Local {
+                    guest_path,
+                    inode: inode_of_directory,
+                } => {
+                    let inode = guard.storage.get(inode_of_directory);
+                    match inode {
+                        Some(Node::Directory(DirectoryNode { children, .. })) => {
+                            ReadDirResolved::Ready(
+                                children
+                                    .iter()
+                                    .filter_map(|inode| guard.storage.get(*inode))
+                                    .map(|node| DirEntry {
+                                        path: {
+                                            let mut entry_path = path.to_path_buf();
+                                            entry_path.push(node.name());
+
+                                            entry_path
+                                        },
+                                        metadata: Ok(node.metadata().clone()),
+                                    })
+                                    .collect(),
+                            )
+                        }
+
+                        Some(Node::ArcDirectory(ArcDirectoryNode {
+                            fs, path: fs_path, ..
+                        })) => ReadDirResolved::Redirect {
+                            fs: fs.clone(),
+                            source_path: fs_path.clone(),
+                            guest_path,
+                        },
+
+                        _ => return Err(FsError::InvalidInput),
+                    }
+                }
+                ReadDirTarget::Redirect {
+                    fs,
+                    source_path,
+                    guest_path,
+                } => ReadDirResolved::Redirect {
+                    fs,
+                    source_path,
+                    guest_path,
+                },
             }
         };
 
-        // Check it's a directory and fetch the immediate children as `DirEntry`.
-        let inode = guard.storage.get(inode_of_directory);
-        let children = match inode {
-            Some(Node::Directory(DirectoryNode { children, .. })) => children
-                .iter()
-                .filter_map(|inode| guard.storage.get(*inode))
-                .map(|node| DirEntry {
-                    path: {
-                        let mut entry_path = path.to_path_buf();
-                        entry_path.push(node.name());
-
-                        entry_path
-                    },
-                    metadata: Ok(node.metadata().clone()),
-                })
-                .collect(),
-
-            Some(Node::ArcDirectory(ArcDirectoryNode {
-                fs, path: fs_path, ..
-            })) => {
-                let mut entries = futures::executor::block_on(fs.read_dir(fs_path.as_path()))?;
+        let children = match resolved {
+            ReadDirResolved::Ready(children) => children,
+            ReadDirResolved::Redirect {
+                fs,
+                source_path,
+                guest_path,
+            } => {
+                let mut entries = fs.read_dir(source_path.as_path()).await?;
                 rebase_entries(&mut entries, &guest_path);
                 return Ok(entries);
             }
-
-            _ => return Err(FsError::InvalidInput),
         };
 
         Ok(ReadDir::new(children))

--- a/lib/virtual-fs/src/mem_fs/stdio.rs
+++ b/lib/virtual-fs/src/mem_fs/stdio.rs
@@ -24,28 +24,29 @@ macro_rules! impl_virtualfile_on_std_streams {
         }
 
         #[async_trait::async_trait]
-        impl VirtualFile for $name {
-            fn last_accessed(&self) -> u64 {
+        #[async_trait::async_trait]
+impl VirtualFile for $name {
+            async fn last_accessed(&self) -> u64 {
                 0
             }
 
-            fn last_modified(&self) -> u64 {
+            async fn last_modified(&self) -> u64 {
                 0
             }
 
-            fn created_time(&self) -> u64 {
+            async fn created_time(&self) -> u64 {
                 0
             }
 
-            fn size(&self) -> u64 {
+            async fn size(&self) -> u64 {
                 0
             }
 
-            fn set_len(& mut self, _new_size: u64) -> Result<()> {
+            async fn set_len(& mut self, _new_size: u64) -> Result<()> {
                 Err(FsError::PermissionDenied)
             }
 
-            fn unlink(&mut self) -> Result<()> {
+            async fn unlink(&mut self) -> Result<()> {
                 Ok(())
             }
 

--- a/lib/virtual-fs/src/mem_fs/stdio.rs
+++ b/lib/virtual-fs/src/mem_fs/stdio.rs
@@ -24,8 +24,7 @@ macro_rules! impl_virtualfile_on_std_streams {
         }
 
         #[async_trait::async_trait]
-        #[async_trait::async_trait]
-impl VirtualFile for $name {
+        impl VirtualFile for $name {
             async fn last_accessed(&self) -> u64 {
                 0
             }

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -267,7 +267,7 @@ impl MountFileSystem {
         }
 
         for (child_name, child) in &node.children {
-            let child_path = path.join(child_name);
+            let child_path = Self::append_guest_components(path, &[child_name.clone()]);
             Self::collect_mount_entries(child, &child_path, entries);
         }
     }

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -185,11 +185,7 @@ impl MountFileSystem {
     }
 
     fn absolute_path(components: &[OsString]) -> PathBuf {
-        let mut path = PathBuf::from("/");
-        for component in components {
-            path.push(component);
-        }
-        path
+        Self::guest_path_from_components(components)
     }
 
     fn normal_components(path: &Path) -> Vec<OsString> {
@@ -202,17 +198,19 @@ impl MountFileSystem {
     }
 
     fn guest_path_from_components(components: &[OsString]) -> PathBuf {
-        let mut path = PathBuf::from("/");
-        for component in components {
-            path.push(component);
-        }
-        path
+        let mut path = String::from("/");
+        path.push_str(
+            &components
+                .iter()
+                .map(|component| component.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/"),
+        );
+        PathBuf::from(path)
     }
 
     fn normalize_source_path(path: &Path) -> PathBuf {
-        let mut normalized = PathBuf::from("/");
-        normalized.push(path.strip_prefix("/").unwrap_or(path));
-        normalized
+        Self::guest_path_from_components(&Self::normal_components(path))
     }
 
     fn now_nanos() -> u64 {
@@ -1726,6 +1724,40 @@ mod tests {
             read_dir_names(&fs, "/runtime").await,
             vec!["lib.py".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn test_mount_with_relative_source_path_exposes_subtree() {
+        let fs = MountFileSystem::new();
+
+        let source = mem_fs::FileSystem::default();
+        source.create_dir(Path::new("/python")).await.unwrap();
+        source
+            .new_open_options()
+            .write(true)
+            .create_new(true)
+            .open(Path::new("/python/lib.py"))
+            .await
+            .unwrap();
+
+        fs.mount_with_source(Path::new("/runtime"), Path::new("python"), Arc::new(source))
+            .unwrap();
+
+        assert!(
+            fs.metadata(Path::new("/runtime/lib.py"))
+                .await
+                .unwrap()
+                .is_file()
+        );
+
+        let entries: Vec<PathBuf> = fs
+            .read_dir(Path::new("/runtime"))
+            .await
+            .unwrap()
+            .map(|entry| entry.unwrap().path)
+            .collect();
+
+        assert_eq!(entries, vec![PathBuf::from("/runtime/lib.py")]);
     }
 
     #[tokio::test]

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -1141,6 +1141,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_host_backed_nested_read_dir_with_root_mount() {
+        let root = tempfile::tempdir().unwrap();
+        let a_dir = root.path().join("a");
+        let b_dir = root.path().join("b");
+        std::fs::create_dir_all(&a_dir).unwrap();
+        std::fs::create_dir_all(&b_dir).unwrap();
+        std::fs::write(a_dir.join("data-a.txt"), b"a").unwrap();
+        std::fs::write(b_dir.join("data-b.txt"), b"b").unwrap();
+
+        let fs = MountFileSystem::new();
+        fs.mount(
+            Path::new("/app/a"),
+            Arc::new(
+                crate::host_fs::FileSystem::new(tokio::runtime::Handle::current(), &a_dir).unwrap(),
+            ),
+        )
+        .unwrap();
+        fs.mount(
+            Path::new("/app/b"),
+            Arc::new(
+                crate::host_fs::FileSystem::new(tokio::runtime::Handle::current(), &b_dir).unwrap(),
+            ),
+        )
+        .unwrap();
+
+        let root_fs = crate::RootFileSystemBuilder::default()
+            .default_root_dirs(true)
+            .build_tmp();
+        fs.mount(Path::new("/"), Arc::new(root_fs)).unwrap();
+
+        assert_eq!(
+            read_dir_names(&fs, "/app/a").await,
+            vec!["data-a.txt".to_string()]
+        );
+        assert_eq!(
+            read_dir_names(&fs, "/app/b").await,
+            vec!["data-b.txt".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn test_nested_metadata() {
         let fs = gen_nested_filesystem().await;
 

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -192,6 +192,23 @@ impl MountFileSystem {
         path
     }
 
+    fn normal_components(path: &Path) -> Vec<OsString> {
+        path.components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(part) => Some(part.to_os_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn guest_path_from_components(components: &[OsString]) -> PathBuf {
+        let mut path = PathBuf::from("/");
+        for component in components {
+            path.push(component);
+        }
+        path
+    }
+
     fn normalize_source_path(path: &Path) -> PathBuf {
         let mut normalized = PathBuf::from("/");
         normalized.push(path.strip_prefix("/").unwrap_or(path));
@@ -313,27 +330,20 @@ impl MountFileSystem {
     }
 
     fn rebase_entries(entries: &mut ReadDir, source_prefix: &Path, target_prefix: &Path) {
+        let source_components = Self::normal_components(source_prefix);
+        let target_components = Self::normal_components(target_prefix);
+
         for entry in &mut entries.data {
-            let component_suffix = || {
-                entry
-                    .path
-                    .components()
-                    .filter_map(|component| match component {
-                        std::path::Component::Normal(part) => Some(part),
-                        _ => None,
-                    })
-                    .collect::<PathBuf>()
-            };
-            let suffix = if source_prefix == Path::new("/") {
-                component_suffix()
-            } else {
-                entry
-                    .path
-                    .strip_prefix(source_prefix)
-                    .map(Path::to_path_buf)
-                    .unwrap_or_else(|_| component_suffix())
-            };
-            entry.path = target_prefix.join(suffix);
+            let entry_components = Self::normal_components(&entry.path);
+            let suffix = entry_components
+                .strip_prefix(source_components.as_slice())
+                .unwrap_or(entry_components.as_slice());
+            let rebased_components = target_components
+                .iter()
+                .chain(suffix.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            entry.path = Self::guest_path_from_components(&rebased_components);
         }
     }
 

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -324,21 +324,22 @@ impl MountFileSystem {
         }
     }
 
-    fn read_dir_from_exact_node(&self, node: &ExactNode) -> Result<ReadDir> {
+    async fn read_dir_from_exact_node(&self, node: &ExactNode) -> Result<ReadDir> {
         let mut entries = Vec::new();
 
         let backing = if let Some(fs) = &node.fs {
             Some((
-                fs.read_dir(&node.source_path),
+                fs.read_dir(&node.source_path).await,
                 Cow::Borrowed(node.source_path.as_path()),
             ))
         } else {
-            self.resolve_mount(&node.path).map(|resolved| {
-                (
-                    resolved.fs.read_dir(&resolved.delegated_path),
+            match self.resolve_mount(&node.path) {
+                Some(resolved) => Some((
+                    resolved.fs.read_dir(&resolved.delegated_path).await,
                     Cow::Owned(resolved.delegated_path),
-                )
-            })
+                )),
+                None => None,
+            }
         };
 
         if let Some((base_entries, source_path)) = backing {
@@ -464,8 +465,9 @@ impl MountFileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl FileSystem for MountFileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
         let path = self.prepare_path(path)?;
 
         if path.as_os_str().is_empty() {
@@ -478,22 +480,22 @@ impl FileSystem for MountFileSystem {
             }
 
             match self.resolve_mount(path) {
-                Some(resolved) => resolved.fs.readlink(&resolved.delegated_path),
+                Some(resolved) => resolved.fs.readlink(&resolved.delegated_path).await,
                 None => Err(FsError::EntryNotFound),
             }
         }
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
         let path = self.prepare_path(path)?;
 
         if let Some(node) = self.exact_node(&path) {
-            return self.read_dir_from_exact_node(&node);
+            return self.read_dir_from_exact_node(&node).await;
         }
 
         match self.resolve_mount(path.clone()) {
             Some(resolved) => {
-                let mut entries = resolved.fs.read_dir(&resolved.delegated_path)?;
+                let mut entries = resolved.fs.read_dir(&resolved.delegated_path).await?;
                 Self::rebase_entries(
                     &mut entries,
                     &resolved.delegated_path,
@@ -505,7 +507,7 @@ impl FileSystem for MountFileSystem {
         }
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    async fn create_dir(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 
         if path.as_os_str().is_empty() {
@@ -514,7 +516,7 @@ impl FileSystem for MountFileSystem {
 
         if let Some(node) = self.exact_node(&path) {
             return if let Some(fs) = node.fs {
-                let result = fs.create_dir(Path::new("/"));
+                let result = fs.create_dir(Path::new("/")).await;
 
                 match result {
                     Ok(()) | Err(FsError::AlreadyExists) => Ok(()),
@@ -528,7 +530,7 @@ impl FileSystem for MountFileSystem {
 
         match self.resolve_mount(path) {
             Some(resolved) => {
-                let result = resolved.fs.create_dir(&resolved.delegated_path);
+                let result = resolved.fs.create_dir(&resolved.delegated_path).await;
 
                 if let Err(error) = result
                     && error == FsError::AlreadyExists
@@ -542,7 +544,7 @@ impl FileSystem for MountFileSystem {
         }
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
         let target = self.prepare_path(target)?;
 
         if target.as_os_str().is_empty() {
@@ -554,12 +556,17 @@ impl FileSystem for MountFileSystem {
         }
 
         match self.resolve_mount(target) {
-            Some(resolved) => resolved.fs.create_symlink(source, &resolved.delegated_path),
+            Some(resolved) => {
+                resolved
+                    .fs
+                    .create_symlink(source, &resolved.delegated_path)
+                    .await
+            }
             None => Err(FsError::EntryNotFound),
         }
     }
 
-    fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+    async fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
         let source = self.prepare_path(source)?;
         let target = self.prepare_path(target)?;
 
@@ -584,13 +591,14 @@ impl FileSystem for MountFileSystem {
                 source_mount
                     .fs
                     .hard_link(&source_mount.delegated_path, &target_mount.delegated_path)
+                    .await
             }
             (Some(_), Some(_)) => Err(FsError::Unsupported),
             _ => Err(FsError::EntryNotFound),
         }
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 
         if path.as_os_str().is_empty() {
@@ -606,13 +614,12 @@ impl FileSystem for MountFileSystem {
         }
 
         match self.resolve_mount(path) {
-            Some(resolved) => resolved.fs.remove_dir(&resolved.delegated_path),
+            Some(resolved) => resolved.fs.remove_dir(&resolved.delegated_path).await,
             None => Err(FsError::EntryNotFound),
         }
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async move {
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
             let from = self.prepare_path(from)?;
             let to = self.prepare_path(to)?;
 
@@ -652,21 +659,23 @@ impl FileSystem for MountFileSystem {
                 }
                 _ => Err(FsError::EntryNotFound),
             }
-        })
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
         let path = self.prepare_path(path)?;
 
         if let Some(node) = self.exact_node(&path) {
             return if let Some(fs) = node.fs {
-                fs.metadata(&node.source_path).or_else(|error| {
+                match fs.metadata(&node.source_path).await {
+                    Ok(metadata) => Ok(metadata),
+                    Err(error) => {
                     if Self::should_fallback_to_synthetic_dir(&error) {
                         Ok(Self::directory_metadata_at(node.created_at))
                     } else {
                         Err(error)
                     }
-                })
+                    }
+                }
             } else if node.has_children() {
                 Ok(Self::directory_metadata_at(node.created_at))
             } else {
@@ -675,23 +684,26 @@ impl FileSystem for MountFileSystem {
         }
 
         match self.resolve_mount(path) {
-            Some(resolved) => resolved.fs.metadata(&resolved.delegated_path),
+            Some(resolved) => resolved.fs.metadata(&resolved.delegated_path).await,
             None => Err(FsError::EntryNotFound),
         }
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
         let path = self.prepare_path(path)?;
 
         if let Some(node) = self.exact_node(&path) {
             return if let Some(fs) = node.fs {
-                fs.symlink_metadata(&node.source_path).or_else(|error| {
+                match fs.symlink_metadata(&node.source_path).await {
+                    Ok(metadata) => Ok(metadata),
+                    Err(error) => {
                     if Self::should_fallback_to_synthetic_dir(&error) {
                         Ok(Self::directory_metadata_at(node.created_at))
                     } else {
                         Err(error)
                     }
-                })
+                    }
+                }
             } else if node.has_children() {
                 Ok(Self::directory_metadata_at(node.created_at))
             } else {
@@ -700,12 +712,12 @@ impl FileSystem for MountFileSystem {
         }
 
         match self.resolve_mount(path) {
-            Some(resolved) => resolved.fs.symlink_metadata(&resolved.delegated_path),
+            Some(resolved) => resolved.fs.symlink_metadata(&resolved.delegated_path).await,
             None => Err(FsError::EntryNotFound),
         }
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
+    async fn remove_file(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 
         if path.as_os_str().is_empty() {
@@ -721,7 +733,7 @@ impl FileSystem for MountFileSystem {
         }
 
         match self.resolve_mount(path) {
-            Some(resolved) => resolved.fs.remove_file(&resolved.delegated_path),
+            Some(resolved) => resolved.fs.remove_file(&resolved.delegated_path).await,
             None => Err(FsError::EntryNotFound),
         }
     }
@@ -729,17 +741,8 @@ impl FileSystem for MountFileSystem {
     fn new_open_options(&self) -> OpenOptions<'_> {
         OpenOptions::new(self)
     }
-}
 
-#[derive(Debug)]
-pub struct MountPointRef<'a> {
-    pub path: PathBuf,
-    pub name: String,
-    pub fs: Option<&'a (dyn FileSystem + Send + Sync)>,
-}
-
-impl FileOpener for MountFileSystem {
-    fn open(
+    async fn open(
         &self,
         path: &Path,
         conf: &OpenOptionsConfig,
@@ -759,12 +762,18 @@ impl FileOpener for MountFileSystem {
         match self.resolve_mount(path) {
             Some(resolved) => resolved
                 .fs
-                .new_open_options()
-                .options(conf.clone())
-                .open(resolved.delegated_path),
+                .open(&resolved.delegated_path, conf)
+                .await,
             None => Err(FsError::EntryNotFound),
         }
     }
+}
+
+#[derive(Debug)]
+pub struct MountPointRef<'a> {
+    pub path: PathBuf,
+    pub name: String,
+    pub fs: Option<&'a (dyn FileSystem + Send + Sync)>,
 }
 
 #[cfg(test)]
@@ -779,7 +788,7 @@ mod tests {
 
     use crate::{FileSystem as FileSystemTrait, FsError, MountFileSystem, TmpFileSystem, mem_fs};
 
-    use super::{FileOpener, OpenOptionsConfig};
+    use super::OpenOptionsConfig;
 
     #[derive(Debug, Clone, Default)]
     struct MountlessFileSystem {
@@ -794,50 +803,45 @@ mod tests {
     #[derive(Debug, Clone, Default)]
     struct RootPermissionDeniedFileSystem;
 
+    #[async_trait::async_trait]
     impl FileSystemTrait for MountlessFileSystem {
-        fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
-            self.inner.readlink(path)
+        async fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
+            self.inner.readlink(path).await
         }
 
-        fn read_dir(&self, path: &Path) -> crate::Result<crate::ReadDir> {
-            self.inner.read_dir(path)
+        async fn read_dir(&self, path: &Path) -> crate::Result<crate::ReadDir> {
+            self.inner.read_dir(path).await
         }
 
-        fn create_dir(&self, path: &Path) -> crate::Result<()> {
-            self.inner.create_dir(path)
+        async fn create_dir(&self, path: &Path) -> crate::Result<()> {
+            self.inner.create_dir(path).await
         }
 
-        fn remove_dir(&self, path: &Path) -> crate::Result<()> {
-            self.inner.remove_dir(path)
+        async fn remove_dir(&self, path: &Path) -> crate::Result<()> {
+            self.inner.remove_dir(path).await
         }
 
-        fn rename<'a>(
-            &'a self,
-            from: &'a Path,
-            to: &'a Path,
-        ) -> futures::future::BoxFuture<'a, crate::Result<()>> {
-            Box::pin(async move { self.inner.rename(from, to).await })
+        async fn rename(&self, from: &Path, to: &Path) -> crate::Result<()> {
+            self.inner.rename(from, to).await
         }
 
-        fn metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
-            self.inner.metadata(path)
+        async fn metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
+            self.inner.metadata(path).await
         }
 
-        fn symlink_metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
-            self.inner.symlink_metadata(path)
+        async fn symlink_metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
+            self.inner.symlink_metadata(path).await
         }
 
-        fn remove_file(&self, path: &Path) -> crate::Result<()> {
-            self.inner.remove_file(path)
+        async fn remove_file(&self, path: &Path) -> crate::Result<()> {
+            self.inner.remove_file(path).await
         }
 
         fn new_open_options(&self) -> crate::OpenOptions<'_> {
-            self.inner.new_open_options()
+            crate::OpenOptions::new(self)
         }
-    }
 
-    impl FileOpener for MountlessFileSystem {
-        fn open(
+        async fn open(
             &self,
             path: &Path,
             conf: &OpenOptionsConfig,
@@ -846,65 +850,61 @@ mod tests {
                 .new_open_options()
                 .options(conf.clone())
                 .open(path)
+                .await
         }
     }
 
+    #[async_trait::async_trait]
     impl FileSystemTrait for RootOpaqueFileSystem {
-        fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
-            self.inner.readlink(path)
+        async fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
+            self.inner.readlink(path).await
         }
 
-        fn read_dir(&self, path: &Path) -> crate::Result<crate::ReadDir> {
+        async fn read_dir(&self, path: &Path) -> crate::Result<crate::ReadDir> {
             if path == Path::new("/") {
                 Err(FsError::Unsupported)
             } else {
-                self.inner.read_dir(path)
+                self.inner.read_dir(path).await
             }
         }
 
-        fn create_dir(&self, path: &Path) -> crate::Result<()> {
-            self.inner.create_dir(path)
+        async fn create_dir(&self, path: &Path) -> crate::Result<()> {
+            self.inner.create_dir(path).await
         }
 
-        fn remove_dir(&self, path: &Path) -> crate::Result<()> {
-            self.inner.remove_dir(path)
+        async fn remove_dir(&self, path: &Path) -> crate::Result<()> {
+            self.inner.remove_dir(path).await
         }
 
-        fn rename<'a>(
-            &'a self,
-            from: &'a Path,
-            to: &'a Path,
-        ) -> futures::future::BoxFuture<'a, crate::Result<()>> {
-            Box::pin(async move { self.inner.rename(from, to).await })
+        async fn rename(&self, from: &Path, to: &Path) -> crate::Result<()> {
+            self.inner.rename(from, to).await
         }
 
-        fn metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
+        async fn metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
             if path == Path::new("/") {
                 Err(FsError::Unsupported)
             } else {
-                self.inner.metadata(path)
+                self.inner.metadata(path).await
             }
         }
 
-        fn symlink_metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
+        async fn symlink_metadata(&self, path: &Path) -> crate::Result<crate::Metadata> {
             if path == Path::new("/") {
                 Err(FsError::Unsupported)
             } else {
-                self.inner.symlink_metadata(path)
+                self.inner.symlink_metadata(path).await
             }
         }
 
-        fn remove_file(&self, path: &Path) -> crate::Result<()> {
-            self.inner.remove_file(path)
+        async fn remove_file(&self, path: &Path) -> crate::Result<()> {
+            self.inner.remove_file(path).await
         }
 
         fn new_open_options(&self) -> crate::OpenOptions<'_> {
-            self.inner.new_open_options()
+            crate::OpenOptions::new(self)
         }
-    }
 
-    impl FileOpener for RootOpaqueFileSystem {
-        fn open(
+        async fn open(
             &self,
             path: &Path,
             conf: &OpenOptionsConfig,
@@ -913,53 +913,49 @@ mod tests {
                 .new_open_options()
                 .options(conf.clone())
                 .open(path)
+                .await
         }
     }
 
+    #[async_trait::async_trait]
     impl FileSystemTrait for RootPermissionDeniedFileSystem {
-        fn readlink(&self, _path: &Path) -> crate::Result<PathBuf> {
+        async fn readlink(&self, _path: &Path) -> crate::Result<PathBuf> {
             Err(FsError::PermissionDenied)
         }
 
-        fn read_dir(&self, _path: &Path) -> crate::Result<crate::ReadDir> {
+        async fn read_dir(&self, _path: &Path) -> crate::Result<crate::ReadDir> {
             Err(FsError::PermissionDenied)
         }
 
-        fn create_dir(&self, _path: &Path) -> crate::Result<()> {
+        async fn create_dir(&self, _path: &Path) -> crate::Result<()> {
             Err(FsError::PermissionDenied)
         }
 
-        fn remove_dir(&self, _path: &Path) -> crate::Result<()> {
+        async fn remove_dir(&self, _path: &Path) -> crate::Result<()> {
             Err(FsError::PermissionDenied)
         }
 
-        fn rename<'a>(
-            &'a self,
-            _from: &'a Path,
-            _to: &'a Path,
-        ) -> futures::future::BoxFuture<'a, crate::Result<()>> {
-            Box::pin(async { Err(FsError::PermissionDenied) })
-        }
-
-        fn metadata(&self, _path: &Path) -> crate::Result<crate::Metadata> {
+        async fn rename(&self, _from: &Path, _to: &Path) -> crate::Result<()> {
             Err(FsError::PermissionDenied)
         }
 
-        fn symlink_metadata(&self, _path: &Path) -> crate::Result<crate::Metadata> {
+        async fn metadata(&self, _path: &Path) -> crate::Result<crate::Metadata> {
             Err(FsError::PermissionDenied)
         }
 
-        fn remove_file(&self, _path: &Path) -> crate::Result<()> {
+        async fn symlink_metadata(&self, _path: &Path) -> crate::Result<crate::Metadata> {
+            Err(FsError::PermissionDenied)
+        }
+
+        async fn remove_file(&self, _path: &Path) -> crate::Result<()> {
             Err(FsError::PermissionDenied)
         }
 
         fn new_open_options(&self) -> crate::OpenOptions<'_> {
             crate::OpenOptions::new(self)
         }
-    }
 
-    impl FileOpener for RootPermissionDeniedFileSystem {
-        fn open(
+        async fn open(
             &self,
             _path: &Path,
             _conf: &OpenOptionsConfig,
@@ -1007,7 +1003,7 @@ mod tests {
         union
     }
 
-    fn gen_nested_filesystem() -> MountFileSystem {
+    async fn gen_nested_filesystem() -> MountFileSystem {
         let union = MountFileSystem::new();
         let a = mem_fs::FileSystem::default();
         a.open(
@@ -1021,6 +1017,7 @@ mod tests {
                 truncate: false,
             },
         )
+        .await
         .unwrap();
         let b = mem_fs::FileSystem::default();
         b.open(
@@ -1034,6 +1031,7 @@ mod tests {
                 truncate: false,
             },
         )
+        .await
         .unwrap();
 
         union
@@ -1048,10 +1046,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_nested_read_dir() {
-        let fs = gen_nested_filesystem();
+        let fs = gen_nested_filesystem().await;
 
         let root_contents: Vec<PathBuf> = fs
             .read_dir(&PathBuf::from("/"))
+            .await
             .unwrap()
             .map(|e| e.unwrap().path.clone())
             .collect();
@@ -1059,6 +1058,7 @@ mod tests {
 
         let app_contents: HashSet<PathBuf> = fs
             .read_dir(&PathBuf::from("/app"))
+            .await
             .unwrap()
             .map(|e| e.unwrap().path)
             .collect();
@@ -1069,6 +1069,7 @@ mod tests {
 
         let a_contents: Vec<PathBuf> = fs
             .read_dir(&PathBuf::from("/app/a"))
+            .await
             .unwrap()
             .map(|e| e.unwrap().path.clone())
             .collect();
@@ -1076,6 +1077,7 @@ mod tests {
 
         let b_contents: Vec<PathBuf> = fs
             .read_dir(&PathBuf::from("/app/b"))
+            .await
             .unwrap()
             .map(|e| e.unwrap().path)
             .collect();
@@ -1084,30 +1086,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_nested_metadata() {
-        let fs = gen_nested_filesystem();
+        let fs = gen_nested_filesystem().await;
 
-        assert!(fs.metadata(&PathBuf::from("/")).is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app")).is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app/a")).is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app/b")).is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app/a/data-a.txt")).is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app/b/data-b.txt")).is_ok());
+        assert!(fs.metadata(&PathBuf::from("/")).await.is_ok());
+        assert!(fs.metadata(&PathBuf::from("/app")).await.is_ok());
+        assert!(fs.metadata(&PathBuf::from("/app/a")).await.is_ok());
+        assert!(fs.metadata(&PathBuf::from("/app/b")).await.is_ok());
+        assert!(fs.metadata(&PathBuf::from("/app/a/data-a.txt")).await.is_ok());
+        assert!(fs.metadata(&PathBuf::from("/app/b/data-b.txt")).await.is_ok());
     }
 
     #[tokio::test]
     async fn test_nested_symlink_metadata() {
-        let fs = gen_nested_filesystem();
+        let fs = gen_nested_filesystem().await;
 
-        assert!(fs.symlink_metadata(&PathBuf::from("/")).is_ok());
-        assert!(fs.symlink_metadata(&PathBuf::from("/app")).is_ok());
-        assert!(fs.symlink_metadata(&PathBuf::from("/app/a")).is_ok());
-        assert!(fs.symlink_metadata(&PathBuf::from("/app/b")).is_ok());
+        assert!(fs.symlink_metadata(&PathBuf::from("/")).await.is_ok());
+        assert!(fs.symlink_metadata(&PathBuf::from("/app")).await.is_ok());
+        assert!(fs.symlink_metadata(&PathBuf::from("/app/a")).await.is_ok());
+        assert!(fs.symlink_metadata(&PathBuf::from("/app/b")).await.is_ok());
         assert!(
             fs.symlink_metadata(&PathBuf::from("/app/a/data-a.txt"))
+                .await
                 .is_ok()
         );
         assert!(
             fs.symlink_metadata(&PathBuf::from("/app/b/data-b.txt"))
+                .await
                 .is_ok()
         );
     }
@@ -1116,12 +1120,13 @@ mod tests {
     async fn test_import_mounts_preserves_nested_root_mounts() {
         let primary = MountFileSystem::new();
         let openssl = mem_fs::FileSystem::default();
-        openssl.create_dir(Path::new("/certs")).unwrap();
+        openssl.create_dir(Path::new("/certs")).await.unwrap();
         openssl
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/certs/ca.pem"))
+            .await
             .unwrap();
         primary
             .mount(Path::new("/openssl"), Arc::new(openssl))
@@ -1133,16 +1138,18 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/index.php"))
+            .await
             .unwrap();
         injected.mount(Path::new("/app"), Arc::new(app)).unwrap();
 
         let assets = mem_fs::FileSystem::default();
-        assets.create_dir(Path::new("/css")).unwrap();
+        assets.create_dir(Path::new("/css")).await.unwrap();
         assets
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/css/site.css"))
+            .await
             .unwrap();
         injected
             .mount(Path::new("/opt/assets"), Arc::new(assets))
@@ -1155,17 +1162,18 @@ mod tests {
             )
             .unwrap();
 
-        let root_contents = read_dir_names(&primary, "/");
+        let root_contents = read_dir_names(&primary, "/").await;
         assert!(root_contents.contains(&"app".to_string()));
         assert!(root_contents.contains(&"opt".to_string()));
         assert!(root_contents.contains(&"openssl".to_string()));
-        assert!(primary.metadata(Path::new("/app/index.php")).is_ok());
+        assert!(primary.metadata(Path::new("/app/index.php")).await.is_ok());
         assert!(
             primary
                 .metadata(Path::new("/opt/assets/css/site.css"))
+                .await
                 .is_ok()
         );
-        assert!(primary.metadata(Path::new("/openssl/certs/ca.pem")).is_ok());
+        assert!(primary.metadata(Path::new("/openssl/certs/ca.pem")).await.is_ok());
     }
 
     #[tokio::test]
@@ -1173,28 +1181,30 @@ mod tests {
         let fs = MountFileSystem::new();
 
         let top = MountlessFileSystem::default();
-        top.create_dir(Path::new("/bin")).unwrap();
+        top.create_dir(Path::new("/bin")).await.unwrap();
         top.new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/bin/tool"))
+            .await
             .unwrap();
 
         let nested = mem_fs::FileSystem::default();
-        nested.create_dir(Path::new("/css")).unwrap();
+        nested.create_dir(Path::new("/css")).await.unwrap();
         nested
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/css/site.css"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/opt"), Arc::new(top)).unwrap();
         fs.mount(Path::new("/opt/assets"), Arc::new(nested))
             .unwrap();
 
-        assert!(fs.metadata(Path::new("/opt/bin/tool")).is_ok());
-        assert!(fs.metadata(Path::new("/opt/assets/css/site.css")).is_ok());
+        assert!(fs.metadata(Path::new("/opt/bin/tool")).await.is_ok());
+        assert!(fs.metadata(Path::new("/opt/assets/css/site.css")).await.is_ok());
     }
 
     #[tokio::test]
@@ -1202,20 +1212,22 @@ mod tests {
         let fs = MountFileSystem::new();
 
         let top = MountlessFileSystem::default();
-        top.create_dir(Path::new("/bin")).unwrap();
+        top.create_dir(Path::new("/bin")).await.unwrap();
         top.new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/bin/tool"))
+            .await
             .unwrap();
 
         let nested = mem_fs::FileSystem::default();
-        nested.create_dir(Path::new("/css")).unwrap();
+        nested.create_dir(Path::new("/css")).await.unwrap();
         nested
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/css/site.css"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/opt"), Arc::new(top)).unwrap();
@@ -1224,6 +1236,7 @@ mod tests {
 
         assert!(
             fs.metadata(Path::new("/opt/./assets/../assets/css/site.css"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -1235,7 +1248,7 @@ mod tests {
         fs.mount(Path::new("/"), Arc::new(mem_fs::FileSystem::default()))
             .unwrap();
 
-        assert_eq!(fs.metadata(Path::new("../foo")), Err(FsError::InvalidInput));
+        assert_eq!(fs.metadata(Path::new("../foo")).await, Err(FsError::InvalidInput));
     }
 
     #[tokio::test]
@@ -1247,8 +1260,8 @@ mod tests {
         )
         .unwrap();
 
-        let meta1 = fs.metadata(Path::new("/opaque")).unwrap();
-        let sym1 = fs.symlink_metadata(Path::new("/opaque")).unwrap();
+        let meta1 = fs.metadata(Path::new("/opaque")).await.unwrap();
+        let sym1 = fs.symlink_metadata(Path::new("/opaque")).await.unwrap();
         assert!(meta1.is_dir());
         assert!(sym1.is_dir());
 
@@ -1258,12 +1271,12 @@ mod tests {
         assert!(meta1.accessed > 0, "accessed timestamp must be non-zero");
 
         // Repeated calls must return the same stable timestamps (not re-sampled each time).
-        let meta2 = fs.metadata(Path::new("/opaque")).unwrap();
+        let meta2 = fs.metadata(Path::new("/opaque")).await.unwrap();
         assert_eq!(meta1.created, meta2.created, "created must be stable");
         assert_eq!(meta1.modified, meta2.modified, "modified must be stable");
         assert_eq!(meta1.accessed, meta2.accessed, "accessed must be stable");
 
-        assert_eq!(fs.create_dir(Path::new("/opaque")), Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/opaque")).await, Ok(()));
     }
 
     #[tokio::test]
@@ -1280,7 +1293,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(read_dir_names(&fs, "/opaque"), vec!["assets".to_string()]);
+        assert_eq!(read_dir_names(&fs, "/opaque").await, vec!["assets".to_string()]);
     }
 
     #[tokio::test]
@@ -1298,19 +1311,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            fs.metadata(Path::new("/denied")),
+            fs.metadata(Path::new("/denied")).await,
             Err(FsError::PermissionDenied)
         );
         assert_eq!(
-            fs.symlink_metadata(Path::new("/denied")),
+            fs.symlink_metadata(Path::new("/denied")).await,
             Err(FsError::PermissionDenied)
         );
         assert_eq!(
-            fs.read_dir(Path::new("/denied")).map(|_| ()),
+            fs.read_dir(Path::new("/denied")).await.map(|_| ()),
             Err(FsError::PermissionDenied)
         );
         assert_eq!(
-            fs.create_dir(Path::new("/denied")),
+            fs.create_dir(Path::new("/denied")).await,
             Err(FsError::PermissionDenied)
         );
     }
@@ -1324,6 +1337,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/user.txt"))
+            .await
             .unwrap();
         primary
             .mount(Path::new("/python"), Arc::new(user_mount))
@@ -1336,6 +1350,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/pkg.txt"))
+            .await
             .unwrap();
         injected
             .mount(Path::new("/python"), Arc::new(package_mount))
@@ -1347,6 +1362,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/child.txt"))
+            .await
             .unwrap();
         injected
             .mount(Path::new("/python/lib"), Arc::new(package_child))
@@ -1362,15 +1378,18 @@ mod tests {
         assert!(
             primary
                 .metadata(Path::new("/python/user.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
         assert_eq!(
-            primary.metadata(Path::new("/python/pkg.txt")),
+            primary.metadata(Path::new("/python/pkg.txt")).await,
             Err(FsError::EntryNotFound)
         );
         assert_eq!(
-            primary.metadata(Path::new("/python/lib/child.txt")),
+            primary
+                .metadata(Path::new("/python/lib/child.txt"))
+                .await,
             Err(FsError::EntryNotFound)
         );
     }
@@ -1384,6 +1403,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/user.txt"))
+            .await
             .unwrap();
         let user_child = mem_fs::FileSystem::default();
         user_child
@@ -1391,6 +1411,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/user-child.txt"))
+            .await
             .unwrap();
         primary
             .mount(Path::new("/python"), Arc::new(user_mount))
@@ -1406,6 +1427,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/pkg.txt"))
+            .await
             .unwrap();
         let package_child = mem_fs::FileSystem::default();
         package_child
@@ -1413,6 +1435,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/pkg-child.txt"))
+            .await
             .unwrap();
         injected
             .mount(Path::new("/python"), Arc::new(package_mount))
@@ -1429,22 +1452,26 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            primary.metadata(Path::new("/python/user.txt")),
+            primary.metadata(Path::new("/python/user.txt")).await,
             Err(FsError::EntryNotFound)
         );
         assert_eq!(
-            primary.metadata(Path::new("/python/lib/user-child.txt")),
+            primary
+                .metadata(Path::new("/python/lib/user-child.txt"))
+                .await,
             Err(FsError::EntryNotFound)
         );
         assert!(
             primary
                 .metadata(Path::new("/python/pkg.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
         assert!(
             primary
                 .metadata(Path::new("/python/lib/pkg-child.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -1454,22 +1481,23 @@ mod tests {
     async fn test_exact_mountpoints_reject_destructive_mutation() {
         let fs = MountFileSystem::new();
         let mounted = mem_fs::FileSystem::default();
-        mounted.create_dir(Path::new("/dir")).unwrap();
+        mounted.create_dir(Path::new("/dir")).await.unwrap();
         mounted
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/file.txt"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/mounted"), Arc::new(mounted)).unwrap();
 
         assert_eq!(
-            fs.remove_dir(Path::new("/mounted")),
+            fs.remove_dir(Path::new("/mounted")).await,
             Err(FsError::PermissionDenied)
         );
         assert_eq!(
-            fs.remove_file(Path::new("/mounted")),
+            fs.remove_file(Path::new("/mounted")).await,
             Err(FsError::PermissionDenied)
         );
         assert_eq!(
@@ -1488,27 +1516,29 @@ mod tests {
         let fs = MountFileSystem::new();
 
         let top = MountlessFileSystem::default();
-        top.create_dir(Path::new("/bin")).unwrap();
+        top.create_dir(Path::new("/bin")).await.unwrap();
         top.new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/bin/tool"))
+            .await
             .unwrap();
 
         let nested = mem_fs::FileSystem::default();
-        nested.create_dir(Path::new("/css")).unwrap();
+        nested.create_dir(Path::new("/css")).await.unwrap();
         nested
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/css/site.css"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/opt"), Arc::new(top)).unwrap();
         fs.mount(Path::new("/opt/assets"), Arc::new(nested))
             .unwrap();
 
-        let opt_contents = read_dir_names(&fs, "/opt");
+        let opt_contents = read_dir_names(&fs, "/opt").await;
         assert!(opt_contents.contains(&"bin".to_string()));
         assert!(opt_contents.contains(&"assets".to_string()));
     }
@@ -1522,30 +1552,32 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/assets"))
+            .await
             .unwrap();
 
         let nested = mem_fs::FileSystem::default();
-        nested.create_dir(Path::new("/css")).unwrap();
+        nested.create_dir(Path::new("/css")).await.unwrap();
         nested
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/css/site.css"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/opt"), Arc::new(top)).unwrap();
         fs.mount(Path::new("/opt/assets"), Arc::new(nested))
             .unwrap();
 
-        assert!(fs.metadata(Path::new("/opt/assets")).unwrap().is_dir());
+        assert!(fs.metadata(Path::new("/opt/assets")).await.unwrap().is_dir());
         assert_eq!(
-            read_dir_names(&fs, "/opt")
+            read_dir_names(&fs, "/opt").await
                 .into_iter()
                 .filter(|entry| entry == "assets")
                 .count(),
             1,
         );
-        assert!(fs.metadata(Path::new("/opt/assets/css/site.css")).is_ok());
+        assert!(fs.metadata(Path::new("/opt/assets/css/site.css")).await.is_ok());
     }
 
     #[tokio::test]
@@ -1553,12 +1585,13 @@ mod tests {
         let fs = MountFileSystem::new();
 
         let nested = mem_fs::FileSystem::default();
-        nested.create_dir(Path::new("/css")).unwrap();
+        nested.create_dir(Path::new("/css")).await.unwrap();
         nested
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/css/site.css"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/opt/assets"), Arc::new(nested))
@@ -1566,6 +1599,7 @@ mod tests {
 
         let css_contents: Vec<PathBuf> = fs
             .read_dir(Path::new("/opt/assets/css"))
+            .await
             .unwrap()
             .map(|entry| entry.unwrap().path)
             .collect();
@@ -1581,12 +1615,13 @@ mod tests {
         let fs = MountFileSystem::new();
 
         let source = mem_fs::FileSystem::default();
-        source.create_dir(Path::new("/python")).unwrap();
+        source.create_dir(Path::new("/python")).await.unwrap();
         source
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/python/lib.py"))
+            .await
             .unwrap();
 
         fs.mount_with_source(
@@ -1596,8 +1631,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(fs.metadata(Path::new("/runtime/lib.py")).unwrap().is_file());
-        assert_eq!(read_dir_names(&fs, "/runtime"), vec!["lib.py".to_string()]);
+        assert!(fs.metadata(Path::new("/runtime/lib.py")).await.unwrap().is_file());
+        assert_eq!(read_dir_names(&fs, "/runtime").await, vec!["lib.py".to_string()]);
     }
 
     #[tokio::test]
@@ -1605,12 +1640,13 @@ mod tests {
         let fs = MountFileSystem::new();
 
         let python = mem_fs::FileSystem::default();
-        create_dir_all(&python, Path::new("/usr/local/lib/python3.13/encodings"));
+        create_dir_all(&python, Path::new("/usr/local/lib/python3.13/encodings")).await;
         python
             .new_open_options()
             .write(true)
             .create_new(true)
             .open(Path::new("/usr/local/lib/python3.13/encodings/__init__.py"))
+            .await
             .unwrap();
 
         let host = mem_fs::FileSystem::default();
@@ -1618,6 +1654,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/marker.txt"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/"), Arc::new(python)).unwrap();
@@ -1626,11 +1663,13 @@ mod tests {
 
         assert!(
             fs.metadata(Path::new("/usr/local/lib/python3.13/encodings/__init__.py"))
+                .await
                 .unwrap()
                 .is_file()
         );
         assert!(
             fs.metadata(Path::new("/usr/local/lib/python3.13/test/marker.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -1638,13 +1677,15 @@ mod tests {
         fs.new_open_options()
             .read(true)
             .open(Path::new("/usr/local/lib/python3.13/encodings/__init__.py"))
+            .await
             .unwrap();
         fs.new_open_options()
             .read(true)
             .open(Path::new("/usr/local/lib/python3.13/test/marker.txt"))
+            .await
             .unwrap();
 
-        let mut entries = read_dir_names(&fs, "/usr/local/lib/python3.13");
+        let mut entries = read_dir_names(&fs, "/usr/local/lib/python3.13").await;
         entries.sort();
         assert_eq!(entries, vec!["encodings".to_string(), "test".to_string()]);
     }
@@ -1661,10 +1702,11 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/marker.txt"))
+            .await
             .unwrap();
         fs.mount(Path::new("/foo/bar"), Arc::new(child)).unwrap();
 
-        let entries = read_dir_names(&fs, "/foo");
+        let entries = read_dir_names(&fs, "/foo").await;
         assert_eq!(entries, vec!["bar".to_string()]);
     }
 
@@ -1676,6 +1718,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/tool"))
+            .await
             .unwrap();
         primary.mount(Path::new("/opt/bin"), Arc::new(bin)).unwrap();
 
@@ -1686,6 +1729,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/logo.svg"))
+            .await
             .unwrap();
         injected
             .mount(Path::new("/opt/assets"), Arc::new(assets))
@@ -1698,8 +1742,8 @@ mod tests {
             )
             .unwrap();
 
-        assert!(primary.metadata(Path::new("/opt/bin/tool")).is_ok());
-        assert!(primary.metadata(Path::new("/opt/assets/logo.svg")).is_ok());
+        assert!(primary.metadata(Path::new("/opt/bin/tool")).await.is_ok());
+        assert!(primary.metadata(Path::new("/opt/assets/logo.svg")).await.is_ok());
     }
 
     #[tokio::test]
@@ -1733,7 +1777,9 @@ mod tests {
     async fn test_new_filesystem() {
         let fs = gen_filesystem();
         assert!(
-            fs.read_dir(Path::new("/test_new_filesystem")).is_ok(),
+            fs.read_dir(Path::new("/test_new_filesystem"))
+                .await
+                .is_ok(),
             "hostfs can read root"
         );
         let mut file_write = fs
@@ -1742,6 +1788,7 @@ mod tests {
             .write(true)
             .create_new(true)
             .open(Path::new("/test_new_filesystem/foo2.txt"))
+            .await
             .unwrap();
         file_write.write_all(b"hello").await.unwrap();
         let _ = std::fs::remove_file("/test_new_filesystem/foo2.txt");
@@ -1751,17 +1798,17 @@ mod tests {
     async fn test_create_dir() {
         let fs = gen_filesystem();
 
-        assert_eq!(fs.create_dir(Path::new("/")), Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/")).await, Ok(()));
 
-        assert_eq!(fs.create_dir(Path::new("/test_create_dir")), Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/test_create_dir")).await, Ok(()));
 
         assert_eq!(
-            fs.create_dir(Path::new("/test_create_dir/foo")),
+            fs.create_dir(Path::new("/test_create_dir/foo")).await,
             Ok(()),
             "creating a directory",
         );
 
-        let cur_dir = read_dir_names(&fs, "/test_create_dir");
+        let cur_dir = read_dir_names(&fs, "/test_create_dir").await;
 
         if !cur_dir.contains(&"foo".to_string()) {
             panic!("cur_dir does not contain foo: {cur_dir:#?}");
@@ -1773,19 +1820,19 @@ mod tests {
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("/test_create_dir/foo/bar")),
+            fs.create_dir(Path::new("/test_create_dir/foo/bar")).await,
             Ok(()),
             "creating a sub-directory",
         );
 
-        let foo_dir = read_dir_names(&fs, "/test_create_dir/foo");
+        let foo_dir = read_dir_names(&fs, "/test_create_dir/foo").await;
 
         assert!(
             foo_dir.contains(&"bar".to_string()),
             "the foo directory is updated and well-defined"
         );
 
-        let bar_dir = read_dir_names(&fs, "/test_create_dir/foo/bar");
+        let bar_dir = read_dir_names(&fs, "/test_create_dir/foo/bar").await;
 
         assert!(
             bar_dir.is_empty(),
@@ -1799,75 +1846,76 @@ mod tests {
         let fs = gen_filesystem();
 
         assert_eq!(
-            fs.remove_dir(Path::new("/")),
+            fs.remove_dir(Path::new("/")).await,
             Err(FsError::PermissionDenied),
             "cannot remove the root directory",
         );
 
         assert_eq!(
-            fs.remove_dir(Path::new("/foo")),
+            fs.remove_dir(Path::new("/foo")).await,
             Err(FsError::EntryNotFound),
             "cannot remove a directory that doesn't exist",
         );
 
-        assert_eq!(fs.create_dir(Path::new("/test_remove_dir")), Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/test_remove_dir")).await, Ok(()));
 
         assert_eq!(
-            fs.create_dir(Path::new("/test_remove_dir/foo")),
+            fs.create_dir(Path::new("/test_remove_dir/foo")).await,
             Ok(()),
             "creating a directory",
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("/test_remove_dir/foo/bar")),
+            fs.create_dir(Path::new("/test_remove_dir/foo/bar")).await,
             Ok(()),
             "creating a sub-directory",
         );
 
         assert!(
-            read_dir_names(&fs, "/test_remove_dir/foo").contains(&"bar".to_string()),
+            read_dir_names(&fs, "/test_remove_dir/foo").await.contains(&"bar".to_string()),
             "./foo/bar exists"
         );
 
         assert_eq!(
-            fs.remove_dir(Path::new("/test_remove_dir/foo")),
+            fs.remove_dir(Path::new("/test_remove_dir/foo")).await,
             Err(FsError::DirectoryNotEmpty),
             "removing a directory that has children",
         );
 
         assert_eq!(
-            fs.remove_dir(Path::new("/test_remove_dir/foo/bar")),
+            fs.remove_dir(Path::new("/test_remove_dir/foo/bar")).await,
             Ok(()),
             "removing a sub-directory",
         );
 
         assert_eq!(
-            fs.remove_dir(Path::new("/test_remove_dir/foo")),
+            fs.remove_dir(Path::new("/test_remove_dir/foo")).await,
             Ok(()),
             "removing a directory",
         );
 
         assert!(
-            !read_dir_names(&fs, "/test_remove_dir").contains(&"foo".to_string()),
+            !read_dir_names(&fs, "/test_remove_dir").await.contains(&"foo".to_string()),
             "the foo directory still exists"
         );
     }
 
-    fn read_dir_names(fs: &dyn crate::FileSystem, path: &str) -> Vec<String> {
+    async fn read_dir_names(fs: &dyn crate::FileSystem, path: &str) -> Vec<String> {
         fs.read_dir(Path::new(path))
+            .await
             .unwrap()
             .filter_map(|entry| Some(entry.ok()?.file_name().to_str()?.to_string()))
             .collect::<Vec<_>>()
     }
 
-    fn create_dir_all(fs: &mem_fs::FileSystem, path: &Path) {
+    async fn create_dir_all(fs: &mem_fs::FileSystem, path: &Path) {
         let mut current = PathBuf::from("/");
 
         for component in path.iter().skip(1) {
             current.push(component);
 
-            if fs.metadata(&current).is_err() {
-                fs.create_dir(&current).unwrap();
+            if fs.metadata(&current).await.is_err() {
+                fs.create_dir(&current).await.unwrap();
             }
         }
     }
@@ -1887,9 +1935,9 @@ mod tests {
             "renaming to the synthetic root directory is rejected",
         );
 
-        assert_eq!(fs.create_dir(Path::new("/test_rename")), Ok(()));
-        assert_eq!(fs.create_dir(Path::new("/test_rename/foo")), Ok(()));
-        assert_eq!(fs.create_dir(Path::new("/test_rename/foo/qux")), Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/test_rename")).await, Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/test_rename/foo")).await, Ok(()));
+        assert_eq!(fs.create_dir(Path::new("/test_rename/foo/qux")).await, Ok(()));
 
         assert_eq!(
             fs.rename(
@@ -1901,7 +1949,10 @@ mod tests {
             "renaming to a directory that has parent that doesn't exist",
         );
 
-        assert_eq!(fs.create_dir(Path::new("/test_rename/bar")), Ok(()));
+        assert_eq!(
+            fs.create_dir(Path::new("/test_rename/bar")).await,
+            Ok(())
+        );
 
         assert_eq!(
             fs.rename(Path::new("/test_rename/foo"), Path::new("/test_rename/bar"))
@@ -1915,6 +1966,7 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("/test_rename/bar/hello1.txt"))
+                .await
                 .is_ok(),
             "creating a new file (`hello1.txt`)",
         );
@@ -1923,11 +1975,12 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("/test_rename/bar/hello2.txt"))
+                .await
                 .is_ok(),
             "creating a new file (`hello2.txt`)",
         );
 
-        let cur_dir = read_dir_names(&fs, "/test_rename");
+        let cur_dir = read_dir_names(&fs, "/test_rename").await;
 
         assert!(
             !cur_dir.contains(&"foo".to_string()),
@@ -1939,28 +1992,28 @@ mod tests {
             "the bar directory still exists"
         );
 
-        let bar_dir = read_dir_names(&fs, "/test_rename/bar");
+        let bar_dir = read_dir_names(&fs, "/test_rename/bar").await;
 
         if !bar_dir.contains(&"qux".to_string()) {
             println!("qux does not exist: {bar_dir:?}")
         }
 
-        let qux_dir = read_dir_names(&fs, "/test_rename/bar/qux");
+        let qux_dir = read_dir_names(&fs, "/test_rename/bar/qux").await;
 
         assert!(qux_dir.is_empty(), "the qux directory is empty");
 
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").contains(&"hello1.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello1.txt".to_string()),
             "the /bar/hello1.txt file exists"
         );
 
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").contains(&"hello2.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello2.txt".to_string()),
             "the /bar/hello2.txt file exists"
         );
 
         assert_eq!(
-            fs.create_dir(Path::new("/test_rename/foo")),
+            fs.create_dir(Path::new("/test_rename/foo")).await,
             Ok(()),
             "create ./foo again",
         );
@@ -1996,36 +2049,36 @@ mod tests {
         );
 
         assert!(
-            read_dir_names(&fs, "/test_rename").contains(&"bar".to_string()),
+            read_dir_names(&fs, "/test_rename").await.contains(&"bar".to_string()),
             "./bar exists"
         );
 
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").contains(&"baz".to_string()),
+            read_dir_names(&fs, "/test_rename/bar").await.contains(&"baz".to_string()),
             "/bar/baz exists"
         );
         assert!(
-            !read_dir_names(&fs, "/test_rename").contains(&"foo".to_string()),
+            !read_dir_names(&fs, "/test_rename").await.contains(&"foo".to_string()),
             "foo does not exist anymore"
         );
         assert!(
-            read_dir_names(&fs, "/test_rename/bar/baz").contains(&"world2.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar/baz").await.contains(&"world2.txt".to_string()),
             "/bar/baz/world2.txt exists"
         );
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").contains(&"world1.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar").await.contains(&"world1.txt".to_string()),
             "/bar/world1.txt (ex hello1.txt) exists"
         );
         assert!(
-            !read_dir_names(&fs, "/test_rename/bar").contains(&"hello1.txt".to_string()),
+            !read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello1.txt".to_string()),
             "hello1.txt was moved"
         );
         assert!(
-            !read_dir_names(&fs, "/test_rename/bar").contains(&"hello2.txt".to_string()),
+            !read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello2.txt".to_string()),
             "hello2.txt was moved"
         );
         assert!(
-            read_dir_names(&fs, "/test_rename/bar/baz").contains(&"world2.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar/baz").await.contains(&"world2.txt".to_string()),
             "world2.txt was moved to the correct place"
         );
 
@@ -2042,6 +2095,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/from.txt"))
+            .await
             .unwrap();
 
         fs.mount(Path::new("/left"), Arc::new(left.clone()))
@@ -2054,10 +2108,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            left.metadata(Path::new("/from.txt")),
+            left.metadata(Path::new("/from.txt")).await,
             Err(FsError::EntryNotFound)
         );
-        assert!(right.metadata(Path::new("/to.txt")).unwrap().is_file());
+        assert!(right.metadata(Path::new("/to.txt")).await.unwrap().is_file());
     }
 
     #[tokio::test]
@@ -2067,16 +2121,19 @@ mod tests {
 
         let fs = gen_filesystem();
 
-        let root_metadata = fs.metadata(Path::new("/test_metadata")).unwrap();
+        let root_metadata = fs.metadata(Path::new("/test_metadata")).await.unwrap();
 
         assert!(root_metadata.ft.dir);
         assert_eq!(root_metadata.accessed, root_metadata.created);
         assert_eq!(root_metadata.modified, root_metadata.created);
         assert!(root_metadata.modified > 0);
 
-        assert_eq!(fs.create_dir(Path::new("/test_metadata/foo")), Ok(()));
+        assert_eq!(
+            fs.create_dir(Path::new("/test_metadata/foo")).await,
+            Ok(())
+        );
 
-        let foo_metadata = fs.metadata(Path::new("/test_metadata/foo"));
+        let foo_metadata = fs.metadata(Path::new("/test_metadata/foo")).await;
         assert!(foo_metadata.is_ok());
         let foo_metadata = foo_metadata.unwrap();
 
@@ -2096,13 +2153,13 @@ mod tests {
             Ok(())
         );
 
-        let bar_metadata = fs.metadata(Path::new("/test_metadata/bar")).unwrap();
+        let bar_metadata = fs.metadata(Path::new("/test_metadata/bar")).await.unwrap();
         assert!(bar_metadata.ft.dir);
         assert!(bar_metadata.accessed == foo_metadata.accessed);
         assert!(bar_metadata.created == foo_metadata.created);
         assert!(bar_metadata.modified > foo_metadata.modified);
 
-        let root_metadata = fs.metadata(Path::new("/test_metadata/bar")).unwrap();
+        let root_metadata = fs.metadata(Path::new("/test_metadata/bar")).await.unwrap();
         assert!(
             root_metadata.modified > foo_metadata.modified,
             "the parent modified time was updated"
@@ -2120,22 +2177,23 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("/test_remove_file/foo.txt"))
+                .await
                 .is_ok(),
             "creating a new file",
         );
 
-        assert!(read_dir_names(&fs, "/test_remove_file").contains(&"foo.txt".to_string()));
+        assert!(read_dir_names(&fs, "/test_remove_file").await.contains(&"foo.txt".to_string()));
 
         assert_eq!(
-            fs.remove_file(Path::new("/test_remove_file/foo.txt")),
+            fs.remove_file(Path::new("/test_remove_file/foo.txt")).await,
             Ok(()),
             "removing a file that exists",
         );
 
-        assert!(!read_dir_names(&fs, "/test_remove_file").contains(&"foo.txt".to_string()));
+        assert!(!read_dir_names(&fs, "/test_remove_file").await.contains(&"foo.txt".to_string()));
 
         assert_eq!(
-            fs.remove_file(Path::new("/test_remove_file/foo.txt")),
+            fs.remove_file(Path::new("/test_remove_file/foo.txt")).await,
             Err(FsError::EntryNotFound),
             "removing a file that doesn't exists",
         );
@@ -2148,22 +2206,22 @@ mod tests {
         let fs = gen_filesystem();
 
         assert_eq!(
-            fs.create_dir(Path::new("/test_readdir/foo")),
+            fs.create_dir(Path::new("/test_readdir/foo")).await,
             Ok(()),
             "creating `foo`"
         );
         assert_eq!(
-            fs.create_dir(Path::new("/test_readdir/foo/sub")),
+            fs.create_dir(Path::new("/test_readdir/foo/sub")).await,
             Ok(()),
             "creating `sub`"
         );
         assert_eq!(
-            fs.create_dir(Path::new("/test_readdir/bar")),
+            fs.create_dir(Path::new("/test_readdir/bar")).await,
             Ok(()),
             "creating `bar`"
         );
         assert_eq!(
-            fs.create_dir(Path::new("/test_readdir/baz")),
+            fs.create_dir(Path::new("/test_readdir/baz")).await,
             Ok(()),
             "creating `bar`"
         );
@@ -2172,6 +2230,7 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("/test_readdir/a.txt"))
+                .await
                 .is_ok(),
             "creating `a.txt`",
         );
@@ -2180,13 +2239,14 @@ mod tests {
                 .write(true)
                 .create_new(true)
                 .open(Path::new("/test_readdir/b.txt"))
+                .await
                 .is_ok(),
             "creating `b.txt`",
         );
 
         println!("fs: {fs:?}");
 
-        let readdir = fs.read_dir(Path::new("/test_readdir"));
+        let readdir = fs.read_dir(Path::new("/test_readdir")).await;
 
         assert!(readdir.is_ok(), "reading the directory `/test_readdir/`");
 

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -209,6 +209,14 @@ impl MountFileSystem {
         PathBuf::from(path)
     }
 
+    fn append_guest_components(prefix: &Path, suffix: &[OsString]) -> PathBuf {
+        let components = Self::normal_components(prefix)
+            .into_iter()
+            .chain(suffix.iter().cloned())
+            .collect::<Vec<_>>();
+        Self::guest_path_from_components(&components)
+    }
+
     fn normalize_source_path(path: &Path) -> PathBuf {
         Self::guest_path_from_components(&Self::normal_components(path))
     }
@@ -238,8 +246,9 @@ impl MountFileSystem {
     }
 
     fn synthetic_entry(name: OsString, base: &Path, ts: u64) -> DirEntry {
+        let path = Self::append_guest_components(base, &[name]);
         DirEntry {
-            path: base.join(PathBuf::from(name)),
+            path,
             metadata: Ok(Self::directory_metadata_at(ts)),
         }
     }
@@ -274,7 +283,7 @@ impl MountFileSystem {
     fn exact_node(&self, path: &Path) -> Option<ExactNode> {
         let path = self.prepare_path(path).ok()?;
         let components = Self::path_components(&path);
-        let visible_path = Path::new("/").join(&path);
+        let visible_path = Self::guest_path_from_components(&components);
         let root = self.root.read().unwrap();
         let node = Self::find_node(&root, &components)?;
         let mounted = Self::mounted(node);
@@ -297,11 +306,7 @@ impl MountFileSystem {
         let mut node = &*root;
         let mut best = Self::mounted(node).map(|mount| ResolvedMount {
             mount_path: PathBuf::from("/"),
-            delegated_path: mount.source_path.join(
-                Self::absolute_path(&components)
-                    .strip_prefix("/")
-                    .unwrap_or(Path::new("")),
-            ),
+            delegated_path: Self::append_guest_components(&mount.source_path, &components),
             fs: mount.fs,
         });
 
@@ -314,10 +319,9 @@ impl MountFileSystem {
             if let Some(mount) = Self::mounted(node) {
                 best = Some(ResolvedMount {
                     mount_path: Self::absolute_path(&components[..=index]),
-                    delegated_path: mount.source_path.join(
-                        Self::absolute_path(&components[index + 1..])
-                            .strip_prefix("/")
-                            .unwrap_or(Path::new("")),
+                    delegated_path: Self::append_guest_components(
+                        &mount.source_path,
+                        &components[index + 1..],
                     ),
                     fs: mount.fs,
                 });
@@ -520,7 +524,7 @@ impl FileSystem for MountFileSystem {
                 Self::rebase_entries(
                     &mut entries,
                     &resolved.delegated_path,
-                    &Path::new("/").join(&path),
+                    &Self::guest_path_from_components(&Self::path_components(&path)),
                 );
                 Ok(entries)
             }

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -620,45 +620,43 @@ impl FileSystem for MountFileSystem {
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
-            let from = self.prepare_path(from)?;
-            let to = self.prepare_path(to)?;
+        let from = self.prepare_path(from)?;
+        let to = self.prepare_path(to)?;
 
-            if from.as_os_str().is_empty() {
-                return Err(FsError::PermissionDenied);
-            }
+        if from.as_os_str().is_empty() {
+            return Err(FsError::PermissionDenied);
+        }
 
-            if let Some(node) = self.exact_node(&from)
-                && (node.fs.is_some() || node.has_children())
-            {
-                return Err(FsError::PermissionDenied);
-            }
+        if let Some(node) = self.exact_node(&from)
+            && (node.fs.is_some() || node.has_children())
+        {
+            return Err(FsError::PermissionDenied);
+        }
 
-            if let Some(node) = self.exact_node(&to)
-                && (node.fs.is_some() || node.has_children())
-            {
-                return Err(FsError::PermissionDenied);
-            }
+        if let Some(node) = self.exact_node(&to)
+            && (node.fs.is_some() || node.has_children())
+        {
+            return Err(FsError::PermissionDenied);
+        }
 
-            match (self.resolve_mount(from), self.resolve_mount(to)) {
-                (Some(from_mount), Some(to_mount))
-                    if from_mount.mount_path == to_mount.mount_path =>
-                {
-                    from_mount
-                        .fs
-                        .rename(&from_mount.delegated_path, &to_mount.delegated_path)
-                        .await
-                }
-                (Some(from_mount), Some(to_mount)) => {
-                    ops::move_across_filesystems(
-                        from_mount.fs.as_ref(),
-                        to_mount.fs.as_ref(),
-                        &from_mount.delegated_path,
-                        &to_mount.delegated_path,
-                    )
+        match (self.resolve_mount(from), self.resolve_mount(to)) {
+            (Some(from_mount), Some(to_mount)) if from_mount.mount_path == to_mount.mount_path => {
+                from_mount
+                    .fs
+                    .rename(&from_mount.delegated_path, &to_mount.delegated_path)
                     .await
-                }
-                _ => Err(FsError::EntryNotFound),
             }
+            (Some(from_mount), Some(to_mount)) => {
+                ops::move_across_filesystems(
+                    from_mount.fs.as_ref(),
+                    to_mount.fs.as_ref(),
+                    &from_mount.delegated_path,
+                    &to_mount.delegated_path,
+                )
+                .await
+            }
+            _ => Err(FsError::EntryNotFound),
+        }
     }
 
     async fn metadata(&self, path: &Path) -> Result<Metadata> {
@@ -669,11 +667,11 @@ impl FileSystem for MountFileSystem {
                 match fs.metadata(&node.source_path).await {
                     Ok(metadata) => Ok(metadata),
                     Err(error) => {
-                    if Self::should_fallback_to_synthetic_dir(&error) {
-                        Ok(Self::directory_metadata_at(node.created_at))
-                    } else {
-                        Err(error)
-                    }
+                        if Self::should_fallback_to_synthetic_dir(&error) {
+                            Ok(Self::directory_metadata_at(node.created_at))
+                        } else {
+                            Err(error)
+                        }
                     }
                 }
             } else if node.has_children() {
@@ -697,11 +695,11 @@ impl FileSystem for MountFileSystem {
                 match fs.symlink_metadata(&node.source_path).await {
                     Ok(metadata) => Ok(metadata),
                     Err(error) => {
-                    if Self::should_fallback_to_synthetic_dir(&error) {
-                        Ok(Self::directory_metadata_at(node.created_at))
-                    } else {
-                        Err(error)
-                    }
+                        if Self::should_fallback_to_synthetic_dir(&error) {
+                            Ok(Self::directory_metadata_at(node.created_at))
+                        } else {
+                            Err(error)
+                        }
                     }
                 }
             } else if node.has_children() {
@@ -760,10 +758,7 @@ impl FileSystem for MountFileSystem {
         }
 
         match self.resolve_mount(path) {
-            Some(resolved) => resolved
-                .fs
-                .open(&resolved.delegated_path, conf)
-                .await,
+            Some(resolved) => resolved.fs.open(&resolved.delegated_path, conf).await,
             None => Err(FsError::EntryNotFound),
         }
     }
@@ -1092,8 +1087,16 @@ mod tests {
         assert!(fs.metadata(&PathBuf::from("/app")).await.is_ok());
         assert!(fs.metadata(&PathBuf::from("/app/a")).await.is_ok());
         assert!(fs.metadata(&PathBuf::from("/app/b")).await.is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app/a/data-a.txt")).await.is_ok());
-        assert!(fs.metadata(&PathBuf::from("/app/b/data-b.txt")).await.is_ok());
+        assert!(
+            fs.metadata(&PathBuf::from("/app/a/data-a.txt"))
+                .await
+                .is_ok()
+        );
+        assert!(
+            fs.metadata(&PathBuf::from("/app/b/data-b.txt"))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -1173,7 +1176,12 @@ mod tests {
                 .await
                 .is_ok()
         );
-        assert!(primary.metadata(Path::new("/openssl/certs/ca.pem")).await.is_ok());
+        assert!(
+            primary
+                .metadata(Path::new("/openssl/certs/ca.pem"))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -1204,7 +1212,11 @@ mod tests {
             .unwrap();
 
         assert!(fs.metadata(Path::new("/opt/bin/tool")).await.is_ok());
-        assert!(fs.metadata(Path::new("/opt/assets/css/site.css")).await.is_ok());
+        assert!(
+            fs.metadata(Path::new("/opt/assets/css/site.css"))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -1248,7 +1260,10 @@ mod tests {
         fs.mount(Path::new("/"), Arc::new(mem_fs::FileSystem::default()))
             .unwrap();
 
-        assert_eq!(fs.metadata(Path::new("../foo")).await, Err(FsError::InvalidInput));
+        assert_eq!(
+            fs.metadata(Path::new("../foo")).await,
+            Err(FsError::InvalidInput)
+        );
     }
 
     #[tokio::test]
@@ -1293,7 +1308,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(read_dir_names(&fs, "/opaque").await, vec!["assets".to_string()]);
+        assert_eq!(
+            read_dir_names(&fs, "/opaque").await,
+            vec!["assets".to_string()]
+        );
     }
 
     #[tokio::test]
@@ -1387,9 +1405,7 @@ mod tests {
             Err(FsError::EntryNotFound)
         );
         assert_eq!(
-            primary
-                .metadata(Path::new("/python/lib/child.txt"))
-                .await,
+            primary.metadata(Path::new("/python/lib/child.txt")).await,
             Err(FsError::EntryNotFound)
         );
     }
@@ -1569,15 +1585,25 @@ mod tests {
         fs.mount(Path::new("/opt/assets"), Arc::new(nested))
             .unwrap();
 
-        assert!(fs.metadata(Path::new("/opt/assets")).await.unwrap().is_dir());
+        assert!(
+            fs.metadata(Path::new("/opt/assets"))
+                .await
+                .unwrap()
+                .is_dir()
+        );
         assert_eq!(
-            read_dir_names(&fs, "/opt").await
+            read_dir_names(&fs, "/opt")
+                .await
                 .into_iter()
                 .filter(|entry| entry == "assets")
                 .count(),
             1,
         );
-        assert!(fs.metadata(Path::new("/opt/assets/css/site.css")).await.is_ok());
+        assert!(
+            fs.metadata(Path::new("/opt/assets/css/site.css"))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -1631,8 +1657,16 @@ mod tests {
         )
         .unwrap();
 
-        assert!(fs.metadata(Path::new("/runtime/lib.py")).await.unwrap().is_file());
-        assert_eq!(read_dir_names(&fs, "/runtime").await, vec!["lib.py".to_string()]);
+        assert!(
+            fs.metadata(Path::new("/runtime/lib.py"))
+                .await
+                .unwrap()
+                .is_file()
+        );
+        assert_eq!(
+            read_dir_names(&fs, "/runtime").await,
+            vec!["lib.py".to_string()]
+        );
     }
 
     #[tokio::test]
@@ -1743,7 +1777,12 @@ mod tests {
             .unwrap();
 
         assert!(primary.metadata(Path::new("/opt/bin/tool")).await.is_ok());
-        assert!(primary.metadata(Path::new("/opt/assets/logo.svg")).await.is_ok());
+        assert!(
+            primary
+                .metadata(Path::new("/opt/assets/logo.svg"))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -1777,9 +1816,7 @@ mod tests {
     async fn test_new_filesystem() {
         let fs = gen_filesystem();
         assert!(
-            fs.read_dir(Path::new("/test_new_filesystem"))
-                .await
-                .is_ok(),
+            fs.read_dir(Path::new("/test_new_filesystem")).await.is_ok(),
             "hostfs can read root"
         );
         let mut file_write = fs
@@ -1872,7 +1909,9 @@ mod tests {
         );
 
         assert!(
-            read_dir_names(&fs, "/test_remove_dir/foo").await.contains(&"bar".to_string()),
+            read_dir_names(&fs, "/test_remove_dir/foo")
+                .await
+                .contains(&"bar".to_string()),
             "./foo/bar exists"
         );
 
@@ -1895,7 +1934,9 @@ mod tests {
         );
 
         assert!(
-            !read_dir_names(&fs, "/test_remove_dir").await.contains(&"foo".to_string()),
+            !read_dir_names(&fs, "/test_remove_dir")
+                .await
+                .contains(&"foo".to_string()),
             "the foo directory still exists"
         );
     }
@@ -1937,7 +1978,10 @@ mod tests {
 
         assert_eq!(fs.create_dir(Path::new("/test_rename")).await, Ok(()));
         assert_eq!(fs.create_dir(Path::new("/test_rename/foo")).await, Ok(()));
-        assert_eq!(fs.create_dir(Path::new("/test_rename/foo/qux")).await, Ok(()));
+        assert_eq!(
+            fs.create_dir(Path::new("/test_rename/foo/qux")).await,
+            Ok(())
+        );
 
         assert_eq!(
             fs.rename(
@@ -1949,10 +1993,7 @@ mod tests {
             "renaming to a directory that has parent that doesn't exist",
         );
 
-        assert_eq!(
-            fs.create_dir(Path::new("/test_rename/bar")).await,
-            Ok(())
-        );
+        assert_eq!(fs.create_dir(Path::new("/test_rename/bar")).await, Ok(()));
 
         assert_eq!(
             fs.rename(Path::new("/test_rename/foo"), Path::new("/test_rename/bar"))
@@ -2003,12 +2044,16 @@ mod tests {
         assert!(qux_dir.is_empty(), "the qux directory is empty");
 
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello1.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar")
+                .await
+                .contains(&"hello1.txt".to_string()),
             "the /bar/hello1.txt file exists"
         );
 
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello2.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar")
+                .await
+                .contains(&"hello2.txt".to_string()),
             "the /bar/hello2.txt file exists"
         );
 
@@ -2049,36 +2094,52 @@ mod tests {
         );
 
         assert!(
-            read_dir_names(&fs, "/test_rename").await.contains(&"bar".to_string()),
+            read_dir_names(&fs, "/test_rename")
+                .await
+                .contains(&"bar".to_string()),
             "./bar exists"
         );
 
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").await.contains(&"baz".to_string()),
+            read_dir_names(&fs, "/test_rename/bar")
+                .await
+                .contains(&"baz".to_string()),
             "/bar/baz exists"
         );
         assert!(
-            !read_dir_names(&fs, "/test_rename").await.contains(&"foo".to_string()),
+            !read_dir_names(&fs, "/test_rename")
+                .await
+                .contains(&"foo".to_string()),
             "foo does not exist anymore"
         );
         assert!(
-            read_dir_names(&fs, "/test_rename/bar/baz").await.contains(&"world2.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar/baz")
+                .await
+                .contains(&"world2.txt".to_string()),
             "/bar/baz/world2.txt exists"
         );
         assert!(
-            read_dir_names(&fs, "/test_rename/bar").await.contains(&"world1.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar")
+                .await
+                .contains(&"world1.txt".to_string()),
             "/bar/world1.txt (ex hello1.txt) exists"
         );
         assert!(
-            !read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello1.txt".to_string()),
+            !read_dir_names(&fs, "/test_rename/bar")
+                .await
+                .contains(&"hello1.txt".to_string()),
             "hello1.txt was moved"
         );
         assert!(
-            !read_dir_names(&fs, "/test_rename/bar").await.contains(&"hello2.txt".to_string()),
+            !read_dir_names(&fs, "/test_rename/bar")
+                .await
+                .contains(&"hello2.txt".to_string()),
             "hello2.txt was moved"
         );
         assert!(
-            read_dir_names(&fs, "/test_rename/bar/baz").await.contains(&"world2.txt".to_string()),
+            read_dir_names(&fs, "/test_rename/bar/baz")
+                .await
+                .contains(&"world2.txt".to_string()),
             "world2.txt was moved to the correct place"
         );
 
@@ -2111,7 +2172,13 @@ mod tests {
             left.metadata(Path::new("/from.txt")).await,
             Err(FsError::EntryNotFound)
         );
-        assert!(right.metadata(Path::new("/to.txt")).await.unwrap().is_file());
+        assert!(
+            right
+                .metadata(Path::new("/to.txt"))
+                .await
+                .unwrap()
+                .is_file()
+        );
     }
 
     #[tokio::test]
@@ -2128,10 +2195,7 @@ mod tests {
         assert_eq!(root_metadata.modified, root_metadata.created);
         assert!(root_metadata.modified > 0);
 
-        assert_eq!(
-            fs.create_dir(Path::new("/test_metadata/foo")).await,
-            Ok(())
-        );
+        assert_eq!(fs.create_dir(Path::new("/test_metadata/foo")).await, Ok(()));
 
         let foo_metadata = fs.metadata(Path::new("/test_metadata/foo")).await;
         assert!(foo_metadata.is_ok());
@@ -2182,7 +2246,11 @@ mod tests {
             "creating a new file",
         );
 
-        assert!(read_dir_names(&fs, "/test_remove_file").await.contains(&"foo.txt".to_string()));
+        assert!(
+            read_dir_names(&fs, "/test_remove_file")
+                .await
+                .contains(&"foo.txt".to_string())
+        );
 
         assert_eq!(
             fs.remove_file(Path::new("/test_remove_file/foo.txt")).await,
@@ -2190,7 +2258,11 @@ mod tests {
             "removing a file that exists",
         );
 
-        assert!(!read_dir_names(&fs, "/test_remove_file").await.contains(&"foo.txt".to_string()));
+        assert!(
+            !read_dir_names(&fs, "/test_remove_file")
+                .await
+                .contains(&"foo.txt".to_string())
+        );
 
         assert_eq!(
             fs.remove_file(Path::new("/test_remove_file/foo.txt")).await,

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -314,20 +314,25 @@ impl MountFileSystem {
 
     fn rebase_entries(entries: &mut ReadDir, source_prefix: &Path, target_prefix: &Path) {
         for entry in &mut entries.data {
-            let suffix = entry
-                .path
-                .strip_prefix(source_prefix)
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|_| {
-                    entry
-                        .path
-                        .components()
-                        .filter_map(|component| match component {
-                            std::path::Component::Normal(part) => Some(part),
-                            _ => None,
-                        })
-                        .collect::<PathBuf>()
-                });
+            let component_suffix = || {
+                entry
+                    .path
+                    .components()
+                    .filter_map(|component| match component {
+                        std::path::Component::Normal(part) => Some(part),
+                        _ => None,
+                    })
+                    .collect::<PathBuf>()
+            };
+            let suffix = if source_prefix == Path::new("/") {
+                component_suffix()
+            } else {
+                entry
+                    .path
+                    .strip_prefix(source_prefix)
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|_| component_suffix())
+            };
             entry.path = target_prefix.join(suffix);
         }
     }

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -314,12 +314,20 @@ impl MountFileSystem {
 
     fn rebase_entries(entries: &mut ReadDir, source_prefix: &Path, target_prefix: &Path) {
         for entry in &mut entries.data {
-            let suffix = entry.path.strip_prefix(source_prefix).unwrap_or_else(|_| {
-                entry
-                    .path
-                    .strip_prefix(Path::new("/"))
-                    .unwrap_or(&entry.path)
-            });
+            let suffix = entry
+                .path
+                .strip_prefix(source_prefix)
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|_| {
+                    entry
+                        .path
+                        .components()
+                        .filter_map(|component| match component {
+                            std::path::Component::Normal(part) => Some(part),
+                            _ => None,
+                        })
+                        .collect::<PathBuf>()
+                });
             entry.path = target_prefix.join(suffix);
         }
     }

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -267,7 +267,7 @@ impl MountFileSystem {
         }
 
         for (child_name, child) in &node.children {
-            let child_path = Self::append_guest_components(path, &[child_name.clone()]);
+            let child_path = Self::append_guest_components(path, std::slice::from_ref(child_name));
             Self::collect_mount_entries(child, &child_path, entries);
         }
     }

--- a/lib/virtual-fs/src/mount_fs.rs
+++ b/lib/virtual-fs/src/mount_fs.rs
@@ -1080,6 +1080,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_host_backed_nested_read_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let a_dir = root.path().join("a");
+        let b_dir = root.path().join("b");
+        std::fs::create_dir_all(&a_dir).unwrap();
+        std::fs::create_dir_all(&b_dir).unwrap();
+        std::fs::write(a_dir.join("data-a.txt"), b"a").unwrap();
+        std::fs::write(b_dir.join("data-b.txt"), b"b").unwrap();
+
+        let fs = MountFileSystem::new();
+        fs.mount(
+            Path::new("/app/a"),
+            Arc::new(
+                crate::host_fs::FileSystem::new(tokio::runtime::Handle::current(), &a_dir).unwrap(),
+            ),
+        )
+        .unwrap();
+        fs.mount(
+            Path::new("/app/b"),
+            Arc::new(
+                crate::host_fs::FileSystem::new(tokio::runtime::Handle::current(), &b_dir).unwrap(),
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_dir_names(&fs, "/app/a").await,
+            vec!["data-a.txt".to_string()]
+        );
+        assert_eq!(
+            read_dir_names(&fs, "/app/b").await,
+            vec!["data-b.txt".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn test_nested_metadata() {
         let fs = gen_nested_filesystem().await;
 

--- a/lib/virtual-fs/src/null_file.rs
+++ b/lib/virtual-fs/src/null_file.rs
@@ -57,23 +57,24 @@ impl AsyncRead for NullFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for NullFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         Ok(())
     }
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/virtual-fs/src/ops.rs
+++ b/lib/virtual-fs/src/ops.rs
@@ -355,11 +355,15 @@ mod tests {
         super::write(&fs, "/file.txt", b"").await.unwrap();
 
         assert!(!super::exists(&fs, "/really/nested/directory").await);
-        super::create_dir_all(&fs, "/really/nested/directory").await.unwrap();
+        super::create_dir_all(&fs, "/really/nested/directory")
+            .await
+            .unwrap();
         assert!(super::exists(&fs, "/really/nested/directory").await);
 
         // It's okay to create the same directory multiple times
-        super::create_dir_all(&fs, "/really/nested/directory").await.unwrap();
+        super::create_dir_all(&fs, "/really/nested/directory")
+            .await
+            .unwrap();
 
         // You can't create a directory on top of a file
         assert_eq!(
@@ -367,7 +371,9 @@ mod tests {
             FsError::BaseNotDirectory
         );
         assert_eq!(
-            super::create_dir_all(&fs, "/file.txt/invalid/path").await.unwrap_err(),
+            super::create_dir_all(&fs, "/file.txt/invalid/path")
+                .await
+                .unwrap_err(),
             FsError::BaseNotDirectory
         );
     }

--- a/lib/virtual-fs/src/ops.rs
+++ b/lib/virtual-fs/src/ops.rs
@@ -12,30 +12,30 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use crate::{DirEntry, FileSystem, FsError};
 
 /// Does this item exists?
-pub fn exists<F>(fs: &F, path: impl AsRef<Path>) -> bool
+pub async fn exists<F>(fs: &F, path: impl AsRef<Path>) -> bool
 where
     F: FileSystem + ?Sized,
 {
-    fs.metadata(path.as_ref()).is_ok()
+    fs.metadata(path.as_ref()).await.is_ok()
 }
 
 /// Does this path refer to a directory?
-pub fn is_dir<F>(fs: &F, path: impl AsRef<Path>) -> bool
+pub async fn is_dir<F>(fs: &F, path: impl AsRef<Path>) -> bool
 where
     F: FileSystem + ?Sized,
 {
-    match fs.metadata(path.as_ref()) {
+    match fs.metadata(path.as_ref()).await {
         Ok(meta) => meta.is_dir(),
         Err(_) => false,
     }
 }
 
 /// Does this path refer to a file?
-pub fn is_file<F>(fs: &F, path: impl AsRef<Path>) -> bool
+pub async fn is_file<F>(fs: &F, path: impl AsRef<Path>) -> bool
 where
     F: FileSystem + ?Sized,
 {
-    match fs.metadata(path.as_ref()) {
+    match fs.metadata(path.as_ref()).await {
         Ok(meta) => meta.is_file(),
         Err(_) => false,
     }
@@ -44,31 +44,38 @@ where
 /// Make sure a directory (and all its parents) exist.
 ///
 /// This is analogous to [`std::fs::create_dir_all()`].
-pub fn create_dir_all<F>(fs: &F, path: impl AsRef<Path>) -> Result<(), FsError>
+pub async fn create_dir_all<F>(fs: &F, path: impl AsRef<Path>) -> Result<(), FsError>
 where
     F: FileSystem + ?Sized,
 {
     let path = path.as_ref();
-    if let Some(parent) = path.parent() {
-        create_dir_all(fs, parent)?;
+    let mut stack = Vec::new();
+    let mut current = Some(path);
+    while let Some(path) = current {
+        stack.push(path);
+        current = path.parent();
     }
 
-    if let Ok(metadata) = fs.metadata(path) {
-        if metadata.is_dir() {
-            return Ok(());
+    for path in stack.into_iter().rev() {
+        if let Ok(metadata) = fs.metadata(path).await {
+            if metadata.is_dir() {
+                continue;
+            }
+            if metadata.is_file() {
+                return Err(FsError::BaseNotDirectory);
+            }
         }
-        if metadata.is_file() {
-            return Err(FsError::BaseNotDirectory);
-        }
+
+        fs.create_dir(path).await?;
     }
 
-    fs.create_dir(path)
+    Ok(())
 }
 
 static WHITEOUT_PREFIX: &str = ".wh.";
 
 /// Creates a white out file which hides it from secondary file systems
-pub fn create_white_out<F>(fs: &F, path: impl AsRef<Path>) -> Result<(), FsError>
+pub async fn create_white_out<F>(fs: &F, path: impl AsRef<Path>) -> Result<(), FsError>
 where
     F: FileSystem + ?Sized,
 {
@@ -77,14 +84,15 @@ where
         path.set_file_name(format!("{}{}", WHITEOUT_PREFIX, filename.to_string_lossy()));
 
         if let Some(parent) = path.parent() {
-            create_dir_all(fs, parent).ok();
+            create_dir_all(fs, parent).await.ok();
         }
 
         fs.new_open_options()
             .create_new(true)
             .truncate(true)
             .write(true)
-            .open(path)?;
+            .open(path)
+            .await?;
         Ok(())
     } else {
         Err(FsError::EntryNotFound)
@@ -92,26 +100,26 @@ where
 }
 
 /// Removes a white out file from the primary
-pub fn remove_white_out<F>(fs: &F, path: impl AsRef<Path>)
+pub async fn remove_white_out<F>(fs: &F, path: impl AsRef<Path>)
 where
     F: FileSystem + ?Sized,
 {
     if let Some(filename) = path.as_ref().file_name() {
         let mut path = path.as_ref().to_owned();
         path.set_file_name(format!("{}{}", WHITEOUT_PREFIX, filename.to_string_lossy()));
-        fs.remove_file(&path).ok();
+        fs.remove_file(&path).await.ok();
     }
 }
 
 /// Returns true if the path has been hidden by a whiteout file
-pub fn has_white_out<F>(fs: &F, path: impl AsRef<Path>) -> bool
+pub async fn has_white_out<F>(fs: &F, path: impl AsRef<Path>) -> bool
 where
     F: FileSystem + ?Sized,
 {
     if let Some(filename) = path.as_ref().file_name() {
         let mut path = path.as_ref().to_owned();
         path.set_file_name(format!("{}{}", WHITEOUT_PREFIX, filename.to_string_lossy()));
-        fs.metadata(&path).is_ok()
+        fs.metadata(&path).await.is_ok()
     } else {
         false
     }
@@ -148,13 +156,14 @@ pub fn copy_reference_ext<'a>(
     let from = from.to_owned();
     let to = to.to_owned();
     Box::pin(async move {
-        let src = source.new_open_options().read(true).open(from)?;
+        let src = source.new_open_options().read(true).open(from).await?;
         let mut dst = destination
             .new_open_options()
             .create(true)
             .write(true)
             .truncate(true)
-            .open(to)?;
+            .open(to)
+            .await?;
 
         dst.copy_reference(src).await?;
         Ok(())
@@ -172,7 +181,7 @@ pub fn move_across_filesystems<'a>(
     let from = from.to_owned();
     let to = to.to_owned();
     Box::pin(async move {
-        let metadata = source.metadata(&from)?;
+        let metadata = source.metadata(&from).await?;
         if metadata.is_dir() {
             return Err(FsError::InvalidInput);
         }
@@ -181,7 +190,7 @@ pub fn move_across_filesystems<'a>(
             .await
             .map_err(FsError::from)?;
 
-        if let Err(error) = source.remove_file(&from) {
+        if let Err(error) = source.remove_file(&from).await {
             tracing::warn!(
                 ?from,
                 ?to,
@@ -213,7 +222,8 @@ where
         .create(true)
         .truncate(true)
         .write(true)
-        .open(path)?;
+        .open(path)
+        .await?;
 
     f.write_all(data).await?;
     f.flush().await?;
@@ -228,7 +238,7 @@ pub async fn read<F>(fs: &F, path: impl AsRef<Path> + Send) -> Result<Vec<u8>, F
 where
     F: FileSystem + ?Sized,
 {
-    let mut f = fs.new_open_options().read(true).open(path.as_ref())?;
+    let mut f = fs.new_open_options().read(true).open(path.as_ref()).await?;
     let mut buffer = Vec::new();
     f.read_to_end(&mut buffer).await?;
 
@@ -242,7 +252,7 @@ pub async fn read_to_string<F>(fs: &F, path: impl AsRef<Path> + Send) -> Result<
 where
     F: FileSystem + ?Sized,
 {
-    let mut f = fs.new_open_options().read(true).open(path.as_ref())?;
+    let mut f = fs.new_open_options().read(true).open(path.as_ref()).await?;
     let mut buffer = String::new();
     f.read_to_string(&mut buffer).await?;
 
@@ -251,39 +261,46 @@ where
 
 /// Update a file's modification and access times, creating the file if it
 /// doesn't already exist.
-pub fn touch<F>(fs: &F, path: impl AsRef<Path> + Send) -> Result<(), FsError>
+pub async fn touch<F>(fs: &F, path: impl AsRef<Path> + Send) -> Result<(), FsError>
 where
     F: FileSystem + ?Sized,
 {
-    let _ = fs.new_open_options().create(true).write(true).open(path)?;
+    let _ = fs
+        .new_open_options()
+        .create(true)
+        .write(true)
+        .open(path)
+        .await?;
 
     Ok(())
 }
 
 /// Recursively iterate over all paths inside a directory, ignoring any
 /// errors that may occur along the way.
-pub fn walk<F>(fs: &F, path: impl AsRef<Path>) -> Box<dyn Iterator<Item = DirEntry> + '_>
+pub async fn walk<F>(fs: &F, path: impl AsRef<Path>) -> Vec<DirEntry>
 where
     F: FileSystem + ?Sized,
 {
     let path = path.as_ref();
     let mut dirs_to_visit: VecDeque<_> = fs
         .read_dir(path)
+        .await
         .ok()
         .into_iter()
         .flatten()
         .filter_map(|result| result.ok())
         .collect();
+    let mut entries = Vec::new();
 
-    Box::new(std::iter::from_fn(move || {
-        let next = dirs_to_visit.pop_back()?;
-
-        if let Ok(children) = fs.read_dir(&next.path) {
+    while let Some(next) = dirs_to_visit.pop_back() {
+        if let Ok(children) = fs.read_dir(&next.path).await {
             dirs_to_visit.extend(children.flatten());
         }
 
-        Some(next)
-    }))
+        entries.push(next);
+    }
+
+    entries
 }
 
 #[cfg(test)]
@@ -304,6 +321,7 @@ mod tests {
         fs.new_open_options()
             .read(true)
             .open("/file.txt")
+            .await
             .unwrap()
             .read_to_string(&mut contents)
             .await
@@ -318,6 +336,7 @@ mod tests {
             .create(true)
             .write(true)
             .open("/file.txt")
+            .await
             .unwrap()
             .write_all(b"Hello, World!")
             .await
@@ -335,20 +354,20 @@ mod tests {
         let fs = MemFS::default();
         super::write(&fs, "/file.txt", b"").await.unwrap();
 
-        assert!(!super::exists(&fs, "/really/nested/directory"));
-        super::create_dir_all(&fs, "/really/nested/directory").unwrap();
-        assert!(super::exists(&fs, "/really/nested/directory"));
+        assert!(!super::exists(&fs, "/really/nested/directory").await);
+        super::create_dir_all(&fs, "/really/nested/directory").await.unwrap();
+        assert!(super::exists(&fs, "/really/nested/directory").await);
 
         // It's okay to create the same directory multiple times
-        super::create_dir_all(&fs, "/really/nested/directory").unwrap();
+        super::create_dir_all(&fs, "/really/nested/directory").await.unwrap();
 
         // You can't create a directory on top of a file
         assert_eq!(
-            super::create_dir_all(&fs, "/file.txt").unwrap_err(),
+            super::create_dir_all(&fs, "/file.txt").await.unwrap_err(),
             FsError::BaseNotDirectory
         );
         assert_eq!(
-            super::create_dir_all(&fs, "/file.txt/invalid/path").unwrap_err(),
+            super::create_dir_all(&fs, "/file.txt/invalid/path").await.unwrap_err(),
             FsError::BaseNotDirectory
         );
     }
@@ -357,7 +376,7 @@ mod tests {
     async fn touch() {
         let fs = MemFS::default();
 
-        super::touch(&fs, "/file.txt").unwrap();
+        super::touch(&fs, "/file.txt").await.unwrap();
 
         assert_eq!(super::read(&fs, "/file.txt").await.unwrap(), b"");
     }

--- a/lib/virtual-fs/src/overlay_fs.rs
+++ b/lib/virtual-fs/src/overlay_fs.rs
@@ -8,16 +8,15 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::future::BoxFuture;
 use replace_with::replace_with_or_abort;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 use crate::{
-    FileOpener, FileSystem, FileSystems, FsError, Metadata, OpenOptions, OpenOptionsConfig,
-    ReadDir, VirtualFile, ops,
+    FileSystem, FileSystems, FsError, Metadata, OpenOptions, OpenOptionsConfig, ReadDir,
+    VirtualFile, ops,
 };
 
-fn unlink_overlay_path<P>(primary: &Arc<P>, path: &Path) -> Result<(), FsError>
+async fn unlink_overlay_path<P>(primary: &Arc<P>, path: &Path) -> Result<(), FsError>
 where
     P: FileSystem + ?Sized,
 {
@@ -25,12 +24,12 @@ where
     // fails we abort early so the lower-layer entry never becomes visible.
     // Removing from primary first and then failing to create the whiteout
     // would cause the secondary file to re-appear.
-    match ops::create_white_out(primary, path) {
+    match ops::create_white_out(primary, path).await {
         Ok(()) | Err(FsError::AlreadyExists) => {}
         Err(e) => return Err(e),
     }
 
-    match primary.remove_file(path) {
+    match primary.remove_file(path).await {
         // File was not in primary (only in a secondary) – the whiteout alone
         // is sufficient to suppress it.
         Err(e) if should_continue(e) => Ok(()),
@@ -53,40 +52,41 @@ where
     }
 }
 
+#[async_trait::async_trait]
 impl<P> VirtualFile for SecondaryFile<P>
 where
     P: FileSystem + 'static,
 {
-    fn last_accessed(&self) -> u64 {
-        self.inner.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        self.inner.last_accessed().await
     }
 
-    fn last_modified(&self) -> u64 {
-        self.inner.last_modified()
+    async fn last_modified(&self) -> u64 {
+        self.inner.last_modified().await
     }
 
-    fn created_time(&self) -> u64 {
-        self.inner.created_time()
+    async fn created_time(&self) -> u64 {
+        self.inner.created_time().await
     }
 
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
-        self.inner.set_times(atime, mtime)
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        self.inner.set_times(atime, mtime).await
     }
 
-    fn size(&self) -> u64 {
-        self.inner.size()
+    async fn size(&self) -> u64 {
+        self.inner.size().await
     }
 
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
-        self.inner.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+        self.inner.set_len(new_size).await
     }
 
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         // A SecondaryFile is only created when the primary has no binding for
         // this path at open time. Any file currently at this path in primary is
         // a different, independently-created object. Only create a whiteout to
         // hide the secondary entry; never remove from primary.
-        match ops::create_white_out(&self.primary, &self.path) {
+        match ops::create_white_out(&self.primary, &self.path).await {
             Ok(()) => Ok(()),
             // The whiteout already exists: the path was already deleted from the
             // overlay's perspective, so report it as not found.
@@ -95,20 +95,20 @@ where
         }
     }
 
-    fn is_open(&self) -> bool {
-        self.inner.is_open()
+    async fn is_open(&self) -> bool {
+        self.inner.is_open().await
     }
 
-    fn get_special_fd(&self) -> Option<u32> {
-        self.inner.get_special_fd()
+    async fn get_special_fd(&self) -> Option<u32> {
+        self.inner.get_special_fd().await
     }
 
-    fn write_from_mmap(&mut self, offset: u64, len: u64) -> std::io::Result<()> {
-        self.inner.write_from_mmap(offset, len)
+    async fn write_from_mmap(&mut self, offset: u64, len: u64) -> std::io::Result<()> {
+        self.inner.write_from_mmap(offset, len).await
     }
 
-    fn as_owned_buffer(&self) -> Option<shared_buffer::OwnedBuffer> {
-        self.inner.as_owned_buffer()
+    async fn as_owned_buffer(&self) -> Option<shared_buffer::OwnedBuffer> {
+        self.inner.as_owned_buffer().await
     }
 
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
@@ -260,7 +260,7 @@ where
 
     fn permission_error_or_not_found(&self, path: &Path) -> Result<(), FsError> {
         for fs in self.secondaries.filesystems() {
-            if ops::exists(fs, path) {
+            if futures::executor::block_on(ops::exists(fs, path)) {
                 return Err(FsError::PermissionDenied);
             }
         }
@@ -269,33 +269,34 @@ where
     }
 }
 
+#[async_trait::async_trait]
 impl<P, S> FileSystem for OverlayFileSystem<P, S>
 where
     P: FileSystem + Send + 'static,
     S: for<'a> FileSystems<'a> + Send + Sync + 'static,
     for<'a> <<S as FileSystems<'a>>::Iter as IntoIterator>::IntoIter: Send,
 {
-    fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
         // Whiteout files can not be read, they are just markers
         if ops::is_white_out(path).is_some() {
             return Err(FsError::EntryNotFound);
         }
 
         // Check if the file is in the primary
-        match self.primary.readlink(path) {
+        match self.primary.readlink(path).await {
             Ok(meta) => return Ok(meta),
             Err(e) if should_continue(e) => {}
             Err(e) => return Err(e),
         }
 
         // There might be a whiteout, search for this
-        if ops::has_white_out(&self.primary, path) {
+        if ops::has_white_out(&self.primary, path).await {
             return Err(FsError::EntryNotFound);
         }
 
         // Otherwise scan the secondaries
         for fs in self.secondaries.filesystems() {
-            match fs.readlink(path) {
+            match fs.readlink(path).await {
                 Err(e) if should_continue(e) => continue,
                 other => return other,
             }
@@ -304,7 +305,7 @@ where
         Err(FsError::EntryNotFound)
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
         let mut entries = Vec::new();
         let mut had_at_least_one_success = false;
         let mut white_outs = HashSet::new();
@@ -313,7 +314,7 @@ where
             .chain(self.secondaries().filesystems());
 
         for fs in filesystems {
-            match fs.read_dir(path) {
+            match fs.read_dir(path).await {
                 Ok(r) => {
                     for entry in r {
                         let entry = entry?;
@@ -359,7 +360,7 @@ where
         }
     }
 
-    fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+    async fn create_dir(&self, path: &Path) -> Result<(), FsError> {
         // You can not create directories that use the whiteout prefix
         if ops::is_white_out(path).is_some() {
             return Err(FsError::InvalidInput);
@@ -367,19 +368,19 @@ where
 
         // It could be the case that the directory was earlier hidden in the secondaries
         // by a whiteout file, hence we need to make sure those are cleared out.
-        ops::remove_white_out(self.primary.as_ref(), path);
+        ops::remove_white_out(self.primary.as_ref(), path).await;
 
         // Make sure the parent tree is in place on the primary, this is to cover the
         // scenario where the secondaries has a parent structure that is not yet in the
         // primary and the primary needs it to create a sub-directory
         if let Some(parent) = path.parent()
-            && self.read_dir(parent).is_ok()
+            && self.read_dir(parent).await.is_ok()
         {
-            ops::create_dir_all(&self.primary, parent).ok();
+            ops::create_dir_all(&self.primary, parent).await.ok();
         }
 
         // Create the directory in the primary
-        match self.primary.create_dir(path) {
+        match self.primary.create_dir(path).await {
             Err(e) if should_continue(e) => {}
             other => return other,
         }
@@ -387,39 +388,39 @@ where
         self.permission_error_or_not_found(path)
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<(), FsError> {
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<(), FsError> {
         if ops::is_white_out(target).is_some() {
             return Err(FsError::InvalidInput);
         }
 
-        ops::remove_white_out(self.primary.as_ref(), target);
+        ops::remove_white_out(self.primary.as_ref(), target).await;
 
         if let Some(parent) = target.parent()
-            && self.read_dir(parent).is_ok()
+            && self.read_dir(parent).await.is_ok()
         {
-            ops::create_dir_all(&self.primary, parent).ok();
+            ops::create_dir_all(&self.primary, parent).await.ok();
         }
 
-        self.primary.create_symlink(source, target)
+        self.primary.create_symlink(source, target).await
     }
 
-    fn hard_link(&self, source: &Path, target: &Path) -> Result<(), FsError> {
+    async fn hard_link(&self, source: &Path, target: &Path) -> Result<(), FsError> {
         if ops::is_white_out(source).is_some() || ops::is_white_out(target).is_some() {
             return Err(FsError::InvalidInput);
         }
 
-        ops::remove_white_out(self.primary.as_ref(), target);
+        ops::remove_white_out(self.primary.as_ref(), target).await;
 
         if let Some(parent) = target.parent()
-            && self.read_dir(parent).is_ok()
+            && self.read_dir(parent).await.is_ok()
         {
-            ops::create_dir_all(&self.primary, parent).ok();
+            ops::create_dir_all(&self.primary, parent).await.ok();
         }
 
-        self.primary.hard_link(source, target)
+        self.primary.hard_link(source, target).await
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
+    async fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
         // Whiteout files can not be removed, instead the original directory
         // must be removed or recreated.
         if ops::is_white_out(path).is_some() {
@@ -433,14 +434,20 @@ where
         // If the directory is contained in a secondary file system then we need to create a
         // whiteout file so that it is suppressed and is no longer returned in `readdir` calls.
 
-        let had_at_least_one_success = self.secondaries.filesystems().into_iter().any(|fs| {
-            fs.read_dir(path).is_ok() && ops::create_white_out(&self.primary, path).is_ok()
-        });
+        let mut had_at_least_one_success = false;
+        for fs in self.secondaries.filesystems() {
+            if fs.read_dir(path).await.is_ok()
+                && ops::create_white_out(&self.primary, path).await.is_ok()
+            {
+                had_at_least_one_success = true;
+                break;
+            }
+        }
 
         // Attempt to remove it from the primary, if this succeeds then we may have also
         // added the whiteout file in the earlier step, but are required in this case to
         // properly delete the directory.
-        match self.primary.remove_dir(path) {
+        match self.primary.remove_dir(path).await {
             Err(e) if should_continue(e) => {}
             other => return other,
         }
@@ -451,10 +458,9 @@ where
         self.permission_error_or_not_found(path)
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<(), FsError>> {
+    async fn rename(&self, from: &Path, to: &Path) -> Result<(), FsError> {
         let from = from.to_owned();
         let to = to.to_owned();
-        Box::pin(async move {
             // Whiteout files can not be renamed
             if ops::is_white_out(&from).is_some() {
                 tracing::trace!(
@@ -492,7 +498,7 @@ where
             // primary rather than rename it
             if !had_at_least_one_success {
                 for fs in self.secondaries.filesystems() {
-                    if fs.metadata(&from).is_ok() {
+                    if fs.metadata(&from).await.is_ok() {
                         ops::copy_reference_ext(fs, &self.primary, &from, &to).await?;
                         had_at_least_one_success = true;
                         break;
@@ -504,45 +510,44 @@ where
             // whiteout files on the primary before we return success.
             if had_at_least_one_success {
                 for fs in self.secondaries.filesystems() {
-                    if fs.metadata(&from).is_ok() {
+                    if fs.metadata(&from).await.is_ok() {
                         tracing::trace!(
                             path=%from.display(),
                             "Creating a whiteout for the file that was renamed",
                         );
-                        ops::create_white_out(&self.primary, &from).ok();
+                        ops::create_white_out(&self.primary, &from).await.ok();
                         break;
                     }
                 }
-                ops::remove_white_out(&self.primary, &to);
+                ops::remove_white_out(&self.primary, &to).await;
                 return Ok(());
             }
 
             // Otherwise we are in a failure scenario
             self.permission_error_or_not_found(&from)
-        })
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+    async fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
         // Whiteout files can not be read, they are just markers
         if ops::is_white_out(path).is_some() {
             return Err(FsError::EntryNotFound);
         }
 
         // Check if the file is in the primary
-        match self.primary.metadata(path) {
+        match self.primary.metadata(path).await {
             Ok(meta) => return Ok(meta),
             Err(e) if should_continue(e) => {}
             Err(e) => return Err(e),
         }
 
         // There might be a whiteout, search for this
-        if ops::has_white_out(&self.primary, path) {
+        if ops::has_white_out(&self.primary, path).await {
             return Err(FsError::EntryNotFound);
         }
 
         // Otherwise scan the secondaries
         for fs in self.secondaries.filesystems() {
-            match fs.metadata(path) {
+            match fs.metadata(path).await {
                 Err(e) if should_continue(e) => continue,
                 other => return other,
             }
@@ -551,27 +556,27 @@ where
         Err(FsError::EntryNotFound)
     }
 
-    fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
+    async fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
         // Whiteout files can not be read, they are just markers
         if ops::is_white_out(path).is_some() {
             return Err(FsError::EntryNotFound);
         }
 
         // Check if the file is in the primary
-        match self.primary.symlink_metadata(path) {
+        match self.primary.symlink_metadata(path).await {
             Ok(meta) => return Ok(meta),
             Err(e) if should_continue(e) => {}
             Err(e) => return Err(e),
         }
 
         // There might be a whiteout, search for this
-        if ops::has_white_out(&self.primary, path) {
+        if ops::has_white_out(&self.primary, path).await {
             return Err(FsError::EntryNotFound);
         }
 
         // Otherwise scan the secondaries
         for fs in self.secondaries.filesystems() {
-            match fs.symlink_metadata(path) {
+            match fs.symlink_metadata(path).await {
                 Err(e) if should_continue(e) => continue,
                 other => return other,
             }
@@ -580,7 +585,7 @@ where
         Err(FsError::EntryNotFound)
     }
 
-    fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+    async fn remove_file(&self, path: &Path) -> Result<(), FsError> {
         // It is not possible to delete whiteout files directly, instead
         // one must delete the original file
         if ops::is_white_out(path).is_some() {
@@ -589,12 +594,18 @@ where
 
         // If the file is contained in a secondary then then we need to create a
         // whiteout file so that it is suppressed.
-        let had_at_least_one_success = self.secondaries.filesystems().into_iter().any(|fs| {
-            fs.metadata(path).is_ok() && ops::create_white_out(&self.primary, path).is_ok()
-        });
+        let mut had_at_least_one_success = false;
+        for fs in self.secondaries.filesystems() {
+            if fs.metadata(path).await.is_ok()
+                && ops::create_white_out(&self.primary, path).await.is_ok()
+            {
+                had_at_least_one_success = true;
+                break;
+            }
+        }
 
         // Attempt to remove it from the primary
-        match self.primary.remove_file(path) {
+        match self.primary.remove_file(path).await {
             Err(e) if should_continue(e) => {}
             other => return other,
         }
@@ -608,15 +619,8 @@ where
     fn new_open_options(&self) -> OpenOptions<'_> {
         OpenOptions::new(self)
     }
-}
 
-impl<P, S> FileOpener for OverlayFileSystem<P, S>
-where
-    P: FileSystem + Send + 'static,
-    S: for<'a> FileSystems<'a> + Send + Sync + 'static,
-    for<'a> <<S as FileSystems<'a>>::Iter as IntoIterator>::IntoIter: Send,
-{
-    fn open(
+    async fn open(
         &self,
         path: &Path,
         conf: &OpenOptionsConfig,
@@ -637,7 +641,7 @@ where
             let mut conf = conf.clone();
             conf.create = false;
             conf.create_new = false;
-            match self.primary.new_open_options().options(conf).open(path) {
+            match self.primary.open(path, &conf).await {
                 Err(e) if should_continue(e) => {}
                 other => return other,
             }
@@ -650,32 +654,31 @@ where
             // does not then we need to make sure we create all the structure
             // in the primary
             if let Some(parent) = path.parent() {
-                if ops::exists(self, parent) {
+                if ops::exists(self, parent).await {
                     // We create the directory structure on the primary so that
                     // the new file can be created, this will make it override
                     // whatever is in the primary
-                    ops::create_dir_all(&self.primary, parent)?;
+                    ops::create_dir_all(&self.primary, parent).await?;
                 } else {
                     return Err(FsError::EntryNotFound);
                 }
             }
 
             // Remove any whiteout
-            ops::remove_white_out(&self.primary, path);
+            ops::remove_white_out(&self.primary, path).await;
 
             // Create the file in the primary
             return self
                 .primary
-                .new_open_options()
-                .options(conf.clone())
-                .open(path);
+                .open(path, conf)
+                .await;
         }
 
         // There might be a whiteout, search for this and if its found then
         // we are done as the secondary file or directory has been earlier
         // deleted via a white out (when the create flag is set then
         // the white out marker is ignored)
-        if !conf.create && ops::has_white_out(&self.primary, path) {
+        if !conf.create && ops::has_white_out(&self.primary, path).await {
             tracing::trace!(
                 path=%path.display(),
                 "The file has been whited out",
@@ -687,14 +690,14 @@ where
         let require_mutations = conf.append || conf.write || conf.create_new | conf.truncate;
 
         // If the file is on a secondary then we should open it
-        if !ops::has_white_out(&self.primary, path) {
+        if !ops::has_white_out(&self.primary, path).await {
             for fs in self.secondaries.filesystems() {
                 let mut sub_conf = conf.clone();
                 sub_conf.create = false;
                 sub_conf.create_new = false;
                 sub_conf.append = false;
                 sub_conf.truncate = false;
-                match fs.new_open_options().options(sub_conf.clone()).open(path) {
+                match fs.open(path, &sub_conf).await {
                     Err(e) if should_continue(e) => continue,
                     Ok(file) if require_mutations => {
                         // If the file was opened with the ability to mutate then we need
@@ -719,18 +722,17 @@ where
         if conf.create {
             // Create the parent structure and remove any whiteouts
             if let Some(parent) = path.parent()
-                && ops::exists(self, parent)
+                && ops::exists(self, parent).await
             {
-                ops::create_dir_all(&self.primary, parent)?;
+                ops::create_dir_all(&self.primary, parent).await?;
             }
-            ops::remove_white_out(&self.primary, path);
+            ops::remove_white_out(&self.primary, path).await;
 
             // Create the file in the primary
             return self
                 .primary
-                .new_open_options()
-                .options(conf.clone())
-                .open(path);
+                .open(path, conf)
+                .await;
         }
 
         // The file does not exist anywhere
@@ -873,21 +875,32 @@ where
                                 // Remove the whiteout, create the parent structure and open
                                 // the new file on the primary
                                 if let Some(parent) = self.path.parent() {
-                                    ops::create_dir_all(&self.primary, parent).ok();
+                                    futures::executor::block_on(ops::create_dir_all(
+                                        &self.primary,
+                                        parent,
+                                    ))
+                                    .ok();
                                 }
                                 let mut had_white_out = false;
-                                if ops::has_white_out(&self.primary, &self.path) {
-                                    ops::remove_white_out(&self.primary, &self.path);
+                                if futures::executor::block_on(ops::has_white_out(
+                                    &self.primary,
+                                    &self.path,
+                                )) {
+                                    futures::executor::block_on(ops::remove_white_out(
+                                        &self.primary,
+                                        &self.path,
+                                    ));
                                     had_white_out = true;
                                 }
-                                let dst = self
-                                    .primary
-                                    .new_open_options()
-                                    .create(true)
-                                    .read(self.readable)
-                                    .write(true)
-                                    .truncate(true)
-                                    .open(&self.path);
+                                let dst = futures::executor::block_on(
+                                    self.primary
+                                        .new_open_options()
+                                        .create(true)
+                                        .read(self.readable)
+                                        .write(true)
+                                        .truncate(true)
+                                        .open(&self.path),
+                                );
                                 match dst {
                                     Ok(dst) if had_white_out => {
                                         again = true;
@@ -989,7 +1002,7 @@ where
                             Poll::Ready(_) => {
                                 // If we have changed the length then set it
                                 if let Some(new_size) = self.new_size.take() {
-                                    dst.set_len(new_size).ok();
+                                    futures::executor::block_on(dst.set_len(new_size)).ok();
                                 }
                                 CowState::Copied(dst)
                             }
@@ -1045,31 +1058,32 @@ where
         }
     }
 
-    impl<P> VirtualFile for CopyOnWriteFile<P>
+    #[async_trait::async_trait]
+impl<P> VirtualFile for CopyOnWriteFile<P>
     where
         P: FileSystem + 'static,
     {
-        fn last_accessed(&self) -> u64 {
-            self.state.as_ref().last_accessed()
+        async fn last_accessed(&self) -> u64 {
+            self.state.as_ref().last_accessed().await
         }
 
-        fn last_modified(&self) -> u64 {
-            self.state.as_ref().last_modified()
+        async fn last_modified(&self) -> u64 {
+            self.state.as_ref().last_modified().await
         }
 
-        fn created_time(&self) -> u64 {
-            self.state.as_ref().created_time()
+        async fn created_time(&self) -> u64 {
+            self.state.as_ref().created_time().await
         }
 
-        fn size(&self) -> u64 {
-            self.state.as_ref().size()
+        async fn size(&self) -> u64 {
+            self.state.as_ref().size().await
         }
 
-        fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+        async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
             self.new_size = Some(new_size);
             replace_with_or_abort(&mut self.state, |state| match state {
                 CowState::Copied(mut file) => {
-                    file.set_len(new_size).ok();
+                    futures::executor::block_on(file.set_len(new_size)).ok();
                     CowState::Copied(file)
                 }
                 state => {
@@ -1083,16 +1097,18 @@ where
                     // in the scenario where the length is set but the file is not
                     // polled then we need to make sure we create a file properly
                     if let Some(parent) = self.path.parent() {
-                        ops::create_dir_all(&self.primary, parent).ok();
+                        futures::executor::block_on(ops::create_dir_all(&self.primary, parent))
+                            .ok();
                     }
-                    let dst = self
-                        .primary
-                        .new_open_options()
-                        .create(true)
-                        .write(true)
-                        .open(&self.path);
+                    let dst = futures::executor::block_on(
+                        self.primary
+                            .new_open_options()
+                            .create(true)
+                            .write(true)
+                            .open(&self.path),
+                    );
                     if let Ok(mut file) = dst {
-                        file.set_len(new_size).ok();
+                        futures::executor::block_on(file.set_len(new_size)).ok();
                     }
                     state
                 }
@@ -1100,19 +1116,19 @@ where
             Ok(())
         }
 
-        fn unlink(&mut self) -> crate::Result<()> {
+        async fn unlink(&mut self) -> crate::Result<()> {
             match &self.state {
                 CowState::Copied(_) => {
                     // The COW copy has landed in primary – it is our file, so it
                     // is safe to remove it and create a whiteout for the secondary.
-                    unlink_overlay_path(&self.primary, &self.path)?;
+                    unlink_overlay_path(&self.primary, &self.path).await?;
                 }
                 _ => {
                     // The file has not yet been written to primary. Only create a
                     // whiteout to hide the secondary entry; do NOT remove anything
                     // from primary, because whatever is currently bound to this
                     // path may be an independently-created file.
-                    match ops::create_white_out(&self.primary, &self.path) {
+                    match ops::create_white_out(&self.primary, &self.path).await {
                         Ok(()) => {}
                         // The whiteout already exists: the path was already deleted
                         // from the overlay's perspective.
@@ -1262,8 +1278,7 @@ where
                             .checked_add_signed(delta)
                             .unwrap_or(*original_offset),
                         SeekFrom::Start(pos) => pos,
-                        SeekFrom::End(pos) => src
-                            .size()
+                        SeekFrom::End(pos) => futures::executor::block_on(src.size())
                             .checked_add_signed(pos)
                             .unwrap_or(*original_offset),
                     };
@@ -1349,16 +1364,16 @@ mod tests {
     use crate::mem_fs::FileSystem as MemFS;
     use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
-    #[test]
-    fn overlay_read_dir_rebases_mounted_entries() {
+    #[tokio::test]
+    async fn overlay_read_dir_rebases_mounted_entries() {
         let primary = MemFS::default();
-        ops::create_dir_all(&primary, "/app").unwrap();
+        ops::create_dir_all(&primary, "/app").await.unwrap();
 
         let volume = MemFS::default();
-        ops::create_dir_all(&volume, "/themes/twentytwentyfour").unwrap();
+        ops::create_dir_all(&volume, "/themes/twentytwentyfour").await.unwrap();
 
         let container = MemFS::default();
-        ops::create_dir_all(&container, "/app/wp-content/themes/twentytwentyfour").unwrap();
+        ops::create_dir_all(&container, "/app/wp-content/themes/twentytwentyfour").await.unwrap();
 
         let volume: Arc<dyn FileSystem + Send + Sync> = Arc::new(volume);
         primary
@@ -1373,6 +1388,7 @@ mod tests {
 
         let mut entries: Vec<_> = overlay
             .read_dir(Path::new("/app/wp-content/themes"))
+            .await
             .unwrap()
             .map(|entry| entry.unwrap().path)
             .collect();
@@ -1392,56 +1408,57 @@ mod tests {
         let second = Path::new("/second");
         let file_txt = second.join("file.txt");
         let third = Path::new("/third");
-        primary.create_dir(first).unwrap();
-        primary.create_dir(second).unwrap();
+        primary.create_dir(first).await.unwrap();
+        primary.create_dir(second).await.unwrap();
         primary
             .new_open_options()
             .create(true)
             .write(true)
             .open(&file_txt)
+            .await
             .unwrap()
             .write_all(b"Hello, World!")
             .await
             .unwrap();
-        secondary.create_dir(third).unwrap();
+        secondary.create_dir(third).await.unwrap();
 
         let overlay = OverlayFileSystem::new(primary, [secondary]);
 
         // Delete a folder on the primary filesystem
-        overlay.remove_dir(first).unwrap();
+        overlay.remove_dir(first).await.unwrap();
         assert_eq!(
-            overlay.primary().metadata(first).unwrap_err(),
+            overlay.primary().metadata(first).await.unwrap_err(),
             FsError::EntryNotFound,
             "Deleted from primary"
         );
-        assert!(!ops::exists(&overlay.secondaries[0], second));
+        assert!(!ops::exists(&overlay.secondaries[0], second).await);
 
         // Directory on the primary fs isn't empty
         assert_eq!(
-            overlay.remove_dir(second).unwrap_err(),
+            overlay.remove_dir(second).await.unwrap_err(),
             FsError::DirectoryNotEmpty,
         );
 
         // Try to remove something on one of the overlay filesystems
-        assert_eq!(overlay.remove_dir(third), Ok(()));
+        assert_eq!(overlay.remove_dir(third).await, Ok(()));
 
         // It should no longer exist
-        assert_eq!(overlay.metadata(third).unwrap_err(), FsError::EntryNotFound);
+        assert_eq!(overlay.metadata(third).await.unwrap_err(), FsError::EntryNotFound);
 
-        assert!(ops::exists(&overlay.secondaries[0], third));
+        assert!(ops::exists(&overlay.secondaries[0], third).await);
     }
 
     #[tokio::test]
     async fn open_files() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&primary, "/primary").unwrap();
-        ops::touch(&primary, "/primary/read.txt").unwrap();
-        ops::touch(&primary, "/primary/write.txt").unwrap();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
-        ops::touch(&secondary, "/secondary/read.txt").unwrap();
-        ops::touch(&secondary, "/secondary/write.txt").unwrap();
-        ops::create_dir_all(&secondary, "/primary").unwrap();
+        ops::create_dir_all(&primary, "/primary").await.unwrap();
+        ops::touch(&primary, "/primary/read.txt").await.unwrap();
+        ops::touch(&primary, "/primary/write.txt").await.unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
+        ops::touch(&secondary, "/secondary/read.txt").await.unwrap();
+        ops::touch(&secondary, "/secondary/write.txt").await.unwrap();
+        ops::create_dir_all(&secondary, "/primary").await.unwrap();
         ops::write(&secondary, "/primary/read.txt", "This is shadowed")
             .await
             .unwrap();
@@ -1454,9 +1471,10 @@ mod tests {
             .create(true)
             .write(true)
             .open("/new.txt")
+            .await
             .unwrap();
-        assert!(ops::exists(&fs.primary, "/new.txt"));
-        assert!(!ops::exists(&fs.secondaries[0], "/new.txt"));
+        assert!(ops::exists(&fs.primary, "/new.txt").await);
+        assert!(!ops::exists(&fs.secondaries[0], "/new.txt").await);
 
         // You can open a file for reading and writing on the primary fs
         let _ = fs
@@ -1465,6 +1483,7 @@ mod tests {
             .write(true)
             .read(true)
             .open("/primary/write.txt")
+            .await
             .unwrap();
 
         // Files on the primary should always shadow the secondary
@@ -1476,7 +1495,7 @@ mod tests {
     async fn open_secondary_file_preserves_owned_buffer_access() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         secondary
             .insert_ro_file(
                 "/secondary/buffer.txt".as_ref(),
@@ -1490,10 +1509,12 @@ mod tests {
             .new_open_options()
             .read(true)
             .open("/secondary/buffer.txt")
+            .await
             .unwrap();
 
         let buffer = file
             .as_owned_buffer()
+            .await
             .expect("secondary wrapper should preserve inner owned-buffer access");
         assert_eq!(buffer.as_slice(), b"overlay-buffer");
     }
@@ -1502,15 +1523,15 @@ mod tests {
     async fn create_file_that_looks_like_it_is_in_a_secondary_filesystem_folder() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/path/to/").unwrap();
-        assert!(!ops::is_dir(&primary, "/path/to/"));
+        ops::create_dir_all(&secondary, "/path/to/").await.unwrap();
+        assert!(!ops::is_dir(&primary, "/path/to/").await);
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        ops::touch(&fs, "/path/to/file.txt").unwrap();
+        ops::touch(&fs, "/path/to/file.txt").await.unwrap();
 
-        assert!(ops::is_dir(&fs.primary, "/path/to/"));
-        assert!(ops::is_file(&fs.primary, "/path/to/file.txt"));
-        assert!(!ops::is_file(&fs.secondaries[0], "/path/to/file.txt"));
+        assert!(ops::is_dir(&fs.primary, "/path/to/").await);
+        assert!(ops::is_file(&fs.primary, "/path/to/file.txt").await);
+        assert!(!ops::is_file(&fs.secondaries[0], "/path/to/file.txt").await);
     }
 
     #[tokio::test]
@@ -1518,20 +1539,24 @@ mod tests {
         let primary = MemFS::default();
         let secondary = MemFS::default();
         let secondary_overlaid = MemFS::default();
-        ops::create_dir_all(&primary, "/primary").unwrap();
-        ops::touch(&primary, "/primary/read.txt").unwrap();
-        ops::touch(&primary, "/primary/write.txt").unwrap();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
-        ops::touch(&secondary, "/secondary/read.txt").unwrap();
-        ops::touch(&secondary, "/secondary/write.txt").unwrap();
+        ops::create_dir_all(&primary, "/primary").await.unwrap();
+        ops::touch(&primary, "/primary/read.txt").await.unwrap();
+        ops::touch(&primary, "/primary/write.txt").await.unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
+        ops::touch(&secondary, "/secondary/read.txt").await.unwrap();
+        ops::touch(&secondary, "/secondary/write.txt").await.unwrap();
         // This second "secondary" filesystem should share the same folders as
         // the first one.
-        ops::create_dir_all(&secondary_overlaid, "/secondary").unwrap();
-        ops::touch(&secondary_overlaid, "/secondary/overlayed.txt").unwrap();
+        ops::create_dir_all(&secondary_overlaid, "/secondary").await.unwrap();
+        ops::touch(&secondary_overlaid, "/secondary/overlayed.txt").await.unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary, secondary_overlaid]);
 
-        let paths: Vec<_> = ops::walk(&fs, "/").map(|entry| entry.path()).collect();
+        let paths: Vec<_> = ops::walk(&fs, "/")
+            .await
+            .into_iter()
+            .map(|entry| entry.path())
+            .collect();
         assert_eq!(
             paths,
             vec![
@@ -1550,7 +1575,7 @@ mod tests {
     async fn open_secondary_fs_files_in_write_mode() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1562,6 +1587,7 @@ mod tests {
             .write(true)
             .read(true)
             .open("/secondary/file.txt")
+            .await
             .unwrap();
         // reading is fine
         let mut buf = String::new();
@@ -1569,7 +1595,7 @@ mod tests {
         assert_eq!(buf, "Hello, World!");
         f.seek(SeekFrom::Start(0)).await.unwrap();
         // next we will write a new set of bytes
-        f.set_len(0).unwrap();
+        f.set_len(0).await.unwrap();
         assert_eq!(f.write(b"Hi").await.unwrap(), 2);
         // Same with flushing
         assert_eq!(f.flush().await.unwrap(), ());
@@ -1586,6 +1612,7 @@ mod tests {
             .new_open_options()
             .read(true)
             .open("/secondary/file.txt")
+            .await
             .unwrap();
         buf = String::new();
         f.read_to_string(&mut buf).await.unwrap();
@@ -1596,19 +1623,19 @@ mod tests {
     async fn open_secondary_fs_files_unlink() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        fs.metadata(Path::new("/secondary/file.txt")).unwrap();
+        fs.metadata(Path::new("/secondary/file.txt")).await.unwrap();
 
         // Now delete the file and make sure its not found
-        fs.remove_file(Path::new("/secondary/file.txt")).unwrap();
+        fs.remove_file(Path::new("/secondary/file.txt")).await.unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
             FsError::EntryNotFound
         )
     }
@@ -1617,7 +1644,7 @@ mod tests {
     async fn open_secondary_fs_without_cow() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1629,25 +1656,26 @@ mod tests {
             .create(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
-        assert_eq!(f.size() as usize, 13);
+        assert_eq!(f.size().await as usize, 13);
 
         let mut buf = String::new();
         f.read_to_string(&mut buf).await.unwrap();
         assert_eq!(buf, "Hello, World!");
 
         // it should not be in the primary and nor should the secondary folder
-        assert!(!ops::is_dir(&fs.primary, "/secondary"));
-        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/secondary"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(!ops::is_dir(&fs.primary, "/secondary").await);
+        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/secondary").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
     }
 
     #[tokio::test]
     async fn unlink_open_secondary_fs_without_cow_keeps_handle_alive() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1658,16 +1686,17 @@ mod tests {
             .new_open_options()
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
 
-        f.unlink().unwrap();
+        f.unlink().await.unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
             FsError::EntryNotFound
         );
-        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt"));
-        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
+        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
 
         let mut buf = String::new();
         f.read_to_string(&mut buf).await.unwrap();
@@ -1678,7 +1707,7 @@ mod tests {
     async fn unlink_open_secondary_fs_without_cow_returns_not_found_when_whiteout_already_exists() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1689,12 +1718,15 @@ mod tests {
             .new_open_options()
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
 
         // The path was already deleted via another route before this handle
         // called unlink(). The handle should see EntryNotFound, not Ok(()).
-        ops::create_white_out(&fs.primary, "/secondary/file.txt").unwrap();
-        assert_eq!(f.unlink(), Err(FsError::EntryNotFound));
+        ops::create_white_out(&fs.primary, "/secondary/file.txt")
+            .await
+            .unwrap();
+        assert_eq!(f.unlink().await, Err(FsError::EntryNotFound));
     }
 
     #[tokio::test]
@@ -1704,7 +1736,7 @@ mod tests {
         ops::write(&primary, "/secondary", b"not a directory")
             .await
             .unwrap();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1715,16 +1747,17 @@ mod tests {
             .new_open_options()
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
 
-        assert_eq!(f.unlink(), Err(FsError::BaseNotDirectory));
+        assert_eq!(f.unlink().await, Err(FsError::BaseNotDirectory));
     }
 
     #[tokio::test]
     async fn create_and_append_secondary_fs_with_cow() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1737,11 +1770,12 @@ mod tests {
             .append(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
-        assert_eq!(f.size() as usize, 13);
+        assert_eq!(f.size().await as usize, 13);
 
         f.write_all(b"asdf").await.unwrap();
-        assert_eq!(f.size() as usize, 17);
+        assert_eq!(f.size().await as usize, 17);
 
         f.seek(SeekFrom::Start(0)).await.unwrap();
 
@@ -1757,29 +1791,31 @@ mod tests {
             .append(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
-        assert_eq!(f.size() as usize, 17);
+        assert_eq!(f.size().await as usize, 17);
         let f = fs.secondaries[0]
             .new_open_options()
             .create(true)
             .append(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
-        assert_eq!(f.size() as usize, 13);
+        assert_eq!(f.size().await as usize, 13);
 
         // it should now exist in both the primary and secondary
-        assert!(ops::is_dir(&fs.primary, "/secondary"));
-        assert!(ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/secondary"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(ops::is_dir(&fs.primary, "/secondary").await);
+        assert!(ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/secondary").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
     }
 
     #[tokio::test]
     async fn unlink_open_secondary_fs_with_cow_does_not_recreate_path() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -1791,16 +1827,17 @@ mod tests {
             .append(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
 
-        f.unlink().unwrap();
+        f.unlink().await.unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
             FsError::EntryNotFound
         );
-        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt"));
-        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
+        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
 
         f.write_all(b"asdf").await.unwrap();
         f.seek(SeekFrom::Start(0)).await.unwrap();
@@ -1810,12 +1847,12 @@ mod tests {
         assert_eq!(buf, "Hello, World!asdf");
 
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
             FsError::EntryNotFound
         );
-        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt"));
-        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
+        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
     }
 
     /// Regression test: unlinking a handle opened from the secondary must not
@@ -1825,7 +1862,7 @@ mod tests {
     async fn unlink_secondary_handle_does_not_delete_later_primary_file() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/dir").unwrap();
+        ops::create_dir_all(&secondary, "/dir").await.unwrap();
         ops::write(&secondary, "/dir/file.txt", b"secondary")
             .await
             .unwrap();
@@ -1837,23 +1874,24 @@ mod tests {
             .new_open_options()
             .read(true)
             .open(Path::new("/dir/file.txt"))
+            .await
             .unwrap();
 
         // A new file is created at the same path in primary AFTER the handle
         // was opened.
-        ops::create_dir_all(&fs.primary, "/dir").unwrap();
+        ops::create_dir_all(&fs.primary, "/dir").await.unwrap();
         ops::write(&fs.primary, "/dir/file.txt", b"primary replacement")
             .await
             .unwrap();
 
         // Unlinking the old handle should only whiteout the secondary entry,
         // never delete the new primary file.
-        f.unlink().unwrap();
+        f.unlink().await.unwrap();
 
         // The whiteout must exist.
-        assert!(ops::is_file(&fs.primary, "/dir/.wh.file.txt"));
+        assert!(ops::is_file(&fs.primary, "/dir/.wh.file.txt").await);
         // The newer primary file must still be intact.
-        assert!(ops::is_file(&fs.primary, "/dir/file.txt"));
+        assert!(ops::is_file(&fs.primary, "/dir/file.txt").await);
         assert_eq!(
             ops::read_to_string(&fs.primary, "/dir/file.txt")
                 .await
@@ -1868,7 +1906,7 @@ mod tests {
     async fn unlink_cow_handle_does_not_delete_later_primary_file() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/dir").unwrap();
+        ops::create_dir_all(&secondary, "/dir").await.unwrap();
         ops::write(&secondary, "/dir/file.txt", b"secondary")
             .await
             .unwrap();
@@ -1882,21 +1920,22 @@ mod tests {
             .write(true)
             .read(true)
             .open(Path::new("/dir/file.txt"))
+            .await
             .unwrap();
 
         // A new file is created at the same path in primary AFTER the handle
         // was opened.
-        ops::create_dir_all(&fs.primary, "/dir").unwrap();
+        ops::create_dir_all(&fs.primary, "/dir").await.unwrap();
         ops::write(&fs.primary, "/dir/file.txt", b"primary replacement")
             .await
             .unwrap();
 
         // Unlink before any write → COW copy has not started, so the primary
         // file we just created must not be deleted.
-        f.unlink().unwrap();
+        f.unlink().await.unwrap();
 
-        assert!(ops::is_file(&fs.primary, "/dir/.wh.file.txt"));
-        assert!(ops::is_file(&fs.primary, "/dir/file.txt"));
+        assert!(ops::is_file(&fs.primary, "/dir/.wh.file.txt").await);
+        assert!(ops::is_file(&fs.primary, "/dir/file.txt").await);
         assert_eq!(
             ops::read_to_string(&fs.primary, "/dir/file.txt")
                 .await
@@ -1909,18 +1948,21 @@ mod tests {
     async fn unlink_file_from_secondary_fs() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        fs.remove_file(Path::new("/secondary/file.txt")).unwrap();
-        assert_eq!(ops::exists(&fs, Path::new("/secondary/file.txt")), false);
+        fs.remove_file(Path::new("/secondary/file.txt")).await.unwrap();
+        assert_eq!(
+            ops::exists(&fs, Path::new("/secondary/file.txt")).await,
+            false
+        );
 
-        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
 
         // Now create the file again after the unlink
         let mut f = fs
@@ -1929,66 +1971,67 @@ mod tests {
             .write(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
-        assert_eq!(f.size() as usize, 0);
+        assert_eq!(f.size().await as usize, 0);
         f.write_all(b"asdf").await.unwrap();
-        assert_eq!(f.size() as usize, 4);
+        assert_eq!(f.size().await as usize, 4);
 
         // The whiteout should be gone and new file exist
-        assert!(!ops::is_file(&fs.primary, "/secondary/.wh.file.txt"));
-        assert!(ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(!ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
+        assert!(ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
     }
 
     #[tokio::test]
     async fn rmdir_from_secondary_fs() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        assert!(ops::is_dir(&fs, "/secondary"));
-        fs.remove_dir(Path::new("/secondary")).unwrap();
+        assert!(ops::is_dir(&fs, "/secondary").await);
+        fs.remove_dir(Path::new("/secondary")).await.unwrap();
 
-        assert!(!ops::is_dir(&fs, "/secondary"));
-        assert!(ops::is_file(&fs.primary, "/.wh.secondary"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/secondary"));
+        assert!(!ops::is_dir(&fs, "/secondary").await);
+        assert!(ops::is_file(&fs.primary, "/.wh.secondary").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/secondary").await);
 
-        fs.create_dir(Path::new("/secondary")).unwrap();
-        assert!(ops::is_dir(&fs, "/secondary"));
-        assert!(ops::is_dir(&fs.primary, "/secondary"));
-        assert!(!ops::is_file(&fs.primary, "/.wh.secondary"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/secondary"));
+        fs.create_dir(Path::new("/secondary")).await.unwrap();
+        assert!(ops::is_dir(&fs, "/secondary").await);
+        assert!(ops::is_dir(&fs.primary, "/secondary").await);
+        assert!(!ops::is_file(&fs.primary, "/.wh.secondary").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/secondary").await);
     }
 
     #[tokio::test]
     async fn rmdir_sub_from_secondary_fs() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/first/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/first/secondary").await.unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        assert!(ops::is_dir(&fs, "/first/secondary"));
-        fs.remove_dir(Path::new("/first/secondary")).unwrap();
+        assert!(ops::is_dir(&fs, "/first/secondary").await);
+        fs.remove_dir(Path::new("/first/secondary")).await.unwrap();
 
-        assert!(!ops::is_dir(&fs, "/first/secondary"));
-        assert!(ops::is_file(&fs.primary, "/first/.wh.secondary"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/first/secondary"));
+        assert!(!ops::is_dir(&fs, "/first/secondary").await);
+        assert!(ops::is_file(&fs.primary, "/first/.wh.secondary").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/first/secondary").await);
 
-        fs.create_dir(Path::new("/first/secondary")).unwrap();
-        assert!(ops::is_dir(&fs, "/first/secondary"));
-        assert!(ops::is_dir(&fs.primary, "/first/secondary"));
-        assert!(!ops::is_file(&fs.primary, "/first/.wh.secondary"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/first/secondary"));
+        fs.create_dir(Path::new("/first/secondary")).await.unwrap();
+        assert!(ops::is_dir(&fs, "/first/secondary").await);
+        assert!(ops::is_dir(&fs.primary, "/first/secondary").await);
+        assert!(!ops::is_file(&fs.primary, "/first/.wh.secondary").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/first/secondary").await);
     }
 
     #[tokio::test]
     async fn create_new_secondary_fs_without_cow() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -2000,34 +2043,35 @@ mod tests {
             .create_new(true)
             .read(true)
             .open(Path::new("/secondary/file.txt"))
+            .await
             .unwrap();
-        assert_eq!(f.size() as usize, 0);
+        assert_eq!(f.size().await as usize, 0);
 
         let mut buf = String::new();
         f.read_to_string(&mut buf).await.unwrap();
         assert_eq!(buf, "");
 
         // it should now exist in both the primary and secondary
-        assert!(ops::is_dir(&fs.primary, "/secondary"));
-        assert!(ops::is_file(&fs.primary, "/secondary/file.txt"));
-        assert!(ops::is_dir(&fs.secondaries[0], "/secondary"));
-        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt"));
+        assert!(ops::is_dir(&fs.primary, "/secondary").await);
+        assert!(ops::is_file(&fs.primary, "/secondary/file.txt").await);
+        assert!(ops::is_dir(&fs.secondaries[0], "/secondary").await);
+        assert!(ops::is_file(&fs.secondaries[0], "/secondary/file.txt").await);
     }
 
     #[tokio::test]
     async fn open_secondary_fs_files_remove_dir() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        fs.metadata(Path::new("/secondary")).unwrap();
+        fs.metadata(Path::new("/secondary")).await.unwrap();
 
         // Now delete the file and make sure its not found
-        fs.remove_dir(Path::new("/secondary")).unwrap();
+        fs.remove_dir(Path::new("/secondary")).await.unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary")).unwrap_err(),
+            fs.metadata(Path::new("/secondary")).await.unwrap_err(),
             FsError::EntryNotFound
         )
     }
@@ -2039,7 +2083,7 @@ mod tests {
     async fn test_overlayfs_readonly_files_not_copied() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/secondary").unwrap();
+        ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::write(&secondary, "/secondary/file.txt", b"Hello, World!")
             .await
             .unwrap();
@@ -2052,6 +2096,7 @@ mod tests {
                 .read(true)
                 .write(true)
                 .open(Path::new("/secondary/file.txt"))
+                .await
                 .unwrap();
             let mut s = String::new();
             f.read_to_string(&mut s).await.unwrap();
@@ -2062,7 +2107,7 @@ mod tests {
         }
 
         // Primary should not have the file
-        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt"));
+        assert!(!ops::is_file(&fs.primary, "/secondary/file.txt").await);
     }
 
     // OLD tests that used WebcFileSystem.
@@ -2096,13 +2141,13 @@ mod tests {
     //     let fs = OverlayFileSystem::new(primary, [webc]);
     //
     //     // We should get all the normal directories from rootfs (primary)
-    //     assert!(ops::is_dir(&fs, "/lib"));
-    //     assert!(ops::is_dir(&fs, "/bin"));
-    //     assert!(ops::is_file(&fs, "/dev/stdin"));
-    //     assert!(ops::is_file(&fs, "/dev/stdout"));
+    //     assert!(ops::is_dir(&fs, "/lib").await);
+    //     assert!(ops::is_dir(&fs, "/bin").await);
+    //     assert!(ops::is_file(&fs, "/dev/stdin").await);
+    //     assert!(ops::is_file(&fs, "/dev/stdout").await);
     //     // We also want to see files from the WEBC volumes (secondary)
-    //     assert!(ops::is_dir(&fs, "/lib/python3.6"));
-    //     assert!(ops::is_file(&fs, "/lib/python3.6/collections/__init__.py"));
+    //     assert!(ops::is_dir(&fs, "/lib/python3.6").await);
+    //     assert!(ops::is_file(&fs, "/lib/python3.6/collections/__init__.py").await);
     //     #[cfg(never)]
     //     {
     //         // files on a secondary fs aren't writable
@@ -2118,7 +2163,7 @@ mod tests {
     //     }
     //     // you are allowed to create files that look like they are in a secondary
     //     // folder, though
-    //     ops::touch(&fs, "/lib/python3.6/collections/something-else.py").unwrap();
+    //     ops::touch(&fs, "/lib/python3.6/collections/something-else.py").await.unwrap();
     //     // But it'll be on the primary filesystem, not the secondary one
     //     assert!(ops::is_file(
     //         &fs.primary,
@@ -2131,7 +2176,7 @@ mod tests {
     //     // You can do the same thing with folders
     //     fs.create_dir("/lib/python3.6/something-else".as_ref())
     //         .unwrap();
-    //     assert!(ops::is_dir(&fs.primary, "/lib/python3.6/something-else"));
+    //     assert!(ops::is_dir(&fs.primary, "/lib/python3.6/something-else").await);
     //     assert!(!ops::is_dir(
     //         &fs.secondaries[0],
     //         "/lib/python3.6/something-else"
@@ -2143,8 +2188,8 @@ mod tests {
     //         FsError::EntryNotFound
     //     );
     //     // you should also be able to read files mounted from the host
-    //     assert!(ops::is_dir(&fs, "/first"));
-    //     assert!(ops::is_file(&fs, "/first/file.txt"));
+    //     assert!(ops::is_dir(&fs, "/first").await);
+    //     assert!(ops::is_file(&fs, "/first/file.txt").await);
     //     assert_eq!(
     //         ops::read_to_string(&fs, "/first/file.txt").await.unwrap(),
     //         "First!"

--- a/lib/virtual-fs/src/overlay_fs.rs
+++ b/lib/virtual-fs/src/overlay_fs.rs
@@ -461,70 +461,70 @@ where
     async fn rename(&self, from: &Path, to: &Path) -> Result<(), FsError> {
         let from = from.to_owned();
         let to = to.to_owned();
-            // Whiteout files can not be renamed
-            if ops::is_white_out(&from).is_some() {
-                tracing::trace!(
-                    from=%from.display(),
-                    to=%to.display(),
-                    "Attempting to rename a file that was whited out"
-                );
-                return Err(FsError::EntryNotFound);
-            }
-            // You can not rename a file into a whiteout file
-            if ops::is_white_out(&to).is_some() {
-                tracing::trace!(
-                    from=%from.display(),
-                    to=%to.display(),
-                    "Attempting to rename a file into a whiteout file"
-                );
-                return Err(FsError::InvalidInput);
-            }
+        // Whiteout files can not be renamed
+        if ops::is_white_out(&from).is_some() {
+            tracing::trace!(
+                from=%from.display(),
+                to=%to.display(),
+                "Attempting to rename a file that was whited out"
+            );
+            return Err(FsError::EntryNotFound);
+        }
+        // You can not rename a file into a whiteout file
+        if ops::is_white_out(&to).is_some() {
+            tracing::trace!(
+                from=%from.display(),
+                to=%to.display(),
+                "Attempting to rename a file into a whiteout file"
+            );
+            return Err(FsError::InvalidInput);
+        }
 
-            // We attempt to rename the file or directory in the primary
-            // if this succeeds then we also need to ensure the white out
-            // files are created where we need them, so we do not immediately
-            // return until that is done
-            let mut had_at_least_one_success = false;
-            match self.primary.rename(&from, &to).await {
-                Err(e) if should_continue(e) => {}
-                Ok(()) => {
+        // We attempt to rename the file or directory in the primary
+        // if this succeeds then we also need to ensure the white out
+        // files are created where we need them, so we do not immediately
+        // return until that is done
+        let mut had_at_least_one_success = false;
+        match self.primary.rename(&from, &to).await {
+            Err(e) if should_continue(e) => {}
+            Ok(()) => {
+                had_at_least_one_success = true;
+            }
+            other => return other,
+        }
+
+        // If we have not yet renamed the file it may still reside in
+        // the secondaries, in which case we need to copy it to the
+        // primary rather than rename it
+        if !had_at_least_one_success {
+            for fs in self.secondaries.filesystems() {
+                if fs.metadata(&from).await.is_ok() {
+                    ops::copy_reference_ext(fs, &self.primary, &from, &to).await?;
                     had_at_least_one_success = true;
-                }
-                other => return other,
-            }
-
-            // If we have not yet renamed the file it may still reside in
-            // the secondaries, in which case we need to copy it to the
-            // primary rather than rename it
-            if !had_at_least_one_success {
-                for fs in self.secondaries.filesystems() {
-                    if fs.metadata(&from).await.is_ok() {
-                        ops::copy_reference_ext(fs, &self.primary, &from, &to).await?;
-                        had_at_least_one_success = true;
-                        break;
-                    }
+                    break;
                 }
             }
+        }
 
-            // If the rename operation was a success then we need to update any
-            // whiteout files on the primary before we return success.
-            if had_at_least_one_success {
-                for fs in self.secondaries.filesystems() {
-                    if fs.metadata(&from).await.is_ok() {
-                        tracing::trace!(
-                            path=%from.display(),
-                            "Creating a whiteout for the file that was renamed",
-                        );
-                        ops::create_white_out(&self.primary, &from).await.ok();
-                        break;
-                    }
+        // If the rename operation was a success then we need to update any
+        // whiteout files on the primary before we return success.
+        if had_at_least_one_success {
+            for fs in self.secondaries.filesystems() {
+                if fs.metadata(&from).await.is_ok() {
+                    tracing::trace!(
+                        path=%from.display(),
+                        "Creating a whiteout for the file that was renamed",
+                    );
+                    ops::create_white_out(&self.primary, &from).await.ok();
+                    break;
                 }
-                ops::remove_white_out(&self.primary, &to).await;
-                return Ok(());
             }
+            ops::remove_white_out(&self.primary, &to).await;
+            return Ok(());
+        }
 
-            // Otherwise we are in a failure scenario
-            self.permission_error_or_not_found(&from)
+        // Otherwise we are in a failure scenario
+        self.permission_error_or_not_found(&from)
     }
 
     async fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
@@ -668,10 +668,7 @@ where
             ops::remove_white_out(&self.primary, path).await;
 
             // Create the file in the primary
-            return self
-                .primary
-                .open(path, conf)
-                .await;
+            return self.primary.open(path, conf).await;
         }
 
         // There might be a whiteout, search for this and if its found then
@@ -729,10 +726,7 @@ where
             ops::remove_white_out(&self.primary, path).await;
 
             // Create the file in the primary
-            return self
-                .primary
-                .open(path, conf)
-                .await;
+            return self.primary.open(path, conf).await;
         }
 
         // The file does not exist anywhere
@@ -1059,7 +1053,7 @@ where
     }
 
     #[async_trait::async_trait]
-impl<P> VirtualFile for CopyOnWriteFile<P>
+    impl<P> VirtualFile for CopyOnWriteFile<P>
     where
         P: FileSystem + 'static,
     {
@@ -1370,10 +1364,14 @@ mod tests {
         ops::create_dir_all(&primary, "/app").await.unwrap();
 
         let volume = MemFS::default();
-        ops::create_dir_all(&volume, "/themes/twentytwentyfour").await.unwrap();
+        ops::create_dir_all(&volume, "/themes/twentytwentyfour")
+            .await
+            .unwrap();
 
         let container = MemFS::default();
-        ops::create_dir_all(&container, "/app/wp-content/themes/twentytwentyfour").await.unwrap();
+        ops::create_dir_all(&container, "/app/wp-content/themes/twentytwentyfour")
+            .await
+            .unwrap();
 
         let volume: Arc<dyn FileSystem + Send + Sync> = Arc::new(volume);
         primary
@@ -1443,7 +1441,10 @@ mod tests {
         assert_eq!(overlay.remove_dir(third).await, Ok(()));
 
         // It should no longer exist
-        assert_eq!(overlay.metadata(third).await.unwrap_err(), FsError::EntryNotFound);
+        assert_eq!(
+            overlay.metadata(third).await.unwrap_err(),
+            FsError::EntryNotFound
+        );
 
         assert!(ops::exists(&overlay.secondaries[0], third).await);
     }
@@ -1457,7 +1458,9 @@ mod tests {
         ops::touch(&primary, "/primary/write.txt").await.unwrap();
         ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::touch(&secondary, "/secondary/read.txt").await.unwrap();
-        ops::touch(&secondary, "/secondary/write.txt").await.unwrap();
+        ops::touch(&secondary, "/secondary/write.txt")
+            .await
+            .unwrap();
         ops::create_dir_all(&secondary, "/primary").await.unwrap();
         ops::write(&secondary, "/primary/read.txt", "This is shadowed")
             .await
@@ -1544,11 +1547,17 @@ mod tests {
         ops::touch(&primary, "/primary/write.txt").await.unwrap();
         ops::create_dir_all(&secondary, "/secondary").await.unwrap();
         ops::touch(&secondary, "/secondary/read.txt").await.unwrap();
-        ops::touch(&secondary, "/secondary/write.txt").await.unwrap();
+        ops::touch(&secondary, "/secondary/write.txt")
+            .await
+            .unwrap();
         // This second "secondary" filesystem should share the same folders as
         // the first one.
-        ops::create_dir_all(&secondary_overlaid, "/secondary").await.unwrap();
-        ops::touch(&secondary_overlaid, "/secondary/overlayed.txt").await.unwrap();
+        ops::create_dir_all(&secondary_overlaid, "/secondary")
+            .await
+            .unwrap();
+        ops::touch(&secondary_overlaid, "/secondary/overlayed.txt")
+            .await
+            .unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary, secondary_overlaid]);
 
@@ -1633,9 +1642,13 @@ mod tests {
         fs.metadata(Path::new("/secondary/file.txt")).await.unwrap();
 
         // Now delete the file and make sure its not found
-        fs.remove_file(Path::new("/secondary/file.txt")).await.unwrap();
+        fs.remove_file(Path::new("/secondary/file.txt"))
+            .await
+            .unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt"))
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound
         )
     }
@@ -1691,7 +1704,9 @@ mod tests {
 
         f.unlink().await.unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt"))
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound
         );
         assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
@@ -1832,7 +1847,9 @@ mod tests {
 
         f.unlink().await.unwrap();
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt"))
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound
         );
         assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
@@ -1847,7 +1864,9 @@ mod tests {
         assert_eq!(buf, "Hello, World!asdf");
 
         assert_eq!(
-            fs.metadata(Path::new("/secondary/file.txt")).await.unwrap_err(),
+            fs.metadata(Path::new("/secondary/file.txt"))
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound
         );
         assert!(ops::is_file(&fs.primary, "/secondary/.wh.file.txt").await);
@@ -1955,7 +1974,9 @@ mod tests {
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 
-        fs.remove_file(Path::new("/secondary/file.txt")).await.unwrap();
+        fs.remove_file(Path::new("/secondary/file.txt"))
+            .await
+            .unwrap();
         assert_eq!(
             ops::exists(&fs, Path::new("/secondary/file.txt")).await,
             false
@@ -2009,7 +2030,9 @@ mod tests {
     async fn rmdir_sub_from_secondary_fs() {
         let primary = MemFS::default();
         let secondary = MemFS::default();
-        ops::create_dir_all(&secondary, "/first/secondary").await.unwrap();
+        ops::create_dir_all(&secondary, "/first/secondary")
+            .await
+            .unwrap();
 
         let fs = OverlayFileSystem::new(primary, [secondary]);
 

--- a/lib/virtual-fs/src/passthru_fs.rs
+++ b/lib/virtual-fs/src/passthru_fs.rs
@@ -24,45 +24,54 @@ impl PassthruFileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl FileSystem for PassthruFileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
-        self.fs.readlink(path)
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
+        self.fs.readlink(path).await
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
-        self.fs.read_dir(path)
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+        self.fs.read_dir(path).await
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
-        self.fs.create_dir(path)
+    async fn create_dir(&self, path: &Path) -> Result<()> {
+        self.fs.create_dir(path).await
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
-        self.fs.create_symlink(source, target)
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+        self.fs.create_symlink(source, target).await
     }
 
-    fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
-        self.fs.hard_link(source, target)
+    async fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+        self.fs.hard_link(source, target).await
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
-        self.fs.remove_dir(path)
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
+        self.fs.remove_dir(path).await
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async { self.fs.rename(from, to).await })
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.fs.rename(from, to).await
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
-        self.fs.metadata(path)
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
+        self.fs.metadata(path).await
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
-        self.fs.symlink_metadata(path)
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+        self.fs.symlink_metadata(path).await
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
-        self.fs.remove_file(path)
+    async fn remove_file(&self, path: &Path) -> Result<()> {
+        self.fs.remove_file(path).await
+    }
+
+    async fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        self.fs.open(path, conf).await
     }
 
     fn new_open_options(&self) -> OpenOptions<'_> {
@@ -88,6 +97,7 @@ mod test_builder {
             .write(true)
             .create(true)
             .open("/foo.txt")
+            .await
             .unwrap()
             .write_all(b"hello")
             .await
@@ -98,6 +108,7 @@ mod test_builder {
             .new_open_options()
             .read(true)
             .open("/foo.txt")
+            .await
             .unwrap()
             .read_to_end(&mut buf)
             .await
@@ -110,6 +121,7 @@ mod test_builder {
             .new_open_options()
             .read(true)
             .open("/foo.txt")
+            .await
             .unwrap()
             .read_to_end(&mut buf)
             .await

--- a/lib/virtual-fs/src/pipe.rs
+++ b/lib/virtual-fs/src/pipe.rs
@@ -482,41 +482,42 @@ impl AsyncRead for PipeRx {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for Pipe {
     /// the last time the file was accessed in nanoseconds as a UNIX timestamp
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
 
     /// the last time the file was modified in nanoseconds as a UNIX timestamp
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
 
     /// the time at which the file was created in nanoseconds as a UNIX timestamp
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
 
     /// the size of the file in bytes
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
 
     /// Change the size of the file, if the `new_size` is greater than the current size
     /// the extra bytes will be allocated and zeroed
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
 
     /// Request deletion of the file
-    fn unlink(&mut self) -> Result<(), FsError> {
+    async fn unlink(&mut self) -> Result<(), FsError> {
         Ok(())
     }
 
     /// Indicates if the file is opened or closed. This function must not block
     /// Defaults to a status of being constantly open
-    fn is_open(&self) -> bool {
+    async fn is_open(&self) -> bool {
         self.send
             .tx
             .as_ref()

--- a/lib/virtual-fs/src/random_file.rs
+++ b/lib/virtual-fs/src/random_file.rs
@@ -60,23 +60,24 @@ impl AsyncRead for RandomFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for RandomFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         Ok(())
     }
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/virtual-fs/src/special_file.rs
+++ b/lib/virtual-fs/src/special_file.rs
@@ -77,26 +77,27 @@ impl AsyncRead for DeviceFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for DeviceFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         Ok(())
     }
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         Some(self.fd)
     }
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/virtual-fs/src/static_file.rs
+++ b/lib/virtual-fs/src/static_file.rs
@@ -27,32 +27,33 @@ impl StaticFile {
 
 #[async_trait::async_trait]
 impl VirtualFile for StaticFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         self.0.get_ref().len().try_into().unwrap()
     }
 
-    fn set_len(&mut self, _new_size: u64) -> Result<(), FsError> {
+    async fn set_len(&mut self, _new_size: u64) -> Result<(), FsError> {
         Err(FsError::PermissionDenied)
     }
 
-    fn unlink(&mut self) -> Result<(), FsError> {
+    async fn unlink(&mut self) -> Result<(), FsError> {
         Err(FsError::PermissionDenied)
     }
 
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        let remaining = self.size() - self.0.position();
+        let size = self.0.get_ref().len() as u64;
+        let remaining = size - self.0.position();
         Poll::Ready(Ok(remaining.try_into().unwrap()))
     }
 

--- a/lib/virtual-fs/src/static_fs.rs
+++ b/lib/virtual-fs/src/static_fs.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::mem_fs::FileSystem as MemFileSystem;
-use crate::{
-    FileSystem, FsError, Metadata, OpenOptions, OpenOptionsConfig, ReadDir, VirtualFile,
-};
+use crate::{FileSystem, FsError, Metadata, OpenOptions, OpenOptionsConfig, ReadDir, VirtualFile};
 use indexmap::IndexMap;
 use webc::v1::{FsEntry, FsEntryType, OwnedFsEntryFile};
 
@@ -244,19 +242,19 @@ impl FileSystem for StaticFileSystem {
         }
     }
     async fn rename(&self, from: &Path, to: &Path) -> Result<(), FsError> {
-            let from = normalizes_path(from);
-            let to = normalizes_path(to);
-            let result = self.memory.rename(Path::new(&from), Path::new(&to)).await;
-            if self
-                .volumes
-                .values()
-                .find_map(|v| v.get_file_entry(&from).ok())
-                .is_some()
-            {
-                Ok(())
-            } else {
-                result
-            }
+        let from = normalizes_path(from);
+        let to = normalizes_path(to);
+        let result = self.memory.rename(Path::new(&from), Path::new(&to)).await;
+        if self
+            .volumes
+            .values()
+            .find_map(|v| v.get_file_entry(&from).ok())
+            .is_some()
+        {
+            Ok(())
+        } else {
+            result
+        }
     }
     async fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
         let path = normalizes_path(path);

--- a/lib/virtual-fs/src/static_fs.rs
+++ b/lib/virtual-fs/src/static_fs.rs
@@ -1,5 +1,4 @@
 use anyhow::anyhow;
-use futures::future::BoxFuture;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 
 use std::convert::TryInto;
@@ -12,7 +11,7 @@ use std::task::{Context, Poll};
 
 use crate::mem_fs::FileSystem as MemFileSystem;
 use crate::{
-    FileOpener, FileSystem, FsError, Metadata, OpenOptions, OpenOptionsConfig, ReadDir, VirtualFile,
+    FileSystem, FsError, Metadata, OpenOptions, OpenOptionsConfig, ReadDir, VirtualFile,
 };
 use indexmap::IndexMap;
 use webc::v1::{FsEntry, FsEntryType, OwnedFsEntryFile};
@@ -37,56 +36,10 @@ impl StaticFileSystem {
         for volume_name in volume_names {
             let directories = volumes.get(&volume_name).unwrap().list_directories();
             for directory in directories {
-                let _ = fs.create_dir(Path::new(&directory));
+                let _ = futures::executor::block_on(fs.create_dir(Path::new(&directory)));
             }
         }
         Some(fs)
-    }
-}
-
-/// Custom file opener, returns a WebCFile
-impl FileOpener for StaticFileSystem {
-    fn open(
-        &self,
-        path: &Path,
-        _conf: &OpenOptionsConfig,
-    ) -> Result<Box<dyn VirtualFile + Send + Sync>, FsError> {
-        match get_volume_name_opt(path) {
-            Some(volume) => {
-                let file = (*self.volumes)
-                    .get(&volume)
-                    .ok_or(FsError::EntryNotFound)?
-                    .get_file_entry(path.to_string_lossy().as_ref())
-                    .map_err(|_e| FsError::EntryNotFound)?;
-
-                Ok(Box::new(WebCFile {
-                    package: self.package.clone(),
-                    volume,
-                    volumes: self.volumes.clone(),
-                    path: path.to_path_buf(),
-                    entry: file,
-                    cursor: 0,
-                }))
-            }
-            None => {
-                for (volume, v) in self.volumes.iter() {
-                    let entry = match v.get_file_entry(path.to_string_lossy().as_ref()) {
-                        Ok(s) => s,
-                        Err(_) => continue, // error
-                    };
-
-                    return Ok(Box::new(WebCFile {
-                        package: self.package.clone(),
-                        volume: volume.clone(),
-                        volumes: self.volumes.clone(),
-                        path: path.to_path_buf(),
-                        entry,
-                        cursor: 0,
-                    }));
-                }
-                self.memory.new_open_options().open(path)
-            }
-        }
     }
 }
 
@@ -102,22 +55,22 @@ pub struct WebCFile {
 
 #[async_trait::async_trait]
 impl VirtualFile for WebCFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         self.entry.get_len()
     }
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
-    fn unlink(&mut self) -> Result<(), FsError> {
+    async fn unlink(&mut self) -> Result<(), FsError> {
         Ok(())
     }
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
@@ -181,7 +134,7 @@ impl AsyncWrite for WebCFile {
 
 impl AsyncSeek for WebCFile {
     fn start_seek(mut self: Pin<&mut Self>, pos: io::SeekFrom) -> io::Result<()> {
-        let self_size = self.size();
+        let self_size = self.entry.get_len();
         match pos {
             SeekFrom::Start(s) => {
                 self.cursor = s.min(self_size);
@@ -236,8 +189,9 @@ fn transform_into_read_dir(path: &Path, fs_entries: &[FsEntry<'_>]) -> crate::Re
     crate::ReadDir::new(entries)
 }
 
+#[async_trait::async_trait]
 impl FileSystem for StaticFileSystem {
-    fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
         let path = normalizes_path(path);
         if self
             .volumes
@@ -247,11 +201,11 @@ impl FileSystem for StaticFileSystem {
         {
             Err(FsError::InvalidInput)
         } else {
-            self.memory.readlink(Path::new(&path))
+            self.memory.readlink(Path::new(&path)).await
         }
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
         let path = normalizes_path(path);
         for volume in self.volumes.values() {
             let read_dir_result = volume
@@ -269,15 +223,15 @@ impl FileSystem for StaticFileSystem {
             }
         }
 
-        self.memory.read_dir(Path::new(&path))
+        self.memory.read_dir(Path::new(&path)).await
     }
-    fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+    async fn create_dir(&self, path: &Path) -> Result<(), FsError> {
         let path = normalizes_path(path);
-        self.memory.create_dir(Path::new(&path))
+        self.memory.create_dir(Path::new(&path)).await
     }
-    fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
+    async fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
         let path = normalizes_path(path);
-        let result = self.memory.remove_dir(Path::new(&path));
+        let result = self.memory.remove_dir(Path::new(&path)).await;
         if self
             .volumes
             .values()
@@ -289,8 +243,7 @@ impl FileSystem for StaticFileSystem {
             result
         }
     }
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<(), FsError>> {
-        Box::pin(async {
+    async fn rename(&self, from: &Path, to: &Path) -> Result<(), FsError> {
             let from = normalizes_path(from);
             let to = normalizes_path(to);
             let result = self.memory.rename(Path::new(&from), Path::new(&to)).await;
@@ -304,9 +257,8 @@ impl FileSystem for StaticFileSystem {
             } else {
                 result
             }
-        })
     }
-    fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+    async fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
         let path = normalizes_path(path);
         if let Some(fs_entry) = self
             .volumes
@@ -329,12 +281,12 @@ impl FileSystem for StaticFileSystem {
                 len: 0,
             })
         } else {
-            self.memory.metadata(Path::new(&path))
+            self.memory.metadata(Path::new(&path)).await
         }
     }
-    fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+    async fn remove_file(&self, path: &Path) -> Result<(), FsError> {
         let path = normalizes_path(path);
-        let result = self.memory.remove_file(Path::new(&path));
+        let result = self.memory.remove_file(Path::new(&path)).await;
         if self
             .volumes
             .values()
@@ -349,7 +301,7 @@ impl FileSystem for StaticFileSystem {
     fn new_open_options(&self) -> OpenOptions<'_> {
         OpenOptions::new(self)
     }
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata, FsError> {
         let path = normalizes_path(path);
         if let Some(fs_entry) = self
             .volumes
@@ -377,7 +329,50 @@ impl FileSystem for StaticFileSystem {
                 len: 0,
             })
         } else {
-            self.memory.symlink_metadata(Path::new(&path))
+            self.memory.symlink_metadata(Path::new(&path)).await
+        }
+    }
+
+    async fn open(
+        &self,
+        path: &Path,
+        _conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync>, FsError> {
+        match get_volume_name_opt(path) {
+            Some(volume) => {
+                let file = (*self.volumes)
+                    .get(&volume)
+                    .ok_or(FsError::EntryNotFound)?
+                    .get_file_entry(path.to_string_lossy().as_ref())
+                    .map_err(|_e| FsError::EntryNotFound)?;
+
+                Ok(Box::new(WebCFile {
+                    package: self.package.clone(),
+                    volume,
+                    volumes: self.volumes.clone(),
+                    path: path.to_path_buf(),
+                    entry: file,
+                    cursor: 0,
+                }))
+            }
+            None => {
+                for (volume, v) in self.volumes.iter() {
+                    let entry = match v.get_file_entry(path.to_string_lossy().as_ref()) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    };
+
+                    return Ok(Box::new(WebCFile {
+                        package: self.package.clone(),
+                        volume: volume.clone(),
+                        volumes: self.volumes.clone(),
+                        path: path.to_path_buf(),
+                        entry,
+                        cursor: 0,
+                    }));
+                }
+                self.memory.open(path, _conf).await
+            }
         }
     }
 }
@@ -447,6 +442,7 @@ mod tests {
             .new_open_options()
             .read(true)
             .open("/lib/python.wasm")
+            .await
             .unwrap();
 
         let mut first = [0; 4];

--- a/lib/virtual-fs/src/tmp_fs.rs
+++ b/lib/virtual-fs/src/tmp_fs.rs
@@ -4,8 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use crate::{
-    BoxFuture, FileSystem, Metadata, OpenOptions, ReadDir, Result, limiter::DynFsMemoryLimiter,
-    mem_fs,
+    FileSystem, Metadata, OpenOptions, OpenOptionsConfig, ReadDir, Result, VirtualFile,
+    limiter::DynFsMemoryLimiter, mem_fs,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -40,45 +40,54 @@ impl TmpFileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl FileSystem for TmpFileSystem {
-    fn readlink(&self, path: &Path) -> Result<PathBuf> {
-        self.fs.readlink(path)
+    async fn readlink(&self, path: &Path) -> Result<PathBuf> {
+        self.fs.readlink(path).await
     }
 
-    fn read_dir(&self, path: &Path) -> Result<ReadDir> {
-        self.fs.read_dir(path)
+    async fn read_dir(&self, path: &Path) -> Result<ReadDir> {
+        self.fs.read_dir(path).await
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
-        self.fs.create_dir(path)
+    async fn create_dir(&self, path: &Path) -> Result<()> {
+        self.fs.create_dir(path).await
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
+    async fn create_symlink(&self, source: &Path, target: &Path) -> Result<()> {
         self.fs.create_symlink(source, target)
     }
 
-    fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
-        self.fs.hard_link(source, target)
+    async fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+        self.fs.hard_link(source, target).await
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
-        self.fs.remove_dir(path)
+    async fn remove_dir(&self, path: &Path) -> Result<()> {
+        self.fs.remove_dir(path).await
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<()>> {
-        Box::pin(async { self.fs.rename(from, to).await })
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.fs.rename(from, to).await
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata> {
-        self.fs.metadata(path)
+    async fn metadata(&self, path: &Path) -> Result<Metadata> {
+        self.fs.metadata(path).await
     }
 
-    fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
-        self.fs.symlink_metadata(path)
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata> {
+        self.fs.symlink_metadata(path).await
     }
 
-    fn remove_file(&self, path: &Path) -> Result<()> {
-        self.fs.remove_file(path)
+    async fn remove_file(&self, path: &Path) -> Result<()> {
+        self.fs.remove_file(path).await
+    }
+
+    async fn open(
+        &self,
+        path: &Path,
+        conf: &OpenOptionsConfig,
+    ) -> Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
+        self.fs.open(path, conf).await
     }
 
     fn new_open_options(&self) -> OpenOptions<'_> {

--- a/lib/virtual-fs/src/trace_fs.rs
+++ b/lib/virtual-fs/src/trace_fs.rs
@@ -4,10 +4,9 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::future::BoxFuture;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
-use crate::{FileOpener, FileSystem, OpenOptionsConfig, VirtualFile};
+use crate::{FileSystem, OpenOptionsConfig, VirtualFile};
 
 /// A [`FileSystem`] wrapper that will automatically log all operations at the
 /// `trace` level.
@@ -35,71 +34,62 @@ impl<F> TraceFileSystem<F> {
     }
 }
 
+#[async_trait::async_trait]
 impl<F> FileSystem for TraceFileSystem<F>
 where
     F: FileSystem,
 {
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn readlink(&self, path: &std::path::Path) -> crate::Result<PathBuf> {
-        self.0.readlink(path)
+    async fn readlink(&self, path: &std::path::Path) -> crate::Result<PathBuf> {
+        self.0.readlink(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn read_dir(&self, path: &std::path::Path) -> crate::Result<crate::ReadDir> {
-        self.0.read_dir(path)
+    async fn read_dir(&self, path: &std::path::Path) -> crate::Result<crate::ReadDir> {
+        self.0.read_dir(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn create_dir(&self, path: &std::path::Path) -> crate::Result<()> {
-        self.0.create_dir(path)
+    async fn create_dir(&self, path: &std::path::Path) -> crate::Result<()> {
+        self.0.create_dir(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn remove_dir(&self, path: &std::path::Path) -> crate::Result<()> {
-        self.0.remove_dir(path)
+    async fn remove_dir(&self, path: &std::path::Path) -> crate::Result<()> {
+        self.0.remove_dir(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn rename<'a>(
-        &'a self,
-        from: &'a std::path::Path,
-        to: &'a std::path::Path,
-    ) -> BoxFuture<'a, crate::Result<()>> {
-        Box::pin(async { self.0.rename(from, to).await })
+    async fn rename(&self, from: &std::path::Path, to: &std::path::Path) -> crate::Result<()> {
+        self.0.rename(from, to).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn metadata(&self, path: &std::path::Path) -> crate::Result<crate::Metadata> {
-        self.0.metadata(path)
+    async fn metadata(&self, path: &std::path::Path) -> crate::Result<crate::Metadata> {
+        self.0.metadata(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn symlink_metadata(&self, path: &std::path::Path) -> crate::Result<crate::Metadata> {
-        self.0.symlink_metadata(path)
+    async fn symlink_metadata(&self, path: &std::path::Path) -> crate::Result<crate::Metadata> {
+        self.0.symlink_metadata(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), err)]
-    fn remove_file(&self, path: &std::path::Path) -> crate::Result<()> {
-        self.0.remove_file(path)
+    async fn remove_file(&self, path: &std::path::Path) -> crate::Result<()> {
+        self.0.remove_file(path).await
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
     fn new_open_options(&self) -> crate::OpenOptions<'_> {
         crate::OpenOptions::new(self)
     }
-}
-
-impl<F> FileOpener for TraceFileSystem<F>
-where
-    F: FileSystem,
-{
     #[tracing::instrument(level = "trace", skip(self))]
-    fn open(
+    async fn open(
         &self,
         path: &std::path::Path,
         conf: &OpenOptionsConfig,
     ) -> crate::Result<Box<dyn crate::VirtualFile + Send + Sync + 'static>> {
-        let file = self.0.new_open_options().options(conf.clone()).open(path)?;
+        let file = self.0.open(path, conf).await?;
         Ok(Box::new(TraceFile {
             file,
             path: path.to_owned(),
@@ -113,39 +103,40 @@ struct TraceFile {
     file: Box<dyn crate::VirtualFile + Send + Sync + 'static>,
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for TraceFile {
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
-    fn last_accessed(&self) -> u64 {
-        self.file.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        self.file.last_accessed().await
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
-    fn last_modified(&self) -> u64 {
-        self.file.last_modified()
+    async fn last_modified(&self) -> u64 {
+        self.file.last_modified().await
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
-    fn created_time(&self) -> u64 {
-        self.file.created_time()
+    async fn created_time(&self) -> u64 {
+        self.file.created_time().await
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
-    fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
-        self.file.set_times(atime, mtime)
+    async fn set_times(&mut self, atime: Option<u64>, mtime: Option<u64>) -> crate::Result<()> {
+        self.file.set_times(atime, mtime).await
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()))]
-    fn size(&self) -> u64 {
-        self.file.size()
+    async fn size(&self) -> u64 {
+        self.file.size().await
     }
 
     #[tracing::instrument(level = "trace", skip(self), fields(path=%self.path.display()), err)]
-    fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
-        self.file.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
+        self.file.set_len(new_size).await
     }
 
-    fn unlink(&mut self) -> crate::Result<()> {
-        self.file.unlink()
+    async fn unlink(&mut self) -> crate::Result<()> {
+        self.file.unlink().await
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(path=%self.path.display()))]

--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -123,18 +123,18 @@ impl FileSystem for WebcVolumeFileSystem {
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> Result<(), FsError> {
-            // The original file should exist
-            let _ = self.metadata(from).await?;
+        // The original file should exist
+        let _ = self.metadata(from).await?;
 
-            // we also want to make sure the destination's folder exists, too
-            let dest_parent = to.parent().unwrap_or_else(|| Path::new("/"));
-            let parent_meta = self.metadata(dest_parent).await?;
-            if !parent_meta.is_dir() {
-                return Err(FsError::BaseNotDirectory);
-            }
+        // we also want to make sure the destination's folder exists, too
+        let dest_parent = to.parent().unwrap_or_else(|| Path::new("/"));
+        let parent_meta = self.metadata(dest_parent).await?;
+        if !parent_meta.is_dir() {
+            return Err(FsError::BaseNotDirectory);
+        }
 
-            // but we are a readonly filesystem, so you can't modify anything
-            Err(FsError::PermissionDenied)
+        // but we are a readonly filesystem, so you can't modify anything
+        Err(FsError::PermissionDenied)
     }
 
     async fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {

--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -7,7 +7,6 @@ use std::{
     task::Poll,
 };
 
-use futures::future::BoxFuture;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use webc::{
     Container, Metadata as WebcMetadata, PathSegmentError, PathSegments, ToPathSegments, Volume,
@@ -15,8 +14,8 @@ use webc::{
 };
 
 use crate::{
-    DirEntry, EmptyFileSystem, FileOpener, FileSystem, FileType, FsError, Metadata,
-    OpenOptionsConfig, OverlayFileSystem, ReadDir, VirtualFile,
+    DirEntry, EmptyFileSystem, FileSystem, FileType, FsError, Metadata, OpenOptionsConfig,
+    OverlayFileSystem, ReadDir, VirtualFile,
 };
 
 #[derive(Debug, Clone)]
@@ -48,8 +47,9 @@ impl WebcVolumeFileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl FileSystem for WebcVolumeFileSystem {
-    fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
+    async fn readlink(&self, path: &Path) -> crate::Result<PathBuf> {
         let path = normalize(path).map_err(|_| FsError::InvalidInput)?;
 
         match self.volume().metadata(&path) {
@@ -63,8 +63,8 @@ impl FileSystem for WebcVolumeFileSystem {
         }
     }
 
-    fn read_dir(&self, path: &Path) -> Result<crate::ReadDir, FsError> {
-        let meta = self.metadata(path)?;
+    async fn read_dir(&self, path: &Path) -> Result<crate::ReadDir, FsError> {
+        let meta = self.metadata(path).await?;
 
         if !meta.is_dir() {
             return Err(FsError::BaseNotDirectory);
@@ -89,16 +89,16 @@ impl FileSystem for WebcVolumeFileSystem {
         Ok(ReadDir::new(entries))
     }
 
-    fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+    async fn create_dir(&self, path: &Path) -> Result<(), FsError> {
         // the directory shouldn't exist yet
-        if self.metadata(path).is_ok() {
+        if self.metadata(path).await.is_ok() {
             return Err(FsError::AlreadyExists);
         }
 
         // it's parent should exist
         let parent = path.parent().unwrap_or_else(|| Path::new("/"));
 
-        match self.metadata(parent) {
+        match self.metadata(parent).await {
             Ok(parent_meta) if parent_meta.is_dir() => {
                 // The operation would normally be doable... but we're a readonly
                 // filesystem
@@ -109,9 +109,9 @@ impl FileSystem for WebcVolumeFileSystem {
         }
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
+    async fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
         // The original directory should exist
-        let meta = self.metadata(path)?;
+        let meta = self.metadata(path).await?;
 
         // and it should be a directory
         if !meta.is_dir() {
@@ -122,24 +122,22 @@ impl FileSystem for WebcVolumeFileSystem {
         Err(FsError::PermissionDenied)
     }
 
-    fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<(), FsError>> {
-        Box::pin(async {
+    async fn rename(&self, from: &Path, to: &Path) -> Result<(), FsError> {
             // The original file should exist
-            let _ = self.metadata(from)?;
+            let _ = self.metadata(from).await?;
 
             // we also want to make sure the destination's folder exists, too
             let dest_parent = to.parent().unwrap_or_else(|| Path::new("/"));
-            let parent_meta = self.metadata(dest_parent)?;
+            let parent_meta = self.metadata(dest_parent).await?;
             if !parent_meta.is_dir() {
                 return Err(FsError::BaseNotDirectory);
             }
 
             // but we are a readonly filesystem, so you can't modify anything
             Err(FsError::PermissionDenied)
-        })
     }
 
-    fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+    async fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
         let path = normalize(path).map_err(|_| FsError::InvalidInput)?;
 
         self.volume()
@@ -148,12 +146,12 @@ impl FileSystem for WebcVolumeFileSystem {
             .ok_or(FsError::EntryNotFound)
     }
 
-    fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
-        self.metadata(path)
+    async fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
+        self.metadata(path).await
     }
 
-    fn remove_file(&self, path: &Path) -> Result<(), FsError> {
-        let meta = self.metadata(path)?;
+    async fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+        let meta = self.metadata(path).await?;
 
         if !meta.is_file() {
             return Err(FsError::NotAFile);
@@ -165,16 +163,14 @@ impl FileSystem for WebcVolumeFileSystem {
     fn new_open_options(&self) -> crate::OpenOptions<'_> {
         crate::OpenOptions::new(self)
     }
-}
 
-impl FileOpener for WebcVolumeFileSystem {
-    fn open(
+    async fn open(
         &self,
         path: &Path,
         conf: &OpenOptionsConfig,
     ) -> crate::Result<Box<dyn crate::VirtualFile + Send + Sync + 'static>> {
         if let Some(parent) = path.parent() {
-            let parent_meta = self.metadata(parent)?;
+            let parent_meta = self.metadata(parent).await?;
             if !parent_meta.is_dir() {
                 return Err(FsError::BaseNotDirectory);
             }
@@ -210,30 +206,31 @@ struct File {
     content: Cursor<SharedBytes>,
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for File {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         self.timestamps
             .map(|t| t.modified())
             .unwrap_or_else(|| get_modified(None))
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         self.content.get_ref().len().try_into().unwrap()
     }
 
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Err(FsError::PermissionDenied)
     }
 
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         Err(FsError::PermissionDenied)
     }
 
@@ -253,7 +250,7 @@ impl VirtualFile for File {
         Poll::Ready(Err(std::io::ErrorKind::PermissionDenied.into()))
     }
 
-    fn as_owned_buffer(&self) -> Option<SharedBytes> {
+    async fn as_owned_buffer(&self) -> Option<SharedBytes> {
         Some(self.content.get_ref().clone())
     }
 }
@@ -473,24 +470,29 @@ mod tests {
         }
     }
 
-    #[test]
-    fn symlink_metadata_and_readlink() {
+    #[tokio::test]
+    async fn symlink_metadata_and_readlink() {
         let fs = symlink_fs();
 
-        let link = fs.symlink_metadata("/link".as_ref()).unwrap();
+        let link = fs.symlink_metadata("/link".as_ref()).await.unwrap();
         assert!(link.ft.is_symlink());
         assert_eq!(link.len(), "target.txt".len() as u64);
         assert_eq!(
-            fs.readlink("/link".as_ref()).unwrap(),
+            fs.readlink("/link".as_ref()).await.unwrap(),
             Path::new("target.txt")
         );
         assert_eq!(
-            fs.new_open_options().read(true).open("/link").unwrap_err(),
+            fs.new_open_options()
+                .read(true)
+                .open("/link")
+                .await
+                .unwrap_err(),
             FsError::NotAFile,
         );
 
         let entries: Vec<_> = fs
             .read_dir("/".as_ref())
+            .await
             .unwrap()
             .map(|entry| entry.unwrap())
             .collect();
@@ -501,28 +503,28 @@ mod tests {
         assert!(link_entry.metadata().unwrap().ft.is_symlink());
 
         assert_eq!(
-            fs.readlink("/target.txt".as_ref()).unwrap_err(),
+            fs.readlink("/target.txt".as_ref()).await.unwrap_err(),
             FsError::InvalidInput
         );
         assert_eq!(
-            fs.readlink("/missing".as_ref()).unwrap_err(),
+            fs.readlink("/missing".as_ref()).await.unwrap_err(),
             FsError::EntryNotFound
         );
     }
 
-    #[test]
-    fn mount_all_volumes_in_python() {
+    #[tokio::test]
+    async fn mount_all_volumes_in_python() {
         let container = from_bytes(PYTHON_WEBC).unwrap();
 
         let fs = WebcVolumeFileSystem::mount_all(&container);
 
         // We should now have access to the python directory
-        let lib_meta = fs.metadata("/lib/python3.6/".as_ref()).unwrap();
+        let lib_meta = fs.metadata("/lib/python3.6/".as_ref()).await.unwrap();
         assert!(lib_meta.is_dir());
     }
 
-    #[test]
-    fn read_dir() {
+    #[tokio::test]
+    async fn read_dir() {
         let container = from_bytes(PYTHON_WEBC).unwrap();
         let volumes = container.volumes();
         let volume = volumes["atom"].clone();
@@ -531,6 +533,7 @@ mod tests {
 
         let entries: Vec<_> = fs
             .read_dir("/lib".as_ref())
+            .await
             .unwrap()
             .map(|r| r.unwrap())
             .collect();
@@ -593,8 +596,8 @@ mod tests {
         assert_eq!(entries, expected);
     }
 
-    #[test]
-    fn metadata() {
+    #[tokio::test]
+    async fn metadata() {
         let container = from_bytes(PYTHON_WEBC).unwrap();
         let volumes = container.volumes();
         let volume = volumes["atom"].clone();
@@ -613,21 +616,23 @@ mod tests {
             len: 4694941,
         };
         assert_eq!(
-            fs.metadata("/lib/python.wasm".as_ref()).unwrap(),
+            fs.metadata("/lib/python.wasm".as_ref()).await.unwrap(),
             python_wasm,
         );
         assert_eq!(
             fs.metadata("/../../../../lib/python.wasm".as_ref())
+                .await
                 .unwrap(),
             python_wasm,
         );
         assert_eq!(
             fs.metadata("/lib/python3.6/../python3.6/../python.wasm".as_ref())
+                .await
                 .unwrap(),
             python_wasm,
         );
         assert_eq!(
-            fs.metadata("/lib/python3.6".as_ref()).unwrap(),
+            fs.metadata("/lib/python3.6".as_ref()).await.unwrap(),
             crate::Metadata {
                 ft: crate::FileType {
                     dir: true,
@@ -640,7 +645,9 @@ mod tests {
             },
         );
         assert_eq!(
-            fs.metadata("/this/does/not/exist".as_ref()).unwrap_err(),
+            fs.metadata("/this/does/not/exist".as_ref())
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound
         );
     }
@@ -658,17 +665,23 @@ mod tests {
                 .create(true)
                 .write(true)
                 .open("/file.txt")
+                .await
                 .unwrap_err(),
             FsError::PermissionDenied,
         );
         assert_eq!(
-            fs.new_open_options().read(true).open("/lib").unwrap_err(),
+            fs.new_open_options()
+                .read(true)
+                .open("/lib")
+                .await
+                .unwrap_err(),
             FsError::NotAFile,
         );
         assert_eq!(
             fs.new_open_options()
                 .read(true)
                 .open("/this/does/not/exist.txt")
+                .await
                 .unwrap_err(),
             FsError::EntryNotFound,
         );
@@ -678,18 +691,22 @@ mod tests {
             .new_open_options()
             .read(true)
             .open("/lib/python.wasm")
+            .await
             .unwrap();
         let mut buffer = Vec::new();
         f.read_to_end(&mut buffer).await.unwrap();
         assert!(buffer.starts_with(b"\0asm"));
         assert_eq!(
-            fs.metadata("/lib/python.wasm".as_ref()).unwrap().len(),
+            fs.metadata("/lib/python.wasm".as_ref())
+                .await
+                .unwrap()
+                .len(),
             u64::try_from(buffer.len()).unwrap(),
         );
     }
 
-    #[test]
-    fn remove_dir_is_not_allowed() {
+    #[tokio::test]
+    async fn remove_dir_is_not_allowed() {
         let container = from_bytes(PYTHON_WEBC).unwrap();
         let volumes = container.volumes();
         let volume = volumes["atom"].clone();
@@ -697,21 +714,25 @@ mod tests {
         let fs = WebcVolumeFileSystem::new(volume);
 
         assert_eq!(
-            fs.remove_dir("/lib".as_ref()).unwrap_err(),
+            fs.remove_dir("/lib".as_ref()).await.unwrap_err(),
             FsError::PermissionDenied,
         );
         assert_eq!(
-            fs.remove_dir("/this/does/not/exist".as_ref()).unwrap_err(),
+            fs.remove_dir("/this/does/not/exist".as_ref())
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound,
         );
         assert_eq!(
-            fs.remove_dir("/lib/python.wasm".as_ref()).unwrap_err(),
+            fs.remove_dir("/lib/python.wasm".as_ref())
+                .await
+                .unwrap_err(),
             FsError::BaseNotDirectory,
         );
     }
 
-    #[test]
-    fn remove_file_is_not_allowed() {
+    #[tokio::test]
+    async fn remove_file_is_not_allowed() {
         let container = from_bytes(PYTHON_WEBC).unwrap();
         let volumes = container.volumes();
         let volume = volumes["atom"].clone();
@@ -719,21 +740,25 @@ mod tests {
         let fs = WebcVolumeFileSystem::new(volume);
 
         assert_eq!(
-            fs.remove_file("/lib".as_ref()).unwrap_err(),
+            fs.remove_file("/lib".as_ref()).await.unwrap_err(),
             FsError::NotAFile,
         );
         assert_eq!(
-            fs.remove_file("/this/does/not/exist".as_ref()).unwrap_err(),
+            fs.remove_file("/this/does/not/exist".as_ref())
+                .await
+                .unwrap_err(),
             FsError::EntryNotFound,
         );
         assert_eq!(
-            fs.remove_file("/lib/python.wasm".as_ref()).unwrap_err(),
+            fs.remove_file("/lib/python.wasm".as_ref())
+                .await
+                .unwrap_err(),
             FsError::PermissionDenied,
         );
     }
 
-    #[test]
-    fn create_dir_is_not_allowed() {
+    #[tokio::test]
+    async fn create_dir_is_not_allowed() {
         let container = from_bytes(PYTHON_WEBC).unwrap();
         let volumes = container.volumes();
         let volume = volumes["atom"].clone();
@@ -741,15 +766,17 @@ mod tests {
         let fs = WebcVolumeFileSystem::new(volume);
 
         assert_eq!(
-            fs.create_dir("/lib".as_ref()).unwrap_err(),
+            fs.create_dir("/lib".as_ref()).await.unwrap_err(),
             FsError::AlreadyExists,
         );
         assert_eq!(
-            fs.create_dir("/this/does/not/exist".as_ref()).unwrap_err(),
+            fs.create_dir("/this/does/not/exist".as_ref())
+                .await
+                .unwrap_err(),
             FsError::BaseNotDirectory,
         );
         assert_eq!(
-            fs.create_dir("/lib/nested/".as_ref()).unwrap_err(),
+            fs.create_dir("/lib/nested/".as_ref()).await.unwrap_err(),
             FsError::PermissionDenied,
         );
     }

--- a/lib/virtual-fs/src/zero_file.rs
+++ b/lib/virtual-fs/src/zero_file.rs
@@ -62,23 +62,24 @@ impl AsyncRead for ZeroFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for ZeroFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         0
     }
-    fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
+    async fn set_len(&mut self, _new_size: u64) -> crate::Result<()> {
         Ok(())
     }
-    fn unlink(&mut self) -> crate::Result<()> {
+    async fn unlink(&mut self) -> crate::Result<()> {
         Ok(())
     }
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -415,6 +415,7 @@ mod tests {
             .new_open_options()
             .read(true)
             .open("/public/file.txt")
+            .await
             .unwrap();
         let mut buffer = String::new();
         f.read_to_string(&mut buffer).await.unwrap();

--- a/lib/wasix/src/bin_factory/mod.rs
+++ b/lib/wasix/src/bin_factory/mod.rs
@@ -223,11 +223,12 @@ async fn load_executable_from_filesystem(
         .new_open_options()
         .read(true)
         .open(path)
+        .await
         .context("Unable to open the file")?;
 
     // Fast path if the file is fully available in memory.
     // Prevents redundant copying of the file data.
-    if let Some(buf) = f.as_owned_buffer() {
+    if let Some(buf) = f.as_owned_buffer().await {
         if wasmer_package::utils::is_container(buf.as_slice()) {
             let bytes = buf.clone().into_bytes();
             if let Ok(container) = from_bytes(bytes.clone()) {
@@ -241,7 +242,7 @@ async fn load_executable_from_filesystem(
 
         Ok(Executable::Wasm(buf))
     } else {
-        let mut data = Vec::with_capacity(f.size() as usize);
+        let mut data = Vec::with_capacity(f.size().await as usize);
         f.read_to_end(&mut data).await.context("Read failed")?;
 
         let bytes: bytes::Bytes = data.into();

--- a/lib/wasix/src/fs/fd.rs
+++ b/lib/wasix/src/fs/fd.rs
@@ -5,6 +5,8 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard, atomic::AtomicU64},
 };
 
+use tokio::sync::Mutex;
+
 use virtual_fs::{Pipe, PipeRx, PipeTx, VirtualFile};
 use wasmer_wasix_types::wasi::{Fdflags, Fdflagsext, Filestat, Rights};
 
@@ -14,7 +16,7 @@ use crate::os::epoll::EpollState;
 use super::{InodeGuard, InodeWeakGuard, NotificationInner};
 
 /// Shared handle to an open [`VirtualFile`].
-pub(crate) type VirtualFileLock = Arc<RwLock<Box<dyn VirtualFile + Send + Sync + 'static>>>;
+pub(crate) type VirtualFileLock = Arc<Mutex<Box<dyn VirtualFile + Send + Sync + 'static>>>;
 
 #[derive(Debug, Clone)]
 pub struct Fd {

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
+use tokio::sync::OwnedMutexGuard;
 use virtual_fs::{FsError, Pipe, PipeRx, PipeTx, VirtualFile};
 use wasmer_wasix_types::{
     types::Eventtype,
@@ -20,7 +21,6 @@ use crate::{
     net::socket::{InodeSocketInner, InodeSocketKind},
     state::{PollEvent, PollEventSet, WasiState, iterate_poll_events},
     syscalls::{EventResult, EventResultType, map_io_err},
-    utils::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard},
 };
 
 #[derive(Debug, Clone)]
@@ -189,9 +189,11 @@ impl Future for InodeValFilePollGuardJoin {
         if has_read {
             let poll_result = match &mut self.mode {
                 InodeValFilePollGuardMode::File(file) => {
-                    let mut guard = file.write().unwrap();
-                    let file = Pin::new(guard.as_mut());
-                    file.poll_read_ready(cx)
+                    let Ok(mut guard) = file.try_lock() else {
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    };
+                    Pin::new(guard.as_mut()).poll_read_ready(cx)
                 }
                 InodeValFilePollGuardMode::EventNotifications(inner) => inner.poll(waker).map(Ok),
                 InodeValFilePollGuardMode::Socket { inner } => {
@@ -288,9 +290,11 @@ impl Future for InodeValFilePollGuardJoin {
         if has_write {
             let poll_result = match &mut self.mode {
                 InodeValFilePollGuardMode::File(file) => {
-                    let mut guard = file.write().unwrap();
-                    let file = Pin::new(guard.as_mut());
-                    file.poll_write_ready(cx)
+                    let Ok(mut guard) = file.try_lock() else {
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    };
+                    Pin::new(guard.as_mut()).poll_write_ready(cx)
                 }
                 InodeValFilePollGuardMode::EventNotifications(inner) => inner.poll(waker).map(Ok),
                 InodeValFilePollGuardMode::Socket { inner } => {
@@ -393,14 +397,15 @@ impl Future for InodeValFilePollGuardJoin {
 
 #[derive(Debug)]
 pub(crate) struct InodeValFileReadGuard {
-    guard: OwnedRwLockReadGuard<Box<dyn VirtualFile + Send + Sync + 'static>>,
+    guard: OwnedMutexGuard<Box<dyn VirtualFile + Send + Sync + 'static>>,
 }
 
 impl InodeValFileReadGuard {
-    pub(crate) fn new(file: &VirtualFileLock) -> Self {
-        Self {
-            guard: crate::utils::read_owned(file).unwrap(),
-        }
+    pub(crate) fn new(file: &VirtualFileLock) -> Option<Self> {
+        file.clone()
+            .try_lock_owned()
+            .ok()
+            .map(|guard| Self { guard })
     }
 }
 
@@ -413,14 +418,15 @@ impl Deref for InodeValFileReadGuard {
 
 #[derive(Debug)]
 pub struct InodeValFileWriteGuard {
-    guard: OwnedRwLockWriteGuard<Box<dyn VirtualFile + Send + Sync + 'static>>,
+    guard: OwnedMutexGuard<Box<dyn VirtualFile + Send + Sync + 'static>>,
 }
 
 impl InodeValFileWriteGuard {
-    pub(crate) fn new(file: &VirtualFileLock) -> Self {
-        Self {
-            guard: crate::utils::write_owned(file).unwrap(),
-        }
+    pub(crate) fn new(file: &VirtualFileLock) -> Option<Self> {
+        file.clone()
+            .try_lock_owned()
+            .ok()
+            .map(|guard| Self { guard })
     }
     pub(crate) fn swap(
         &mut self,
@@ -463,7 +469,7 @@ impl WasiStateFileGuard {
     pub fn lock_read(&self) -> Option<InodeValFileReadGuard> {
         let guard = self.inode.read();
         if let Kind::File { handle, .. } = guard.deref() {
-            handle.as_ref().map(InodeValFileReadGuard::new)
+            handle.as_ref().and_then(InodeValFileReadGuard::new)
         } else {
             // Our public API should ensure that this is not possible
             unreachable!("Non-file found in standard device location")
@@ -473,7 +479,7 @@ impl WasiStateFileGuard {
     pub fn lock_write(&self) -> Option<InodeValFileWriteGuard> {
         let guard = self.inode.read();
         if let Kind::File { handle, .. } = guard.deref() {
-            handle.as_ref().map(InodeValFileWriteGuard::new)
+            handle.as_ref().and_then(InodeValFileWriteGuard::new)
         } else {
             // Our public API should ensure that this is not possible
             unreachable!("Non-file found in standard device location")
@@ -481,78 +487,135 @@ impl WasiStateFileGuard {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFile for WasiStateFileGuard {
-    fn last_accessed(&self) -> u64 {
-        let guard = self.lock_read();
-        if let Some(file) = guard.as_ref() {
-            file.last_accessed()
+    async fn last_accessed(&self) -> u64 {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.last_accessed().await
         } else {
             0
         }
     }
 
-    fn last_modified(&self) -> u64 {
-        let guard = self.lock_read();
-        if let Some(file) = guard.as_ref() {
-            file.last_modified()
+    async fn last_modified(&self) -> u64 {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.last_modified().await
         } else {
             0
         }
     }
 
-    fn created_time(&self) -> u64 {
-        let guard = self.lock_read();
-        if let Some(file) = guard.as_ref() {
-            file.created_time()
+    async fn created_time(&self) -> u64 {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.created_time().await
         } else {
             0
         }
     }
 
-    fn set_times(
+    async fn set_times(
         &mut self,
         atime: Option<u64>,
         mtime: Option<u64>,
     ) -> Result<(), virtual_fs::FsError> {
-        let mut guard = self.lock_write();
-        if let Some(file) = guard.as_mut() {
-            file.set_times(atime, mtime)
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.set_times(atime, mtime).await
         } else {
             Err(crate::FsError::Lock)
         }
     }
 
-    fn size(&self) -> u64 {
-        let guard = self.lock_read();
-        if let Some(file) = guard.as_ref() {
-            file.size()
+    async fn size(&self) -> u64 {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.size().await
         } else {
             0
         }
     }
 
-    fn set_len(&mut self, new_size: u64) -> Result<(), FsError> {
-        let mut guard = self.lock_write();
-        if let Some(file) = guard.as_mut() {
-            file.set_len(new_size)
+    async fn set_len(&mut self, new_size: u64) -> Result<(), FsError> {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.set_len(new_size).await
         } else {
             Err(FsError::IOError)
         }
     }
 
-    fn unlink(&mut self) -> Result<(), FsError> {
-        let mut guard = self.lock_write();
-        if let Some(file) = guard.as_mut() {
-            file.unlink()
+    async fn unlink(&mut self) -> Result<(), FsError> {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.unlink().await
         } else {
             Err(FsError::IOError)
         }
     }
 
-    fn is_open(&self) -> bool {
-        let guard = self.lock_read();
-        if let Some(file) = guard.as_ref() {
-            file.is_open()
+    async fn is_open(&self) -> bool {
+        let handle = {
+            let guard = self.inode.read();
+            if let Kind::File { handle, .. } = guard.deref() {
+                handle.clone()
+            } else {
+                unreachable!("Non-file found in standard device location")
+            }
+        };
+        if let Some(file) = handle {
+            file.lock().await.is_open().await
         } else {
             false
         }

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -466,6 +466,7 @@ impl WasiStateFileGuard {
         }
     }
 
+    #[allow(dead_code)]
     pub fn lock_read(&self) -> Option<InodeValFileReadGuard> {
         let guard = self.inode.read();
         if let Kind::File { handle, .. } = guard.deref() {

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -1137,23 +1137,29 @@ impl WasiFs {
                     return Err(Errno::Badf);
                 }
             }
-            Kind::Dir { path, .. } => {
-                self.root_fs.metadata(path).await.map_err(fs_error_into_wasi_err)?
-            }
+            Kind::Dir { path, .. } => self
+                .root_fs
+                .metadata(path)
+                .await
+                .map_err(fs_error_into_wasi_err)?,
             Kind::Root { .. } => {
-                let mut stat = Filestat::default();
-                stat.st_filetype = Filetype::Directory;
-                return Ok(stat);
+                return Ok(Filestat {
+                    st_filetype: Filetype::Directory,
+                    ..Filestat::default()
+                });
             }
-            Kind::Symlink { path_to_symlink, .. } => self
+            Kind::Symlink {
+                path_to_symlink, ..
+            } => self
                 .root_fs
                 .symlink_metadata(path_to_symlink)
                 .await
                 .map_err(fs_error_into_wasi_err)?,
             Kind::Buffer { buffer } => {
-                let mut stat = Filestat::default();
-                stat.st_size = buffer.len() as u64;
-                return Ok(stat);
+                return Ok(Filestat {
+                    st_size: buffer.len() as u64,
+                    ..Filestat::default()
+                });
             }
             _ => return Err(Errno::Inval),
         };
@@ -1165,6 +1171,82 @@ impl WasiFs {
             st_ctim: md.created,
             ..Filestat::default()
         })
+    }
+
+    pub async fn get_stat_for_inode(&self, inode: &InodeGuard) -> Result<Filestat, Errno> {
+        enum StatSource {
+            File(VirtualFileLock),
+            Dir(PathBuf),
+            Root,
+            Symlink(PathBuf),
+            Buffer(u64),
+        }
+
+        let source = {
+            let guard = inode.read();
+            match guard.deref() {
+                Kind::File { handle, .. } => StatSource::File(handle.clone().ok_or(Errno::Badf)?),
+                Kind::Dir { path, .. } => StatSource::Dir(path.clone()),
+                Kind::Root { .. } => StatSource::Root,
+                Kind::Symlink {
+                    path_to_symlink, ..
+                } => StatSource::Symlink(path_to_symlink.clone()),
+                Kind::Buffer { buffer } => StatSource::Buffer(buffer.len() as u64),
+                _ => return Err(Errno::Inval),
+            }
+        };
+
+        match source {
+            StatSource::File(handle) => {
+                let handle = handle.lock().await;
+                Ok(Filestat {
+                    st_filetype: Filetype::RegularFile,
+                    st_size: handle.size().await,
+                    st_atim: handle.last_accessed().await,
+                    st_mtim: handle.last_modified().await,
+                    st_ctim: handle.created_time().await,
+                    ..Filestat::default()
+                })
+            }
+            StatSource::Dir(path) => {
+                let md = self
+                    .root_fs
+                    .metadata(&path)
+                    .await
+                    .map_err(fs_error_into_wasi_err)?;
+                Ok(Filestat {
+                    st_filetype: virtual_file_type_to_wasi_file_type(md.file_type()),
+                    st_size: md.len,
+                    st_atim: md.accessed,
+                    st_mtim: md.modified,
+                    st_ctim: md.created,
+                    ..Filestat::default()
+                })
+            }
+            StatSource::Root => Ok(Filestat {
+                st_filetype: Filetype::Directory,
+                ..Filestat::default()
+            }),
+            StatSource::Symlink(path) => {
+                let md = self
+                    .root_fs
+                    .symlink_metadata(&path)
+                    .await
+                    .map_err(fs_error_into_wasi_err)?;
+                Ok(Filestat {
+                    st_filetype: virtual_file_type_to_wasi_file_type(md.file_type()),
+                    st_size: md.len,
+                    st_atim: md.accessed,
+                    st_mtim: md.modified,
+                    st_ctim: md.created,
+                    ..Filestat::default()
+                })
+            }
+            StatSource::Buffer(size) => Ok(Filestat {
+                st_size: size,
+                ..Filestat::default()
+            }),
+        }
     }
 
     /// Changes the current directory
@@ -1194,13 +1276,15 @@ impl WasiFs {
             guard.clone()
         };
         let cur_inode = self.get_fd_inode(base)?;
-        let inode = self.get_inode_at_path_inner(
-            inodes,
-            cur_inode,
-            current_dir.clone(),
-            &mut symlink_count,
-            true,
-        ).await?;
+        let inode = self
+            .get_inode_at_path_inner(
+                inodes,
+                cur_inode,
+                current_dir.clone(),
+                &mut symlink_count,
+                true,
+            )
+            .await?;
         Ok((inode, current_dir))
     }
 
@@ -1288,6 +1372,7 @@ impl WasiFs {
     /// without re-statting. Syscalls that mutate the filesystem are responsible
     /// for keeping the inode cache and ephemeral symlink map coherent with their
     /// changes.
+    #[allow(clippy::await_holding_lock)]
     fn get_inode_at_path_inner<'a>(
         &'a self,
         inodes: &'a WasiInodes,
@@ -1297,430 +1382,436 @@ impl WasiFs {
         follow_symlinks: bool,
     ) -> LocalBoxFuture<'a, Result<InodeGuard, Errno>> {
         Box::pin(async move {
-        let path_str = path_str.as_str();
-        if *symlink_count > MAX_SYMLINKS {
-            return Err(Errno::Loop);
-        }
-
-        if path_str.is_empty() {
-            return Err(Errno::Noent);
-        }
-
-        if path_str.starts_with('/') {
-            cur_inode = self.get_fd_inode(VIRTUAL_ROOT_FD)?;
-        }
-
-        let is_all_slashes = path_str.bytes().all(|b| b == b'/');
-
-        // Absolute root paths should resolve to the mounted "/" inode when present.
-        // This keeps "/" behavior aligned with historical path traversal semantics.
-        if is_all_slashes {
-            if let Kind::Root { entries } = cur_inode.read().deref()
-                && let Some(root_entry) = entries.get("/")
-            {
-                return Ok(root_entry.clone());
-            }
-            return Ok(cur_inode);
-        }
-
-        // POSIX path resolution is stricter than `Path::components()`: explicit
-        // `.`/`..` and a trailing slash are observable because they require the
-        // current result to be a directory after symlink resolution.
-        let path = PosixPath::new(path_str);
-        let components = path.components(true, true);
-
-        let n_components = components.len();
-
-        // TODO: rights checks
-        // for each component traverse file structure loading inodes as
-        // necessary.
-        'path_iter: for (i, component) in components.into_iter().enumerate() {
-            // Since we're resolving the path against the given inode, we want to
-            // assume '/a/b' to be the same as `a/b` relative to the inode, so
-            // we skip over the RootDir component.
-            if matches!(component, PosixPathComponent::RootDir) {
-                continue 'path_iter;
+            let path_str = path_str.as_str();
+            if *symlink_count > MAX_SYMLINKS {
+                return Err(Errno::Loop);
             }
 
-            // Note: when current component is last and follow is off, then we
-            // return inode of the symlink itself, however if current component
-            // is inner we will follow symlinks even with follow off.
-            // Following symlinks uses recursive resolution, thus if current
-            // component is not last, we recurse with follow always on. Only
-            // last component with follow off will result in symlink not being
-            // followed.
-            let last_component = i == n_components - 1;
+            if path_str.is_empty() {
+                return Err(Errno::Noent);
+            }
 
-            let component_str = match component {
-                PosixPathComponent::CurDir => {
-                    let is_dir = {
-                        let guard = cur_inode.read();
-                        matches!(guard.deref(), Kind::Dir { .. } | Kind::Root { .. })
-                    };
-                    if is_dir {
-                        continue 'path_iter;
-                    }
-                    return Err(Errno::Notdir);
+            if path_str.starts_with('/') {
+                cur_inode = self.get_fd_inode(VIRTUAL_ROOT_FD)?;
+            }
+
+            let is_all_slashes = path_str.bytes().all(|b| b == b'/');
+
+            // Absolute root paths should resolve to the mounted "/" inode when present.
+            // This keeps "/" behavior aligned with historical path traversal semantics.
+            if is_all_slashes {
+                if let Kind::Root { entries } = cur_inode.read().deref()
+                    && let Some(root_entry) = entries.get("/")
+                {
+                    return Ok(root_entry.clone());
                 }
-                PosixPathComponent::ParentDir => {
-                    let parent_inode = {
-                        let guard = cur_inode.read();
-                        match guard.deref() {
-                            Kind::Root { .. } => None,
-                            Kind::Dir { parent, .. } => {
-                                Some(parent.upgrade().ok_or(Errno::Access)?)
-                            }
-                            _ => return Err(Errno::Notdir),
-                        }
-                    };
-                    if let Some(parent_inode) = parent_inode {
-                        cur_inode = parent_inode;
-                    }
+                return Ok(cur_inode);
+            }
+
+            // POSIX path resolution is stricter than `Path::components()`: explicit
+            // `.`/`..` and a trailing slash are observable because they require the
+            // current result to be a directory after symlink resolution.
+            let path = PosixPath::new(path_str);
+            let components = path.components(true, true);
+
+            let n_components = components.len();
+
+            // TODO: rights checks
+            // for each component traverse file structure loading inodes as
+            // necessary.
+            'path_iter: for (i, component) in components.into_iter().enumerate() {
+                // Since we're resolving the path against the given inode, we want to
+                // assume '/a/b' to be the same as `a/b` relative to the inode, so
+                // we skip over the RootDir component.
+                if matches!(component, PosixPathComponent::RootDir) {
                     continue 'path_iter;
                 }
-                PosixPathComponent::Normal(component) => component,
-                PosixPathComponent::RootDir => unreachable!("RootDir is handled above"),
-            };
 
-            'component_lookup: loop {
-                // 1. Read-Only Lookup Phase
-                // --
-                // Match current inode against known entry types, and if it happens
-                // to be a directory, then resolve current component as an entry in
-                // that directory.
-                // Note: this loop practically never does more than one iteration.
-                // There is only one exotic case when this loop would do another
-                // iteration, and it is when current inode happens to be Root
-                // containing '/' entry.
-                let component_resolution = {
-                    match cur_inode.clone().read().deref() {
-                        Kind::Buffer { .. } => {
-                            unimplemented!("state::get_inode_at_path for buffers")
+                // Note: when current component is last and follow is off, then we
+                // return inode of the symlink itself, however if current component
+                // is inner we will follow symlinks even with follow off.
+                // Following symlinks uses recursive resolution, thus if current
+                // component is not last, we recurse with follow always on. Only
+                // last component with follow off will result in symlink not being
+                // followed.
+                let last_component = i == n_components - 1;
+
+                let component_str = match component {
+                    PosixPathComponent::CurDir => {
+                        let is_dir = {
+                            let guard = cur_inode.read();
+                            matches!(guard.deref(), Kind::Dir { .. } | Kind::Root { .. })
+                        };
+                        if is_dir {
+                            continue 'path_iter;
                         }
-                        Kind::File { .. }
-                        | Kind::Socket { .. }
-                        | Kind::PipeRx { .. }
-                        | Kind::PipeTx { .. }
-                        | Kind::DuplexPipe { .. }
-                        | Kind::EventNotifications { .. }
-                        | Kind::Epoll { .. } => {
-                            return Err(Errno::Notdir);
-                        }
-                        Kind::Symlink { .. } => break 'component_lookup,
-                        Kind::Root { entries } => {
-                            if let Some(entry) = entries.get(component_str) {
-                                cur_inode = entry.clone();
-                                break 'component_lookup;
-                            } else if let Some(root) = entries.get("/") {
-                                // This is quite exotic case where Root itself
-                                // has '/' entry in it, and we want to follow
-                                // from there.
-                                // Note: this is one and only case where
-                                // 'component_lookup loop would do another
-                                // iteration - the only actual reason for it to
-                                // be a loop.
-                                cur_inode = root.clone();
-                                continue 'component_lookup;
-                            } else {
-                                // Root is not capable of having something other
-                                // then preopenned folders
-                                return Err(Errno::Notcapable);
-                            }
-                        }
-                        Kind::Dir {
-                            entries,
-                            path: cur_dir,
-                            ..
-                        } => {
-                            // When component resolves to directory entry, then
-                            // next component needs to resolve to a child node
-                            // within that directory.
-                            // Here we are handling all variants of directory
-                            // children.
-
-                            if let Some(entry) = entries.get(component_str) {
-                                // We found component in cached entries, so we
-                                // can continue. If it is a symlink it will be
-                                // resolved in next the step.
-                                cur_inode = entry.clone();
-                                break 'component_lookup;
-                            }
-
-                            // We did not find the component in cached entries,
-                            // so we will create new inode for it.
-                            let entry_path_buf = PosixPath::from_path(cur_dir)
-                                .join(&PosixPath::new(component_str))
-                                .into_path_buf();
-
-                            // Current component of the path we're resolving, as
-                            // a string...
-                            let entry_name = component_str.to_string();
-
-                            // ...and its relevant path within current inode
-                            // being the directory.
-                            // Note: the entry_path does not need to match the
-                            // path we're resolving, e.g. if this is a recursive
-                            // call from symlink resolution branch.
-                            let entry_path = entry_path_buf.to_string_lossy().to_string();
-
-                            if let Some((path_to_symlink, relative_path)) =
-                                self.ephemeral_symlink_at(&entry_path_buf)
-                            {
-                                // Ephemeral symlink are transient records; they
-                                // are virtual, and they are not persisted in
-                                // directory like symbolic links, so we will
-                                // create a temporary inode for them.
-                                // We resolve them but don't cache them as dir
-                                // entries.
-                                ComponentResolution::Create {
-                                    kind: Kind::Symlink {
-                                        symlink_kind: SymlinkKind::Virtual,
-                                        path_to_symlink,
-                                        relative_path,
-                                    },
-                                    name: entry_path,
-                                    entry_name,
-                                    is_ephemeral: true,
+                        return Err(Errno::Notdir);
+                    }
+                    PosixPathComponent::ParentDir => {
+                        let parent_inode = {
+                            let guard = cur_inode.read();
+                            match guard.deref() {
+                                Kind::Root { .. } => None,
+                                Kind::Dir { parent, .. } => {
+                                    Some(parent.upgrade().ok_or(Errno::Access)?)
                                 }
-                            } else {
-                                // Otherwise it is persistent, and we create new
-                                // inode for it that we will cache in directory
-                                // entries.
-                                // Note: this gets metadata of the file entry
-                                // without following symbolic links.
-                                let metadata = self
-                                    .root_fs
-                                    .symlink_metadata(&entry_path_buf)
-                                    .await
-                                    .ok()
-                                    .ok_or(Errno::Noent)?;
-                                let file_type = metadata.file_type();
-                                if file_type.is_dir() {
-                                    // load DIR
+                                _ => return Err(Errno::Notdir),
+                            }
+                        };
+                        if let Some(parent_inode) = parent_inode {
+                            cur_inode = parent_inode;
+                        }
+                        continue 'path_iter;
+                    }
+                    PosixPathComponent::Normal(component) => component,
+                    PosixPathComponent::RootDir => unreachable!("RootDir is handled above"),
+                };
+
+                'component_lookup: loop {
+                    // 1. Read-Only Lookup Phase
+                    // --
+                    // Match current inode against known entry types, and if it happens
+                    // to be a directory, then resolve current component as an entry in
+                    // that directory.
+                    // Note: this loop practically never does more than one iteration.
+                    // There is only one exotic case when this loop would do another
+                    // iteration, and it is when current inode happens to be Root
+                    // containing '/' entry.
+                    let component_resolution = {
+                        match cur_inode.clone().read().deref() {
+                            Kind::Buffer { .. } => {
+                                unimplemented!("state::get_inode_at_path for buffers")
+                            }
+                            Kind::File { .. }
+                            | Kind::Socket { .. }
+                            | Kind::PipeRx { .. }
+                            | Kind::PipeTx { .. }
+                            | Kind::DuplexPipe { .. }
+                            | Kind::EventNotifications { .. }
+                            | Kind::Epoll { .. } => {
+                                return Err(Errno::Notdir);
+                            }
+                            Kind::Symlink { .. } => break 'component_lookup,
+                            Kind::Root { entries } => {
+                                if let Some(entry) = entries.get(component_str) {
+                                    cur_inode = entry.clone();
+                                    break 'component_lookup;
+                                } else if let Some(root) = entries.get("/") {
+                                    // This is quite exotic case where Root itself
+                                    // has '/' entry in it, and we want to follow
+                                    // from there.
+                                    // Note: this is one and only case where
+                                    // 'component_lookup loop would do another
+                                    // iteration - the only actual reason for it to
+                                    // be a loop.
+                                    cur_inode = root.clone();
+                                    continue 'component_lookup;
+                                } else {
+                                    // Root is not capable of having something other
+                                    // then preopenned folders
+                                    return Err(Errno::Notcapable);
+                                }
+                            }
+                            Kind::Dir {
+                                entries,
+                                path: cur_dir,
+                                ..
+                            } => {
+                                // When component resolves to directory entry, then
+                                // next component needs to resolve to a child node
+                                // within that directory.
+                                // Here we are handling all variants of directory
+                                // children.
+
+                                if let Some(entry) = entries.get(component_str) {
+                                    // We found component in cached entries, so we
+                                    // can continue. If it is a symlink it will be
+                                    // resolved in next the step.
+                                    cur_inode = entry.clone();
+                                    break 'component_lookup;
+                                }
+
+                                // We did not find the component in cached entries,
+                                // so we will create new inode for it.
+                                let entry_path_buf = PosixPath::from_path(cur_dir)
+                                    .join(&PosixPath::new(component_str))
+                                    .into_path_buf();
+
+                                // Current component of the path we're resolving, as
+                                // a string...
+                                let entry_name = component_str.to_string();
+
+                                // ...and its relevant path within current inode
+                                // being the directory.
+                                // Note: the entry_path does not need to match the
+                                // path we're resolving, e.g. if this is a recursive
+                                // call from symlink resolution branch.
+                                let entry_path = entry_path_buf.to_string_lossy().to_string();
+
+                                if let Some((path_to_symlink, relative_path)) =
+                                    self.ephemeral_symlink_at(&entry_path_buf)
+                                {
+                                    // Ephemeral symlink are transient records; they
+                                    // are virtual, and they are not persisted in
+                                    // directory like symbolic links, so we will
+                                    // create a temporary inode for them.
+                                    // We resolve them but don't cache them as dir
+                                    // entries.
                                     ComponentResolution::Create {
-                                        kind: Kind::Dir {
-                                            parent: cur_inode.downgrade(),
-                                            path: entry_path_buf,
-                                            entries: Default::default(),
+                                        kind: Kind::Symlink {
+                                            symlink_kind: SymlinkKind::Virtual,
+                                            path_to_symlink,
+                                            relative_path,
                                         },
                                         name: entry_path,
                                         entry_name,
-                                        is_ephemeral: false,
+                                        is_ephemeral: true,
                                     }
-                                } else if file_type.is_file() {
-                                    // load file
-                                    ComponentResolution::Create {
-                                        kind: Kind::File {
-                                            handle: None,
-                                            path: entry_path_buf,
-                                            fd: None,
-                                        },
-                                        name: entry_path,
-                                        entry_name,
-                                        is_ephemeral: false,
-                                    }
-                                } else if file_type.is_symlink() {
-                                    // load symbolic link
-                                    // Note: as opposed to ephemeral symlinks,
-                                    // which are transient, these are
-                                    // persistent, i.e. they have actual entry
-                                    // in the directory
-                                    // structure.
-                                    let link_value = self
+                                } else {
+                                    // Otherwise it is persistent, and we create new
+                                    // inode for it that we will cache in directory
+                                    // entries.
+                                    // Note: this gets metadata of the file entry
+                                    // without following symbolic links.
+                                    let metadata = self
                                         .root_fs
-                                        .readlink(&entry_path_buf)
+                                        .symlink_metadata(&entry_path_buf)
                                         .await
                                         .ok()
                                         .ok_or(Errno::Noent)?;
-                                    debug!("attempting to decompose path {:?}", link_value);
-                                    ComponentResolution::BackingSymlink {
-                                        file: entry_path_buf,
-                                        link_value,
-                                        entry_name,
-                                    }
-                                } else {
-                                    #[cfg(unix)]
-                                    {
-                                        //use std::os::unix::fs::FileTypeExt;
-                                        let file_type: Filetype = if file_type.is_char_device() {
-                                            Filetype::CharacterDevice
-                                        } else if file_type.is_block_device() {
-                                            Filetype::BlockDevice
-                                        } else if file_type.is_fifo() {
-                                            // FIFO doesn't seem to fit any other type, so unknown
-                                            Filetype::Unknown
-                                        } else if file_type.is_socket() {
-                                            // TODO: how do we know if it's a `SocketStream` or
-                                            // a `SocketDgram`?
-                                            Filetype::SocketStream
-                                        } else {
-                                            unimplemented!(
-                                                "state::get_inode_at_path unknown file type: not file, directory, symlink, char device, block device, fifo, or socket"
-                                            );
-                                        };
-
-                                        ComponentResolution::Special {
+                                    let file_type = metadata.file_type();
+                                    if file_type.is_dir() {
+                                        // load DIR
+                                        ComponentResolution::Create {
+                                            kind: Kind::Dir {
+                                                parent: cur_inode.downgrade(),
+                                                path: entry_path_buf,
+                                                entries: Default::default(),
+                                            },
+                                            name: entry_path,
+                                            entry_name,
+                                            is_ephemeral: false,
+                                        }
+                                    } else if file_type.is_file() {
+                                        // load file
+                                        ComponentResolution::Create {
                                             kind: Kind::File {
                                                 handle: None,
                                                 path: entry_path_buf,
                                                 fd: None,
                                             },
-                                            name: entry_path.into(),
+                                            name: entry_path,
                                             entry_name,
-                                            stat: Filestat {
-                                                st_filetype: file_type,
-                                                st_ino: Inode::from_path(path_str).as_u64(),
-                                                st_size: metadata.len(),
-                                                st_ctim: metadata.created(),
-                                                st_mtim: metadata.modified(),
-                                                st_atim: metadata.accessed(),
-                                                ..Filestat::default()
-                                            },
+                                            is_ephemeral: false,
                                         }
+                                    } else if file_type.is_symlink() {
+                                        // load symbolic link
+                                        // Note: as opposed to ephemeral symlinks,
+                                        // which are transient, these are
+                                        // persistent, i.e. they have actual entry
+                                        // in the directory
+                                        // structure.
+                                        let link_value = self
+                                            .root_fs
+                                            .readlink(&entry_path_buf)
+                                            .await
+                                            .ok()
+                                            .ok_or(Errno::Noent)?;
+                                        debug!("attempting to decompose path {:?}", link_value);
+                                        ComponentResolution::BackingSymlink {
+                                            file: entry_path_buf,
+                                            link_value,
+                                            entry_name,
+                                        }
+                                    } else {
+                                        #[cfg(unix)]
+                                        {
+                                            //use std::os::unix::fs::FileTypeExt;
+                                            let file_type: Filetype = if file_type.is_char_device()
+                                            {
+                                                Filetype::CharacterDevice
+                                            } else if file_type.is_block_device() {
+                                                Filetype::BlockDevice
+                                            } else if file_type.is_fifo() {
+                                                // FIFO doesn't seem to fit any other type, so unknown
+                                                Filetype::Unknown
+                                            } else if file_type.is_socket() {
+                                                // TODO: how do we know if it's a `SocketStream` or
+                                                // a `SocketDgram`?
+                                                Filetype::SocketStream
+                                            } else {
+                                                unimplemented!(
+                                                    "state::get_inode_at_path unknown file type: not file, directory, symlink, char device, block device, fifo, or socket"
+                                                );
+                                            };
+
+                                            ComponentResolution::Special {
+                                                kind: Kind::File {
+                                                    handle: None,
+                                                    path: entry_path_buf,
+                                                    fd: None,
+                                                },
+                                                name: entry_path.into(),
+                                                entry_name,
+                                                stat: Filestat {
+                                                    st_filetype: file_type,
+                                                    st_ino: Inode::from_path(path_str).as_u64(),
+                                                    st_size: metadata.len(),
+                                                    st_ctim: metadata.created(),
+                                                    st_mtim: metadata.modified(),
+                                                    st_atim: metadata.accessed(),
+                                                    ..Filestat::default()
+                                                },
+                                            }
+                                        }
+                                        #[cfg(not(unix))]
+                                        unimplemented!(
+                                            "state::get_inode_at_path unknown file type: not file, directory, or symlink"
+                                        );
                                     }
-                                    #[cfg(not(unix))]
-                                    unimplemented!(
-                                        "state::get_inode_at_path unknown file type: not file, directory, or symlink"
-                                    );
-                                }
-                            } // end of non-ephemeral entry case
-                        } // end of Kind::Dir match case
-                    } // end of match
-                }; // end of component_resolution block
+                                } // end of non-ephemeral entry case
+                            } // end of Kind::Dir match case
+                        } // end of match
+                    }; // end of component_resolution block
 
-                // 2. Create an INode and update directory entries
+                    // 2. Create an INode and update directory entries
+                    // --
+                    // The cur_inode is definitely a directory (Kind::Dir) at this
+                    // stage, and we need to create an inode (new_inode) and cache
+                    // as an entry in current directory (entry_name => cur_inode).
+                    let (entry_name, new_inode, should_insert, should_return) =
+                        match component_resolution {
+                            ComponentResolution::Create {
+                                kind,
+                                name,
+                                entry_name,
+                                is_ephemeral,
+                            } => {
+                                let new_inode = self.create_inode(inodes, kind, false, name)?;
+                                (entry_name, new_inode, !is_ephemeral, false)
+                            }
+                            ComponentResolution::BackingSymlink {
+                                file,
+                                link_value,
+                                entry_name,
+                            } => {
+                                let new_inode = self.create_inode(
+                                    inodes,
+                                    Kind::Symlink {
+                                        symlink_kind: SymlinkKind::Backing,
+                                        path_to_symlink: PosixPath::from_path(&file)
+                                            .strip_root_prefix()
+                                            .into_path_buf(),
+                                        relative_path: link_value,
+                                    },
+                                    false,
+                                    file.to_string_lossy().to_string(),
+                                )?;
+                                (entry_name, new_inode, false, false)
+                            }
+                            #[cfg(unix)]
+                            ComponentResolution::Special {
+                                kind,
+                                name,
+                                entry_name,
+                                stat,
+                            } => {
+                                let new_inode =
+                                    self.create_inode_with_stat(inodes, kind, false, name, stat);
+                                (entry_name, new_inode, true, true)
+                            }
+                        };
+
+                    {
+                        let mut guard = cur_inode.write();
+                        let Kind::Dir { entries, .. } = guard.deref_mut() else {
+                            unreachable!("Attempted to insert special device into non-directory");
+                        };
+
+                        if should_insert {
+                            entries.insert(entry_name, new_inode.clone());
+                        }
+
+                        if should_return {
+                            // Special files cannot be traversed further, so return the inode directly.
+                            if last_component {
+                                return Ok(new_inode);
+                            }
+                            return Err(Errno::Notdir);
+                        }
+                    }
+
+                    // Assign current inode and leave 'component_loop
+                    // Note: this is a shortcut for doing next iteration matching
+                    // Kind::Dir for same cur_inode and finding there matching entry
+                    // that we just inserted, and exiting 'component_lookup.
+                    cur_inode = new_inode;
+                    break 'component_lookup;
+                } // end of 'component_lookup loop
+
+                // 3. Follow Symbolic Links
                 // --
-                // The cur_inode is definitely a directory (Kind::Dir) at this
-                // stage, and we need to create an inode (new_inode) and cache
-                // as an entry in current directory (entry_name => cur_inode).
-                let (entry_name, new_inode, should_insert, should_return) =
-                    match component_resolution {
-                        ComponentResolution::Create {
-                            kind,
-                            name,
-                            entry_name,
-                            is_ephemeral,
-                        } => {
-                            let new_inode = self.create_inode(inodes, kind, false, name)?;
-                            (entry_name, new_inode, !is_ephemeral, false)
-                        }
-                        ComponentResolution::BackingSymlink {
-                            file,
-                            link_value,
-                            entry_name,
-                        } => {
-                            let new_inode = self.create_inode(
-                                inodes,
-                                Kind::Symlink {
-                                    symlink_kind: SymlinkKind::Backing,
-                                    path_to_symlink: PosixPath::from_path(&file)
-                                        .strip_root_prefix()
-                                        .into_path_buf(),
-                                    relative_path: link_value,
-                                },
-                                false,
-                                file.to_string_lossy().to_string(),
-                            )?;
-                            (entry_name, new_inode, false, false)
-                        }
-                        #[cfg(unix)]
-                        ComponentResolution::Special {
-                            kind,
-                            name,
-                            entry_name,
-                            stat,
-                        } => {
-                            let new_inode =
-                                self.create_inode_with_stat(inodes, kind, false, name, stat);
-                            (entry_name, new_inode, true, true)
-                        }
-                    };
-
-                {
-                    let mut guard = cur_inode.write();
-                    let Kind::Dir { entries, .. } = guard.deref_mut() else {
-                        unreachable!("Attempted to insert special device into non-directory");
-                    };
-
-                    if should_insert {
-                        entries.insert(entry_name, new_inode.clone());
-                    }
-
-                    if should_return {
-                        // Special files cannot be traversed further, so return the inode directly.
-                        if last_component {
-                            return Ok(new_inode);
-                        }
-                        return Err(Errno::Notdir);
-                    }
+                // We continue with Symlink resolution unless...
+                if last_component && !follow_symlinks {
+                    // ...this symlink is the very last component of the path to
+                    // resolve, and symlink following is off,
+                    // ...or this is not a symlink at all
+                    continue 'path_iter;
                 }
 
-                // Assign current inode and leave 'component_loop
-                // Note: this is a shortcut for doing next iteration matching
-                // Kind::Dir for same cur_inode and finding there matching entry
-                // that we just inserted, and exiting 'component_lookup.
-                cur_inode = new_inode;
-                break 'component_lookup;
-            } // end of 'component_lookup loop
-
-            // 3. Follow Symbolic Links
-            // --
-            // We continue with Symlink resolution unless...
-            if last_component && !follow_symlinks {
-                // ...this symlink is the very last component of the path to
-                // resolve, and symlink following is off,
-                // ...or this is not a symlink at all
-                continue 'path_iter;
-            }
-
-            // The cur_inode can be a symlink (Kind::Symlink) or something else.
-            let (symlink_kind, path_to_symlink, relative_path) = {
-                let guard = cur_inode.read();
-                let Kind::Symlink {
-                    symlink_kind,
-                    path_to_symlink,
-                    relative_path,
-                } = guard.deref()
-                else {
-                    // not a symlink, so we continue with next path component
-                    continue 'path_iter;
+                // The cur_inode can be a symlink (Kind::Symlink) or something else.
+                let (symlink_kind, path_to_symlink, relative_path) = {
+                    let guard = cur_inode.read();
+                    let Kind::Symlink {
+                        symlink_kind,
+                        path_to_symlink,
+                        relative_path,
+                    } = guard.deref()
+                    else {
+                        // not a symlink, so we continue with next path component
+                        continue 'path_iter;
+                    };
+                    (
+                        *symlink_kind,
+                        path_to_symlink.clone(),
+                        relative_path.clone(),
+                    )
                 };
-                (
-                    *symlink_kind,
-                    path_to_symlink.clone(),
-                    relative_path.clone(),
-                )
-            };
 
-            let (new_base_fd, new_path) =
-                self.resolve_symlink_target_path(symlink_kind, &path_to_symlink, &relative_path)?;
-            let new_base_inode = self.get_fd_inode(new_base_fd)?;
-            let new_path = PosixPath::from_path(&new_path).as_str().to_owned();
+                let (new_base_fd, new_path) = self.resolve_symlink_target_path(
+                    symlink_kind,
+                    &path_to_symlink,
+                    &relative_path,
+                )?;
+                let new_base_inode = self.get_fd_inode(new_base_fd)?;
+                let new_path = PosixPath::from_path(&new_path).as_str().to_owned();
 
-            // We want to always follow symlinks unless we're resolving very
-            // last path component, then and only then we want to stop symlink
-            // following if it was originally off.
-            let follow_symlinks_inner = !last_component || follow_symlinks;
+                // We want to always follow symlinks unless we're resolving very
+                // last path component, then and only then we want to stop symlink
+                // following if it was originally off.
+                let follow_symlinks_inner = !last_component || follow_symlinks;
 
-            debug!("Following symlink recursively");
-            *symlink_count += 1;
-            if *symlink_count > MAX_SYMLINKS {
-                return Err(Errno::Loop);
+                debug!("Following symlink recursively");
+                *symlink_count += 1;
+                if *symlink_count > MAX_SYMLINKS {
+                    return Err(Errno::Loop);
+                }
+                let symlink_inode = self
+                    .get_inode_at_path_inner(
+                        inodes,
+                        new_base_inode,
+                        new_path,
+                        symlink_count,
+                        follow_symlinks_inner,
+                    )
+                    .await?;
+
+                // The rest of the path resolution will be relative to resolved
+                // symlink target.
+                cur_inode = symlink_inode;
             }
-            let symlink_inode = self.get_inode_at_path_inner(
-                inodes,
-                new_base_inode,
-                new_path,
-                symlink_count,
-                follow_symlinks_inner,
-            ).await?;
 
-            // The rest of the path resolution will be relative to resolved
-            // symlink target.
-            cur_inode = symlink_inode;
-        }
-
-        Ok(cur_inode)
+            Ok(cur_inode)
         })
     }
 
@@ -1821,7 +1912,8 @@ impl WasiFs {
             path.to_string(),
             &mut symlink_count,
             follow_symlinks,
-        ).await
+        )
+        .await
     }
 
     pub(crate) async fn get_inode_at_path_from_inode(
@@ -1838,7 +1930,8 @@ impl WasiFs {
             path.to_string(),
             &mut symlink_count,
             follow_symlinks,
-        ).await
+        )
+        .await
     }
 
     /// Returns the parent Dir or Root that the file at a given path is in and the file name
@@ -3090,6 +3183,7 @@ mod tests {
 
         let literal_link = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/host/dir2", false)
+            .await
             .unwrap();
         assert!(matches!(
             literal_link.read().deref(),
@@ -3102,6 +3196,7 @@ mod tests {
 
         let followed_dir = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/host/dir2", true)
+            .await
             .unwrap();
         let followed_dir_path = {
             let guard = followed_dir.read();
@@ -3111,11 +3206,12 @@ mod tests {
             assert_eq!(path, Path::new("/host/dir1"));
             path.clone()
         };
-        let mut entries = wasi_fs.root_fs.read_dir(&followed_dir_path).unwrap();
+        let mut entries = wasi_fs.root_fs.read_dir(&followed_dir_path).await.unwrap();
         assert!(entries.any(|entry| entry.unwrap().path() == Path::new("/host/dir1/file1")));
 
         let child = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/host/dir2/file1", true)
+            .await
             .unwrap();
         assert!(matches!(
             child.read().deref(),
@@ -3158,17 +3254,20 @@ mod tests {
             WasiFs::new_with_preopen(&inodes, &[], &["/".to_string()], fs_backing).unwrap();
         let root = &wasi_fs.root_fs;
 
-        root.create_dir(Path::new("/orig")).unwrap();
+        root.create_dir(Path::new("/orig")).await.unwrap();
         root.new_open_options()
             .create(true)
             .write(true)
             .open(Path::new("/orig/child.txt"))
+            .await
             .unwrap();
         root.create_symlink(Path::new("/orig"), Path::new("/linked"))
+            .await
             .unwrap();
 
         let literal_link = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/linked", false)
+            .await
             .unwrap();
         assert!(matches!(
             literal_link.read().deref(),
@@ -3180,6 +3279,7 @@ mod tests {
 
         let followed_dir = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/linked", true)
+            .await
             .unwrap();
         assert!(matches!(
             followed_dir.read().deref(),
@@ -3188,6 +3288,7 @@ mod tests {
 
         let child = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/linked/child.txt", true)
+            .await
             .unwrap();
         assert!(matches!(
             child.read().deref(),
@@ -3196,6 +3297,7 @@ mod tests {
 
         let child_without_final_follow = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/linked/child.txt", false)
+            .await
             .unwrap();
         assert!(matches!(
             child_without_final_follow.read().deref(),
@@ -3212,6 +3314,7 @@ mod tests {
 
         let literal_link = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/link", false)
+            .await
             .unwrap();
         assert!(matches!(
             literal_link.read().deref(),
@@ -3223,6 +3326,7 @@ mod tests {
 
         let followed_file = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/link", true)
+            .await
             .unwrap();
         assert!(matches!(
             followed_file.read().deref(),
@@ -3239,24 +3343,29 @@ mod tests {
             WasiFs::new_with_preopen(&inodes, &[], &["/".to_string()], fs_backing).unwrap();
         let root = &wasi_fs.root_fs;
 
-        root.create_dir(Path::new("/dir")).unwrap();
+        root.create_dir(Path::new("/dir")).await.unwrap();
         root.new_open_options()
             .create(true)
             .write(true)
             .open(Path::new("/file"))
+            .await
             .unwrap();
         root.create_symlink(Path::new("/dir"), Path::new("/dir-link"))
+            .await
             .unwrap();
         root.create_symlink(Path::new("/file"), Path::new("/file-link"))
+            .await
             .unwrap();
 
         let empty_path = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "", true)
+            .await
             .unwrap_err();
         assert_eq!(empty_path, Errno::Noent);
 
         let (single_component_parent, single_component_name) = wasi_fs
             .get_parent_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, Path::new("new-file"), true)
+            .await
             .unwrap();
         assert_eq!(single_component_name, "new-file");
         assert!(matches!(
@@ -3266,6 +3375,7 @@ mod tests {
 
         let root_parent = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/..", true)
+            .await
             .unwrap();
         assert!(matches!(root_parent.read().deref(), Kind::Root { .. }));
 
@@ -3305,15 +3415,17 @@ mod tests {
             .unwrap_err();
         assert_eq!(escaped_sibling_preopen_symlink_target, Errno::Perm);
 
-        root.create_dir(Path::new("/outerdir")).unwrap();
-        root.create_dir(Path::new("/outerdir/dest")).unwrap();
+        root.create_dir(Path::new("/outerdir")).await.unwrap();
+        root.create_dir(Path::new("/outerdir/dest")).await.unwrap();
         root.new_open_options()
             .create(true)
             .write(true)
             .open(Path::new("/outerdir/evil"))
+            .await
             .unwrap();
         let dest_dir = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/outerdir/dest", true)
+            .await
             .unwrap();
         let current_link = wasi_fs.create_inode_with_default_stat(
             &inodes,
@@ -3351,6 +3463,7 @@ mod tests {
                 "/outerdir/dest/parent/evil",
                 true,
             )
+            .await
             .unwrap();
         assert!(matches!(
             parent_symlink_target.read().deref(),
@@ -3359,16 +3472,19 @@ mod tests {
 
         let file_dot = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/file/.", true)
+            .await
             .unwrap_err();
         assert_eq!(file_dot, Errno::Notdir);
 
         let file_slash = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/file/", true)
+            .await
             .unwrap_err();
         assert_eq!(file_slash, Errno::Notdir);
 
         let symlinked_dir_slash = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/dir-link/", false)
+            .await
             .unwrap();
         assert!(matches!(
             symlinked_dir_slash.read().deref(),
@@ -3377,13 +3493,16 @@ mod tests {
 
         let symlinked_file_slash = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/file-link/", false)
+            .await
             .unwrap_err();
         assert_eq!(symlinked_file_slash, Errno::Notdir);
 
         root.create_symlink(Path::new("/loop"), Path::new("/loop"))
+            .await
             .unwrap();
         let symlink_loop = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/loop", true)
+            .await
             .unwrap_err();
         assert_eq!(symlink_loop, Errno::Loop);
     }
@@ -3413,6 +3532,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/root.txt"))
+            .await
             .unwrap();
 
         let public_mount = TmpFileSystem::new();
@@ -3421,6 +3541,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/index.html"))
+            .await
             .unwrap();
 
         let pkg = BinaryPackage {
@@ -3448,6 +3569,7 @@ mod tests {
             wasi_fs
                 .root_fs
                 .metadata(Path::new("/root.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -3455,6 +3577,7 @@ mod tests {
             wasi_fs
                 .root_fs
                 .metadata(Path::new("/public/index.html"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -3464,6 +3587,7 @@ mod tests {
             wasi_fs
                 .root_fs
                 .metadata(Path::new("/root.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -3471,6 +3595,7 @@ mod tests {
             wasi_fs
                 .root_fs
                 .metadata(Path::new("/public/index.html"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -3494,6 +3619,7 @@ mod tests {
 
         let link = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/link", false)
+            .await
             .unwrap();
         assert!(matches!(
             link.read().deref(),
@@ -3507,6 +3633,7 @@ mod tests {
         // Parent must not have cached the symlink.
         let (parent_inode, child_name) = wasi_fs
             .get_parent_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, Path::new("/link"), false)
+            .await
             .unwrap();
         assert_eq!(child_name, "link");
         match parent_inode.read().deref() {
@@ -3532,6 +3659,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/target.txt"))
+            .await
             .unwrap();
         wasi_fs.register_ephemeral_symlink(
             PathBuf::from("/link"),
@@ -3541,7 +3669,7 @@ mod tests {
         assert!(wasi_fs.ephemeral_symlink_at(Path::new("/link")).is_some());
 
         assert_eq!(
-            wasi_fs.remove_symlink_file(Path::new("/link")),
+            wasi_fs.remove_symlink_file(Path::new("/link")).await,
             Errno::Success
         );
         assert!(wasi_fs.ephemeral_symlink_at(Path::new("/link")).is_none());
@@ -3549,6 +3677,7 @@ mod tests {
             wasi_fs
                 .root_fs
                 .metadata(Path::new("/target.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -3563,7 +3692,7 @@ mod tests {
             WasiFs::new_with_preopen(&inodes, &[], &["/".to_string()], fs_backing).unwrap();
 
         assert_eq!(
-            wasi_fs.remove_symlink_file(Path::new("/missing")),
+            wasi_fs.remove_symlink_file(Path::new("/missing")).await,
             Errno::Noent
         );
     }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -32,12 +32,14 @@ use std::{
     },
     task::{Context, Poll},
 };
+use tokio::sync::Mutex as AsyncMutex;
+use virtual_mio::block_on;
 
 use crate::{
     net::socket::InodeSocketKind,
     state::{Stderr, Stdin, Stdout},
 };
-use futures::{Future, future::BoxFuture};
+use futures::{Future, future::LocalBoxFuture};
 use tracing::{debug, trace, warn};
 use virtual_fs::{
     ArcFileSystem, FileSystem, FsError, MountFileSystem, OpenOptions, OverlayFileSystem,
@@ -94,7 +96,10 @@ impl Future for FlushPoller {
     type Output = Result<(), Errno>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut file = self.file.write().unwrap();
+        let Ok(mut file) = self.file.try_lock() else {
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        };
         Pin::new(file.as_mut())
             .poll_flush(cx)
             .map_err(|_| Errno::Io)
@@ -386,7 +391,7 @@ impl WasiInodes {
                 ..
             } = guard.deref()
             {
-                Ok(InodeValFileReadGuard::new(handle))
+                InodeValFileReadGuard::new(handle).ok_or(FsError::Lock)
             } else {
                 // Our public API should ensure that this is not possible
                 Err(FsError::NotAFile)
@@ -409,7 +414,7 @@ impl WasiInodes {
                 ..
             } = guard.deref()
             {
-                Ok(InodeValFileWriteGuard::new(handle))
+                InodeValFileWriteGuard::new(handle).ok_or(FsError::Lock)
             } else {
                 // Our public API should ensure that this is not possible
                 Err(FsError::NotAFile)
@@ -510,48 +515,46 @@ fn find_writable_root(fs: &(dyn FileSystem + Send + Sync)) -> Option<TmpFileSyst
     None
 }
 
+#[async_trait::async_trait]
 impl FileSystem for WasiFsRoot {
-    fn readlink(&self, path: &Path) -> virtual_fs::Result<PathBuf> {
-        self.root.readlink(path)
+    async fn readlink(&self, path: &Path) -> virtual_fs::Result<PathBuf> {
+        self.root.readlink(path).await
     }
 
-    fn read_dir(&self, path: &Path) -> virtual_fs::Result<virtual_fs::ReadDir> {
-        self.root.read_dir(path)
+    async fn read_dir(&self, path: &Path) -> virtual_fs::Result<virtual_fs::ReadDir> {
+        self.root.read_dir(path).await
     }
 
-    fn create_dir(&self, path: &Path) -> virtual_fs::Result<()> {
-        self.root.create_dir(path)
+    async fn create_dir(&self, path: &Path) -> virtual_fs::Result<()> {
+        self.root.create_dir(path).await
     }
 
-    fn create_symlink(&self, source: &Path, target: &Path) -> virtual_fs::Result<()> {
-        self.root.create_symlink(source, target)
+    async fn create_symlink(&self, source: &Path, target: &Path) -> virtual_fs::Result<()> {
+        self.root.create_symlink(source, target).await
     }
 
-    fn hard_link(&self, source: &Path, target: &Path) -> virtual_fs::Result<()> {
-        self.root.hard_link(source, target)
+    async fn hard_link(&self, source: &Path, target: &Path) -> virtual_fs::Result<()> {
+        self.root.hard_link(source, target).await
     }
 
-    fn remove_dir(&self, path: &Path) -> virtual_fs::Result<()> {
-        self.root.remove_dir(path)
+    async fn remove_dir(&self, path: &Path) -> virtual_fs::Result<()> {
+        self.root.remove_dir(path).await
     }
 
-    fn rename<'a>(&'a self, from: &Path, to: &Path) -> BoxFuture<'a, virtual_fs::Result<()>> {
-        let from = from.to_owned();
-        let to = to.to_owned();
-        let this = self.clone();
-        Box::pin(async move { this.root.rename(&from, &to).await })
+    async fn rename(&self, from: &Path, to: &Path) -> virtual_fs::Result<()> {
+        self.root.rename(from, to).await
     }
 
-    fn metadata(&self, path: &Path) -> virtual_fs::Result<virtual_fs::Metadata> {
-        self.root.metadata(path)
+    async fn metadata(&self, path: &Path) -> virtual_fs::Result<virtual_fs::Metadata> {
+        self.root.metadata(path).await
     }
 
-    fn symlink_metadata(&self, path: &Path) -> virtual_fs::Result<virtual_fs::Metadata> {
-        self.root.symlink_metadata(path)
+    async fn symlink_metadata(&self, path: &Path) -> virtual_fs::Result<virtual_fs::Metadata> {
+        self.root.symlink_metadata(path).await
     }
 
-    fn remove_file(&self, path: &Path) -> virtual_fs::Result<()> {
-        self.root.remove_file(path)
+    async fn remove_file(&self, path: &Path) -> virtual_fs::Result<()> {
+        self.root.remove_file(path).await
     }
 
     fn new_open_options(&self) -> OpenOptions<'_> {
@@ -653,10 +656,11 @@ impl WasiFs {
     /// A purely ephemeral (virtual) link has no host file, so `Noent` for a
     /// still-registered ephemeral link counts as success. Returns the `Errno`
     /// the syscall should report.
-    pub(crate) fn remove_symlink_file(&self, host_path: &Path) -> Errno {
+    pub(crate) async fn remove_symlink_file(&self, host_path: &Path) -> Errno {
         match self
             .root_fs
             .remove_file(host_path)
+            .await
             .map_err(fs_error_into_wasi_err)
         {
             Ok(()) => {
@@ -989,7 +993,7 @@ impl WasiFs {
                 }
 
                 let kind = Kind::File {
-                    handle: Some(Arc::new(RwLock::new(file))),
+                    handle: Some(Arc::new(AsyncMutex::new(file))),
                     path: PathBuf::from(""),
                     fd: None,
                 };
@@ -1067,7 +1071,7 @@ impl WasiFs {
                     match guard.deref() {
                         Kind::File { handle, .. } => {
                             if let Some(handle) = handle {
-                                let mut handle = handle.write().unwrap();
+                                let mut handle = handle.try_lock().map_err(|_| FsError::Lock)?;
                                 std::mem::swap(handle.deref_mut(), &mut file);
                                 return Ok(Some(file));
                             }
@@ -1080,11 +1084,11 @@ impl WasiFs {
                 match guard.deref_mut() {
                     Kind::File { handle, .. } => {
                         if let Some(handle) = handle {
-                            let mut handle = handle.write().unwrap();
+                            let mut handle = handle.try_lock().map_err(|_| FsError::Lock)?;
                             std::mem::swap(handle.deref_mut(), &mut file);
                             Ok(Some(file))
                         } else {
-                            handle.replace(Arc::new(RwLock::new(file)));
+                            handle.replace(Arc::new(AsyncMutex::new(file)));
                             Ok(None)
                         }
                     }
@@ -1095,26 +1099,72 @@ impl WasiFs {
     }
 
     /// refresh size from filesystem
-    pub fn filestat_resync_size(&self, fd: WasiFd) -> Result<Filesize, Errno> {
+    pub async fn filestat_resync_size(&self, fd: WasiFd) -> Result<Filesize, Errno> {
         let inode = self.get_fd_inode(fd)?;
-        let mut guard = inode.write();
-        match guard.deref_mut() {
+        let handle = {
+            let guard = inode.read();
+            match guard.deref() {
+                Kind::File { handle, .. } => handle.clone(),
+                Kind::Dir { .. } | Kind::Root { .. } => return Err(Errno::Isdir),
+                _ => return Err(Errno::Inval),
+            }
+        };
+        match handle {
+            Some(h) => {
+                let new_size = h.lock().await.size().await;
+                inode.stat.write().unwrap().st_size = new_size;
+                Ok(new_size as Filesize)
+            }
+            None => Err(Errno::Badf),
+        }
+    }
+
+    pub async fn get_stat_for_kind(&self, kind: &Kind) -> Result<Filestat, Errno> {
+        let md = match kind {
             Kind::File { handle, .. } => {
                 if let Some(h) = handle {
-                    let h = h.read().unwrap();
-                    let new_size = h.size();
-                    drop(h);
-                    drop(guard);
+                    let h = h.lock().await;
+                    return Ok(Filestat {
+                        st_filetype: Filetype::RegularFile,
+                        st_size: h.size().await,
+                        st_atim: h.last_accessed().await,
+                        st_mtim: h.last_modified().await,
+                        st_ctim: h.created_time().await,
 
-                    inode.stat.write().unwrap().st_size = new_size;
-                    Ok(new_size as Filesize)
+                        ..Filestat::default()
+                    });
                 } else {
-                    Err(Errno::Badf)
+                    return Err(Errno::Badf);
                 }
             }
-            Kind::Dir { .. } | Kind::Root { .. } => Err(Errno::Isdir),
-            _ => Err(Errno::Inval),
-        }
+            Kind::Dir { path, .. } => {
+                self.root_fs.metadata(path).await.map_err(fs_error_into_wasi_err)?
+            }
+            Kind::Root { .. } => {
+                let mut stat = Filestat::default();
+                stat.st_filetype = Filetype::Directory;
+                return Ok(stat);
+            }
+            Kind::Symlink { path_to_symlink, .. } => self
+                .root_fs
+                .symlink_metadata(path_to_symlink)
+                .await
+                .map_err(fs_error_into_wasi_err)?,
+            Kind::Buffer { buffer } => {
+                let mut stat = Filestat::default();
+                stat.st_size = buffer.len() as u64;
+                return Ok(stat);
+            }
+            _ => return Err(Errno::Inval),
+        };
+        Ok(Filestat {
+            st_filetype: virtual_file_type_to_wasi_file_type(md.file_type()),
+            st_size: md.len,
+            st_atim: md.accessed,
+            st_mtim: md.modified,
+            st_ctim: md.created,
+            ..Filestat::default()
+        })
     }
 
     /// Changes the current directory
@@ -1124,15 +1174,15 @@ impl WasiFs {
     }
 
     /// Gets the current directory
-    pub fn get_current_dir(
+    pub async fn get_current_dir(
         &self,
         inodes: &WasiInodes,
         base: WasiFd,
     ) -> Result<(InodeGuard, String), Errno> {
-        self.get_current_dir_inner(inodes, base, 0)
+        self.get_current_dir_inner(inodes, base, 0).await
     }
 
-    pub(crate) fn get_current_dir_inner(
+    pub(crate) async fn get_current_dir_inner(
         &self,
         inodes: &WasiInodes,
         base: WasiFd,
@@ -1147,10 +1197,10 @@ impl WasiFs {
         let inode = self.get_inode_at_path_inner(
             inodes,
             cur_inode,
-            current_dir.as_str(),
+            current_dir.clone(),
             &mut symlink_count,
             true,
-        )?;
+        ).await?;
         Ok((inode, current_dir))
     }
 
@@ -1238,14 +1288,16 @@ impl WasiFs {
     /// without re-statting. Syscalls that mutate the filesystem are responsible
     /// for keeping the inode cache and ephemeral symlink map coherent with their
     /// changes.
-    fn get_inode_at_path_inner(
-        &self,
-        inodes: &WasiInodes,
+    fn get_inode_at_path_inner<'a>(
+        &'a self,
+        inodes: &'a WasiInodes,
         mut cur_inode: InodeGuard,
-        path_str: &str,
-        symlink_count: &mut u32,
+        path_str: String,
+        symlink_count: &'a mut u32,
         follow_symlinks: bool,
-    ) -> Result<InodeGuard, Errno> {
+    ) -> LocalBoxFuture<'a, Result<InodeGuard, Errno>> {
+        Box::pin(async move {
+        let path_str = path_str.as_str();
         if *symlink_count > MAX_SYMLINKS {
             return Err(Errno::Loop);
         }
@@ -1439,6 +1491,7 @@ impl WasiFs {
                                 let metadata = self
                                     .root_fs
                                     .symlink_metadata(&entry_path_buf)
+                                    .await
                                     .ok()
                                     .ok_or(Errno::Noent)?;
                                 let file_type = metadata.file_type();
@@ -1476,6 +1529,7 @@ impl WasiFs {
                                     let link_value = self
                                         .root_fs
                                         .readlink(&entry_path_buf)
+                                        .await
                                         .ok()
                                         .ok_or(Errno::Noent)?;
                                     debug!("attempting to decompose path {:?}", link_value);
@@ -1656,10 +1710,10 @@ impl WasiFs {
             let symlink_inode = self.get_inode_at_path_inner(
                 inodes,
                 new_base_inode,
-                &new_path,
+                new_path,
                 symlink_count,
                 follow_symlinks_inner,
-            )?;
+            ).await?;
 
             // The rest of the path resolution will be relative to resolved
             // symlink target.
@@ -1667,6 +1721,7 @@ impl WasiFs {
         }
 
         Ok(cur_inode)
+        })
     }
 
     pub(crate) fn resolve_symlink_target_path(
@@ -1751,7 +1806,7 @@ impl WasiFs {
     // even if it's false, it still follows symlinks, just not the last
     // symlink so
     // This will be resolved when we have tests asserting the correct behavior
-    pub(crate) fn get_inode_at_path(
+    pub(crate) async fn get_inode_at_path(
         &self,
         inodes: &WasiInodes,
         base: WasiFd,
@@ -1763,13 +1818,13 @@ impl WasiFs {
         self.get_inode_at_path_inner(
             inodes,
             base_inode,
-            path,
+            path.to_string(),
             &mut symlink_count,
             follow_symlinks,
-        )
+        ).await
     }
 
-    pub(crate) fn get_inode_at_path_from_inode(
+    pub(crate) async fn get_inode_at_path_from_inode(
         &self,
         inodes: &WasiInodes,
         base_inode: InodeGuard,
@@ -1780,15 +1835,15 @@ impl WasiFs {
         self.get_inode_at_path_inner(
             inodes,
             base_inode,
-            path,
+            path.to_string(),
             &mut symlink_count,
             follow_symlinks,
-        )
+        ).await
     }
 
     /// Returns the parent Dir or Root that the file at a given path is in and the file name
     /// stripped off
-    pub(crate) fn get_parent_inode_at_path(
+    pub(crate) async fn get_parent_inode_at_path(
         &self,
         inodes: &WasiInodes,
         base: WasiFd,
@@ -1800,6 +1855,7 @@ impl WasiFs {
             return self.get_fd_inode(base).map(|v| (v, new_entity_name));
         }
         self.get_inode_at_path(inodes, base, parent_dir.as_str(), follow_symlinks)
+            .await
             .map(|v| (v, new_entity_name))
     }
 
@@ -1934,7 +1990,7 @@ impl WasiFs {
         is_preopened: bool,
         name: String,
     ) -> Result<InodeGuard, Errno> {
-        let stat = self.get_stat_for_kind(&kind)?;
+        let stat = Filestat::default();
         Ok(self.create_inode_with_stat(inodes, kind, is_preopened, name.into(), stat))
     }
 
@@ -1960,13 +2016,7 @@ impl WasiFs {
         mut stat: Filestat,
     ) -> InodeGuard {
         match &kind {
-            Kind::File {
-                handle: Some(handle),
-                ..
-            } => {
-                let guard = handle.read().unwrap();
-                stat.st_size = guard.size();
-            }
+            Kind::File { .. } => {}
             Kind::Buffer { buffer } => {
                 stat.st_size = buffer.len() as u64;
             }
@@ -2447,9 +2497,7 @@ impl WasiFs {
                 &path.to_string_lossy(),
                 &alias
             );
-            let cur_dir_metadata = self
-                .root_fs
-                .metadata(path)
+            let cur_dir_metadata = block_on(self.root_fs.metadata(path))
                 .map_err(|e| format!("Could not get metadata for file {path:?}: {e}"))?;
 
             let kind = if cur_dir_metadata.is_dir() {
@@ -2579,7 +2627,7 @@ impl WasiFs {
             };
             let kind = Kind::File {
                 fd: Some(raw_fd),
-                handle: Some(Arc::new(RwLock::new(handle))),
+                handle: Some(Arc::new(AsyncMutex::new(handle))),
                 path: "".into(),
             };
             inodes.add_inode_val(InodeVal {
@@ -2606,66 +2654,6 @@ impl WasiFs {
                 is_stdio: true,
             },
         );
-    }
-
-    pub fn get_stat_for_kind(&self, kind: &Kind) -> Result<Filestat, Errno> {
-        let md = match kind {
-            Kind::File { handle, path, .. } => match handle {
-                Some(wf) => {
-                    let wf = wf.read().unwrap();
-                    return Ok(Filestat {
-                        st_filetype: Filetype::RegularFile,
-                        st_ino: Inode::from_path(path.to_string_lossy().as_ref()).as_u64(),
-                        st_size: wf.size(),
-                        st_atim: wf.last_accessed(),
-                        st_mtim: wf.last_modified(),
-                        st_ctim: wf.created_time(),
-
-                        ..Filestat::default()
-                    });
-                }
-                None => self
-                    .root_fs
-                    .metadata(path)
-                    .map_err(fs_error_into_wasi_err)?,
-            },
-            Kind::Dir { path, .. } => self
-                .root_fs
-                .metadata(path)
-                .map_err(fs_error_into_wasi_err)?,
-            Kind::Symlink {
-                path_to_symlink,
-                relative_path,
-                ..
-            } => {
-                let symlink_path = PosixPath::new("/")
-                    .join(&PosixPath::from_path(path_to_symlink))
-                    .into_path_buf();
-
-                match self.root_fs.symlink_metadata(&symlink_path) {
-                    Ok(md) => md,
-                    Err(FsError::EntryNotFound)
-                        if self.ephemeral_symlink_at(&symlink_path).is_some() =>
-                    {
-                        return Ok(Filestat {
-                            st_filetype: Filetype::SymbolicLink,
-                            st_size: relative_path.as_os_str().len() as u64,
-                            ..Filestat::default()
-                        });
-                    }
-                    Err(err) => return Err(fs_error_into_wasi_err(err)),
-                }
-            }
-            _ => return Err(Errno::Io),
-        };
-        Ok(Filestat {
-            st_filetype: virtual_file_type_to_wasi_file_type(md.file_type()),
-            st_size: md.len(),
-            st_atim: md.accessed(),
-            st_mtim: md.modified(),
-            st_ctim: md.created(),
-            ..Filestat::default()
-        })
     }
 
     /// Closes an open FD under `fd_map.write()`, capturing a file handle for
@@ -2792,29 +2780,30 @@ impl FallbackFileSystem {
     }
 }
 
+#[async_trait::async_trait]
 impl FileSystem for FallbackFileSystem {
-    fn readlink(&self, _path: &Path) -> virtual_fs::Result<PathBuf> {
+    async fn readlink(&self, _path: &Path) -> virtual_fs::Result<PathBuf> {
         Self::fail()
     }
-    fn read_dir(&self, _path: &Path) -> Result<virtual_fs::ReadDir, FsError> {
+    async fn read_dir(&self, _path: &Path) -> Result<virtual_fs::ReadDir, FsError> {
         Self::fail();
     }
-    fn create_dir(&self, _path: &Path) -> Result<(), FsError> {
+    async fn create_dir(&self, _path: &Path) -> Result<(), FsError> {
         Self::fail();
     }
-    fn remove_dir(&self, _path: &Path) -> Result<(), FsError> {
+    async fn remove_dir(&self, _path: &Path) -> Result<(), FsError> {
         Self::fail();
     }
-    fn rename<'a>(&'a self, _from: &Path, _to: &Path) -> BoxFuture<'a, Result<(), FsError>> {
+    async fn rename(&self, _from: &Path, _to: &Path) -> Result<(), FsError> {
         Self::fail();
     }
-    fn metadata(&self, _path: &Path) -> Result<virtual_fs::Metadata, FsError> {
+    async fn metadata(&self, _path: &Path) -> Result<virtual_fs::Metadata, FsError> {
         Self::fail();
     }
-    fn symlink_metadata(&self, _path: &Path) -> Result<virtual_fs::Metadata, FsError> {
+    async fn symlink_metadata(&self, _path: &Path) -> Result<virtual_fs::Metadata, FsError> {
         Self::fail();
     }
-    fn remove_file(&self, _path: &Path) -> Result<(), FsError> {
+    async fn remove_file(&self, _path: &Path) -> Result<(), FsError> {
         Self::fail();
     }
     fn new_open_options(&self) -> virtual_fs::OpenOptions<'_> {

--- a/lib/wasix/src/journal/effector/syscalls/chdir.rs
+++ b/lib/wasix/src/journal/effector/syscalls/chdir.rs
@@ -6,7 +6,12 @@ impl JournalEffector {
     }
 
     pub fn apply_chdir(ctx: &mut FunctionEnvMut<'_, WasiEnv>, path: &str) -> anyhow::Result<()> {
-        crate::syscalls::chdir_internal(ctx.data(), path).map_err(|err| {
+        crate::syscalls::__asyncify_light(
+            ctx.data(),
+            None,
+            crate::syscalls::chdir_internal(ctx.data(), path),
+        )?
+        .map_err(|err| {
             anyhow::format_err!(
                 "snapshot restore error: failed to change directory (path={path}) - {err}"
             )

--- a/lib/wasix/src/journal/effector/syscalls/fd_allocate.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_allocate.rs
@@ -19,8 +19,12 @@ impl JournalEffector {
         offset: Filesize,
         len: Filesize,
     ) -> anyhow::Result<()> {
-        crate::syscalls::fd_allocate_internal(ctx, fd, offset, len)
-            .map_err(|err| {
+        crate::syscalls::__asyncify_light(
+            ctx.data(),
+            None,
+            crate::syscalls::fd_allocate_internal(ctx.data(), fd, offset, len),
+        )?
+        .map_err(|err| {
                 anyhow::format_err!(
                     "journal restore error: failed to allocate on file descriptor (fd={fd}, offset={offset}, len={len}) - {err}")
             })?;

--- a/lib/wasix/src/journal/effector/syscalls/fd_set_size.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_set_size.rs
@@ -14,7 +14,12 @@ impl JournalEffector {
         fd: Fd,
         st_size: Filesize,
     ) -> anyhow::Result<()> {
-        crate::syscalls::fd_filestat_set_size_internal(ctx, fd, st_size).map_err(|err| {
+        crate::syscalls::__asyncify_light(
+            ctx.data(),
+            None,
+            crate::syscalls::fd_filestat_set_size_internal(ctx.data(), fd, st_size),
+        )?
+        .map_err(|err| {
             anyhow::format_err!(
                 "journal restore error: failed to set file size (fd={fd}, st_size={st_size}) - {err}")
         })?;

--- a/lib/wasix/src/journal/effector/syscalls/fd_set_times.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_set_times.rs
@@ -26,8 +26,18 @@ impl JournalEffector {
         st_mtim: Timestamp,
         fst_flags: Fstflags,
     ) -> anyhow::Result<()> {
-        crate::syscalls::fd_filestat_set_times_internal(ctx, fd, st_atim, st_mtim, fst_flags)
-            .map_err(|err| {
+        crate::syscalls::__asyncify_light(
+            ctx.data(),
+            None,
+            crate::syscalls::fd_filestat_set_times_internal(
+                ctx.data(),
+                fd,
+                st_atim,
+                st_mtim,
+                fst_flags,
+            ),
+        )?
+        .map_err(|err| {
                 anyhow::format_err!(
                     "journal restore error: failed to set file times (fd={fd}, st_atim={st_atim}, st_mtim={st_mtim}, fst_flags={fst_flags:?}) - {err}")
             })?;

--- a/lib/wasix/src/journal/effector/syscalls/path_create_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_create_directory.rs
@@ -28,9 +28,26 @@ impl JournalEffector {
     ) -> anyhow::Result<()> {
         // see `VIRTUAL_ROOT_FD` for details as to why this exists
         if fd == VIRTUAL_ROOT_FD {
-            ctx.data().state.fs.root_fs.create_dir(Path::new(path))?;
+            crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                async {
+                    ctx.data()
+                        .state
+                        .fs
+                        .root_fs
+                        .create_dir(Path::new(path))
+                        .await
+                        .map_err(crate::fs::fs_error_into_wasi_err)
+                },
+            )??;
         } else {
-            crate::syscalls::path_create_directory_internal(ctx, fd, path).map_err(|err| {
+            crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                crate::syscalls::path_create_directory_internal(ctx.data(), fd, path),
+            )?
+            .map_err(|err| {
                 anyhow::format_err!(
                     "journal restore error: failed to create directory path (fd={fd}, path={path}) - {err}")
             })?;

--- a/lib/wasix/src/journal/effector/syscalls/path_create_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_create_directory.rs
@@ -28,19 +28,15 @@ impl JournalEffector {
     ) -> anyhow::Result<()> {
         // see `VIRTUAL_ROOT_FD` for details as to why this exists
         if fd == VIRTUAL_ROOT_FD {
-            crate::syscalls::__asyncify_light(
-                ctx.data(),
-                None,
-                async {
-                    ctx.data()
-                        .state
-                        .fs
-                        .root_fs
-                        .create_dir(Path::new(path))
-                        .await
-                        .map_err(crate::fs::fs_error_into_wasi_err)
-                },
-            )??;
+            crate::syscalls::__asyncify_light(ctx.data(), None, async {
+                ctx.data()
+                    .state
+                    .fs
+                    .root_fs
+                    .create_dir(Path::new(path))
+                    .await
+                    .map_err(crate::fs::fs_error_into_wasi_err)
+            })??;
         } else {
             crate::syscalls::__asyncify_light(
                 ctx.data(),

--- a/lib/wasix/src/journal/effector/syscalls/path_link.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_link.rs
@@ -29,8 +29,19 @@ impl JournalEffector {
         new_fd: Fd,
         new_path: &str,
     ) -> anyhow::Result<()> {
-        crate::syscalls::path_link_internal(ctx, old_fd, old_flags, old_path, new_fd, new_path)
-            .map_err(|err| {
+        crate::syscalls::__asyncify_light(
+            ctx.data(),
+            None,
+            crate::syscalls::path_link_internal(
+                ctx.data(),
+                old_fd,
+                old_flags,
+                old_path,
+                new_fd,
+                new_path,
+            ),
+        )?
+        .map_err(|err| {
                 anyhow::format_err!(
                     "journal restore error: failed to create hard link (old_fd={old_fd}, old_flags={old_flags}, old_path={old_path}, new_fd={new_fd}, new_path={new_path}) - {err}")
             })?;

--- a/lib/wasix/src/journal/effector/syscalls/path_open.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_open.rs
@@ -47,7 +47,7 @@ impl JournalEffector {
             ctx.data(),
             dirfd,
             dirflags,
-            path,
+            path.to_string(),
             o_flags,
             fs_rights_base,
             fs_rights_inheriting,
@@ -55,7 +55,7 @@ impl JournalEffector {
             fd_flags,
             Some(fd),
         );
-        match res? {
+        match crate::syscalls::__asyncify_light(ctx.data(), None, res)?? {
             Ok(fd) => fd,
             Err(err) => {
                 bail!(

--- a/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
@@ -28,19 +28,15 @@ impl JournalEffector {
     ) -> anyhow::Result<()> {
         // see `VIRTUAL_ROOT_FD` for details as to why this exists
         if fd == VIRTUAL_ROOT_FD {
-            crate::syscalls::__asyncify_light(
-                ctx.data(),
-                None,
-                async {
-                    ctx.data()
-                        .state
-                        .fs
-                        .root_fs
-                        .remove_dir(Path::new(path))
-                        .await
-                        .map_err(crate::fs::fs_error_into_wasi_err)
-                },
-            )??;
+            crate::syscalls::__asyncify_light(ctx.data(), None, async {
+                ctx.data()
+                    .state
+                    .fs
+                    .root_fs
+                    .remove_dir(Path::new(path))
+                    .await
+                    .map_err(crate::fs::fs_error_into_wasi_err)
+            })??;
         } else {
             let base_dir = ctx.data().state.fs.get_fd(fd).map_err(|err| {
                 anyhow::format_err!(

--- a/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
@@ -28,16 +28,30 @@ impl JournalEffector {
     ) -> anyhow::Result<()> {
         // see `VIRTUAL_ROOT_FD` for details as to why this exists
         if fd == VIRTUAL_ROOT_FD {
-            ctx.data().state.fs.root_fs.remove_dir(Path::new(path))?;
+            crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                async {
+                    ctx.data()
+                        .state
+                        .fs
+                        .root_fs
+                        .remove_dir(Path::new(path))
+                        .await
+                        .map_err(crate::fs::fs_error_into_wasi_err)
+                },
+            )??;
         } else {
             let base_dir = ctx.data().state.fs.get_fd(fd).map_err(|err| {
                 anyhow::format_err!(
                     "journal restore error: invalid directory descriptor (fd={fd}) - {err}"
                 )
             })?;
-            if let Err(err) =
-                crate::syscalls::path_remove_directory_internal(ctx, fd, base_dir, path)
-            {
+            if let Err(err) = crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                crate::syscalls::path_remove_directory_internal(ctx.data(), fd, base_dir, path),
+            )? {
                 bail!("journal restore error: failed to remove directory - {err}");
             }
         }

--- a/lib/wasix/src/journal/effector/syscalls/path_rename.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_rename.rs
@@ -37,8 +37,17 @@ impl JournalEffector {
                 state.fs_rename(old_path, new_path).await
             })??;
         } else {
-            let ret =
-                crate::syscalls::path_rename_internal(ctx, old_fd, old_path, new_fd, new_path)?;
+            let ret = __asyncify_light(
+                ctx.data(),
+                None,
+                crate::syscalls::path_rename_internal(
+                    ctx.data(),
+                    old_fd,
+                    old_path,
+                    new_fd,
+                    new_path,
+                ),
+            )??;
             if ret != Errno::Success {
                 bail!(
                     "journal restore error: failed to rename path (old_fd={old_fd}, old_path={old_path}, new_fd={new_fd}, new_path={new_path}) - {ret}"

--- a/lib/wasix/src/journal/effector/syscalls/path_set_times.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_set_times.rs
@@ -38,8 +38,20 @@ impl JournalEffector {
         if fd == VIRTUAL_ROOT_FD {
             // we ignore this record as its not implemented yet
         } else {
-            crate::syscalls::path_filestat_set_times_internal(ctx, fd, flags, path, st_atim, st_mtim, fst_flags)
-                .map_err(|err| {
+            crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                crate::syscalls::path_filestat_set_times_internal(
+                    ctx.data(),
+                    fd,
+                    flags,
+                    path,
+                    st_atim,
+                    st_mtim,
+                    fst_flags,
+                ),
+            )?
+            .map_err(|err| {
                     anyhow::format_err!(
                         "journal restore error: failed to set path times (fd={fd}, flags={flags}, path={path}, st_atim={st_atim}, st_mtim={st_mtim}, fst_flags={fst_flags:?}) - {err}")
                 })?;

--- a/lib/wasix/src/journal/effector/syscalls/path_symlink.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_symlink.rs
@@ -23,8 +23,12 @@ impl JournalEffector {
         fd: Fd,
         new_path: &str,
     ) -> anyhow::Result<()> {
-        crate::syscalls::path_symlink_internal(ctx, old_path, fd, new_path)
-            .map_err(|err| {
+        crate::syscalls::__asyncify_light(
+            ctx.data(),
+            None,
+            crate::syscalls::path_symlink_internal(ctx.data(), old_path, fd, new_path),
+        )?
+        .map_err(|err| {
                 anyhow::format_err!(
                     "journal restore error: failed to create symlink (old_path={old_path}, fd={fd}, new_path={new_path}) - {err}")
             })?;

--- a/lib/wasix/src/journal/effector/syscalls/path_unlink.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_unlink.rs
@@ -28,19 +28,15 @@ impl JournalEffector {
     ) -> anyhow::Result<()> {
         // see `VIRTUAL_ROOT_FD` for details as to why this exists
         if fd == VIRTUAL_ROOT_FD {
-            crate::syscalls::__asyncify_light(
-                ctx.data(),
-                None,
-                async {
-                    ctx.data()
-                        .state
-                        .fs
-                        .root_fs
-                        .remove_file(Path::new(path))
-                        .await
-                        .map_err(crate::fs::fs_error_into_wasi_err)
-                },
-            )??;
+            crate::syscalls::__asyncify_light(ctx.data(), None, async {
+                ctx.data()
+                    .state
+                    .fs
+                    .root_fs
+                    .remove_file(Path::new(path))
+                    .await
+                    .map_err(crate::fs::fs_error_into_wasi_err)
+            })??;
         } else {
             let ret = crate::syscalls::__asyncify_light(
                 ctx.data(),

--- a/lib/wasix/src/journal/effector/syscalls/path_unlink.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_unlink.rs
@@ -28,9 +28,25 @@ impl JournalEffector {
     ) -> anyhow::Result<()> {
         // see `VIRTUAL_ROOT_FD` for details as to why this exists
         if fd == VIRTUAL_ROOT_FD {
-            ctx.data().state.fs.root_fs.remove_file(Path::new(path))?;
+            crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                async {
+                    ctx.data()
+                        .state
+                        .fs
+                        .root_fs
+                        .remove_file(Path::new(path))
+                        .await
+                        .map_err(crate::fs::fs_error_into_wasi_err)
+                },
+            )??;
         } else {
-            let ret = crate::syscalls::path_unlink_file_internal(ctx, fd, path)?;
+            let ret = crate::syscalls::__asyncify_light(
+                ctx.data(),
+                None,
+                crate::syscalls::path_unlink_file_internal(ctx.data(), fd, path),
+            )??;
             if ret != Errno::Success {
                 bail!(
                     "journal restore error: failed to remove file (fd={fd}, path={path}) - {ret}"

--- a/lib/wasix/src/os/command/builtins/cmd_wasmer.rs
+++ b/lib/wasix/src/os/command/builtins/cmd_wasmer.rs
@@ -91,9 +91,10 @@ impl CmdWasmer {
             };
 
             let fs = env.fs_root();
-            let f = fs.new_open_options().read(true).open(&file_path);
-            let executable = if let Ok(mut file) = f {
-                let mut data = Vec::with_capacity(file.size() as usize);
+            let mut open_options = fs.new_open_options();
+            let f = open_options.read(true).open(&file_path);
+            let executable = if let Ok(mut file) = f.await {
+                let mut data = Vec::with_capacity(file.size().await as usize);
                 file.read_to_end(&mut data).await.unwrap();
 
                 let bytes: bytes::Bytes = data.into();

--- a/lib/wasix/src/os/console/mod.rs
+++ b/lib/wasix/src/os/console/mod.rs
@@ -262,17 +262,21 @@ impl Console {
         // otherwise they will be overridden by their attached file systems
         for (path, data) in self.ro_files.clone() {
             let path = PathBuf::from(path);
-            env.fs_root().remove_file(&path).ok();
-            let mut file = env
-                .fs_root()
-                .new_open_options()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .open(&path)
-                .map_err(|err| SpawnError::Other(err.into()))?;
-            block_on(file.copy_reference(Box::new(StaticFile::new(data))))
-                .map_err(|err| SpawnError::Other(err.into()))?;
+            block_on(async {
+                env.fs_root().remove_file(&path).await.ok();
+                let mut file = env
+                    .fs_root()
+                    .new_open_options()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&path)
+                    .await
+                    .map_err(|err| SpawnError::Other(err.into()))?;
+                file.copy_reference(Box::new(StaticFile::new(data)))
+                    .await
+                    .map_err(|err| SpawnError::Other(err.into()))
+            })?;
         }
 
         // Build the config

--- a/lib/wasix/src/os/tty/mod.rs
+++ b/lib/wasix/src/os/tty/mod.rs
@@ -805,36 +805,37 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl VirtualFileTrait for CaptureFile {
-        fn last_accessed(&self) -> u64 {
+        async fn last_accessed(&self) -> u64 {
             0
         }
 
-        fn last_modified(&self) -> u64 {
+        async fn last_modified(&self) -> u64 {
             0
         }
 
-        fn created_time(&self) -> u64 {
+        async fn created_time(&self) -> u64 {
             0
         }
 
-        fn size(&self) -> u64 {
+        async fn size(&self) -> u64 {
             self.buffer.lock().unwrap().len() as u64
         }
 
-        fn set_len(&mut self, _new_size: u64) -> Result<(), virtual_fs::FsError> {
+        async fn set_len(&mut self, _new_size: u64) -> Result<(), virtual_fs::FsError> {
             Err(virtual_fs::FsError::PermissionDenied)
         }
 
-        fn unlink(&mut self) -> Result<(), virtual_fs::FsError> {
+        async fn unlink(&mut self) -> Result<(), virtual_fs::FsError> {
             Ok(())
         }
 
-        fn is_open(&self) -> bool {
+        async fn is_open(&self) -> bool {
             true
         }
 
-        fn get_special_fd(&self) -> Option<u32> {
+        async fn get_special_fd(&self) -> Option<u32> {
             None
         }
 

--- a/lib/wasix/src/runners/wasi.rs
+++ b/lib/wasix/src/runners/wasi.rs
@@ -648,7 +648,7 @@ mod tests {
 
         let fs = &init.state.fs.root_fs;
 
-        fs.read_dir(std::path::Path::new("/host")).unwrap();
+        fs.read_dir(std::path::Path::new("/host")).await.unwrap();
     }
 
     #[cfg(all(feature = "host-fs", feature = "sys"))]
@@ -699,7 +699,9 @@ mod tests {
 
         let fs = &init.state.fs.root_fs;
 
-        fs.read_dir(std::path::Path::new("/host")).unwrap();
-        fs.read_dir(std::path::Path::new("/settings")).unwrap();
+        fs.read_dir(std::path::Path::new("/host")).await.unwrap();
+        fs.read_dir(std::path::Path::new("/settings"))
+            .await
+            .unwrap();
     }
 }

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -555,15 +555,22 @@ mod tests {
         .unwrap();
 
         use virtual_fs::FileSystem;
-        assert!(fs.metadata("/home/file.txt".as_ref()).unwrap().is_file());
-        assert!(fs.metadata("lib".as_ref()).unwrap().is_dir());
+        assert!(
+            fs.metadata("/home/file.txt".as_ref())
+                .await
+                .unwrap()
+                .is_file()
+        );
+        assert!(fs.metadata("lib".as_ref()).await.unwrap().is_dir());
         assert!(
             fs.metadata("lib/python3.6/collections/__init__.py".as_ref())
+                .await
                 .unwrap()
                 .is_file()
         );
         assert!(
             fs.metadata("lib/python3.6/encodings/__init__.py".as_ref())
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -591,20 +598,23 @@ mod tests {
         )
         .unwrap();
 
-        fs.create_dir(Path::new("/python/custom")).unwrap();
+        fs.create_dir(Path::new("/python/custom")).await.unwrap();
         fs.new_open_options()
             .create(true)
             .write(true)
             .open(Path::new("/python/custom/sitecustomize.py"))
+            .await
             .unwrap();
 
         assert!(
             fs.metadata(Path::new("/python/custom/sitecustomize.py"))
+                .await
                 .unwrap()
                 .is_file()
         );
         assert!(
             fs.metadata(Path::new("/python/lib/python3.6/collections/__init__.py"))
+                .await
                 .unwrap()
                 .is_file()
         );
@@ -636,14 +646,18 @@ mod tests {
             Path::new("lib/python3.6/collections"),
             Path::new("/python/collections-link"),
         )
+        .await
         .unwrap();
 
         assert_eq!(
-            fs.readlink(Path::new("/python/collections-link")).unwrap(),
+            fs.readlink(Path::new("/python/collections-link"))
+                .await
+                .unwrap(),
             Path::new("lib/python3.6/collections")
         );
         assert!(
             fs.symlink_metadata(Path::new("/python/collections-link"))
+                .await
                 .unwrap()
                 .ft
                 .is_symlink()
@@ -660,6 +674,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/user.txt"))
+            .await
             .unwrap();
 
         let package_mount = TmpFileSystem::new();
@@ -668,6 +683,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/pkg.txt"))
+            .await
             .unwrap();
 
         let mounted_dirs = [MountedDirectory {
@@ -692,11 +708,12 @@ mod tests {
 
         assert!(
             fs.metadata(Path::new("/python/user.txt"))
+                .await
                 .unwrap()
                 .is_file()
         );
         assert_eq!(
-            fs.metadata(Path::new("/python/pkg.txt")),
+            fs.metadata(Path::new("/python/pkg.txt")).await,
             Err(virtual_fs::FsError::EntryNotFound)
         );
     }
@@ -744,6 +761,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/user.txt"))
+            .await
             .unwrap();
 
         let mounted_dirs = [MountedDirectory {
@@ -758,6 +776,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/pkg.txt"))
+            .await
             .unwrap();
         container_mounts
             .mount(Path::new("/"), Arc::new(container_root))
@@ -773,8 +792,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(fs.metadata(Path::new("/user.txt")).unwrap().is_file());
-        assert!(fs.metadata(Path::new("/pkg.txt")).unwrap().is_file());
+        assert!(fs.metadata(Path::new("/user.txt")).await.unwrap().is_file());
+        assert!(fs.metadata(Path::new("/pkg.txt")).await.unwrap().is_file());
     }
 
     #[tokio::test]
@@ -787,6 +806,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/first.txt"))
+            .await
             .unwrap();
 
         let second_root = TmpFileSystem::new();
@@ -795,6 +815,7 @@ mod tests {
             .create(true)
             .write(true)
             .open(Path::new("/second.txt"))
+            .await
             .unwrap();
 
         let mounted_dirs = [
@@ -818,8 +839,18 @@ mod tests {
         )
         .unwrap();
 
-        assert!(fs.metadata(Path::new("/first.txt")).unwrap().is_file());
-        assert!(fs.metadata(Path::new("/second.txt")).unwrap().is_file());
+        assert!(
+            fs.metadata(Path::new("/first.txt"))
+                .await
+                .unwrap()
+                .is_file()
+        );
+        assert!(
+            fs.metadata(Path::new("/second.txt"))
+                .await
+                .unwrap()
+                .is_file()
+        );
     }
 
     #[tokio::test]
@@ -874,6 +905,7 @@ mod tests {
         let directory_contents: Vec<_> = got
             .fs
             .read_dir("/".as_ref())
+            .await
             .unwrap()
             .map(|entry| entry.unwrap())
             .collect();

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -178,19 +178,31 @@ impl CommonWasiOptions {
 //     OverlayFileSystem<TmpFileSystem, [RelativeOrAbsolutePathHack<Arc<dyn FileSystem>>; 1]>;
 
 fn normalized_mount_path(guest_path: &str) -> Result<PathBuf, Error> {
+    fn guest_path_from_components(components: &[std::ffi::OsString]) -> PathBuf {
+        let mut path = String::from("/");
+        path.push_str(
+            &components
+                .iter()
+                .map(|component| component.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/"),
+        );
+        PathBuf::from(path)
+    }
+
     let mut guest_path = PathBuf::from(guest_path);
 
     if guest_path.is_relative() {
         guest_path = apply_relative_path_mounting_hack(&guest_path);
     }
 
-    let mut normalized = PathBuf::from("/");
+    let mut normalized = Vec::new();
     for component in guest_path.components() {
         match component {
-            Component::RootDir => normalized = PathBuf::from("/"),
+            Component::RootDir => normalized.clear(),
             Component::CurDir => {}
             Component::ParentDir => {
-                if normalized.as_os_str() == "/" {
+                if normalized.is_empty() {
                     anyhow::bail!(
                         "Invalid guest mount path \"{}\": parent traversal escapes the virtual root",
                         guest_path.display()
@@ -198,7 +210,7 @@ fn normalized_mount_path(guest_path: &str) -> Result<PathBuf, Error> {
                 }
                 normalized.pop();
             }
-            Component::Normal(part) => normalized.push(part),
+            Component::Normal(part) => normalized.push(part.to_os_string()),
             Component::Prefix(_) => {
                 anyhow::bail!(
                     "Invalid guest mount path \"{}\": platform-specific prefixes are not supported",
@@ -208,7 +220,7 @@ fn normalized_mount_path(guest_path: &str) -> Result<PathBuf, Error> {
         }
     }
 
-    Ok(normalized)
+    Ok(guest_path_from_components(&normalized))
 }
 
 fn prepare_filesystem(
@@ -884,6 +896,18 @@ mod tests {
                 .to_string()
                 .contains("parent traversal escapes the virtual root"),
             "{error:#}"
+        );
+    }
+
+    #[test]
+    fn normalized_guest_mount_paths_use_guest_separators() {
+        assert_eq!(
+            normalized_mount_path("/mnt/dir").unwrap(),
+            PathBuf::from("/mnt/dir")
+        );
+        assert_eq!(
+            normalized_mount_path("/mnt/./dir/../data").unwrap(),
+            PathBuf::from("/mnt/data")
         );
     }
 

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -724,10 +724,13 @@ mod tests {
 
         let mounts = filesystem_v2(&packages, &pkg, false).unwrap();
         let mount_fs = mounts.to_mount_fs().unwrap();
-        assert!(mount_fs.metadata(Path::new("/public")).unwrap().is_dir());
         assert!(
-            mount_fs
-                .metadata(Path::new("/public/index.html"))
+            virtual_mio::block_on(mount_fs.metadata(Path::new("/public")))
+                .unwrap()
+                .is_dir()
+        );
+        assert!(
+            virtual_mio::block_on(mount_fs.metadata(Path::new("/public/index.html")))
                 .unwrap()
                 .is_file()
         );
@@ -929,8 +932,7 @@ mod tests {
             .as_ref()
             .expect("expected root layer mount");
         assert!(
-            root_layer
-                .metadata(Path::new("/root.txt"))
+            virtual_mio::block_on(root_layer.metadata(Path::new("/root.txt")))
                 .unwrap()
                 .is_file()
         );

--- a/lib/wasix/src/runtime/package_loader/load_package_tree.rs
+++ b/lib/wasix/src/runtime/package_loader/load_package_tree.rs
@@ -9,6 +9,7 @@ use futures::{StreamExt, TryStreamExt};
 use once_cell::sync::OnceCell;
 use petgraph::visit::EdgeRef;
 use virtual_fs::{FileSystem, WebcVolumeFileSystem};
+use virtual_mio::block_on;
 use wasmer_config::package::PackageId;
 use wasmer_package::utils::wasm_annotations_to_features;
 use webc::metadata::annotations::Atom as AtomAnnotation;
@@ -366,7 +367,7 @@ fn packages_needed_for_load(pkg: &ResolvedPackage) -> HashSet<PackageId> {
 fn count_file_system(fs: &dyn FileSystem, path: &Path) -> u64 {
     let mut total = 0;
 
-    let dir = match fs.read_dir(path) {
+    let dir = match block_on(fs.read_dir(path)) {
         Ok(d) => d,
         Err(_err) => {
             return 0;

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use virtual_fs::{
     ArcFile, FileSystem, FsError, MountFileSystem, RootFileSystemBuilder, VirtualFile,
 };
+use virtual_mio::block_on;
 use wasmer::{AsStoreMut, Engine, Instance, Module};
 use wasmer_config::package::PackageId;
 
@@ -922,12 +923,12 @@ impl WasiEnvBuilder {
         });
 
         if let Some(dir) = &self.current_dir {
-            match fs_backing.read_dir(dir) {
+            match block_on(fs_backing.read_dir(dir)) {
                 Ok(_) => {
                     // All good
                 }
                 Err(FsError::EntryNotFound) => {
-                    fs_backing.create_dir(dir).map_err(|err| {
+                    block_on(fs_backing.create_dir(dir)).map_err(|err| {
                         WasiStateCreationError::WasiFsSetupError(format!(
                             "Could not create specified current directory at '{}': {err}",
                             dir.display()

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -1129,9 +1129,9 @@ impl WasiEnv {
         // Next, make sure all commands will be available
 
         if !pkg.commands.is_empty() {
-            let _ = root_fs.create_dir(Path::new("/bin"));
-            let _ = root_fs.create_dir(Path::new("/usr"));
-            let _ = root_fs.create_dir(Path::new("/usr/bin"));
+            let _ = root_fs.create_dir(Path::new("/bin")).await;
+            let _ = root_fs.create_dir(Path::new("/usr")).await;
+            let _ = root_fs.create_dir(Path::new("/usr/bin")).await;
 
             for command in &pkg.commands {
                 let path = format!("/bin/{}", command.name());

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -50,7 +50,7 @@ async fn write_readonly_buffer_to_fs(
     contents: &shared_buffer::OwnedBuffer,
 ) -> Result<(), FsError> {
     if let Some(parent) = path.parent() {
-        virtual_fs::create_dir_all(fs, parent)?;
+        virtual_fs::create_dir_all(fs, parent).await?;
     }
 
     if let Some(root_fs) = fs.writable_root() {
@@ -64,7 +64,8 @@ async fn write_readonly_buffer_to_fs(
         .create(true)
         .truncate(true)
         .write(true)
-        .open(path)?;
+        .open(path)
+        .await?;
     file.copy_from_owned_buffer(contents)
         .await
         .map_err(virtual_fs::FsError::from)

--- a/lib/wasix/src/state/linker/locator.rs
+++ b/lib/wasix/src/state/linker/locator.rs
@@ -25,18 +25,19 @@ pub(super) async fn locate_module(
         fs: &WasiFsRoot,
         path: impl AsRef<Path>,
     ) -> Result<(PathBuf, OwnedBuffer), FsError> {
-        let mut file = match fs.new_open_options().read(true).open(path.as_ref()) {
+        let mut file = match fs.new_open_options().read(true).open(path.as_ref()).await {
             Ok(f) => f,
             // Fallback for cases where the module thinks it's running on unix,
             // but the compiled side module is a .wasm file
             Err(_) if path.as_ref().extension() == Some(OsStr::new("so")) => fs
                 .new_open_options()
                 .read(true)
-                .open(path.as_ref().with_extension("wasm"))?,
+                .open(path.as_ref().with_extension("wasm"))
+                .await?,
             Err(e) => return Err(e),
         };
 
-        let buf = if let Some(buf) = file.as_owned_buffer() {
+        let buf = if let Some(buf) = file.as_owned_buffer().await {
             buf
         } else {
             let mut buf = Vec::new();

--- a/lib/wasix/src/state/linker/locator.rs
+++ b/lib/wasix/src/state/linker/locator.rs
@@ -29,11 +29,12 @@ pub(super) async fn locate_module(
             Ok(f) => f,
             // Fallback for cases where the module thinks it's running on unix,
             // but the compiled side module is a .wasm file
-            Err(_) if path.as_ref().extension() == Some(OsStr::new("so")) => fs
-                .new_open_options()
-                .read(true)
-                .open(path.as_ref().with_extension("wasm"))
-                .await?,
+            Err(_) if path.as_ref().extension() == Some(OsStr::new("so")) => {
+                fs.new_open_options()
+                    .read(true)
+                    .open(path.as_ref().with_extension("wasm"))
+                    .await?
+            }
             Err(e) => return Err(e),
         };
 

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -31,7 +31,7 @@ use std::{
     time::Duration,
 };
 
-use virtual_fs::{FileOpener, FileSystem, FsError, OpenOptions, VirtualFile};
+use virtual_fs::{FileSystem, FsError, OpenOptions, VirtualFile};
 use wasmer_wasix_types::wasi::{
     Disposition, Errno, Fd as WasiFd, Rights, Signal, Snapshot0Clockid,
 };
@@ -53,23 +53,6 @@ pub(crate) use linker::*;
 
 /// all the rights enabled
 pub const ALL_RIGHTS: Rights = Rights::all();
-
-#[allow(dead_code)]
-struct WasiStateOpener {
-    root_fs: WasiFsRoot,
-}
-
-impl FileOpener for WasiStateOpener {
-    fn open(
-        &self,
-        path: &Path,
-        conf: &virtual_fs::OpenOptionsConfig,
-    ) -> virtual_fs::Result<Box<dyn VirtualFile + Send + Sync + 'static>> {
-        let mut new_options = self.root_fs.new_open_options();
-        new_options.options(conf.clone());
-        new_options.open(path)
-    }
-}
 
 /// Represents a futex which will make threads wait for completion in a more
 /// CPU efficient manner
@@ -159,27 +142,30 @@ impl WasiState {
 
 // Implementations of direct to FS calls so that we can easily change their implementation
 impl WasiState {
-    pub(crate) fn fs_read_dir<P: AsRef<Path>>(
+    pub(crate) async fn fs_read_dir<P: AsRef<Path>>(
         &self,
         path: P,
     ) -> Result<virtual_fs::ReadDir, Errno> {
         self.fs
             .root_fs
             .read_dir(path.as_ref())
+            .await
             .map_err(fs_error_into_wasi_err)
     }
 
-    pub(crate) fn fs_create_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
+    pub(crate) async fn fs_create_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
         self.fs
             .root_fs
             .create_dir(path.as_ref())
+            .await
             .map_err(fs_error_into_wasi_err)
     }
 
-    pub(crate) fn fs_remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
+    pub(crate) async fn fs_remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
         self.fs
             .root_fs
             .remove_dir(path.as_ref())
+            .await
             .map_err(fs_error_into_wasi_err)
     }
 
@@ -195,10 +181,11 @@ impl WasiState {
             .map_err(fs_error_into_wasi_err)
     }
 
-    pub(crate) fn fs_remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
+    pub(crate) async fn fs_remove_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
         self.fs
             .root_fs
             .remove_file(path.as_ref())
+            .await
             .map_err(fs_error_into_wasi_err)
     }
 

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -44,7 +44,7 @@ pub use self::{
 };
 pub use crate::fs::{InodeGuard, InodeWeakGuard};
 use crate::{
-    fs::{WasiFs, WasiFsRoot, WasiInodes, WasiStateFileGuard, fs_error_into_wasi_err},
+    fs::{WasiFs, WasiInodes, WasiStateFileGuard, fs_error_into_wasi_err},
     syscalls::types::*,
     utils::WasiParkingLot,
 };

--- a/lib/wasix/src/syscalls/wasi/fd_allocate.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_allocate.rs
@@ -19,7 +19,11 @@ pub fn fd_allocate(
 ) -> Result<Errno, WasiError> {
     WasiEnv::do_pending_operations(&mut ctx)?;
 
-    wasi_try_ok!(fd_allocate_internal(&mut ctx, fd, offset, len));
+    wasi_try_ok!(__asyncify_light(
+        ctx.data(),
+        None,
+        fd_allocate_internal(ctx.data(), fd, offset, len)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -33,14 +37,13 @@ pub fn fd_allocate(
     Ok(Errno::Success)
 }
 
-pub(crate) fn fd_allocate_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn fd_allocate_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     offset: Filesize,
     len: Filesize,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (_, mut state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
+    let mut state = env.state();
     let fd_entry = state.fs.get_fd(fd)?;
     let inode = fd_entry.inode;
 
@@ -53,11 +56,15 @@ pub(crate) fn fd_allocate_internal(
         let mut guard = inode.write();
         match guard.deref_mut() {
             Kind::File { handle, .. } => {
-                if let Some(handle) = handle {
-                    let mut handle = handle.write().unwrap();
-                    current_size = handle.size();
+                if let Some(handle) = handle.clone() {
+                    drop(guard);
+                    let mut handle = handle.lock().await;
+                    current_size = handle.size().await;
                     if new_size > current_size {
-                        handle.set_len(new_size).map_err(fs_error_into_wasi_err)?;
+                        handle
+                            .set_len(new_size)
+                            .await
+                            .map_err(fs_error_into_wasi_err)?;
                         current_size = new_size;
                     }
                 } else {

--- a/lib/wasix/src/syscalls/wasi/fd_allocate.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_allocate.rs
@@ -51,32 +51,18 @@ pub(crate) async fn fd_allocate_internal(
         return Err(Errno::Access);
     }
     let new_size = offset.checked_add(len).ok_or(Errno::Inval)?;
-    let mut current_size;
-    {
+    let mut current_size = 0;
+    let handle = {
         let mut guard = inode.write();
         match guard.deref_mut() {
-            Kind::File { handle, .. } => {
-                if let Some(handle) = handle.clone() {
-                    drop(guard);
-                    let mut handle = handle.lock().await;
-                    current_size = handle.size().await;
-                    if new_size > current_size {
-                        handle
-                            .set_len(new_size)
-                            .await
-                            .map_err(fs_error_into_wasi_err)?;
-                        current_size = new_size;
-                    }
-                } else {
-                    return Err(Errno::Badf);
-                }
-            }
+            Kind::File { handle, .. } => Some(handle.clone().ok_or(Errno::Badf)?),
             Kind::Buffer { buffer } => {
                 current_size = buffer.len() as u64;
                 if new_size > current_size {
                     buffer.resize(new_size as usize, 0);
                     current_size = new_size;
                 }
+                None
             }
             Kind::Socket { .. }
             | Kind::PipeRx { .. }
@@ -86,6 +72,17 @@ pub(crate) async fn fd_allocate_internal(
             | Kind::EventNotifications { .. }
             | Kind::Epoll { .. } => return Err(Errno::Badf),
             Kind::Dir { .. } | Kind::Root { .. } => return Err(Errno::Isdir),
+        }
+    };
+    if let Some(handle) = handle {
+        let mut handle = handle.lock().await;
+        current_size = handle.size().await;
+        if new_size > current_size {
+            handle
+                .set_len(new_size)
+                .await
+                .map_err(fs_error_into_wasi_err)?;
+            current_size = new_size;
         }
     }
     inode.stat.write().unwrap().st_size = current_size;

--- a/lib/wasix/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_close.rs
@@ -1,13 +1,11 @@
 use super::*;
-use crate::fs::FlushPoller;
+use crate::fs::{FlushPoller, VirtualFileLock};
 use crate::syscalls::*;
 
 /// Best-effort flush of a file handle captured before fd removal.
 pub(crate) fn flush_captured_handle(
     env: &WasiEnv,
-    flush_target: Option<
-        std::sync::Arc<std::sync::RwLock<Box<dyn virtual_fs::VirtualFile + Send + Sync>>>,
-    >,
+    flush_target: Option<VirtualFileLock>,
 ) -> Result<Errno, WasiError> {
     let Some(file) = flush_target else {
         return Ok(Errno::Success);

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_size.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_size.rs
@@ -16,7 +16,11 @@ pub fn fd_filestat_set_size(
 ) -> Result<Errno, WasiError> {
     WasiEnv::do_pending_operations(&mut ctx)?;
 
-    wasi_try_ok!(fd_filestat_set_size_internal(&mut ctx, fd, st_size));
+    wasi_try_ok!(__asyncify_light(
+        ctx.data(),
+        None,
+        fd_filestat_set_size_internal(ctx.data(), fd, st_size)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -30,13 +34,12 @@ pub fn fd_filestat_set_size(
     Ok(Errno::Success)
 }
 
-pub(crate) fn fd_filestat_set_size_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn fd_filestat_set_size_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     st_size: Filesize,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (_, mut state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
+    let mut state = env.state();
     let fd_entry = state.fs.get_fd(fd)?;
     let inode = fd_entry.inode;
 
@@ -48,9 +51,13 @@ pub(crate) fn fd_filestat_set_size_internal(
         let mut guard = inode.write();
         match guard.deref_mut() {
             Kind::File { handle, .. } => {
-                if let Some(handle) = handle {
-                    let mut handle = handle.write().unwrap();
-                    handle.set_len(st_size).map_err(fs_error_into_wasi_err)?;
+                if let Some(handle) = handle.clone() {
+                    drop(guard);
+                    let mut handle = handle.lock().await;
+                    handle
+                        .set_len(st_size)
+                        .await
+                        .map_err(fs_error_into_wasi_err)?;
                 } else {
                     return Err(Errno::Badf);
                 }

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_size.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_size.rs
@@ -47,23 +47,13 @@ pub(crate) async fn fd_filestat_set_size_internal(
         return Err(Errno::Access);
     }
 
-    {
+    let handle = {
         let mut guard = inode.write();
         match guard.deref_mut() {
-            Kind::File { handle, .. } => {
-                if let Some(handle) = handle.clone() {
-                    drop(guard);
-                    let mut handle = handle.lock().await;
-                    handle
-                        .set_len(st_size)
-                        .await
-                        .map_err(fs_error_into_wasi_err)?;
-                } else {
-                    return Err(Errno::Badf);
-                }
-            }
+            Kind::File { handle, .. } => Some(handle.clone().ok_or(Errno::Badf)?),
             Kind::Buffer { buffer } => {
                 buffer.resize(st_size as usize, 0);
+                None
             }
             Kind::Socket { .. }
             | Kind::PipeRx { .. }
@@ -74,6 +64,13 @@ pub(crate) async fn fd_filestat_set_size_internal(
             | Kind::Epoll { .. } => return Err(Errno::Badf),
             Kind::Dir { .. } | Kind::Root { .. } => return Err(Errno::Isdir),
         }
+    };
+    if let Some(handle) = handle {
+        let mut handle = handle.lock().await;
+        handle
+            .set_len(st_size)
+            .await
+            .map_err(fs_error_into_wasi_err)?;
     }
     inode.stat.write().unwrap().st_size = st_size;
 

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
@@ -22,9 +22,11 @@ pub fn fd_filestat_set_times(
 ) -> Result<Errno, WasiError> {
     WasiEnv::do_pending_operations(&mut ctx)?;
 
-    wasi_try_ok!(fd_filestat_set_times_internal(
-        &mut ctx, fd, st_atim, st_mtim, fst_flags
-    ));
+    wasi_try_ok!(__asyncify_light(
+        ctx.data(),
+        None,
+        fd_filestat_set_times_internal(ctx.data(), fd, st_atim, st_mtim, fst_flags)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -40,15 +42,14 @@ pub fn fd_filestat_set_times(
     Ok(Errno::Success)
 }
 
-pub(crate) fn fd_filestat_set_times_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn fd_filestat_set_times_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     st_atim: Timestamp,
     st_mtim: Timestamp,
     fst_flags: Fstflags,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (_, mut state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
+    let mut state = env.state();
     let fd_entry = state.fs.get_fd(fd)?;
 
     if !fd_entry
@@ -90,14 +91,22 @@ pub(crate) fn fd_filestat_set_times_internal(
         mtime = Some(time_to_set);
     }
 
-    if let Kind::File {
-        handle: Some(handle),
-        ..
-    } = inode.kind.write().unwrap().deref()
-    {
-        let mut handle = handle.write().unwrap();
-
-        handle.set_times(atime, mtime);
+    let handle = {
+        let guard = inode.kind.write().unwrap();
+        match guard.deref() {
+            Kind::File {
+                handle: Some(handle),
+                ..
+            } => Some(handle.clone()),
+            _ => None,
+        }
+    };
+    if let Some(handle) = handle {
+        let mut handle = handle.lock().await;
+        handle
+            .set_times(atime, mtime)
+            .await
+            .map_err(fs_error_into_wasi_err)?;
     }
 
     Ok(())

--- a/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_set_times.rs
@@ -92,7 +92,7 @@ pub(crate) async fn fd_filestat_set_times_internal(
     }
 
     let handle = {
-        let guard = inode.kind.write().unwrap();
+        let guard = inode.kind.read().unwrap();
         match guard.deref() {
             Kind::File {
                 handle: Some(handle),

--- a/lib/wasix/src/syscalls/wasi/fd_read.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_read.rs
@@ -176,10 +176,7 @@ pub(crate) fn fd_read_internal<M: MemorySize>(
                             None
                         },
                         async move {
-                            let mut handle = match handle.write() {
-                                Ok(a) => a,
-                                Err(_) => return Err(Errno::Fault),
-                            };
+                            let mut handle = handle.lock().await;
                             if !is_stdio {
                                 handle
                                     .seek(std::io::SeekFrom::Start(offset as u64))

--- a/lib/wasix/src/syscalls/wasi/fd_readdir.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_readdir.rs
@@ -42,12 +42,21 @@ pub fn fd_readdir<M: MemorySize>(
         match guard.deref() {
             Kind::Dir { path, entries, .. } => {
                 trace!("reading dir {:?}", path);
+                let path = path.clone();
+                let memory_entries = entries
+                    .iter()
+                    .map(|(name, inode)| {
+                        let stat = inode.stat.read().unwrap();
+                        (name.clone(), stat.st_filetype, stat.st_ino)
+                    })
+                    .collect::<Vec<_>>();
+                drop(guard);
                 // TODO: refactor this code
                 // we need to support multiple calls,
                 // simple and obviously correct implementation for now:
                 // maintain consistent order via lexacographic sorting
                 let fs_info = wasi_try_ok!(
-                    wasi_try_ok!(state.fs_read_dir(path))
+                    wasi_try_ok!(__asyncify_light(env, None, state.fs_read_dir(&path))?)
                         .collect::<Result<Vec<_>, _>>()
                         .map_err(fs_error_into_wasi_err)
                 );
@@ -69,13 +78,9 @@ pub fn fd_readdir<M: MemorySize>(
                 let entry_names: std::collections::HashSet<_> =
                     entry_vec.iter().map(|(name, _, _)| name.clone()).collect();
                 entry_vec.extend(
-                    entries
-                        .iter()
-                        .filter(|(name, _)| !entry_names.contains(*name))
-                        .map(|(name, inode)| {
-                            let stat = inode.stat.read().unwrap();
-                            (name.clone(), stat.st_filetype, stat.st_ino)
-                        }),
+                    memory_entries
+                        .into_iter()
+                        .filter(|(name, _, _)| !entry_names.contains(name))
                 );
                 // adding . and .. special folders
                 // TODO: inode

--- a/lib/wasix/src/syscalls/wasi/fd_readdir.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_readdir.rs
@@ -80,7 +80,7 @@ pub fn fd_readdir<M: MemorySize>(
                 entry_vec.extend(
                     memory_entries
                         .into_iter()
-                        .filter(|(name, _, _)| !entry_names.contains(name))
+                        .filter(|(name, _, _)| !entry_names.contains(name)),
                 );
                 // adding . and .. special folders
                 // TODO: inode

--- a/lib/wasix/src/syscalls/wasi/fd_seek.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_seek.rs
@@ -98,7 +98,7 @@ pub(crate) fn fd_seek_internal(
                         drop(guard);
 
                         wasi_try_ok_ok!(__asyncify(ctx, None, async move {
-                            let mut handle = handle.write().unwrap();
+                            let mut handle = handle.lock().await;
                             let end = handle
                                 .seek(SeekFrom::End(offset))
                                 .await

--- a/lib/wasix/src/syscalls/wasi/fd_sync.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_sync.rs
@@ -37,9 +37,9 @@ pub fn fd_sync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errno
                         wasi_try_ok!(__asyncify(&mut ctx, None, async move {
                             // TODO: remove allow once inodes are refactored (see comments on [`WasiState`])
                             #[allow(clippy::await_holding_lock)]
-                            let mut handle = handle.write().unwrap();
+                            let mut handle = handle.lock().await;
                             handle.flush().await.map_err(map_io_err)?;
-                            Ok(handle.size())
+                            Ok(handle.size().await)
                         })?)
                     };
 

--- a/lib/wasix/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_write.rs
@@ -207,7 +207,7 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                                 None
                             },
                             async {
-                                let mut handle = handle.write().unwrap();
+                                let mut handle = handle.lock().await;
                                 if !is_stdio {
                                     if fd_entry.inner.flags.contains(Fdflags::APPEND) {
                                         // `fdflags::append` means we need to seek to the end before writing.

--- a/lib/wasix/src/syscalls/wasi/path_create_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_create_directory.rs
@@ -34,7 +34,11 @@ pub fn path_create_directory<M: MemorySize>(
     let mut path_string = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    wasi_try_ok!(path_create_directory_internal(&mut ctx, fd, &path_string));
+    wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_create_directory_internal(env, fd, &path_string)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -48,13 +52,13 @@ pub fn path_create_directory<M: MemorySize>(
     Ok(Errno::Success)
 }
 
-pub(crate) fn path_create_directory_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn path_create_directory_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     path: &str,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (memory, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let state = env.state();
+    let inodes = &state.inodes;
     let working_dir = state.fs.get_fd(fd)?;
 
     if !working_dir
@@ -69,7 +73,8 @@ pub(crate) fn path_create_directory_internal(
     let (parent_inode, dir_name) =
         state
             .fs
-            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)?;
+            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)
+            .await?;
 
     let mut guard = parent_inode.write();
     match guard.deref_mut() {
@@ -86,19 +91,19 @@ pub(crate) fn path_create_directory_internal(
             // TODO: This condition should already have been checked by the entries.get check
             // above, but it was in the code before my refactor and I'm keeping it just in case.
             if path_filestat_get_internal(
-                &memory,
                 state,
                 inodes,
                 fd,
                 0,
                 &new_dir_path.to_string_lossy(),
             )
+            .await
             .is_ok()
             {
                 return Err(Errno::Exist);
             }
 
-            state.fs_create_dir(&new_dir_path)?;
+            state.fs_create_dir(&new_dir_path).await?;
 
             let kind = Kind::Dir {
                 parent: parent_inode.downgrade(),

--- a/lib/wasix/src/syscalls/wasi/path_create_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_create_directory.rs
@@ -70,68 +70,61 @@ pub(crate) async fn path_create_directory_internal(
         return Err(Errno::Access);
     }
 
-    let (parent_inode, dir_name) =
-        state
-            .fs
-            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)
-            .await?;
+    let (parent_inode, dir_name) = state
+        .fs
+        .get_parent_inode_at_path(inodes, fd, Path::new(path), true)
+        .await?;
 
-    let mut guard = parent_inode.write();
-    match guard.deref_mut() {
-        Kind::Dir { entries, path, .. } => {
-            if let Some(child) = entries.get(&dir_name) {
-                return Err(Errno::Exist);
+    let new_dir_path = {
+        let guard = parent_inode.read();
+        match guard.deref() {
+            Kind::Dir { entries, path, .. } => {
+                if let Some(child) = entries.get(&dir_name) {
+                    return Err(Errno::Exist);
+                }
+
+                let mut new_dir_path = path.clone();
+                new_dir_path.push(&dir_name);
+                new_dir_path
             }
-
-            let mut new_dir_path = path.clone();
-            new_dir_path.push(&dir_name);
-
-            drop(guard);
-
-            // TODO: This condition should already have been checked by the entries.get check
-            // above, but it was in the code before my refactor and I'm keeping it just in case.
-            if path_filestat_get_internal(
-                state,
-                inodes,
-                fd,
-                0,
-                &new_dir_path.to_string_lossy(),
-            )
-            .await
-            .is_ok()
-            {
-                return Err(Errno::Exist);
+            Kind::Root { .. } => {
+                trace!("the root node can only contain pre-opened directories");
+                return Err(Errno::Access);
             }
-
-            state.fs_create_dir(&new_dir_path).await?;
-
-            let kind = Kind::Dir {
-                parent: parent_inode.downgrade(),
-                path: new_dir_path,
-                entries: Default::default(),
-            };
-            let new_inode = state
-                .fs
-                .create_inode(inodes, kind, false, dir_name.clone())?;
-
-            // reborrow to insert
-            {
-                let mut guard = parent_inode.write();
-                let Kind::Dir { entries, .. } = guard.deref_mut() else {
-                    unreachable!();
-                };
-
-                entries.insert(dir_name, new_inode.clone());
+            _ => {
+                trace!("path is not a directory");
+                return Err(Errno::Notdir);
             }
         }
-        Kind::Root { .. } => {
-            trace!("the root node can only contain pre-opened directories");
-            return Err(Errno::Access);
-        }
-        _ => {
-            trace!("path is not a directory");
-            return Err(Errno::Notdir);
-        }
+    };
+
+    // TODO: This condition should already have been checked by the entries.get check
+    // above, but it was in the code before my refactor and I'm keeping it just in case.
+    if path_filestat_get_internal(state, inodes, fd, 0, &new_dir_path.to_string_lossy())
+        .await
+        .is_ok()
+    {
+        return Err(Errno::Exist);
+    }
+
+    state.fs_create_dir(&new_dir_path).await?;
+
+    let kind = Kind::Dir {
+        parent: parent_inode.downgrade(),
+        path: new_dir_path,
+        entries: Default::default(),
+    };
+    let new_inode = state
+        .fs
+        .create_inode(inodes, kind, false, dir_name.clone())?;
+
+    {
+        let mut guard = parent_inode.write();
+        let Kind::Dir { entries, .. } = guard.deref_mut() else {
+            unreachable!();
+        };
+
+        entries.insert(dir_name, new_inode.clone());
     }
 
     Ok(())

--- a/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
@@ -71,20 +71,21 @@ pub(crate) async fn path_filestat_get_internal(
     if !root_dir.inner.rights.contains(Rights::PATH_FILESTAT_GET) {
         return Err(Errno::Access);
     }
-    let file_inode = state.fs.get_inode_at_path_from_inode(
-        inodes,
-        root_dir.inode,
-        path_string,
-        flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
-    )
-    .await?;
+    let file_inode = state
+        .fs
+        .get_inode_at_path_from_inode(
+            inodes,
+            root_dir.inode,
+            path_string,
+            flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
+        )
+        .await?;
 
     let st_ino = file_inode.ino().as_u64();
     let mut stat = if file_inode.is_preopened {
         *file_inode.stat.read().unwrap().deref()
     } else {
-        let guard = file_inode.read();
-        state.fs.get_stat_for_kind(guard.deref()).await?
+        state.fs.get_stat_for_inode(&file_inode).await?
     };
     stat.st_ino = st_ino;
     Ok(stat)

--- a/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
@@ -43,14 +43,14 @@ pub fn path_filestat_get<M: MemorySize>(
     // }
     tracing::trace!(path = path_string.as_str());
 
-    let stat = wasi_try!(path_filestat_get_internal(
-        &memory,
-        state,
-        inodes,
-        fd,
-        flags,
-        &path_string
-    ));
+    let stat = match __asyncify_light(
+        env,
+        None,
+        path_filestat_get_internal(state, inodes, fd, flags, &path_string),
+    ) {
+        Ok(res) => wasi_try!(res),
+        Err(_) => return Errno::Fault,
+    };
 
     wasi_try_mem!(buf.deref(&memory).write(stat));
 
@@ -59,8 +59,7 @@ pub fn path_filestat_get<M: MemorySize>(
 
 /// ### `path_filestat_get_internal()`
 /// return a Filstat or Errno
-pub(crate) fn path_filestat_get_internal(
-    memory: &MemoryView,
+pub(crate) async fn path_filestat_get_internal(
     state: &WasiState,
     inodes: &crate::WasiInodes,
     fd: WasiFd,
@@ -77,14 +76,15 @@ pub(crate) fn path_filestat_get_internal(
         root_dir.inode,
         path_string,
         flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
-    )?;
+    )
+    .await?;
 
     let st_ino = file_inode.ino().as_u64();
     let mut stat = if file_inode.is_preopened {
         *file_inode.stat.read().unwrap().deref()
     } else {
         let guard = file_inode.read();
-        state.fs.get_stat_for_kind(guard.deref())?
+        state.fs.get_stat_for_kind(guard.deref()).await?
     };
     stat.st_ino = st_ino;
     Ok(stat)
@@ -119,14 +119,14 @@ pub fn path_filestat_get_old<M: MemorySize>(
     let path_string = unsafe { get_input_str!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    let stat = wasi_try!(path_filestat_get_internal(
-        &memory,
-        state,
-        inodes,
-        fd,
-        flags,
-        &path_string
-    ));
+    let stat = match __asyncify_light(
+        env,
+        None,
+        path_filestat_get_internal(state, inodes, fd, flags, &path_string),
+    ) {
+        Ok(res) => wasi_try!(res),
+        Err(_) => return Errno::Fault,
+    };
 
     let old_stat = Snapshot0Filestat {
         st_dev: stat.st_dev,

--- a/lib/wasix/src/syscalls/wasi/path_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_set_times.rs
@@ -40,15 +40,7 @@ pub fn path_filestat_set_times<M: MemorySize>(
     wasi_try_ok!(__asyncify_light(
         env,
         None,
-        path_filestat_set_times_internal(
-            env,
-            fd,
-            flags,
-            &path_string,
-            st_atim,
-            st_mtim,
-            fst_flags
-        )
+        path_filestat_set_times_internal(env, fd, flags, &path_string, st_atim, st_mtim, fst_flags)
     )?);
     let env = ctx.data();
 
@@ -98,15 +90,11 @@ pub(crate) async fn path_filestat_set_times_internal(
         return Err(Errno::Inval);
     }
 
-    let file_inode =
-        state
-            .fs
-            .get_inode_at_path(inodes, fd, path, flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0)
-            .await?;
-    let stat = {
-        let guard = file_inode.read();
-        state.fs.get_stat_for_kind(guard.deref()).await?
-    };
+    let file_inode = state
+        .fs
+        .get_inode_at_path(inodes, fd, path, flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0)
+        .await?;
+    let stat = state.fs.get_stat_for_inode(&file_inode).await?;
 
     if fst_flags.contains(Fstflags::SET_ATIM) || fst_flags.contains(Fstflags::SET_ATIM_NOW) {
         let time_to_set = if fst_flags.contains(Fstflags::SET_ATIM) {

--- a/lib/wasix/src/syscalls/wasi/path_filestat_set_times.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_set_times.rs
@@ -37,15 +37,19 @@ pub fn path_filestat_set_times<M: MemorySize>(
     let path_string = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    wasi_try_ok!(path_filestat_set_times_internal(
-        &mut ctx,
-        fd,
-        flags,
-        &path_string,
-        st_atim,
-        st_mtim,
-        fst_flags
-    ));
+    wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_filestat_set_times_internal(
+            env,
+            fd,
+            flags,
+            &path_string,
+            st_atim,
+            st_mtim,
+            fst_flags
+        )
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -68,8 +72,8 @@ pub fn path_filestat_set_times<M: MemorySize>(
     Ok(Errno::Success)
 }
 
-pub(crate) fn path_filestat_set_times_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn path_filestat_set_times_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     flags: LookupFlags,
     path: &str,
@@ -77,8 +81,8 @@ pub(crate) fn path_filestat_set_times_internal(
     st_mtim: Timestamp,
     fst_flags: Fstflags,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let state = env.state();
+    let inodes = &state.inodes;
     let fd_entry = state.fs.get_fd(fd)?;
     let fd_inode = fd_entry.inode;
     if !fd_entry
@@ -97,10 +101,11 @@ pub(crate) fn path_filestat_set_times_internal(
     let file_inode =
         state
             .fs
-            .get_inode_at_path(inodes, fd, path, flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0)?;
+            .get_inode_at_path(inodes, fd, path, flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0)
+            .await?;
     let stat = {
         let guard = file_inode.read();
-        state.fs.get_stat_for_kind(guard.deref())?
+        state.fs.get_stat_for_kind(guard.deref()).await?
     };
 
     if fst_flags.contains(Fstflags::SET_ATIM) || fst_flags.contains(Fstflags::SET_ATIM_NOW) {

--- a/lib/wasix/src/syscalls/wasi/path_link.rs
+++ b/lib/wasix/src/syscalls/wasi/path_link.rs
@@ -44,14 +44,7 @@ pub fn path_link<M: MemorySize>(
     wasi_try_ok!(__asyncify_light(
         env,
         None,
-        path_link_internal(
-            env,
-            old_fd,
-            old_flags,
-            &old_path_str,
-            new_fd,
-            &new_path_str
-        )
+        path_link_internal(env, old_fd, old_flags, &old_path_str, new_fd, &new_path_str)
     )?);
     let env = ctx.data();
 
@@ -96,19 +89,20 @@ pub(crate) async fn path_link_internal(
     Span::current().record("old_path", old_path);
     Span::current().record("new_path", new_path);
 
-    let source_inode = state.fs.get_inode_at_path(
-        inodes,
-        old_fd,
-        old_path,
-        old_flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
-    )
-    .await?;
+    let source_inode = state
+        .fs
+        .get_inode_at_path(
+            inodes,
+            old_fd,
+            old_path,
+            old_flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
+        )
+        .await?;
     let target_path_arg = std::path::PathBuf::from(new_path);
-    let (target_parent_inode, new_entry_name) =
-        state
-            .fs
-            .get_parent_inode_at_path(inodes, new_fd, &target_path_arg, true)
-            .await?;
+    let (target_parent_inode, new_entry_name) = state
+        .fs
+        .get_parent_inode_at_path(inodes, new_fd, &target_path_arg, true)
+        .await?;
 
     if source_inode.stat.write().unwrap().st_nlink == Linkcount::MAX {
         return Err(Errno::Mlink);

--- a/lib/wasix/src/syscalls/wasi/path_link.rs
+++ b/lib/wasix/src/syscalls/wasi/path_link.rs
@@ -41,14 +41,18 @@ pub fn path_link<M: MemorySize>(
     let mut new_path_str = unsafe { get_input_str_ok!(&memory, new_path, new_path_len) };
     Span::current().record("new_path", new_path_str.as_str());
 
-    wasi_try_ok!(path_link_internal(
-        &mut ctx,
-        old_fd,
-        old_flags,
-        &old_path_str,
-        new_fd,
-        &new_path_str
-    ));
+    wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_link_internal(
+            env,
+            old_fd,
+            old_flags,
+            &old_path_str,
+            new_fd,
+            &new_path_str
+        )
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -70,16 +74,16 @@ pub fn path_link<M: MemorySize>(
     Ok(Errno::Success)
 }
 
-pub(crate) fn path_link_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn path_link_internal(
+    env: &WasiEnv,
     old_fd: WasiFd,
     old_flags: LookupFlags,
     old_path: &str,
     new_fd: WasiFd,
     new_path: &str,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let state = env.state();
+    let inodes = &state.inodes;
     let source_fd = state.fs.get_fd(old_fd)?;
     let target_fd = state.fs.get_fd(new_fd)?;
 
@@ -97,12 +101,14 @@ pub(crate) fn path_link_internal(
         old_fd,
         old_path,
         old_flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
-    )?;
+    )
+    .await?;
     let target_path_arg = std::path::PathBuf::from(new_path);
     let (target_parent_inode, new_entry_name) =
         state
             .fs
-            .get_parent_inode_at_path(inodes, new_fd, &target_path_arg, true)?;
+            .get_parent_inode_at_path(inodes, new_fd, &target_path_arg, true)
+            .await?;
 
     if source_inode.stat.write().unwrap().st_nlink == Linkcount::MAX {
         return Err(Errno::Mlink);
@@ -158,13 +164,13 @@ pub(crate) fn path_link_internal(
     };
 
     let target_inode = if let Some((source_path, target_path)) = materialized_paths {
-        match state.fs.root_fs.symlink_metadata(&target_path) {
+        match state.fs.root_fs.symlink_metadata(&target_path).await {
             Ok(_) => return Err(Errno::Exist),
             Err(virtual_fs::FsError::EntryNotFound) => {}
             Err(err) => return Err(fs_error_into_wasi_err(err)),
         }
 
-        match state.fs.root_fs.hard_link(&source_path, &target_path) {
+        match state.fs.root_fs.hard_link(&source_path, &target_path).await {
             Ok(()) => {
                 let kind = Kind::File {
                     handle: None,
@@ -177,7 +183,7 @@ pub(crate) fn path_link_internal(
                 {
                     Ok(inode) => inode,
                     Err(err) => {
-                        let _ = state.fs.root_fs.remove_file(&target_path);
+                        let _ = state.fs.root_fs.remove_file(&target_path).await;
                         return Err(err);
                     }
                 }

--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -65,18 +65,22 @@ pub fn path_open<M: MemorySize>(
     let path_string = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    let out_fd = wasi_try_ok!(wasi_try_ok!(__asyncify_light(env, None, path_open_internal(
-        ctx.data(),
-        dirfd,
-        dirflags,
-        path_string.clone(),
-        o_flags,
-        fs_rights_base,
-        fs_rights_inheriting,
-        fs_flags,
-        Fdflagsext::empty(),
+    let out_fd = wasi_try_ok!(wasi_try_ok!(__asyncify_light(
+        env,
         None,
-    ))?));
+        path_open_internal(
+            ctx.data(),
+            dirfd,
+            dirflags,
+            path_string.clone(),
+            o_flags,
+            fs_rights_base,
+            fs_rights_inheriting,
+            fs_flags,
+            Fdflagsext::empty(),
+            None,
+        )
+    )?));
     let env = ctx.data();
 
     #[cfg(feature = "journal")]

--- a/lib/wasix/src/syscalls/wasi/path_open.rs
+++ b/lib/wasix/src/syscalls/wasi/path_open.rs
@@ -65,18 +65,18 @@ pub fn path_open<M: MemorySize>(
     let path_string = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    let out_fd = wasi_try_ok!(path_open_internal(
+    let out_fd = wasi_try_ok!(wasi_try_ok!(__asyncify_light(env, None, path_open_internal(
         ctx.data(),
         dirfd,
         dirflags,
-        &path_string,
+        path_string.clone(),
         o_flags,
         fs_rights_base,
         fs_rights_inheriting,
         fs_flags,
         Fdflagsext::empty(),
         None,
-    )?);
+    ))?));
     let env = ctx.data();
 
     #[cfg(feature = "journal")]

--- a/lib/wasix/src/syscalls/wasi/path_readlink.rs
+++ b/lib/wasix/src/syscalls/wasi/path_readlink.rs
@@ -39,7 +39,11 @@ pub fn path_readlink<M: MemorySize>(
     let mut path_str = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_str.as_str());
 
-    let inode = wasi_try_ok!(state.fs.get_inode_at_path(inodes, dir_fd, &path_str, false));
+    let inode = wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        state.fs.get_inode_at_path(inodes, dir_fd, &path_str, false)
+    )?);
 
     {
         let guard = inode.read();

--- a/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
@@ -50,28 +50,28 @@ pub(crate) async fn path_remove_directory_internal(
     let state = env.state();
     let inodes = &state.inodes;
 
-    let (parent_inode, dir_name) =
-        state
-            .fs
-            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)
-            .await?;
+    let (parent_inode, dir_name) = state
+        .fs
+        .get_parent_inode_at_path(inodes, fd, Path::new(path), true)
+        .await?;
 
-    let mut guard = parent_inode.write();
-    match guard.deref_mut() {
-        Kind::Dir {
-            entries: parent_entries,
-            ..
-        } => {
-            let Some(child_inode) = parent_entries.get(&dir_name) else {
-                return Err(Errno::Noent);
-            };
+    let child_path = {
+        let guard = parent_inode.read();
+        match guard.deref() {
+            Kind::Dir {
+                entries: parent_entries,
+                ..
+            } => {
+                let Some(child_inode) = parent_entries.get(&dir_name) else {
+                    return Err(Errno::Noent);
+                };
 
-            {
+                let child_guard = child_inode.read();
                 let Kind::Dir {
-                    entries: ref child_entries,
-                    path: ref child_path,
+                    entries: child_entries,
+                    path: child_path,
                     ..
-                } = *child_inode.read()
+                } = child_guard.deref()
                 else {
                     return Err(Errno::Notdir);
                 };
@@ -80,25 +80,32 @@ pub(crate) async fn path_remove_directory_internal(
                     return Err(Errno::Notempty);
                 }
 
-                if let Err(e) = state.fs_remove_dir(child_path).await {
-                    tracing::warn!(path = ?child_path, error = ?e, "failed to remove directory");
-                    return Err(e);
-                }
+                child_path.clone()
             }
+            Kind::Root { .. } => {
+                trace!("directories directly in the root node can not be removed");
+                return Err(Errno::Access);
+            }
+            _ => {
+                trace!("path is not a directory");
+                return Err(Errno::Notdir);
+            }
+        }
+    };
 
-            parent_entries.remove(&dir_name).expect(
+    if let Err(e) = state.fs_remove_dir(&child_path).await {
+        tracing::warn!(path = ?child_path, error = ?e, "failed to remove directory");
+        return Err(e);
+    }
+
+    {
+        let mut guard = parent_inode.write();
+        if let Kind::Dir { entries, .. } = guard.deref_mut() {
+            entries.remove(&dir_name).expect(
                 "Entry should exist since we checked before and have an exclusive write lock",
             );
+        }
+    };
 
-            Ok(())
-        }
-        Kind::Root { .. } => {
-            trace!("directories directly in the root node can not be removed");
-            Err(Errno::Access)
-        }
-        _ => {
-            trace!("path is not a directory");
-            Err(Errno::Notdir)
-        }
-    }
+    Ok(())
 }

--- a/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
@@ -21,9 +21,11 @@ pub fn path_remove_directory<M: MemorySize>(
     let path_str = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_str.as_str());
 
-    wasi_try_ok!(path_remove_directory_internal(
-        &mut ctx, fd, base_dir, &path_str
-    ));
+    wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_remove_directory_internal(env, fd, base_dir, &path_str)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -39,19 +41,20 @@ pub fn path_remove_directory<M: MemorySize>(
     Ok(Errno::Success)
 }
 
-pub(crate) fn path_remove_directory_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn path_remove_directory_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     _base_dir: Fd,
     path: &str,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (memory, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let state = env.state();
+    let inodes = &state.inodes;
 
     let (parent_inode, dir_name) =
         state
             .fs
-            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)?;
+            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)
+            .await?;
 
     let mut guard = parent_inode.write();
     match guard.deref_mut() {
@@ -77,7 +80,7 @@ pub(crate) fn path_remove_directory_internal(
                     return Err(Errno::Notempty);
                 }
 
-                if let Err(e) = state.fs_remove_dir(child_path) {
+                if let Err(e) = state.fs_remove_dir(child_path).await {
                     tracing::warn!(path = ?child_path, error = ?e, "failed to remove directory");
                     return Err(e);
                 }

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -83,32 +83,29 @@ pub async fn path_rename_internal(
     }
 
     // this is to be sure the source file is fetched from the filesystem if needed
-    let source_inode = wasi_try_ok!(state.fs.get_inode_at_path(
-        inodes,
-        source_fd,
-        source_path,
-        true
-    )
-    .await);
+    let source_inode = wasi_try_ok!(
+        state
+            .fs
+            .get_inode_at_path(inodes, source_fd, source_path, true)
+            .await
+    );
     // Create the destination inode if the file exists.
     let _ = state
         .fs
         .get_inode_at_path(inodes, target_fd, target_path, true)
         .await;
-    let (source_parent_inode, source_entry_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
-        inodes,
-        source_fd,
-        Path::new(source_path),
-        true
-    )
-    .await);
-    let (target_parent_inode, target_entry_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
-        inodes,
-        target_fd,
-        Path::new(target_path),
-        true
-    )
-    .await);
+    let (source_parent_inode, source_entry_name) = wasi_try_ok!(
+        state
+            .fs
+            .get_parent_inode_at_path(inodes, source_fd, Path::new(source_path), true)
+            .await
+    );
+    let (target_parent_inode, target_entry_name) = wasi_try_ok!(
+        state
+            .fs
+            .get_parent_inode_at_path(inodes, target_fd, Path::new(target_path), true)
+            .await
+    );
     let source_guest_path = {
         let guard = source_parent_inode.read();
         match guard.deref() {
@@ -194,91 +191,101 @@ pub async fn path_rename_internal(
         }
     };
 
-    {
-        let mut guard = source_entry.write();
-        match guard.deref_mut() {
-            Kind::File { path, .. } => {
-                let result = {
-                    let path_clone = path.clone();
-                    drop(guard);
-                    let target_guest_path = target_guest_path.clone();
-                    state.fs_rename(path_clone, &target_guest_path).await
-                };
-                // if the above operation failed we have to revert the previous change and then fail
-                if let Err(e) = result {
-                    let mut guard = source_parent_inode.write();
-                    if let Kind::Dir { entries, .. } = guard.deref_mut() {
-                        entries.insert(source_entry_name, source_entry);
-                        return Ok(e);
-                    }
-                } else {
-                    let mut guard = source_entry.write();
-                    if let Kind::File { path, .. } = guard.deref_mut() {
-                        *path = target_guest_path.clone();
-                    } else {
-                        unreachable!()
-                    }
-                }
-            }
-            Kind::Dir { path, .. } => {
-                let cloned_path = path.clone();
-                let source_dir_path = path.clone();
-                drop(guard);
-                let res = {
-                    let target_guest_path = target_guest_path.clone();
-                    state.fs_rename(cloned_path, &target_guest_path).await
-                };
-                if let Err(e) = res {
-                    return Ok(e);
-                }
-                rename_inode_tree(&source_entry, &source_dir_path, &target_guest_path);
-            }
-            Kind::Symlink {
-                path_to_symlink,
-                relative_path,
-                ..
-            } => {
-                let is_ephemeral = state
-                    .fs
-                    .ephemeral_symlink_at(source_guest_path.as_path())
-                    .is_some();
-                let from = source_guest_path.clone();
-                let to = target_guest_path.clone();
-                let res = state.fs_rename(from, to).await;
-                match (res, is_ephemeral) {
-                    (Ok(()), _) | (Err(Errno::Noent), true) => {}
-                    (Err(e), _) => {
-                        let mut guard = source_parent_inode.write();
-                        if let Kind::Dir { entries, .. } = guard.deref_mut() {
-                            entries.insert(source_entry_name, source_entry.clone());
-                            return Ok(e);
-                        }
-                    }
-                }
+    enum RenameSource {
+        File(PathBuf),
+        Dir(PathBuf),
+        Symlink(PathBuf),
+        Other,
+    }
 
-                let new_path_to_symlink = state
-                    .fs
-                    .rebase_symlink_location(target_guest_path.as_path());
-                *path_to_symlink = new_path_to_symlink.clone();
-                if is_ephemeral {
-                    state.fs.move_ephemeral_symlink(
-                        source_guest_path.as_path(),
-                        target_guest_path.as_path(),
-                        new_path_to_symlink,
-                        relative_path.clone(),
-                    );
-                    moved_ephemeral_symlink = true;
-                }
-            }
+    let rename_source = {
+        let guard = source_entry.read();
+        match guard.deref() {
+            Kind::File { path, .. } => RenameSource::File(path.clone()),
+            Kind::Dir { path, .. } => RenameSource::Dir(path.clone()),
+            Kind::Symlink { relative_path, .. } => RenameSource::Symlink(relative_path.clone()),
             Kind::Buffer { .. }
             | Kind::Socket { .. }
             | Kind::PipeTx { .. }
             | Kind::PipeRx { .. }
             | Kind::DuplexPipe { .. }
             | Kind::Epoll { .. }
-            | Kind::EventNotifications { .. } => {}
+            | Kind::EventNotifications { .. } => RenameSource::Other,
             Kind::Root { .. } => unreachable!("The root can not be moved"),
         }
+    };
+
+    match rename_source {
+        RenameSource::File(path) => {
+            let result = state.fs_rename(path, &target_guest_path).await;
+            // if the above operation failed we have to revert the previous change and then fail
+            if let Err(e) = result {
+                let mut guard = source_parent_inode.write();
+                if let Kind::Dir { entries, .. } = guard.deref_mut() {
+                    entries.insert(source_entry_name, source_entry.clone());
+                    return Ok(e);
+                }
+            } else {
+                let mut guard = source_entry.write();
+                if let Kind::File { path, .. } = guard.deref_mut() {
+                    *path = target_guest_path.clone();
+                } else {
+                    unreachable!()
+                }
+            }
+        }
+        RenameSource::Dir(source_dir_path) => {
+            let res = state
+                .fs_rename(source_dir_path.clone(), &target_guest_path)
+                .await;
+            if let Err(e) = res {
+                return Ok(e);
+            }
+            rename_inode_tree(&source_entry, &source_dir_path, &target_guest_path);
+        }
+        RenameSource::Symlink(relative_path) => {
+            let is_ephemeral = state
+                .fs
+                .ephemeral_symlink_at(source_guest_path.as_path())
+                .is_some();
+            let from = source_guest_path.clone();
+            let to = target_guest_path.clone();
+            let res = state.fs_rename(from, to).await;
+            match (res, is_ephemeral) {
+                (Ok(()), _) | (Err(Errno::Noent), true) => {}
+                (Err(e), _) => {
+                    let mut guard = source_parent_inode.write();
+                    if let Kind::Dir { entries, .. } = guard.deref_mut() {
+                        entries.insert(source_entry_name, source_entry.clone());
+                        return Ok(e);
+                    }
+                }
+            }
+
+            let new_path_to_symlink = state
+                .fs
+                .rebase_symlink_location(target_guest_path.as_path());
+            {
+                let mut guard = source_entry.write();
+                let Kind::Symlink {
+                    path_to_symlink, ..
+                } = guard.deref_mut()
+                else {
+                    unreachable!()
+                };
+                *path_to_symlink = new_path_to_symlink.clone();
+            }
+            if is_ephemeral {
+                state.fs.move_ephemeral_symlink(
+                    source_guest_path.as_path(),
+                    target_guest_path.as_path(),
+                    new_path_to_symlink,
+                    relative_path,
+                );
+                moved_ephemeral_symlink = true;
+            }
+        }
+        RenameSource::Other => {}
     }
 
     let source_size = source_entry.stat.read().unwrap().st_size;

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -39,7 +39,11 @@ pub fn path_rename<M: MemorySize>(
     let target_str = unsafe { get_input_str_ok!(&memory, new_path, new_path_len) };
     Span::current().record("new_path", target_str.as_str());
 
-    let ret = path_rename_internal(&mut ctx, old_fd, &source_str, new_fd, &target_str)?;
+    let ret = wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_rename_internal(env, old_fd, &source_str, new_fd, &target_str),
+    )?);
     let env = ctx.data();
 
     if ret == Errno::Success {
@@ -55,15 +59,15 @@ pub fn path_rename<M: MemorySize>(
     Ok(ret)
 }
 
-pub fn path_rename_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub async fn path_rename_internal(
+    env: &WasiEnv,
     source_fd: WasiFd,
     source_path: &str,
     target_fd: WasiFd,
     target_path: &str,
-) -> Result<Errno, WasiError> {
-    let env = ctx.data();
-    let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+) -> Result<Errno, Errno> {
+    let state = env.state();
+    let inodes = &state.inodes;
 
     let mut moved_ephemeral_symlink = false;
 
@@ -84,23 +88,27 @@ pub fn path_rename_internal(
         source_fd,
         source_path,
         true
-    ));
+    )
+    .await);
     // Create the destination inode if the file exists.
     let _ = state
         .fs
-        .get_inode_at_path(inodes, target_fd, target_path, true);
+        .get_inode_at_path(inodes, target_fd, target_path, true)
+        .await;
     let (source_parent_inode, source_entry_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
         inodes,
         source_fd,
         Path::new(source_path),
         true
-    ));
+    )
+    .await);
     let (target_parent_inode, target_entry_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
         inodes,
         target_fd,
         Path::new(target_path),
         true
-    ));
+    )
+    .await);
     let source_guest_path = {
         let guard = source_parent_inode.read();
         match guard.deref() {
@@ -193,11 +201,8 @@ pub fn path_rename_internal(
                 let result = {
                     let path_clone = path.clone();
                     drop(guard);
-                    let state = state;
                     let target_guest_path = target_guest_path.clone();
-                    __asyncify_light(env, None, async move {
-                        state.fs_rename(path_clone, &target_guest_path).await
-                    })?
+                    state.fs_rename(path_clone, &target_guest_path).await
                 };
                 // if the above operation failed we have to revert the previous change and then fail
                 if let Err(e) = result {
@@ -217,21 +222,16 @@ pub fn path_rename_internal(
             }
             Kind::Dir { path, .. } => {
                 let cloned_path = path.clone();
+                let source_dir_path = path.clone();
+                drop(guard);
                 let res = {
-                    let state = state;
                     let target_guest_path = target_guest_path.clone();
-                    __asyncify_light(env, None, async move {
-                        state.fs_rename(cloned_path, &target_guest_path).await
-                    })?
+                    state.fs_rename(cloned_path, &target_guest_path).await
                 };
                 if let Err(e) = res {
                     return Ok(e);
                 }
-                {
-                    let source_dir_path = path.clone();
-                    drop(guard);
-                    rename_inode_tree(&source_entry, &source_dir_path, &target_guest_path);
-                }
+                rename_inode_tree(&source_entry, &source_dir_path, &target_guest_path);
             }
             Kind::Symlink {
                 path_to_symlink,
@@ -242,12 +242,9 @@ pub fn path_rename_internal(
                     .fs
                     .ephemeral_symlink_at(source_guest_path.as_path())
                     .is_some();
-                let res = {
-                    let state = state;
-                    let from = source_guest_path.clone();
-                    let to = target_guest_path.clone();
-                    __asyncify_light(env, None, async move { state.fs_rename(from, to).await })?
-                };
+                let from = source_guest_path.clone();
+                let to = target_guest_path.clone();
+                let res = state.fs_rename(from, to).await;
                 match (res, is_ephemeral) {
                     (Ok(()), _) | (Err(Errno::Noent), true) => {}
                     (Err(e), _) => {
@@ -301,6 +298,7 @@ pub fn path_rename_internal(
     let target_inode = state
         .fs
         .get_inode_at_path(inodes, target_fd, target_path, true)
+        .await
         .expect("Expected target inode to exist, and it's too late to safely fail");
     *target_inode.name.write().unwrap() = target_entry_name.into();
     target_inode.stat.write().unwrap().st_size = source_size;

--- a/lib/wasix/src/syscalls/wasi/path_symlink.rs
+++ b/lib/wasix/src/syscalls/wasi/path_symlink.rs
@@ -67,11 +67,10 @@ pub async fn path_symlink_internal(
     }
 
     let new_path_path = std::path::Path::new(new_path);
-    let (target_parent_inode, entry_name) =
-        state
-            .fs
-            .get_parent_inode_at_path(inodes, fd, new_path_path, true)
-            .await?;
+    let (target_parent_inode, entry_name) = state
+        .fs
+        .get_parent_inode_at_path(inodes, fd, new_path_path, true)
+        .await?;
 
     let symlink_path = {
         let guard = target_parent_inode.read();

--- a/lib/wasix/src/syscalls/wasi/path_symlink.rs
+++ b/lib/wasix/src/syscalls/wasi/path_symlink.rs
@@ -32,12 +32,11 @@ pub fn path_symlink<M: MemorySize>(
     let new_path_str = unsafe { get_input_str_ok!(&memory, new_path, new_path_len) };
     Span::current().record("new_path", new_path_str.as_str());
 
-    wasi_try_ok!(path_symlink_internal(
-        &mut ctx,
-        &old_path_str,
-        fd,
-        &new_path_str
-    ));
+    wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_symlink_internal(env, &old_path_str, fd, &new_path_str)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -53,14 +52,14 @@ pub fn path_symlink<M: MemorySize>(
     Ok(Errno::Success)
 }
 
-pub fn path_symlink_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub async fn path_symlink_internal(
+    env: &WasiEnv,
     old_path: &str,
     fd: WasiFd,
     new_path: &str,
 ) -> Result<(), Errno> {
-    let env = ctx.data();
-    let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+    let state = env.state();
+    let inodes = &state.inodes;
 
     let base_fd = state.fs.get_fd(fd)?;
     if !base_fd.inner.rights.contains(Rights::PATH_SYMLINK) {
@@ -71,7 +70,8 @@ pub fn path_symlink_internal(
     let (target_parent_inode, entry_name) =
         state
             .fs
-            .get_parent_inode_at_path(inodes, fd, new_path_path, true)?;
+            .get_parent_inode_at_path(inodes, fd, new_path_path, true)
+            .await?;
 
     let symlink_path = {
         let guard = target_parent_inode.read();
@@ -108,7 +108,11 @@ pub fn path_symlink_internal(
 
     let source_path = std::path::Path::new(old_path);
     let target_path = symlink_path.as_path();
-    let persisted_in_backing_fs = state.fs.root_fs.create_symlink(source_path, target_path);
+    let persisted_in_backing_fs = state
+        .fs
+        .root_fs
+        .create_symlink(source_path, target_path)
+        .await;
 
     let needs_ephemeral_fallback = match persisted_in_backing_fs {
         Ok(()) => false,

--- a/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
@@ -60,13 +60,12 @@ pub(crate) async fn path_unlink_file_internal(
     let inodes = &state.inodes;
 
     let inode = wasi_try_ok!(state.fs.get_inode_at_path(inodes, fd, path, false).await);
-    let (parent_inode, child_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
-        inodes,
-        fd,
-        std::path::Path::new(path),
-        false
-    )
-    .await);
+    let (parent_inode, child_name) = wasi_try_ok!(
+        state
+            .fs
+            .get_parent_inode_at_path(inodes, fd, std::path::Path::new(path), false)
+            .await
+    );
     let host_adjusted_path = {
         let guard = parent_inode.read();
         match guard.deref() {
@@ -80,35 +79,34 @@ pub(crate) async fn path_unlink_file_internal(
 
     let removed_inode = {
         let mut guard = parent_inode.write();
-        let entry = match guard.deref_mut() {
+        match guard.deref_mut() {
             Kind::Dir { entries, .. } => entries.remove(&child_name),
             Kind::Root { .. } => return Ok(Errno::Access),
             _ => unreachable!(
                 "Internal logic error in wasi::path_unlink_file, parent is not a directory"
             ),
-        };
-        let Some(removed_inode) = entry else {
-            drop(guard);
-
-            let inode_is_symlink = matches!(inode.read().deref(), Kind::Symlink { .. });
-            if !inode_is_symlink {
-                tracing::warn!(
-                    "wasi::path_unlink_file: path resolution returned inode {:?} for {:?}, but parent directory had no matching entry",
-                    inode.ino(),
-                    child_name
-                );
-                return Ok(Errno::Noent);
-            }
-            return Ok(state
-                .fs
-                .remove_symlink_file(host_adjusted_path.as_path())
-                .await);
-        };
+        }
+    };
+    let Some(removed_inode) = removed_inode else {
+        let inode_is_symlink = matches!(inode.read().deref(), Kind::Symlink { .. });
+        if !inode_is_symlink {
+            tracing::warn!(
+                "wasi::path_unlink_file: path resolution returned inode {:?} for {:?}, but parent directory had no matching entry",
+                inode.ino(),
+                child_name
+            );
+            return Ok(Errno::Noent);
+        }
+        return Ok(state
+            .fs
+            .remove_symlink_file(host_adjusted_path.as_path())
+            .await);
+    };
+    {
         // TODO: make this a debug assert in the future
         assert!(inode.ino() == removed_inode.ino());
         debug_assert!(inode.stat.read().unwrap().st_nlink > 0);
-        removed_inode
-    };
+    }
 
     let st_nlink = {
         let mut guard = removed_inode.stat.write().unwrap();
@@ -116,36 +114,41 @@ pub(crate) async fn path_unlink_file_internal(
         guard.st_nlink
     };
     if st_nlink == 0 {
-        {
-            let mut guard = removed_inode.read();
+        enum RemoveTarget {
+            OpenFile(crate::fs::VirtualFileLock),
+            ClosedFile(std::path::PathBuf),
+            Symlink,
+        }
+
+        let target = {
+            let guard = removed_inode.read();
             match guard.deref() {
-                Kind::File { handle, path, .. } => {
-                    if let Some(h) = handle {
-                        let h = h.clone();
-                        drop(guard);
-                        let mut h = h.lock().await;
-                        wasi_try_ok!(h.unlink().await.map_err(fs_error_into_wasi_err));
-                    } else {
-                        // File is closed
-                        // problem with the abstraction, we can't call unlink because there's no handle
-                        // drop mutable borrow on `path`
-                        let path = path.clone();
-                        drop(guard);
-                        wasi_try_ok!(state.fs_remove_file(path).await);
-                    }
-                }
+                Kind::File { handle, path, .. } => match handle {
+                    Some(h) => RemoveTarget::OpenFile(h.clone()),
+                    None => RemoveTarget::ClosedFile(path.clone()),
+                },
                 Kind::Dir { .. } | Kind::Root { .. } => return Ok(Errno::Isdir),
-                Kind::Symlink { .. } => {
-                    drop(guard);
-                    let errno = state
-                        .fs
-                        .remove_symlink_file(host_adjusted_path.as_path())
-                        .await;
-                    if errno != Errno::Success {
-                        return Ok(errno);
-                    }
-                }
+                Kind::Symlink { .. } => RemoveTarget::Symlink,
                 _ => unimplemented!("wasi::path_unlink_file for Buffer"),
+            }
+        };
+
+        match target {
+            RemoveTarget::OpenFile(h) => {
+                let mut h = h.lock().await;
+                wasi_try_ok!(h.unlink().await.map_err(fs_error_into_wasi_err));
+            }
+            RemoveTarget::ClosedFile(path) => {
+                wasi_try_ok!(state.fs_remove_file(path).await);
+            }
+            RemoveTarget::Symlink => {
+                let errno = state
+                    .fs
+                    .remove_symlink_file(host_adjusted_path.as_path())
+                    .await;
+                if errno != Errno::Success {
+                    return Ok(errno);
+                }
             }
         }
     }

--- a/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
@@ -29,7 +29,11 @@ pub fn path_unlink_file<M: MemorySize>(
     let path_str = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_str.as_str());
 
-    let ret = path_unlink_file_internal(&mut ctx, fd, &path_str)?;
+    let ret = wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        path_unlink_file_internal(env, fd, &path_str)
+    )?);
     let env = ctx.data();
 
     if ret == Errno::Success {
@@ -47,21 +51,22 @@ pub fn path_unlink_file<M: MemorySize>(
     Ok(ret)
 }
 
-pub(crate) fn path_unlink_file_internal(
-    ctx: &mut FunctionEnvMut<'_, WasiEnv>,
+pub(crate) async fn path_unlink_file_internal(
+    env: &WasiEnv,
     fd: WasiFd,
     path: &str,
-) -> Result<Errno, WasiError> {
-    let env = ctx.data();
-    let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
+) -> Result<Errno, Errno> {
+    let state = env.state();
+    let inodes = &state.inodes;
 
-    let inode = wasi_try_ok!(state.fs.get_inode_at_path(inodes, fd, path, false));
+    let inode = wasi_try_ok!(state.fs.get_inode_at_path(inodes, fd, path, false).await);
     let (parent_inode, child_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
         inodes,
         fd,
         std::path::Path::new(path),
         false
-    ));
+    )
+    .await);
     let host_adjusted_path = {
         let guard = parent_inode.read();
         match guard.deref() {
@@ -94,7 +99,10 @@ pub(crate) fn path_unlink_file_internal(
                 );
                 return Ok(Errno::Noent);
             }
-            return Ok(state.fs.remove_symlink_file(host_adjusted_path.as_path()));
+            return Ok(state
+                .fs
+                .remove_symlink_file(host_adjusted_path.as_path())
+                .await);
         };
         // TODO: make this a debug assert in the future
         assert!(inode.ino() == removed_inode.ino());
@@ -113,21 +121,26 @@ pub(crate) fn path_unlink_file_internal(
             match guard.deref() {
                 Kind::File { handle, path, .. } => {
                     if let Some(h) = handle {
-                        let mut h = h.write().unwrap();
-                        wasi_try_ok!(h.unlink().map_err(fs_error_into_wasi_err));
+                        let h = h.clone();
+                        drop(guard);
+                        let mut h = h.lock().await;
+                        wasi_try_ok!(h.unlink().await.map_err(fs_error_into_wasi_err));
                     } else {
                         // File is closed
                         // problem with the abstraction, we can't call unlink because there's no handle
                         // drop mutable borrow on `path`
                         let path = path.clone();
                         drop(guard);
-                        wasi_try_ok!(state.fs_remove_file(path));
+                        wasi_try_ok!(state.fs_remove_file(path).await);
                     }
                 }
                 Kind::Dir { .. } | Kind::Root { .. } => return Ok(Errno::Isdir),
                 Kind::Symlink { .. } => {
                     drop(guard);
-                    let errno = state.fs.remove_symlink_file(host_adjusted_path.as_path());
+                    let errno = state
+                        .fs
+                        .remove_symlink_file(host_adjusted_path.as_path())
+                        .await;
                     if errno != Errno::Success {
                         return Ok(errno);
                     }

--- a/lib/wasix/src/syscalls/wasix/chdir.rs
+++ b/lib/wasix/src/syscalls/wasix/chdir.rs
@@ -16,7 +16,7 @@ pub fn chdir<M: MemorySize>(
     let path = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path.as_str());
 
-    wasi_try_ok!(chdir_internal(ctx.data(), &path));
+    wasi_try_ok!(__asyncify_light(env, None, chdir_internal(ctx.data(), &path))?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -52,7 +52,7 @@ pub fn chdir<M: MemorySize>(
 /// For resolved non-root directories, the final `read_dir` check refreshes the
 /// backing filesystem view enough to reject stale cached directories that can no
 /// longer be listed.
-pub fn chdir_internal(env: &WasiEnv, path: &str) -> Result<(), Errno> {
+pub async fn chdir_internal(env: &WasiEnv, path: &str) -> Result<(), Errno> {
     let state = &env.state;
     if path.is_empty() {
         return Err(Errno::Noent);
@@ -61,7 +61,8 @@ pub fn chdir_internal(env: &WasiEnv, path: &str) -> Result<(), Errno> {
     let path = state.fs.relative_path_to_absolute(path.to_string());
     let inode = state
         .fs
-        .get_inode_at_path(&state.inodes, crate::VIRTUAL_ROOT_FD, &path, true)?;
+        .get_inode_at_path(&state.inodes, crate::VIRTUAL_ROOT_FD, &path, true)
+        .await?;
 
     let resolved_path = {
         let guard = inode.read();
@@ -72,6 +73,7 @@ pub fn chdir_internal(env: &WasiEnv, path: &str) -> Result<(), Errno> {
                     .fs
                     .root_fs
                     .read_dir(Path::new(&resolved_path))
+                    .await
                     .is_err()
                 {
                     return Err(Errno::Noent);

--- a/lib/wasix/src/syscalls/wasix/chdir.rs
+++ b/lib/wasix/src/syscalls/wasix/chdir.rs
@@ -16,7 +16,11 @@ pub fn chdir<M: MemorySize>(
     let path = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path.as_str());
 
-    wasi_try_ok!(__asyncify_light(env, None, chdir_internal(ctx.data(), &path))?);
+    wasi_try_ok!(__asyncify_light(
+        env,
+        None,
+        chdir_internal(ctx.data(), &path)
+    )?);
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -67,23 +71,21 @@ pub async fn chdir_internal(env: &WasiEnv, path: &str) -> Result<(), Errno> {
     let resolved_path = {
         let guard = inode.read();
         match guard.deref() {
-            Kind::Dir { path, .. } => {
-                let resolved_path = crate::fs::PosixPath::from_path(path).as_str().to_owned();
-                if state
-                    .fs
-                    .root_fs
-                    .read_dir(Path::new(&resolved_path))
-                    .await
-                    .is_err()
-                {
-                    return Err(Errno::Noent);
-                }
-                resolved_path
-            }
+            Kind::Dir { path, .. } => crate::fs::PosixPath::from_path(path).as_str().to_owned(),
             Kind::Root { .. } => "/".to_string(),
             _ => return Err(Errno::Notdir),
         }
     };
+    if resolved_path != "/"
+        && state
+            .fs
+            .root_fs
+            .read_dir(Path::new(&resolved_path))
+            .await
+            .is_err()
+    {
+        return Err(Errno::Noent);
+    }
 
     state.fs.set_current_dir(&resolved_path);
     Ok(())

--- a/lib/wasix/src/syscalls/wasix/getcwd.rs
+++ b/lib/wasix/src/syscalls/wasix/getcwd.rs
@@ -17,7 +17,14 @@ pub fn getcwd<M: MemorySize>(
     let max_path_len64: u64 = wasi_try_mem!(path_len.read(&memory)).into();
     Span::current().record("max_path_len", max_path_len64);
 
-    let (_, cur_dir) = wasi_try!(state.fs.get_current_dir(inodes, crate::VIRTUAL_ROOT_FD));
+    let (_, cur_dir) = match __asyncify_light(
+        env,
+        None,
+        state.fs.get_current_dir(inodes, crate::VIRTUAL_ROOT_FD),
+    ) {
+        Ok(res) => wasi_try!(res),
+        Err(_) => return Errno::Fault,
+    };
     Span::current().record("path", cur_dir.as_str());
 
     let cur_dir_len = cur_dir.len();

--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::VIRTUAL_ROOT_FD;
 use crate::fs::{FdList, WasiFs};
 use crate::syscalls::*;
+use futures::future::LocalBoxFuture;
+use tokio::sync::Mutex as AsyncMutex;
 
 /// ### `path_open()`
 /// Open file located at the given path
@@ -68,18 +70,18 @@ pub fn path_open2<M: MemorySize>(
     let path_string = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    let out_fd = wasi_try_ok!(path_open_internal(
+    let out_fd = wasi_try_ok!(wasi_try_ok!(__asyncify_light(env, None, path_open_internal(
         ctx.data(),
         dirfd,
         dirflags,
-        &path_string,
+        path_string.clone(),
         o_flags,
         fs_rights_base,
         fs_rights_inheriting,
         fs_flags,
         fd_flags,
         None,
-    )?);
+    ))?));
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -159,14 +161,14 @@ pub(crate) fn path_open_internal(
     env: &WasiEnv,
     dirfd: WasiFd,
     dirflags: LookupFlags,
-    path: &str,
+    path: String,
     o_flags: Oflags,
     fs_rights_base: Rights,
     fs_rights_inheriting: Rights,
     fs_flags: Fdflags,
     fd_flags: Fdflagsext,
     with_fd: Option<WasiFd>,
-) -> Result<Result<WasiFd, Errno>, WasiError> {
+) -> LocalBoxFuture<'_, Result<Result<WasiFd, Errno>, Errno>> {
     path_open_internal_with_symlink_depth(
         env,
         dirfd,
@@ -187,7 +189,7 @@ fn path_open_internal_with_symlink_depth(
     env: &WasiEnv,
     dirfd: WasiFd,
     dirflags: LookupFlags,
-    path: &str,
+    path: String,
     o_flags: Oflags,
     fs_rights_base: Rights,
     fs_rights_inheriting: Rights,
@@ -195,7 +197,9 @@ fn path_open_internal_with_symlink_depth(
     fd_flags: Fdflagsext,
     with_fd: Option<WasiFd>,
     symlink_depth: u32,
-) -> Result<Result<WasiFd, Errno>, WasiError> {
+) -> LocalBoxFuture<'_, Result<Result<WasiFd, Errno>, Errno>> {
+    Box::pin(async move {
+    let path = path.as_str();
     fn implied_fd_rights(has_read_access: bool, has_write_access: bool) -> Rights {
         let mut rights = Rights::FD_ADVISE | Rights::FD_TELL | Rights::FD_SEEK;
 
@@ -232,7 +236,8 @@ fn path_open_internal_with_symlink_depth(
     };
     let maybe_inode = state
         .fs
-        .get_inode_at_path(inodes, effective_dirfd, path, follow_symlinks);
+        .get_inode_at_path(inodes, effective_dirfd, path, follow_symlinks)
+        .await;
     let working_dir_rights_inheriting = working_dir.inner.rights_inheriting;
 
     // ASSUMPTION: open rights apply recursively
@@ -314,13 +319,14 @@ fn path_open_internal_with_symlink_depth(
     // open (and vice versa). If the backing filesystem denies duplex access,
     // fall back to the narrower requested mode.
     let open_shared_file_handle =
-        |path: &std::path::Path,
+        |path: std::path::PathBuf,
          requested_config: virtual_fs::OpenOptionsConfig,
          shared_config: virtual_fs::OpenOptionsConfig|
-         -> Result<Box<dyn VirtualFile + Send + Sync + 'static>, Errno> {
+         -> LocalBoxFuture<'_, Result<Box<dyn VirtualFile + Send + Sync + 'static>, Errno>> {
+            Box::pin(async move {
             let mut open_options = state.fs_new_open_options();
             open_options.options(shared_config.clone());
-            match open_options.open(path) {
+            match open_options.open(&path).await {
                 Ok(handle) => Ok(handle),
                 Err(FsError::PermissionDenied)
                     if shared_config.read != requested_config.read
@@ -328,10 +334,11 @@ fn path_open_internal_with_symlink_depth(
                 {
                     let mut open_options = state.fs_new_open_options();
                     open_options.options(requested_config);
-                    open_options.open(path).map_err(fs_error_into_wasi_err)
+                    open_options.open(&path).await.map_err(fs_error_into_wasi_err)
                 }
                 Err(err) => Err(fs_error_into_wasi_err(err)),
             }
+            })
         };
 
     let orig_path = path;
@@ -370,7 +377,7 @@ fn path_open_internal_with_symlink_depth(
                     env,
                     resolved_base_fd,
                     __WASI_LOOKUP_SYMLINK_FOLLOW,
-                    &resolved_path,
+                    resolved_path,
                     o_flags,
                     fs_rights_base,
                     fs_rights_inheriting,
@@ -378,7 +385,7 @@ fn path_open_internal_with_symlink_depth(
                     fd_flags,
                     with_fd,
                     next_symlink_depth,
-                );
+                ).await;
             }
         }
 
@@ -414,6 +421,30 @@ fn path_open_internal_with_symlink_depth(
             file_open_flags |= Fd::TRUNCATE;
         }
 
+        let mut preopened_file = None;
+        {
+            let guard = inode.read();
+            if let Kind::File {
+                handle,
+                path,
+                fd: None,
+                ..
+            } = guard.deref()
+                && handle.is_none()
+            {
+                let open_path = path.clone();
+                drop(guard);
+                preopened_file = Some(wasi_try_ok_ok!(
+                    open_shared_file_handle(
+                        open_path,
+                        file_requested_config.clone(),
+                        file_shared_config.clone(),
+                    )
+                    .await
+                ));
+            }
+        }
+
         // Phase B: fd_map first; every inode-dependent decision under lock. For regular
         // files keep inode write through insert_fd so handle install and acquire_handle()
         // cannot interleave with close on this inode.
@@ -442,36 +473,11 @@ fn path_open_internal_with_symlink_depth(
                 // Install or refresh the shared inode handle before checking for special
                 // stdio paths (/dev/stdin, /dev/stdout, /dev/stderr). DeviceFile stubs
                 // only report get_special_fd() once the backing open has run.
-                if handle.is_none() || requires_stronger_handle {
-                    let file = wasi_try_ok_ok!(open_shared_file_handle(
-                        path.as_path(),
-                        file_requested_config.clone(),
-                        file_shared_config.clone(),
-                    ));
-                    if handle.is_none() {
-                        *handle = Some(Arc::new(std::sync::RwLock::new(file)));
-                    } else {
-                        let mut existing = handle.as_ref().unwrap().write().unwrap();
-                        *existing = file;
-                    }
-                }
-
-                if let Some(file_handle) = handle.as_ref()
-                    && let Some(special_fd) = {
-                        let file = file_handle.read().unwrap();
-                        file.get_special_fd()
-                    }
-                {
-                    drop(guard);
-                    let dup_fd = wasi_try_ok_ok!(WasiFs::clone_fd_locked(
-                        &state.fs,
-                        &mut fd_map,
-                        special_fd,
-                        0,
-                        None,
-                    ));
-                    trace!(%dup_fd);
-                    return Ok(Ok(dup_fd));
+                if handle.is_none() {
+                    let Some(file) = preopened_file.take() else {
+                        return Ok(Err(Errno::Io));
+                    };
+                    *handle = Some(Arc::new(AsyncMutex::new(file)));
                 }
 
                 let out_fd = wasi_try_ok_ok!(insert_fd_locked(
@@ -566,7 +572,8 @@ fn path_open_internal_with_symlink_depth(
                 let final_symlink_target_lookup =
                     state
                         .fs
-                        .get_inode_at_path(inodes, effective_dirfd, path, false);
+                        .get_inode_at_path(inodes, effective_dirfd, path, false)
+                        .await;
                 let final_symlink_target = match final_symlink_target_lookup {
                     Ok(inode) => {
                         let guard = inode.read();
@@ -607,7 +614,7 @@ fn path_open_internal_with_symlink_depth(
                         env,
                         resolved_base_fd,
                         __WASI_LOOKUP_SYMLINK_FOLLOW,
-                        &resolved_path,
+                        resolved_path,
                         o_flags,
                         fs_rights_base,
                         fs_rights_inheriting,
@@ -615,7 +622,7 @@ fn path_open_internal_with_symlink_depth(
                         fd_flags,
                         with_fd,
                         next_symlink_depth,
-                    );
+                    ).await;
                 }
             }
 
@@ -627,7 +634,7 @@ fn path_open_internal_with_symlink_depth(
                     effective_dirfd,
                     &path_arg,
                     follow_symlinks
-                ));
+                ).await);
             let new_file_host_path = {
                 let guard = parent_inode.read();
                 match guard.deref() {
@@ -668,10 +675,10 @@ fn path_open_internal_with_symlink_depth(
             }
 
             let handle = match open_shared_file_handle(
-                new_file_host_path.as_path(),
+                new_file_host_path.clone(),
                 requested_config,
                 shared_config,
-            ) {
+            ).await {
                 Ok(handle) => Some(handle),
                 Err(err) => {
                     if err == Errno::Exist {
@@ -683,7 +690,7 @@ fn path_open_internal_with_symlink_depth(
 
             let new_inode = {
                 let kind = Kind::File {
-                    handle: handle.map(|a| Arc::new(std::sync::RwLock::new(a))),
+                    handle: handle.map(|a| Arc::new(AsyncMutex::new(a))),
                     path: new_file_host_path,
                     fd: None,
                 };
@@ -716,6 +723,7 @@ fn path_open_internal_with_symlink_depth(
             Ok(Err(maybe_inode.unwrap_err()))
         }
     }
+    })
 }
 
 fn insert_fd_locked(

--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -70,18 +70,22 @@ pub fn path_open2<M: MemorySize>(
     let path_string = unsafe { get_input_str_ok!(&memory, path, path_len) };
     Span::current().record("path", path_string.as_str());
 
-    let out_fd = wasi_try_ok!(wasi_try_ok!(__asyncify_light(env, None, path_open_internal(
-        ctx.data(),
-        dirfd,
-        dirflags,
-        path_string.clone(),
-        o_flags,
-        fs_rights_base,
-        fs_rights_inheriting,
-        fs_flags,
-        fd_flags,
+    let out_fd = wasi_try_ok!(wasi_try_ok!(__asyncify_light(
+        env,
         None,
-    ))?));
+        path_open_internal(
+            ctx.data(),
+            dirfd,
+            dirflags,
+            path_string.clone(),
+            o_flags,
+            fs_rights_base,
+            fs_rights_inheriting,
+            fs_flags,
+            fd_flags,
+            None,
+        )
+    )?));
     let env = ctx.data();
 
     #[cfg(feature = "journal")]
@@ -199,180 +203,190 @@ fn path_open_internal_with_symlink_depth(
     symlink_depth: u32,
 ) -> LocalBoxFuture<'_, Result<Result<WasiFd, Errno>, Errno>> {
     Box::pin(async move {
-    let path = path.as_str();
-    fn implied_fd_rights(has_read_access: bool, has_write_access: bool) -> Rights {
-        let mut rights = Rights::FD_ADVISE | Rights::FD_TELL | Rights::FD_SEEK;
+        let path = path.as_str();
+        fn implied_fd_rights(has_read_access: bool, has_write_access: bool) -> Rights {
+            let mut rights = Rights::FD_ADVISE | Rights::FD_TELL | Rights::FD_SEEK;
 
-        if has_read_access {
-            rights |= Rights::FD_READ | Rights::FD_FILESTAT_GET;
-        }
-
-        if has_write_access {
-            rights |= Rights::FD_DATASYNC
-                | Rights::FD_FDSTAT_SET_FLAGS
-                | Rights::FD_WRITE
-                | Rights::FD_SYNC
-                | Rights::FD_ALLOCATE
-                | Rights::FD_FILESTAT_GET
-                | Rights::FD_FILESTAT_SET_SIZE
-                | Rights::FD_FILESTAT_SET_TIMES;
-        }
-
-        rights
-    }
-
-    let state = env.state.deref();
-    let inodes = &state.inodes;
-    let follow_symlinks = dirflags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0;
-    let effective_dirfd = if path.starts_with('/') {
-        VIRTUAL_ROOT_FD
-    } else {
-        dirfd
-    };
-    let path_arg = std::path::PathBuf::from(path);
-    let working_dir = match state.fs.get_fd(effective_dirfd) {
-        Ok(fd) => fd,
-        Err(err) => return Ok(Err(err)),
-    };
-    let maybe_inode = state
-        .fs
-        .get_inode_at_path(inodes, effective_dirfd, path, follow_symlinks)
-        .await;
-    let working_dir_rights_inheriting = working_dir.inner.rights_inheriting;
-
-    // ASSUMPTION: open rights apply recursively
-    if !working_dir.inner.rights.contains(Rights::PATH_OPEN) {
-        return Ok(Err(Errno::Access));
-    }
-
-    let mut open_flags = 0;
-    // TODO: traverse rights of dirs properly
-    // COMMENTED OUT: WASI isn't giving appropriate rights here when opening
-    //              TODO: look into this; file a bug report if this is a bug
-    //
-    let has_read_access = fs_rights_base.contains(Rights::FD_READ);
-    let has_write_access = fs_rights_base.contains(Rights::FD_WRITE)
-        || fs_flags.contains(Fdflags::APPEND)
-        || o_flags.contains(Oflags::TRUNC)
-        || o_flags.contains(Oflags::CREATE);
-    let requested_base_rights =
-        fs_rights_base | implied_fd_rights(has_read_access, has_write_access);
-
-    // Maximum rights: whatever the parent fd may delegate
-    // Minimum rights: whatever rights the caller requested or the open mode implies
-    let adjusted_rights = requested_base_rights & working_dir_rights_inheriting;
-    let adjusted_rights_inheriting = fs_rights_inheriting & working_dir_rights_inheriting;
-    let mut open_options = state.fs_new_open_options();
-
-    let target_rights = match maybe_inode {
-        Ok(_) => {
-            let write_permission = adjusted_rights.contains(Rights::FD_WRITE);
-
-            // append, truncate, and create all require the permission to write
-            let (append_permission, truncate_permission, create_permission) = if write_permission {
-                (
-                    fs_flags.contains(Fdflags::APPEND),
-                    o_flags.contains(Oflags::TRUNC),
-                    o_flags.contains(Oflags::CREATE),
-                )
-            } else {
-                (false, false, false)
-            };
-
-            virtual_fs::OpenOptionsConfig {
-                read: adjusted_rights.contains(Rights::FD_READ),
-                write: write_permission,
-                create_new: create_permission && o_flags.contains(Oflags::EXCL),
-                create: create_permission,
-                append: append_permission,
-                truncate: truncate_permission,
+            if has_read_access {
+                rights |= Rights::FD_READ | Rights::FD_FILESTAT_GET;
             }
+
+            if has_write_access {
+                rights |= Rights::FD_DATASYNC
+                    | Rights::FD_FDSTAT_SET_FLAGS
+                    | Rights::FD_WRITE
+                    | Rights::FD_SYNC
+                    | Rights::FD_ALLOCATE
+                    | Rights::FD_FILESTAT_GET
+                    | Rights::FD_FILESTAT_SET_SIZE
+                    | Rights::FD_FILESTAT_SET_TIMES;
+            }
+
+            rights
         }
-        Err(_) => virtual_fs::OpenOptionsConfig {
-            append: fs_flags.contains(Fdflags::APPEND),
-            write: adjusted_rights.contains(Rights::FD_WRITE),
-            read: adjusted_rights.contains(Rights::FD_READ),
-            create_new: o_flags.contains(Oflags::CREATE) && o_flags.contains(Oflags::EXCL),
-            create: o_flags.contains(Oflags::CREATE),
-            truncate: o_flags.contains(Oflags::TRUNC),
-        },
-    };
 
-    let parent_rights = virtual_fs::OpenOptionsConfig {
-        read: working_dir.inner.rights.contains(Rights::FD_READ),
-        write: working_dir.inner.rights.contains(Rights::FD_WRITE),
-        // The parent is a directory, which is why these options
-        // aren't inherited from the parent (append / truncate doesn't work on directories)
-        create_new: true,
-        create: true,
-        append: true,
-        truncate: true,
-    };
+        let state = env.state.deref();
+        let inodes = &state.inodes;
+        let follow_symlinks = dirflags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0;
+        let effective_dirfd = if path.starts_with('/') {
+            VIRTUAL_ROOT_FD
+        } else {
+            dirfd
+        };
+        let path_arg = std::path::PathBuf::from(path);
+        let working_dir = match state.fs.get_fd(effective_dirfd) {
+            Ok(fd) => fd,
+            Err(err) => return Ok(Err(err)),
+        };
+        let maybe_inode = state
+            .fs
+            .get_inode_at_path(inodes, effective_dirfd, path, follow_symlinks)
+            .await;
+        let working_dir_rights_inheriting = working_dir.inner.rights_inheriting;
 
-    let minimum_rights = target_rights.minimum_rights(&parent_rights);
+        // ASSUMPTION: open rights apply recursively
+        if !working_dir.inner.rights.contains(Rights::PATH_OPEN) {
+            return Ok(Err(Errno::Access));
+        }
 
-    open_options.options(minimum_rights.clone());
+        let mut open_flags = 0;
+        // TODO: traverse rights of dirs properly
+        // COMMENTED OUT: WASI isn't giving appropriate rights here when opening
+        //              TODO: look into this; file a bug report if this is a bug
+        //
+        let has_read_access = fs_rights_base.contains(Rights::FD_READ);
+        let has_write_access = fs_rights_base.contains(Rights::FD_WRITE)
+            || fs_flags.contains(Fdflags::APPEND)
+            || o_flags.contains(Oflags::TRUNC)
+            || o_flags.contains(Oflags::CREATE);
+        let requested_base_rights =
+            fs_rights_base | implied_fd_rights(has_read_access, has_write_access);
 
-    // Regular files share a single inode-level handle across all WASIX file
-    // descriptors, so prefer opening that shared handle with duplex access.
-    // That lets a later read-only fd keep working after an earlier write-only
-    // open (and vice versa). If the backing filesystem denies duplex access,
-    // fall back to the narrower requested mode.
-    let open_shared_file_handle =
-        |path: std::path::PathBuf,
-         requested_config: virtual_fs::OpenOptionsConfig,
-         shared_config: virtual_fs::OpenOptionsConfig|
-         -> LocalBoxFuture<'_, Result<Box<dyn VirtualFile + Send + Sync + 'static>, Errno>> {
-            Box::pin(async move {
-            let mut open_options = state.fs_new_open_options();
-            open_options.options(shared_config.clone());
-            match open_options.open(&path).await {
-                Ok(handle) => Ok(handle),
-                Err(FsError::PermissionDenied)
-                    if shared_config.read != requested_config.read
-                        || shared_config.write != requested_config.write =>
-                {
-                    let mut open_options = state.fs_new_open_options();
-                    open_options.options(requested_config);
-                    open_options.open(&path).await.map_err(fs_error_into_wasi_err)
+        // Maximum rights: whatever the parent fd may delegate
+        // Minimum rights: whatever rights the caller requested or the open mode implies
+        let adjusted_rights = requested_base_rights & working_dir_rights_inheriting;
+        let adjusted_rights_inheriting = fs_rights_inheriting & working_dir_rights_inheriting;
+        let mut open_options = state.fs_new_open_options();
+
+        let target_rights = match maybe_inode {
+            Ok(_) => {
+                let write_permission = adjusted_rights.contains(Rights::FD_WRITE);
+
+                // append, truncate, and create all require the permission to write
+                let (append_permission, truncate_permission, create_permission) =
+                    if write_permission {
+                        (
+                            fs_flags.contains(Fdflags::APPEND),
+                            o_flags.contains(Oflags::TRUNC),
+                            o_flags.contains(Oflags::CREATE),
+                        )
+                    } else {
+                        (false, false, false)
+                    };
+
+                virtual_fs::OpenOptionsConfig {
+                    read: adjusted_rights.contains(Rights::FD_READ),
+                    write: write_permission,
+                    create_new: create_permission && o_flags.contains(Oflags::EXCL),
+                    create: create_permission,
+                    append: append_permission,
+                    truncate: truncate_permission,
                 }
-                Err(err) => Err(fs_error_into_wasi_err(err)),
             }
+            Err(_) => virtual_fs::OpenOptionsConfig {
+                append: fs_flags.contains(Fdflags::APPEND),
+                write: adjusted_rights.contains(Rights::FD_WRITE),
+                read: adjusted_rights.contains(Rights::FD_READ),
+                create_new: o_flags.contains(Oflags::CREATE) && o_flags.contains(Oflags::EXCL),
+                create: o_flags.contains(Oflags::CREATE),
+                truncate: o_flags.contains(Oflags::TRUNC),
+            },
+        };
+
+        let parent_rights = virtual_fs::OpenOptionsConfig {
+            read: working_dir.inner.rights.contains(Rights::FD_READ),
+            write: working_dir.inner.rights.contains(Rights::FD_WRITE),
+            // The parent is a directory, which is why these options
+            // aren't inherited from the parent (append / truncate doesn't work on directories)
+            create_new: true,
+            create: true,
+            append: true,
+            truncate: true,
+        };
+
+        let minimum_rights = target_rights.minimum_rights(&parent_rights);
+
+        open_options.options(minimum_rights.clone());
+
+        // Regular files share a single inode-level handle across all WASIX file
+        // descriptors, so prefer opening that shared handle with duplex access.
+        // That lets a later read-only fd keep working after an earlier write-only
+        // open (and vice versa). If the backing filesystem denies duplex access,
+        // fall back to the narrower requested mode.
+        let open_shared_file_handle = |path: std::path::PathBuf,
+                                       requested_config: virtual_fs::OpenOptionsConfig,
+                                       shared_config: virtual_fs::OpenOptionsConfig|
+         -> LocalBoxFuture<
+            '_,
+            Result<Box<dyn VirtualFile + Send + Sync + 'static>, Errno>,
+        > {
+            Box::pin(async move {
+                let mut open_options = state.fs_new_open_options();
+                open_options.options(shared_config.clone());
+                match open_options.open(&path).await {
+                    Ok(handle) => Ok(handle),
+                    Err(FsError::PermissionDenied)
+                        if shared_config.read != requested_config.read
+                            || shared_config.write != requested_config.write =>
+                    {
+                        let mut open_options = state.fs_new_open_options();
+                        open_options.options(requested_config);
+                        open_options
+                            .open(&path)
+                            .await
+                            .map_err(fs_error_into_wasi_err)
+                    }
+                    Err(err) => Err(fs_error_into_wasi_err(err)),
+                }
             })
         };
 
-    let orig_path = path;
+        let orig_path = path;
 
-    if let Ok(inode) = maybe_inode {
-        // Phase A: path resolution only — symlink follow recurses without committing.
-        {
-            let guard = inode.read();
-            if let Kind::Symlink {
-                symlink_kind,
-                path_to_symlink,
-                relative_path,
-            } = guard.deref()
-            {
-                if !follow_symlinks {
-                    return Ok(Err(Errno::Loop));
-                }
-
-                let (resolved_base_fd, resolved_path) = match state.fs.resolve_symlink_target_path(
-                    *symlink_kind,
+        if let Ok(inode) = maybe_inode {
+            // Phase A: path resolution only — symlink follow recurses without committing.
+            let symlink_target = {
+                let guard = inode.read();
+                if let Kind::Symlink {
+                    symlink_kind,
                     path_to_symlink,
                     relative_path,
-                ) {
-                    Ok(resolved) => resolved,
-                    Err(err) => return Ok(Err(err)),
-                };
-                let next_symlink_depth = symlink_depth + 1;
-                if next_symlink_depth > MAX_SYMLINKS {
-                    return Ok(Err(Errno::Loop));
+                } = guard.deref()
+                {
+                    if !follow_symlinks {
+                        return Ok(Err(Errno::Loop));
+                    }
+
+                    let (resolved_base_fd, resolved_path) = match state
+                        .fs
+                        .resolve_symlink_target_path(*symlink_kind, path_to_symlink, relative_path)
+                    {
+                        Ok(resolved) => resolved,
+                        Err(err) => return Ok(Err(err)),
+                    };
+                    let next_symlink_depth = symlink_depth + 1;
+                    if next_symlink_depth > MAX_SYMLINKS {
+                        return Ok(Err(Errno::Loop));
+                    }
+                    let resolved_path = crate::fs::PosixPath::from_path(&resolved_path)
+                        .as_str()
+                        .to_owned();
+                    Some((resolved_base_fd, resolved_path, next_symlink_depth))
+                } else {
+                    None
                 }
-                let resolved_path = crate::fs::PosixPath::from_path(&resolved_path)
-                    .as_str()
-                    .to_owned();
-                drop(guard);
+            };
+            if let Some((resolved_base_fd, resolved_path, next_symlink_depth)) = symlink_target {
                 return path_open_internal_with_symlink_depth(
                     env,
                     resolved_base_fd,
@@ -385,344 +399,353 @@ fn path_open_internal_with_symlink_depth(
                     fd_flags,
                     with_fd,
                     next_symlink_depth,
-                ).await;
+                )
+                .await;
             }
-        }
 
-        if o_flags.contains(Oflags::EXCL) && o_flags.contains(Oflags::CREATE) {
-            return Ok(Err(Errno::Exist));
-        }
+            if o_flags.contains(Oflags::EXCL) && o_flags.contains(Oflags::CREATE) {
+                return Ok(Err(Errno::Exist));
+            }
 
-        // Open-mode inputs derived from syscall args only (no inode-state decisions).
-        let file_requested_config = open_options
-            .write(minimum_rights.write)
-            .create(minimum_rights.create)
-            .append(false)
-            .truncate(minimum_rights.truncate)
-            .get_config();
-        let file_shared_config = virtual_fs::OpenOptionsConfig {
-            read: true,
-            write: true,
-            ..file_requested_config.clone()
-        };
-        let requires_stronger_handle =
-            minimum_rights.write || minimum_rights.truncate || minimum_rights.create;
-        let mut file_open_flags = open_flags;
-        if minimum_rights.read {
-            file_open_flags |= Fd::READ;
-        }
-        if minimum_rights.write {
-            file_open_flags |= Fd::WRITE;
-        }
-        if minimum_rights.create {
-            file_open_flags |= Fd::CREATE;
-        }
-        if minimum_rights.truncate {
-            file_open_flags |= Fd::TRUNCATE;
-        }
+            // Open-mode inputs derived from syscall args only (no inode-state decisions).
+            let file_requested_config = open_options
+                .write(minimum_rights.write)
+                .create(minimum_rights.create)
+                .append(false)
+                .truncate(minimum_rights.truncate)
+                .get_config();
+            let file_shared_config = virtual_fs::OpenOptionsConfig {
+                read: true,
+                write: true,
+                ..file_requested_config.clone()
+            };
+            let requires_stronger_handle =
+                minimum_rights.write || minimum_rights.truncate || minimum_rights.create;
+            let mut file_open_flags = open_flags;
+            if minimum_rights.read {
+                file_open_flags |= Fd::READ;
+            }
+            if minimum_rights.write {
+                file_open_flags |= Fd::WRITE;
+            }
+            if minimum_rights.create {
+                file_open_flags |= Fd::CREATE;
+            }
+            if minimum_rights.truncate {
+                file_open_flags |= Fd::TRUNCATE;
+            }
 
-        let mut preopened_file = None;
-        {
-            let guard = inode.read();
-            if let Kind::File {
-                handle,
-                path,
-                fd: None,
-                ..
-            } = guard.deref()
-                && handle.is_none()
-            {
-                let open_path = path.clone();
-                drop(guard);
-                preopened_file = Some(wasi_try_ok_ok!(
+            let preopen_path = {
+                let guard = inode.read();
+                if let Kind::File {
+                    handle,
+                    path,
+                    fd: None,
+                    ..
+                } = guard.deref()
+                    && handle.is_none()
+                {
+                    Some(path.clone())
+                } else {
+                    None
+                }
+            };
+            let mut preopened_file = if let Some(open_path) = preopen_path {
+                Some(wasi_try_ok_ok!(
                     open_shared_file_handle(
                         open_path,
                         file_requested_config.clone(),
                         file_shared_config.clone(),
                     )
                     .await
-                ));
-            }
-        }
+                ))
+            } else {
+                None
+            };
 
-        // Phase B: fd_map first; every inode-dependent decision under lock. For regular
-        // files keep inode write through insert_fd so handle install and acquire_handle()
-        // cannot interleave with close on this inode.
-        let mut fd_map = state.fs.fd_map.write().unwrap();
-        let mut guard = inode.write();
-        let out_fd = match guard.deref_mut() {
-            Kind::File {
-                handle,
-                path,
-                fd: Some(special_fd),
-                ..
-            } => {
-                assert!(handle.is_some());
-                *special_fd
-            }
-            Kind::File {
-                handle,
-                path,
-                fd: None,
-                ..
-            } => {
-                if o_flags.contains(Oflags::DIRECTORY) || orig_path.ends_with('/') {
+            // Phase B: fd_map first; every inode-dependent decision under lock. For regular
+            // files keep inode write through insert_fd so handle install and acquire_handle()
+            // cannot interleave with close on this inode.
+            let mut fd_map = state.fs.fd_map.write().unwrap();
+            let mut guard = inode.write();
+            let out_fd = match guard.deref_mut() {
+                Kind::File {
+                    handle,
+                    path,
+                    fd: Some(special_fd),
+                    ..
+                } => {
+                    assert!(handle.is_some());
+                    *special_fd
+                }
+                Kind::File {
+                    handle,
+                    path,
+                    fd: None,
+                    ..
+                } => {
+                    if o_flags.contains(Oflags::DIRECTORY) || orig_path.ends_with('/') {
+                        return Ok(Err(Errno::Notdir));
+                    }
+
+                    // Install or refresh the shared inode handle before checking for special
+                    // stdio paths (/dev/stdin, /dev/stdout, /dev/stderr). DeviceFile stubs
+                    // only report get_special_fd() once the backing open has run.
+                    if handle.is_none() {
+                        let Some(file) = preopened_file.take() else {
+                            return Ok(Err(Errno::Io));
+                        };
+                        *handle = Some(Arc::new(AsyncMutex::new(file)));
+                    }
+
+                    let out_fd = wasi_try_ok_ok!(insert_fd_locked(
+                        &mut fd_map,
+                        state,
+                        adjusted_rights,
+                        adjusted_rights_inheriting,
+                        fs_flags,
+                        fd_flags,
+                        file_open_flags,
+                        inode.clone(),
+                        with_fd,
+                    ));
+                    drop(guard);
+                    out_fd
+                }
+                Kind::Buffer { .. } => unimplemented!("wasi::path_open for Buffer type files"),
+                Kind::Root { .. } => {
+                    if !o_flags.contains(Oflags::DIRECTORY) {
+                        return Ok(Err(Errno::Isdir));
+                    }
+                    drop(guard);
+                    wasi_try_ok_ok!(insert_fd_locked(
+                        &mut fd_map,
+                        state,
+                        adjusted_rights,
+                        adjusted_rights_inheriting,
+                        fs_flags,
+                        fd_flags,
+                        open_flags,
+                        inode,
+                        with_fd,
+                    ))
+                }
+                Kind::Dir { .. } => {
+                    if fs_rights_base.contains(Rights::FD_WRITE) {
+                        return Ok(Err(Errno::Isdir));
+                    }
+                    drop(guard);
+                    wasi_try_ok_ok!(insert_fd_locked(
+                        &mut fd_map,
+                        state,
+                        adjusted_rights,
+                        adjusted_rights_inheriting,
+                        fs_flags,
+                        fd_flags,
+                        open_flags,
+                        inode,
+                        with_fd,
+                    ))
+                }
+                Kind::Socket { .. }
+                | Kind::PipeTx { .. }
+                | Kind::PipeRx { .. }
+                | Kind::DuplexPipe { .. }
+                | Kind::EventNotifications { .. }
+                | Kind::Epoll { .. } => {
+                    drop(guard);
+                    wasi_try_ok_ok!(insert_fd_locked(
+                        &mut fd_map,
+                        state,
+                        adjusted_rights,
+                        adjusted_rights_inheriting,
+                        fs_flags,
+                        fd_flags,
+                        open_flags,
+                        inode,
+                        with_fd,
+                    ))
+                }
+                Kind::Symlink { .. } => return Ok(Err(Errno::Loop)),
+            };
+            Ok(Ok(out_fd))
+        } else {
+            // less-happy path, we have to try to create the file
+            if o_flags.contains(Oflags::CREATE) {
+                if o_flags.contains(Oflags::DIRECTORY) {
                     return Ok(Err(Errno::Notdir));
                 }
 
-                // Install or refresh the shared inode handle before checking for special
-                // stdio paths (/dev/stdin, /dev/stdout, /dev/stderr). DeviceFile stubs
-                // only report get_special_fd() once the backing open has run.
-                if handle.is_none() {
-                    let Some(file) = preopened_file.take() else {
-                        return Ok(Err(Errno::Io));
-                    };
-                    *handle = Some(Arc::new(AsyncMutex::new(file)));
-                }
-
-                let out_fd = wasi_try_ok_ok!(insert_fd_locked(
-                    &mut fd_map,
-                    state,
-                    adjusted_rights,
-                    adjusted_rights_inheriting,
-                    fs_flags,
-                    fd_flags,
-                    file_open_flags,
-                    inode.clone(),
-                    with_fd,
-                ));
-                drop(guard);
-                out_fd
-            }
-            Kind::Buffer { .. } => unimplemented!("wasi::path_open for Buffer type files"),
-            Kind::Root { .. } => {
-                if !o_flags.contains(Oflags::DIRECTORY) {
+                // Trailing slash matters. But the underlying opener normalizes it away later.
+                if path.ends_with('/') {
                     return Ok(Err(Errno::Isdir));
                 }
-                drop(guard);
-                wasi_try_ok_ok!(insert_fd_locked(
-                    &mut fd_map,
-                    state,
-                    adjusted_rights,
-                    adjusted_rights_inheriting,
-                    fs_flags,
-                    fd_flags,
-                    open_flags,
-                    inode,
-                    with_fd,
-                ))
-            }
-            Kind::Dir { .. } => {
-                if fs_rights_base.contains(Rights::FD_WRITE) {
-                    return Ok(Err(Errno::Isdir));
-                }
-                drop(guard);
-                wasi_try_ok_ok!(insert_fd_locked(
-                    &mut fd_map,
-                    state,
-                    adjusted_rights,
-                    adjusted_rights_inheriting,
-                    fs_flags,
-                    fd_flags,
-                    open_flags,
-                    inode,
-                    with_fd,
-                ))
-            }
-            Kind::Socket { .. }
-            | Kind::PipeTx { .. }
-            | Kind::PipeRx { .. }
-            | Kind::DuplexPipe { .. }
-            | Kind::EventNotifications { .. }
-            | Kind::Epoll { .. } => {
-                drop(guard);
-                wasi_try_ok_ok!(insert_fd_locked(
-                    &mut fd_map,
-                    state,
-                    adjusted_rights,
-                    adjusted_rights_inheriting,
-                    fs_flags,
-                    fd_flags,
-                    open_flags,
-                    inode,
-                    with_fd,
-                ))
-            }
-            Kind::Symlink { .. } => return Ok(Err(Errno::Loop)),
-        };
-        Ok(Ok(out_fd))
-    } else {
-        // less-happy path, we have to try to create the file
-        if o_flags.contains(Oflags::CREATE) {
-            if o_flags.contains(Oflags::DIRECTORY) {
-                return Ok(Err(Errno::Notdir));
-            }
 
-            // Trailing slash matters. But the underlying opener normalizes it away later.
-            if path.ends_with('/') {
-                return Ok(Err(Errno::Isdir));
-            }
-
-            // The follow-style lookup above may have failed because the final
-            // component is a symlink whose target does not exist yet. POSIX
-            // create opens should follow that final symlink and create the
-            // target, while O_EXCL still treats the symlink itself as an
-            // existing path.
-            if follow_symlinks {
-                let final_symlink_target_lookup =
-                    state
+                // The follow-style lookup above may have failed because the final
+                // component is a symlink whose target does not exist yet. POSIX
+                // create opens should follow that final symlink and create the
+                // target, while O_EXCL still treats the symlink itself as an
+                // existing path.
+                if follow_symlinks {
+                    let final_symlink_target_lookup = state
                         .fs
                         .get_inode_at_path(inodes, effective_dirfd, path, false)
                         .await;
-                let final_symlink_target = match final_symlink_target_lookup {
-                    Ok(inode) => {
-                        let guard = inode.read();
-                        match guard.deref() {
-                            Kind::Symlink {
-                                symlink_kind,
-                                path_to_symlink,
-                                relative_path,
-                            } => {
-                                match state.fs.resolve_symlink_target_path(
-                                    *symlink_kind,
+                    let final_symlink_target = match final_symlink_target_lookup {
+                        Ok(inode) => {
+                            let guard = inode.read();
+                            match guard.deref() {
+                                Kind::Symlink {
+                                    symlink_kind,
                                     path_to_symlink,
                                     relative_path,
-                                ) {
-                                    Ok(resolved) => Some(resolved),
-                                    Err(err) => return Ok(Err(err)),
+                                } => {
+                                    match state.fs.resolve_symlink_target_path(
+                                        *symlink_kind,
+                                        path_to_symlink,
+                                        relative_path,
+                                    ) {
+                                        Ok(resolved) => Some(resolved),
+                                        Err(err) => return Ok(Err(err)),
+                                    }
                                 }
+                                _ => None,
                             }
-                            _ => None,
                         }
-                    }
-                    Err(_) => None,
-                };
+                        Err(_) => None,
+                    };
 
-                if let Some((resolved_base_fd, resolved_path)) = final_symlink_target {
-                    if o_flags.contains(Oflags::EXCL) {
-                        return Ok(Err(Errno::Exist));
-                    }
+                    if let Some((resolved_base_fd, resolved_path)) = final_symlink_target {
+                        if o_flags.contains(Oflags::EXCL) {
+                            return Ok(Err(Errno::Exist));
+                        }
 
-                    let resolved_path = crate::fs::PosixPath::from_path(&resolved_path)
-                        .as_str()
-                        .to_owned();
-                    let next_symlink_depth = symlink_depth + 1;
-                    if next_symlink_depth > MAX_SYMLINKS {
-                        return Ok(Err(Errno::Loop));
+                        let resolved_path = crate::fs::PosixPath::from_path(&resolved_path)
+                            .as_str()
+                            .to_owned();
+                        let next_symlink_depth = symlink_depth + 1;
+                        if next_symlink_depth > MAX_SYMLINKS {
+                            return Ok(Err(Errno::Loop));
+                        }
+                        return path_open_internal_with_symlink_depth(
+                            env,
+                            resolved_base_fd,
+                            __WASI_LOOKUP_SYMLINK_FOLLOW,
+                            resolved_path,
+                            o_flags,
+                            fs_rights_base,
+                            fs_rights_inheriting,
+                            fs_flags,
+                            fd_flags,
+                            with_fd,
+                            next_symlink_depth,
+                        )
+                        .await;
                     }
-                    return path_open_internal_with_symlink_depth(
-                        env,
-                        resolved_base_fd,
-                        __WASI_LOOKUP_SYMLINK_FOLLOW,
-                        resolved_path,
-                        o_flags,
-                        fs_rights_base,
-                        fs_rights_inheriting,
-                        fs_flags,
-                        fd_flags,
-                        with_fd,
-                        next_symlink_depth,
-                    ).await;
                 }
-            }
 
-            // strip end file name
+                // strip end file name
 
-            let (parent_inode, new_entity_name) =
-                wasi_try_ok_ok!(state.fs.get_parent_inode_at_path(
-                    inodes,
-                    effective_dirfd,
-                    &path_arg,
-                    follow_symlinks
-                ).await);
-            let new_file_host_path = {
-                let guard = parent_inode.read();
-                match guard.deref() {
-                    Kind::Dir { path, .. } => crate::fs::PosixPath::from_path(path)
-                        .join(&crate::fs::PosixPath::new(&new_entity_name))
-                        .into_path_buf(),
-                    Kind::Root { .. } => return Ok(Err(Errno::Perm)),
-                    _ => return Ok(Err(Errno::Notdir)),
-                }
-            };
-            // Host create, inode wiring, and fd insert run under one fd_map write lock so
-            // no other thread can observe the inode (or clear its handle) without a map entry.
-            let mut fd_map = state.fs.fd_map.write().unwrap();
-
-            let requested_config = open_options
-                .read(minimum_rights.read)
-                .append(minimum_rights.append)
-                .write(minimum_rights.write)
-                .create_new(true)
-                .get_config();
-            let shared_config = virtual_fs::OpenOptionsConfig {
-                read: true,
-                write: true,
-                ..requested_config.clone()
-            };
-
-            if minimum_rights.read {
-                open_flags |= Fd::READ;
-            }
-            if minimum_rights.write {
-                open_flags |= Fd::WRITE;
-            }
-            if minimum_rights.create_new {
-                open_flags |= Fd::CREATE;
-            }
-            if minimum_rights.truncate {
-                open_flags |= Fd::TRUNCATE;
-            }
-
-            let handle = match open_shared_file_handle(
-                new_file_host_path.clone(),
-                requested_config,
-                shared_config,
-            ).await {
-                Ok(handle) => Some(handle),
-                Err(err) => {
-                    if err == Errno::Exist {
-                        return Ok(Err(Errno::Perm));
-                    }
-                    return Ok(Err(err));
-                }
-            };
-
-            let new_inode = {
-                let kind = Kind::File {
-                    handle: handle.map(|a| Arc::new(AsyncMutex::new(a))),
-                    path: new_file_host_path,
-                    fd: None,
-                };
-                wasi_try_ok_ok!(
+                let (parent_inode, new_entity_name) = wasi_try_ok_ok!(
                     state
                         .fs
-                        .create_inode(inodes, kind, false, new_entity_name.clone())
-                )
-            };
+                        .get_parent_inode_at_path(
+                            inodes,
+                            effective_dirfd,
+                            &path_arg,
+                            follow_symlinks
+                        )
+                        .await
+                );
+                let new_file_host_path = {
+                    let guard = parent_inode.read();
+                    match guard.deref() {
+                        Kind::Dir { path, .. } => crate::fs::PosixPath::from_path(path)
+                            .join(&crate::fs::PosixPath::new(&new_entity_name))
+                            .into_path_buf(),
+                        Kind::Root { .. } => return Ok(Err(Errno::Perm)),
+                        _ => return Ok(Err(Errno::Notdir)),
+                    }
+                };
+                let requested_config = open_options
+                    .read(minimum_rights.read)
+                    .append(minimum_rights.append)
+                    .write(minimum_rights.write)
+                    .create_new(true)
+                    .get_config();
+                let shared_config = virtual_fs::OpenOptionsConfig {
+                    read: true,
+                    write: true,
+                    ..requested_config.clone()
+                };
 
-            {
-                let mut guard = parent_inode.write();
-                if let Kind::Dir { entries, .. } = guard.deref_mut() {
-                    entries.insert(new_entity_name, new_inode.clone());
+                if minimum_rights.read {
+                    open_flags |= Fd::READ;
                 }
-            }
+                if minimum_rights.write {
+                    open_flags |= Fd::WRITE;
+                }
+                if minimum_rights.create_new {
+                    open_flags |= Fd::CREATE;
+                }
+                if minimum_rights.truncate {
+                    open_flags |= Fd::TRUNCATE;
+                }
 
-            Ok(Ok(wasi_try_ok_ok!(insert_fd_locked(
-                &mut fd_map,
-                state,
-                adjusted_rights,
-                adjusted_rights_inheriting,
-                fs_flags,
-                fd_flags,
-                open_flags,
-                new_inode,
-                with_fd,
-            ))))
-        } else {
-            Ok(Err(maybe_inode.unwrap_err()))
+                let handle = match open_shared_file_handle(
+                    new_file_host_path.clone(),
+                    requested_config,
+                    shared_config,
+                )
+                .await
+                {
+                    Ok(handle) => Some(handle),
+                    Err(err) => {
+                        if err == Errno::Exist {
+                            return Ok(Err(Errno::Perm));
+                        }
+                        return Ok(Err(err));
+                    }
+                };
+
+                let mut fd_map = state.fs.fd_map.write().unwrap();
+
+                let new_inode = {
+                    let kind = Kind::File {
+                        handle: handle.map(|a| Arc::new(AsyncMutex::new(a))),
+                        path: new_file_host_path,
+                        fd: None,
+                    };
+                    wasi_try_ok_ok!(state.fs.create_inode(
+                        inodes,
+                        kind,
+                        false,
+                        new_entity_name.clone()
+                    ))
+                };
+
+                {
+                    let mut guard = parent_inode.write();
+                    if let Kind::Dir { entries, .. } = guard.deref_mut() {
+                        entries.insert(new_entity_name, new_inode.clone());
+                    }
+                }
+
+                Ok(Ok(wasi_try_ok_ok!(insert_fd_locked(
+                    &mut fd_map,
+                    state,
+                    adjusted_rights,
+                    adjusted_rights_inheriting,
+                    fs_flags,
+                    fd_flags,
+                    open_flags,
+                    new_inode,
+                    with_fd,
+                ))))
+            } else {
+                Ok(Err(maybe_inode.unwrap_err()))
+            }
         }
-    }
     })
 }
 

--- a/lib/wasix/src/syscalls/wasix/proc_exec4.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_exec4.rs
@@ -92,16 +92,13 @@ pub(crate) fn proc_exec4_impl<M: MemorySize>(
         };
         let (_, state, inodes) =
             unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match wasi_try_ok!(__asyncify_light(
-            ctx.data(),
-            None,
-            async {
-                Ok(
-                    find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name)
-                        .await,
-                )
-            },
-        )?) {
+        match wasi_try_ok!(__asyncify_light(ctx.data(), None, async {
+            Ok(
+                find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name)
+                    .await,
+            )
+        },)?)
+        {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
             FindExecutableResult::NotFound => return Ok(Errno::Noent),

--- a/lib/wasix/src/syscalls/wasix/proc_exec4.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_exec4.rs
@@ -92,7 +92,16 @@ pub(crate) fn proc_exec4_impl<M: MemorySize>(
         };
         let (_, state, inodes) =
             unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name) {
+        match wasi_try_ok!(__asyncify_light(
+            ctx.data(),
+            None,
+            async {
+                Ok(
+                    find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name)
+                        .await,
+                )
+            },
+        )?) {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
             FindExecutableResult::NotFound => return Ok(Errno::Noent),
@@ -115,10 +124,13 @@ pub(crate) fn proc_exec4_impl<M: MemorySize>(
     if name.contains('/') {
         let (_, state, inodes) =
             unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match state
-            .fs
-            .get_inode_at_path(inodes, VIRTUAL_ROOT_FD, name, true)
-        {
+        match __asyncify_light(
+            ctx.data(),
+            None,
+            state
+                .fs
+                .get_inode_at_path(inodes, VIRTUAL_ROOT_FD, name, true),
+        )? {
             Ok(_) => (),
             Err(Errno::Notdir) => return Ok(Errno::Notdir),
             Err(Errno::Noent) => return Ok(Errno::Noent),
@@ -134,7 +146,11 @@ pub(crate) fn proc_exec4_impl<M: MemorySize>(
     let (_, cur_dir) = {
         let (memory, state, inodes) =
             unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match state.fs.get_current_dir(inodes, crate::VIRTUAL_ROOT_FD) {
+        match __asyncify_light(
+            ctx.data(),
+            None,
+            state.fs.get_current_dir(inodes, crate::VIRTUAL_ROOT_FD),
+        )? {
             Ok(a) => a,
             Err(err) => {
                 warn!("failed to create subprocess for fork - {}", err);
@@ -336,7 +352,7 @@ pub(crate) enum FindExecutableResult {
     NotFound,
 }
 
-pub(crate) fn find_executable_in_path<'a>(
+pub(crate) async fn find_executable_in_path<'a>(
     fs: &WasiFs,
     inodes: &WasiInodes,
     path: impl IntoIterator<Item = &'a str>,
@@ -345,7 +361,10 @@ pub(crate) fn find_executable_in_path<'a>(
     let mut encountered_eaccess = false;
     for p in path {
         let full_path = format!("{}/{}", p.trim_end_matches('/'), file_name);
-        match fs.get_inode_at_path(inodes, VIRTUAL_ROOT_FD, &full_path, true) {
+        match fs
+            .get_inode_at_path(inodes, VIRTUAL_ROOT_FD, &full_path, true)
+            .await
+        {
             Ok(_) => return FindExecutableResult::Found(full_path),
             Err(Errno::Access) => encountered_eaccess = true,
             Err(_) => (),

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -108,16 +108,13 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         };
         let (_, state, inodes) =
             unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match wasi_try_ok!(__asyncify_light(
-            ctx.data(),
-            None,
-            async {
-                Ok(
-                    find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name)
-                        .await,
-                )
-            },
-        )?) {
+        match wasi_try_ok!(__asyncify_light(ctx.data(), None, async {
+            Ok(
+                find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name)
+                    .await,
+            )
+        },)?)
+        {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
             FindExecutableResult::NotFound => return Ok(Errno::Noexec),

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -108,7 +108,16 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         };
         let (_, state, inodes) =
             unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name) {
+        match wasi_try_ok!(__asyncify_light(
+            ctx.data(),
+            None,
+            async {
+                Ok(
+                    find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name)
+                        .await,
+                )
+            },
+        )?) {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
             FindExecutableResult::NotFound => return Ok(Errno::Noexec),
@@ -216,18 +225,24 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
                     .map_err(mem_error_to_wasi)?
             };
             name = env.state.fs.relative_path_to_absolute(name.to_owned());
-            match path_open_internal(
+            match __asyncify_light(
                 env,
-                VIRTUAL_ROOT_FD,
-                op.dirflags,
-                &name,
-                op.oflags,
-                op.fs_rights_base,
-                op.fs_rights_inheriting,
-                op.fdflags,
-                op.fdflagsext,
-                Some(op.fd),
-            ) {
+                None,
+                path_open_internal(
+                    env,
+                    VIRTUAL_ROOT_FD,
+                    op.dirflags,
+                    name,
+                    op.oflags,
+                    op.fs_rights_base,
+                    op.fs_rights_inheriting,
+                    op.fdflags,
+                    op.fdflagsext,
+                    Some(op.fd),
+                ),
+            )
+            .map_err(|_| Errno::Io)?
+            {
                 Err(e) => {
                     tracing::warn!("Failed to open file for posix_spawn: {:?}", e);
                     Err(Errno::Io)
@@ -243,7 +258,7 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
                     .map_err(mem_error_to_wasi)?
             };
             path = env.state.fs.relative_path_to_absolute(path.to_owned());
-            chdir_internal(env, &path)
+            __asyncify_light(env, None, chdir_internal(env, &path)).map_err(|_| Errno::Io)?
         }
         ProcSpawnFdOpName::Fchdir => {
             let fd = env.state.fs.get_fd(op.fd)?;

--- a/lib/wasix/src/syscalls/wasix/sock_send_file.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_send_file.rs
@@ -107,7 +107,7 @@ pub(crate) fn sock_send_file_internal(
                                         wasi_try_ok_ok!(__asyncify(ctx, None, async move {
                                             let mut buf = vec![0u8; sub_count as usize];
 
-                                            let mut handle = handle.write().unwrap();
+                                            let mut handle = handle.lock().await;
                                             handle
                                                 .seek(std::io::SeekFrom::Start(offset as u64))
                                                 .await

--- a/lib/wasix/src/utils/mod.rs
+++ b/lib/wasix/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod web;
 
 pub use self::{dummy_waker::WasiDummyWaker, thread_parker::WasiParkingLot};
 
+#[allow(unused_imports)]
 pub(crate) use owned_mutex_guard::{
     OwnedRwLockReadGuard, OwnedRwLockWriteGuard, read_owned, write_owned,
 };

--- a/lib/wasix/src/utils/owned_mutex_guard.rs
+++ b/lib/wasix/src/utils/owned_mutex_guard.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 /// Extends the standard library RwLock to include an owned version of the read
 /// and write locking functions.
 ///

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -827,30 +827,33 @@ fn copy_host_tree_to_virtual_fs(
         guest_root,
         CopyHostTreeActions {
             create_directory: |path: &Path| {
-                create_virtual_dir_all(fs, path).with_context(|| {
-                    format!(
-                        "failed to create mapped directory {} in virtual filesystem",
-                        path.display()
-                    )
+                block_on(async {
+                    create_virtual_dir_all(fs, path).await.with_context(|| {
+                        format!(
+                            "failed to create mapped directory {} in virtual filesystem",
+                            path.display()
+                        )
+                    })
                 })
             },
             copy_file: |source: &Path, target: &Path| {
                 let bytes = fs::read(source).with_context(|| {
                     format!("failed to read mapped fixture {}", source.display())
                 })?;
-                let mut file = fs
-                    .new_open_options()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(target)
-                    .with_context(|| {
-                        format!(
-                            "failed to open mapped fixture {} in virtual filesystem",
-                            target.display()
-                        )
-                    })?;
                 block_on(async {
+                    let mut file = fs
+                        .new_open_options()
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .open(target)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to open mapped fixture {} in virtual filesystem",
+                                target.display()
+                            )
+                        })?;
                     file.write_all(&bytes).await.with_context(|| {
                         format!("failed to write mapped fixture {}", target.display())
                     })
@@ -860,11 +863,15 @@ fn copy_host_tree_to_virtual_fs(
                 let link_target = fs::read_link(source).with_context(|| {
                     format!("failed to read symlink fixture {}", source.display())
                 })?;
-                fs.create_symlink(&link_target, target).with_context(|| {
-                    format!(
-                        "failed to create symlink fixture {} in virtual filesystem",
-                        target.display()
-                    )
+                block_on(async {
+                    fs.create_symlink(&link_target, target)
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "failed to create symlink fixture {} in virtual filesystem",
+                                target.display()
+                            )
+                        })
                 })
             },
         },
@@ -896,11 +903,13 @@ fn create_filesystem(kind: FileSystemKind) -> Arc<dyn FileSystem + Send + Sync> 
 }
 
 fn create_empty_dir_in_virtual_fs(fs: &(dyn FileSystem + Send + Sync), guest: &Path) -> Result<()> {
-    create_virtual_dir_all(fs, guest).with_context(|| {
-        format!(
-            "failed to create empty mapped directory {} in virtual filesystem",
-            guest.display()
-        )
+    block_on(async {
+        create_virtual_dir_all(fs, guest).await.with_context(|| {
+            format!(
+                "failed to create empty mapped directory {} in virtual filesystem",
+                guest.display()
+            )
+        })
     })
 }
 

--- a/lib/wasix/tests/wasm_tests/runner.rs
+++ b/lib/wasix/tests/wasm_tests/runner.rs
@@ -116,36 +116,37 @@ impl CaptureFile {
     }
 }
 
+#[async_trait::async_trait]
 impl VirtualFileTrait for CaptureFile {
-    fn last_accessed(&self) -> u64 {
+    async fn last_accessed(&self) -> u64 {
         0
     }
 
-    fn last_modified(&self) -> u64 {
+    async fn last_modified(&self) -> u64 {
         0
     }
 
-    fn created_time(&self) -> u64 {
+    async fn created_time(&self) -> u64 {
         0
     }
 
-    fn size(&self) -> u64 {
+    async fn size(&self) -> u64 {
         self.buffer.lock().unwrap().len() as u64
     }
 
-    fn set_len(&mut self, _new_size: u64) -> Result<(), wasmer_wasix::FsError> {
+    async fn set_len(&mut self, _new_size: u64) -> Result<(), wasmer_wasix::FsError> {
         Err(wasmer_wasix::FsError::PermissionDenied)
     }
 
-    fn unlink(&mut self) -> Result<(), wasmer_wasix::FsError> {
+    async fn unlink(&mut self) -> Result<(), wasmer_wasix::FsError> {
         Ok(())
     }
 
-    fn is_open(&self) -> bool {
+    async fn is_open(&self) -> bool {
         true
     }
 
-    fn get_special_fd(&self) -> Option<u32> {
+    async fn get_special_fd(&self) -> Option<u32> {
         None
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94"
+channel = "1.93"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93"
+channel = "1.94"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- convert virtual-fs filesystem/file operations to async APIs
- update in-memory, host, mount, overlay, static, and wrapper filesystem implementations
- adjust virtual-fs operation helpers for async behavior

## Testing
- not run in this phase

Closes #6779 