### PR TITLE
fix(cli): migrate app volume commands to per-volume S3 credentials

### DIFF
--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -18,18 +18,80 @@ use crate::{
 
 pub const CRON_JOB_PAGE_SIZE: i32 = 100;
 
-/// Rotate the s3 secrets tied to an app given its id.
-pub async fn rotate_s3_secrets(
+/// Retrieve the persistent `AppVolume` nodes of an app, including their S3
+/// state and (for S3-enabled volumes) credentials.
+///
+/// Unlike [`get_app_volumes`], which returns the active version's volume
+/// descriptors (`AppVersionVolume`, keyed by the user-chosen name), this returns
+/// the persistent `DeployApp.volumes` nodes with the ids required to rotate S3
+/// credentials or toggle the S3 endpoint per volume.
+pub async fn get_deploy_app_volumes(
     client: &WasmerClient,
-    app_id: types::Id,
-) -> Result<(), anyhow::Error> {
-    client
-        .run_graphql_strict(types::RotateS3SecretsForApp::build(
-            RotateS3SecretsForAppVariables { id: app_id },
-        ))
-        .await?;
+    owner: impl Into<String>,
+    name: impl Into<String>,
+) -> Result<Vec<types::AppVolume>, anyhow::Error> {
+    let mut vars = types::GetDeployAppVolumesVars {
+        owner: owner.into(),
+        name: name.into(),
+        after: None,
+    };
 
-    Ok(())
+    let mut volumes = Vec::new();
+    loop {
+        let connection = client
+            .run_graphql_strict(types::GetDeployAppVolumes::build(vars.clone()))
+            .await?
+            .get_deploy_app
+            .context("app not found")?
+            .volumes;
+
+        volumes.extend(connection.edges.into_iter().map(|edge| edge.node));
+
+        match connection
+            .page_info
+            .end_cursor
+            .filter(|_| connection.page_info.has_next_page)
+        {
+            Some(after) => vars.after = Some(after),
+            None => break,
+        }
+    }
+
+    Ok(volumes)
+}
+
+/// Rotate the S3 credentials of a single app volume, identified by its
+/// `AppVolume` id.
+pub async fn rotate_s3_credentials(
+    client: &WasmerClient,
+    volume_id: types::Id,
+) -> Result<types::RotateS3CredentialsPayload, anyhow::Error> {
+    let payload = client
+        .run_graphql_strict(types::RotateS3Credentials::build(
+            RotateS3CredentialsVariables { id: volume_id },
+        ))
+        .await?
+        .rotate_s3_credentials;
+
+    Ok(payload)
+}
+
+/// Enable or disable the S3 endpoint of a single app volume, identified by its
+/// `AppVolume` id.
+pub async fn update_volume_s3_enabled(
+    client: &WasmerClient,
+    volume_id: types::Id,
+    s3_enabled: bool,
+) -> Result<types::UpdateVolumePayload, anyhow::Error> {
+    let payload = client
+        .run_graphql_strict(types::UpdateVolume::build(types::UpdateVolumeVariables {
+            id: volume_id,
+            s3_enabled: Some(s3_enabled),
+        }))
+        .await?
+        .update_volume;
+
+    Ok(payload)
 }
 
 pub async fn viewer_can_deploy_to_namespace(

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -891,24 +891,92 @@ mod queries {
         pub endpoint: String,
     }
 
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub(crate) struct GetDeployAppVolumesVars {
+        pub owner: String,
+        pub name: String,
+        pub after: Option<String>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Query", variables = "GetDeployAppVolumesVars")]
+    pub(crate) struct GetDeployAppVolumes {
+        #[arguments(owner: $owner, name: $name)]
+        pub get_deploy_app: Option<AppWithVolumes>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "DeployApp", variables = "GetDeployAppVolumesVars")]
+    pub(crate) struct AppWithVolumes {
+        #[arguments(first: 100, after: $after)]
+        pub volumes: AppVolumeConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub(crate) struct AppVolumeConnection {
+        pub page_info: PageInfo,
+        pub edges: Vec<AppVolumeEdge>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub(crate) struct AppVolumeEdge {
+        pub node: AppVolume,
+    }
+
+    /// A persistent `DeployApp.volumes` node, including its S3 state and (if S3
+    /// is enabled) credentials. `s3` is `None` unless the volume has S3 enabled.
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct AppVolume {
+        pub id: cynic::Id,
+        pub volume_id: String,
+        pub mount_path: String,
+        pub s3_enabled: bool,
+        pub s3: Option<S3>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct S3 {
+        pub access_key: String,
+        pub secret_key: String,
+        pub endpoint: String,
+    }
+
     #[derive(cynic::QueryVariables, Debug)]
-    pub struct RotateS3SecretsForAppVariables {
+    pub struct UpdateVolumeVariables {
+        pub id: cynic::Id,
+        pub s3_enabled: Option<bool>,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    #[cynic(graphql_type = "Mutation", variables = "UpdateVolumeVariables")]
+    pub struct UpdateVolume {
+        #[arguments(input: { id: $id, s3Enabled: $s3_enabled })]
+        pub update_volume: UpdateVolumePayload,
+    }
+
+    #[derive(cynic::QueryFragment, Debug)]
+    pub struct UpdateVolumePayload {
+        pub success: bool,
+    }
+
+    #[derive(cynic::QueryVariables, Debug)]
+    pub struct RotateS3CredentialsVariables {
         pub id: cynic::Id,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    #[cynic(
-        graphql_type = "Mutation",
-        variables = "RotateS3SecretsForAppVariables"
-    )]
-    pub struct RotateS3SecretsForApp {
+    #[cynic(graphql_type = "Mutation", variables = "RotateS3CredentialsVariables")]
+    pub struct RotateS3Credentials {
         #[arguments(input: { id: $id })]
-        pub rotate_s3_secrets_for_app: Option<RotateS3SecretsForAppPayload>,
+        pub rotate_s3_credentials: RotateS3CredentialsPayload,
     }
 
     #[derive(cynic::QueryFragment, Debug)]
-    pub struct RotateS3SecretsForAppPayload {
-        pub client_mutation_id: Option<String>,
+    pub struct RotateS3CredentialsPayload {
+        pub access_key: String,
+        pub secret_key: String,
+        pub endpoint: String,
+        pub success: bool,
     }
 
     #[derive(cynic::QueryVariables, Debug, Clone)]
@@ -1026,6 +1094,12 @@ mod queries {
         pub name: String,
         pub size: Option<BigInt>,
         pub used_size: Option<BigInt>,
+        pub mount_paths: Vec<AppVersionVolumeMountPath>,
+    }
+
+    #[derive(serde::Serialize, cynic::QueryFragment, Debug)]
+    pub struct AppVersionVolumeMountPath {
+        pub path: String,
     }
 
     #[derive(cynic::QueryVariables, Debug)]

--- a/lib/cli/src/commands/app/volumes/credentials/mod.rs
+++ b/lib/cli/src/commands/app/volumes/credentials/mod.rs
@@ -29,16 +29,106 @@ impl AsyncCliCommand for CmdAppVolumesCredentials {
         let client = self.env.client()?;
         let (_ident, app) = self.ident.load_app(&client).await?;
 
-        let creds =
-            wasmer_backend_api::query::get_app_s3_credentials(&client, app.id.clone().into_inner())
-                .await?;
+        // S3 credentials are per-volume; fetch every volume and print the
+        // credentials of those that have S3 enabled.
+        let volumes = super::list_volumes(&client, &app.owner.global_name, &app.name).await?;
 
-        match self.fmt.format {
-            CredsItemFormat::Rclone => {
-                let rclone_config = format!(
-                    r#"
-[edge-{app_name}]
-# rclone configuration for volumes of {app_name}
+        let with_creds: Vec<_> = volumes
+            .iter()
+            .filter_map(|volume| volume.s3.as_ref().map(|s3| (volume, s3)))
+            .collect();
+
+        if with_creds.is_empty() {
+            // Hint on stderr, but still render below so json/yaml emit `[]`.
+            eprintln!(
+                "App {} has no S3-enabled volumes with credentials. \
+                 Enable S3 with `wasmer app volume enable-s3`.",
+                app.name
+            );
+        }
+
+        let records: Vec<S3CredentialRecord> = with_creds
+            .into_iter()
+            .map(|(volume, s3)| S3CredentialRecord {
+                app_name: app.name.clone(),
+                volume: volume.mount_path.clone(),
+                access_key: s3.access_key.clone(),
+                secret_key: s3.secret_key.clone(),
+                endpoint: s3.endpoint.clone(),
+            })
+            .collect();
+
+        println!("{}", render_s3_credentials(self.fmt.format, &records));
+
+        Ok(())
+    }
+}
+
+/// One volume's S3 credentials, ready to be rendered.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct S3CredentialRecord {
+    pub app_name: String,
+    /// The mount path the credentials belong to.
+    pub volume: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub endpoint: String,
+}
+
+/// Render a set of volumes' S3 credentials in the requested format.
+///
+/// For `json`/`yaml` the records are emitted as a single array/list so that the
+/// output is one valid document no matter how many volumes there are; for
+/// `rclone`/`table` each record is rendered in turn (concatenated sections, one
+/// table with a row per volume). The returned string is ready to print as-is.
+pub(crate) fn render_s3_credentials(
+    format: CredsItemFormat,
+    records: &[S3CredentialRecord],
+) -> String {
+    match format {
+        CredsItemFormat::Rclone => records.iter().map(render_rclone_section).collect(),
+        CredsItemFormat::Json => serde_json::to_string_pretty(records).unwrap(),
+        CredsItemFormat::Yaml => serde_yaml::to_string(records).unwrap(),
+        CredsItemFormat::Table => {
+            let mut table = comfy_table::Table::new();
+            table.add_row(vec![
+                "App name",
+                "Volume",
+                "Access key",
+                "Secret key",
+                "Endpoint",
+            ]);
+            for record in records {
+                table.add_row(vec![
+                    record.app_name.as_str(),
+                    record.volume.as_str(),
+                    record.access_key.as_str(),
+                    record.secret_key.as_str(),
+                    record.endpoint.as_str(),
+                ]);
+            }
+            table.to_string()
+        }
+    }
+}
+
+/// Render one volume's credentials as an rclone configuration section.
+fn render_rclone_section(record: &S3CredentialRecord) -> String {
+    let S3CredentialRecord {
+        app_name,
+        volume,
+        access_key,
+        secret_key,
+        endpoint,
+    } = record;
+    let section = format!(
+        "edge-{app_name}-{}",
+        volume.trim_start_matches('/').replace('/', "-")
+    );
+    format!(
+        r#"
+[{section}]
+# rclone configuration for volume {volume} of {app_name}
 type = s3
 provider = Other
 acl = private
@@ -46,56 +136,8 @@ access_key_id = {access_key}
 secret_access_key = {secret_key}
 endpoint = {endpoint}
 
-"#,
-                    app_name = app.name,
-                    access_key = creds.access_key,
-                    secret_key = creds.secret_key,
-                    endpoint = creds.endpoint,
-                );
-                println!("{rclone_config}");
-            }
-            CredsItemFormat::Json => {
-                let value = serde_json::json!({
-                    "app_name": app.name,
-                    "access_key": creds.access_key,
-                    "secret_key": creds.secret_key,
-                    "endpoint": creds.endpoint,
-                });
-
-                println!("{}", serde_json::to_string_pretty(&value).unwrap());
-            }
-            CredsItemFormat::Yaml => {
-                let config = format!(
-                    r#"
-app_name: {app_name}
-access_key: {access_key}
-secret_key: {secret_key}
-endpoint: {endpoint}
-"#,
-                    app_name = app.name,
-                    access_key = creds.access_key,
-                    secret_key = creds.secret_key,
-                    endpoint = creds.endpoint,
-                );
-                println!("{config}");
-            }
-
-            CredsItemFormat::Table => {
-                let mut table = comfy_table::Table::new();
-                table.add_row(vec!["App name", "Access key", "Secret key", "Endpoint"]);
-                table.add_row(vec![
-                    app.name,
-                    creds.access_key,
-                    creds.secret_key,
-                    creds.endpoint,
-                ]);
-
-                println!("{table}");
-            }
-        }
-
-        Ok(())
-    }
+"#
+    )
 }
 
 /*

--- a/lib/cli/src/commands/app/volumes/credentials/rotate_secrets.rs
+++ b/lib/cli/src/commands/app/volumes/credentials/rotate_secrets.rs
@@ -1,9 +1,6 @@
-use super::ItemFormatOpts;
+use super::{ItemFormatOpts, S3CredentialRecord, render_s3_credentials};
 use crate::{
-    commands::{
-        AsyncCliCommand,
-        app::util::{AppIdent, AppIdentOpts},
-    },
+    commands::{AsyncCliCommand, app::util::AppIdentOpts},
     config::WasmerEnv,
 };
 
@@ -18,6 +15,11 @@ pub struct CmdAppVolumesRotateSecrets {
 
     #[clap(flatten)]
     pub fmt: ItemFormatOpts,
+
+    /// Only rotate this volume's credentials, by name, mount path, or volume id.
+    /// Without it, every S3-enabled volume of the app is rotated.
+    #[clap(long)]
+    pub volume: Option<String>,
 }
 
 #[async_trait::async_trait]
@@ -28,26 +30,78 @@ impl AsyncCliCommand for CmdAppVolumesRotateSecrets {
         let client = self.env.client()?;
         let (_ident, app) = self.ident.load_app(&client).await?;
 
-        wasmer_backend_api::query::rotate_s3_secrets(&client, app.id).await?;
+        // rotateS3Credentials operates per AppVolume, so resolve the app's
+        // volumes and rotate each one.
+        let volumes =
+            super::super::list_volumes(&client, &app.owner.global_name, &app.name).await?;
 
-        // Don't print it here and leave it implied, so users can append the output
-        // of `wasmer app volumes credentials` without worrying about this message.
-        //
-        //println!(
-        //    "Correctly rotated s3 secrets for app {} ({})",
-        //    app.name,
-        //    app.owner.global_name.bold()
-        //);
+        let selected: Vec<&_> = match &self.volume {
+            Some(sel) => vec![super::super::select_volume_by_selector(
+                &app.name, &volumes, sel,
+            )?],
+            // Rotate every S3-enabled volume; volumes without S3 have no S3
+            // credentials to rotate.
+            None => volumes.iter().filter(|v| v.s3_enabled).collect(),
+        };
 
-        super::CmdAppVolumesCredentials {
-            env: self.env,
-            fmt: self.fmt,
-            ident: AppIdentOpts {
-                app: Some(AppIdent::NamespacedName(app.owner.global_name, app.name)),
-            },
+        if selected.is_empty() {
+            // Hint on stderr, but still render below so json/yaml emit `[]`.
+            eprintln!(
+                "App {} has no S3-enabled volumes to rotate secrets for.",
+                app.name
+            );
         }
-        .run_async()
-        .await?;
+
+        // Rotate every selected volume, recording failures instead of aborting
+        // so that a single failing volume does not leave the rest un-rotated
+        // and unreported.
+        let mut records = Vec::new();
+        let mut failures = Vec::new();
+        for volume in selected {
+            let result =
+                wasmer_backend_api::query::rotate_s3_credentials(&client, volume.id.clone()).await;
+
+            match result {
+                Ok(payload) if payload.success => {
+                    // Per-volume status on stderr, so the rotated credentials on
+                    // stdout stay pipeable.
+                    eprintln!("Rotated S3 credentials for volume {}", volume.label());
+                    records.push(S3CredentialRecord {
+                        app_name: app.name.clone(),
+                        volume: volume.mount_path.clone(),
+                        access_key: payload.access_key,
+                        secret_key: payload.secret_key,
+                        endpoint: payload.endpoint,
+                    });
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "Failed to rotate S3 credentials for volume {}",
+                        volume.label()
+                    );
+                    failures.push(volume.label());
+                }
+                Err(err) => {
+                    eprintln!(
+                        "Failed to rotate S3 credentials for volume {}: {err:#}",
+                        volume.label()
+                    );
+                    failures.push(volume.label());
+                }
+            }
+        }
+
+        // Emit the rotated credentials as a single document; json/yaml stay one
+        // array/list (empty `[]` when nothing rotated).
+        println!("{}", render_s3_credentials(self.fmt.format, &records));
+
+        if !failures.is_empty() {
+            anyhow::bail!(
+                "Failed to rotate S3 credentials for {} volume(s): {}",
+                failures.len(),
+                failures.join(", ")
+            );
+        }
 
         Ok(())
     }

--- a/lib/cli/src/commands/app/volumes/enable_s3.rs
+++ b/lib/cli/src/commands/app/volumes/enable_s3.rs
@@ -1,0 +1,107 @@
+use super::select_volume_by_selector;
+use crate::{
+    commands::{AsyncCliCommand, app::util::AppIdentOpts},
+    config::WasmerEnv,
+};
+
+/// Enable (or disable) the S3 endpoint for an app's volumes.
+///
+/// Enabling S3 provisions per-volume S3 credentials; retrieve them with
+/// `wasmer app volume credentials` and rotate them with `wasmer app volume
+/// rotate-secrets`.
+#[derive(clap::Parser, Debug)]
+pub struct CmdAppVolumesEnableS3 {
+    #[clap(flatten)]
+    pub env: WasmerEnv,
+
+    #[clap(flatten)]
+    pub ident: AppIdentOpts,
+
+    /// Only change this volume, by name, mount path, or volume id.
+    /// Without it, every volume of the app is affected.
+    #[clap(long)]
+    pub volume: Option<String>,
+
+    /// Disable S3 instead of enabling it.
+    #[clap(long)]
+    pub disable: bool,
+}
+
+#[async_trait::async_trait]
+impl AsyncCliCommand for CmdAppVolumesEnableS3 {
+    type Output = ();
+
+    async fn run_async(self) -> Result<Self::Output, anyhow::Error> {
+        let client = self.env.client()?;
+        let (_ident, app) = self.ident.load_app(&client).await?;
+
+        let volumes = super::list_volumes(&client, &app.owner.global_name, &app.name).await?;
+
+        let selected: Vec<&_> = match &self.volume {
+            Some(sel) => vec![select_volume_by_selector(&app.name, &volumes, sel)?],
+            None => volumes.iter().collect(),
+        };
+
+        if selected.is_empty() {
+            eprintln!("App {} has no volumes.", app.name);
+            return Ok(());
+        }
+
+        let enable = !self.disable;
+        let mut changed = 0usize;
+        let mut failures = Vec::new();
+        for volume in selected {
+            // Skip volumes already in the desired state.
+            if volume.s3_enabled == enable {
+                eprintln!(
+                    "S3 already {} for volume {}",
+                    if enable { "enabled" } else { "disabled" },
+                    volume.label()
+                );
+                continue;
+            }
+
+            match wasmer_backend_api::query::update_volume_s3_enabled(
+                &client,
+                volume.id.clone(),
+                enable,
+            )
+            .await
+            {
+                Ok(payload) if payload.success => {
+                    changed += 1;
+                    eprintln!(
+                        "{} S3 for volume {}",
+                        if enable { "Enabled" } else { "Disabled" },
+                        volume.label()
+                    );
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "Failed to update S3 for volume {}: backend reported failure",
+                        volume.label()
+                    );
+                    failures.push(volume.label());
+                }
+                Err(err) => {
+                    eprintln!("Failed to update S3 for volume {}: {err:#}", volume.label());
+                    failures.push(volume.label());
+                }
+            }
+        }
+
+        if !failures.is_empty() {
+            anyhow::bail!(
+                "Failed to update S3 for {} volume(s): {}",
+                failures.len(),
+                failures.join(", ")
+            );
+        }
+
+        if enable && changed > 0 {
+            eprintln!("Retrieve the S3 credentials with `wasmer app volume credentials`.");
+        }
+
+        Ok(())
+    }
+}

--- a/lib/cli/src/commands/app/volumes/list.rs
+++ b/lib/cli/src/commands/app/volumes/list.rs
@@ -24,14 +24,14 @@ impl AsyncCliCommand for CmdAppVolumesList {
         let client = self.env.client()?;
 
         let (_ident, app) = self.ident.load_app(&client).await?;
-        let volumes =
-            wasmer_backend_api::query::get_app_volumes(&client, &app.owner.global_name, &app.name)
-                .await?;
+        let volumes = super::list_volumes(&client, &app.owner.global_name, &app.name).await?;
 
         if volumes.is_empty() {
             eprintln!("App {} has no volumes!", app.name);
         } else {
-            println!("{}", self.fmt.format.render(volumes.as_slice()));
+            let items: Vec<super::VolumeListItem> =
+                volumes.iter().map(super::VolumeListItem::from).collect();
+            println!("{}", self.fmt.format.render(items.as_slice()));
         }
 
         Ok(())

--- a/lib/cli/src/commands/app/volumes/mod.rs
+++ b/lib/cli/src/commands/app/volumes/mod.rs
@@ -1,6 +1,11 @@
+use comfy_table::Table;
+use wasmer_backend_api::WasmerClient;
+
 use crate::commands::AsyncCliCommand;
+use crate::utils::render::CliRender;
 
 pub mod credentials;
+pub mod enable_s3;
 pub mod list;
 
 /// App volume management.
@@ -9,6 +14,7 @@ pub enum CmdAppVolumes {
     Credentials(credentials::CmdAppVolumesCredentials),
     List(list::CmdAppVolumesList),
     RotateSecrets(credentials::rotate_secrets::CmdAppVolumesRotateSecrets),
+    EnableS3(enable_s3::CmdAppVolumesEnableS3),
 }
 
 #[async_trait::async_trait]
@@ -29,6 +35,196 @@ impl AsyncCliCommand for CmdAppVolumes {
                 c.run_async().await?;
                 Ok(())
             }
+            Self::EnableS3(c) => {
+                c.run_async().await?;
+                Ok(())
+            }
         }
+    }
+}
+
+/// A volume of an app: the single view every `wasmer app volume` subcommand
+/// operates on.
+///
+/// It unifies the persistent `AppVolume` node (the manageable entity with id, mount
+/// path, S3 state and credentials) with the active version's descriptor
+/// (friendly name, used size), joined by mount path. Volumes not declared in the
+/// active version (e.g. created via the dashboard) simply have no `name`/
+/// `used_size`.
+pub(crate) struct Volume {
+    pub id: wasmer_backend_api::types::Id,
+    pub volume_id: String,
+    pub mount_path: String,
+    pub s3_enabled: bool,
+    pub s3: Option<wasmer_backend_api::types::S3>,
+    pub name: Option<String>,
+    /// Used size in bytes, from the active version descriptor.
+    pub used_size: Option<i64>,
+}
+
+impl Volume {
+    /// A human-readable label for status messages and error lists.
+    pub fn label(&self) -> String {
+        match &self.name {
+            Some(name) => format!("{name} ({})", self.mount_path),
+            None => self.mount_path.clone(),
+        }
+    }
+}
+
+/// List the app's volumes: the persistent `AppVolume` nodes enriched with the
+/// friendly name and used size from the active version's descriptors, joined by
+/// mount path.
+pub(crate) async fn list_volumes(
+    client: &WasmerClient,
+    owner: &str,
+    app_name: &str,
+) -> Result<Vec<Volume>, anyhow::Error> {
+    let persistent =
+        wasmer_backend_api::query::get_deploy_app_volumes(client, owner, app_name).await?;
+
+    // The active-version descriptors carry the friendly name and used size.
+    // They're best-effort decoration, so don't fail the command if unavailable.
+    let version = wasmer_backend_api::query::get_app_volumes(client, owner, app_name)
+        .await
+        .unwrap_or_default();
+
+    let mut meta_by_mount: std::collections::HashMap<String, (String, Option<i64>)> =
+        std::collections::HashMap::new();
+    for descriptor in version {
+        let used_size = descriptor.used_size.map(|b| b.0);
+        for mount in descriptor.mount_paths {
+            meta_by_mount
+                .entry(mount.path.trim_end_matches('/').to_string())
+                .or_insert_with(|| (descriptor.name.clone(), used_size));
+        }
+    }
+
+    Ok(persistent
+        .into_iter()
+        .map(|volume| {
+            let meta = meta_by_mount.get(volume.mount_path.trim_end_matches('/'));
+            Volume {
+                id: volume.id,
+                volume_id: volume.volume_id,
+                mount_path: volume.mount_path,
+                s3_enabled: volume.s3_enabled,
+                s3: volume.s3,
+                name: meta.map(|(name, _)| name.clone()),
+                used_size: meta.and_then(|(_, used)| *used),
+            }
+        })
+        .collect())
+}
+
+/// Resolve a `--volume` selector to a single volume. The selector may be the
+/// friendly name, the mount path (exactly as shown by `wasmer app volume list`,
+/// e.g. `/data`), or the volume id.
+///
+/// The volume id is opaque and unique, so an exact id match is unambiguous and
+/// always wins: a volume can never be shadowed by another volume's (user-chosen)
+/// name or mount path. If a volume's name collides with a volume's id, the id
+/// always wins.
+pub(crate) fn select_volume_by_selector<'a>(
+    app_name: &str,
+    volumes: &'a [Volume],
+    selector: &str,
+) -> Result<&'a Volume, anyhow::Error> {
+    if let Some(volume) = volumes.iter().find(|v| v.volume_id == selector) {
+        return Ok(volume);
+    }
+
+    let matched: Vec<&Volume> = volumes
+        .iter()
+        .filter(|v| v.name.as_deref() == Some(selector) || v.mount_path == selector)
+        .collect();
+
+    match matched.as_slice() {
+        [] => {
+            let available = volumes
+                .iter()
+                .map(Volume::label)
+                .collect::<Vec<_>>()
+                .join(", ");
+            if available.is_empty() {
+                anyhow::bail!("App {app_name} has no volumes.");
+            }
+            anyhow::bail!(
+                "App {app_name} has no volume matching '{selector}'. Available volumes: {available}"
+            );
+        }
+        [volume] => Ok(volume),
+        multiple => {
+            let colliding = multiple
+                .iter()
+                .map(|v| format!("{} [id {}]", v.label(), v.volume_id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "'{selector}' matches multiple volumes of app {app_name}: {colliding}. \
+                 Pass the volume id to select one."
+            )
+        }
+    }
+}
+
+/// The `wasmer app volume list` row for a [`Volume`].
+#[derive(serde::Serialize)]
+pub(crate) struct VolumeListItem {
+    pub name: Option<String>,
+    pub mount_path: String,
+    pub volume_id: String,
+    pub used_size: Option<i64>,
+    pub s3_enabled: bool,
+}
+
+impl From<&Volume> for VolumeListItem {
+    fn from(volume: &Volume) -> Self {
+        Self {
+            name: volume.name.clone(),
+            mount_path: volume.mount_path.clone(),
+            volume_id: volume.volume_id.clone(),
+            used_size: volume.used_size,
+            s3_enabled: volume.s3_enabled,
+        }
+    }
+}
+
+impl VolumeListItem {
+    fn row(&self) -> Vec<String> {
+        vec![
+            self.name.clone().unwrap_or_else(|| "-".to_string()),
+            self.mount_path.clone(),
+            crate::types::format_disk_size_opt(
+                self.used_size.map(wasmer_backend_api::types::BigInt),
+            ),
+            if self.s3_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            }
+            .to_string(),
+        ]
+    }
+}
+
+impl CliRender for VolumeListItem {
+    fn render_item_table(&self) -> String {
+        let row = self.row();
+        let mut table = Table::new();
+        table.add_rows([
+            vec!["Name".to_string(), row[0].clone()],
+            vec!["Mount path".to_string(), row[1].clone()],
+            vec!["Used size".to_string(), row[2].clone()],
+            vec!["S3".to_string(), row[3].clone()],
+        ]);
+        table.to_string()
+    }
+
+    fn render_list_table(items: &[Self]) -> String {
+        let mut table = Table::new();
+        table.set_header(vec!["Name", "Mount path", "Used size", "S3"]);
+        table.add_rows(items.iter().map(|item| item.row()));
+        table.to_string()
     }
 }

--- a/lib/cli/src/types.rs
+++ b/lib/cli/src/types.rs
@@ -415,32 +415,6 @@ impl CliRender for DeployAppVersion {
     }
 }
 
-impl CliRender for wasmer_backend_api::types::AppVersionVolume {
-    fn render_item_table(&self) -> String {
-        let mut table = Table::new();
-        table.add_rows([
-            vec!["Name".to_string(), self.name.clone()],
-            vec![
-                "Used size".to_string(),
-                format_disk_size_opt(self.used_size.clone()),
-            ],
-        ]);
-        table.to_string()
-    }
-
-    fn render_list_table(items: &[Self]) -> String {
-        let mut table = Table::new();
-        table.set_header(vec!["Name".to_string(), "Used size".to_string()]);
-        table.add_rows(items.iter().map(|vol| {
-            vec![
-                vol.name.clone(),
-                format_disk_size_opt(vol.used_size.clone()),
-            ]
-        }));
-        table.to_string()
-    }
-}
-
 impl CliRender for wasmer_backend_api::types::AppDatabase {
     fn render_item_table(&self) -> String {
         let mut table = Table::new();
@@ -487,7 +461,7 @@ impl CliRender for wasmer_backend_api::types::AppDatabase {
     }
 }
 
-fn format_disk_size_opt(value: Option<wasmer_backend_api::types::BigInt>) -> String {
+pub(crate) fn format_disk_size_opt(value: Option<wasmer_backend_api::types::BigInt>) -> String {
     let value = value.and_then(|x| {
         let y: Option<u64> = x.0.try_into().ok();
         y


### PR DESCRIPTION
Fixes the wasmer app volume commands after the backend moved S3 credentials to per-volume (partially fixes [QA-545](https://linear.app/wasmer/issue/QA-545/s3-compatibility-silently-dropped-for-app-volumes)).

- `rotate-secrets`: use per-volume `rotateS3Credentials` (was the deprecated `rotateS3SecretsForApp`); continue past per-volume failures; non-zero exit on failure.
- `credentials`: per-volume (via `AppVolume.s3`), was the broken app-level query.
- `enable-s3`: new command wrapping `updateVolume(s3Enabled)`.
- the above commands gain `--volume`, which accepts name / mount path / volume id, to specify a single one. If unspecified, they iterate over all.
- `list`: rebuilt to join both views, such that S3, Name, Mount Path, Used size all get shown (if they exist).

If, for some reason, a user names a volume the same as some volume ID, the actual ID wins over the colliding name.

For testing:
```
wasmer app volume enable-s3 <app> --volume data
wasmer app volume list <app>
wasmer app volume credentials <app>
wasmer app volume rotate-secrets <app>
```
should now all work as expected.

One small nit: the pendant to `enable-s3` is currently `enable-s3 --disable`, which is not great. Maybe this should be two verbs? Or `set-s3-enabled true/false`?