### PR TITLE
fix(c-api): handle newer Cargo build-script directory layout in shared_object_dir

### DIFF
--- a/lib/c-api/build.rs
+++ b/lib/c-api/build.rs
@@ -349,6 +349,22 @@ fn shared_object_dir() -> PathBuf {
     assert_eq!(shared_object_dir.file_name(), Some(OsStr::new("out")));
     shared_object_dir.pop();
 
+    // Depending on the Cargo/toolchain version, the build script's
+    // fingerprint directory is laid out either as `build/<pkg>-<hash>/out`
+    // (older Cargo, package name and hash in one hyphenated directory) or
+    // `build/<pkg>/<hash>/out` (newer Cargo, package name and hash split
+    // into separate nested directories). If this component isn't the
+    // package directory itself, assume it's the hash-only directory from
+    // the newer layout and pop once more to reach it.
+    if !shared_object_dir
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .starts_with("wasmer-c-api")
+    {
+        shared_object_dir.pop();
+    }
+
     assert!(
         shared_object_dir
             .file_name()
@@ -356,7 +372,9 @@ fn shared_object_dir() -> PathBuf {
             .unwrap()
             .to_string_lossy()
             .to_string()
-            .starts_with("wasmer-c-api")
+            .starts_with("wasmer-c-api"),
+        "unexpected OUT_DIR layout, could not locate the wasmer-c-api build directory: {:?}",
+        env::var("OUT_DIR")
     );
     shared_object_dir.pop();
 


### PR DESCRIPTION
## Summary
- Fixes the `Build docs.rs` CI job, which has been failing since #6844 with a panic in `lib/c-api/build.rs`: `assertion failed: shared_object_dir.file_name()...starts_with("wasmer-c-api")`.
- Root cause: `shared_object_dir()` assumed `OUT_DIR` always nests as `build/<pkg>-<hash>/out` (package name and hash combined into one hyphenated directory component). Newer Cargo/nightly toolchains instead lay out the build-script fingerprint directory as `build/<pkg>/<hash>/out` — package name and hash as two separate nested directories. Under that layout the hardcoded assertion fails because the component right after `out` is just the hash, which doesn't start with `"wasmer-c-api"`.
- This surfaced now (not caused by any of the preceding commits in this stack) because the CI job's pinned nightly (`nightly-2025-09-27`) is below the MSRV several dependencies now require (rustc 1.94), so `cargo +nightly` (a separate, unpinned toolchain reference used by `make test-build-docs-rs-ci`) ends up resolving to whatever nightly is currently available — new enough to build the project, but also new enough to hit this directory-layout change.
- Fix: detect which layout is in play by checking whether the directory popped after `"out"` already starts with `"wasmer-c-api"`; if not, pop once more to reach it, matching either layout.

## Test plan
- [x] `RUSTDOCFLAGS="--cfg=docsrs" cargo doc --manifest-path lib/c-api/Cargo.toml --no-deps --locked` — passes on both the repo's default (stable) toolchain (old directory layout) and a newer nightly (new directory layout, previously reproduced the panic before this fix, confirmed clean after).
- [x] `cargo build -p wasmer-c-api --features wat,sys-default,compiler,wasi,middlewares,webc_runner` — normal (non-doc) build still succeeds.

Stacked on #6850.