### PR TITLE
deps(Cranelift): update to 0.134.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,27 +1136,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+checksum = "8f0435c6939d6ef218bf0a3063094f2cc5c46f7a44a88f81cf932da8d3922ff8"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+checksum = "aca52511cc21a2c9c927aef493d11c8087bdc5483249a3d93aee41e81b8bd4d1"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2e9b7adf77fa02204d4d523ae4f171b6591c2632b030865336335c7d7b420e"
+checksum = "6867e99f068454b0c81c50b807af88aa80aaf383105e2be26675d81fc4278466"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f09d9f397eae612ac15becf0e0b2165d2232003f4f2a1549572a724d1c48c5"
+checksum = "3cf66017aed971344230199ad35ca01c955cf824a0e65fed5240452d2a302445"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1175,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e004cf1270abc82f7b9fb32d1a9d73a1cc0d5a0215b97db8c32658748e78b01"
+checksum = "933b2e5237665bf9367a34ad2100eed70c94b2796586cb09d9ba11693e061667"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f32034641f96b123e4fdb5666e726d9f252e222638fc8fdd905b4ff18c3c4e"
+checksum = "322e3ca0603683cc17f0c808559c0fb85ad52b0f20ace0478bdd4ba2fa1e9678"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1217,24 +1217,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
+checksum = "287ab88211d049178dc8dda243e2db176919d8b29db605c0efc7c6d76ebea0f7"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
+checksum = "c11438f9becf9a1e1e061bf76a33241b941a07ed01a489e9dad5fa79dc3624e9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341d5e1e071320505ebbc8194a8eb61fa94394b1ed93ba3cbec3be5fa1c3c1ce"
+checksum = "584ecabe1462593a9cba9efbf9022e0987421ddb548989b455ab8bdd444b743c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c6f3e2419ecb54a5503994d35421554c5e487d0493bc86ea96907bab51fd29"
+checksum = "34249873145213a12106d5fd8a98a9dc9e90e16525e2337b2907874d1e7e9ee7"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1257,15 +1257,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.0"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21aa47a5e0b1e9fb2c9348459088d5dbb872ebe17781ada1270d8364c7e73257"
+checksum = "b6f1c1dc4d6b4bc4f0be12b08cee0e59f7610287827aa62590f8e9ec6f45dff4"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.134.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
+checksum = "4155f8a1afdef96a0272c67804926eee4ef35f9708ab22ad6878d4c9543df596"
 
 [[package]]
 name = "crc"
@@ -4409,9 +4409,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.0"
+version = "47.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047bda68096e5f290619ce037b7c3fa352d11f08edf0fce3030c351adc0f8ec0"
+checksum = "f6064e52588328c1275d690baad99f8d4b3fdd870736966f1a63cfcbb20560b6"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4420,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.0"
+version = "47.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83258a9bcc97d3fb15bf4e1c43bc2cc85c718e3563a697f145f245e651f2828f"
+checksum = "7e832980317bfc7f8c8538ffc9c69b82912f3e33ec70f7c855d521654c70fa62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8109,9 +8109,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.0"
+version = "47.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6ce74d60a8ed870548e7efa9710c54f982bbfcf80e5ee5eee8498318616483"
+checksum = "ea33e1f9685be82f90223bebcf2ffefb6b596ea3d82a3c42384527b9c6f5b447"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,9 @@ console = "0.16.1"
 console-subscriber = "0.5.0"
 cooked-waker = "5"
 corosensei = "0.3.0"
-cranelift-codegen = { version = "=0.133.0", default-features = false }
-cranelift-entity = { version = "=0.133.0", default-features = false }
-cranelift-frontend = { version = "=0.133.0", default-features = false }
+cranelift-codegen = { version = "=0.134.2", default-features = false }
+cranelift-entity = { version = "=0.134.2", default-features = false }
+cranelift-frontend = { version = "=0.134.2", default-features = false }
 crc32fast = "1.5.0"
 criterion = { version = "0.8.1", default-features = false }
 crossbeam-channel = "0.5.15"

