### PR TITLE
Add async JavaScript API and JSPI support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,6 +7188,7 @@ dependencies = [
  "tracing",
  "ureq 3.3.0",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -33,7 +33,7 @@ bytes.workspace = true
 tracing = { workspace = true, default-features = true }
 # - Optional shared dependencies.
 wat = { workspace = true, optional = true }
-symbolic-demangle.workspace = true
+symbolic-demangle = { workspace = true, optional = true }
 shared-buffer.workspace = true
 
 loupe = { workspace = true, optional = true, features = [
@@ -126,7 +126,10 @@ artifact-size = [
 
 # Features for `sys`.
 sys = ["std", "dep:wasmer-vm", "dep:wasmer-compiler"]
-sys-default = ["sys", "wat", "cranelift"]
+sys-default = ["sys", "wat", "cranelift", "demangle"]
+
+# Improve native stack traces without forcing the demanglers into browser builds.
+demangle = ["dep:symbolic-demangle"]
 
 headless = []
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -86,6 +86,7 @@ wasmer-types = { path = "../types", version = "=7.2.1", default-features = false
   "std",
 ] }
 wasm-bindgen.workspace = true
+wasm-bindgen-futures = { workspace = true, optional = true }
 js-sys.workspace = true
 wasmer-derive = { path = "../derive", version = "=7.2.1" }
 wasmer-compiler = { path = "../compiler", version = "=7.2.1" }
@@ -162,7 +163,7 @@ v8-default = ["v8", "wat"]
 wasm-c-api = ["wasm-types-polyfill"]
 
 # Features for `js`.
-js = ["wasm-bindgen", "js-sys"]
+js = ["wasm-bindgen", "wasm-bindgen-futures", "js-sys"]
 js-default = ["js", "std", "wasm-types-polyfill"]
 
 wasm-types-polyfill = ["wasmparser"]

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -101,6 +101,7 @@ target-lexicon.workspace = true
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wat.workspace = true
 anyhow.workspace = true
+futures.workspace = true
 wasm-bindgen-test.workspace = true
 macro-wasmer-engine-test = { version = "7.2.1", path = "./macro-wasmer-engine-test" }
 

--- a/lib/api/src/backend/js/entities/external.rs
+++ b/lib/api/src/backend/js/entities/external.rs
@@ -1,44 +1,127 @@
 use std::any::Any;
 
+use js_sys::{Object, Symbol};
+use wasm_bindgen::JsValue;
+
+use crate::js::entities::store::StoreHandle;
+use crate::js::utils::js_handle::JsHandle;
 use crate::js::vm::VMExternRef;
 use crate::store::{AsStoreMut, AsStoreRef};
 
-#[derive(Debug, Clone)]
 #[repr(transparent)]
 /// A WebAssembly `extern ref` in `js`.
-pub struct ExternRef;
+pub(crate) struct ExternRefData(pub(crate) Box<dyn Any + Send + Sync>);
+
+impl std::fmt::Debug for ExternRefData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExternRefData").finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternRef {
+    value: JsHandle<JsValue>,
+    host_data: Option<StoreHandle<ExternRefData>>,
+}
+
+unsafe impl Send for ExternRef {}
+unsafe impl Sync for ExternRef {}
 
 impl ExternRef {
-    pub fn new<T>(_store: &mut impl AsStoreMut, _value: T) -> Self
+    pub fn new<T>(store: &mut impl AsStoreMut, value: T) -> Self
     where
         T: Any + Send + Sync + 'static + Sized,
     {
-        unimplemented!("ExternRef is not yet supported in Javascript");
+        let handle = StoreHandle::new(
+            store.objects_mut().as_js_mut(),
+            ExternRefData(Box::new(value)),
+        );
+        let object = Object::new();
+        js_sys::Reflect::set(
+            &object,
+            host_ref_index_key().as_ref(),
+            &JsValue::from_f64(handle.internal_handle().index() as f64),
+        )
+        .expect("setting the externref store index should succeed");
+        js_sys::Reflect::set(
+            &object,
+            host_ref_store_key().as_ref(),
+            &JsValue::from_f64(handle.store_id().as_raw().get() as f64),
+        )
+        .expect("setting the externref store ID should succeed");
+        Self {
+            value: JsHandle::new(object.into()),
+            host_data: Some(handle),
+        }
     }
 
-    pub fn downcast<'a, T>(&self, _store: &'a impl AsStoreRef) -> Option<&'a T>
+    pub(crate) fn from_js_value(store: &mut impl AsStoreMut, value: JsValue) -> Self {
+        let host_data = host_handle_from_js_value(store, &value);
+        Self {
+            value: JsHandle::new(value),
+            host_data,
+        }
+    }
+
+    pub(crate) fn as_js_value(&self) -> JsValue {
+        (*self.value).clone()
+    }
+
+    pub fn downcast<'a, T>(&self, store: &'a impl AsStoreRef) -> Option<&'a T>
     where
         T: Any + Send + Sync + 'static + Sized,
     {
-        unimplemented!("ExternRef is not yet supported in Javascript");
+        self.host_data
+            .as_ref()?
+            .get(store.as_store_ref().objects().as_js())
+            .0
+            .downcast_ref()
     }
 
     pub(crate) fn vm_externref(&self) -> VMExternRef {
-        unimplemented!("ExternRef is not yet supported in Javascript");
+        VMExternRef::new(self.as_js_value())
     }
 
     pub(crate) unsafe fn from_vm_externref(
-        _store: &mut impl AsStoreMut,
-        _vm_externref: VMExternRef,
+        store: &mut impl AsStoreMut,
+        vm_externref: VMExternRef,
     ) -> Self {
-        unimplemented!("ExternRef is not yet supported in Javascript");
+        Self::from_js_value(store, vm_externref.into_js_value())
     }
 
-    pub fn is_from_store(&self, _store: &impl AsStoreRef) -> bool {
-        true
+    pub fn is_from_store(&self, store: &impl AsStoreRef) -> bool {
+        self.host_data
+            .as_ref()
+            .is_none_or(|handle| handle.store_id() == store.as_store_ref().objects().id())
     }
 
-    pub fn ptr_eq(&self, _other: &Self) -> bool {
-        unimplemented!("ExternRef is not yet supported in Javascript");
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        js_sys::Object::is(&self.value, &other.value)
     }
+}
+
+fn host_ref_index_key() -> Symbol {
+    Symbol::for_("wasmer.externref-index")
+}
+
+fn host_ref_store_key() -> Symbol {
+    Symbol::for_("wasmer.externref-store")
+}
+
+fn host_handle_from_js_value(
+    store: &mut impl AsStoreMut,
+    value: &JsValue,
+) -> Option<StoreHandle<ExternRefData>> {
+    let index = js_sys::Reflect::get(value, host_ref_index_key().as_ref())
+        .ok()?
+        .as_f64()? as usize;
+    let store_id = js_sys::Reflect::get(value, host_ref_store_key().as_ref())
+        .ok()?
+        .as_f64()? as u64;
+    let objects = store.objects_mut();
+    if objects.id().as_raw().get() as u64 != store_id {
+        return None;
+    }
+    let internal = crate::js::entities::store::InternalStoreHandle::from_index(index)?;
+    Some(unsafe { StoreHandle::from_internal(objects.id(), internal) })
 }

--- a/lib/api/src/backend/js/entities/function/env.rs
+++ b/lib/api/src/backend/js/entities/function/env.rs
@@ -5,6 +5,12 @@ use crate::{
     js::{store::StoreHandle, vm::VMFunctionEnvironment},
     store::{AsStoreMut, AsStoreRef, StoreRef},
 };
+#[cfg(feature = "experimental-async")]
+use crate::{
+    AsStoreAsync, StoreAsync, StoreAsyncReadLock, StoreAsyncWriteLock,
+};
+#[cfg(feature = "experimental-async")]
+use wasmer_types::StoreId;
 
 #[derive(Debug)]
 #[repr(transparent)]
@@ -33,7 +39,7 @@ impl<T> FunctionEnv<T> {
     /// Get the data as reference
     pub fn as_ref<'a>(&self, store: &'a impl AsStoreRef) -> &'a T
     where
-        T: Any + Send + 'static + Sized,
+        T: Any + 'static + Sized,
     {
         self.handle
             .get(store.as_store_ref().objects().as_js())
@@ -52,7 +58,7 @@ impl<T> FunctionEnv<T> {
     /// Get the data as mutable
     pub fn as_mut<'a>(&self, store: &'a mut impl AsStoreMut) -> &'a mut T
     where
-        T: Any + Send + 'static + Sized,
+        T: Any + 'static + Sized,
     {
         self.handle
             .get_mut(store.objects_mut().as_js_mut())
@@ -64,7 +70,7 @@ impl<T> FunctionEnv<T> {
     /// Convert it into a `FunctionEnvMut`
     pub fn into_mut(self, store: &mut impl AsStoreMut) -> FunctionEnvMut<'_, T>
     where
-        T: Any + Send + 'static + Sized,
+        T: Any + 'static + Sized,
     {
         FunctionEnvMut {
             store_mut: store.as_store_mut(),
@@ -146,6 +152,11 @@ impl<T: Send + 'static> FunctionEnvMut<'_, T> {
         let data = unsafe { &mut *data };
         (data, self.store_mut.as_store_mut())
     }
+
+    #[cfg(feature = "experimental-async")]
+    pub fn as_store_async(&self) -> Option<impl AsStoreAsync + 'static> {
+        self.store_mut.as_store_async()
+    }
 }
 
 impl<T> AsStoreRef for FunctionEnvMut<'_, T> {
@@ -203,5 +214,141 @@ impl<'a, T> From<FunctionEnvMut<'a, T>> for crate::FunctionEnvMut<'a, T> {
 impl<T> From<FunctionEnv<T>> for crate::FunctionEnv<T> {
     fn from(value: FunctionEnv<T>) -> Self {
         Self(crate::BackendFunctionEnv::Js(value))
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+pub struct AsyncFunctionEnvMut<T> {
+    pub(crate) store: StoreAsync,
+    pub(crate) func_env: FunctionEnv<T>,
+}
+
+#[cfg(feature = "experimental-async")]
+pub struct AsyncFunctionEnvHandle<T> {
+    read_lock: StoreAsyncReadLock,
+    pub(crate) func_env: FunctionEnv<T>,
+}
+
+#[cfg(feature = "experimental-async")]
+pub struct AsyncFunctionEnvHandleMut<T> {
+    write_lock: StoreAsyncWriteLock,
+    pub(crate) func_env: FunctionEnv<T>,
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T> Clone for AsyncFunctionEnvMut<T> {
+    fn clone(&self) -> Self {
+        Self {
+            store: StoreAsync {
+                id: self.store.id,
+                inner: self.store.inner.clone(),
+            },
+            func_env: self.func_env.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T> Debug for AsyncFunctionEnvMut<T>
+where
+    T: Send + Debug + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.store.inner.try_read() {
+            Some(read_lock) => self.func_env.as_ref(&read_lock).fmt(f),
+            None => write!(f, "AsyncFunctionEnvMut {{ <STORE LOCKED> }}"),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T: 'static> AsyncFunctionEnvMut<T> {
+    pub(crate) fn store_id(&self) -> StoreId {
+        self.store.id
+    }
+
+    pub async fn read(&self) -> AsyncFunctionEnvHandle<T> {
+        AsyncFunctionEnvHandle {
+            read_lock: self.store.read_lock().await,
+            func_env: self.func_env.clone(),
+        }
+    }
+
+    pub async fn write(&self) -> AsyncFunctionEnvHandleMut<T> {
+        AsyncFunctionEnvHandleMut {
+            write_lock: self.store.write_lock().await,
+            func_env: self.func_env.clone(),
+        }
+    }
+
+    pub fn as_ref(&self) -> FunctionEnv<T> {
+        self.func_env.clone()
+    }
+
+    pub fn as_mut(&mut self) -> Self {
+        self.clone()
+    }
+
+    pub fn as_store_async(&self) -> impl AsStoreAsync + 'static {
+        StoreAsync {
+            id: self.store.id,
+            inner: self.store.inner.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T: 'static> AsyncFunctionEnvHandle<T> {
+    pub fn data(&self) -> &T {
+        self.func_env.as_ref(&self.read_lock)
+    }
+
+    pub fn data_and_store(&self) -> (&T, &impl AsStoreRef) {
+        (self.data(), &self.read_lock)
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T: 'static> AsStoreRef for AsyncFunctionEnvHandle<T> {
+    fn as_store_ref(&self) -> StoreRef<'_> {
+        self.read_lock.as_store_ref()
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T: 'static> AsyncFunctionEnvHandleMut<T> {
+    pub fn data_mut(&mut self) -> &mut T {
+        self.func_env.as_mut(&mut self.write_lock)
+    }
+
+    pub fn data_and_store_mut(&mut self) -> (&mut T, &mut impl AsStoreMut) {
+        let data = self.data_mut() as *mut T;
+        let data = unsafe { &mut *data };
+        (data, &mut self.write_lock)
+    }
+
+    pub fn as_function_env_mut(&mut self) -> FunctionEnvMut<'_, T> {
+        FunctionEnvMut {
+            store_mut: self.write_lock.as_store_mut(),
+            func_env: self.func_env.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T: 'static> AsStoreRef for AsyncFunctionEnvHandleMut<T> {
+    fn as_store_ref(&self) -> StoreRef<'_> {
+        self.write_lock.as_store_ref()
+    }
+}
+
+#[cfg(feature = "experimental-async")]
+impl<T: 'static> AsStoreMut for AsyncFunctionEnvHandleMut<T> {
+    fn as_store_mut(&mut self) -> StoreMut<'_> {
+        self.write_lock.as_store_mut()
+    }
+
+    fn objects_mut(&mut self) -> &mut crate::StoreObjects {
+        self.write_lock.objects_mut()
     }
 }

--- a/lib/api/src/backend/js/entities/function/mod.rs
+++ b/lib/api/src/backend/js/entities/function/mod.rs
@@ -113,17 +113,20 @@ impl Function {
             };
             let env_mut =
                 AsyncFunctionEnvMut(BackendAsyncFunctionEnvMut::Js(js_env));
-            let values = function_type
-                .params()
-                .iter()
-                .enumerate()
-                .map(|(index, ty)| js_value_to_wasmer(ty, &args.get(index as u32)))
-                .collect::<Vec<_>>();
+            let parameter_types = function_type.params().to_vec();
             let result_types = function_type.results().to_vec();
+            let args = args.clone();
             let func = Rc::clone(&func);
 
             future_to_promise(async move {
-                let write_lock = callback_store.write_lock().await;
+                let mut write_lock = callback_store.write_lock().await;
+                let values = parameter_types
+                    .iter()
+                    .enumerate()
+                    .map(|(index, ty)| {
+                        js_value_to_wasmer(&mut write_lock, ty, &args.get(index as u32))
+                    })
+                    .collect::<Vec<_>>();
                 let store_context = StoreContext::install_async(write_lock.inner);
                 let future = func(env_mut, &values);
                 drop(store_context);
@@ -288,13 +291,15 @@ impl Function {
         let wrapped_func: JsValue = match function_type.results().len() {
             0 => Closure::wrap(Box::new(move |args: &Array| {
                 let mut store: StoreMut = unsafe { StoreMut::from_raw(raw_store as _) };
-                let env: FunctionEnvMut<T> = raw_env.clone().into_mut(&mut store);
                 let wasm_arguments = function_type
                     .params()
                     .iter()
                     .enumerate()
-                    .map(|(i, param)| js_value_to_wasmer(param, &args.get(i as u32)))
+                    .map(|(i, param)| {
+                        js_value_to_wasmer(&mut store, param, &args.get(i as u32))
+                    })
                     .collect::<Vec<_>>();
+                let env: FunctionEnvMut<T> = raw_env.clone().into_mut(&mut store);
                 let _results = func(env, &wasm_arguments)?;
                 Ok(())
             })
@@ -302,13 +307,15 @@ impl Function {
             .into_js_value(),
             1 => Closure::wrap(Box::new(move |args: &Array| {
                 let mut store: StoreMut = unsafe { StoreMut::from_raw(raw_store as _) };
-                let env: FunctionEnvMut<T> = raw_env.clone().into_mut(&mut store);
                 let wasm_arguments = function_type
                     .params()
                     .iter()
                     .enumerate()
-                    .map(|(i, param)| js_value_to_wasmer(param, &args.get(i as u32)))
+                    .map(|(i, param)| {
+                        js_value_to_wasmer(&mut store, param, &args.get(i as u32))
+                    })
                     .collect::<Vec<_>>();
+                let env: FunctionEnvMut<T> = raw_env.clone().into_mut(&mut store);
                 let results = func(env, &wasm_arguments)?;
                 Ok(wasmer_value_to_js(&results[0]))
             })
@@ -316,13 +323,15 @@ impl Function {
             .into_js_value(),
             _n => Closure::wrap(Box::new(move |args: &Array| {
                 let mut store: StoreMut = unsafe { StoreMut::from_raw(raw_store as _) };
-                let env: FunctionEnvMut<T> = raw_env.clone().into_mut(&mut store);
                 let wasm_arguments = function_type
                     .params()
                     .iter()
                     .enumerate()
-                    .map(|(i, param)| js_value_to_wasmer(param, &args.get(i as u32)))
+                    .map(|(i, param)| {
+                        js_value_to_wasmer(&mut store, param, &args.get(i as u32))
+                    })
                     .collect::<Vec<_>>();
+                let env: FunctionEnvMut<T> = raw_env.clone().into_mut(&mut store);
                 let results = func(env, &wasm_arguments)?;
                 Ok(wasmer_array_to_js_array(&results))
             })
@@ -463,7 +472,7 @@ impl Function {
         match result_types.len() {
             0 => Ok(Box::new([])),
             1 => {
-                let value = js_value_to_wasmer(&result_types[0], &result);
+                let value = js_value_to_wasmer(store, &result_types[0], &result);
                 Ok(vec![value].into_boxed_slice())
             }
             _n => {
@@ -471,7 +480,9 @@ impl Function {
                 Ok(result_array
                     .iter()
                     .enumerate()
-                    .map(|(i, js_val)| js_value_to_wasmer(&result_types[i], &js_val))
+                    .map(|(i, js_val)| {
+                        js_value_to_wasmer(store, &result_types[i], &js_val)
+                    })
                     .collect::<Vec<_>>()
                     .into_boxed_slice())
             }
@@ -506,9 +517,11 @@ impl Function {
             drop(store_context);
 
             let result = JsFuture::from(promise).await.map_err(RuntimeError::from)?;
+            let mut write_lock = store.write_lock().await;
             match function_type.results().len() {
                 0 => Ok(Box::<[Value]>::default()),
                 1 => Ok(vec![js_value_to_wasmer(
+                    &mut write_lock,
                     &function_type.results()[0],
                     &result,
                 )]
@@ -519,7 +532,13 @@ impl Function {
                         .results()
                         .iter()
                         .enumerate()
-                        .map(|(index, ty)| js_value_to_wasmer(ty, &result.get(index as u32)))
+                        .map(|(index, ty)| {
+                            js_value_to_wasmer(
+                                &mut write_lock,
+                                ty,
+                                &result.get(index as u32),
+                            )
+                        })
                         .collect::<Vec<_>>()
                         .into_boxed_slice())
                 }

--- a/lib/api/src/backend/js/entities/function/mod.rs
+++ b/lib/api/src/backend/js/entities/function/mod.rs
@@ -1,11 +1,17 @@
 pub(crate) mod env;
 pub(crate) mod typed;
 use std::marker::PhantomData;
+#[cfg(feature = "experimental-async")]
+use std::{future::Future, pin::Pin, rc::Rc, sync::Arc};
 
 pub(crate) use typed::*;
 
 use js_sys::{Array, Function as JsFunction};
+#[cfg(feature = "experimental-async")]
+use js_sys::{Promise, Reflect};
 use wasm_bindgen::{JsCast, prelude::*};
+#[cfg(feature = "experimental-async")]
+use wasm_bindgen_futures::{JsFuture, future_to_promise};
 use wasmer_types::{FunctionType, RawValue};
 
 use crate::{
@@ -18,6 +24,12 @@ use crate::{
         vm::{VMFuncRef, VMFunctionCallback, function::VMFunction},
     },
     vm::{VMExtern, VMExternFunction},
+};
+#[cfg(feature = "experimental-async")]
+use crate::{
+    AsStoreAsync, AsyncFunctionEnvMut, BackendAsyncFunctionEnvMut, StoreAsync, StoreContext,
+    entities::function::async_host::{AsyncFunctionEnv, AsyncHostFunction},
+    js::{function::env::AsyncFunctionEnvMut as JsAsyncFunctionEnvMut, jspi},
 };
 
 use std::panic::{self, AssertUnwindSafe};
@@ -48,6 +60,210 @@ impl Function {
         VMExtern::Js(crate::js::vm::external::VMExtern::Function(
             self.handle.clone(),
         ))
+    }
+
+    #[cfg(feature = "experimental-async")]
+    pub(crate) fn new_async<FT, F, Fut>(
+        store: &mut impl AsStoreMut,
+        ty: FT,
+        func: F,
+    ) -> Self
+    where
+        FT: Into<FunctionType>,
+        F: Fn(&[Value]) -> Fut + 'static,
+        Fut: Future<Output = Result<Vec<Value>, RuntimeError>> + 'static,
+    {
+        let env = FunctionEnv::new(store, ());
+        Self::new_with_env_async(store, &env, ty, move |_env, values| func(values))
+    }
+
+    #[cfg(feature = "experimental-async")]
+    pub(crate) fn new_with_env_async<FT, F, Fut, T>(
+        store: &mut impl AsStoreMut,
+        env: &FunctionEnv<T>,
+        ty: FT,
+        func: F,
+    ) -> Self
+    where
+        FT: Into<FunctionType>,
+        F: Fn(AsyncFunctionEnvMut<T>, &[Value]) -> Fut + 'static,
+        Fut: Future<Output = Result<Vec<Value>, RuntimeError>> + 'static,
+        T: 'static,
+    {
+        assert!(
+            jspi::is_supported(),
+            "the JavaScript host does not support WebAssembly JSPI"
+        );
+
+        let function_type = ty.into();
+        let func_ty = function_type.clone();
+        let store_id = store.objects_mut().id();
+        let raw_env = env.as_js().clone();
+        let func = Rc::new(func);
+        let wrapped_func = Closure::wrap(Box::new(move |args: &Array| -> Promise {
+            let Some(async_store) = jspi::active_store(store_id) else {
+                return Promise::reject(&JsValue::from_str(
+                    "an async host function was called outside Function::call_async",
+                ));
+            };
+            let callback_store = async_store.store();
+            let js_env = JsAsyncFunctionEnvMut {
+                store: async_store,
+                func_env: raw_env.clone(),
+            };
+            let env_mut =
+                AsyncFunctionEnvMut(BackendAsyncFunctionEnvMut::Js(js_env));
+            let values = function_type
+                .params()
+                .iter()
+                .enumerate()
+                .map(|(index, ty)| js_value_to_wasmer(ty, &args.get(index as u32)))
+                .collect::<Vec<_>>();
+            let result_types = function_type.results().to_vec();
+            let func = Rc::clone(&func);
+
+            future_to_promise(async move {
+                let write_lock = callback_store.write_lock().await;
+                let store_context = StoreContext::install_async(write_lock.inner);
+                let future = func(env_mut, &values);
+                drop(store_context);
+
+                let results = future.await.map_err(JsValue::from)?;
+                match result_types.len() {
+                    0 => Ok(JsValue::UNDEFINED),
+                    1 => Ok(wasmer_value_to_js(&results[0])),
+                    _ => Ok(wasmer_array_to_js_array(&results).into()),
+                }
+            })
+        }) as Box<dyn FnMut(&Array) -> Promise>)
+        .into_js_value();
+
+        let variadic =
+            JsFunction::new_with_args("f", "return f(Array.prototype.slice.call(arguments, 1))");
+        let function = variadic
+            .bind1(&JsValue::UNDEFINED, &wrapped_func)
+            .unchecked_into::<JsFunction>();
+        let function = match jspi::suspending(&function) {
+            Ok(function) => function,
+            Err(error) => wasm_bindgen::throw_val(error),
+        };
+        let vm_function = VMFunction::new(function, func_ty);
+        Self::from_vm_extern(
+            &mut store.as_store_mut(),
+            VMExternFunction::Js(vm_function),
+        )
+    }
+
+    #[cfg(feature = "experimental-async")]
+    pub(crate) fn new_typed_async<F, Args, Rets>(
+        store: &mut impl AsStoreMut,
+        func: F,
+    ) -> Self
+    where
+        Args: WasmTypeList + 'static,
+        Rets: WasmTypeList + 'static,
+        F: AsyncHostFunction<(), Args, Rets, WithoutEnv> + 'static,
+    {
+        let env = FunctionEnv::new(store, ());
+        let signature = FunctionType::new(Args::wasm_types(), Rets::wasm_types());
+        let args_sig = Arc::new(signature.clone());
+        let results_sig = Arc::new(signature.clone());
+        let func = Arc::new(func);
+        Self::new_with_env_async(
+            store,
+            &env,
+            signature,
+            move |mut env_mut, values| -> Pin<
+                Box<dyn Future<Output = Result<Vec<Value>, RuntimeError>>>,
+            > {
+                let js_env = match env_mut.0 {
+                    BackendAsyncFunctionEnvMut::Js(ref mut js_env) => js_env,
+                    _ => panic!("Not a js backend"),
+                };
+                let mut store_wrapper = unsafe { StoreContext::get_current(js_env.store_id()) };
+                let mut store_mut = store_wrapper.as_mut();
+                let args = match typed_args_from_values::<Args>(
+                    &mut store_mut,
+                    args_sig.as_ref(),
+                    values,
+                ) {
+                    Ok(args) => args,
+                    Err(error) => return Box::pin(async { Err(error) }),
+                };
+                drop(store_wrapper);
+                let func = Arc::clone(&func);
+                let results_sig = Arc::clone(&results_sig);
+                let future = func
+                    .as_ref()
+                    .call_async(AsyncFunctionEnv::new(), args);
+                Box::pin(async move {
+                    let typed_result = future.await?;
+                    let mut store_mut = env_mut.write().await;
+                    typed_results_to_values::<Rets>(
+                        &mut store_mut.as_store_mut(),
+                        results_sig.as_ref(),
+                        typed_result,
+                    )
+                })
+            },
+        )
+    }
+
+    #[cfg(feature = "experimental-async")]
+    pub(crate) fn new_typed_with_env_async<T, F, Args, Rets>(
+        store: &mut impl AsStoreMut,
+        env: &FunctionEnv<T>,
+        func: F,
+    ) -> Self
+    where
+        T: 'static,
+        F: AsyncHostFunction<T, Args, Rets, WithEnv> + 'static,
+        Args: WasmTypeList + 'static,
+        Rets: WasmTypeList + 'static,
+    {
+        let signature = FunctionType::new(Args::wasm_types(), Rets::wasm_types());
+        let args_sig = Arc::new(signature.clone());
+        let results_sig = Arc::new(signature.clone());
+        let func = Arc::new(func);
+        Self::new_with_env_async(
+            store,
+            env,
+            signature,
+            move |mut env_mut, values| -> Pin<
+                Box<dyn Future<Output = Result<Vec<Value>, RuntimeError>>>,
+            > {
+                let js_env = match env_mut.0 {
+                    BackendAsyncFunctionEnvMut::Js(ref mut js_env) => js_env,
+                    _ => panic!("Not a js backend"),
+                };
+                let mut store_wrapper = unsafe { StoreContext::get_current(js_env.store_id()) };
+                let mut store_mut = store_wrapper.as_mut();
+                let args = match typed_args_from_values::<Args>(
+                    &mut store_mut,
+                    args_sig.as_ref(),
+                    values,
+                ) {
+                    Ok(args) => args,
+                    Err(error) => return Box::pin(async { Err(error) }),
+                };
+                drop(store_wrapper);
+                let env_mut_clone = env_mut.as_mut();
+                let func = Arc::clone(&func);
+                let results_sig = Arc::clone(&results_sig);
+                let future = func
+                    .as_ref()
+                    .call_async(AsyncFunctionEnv::with_env(env_mut), args);
+                Box::pin(async move {
+                    let typed_result = future.await?;
+                    let mut store_mut = env_mut_clone.write().await;
+                    typed_results_to_values::<Rets>(
+                        &mut store_mut.as_store_mut(),
+                        results_sig.as_ref(),
+                        typed_result,
+                    )
+                })
+            },
+        )
     }
 
     #[allow(clippy::cast_ptr_alignment)]
@@ -262,6 +478,55 @@ impl Function {
         }
     }
 
+    #[cfg(feature = "experimental-async")]
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn call_async(
+        &self,
+        store: &impl AsStoreAsync,
+        params: Vec<Value>,
+    ) -> Pin<Box<dyn Future<Output = Result<Box<[Value]>, RuntimeError>> + 'static>> {
+        let function = self.clone();
+        let store = store.store();
+        Box::pin(async move {
+            let _active_store = jspi::install_store(store.store());
+            let function_type = function.handle.ty.clone();
+            let write_lock = store.write_lock().await;
+            let arguments = Array::new_with_length(params.len() as u32);
+            for (index, param) in params.iter().enumerate() {
+                arguments.set(index as u32, param.as_jsvalue(&write_lock));
+            }
+
+            let store_context = StoreContext::install_async(write_lock.inner);
+            let promising = jspi::promising(&function.handle.function)
+                .map_err(RuntimeError::from)?;
+            let promise = Reflect::apply(&promising, &JsValue::NULL, &arguments)
+                .map_err(RuntimeError::from)?
+                .dyn_into::<Promise>()
+                .map_err(RuntimeError::from)?;
+            drop(store_context);
+
+            let result = JsFuture::from(promise).await.map_err(RuntimeError::from)?;
+            match function_type.results().len() {
+                0 => Ok(Box::<[Value]>::default()),
+                1 => Ok(vec![js_value_to_wasmer(
+                    &function_type.results()[0],
+                    &result,
+                )]
+                .into_boxed_slice()),
+                _ => {
+                    let result: Array = result.into();
+                    Ok(function_type
+                        .results()
+                        .iter()
+                        .enumerate()
+                        .map(|(index, ty)| js_value_to_wasmer(ty, &result.get(index as u32)))
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice())
+                }
+            }
+        })
+    }
+
     pub(crate) fn from_vm_extern(_store: &mut impl AsStoreMut, internal: VMExternFunction) -> Self {
         Self {
             handle: internal.unwrap_js(),
@@ -290,6 +555,50 @@ impl Function {
     pub fn is_from_store(&self, _store: &impl AsStoreRef) -> bool {
         true
     }
+}
+
+#[cfg(feature = "experimental-async")]
+fn typed_args_from_values<Args>(
+    store: &mut StoreMut,
+    function_type: &FunctionType,
+    values: &[Value],
+) -> Result<Args, RuntimeError>
+where
+    Args: WasmTypeList,
+{
+    if values.len() != function_type.params().len() {
+        return Err(RuntimeError::new(
+            "typed host function received wrong number of parameters",
+        ));
+    }
+    let mut raw_array = Args::empty_array();
+    for (slot, value) in raw_array.as_mut().iter_mut().zip(values) {
+        *slot = value.as_raw(store);
+    }
+    unsafe { Ok(Args::from_array(store, raw_array)) }
+}
+
+#[cfg(feature = "experimental-async")]
+fn typed_results_to_values<Rets>(
+    store: &mut StoreMut,
+    function_type: &FunctionType,
+    results: Rets,
+) -> Result<Vec<Value>, RuntimeError>
+where
+    Rets: WasmTypeList,
+{
+    let mut raw_array = unsafe { results.into_array(store) };
+    let mut values = Vec::with_capacity(function_type.results().len());
+    for (raw, ty) in raw_array
+        .as_mut()
+        .iter()
+        .zip(function_type.results())
+    {
+        unsafe {
+            values.push(Value::from_raw(store, *ty, *raw));
+        }
+    }
+    Ok(values)
 }
 
 impl std::fmt::Debug for Function {

--- a/lib/api/src/backend/js/entities/function/mod.rs
+++ b/lib/api/src/backend/js/entities/function/mod.rs
@@ -34,6 +34,28 @@ use crate::{
 
 use std::panic::{self, AssertUnwindSafe};
 
+#[derive(Debug)]
+struct HostFunctionPanic(String);
+
+impl std::fmt::Display for HostFunctionPanic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for HostFunctionPanic {}
+
+fn raise_host_function_panic(payload: Box<dyn std::any::Any + Send>) -> ! {
+    let message = if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "host function panicked with a non-string payload".to_owned()
+    };
+    crate::backend::js::error::raise(Box::new(HostFunctionPanic(message)))
+}
+
 #[inline]
 fn wasmer_array_to_js_array(values: &[Value]) -> Array {
     Array::from_iter(values.iter().map(wasmer_value_to_js))
@@ -731,7 +753,7 @@ macro_rules! impl_host_function {
                         return c_struct;
                     },
                     Ok(Err(trap)) => crate::backend::js::error::raise(Box::new(trap)),
-                    Err(_panic) => unimplemented!(),
+                    Err(panic) => raise_host_function_panic(panic),
                 }
             }
 
@@ -791,7 +813,7 @@ macro_rules! impl_host_function {
                     #[cfg(feature = "core")]
                     #[allow(deprecated)]
                     Ok(Err(trap)) => crate::js::error::raise(Box::new(trap)),
-                    Err(_panic) => unimplemented!(),
+                    Err(panic) => raise_host_function_panic(panic),
                 }
             }
 

--- a/lib/api/src/backend/js/entities/function/typed.rs
+++ b/lib/api/src/backend/js/entities/function/typed.rs
@@ -12,7 +12,11 @@ use crate::{
     TypedFunction, Value, WasmTypeList,
     js::utils::convert::{AsJs, js_value_to_wasmer},
 };
+#[cfg(feature = "experimental-async")]
+use crate::{AsStoreAsync, StoreAsync};
 use js_sys::Array;
+#[cfg(feature = "experimental-async")]
+use std::future::Future;
 use std::iter::FromIterator;
 use wasm_bindgen::JsValue;
 use wasmer_types::RawValue;
@@ -25,6 +29,35 @@ macro_rules! impl_native_traits {
             $( $x: FromToNativeWasmType, )*
             Rets: WasmTypeList,
         {
+            /// Call the typed func asynchronously through JSPI.
+            #[allow(clippy::too_many_arguments)]
+            #[cfg(feature = "experimental-async")]
+            pub(crate) fn call_async_js(
+                func: crate::Function,
+                store: StoreAsync,
+                $( $x: $x, )*
+            ) -> impl Future<Output = Result<Rets, RuntimeError>> + 'static
+            where
+                $( $x: FromToNativeWasmType + 'static, )*
+            {
+                async move {
+                    let mut write = store.write_lock().await;
+                    let func_ty = func.ty(&mut write);
+                    let mut params_raw = [ $( $x.to_native().into_raw(&mut write) ),* ];
+                    let mut params_values = Vec::with_capacity(params_raw.len());
+                    for (raw, ty) in params_raw.iter().zip(func_ty.params()) {
+                        unsafe {
+                            params_values.push(Value::from_raw(&mut write, *ty, *raw));
+                        }
+                    }
+                    drop(write);
+
+                    let results = func.call_async(&store, params_values).await?;
+                    let mut write = store.write_lock().await;
+                    convert_results::<Rets>(&mut write, func_ty, &results)
+                }
+            }
+
             /// Call the typed func and return results.
             #[allow(clippy::too_many_arguments)]
             pub fn call_js(&self, mut store: &mut impl AsStoreMut, $( $x: $x, )* ) -> Result<Rets, RuntimeError> where
@@ -133,3 +166,27 @@ impl_native_traits!(
 impl_native_traits!(
     A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20
 );
+
+#[cfg(feature = "experimental-async")]
+fn convert_results<Rets: WasmTypeList>(
+    store: &mut impl AsStoreMut,
+    func_ty: wasmer_types::FunctionType,
+    results: &[Value],
+) -> Result<Rets, RuntimeError> {
+    if results.len() != func_ty.results().len() {
+        return Err(RuntimeError::new("result arity mismatch"));
+    }
+
+    let mut rets_list_array = Rets::empty_array();
+    for ((slot, ty), value) in rets_list_array
+        .as_mut()
+        .iter_mut()
+        .zip(func_ty.results())
+        .zip(results)
+    {
+        debug_assert_eq!(value.ty(), *ty);
+        *slot = value.as_raw(store);
+    }
+
+    Ok(unsafe { Rets::from_array(store, rets_list_array) })
+}

--- a/lib/api/src/backend/js/entities/function/typed.rs
+++ b/lib/api/src/backend/js/entities/function/typed.rs
@@ -104,7 +104,7 @@ macro_rules! impl_native_traits {
                     0 => {},
                     1 => unsafe {
                         let ty = Rets::wasm_types()[0];
-                        let val = js_value_to_wasmer(&ty, &results);
+                        let val = js_value_to_wasmer(&mut store, &ty, &results);
                         *mut_rets = val.as_raw(&mut store);
                     }
                     _n => {
@@ -112,7 +112,7 @@ macro_rules! impl_native_traits {
                         for (i, ret_type) in Rets::wasm_types().iter().enumerate() {
                             let ret = results.get(i as u32);
                             unsafe {
-                                let val = js_value_to_wasmer(&ret_type, &ret);
+                                let val = js_value_to_wasmer(&mut store, &ret_type, &ret);
                                 let slot = mut_rets.add(i);
                                 *slot = val.as_raw(&mut store);
                             }

--- a/lib/api/src/backend/js/entities/memory/mod.rs
+++ b/lib/api/src/backend/js/entities/memory/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 // prevent browsers from creating the other shared memories used by the SDK.
 // 512 MiB is large enough for substantial WASIX workloads while leaving useful
 // address-space headroom for the runtime and concurrent processes.
-const JS_SHARED_MEMORY_MAXIMUM_PAGES: Pages = Pages(6_144);
+const JS_SHARED_MEMORY_MAXIMUM_PAGES: Pages = Pages(16_384);
 
 #[derive(Debug, Clone, Eq)]
 pub struct Memory {

--- a/lib/api/src/backend/js/entities/memory/mod.rs
+++ b/lib/api/src/backend/js/entities/memory/mod.rs
@@ -16,11 +16,10 @@ use crate::{
     vm::{VMExtern, VMExternMemory},
 };
 
-// Reserving the multi-gigabyte maximum declared by some WASIX programs can
-// prevent browsers from creating the other shared memories used by the SDK.
-// 512 MiB is large enough for substantial WASIX workloads while leaving useful
-// address-space headroom for the runtime and concurrent processes.
-const JS_SHARED_MEMORY_MAXIMUM_PAGES: Pages = Pages(16_384);
+// QuickJS currently represents ArrayBuffer lengths with a signed 32-bit value.
+// Keep shared WASIX memories just below 2 GiB so nested WebAssembly runtimes can
+// grow large workloads without exposing a buffer QuickJS cannot address.
+const JS_SHARED_MEMORY_MAXIMUM_PAGES: Pages = Pages(32_767);
 
 #[derive(Debug, Clone, Eq)]
 pub struct Memory {

--- a/lib/api/src/backend/js/entities/memory/mod.rs
+++ b/lib/api/src/backend/js/entities/memory/mod.rs
@@ -16,6 +16,12 @@ use crate::{
     vm::{VMExtern, VMExternMemory},
 };
 
+// Reserving the multi-gigabyte maximum declared by some WASIX programs can
+// prevent browsers from creating the other shared memories used by the SDK.
+// 512 MiB is large enough for substantial WASIX workloads while leaving useful
+// address-space headroom for the runtime and concurrent processes.
+const JS_SHARED_MEMORY_MAXIMUM_PAGES: Pages = Pages(6_144);
+
 #[derive(Debug, Clone, Eq)]
 pub struct Memory {
     pub(crate) handle: VMMemory,
@@ -37,8 +43,46 @@ unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}
 
 impl Memory {
-    pub fn new(store: &mut impl AsStoreMut, ty: MemoryType) -> Result<Self, MemoryError> {
-        let vm_memory = VMMemory::new(Self::js_memory_from_type(&ty)?, ty);
+    pub fn new(store: &mut impl AsStoreMut, mut ty: MemoryType) -> Result<Self, MemoryError> {
+        if ty.shared
+            && let Some(maximum) = ty.maximum
+            && maximum > JS_SHARED_MEMORY_MAXIMUM_PAGES
+            && ty.minimum <= JS_SHARED_MEMORY_MAXIMUM_PAGES
+        {
+            ty.maximum = Some(JS_SHARED_MEMORY_MAXIMUM_PAGES);
+            tracing::debug!(
+                requested_maximum = maximum.0,
+                allocated_maximum = JS_SHARED_MEMORY_MAXIMUM_PAGES.0,
+                "bounding shared memory growth for the JavaScript backend",
+            );
+        }
+        let js_memory = match Self::js_memory_from_type(&ty) {
+            Ok(memory) => memory,
+            Err(original_error) if ty.shared => {
+                let Some(requested_maximum) = ty.maximum else {
+                    return Err(original_error);
+                };
+
+                let mut allocated = None;
+                for maximum in smaller_shared_memory_maxima(ty.minimum, requested_maximum) {
+                    let candidate = MemoryType::new(ty.minimum, Some(maximum), true);
+                    if let Ok(memory) = Self::js_memory_from_type(&candidate) {
+                        tracing::debug!(
+                            requested_maximum = requested_maximum.0,
+                            allocated_maximum = maximum.0,
+                            "browser rejected the requested shared memory maximum; using a smaller compatible maximum",
+                        );
+                        ty = candidate;
+                        allocated = Some(memory);
+                        break;
+                    }
+                }
+
+                allocated.ok_or(original_error)?
+            }
+            Err(error) => return Err(error),
+        };
+        let vm_memory = VMMemory::new(js_memory, ty);
         Ok(Self::from_vm_extern(store, VMExternMemory::Js(vm_memory)))
     }
 
@@ -174,6 +218,21 @@ impl Memory {
             self.handle.try_clone()?,
         )))
     }
+}
+
+fn smaller_shared_memory_maxima(minimum: Pages, maximum: Pages) -> impl Iterator<Item = Pages> {
+    // Shared memories reserve their declared maximum in the browser. Reduce the
+    // reservation gradually so a child process can still retain a useful heap
+    // alongside its parent instead of jumping straight to half the capacity.
+    const STEP: u32 = 1_024; // 64 MiB
+    let mut candidate = maximum.0;
+    std::iter::from_fn(move || {
+        if candidate <= minimum.0 {
+            return None;
+        }
+        candidate = candidate.saturating_sub(STEP).max(minimum.0);
+        Some(Pages(candidate))
+    })
 }
 
 impl std::cmp::PartialEq for Memory {

--- a/lib/api/src/backend/js/entities/memory/view.rs
+++ b/lib/api/src/backend/js/entities/memory/view.rs
@@ -268,17 +268,32 @@ impl<'a> MemoryView<'a> {
 
     /// Copies the memory to another new memory object
     pub fn copy_to_memory(&self, amount: u64, new_memory: &Self) -> Result<(), MemoryAccessError> {
-        let mut offset = 0;
-        let mut chunk = [0u8; 40960];
-        while offset < amount {
-            let remaining = amount - offset;
-            let sublen = remaining.min(chunk.len() as u64) as usize;
-            self.read(offset, &mut chunk[..sublen])?;
+        self.copy_range_to_memory(0, 0, amount, new_memory)
+    }
 
-            new_memory.write(offset, &chunk[..sublen])?;
-
-            offset += sublen as u64;
+    /// Copies a memory range directly between JavaScript WebAssembly memories.
+    pub(crate) fn copy_range_to_memory(
+        &self,
+        source_offset: u64,
+        target_offset: u64,
+        amount: u64,
+        new_memory: &Self,
+    ) -> Result<(), MemoryAccessError> {
+        let source_offset = u32::try_from(source_offset).map_err(|_| MemoryAccessError::Overflow)?;
+        let target_offset = u32::try_from(target_offset).map_err(|_| MemoryAccessError::Overflow)?;
+        let amount = u32::try_from(amount).map_err(|_| MemoryAccessError::Overflow)?;
+        let source_end = source_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        let target_end = target_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        if source_end > self.view.length() || target_end > new_memory.view.length() {
+            return Err(MemoryAccessError::HeapOutOfBounds);
         }
+
+        let source = self.view.subarray(source_offset, source_end);
+        new_memory.view.set(&source, target_offset);
         Ok(())
     }
 }

--- a/lib/api/src/backend/js/entities/module.rs
+++ b/lib/api/src/backend/js/entities/module.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use bytes::Bytes;
 use js_sys::{Reflect, Uint8Array, WebAssembly};
@@ -10,8 +10,8 @@ use wasm_bindgen::{JsValue, prelude::*};
 use wasm_bindgen_futures::JsFuture;
 use wasmer_types::{
     CompileError, DeserializeError, ExportType, ExportsIterator, ExternType, FunctionType,
-    GlobalType, ImportType, ImportsIterator, MemoryType, ModuleInfo, Mutability, Pages,
-    SerializeError, TableType, Type,
+    GlobalIndex, GlobalType, ImportIndex, ImportType, ImportsIterator, InitExpr, InitExprOp,
+    MemoryType, ModuleInfo, Mutability, Pages, SerializeError, TableIndex, TableType, Type,
 };
 
 use crate::{
@@ -50,6 +50,39 @@ pub struct Module {
     type_hints: Option<ModuleTypeHints>,
     #[cfg(feature = "js-serializable-module")]
     raw_bytes: Option<Bytes>,
+}
+
+#[cfg(feature = "wasm-types-polyfill")]
+fn evaluate_i32_init_expr(
+    expression: &InitExpr,
+    globals: &HashMap<GlobalIndex, i64>,
+) -> Option<u32> {
+    let mut stack = Vec::<i64>::new();
+    for operation in expression.ops() {
+        match operation {
+            InitExprOp::GlobalGetI32(index) | InitExprOp::GlobalGetI64(index) => {
+                stack.push(*globals.get(index)?);
+            }
+            InitExprOp::I32Const(value) => stack.push(i64::from(*value)),
+            InitExprOp::I64Const(value) => stack.push(*value),
+            InitExprOp::I32Add | InitExprOp::I64Add => {
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                stack.push(lhs.checked_add(rhs)?);
+            }
+            InitExprOp::I32Sub | InitExprOp::I64Sub => {
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                stack.push(lhs.checked_sub(rhs)?);
+            }
+            InitExprOp::I32Mul | InitExprOp::I64Mul => {
+                let rhs = stack.pop()?;
+                let lhs = stack.pop()?;
+                stack.push(lhs.checked_mul(rhs)?);
+            }
+        }
+    }
+    u32::try_from(stack.pop()?).ok().filter(|_| stack.is_empty())
 }
 
 // XXX
@@ -246,8 +279,66 @@ impl Module {
             // in case the import is not found, the JS Wasm VM will handle
             // the error for us, so we don't need to handle it
         }
-        WebAssembly::Instance::new(&self.module, &imports_object)
-            .map_err(|e: JsValue| -> RuntimeError { e.into() })
+        let instance = WebAssembly::Instance::new(&self.module, &imports_object)
+            .map_err(|e: JsValue| -> RuntimeError { e.into() })?;
+        #[cfg(feature = "wasm-types-polyfill")]
+        self.annotate_imported_table_functions(store, imports);
+        Ok(instance)
+    }
+
+    #[cfg(feature = "wasm-types-polyfill")]
+    fn annotate_imported_table_functions(
+        &self,
+        store: &mut impl AsStoreMut,
+        imports: &Imports,
+    ) {
+        let mut tables = HashMap::<TableIndex, crate::Table>::new();
+        let mut globals = HashMap::<GlobalIndex, i64>::new();
+
+        for (key, import_index) in &self.info.imports {
+            let Some(extern_) = imports.get_export(&key.module, &key.field) else {
+                continue;
+            };
+            match (import_index, extern_) {
+                (ImportIndex::Table(index), Extern::Table(table)) => {
+                    tables.insert(*index, table);
+                }
+                (ImportIndex::Global(index), Extern::Global(global)) => {
+                    let value = match global.get(store) {
+                        crate::Value::I32(value) => i64::from(value),
+                        crate::Value::I64(value) => value,
+                        _ => continue,
+                    };
+                    globals.insert(*index, value);
+                }
+                _ => {}
+            }
+        }
+        for initializer in &self.info.table_initializers {
+            let Some(table) = tables.get(&initializer.table_index) else {
+                continue;
+            };
+            let Some(start) = evaluate_i32_init_expr(&initializer.offset_expr, &globals) else {
+                continue;
+            };
+            for (offset, function_index) in initializer.elements.iter().enumerate() {
+                let Some(signature_index) = self.info.functions.get(*function_index) else {
+                    continue;
+                };
+                let Some(function_type) = self.info.signatures.get(*signature_index) else {
+                    continue;
+                };
+                let Ok(function) = table
+                    .as_js()
+                    .handle
+                    .table
+                    .get(start.saturating_add(offset as u32))
+                else {
+                    continue;
+                };
+                crate::js::vm::VMFunction::annotate_type(&function, function_type);
+            }
+        }
     }
 
     pub fn name(&self) -> Option<&str> {

--- a/lib/api/src/backend/js/entities/module.rs
+++ b/lib/api/src/backend/js/entities/module.rs
@@ -9,9 +9,10 @@ use wasm_bindgen::{JsValue, prelude::*};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::JsFuture;
 use wasmer_types::{
-    CompileError, DeserializeError, ExportType, ExportsIterator, ExternType, FunctionType,
-    GlobalIndex, GlobalType, ImportIndex, ImportType, ImportsIterator, InitExpr, InitExprOp,
-    MemoryType, ModuleInfo, Mutability, Pages, SerializeError, TableIndex, TableType, Type,
+    CompileError, DeserializeError, ExportIndex, ExportType, ExportsIterator, ExternType,
+    FunctionType, GlobalIndex, GlobalType, ImportIndex, ImportType, ImportsIterator, InitExpr,
+    InitExprOp, MemoryType, ModuleInfo, Mutability, Pages, SerializeError, TableIndex, TableType,
+    Type,
 };
 
 use crate::{
@@ -82,7 +83,9 @@ fn evaluate_i32_init_expr(
             }
         }
     }
-    u32::try_from(stack.pop()?).ok().filter(|_| stack.is_empty())
+    u32::try_from(stack.pop()?)
+        .ok()
+        .filter(|_| stack.is_empty())
 }
 
 // XXX
@@ -282,17 +285,18 @@ impl Module {
         let instance = WebAssembly::Instance::new(&self.module, &imports_object)
             .map_err(|e: JsValue| -> RuntimeError { e.into() })?;
         #[cfg(feature = "wasm-types-polyfill")]
-        self.annotate_imported_table_functions(store, imports);
+        self.annotate_table_functions(store, imports, &instance);
         Ok(instance)
     }
 
     #[cfg(feature = "wasm-types-polyfill")]
-    fn annotate_imported_table_functions(
+    fn annotate_table_functions(
         &self,
         store: &mut impl AsStoreMut,
         imports: &Imports,
+        instance: &WebAssembly::Instance,
     ) {
-        let mut tables = HashMap::<TableIndex, crate::Table>::new();
+        let mut tables = HashMap::<TableIndex, WebAssembly::Table>::new();
         let mut globals = HashMap::<GlobalIndex, i64>::new();
 
         for (key, import_index) in &self.info.imports {
@@ -301,7 +305,7 @@ impl Module {
             };
             match (import_index, extern_) {
                 (ImportIndex::Table(index), Extern::Table(table)) => {
-                    tables.insert(*index, table);
+                    tables.insert(*index, table.as_js().handle.table.clone());
                 }
                 (ImportIndex::Global(index), Extern::Global(global)) => {
                     let value = match global.get(store) {
@@ -313,6 +317,16 @@ impl Module {
                 }
                 _ => {}
             }
+        }
+        let instance_exports = instance.exports();
+        for (name, export_index) in &self.info.exports {
+            let ExportIndex::Table(index) = export_index else {
+                continue;
+            };
+            let Ok(value) = Reflect::get(&instance_exports, &name.into()) else {
+                continue;
+            };
+            tables.insert(*index, value.into());
         }
         for initializer in &self.info.table_initializers {
             let Some(table) = tables.get(&initializer.table_index) else {
@@ -328,12 +342,7 @@ impl Module {
                 let Some(function_type) = self.info.signatures.get(*signature_index) else {
                     continue;
                 };
-                let Ok(function) = table
-                    .as_js()
-                    .handle
-                    .table
-                    .get(start.saturating_add(offset as u32))
-                else {
+                let Ok(function) = table.get(start.saturating_add(offset as u32)) else {
                     continue;
                 };
                 crate::js::vm::VMFunction::annotate_type(&function, function_type);

--- a/lib/api/src/backend/js/entities/module.rs
+++ b/lib/api/src/backend/js/entities/module.rs
@@ -3,7 +3,11 @@ use std::path::Path;
 use bytes::Bytes;
 use js_sys::{Reflect, Uint8Array, WebAssembly};
 use tracing::{debug, warn};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
 use wasm_bindgen::{JsValue, prelude::*};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::JsFuture;
 use wasmer_types::{
     CompileError, DeserializeError, ExportType, ExportsIterator, ExternType, FunctionType,
     GlobalType, ImportType, ImportsIterator, MemoryType, ModuleInfo, Mutability, Pages,
@@ -62,6 +66,38 @@ impl From<Module> for JsValue {
 }
 
 impl Module {
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) async fn new_async(
+        _engine: &impl AsEngineRef,
+        binary: &[u8],
+    ) -> Result<Self, CompileError> {
+        // Copy the bytes into JavaScript-owned memory before awaiting. A view
+        // into Wasm linear memory could be invalidated if that memory grows.
+        let js_bytes = Uint8Array::from(binary);
+        let module = JsFuture::from(WebAssembly::compile(&js_bytes))
+            .await
+            .map_err(|error| {
+                CompileError::Validate(
+                    error
+                        .as_string()
+                        .or_else(|| {
+                            Reflect::get(&error, &JsValue::from_str("message"))
+                                .ok()
+                                .and_then(|message| message.as_string())
+                        })
+                        .unwrap_or_else(|| "Unknown validation error".to_owned()),
+                )
+            })?
+            .dyn_into::<WebAssembly::Module>()
+            .map_err(|_| {
+                CompileError::Validate(
+                    "WebAssembly.compile returned an unexpected value".to_owned(),
+                )
+            })?;
+
+        Ok(unsafe { Self::from_js_module(module, binary) })
+    }
+
     pub(crate) fn from_binary(
         _engine: &impl AsEngineRef,
         binary: &[u8],

--- a/lib/api/src/backend/js/entities/module.rs
+++ b/lib/api/src/backend/js/entities/module.rs
@@ -40,6 +40,8 @@ pub struct ModuleTypeHints {
 pub struct Module {
     module: JsHandle<WebAssembly::Module>,
     name: Option<String>,
+    #[cfg(feature = "wasm-types-polyfill")]
+    info: ModuleInfo,
     // WebAssembly type hints
     type_hints: Option<ModuleTypeHints>,
     #[cfg(feature = "js-serializable-module")]
@@ -91,23 +93,24 @@ impl Module {
 
         // The module is now validated, so we can safely parse it's types
         #[cfg(feature = "wasm-types-polyfill")]
-        let (type_hints, name) = {
-            let info = crate::polyfill::translate_module(&binary[..]).unwrap();
+        let (type_hints, name, module_info) = {
+            let translated = crate::polyfill::translate_module(&binary[..]).unwrap();
 
             (
                 Some(ModuleTypeHints {
-                    imports: info
+                    imports: translated
                         .info
                         .imports()
                         .map(|import| import.ty().clone())
                         .collect::<Vec<_>>(),
-                    exports: info
+                    exports: translated
                         .info
                         .exports()
                         .map(|export| export.ty().clone())
                         .collect::<Vec<_>>(),
                 }),
-                info.info.name,
+                translated.info.name.clone(),
+                translated.info,
             )
         };
         #[cfg(not(feature = "wasm-types-polyfill"))]
@@ -117,6 +120,8 @@ impl Module {
             module: JsHandle::new(module),
             type_hints,
             name,
+            #[cfg(feature = "wasm-types-polyfill")]
+            info: module_info,
             #[cfg(feature = "js-serializable-module")]
             raw_bytes: Some(binary),
         }
@@ -458,7 +463,14 @@ impl Module {
     }
 
     pub(crate) fn info(&self) -> &ModuleInfo {
-        unimplemented!()
+        #[cfg(feature = "wasm-types-polyfill")]
+        {
+            &self.info
+        }
+        #[cfg(not(feature = "wasm-types-polyfill"))]
+        {
+            unimplemented!("module info requires the wasm-types-polyfill feature")
+        }
     }
 }
 
@@ -469,6 +481,8 @@ impl From<WebAssembly::Module> for Module {
             module: JsHandle::new(module),
             name: None,
             type_hints: None,
+            #[cfg(feature = "wasm-types-polyfill")]
+            info: ModuleInfo::default(),
             #[cfg(feature = "js-serializable-module")]
             raw_bytes: None,
         }

--- a/lib/api/src/backend/js/entities/store/obj.rs
+++ b/lib/api/src/backend/js/entities/store/obj.rs
@@ -3,7 +3,10 @@ use std::{marker::PhantomData, num::NonZeroUsize};
 use wasm_bindgen::JsValue;
 use wasmer_types::StoreId;
 
-use crate::js::vm::{function::VMFunctionEnvironment, global::VMGlobal};
+use crate::js::{
+    entities::external::ExternRefData,
+    vm::{function::VMFunctionEnvironment, global::VMGlobal},
+};
 
 use super::handle::InternalStoreHandle;
 
@@ -40,6 +43,7 @@ impl_store_object! {
     // since the other JS objects (table, globals, memory and functions)
     // live in the JS VM Store by default
     function_environments => VMFunctionEnvironment,
+    externrefs => ExternRefData,
 }
 
 /// Set of objects managed by a context.
@@ -48,6 +52,7 @@ pub struct StoreObjects {
     id: StoreId,
     globals: Vec<VMGlobal>,
     function_environments: Vec<VMFunctionEnvironment>,
+    externrefs: Vec<ExternRefData>,
 }
 
 impl StoreObjects {

--- a/lib/api/src/backend/js/entities/table.rs
+++ b/lib/api/src/backend/js/entities/table.rs
@@ -3,8 +3,8 @@ use crate::{
     js::vm::{VMFunction, VMTable},
     vm::{VMExtern, VMExternTable},
 };
-use js_sys::Function;
-use wasmer_types::{FunctionType, TableType};
+use wasm_bindgen::{JsCast, JsValue};
+use wasmer_types::{FunctionType, TableType, Type};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Table {
@@ -15,20 +15,27 @@ pub struct Table {
 // https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
 // unsafe impl Send for Table {}
 
-fn set_table_item(table: &VMTable, item_index: u32, item: &Function) -> Result<(), RuntimeError> {
-    table.table.set(item_index, item).map_err(|e| e.into())
+fn set_table_item(table: &VMTable, item_index: u32, item: &JsValue) -> Result<(), RuntimeError> {
+    table
+        .table
+        .set_raw(item_index, item)
+        .map_err(|e| e.into())
 }
 
-fn get_function(store: &mut impl AsStoreMut, val: Value) -> Result<Option<Function>, RuntimeError> {
+fn get_table_item(store: &mut impl AsStoreMut, val: Value) -> Result<JsValue, RuntimeError> {
     if !val.is_from_store(store) {
         return Err(RuntimeError::new("cannot pass Value across contexts"));
     }
     match val {
-        Value::FuncRef(Some(ref func)) => {
-            Ok(Some(func.as_js().handle.function.clone().into_inner()))
-        }
-        Value::FuncRef(None) => Ok(None),
-        // Only funcrefs is supported by the spec atm
+        Value::FuncRef(Some(ref func)) => Ok(func.as_js().handle.function.clone().into_inner().into()),
+        Value::FuncRef(None) | Value::ExternRef(None) => Ok(JsValue::null()),
+        Value::ExternRef(Some(ref reference)) => match &reference.0 {
+            crate::BackendExternRef::Js(reference) => Ok(reference.as_js_value()),
+            #[allow(unreachable_patterns)]
+            _ => Err(RuntimeError::new(
+                "cannot pass an externref across backends",
+            )),
+        },
         _ => unimplemented!("The {val:?} is not yet supported"),
     }
 }
@@ -45,19 +52,20 @@ impl Table {
         if let Some(max) = ty.maximum {
             js_sys::Reflect::set(&descriptor, &"maximum".into(), &max.into())?;
         }
-        js_sys::Reflect::set(&descriptor, &"element".into(), &"anyfunc".into())?;
-
-        let js_table = js_sys::WebAssembly::Table::new(&descriptor)?;
-        // TODO: use `Table.new_with_value` method from wasm-bindgen
-        // https://github.com/wasm-bindgen/wasm-bindgen/pull/4698
-        let table = VMTable::new(js_table, ty);
-        let num_elements = table.table.length();
-        let func = get_function(&mut store, init)?;
-        if let Some(func) = func {
-            for i in 0..num_elements {
-                set_table_item(&table, i, &func)?;
+        let element = match ty.ty {
+            Type::FuncRef => "anyfunc",
+            Type::ExternRef => "externref",
+            other => {
+                return Err(RuntimeError::new(format!(
+                    "{other:?} is not a valid JavaScript table element type"
+                )));
             }
-        }
+        };
+        js_sys::Reflect::set(&descriptor, &"element".into(), &element.into())?;
+
+        let initial_value = get_table_item(&mut store, init)?;
+        let js_table = js_sys::WebAssembly::Table::new_with_value(&descriptor, initial_value)?;
+        let table = VMTable::new(js_table, ty);
 
         Ok(Self { handle: table })
     }
@@ -71,17 +79,32 @@ impl Table {
     }
 
     pub fn get(&self, store: &mut impl AsStoreMut, index: u32) -> Option<Value> {
-        if let Ok(func) = self.handle.table.get(index) {
-            let ty = VMFunction::type_from_js(&func)
-                .unwrap_or_else(|| FunctionType::new(vec![], vec![]));
-            let vm_function = VMFunction::new(func, ty);
-            let function = crate::Function::from_vm_extern(
-                store,
-                crate::vm::VMExternFunction::Js(vm_function),
-            );
-            Some(Value::FuncRef(Some(function)))
-        } else {
-            None
+        let value = self.handle.table.get_raw(index).ok()?;
+        if value.is_null() {
+            return Some(match self.handle.ty.ty {
+                Type::FuncRef => Value::FuncRef(None),
+                Type::ExternRef => Value::ExternRef(None),
+                _ => return None,
+            });
+        }
+        match self.handle.ty.ty {
+            Type::FuncRef => {
+                let func = value.dyn_into::<js_sys::Function>().ok()?;
+                let ty = VMFunction::type_from_js(&func)
+                    .unwrap_or_else(|| FunctionType::new(vec![], vec![]));
+                let vm_function = VMFunction::new(func, ty);
+                let function = crate::Function::from_vm_extern(
+                    store,
+                    crate::vm::VMExternFunction::Js(vm_function),
+                );
+                Some(Value::FuncRef(Some(function)))
+            }
+            Type::ExternRef => Some(Value::ExternRef(Some(crate::ExternRef(
+                crate::BackendExternRef::Js(
+                    crate::backend::js::entities::external::ExternRef::from_js_value(store, value),
+                ),
+            )))),
+            _ => None,
         }
     }
 
@@ -91,11 +114,8 @@ impl Table {
         index: u32,
         val: Value,
     ) -> Result<(), RuntimeError> {
-        let item = get_function(store, val)?;
-        if let Some(item) = item {
-            set_table_item(&self.handle, index, &item)?;
-        }
-        Ok(())
+        let item = get_table_item(store, val)?;
+        set_table_item(&self.handle, index, &item)
     }
 
     pub fn size(&self, _store: &impl AsStoreRef) -> u32 {
@@ -108,15 +128,11 @@ impl Table {
         delta: u32,
         init: Value,
     ) -> Result<u32, RuntimeError> {
-        // TODO: use `Table.grow_with_value` method from wasm-bindgen
-        // https://github.com/wasm-bindgen/wasm-bindgen/pull/4698
-        let grow_by = self.handle.table.grow(delta)?;
-        if let Some(func) = get_function(store, init)? {
-            for i in grow_by..(grow_by + delta) {
-                set_table_item(&self.handle, i, &func)?;
-            }
-        }
-        Ok(grow_by)
+        let initial_value = get_table_item(store, init)?;
+        self.handle
+            .table
+            .grow_with_value(delta, initial_value)
+            .map_err(Into::into)
     }
 
     pub fn copy(

--- a/lib/api/src/backend/js/entities/table.rs
+++ b/lib/api/src/backend/js/entities/table.rs
@@ -72,7 +72,8 @@ impl Table {
 
     pub fn get(&self, store: &mut impl AsStoreMut, index: u32) -> Option<Value> {
         if let Ok(func) = self.handle.table.get(index) {
-            let ty = FunctionType::new(vec![], vec![]);
+            let ty = VMFunction::type_from_js(&func)
+                .unwrap_or_else(|| FunctionType::new(vec![], vec![]));
             let vm_function = VMFunction::new(func, ty);
             let function = crate::Function::from_vm_extern(
                 store,

--- a/lib/api/src/backend/js/error.rs
+++ b/lib/api/src/backend/js/error.rs
@@ -139,11 +139,59 @@ fn downcast_from_ptr(value: &JsValue) -> Option<Trap> {
             .ok()
             .and_then(|v| v.dyn_into::<js_sys::Function>().ok())
             .and_then(|destroy_into_raw| destroy_into_raw.call0(value).ok())
-            .and_then(|ret| ret.as_f64())?;
+            .and_then(|ret| ret.as_f64())
+            .and_then(wasm32_pointer_from_js_number)?;
 
         Some(<Trap as wasm_bindgen::convert::FromWasmAbi>::from_abi(
-            wasm_bindgen::__rt::WasmPtr::from_usize(ptr as u32 as usize),
+            wasm_bindgen::__rt::WasmPtr::from_usize(ptr as usize),
         ))
+    }
+}
+
+/// JavaScript exposes a WebAssembly `i32` result as a signed number, while
+/// newer glue may explicitly coerce pointer results to an unsigned number.
+/// Accept both representations and preserve the original wasm32 bit pattern.
+fn wasm32_pointer_from_js_number(value: f64) -> Option<u32> {
+    if !value.is_finite() || value.fract() != 0.0 {
+        return None;
+    }
+
+    if (0.0..=u32::MAX as f64).contains(&value) {
+        Some(value as u32)
+    } else if ((i32::MIN as f64)..0.0).contains(&value) {
+        Some(value as i32 as u32)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wasm32_pointer_from_js_number;
+
+    #[test]
+    fn converts_signed_and_unsigned_wasm32_pointers() {
+        assert_eq!(wasm32_pointer_from_js_number(42.0), Some(42));
+        assert_eq!(
+            wasm32_pointer_from_js_number(i32::MIN as f64),
+            Some(0x8000_0000),
+        );
+        assert_eq!(
+            wasm32_pointer_from_js_number(-1.0),
+            Some(u32::MAX),
+        );
+        assert_eq!(
+            wasm32_pointer_from_js_number(u32::MAX as f64),
+            Some(u32::MAX),
+        );
+    }
+
+    #[test]
+    fn rejects_numbers_that_cannot_be_wasm32_pointers() {
+        assert_eq!(wasm32_pointer_from_js_number(f64::NAN), None);
+        assert_eq!(wasm32_pointer_from_js_number(1.5), None);
+        assert_eq!(wasm32_pointer_from_js_number(i32::MIN as f64 - 1.0), None);
+        assert_eq!(wasm32_pointer_from_js_number(u32::MAX as f64 + 1.0), None);
     }
 }
 

--- a/lib/api/src/backend/js/error.rs
+++ b/lib/api/src/backend/js/error.rs
@@ -208,7 +208,16 @@ impl From<JsValue> for JsTrap {
     fn from(value: JsValue) -> Self {
         // Let's try some easy special cases first
         if let Some(error) = value.dyn_ref::<js_sys::Error>() {
-            return Self::Message(error.message().into());
+            let message = String::from(error.message());
+            let stack = Reflect::get(&value, &JsValue::from_str("stack"))
+                .ok()
+                .and_then(|value| value.as_string())
+                .unwrap_or_default();
+            return Self::Message(if stack.is_empty() || stack == message {
+                message
+            } else {
+                format!("{message}\n{stack}")
+            });
         }
 
         if let Some(s) = value.as_string() {

--- a/lib/api/src/backend/js/jspi.rs
+++ b/lib/api/src/backend/js/jspi.rs
@@ -1,0 +1,81 @@
+use std::{cell::RefCell, collections::HashMap};
+
+use crate::{AsStoreAsync, StoreAsync};
+use js_sys::{Function, Reflect};
+use wasm_bindgen::{JsCast, JsValue, prelude::wasm_bindgen};
+use wasmer_types::StoreId;
+
+struct ActiveStore {
+    store: StoreAsync,
+    users: usize,
+}
+
+thread_local! {
+    static ACTIVE_STORES: RefCell<HashMap<StoreId, ActiveStore>> =
+        RefCell::new(HashMap::new());
+}
+
+pub(crate) struct ActiveStoreGuard {
+    id: StoreId,
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = WebAssembly, js_name = promising, catch)]
+    fn promising_raw(function: &Function) -> Result<Function, JsValue>;
+
+    #[wasm_bindgen(js_namespace = WebAssembly, js_name = Suspending)]
+    type Suspending;
+
+    #[wasm_bindgen(constructor, js_namespace = WebAssembly, catch)]
+    fn new(function: &Function) -> Result<Suspending, JsValue>;
+}
+
+pub(crate) fn is_supported() -> bool {
+    let Ok(webassembly) = Reflect::get(&js_sys::global(), &JsValue::from_str("WebAssembly")) else {
+        return false;
+    };
+    Reflect::get(&webassembly, &JsValue::from_str("promising"))
+        .is_ok_and(|value| value.is_function())
+        && Reflect::get(&webassembly, &JsValue::from_str("Suspending"))
+            .is_ok_and(|value| value.is_function())
+}
+
+pub(crate) fn promising(function: &Function) -> Result<Function, JsValue> {
+    promising_raw(function)
+}
+
+pub(crate) fn suspending(function: &Function) -> Result<Function, JsValue> {
+    Suspending::new(function).map(JsCast::unchecked_into)
+}
+
+pub(crate) fn install_store(store: StoreAsync) -> ActiveStoreGuard {
+    let id = store.store_id();
+    ACTIVE_STORES.with(|stores| {
+        let mut stores = stores.borrow_mut();
+        stores
+            .entry(id)
+            .and_modify(|active| active.users += 1)
+            .or_insert(ActiveStore { store, users: 1 });
+    });
+    ActiveStoreGuard { id }
+}
+
+pub(crate) fn active_store(id: StoreId) -> Option<StoreAsync> {
+    ACTIVE_STORES.with(|stores| stores.borrow().get(&id).map(|active| active.store.store()))
+}
+
+impl Drop for ActiveStoreGuard {
+    fn drop(&mut self) {
+        ACTIVE_STORES.with(|stores| {
+            let mut stores = stores.borrow_mut();
+            let active = stores
+                .get_mut(&self.id)
+                .expect("active JSPI store guard is unbalanced");
+            active.users -= 1;
+            if active.users == 0 {
+                stores.remove(&self.id);
+            }
+        });
+    }
+}

--- a/lib/api/src/backend/js/mod.rs
+++ b/lib/api/src/backend/js/mod.rs
@@ -2,6 +2,8 @@
 
 pub(crate) mod entities;
 pub(crate) mod error;
+#[cfg(feature = "experimental-async")]
+pub(crate) mod jspi;
 pub(crate) mod utils;
 pub(crate) mod vm;
 

--- a/lib/api/src/backend/js/utils/convert.rs
+++ b/lib/api/src/backend/js/utils/convert.rs
@@ -35,7 +35,11 @@ pub trait AsJs: Sized {
 
 #[inline]
 /// Convert a JsValue into a wasmer Value
-pub fn js_value_to_wasmer(ty: &Type, js_val: &JsValue) -> Value {
+pub fn js_value_to_wasmer(
+    store: &mut impl AsStoreMut,
+    ty: &Type,
+    js_val: &JsValue,
+) -> Value {
     match ty {
         Type::I32 => Value::I32(js_val.as_f64().unwrap() as _),
         Type::I64 => Value::I64(if js_val.is_bigint() {
@@ -49,7 +53,19 @@ pub fn js_value_to_wasmer(ty: &Type, js_val: &JsValue) -> Value {
             let big_num: u128 = js_sys::BigInt::from(js_val.clone()).try_into().unwrap();
             Value::V128(big_num)
         }
-        Type::ExternRef | Type::FuncRef | Type::ExceptionRef => unimplemented!(
+        Type::ExternRef => {
+            if js_val.is_null() {
+                Value::ExternRef(None)
+            } else {
+                Value::ExternRef(Some(crate::ExternRef(crate::BackendExternRef::Js(
+                    crate::backend::js::entities::external::ExternRef::from_js_value(
+                        store,
+                        js_val.clone(),
+                    ),
+                ))))
+            }
+        }
+        Type::FuncRef | Type::ExceptionRef => unimplemented!(
             "The type `{:?}` is not yet supported in the JS Function API",
             ty
         ),
@@ -65,6 +81,12 @@ pub fn wasmer_value_to_js(val: &Value) -> JsValue {
         Value::F32(f) => JsValue::from_f64(*f as _),
         Value::F64(f) => JsValue::from_f64(*f),
         Value::V128(f) => JsValue::from_f64(*f as _),
+        Value::ExternRef(Some(reference)) => match &reference.0 {
+            crate::BackendExternRef::Js(reference) => reference.as_js_value(),
+            #[allow(unreachable_patterns)]
+            _ => unreachable!("a JS function received an externref from another backend"),
+        },
+        Value::ExternRef(None) => JsValue::null(),
         val => unimplemented!(
             "The value `{:?}` is not yet supported in the JS Function API",
             val
@@ -84,9 +106,12 @@ impl AsJs for Value {
             Self::V128(v) => JsValue::from(*v),
             Self::FuncRef(Some(func)) => func.as_js().handle.function.clone().into(),
             Self::FuncRef(None) => JsValue::null(),
-            Self::ExternRef(_) => {
-                unimplemented!("ExternRefs are not yet supported in the JS Function API",)
-            }
+            Self::ExternRef(Some(reference)) => match &reference.0 {
+                crate::BackendExternRef::Js(reference) => reference.as_js_value(),
+                #[allow(unreachable_patterns)]
+                _ => unreachable!("a JS function received an externref from another backend"),
+            },
+            Self::ExternRef(None) => JsValue::null(),
             Self::ExceptionRef(_) => {
                 unimplemented!("ExceptionRefs are not yet supported in the JS Function API",)
             }
@@ -94,11 +119,11 @@ impl AsJs for Value {
     }
 
     fn from_jsvalue(
-        _store: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         type_: &Self::DefinitionType,
         value: &JsValue,
     ) -> Result<Self, JsError> {
-        Ok(js_value_to_wasmer(type_, value))
+        Ok(js_value_to_wasmer(store, type_, value))
     }
 }
 

--- a/lib/api/src/backend/js/vm/external.rs
+++ b/lib/api/src/backend/js/vm/external.rs
@@ -1,4 +1,7 @@
 use wasmer_types::RawValue;
+use wasm_bindgen::JsValue;
+
+use crate::js::utils::js_handle::JsHandle;
 
 use crate::{AsStoreMut, Extern, VMExternToExtern};
 
@@ -50,9 +53,25 @@ impl VMExternToExtern for VMExtern {
 }
 
 /// A reference to an external value in the `js` VM.
-pub struct VMExternRef;
+#[derive(Debug, Clone)]
+pub struct VMExternRef {
+    value: JsHandle<JsValue>,
+}
+
+unsafe impl Send for VMExternRef {}
+unsafe impl Sync for VMExternRef {}
 
 impl VMExternRef {
+    pub(crate) fn new(value: JsValue) -> Self {
+        Self {
+            value: JsHandle::new(value),
+        }
+    }
+
+    pub(crate) fn into_js_value(self) -> JsValue {
+        self.value.into_inner()
+    }
+
     /// Converts the `VMExternRef` into a `RawValue`.
     pub fn into_raw(self) -> RawValue {
         unimplemented!();

--- a/lib/api/src/backend/js/vm/function.rs
+++ b/lib/api/src/backend/js/vm/function.rs
@@ -54,7 +54,7 @@ impl VMFunction {
             &encode_types(ty.params()).into(),
             &encode_types(ty.results()).into(),
         );
-        let _ = Reflect::set(&function, type_key().as_ref(), &encoded);
+        let _ = Reflect::set(function, type_key().as_ref(), &encoded);
     }
 
     pub(crate) fn type_from_js(function: &JsFunction) -> Option<FunctionType> {

--- a/lib/api/src/backend/js/vm/function.rs
+++ b/lib/api/src/backend/js/vm/function.rs
@@ -1,8 +1,45 @@
 use std::any::Any;
 
 use crate::js::utils::js_handle::JsHandle;
-use js_sys::Function as JsFunction;
-use wasmer_types::{FunctionType, RawValue};
+use js_sys::{Array, Function as JsFunction, Reflect, Symbol};
+use wasm_bindgen::{JsCast, JsValue};
+use wasmer_types::{FunctionType, RawValue, Type};
+
+fn type_key() -> Symbol {
+    Symbol::for_("wasmer.function-type")
+}
+
+fn encode_types(types: &[Type]) -> Array {
+    Array::from_iter(types.iter().map(|ty| {
+        JsValue::from_f64(match ty {
+            Type::I32 => 0.0,
+            Type::I64 => 1.0,
+            Type::F32 => 2.0,
+            Type::F64 => 3.0,
+            Type::V128 => 4.0,
+            Type::ExternRef => 5.0,
+            Type::FuncRef => 6.0,
+            Type::ExceptionRef => 7.0,
+        })
+    }))
+}
+
+fn decode_types(types: &Array) -> Option<Vec<Type>> {
+    types
+        .iter()
+        .map(|value| match value.as_f64()? as u8 {
+            0 => Some(Type::I32),
+            1 => Some(Type::I64),
+            2 => Some(Type::F32),
+            3 => Some(Type::F64),
+            4 => Some(Type::V128),
+            5 => Some(Type::ExternRef),
+            6 => Some(Type::FuncRef),
+            7 => Some(Type::ExceptionRef),
+            _ => None,
+        })
+        .collect()
+}
 
 /// The VM Function type
 #[derive(Clone, Eq)]
@@ -16,10 +53,32 @@ unsafe impl Sync for VMFunction {}
 
 impl VMFunction {
     pub(crate) fn new(function: JsFunction, ty: FunctionType) -> Self {
+        Self::annotate_type(&function, &ty);
         Self {
             function: JsHandle::new(function),
             ty,
         }
+    }
+
+    pub(crate) fn annotate_type(function: &JsFunction, ty: &FunctionType) {
+        let encoded = Array::of2(
+            &encode_types(ty.params()).into(),
+            &encode_types(ty.results()).into(),
+        );
+        let _ = Reflect::set(&function, type_key().as_ref(), &encoded);
+    }
+
+    pub(crate) fn type_from_js(function: &JsFunction) -> Option<FunctionType> {
+        let encoded = Reflect::get(function, type_key().as_ref())
+            .ok()?
+            .dyn_into::<Array>()
+            .ok()?;
+        let params = encoded.get(0).dyn_into::<Array>().ok()?;
+        let results = encoded.get(1).dyn_into::<Array>().ok()?;
+        Some(FunctionType::new(
+            decode_types(&params)?,
+            decode_types(&results)?,
+        ))
     }
 }
 

--- a/lib/api/src/backend/js/vm/function.rs
+++ b/lib/api/src/backend/js/vm/function.rs
@@ -10,32 +10,21 @@ fn type_key() -> Symbol {
 }
 
 fn encode_types(types: &[Type]) -> Array {
-    Array::from_iter(types.iter().map(|ty| {
-        JsValue::from_f64(match ty {
-            Type::I32 => 0.0,
-            Type::I64 => 1.0,
-            Type::F32 => 2.0,
-            Type::F64 => 3.0,
-            Type::V128 => 4.0,
-            Type::ExternRef => 5.0,
-            Type::FuncRef => 6.0,
-            Type::ExceptionRef => 7.0,
-        })
-    }))
+    Array::from_iter(types.iter().map(|ty| JsValue::from_f64(*ty as u8 as f64)))
 }
 
 fn decode_types(types: &Array) -> Option<Vec<Type>> {
     types
         .iter()
         .map(|value| match value.as_f64()? as u8 {
-            0 => Some(Type::I32),
-            1 => Some(Type::I64),
-            2 => Some(Type::F32),
-            3 => Some(Type::F64),
-            4 => Some(Type::V128),
-            5 => Some(Type::ExternRef),
-            6 => Some(Type::FuncRef),
-            7 => Some(Type::ExceptionRef),
+            value if value == Type::I32 as u8 => Some(Type::I32),
+            value if value == Type::I64 as u8 => Some(Type::I64),
+            value if value == Type::F32 as u8 => Some(Type::F32),
+            value if value == Type::F64 as u8 => Some(Type::F64),
+            value if value == Type::V128 as u8 => Some(Type::V128),
+            value if value == Type::ExternRef as u8 => Some(Type::ExternRef),
+            value if value == Type::FuncRef as u8 => Some(Type::FuncRef),
+            value if value == Type::ExceptionRef as u8 => Some(Type::ExceptionRef),
             _ => None,
         })
         .collect()

--- a/lib/api/src/backend/sys/entities/memory/view.rs
+++ b/lib/api/src/backend/sys/entities/memory/view.rs
@@ -192,16 +192,35 @@ impl<'a> MemoryView<'a> {
     #[allow(unused)]
     /// Copies the memory to another new memory object
     pub fn copy_to_memory(&self, amount: u64, new_memory: &Self) -> Result<(), MemoryAccessError> {
-        let mut offset = 0;
-        let mut chunk = [0u8; 40960];
-        while offset < amount {
-            let remaining = amount - offset;
-            let sublen = remaining.min(chunk.len() as u64) as usize;
-            self.read(offset, &mut chunk[..sublen])?;
+        self.copy_range_to_memory(0, 0, amount, new_memory)
+    }
 
-            new_memory.write(offset, &chunk[..sublen])?;
+    pub(crate) fn copy_range_to_memory(
+        &self,
+        source_offset: u64,
+        target_offset: u64,
+        amount: u64,
+        new_memory: &Self,
+    ) -> Result<(), MemoryAccessError> {
+        let source_offset = usize::try_from(source_offset).map_err(|_| MemoryAccessError::Overflow)?;
+        let target_offset = usize::try_from(target_offset).map_err(|_| MemoryAccessError::Overflow)?;
+        let amount = usize::try_from(amount).map_err(|_| MemoryAccessError::Overflow)?;
+        let source_end = source_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        let target_end = target_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        if source_end > self.buffer.len || target_end > new_memory.buffer.len {
+            return Err(MemoryAccessError::HeapOutOfBounds);
+        }
 
-            offset += sublen as u64;
+        unsafe {
+            std::ptr::copy(
+                self.buffer.base.add(source_offset),
+                new_memory.buffer.base.add(target_offset),
+                amount,
+            );
         }
         Ok(())
     }

--- a/lib/api/src/backend/v8/entities/memory/view.rs
+++ b/lib/api/src/backend/v8/entities/memory/view.rs
@@ -187,16 +187,35 @@ impl<'a> MemoryView<'a> {
     #[allow(unused)]
     /// Copies the memory to another new memory object
     pub fn copy_to_memory(&self, amount: u64, new_memory: &Self) -> Result<(), MemoryAccessError> {
-        let mut offset = 0;
-        let mut chunk = [0u8; 40960];
-        while offset < amount {
-            let remaining = amount - offset;
-            let sublen = remaining.min(chunk.len() as u64) as usize;
-            self.read(offset, &mut chunk[..sublen])?;
+        self.copy_range_to_memory(0, 0, amount, new_memory)
+    }
 
-            new_memory.write(offset, &chunk[..sublen])?;
+    pub(crate) fn copy_range_to_memory(
+        &self,
+        source_offset: u64,
+        target_offset: u64,
+        amount: u64,
+        new_memory: &Self,
+    ) -> Result<(), MemoryAccessError> {
+        let source_offset = usize::try_from(source_offset).map_err(|_| MemoryAccessError::Overflow)?;
+        let target_offset = usize::try_from(target_offset).map_err(|_| MemoryAccessError::Overflow)?;
+        let amount = usize::try_from(amount).map_err(|_| MemoryAccessError::Overflow)?;
+        let source_end = source_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        let target_end = target_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        if source_end > self.buffer.len || target_end > new_memory.buffer.len {
+            return Err(MemoryAccessError::HeapOutOfBounds);
+        }
 
-            offset += sublen as u64;
+        unsafe {
+            std::ptr::copy(
+                self.buffer.base.add(source_offset),
+                new_memory.buffer.base.add(target_offset),
+                amount,
+            );
         }
         Ok(())
     }

--- a/lib/api/src/backend/v8/entities/module.rs
+++ b/lib/api/src/backend/v8/entities/module.rs
@@ -184,9 +184,12 @@ impl Module {
         let mut binary = binary.to_vec();
         let binary = binary.into_bytes();
         let module = ModuleHandle::new(engine, &binary)?;
-        let info = crate::utils::polyfill::translate_module(&binary[..])
-            .map_err(CompileError::Validate)?
-            .info;
+        let translated = crate::utils::polyfill::translate_module(&binary[..])
+            .map_err(CompileError::Validate)?;
+        translated
+            .validate_no_exported_externrefs()
+            .map_err(CompileError::Validate)?;
+        let info = translated.info;
         let imports = info.imports().collect();
         let exports = info.exports().collect();
         let custom_sections = get_custom_sections(&binary)?;

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -231,7 +231,9 @@ impl Engine {
     pub fn supports_async(&self) -> bool {
         match self.be {
             #[cfg(feature = "sys")]
-            BackendEngine::Sys(ref e) => true,
+            BackendEngine::Sys(_) => true,
+            #[cfg(feature = "js")]
+            BackendEngine::Js(_) => crate::backend::js::jspi::is_supported(),
             _ => false,
         }
     }

--- a/lib/api/src/entities/function/env/inner.rs
+++ b/lib/api/src/entities/function/env/inner.rs
@@ -155,14 +155,8 @@ impl<T: Send + 'static> BackendFunctionEnvMut<'_, T> {
     /// context is async.
     #[cfg(feature = "experimental-async")]
     pub fn as_store_async(&self) -> Option<impl AsStoreAsync + 'static> {
-        match self {
-            #[cfg(feature = "sys")]
-            Self::Sys(f) => f.as_store_async(),
-            #[cfg(feature = "sys")]
-            _ => unsupported_async_backend(),
-            #[cfg(not(feature = "sys"))]
-            _ => unsupported_async_backend::<Option<crate::StoreAsync>>(),
-        }
+        let id = self.as_store_ref().inner.objects.id();
+        crate::StoreAsync::from_context(id)
     }
 }
 
@@ -207,7 +201,10 @@ pub enum BackendAsyncFunctionEnvMut<T> {
     #[cfg(feature = "sys")]
     /// The function environment for the `sys` runtime.
     Sys(crate::backend::sys::function::env::AsyncFunctionEnvMut<T>),
-    #[cfg(any(feature = "v8", feature = "js"))]
+    #[cfg(feature = "js")]
+    /// The function environment for the `js` runtime.
+    Js(crate::backend::js::function::env::AsyncFunctionEnvMut<T>),
+    #[cfg(feature = "v8")]
     /// Placeholder for unsupported backends.
     Unsupported(PhantomData<T>),
 }
@@ -218,7 +215,10 @@ pub enum BackendAsyncFunctionEnvHandle<T> {
     #[cfg(feature = "sys")]
     /// The function environment handle for the `sys` runtime.
     Sys(crate::backend::sys::function::env::AsyncFunctionEnvHandle<T>),
-    #[cfg(any(feature = "v8", feature = "js"))]
+    #[cfg(feature = "js")]
+    /// The function environment handle for the `js` runtime.
+    Js(crate::backend::js::function::env::AsyncFunctionEnvHandle<T>),
+    #[cfg(feature = "v8")]
     /// Placeholder for unsupported backends.
     Unsupported(PhantomData<T>),
 }
@@ -229,7 +229,10 @@ pub enum BackendAsyncFunctionEnvHandleMut<T> {
     #[cfg(feature = "sys")]
     /// The function environment handle for the `sys` runtime.
     Sys(crate::backend::sys::function::env::AsyncFunctionEnvHandleMut<T>),
-    #[cfg(any(feature = "v8", feature = "js"))]
+    #[cfg(feature = "js")]
+    /// The function environment handle for the `js` runtime.
+    Js(crate::backend::js::function::env::AsyncFunctionEnvHandleMut<T>),
+    #[cfg(feature = "v8")]
     /// Placeholder for unsupported backends.
     Unsupported(PhantomData<T>),
 }
@@ -242,7 +245,9 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => BackendAsyncFunctionEnvHandle::Sys(f.read().await),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => BackendAsyncFunctionEnvHandle::Js(f.read().await),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -253,7 +258,9 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => BackendAsyncFunctionEnvHandleMut::Sys(f.write().await),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => BackendAsyncFunctionEnvHandleMut::Js(f.write().await),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -263,7 +270,9 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => BackendFunctionEnv::Sys(f.as_ref()),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => BackendFunctionEnv::Js(f.as_ref()),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -273,7 +282,9 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => Self::Sys(f.as_mut()),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => Self::Js(f.as_mut()),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -283,9 +294,11 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => f.as_store_async(),
-            #[cfg(all(feature = "sys", any(feature = "v8", feature = "js")))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => f.as_store_async(),
+            #[cfg(all(feature = "sys", feature = "v8"))]
             _ => unsupported_async_backend(),
-            #[cfg(all(not(feature = "sys"), any(feature = "v8", feature = "js")))]
+            #[cfg(all(not(feature = "sys"), feature = "v8"))]
             _ => unsupported_async_backend::<crate::StoreAsync>(),
         }
     }
@@ -298,7 +311,9 @@ impl<T: 'static> BackendAsyncFunctionEnvHandle<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => f.data(),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => f.data(),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -308,9 +323,11 @@ impl<T: 'static> BackendAsyncFunctionEnvHandle<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => f.data_and_store(),
-            #[cfg(all(feature = "sys", any(feature = "v8", feature = "js")))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => f.data_and_store(),
+            #[cfg(all(feature = "sys", feature = "v8"))]
             _ => unsupported_async_backend(),
-            #[cfg(all(not(feature = "sys"), any(feature = "v8", feature = "js")))]
+            #[cfg(all(not(feature = "sys"), feature = "v8"))]
             _ => unsupported_async_backend::<(&T, &StoreRef)>(),
         }
     }
@@ -322,7 +339,9 @@ impl<T: 'static> AsStoreRef for BackendAsyncFunctionEnvHandle<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => AsStoreRef::as_store_ref(f),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => AsStoreRef::as_store_ref(f),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -335,7 +354,9 @@ impl<T: 'static> BackendAsyncFunctionEnvHandleMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => f.data_mut(),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => f.data_mut(),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -345,9 +366,11 @@ impl<T: 'static> BackendAsyncFunctionEnvHandleMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => f.data_and_store_mut(),
-            #[cfg(all(feature = "sys", any(feature = "v8", feature = "js")))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => f.data_and_store_mut(),
+            #[cfg(all(feature = "sys", feature = "v8"))]
             _ => unsupported_async_backend(),
-            #[cfg(all(not(feature = "sys"), any(feature = "v8", feature = "js")))]
+            #[cfg(all(not(feature = "sys"), feature = "v8"))]
             _ => unsupported_async_backend::<(&mut T, &mut crate::StoreMut)>(),
         }
     }
@@ -358,7 +381,9 @@ impl<T: 'static> BackendAsyncFunctionEnvHandleMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => BackendFunctionEnvMut::Sys(f.as_function_env_mut()),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => BackendFunctionEnvMut::Js(f.as_function_env_mut()),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -370,7 +395,9 @@ impl<T: 'static> AsStoreRef for BackendAsyncFunctionEnvHandleMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => AsStoreRef::as_store_ref(f),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => AsStoreRef::as_store_ref(f),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -382,7 +409,9 @@ impl<T: 'static> AsStoreMut for BackendAsyncFunctionEnvHandleMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => AsStoreMut::as_store_mut(f),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => AsStoreMut::as_store_mut(f),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }
@@ -391,7 +420,9 @@ impl<T: 'static> AsStoreMut for BackendAsyncFunctionEnvHandleMut<T> {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(f) => AsStoreMut::objects_mut(f),
-            #[cfg(any(feature = "v8", feature = "js"))]
+            #[cfg(feature = "js")]
+            Self::Js(f) => AsStoreMut::objects_mut(f),
+            #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
         }
     }

--- a/lib/api/src/entities/function/inner.rs
+++ b/lib/api/src/entities/function/inner.rs
@@ -229,7 +229,9 @@ impl BackendFunction {
             #[cfg(feature = "v8")]
             crate::BackendStore::V8(_) => unsupported_async_backend("v8"),
             #[cfg(feature = "js")]
-            crate::BackendStore::Js(_) => unsupported_async_backend("js"),
+            crate::BackendStore::Js(_) => Self::Js(
+                crate::backend::js::entities::function::Function::new_async(store, ty, func),
+            ),
         }
     }
 
@@ -264,7 +266,11 @@ impl BackendFunction {
             #[cfg(feature = "v8")]
             crate::BackendStore::V8(_) => unsupported_async_backend("v8"),
             #[cfg(feature = "js")]
-            crate::BackendStore::Js(_) => unsupported_async_backend("js"),
+            crate::BackendStore::Js(_) => Self::Js(
+                crate::backend::js::entities::function::Function::new_with_env_async(
+                    store, env, ty, func,
+                ),
+            ),
         }
     }
 
@@ -288,7 +294,9 @@ impl BackendFunction {
             #[cfg(feature = "v8")]
             crate::BackendStore::V8(_) => unsupported_async_backend("v8"),
             #[cfg(feature = "js")]
-            crate::BackendStore::Js(_) => unsupported_async_backend("js"),
+            crate::BackendStore::Js(_) => Self::Js(
+                crate::backend::js::entities::function::Function::new_typed_async(store, func),
+            ),
         }
     }
 
@@ -315,7 +323,11 @@ impl BackendFunction {
             #[cfg(feature = "v8")]
             crate::BackendStore::V8(_) => unsupported_async_backend("v8"),
             #[cfg(feature = "js")]
-            crate::BackendStore::Js(_) => unsupported_async_backend("js"),
+            crate::BackendStore::Js(_) => Self::Js(
+                crate::backend::js::entities::function::Function::new_typed_with_env_async(
+                    store, env, func,
+                ),
+            ),
         }
     }
 
@@ -456,7 +468,7 @@ impl BackendFunction {
             #[cfg(feature = "v8")]
             Self::V8(_) => unsupported_async_future(),
             #[cfg(feature = "js")]
-            Self::Js(_) => unsupported_async_future(),
+            Self::Js(f) => f.call_async(store, params),
         }
     }
 

--- a/lib/api/src/entities/memory/view/inner.rs
+++ b/lib/api/src/entities/memory/view/inner.rs
@@ -222,16 +222,54 @@ impl<'a> BackendMemoryView<'a> {
     /// Copies the memory to another new memory object
     #[inline]
     pub fn copy_to_memory(&self, amount: u64, new_memory: &Self) -> Result<(), MemoryAccessError> {
-        let mut offset = 0;
+        self.copy_range_to_memory(0, 0, amount, new_memory)
+    }
+
+    #[inline]
+    #[allow(unreachable_patterns)]
+    pub fn copy_range_to_memory(
+        &self,
+        source_offset: u64,
+        target_offset: u64,
+        amount: u64,
+        new_memory: &Self,
+    ) -> Result<(), MemoryAccessError> {
+        match (self, new_memory) {
+            #[cfg(feature = "sys")]
+            (Self::Sys(source), Self::Sys(target)) => {
+                return source.copy_range_to_memory(source_offset, target_offset, amount, target);
+            }
+            #[cfg(feature = "v8")]
+            (Self::V8(source), Self::V8(target)) => {
+                return source.copy_range_to_memory(source_offset, target_offset, amount, target);
+            }
+            #[cfg(feature = "js")]
+            (Self::Js(source), Self::Js(target)) => {
+                return source.copy_range_to_memory(source_offset, target_offset, amount, target);
+            }
+            _ => {}
+        }
+
+        let source_end = source_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        let target_end = target_offset
+            .checked_add(amount)
+            .ok_or(MemoryAccessError::Overflow)?;
+        if source_end > self.data_size() || target_end > new_memory.data_size() {
+            return Err(MemoryAccessError::HeapOutOfBounds);
+        }
+
+        let mut copied = 0;
         let mut chunk = [0u8; 40960];
-        while offset < amount {
-            let remaining = amount - offset;
+        while copied < amount {
+            let remaining = amount - copied;
             let sublen = remaining.min(chunk.len() as u64) as usize;
-            self.read(offset, &mut chunk[..sublen])?;
+            self.read(source_offset + copied, &mut chunk[..sublen])?;
 
-            new_memory.write(offset, &chunk[..sublen])?;
+            new_memory.write(target_offset + copied, &chunk[..sublen])?;
 
-            offset += sublen as u64;
+            copied += sublen as u64;
         }
         Ok(())
     }

--- a/lib/api/src/entities/memory/view/mod.rs
+++ b/lib/api/src/entities/memory/view/mod.rs
@@ -152,4 +152,17 @@ impl<'a> MemoryView<'a> {
     pub fn copy_to_memory(&self, amount: u64, new_memory: &Self) -> Result<(), MemoryAccessError> {
         self.0.copy_to_memory(amount, &new_memory.0)
     }
+
+    /// Copies a range directly to another memory view.
+    #[doc(hidden)]
+    pub fn copy_range_to_memory(
+        &self,
+        source_offset: u64,
+        target_offset: u64,
+        amount: u64,
+        new_memory: &Self,
+    ) -> Result<(), MemoryAccessError> {
+        self.0
+            .copy_range_to_memory(source_offset, target_offset, amount, &new_memory.0)
+    }
 }

--- a/lib/api/src/entities/module/inner.rs
+++ b/lib/api/src/entities/module/inner.rs
@@ -45,6 +45,28 @@ impl BackendModule {
     }
 
     #[inline]
+    pub async fn new_async(
+        engine: &impl AsEngineRef,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<Self, CompileError> {
+        #[cfg(all(feature = "js", target_arch = "wasm32"))]
+        if matches!(engine.as_engine_ref().inner.be, crate::BackendEngine::Js(_)) {
+            #[cfg(feature = "wat")]
+            let bytes = wat::parse_bytes(bytes.as_ref()).map_err(|e| {
+                CompileError::Wasm(WasmError::Generic(format!(
+                    "Error when converting wat: {e}",
+                )))
+            })?;
+
+            return crate::backend::js::entities::module::Module::new_async(engine, bytes.as_ref())
+                .await
+                .map(Self::Js);
+        }
+
+        Self::new(engine, bytes)
+    }
+
+    #[inline]
     pub fn new_with_progress(
         engine: &impl AsEngineRef,
         bytes: impl AsRef<[u8]>,

--- a/lib/api/src/entities/module/mod.rs
+++ b/lib/api/src/entities/module/mod.rs
@@ -113,6 +113,20 @@ impl Module {
         BackendModule::new(engine, bytes).map(Self)
     }
 
+    /// Asynchronously creates a new WebAssembly module.
+    ///
+    /// This is equivalent to [`Module::new`] on backends whose compilation is
+    /// synchronous. The JavaScript backend uses the host's asynchronous
+    /// WebAssembly compilation API, which avoids blocking the browser's main
+    /// thread and supports modules that browsers reject for synchronous
+    /// compilation there.
+    pub async fn new_async(
+        engine: &impl AsEngineRef,
+        bytes: impl AsRef<[u8]>,
+    ) -> Result<Self, CompileError> {
+        BackendModule::new_async(engine, bytes).await.map(Self)
+    }
+
     /// Creates a new WebAssembly module from a file path.
     pub fn from_file(
         engine: &impl AsEngineRef,

--- a/lib/api/src/error.rs
+++ b/lib/api/src/error.rs
@@ -253,7 +253,12 @@ impl RuntimeError {
             writeln!(f)?;
             write!(f, "    at ")?;
             match frame.function_name() {
-                Some(name) => write!(f, "{}", symbolic_demangle::demangle(name))?,
+                Some(name) => {
+                    #[cfg(feature = "demangle")]
+                    write!(f, "{}", symbolic_demangle::demangle(name))?;
+                    #[cfg(not(feature = "demangle"))]
+                    write!(f, "{name}")?;
+                }
                 None => write!(f, "<unnamed>")?,
             }
             write!(

--- a/lib/api/src/utils/native/typed_func.rs
+++ b/lib/api/src/utils/native/typed_func.rs
@@ -103,7 +103,10 @@ macro_rules! impl_native_traits {
                         #[cfg(feature = "v8")]
                         BackendStore::V8(_) => async_backend_error(),
                         #[cfg(feature = "js")]
-                        BackendStore::Js(_) => async_backend_error(),
+                        BackendStore::Js(_) => {
+                            drop(read_lock);
+                            Self::call_async_js(func, store, $([<p_ $x>]),*).await
+                        }
                     }
                 }
             }
@@ -163,6 +166,6 @@ impl_native_traits!(
 
 fn async_backend_error<Rets>() -> Result<Rets, RuntimeError> {
     Err(RuntimeError::new(
-        "async calls are only supported with the `sys` backend",
+        "async calls are not supported with the `v8` backend",
     ))
 }

--- a/lib/api/src/utils/polyfill.rs
+++ b/lib/api/src/utils/polyfill.rs
@@ -375,7 +375,6 @@ pub fn translate_module(data: &[u8]) -> WasmResult<ModuleInfoPolyfill> {
         .info
         .validate_signature_hashes()
         .map_err(|err| err.to_string())?;
-    validate_exported_types(&module_info)?;
     Ok(module_info)
 }
 
@@ -474,53 +473,6 @@ fn parse_init_expr(
         }
     }
     Ok(InitExpr::new(operations.into_boxed_slice()))
-}
-
-fn validate_exported_types(module_info: &ModuleInfoPolyfill) -> WasmResult<()> {
-    for (name, export) in module_info.info.exports.iter() {
-        let uses_externref = match export {
-            ExportIndex::Function(index) => {
-                let signature = module_info.info.functions.get(*index).ok_or_else(|| {
-                    format!("function export `{name}` references unknown function {index:?}")
-                })?;
-                let ty = module_info.info.signatures.get(*signature).ok_or_else(|| {
-                    format!("function export `{name}` references unknown signature {signature:?}")
-                })?;
-                ty.params()
-                    .iter()
-                    .chain(ty.results().iter())
-                    .any(|ty| *ty == Type::ExternRef)
-            }
-            ExportIndex::Table(index) => {
-                let ty = module_info.info.tables.get(*index).ok_or_else(|| {
-                    format!("table export `{name}` references unknown table {index:?}")
-                })?;
-                ty.ty == Type::ExternRef
-            }
-            ExportIndex::Memory(_) => false,
-            ExportIndex::Global(index) => {
-                let ty = module_info.info.globals.get(*index).ok_or_else(|| {
-                    format!("global export `{name}` references unknown global {index:?}")
-                })?;
-                ty.ty == Type::ExternRef
-            }
-            ExportIndex::Tag(index) => {
-                let signature = module_info.info.tags.get(*index).ok_or_else(|| {
-                    format!("tag export `{name}` references unknown tag {index:?}")
-                })?;
-                let ty = module_info.info.signatures.get(*signature).ok_or_else(|| {
-                    format!("tag export `{name}` references unknown signature {signature:?}")
-                })?;
-                ty.params().contains(&Type::ExternRef)
-            }
-        };
-
-        if uses_externref {
-            return Err("ExternRef is not supported by this backend yet".to_string());
-        }
-    }
-
-    Ok(())
 }
 
 /// Helper function translating wasmparser types to Wasm Type.

--- a/lib/api/src/utils/polyfill.rs
+++ b/lib/api/src/utils/polyfill.rs
@@ -7,17 +7,19 @@
 use core::convert::TryFrom;
 use std::vec::Vec;
 use wasmer_types::entity::EntityRef;
+use wasmer_types::entity::packed_option::ReservedValue;
 use wasmer_types::{
     ExportIndex, FunctionIndex, FunctionType, GlobalIndex, GlobalType, ImportIndex, MemoryIndex,
-    MemoryType, ModuleInfo, Pages, SignatureHash, SignatureIndex, TableIndex, TableType, TagIndex,
-    TagType, Type,
+    InitExpr, InitExprOp, MemoryType, ModuleInfo, Pages, SignatureHash, SignatureIndex,
+    TableIndex, TableInitializer, TableType, TagIndex, TagType, Type,
 };
 
 use wasmparser::{
-    self, BinaryReaderError, Export, ExportSectionReader, ExternalKind, FunctionSectionReader,
-    GlobalSectionReader, GlobalType as WPGlobalType, ImportSectionReader, Imports,
-    MemorySectionReader, MemoryType as WPMemoryType, NameSectionReader, Parser, Payload,
-    TableSectionReader, TagType as WPTagType, TypeRef, TypeSectionReader,
+    self, BinaryReaderError, ElementItems, ElementKind, ElementSectionReader, Export,
+    ExportSectionReader, ExternalKind, FunctionSectionReader, GlobalSectionReader,
+    GlobalType as WPGlobalType, ImportSectionReader, Imports, MemorySectionReader,
+    MemoryType as WPMemoryType, NameSectionReader, Operator, Parser, Payload, TableSectionReader,
+    TagType as WPTagType, TypeRef, TypeSectionReader,
 };
 
 pub type WasmResult<T> = Result<T, String>;
@@ -343,6 +345,10 @@ pub fn translate_module(data: &[u8]) -> WasmResult<ModuleInfoPolyfill> {
                 parse_start_section(func, &mut module_info)?;
             }
 
+            Payload::ElementSection(elements) => {
+                parse_element_section(elements, &mut module_info)?;
+            }
+
             Payload::TagSection(tags) => {
                 parse_tag_section(tags, &mut module_info)?;
             }
@@ -371,6 +377,103 @@ pub fn translate_module(data: &[u8]) -> WasmResult<ModuleInfoPolyfill> {
         .map_err(|err| err.to_string())?;
     validate_exported_types(&module_info)?;
     Ok(module_info)
+}
+
+fn parse_element_section(
+    elements: ElementSectionReader<'_>,
+    module: &mut ModuleInfoPolyfill,
+) -> WasmResult<()> {
+    for element in elements {
+        let element = element.map_err(transform_err)?;
+        let ElementKind::Active {
+            table_index,
+            offset_expr,
+        } = element.kind
+        else {
+            continue;
+        };
+
+        let mut functions = Vec::new();
+        match element.items {
+            ElementItems::Functions(items) => {
+                for item in items {
+                    functions.push(FunctionIndex::from_u32(item.map_err(transform_err)?));
+                }
+            }
+            ElementItems::Expressions(_, items) => {
+                for item in items {
+                    let expression = item.map_err(transform_err)?;
+                    let operator = expression
+                        .get_operators_reader()
+                        .read()
+                        .map_err(transform_err)?;
+                    match operator {
+                        Operator::RefFunc { function_index } => {
+                            functions.push(FunctionIndex::from_u32(function_index));
+                        }
+                        Operator::RefNull { .. } => {
+                            functions.push(FunctionIndex::reserved_value());
+                        }
+                        other => {
+                            return Err(format!(
+                                "unsupported element expression in type polyfill: {other:?}"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        module.info.table_initializers.push(TableInitializer {
+            table_index: TableIndex::from_u32(table_index.unwrap_or(0)),
+            offset_expr: parse_init_expr(&offset_expr, &module.info)?,
+            elements: functions.into_boxed_slice(),
+        });
+    }
+    Ok(())
+}
+
+fn parse_init_expr(
+    expression: &wasmparser::ConstExpr<'_>,
+    module: &ModuleInfo,
+) -> WasmResult<InitExpr> {
+    let mut reader = expression.get_operators_reader();
+    let mut operations = Vec::new();
+    loop {
+        match reader.read().map_err(transform_err)? {
+            Operator::End => break,
+            Operator::I32Const { value } => operations.push(InitExprOp::I32Const(value)),
+            Operator::I64Const { value } => operations.push(InitExprOp::I64Const(value)),
+            Operator::GlobalGet { global_index } => {
+                let index = GlobalIndex::from_u32(global_index);
+                match module
+                    .global_type(index)
+                    .ok_or_else(|| format!("unknown global {global_index} in element offset"))?
+                    .ty
+                {
+                    Type::I32 => operations.push(InitExprOp::GlobalGetI32(index)),
+                    Type::I64 => operations.push(InitExprOp::GlobalGetI64(index)),
+                    other => {
+                        return Err(format!(
+                            "unsupported {other:?} global in element offset"
+                        ));
+                    }
+                }
+            }
+            Operator::I32Add => operations.push(InitExprOp::I32Add),
+            Operator::I32Sub => operations.push(InitExprOp::I32Sub),
+            Operator::I32Mul => operations.push(InitExprOp::I32Mul),
+            Operator::I64Add => operations.push(InitExprOp::I64Add),
+            Operator::I64Sub => operations.push(InitExprOp::I64Sub),
+            Operator::I64Mul => operations.push(InitExprOp::I64Mul),
+            other => {
+                return Err(format!(
+                    "unsupported operator in element offset: {other:?}"
+                ));
+            }
+        }
+    }
+    Ok(InitExpr::new(operations.into_boxed_slice()))
 }
 
 fn validate_exported_types(module_info: &ModuleInfoPolyfill) -> WasmResult<()> {

--- a/lib/api/src/utils/polyfill.rs
+++ b/lib/api/src/utils/polyfill.rs
@@ -30,6 +30,60 @@ pub struct ModuleInfoPolyfill {
 }
 
 impl ModuleInfoPolyfill {
+    /// Rejects externrefs that would cross a backend's host API boundary.
+    ///
+    /// The V8 wasm-c-api backend can compile reference-types instructions,
+    /// but it cannot currently marshal externrefs through exported values.
+    #[cfg(feature = "v8")]
+    pub(crate) fn validate_no_exported_externrefs(&self) -> WasmResult<()> {
+        for (name, export) in self.info.exports.iter() {
+            let uses_externref = match export {
+                ExportIndex::Function(index) => {
+                    let signature = self.info.functions.get(*index).ok_or_else(|| {
+                        format!("function export `{name}` references unknown function {index:?}")
+                    })?;
+                    let ty = self.info.signatures.get(*signature).ok_or_else(|| {
+                        format!(
+                            "function export `{name}` references unknown signature {signature:?}"
+                        )
+                    })?;
+                    ty.params()
+                        .iter()
+                        .chain(ty.results().iter())
+                        .any(|ty| *ty == Type::ExternRef)
+                }
+                ExportIndex::Table(index) => {
+                    let ty = self.info.tables.get(*index).ok_or_else(|| {
+                        format!("table export `{name}` references unknown table {index:?}")
+                    })?;
+                    ty.ty == Type::ExternRef
+                }
+                ExportIndex::Memory(_) => false,
+                ExportIndex::Global(index) => {
+                    let ty = self.info.globals.get(*index).ok_or_else(|| {
+                        format!("global export `{name}` references unknown global {index:?}")
+                    })?;
+                    ty.ty == Type::ExternRef
+                }
+                ExportIndex::Tag(index) => {
+                    let signature = self.info.tags.get(*index).ok_or_else(|| {
+                        format!("tag export `{name}` references unknown tag {index:?}")
+                    })?;
+                    let ty = self.info.signatures.get(*signature).ok_or_else(|| {
+                        format!("tag export `{name}` references unknown signature {signature:?}")
+                    })?;
+                    ty.params().contains(&Type::ExternRef)
+                }
+            };
+
+            if uses_externref {
+                return Err("ExternRef is not supported by this backend yet".to_string());
+            }
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn declare_export(&mut self, export: ExportIndex, name: &str) -> WasmResult<()> {
         // See #6560 for more context why such names are unsupported by V8.
         if !name.is_empty() && name.bytes().all(|b| b.is_ascii_digit()) {
@@ -413,11 +467,12 @@ fn parse_element_section(
                         Operator::RefNull { .. } => {
                             functions.push(FunctionIndex::reserved_value());
                         }
-                        other => {
-                            return Err(format!(
-                                "unsupported element expression in type polyfill: {other:?}"
-                            ));
-                        }
+                        // The polyfill only needs function indices to annotate
+                        // JavaScript table entries with their signatures. Other
+                        // valid expressions (for example an imported funcref
+                        // global) cannot provide that signature, so retain the
+                        // table slot with an unresolvable sentinel.
+                        _ => functions.push(FunctionIndex::reserved_value()),
                     }
                 }
             }

--- a/lib/api/tests/jspi_async.rs
+++ b/lib/api/tests/jspi_async.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "experimental-async")]
+#![cfg(all(feature = "experimental-async", not(target_arch = "wasm32")))]
 
 use std::{cell::RefCell, sync::OnceLock};
 

--- a/lib/api/tests/jspi_async_js.rs
+++ b/lib/api/tests/jspi_async_js.rs
@@ -1,0 +1,42 @@
+#![cfg(all(feature = "experimental-async", feature = "js", target_arch = "wasm32"))]
+
+use js_sys::Promise;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::wasm_bindgen_test;
+use wasmer::{Function, Instance, Module, Store, TypedFunction, imports};
+
+#[wasm_bindgen_test]
+async fn typed_async_host_and_guest_calls_use_jspi() {
+    let mut store = Store::default();
+    let module = Module::new(
+        &store,
+        r#"
+        (module
+          (import "host" "increment" (func $increment (param i32) (result i32)))
+          (func (export "compute") (param i32) (result i32)
+            local.get 0
+            call $increment))
+        "#,
+    )
+    .unwrap();
+    let increment = Function::new_typed_async(&mut store, async move |value: i32| {
+        JsFuture::from(Promise::resolve(&JsValue::UNDEFINED))
+            .await
+            .unwrap();
+        value + 1
+    });
+    let imports = imports! {
+        "host" => {
+            "increment" => increment,
+        }
+    };
+    let instance = Instance::new(&mut store, &module, &imports).unwrap();
+    let compute: TypedFunction<i32, i32> = instance
+        .exports
+        .get_typed_function(&store, "compute")
+        .unwrap();
+
+    let result = compute.call_async(&store.into_async(), 41).await.unwrap();
+    assert_eq!(result, 42);
+}

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -1,4 +1,6 @@
 use macro_wasmer_engine_test::engine_test;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsValue;
 #[cfg(feature = "js")]
 use wasm_bindgen_test::*;
 
@@ -27,7 +29,50 @@ fn module_new_async() -> Result<(), String> {
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen_test]
 async fn module_new_async() -> Result<(), JsValue> {
-    assert_module_new_async().await.map_err(JsValue::from_str)
+    assert_module_new_async()
+        .await
+        .map_err(|error| JsValue::from_str(&error))
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "js"))]
+#[wasm_bindgen_test]
+fn imported_table_elements_preserve_function_types() {
+    let mut store = Store::default();
+    let module = Module::new(
+        &store,
+        r#"
+        (module
+          (import "env" "table" (table 8 funcref))
+          (import "env" "table_base" (global $table_base i32))
+          (type $trampoline_type (func (param i32 i32 i32) (result i32)))
+          (func $trampoline (type $trampoline_type)
+            local.get 0)
+          (elem (global.get $table_base) func $trampoline))
+        "#,
+    )
+    .unwrap();
+    let table = Table::new(
+        &mut store,
+        TableType::new(Type::FuncRef, 8, None),
+        Value::FuncRef(None),
+    )
+    .unwrap();
+    let table_base = Global::new(&mut store, Value::I32(3));
+    let imports = imports! {
+        "env" => {
+            "table" => table.clone(),
+            "table_base" => table_base,
+        }
+    };
+
+    Instance::new(&mut store, &module, &imports).unwrap();
+    let Value::FuncRef(Some(function)) = table.get(&mut store, 3).unwrap() else {
+        panic!("expected the initialized table element to be a function");
+    };
+    assert_eq!(
+        function.ty(&store),
+        FunctionType::new(vec![Type::I32, Type::I32, Type::I32], vec![Type::I32])
+    );
 }
 
 #[engine_test]

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -9,6 +9,27 @@ use std::ffi::OsStr;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 
+async fn assert_module_new_async() -> Result<(), String> {
+    let store = Store::default();
+    let module = Module::new_async(&store, "(module (func (export \"run\")))")
+        .await
+        .map_err(|error| format!("{error:?}"))?;
+    assert!(module.exports().any(|export| export.name() == "run"));
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn module_new_async() -> Result<(), String> {
+    futures::executor::block_on(assert_module_new_async())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen_test]
+async fn module_new_async() -> Result<(), JsValue> {
+    assert_module_new_async().await.map_err(JsValue::from_str)
+}
+
 #[engine_test]
 fn module_get_name() -> Result<(), String> {
     let store = Store::default();

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -1,8 +1,8 @@
 use macro_wasmer_engine_test::engine_test;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsValue;
-#[cfg(feature = "js")]
-use wasm_bindgen_test::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
 
 use wasmer::*;
 
@@ -13,7 +13,9 @@ use std::os::unix::ffi::OsStrExt;
 
 async fn assert_module_new_async() -> Result<(), String> {
     let store = Store::default();
-    let module = Module::new_async(&store, "(module (func (export \"run\")))")
+    let wasm =
+        wat::parse_str("(module (func (export \"run\")))").map_err(|error| format!("{error:?}"))?;
+    let module = Module::new_async(&store, wasm)
         .await
         .map_err(|error| format!("{error:?}"))?;
     assert!(module.exports().any(|export| export.name() == "run"));

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -75,6 +75,33 @@ fn imported_table_elements_preserve_function_types() {
     );
 }
 
+#[cfg(all(target_arch = "wasm32", feature = "js"))]
+#[wasm_bindgen_test]
+fn exported_table_elements_preserve_function_types() {
+    let mut store = Store::default();
+    let module = Module::new(
+        &store,
+        r#"
+        (module
+          (type $callback_type (func (param i32 i32) (result i32)))
+          (func $callback (type $callback_type)
+            local.get 0)
+          (table (export "table") 1 funcref)
+          (elem (i32.const 0) func $callback))
+        "#,
+    )
+    .unwrap();
+    let instance = Instance::new(&mut store, &module, &imports! {}).unwrap();
+    let table = instance.exports.get_table("table").unwrap();
+    let Value::FuncRef(Some(function)) = table.get(&mut store, 0).unwrap() else {
+        panic!("expected the initialized table element to be a function");
+    };
+    assert_eq!(
+        function.ty(&store),
+        FunctionType::new(vec![Type::I32, Type::I32], vec![Type::I32])
+    );
+}
+
 #[engine_test]
 fn module_get_name() -> Result<(), String> {
     let store = Store::default();

--- a/lib/api/tests/simple_greenthread.rs
+++ b/lib/api/tests/simple_greenthread.rs
@@ -206,7 +206,8 @@ async fn greenthread_switch(env: AsyncFunctionEnvMut<GreenEnv>, next_greenthread
 
 async fn run_greenthread_test(wat: &[u8], spawner: TestSpawner) -> Result<Vec<String>> {
     let mut store = Store::default();
-    let module = Module::new(&store.engine(), wat)?;
+    let wasm = wat::parse_bytes(wat)?;
+    let module = Module::new(&store.engine(), wasm)?;
 
     let env = FunctionEnv::new(&mut store, GreenEnv::new());
 

--- a/lib/api/tests/simple_greenthread.rs
+++ b/lib/api/tests/simple_greenthread.rs
@@ -1,4 +1,7 @@
-#![cfg(feature = "experimental-async")]
+#![cfg(all(
+    feature = "experimental-async",
+    any(not(target_arch = "wasm32"), feature = "js")
+))]
 
 use std::collections::BTreeMap;
 use std::future::Future;

--- a/lib/api/tests/simple_greenthread.rs
+++ b/lib/api/tests/simple_greenthread.rs
@@ -1,16 +1,66 @@
 #![cfg(feature = "experimental-async")]
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
+use futures::channel::oneshot;
+use futures::future::{AbortHandle, Abortable};
+#[cfg(not(target_arch = "wasm32"))]
 use futures::task::LocalSpawnExt;
-use futures::{FutureExt, channel::oneshot};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
 use wasmer::{
-    AsyncFunctionEnvMut, Function, FunctionEnv, FunctionEnvMut, FunctionType, Instance, Memory,
-    Module, RuntimeError, Store, Type, Value, imports,
+    AsStoreAsync, AsyncFunctionEnvMut, Function, FunctionEnv, FunctionEnvMut, FunctionType,
+    Instance, Memory, Module, RuntimeError, Store, Type, Value, imports,
 };
+
+const SWITCHING_WAT: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tests/examples/simple-greenthread.wat"
+));
+const SWITCHING_LOGS: &[&str] = &[
+    "[gr1] main  -> test1",
+    "[gr2] test1 -> test2",
+    "[gr1] test1 <- test2",
+    "[gr2] test1 -> test2",
+    "[gr1] test1 <- test2",
+    "[main] main <- test1",
+];
+const REGRESSION_WAT: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tests/examples/simple-greenthread2.wat"
+));
+const REGRESSION_LOGS: &[&str] = &[
+    "[main] switching to side",
+    "[side] switching to main",
+    "[main] switching to side",
+    "[side] switching to main",
+    "[main] returned",
+];
+
+#[derive(Clone)]
+struct TestSpawner {
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: futures::executor::LocalSpawner,
+}
+
+impl TestSpawner {
+    fn spawn(&self, future: impl Future<Output = ()> + 'static) {
+        #[cfg(not(target_arch = "wasm32"))]
+        self.inner.spawn_local(future).unwrap();
+
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(future);
+    }
+}
+
+struct SpawnedTask {
+    abort: AbortHandle,
+    done: oneshot::Receiver<()>,
+}
 
 struct GreenEnv {
     logs: Vec<String>,
@@ -19,7 +69,8 @@ struct GreenEnv {
     current_greenthread_id: Arc<RwLock<u32>>,
     next_free_id: AtomicU32,
     entrypoint: Option<Function>,
-    spawner: Option<futures::executor::LocalSpawner>,
+    spawner: Option<TestSpawner>,
+    spawned_tasks: Vec<SpawnedTask>,
 }
 
 // Required for carrying the spawner around. Safe because we don't do threads.
@@ -38,6 +89,7 @@ impl GreenEnv {
             next_free_id: AtomicU32::new(1),
             entrypoint: None,
             spawner: None,
+            spawned_tasks: Vec::new(),
         }
     }
 }
@@ -84,15 +136,25 @@ async fn greenthread_new(
         .insert(new_greenthread_id, new_greenthread);
 
     let spawner = data.spawner.as_ref().expect("spawner set").clone();
-    spawner
-        .spawn_local(async move {
-            receiver.await.unwrap();
-            let resumer = function
-                .call_async(&async_store, vec![Value::I32(entrypoint_data as i32)])
-                .await;
-            panic!("Greenthread function returned {:?}", resumer);
-        })
-        .unwrap();
+    let (abort, registration) = AbortHandle::new_pair();
+    let (done_tx, done) = oneshot::channel();
+    data.spawned_tasks.push(SpawnedTask { abort, done });
+    spawner.spawn(async move {
+        let result = Abortable::new(
+            async move {
+                receiver.await.unwrap();
+                function
+                    .call_async(&async_store, vec![Value::I32(entrypoint_data as i32)])
+                    .await
+            },
+            registration,
+        )
+        .await;
+        if let Ok(result) = result {
+            panic!("Greenthread function returned {result:?}");
+        }
+        let _ = done_tx.send(());
+    });
 
     Ok(new_greenthread_id)
 }
@@ -137,12 +199,12 @@ async fn greenthread_switch(env: AsyncFunctionEnvMut<GreenEnv>, next_greenthread
         (receiver, current_id_arc, current_greenthread_id)
     };
 
-    let _ = receiver.map(|_| ()).await;
+    let _ = receiver.await;
 
     *current_id_arc.write().unwrap() = current_greenthread_id;
 }
 
-fn run_greenthread_test(wat: &[u8]) -> Result<Vec<String>> {
+async fn run_greenthread_test(wat: &[u8], spawner: TestSpawner) -> Result<Vec<String>> {
     let mut store = Store::default();
     let module = Module::new(&store.engine(), wat)?;
 
@@ -203,73 +265,78 @@ fn run_greenthread_test(wat: &[u8]) -> Result<Vec<String>> {
         .unwrap()
         .insert(0, main_greenthread);
 
-    let mut localpool = futures::executor::LocalPool::new();
-    let local_spawner = localpool.spawner();
-    env.as_mut(&mut store).spawner = Some(local_spawner);
+    env.as_mut(&mut store).spawner = Some(spawner);
 
     let store_async = store.into_async();
 
-    localpool
-        .run_until(main_fn.call_async(&store_async, vec![]))
-        .unwrap();
+    main_fn.call_async(&store_async, vec![]).await?;
 
-    // If there are no more clones of it, StoreAsync can also be
-    // turned back into a store. We need to drop the local pool
-    // first to drop the futures and their references to the store.
-    drop(localpool);
+    let spawned_tasks = {
+        let mut store = store_async.write_lock().await;
+        std::mem::take(&mut env.as_mut(&mut store).spawned_tasks)
+    };
+    for task in &spawned_tasks {
+        task.abort.abort();
+    }
+    for task in spawned_tasks {
+        let _ = task.done.await;
+    }
 
-    let store = store_async.into_store().ok().unwrap();
+    let store = store_async.read_lock().await;
     Ok(env.as_ref(&store).logs.clone())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn run_greenthread_test_native(wat: &[u8]) -> Result<Vec<String>> {
+    let mut local_pool = futures::executor::LocalPool::new();
+    let spawner = TestSpawner {
+        inner: local_pool.spawner(),
+    };
+    local_pool.run_until(run_greenthread_test(wat, spawner))
+}
+
+fn assert_logs(logs: &[String], expected: &[&str]) {
+    assert_eq!(logs.len(), expected.len());
+    for (index, expected) in expected.iter().enumerate() {
+        assert_eq!(
+            logs[index], *expected,
+            "Log entry mismatch at index {index}: {logs:?}"
+        );
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn green_threads_switch_and_log_in_expected_order() -> Result<()> {
-    let logs = run_greenthread_test(include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../tests/examples/simple-greenthread.wat"
-    )))?;
-
-    // Expected logs
-    let expected = [
-        "[gr1] main  -> test1",
-        "[gr2] test1 -> test2",
-        "[gr1] test1 <- test2",
-        "[gr2] test1 -> test2",
-        "[gr1] test1 <- test2",
-        "[main] main <- test1",
-    ];
-
-    assert_eq!(logs.len(), expected.len(),);
-    for (i, exp) in expected.iter().enumerate() {
-        assert_eq!(logs[i], *exp, "Log entry mismatch at index {i}: {:?}", logs);
-    }
+    let logs = run_greenthread_test_native(SWITCHING_WAT)?;
+    assert_logs(&logs, SWITCHING_LOGS);
 
     Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen_test]
+async fn green_threads_switch_and_log_in_expected_order() {
+    let logs = run_greenthread_test(SWITCHING_WAT, TestSpawner {})
+        .await
+        .unwrap();
+    assert_logs(&logs, SWITCHING_LOGS);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn green_threads_switch_main_crashed() -> Result<()> {
-    let logs = run_greenthread_test(include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../tests/examples/simple-greenthread2.wat"
-    )))?;
-
-    // Expected logs
-    let expected = [
-        "[main] switching to side",
-        "[side] switching to main",
-        "[main] switching to side",
-        "[side] switching to main",
-        "[main] returned",
-    ];
-
-    eprintln!("logs: {:?}", logs);
-    assert_eq!(logs.len(), expected.len());
-    for (i, exp) in expected.iter().enumerate() {
-        assert_eq!(logs[i], *exp, "Log entry mismatch at index {i}: {:?}", logs);
-    }
+    let logs = run_greenthread_test_native(REGRESSION_WAT)?;
+    assert_logs(&logs, REGRESSION_LOGS);
 
     Ok(())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen_test]
+async fn green_threads_switch_main_crashed() {
+    let logs = run_greenthread_test(REGRESSION_WAT, TestSpawner {})
+        .await
+        .unwrap();
+    assert_logs(&logs, REGRESSION_LOGS);
 }

--- a/lib/c-api-imports/src/lib.rs
+++ b/lib/c-api-imports/src/lib.rs
@@ -1,7 +1,5 @@
 use anyhow::{Context, Result, bail};
-use std::{
-    collections::HashMap, fmt::Display, mem::size_of, num::NonZeroI32, ptr, slice, sync::Arc,
-};
+use std::{collections::HashMap, fmt::Display, mem::size_of, num::NonZeroI32, slice, sync::Arc};
 
 use wasmer_api::{
     Extern, ExternRef, ExternType, Function, Function as WasmerFunction, FunctionEnv,
@@ -668,11 +666,20 @@ fn allocate_guest_memory(env: &mut FunctionEnvMut<WasmCapiEnv>, len: usize) -> O
         return Some(0);
     }
 
-    let malloc_fn = env.data().malloc_fn.clone()?;
-    let len = i32::try_from(len).ok()?;
+    let Some(malloc_fn) = env.data().malloc_fn.clone() else {
+        return None;
+    };
+    let Ok(len) = i32::try_from(len) else {
+        return None;
+    };
     let guest_ptr: i32 = {
         let (_, mut store_ref) = env.data_and_store_mut();
-        malloc_fn.call(&mut store_ref, len).ok()?
+        match malloc_fn.call(&mut store_ref, len) {
+            Ok(ptr) => ptr,
+            Err(error) => {
+                return None;
+            }
+        }
     };
     if guest_ptr <= INVALID_HANDLE {
         return None;
@@ -1328,20 +1335,17 @@ fn copy_wasmer_memory_to_guest(
     let Some(guest_offset) = checked_memory_offset(guest_ptr, len, guest_view.data_size()) else {
         return false;
     };
-    let source_base = source_view.data_ptr();
-    let guest_base = guest_view.data_ptr();
-    if ptr::eq(source_base, guest_base) {
+    if memory == &guest_memory {
         return false;
     }
-    unsafe {
-        // Both ranges are bounds-checked above and same-memory copies are rejected.
-        ptr::copy_nonoverlapping(
-            source_base.add(source_offset),
-            guest_base.add(guest_offset),
-            len,
-        );
-    }
-    true
+    source_view
+        .copy_range_to_memory(
+            source_offset as u64,
+            guest_offset as u64,
+            len as u64,
+            &guest_view,
+        )
+        .is_ok()
 }
 
 fn copy_guest_memory_to_wasmer(
@@ -1364,20 +1368,17 @@ fn copy_guest_memory_to_wasmer(
     let Some(target_offset) = checked_memory_offset(0, len, target_view.data_size()) else {
         return false;
     };
-    let guest_base = guest_view.data_ptr();
-    let target_base = target_view.data_ptr();
-    if ptr::eq(guest_base, target_base) {
+    if memory == &guest_memory {
         return false;
     }
-    unsafe {
-        // Both ranges are bounds-checked above and same-memory copies are rejected.
-        ptr::copy_nonoverlapping(
-            guest_base.add(guest_offset),
-            target_base.add(target_offset),
-            len,
-        );
-    }
-    true
+    guest_view
+        .copy_range_to_memory(
+            guest_offset as u64,
+            target_offset as u64,
+            len as u64,
+            &target_view,
+        )
+        .is_ok()
 }
 
 fn wasm_memory_data_size(env: FunctionEnvMut<WasmCapiEnv>, memory_handle: i32) -> i32 {

--- a/lib/c-api-imports/src/lib.rs
+++ b/lib/c-api-imports/src/lib.rs
@@ -666,20 +666,11 @@ fn allocate_guest_memory(env: &mut FunctionEnvMut<WasmCapiEnv>, len: usize) -> O
         return Some(0);
     }
 
-    let Some(malloc_fn) = env.data().malloc_fn.clone() else {
-        return None;
-    };
-    let Ok(len) = i32::try_from(len) else {
-        return None;
-    };
+    let malloc_fn = env.data().malloc_fn.clone()?;
+    let len = i32::try_from(len).ok()?;
     let guest_ptr: i32 = {
         let (_, mut store_ref) = env.data_and_store_mut();
-        match malloc_fn.call(&mut store_ref, len) {
-            Ok(ptr) => ptr,
-            Err(error) => {
-                return None;
-            }
-        }
+        malloc_fn.call(&mut store_ref, len).ok()?
     };
     if guest_ptr <= INVALID_HANDLE {
         return None;


### PR DESCRIPTION
This PR takes the subset of changes of the `sdk` improvements that only affect the API:

- add async module creation and JSPI-backed async functions for the JavaScript backend
- improve JavaScript table element polyfills and add API-focused tests
