### PR TITLE
fix(wasix): make package resolution semver-compliant

### DIFF
--- a/lib/wasix/src/runtime/resolver/in_memory_source.rs
+++ b/lib/wasix/src/runtime/resolver/in_memory_source.rs
@@ -87,7 +87,8 @@ impl InMemorySource {
                     .entry(ident.full_name.clone())
                     .or_default();
                 summaries.push(NamedPackageSummary { ident, summary });
-                summaries.sort_by(|left, right| left.ident.version.cmp(&right.ident.version));
+                summaries
+                    .sort_by(|left, right| left.ident.version.cmp_precedence(&right.ident.version));
                 summaries.dedup_by(|left, right| left.ident.version == right.ident.version);
             }
             PackageId::Hash(hash) => {

--- a/lib/wasix/src/runtime/resolver/local_registry_source.rs
+++ b/lib/wasix/src/runtime/resolver/local_registry_source.rs
@@ -59,7 +59,7 @@ impl LocalRegistrySource {
             .map_err(|error| QueryError::new_other(error, query))?
             .into_iter()
             .filter(|(version, _)| constraint.matches(version))
-            .sorted_by(|(left, _), (right, _)| left.cmp(right))
+            .sorted_by(|(left, _), (right, _)| left.cmp_precedence(right))
             .collect();
 
         if matches.is_empty() {

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -14,6 +14,7 @@ use crate::runtime::resolver::{
     Dependency, DependencyGraph, ItemLocation, PackageInfo, PackageSummary, QueryError, Resolution,
     ResolvedPackage, Source,
     outputs::{Edge, Node},
+    utils::cmp_version_precedence,
 };
 
 use super::ResolvedFileSystemMapping;
@@ -296,7 +297,7 @@ fn select_latest_named_dependency(
             let left_version = left.pkg.id.as_named().map(|id| &id.version);
             let right_version = right.pkg.id.as_named().map(|id| &id.version);
 
-            left_version.cmp(&right_version)
+            cmp_version_precedence(left_version, right_version)
         })
         .ok_or_else(|| QueryError::NoMatches {
             query: dep.pkg.clone(),
@@ -368,7 +369,7 @@ async fn select_unified_named_dependency(
         let left_version = left.pkg.id.as_named().map(|id| &id.version);
         let right_version = right.pkg.id.as_named().map(|id| &id.version);
 
-        left_version.cmp(&right_version)
+        cmp_version_precedence(left_version, right_version)
     }))
 }
 
@@ -559,7 +560,7 @@ fn sort_named_candidates_desc(candidates: &mut [PackageSummary]) {
         let left_version = left.pkg.id.as_named().map(|id| &id.version);
         let right_version = right.pkg.id.as_named().map(|id| &id.version);
 
-        right_version.cmp(&left_version)
+        cmp_version_precedence(right_version, left_version)
     });
 }
 

--- a/lib/wasix/src/runtime/resolver/source.rs
+++ b/lib/wasix/src/runtime/resolver/source.rs
@@ -5,7 +5,7 @@ use std::{
 
 use wasmer_config::package::{PackageIdent, PackageSource};
 
-use crate::runtime::resolver::PackageSummary;
+use crate::runtime::resolver::{PackageSummary, utils::cmp_version_precedence};
 
 /// Something that packages can be downloaded from.
 #[async_trait::async_trait]
@@ -34,7 +34,7 @@ pub trait Source: Sync + Debug {
                     let left_version = left.pkg.id.as_named().map(|x| &x.version);
                     let right_version = right.pkg.id.as_named().map(|x| &x.version);
 
-                    left_version.cmp(&right_version)
+                    cmp_version_precedence(left_version, right_version)
                 })
                 .ok_or(QueryError::NoMatches {
                     query: pkg.clone(),

--- a/lib/wasix/src/runtime/resolver/utils.rs
+++ b/lib/wasix/src/runtime/resolver/utils.rs
@@ -1,10 +1,24 @@
-use std::path::{Path, PathBuf};
+use std::{
+    cmp::Ordering,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Error;
 use http::{HeaderMap, StatusCode};
+use semver::Version;
 use url::Url;
 
 use crate::http::{HttpResponse, USER_AGENT};
+
+/// Compare optional package versions by SemVer *precedence*, i.e. ignoring build
+/// metadata as the spec requires (`1.0.0+a` and `1.0.0+b` rank equally). `None`
+/// orders below any `Some`, matching [`Option`]'s own ordering.
+pub(crate) fn cmp_version_precedence(left: Option<&Version>, right: Option<&Version>) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => left.cmp_precedence(right),
+        (left, right) => left.is_some().cmp(&right.is_some()),
+    }
+}
 
 /// Polyfill for [`Url::from_file_path()`] that works on `wasm32-unknown-unknown`.
 pub(crate) fn url_from_file_path(path: impl AsRef<Path>) -> Option<Url> {


### PR DESCRIPTION
Previously, we sorted packages by their `Ord` impl, which does not (fully) follow semver.
It sorts by build-metadata, because `Ord` does not allow `Ordering::Equal` yet `!PartialEq::eq`.
The correct ordering requires using `cmp_precedence`, which is what this PR switches it over to.
