### PR TITLE
feat: support self-executing Wasm modules

### DIFF
--- a/lib/api/src/entities/module/inner.rs
+++ b/lib/api/src/entities/module/inner.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use wasmer_types::WasmError;
 use wasmer_types::{
     CompilationProgressCallback, CompileError, DeserializeError, ExportType, ExportsIterator,
-    ImportType, ImportsIterator, ModuleInfo, SerializeError,
+    ImportType, ImportsIterator, ModuleInfo, SerializeError, strip_wasm_shebang,
 };
 
 use crate::{
@@ -35,6 +35,7 @@ gen_rt_ty! {
 impl BackendModule {
     #[inline]
     pub fn new(engine: &impl AsEngineRef, bytes: impl AsRef<[u8]>) -> Result<Self, CompileError> {
+        let bytes = strip_wasm_shebang(bytes.as_ref());
         #[cfg(feature = "wat")]
         let bytes = wat::parse_bytes(bytes.as_ref()).map_err(|e| {
             CompileError::Wasm(WasmError::Generic(format!(
@@ -50,6 +51,7 @@ impl BackendModule {
         bytes: impl AsRef<[u8]>,
         callback: CompilationProgressCallback,
     ) -> Result<Self, CompileError> {
+        let bytes = strip_wasm_shebang(bytes.as_ref());
         #[cfg(feature = "wat")]
         let bytes = wat::parse_bytes(bytes.as_ref()).map_err(|e| {
             CompileError::Wasm(WasmError::Generic(format!(

--- a/lib/api/tests/module.rs
+++ b/lib/api/tests/module.rs
@@ -33,6 +33,16 @@ fn module_set_name() -> Result<(), String> {
 }
 
 #[engine_test]
+fn module_new_accepts_shebang_prefixed_wasm() -> Result<(), String> {
+    let store = Store::default();
+    let wasm = b"#!/path/to/wasix-run\n\0asm\x01\0\0\0";
+
+    Module::new(&store, wasm).map_err(|e| format!("{e:?}"))?;
+
+    Ok(())
+}
+
+#[engine_test]
 fn imports() -> Result<(), String> {
     let store = Store::default();
     let wat = r#"(module

--- a/lib/api/tests/module_compilation_progress.rs
+++ b/lib/api/tests/module_compilation_progress.rs
@@ -109,3 +109,14 @@ fn test_module_compilation_abort(engine: Engine) {
         }
     }
 }
+
+#[test]
+fn module_compilation_progress_accepts_shebang_prefixed_wasm() {
+    let engine = Engine::default();
+    let callback = wasmer_types::CompilationProgressCallback::new(|_| Ok(()));
+    let wasm = b"#!/path/to/wasix-run\n\0asm\x01\0\0\0";
+
+    engine
+        .new_module_with_progress(wasm, callback)
+        .expect("shebang-prefixed Wasm compiles");
+}

--- a/lib/cli/src/commands/run/target.rs
+++ b/lib/cli/src/commands/run/target.rs
@@ -10,7 +10,7 @@ use indicatif::ProgressBar;
 use wasmer::Module;
 #[cfg(feature = "compiler")]
 use wasmer_compiler::ArtifactBuild;
-use wasmer_types::ModuleHash;
+use wasmer_types::{ModuleHash, strip_wasm_shebang};
 use wasmer_wasix::{
     Runtime,
     bin_factory::BinaryPackage,
@@ -39,7 +39,7 @@ impl TargetOnDisk {
 
         let leading_bytes = &buffer[..bytes_read];
 
-        if wasmer::is_wasm(leading_bytes) {
+        if wasmer::is_wasm(strip_wasm_shebang(leading_bytes)) {
             return Ok(TargetOnDisk::WebAssemblyBinary);
         }
 
@@ -62,6 +62,23 @@ impl TargetOnDisk {
             Some("wasmu") => Ok(TargetOnDisk::WebAssemblyBinary),
             _ => bail!("Unable to determine how to execute \"{}\"", path.display()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_extensionless_shebang_prefixed_wasm() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("self-executing-wasm");
+        std::fs::write(&path, b"#!/path/to/wasix-run\n\0asm\x01\0\0\0").unwrap();
+
+        assert!(matches!(
+            TargetOnDisk::from_file(&path),
+            Ok(TargetOnDisk::WebAssemblyBinary)
+        ));
     }
 }
 

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -112,7 +112,7 @@ pub use crate::exception::CATCH_ALL_TAG_VALUE;
 pub use crate::stack::{FrameInfo, SourceLoc, TrapInformation};
 pub use crate::store_id::StoreId;
 pub use crate::trapcode::{OnCalledAction, TrapCode};
-pub use crate::utils::is_wasm;
+pub use crate::utils::{is_wasm, strip_wasm_shebang};
 pub use crate::vmoffsets::{VMBuiltinFunctionIndex, VMOffsets};
 
 /// Offset in bytes from the beginning of the function.

--- a/lib/types/src/utils.rs
+++ b/lib/types/src/utils.rs
@@ -2,3 +2,18 @@
 pub fn is_wasm(bytes: impl AsRef<[u8]>) -> bool {
     bytes.as_ref().starts_with(b"\0asm")
 }
+
+/// Remove a leading `#!...\n` shebang line from a self-executing Wasm module.
+///
+/// Returns an empty slice when the input starts with `#!` but has no terminating
+/// newline.
+pub fn strip_wasm_shebang(bytes: &[u8]) -> &[u8] {
+    if let [b'#', b'!', ..] = bytes {
+        match bytes.iter().position(|&byte| byte == b'\n') {
+            Some(newline) => &bytes[newline + 1..],
+            None => &[],
+        }
+    } else {
+        bytes
+    }
+}


### PR DESCRIPTION
Closes WARP-77

This adds support for shebang-prefixed Wasm modules so self-executing binaries are recognized and compiled correctly.

Changes:
- add `strip_wasm_shebang` in `wasmer_types`
- strip the shebang before module compilation in the API
- strip the shebang when detecting Wasm binaries on disk in the CLI
- add coverage for module creation, compilation with progress, and extensionless self-executing Wasm files

This makes inputs like `#!/path/to/wasix-run` + Wasm bytes work.