### PR TITLE
fix: don't panic when forwarding a non-UTF-8 host environment

### DIFF
--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeSet, HashMap},
+    ffi::OsString,
     path::{Path, PathBuf},
     str::FromStr,
     sync::{Arc, mpsc::Sender},
@@ -267,6 +268,13 @@ pub struct RunProperties {
     pub path: PathBuf,
     pub invoke: Option<String>,
     pub args: Vec<String>,
+}
+
+/// Environment variables are arbitrary byte strings on unix, but `Wasi` stores
+/// them as `String`, so reject the ones that cannot be represented.
+fn utf8_env_part(part: OsString) -> Result<String> {
+    part.into_string()
+        .map_err(|part| anyhow::anyhow!("environment variable is not valid UTF-8: {part:?}"))
 }
 
 #[allow(dead_code)]
@@ -682,18 +690,9 @@ impl Wasi {
             .unwrap_or_else(|| PathBuf::from("."));
         Ok(Self {
             deny_multiple_wasi_versions: true,
-            // `std::env::vars` panics on entries that are not valid UTF-8, and
-            // environment variables are arbitrary byte strings on unix. This
-            // field is a `String` map, so invalid bytes are replaced rather
-            // than preserved, but the process no longer aborts.
             env_vars: std::env::vars_os()
-                .map(|(name, value)| {
-                    (
-                        name.to_string_lossy().into_owned(),
-                        value.to_string_lossy().into_owned(),
-                    )
-                })
-                .collect(),
+                .map(|(name, value)| Ok((utf8_env_part(name)?, utf8_env_part(value)?)))
+                .collect::<Result<_>>()?,
             volumes: vec![MappedDirectory {
                 host: dir.clone(),
                 guest: dir

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -682,7 +682,18 @@ impl Wasi {
             .unwrap_or_else(|| PathBuf::from("."));
         Ok(Self {
             deny_multiple_wasi_versions: true,
-            env_vars: std::env::vars().collect(),
+            // `std::env::vars` panics on entries that are not valid UTF-8, and
+            // environment variables are arbitrary byte strings on unix. This
+            // field is a `String` map, so invalid bytes are replaced rather
+            // than preserved, but the process no longer aborts.
+            env_vars: std::env::vars_os()
+                .map(|(name, value)| {
+                    (
+                        name.to_string_lossy().into_owned(),
+                        value.to_string_lossy().into_owned(),
+                    )
+                })
+                .collect(),
             volumes: vec![MappedDirectory {
                 host: dir.clone(),
                 guest: dir

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -178,17 +178,10 @@ impl CommonWasiOptions {
 // type ContainerFs =
 //     OverlayFileSystem<TmpFileSystem, [RelativeOrAbsolutePathHack<Arc<dyn FileSystem>>; 1]>;
 
-/// Turn host environment variables into the raw byte pairs
-/// [`WasiEnvBuilder::add_envs`] expects.
+/// Turn host environment variables into raw byte pairs.
 ///
-/// Environment variables are arbitrary byte strings on unix, so
-/// [`std::env::vars`] cannot be used here: it panics as soon as any entry is
-/// not valid UTF-8. WASI environment variables are byte strings as well, so the
-/// bytes are handed to the guest unchanged.
-///
-/// Note that [`WasiEnvBuilder::add_env`] still stores the *name* as a `String`
-/// and replaces invalid bytes in it; only the value is guaranteed to survive
-/// untouched.
+/// [`std::env::vars`] panics on entries that are not valid UTF-8, while both
+/// unix and WASI environment variables are byte strings.
 fn os_env_vars(
     vars: impl IntoIterator<Item = (OsString, OsString)>,
 ) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
@@ -442,12 +435,10 @@ mod tests {
 
     use super::*;
 
-    /// Regression test for <https://github.com/wasmerio/wasmer/issues/6835>:
-    /// forwarding the host environment used to panic when any entry was not
-    /// valid UTF-8.
+    /// See <https://github.com/wasmerio/wasmer/issues/6835>.
     #[cfg(unix)]
     #[test]
-    fn non_utf8_host_env_vars_are_forwarded_as_raw_bytes() {
+    fn issue_6835_non_utf8_host_env_vars_are_forwarded_as_raw_bytes() {
         use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
         let vars = [

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    ffi::OsString,
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
@@ -159,7 +160,7 @@ impl CommonWasiOptions {
         }
 
         if self.forward_host_env {
-            builder.add_envs(std::env::vars());
+            builder.add_envs(os_env_vars(std::env::vars_os()));
         }
 
         builder.add_envs(self.env.clone());
@@ -176,6 +177,24 @@ impl CommonWasiOptions {
 
 // type ContainerFs =
 //     OverlayFileSystem<TmpFileSystem, [RelativeOrAbsolutePathHack<Arc<dyn FileSystem>>; 1]>;
+
+/// Turn host environment variables into the raw byte pairs
+/// [`WasiEnvBuilder::add_envs`] expects.
+///
+/// Environment variables are arbitrary byte strings on unix, so
+/// [`std::env::vars`] cannot be used here: it panics as soon as any entry is
+/// not valid UTF-8. WASI environment variables are byte strings as well, so the
+/// bytes are handed to the guest unchanged.
+///
+/// Note that [`WasiEnvBuilder::add_env`] still stores the *name* as a `String`
+/// and replaces invalid bytes in it; only the value is guaranteed to survive
+/// untouched.
+fn os_env_vars(
+    vars: impl IntoIterator<Item = (OsString, OsString)>,
+) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
+    vars.into_iter()
+        .map(|(name, value)| (name.into_encoded_bytes(), value.into_encoded_bytes()))
+}
 
 fn normalized_mount_path(guest_path: &str) -> Result<PathBuf, Error> {
     let mut guest_path = PathBuf::from(guest_path);
@@ -422,6 +441,37 @@ mod tests {
     use virtual_fs::{DirEntry, FileType, FsError, Metadata, limiter::FsMemoryLimiter};
 
     use super::*;
+
+    /// Regression test for <https://github.com/wasmerio/wasmer/issues/6835>:
+    /// forwarding the host environment used to panic when any entry was not
+    /// valid UTF-8.
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_host_env_vars_are_forwarded_as_raw_bytes() {
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+        let vars = [
+            (
+                OsStr::from_bytes(b"VALID").to_os_string(),
+                OsStr::from_bytes(b"ok").to_os_string(),
+            ),
+            (
+                OsStr::from_bytes(b"INVALID").to_os_string(),
+                OsStr::from_bytes(b"V\xffW").to_os_string(),
+            ),
+        ];
+
+        let mut builder = WasiEnvBuilder::new("test");
+        builder.add_envs(os_env_vars(vars));
+
+        assert_eq!(
+            builder.get_env(),
+            [
+                ("VALID".to_string(), b"ok".to_vec()),
+                ("INVALID".to_string(), b"V\xffW".to_vec()),
+            ]
+        );
+    }
 
     fn base_root(root_fs: &MountFileSystem) -> Arc<dyn FileSystem + Send + Sync> {
         root_fs.filesystem_at(Path::new("/")).unwrap()

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -174,12 +174,11 @@ fn run_wasi_works() {
     assert.stdout("27\n");
 }
 
-/// Regression test for <https://github.com/wasmerio/wasmer/issues/6835>:
-/// `--forward-host-env` aborted before the guest started whenever the host
-/// environment held a variable that was not valid UTF-8.
+/// See <https://github.com/wasmerio/wasmer/issues/6835>. Needs a WASI module:
+/// `fixtures::fib()` imports nothing, so it never reaches the WASI runner.
 #[cfg(unix)]
 #[test]
-fn run_wasi_forwards_non_utf8_host_env() {
+fn issue_6835_run_wasi_forwards_non_utf8_host_env() {
     use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
     let assert = wasmer_command()

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -174,6 +174,28 @@ fn run_wasi_works() {
     assert.stdout("27\n");
 }
 
+/// Regression test for <https://github.com/wasmerio/wasmer/issues/6835>:
+/// `--forward-host-env` aborted before the guest started whenever the host
+/// environment held a variable that was not valid UTF-8.
+#[cfg(unix)]
+#[test]
+fn run_wasi_forwards_non_utf8_host_env() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+    let assert = wasmer_command()
+        .arg("run")
+        .arg("--forward-host-env")
+        .arg(fixtures::qjs())
+        .arg("--")
+        .arg("-e")
+        .arg("print(3 * (4 + 5))")
+        .env("WASMER_TEST_NON_UTF8", OsStr::from_bytes(b"V\xffW"))
+        .assert()
+        .success();
+
+    assert.stdout("27\n");
+}
+
 // The test would be very slow on Windows and macOS
 #[cfg_attr(any(target_os = "windows", target_os = "macos"), ignore)]
 #[test]


### PR DESCRIPTION
# Description

Fixes #6835.

`wasmer run --forward-host-env` aborted before the guest started whenever the host
environment held an entry that is not valid UTF-8:

```console
$ env BADV=$'\xff' wasmer run --forward-host-env wasi-noop.wasm
thread 'main' panicked at library/std/src/env.rs:162:83:
called `Result::unwrap()` on an `Err` value: "\xFF"
$ echo $?
101
```

Environment variables are arbitrary byte strings on unix, so that is a legal host state
rather than a malformed one.

## Cause

`CommonWasiOptions::populate_env` forwarded the host environment with `std::env::vars()`,
which yields `(String, String)` and unwraps `into_string()` on every entry.

## Fix

`WasiEnvBuilder` is already byte-oriented — it stores `Vec<(String, Vec<u8>)>` and
`add_env` takes `impl AsRef<[u8]>` for both halves — so switching to `std::env::vars_os()`
is enough to hand the bytes to the guest unchanged, which is what preview1's `environ_get`
expects:

```rust
if self.forward_host_env {
    builder.add_envs(os_env_vars(std::env::vars_os()));
}
```

A guest given `BADV=V\xffW` now receives the bytes `56 ff 57`, which is what WAMR and
WasmEdge do with the same host state.

On Windows this changes behaviour too: `OsString::into_encoded_bytes` yields WTF-8, so a
lone surrogate is now forwarded as its WTF-8 encoding instead of aborting the process.

One caveat worth flagging: `WasiEnvBuilder::add_env` stores the variable *name* as a
`String` via `String::from_utf8_lossy`, so invalid bytes in a name are still replaced with
U+FFFD — only the value is guaranteed to survive untouched. Making names byte-exact would
mean changing the `envs` field and the public `get_env`/`get_env_mut` signatures, which
seemed out of scope for a bug fix. Happy to do it in a follow-up if you'd prefer that.

The same `std::env::vars()` pattern in `Wasi::for_binfmt_interpreter` is fixed as well.
That path stores `Vec<(String, String)>`, so bytes cannot be preserved there; it now uses
`vars_os()` with a lossy conversion so it no longer aborts.

## Testing

* `lib/wasix/src/runners/wasi_common.rs` — a unit test asserting that a non-UTF-8 value
  reaches the builder byte for byte.
* `tests/integration/cli/tests/run.rs` — an end-to-end test that runs
  `wasmer run --forward-host-env` with a non-UTF-8 variable in the child environment.
  It fails on `main` with exit code 101 and passes with this change.

Both are `#[cfg(unix)]`, since constructing a non-UTF-8 `OsString` is platform specific.
