### PR TITLE
fix(wasix): report SocketStream filetype for socketpair fds

### DIFF
--- a/lib/wasix/src/syscalls/wasix/sock_pair.rs
+++ b/lib/wasix/src/syscalls/wasix/sock_pair.rs
@@ -83,17 +83,26 @@ pub(crate) fn sock_pair_internal(
     let (memory, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
     let (end1, end2) = Pipe::channel();
 
-    let inode1 = state.fs.create_inode_with_default_stat(
+    // Report a proper socket filetype: callers (e.g. libuv's uv_guess_handle)
+    // fstat socketpair fds to classify them, and the default filestat's
+    // Unknown filetype makes them unusable as streams.
+    let stat = Filestat {
+        st_filetype: Filetype::SocketStream,
+        ..Filestat::default()
+    };
+    let inode1 = state.fs.create_inode_with_stat(
         inodes,
         Kind::DuplexPipe { pipe: end1 },
         false,
         "socketpair".into(),
+        stat,
     );
-    let inode2 = state.fs.create_inode_with_default_stat(
+    let inode2 = state.fs.create_inode_with_stat(
         inodes,
         Kind::DuplexPipe { pipe: end2 },
         false,
         "socketpair".into(),
+        stat,
     );
 
     let rights = Rights::all_socket();


### PR DESCRIPTION
## Description

`sock_pair` (socketpair) created its inodes with the default filestat, which reports an `Unknown` filetype. Callers such as libuv's `uv_guess_handle` `fstat` these fds to classify them, and an `Unknown` filetype makes the fds unusable as streams.

This change creates both socketpair inodes with an explicit `SocketStream` filetype via `create_inode_with_stat`.

## Change

- Build a `Filestat` with `st_filetype: Filetype::SocketStream` and pass it to `create_inode_with_stat` for both ends of the pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)