### PR TITLE
feat(experimental-artifact): add --profiler gdb/lldb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7485,6 +7485,7 @@ dependencies = [
  "serde_bytes",
  "shared-buffer",
  "smallvec",
+ "strum",
  "target-lexicon 0.13.5",
  "tempfile",
  "thiserror 2.0.19",

--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -19,6 +19,8 @@ use wasmer_types::{Features, target::Target};
 
 #[cfg(feature = "compiler")]
 use wasmer_compiler::CompilerConfig;
+#[cfg(all(feature = "compiler", feature = "experimental-artifact"))]
+use wasmer_compiler::Debugger;
 
 use wasmer::Engine;
 
@@ -192,6 +194,12 @@ pub struct RuntimeOptions {
 pub enum Profiler {
     /// Perfmap-based profilers.
     Perfmap,
+    /// GDB command file.
+    #[cfg(feature = "experimental-artifact")]
+    Gdb,
+    /// LLDB command file.
+    #[cfg(feature = "experimental-artifact")]
+    Lldb,
 }
 
 impl FromStr for Profiler {
@@ -200,6 +208,10 @@ impl FromStr for Profiler {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "perfmap" => Ok(Self::Perfmap),
+            #[cfg(feature = "experimental-artifact")]
+            "gdb" => Ok(Self::Gdb),
+            #[cfg(feature = "experimental-artifact")]
+            "lldb" => Ok(Self::Lldb),
             _ => Err(anyhow::anyhow!("Unrecognized profiler: {s}")),
         }
     }
@@ -422,6 +434,10 @@ impl RuntimeOptions {
                 if let Some(p) = &self.profiler {
                     match p {
                         Profiler::Perfmap => config.enable_perfmap(),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Gdb => config.enable_debugger(Debugger::Gdb),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Lldb => config.enable_debugger(Debugger::Lldb),
                     }
                 }
                 if let Some(mut debug_dir) = self.compiler_debug_dir.clone() {
@@ -450,6 +466,10 @@ impl RuntimeOptions {
                 if let Some(p) = &self.profiler {
                     match p {
                         Profiler::Perfmap => config.enable_perfmap(),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Gdb => config.enable_debugger(Debugger::Gdb),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Lldb => config.enable_debugger(Debugger::Lldb),
                     }
                 }
                 if let Some(mut debug_dir) = self.compiler_debug_dir.clone() {
@@ -491,6 +511,10 @@ impl RuntimeOptions {
                 if let Some(p) = &self.profiler {
                     match p {
                         Profiler::Perfmap => config.enable_perfmap(),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Gdb => config.enable_debugger(Debugger::Gdb),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Lldb => config.enable_debugger(Debugger::Lldb),
                     }
                 }
 
@@ -565,6 +589,10 @@ impl BackendType {
                 if let Some(p) = &runtime_opts.profiler {
                     match p {
                         Profiler::Perfmap => config.enable_perfmap(),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Gdb => config.enable_debugger(Debugger::Gdb),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Lldb => config.enable_debugger(Debugger::Lldb),
                     }
                 }
                 if let Some(mut debug_dir) = runtime_opts.compiler_debug_dir.clone() {
@@ -599,6 +627,10 @@ impl BackendType {
                 if let Some(p) = &runtime_opts.profiler {
                     match p {
                         Profiler::Perfmap => config.enable_perfmap(),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Gdb => config.enable_debugger(Debugger::Gdb),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Lldb => config.enable_debugger(Debugger::Lldb),
                     }
                 }
                 if let Some(mut debug_dir) = runtime_opts.compiler_debug_dir.clone() {
@@ -648,6 +680,10 @@ impl BackendType {
                 if let Some(p) = &runtime_opts.profiler {
                     match p {
                         Profiler::Perfmap => config.enable_perfmap(),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Gdb => config.enable_debugger(Debugger::Gdb),
+                        #[cfg(feature = "experimental-artifact")]
+                        Profiler::Lldb => config.enable_debugger(Debugger::Lldb),
                     }
                 }
 

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -49,7 +49,7 @@ use wasmer_compiler::progress::ProgressContext;
 use wasmer_compiler::types::{section::SectionIndex, unwind::CompiledFunctionUnwindInfo};
 use wasmer_compiler::{
     Compiler, FunctionBinaryReader, FunctionBodyData, MiddlewareBinaryReader, ModuleMiddleware,
-    ModuleMiddlewareChain, ModuleTranslationState,
+    ModuleMiddlewareChain, ModuleTranslationState, WasmSourceMap,
     types::{
         function::{
             CompiledFunction, CompiledFunctionFrameInfo, FunctionBody, RkyvCompilation, UnwindInfo,
@@ -135,6 +135,11 @@ impl CraneliftCompiler {
         let memory_styles = &compile_info.memory_styles;
         let table_styles = &compile_info.table_styles;
         let module = &compile_info.module;
+        let source_map = Arc::new(if cfg!(feature = "experimental-artifact") {
+            WasmSourceMap::new(module, module_translation_state, &function_body_inputs)
+        } else {
+            WasmSourceMap::default()
+        });
 
         let build_directory = cfg!(feature = "experimental-artifact")
             .then(|| {
@@ -391,6 +396,7 @@ impl CraneliftCompiler {
                     &compile_info.module.get_function_name(func_index),
                     compile_info.module.name.as_deref(),
                     &compiled.function,
+                    &source_map,
                     #[cfg(feature = "unwind")]
                     compiled.fde,
                     #[cfg(feature = "unwind")]

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -137,6 +137,7 @@ impl CraneliftCompiler {
         let module = &compile_info.module;
         let source_map = Arc::new(if cfg!(feature = "experimental-artifact") {
             WasmSourceMap::new(module, module_translation_state, &function_body_inputs)
+                .map_err(CompileError::Codegen)?
         } else {
             WasmSourceMap::default()
         });

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -740,6 +740,10 @@ impl Compiler for CraneliftCompiler {
         self.config.enable_perfmap
     }
 
+    fn get_debugger(&self) -> Option<wasmer_compiler::Debugger> {
+        self.config.debugger
+    }
+
     fn deterministic_id(&self) -> String {
         String::from("cranelift")
     }

--- a/lib/compiler-cranelift/src/config.rs
+++ b/lib/compiler-cranelift/src/config.rs
@@ -13,7 +13,7 @@ use std::{
 use std::{num::NonZero, path::PathBuf};
 use target_lexicon::{OperatingSystem, Vendor};
 use wasmer_compiler::{
-    Compiler, CompilerConfig, Engine, EngineBuilder, ModuleMiddleware,
+    Compiler, CompilerConfig, Debugger, Engine, EngineBuilder, ModuleMiddleware,
     misc::{CompiledKind, function_kind_to_filename, save_assembly_to_file},
 };
 use wasmer_types::{
@@ -114,6 +114,7 @@ pub struct Cranelift {
     pub(crate) allow_experimental_unaligned_memory_accesses: bool,
     enable_verifier: bool,
     pub(crate) enable_perfmap: bool,
+    pub(crate) debugger: Option<Debugger>,
     enable_pic: bool,
     opt_level: CraneliftOptLevel,
     /// The number of threads to use for compilation.
@@ -136,6 +137,7 @@ impl Cranelift {
             num_threads: std::thread::available_parallelism().unwrap_or(NonZero::new(1).unwrap()),
             middlewares: vec![],
             enable_perfmap: false,
+            debugger: None,
             callbacks: None,
         }
     }
@@ -307,6 +309,10 @@ impl CompilerConfig for Cranelift {
 
     fn enable_perfmap(&mut self) {
         self.enable_perfmap = true;
+    }
+
+    fn enable_debugger(&mut self, debugger: Debugger) {
+        self.debugger = Some(debugger);
     }
 
     fn enable_experimental_unaligned_memory_accesses(&mut self) {

--- a/lib/compiler-cranelift/src/elf.rs
+++ b/lib/compiler-cranelift/src/elf.rs
@@ -31,6 +31,7 @@ use wasmer_compiler::dwarf::{EhRelocation, EhTarget, WriterRelocate};
 #[cfg(feature = "unwind")]
 use wasmer_compiler::elf::emit_eh_frame_section;
 use wasmer_compiler::{
+    WasmSourceMap,
     elf::{add_relocations, emit_trap_section, save_object},
     misc::{CompiledFunctionExt, CompiledKind},
     object::get_object_for_target,
@@ -228,6 +229,7 @@ pub(crate) fn emit_local_function(
     function_name: &str,
     module_name: Option<&str>,
     function: &CompiledFunction,
+    source_map: &WasmSourceMap,
     #[cfg(feature = "unwind")] fde: Option<FrameDescriptionEntry>,
     #[cfg(feature = "unwind")] lsda: Option<FunctionLsdaData>,
 ) -> Result<PathBuf, CompileError> {
@@ -258,7 +260,11 @@ pub(crate) fn emit_local_function(
     // Populate DWARF line info from the address map.
     if let Ok(mut dwarf_state) = init_dwarf_unit(function_name, module_name, "Wasmer (Cranelift)") {
         for instruction in &function.frame_info.address_map.instructions {
-            dwarf_state.add_row(instruction.code_offset as u64, instruction.srcloc);
+            dwarf_state.add_source_map_row(
+                instruction.code_offset as u64,
+                instruction.srcloc,
+                source_map,
+            );
         }
         dwarf_state.write_sections(
             &mut object,

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -271,6 +271,7 @@ impl Compiler for LLVMCompiler {
 
         let source_map = Arc::new(if cfg!(feature = "experimental-artifact") {
             WasmSourceMap::new(module, module_translation, &function_body_inputs)
+                .map_err(CompileError::Codegen)?
         } else {
             WasmSourceMap::default()
         });

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -183,6 +183,10 @@ impl Compiler for LLVMCompiler {
         self.config.enable_perfmap
     }
 
+    fn get_debugger(&self) -> Option<wasmer_compiler::Debugger> {
+        self.config.debugger
+    }
+
     fn deterministic_id(&self) -> String {
         format!(
             "llvm-{}{}",

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -21,7 +21,7 @@ use wasmer_compiler::types::module::CompileModuleInfo;
 use wasmer_compiler::types::relocation::RelocationKind;
 use wasmer_compiler::{
     CompiledObjects, Compiler, FunctionBodyData, ModuleMiddleware, ModuleTranslationState,
-    emit_metadata_and_link,
+    WasmSourceMap, emit_metadata_and_link,
     types::{
         relocation::RelocationTarget,
         section::{CustomSection, CustomSectionProtection, SectionBody, SectionIndex},
@@ -269,6 +269,11 @@ impl Compiler for LLVMCompiler {
             .build()
             .map_err(|e| CompileError::Resource(e.to_string()))?;
 
+        let source_map = Arc::new(if cfg!(feature = "experimental-artifact") {
+            WasmSourceMap::new(module, module_translation, &function_body_inputs)
+        } else {
+            WasmSourceMap::default()
+        });
         let buckets =
             build_function_buckets(&function_body_inputs, WASM_LARGE_FUNCTION_THRESHOLD / 3);
         let largest_bucket = buckets.first().map(|b| b.size).unwrap_or_default();
@@ -297,6 +302,7 @@ impl Compiler for LLVMCompiler {
                     pointer_width,
                     *target.cpu_features(),
                     self.config.enable_non_volatile_memops,
+                    source_map.clone(),
                     module
                         .exports
                         .get("__wasm_apply_data_relocs")

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 use std::{fmt::Debug, num::NonZero};
 use target_lexicon::BinaryFormat;
 use wasmer_compiler::misc::{CompiledKind, function_kind_to_filename};
-use wasmer_compiler::{Compiler, CompilerConfig, Engine, EngineBuilder, ModuleMiddleware};
+use wasmer_compiler::{
+    Compiler, CompilerConfig, Debugger, Engine, EngineBuilder, ModuleMiddleware,
+};
 use wasmer_types::{
     Features,
     target::{Architecture, OperatingSystem, Target, Triple},
@@ -113,6 +115,7 @@ pub struct LLVM {
     pub(crate) enable_readonly_funcref_table: bool,
     pub(crate) enable_verifier: bool,
     pub(crate) enable_perfmap: bool,
+    pub(crate) debugger: Option<Debugger>,
     pub(crate) opt_level: LLVMOptLevel,
     is_pic: bool,
     pub(crate) callbacks: Option<LLVMCallbacks>,
@@ -140,6 +143,7 @@ impl LLVM {
             enable_readonly_funcref_table: false,
             enable_verifier: false,
             enable_perfmap: false,
+            debugger: None,
             opt_level: LLVMOptLevel::Aggressive,
             // We will link a shared library and so PIC must be enabled.
             is_pic: cfg!(feature = "experimental-artifact"),
@@ -376,6 +380,10 @@ impl CompilerConfig for LLVM {
 
     fn enable_perfmap(&mut self) {
         self.enable_perfmap = true
+    }
+
+    fn enable_debugger(&mut self, debugger: Debugger) {
+        self.debugger = Some(debugger)
     }
 
     /// Whether to verify compiler IR.

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -449,6 +449,7 @@ impl FuncTranslator {
                 let (line, column, scope) =
                     if let Some(location) = self.source_map.get(original_pos as usize) {
                         let file = dibuilder.create_file(&location.file, &location.directory);
+                        // TODO: try caching the lexical scopes (might be a space saver)
                         let block = dibuilder.create_lexical_block(
                             subprogram.as_debug_info_scope(),
                             file,

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -89,6 +89,7 @@ pub struct FuncTranslator {
 impl wasmer_compiler::FuncTranslator for FuncTranslator {}
 
 impl FuncTranslator {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         target_triple: Triple,
         target_machines: HashMap<OptimizationStyle, TargetMachine>,

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1,5 +1,5 @@
 use std::num::NonZero;
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use super::{
     intrinsics::{
@@ -45,7 +45,7 @@ use wasmer_compiler::{
     GEF64_LEQ_I64_MAX, GEF64_LEQ_U32_MAX, GEF64_LEQ_U64_MAX, LEF32_GEQ_I32_MIN, LEF32_GEQ_I64_MIN,
     LEF32_GEQ_U32_MIN, LEF32_GEQ_U64_MIN, LEF64_GEQ_I32_MIN, LEF64_GEQ_I64_MIN, LEF64_GEQ_U32_MIN,
     LEF64_GEQ_U64_MIN, MiddlewareBinaryReader, ModuleMiddlewareChain, ModuleTranslationState,
-    from_binaryreadererror_wasmerror,
+    WasmSourceMap, from_binaryreadererror_wasmerror,
     misc::{CompiledFunctionExt, CompiledKind},
     types::{
         relocation::RelocationTarget,
@@ -82,6 +82,7 @@ pub struct FuncTranslator {
     pointer_width: u8,
     cpu_features: EnumSet<CpuFeature>,
     non_volatile_memory_ops: bool,
+    source_map: Arc<WasmSourceMap>,
     wasm_apply_data_relocs_fn_index: Option<FunctionIndex>,
 }
 
@@ -95,6 +96,7 @@ impl FuncTranslator {
         pointer_width: u8,
         cpu_features: EnumSet<CpuFeature>,
         non_volatile_memory_ops: bool,
+        source_map: Arc<WasmSourceMap>,
         wasm_apply_data_relocs_fn_index: Option<FunctionIndex>,
     ) -> Result<Self, CompileError> {
         let abi_source_tm = target_machines
@@ -119,6 +121,7 @@ impl FuncTranslator {
             pointer_width,
             cpu_features,
             non_volatile_memory_ops,
+            source_map,
             wasm_apply_data_relocs_fn_index,
         })
     }
@@ -191,6 +194,7 @@ impl FuncTranslator {
 
         let func = module.add_function(&function_name, func_type, Some(Linkage::External));
         let debug_info = if cfg!(feature = "experimental-artifact") {
+            let source_location = self.source_map.first_in_function(function_body);
             let debug_metadata_version = self
                 .ctx
                 .i32_type()
@@ -206,11 +210,15 @@ impl FuncTranslator {
                 self.ctx.i32_type().const_int(4, false),
             );
 
+            let fallback_source_file = wasm_module.name();
+            let (source_file, source_directory) = source_location
+                .map(|location| (location.file.as_str(), location.directory.as_str()))
+                .unwrap_or((&fallback_source_file, "."));
             let (dibuilder, compile_unit) = module.create_debug_info_builder(
                 true,
                 DWARFSourceLanguage::C,
-                &wasm_module.name(),
-                ".",
+                source_file,
+                source_directory,
                 "wasmer",
                 true,
                 "",
@@ -230,7 +238,9 @@ impl FuncTranslator {
                 DIFlags::PUBLIC,
             );
             let function_name = wasm_module.get_function_name(func_index);
-            let start_line = (function_body.module_offset as u32).saturating_add(1);
+            let start_line = source_location
+                .map(|location| location.line)
+                .unwrap_or_else(|| (function_body.module_offset as u32).saturating_add(1));
             let subprogram = dibuilder.create_function(
                 compile_unit.as_debug_info_scope(),
                 &function_name,
@@ -435,14 +445,24 @@ impl FuncTranslator {
             let original_pos = reader.original_position() as u32;
             let op = reader.read_operator()?;
             if let Some((dibuilder, subprogram)) = debug_info.as_ref() {
-                let line = original_pos.saturating_add(1);
-                let loc = dibuilder.create_debug_location(
-                    &self.ctx,
-                    line,
-                    1,
-                    subprogram.as_debug_info_scope(),
-                    None,
-                );
+                let (line, column, scope) =
+                    if let Some(location) = self.source_map.get(original_pos as usize) {
+                        let file = dibuilder.create_file(&location.file, &location.directory);
+                        let block = dibuilder.create_lexical_block(
+                            subprogram.as_debug_info_scope(),
+                            file,
+                            location.line,
+                            location.column,
+                        );
+                        (location.line, location.column, block.as_debug_info_scope())
+                    } else {
+                        (
+                            original_pos.saturating_add(1),
+                            1,
+                            subprogram.as_debug_info_scope(),
+                        )
+                    };
+                let loc = dibuilder.create_debug_location(&self.ctx, line, column, scope, None);
                 fcg.builder.set_current_debug_location(loc);
             }
             fcg.translate_operator(op, pos)?;

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -30,7 +30,7 @@ use target_lexicon::Architecture;
 use wasmer_compiler::dwarf::{DwarfState, init_dwarf_unit};
 
 use wasmer_compiler::{
-    FunctionBodyData,
+    FunctionBodyData, WasmSourceMap,
     misc::CompiledKind,
     types::{
         function::{CompiledFunction, CompiledFunctionFrameInfo, FunctionBody},
@@ -5964,6 +5964,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         arch: Architecture,
         target: &Target,
         build_directory: Option<&Path>,
+        source_map: &WasmSourceMap,
     ) -> Result<CompileOutput<(CompiledFunction, Option<UnwindFrame>)>, CompileError> {
         self.stack_offset -= RED_ZONE_SIZE;
 
@@ -6040,7 +6041,11 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         #[cfg(feature = "unwind")]
         if let Some(dwarf_state) = self.dwarf_state.as_mut() {
             for instruction in &address_map.instructions {
-                dwarf_state.add_row(instruction.code_offset as u64, instruction.srcloc);
+                dwarf_state.add_source_map_row(
+                    instruction.code_offset as u64,
+                    instruction.srcloc,
+                    source_map,
+                );
             }
         }
         let traps = self.machine.collect_trap_information();

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -5964,7 +5964,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         arch: Architecture,
         target: &Target,
         build_directory: Option<&Path>,
-        source_map: &WasmSourceMap,
+        _source_map: &WasmSourceMap,
     ) -> Result<CompileOutput<(CompiledFunction, Option<UnwindFrame>)>, CompileError> {
         self.stack_offset -= RED_ZONE_SIZE;
 
@@ -6044,7 +6044,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 dwarf_state.add_source_map_row(
                     instruction.code_offset as u64,
                     instruction.srcloc,
-                    source_map,
+                    _source_map,
                 );
             }
         }

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -440,6 +440,10 @@ impl Compiler for SinglepassCompiler {
         "singlepass"
     }
 
+    fn get_debugger(&self) -> Option<wasmer_compiler::Debugger> {
+        self.config.debugger
+    }
+
     fn deterministic_id(&self) -> String {
         String::from("singlepass")
     }

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -110,6 +110,7 @@ impl SinglepassCompiler {
         let module = &compile_info.module;
         let source_map = Arc::new(if cfg!(feature = "experimental-artifact") {
             WasmSourceMap::new(module, module_translation, &function_body_inputs)
+                .map_err(CompileError::Codegen)?
         } else {
             WasmSourceMap::default()
         });

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -31,7 +31,7 @@ use wasmer_compiler::serialize::SerializableModule;
 use wasmer_compiler::types::function::Compilation;
 use wasmer_compiler::{
     Compiler, CompilerConfig, FunctionBinaryReader, FunctionBodyData, MiddlewareBinaryReader,
-    ModuleMiddleware, ModuleMiddlewareChain, ModuleTranslationState,
+    ModuleMiddleware, ModuleMiddlewareChain, ModuleTranslationState, WasmSourceMap,
     types::{
         function::{FunctionBody, RkyvCompilation, UnwindInfo},
         module::CompileModuleInfo,
@@ -68,6 +68,7 @@ impl SinglepassCompiler {
         target: &Target,
         compile_info: &CompileModuleInfo,
         compile_info_blob: &[u8],
+        module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
         progress_callback: Option<&CompilationProgressCallback>,
     ) -> Result<Compilation, CompileError> {
@@ -107,6 +108,11 @@ impl SinglepassCompiler {
         let build_directory_path = build_directory.as_ref().map(|d| d.path());
 
         let module = &compile_info.module;
+        let source_map = Arc::new(if cfg!(feature = "experimental-artifact") {
+            WasmSourceMap::new(module, module_translation, &function_body_inputs)
+        } else {
+            WasmSourceMap::default()
+        });
         let total_function_call_trampolines = module.signatures.len() as u64;
         let total_dynamic_trampolines = module.num_imported_functions as u64;
         let total_steps = WASM_TRAMPOLINE_ESTIMATED_BODY_SIZE
@@ -204,7 +210,7 @@ impl SinglepassCompiler {
                             generator.feed_operator(op)?;
                         }
 
-                        generator.finalize(input, arch, target, build_directory_path)
+                        generator.finalize(input, arch, target, build_directory_path, &source_map)
                     }
                     Architecture::Aarch64(_) => {
                         let machine = MachineARM64::new(Some(target.clone()));
@@ -225,7 +231,7 @@ impl SinglepassCompiler {
                             generator.feed_operator(op)?;
                         }
 
-                        generator.finalize(input, arch, target, build_directory_path)
+                        generator.finalize(input, arch, target, build_directory_path, &source_map)
                     }
                     Architecture::Riscv64(_) => {
                         let machine = MachineRiscv::new(
@@ -249,7 +255,7 @@ impl SinglepassCompiler {
                             generator.feed_operator(op)?;
                         }
 
-                        generator.finalize(input, arch, target, build_directory_path)
+                        generator.finalize(input, arch, target, build_directory_path, &source_map)
                     }
                     _ => unimplemented!(),
                 }?;
@@ -449,7 +455,7 @@ impl Compiler for SinglepassCompiler {
         target: &Target,
         compile_info: &CompileModuleInfo,
         compile_info_blob: &[u8],
-        _module_translation: &ModuleTranslationState,
+        module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
         progress_callback: Option<&CompilationProgressCallback>,
     ) -> Result<Compilation, CompileError> {
@@ -466,6 +472,7 @@ impl Compiler for SinglepassCompiler {
                 target,
                 compile_info,
                 compile_info_blob,
+                module_translation,
                 function_body_inputs,
                 progress_callback,
             )

--- a/lib/compiler-singlepass/src/config.rs
+++ b/lib/compiler-singlepass/src/config.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use target_lexicon::Architecture;
 use wasmer_compiler::{
-    Compiler, CompilerConfig, Engine, EngineBuilder, ModuleMiddleware,
+    Compiler, CompilerConfig, Debugger, Engine, EngineBuilder, ModuleMiddleware,
     misc::{CompiledKind, function_kind_to_filename, save_assembly_to_file},
 };
 use wasmer_types::{
@@ -82,6 +82,7 @@ impl SinglepassCallbacks {
 pub struct Singlepass {
     pub(crate) enable_nan_canonicalization: bool,
     pub(crate) allow_experimental_unaligned_memory_accesses: bool,
+    pub(crate) debugger: Option<Debugger>,
 
     /// The middleware chain.
     pub(crate) middlewares: Vec<Arc<dyn ModuleMiddleware>>,
@@ -99,6 +100,7 @@ impl Singlepass {
         Self {
             enable_nan_canonicalization: true,
             allow_experimental_unaligned_memory_accesses: false,
+            debugger: None,
             middlewares: vec![],
             callbacks: None,
             num_threads: std::thread::available_parallelism().unwrap_or(NonZero::new(1).unwrap()),
@@ -139,6 +141,10 @@ impl CompilerConfig for Singlepass {
     fn enable_pic(&mut self) {
         // Do nothing, since singlepass already emits
         // PIC code.
+    }
+
+    fn enable_debugger(&mut self, debugger: Debugger) {
+        self.debugger = Some(debugger);
     }
 
     /// Transform it into the compiler

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true, optional = true }
 thiserror.workspace = true
 serde_bytes = { workspace = true, optional = true }
 smallvec.workspace = true
+strum = { workspace = true, optional = true }
 loupe = { workspace = true, optional = true, features = [
   "indexmap",
   "enable-indexmap",
@@ -70,7 +71,7 @@ default = ["std"]
 # `CompilerConfig`, as well as the included wasmparser.
 # Disable this feature if you just want a headless engine.
 translator = ["wasmparser"]
-compiler = ["translator"]
+compiler = ["translator", "dep:strum"]
 wasmer-artifact-load = []
 wasmer-artifact-create = []
 static-artifact-load = []

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -78,7 +78,9 @@ pub trait CompilerConfig {
     }
 
     /// Enable generation of a debugger command file for JIT compiled frames.
-    fn enable_debugger(&mut self, _debugger: Debugger);
+    fn enable_debugger(&mut self, _debugger: Debugger) {
+        // By default we do nothing, each backend will need to customize this.
+    }
 
     /// For the LLVM compiler, we can use non-volatile memory operations which lead to a better performance
     /// (but are not 100% SPEC compliant).

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -36,6 +36,17 @@ use wasmer_types::{FunctionType, SignatureIndex};
 #[cfg(feature = "translator")]
 use wasmparser::{Validator, WasmFeatures};
 
+/// A debugger command-file format for registering JIT-compiled modules.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
+pub enum Debugger {
+    /// GDB command file.
+    #[strum(serialize = "GDB")]
+    Gdb,
+    /// LLDB command file.
+    #[strum(serialize = "LLDB")]
+    Lldb,
+}
+
 /// The compiler configuration options.
 pub trait CompilerConfig {
     /// Enable Position Independent Code (PIC).
@@ -59,9 +70,11 @@ pub trait CompilerConfig {
 
     /// Enable generation of perfmaps to sample the JIT compiled frames.
     fn enable_perfmap(&mut self) {
-        // By default we do nothing, each backend will need to customize this
-        // in case they create an IR that they can verify.
+        // By default we do nothing, each backend will need to customize this.
     }
+
+    /// Enable generation of a debugger command file for JIT compiled frames.
+    fn enable_debugger(&mut self, _debugger: Debugger);
 
     /// For the LLVM compiler, we can use non-volatile memory operations which lead to a better performance
     /// (but are not 100% SPEC compliant).
@@ -200,6 +213,11 @@ pub trait Compiler: Send + std::fmt::Debug {
     /// Get whether `perfmap` is enabled or not.
     fn get_perfmap_enabled(&self) -> bool {
         false
+    }
+
+    /// Get the enabled debugger command-file format, if any.
+    fn get_debugger(&self) -> Option<Debugger> {
+        None
     }
 }
 

--- a/lib/compiler/src/dwarf.rs
+++ b/lib/compiler/src/dwarf.rs
@@ -19,6 +19,8 @@ use object::{
 };
 use wasmer_types::{CompileError, SourceLoc, target::Endianness};
 
+use crate::WasmSourceMap;
+
 /// The symbolic target of an `.eh_frame` relocation. The gimli `Address`
 /// `symbol` field is used as a discriminant value (see [`WriterRelocate`]).
 #[derive(Clone, Copy, Debug)]
@@ -390,6 +392,36 @@ impl DwarfState {
         row.file = self.file_id;
         row.line = (srcloc.bits() as u64).saturating_add(1);
         row.column = 0;
+        self.dwarf.unit.line_program.generate_row();
+    }
+
+    /// Emit a line program row using original source information when available.
+    pub fn add_source_map_row(
+        &mut self,
+        code_offset: u64,
+        srcloc: SourceLoc,
+        source_map: &WasmSourceMap,
+    ) {
+        let Some(location) = source_map.get(srcloc.bits() as usize) else {
+            self.add_row(code_offset, srcloc);
+            return;
+        };
+
+        let directory = self
+            .dwarf
+            .unit
+            .line_program
+            .add_directory(LineString::String(location.directory.as_bytes().to_vec()));
+        let file = self.dwarf.unit.line_program.add_file(
+            LineString::String(location.file.as_bytes().to_vec()),
+            directory,
+            None,
+        );
+        let row = self.dwarf.unit.line_program.row();
+        row.address_offset = code_offset;
+        row.file = file;
+        row.line = u64::from(location.line);
+        row.column = u64::from(location.column);
         self.dwarf.unit.line_program.generate_row();
     }
 

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -797,24 +797,6 @@ impl Artifact {
         Ok(artifact)
     }
 
-    /// Build an [`AllocatedArtifact`] from a compiled native ELF image.
-    fn allocate_elf_artifact(
-        engine_inner: &mut EngineInner,
-        module_info: &ModuleInfo,
-        elf_file_data: &[u8],
-    ) -> Result<AllocatedArtifact, DeserializeError> {
-        let image = object::File::parse(elf_file_data)
-            .map_err(|e| DeserializeError::CorruptedBinary(format!("cannot parse image: {e}")))?;
-        let base = engine_inner.map_elf_binary(&image, elf_file_data)?;
-        Self::allocate_elf_artifact_from_image(
-            engine_inner,
-            module_info,
-            &image,
-            base,
-            DebugInfoSource::Bytes(Arc::from(elf_file_data)),
-        )
-    }
-
     #[cfg(unix)]
     fn allocate_elf_artifact_from_path(
         engine_inner: &mut EngineInner,

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -832,7 +832,11 @@ impl Artifact {
                 "file-backed Artifact is not ELF".to_string(),
             ));
         }
-        let base = engine_inner.map_elf_binary_file(&image, fd, path)?;
+        let base = engine_inner.map_elf_binary_file(&image, fd)?;
+        #[cfg(feature = "compiler")]
+        if let Some(debugger) = engine_inner.debugger() {
+            engine_inner.register_debugger(path, base, debugger)?;
+        }
         Self::allocate_elf_artifact_from_image(
             engine_inner,
             module_info,

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs::File,
-    io::BufReader,
+    io::{BufReader, Write},
     mem::size_of,
     path::{Path, PathBuf},
     sync::{
@@ -487,7 +487,11 @@ impl Artifact {
             }
             Self::allocate_elf_artifact_from_path(engine_inner, module_info, module_file)?
         } else if let Some(elf_file_data) = elf_file_data {
-            Self::allocate_elf_artifact(engine_inner, module_info, elf_file_data)?
+            let mut module_file = tempfile::NamedTempFile::new()?;
+            module_file.write_all(elf_file_data)?;
+            module_file.flush()?;
+            let module_file_path = module_file.keep().map_err(|error| error.error)?.1;
+            Self::allocate_elf_artifact_from_path(engine_inner, module_info, &module_file_path)?
         } else {
             let (
                 finished_functions,
@@ -828,7 +832,7 @@ impl Artifact {
                 "file-backed Artifact is not ELF".to_string(),
             ));
         }
-        let base = engine_inner.map_elf_binary_file(&image, fd)?;
+        let base = engine_inner.map_elf_binary_file(&image, fd, path)?;
         Self::allocate_elf_artifact_from_image(
             engine_inner,
             module_info,

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs::File,
-    io::{BufReader, Write},
+    io::BufReader,
     mem::size_of,
     path::{Path, PathBuf},
     sync::{
@@ -487,11 +487,7 @@ impl Artifact {
             }
             Self::allocate_elf_artifact_from_path(engine_inner, module_info, module_file)?
         } else if let Some(elf_file_data) = elf_file_data {
-            let mut module_file = tempfile::NamedTempFile::new()?;
-            module_file.write_all(elf_file_data)?;
-            module_file.flush()?;
-            let module_file_path = module_file.keep().map_err(|error| error.error)?.1;
-            Self::allocate_elf_artifact_from_path(engine_inner, module_info, &module_file_path)?
+            Self::allocate_elf_artifact(engine_inner, module_info, elf_file_data)?
         } else {
             let (
                 finished_functions,
@@ -795,6 +791,28 @@ impl Artifact {
         }
 
         Ok(artifact)
+    }
+
+    /// Build an [`AllocatedArtifact`] from a compiled native ELF image.
+    ///
+    /// Note that, unlike [`Self::allocate_elf_artifact_from_path`], no debugger
+    /// command file is registered here: the image only exists in memory, so
+    /// there is no path a debugger could load symbols from.
+    fn allocate_elf_artifact(
+        engine_inner: &mut EngineInner,
+        module_info: &ModuleInfo,
+        elf_file_data: &[u8],
+    ) -> Result<AllocatedArtifact, DeserializeError> {
+        let image = object::File::parse(elf_file_data)
+            .map_err(|e| DeserializeError::CorruptedBinary(format!("cannot parse image: {e}")))?;
+        let base = engine_inner.map_elf_binary(&image, elf_file_data)?;
+        Self::allocate_elf_artifact_from_image(
+            engine_inner,
+            module_info,
+            &image,
+            base,
+            DebugInfoSource::Bytes(Arc::from(elf_file_data)),
+        )
     }
 
     #[cfg(unix)]

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -586,9 +586,10 @@ impl EngineInner {
         &mut self,
         object_file: &object::File<'a, R>,
         file: RawFd,
+        path: &Path,
     ) -> Result<*mut c_void, CompileError> {
-        let map =
-            MemoryMappedBinary::try_from_file(object_file, file).map_err(CompileError::Resource)?;
+        let map = MemoryMappedBinary::try_from_file(object_file, file, path)
+            .map_err(CompileError::Resource)?;
         let base = map.base();
         self.elf_mapped_binary.push(map);
         Ok(base)

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::engine::builder::EngineBuilder;
 #[cfg(feature = "compiler")]
-use crate::{Compiler, CompilerConfig};
+use crate::{Compiler, CompilerConfig, Debugger};
 
 #[cfg(not(target_arch = "wasm32"))]
 use wasmer_types::CompilationProgressCallback;
@@ -586,13 +586,66 @@ impl EngineInner {
         &mut self,
         object_file: &object::File<'a, R>,
         file: RawFd,
-        path: &Path,
     ) -> Result<*mut c_void, CompileError> {
-        let map = MemoryMappedBinary::try_from_file(object_file, file, path)
-            .map_err(CompileError::Resource)?;
+        let map =
+            MemoryMappedBinary::try_from_file(object_file, file).map_err(CompileError::Resource)?;
         let base = map.base();
         self.elf_mapped_binary.push(map);
         Ok(base)
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), unix, feature = "compiler"))]
+    pub(crate) fn debugger(&self) -> Option<Debugger> {
+        self.compiler
+            .as_ref()
+            .and_then(|compiler| compiler.get_debugger())
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), unix, feature = "compiler"))]
+    pub(crate) fn register_debugger(
+        &self,
+        path: &Path,
+        base: *mut c_void,
+        debugger: Debugger,
+    ) -> Result<(), CompileError> {
+        use std::io::Write as _;
+
+        let path = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"");
+        let (command, source_command) = match debugger {
+            Debugger::Gdb => (
+                format!("add-symbol-file \"{path}\" -o 0x{:x}", base as usize),
+                "source",
+            ),
+            Debugger::Lldb => (
+                format!(
+                    "target modules add \"{path}\"\ntarget modules load --file \"{path}\" --slide 0x{:x}",
+                    base as usize
+                ),
+                "command source",
+            ),
+        };
+        let filename = format!(
+            "/tmp/wasmer-{}.{}",
+            debugger.to_string().to_lowercase(),
+            std::process::id()
+        );
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&filename)
+            .map_err(|error| CompileError::Resource(format!("Cannot open {filename}: {error}")))?;
+        writeln!(file, "{command}")
+            .map_err(|error| CompileError::Resource(format!("Cannot write {filename}: {error}")))?;
+
+        eprintln!("**************************");
+        eprintln!("For debugging under {debugger}, use: {source_command} {filename}");
+        eprintln!("**************************");
+        Ok(())
     }
 
     /// Register DWARF-type exception handling information associated with the code.

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -564,22 +564,6 @@ impl EngineInner {
         Ok(())
     }
 
-    /// Memory-map a compiled ELF artifact image, keeping the mapping alive
-    /// for the lifetime of the engine. Returns the base address of the
-    /// mapping, which section/symbol offsets from the image are relative to.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn map_elf_binary<'a, R: object::ReadRef<'a>>(
-        &mut self,
-        object_file: &object::File<'a, R>,
-        data: &[u8],
-    ) -> Result<*mut c_void, CompileError> {
-        let map = MemoryMappedBinary::try_from_bytes(object_file, data)
-            .map_err(CompileError::Resource)?;
-        let base = map.base();
-        self.elf_mapped_binary.push(map);
-        Ok(base)
-    }
-
     /// Memory-map a compiled ELF artifact directly from a file.
     #[cfg(all(not(target_arch = "wasm32"), unix))]
     pub(crate) fn map_elf_binary_file<'a, R: object::ReadRef<'a>>(

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -614,8 +614,7 @@ impl EngineInner {
             .canonicalize()
             .unwrap_or_else(|_| path.to_path_buf())
             .to_string_lossy()
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"");
+            .to_string();
         let (command, source_command) = match debugger {
             Debugger::Gdb => (
                 format!("add-symbol-file \"{path}\" -o 0x{:x}", base as usize),

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -564,6 +564,22 @@ impl EngineInner {
         Ok(())
     }
 
+    /// Memory-map a compiled ELF artifact image, keeping the mapping alive
+    /// for the lifetime of the engine. Returns the base address of the
+    /// mapping, which section/symbol offsets from the image are relative to.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn map_elf_binary<'a, R: object::ReadRef<'a>>(
+        &mut self,
+        object_file: &object::File<'a, R>,
+        data: &[u8],
+    ) -> Result<*mut c_void, CompileError> {
+        let map = MemoryMappedBinary::try_from_bytes(object_file, data)
+            .map_err(CompileError::Resource)?;
+        let base = map.base();
+        self.elf_mapped_binary.push(map);
+        Ok(base)
+    }
+
     /// Memory-map a compiled ELF artifact directly from a file.
     #[cfg(all(not(target_arch = "wasm32"), unix))]
     pub(crate) fn map_elf_binary_file<'a, R: object::ReadRef<'a>>(

--- a/lib/compiler/src/engine/mapped_binary.rs
+++ b/lib/compiler/src/engine/mapped_binary.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 #[cfg(unix)]
-use std::{os::fd::RawFd, ptr, slice};
+use std::{os::fd::RawFd, path::Path, ptr, slice};
 
 #[cfg(unix)]
 use itertools::Itertools;
@@ -258,21 +258,23 @@ impl MemoryMappedBinary {
         object_file: &object::File<'a, R>,
         data: &[u8],
     ) -> Result<Self, String> {
-        Self::try_from_source(object_file, Some(data), None)
+        Self::try_from_source(object_file, Some(data), None, None)
     }
 
     /// Maps an ELF image's load segments directly from an open file.
     pub(crate) fn try_from_file<'a, R: ReadRef<'a>>(
         object_file: &object::File<'a, R>,
         file: RawFd,
+        path: &Path,
     ) -> Result<Self, String> {
-        Self::try_from_source(object_file, None, Some(file))
+        Self::try_from_source(object_file, None, Some(file), Some(path))
     }
 
     fn try_from_source<'a, R: ReadRef<'a>>(
         object_file: &object::File<'a, R>,
         data: Option<&[u8]>,
         file: Option<RawFd>,
+        path: Option<&Path>,
     ) -> Result<Self, String> {
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
         if page_size == -1 {
@@ -308,6 +310,22 @@ impl MemoryMappedBinary {
         // per-partes with the individual protection flags.
         let map = Self::new_mmap(total_memory_size)?;
         let base = map.base();
+        if let Some(path) = path {
+            let path = path
+                .canonicalize()
+                .unwrap_or_else(|_| path.to_path_buf())
+                .to_string_lossy()
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"");
+            std::fs::write(
+                "/tmp/wasmer.gdb",
+                format!("add-symbol-file \"{path}\" -o 0x{:x}\n", base as usize),
+            )
+            .map_err(|error| format!("Cannot write /tmp/wasmer.gdb: {error}"))?;
+            eprintln!("**************************");
+            eprintln!("For debugging under GDB, use: source /tmp/wasmer.gdb");
+            eprintln!("**************************");
+        }
 
         // Mmap individual load segments
         for load_segment in segments {

--- a/lib/compiler/src/engine/mapped_binary.rs
+++ b/lib/compiler/src/engine/mapped_binary.rs
@@ -251,16 +251,6 @@ unsafe impl Sync for MemoryMappedBinary {}
 
 #[cfg(unix)]
 impl MemoryMappedBinary {
-    /// Maps `object_file`'s load segments into a freshly allocated, private
-    /// virtual address range, copying segment bytes out of the in-memory
-    /// `data` buffer (rather than mapping a file directly).
-    pub(crate) fn try_from_bytes<'a, R: ReadRef<'a>>(
-        object_file: &object::File<'a, R>,
-        data: &[u8],
-    ) -> Result<Self, String> {
-        Self::try_from_source(object_file, Some(data), None)
-    }
-
     /// Maps an ELF image's load segments directly from an open file.
     pub(crate) fn try_from_file<'a, R: ReadRef<'a>>(
         object_file: &object::File<'a, R>,

--- a/lib/compiler/src/engine/mapped_binary.rs
+++ b/lib/compiler/src/engine/mapped_binary.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 #[cfg(unix)]
-use std::{os::fd::RawFd, path::Path, ptr, slice};
+use std::{os::fd::RawFd, ptr, slice};
 
 #[cfg(unix)]
 use itertools::Itertools;
@@ -258,23 +258,21 @@ impl MemoryMappedBinary {
         object_file: &object::File<'a, R>,
         data: &[u8],
     ) -> Result<Self, String> {
-        Self::try_from_source(object_file, Some(data), None, None)
+        Self::try_from_source(object_file, Some(data), None)
     }
 
     /// Maps an ELF image's load segments directly from an open file.
     pub(crate) fn try_from_file<'a, R: ReadRef<'a>>(
         object_file: &object::File<'a, R>,
         file: RawFd,
-        path: &Path,
     ) -> Result<Self, String> {
-        Self::try_from_source(object_file, None, Some(file), Some(path))
+        Self::try_from_source(object_file, None, Some(file))
     }
 
     fn try_from_source<'a, R: ReadRef<'a>>(
         object_file: &object::File<'a, R>,
         data: Option<&[u8]>,
         file: Option<RawFd>,
-        path: Option<&Path>,
     ) -> Result<Self, String> {
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
         if page_size == -1 {
@@ -310,22 +308,6 @@ impl MemoryMappedBinary {
         // per-partes with the individual protection flags.
         let map = Self::new_mmap(total_memory_size)?;
         let base = map.base();
-        if let Some(path) = path {
-            let path = path
-                .canonicalize()
-                .unwrap_or_else(|_| path.to_path_buf())
-                .to_string_lossy()
-                .replace('\\', "\\\\")
-                .replace('"', "\\\"");
-            std::fs::write(
-                "/tmp/wasmer.gdb",
-                format!("add-symbol-file \"{path}\" -o 0x{:x}\n", base as usize),
-            )
-            .map_err(|error| format!("Cannot write /tmp/wasmer.gdb: {error}"))?;
-            eprintln!("**************************");
-            eprintln!("For debugging under GDB, use: source /tmp/wasmer.gdb");
-            eprintln!("**************************");
-        }
 
         // Mmap individual load segments
         for load_segment in segments {

--- a/lib/compiler/src/engine/mapped_binary.rs
+++ b/lib/compiler/src/engine/mapped_binary.rs
@@ -251,6 +251,16 @@ unsafe impl Sync for MemoryMappedBinary {}
 
 #[cfg(unix)]
 impl MemoryMappedBinary {
+    /// Maps `object_file`'s load segments into a freshly allocated, private
+    /// virtual address range, copying segment bytes out of the in-memory
+    /// `data` buffer (rather than mapping a file directly).
+    pub(crate) fn try_from_bytes<'a, R: ReadRef<'a>>(
+        object_file: &object::File<'a, R>,
+        data: &[u8],
+    ) -> Result<Self, String> {
+        Self::try_from_source(object_file, Some(data), None)
+    }
+
     /// Maps an ELF image's load segments directly from an open file.
     pub(crate) fn try_from_file<'a, R: ReadRef<'a>>(
         object_file: &object::File<'a, R>,

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -82,9 +82,9 @@ cfg_std_or_core! {
 mod compiler;
 #[cfg(feature = "compiler")]
 pub use crate::compiler::{
-    CompiledFunction, CompiledObjects, Compiler, CompilerConfig, FuncTranslator, FunctionBucket,
-    WASM_LARGE_FUNCTION_THRESHOLD, WASM_TRAMPOLINE_ESTIMATED_BODY_SIZE, build_function_buckets,
-    emit_metadata_and_link, translate_function_buckets,
+    CompiledFunction, CompiledObjects, Compiler, CompilerConfig, Debugger, FuncTranslator,
+    FunctionBucket, WASM_LARGE_FUNCTION_THRESHOLD, WASM_TRAMPOLINE_ESTIMATED_BODY_SIZE,
+    build_function_buckets, emit_metadata_and_link, translate_function_buckets,
 };
 
 #[cfg(feature = "compiler")]

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -91,6 +91,10 @@ pub use crate::compiler::{
 pub mod dwarf;
 #[cfg(feature = "compiler")]
 pub mod elf;
+#[cfg(feature = "compiler")]
+mod source_map;
+#[cfg(feature = "compiler")]
+pub use source_map::{SourceLocation, WasmSourceMap};
 
 mod constants;
 pub use crate::constants::*;

--- a/lib/compiler/src/source_map.rs
+++ b/lib/compiler/src/source_map.rs
@@ -42,7 +42,8 @@ impl WasmSourceMap {
         functions: &PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
     ) -> Result<Self, String> {
         let Some(code_base) = translation.code_section_offset() else {
-            return Err("code offset expected in Wasm file".to_string());
+            // We must support a Wasm modules without code section.
+            return Ok(Self::default());
         };
 
         type Reader = EndianRcSlice<LittleEndian>;

--- a/lib/compiler/src/source_map.rs
+++ b/lib/compiler/src/source_map.rs
@@ -1,6 +1,7 @@
 use addr2line::gimli::{Dwarf, EndianRcSlice, LittleEndian, SectionId};
 #[cfg(feature = "core")]
 use alloc::{collections::BTreeMap, rc::Rc};
+use std::path::PathBuf;
 #[cfg(feature = "std")]
 use std::{collections::BTreeMap, rc::Rc};
 use wasmer_types::{LocalFunctionIndex, ModuleInfo, entity::PrimaryMap};
@@ -39,9 +40,9 @@ impl WasmSourceMap {
         module: &ModuleInfo,
         translation: &ModuleTranslationState,
         functions: &PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
-    ) -> Self {
+    ) -> Result<Self, String> {
         let Some(code_base) = translation.code_section_offset() else {
-            return Self::default();
+            return Err("code offset expected in Wasm file".to_string());
         };
 
         type Reader = EndianRcSlice<LittleEndian>;
@@ -50,11 +51,11 @@ impl WasmSourceMap {
             Ok::<_, addr2line::gimli::Error>(Reader::new(Rc::from(data), LittleEndian))
         }) {
             Ok(dwarf) => dwarf,
-            Err(_) => return Self::default(),
+            Err(err) => return Err(format!("cannot parse DWARF file: {err}")),
         };
         let context = match addr2line::Context::from_dwarf(dwarf) {
             Ok(context) => context,
-            Err(_) => return Self::default(),
+            Err(err) => return Err(format!("cannot construct addr2line Context: {err}")),
         };
 
         let mut locations = BTreeMap::new();
@@ -66,26 +67,33 @@ impl WasmSourceMap {
             while !operators.eof() {
                 let offset = operators.original_position();
                 if operators.read().is_err() {
-                    break;
+                    return Err("Wasm parsing error".to_string());
                 }
-                let Some(address) = offset.checked_sub(code_base).map(|value| value as u64) else {
-                    continue;
-                };
+                let address = offset.checked_sub(code_base).ok_or_else(|| {
+                    format!(
+                        "Wasm operator offset {offset} precedes code section offset {code_base}"
+                    )
+                })? as u64;
                 let Ok(Some(location)) = context.find_location(address) else {
                     continue;
                 };
                 let (Some(file), Some(line)) = (location.file, location.line) else {
                     continue;
                 };
-                let (directory, file) = file
-                    .rfind(['/', '\\'])
-                    .map(|separator| (&file[..separator], &file[separator + 1..]))
-                    .unwrap_or(("", file));
+                let path = PathBuf::from(file);
+                let directory = path
+                    .parent()
+                    .and_then(|p| p.to_str().map(|p| p.to_string()))
+                    .unwrap_or_default();
+                let filename = path
+                    .file_name()
+                    .and_then(|p| p.to_str().map(|p| p.to_string()))
+                    .unwrap_or_default();
                 locations.insert(
                     offset,
                     SourceLocation {
-                        file: file.to_owned(),
-                        directory: directory.to_owned(),
+                        file: filename,
+                        directory,
                         line,
                         column: location.column.unwrap_or(0),
                     },
@@ -93,7 +101,7 @@ impl WasmSourceMap {
             }
         }
 
-        Self { locations }
+        Ok(Self { locations })
     }
 
     /// Return the source location for a module-relative Wasm offset.

--- a/lib/compiler/src/source_map.rs
+++ b/lib/compiler/src/source_map.rs
@@ -1,0 +1,111 @@
+use addr2line::gimli::{Dwarf, EndianRcSlice, LittleEndian, SectionId};
+#[cfg(feature = "core")]
+use alloc::{collections::BTreeMap, rc::Rc};
+#[cfg(feature = "std")]
+use std::{collections::BTreeMap, rc::Rc};
+use wasmer_types::{LocalFunctionIndex, ModuleInfo, entity::PrimaryMap};
+
+use crate::{
+    FunctionBodyData, ModuleTranslationState,
+    wasmparser::{BinaryReader, FunctionBody},
+};
+
+/// An original source position associated with a Wasm operator.
+#[derive(Clone, Debug)]
+pub struct SourceLocation {
+    /// Source file name.
+    pub file: String,
+    /// Directory containing the source file.
+    pub directory: String,
+    /// One-based source line number.
+    pub line: u32,
+    /// Source column number.
+    pub column: u32,
+}
+
+/// Source locations recovered from an input Wasm module's DWARF sections.
+///
+/// Wasm DWARF addresses are relative to the beginning of the code-section
+/// payload, whereas [`FunctionBodyData`] offsets are relative to the complete
+/// module. This map performs that translation once before parallel codegen.
+#[derive(Default)]
+pub struct WasmSourceMap {
+    locations: BTreeMap<usize, SourceLocation>,
+}
+
+impl WasmSourceMap {
+    /// Build a source map for all local function operators in a module.
+    pub fn new(
+        module: &ModuleInfo,
+        translation: &ModuleTranslationState,
+        functions: &PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
+    ) -> Self {
+        let Some(code_base) = translation.code_section_offset() else {
+            return Self::default();
+        };
+
+        type Reader = EndianRcSlice<LittleEndian>;
+        let dwarf = match Dwarf::<Reader>::load(|id: SectionId| {
+            let data = module.custom_sections(id.name()).next().unwrap_or_default();
+            Ok::<_, addr2line::gimli::Error>(Reader::new(Rc::from(data), LittleEndian))
+        }) {
+            Ok(dwarf) => dwarf,
+            Err(_) => return Self::default(),
+        };
+        let context = match addr2line::Context::from_dwarf(dwarf) {
+            Ok(context) => context,
+            Err(_) => return Self::default(),
+        };
+
+        let mut locations = BTreeMap::new();
+        for (_, input) in functions.iter() {
+            let body = FunctionBody::new(BinaryReader::new(input.data, input.module_offset));
+            let Ok(mut operators) = body.get_operators_reader() else {
+                continue;
+            };
+            while !operators.eof() {
+                let offset = operators.original_position();
+                if operators.read().is_err() {
+                    break;
+                }
+                let Some(address) = offset.checked_sub(code_base).map(|value| value as u64) else {
+                    continue;
+                };
+                let Ok(Some(location)) = context.find_location(address) else {
+                    continue;
+                };
+                let (Some(file), Some(line)) = (location.file, location.line) else {
+                    continue;
+                };
+                let (directory, file) = file
+                    .rfind(['/', '\\'])
+                    .map(|separator| (&file[..separator], &file[separator + 1..]))
+                    .unwrap_or(("", file));
+                locations.insert(
+                    offset,
+                    SourceLocation {
+                        file: file.to_owned(),
+                        directory: directory.to_owned(),
+                        line,
+                        column: location.column.unwrap_or(0),
+                    },
+                );
+            }
+        }
+
+        Self { locations }
+    }
+
+    /// Return the source location for a module-relative Wasm offset.
+    pub fn get(&self, wasm_offset: usize) -> Option<&SourceLocation> {
+        self.locations.get(&wasm_offset)
+    }
+
+    /// Return the first mapped source location in a function body.
+    pub fn first_in_function(&self, body: &FunctionBodyData<'_>) -> Option<&SourceLocation> {
+        self.locations
+            .range(body.module_offset..body.module_offset.saturating_add(body.data.len()))
+            .next()
+            .map(|(_, location)| location)
+    }
+}

--- a/lib/compiler/src/translator/module.rs
+++ b/lib/compiler/src/translator/module.rs
@@ -180,7 +180,9 @@ pub fn translate_module<'data>(
                 parse_element_section(elements, environ)?;
             }
 
-            Payload::CodeSectionStart { .. } => {}
+            Payload::CodeSectionStart { range, .. } => {
+                module_translation_state.code_section_offset = Some(range.start);
+            }
             Payload::CodeSectionEntry(code) => {
                 let mut code = code.get_binary_reader();
                 let size = code.bytes_remaining();

--- a/lib/compiler/src/translator/state.rs
+++ b/lib/compiler/src/translator/state.rs
@@ -17,6 +17,9 @@ pub(crate) type WasmTypes =
 /// embedder is represented with `ModuleEnvironment`.
 #[derive(Debug)]
 pub struct ModuleTranslationState {
+    /// Offset of the code-section payload in the original Wasm file.
+    pub(crate) code_section_offset: Option<usize>,
+
     /// A map containing a Wasm module's original, raw signatures.
     ///
     /// This is used for translating multi-value Wasm blocks inside functions,
@@ -28,8 +31,14 @@ impl ModuleTranslationState {
     /// Creates a new empty ModuleTranslationState.
     pub fn new() -> Self {
         Self {
+            code_section_offset: None,
             wasm_types: PrimaryMap::new(),
         }
+    }
+
+    /// Get the offset of the code-section payload in the original Wasm file.
+    pub fn code_section_offset(&self) -> Option<usize> {
+        self.code_section_offset
     }
 
     /// Get the parameter and result types for the given Wasm blocktype.


### PR DESCRIPTION
With the introduction of the native artifact format, we can map the input DWARF debug information into the output DWARF, allowing debuggers such as GDB and LLDB to access debug information for JIT-compiled code.