### PR TITLE
feat: add CLI support for offline dependency resolution

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -38,7 +38,8 @@ use wasmer_wasix::{
         module_cache::{FileSystemCache, ModuleCache},
         package_loader::{BuiltinPackageLoader, PackageLoader},
         resolver::{
-            BackendSource, FileSystemSource, InMemorySource, MultiSource, Source, WebSource,
+            BackendSource, FileSystemSource, InMemorySource, LocalRegistrySource, MultiSource,
+            Source, WebSource,
         },
         task_manager::{
             VirtualTaskManagerExt,
@@ -106,10 +107,17 @@ pub struct Wasi {
     #[clap(long = "use", name = "USE")]
     pub(crate) uses: Vec<String>,
 
-    /// List of webc packages that are explicitly included for execution
-    /// Note: these packages will be used instead of those in the registry
+    /// Webc packages to use instead of the registry ones: either a `*.webc`
+    /// file, or a directory laid out `<namespace>/<name>/<version>.webc` and
+    /// queried on demand like a registry. Resolves named dependencies from
+    /// local files, offline.
     #[clap(long = "include-webc", name = "WEBC")]
     pub(super) include_webcs: Vec<PathBuf>,
+
+    /// Resolve only from local sources (`--include-webc`, filesystem paths), never
+    /// the registry. Needed offline, where a registry query would fail resolution.
+    #[clap(long = "offline")]
+    pub(super) offline: bool,
 
     /// List of injected atoms
     #[clap(long = "map-command", name = "MAPCMD")]
@@ -709,32 +717,42 @@ impl Wasi {
     ) -> Result<MultiSource> {
         let mut source = MultiSource::default();
 
-        // Note: This should be first so our "preloaded" sources get a chance to
-        // override the main registry.
+        // Local packages go first so they override the registry. A directory
+        // is served on demand as a local registry; a single file is loaded
+        // eagerly under its manifest id.
         let mut preloaded = InMemorySource::new();
         for path in &self.include_webcs {
-            preloaded
-                .add_webc(path)
-                .with_context(|| format!("Unable to load \"{}\"", path.display()))?;
+            if path.is_dir() {
+                source.add_source(LocalRegistrySource::new(path)?);
+            } else {
+                preloaded
+                    .add_webc(path)
+                    .with_context(|| format!("Unable to load \"{}\"", path.display()))?;
+            }
         }
         source.add_source(preloaded);
 
-        let graphql_endpoint = self.graphql_endpoint(env)?;
-        let cache_dir = registry_query_cache_dir(env.cache_dir(), &graphql_endpoint);
-        let mut wapm_source = BackendSource::new(graphql_endpoint, Arc::clone(&client))
-            .with_local_cache(cache_dir, WAPM_SOURCE_CACHE_TIMEOUT)
-            .with_preferred_webc_version(preferred_webc_version);
-        if let Some(token) = env
-            .config()?
-            .registry
-            .get_login_token_for_registry(wapm_source.registry_endpoint().as_str())
-        {
-            wapm_source = wapm_source.with_auth_token(token);
-        }
-        source.add_source(wapm_source);
+        // Drop the registry/web sources offline. Their network errors bubble out
+        // of the merging MultiSource and abort resolution even when a local
+        // source already matched.
+        if !self.offline {
+            let graphql_endpoint = self.graphql_endpoint(env)?;
+            let cache_dir = registry_query_cache_dir(env.cache_dir(), &graphql_endpoint);
+            let mut wapm_source = BackendSource::new(graphql_endpoint, Arc::clone(&client))
+                .with_local_cache(cache_dir, WAPM_SOURCE_CACHE_TIMEOUT)
+                .with_preferred_webc_version(preferred_webc_version);
+            if let Some(token) = env
+                .config()?
+                .registry
+                .get_login_token_for_registry(wapm_source.registry_endpoint().as_str())
+            {
+                wapm_source = wapm_source.with_auth_token(token);
+            }
+            source.add_source(wapm_source);
 
-        let cache_dir = env.cache_dir().join("downloads");
-        source.add_source(WebSource::new(cache_dir, client));
+            let cache_dir = env.cache_dir().join("downloads");
+            source.add_source(WebSource::new(cache_dir, client));
+        }
 
         source.add_source(FileSystemSource::default());
 

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -107,10 +107,11 @@ pub struct Wasi {
     #[clap(long = "use", name = "USE")]
     pub(crate) uses: Vec<String>,
 
-    /// Webc packages to use instead of the registry ones: either a `*.webc`
-    /// file, or a directory laid out `<namespace>/<name>/<version>.webc` and
-    /// queried on demand like a registry. Resolves named dependencies from
-    /// local files, offline.
+    /// Webc packages that are explicitly included for execution, taking
+    /// precedence over the registry ones: either a `*.webc` file, or a
+    /// directory laid out `<namespace>/<name>/<version>.webc` and queried on
+    /// demand like a registry. Resolves named dependencies from local files,
+    /// offline.
     #[clap(long = "include-webc", name = "WEBC")]
     pub(super) include_webcs: Vec<PathBuf>,
 

--- a/lib/wasix/src/runtime/resolver/local_registry_source.rs
+++ b/lib/wasix/src/runtime/resolver/local_registry_source.rs
@@ -277,6 +277,16 @@ mod tests {
         PackageId::Named(NamedPackageId::try_new(id, version).unwrap())
     }
 
+    /// Run [`Source::query`] synchronously via block_on.
+    /// The implementation does no async work currently,
+    /// the only reason it's async is due to the trait forcing it.
+    fn query(
+        source: &LocalRegistrySource,
+        package: &PackageSource,
+    ) -> Result<Vec<PackageSummary>, QueryError> {
+        futures::executor::block_on(source.query(package))
+    }
+
     #[test]
     fn new_rejects_a_missing_directory() {
         let temp = TempDir::new().unwrap();
@@ -284,14 +294,14 @@ mod tests {
         assert!(LocalRegistrySource::new(temp.path()).is_ok());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn named_query_ids_come_from_the_layout() {
+    #[test]
+    fn named_query_ids_come_from_the_layout() {
         // COREUTILS_16's manifest is "sharrattj/coreutils@1.0.16"; the layout
         // must win, proving resolution keys off the path, not the artifact.
         let temp = registry(&[("acme/cutils/9.9.9.webc", COREUTILS_16)]);
         let source = LocalRegistrySource::new(temp.path()).unwrap();
 
-        let summaries = source.query(&"acme/cutils".parse().unwrap()).await.unwrap();
+        let summaries = query(&source, &"acme/cutils".parse().unwrap()).unwrap();
 
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].pkg.id, named("acme/cutils", "9.9.9"));
@@ -299,8 +309,8 @@ mod tests {
         assert!(!summaries[0].pkg.commands.is_empty());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn only_matching_versions_are_opened() {
+    #[test]
+    fn only_matching_versions_are_opened() {
         // 0.1.0 is garbage; a constraint that rules it out never reads it.
         let temp = registry(&[
             ("acme/cutils/0.1.0.webc", b"not a webc".as_slice()),
@@ -308,31 +318,25 @@ mod tests {
         ]);
         let source = LocalRegistrySource::new(temp.path()).unwrap();
 
-        let summaries = source
-            .query(&"acme/cutils@9.9.9".parse().unwrap())
-            .await
-            .unwrap();
+        let summaries = query(&source, &"acme/cutils@9.9.9".parse().unwrap()).unwrap();
         assert_eq!(summaries[0].pkg.id, named("acme/cutils", "9.9.9"));
 
         // ...while a constraint that pulls it in surfaces the corruption.
         assert!(matches!(
-            source.query(&"acme/cutils".parse().unwrap()).await,
+            query(&source, &"acme/cutils".parse().unwrap()),
             Err(QueryError::Other { .. })
         ));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn version_constraints_filter_the_listing() {
+    #[test]
+    fn version_constraints_filter_the_listing() {
         let temp = registry(&[
             ("sharrattj/coreutils/1.0.11.webc", COREUTILS_11),
             ("sharrattj/coreutils/1.0.16.webc", COREUTILS_16),
         ]);
         let source = LocalRegistrySource::new(temp.path()).unwrap();
 
-        let all = source
-            .query(&"sharrattj/coreutils".parse().unwrap())
-            .await
-            .unwrap();
+        let all = query(&source, &"sharrattj/coreutils".parse().unwrap()).unwrap();
         assert_eq!(
             all.iter().map(|s| s.pkg.id.clone()).collect::<Vec<_>>(),
             [
@@ -341,69 +345,62 @@ mod tests {
             ]
         );
 
-        let pinned = source
-            .query(&"sharrattj/coreutils@^1.0.16".parse().unwrap())
-            .await
-            .unwrap();
+        let pinned = query(&source, &"sharrattj/coreutils@^1.0.16".parse().unwrap()).unwrap();
         assert_eq!(pinned.len(), 1);
         assert_eq!(pinned[0].pkg.id, named("sharrattj/coreutils", "1.0.16"));
 
         assert!(matches!(
-            source.query(&"sharrattj/unknown".parse().unwrap()).await,
+            query(&source, &"sharrattj/unknown".parse().unwrap()),
             Err(QueryError::NotFound { .. })
         ));
         assert!(matches!(
-            source
-                .query(&"sharrattj/coreutils@^2".parse().unwrap())
-                .await,
+            query(&source, &"sharrattj/coreutils@^2".parse().unwrap()),
             Err(QueryError::NoMatches { .. })
         ));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn unnamespaced_packages_sit_one_level_up() {
+    #[test]
+    fn unnamespaced_packages_sit_one_level_up() {
         let temp = registry(&[("cutils/1.0.0.webc", COREUTILS_16)]);
         let source = LocalRegistrySource::new(temp.path()).unwrap();
 
-        let summaries = source.query(&"cutils".parse().unwrap()).await.unwrap();
+        let summaries = query(&source, &"cutils".parse().unwrap()).unwrap();
 
         assert_eq!(summaries[0].pkg.id, named("cutils", "1.0.0"));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn sha256_sidecar_is_verified() {
+    #[test]
+    fn sha256_sidecar_is_verified() {
         let temp = registry(&[("acme/cutils/9.9.9.webc", COREUTILS_16)]);
         let sidecar = temp.path().join("acme/cutils/9.9.9.sha256");
         let source = LocalRegistrySource::new(temp.path()).unwrap();
-        let query: PackageSource = "acme/cutils".parse().unwrap();
+        let pkg: PackageSource = "acme/cutils".parse().unwrap();
 
         std::fs::write(&sidecar, WebcHash::sha256(COREUTILS_16).as_hex()).unwrap();
-        assert!(source.query(&query).await.is_ok());
+        assert!(query(&source, &pkg).is_ok());
 
         std::fs::write(&sidecar, "deadbeef").unwrap();
         assert!(matches!(
-            source.query(&query).await,
+            query(&source, &pkg),
             Err(QueryError::Other { .. })
         ));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn hash_queries_walk_the_tree() {
+    #[test]
+    fn hash_queries_walk_the_tree() {
         let temp = registry(&[
             ("acme/cutils/9.9.9.webc", COREUTILS_16),
             ("other/pkg/1.0.0.webc", COREUTILS_11),
         ]);
         let source = LocalRegistrySource::new(temp.path()).unwrap();
         let hash = |bytes| PackageHash::from_sha256_bytes(WebcHash::sha256(bytes).as_bytes());
-        let query = |hash| PackageSource::Ident(PackageIdent::Hash(hash));
+        let by_hash = |hash| PackageSource::Ident(PackageIdent::Hash(hash));
 
-        let summaries = source.query(&query(hash(COREUTILS_16))).await.unwrap();
+        let summaries = query(&source, &by_hash(hash(COREUTILS_16))).unwrap();
         assert_eq!(summaries[0].pkg.id, named("acme/cutils", "9.9.9"));
 
         assert!(matches!(
-            source
-                .query(&query(PackageHash::from_sha256_bytes([0; 32])))
-                .await,
+            query(&source, &by_hash(PackageHash::from_sha256_bytes([0; 32]))),
             Err(QueryError::NotFound { .. })
         ));
     }

--- a/lib/wasix/src/runtime/resolver/local_registry_source.rs
+++ b/lib/wasix/src/runtime/resolver/local_registry_source.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Error};
+use itertools::Itertools;
 use semver::Version;
 use wasmer_config::package::{
     NamedPackageId, NamedPackageIdent, PackageHash, PackageId, PackageIdent, PackageSource,
@@ -40,22 +41,26 @@ impl LocalRegistrySource {
         query: &PackageSource,
     ) -> Result<Vec<PackageSummary>, QueryError> {
         let full_name = named.full_name();
-        let dir = match package_dir(&self.root, &full_name) {
-            // Either the name can't exist in this layout or nothing is
-            // published under it.
-            Some(dir) if dir.is_dir() => dir,
-            _ => {
-                return Err(QueryError::NotFound {
-                    query: query.clone(),
-                });
-            }
+        // A name that doesn't map into the layout can't be published in it.
+        let Some(dir) = package_dir_path(&self.root, &full_name) else {
+            return Err(QueryError::NotFound {
+                query: query.clone(),
+            });
         };
+        // No directory on disk means no published versions.
+        if !dir.is_dir() {
+            return Err(QueryError::NotFound {
+                query: query.clone(),
+            });
+        }
 
         let constraint = named.version_or_default();
-        let mut matches =
-            published_versions(&dir).map_err(|error| QueryError::new_other(error, query))?;
-        matches.retain(|(version, _)| constraint.matches(version));
-        matches.sort_by(|(left, _), (right, _)| left.cmp(right));
+        let matches: Vec<_> = published_versions(&dir)
+            .map_err(|error| QueryError::new_other(error, query))?
+            .into_iter()
+            .filter(|(version, _)| constraint.matches(version))
+            .sorted_by(|(left, _), (right, _)| left.cmp(right))
+            .collect();
 
         if matches.is_empty() {
             return Err(QueryError::NoMatches {
@@ -95,45 +100,50 @@ impl LocalRegistrySource {
     }
 
     /// Walk the tree for a webc with this hash, stopping at the first match.
-    /// This is the one query shape the layout can't index; a `.sha256` sidecar
-    /// rules a file in or out without opening it, anything else must be hashed.
+    /// This is the one query shape the layout can't index. The `.sha256`
+    /// sidecars rule files in or out without opening them, so they are all
+    /// consulted first; only if none matched are the sidecar-less webcs
+    /// hashed.
     fn find_by_hash(&self, hash: &PackageHash) -> Result<Option<PackageSummary>, Error> {
         let Some(expected) = hash.as_sha256().map(|digest| digest.to_string()) else {
             return Ok(None);
         };
 
-        let mut stack = vec![self.root.clone()];
-        while let Some(current) = stack.pop() {
-            if current.is_dir() {
-                for entry in std::fs::read_dir(&current)
-                    .with_context(|| format!("Unable to read \"{}\"", current.display()))?
-                {
-                    stack.push(entry?.path());
-                }
-                continue;
-            }
-            if current.extension().and_then(|e| e.to_str()) != Some("webc") {
-                continue;
-            }
-            let matches = match read_sha256_sibling(&current) {
-                Some(claimed) => claimed
-                    .strip_prefix("sha256:")
-                    .unwrap_or(&claimed)
-                    .eq_ignore_ascii_case(&expected),
-                None => WebcHash::for_file(&current)
-                    .with_context(|| format!("Unable to hash \"{}\"", current.display()))?
-                    .as_hex()
-                    .eq_ignore_ascii_case(&expected),
-            };
-            if !matches {
-                continue;
-            }
-
-            let id = id_from_path(&self.root, &current).map(PackageId::Named);
-            let summary = load_summary(&current, id)?;
+        let load_match = |webc: &Path| -> Result<PackageSummary, Error> {
+            let id = id_from_path(&self.root, webc).map(PackageId::Named);
+            let summary = load_summary(webc, id)?;
             // A sidecar may match the query and still misdescribe the file.
-            verify_sha256(&current, &summary.dist.webc_sha256, &expected)?;
-            return Ok(Some(summary));
+            verify_sha256(webc, &summary.dist.webc_sha256, &expected)?;
+            Ok(summary)
+        };
+
+        let mut unclaimed = Vec::new();
+        for entry in walkdir::WalkDir::new(&self.root).follow_links(true) {
+            let entry = entry.context("Unable to walk the package directory")?;
+            let path = entry.path();
+            if !entry.file_type().is_file()
+                || path.extension().and_then(|e| e.to_str()) != Some("webc")
+            {
+                continue;
+            }
+            match read_sha256_sibling(path) {
+                Some(claimed) => {
+                    let claimed = claimed.strip_prefix("sha256:").unwrap_or(&claimed);
+                    if claimed.eq_ignore_ascii_case(&expected) {
+                        return load_match(path).map(Some);
+                    }
+                }
+                None => unclaimed.push(path.to_path_buf()),
+            }
+        }
+
+        // No sidecar matched; hash the webcs that don't have one.
+        for path in unclaimed {
+            let actual = WebcHash::for_file(&path)
+                .with_context(|| format!("Unable to hash \"{}\"", path.display()))?;
+            if actual.as_hex().eq_ignore_ascii_case(&expected) {
+                return load_match(&path).map(Some);
+            }
         }
 
         Ok(None)
@@ -158,11 +168,12 @@ impl Source for LocalRegistrySource {
     }
 }
 
-/// The directory holding a package's published versions: the full name's
-/// components (namespace, then name) become path components under `root`.
+/// Where the layout would keep a package's published versions: the full
+/// name's components (namespace, then name) become path components under
+/// `root`. Only builds the path — existence is the caller's question.
 /// `None` for names the layout can't hold (empty or path-like components),
 /// rather than letting them escape the root.
-fn package_dir(root: &Path, full_name: &str) -> Option<PathBuf> {
+fn package_dir_path(root: &Path, full_name: &str) -> Option<PathBuf> {
     let mut dir = root.to_path_buf();
     for part in full_name.split('/') {
         if part.is_empty() || part == "." || part == ".." || part.contains(std::path::is_separator)
@@ -199,7 +210,7 @@ fn published_versions(dir: &Path) -> Result<Vec<(Version, PathBuf)>, Error> {
 /// The package id encoded by a webc's location under `root`
 /// (`<namespace>/<name>/<version>.webc` or `<name>/<version>.webc`), if it
 /// fits the layout. Used where a walk finds a file and its id must be derived
-/// backwards; named lookups go the other way via [`package_dir`].
+/// backwards; named lookups go the other way via [`package_dir_path`].
 fn id_from_path(root: &Path, webc: &Path) -> Option<NamedPackageId> {
     let rel = webc.strip_prefix(root).ok()?;
     let parts = rel.iter().map(|p| p.to_str()).collect::<Option<Vec<_>>>()?;
@@ -427,11 +438,14 @@ mod tests {
         let root = Path::new("/pkgs");
 
         assert_eq!(
-            package_dir(root, "ns/name"),
+            package_dir_path(root, "ns/name"),
             Some(PathBuf::from("/pkgs/ns/name"))
         );
-        assert_eq!(package_dir(root, "name"), Some(PathBuf::from("/pkgs/name")));
-        assert_eq!(package_dir(root, "ns/.."), None);
-        assert_eq!(package_dir(root, ""), None);
+        assert_eq!(
+            package_dir_path(root, "name"),
+            Some(PathBuf::from("/pkgs/name"))
+        );
+        assert_eq!(package_dir_path(root, "ns/.."), None);
+        assert_eq!(package_dir_path(root, ""), None);
     }
 }

--- a/lib/wasix/src/runtime/resolver/local_registry_source.rs
+++ b/lib/wasix/src/runtime/resolver/local_registry_source.rs
@@ -1,0 +1,440 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Error};
+use semver::Version;
+use wasmer_config::package::{
+    NamedPackageId, NamedPackageIdent, PackageHash, PackageId, PackageIdent, PackageSource,
+};
+
+use crate::runtime::resolver::{PackageSummary, QueryError, Source, WebcHash};
+
+/// A [`Source`] backed by a directory tree laid out like a registry:
+/// `<root>/<namespace>/<name>/<version>.webc`, or `<root>/<name>/<version>.webc`
+/// for un-namespaced packages.
+///
+/// Queries are answered from the layout alone: a named query lists the queried
+/// package's directory and picks versions off the file names, so only the webcs
+/// that match the version constraint are ever opened. A large tree costs no
+/// more than the packages actually resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalRegistrySource {
+    root: PathBuf,
+}
+
+impl LocalRegistrySource {
+    pub fn new(root: impl Into<PathBuf>) -> Result<Self, Error> {
+        let root = root.into();
+        // Fail fast if the directory doesn't exist rather than
+        // leaving all packages to resolve to 'not found'
+        anyhow::ensure!(
+            root.is_dir(),
+            "package directory does not exist: \"{}\"",
+            root.display()
+        );
+        Ok(LocalRegistrySource { root })
+    }
+
+    fn query_named(
+        &self,
+        named: &NamedPackageIdent,
+        query: &PackageSource,
+    ) -> Result<Vec<PackageSummary>, QueryError> {
+        let full_name = named.full_name();
+        let dir = match package_dir(&self.root, &full_name) {
+            // Either the name can't exist in this layout or nothing is
+            // published under it.
+            Some(dir) if dir.is_dir() => dir,
+            _ => {
+                return Err(QueryError::NotFound {
+                    query: query.clone(),
+                });
+            }
+        };
+
+        let constraint = named.version_or_default();
+        let mut matches =
+            published_versions(&dir).map_err(|error| QueryError::new_other(error, query))?;
+        matches.retain(|(version, _)| constraint.matches(version));
+        matches.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        if matches.is_empty() {
+            return Err(QueryError::NoMatches {
+                query: query.clone(),
+                archived_versions: Vec::new(),
+            });
+        }
+
+        // Only now is any webc opened, and only the matching ones.
+        matches
+            .into_iter()
+            .map(|(version, path)| {
+                let id = NamedPackageId {
+                    full_name: full_name.clone(),
+                    version,
+                };
+                load_summary(&path, Some(PackageId::Named(id)))
+            })
+            .collect::<Result<Vec<_>, Error>>()
+            .map_err(|error| QueryError::new_other(error, query))
+    }
+
+    fn query_hash(
+        &self,
+        hash: &PackageHash,
+        query: &PackageSource,
+    ) -> Result<Vec<PackageSummary>, QueryError> {
+        match self
+            .find_by_hash(hash)
+            .map_err(|error| QueryError::new_other(error, query))?
+        {
+            Some(summary) => Ok(vec![summary]),
+            None => Err(QueryError::NotFound {
+                query: query.clone(),
+            }),
+        }
+    }
+
+    /// Walk the tree for a webc with this hash, stopping at the first match.
+    /// This is the one query shape the layout can't index; a `.sha256` sidecar
+    /// rules a file in or out without opening it, anything else must be hashed.
+    fn find_by_hash(&self, hash: &PackageHash) -> Result<Option<PackageSummary>, Error> {
+        let Some(expected) = hash.as_sha256().map(|digest| digest.to_string()) else {
+            return Ok(None);
+        };
+
+        let mut stack = vec![self.root.clone()];
+        while let Some(current) = stack.pop() {
+            if current.is_dir() {
+                for entry in std::fs::read_dir(&current)
+                    .with_context(|| format!("Unable to read \"{}\"", current.display()))?
+                {
+                    stack.push(entry?.path());
+                }
+                continue;
+            }
+            if current.extension().and_then(|e| e.to_str()) != Some("webc") {
+                continue;
+            }
+            let matches = match read_sha256_sibling(&current) {
+                Some(claimed) => claimed
+                    .strip_prefix("sha256:")
+                    .unwrap_or(&claimed)
+                    .eq_ignore_ascii_case(&expected),
+                None => WebcHash::for_file(&current)
+                    .with_context(|| format!("Unable to hash \"{}\"", current.display()))?
+                    .as_hex()
+                    .eq_ignore_ascii_case(&expected),
+            };
+            if !matches {
+                continue;
+            }
+
+            let id = id_from_path(&self.root, &current).map(PackageId::Named);
+            let summary = load_summary(&current, id)?;
+            // A sidecar may match the query and still misdescribe the file.
+            verify_sha256(&current, &summary.dist.webc_sha256, &expected)?;
+            return Ok(Some(summary));
+        }
+
+        Ok(None)
+    }
+}
+
+#[async_trait::async_trait]
+impl Source for LocalRegistrySource {
+    #[tracing::instrument(level = "debug", skip_all, fields(%package))]
+    async fn query(&self, package: &PackageSource) -> Result<Vec<PackageSummary>, QueryError> {
+        match package {
+            PackageSource::Ident(PackageIdent::Named(named)) => {
+                crate::block_in_place(|| self.query_named(named, package))
+            }
+            PackageSource::Ident(PackageIdent::Hash(hash)) => {
+                crate::block_in_place(|| self.query_hash(hash, package))
+            }
+            PackageSource::Url(_) | PackageSource::Path(_) => Err(QueryError::Unsupported {
+                query: package.clone(),
+            }),
+        }
+    }
+}
+
+/// The directory holding a package's published versions: the full name's
+/// components (namespace, then name) become path components under `root`.
+/// `None` for names the layout can't hold (empty or path-like components),
+/// rather than letting them escape the root.
+fn package_dir(root: &Path, full_name: &str) -> Option<PathBuf> {
+    let mut dir = root.to_path_buf();
+    for part in full_name.split('/') {
+        if part.is_empty() || part == "." || part == ".." || part.contains(std::path::is_separator)
+        {
+            return None;
+        }
+        dir.push(part);
+    }
+    Some(dir)
+}
+
+/// The versions published for one package: its directory's `<version>.webc`
+/// files, read from the names alone. No webc is opened.
+fn published_versions(dir: &Path) -> Result<Vec<(Version, PathBuf)>, Error> {
+    let mut versions = Vec::new();
+    for entry in dir
+        .read_dir()
+        .with_context(|| format!("Unable to read \"{}\"", dir.display()))?
+    {
+        let path = entry?.path();
+        let Some(version) = path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .and_then(|f| f.strip_suffix(".webc"))
+            .and_then(|stem| stem.parse().ok())
+        else {
+            continue;
+        };
+        versions.push((version, path));
+    }
+    Ok(versions)
+}
+
+/// The package id encoded by a webc's location under `root`
+/// (`<namespace>/<name>/<version>.webc` or `<name>/<version>.webc`), if it
+/// fits the layout. Used where a walk finds a file and its id must be derived
+/// backwards; named lookups go the other way via [`package_dir`].
+fn id_from_path(root: &Path, webc: &Path) -> Option<NamedPackageId> {
+    let rel = webc.strip_prefix(root).ok()?;
+    let parts = rel.iter().map(|p| p.to_str()).collect::<Option<Vec<_>>>()?;
+    let (full_name, file) = match parts.as_slice() {
+        [namespace, name, file] => (format!("{namespace}/{name}"), *file),
+        [name, file] => (name.to_string(), *file),
+        _ => return None,
+    };
+    let version = file.strip_suffix(".webc")?.parse().ok()?;
+    Some(NamedPackageId { full_name, version })
+}
+
+/// Open one matched webc and build its summary. The layout's id (when given)
+/// wins over the manifest's; a `<stem>.sha256` sibling, if present, must match
+/// the content.
+fn load_summary(webc: &Path, id: Option<PackageId>) -> Result<PackageSummary, Error> {
+    let mut summary = PackageSummary::from_webc_file(webc)
+        .with_context(|| format!("Unable to load \"{}\"", webc.display()))?;
+    if let Some(expected) = read_sha256_sibling(webc) {
+        verify_sha256(webc, &summary.dist.webc_sha256, &expected)?;
+    }
+    if let Some(id) = id {
+        summary.pkg.id = id;
+    }
+    Ok(summary)
+}
+
+/// The trimmed digest of an optional `<stem>.sha256` sibling, if present.
+fn read_sha256_sibling(webc: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(webc.with_extension("sha256")).ok()?;
+    Some(contents.trim().to_string())
+}
+
+/// Error if `actual` doesn't match `expected` (hex, an optional `sha256:`
+/// prefix allowed).
+fn verify_sha256(webc: &Path, actual: &WebcHash, expected: &str) -> Result<(), Error> {
+    let expected = expected.trim();
+    let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+    if !expected.eq_ignore_ascii_case(&actual.as_hex()) {
+        anyhow::bail!(
+            "sha256 mismatch for \"{}\": expected {expected}, file hashes to {}",
+            webc.display(),
+            actual.as_hex(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const COREUTILS_16: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../wasmer-test-files/integration/webc/coreutils-1.0.16-e27dbb4f-2ef2-4b44-b46a-ddd86497c6d7.webc"
+    ));
+    const COREUTILS_11: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../wasmer-test-files/integration/webc/coreutils-1.0.11-9d7746ca-694f-11ed-b932-dead3543c068.webc"
+    ));
+
+    fn registry(files: &[(&str, &[u8])]) -> TempDir {
+        let temp = TempDir::new().unwrap();
+        for (rel, bytes) in files {
+            let path = temp.path().join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, bytes).unwrap();
+        }
+        temp
+    }
+
+    fn named(id: &str, version: &str) -> PackageId {
+        PackageId::Named(NamedPackageId::try_new(id, version).unwrap())
+    }
+
+    #[test]
+    fn new_rejects_a_missing_directory() {
+        let temp = TempDir::new().unwrap();
+        assert!(LocalRegistrySource::new(temp.path().join("nope")).is_err());
+        assert!(LocalRegistrySource::new(temp.path()).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn named_query_ids_come_from_the_layout() {
+        // COREUTILS_16's manifest is "sharrattj/coreutils@1.0.16"; the layout
+        // must win, proving resolution keys off the path, not the artifact.
+        let temp = registry(&[("acme/cutils/9.9.9.webc", COREUTILS_16)]);
+        let source = LocalRegistrySource::new(temp.path()).unwrap();
+
+        let summaries = source.query(&"acme/cutils".parse().unwrap()).await.unwrap();
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].pkg.id, named("acme/cutils", "9.9.9"));
+        // The metadata itself still comes from the webc.
+        assert!(!summaries[0].pkg.commands.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn only_matching_versions_are_opened() {
+        // 0.1.0 is garbage; a constraint that rules it out never reads it.
+        let temp = registry(&[
+            ("acme/cutils/0.1.0.webc", b"not a webc".as_slice()),
+            ("acme/cutils/9.9.9.webc", COREUTILS_16),
+        ]);
+        let source = LocalRegistrySource::new(temp.path()).unwrap();
+
+        let summaries = source
+            .query(&"acme/cutils@9.9.9".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(summaries[0].pkg.id, named("acme/cutils", "9.9.9"));
+
+        // ...while a constraint that pulls it in surfaces the corruption.
+        assert!(matches!(
+            source.query(&"acme/cutils".parse().unwrap()).await,
+            Err(QueryError::Other { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn version_constraints_filter_the_listing() {
+        let temp = registry(&[
+            ("sharrattj/coreutils/1.0.11.webc", COREUTILS_11),
+            ("sharrattj/coreutils/1.0.16.webc", COREUTILS_16),
+        ]);
+        let source = LocalRegistrySource::new(temp.path()).unwrap();
+
+        let all = source
+            .query(&"sharrattj/coreutils".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            all.iter().map(|s| s.pkg.id.clone()).collect::<Vec<_>>(),
+            [
+                named("sharrattj/coreutils", "1.0.11"),
+                named("sharrattj/coreutils", "1.0.16"),
+            ]
+        );
+
+        let pinned = source
+            .query(&"sharrattj/coreutils@^1.0.16".parse().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(pinned.len(), 1);
+        assert_eq!(pinned[0].pkg.id, named("sharrattj/coreutils", "1.0.16"));
+
+        assert!(matches!(
+            source.query(&"sharrattj/unknown".parse().unwrap()).await,
+            Err(QueryError::NotFound { .. })
+        ));
+        assert!(matches!(
+            source
+                .query(&"sharrattj/coreutils@^2".parse().unwrap())
+                .await,
+            Err(QueryError::NoMatches { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unnamespaced_packages_sit_one_level_up() {
+        let temp = registry(&[("cutils/1.0.0.webc", COREUTILS_16)]);
+        let source = LocalRegistrySource::new(temp.path()).unwrap();
+
+        let summaries = source.query(&"cutils".parse().unwrap()).await.unwrap();
+
+        assert_eq!(summaries[0].pkg.id, named("cutils", "1.0.0"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sha256_sidecar_is_verified() {
+        let temp = registry(&[("acme/cutils/9.9.9.webc", COREUTILS_16)]);
+        let sidecar = temp.path().join("acme/cutils/9.9.9.sha256");
+        let source = LocalRegistrySource::new(temp.path()).unwrap();
+        let query: PackageSource = "acme/cutils".parse().unwrap();
+
+        std::fs::write(&sidecar, WebcHash::sha256(COREUTILS_16).as_hex()).unwrap();
+        assert!(source.query(&query).await.is_ok());
+
+        std::fs::write(&sidecar, "deadbeef").unwrap();
+        assert!(matches!(
+            source.query(&query).await,
+            Err(QueryError::Other { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn hash_queries_walk_the_tree() {
+        let temp = registry(&[
+            ("acme/cutils/9.9.9.webc", COREUTILS_16),
+            ("other/pkg/1.0.0.webc", COREUTILS_11),
+        ]);
+        let source = LocalRegistrySource::new(temp.path()).unwrap();
+        let hash = |bytes| PackageHash::from_sha256_bytes(WebcHash::sha256(bytes).as_bytes());
+        let query = |hash| PackageSource::Ident(PackageIdent::Hash(hash));
+
+        let summaries = source.query(&query(hash(COREUTILS_16))).await.unwrap();
+        assert_eq!(summaries[0].pkg.id, named("acme/cutils", "9.9.9"));
+
+        assert!(matches!(
+            source
+                .query(&query(PackageHash::from_sha256_bytes([0; 32])))
+                .await,
+            Err(QueryError::NotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn parse_path_ids() {
+        let root = Path::new("/pkgs");
+        let id = |p: &str| id_from_path(root, &root.join(p)).map(|id| id.to_string());
+
+        assert_eq!(id("ns/name/1.2.3.webc").as_deref(), Some("ns/name@1.2.3"));
+        assert_eq!(id("name/1.2.3.webc").as_deref(), Some("name@1.2.3"));
+        assert_eq!(
+            id("ns/name/1.0.0-rc.1.webc").as_deref(),
+            Some("ns/name@1.0.0-rc.1")
+        );
+        // Doesn't fit the layout -> None, so a walk keeps the manifest id.
+        assert_eq!(id("ns/name/notaversion.webc"), None); // bad semver
+        assert_eq!(id("too/deep/ns/name/1.0.0.webc"), None); // wrong depth
+        assert_eq!(id("flat.webc"), None); // no version directory
+    }
+
+    #[test]
+    fn package_dirs_stay_under_the_root() {
+        let root = Path::new("/pkgs");
+
+        assert_eq!(
+            package_dir(root, "ns/name"),
+            Some(PathBuf::from("/pkgs/ns/name"))
+        );
+        assert_eq!(package_dir(root, "name"), Some(PathBuf::from("/pkgs/name")));
+        assert_eq!(package_dir(root, "ns/.."), None);
+        assert_eq!(package_dir(root, ""), None);
+    }
+}

--- a/lib/wasix/src/runtime/resolver/mod.rs
+++ b/lib/wasix/src/runtime/resolver/mod.rs
@@ -2,6 +2,7 @@ mod backend_source;
 mod filesystem_source;
 mod in_memory_source;
 mod inputs;
+mod local_registry_source;
 mod multi_source;
 mod outputs;
 mod resolve;
@@ -17,6 +18,7 @@ pub use self::{
         Command, Dependency, DistributionInfo, FileSystemMapping, PackageInfo, PackageSummary,
         WebcHash,
     },
+    local_registry_source::LocalRegistrySource,
     multi_source::{MultiSource, MultiSourceStrategy},
     outputs::{
         DependencyGraph, Edge, ItemLocation, Node, Resolution, ResolvedFileSystemMapping,


### PR DESCRIPTION
Supersedes https://github.com/wasmerio/wasmer/pull/6773

This PR 

a) extends `--include-webc` to accept directories, structured as `namespace/name/version.webc` (or just `name/version.webc` for unnamespaced packages). It treats this much like a registry, resolving version constraints from the available versions via listing the respective directories. `.webc`s are only opened when actually needed. The one exception is hash-lookup, which forces traversing the entire tree. For this case, it considers a `.sha256` sibling file, falling back to hashing the `.webc`s (all of them) manually if not found.
b) adds an `--offline` flag that inhibits querying an online registry. Intended to be used in tandem with a) to run things fully hermetically.

This PR does *not* include any functionality to generate the folder structures under a), nor the `.sha256` siblings. Both are currently left to the end-user.