### PR TITLE
GuestHeap: SharedMemory accessor + napi bump + Cargo.lock (ECO-416)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,6 +3737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,6 +3846,16 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd 0.9.0",
+]
+
+[[package]]
+name = "offset-allocator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234d535da3521eb95106f40f0b73483d80bfb3aacf27c40d7e2b72f1a3e00a2"
+dependencies = [
+ "log",
+ "nonmax",
 ]
 
 [[package]]
@@ -7787,6 +7803,7 @@ dependencies = [
  "anyhow",
  "cc",
  "enum-iterator",
+ "offset-allocator",
  "serde",
  "serde_json",
  "tar",

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -75,6 +75,17 @@ impl SharedMemory {
         }
     }
 
+    /// The backing VM shared-memory handle.
+    ///
+    /// Clones of the handle share the same underlying allocation, so an
+    /// embedder can keep a clone and operate on the memory (e.g. grow it via
+    /// [`LinearMemory::grow`]) from any thread without holding a store.
+    ///
+    /// [`LinearMemory::grow`]: wasmer_vm::LinearMemory::grow
+    pub fn vm_shared_memory(&self) -> &VMSharedMemory {
+        &self.memory
+    }
+
     #[inline]
     fn shared_ops(&self) -> Result<&(dyn SharedMemoryOps + Send + Sync), AtomicsError> {
         self.ops


### PR DESCRIPTION
**Stack 4/4 (wasmer) — final; matches local state.** Base: `wasmer-v8-imports-bridge-fixes`.

Wasmer-side of the GuestHeap work:
- `lib/api`: expose the backing `VMSharedMemory` on `SharedMemory` so an embedder can grow a shared memory store-free from any thread
- napi submodule bumps: GuestHeap + copy-layer removal + >2 GiB external-pointer fix, and the shared-heap-per-memory fix (WASIX-threads host-corruption)
- Cargo.lock update for the `offset-allocator` dependency

See wasmerio/napi#43. ⚠️ Final PR of the stack; not yet mergeable. Relates to ECO-416.