### PR TITLE
fix: parse plan-based perish reason

### DIFF
--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -2503,6 +2503,10 @@ enum DeployDeployAppPerishReasonChoices {
 	App Unclaimed
 	"""
 	APP_UNCLAIMED
+	"""
+	Plan Non Persistent
+	"""
+	PLAN_NON_PERSISTENT
 }
 
 """

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1693,6 +1693,8 @@ mod queries {
         UserRequested,
         #[cynic(rename = "APP_UNCLAIMED")]
         AppUnclaimed,
+        #[cynic(rename = "PLAN_NON_PERSISTENT")]
+        PlanNonPersistent,
     }
 
     #[derive(cynic::QueryFragment, Serialize, Debug, Clone)]

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -1348,7 +1348,8 @@ fn perish_reason_link(
         DeployDeployAppPerishReasonChoices::UserPendingVerification => {
             Some("Verify now to keep it online: https://wasmer.io/verify".to_string())
         }
-        DeployDeployAppPerishReasonChoices::UserRequested => None,
+        DeployDeployAppPerishReasonChoices::UserRequested
+        | DeployDeployAppPerishReasonChoices::PlanNonPersistent => None,
     }
 }
 


### PR DESCRIPTION
`PLAN_NON_PERSISTENT` is a new reason an app can be stamped as perishable. 

I believe the proper way to handle this `enum` is to allow a fallback variant using `#[cynic(fallback)]` so backend can add reasons freely without breaking the client. But, I wanted to keep the changes as small as possible so I opted for just parsing this new variant.