### PR TITLE
fix(virtual-fs): follow symlinks in webc volumes

### DIFF
--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -33,14 +33,15 @@ impl WebcVolumeFileSystem {
         &self.volume
     }
 
-    /// Resolve `path` to its final target, following symlinks in the trailing
-    /// component *and* any intermediate directory components.
-    ///
-    /// Relative targets resolve against the link's parent, absolute targets
-    /// against the volume root. Returns the resolved path together with the
-    /// target's metadata (`None` if it doesn't exist) so the caller needn't look
-    /// it up again.
-    fn resolve_symlinks(&self, path: &Path) -> Result<(PathBuf, Option<WebcMetadata>), FsError> {
+    /// Resolve `path`, following symlinks in every intermediate component.
+    /// `follow_trailing` also follows a trailing symlink (`stat`); otherwise it
+    /// is reported as-is (`lstat`). Returns the resolved path and its metadata
+    /// (`None` if missing) so the caller needn't look it up again.
+    fn resolve_symlinks(
+        &self,
+        path: &Path,
+        follow_trailing: bool,
+    ) -> Result<(PathBuf, Option<WebcMetadata>), FsError> {
         // Maximum number of symlinks to follow before giving up, matching Linux's
         // MAXSYMLINKS. Guards against symlink loops.
         const MAX_SYMLINK_DEPTH: usize = 40;
@@ -49,22 +50,25 @@ impl WebcVolumeFileSystem {
 
         for _ in 0..=MAX_SYMLINK_DEPTH {
             match self.volume().metadata(&current) {
-                // Fully resolved: the whole path exists and isn't a symlink.
+                // Fully resolved: exists and isn't a symlink.
                 Some(meta) if !meta.is_symlink() => {
                     return Ok((PathBuf::from(current.to_string()), Some(meta)));
                 }
-                // The trailing component is a symlink; follow it.
-                Some(_) => {
+                // Trailing symlink; intermediates are already resolved (else
+                // metadata() would have returned None, the branch below).
+                Some(meta) => {
+                    if !follow_trailing {
+                        // lstat: keep the link itself.
+                        return Ok((PathBuf::from(current.to_string()), Some(meta)));
+                    }
                     let segments: Vec<PathSegment> = current.iter().cloned().collect();
                     current = self.expand_symlink_at(&segments, segments.len() - 1)?;
                 }
-                // The path doesn't resolve directly. An intermediate component may
-                // be a symlink (a raw metadata() lookup stops at the first symlink
-                // it walks through), so look for one to expand.
+                // Not directly resolvable: an intermediate component may be a
+                // symlink (metadata() stops at the first one), so expand it.
                 None => match self.expand_first_symlink(&current)? {
                     Some(next) => current = next,
-                    // Genuinely missing; let the caller report it.
-                    None => return Ok((PathBuf::from(current.to_string()), None)),
+                    None => return Ok((PathBuf::from(current.to_string()), None)), // missing
                 },
             }
         }
@@ -161,7 +165,7 @@ impl FileSystem for WebcVolumeFileSystem {
 
     fn read_dir(&self, path: &Path) -> Result<crate::ReadDir, FsError> {
         // opendir follows symlinks, including a symlinked directory.
-        let (resolved, meta) = self.resolve_symlinks(path)?;
+        let (resolved, meta) = self.resolve_symlinks(path, true)?;
         let meta = meta.map(compat_meta).ok_or(FsError::EntryNotFound)?;
 
         if !meta.is_dir() {
@@ -191,18 +195,16 @@ impl FileSystem for WebcVolumeFileSystem {
     }
 
     fn create_dir(&self, path: &Path) -> Result<(), FsError> {
-        // These entry-existence checks operate on the path itself, not a symlink
-        // target, so they use lstat (symlink_metadata) semantics.
-
-        // the directory shouldn't exist yet
+        // The name must be free. lstat: a trailing symlink already claims it.
         if self.symlink_metadata(path).is_ok() {
             return Err(FsError::AlreadyExists);
         }
 
-        // it's parent should exist
+        // The parent must exist and be a directory. It's a traversed component,
+        // so follow symlinks to it (stat): a symlinked directory is a valid parent.
         let parent = path.parent().unwrap_or_else(|| Path::new("/"));
 
-        match self.symlink_metadata(parent) {
+        match self.metadata(parent) {
             Ok(parent_meta) if parent_meta.is_dir() => {
                 // The operation would normally be doable... but we're a readonly
                 // filesystem
@@ -229,15 +231,13 @@ impl FileSystem for WebcVolumeFileSystem {
 
     fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<(), FsError>> {
         Box::pin(async {
-            // rename operates on the named entries themselves, so use lstat
-            // semantics rather than following a trailing symlink.
-
-            // The original file should exist
+            // The source must exist. lstat: rename acts on the link, not its target.
             let _ = self.symlink_metadata(from)?;
 
-            // we also want to make sure the destination's folder exists, too
+            // The destination's parent must exist. It's a traversed component,
+            // so follow symlinks to it (stat).
             let dest_parent = to.parent().unwrap_or_else(|| Path::new("/"));
-            let parent_meta = self.symlink_metadata(dest_parent)?;
+            let parent_meta = self.metadata(dest_parent)?;
             if !parent_meta.is_dir() {
                 return Err(FsError::BaseNotDirectory);
             }
@@ -249,19 +249,14 @@ impl FileSystem for WebcVolumeFileSystem {
 
     fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
         // `stat` semantics: follow symlinks and report the target.
-        let (_, meta) = self.resolve_symlinks(path)?;
+        let (_, meta) = self.resolve_symlinks(path, true)?;
         meta.map(compat_meta).ok_or(FsError::EntryNotFound)
     }
 
     fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
-        // `lstat` semantics: report the entry itself, without following a
-        // trailing symlink.
-        let path = normalize(path).map_err(|_| FsError::InvalidInput)?;
-
-        self.volume()
-            .metadata(path)
-            .map(compat_meta)
-            .ok_or(FsError::EntryNotFound)
+        // `lstat` semantics: follow intermediate symlinks, but not a trailing one.
+        let (_, meta) = self.resolve_symlinks(path, false)?;
+        meta.map(compat_meta).ok_or(FsError::EntryNotFound)
     }
 
     fn remove_file(&self, path: &Path) -> Result<(), FsError> {
@@ -289,7 +284,7 @@ impl FileOpener for WebcVolumeFileSystem {
     ) -> crate::Result<Box<dyn crate::VirtualFile + Send + Sync + 'static>> {
         // Follow symlinks so opening (and exec'ing) a symlinked file resolves to
         // its target, matching a real filesystem.
-        let (resolved, resolved_meta) = self.resolve_symlinks(path)?;
+        let (resolved, resolved_meta) = self.resolve_symlinks(path, true)?;
         let path = resolved.as_path();
         if let Some(parent) = path.parent() {
             let parent_meta = self.metadata(parent)?;
@@ -819,6 +814,42 @@ mod tests {
             .map(|entry| entry.unwrap().path)
             .collect();
         assert_eq!(entries, vec![PathBuf::from("/bindir/real.wasm")]);
+    }
+
+    #[test]
+    fn symlink_metadata_follows_intermediate_symlinks() {
+        let fs = follow_symlinks_fs();
+
+        // /bindir -> bin, so lstat resolves the intermediate link and finds the file...
+        let meta = fs.symlink_metadata("/bindir/real.wasm".as_ref()).unwrap();
+        assert!(meta.is_file());
+        assert_eq!(meta.len(), b"\0asm-real".len() as u64);
+
+        // ...but a trailing symlink is reported as-is, not followed.
+        assert!(
+            fs.symlink_metadata("/bindir".as_ref())
+                .unwrap()
+                .ft
+                .is_symlink()
+        );
+    }
+
+    #[tokio::test]
+    async fn write_ops_reach_permission_denied_through_symlinked_parent() {
+        let fs = follow_symlinks_fs();
+
+        // /bindir -> bin is a valid parent, so these should resolve it and reach
+        // the readonly rejection, not mistake the symlink for a non-directory.
+        assert_eq!(
+            fs.create_dir("/bindir/new".as_ref()).unwrap_err(),
+            FsError::PermissionDenied,
+        );
+        assert_eq!(
+            fs.rename("/bin/real.wasm".as_ref(), "/bindir/new.wasm".as_ref())
+                .await
+                .unwrap_err(),
+            FsError::PermissionDenied,
+        );
     }
 
     #[test]

--- a/lib/virtual-fs/src/webc_volume_fs.rs
+++ b/lib/virtual-fs/src/webc_volume_fs.rs
@@ -10,8 +10,8 @@ use std::{
 use futures::future::BoxFuture;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite};
 use webc::{
-    Container, Metadata as WebcMetadata, PathSegmentError, PathSegments, ToPathSegments, Volume,
-    compat::SharedBytes,
+    Container, Metadata as WebcMetadata, PathSegment, PathSegmentError, PathSegments,
+    ToPathSegments, Volume, compat::SharedBytes,
 };
 
 use crate::{
@@ -31,6 +31,102 @@ impl WebcVolumeFileSystem {
 
     pub fn volume(&self) -> &Volume {
         &self.volume
+    }
+
+    /// Resolve `path` to its final target, following symlinks in the trailing
+    /// component *and* any intermediate directory components.
+    ///
+    /// Relative targets resolve against the link's parent, absolute targets
+    /// against the volume root. Returns the resolved path together with the
+    /// target's metadata (`None` if it doesn't exist) so the caller needn't look
+    /// it up again.
+    fn resolve_symlinks(&self, path: &Path) -> Result<(PathBuf, Option<WebcMetadata>), FsError> {
+        // Maximum number of symlinks to follow before giving up, matching Linux's
+        // MAXSYMLINKS. Guards against symlink loops.
+        const MAX_SYMLINK_DEPTH: usize = 40;
+
+        let mut current = normalize(path).map_err(|_| FsError::InvalidInput)?;
+
+        for _ in 0..=MAX_SYMLINK_DEPTH {
+            match self.volume().metadata(&current) {
+                // Fully resolved: the whole path exists and isn't a symlink.
+                Some(meta) if !meta.is_symlink() => {
+                    return Ok((PathBuf::from(current.to_string()), Some(meta)));
+                }
+                // The trailing component is a symlink; follow it.
+                Some(_) => {
+                    let segments: Vec<PathSegment> = current.iter().cloned().collect();
+                    current = self.expand_symlink_at(&segments, segments.len() - 1)?;
+                }
+                // The path doesn't resolve directly. An intermediate component may
+                // be a symlink (a raw metadata() lookup stops at the first symlink
+                // it walks through), so look for one to expand.
+                None => match self.expand_first_symlink(&current)? {
+                    Some(next) => current = next,
+                    // Genuinely missing; let the caller report it.
+                    None => return Ok((PathBuf::from(current.to_string()), None)),
+                },
+            }
+        }
+
+        // Too many levels of symlinks.
+        Err(FsError::InvalidInput)
+    }
+
+    /// Walk `path`'s components and, if any is a symlink, return `path` with the
+    /// first such symlink replaced by its target. Returns `None` when no
+    /// component is a symlink (i.e. the path is already resolved or is genuinely missing).
+    fn expand_first_symlink(&self, path: &PathSegments) -> Result<Option<PathSegments>, FsError> {
+        let segments: Vec<PathSegment> = path.iter().cloned().collect();
+        for i in 0..segments.len() {
+            let prefix: PathSegments = segments[..=i].iter().cloned().collect();
+            match self.volume().metadata(&prefix) {
+                Some(meta) if meta.is_symlink() => {
+                    return Ok(Some(self.expand_symlink_at(&segments, i)?));
+                }
+                // A real directory/file: keep walking.
+                Some(_) => {}
+                // This component is missing, so the whole path is missing.
+                None => return Ok(None),
+            }
+        }
+        Ok(None)
+    }
+
+    /// Replace the symlink at `segments[..=i]` with its target, resolving a
+    /// relative target against the link's parent and keeping any trailing
+    /// components. The result is normalized (so `..` in the target is applied).
+    fn expand_symlink_at(
+        &self,
+        segments: &[PathSegment],
+        i: usize,
+    ) -> Result<PathSegments, FsError> {
+        let link: PathSegments = segments[..=i].iter().cloned().collect();
+        let (target, _) = self
+            .volume()
+            .read_link(&link)
+            .ok_or(FsError::EntryNotFound)?;
+
+        // webc paths are always '/'-rooted, so check the string directly rather
+        // than Path::is_absolute() (which is host-platform dependent).
+        let mut combined = String::new();
+        if target.starts_with('/') {
+            combined.push_str(&target);
+        } else {
+            // Resolve relative to the link's parent, segments[..i].
+            for segment in &segments[..i] {
+                combined.push('/');
+                combined.push_str(segment.as_str());
+            }
+            combined.push('/');
+            combined.push_str(&target);
+        }
+        for segment in &segments[i + 1..] {
+            combined.push('/');
+            combined.push_str(segment.as_str());
+        }
+
+        normalize(Path::new(&combined)).map_err(|_| FsError::InvalidInput)
     }
 
     /// Get a filesystem where all [`Volume`]s in a [`Container`] are mounted to
@@ -64,22 +160,27 @@ impl FileSystem for WebcVolumeFileSystem {
     }
 
     fn read_dir(&self, path: &Path) -> Result<crate::ReadDir, FsError> {
-        let meta = self.metadata(path)?;
+        // opendir follows symlinks, including a symlinked directory.
+        let (resolved, meta) = self.resolve_symlinks(path)?;
+        let meta = meta.map(compat_meta).ok_or(FsError::EntryNotFound)?;
 
         if !meta.is_dir() {
             return Err(FsError::BaseNotDirectory);
         }
 
-        let path = normalize(path).map_err(|_| FsError::InvalidInput)?;
+        // List the resolved directory, but keep the caller's path as the entry
+        // prefix (like `std::fs::read_dir`).
+        let display_path = normalize(path).map_err(|_| FsError::InvalidInput)?;
+        let resolved = normalize(resolved.as_path()).map_err(|_| FsError::InvalidInput)?;
 
         let mut entries = Vec::new();
 
         for (name, _, meta) in self
             .volume()
-            .read_dir(&path)
+            .read_dir(&resolved)
             .ok_or(FsError::EntryNotFound)?
         {
-            let path = PathBuf::from(path.join(name).to_string());
+            let path = PathBuf::from(display_path.join(name).to_string());
             entries.push(DirEntry {
                 path,
                 metadata: Ok(compat_meta(meta)),
@@ -90,15 +191,18 @@ impl FileSystem for WebcVolumeFileSystem {
     }
 
     fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+        // These entry-existence checks operate on the path itself, not a symlink
+        // target, so they use lstat (symlink_metadata) semantics.
+
         // the directory shouldn't exist yet
-        if self.metadata(path).is_ok() {
+        if self.symlink_metadata(path).is_ok() {
             return Err(FsError::AlreadyExists);
         }
 
         // it's parent should exist
         let parent = path.parent().unwrap_or_else(|| Path::new("/"));
 
-        match self.metadata(parent) {
+        match self.symlink_metadata(parent) {
             Ok(parent_meta) if parent_meta.is_dir() => {
                 // The operation would normally be doable... but we're a readonly
                 // filesystem
@@ -110,8 +214,9 @@ impl FileSystem for WebcVolumeFileSystem {
     }
 
     fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
-        // The original directory should exist
-        let meta = self.metadata(path)?;
+        // The original directory should exist. rmdir operates on the entry
+        // itself (a symlink is not a directory), so use lstat semantics.
+        let meta = self.symlink_metadata(path)?;
 
         // and it should be a directory
         if !meta.is_dir() {
@@ -124,12 +229,15 @@ impl FileSystem for WebcVolumeFileSystem {
 
     fn rename<'a>(&'a self, from: &'a Path, to: &'a Path) -> BoxFuture<'a, Result<(), FsError>> {
         Box::pin(async {
+            // rename operates on the named entries themselves, so use lstat
+            // semantics rather than following a trailing symlink.
+
             // The original file should exist
-            let _ = self.metadata(from)?;
+            let _ = self.symlink_metadata(from)?;
 
             // we also want to make sure the destination's folder exists, too
             let dest_parent = to.parent().unwrap_or_else(|| Path::new("/"));
-            let parent_meta = self.metadata(dest_parent)?;
+            let parent_meta = self.symlink_metadata(dest_parent)?;
             if !parent_meta.is_dir() {
                 return Err(FsError::BaseNotDirectory);
             }
@@ -140,6 +248,14 @@ impl FileSystem for WebcVolumeFileSystem {
     }
 
     fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+        // `stat` semantics: follow symlinks and report the target.
+        let (_, meta) = self.resolve_symlinks(path)?;
+        meta.map(compat_meta).ok_or(FsError::EntryNotFound)
+    }
+
+    fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
+        // `lstat` semantics: report the entry itself, without following a
+        // trailing symlink.
         let path = normalize(path).map_err(|_| FsError::InvalidInput)?;
 
         self.volume()
@@ -148,12 +264,10 @@ impl FileSystem for WebcVolumeFileSystem {
             .ok_or(FsError::EntryNotFound)
     }
 
-    fn symlink_metadata(&self, path: &Path) -> crate::Result<Metadata> {
-        self.metadata(path)
-    }
-
     fn remove_file(&self, path: &Path) -> Result<(), FsError> {
-        let meta = self.metadata(path)?;
+        // unlink removes the entry itself; it does not follow a trailing
+        // symlink, so use lstat semantics.
+        let meta = self.symlink_metadata(path)?;
 
         if !meta.is_file() {
             return Err(FsError::NotAFile);
@@ -173,6 +287,10 @@ impl FileOpener for WebcVolumeFileSystem {
         path: &Path,
         conf: &OpenOptionsConfig,
     ) -> crate::Result<Box<dyn crate::VirtualFile + Send + Sync + 'static>> {
+        // Follow symlinks so opening (and exec'ing) a symlinked file resolves to
+        // its target, matching a real filesystem.
+        let (resolved, resolved_meta) = self.resolve_symlinks(path)?;
+        let path = resolved.as_path();
         if let Some(parent) = path.parent() {
             let parent_meta = self.metadata(parent)?;
             if !parent_meta.is_dir() {
@@ -180,7 +298,7 @@ impl FileOpener for WebcVolumeFileSystem {
             }
         }
 
-        let timestamps = match self.volume().metadata(path) {
+        let timestamps = match resolved_meta {
             Some(m) if m.is_file() => m.timestamps(),
             Some(_) => return Err(FsError::NotAFile),
             None if conf.create() || conf.create_new() => {
@@ -484,9 +602,11 @@ mod tests {
             fs.readlink("/link".as_ref()).unwrap(),
             Path::new("target.txt")
         );
-        assert_eq!(
-            fs.new_open_options().read(true).open("/link").unwrap_err(),
-            FsError::NotAFile,
+        // open() follows the symlink to its target (unlike symlink_metadata),
+        // so opening the link succeeds and yields the target file.
+        assert!(
+            fs.new_open_options().read(true).open("/link").is_ok(),
+            "open() should follow the symlink to its target file",
         );
 
         let entries: Vec<_> = fs
@@ -508,6 +628,197 @@ mod tests {
             fs.readlink("/missing".as_ref()).unwrap_err(),
             FsError::EntryNotFound
         );
+    }
+
+    /// A volume exercising the various symlink shapes `resolve_symlinks` handles:
+    /// relative, multi-hop, absolute, `..`-relative, a symlinked intermediate
+    /// directory, and a loop.
+    ///
+    /// ```text
+    /// /a.txt                       "content-a"
+    /// /rel    -> a.txt             (relative, single hop)
+    /// /hop1   -> hop2 -> a.txt     (relative, two hops)
+    /// /loop1  -> loop2 -> loop1    (cycle)
+    /// /bin/real.wasm               "\0asm-real"
+    /// /libexec/git-core/git -> ../../bin/real.wasm
+    /// /bindir -> bin              (symlinked directory)
+    /// ```
+    fn follow_symlinks_fs() -> WebcVolumeFileSystem {
+        use webc::v3::write::{DirEntry, Directory, FileEntry, SymlinkEntry};
+
+        let ts = webc::v3::Timestamps::default();
+        let file = |bytes: &'static [u8]| DirEntry::File(FileEntry::borrowed(bytes, ts));
+        let link = |target: &'static str| DirEntry::Symlink(SymlinkEntry::borrowed(target, ts));
+        let seg = |s: &str| PathSegment::parse(s).unwrap();
+
+        let git_core = Directory::new(
+            BTreeMap::from_iter([(seg("git"), link("../../bin/real.wasm"))]),
+            ts,
+        );
+        let libexec = Directory::new(
+            BTreeMap::from_iter([(seg("git-core"), DirEntry::Dir(git_core))]),
+            ts,
+        );
+        let bin = Directory::new(
+            BTreeMap::from_iter([(seg("real.wasm"), file(b"\0asm-real"))]),
+            ts,
+        );
+        let root = Directory::new(
+            BTreeMap::from_iter([
+                (seg("a.txt"), file(b"content-a")),
+                (seg("rel"), link("a.txt")),
+                (seg("hop1"), link("hop2")),
+                (seg("hop2"), link("a.txt")),
+                (seg("loop1"), link("loop2")),
+                (seg("loop2"), link("loop1")),
+                (seg("bin"), DirEntry::Dir(bin)),
+                (seg("libexec"), DirEntry::Dir(libexec)),
+                (seg("bindir"), link("bin")),
+            ]),
+            ts,
+        );
+
+        let manifest = webc::metadata::Manifest::default();
+        let mut writer = webc::v3::write::Writer::new(webc::v3::ChecksumAlgorithm::Sha256)
+            .write_manifest(&manifest)
+            .unwrap()
+            .write_atoms(BTreeMap::new())
+            .unwrap();
+        writer.write_volume("atom", root).unwrap();
+        let webc = writer.finish(webc::v3::SignatureAlgorithm::None).unwrap();
+        let container = from_bytes(webc).unwrap();
+        let volume = container.volumes()["atom"].clone();
+
+        WebcVolumeFileSystem::new(volume)
+    }
+
+    #[tokio::test]
+    async fn open_follows_symlinks() {
+        let fs = follow_symlinks_fs();
+
+        async fn read(fs: &WebcVolumeFileSystem, path: &str) -> Vec<u8> {
+            let mut f = fs
+                .new_open_options()
+                .read(true)
+                .open(path)
+                .unwrap_or_else(|e| panic!("opening {path}: {e:?}"));
+            let mut buffer = Vec::new();
+            f.read_to_end(&mut buffer).await.unwrap();
+            buffer
+        }
+
+        // Relative single-hop and multi-hop chains resolve to the same file.
+        assert_eq!(read(&fs, "/rel").await, b"content-a");
+        assert_eq!(read(&fs, "/hop1").await, b"content-a");
+        // The motivating case: a `..`-relative link deep in the tree.
+        assert_eq!(read(&fs, "/libexec/git-core/git").await, b"\0asm-real");
+        // A symlink in an intermediate directory component is followed too.
+        assert_eq!(read(&fs, "/bindir/real.wasm").await, b"\0asm-real");
+    }
+
+    #[test]
+    fn open_symlink_loop_fails() {
+        let fs = follow_symlinks_fs();
+
+        assert_eq!(
+            fs.new_open_options().read(true).open("/loop1").unwrap_err(),
+            FsError::InvalidInput,
+        );
+    }
+
+    #[test]
+    fn open_symlink_chain_respects_max_depth() {
+        use webc::v3::write::{DirEntry, Directory, FileEntry, SymlinkEntry};
+
+        // A volume with `link0 -> link1 -> ... -> link{n-1} -> target.txt`, i.e.
+        // `n` symlinks to follow before reaching the file.
+        fn chain_fs(n: usize) -> WebcVolumeFileSystem {
+            let ts = webc::v3::Timestamps::default();
+            let seg = |s: &str| PathSegment::parse(s).unwrap();
+
+            let mut children = BTreeMap::new();
+            children.insert(
+                seg("target.txt"),
+                DirEntry::File(FileEntry::borrowed(b"target", ts)),
+            );
+            for i in 0..n {
+                let target = if i + 1 == n {
+                    "target.txt".to_string()
+                } else {
+                    format!("link{}", i + 1)
+                };
+                children.insert(
+                    seg(&format!("link{i}")),
+                    DirEntry::Symlink(SymlinkEntry::owned(target, ts)),
+                );
+            }
+
+            let manifest = webc::metadata::Manifest::default();
+            let mut writer = webc::v3::write::Writer::new(webc::v3::ChecksumAlgorithm::Sha256)
+                .write_manifest(&manifest)
+                .unwrap()
+                .write_atoms(BTreeMap::new())
+                .unwrap();
+            writer
+                .write_volume("atom", Directory::new(children, ts))
+                .unwrap();
+            let webc = writer.finish(webc::v3::SignatureAlgorithm::None).unwrap();
+            let container = from_bytes(webc).unwrap();
+            WebcVolumeFileSystem::new(container.volumes()["atom"].clone())
+        }
+
+        // A chain of MAX_SYMLINK_DEPTH (40) links resolves (matches Linux
+        // MAXSYMLINKS)...
+        assert!(
+            chain_fs(40)
+                .new_open_options()
+                .read(true)
+                .open("/link0")
+                .is_ok(),
+            "a 40-link chain should resolve",
+        );
+
+        // ...but one more link is too many.
+        assert_eq!(
+            chain_fs(41)
+                .new_open_options()
+                .read(true)
+                .open("/link0")
+                .unwrap_err(),
+            FsError::InvalidInput,
+        );
+    }
+
+    #[test]
+    fn metadata_follows_symlinks() {
+        let fs = symlink_fs();
+
+        // metadata() follows the link to its target file (stat semantics)...
+        let target = fs.metadata("/link".as_ref()).unwrap();
+        assert!(target.is_file());
+        assert_eq!(target.len(), "target".len() as u64);
+
+        // ...while symlink_metadata() reports the link itself (lstat semantics).
+        let link = fs.symlink_metadata("/link".as_ref()).unwrap();
+        assert!(link.ft.is_symlink());
+        assert_eq!(link.len(), "target.txt".len() as u64);
+    }
+
+    #[test]
+    fn read_dir_follows_symlinked_directory() {
+        let fs = follow_symlinks_fs();
+
+        // /bindir -> bin, so stat sees a directory...
+        assert!(fs.metadata("/bindir".as_ref()).unwrap().is_dir());
+
+        // ...and read_dir() lists the target's contents, keeping the caller's
+        // path as the prefix.
+        let entries: Vec<_> = fs
+            .read_dir("/bindir".as_ref())
+            .unwrap()
+            .map(|entry| entry.unwrap().path)
+            .collect();
+        assert_eq!(entries, vec![PathBuf::from("/bindir/real.wasm")]);
     }
 
     #[test]


### PR DESCRIPTION
Makes various functions in `virtual-fs` fully resolve symlinks.
The general semantics should match those of Linux/POSIX.

Motivating case is packaging of git; git is a bundle of way too many symlinks, and `exec`-ing any of those requires symlink resolution.