--- a/lib/compiler-cranelift/src/func_environ.rs
+++ b/lib/compiler-cranelift/src/func_environ.rs
@@ -5,7 +5,7 @@ use crate::{
     HashMap,
     heap::{Heap, HeapData, HeapStyle},
     table::{TableData, TableSize},
-    translator::{EXN_REF_TYPE, LandingPad, TAG_TYPE},
+    translator::{EXN_REF_TYPE, LandingPad, TAG_TYPE, materialize_global_value},
 };
 use cranelift_codegen::{
     cursor::FuncCursor,
@@ -1317,7 +1317,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         // We use an indirect call so that we don't have to patch the code at runtime.
         let pointer_type = self.pointer_type();
         let vmctx = self.vmctx(pos.func);
-        let base = pos.ins().global_value(pointer_type, vmctx);
+        let base = materialize_global_value(pos, pointer_type, vmctx);
 
         let mut mem_flags = ir::MemFlagsData::trusted();
         mem_flags.set_readonly();
@@ -1498,7 +1498,7 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<ir::Value> {
         let bool_is_null =
             pos.ins()
-                .icmp_imm(cranelift_codegen::ir::condcodes::IntCC::Equal, value, 0);
+                .icmp_imm_s(cranelift_codegen::ir::condcodes::IntCC::Equal, value, 0);
         Ok(pos.ins().uextend(ir::types::I32, bool_is_null))
     }
 
@@ -1822,7 +1822,7 @@ impl FuncEnvironment<'_> {
         let pointer_type = self.pointer_type();
         let sig_ref = builder.func.dfg.ext_funcs[callee].signature;
         let vmctx = self.vmctx(builder.func);
-        let base = builder.ins().global_value(pointer_type, vmctx);
+        let base = materialize_global_value(&mut builder.cursor(), pointer_type, vmctx);
 
         let mem_flags = ir::MemFlagsData::trusted();
 

--- a/lib/compiler-cranelift/src/table.rs
+++ b/lib/compiler-cranelift/src/table.rs
@@ -2,7 +2,7 @@ use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::{self, InstBuilder, condcodes::IntCC, immediates::Imm64};
 use cranelift_frontend::FunctionBuilder;
 
-use crate::translator::{MemoryAliasRegion, set_memflags_alias_region};
+use crate::translator::{MemoryAliasRegion, materialize_global_value, set_memflags_alias_region};
 
 /// Size of a WebAssembly table, in elements.
 #[derive(Clone, Debug)]
@@ -25,7 +25,7 @@ impl TableSize {
     pub fn bound(&self, mut pos: FuncCursor, index_ty: ir::Type) -> ir::Value {
         match *self {
             Self::Static { bound } => pos.ins().iconst(index_ty, Imm64::new(i64::from(bound))),
-            Self::Dynamic { bound_gv } => pos.ins().global_value(index_ty, bound_gv),
+            Self::Dynamic { bound_gv } => materialize_global_value(&mut pos, index_ty, bound_gv),
         }
     }
 }
@@ -79,9 +79,9 @@ impl TableData {
         }
 
         // Add the table base address base
-        let mut base = pos.ins().global_value(addr_ty, self.base_gv);
+        let mut base = materialize_global_value(&mut pos.cursor(), addr_ty, self.base_gv);
         if self.base_offset != 0 {
-            base = pos.ins().iadd_imm(base, i64::from(self.base_offset));
+            base = pos.ins().iadd_imm_s(base, i64::from(self.base_offset));
         }
 
         let element_size = self.element_size;
@@ -89,9 +89,9 @@ impl TableData {
             index
         } else if element_size.is_power_of_two() {
             pos.ins()
-                .ishl_imm(index, i64::from(element_size.trailing_zeros()))
+                .ishl_imm_u(index, i64::from(element_size.trailing_zeros()))
         } else {
-            pos.ins().imul_imm(index, element_size as i64)
+            pos.ins().imul_imm_u(index, element_size as i64)
         };
 
         let element_addr = pos.ins().iadd(base, offset);

--- a/lib/compiler-cranelift/src/trampoline/dynamic_function.rs
+++ b/lib/compiler-cranelift/src/trampoline/dynamic_function.rs
@@ -108,7 +108,7 @@ pub fn make_trampoline_dynamic_function(
             results.push(load);
         }
         builder.ins().return_(&results);
-        builder.finalize()
+        builder.finalize(frontend_config)
     }
 
     if let Some(callbacks) = callbacks.as_ref() {

--- a/lib/compiler-cranelift/src/trampoline/function_call.rs
+++ b/lib/compiler-cranelift/src/trampoline/function_call.rs
@@ -107,7 +107,7 @@ pub fn make_trampoline_function_call(
         }
 
         builder.ins().return_(&[]);
-        builder.finalize()
+        builder.finalize(frontend_config)
     }
 
     if let Some(callbacks) = callbacks.as_ref() {

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -80,7 +80,9 @@ pub(crate) const TAG_TYPE: ir::Type = I32;
 pub(crate) const EXN_REF_TYPE: ir::Type = I32;
 
 use super::func_state::{ControlStackFrame, ElseData, FuncTranslationState};
-use super::translation_utils::{block_with_params, f32_translation, f64_translation};
+use super::translation_utils::{
+    block_with_params, f32_translation, f64_translation, materialize_global_value,
+};
 use crate::func_environ::{FuncEnvironment, GlobalVariable};
 use crate::{HashMap, hash_map};
 use core::convert::TryFrom;
@@ -210,7 +212,8 @@ pub fn translate_operator(
             let val = match state.get_global(builder.func, *global_index, environ)? {
                 GlobalVariable::Const(val) => val,
                 GlobalVariable::Memory { gv, offset, ty } => {
-                    let addr = builder.ins().global_value(environ.pointer_type(), gv);
+                    let addr =
+                        materialize_global_value(&mut builder.cursor(), environ.pointer_type(), gv);
                     let mut flags = ir::MemFlagsData::trusted();
                     // Put globals in the "table" abstract heap category as well.
                     set_memflags_alias_region(builder.func, &mut flags, MemoryAliasRegion::Table);
@@ -227,7 +230,8 @@ pub fn translate_operator(
             match state.get_global(builder.func, *global_index, environ)? {
                 GlobalVariable::Const(_) => panic!("global #{} is a constant", *global_index),
                 GlobalVariable::Memory { gv, offset, ty } => {
-                    let addr = builder.ins().global_value(environ.pointer_type(), gv);
+                    let addr =
+                        materialize_global_value(&mut builder.cursor(), environ.pointer_type(), gv);
                     let mut flags = ir::MemFlagsData::trusted();
                     // Put globals in the "table" abstract heap category as well.
                     set_memflags_alias_region(builder.func, &mut flags, MemoryAliasRegion::Table);
@@ -1387,7 +1391,7 @@ pub fn translate_operator(
         }
         Operator::I32Eqz | Operator::I64Eqz => {
             let arg = state.pop1();
-            let val = builder.ins().icmp_imm(IntCC::Equal, arg, 0);
+            let val = builder.ins().icmp_imm_u(IntCC::Equal, arg, 0);
             state.push1(builder.ins().uextend(I32, val));
         }
         Operator::I32Eq | Operator::I64Eq => translate_icmp(IntCC::Equal, builder, state),
@@ -2015,7 +2019,7 @@ pub fn translate_operator(
             let bitwidth = i64::from(type_of(op).lane_bits());
             // The spec expects to shift with `b mod lanewidth`; so, e.g., for 16 bit lane-width
             // we do `b AND 15`; this means fewer instructions than `iconst + urem`.
-            let b_mod_bitwidth = builder.ins().band_imm(b, bitwidth - 1);
+            let b_mod_bitwidth = builder.ins().band_imm_u(b, bitwidth - 1);
             state.push1(builder.ins().ishl(bitcast_a, b_mod_bitwidth))
         }
         Operator::I8x16ShrU | Operator::I16x8ShrU | Operator::I32x4ShrU | Operator::I64x2ShrU => {
@@ -2024,7 +2028,7 @@ pub fn translate_operator(
             let bitwidth = i64::from(type_of(op).lane_bits());
             // The spec expects to shift with `b mod lanewidth`; so, e.g., for 16 bit lane-width
             // we do `b AND 15`; this means fewer instructions than `iconst + urem`.
-            let b_mod_bitwidth = builder.ins().band_imm(b, bitwidth - 1);
+            let b_mod_bitwidth = builder.ins().band_imm_u(b, bitwidth - 1);
             state.push1(builder.ins().ushr(bitcast_a, b_mod_bitwidth))
         }
         Operator::I8x16ShrS | Operator::I16x8ShrS | Operator::I32x4ShrS | Operator::I64x2ShrS => {
@@ -2033,7 +2037,7 @@ pub fn translate_operator(
             let bitwidth = i64::from(type_of(op).lane_bits());
             // The spec expects to shift with `b mod lanewidth`; so, e.g., for 16 bit lane-width
             // we do `b AND 15`; this means fewer instructions than `iconst + urem`.
-            let b_mod_bitwidth = builder.ins().band_imm(b, bitwidth - 1);
+            let b_mod_bitwidth = builder.ins().band_imm_u(b, bitwidth - 1);
             state.push1(builder.ins().sshr(bitcast_a, b_mod_bitwidth))
         }
         Operator::V128Bitselect => {
@@ -2990,13 +2994,13 @@ fn align_atomic_addr(
         } else {
             builder
                 .ins()
-                .iadd_imm(addr, i64::from(memarg.offset as i32))
+                .iadd_imm_s(addr, i64::from(memarg.offset as i32))
         };
         debug_assert!(loaded_bytes.is_power_of_two());
         let misalignment = builder
             .ins()
-            .band_imm(effective_addr, i64::from(loaded_bytes - 1));
-        let f = builder.ins().icmp_imm(IntCC::NotEqual, misalignment, 0);
+            .band_imm_u(effective_addr, i64::from(loaded_bytes - 1));
+        let f = builder.ins().icmp_imm_u(IntCC::NotEqual, misalignment, 0);
         builder.ins().trapnz(f, crate::TRAP_HEAP_MISALIGNED);
     }
 }
@@ -3059,7 +3063,7 @@ fn translate_load(
         let block_merge = builder.create_block();
         builder.append_block_param(block_merge, result_ty);
 
-        let alignment_check = builder.ins().band_imm(base, (mem_op_size - 1) as i64);
+        let alignment_check = builder.ins().band_imm_u(base, (mem_op_size - 1) as i64);
         builder
             .ins()
             .brif(alignment_check, block_unaligned, &[], block_aligned, &[]);
@@ -3090,7 +3094,7 @@ fn translate_load(
             let byte = builder
                 .ins()
                 .uload8(result_uint_type, flags, base, i as i32);
-            let shifted = builder.ins().ishl_imm(byte, (i * 8) as i64);
+            let shifted = builder.ins().ishl_imm_u(byte, (i * 8) as i64);
             slow_val = builder.ins().bor(slow_val, shifted);
         }
         if matches!(
@@ -3144,7 +3148,7 @@ fn translate_store(
         let block_unaligned = builder.create_block();
         let block_merge = builder.create_block();
 
-        let alignment_check = builder.ins().band_imm(base, (mem_op_size - 1) as i64);
+        let alignment_check = builder.ins().band_imm_u(base, (mem_op_size - 1) as i64);
         builder
             .ins()
             .brif(alignment_check, block_unaligned, &[], block_aligned, &[]);
@@ -3174,7 +3178,7 @@ fn translate_store(
             )
         };
         for i in 0..mem_op_size {
-            let shifted = builder.ins().ushr_imm(val, (i * 8) as i64);
+            let shifted = builder.ins().ushr_imm_u(val, (i * 8) as i64);
             builder.ins().istore8(flags, shifted, base, i as i32);
         }
         builder.ins().jump(block_merge, &[]);
@@ -3218,10 +3222,10 @@ fn fold_atomic_mem_addr(
         let linear_mem_addr = builder.ins().uextend(I64, linear_mem_addr);
         let a = builder
             .ins()
-            .iadd_imm(linear_mem_addr, memarg.offset as i64);
+            .iadd_imm_u(linear_mem_addr, memarg.offset as i64);
         let r = builder
             .ins()
-            .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, a, 0x1_0000_0000i64);
+            .icmp_imm_u(IntCC::UnsignedGreaterThanOrEqual, a, 0x1_0000_0000i64);
         builder.ins().trapnz(r, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
         builder.ins().ireduce(I32, a)
     } else {
@@ -3230,10 +3234,10 @@ fn fold_atomic_mem_addr(
     assert!(access_ty_bytes == 4 || access_ty_bytes == 8);
     let final_lma_misalignment = builder
         .ins()
-        .band_imm(final_lma, i64::from(access_ty_bytes - 1));
+        .band_imm_u(final_lma, i64::from(access_ty_bytes - 1));
     let f = builder
         .ins()
-        .icmp_imm(IntCC::Equal, final_lma_misalignment, i64::from(0));
+        .icmp_imm_u(IntCC::Equal, final_lma_misalignment, i64::from(0));
     builder.ins().trapz(f, crate::TRAP_HEAP_MISALIGNED);
     final_lma
 }

--- a/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
@@ -23,6 +23,7 @@ use super::Reachability;
 use crate::{
     func_environ::FuncEnvironment,
     heap::{HeapData, HeapStyle},
+    translator::materialize_global_value,
 };
 use Reachability::*;
 use cranelift_codegen::{
@@ -326,7 +327,7 @@ fn get_dynamic_heap_bound(
         }
         // Load the heap bound from its global variable.
         (_, HeapStyle::Dynamic { bound_gv }) => {
-            builder.ins().global_value(env.pointer_type(), *bound_gv)
+            materialize_global_value(&mut builder.cursor(), env.pointer_type(), *bound_gv)
         }
         (_, HeapStyle::Static { .. }) => unreachable!("not a dynamic heap"),
     }
@@ -411,7 +412,7 @@ fn compute_addr(
 ) -> ir::Value {
     debug_assert_eq!(pos.func.dfg.value_type(index), addr_ty);
 
-    let heap_base = pos.ins().global_value(addr_ty, heap.base);
+    let heap_base = materialize_global_value(pos, addr_ty, heap.base);
 
     let base_and_index = pos.ins().iadd(heap_base, index);
 

--- a/lib/compiler-cranelift/src/translator/func_translator.rs
+++ b/lib/compiler-cranelift/src/translator/func_translator.rs
@@ -124,7 +124,7 @@ impl FuncTranslator {
             self.allow_unaligned_memory_accesses,
         )?;
 
-        builder.finalize();
+        builder.finalize(environ.target_config());
         Ok(())
     }
 }

--- a/lib/compiler-cranelift/src/translator/mod.rs
+++ b/lib/compiler-cranelift/src/translator/mod.rs
@@ -7,6 +7,7 @@ mod translation_utils;
 mod unwind;
 
 pub use self::func_translator::FuncTranslator;
+pub(crate) use self::translation_utils::materialize_global_value;
 pub use self::translation_utils::{
     irlibcall_to_libcall, irreloc_to_relocationkind, signature_to_cranelift_ir,
 };

--- a/lib/compiler-cranelift/src/translator/translation_utils.rs
+++ b/lib/compiler-cranelift/src/translator/translation_utils.rs
@@ -4,7 +4,8 @@ use crate::func_environ::FuncEnvironment;
 use crate::translator::EXN_REF_TYPE;
 use cranelift_codegen::{
     binemit::Reloc,
-    ir::{self, AbiParam},
+    cursor::FuncCursor,
+    ir::{self, AbiParam, InstBuilder},
     isa::TargetFrontendConfig,
 };
 use cranelift_frontend::FunctionBuilder;
@@ -13,6 +14,48 @@ use wasmer_compiler::{
     wasmparser::{self, RefType},
 };
 use wasmer_types::{FunctionType, LibCall, Type, WasmError, WasmResult};
+
+/// Materialize a global value as CLIF instructions.
+pub(crate) fn materialize_global_value(
+    pos: &mut FuncCursor<'_>,
+    pointer_type: ir::Type,
+    global_value: ir::GlobalValue,
+) -> ir::Value {
+    match pos.func.global_values[global_value] {
+        ir::GlobalValueData::VMContext => pos
+            .func
+            .special_param(ir::ArgumentPurpose::VMContext)
+            .expect("missing vmctx parameter"),
+        ir::GlobalValueData::IAddImm {
+            base,
+            offset,
+            global_type,
+        } => {
+            let base = materialize_global_value(pos, global_type, base);
+            pos.ins().iadd_imm_s(base, i64::from(offset))
+        }
+        ir::GlobalValueData::Load {
+            base,
+            offset,
+            global_type,
+            flags,
+        } => {
+            let base = materialize_global_value(pos, pointer_type, base);
+            let flags = pos.func.dfg.mem_flags[flags];
+            pos.ins().load(global_type, flags, base, offset)
+        }
+        ir::GlobalValueData::Symbol { tls, .. } => {
+            if tls {
+                pos.ins().tls_value(pointer_type, global_value)
+            } else {
+                pos.ins().symbol_value(pointer_type, global_value)
+            }
+        }
+        ir::GlobalValueData::DynScaleTargetConst { .. } => {
+            unreachable!("dynamic vector-scale global values are not created by Wasmer")
+        }
+    }
+}
 
 /// Helper function translate a Function signature into Cranelift Ir
 pub fn signature_to_cranelift_ir(


### PR DESCRIPTION
There are 3 particular changes that required a code change in Wasmer:
1. a new function `materialize_global_value` implements what was provided by Cranelift as `builder.ins().global_value`
2. `icmp_imm` got deprecated and is suppose to be replaced with `icmp_imm_s` and `icmp_imm_u`
3. `builder.finalize` has a new argument (front-end config)