### PR TITLE
fix(virtual-io): retry selector poll on EINTR in release builds

### DIFF
--- a/lib/virtual-io/src/selector.rs
+++ b/lib/virtual-io/src/selector.rs
@@ -226,8 +226,8 @@ impl Selector {
         loop {
             // Wait for an event to trigger
             if let Err(e) = poll.poll(&mut events, None) {
-                // This can happen when a debugger is attached
-                #[cfg(debug_assertions)]
+                // This can happen when a debugger is attached, or more generally
+                // whenever a signal interrupts the underlying wait syscall.
                 if e.kind() == std::io::ErrorKind::Interrupted {
                     continue;
                 }


### PR DESCRIPTION
## Summary

The `ErrorKind::Interrupted` guard in the selector poll loop was gated behind `#[cfg(debug_assertions)]`, so release builds panicked on EINTR instead of retrying.

Any signal interrupting the underlying wait syscall triggers this — attaching a debugger or profiler via ptrace being the common case. Once the selector threads die, socket readiness stops being delivered promptly (observed: a guest TCP socket's readable event arriving 30s late via a fallback path).

Dropped the cfg gate so the retry applies in all builds, and widened the comment since a debugger isn't the only cause.

Fixes #6808

## Test plan

- `cargo check -p virtual-mio --release` passes.
- No behavior change in debug builds; release builds now take the same retry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)