### PR TITLE
fix(c-api-imports): key pending Wasm C API sessions by store

### DIFF
--- a/lib/api/src/entities/store/store_ref.rs
+++ b/lib/api/src/entities/store/store_ref.rs
@@ -4,7 +4,7 @@ use super::{StoreObjects, inner::StoreInner};
 use crate::entities::engine::{AsEngineRef, Engine, EngineRef};
 #[cfg(feature = "experimental-async")]
 use crate::{AsStoreAsync, StoreAsync};
-use wasmer_types::{ExternType, OnCalledAction};
+use wasmer_types::{ExternType, OnCalledAction, StoreId};
 //use wasmer_vm::{StoreObjects, TrapHandlerFn};
 
 #[cfg(feature = "sys")]
@@ -32,6 +32,11 @@ impl<'a> StoreRef<'a> {
         StoreObjects::same(&a.inner.objects, &b.inner.objects)
     }
 
+    /// Returns the ID of this store
+    pub fn id(&self) -> StoreId {
+        self.inner.objects.id()
+    }
+
     /// The signal handler
     #[cfg(feature = "sys")]
     #[inline]
@@ -56,6 +61,11 @@ impl StoreMut<'_> {
     /// equal to another store if both have the same engine.
     pub fn same(a: &Self, b: &Self) -> bool {
         StoreObjects::same(&a.inner.objects, &b.inner.objects)
+    }
+
+    /// Returns the ID of this store
+    pub fn id(&self) -> StoreId {
+        self.inner.objects.id()
     }
 
     #[allow(unused)]

--- a/lib/api/src/lib.rs
+++ b/lib/api/src/lib.rs
@@ -470,8 +470,8 @@ pub use wasmer_types::{
     Bytes, CompileError, DeserializeError, ExportIndex, ExportType, ExternType, FrameInfo,
     FunctionType, GlobalInit, GlobalType, ImportType, LocalFunctionIndex, MemoryError, MemoryStyle,
     MemoryType, ModuleInfo, Mutability, OnCalledAction, Pages, ParseCpuFeatureError,
-    SerializeError, TableStyle, TableType, TagKind, TagType, Type, ValueType, WASM_MAX_PAGES,
-    WASM_MIN_PAGES, WASM_PAGE_SIZE, WasmError, WasmResult, is_wasm,
+    SerializeError, StoreId, TableStyle, TableType, TagKind, TagType, Type, ValueType,
+    WASM_MAX_PAGES, WASM_MIN_PAGES, WASM_PAGE_SIZE, WasmError, WasmResult, is_wasm,
 };
 
 #[cfg(feature = "wasmparser")]

--- a/lib/c-api-imports/src/lib.rs
+++ b/lib/c-api-imports/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 use wasmer_api::{
     Extern, ExternType, Function, Function as WasmerFunction, FunctionEnv, FunctionEnvMut,
     FunctionType, Global, GlobalType, Imports, Instance, Memory, Memory32, MemoryType, Module,
-    Mutability, Pages, RuntimeError, StoreMut, Table, Type, TypedFunction, Value, WasmPtr,
+    Mutability, Pages, RuntimeError, StoreId, StoreMut, Table, Type, TypedFunction, Value, WasmPtr,
     namespace,
 };
 
