### PR TITLE
chore: simplify assumptions about `PointerWidth`

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -566,30 +566,14 @@ impl Compiler for LLVMCompiler {
             let mut got = wasmer_compiler::types::function::GOT::empty();
 
             if !got_targets.is_empty() {
-                let pointer_width = target.triple().pointer_width().map_err(|_| {
-                    CompileError::Codegen("Could not get pointer width".to_string())
-                })?;
-
-                let got_entry_size = match pointer_width {
-                    target_lexicon::PointerWidth::U64 => 8,
-                    target_lexicon::PointerWidth::U32 => 4,
-                    target_lexicon::PointerWidth::U16 => todo!(),
-                };
-
-                let got_entry_reloc_kind = match pointer_width {
-                    target_lexicon::PointerWidth::U64 => RelocationKind::Abs8,
-                    target_lexicon::PointerWidth::U32 => RelocationKind::Abs4,
-                    target_lexicon::PointerWidth::U16 => todo!(),
-                };
-
-                let got_data: Vec<u8> = vec![0; got_targets.len() * got_entry_size];
+                let got_data: Vec<u8> = vec![0; got_targets.len() * 8];
                 let mut got_relocs = vec![];
 
                 for (i, target) in got_targets.into_iter().enumerate() {
                     got_relocs.push(wasmer_compiler::types::relocation::Relocation {
-                        kind: got_entry_reloc_kind,
+                        kind: RelocationKind::Abs8,
                         reloc_target: target,
-                        offset: (i * got_entry_size) as u32,
+                        offset: (i * 8) as u32,
                         addend: 0,
                     });
                 }

--- a/lib/compiler/src/object/module.rs
+++ b/lib/compiler/src/object/module.rs
@@ -658,7 +658,7 @@ impl ObjectMetadataBuilder {
 
         aself
             .placeholder_data
-            .extend_from_slice(&aself.serialize_value(aself.num_function_pointers));
+            .extend_from_slice(&aself.serialize_value(aself.num_function_pointers)?);
         aself.placeholder_data.extend_from_slice(&vec![
             0u8;
             (aself.pointer_bytes() * aself.num_function_pointers)
@@ -666,14 +666,14 @@ impl ObjectMetadataBuilder {
         ]);
         aself
             .placeholder_data
-            .extend_from_slice(&aself.serialize_value(aself.num_trampolines));
+            .extend_from_slice(&aself.serialize_value(aself.num_trampolines)?);
         aself.placeholder_data.extend_from_slice(&vec![
             0u8;
             (aself.pointer_bytes() * aself.num_trampolines)
                 as usize
         ]);
         aself.placeholder_data.extend_from_slice(
-            &aself.serialize_value(aself.num_dynamic_function_trampoline_pointers),
+            &aself.serialize_value(aself.num_dynamic_function_trampoline_pointers)?,
         );
         aself.placeholder_data.extend_from_slice(&vec![
             0u8;
@@ -789,14 +789,15 @@ impl ObjectMetadataBuilder {
             + self.pointer_bytes()
     }
 
-    fn serialize_value(&self, value: u64) -> Vec<u8> {
+    fn serialize_value(&self, value: u64) -> Result<Vec<u8>, ObjectError> {
         match (self.endianness, self.pointer_width) {
-            (Endianness::Little, PointerWidth::U16) => (value as u16).to_le_bytes().to_vec(),
-            (Endianness::Big, PointerWidth::U16) => (value as u16).to_be_bytes().to_vec(),
-            (Endianness::Little, PointerWidth::U32) => (value as u32).to_le_bytes().to_vec(),
-            (Endianness::Big, PointerWidth::U32) => (value as u32).to_be_bytes().to_vec(),
-            (Endianness::Little, PointerWidth::U64) => value.to_le_bytes().to_vec(),
-            (Endianness::Big, PointerWidth::U64) => value.to_be_bytes().to_vec(),
+            (Endianness::Little, PointerWidth::U64) => Ok(value.to_le_bytes().to_vec()),
+            (Endianness::Big, PointerWidth::U64) => Ok(value.to_be_bytes().to_vec()),
+            (_, PointerWidth::U16 | PointerWidth::U32) => {
+                Err(ObjectError::UnsupportedArchitecture(
+                    "only 64-bit targets are supported".to_string(),
+                ))
+            }
         }
     }
 }


### PR DESCRIPTION
Right now, all compiler targets are 64-bit systems.