### PR TITLE
fix(memory.atomic): offset, add boundary and alignment checks

### DIFF
--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -765,8 +765,6 @@ pub fn translate_operator(
          * special functions.
          ************************************************************************************/
         Operator::MemoryGrow { mem } => {
-            // The WebAssembly MVP only supports one linear memory, but we expect the reserved
-            // argument to be a memory index.
             let heap_index = MemoryIndex::from_u32(*mem);
             let heap = state.get_heap(builder.func, *mem, environ)?;
             let val = state.pop1();
@@ -1406,9 +1404,6 @@ pub fn translate_operator(
             state.push1(environ.translate_ref_func(builder.cursor(), index)?);
         }
         Operator::MemoryAtomicWait32 { memarg } | Operator::MemoryAtomicWait64 { memarg } => {
-            // The WebAssembly MVP only supports one linear memory and
-            // wasmparser will ensure that the memory indices specified are
-            // zero.
             let implied_ty = match op {
                 Operator::MemoryAtomicWait64 { .. } => I64,
                 Operator::MemoryAtomicWait32 { .. } => I32,
@@ -3213,7 +3208,7 @@ fn fold_atomic_mem_addr(
             .iadd_imm_u(linear_mem_addr, memarg.offset as i64);
         let r = builder
             .ins()
-            .icmp_imm_u(IntCC::UnsignedGreaterThanOrEqual, a, 0x1_0000_0000i64);
+            .icmp_imm_u(IntCC::UnsignedGreaterThanOrEqual, a, u32::MAX as i64);
         builder.ins().trapnz(r, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
         builder.ins().ireduce(I32, a)
     } else {

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -1414,7 +1414,7 @@ pub fn translate_operator(
             let timeout = state.pop1(); // 64 (fixed)
             let expected = state.pop1(); // 32 or 64 (per the `Ixx` in `IxxAtomicWait`)
             let addr = state.pop1(); // 32 (fixed)
-            let addr = fold_atomic_mem_addr(addr, memarg, implied_ty, builder);
+            let addr = fold_atomic_mem_addr(addr, memarg, builder);
             assert!(builder.func.dfg.value_type(expected) == implied_ty);
             // `fn translate_atomic_wait` can inspect the type of `expected` to figure out what
             // code it needs to generate, if it wants.
@@ -1444,7 +1444,7 @@ pub fn translate_operator(
             let heap = state.get_heap(builder.func, memarg.memory, environ)?;
             let count = state.pop1(); // 32 (fixed)
             let addr = state.pop1(); // 32 (fixed)
-            let addr = fold_atomic_mem_addr(addr, memarg, I32, builder);
+            let addr = fold_atomic_mem_addr(addr, memarg, builder);
             match environ.translate_atomic_notify(builder.cursor(), heap_index, heap, addr, count) {
                 Ok(res) => {
                     state.push1(res);
@@ -3196,11 +3196,9 @@ fn translate_icmp(cc: IntCC, builder: &mut FunctionBuilder, state: &mut FuncTran
 fn fold_atomic_mem_addr(
     linear_mem_addr: Value,
     memarg: &MemArg,
-    access_ty: Type,
     builder: &mut FunctionBuilder,
 ) -> Value {
-    let access_ty_bytes = access_ty.bytes();
-    let final_lma = if memarg.offset > 0 {
+    if memarg.offset > 0 {
         assert!(builder.func.dfg.value_type(linear_mem_addr) == I32);
         let linear_mem_addr = builder.ins().uextend(I64, linear_mem_addr);
         let a = builder
@@ -3213,16 +3211,8 @@ fn fold_atomic_mem_addr(
         builder.ins().ireduce(I32, a)
     } else {
         linear_mem_addr
-    };
-    assert!(access_ty_bytes == 4 || access_ty_bytes == 8);
-    let final_lma_misalignment = builder
-        .ins()
-        .band_imm_u(final_lma, i64::from(access_ty_bytes - 1));
-    let f = builder
-        .ins()
-        .icmp_imm_u(IntCC::Equal, final_lma_misalignment, i64::from(0));
-    builder.ins().trapz(f, crate::TRAP_HEAP_MISALIGNED);
-    final_lma
+    }
+    // Note the alignment is checked at the libcall side.
 }
 
 fn translate_atomic_rmw(

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -3206,7 +3206,7 @@ fn fold_atomic_mem_addr(
             .iadd_imm_u(linear_mem_addr, memarg.offset as i64);
         let r = builder
             .ins()
-            .icmp_imm_u(IntCC::UnsignedGreaterThanOrEqual, a, u32::MAX as i64);
+            .icmp_imm_u(IntCC::UnsignedGreaterThanOrEqual, a, 0x1_0000_0000);
         builder.ins().trapnz(r, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
         builder.ins().ireduce(I32, a)
     } else {

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1735,7 +1735,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
             let out_of_bounds = err!(self.builder.build_int_compare(
                 IntPredicate::UGE,
                 effective_addr,
-                self.intrinsics.i64_ty.const_int(u64::from(u32::MAX), false),
+                self.intrinsics.i64_ty.const_int(0x1_0000_0000, false),
                 "atomic_addr_out_of_bounds"
             ));
             let continue_block = self

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1715,17 +1715,60 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
         Ok(())
     }
 
-    fn apply_memarg_offset_to_i32_addr(
+    fn fold_atomic_mem_addr(
         &self,
         addr: BasicValueEnum<'ctx>,
         memarg: &MemArg,
     ) -> Result<BasicValueEnum<'ctx>, CompileError> {
-        let offset = self.intrinsics.i32_ty.const_int(memarg.offset, false);
-        Ok(err!(
-            self.builder
-                .build_int_add(addr.into_int_value(), offset, "atomic_memarg_offset")
-        )
-        .as_basic_value_enum())
+        let addr = addr.into_int_value();
+        let addr = if memarg.offset > 0 {
+            let extended_addr = err!(self.builder.build_int_z_extend(
+                addr,
+                self.intrinsics.i64_ty,
+                "atomic_addr_extended"
+            ));
+            let effective_addr = err!(self.builder.build_int_add(
+                extended_addr,
+                self.intrinsics.i64_ty.const_int(memarg.offset, false),
+                "atomic_effective_addr"
+            ));
+            let out_of_bounds = err!(self.builder.build_int_compare(
+                IntPredicate::UGE,
+                effective_addr,
+                self.intrinsics.i64_ty.const_int(u64::from(u32::MAX), false),
+                "atomic_addr_out_of_bounds"
+            ));
+            let continue_block = self
+                .context
+                .append_basic_block(self.function, "atomic_addr_in_bounds_block");
+            let trap_block = self
+                .context
+                .append_basic_block(self.function, "atomic_addr_out_of_bounds_block");
+            err!(
+                self.builder
+                    .build_conditional_branch(out_of_bounds, trap_block, continue_block)
+            );
+
+            self.builder.position_at_end(trap_block);
+            self.build_call_with_param_attributes(
+                self.intrinsics.throw_trap,
+                &[self.intrinsics.trap_memory_oob.into()],
+                "throw",
+            )?;
+            err!(self.builder.build_unreachable());
+
+            self.builder.position_at_end(continue_block);
+            err!(self.builder.build_int_truncate(
+                effective_addr,
+                self.intrinsics.i32_ty,
+                "atomic_effective_addr_i32"
+            ))
+        } else {
+            addr
+        };
+
+        // Note the alignment is checked at the libcall side.
+        Ok(addr.as_basic_value_enum())
     }
 
     fn resolve_memory_ptr(
@@ -11253,7 +11296,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                     .local_memory_index(memory_index)
                     .map_or(memarg.memory, |index| index.as_u32());
                 let (dst, val, timeout) = self.state.pop3()?;
-                let dst = self.apply_memarg_offset_to_i32_addr(dst, &memarg)?;
+                let dst = self.fold_atomic_mem_addr(dst, &memarg)?;
                 let wait32_fn_ptr = self.ctx.memory_wait32(memory_index, self.intrinsics)?;
                 let ret = err!(
                     self.builder.build_indirect_call(
@@ -11281,7 +11324,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                     .local_memory_index(memory_index)
                     .map_or(memarg.memory, |index| index.as_u32());
                 let (dst, val, timeout) = self.state.pop3()?;
-                let dst = self.apply_memarg_offset_to_i32_addr(dst, &memarg)?;
+                let dst = self.fold_atomic_mem_addr(dst, &memarg)?;
                 let wait64_fn_ptr = self.ctx.memory_wait64(memory_index, self.intrinsics)?;
                 let ret = err!(
                     self.builder.build_indirect_call(
@@ -11309,7 +11352,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                     .local_memory_index(memory_index)
                     .map_or(memarg.memory, |index| index.as_u32());
                 let (dst, count) = self.state.pop2()?;
-                let dst = self.apply_memarg_offset_to_i32_addr(dst, &memarg)?;
+                let dst = self.fold_atomic_mem_addr(dst, &memarg)?;
                 let notify_fn_ptr = self.ctx.memory_notify(memory_index, self.intrinsics)?;
                 let cnt = err!(
                     self.builder.build_indirect_call(

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -1715,6 +1715,19 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
         Ok(())
     }
 
+    fn apply_memarg_offset_to_i32_addr(
+        &self,
+        addr: BasicValueEnum<'ctx>,
+        memarg: &MemArg,
+    ) -> Result<BasicValueEnum<'ctx>, CompileError> {
+        let offset = self.intrinsics.i32_ty.const_int(memarg.offset, false);
+        Ok(err!(
+            self.builder
+                .build_int_add(addr.into_int_value(), offset, "atomic_memarg_offset")
+        )
+        .as_basic_value_enum())
+    }
+
     fn resolve_memory_ptr(
         &mut self,
         memory_index: MemoryIndex,
@@ -11240,6 +11253,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                     .local_memory_index(memory_index)
                     .map_or(memarg.memory, |index| index.as_u32());
                 let (dst, val, timeout) = self.state.pop3()?;
+                let dst = self.apply_memarg_offset_to_i32_addr(dst, &memarg)?;
                 let wait32_fn_ptr = self.ctx.memory_wait32(memory_index, self.intrinsics)?;
                 let ret = err!(
                     self.builder.build_indirect_call(
@@ -11267,6 +11281,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                     .local_memory_index(memory_index)
                     .map_or(memarg.memory, |index| index.as_u32());
                 let (dst, val, timeout) = self.state.pop3()?;
+                let dst = self.apply_memarg_offset_to_i32_addr(dst, &memarg)?;
                 let wait64_fn_ptr = self.ctx.memory_wait64(memory_index, self.intrinsics)?;
                 let ret = err!(
                     self.builder.build_indirect_call(
@@ -11294,6 +11309,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                     .local_memory_index(memory_index)
                     .map_or(memarg.memory, |index| index.as_u32());
                 let (dst, count) = self.state.pop2()?;
+                let dst = self.apply_memarg_offset_to_i32_addr(dst, &memarg)?;
                 let notify_fn_ptr = self.ctx.memory_notify(memory_index, self.intrinsics)?;
                 let cnt = err!(
                     self.builder.build_indirect_call(

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -674,7 +674,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         let offset = memarg.offset as u32;
         match addr.0 {
             Location::Imm32(value) => Ok((
-                Location::Imm32(value.wrapping_add(offset)),
+                Location::Imm32(value.checked_add(offset).ok_or_else(|| {
+                    CompileError::Codegen("memory.atomic constant out of bounds".to_string())
+                })?),
                 CanonicalizeType::None,
             )),
             Location::Imm64(_) => codegen_error!("memory.atomic address must be i32"),

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -683,6 +683,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             Location::Imm64(_) => codegen_error!("memory.atomic address must be i32"),
             _ => {
                 let effective_addr = self.machine.acquire_temp_gpr().unwrap();
+                let upper_bound = self.machine.acquire_temp_gpr().unwrap();
                 self.machine.move_location_extend(
                     Size::S32,
                     false,
@@ -695,15 +696,22 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Location::Imm64(memarg.offset),
                     Location::GPR(effective_addr),
                 )?;
+                // The use of the temporary register is necessary.
+                self.machine.move_location(
+                    Size::S64,
+                    Location::Imm64(0x1_0000_0000),
+                    Location::GPR(upper_bound),
+                )?;
                 self.machine.jmp_on_condition(
                     UnsignedCondition::AboveEqual,
                     Size::S64,
                     Location::GPR(effective_addr),
-                    Location::Imm64(u64::from(u32::MAX)),
+                    Location::GPR(upper_bound),
                     self.special_labels.heap_access_oob,
                 )?;
                 self.machine
                     .move_location(Size::S32, Location::GPR(effective_addr), addr.0)?;
+                self.machine.release_gpr(upper_bound);
                 self.machine.release_gpr(effective_addr);
                 Ok(addr)
             }

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -37,8 +37,8 @@ use wasmer_compiler::{
         section::SectionIndex,
     },
     wasmparser::{
-        BlockType as WpTypeOrFuncType, HeapType as WpHeapType, Operator, RefType as WpRefType,
-        ValType as WpType,
+        BlockType as WpTypeOrFuncType, HeapType as WpHeapType, MemArg, Operator,
+        RefType as WpRefType, ValType as WpType,
     },
 };
 
@@ -660,6 +660,30 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         })?;
         self.get_location_released(loc)?;
         Ok(loc)
+    }
+
+    fn apply_memarg_offset_to_i32_addr(
+        &mut self,
+        addr: LocationWithCanonicalization<M>,
+        memarg: &MemArg,
+    ) -> Result<LocationWithCanonicalization<M>, CompileError> {
+        if memarg.offset == 0 {
+            return Ok(addr);
+        }
+
+        let offset = memarg.offset as u32;
+        match addr.0 {
+            Location::Imm32(value) => Ok((
+                Location::Imm32(value.wrapping_add(offset)),
+                CanonicalizeType::None,
+            )),
+            Location::Imm64(_) => codegen_error!("memory.atomic address must be i32"),
+            _ => {
+                self.machine
+                    .location_add(Size::S32, Location::Imm32(offset), addr.0, false)?;
+                Ok(addr)
+            }
+        }
     }
 
     /// Prepare data for binary operator with 2 inputs and 1 output.
@@ -5800,6 +5824,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 let timeout = self.value_stack.pop().unwrap();
                 let val = self.value_stack.pop().unwrap();
                 let dst = self.value_stack.pop().unwrap();
+                let dst = self.apply_memarg_offset_to_i32_addr(dst, memarg)?;
 
                 let memory_index = MemoryIndex::new(memarg.memory as usize);
                 let (memory_atomic_wait32, index_arg) =
@@ -5849,6 +5874,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 let timeout = self.value_stack.pop().unwrap();
                 let val = self.value_stack.pop().unwrap();
                 let dst = self.value_stack.pop().unwrap();
+                let dst = self.apply_memarg_offset_to_i32_addr(dst, memarg)?;
 
                 let memory_index = MemoryIndex::new(memarg.memory as usize);
                 let (memory_atomic_wait64, index_arg) =
@@ -5897,6 +5923,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             Operator::MemoryAtomicNotify { ref memarg } => {
                 let cnt = self.value_stack.pop().unwrap();
                 let dst = self.value_stack.pop().unwrap();
+                let dst = self.apply_memarg_offset_to_i32_addr(dst, memarg)?;
 
                 let memory_index = MemoryIndex::new(memarg.memory as usize);
                 let (memory_atomic_notify, index_arg) =

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -662,7 +662,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         Ok(loc)
     }
 
-    fn apply_memarg_offset_to_i32_addr(
+    fn fold_atomic_mem_addr(
         &mut self,
         addr: LocationWithCanonicalization<M>,
         memarg: &MemArg,
@@ -673,16 +673,38 @@ impl<'a, M: Machine> FuncGen<'a, M> {
 
         let offset = memarg.offset as u32;
         match addr.0 {
-            Location::Imm32(value) => Ok((
-                Location::Imm32(value.checked_add(offset).ok_or_else(|| {
-                    CompileError::Codegen("memory.atomic constant out of bounds".to_string())
-                })?),
-                CanonicalizeType::None,
-            )),
+            Location::Imm32(value) => Ok(if let Some(addr) = value.checked_add(offset) {
+                (Location::Imm32(addr), CanonicalizeType::None)
+            } else {
+                self.machine
+                    .jmp_unconditional(self.special_labels.heap_access_oob)?;
+                (Location::Imm32(0), CanonicalizeType::None)
+            }),
             Location::Imm64(_) => codegen_error!("memory.atomic address must be i32"),
             _ => {
+                let effective_addr = self.machine.acquire_temp_gpr().unwrap();
+                self.machine.move_location_extend(
+                    Size::S32,
+                    false,
+                    addr.0,
+                    Size::S64,
+                    Location::GPR(effective_addr),
+                )?;
+                self.machine.emit_binop_add64(
+                    Location::GPR(effective_addr),
+                    Location::Imm64(memarg.offset),
+                    Location::GPR(effective_addr),
+                )?;
+                self.machine.jmp_on_condition(
+                    UnsignedCondition::AboveEqual,
+                    Size::S64,
+                    Location::GPR(effective_addr),
+                    Location::Imm64(u64::from(u32::MAX)),
+                    self.special_labels.heap_access_oob,
+                )?;
                 self.machine
-                    .location_add(Size::S32, Location::Imm32(offset), addr.0, false)?;
+                    .move_location(Size::S32, Location::GPR(effective_addr), addr.0)?;
+                self.machine.release_gpr(effective_addr);
                 Ok(addr)
             }
         }
@@ -5826,7 +5848,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 let timeout = self.value_stack.pop().unwrap();
                 let val = self.value_stack.pop().unwrap();
                 let dst = self.value_stack.pop().unwrap();
-                let dst = self.apply_memarg_offset_to_i32_addr(dst, memarg)?;
+                let dst = self.fold_atomic_mem_addr(dst, memarg)?;
 
                 let memory_index = MemoryIndex::new(memarg.memory as usize);
                 let (memory_atomic_wait32, index_arg) =
@@ -5876,7 +5898,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 let timeout = self.value_stack.pop().unwrap();
                 let val = self.value_stack.pop().unwrap();
                 let dst = self.value_stack.pop().unwrap();
-                let dst = self.apply_memarg_offset_to_i32_addr(dst, memarg)?;
+                let dst = self.fold_atomic_mem_addr(dst, memarg)?;
 
                 let memory_index = MemoryIndex::new(memarg.memory as usize);
                 let (memory_atomic_wait64, index_arg) =
@@ -5925,7 +5947,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             Operator::MemoryAtomicNotify { ref memarg } => {
                 let cnt = self.value_stack.pop().unwrap();
                 let dst = self.value_stack.pop().unwrap();
-                let dst = self.apply_memarg_offset_to_i32_addr(dst, memarg)?;
+                let dst = self.fold_atomic_mem_addr(dst, memarg)?;
 
                 let memory_index = MemoryIndex::new(memarg.memory as usize);
                 let (memory_atomic_notify, index_arg) =

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -17,7 +17,8 @@ use crate::vmcontext::{
     VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionContext,
     VMFunctionImport, VMFunctionKind, VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition,
     VMMemoryImport, VMSharedTagIndex, VMSignatureHash, VMTableDefinition, VMTableImport,
-    VMTrampoline, memory_copy, memory_fill, memory32_atomic_check32, memory32_atomic_check64,
+    VMTrampoline, memory_copy, memory_fill, memory32_atomic_check_notify, memory32_atomic_check32,
+    memory32_atomic_check64,
 };
 use crate::{FunctionBodyPtr, MaybeInstanceOwned, TrapHandlerFn, VMTag, wasmer_call_trampoline};
 use crate::{VMConfig, VMFuncRef, VMFunction, VMGlobal, VMMemory, VMTable};
@@ -1057,6 +1058,8 @@ impl Instance {
         dst: u32,
         count: u32,
     ) -> Result<u32, Trap> {
+        let memory = self.memory(memory_index);
+        memory32_atomic_check_notify(&memory, dst)?;
         let memory = self.get_local_vmmemory_mut(memory_index);
         Ok(memory.do_notify(dst, count))
     }
@@ -1068,6 +1071,9 @@ impl Instance {
         dst: u32,
         count: u32,
     ) -> Result<u32, Trap> {
+        let import = self.imported_memory(memory_index);
+        let memory = unsafe { import.definition.as_ref() };
+        memory32_atomic_check_notify(memory, dst)?;
         let memory = self.get_vmmemory_mut(memory_index);
         Ok(memory.do_notify(dst, count))
     }

--- a/lib/vm/src/vmcontext.rs
+++ b/lib/vm/src/vmcontext.rs
@@ -386,6 +386,27 @@ pub(crate) unsafe fn memory_fill(
     }
 }
 
+/// Check the bounds and alignment of a `memory.atomic.notify` address.
+///
+/// # Errors
+///
+/// Returns a `Trap` error if the memory range is out of bounds or not 32-bit aligned.
+pub(crate) fn memory32_atomic_check_notify(mem: &VMMemoryDefinition, dst: u32) -> Result<(), Trap> {
+    const TYPE_SIZE: usize = size_of::<u32>();
+    let dst = usize::try_from(dst).unwrap();
+    if dst
+        .checked_add(TYPE_SIZE)
+        .is_none_or(|end| end > mem.current_length)
+    {
+        return Err(Trap::lib(TrapCode::HeapAccessOutOfBounds));
+    }
+
+    if !dst.is_multiple_of(TYPE_SIZE) {
+        return Err(Trap::lib(TrapCode::UnalignedAtomic));
+    }
+    Ok(())
+}
+
 /// Perform the `memory32.atomic.check32` operation for the memory. Return 0 if same, 1 if different
 ///
 /// # Errors

--- a/tests/wast/wasmer/atomic_offset_bug.wast
+++ b/tests/wast/wasmer/atomic_offset_bug.wast
@@ -1,0 +1,75 @@
+(module
+  (memory 1 1 shared)
+  ;; [0] = i32(111), [4] = i32(222), [8] = i64(222), [16] = i64(333).
+  (data (i32.const 0) "\6f\00\00\00\de\00\00\00\de\00\00\00\00\00\00\00\4d\01\00\00\00\00\00\00")
+
+  (func (export "wait32_via_offset") (result i32)
+    (memory.atomic.wait32 offset=4
+      (i32.const 0)
+      (i32.const 222)
+      (i64.const 0)))
+
+  (func (export "wait32_via_index") (result i32)
+    (memory.atomic.wait32
+      (i32.const 4)
+      (i32.const 222)
+      (i64.const 0)))
+
+  (func (export "wait64_via_offset") (result i32)
+    (memory.atomic.wait64 offset=8
+      (i32.const 0)
+      (i64.const 222)
+      (i64.const 0)))
+
+  (func (export "wait64_via_index") (result i32)
+    (memory.atomic.wait64
+      (i32.const 8)
+      (i64.const 222)
+      (i64.const 0)))
+
+  (func (export "wait32_oob_via_offset") (result i32)
+    (memory.atomic.wait32 offset=0x10000
+      (i32.const 16)
+      (i32.const 333)
+      (i64.const 0)))
+
+  (func (export "wait64_oob_via_offset") (result i32)
+    (memory.atomic.wait64 offset=0x10000
+      (i32.const 16)
+      (i64.const 333)
+      (i64.const 0)))
+
+  (func (export "wait32_unaligned_via_offset") (result i32)
+    (memory.atomic.wait32 offset=1
+      (i32.const 0)
+      (i32.const 111)
+      (i64.const 0)))
+
+  (func (export "wait64_unaligned_via_offset") (result i32)
+    (memory.atomic.wait64 offset=1
+      (i32.const 16)
+      (i64.const 333)
+      (i64.const 0)))
+
+  (func (export "notify_via_offset") (result i32)
+    (memory.atomic.notify offset=4
+      (i32.const 0)
+      (i32.const 1)))
+
+  (func (export "notify_via_index") (result i32)
+    (memory.atomic.notify
+      (i32.const 4)
+      (i32.const 1)))
+)
+
+(assert_return (invoke "wait32_via_offset") (i32.const 2))
+(assert_return (invoke "wait32_via_index") (i32.const 2))
+(assert_return (invoke "wait64_via_offset") (i32.const 2))
+(assert_return (invoke "wait64_via_index") (i32.const 2))
+
+(assert_trap (invoke "wait32_oob_via_offset") "out of bounds memory access")
+(assert_trap (invoke "wait64_oob_via_offset") "out of bounds memory access")
+(assert_trap (invoke "wait32_unaligned_via_offset") "unaligned atomic")
+(assert_trap (invoke "wait64_unaligned_via_offset") "unaligned atomic")
+(assert_return (invoke "notify_via_offset") (i32.const 0))
+(assert_return (invoke "notify_via_index") (i32.const 0))

--- a/tests/wast/wasmer/atomic_offset_bug.wast
+++ b/tests/wast/wasmer/atomic_offset_bug.wast
@@ -39,7 +39,13 @@
       (i64.const 333)
       (i64.const 0)))
 
-  (func (export "wait32_addr_overflow") (result i32)
+  (func (export "wait32_addr_overflow") (param i32) (result i32)
+    (memory.atomic.wait32 offset=4
+      (local.get 0)
+      (i32.const 111)
+      (i64.const 0)))
+
+  (func (export "wait32_addr_overflow_with_cst") (result i32)
     (memory.atomic.wait32 offset=4
       (i32.const -4)
       (i32.const 111)
@@ -75,7 +81,8 @@
 
 (assert_trap (invoke "wait32_oob_via_offset") "out of bounds memory access")
 (assert_trap (invoke "wait64_oob_via_offset") "out of bounds memory access")
-(assert_trap (invoke "wait32_addr_overflow") "out of bounds memory access")
+(assert_trap (invoke "wait32_addr_overflow_with_cst") "out of bounds memory access")
+(assert_trap (invoke "wait32_addr_overflow" (i32.const -4)) "out of bounds memory access")
 (assert_trap (invoke "wait32_unaligned_via_offset") "unaligned atomic")
 (assert_trap (invoke "wait64_unaligned_via_offset") "unaligned atomic")
 (assert_return (invoke "notify_via_offset") (i32.const 0))

--- a/tests/wast/wasmer/atomic_offset_bug.wast
+++ b/tests/wast/wasmer/atomic_offset_bug.wast
@@ -68,6 +68,16 @@
       (i32.const 0)
       (i32.const 1)))
 
+  (func (export "notify_oob_via_offset") (result i32)
+    (memory.atomic.notify offset=0x10000
+      (i32.const 0)
+      (i32.const 1)))
+
+  (func (export "notify_unaligned_via_offset") (result i32)
+    (memory.atomic.notify offset=1
+      (i32.const 0)
+      (i32.const 1)))
+
   (func (export "notify_via_index") (result i32)
     (memory.atomic.notify
       (i32.const 4)
@@ -86,4 +96,6 @@
 (assert_trap (invoke "wait32_unaligned_via_offset") "unaligned atomic")
 (assert_trap (invoke "wait64_unaligned_via_offset") "unaligned atomic")
 (assert_return (invoke "notify_via_offset") (i32.const 0))
+(assert_trap (invoke "notify_oob_via_offset") "out of bounds memory access")
+(assert_trap (invoke "notify_unaligned_via_offset") "unaligned atomic")
 (assert_return (invoke "notify_via_index") (i32.const 0))

--- a/tests/wast/wasmer/atomic_offset_bug.wast
+++ b/tests/wast/wasmer/atomic_offset_bug.wast
@@ -39,6 +39,12 @@
       (i64.const 333)
       (i64.const 0)))
 
+  (func (export "wait32_addr_overflow") (result i32)
+    (memory.atomic.wait32 offset=4
+      (i32.const -4)
+      (i32.const 111)
+      (i64.const 0)))
+
   (func (export "wait32_unaligned_via_offset") (result i32)
     (memory.atomic.wait32 offset=1
       (i32.const 0)
@@ -69,6 +75,7 @@
 
 (assert_trap (invoke "wait32_oob_via_offset") "out of bounds memory access")
 (assert_trap (invoke "wait64_oob_via_offset") "out of bounds memory access")
+(assert_trap (invoke "wait32_addr_overflow") "out of bounds memory access")
 (assert_trap (invoke "wait32_unaligned_via_offset") "unaligned atomic")
 (assert_trap (invoke "wait64_unaligned_via_offset") "unaligned atomic")
 (assert_return (invoke "notify_via_offset") (i32.const 0))


### PR DESCRIPTION
We wrongly missed to consider `offset` argument of the `atomic.memory.X` instructions for LLVM and the Singlepass compiler.