@@ -261,24 +261,34 @@ impl WasmCapiSession {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct ModuleKey(String);
+struct SessionKey {
+    module_id: String,
+    store_id: StoreId,
+}
 
-impl ModuleKey {
-    fn new(module: &Module) -> Self {
-        Self(module.info().id.id())
+impl SessionKey {
+    fn new(module: &Module, store: &StoreMut<'_>) -> Self {
+        Self {
+            module_id: module.info().id.id(),
+            store_id: store.id(),
+        }
     }
 }
 
 /// Runtime hooks that provide `wasm_c_api_v0` imports for WASIX guests.
 #[derive(Clone, Default)]
 pub struct WasmCapiRuntimeHooks {
-    /// Pending per-instantiation sessions, grouped by compiled module.
+    /// Pending per-instantiation sessions, grouped by compiled module and
+    /// target store.
     ///
     /// `add_imports` creates host functions before instantiation, while
     /// `configure_instance` can only discover exports like guest malloc/free
     /// after instantiation. The queue preserves that pairing when the same
-    /// module is instantiated multiple times.
-    sessions: Arc<Mutex<HashMap<ModuleKey, VecDeque<WasmCapiSession>>>>,
+    /// module is instantiated multiple times. Keying by store keeps
+    /// concurrent instantiations of one module in different stores from
+    /// receiving each other's sessions, whose store-bound function envs
+    /// would panic when used with the wrong store.
+    sessions: Arc<Mutex<HashMap<SessionKey, VecDeque<WasmCapiSession>>>>,
     resolve_module_sync: Option<ResolveModuleSync>,
 }
 
@@ -295,10 +305,6 @@ impl WasmCapiRuntimeHooks {
     ) -> Self {
         self.resolve_module_sync = Some(Arc::new(resolve));
         self
-    }
-
-    fn module_key(module: &Module) -> ModuleKey {
-        ModuleKey::new(module)
     }
 
     /// Creates `wasm_c_api_v0` imports when `module` requests them.
@@ -326,7 +332,7 @@ impl WasmCapiRuntimeHooks {
             .lock()
             .expect("poisoned WasmCapiRuntimeHooks session queue");
         sessions
-            .entry(Self::module_key(module))
+            .entry(SessionKey::new(module, store))
             .or_default()
             .push_back(session);
         Ok(())
@@ -349,7 +355,7 @@ impl WasmCapiRuntimeHooks {
                 .sessions
                 .lock()
                 .expect("poisoned WasmCapiRuntimeHooks session queue");
-            let key = Self::module_key(module);
+            let key = SessionKey::new(module, store);
             let Some(queue) = sessions.get_mut(&key) else {
                 bail!("missing pending Wasm C API session for module instance setup");
             };
@@ -2143,7 +2149,7 @@ fn register_wasm_c_api_imports(
 mod tests {
     use super::{
         INVALID_HANDLE, INVALID_SIZE, MemoryShadow, Type, WASM_EXTERNREF, WASM_F64, WASM_FUNCREF,
-        WASM_I32, WasmCAPIVersion, WasmCapiEnv, WasmCapiState, WasmObject,
+        WASM_I32, WasmCAPIVersion, WasmCapiEnv, WasmCapiRuntimeHooks, WasmCapiState, WasmObject,
         copy_guest_memory_to_wasmer, copy_wasmer_memory_to_guest, guest_byte_ptr,
         guest_memory_offset, guest_ptr_with_offset, module_wasm_c_api_version_used,
         non_null_guest_ptr, refresh_memory_shadows_from_wasmer, sync_memory_shadows_to_wasmer,
@@ -2151,12 +2157,11 @@ mod tests {
         wasm_memory_data_size, wasm_memory_size, wasm_table_size, write_wasm_val,
     };
     use wasmer_api::{
-        FunctionEnv, Memory, MemoryType, Module, Pages, Store, Table, TableType, Value,
+        AsStoreMut, FunctionEnv, Imports, Instance, Memory, MemoryType, Module, Pages, Store,
+        Table, TableType, Value,
     };
     use wat::parse_str;
 
-    #[cfg(feature = "wasi")]
-    use super::WasmCapiRuntimeHooks;
     #[cfg(feature = "wasi")]
     use std::sync::{
         Arc,
@@ -2331,6 +2336,42 @@ mod tests {
             }
         }
         assert_eq!(resolve_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn configure_instance_pairs_sessions_by_store() {
+        let mut store_a = Store::default();
+        let mut store_b = Store::new(store_a.engine().clone());
+        let module = compile_wat(
+            &store_a,
+            r#"(module
+                (import "wasm_c_api_v0" "wasm_engine_new" (func $wasm_engine_new (result i32)))
+                (memory (export "memory") 1)
+            )"#,
+        );
+
+        let hooks = WasmCapiRuntimeHooks::new();
+        let mut imports_a = Imports::new();
+        hooks
+            .add_imports(&module, &mut store_a.as_store_mut(), &mut imports_a)
+            .expect("imports register for store A");
+        let mut imports_b = Imports::new();
+        hooks
+            .add_imports(&module, &mut store_b.as_store_mut(), &mut imports_b)
+            .expect("imports register for store B");
+
+        // Instance setup completes in the reverse of the add_imports order,
+        // like two threads racing to cold-start the same module in separate
+        // stores. Each configure_instance call must receive the session whose
+        // function env lives in its own store.
+        let instance_b = Instance::new(&mut store_b, &module, &imports_b).expect("instance B");
+        hooks
+            .configure_instance(&module, &mut store_b.as_store_mut(), &instance_b, None)
+            .expect("configure instance B");
+        let instance_a = Instance::new(&mut store_a, &module, &imports_a).expect("instance A");
+        hooks
+            .configure_instance(&module, &mut store_a.as_store_mut(), &instance_a, None)
+            .expect("configure instance A");
     }
 
     #[test]


### PR DESCRIPTION
## Problem (WAX-600)

Edge panics under concurrent cold starts of the same module:

```
thread 'wasm_thread_5' panicked at lib/vm/src/store.rs:202:9:
assertion `left == right` failed: object used with the wrong context
  left: StoreId(1281)
 right: StoreId(1025)
   ...
  12: wasmer_c_api_imports::WasmCapiRuntimeHooks::configure_instance
  13: wasmer_wasix::state::env::WasiEnv::instantiate
  14: wasmer_wasix::state::func_env::WasiFunctionEnv::new_with_store
  15: <edge_runtime::instance::task_manager::TaskManager as VirtualTaskManager>::task_wasm::{{closure}}
```

`WasmCapiRuntimeHooks` queues pending sessions between `add_imports` (before instantiation) and `configure_instance` (after), keyed **by module only**. Each session's `FunctionEnv` is bound to the store it was created in. When two threads race to cold-start the same module in different stores, they can pop each other's sessions, and `configure_instance` then touches the env through the wrong store — tripping the `StoreHandle` `StoreId` assertion. The mirrored StoreId pairs in the Edge logs (1281/1025 and 1025/1281) are the two threads holding each other's sessions.

## Fix

- Key the session queue by `(module id, store id)` so `configure_instance` can only ever receive a session created for its own store.
- Expose the store id on `StoreRef`/`StoreMut` (mirroring the existing `Store::id`) and re-export `StoreId` from the `wasmer` crate to support this.
- Bump the `lib/napi` submodule to pull in the same fix for `NapiRuntimeHooks`, which had the identical queue pattern keyed by the transient `&Module` address: wasmerio/napi#37. **Merge that PR first** and, if it lands as a different SHA (squash/rebase), update the submodule pointer here before merging.

## Test

`configure_instance_pairs_sessions_by_store` (in `lib/c-api-imports`, with a twin in the napi PR) deterministically replays the race single-threaded: two stores on one engine, same module, `add_imports` A then B, then instance setup in reverse order. Before the fix it panics at the production crash site (`store.rs:202`, `left: StoreId(1), right: StoreId(2)`); after it passes. Full `wasmer-c-api-imports` suite is green, including `--features wasi` (WASIX guest smoke test).

Reproduced and traced via the wasmer-integration-tests repro `repros/WAX-600-edge-wasix-cross-store-panic.sh` (CPU-starved Edge, cold caches, `next-react-server-components` template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)