### PR TITLE
fix(deterministic_id): include all code-sensitive config flags

### DIFF
--- a/lib/api/src/backend/js/entities/engine.rs
+++ b/lib/api/src/backend/js/entities/engine.rs
@@ -10,6 +10,10 @@ impl Engine {
         String::from("js-generic")
     }
 
+    pub(crate) fn container_format(&self) -> String {
+        String::from("js")
+    }
+
     /// Returns the WebAssembly features supported by the JS engine.
     pub fn supported_features() -> Features {
         // JS-specific features

--- a/lib/api/src/backend/js/entities/engine.rs
+++ b/lib/api/src/backend/js/entities/engine.rs
@@ -10,7 +10,7 @@ impl Engine {
         String::from("js-generic")
     }
 
-    pub(crate) fn container_format(&self) -> String {
+    pub(crate) fn artifact_format(&self) -> String {
         String::from("js")
     }
 

--- a/lib/api/src/backend/v8/entities/engine.rs
+++ b/lib/api/src/backend/v8/entities/engine.rs
@@ -54,7 +54,7 @@ impl Engine {
         String::from("v8")
     }
 
-    pub(crate) fn container_format(&self) -> String {
+    pub(crate) fn artifact_format(&self) -> String {
         String::from("v8")
     }
 

--- a/lib/api/src/backend/v8/entities/engine.rs
+++ b/lib/api/src/backend/v8/entities/engine.rs
@@ -54,6 +54,10 @@ impl Engine {
         String::from("v8")
     }
 
+    pub(crate) fn container_format(&self) -> String {
+        String::from("v8")
+    }
+
     /// Returns the WebAssembly features supported by the V8 engine.
     pub fn supported_features() -> Features {
         // V8-specific features

--- a/lib/api/src/entities/engine/inner.rs
+++ b/lib/api/src/entities/engine/inner.rs
@@ -26,6 +26,14 @@ impl BackendEngine {
         })
     }
 
+    /// Returns the container format used for artifacts produced by this engine.
+    #[inline]
+    pub fn container_format(&self) -> String {
+        match_rt!(on self  => s {
+            s.container_format()
+        })
+    }
+
     #[cfg(all(feature = "sys", not(target_arch = "wasm32")))]
     /// Deserializes a WebAssembly module which was previously serialized with
     /// `Module::serialize`,

--- a/lib/api/src/entities/engine/inner.rs
+++ b/lib/api/src/entities/engine/inner.rs
@@ -26,11 +26,10 @@ impl BackendEngine {
         })
     }
 
-    /// Returns the container format used for artifacts produced by this engine.
-    #[inline]
-    pub fn container_format(&self) -> String {
+    /// Returns the format used for artifacts produced by this engine.
+    pub fn artifact_format(&self) -> String {
         match_rt!(on self  => s {
-            s.container_format()
+            s.artifact_format()
         })
     }
 

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -69,6 +69,11 @@ impl Engine {
         self.be.deterministic_id()
     }
 
+    /// Returns the container format used for artifacts produced by this engine.
+    pub fn container_format(&self) -> String {
+        self.be.container_format()
+    }
+
     /// Returns the unique id of this engine.
     pub fn id(&self) -> EngineId {
         EngineId(self.id)

--- a/lib/api/src/entities/engine/mod.rs
+++ b/lib/api/src/entities/engine/mod.rs
@@ -69,9 +69,9 @@ impl Engine {
         self.be.deterministic_id()
     }
 
-    /// Returns the container format used for artifacts produced by this engine.
-    pub fn container_format(&self) -> String {
-        self.be.container_format()
+    /// Returns the format used for artifacts produced by this engine.
+    pub fn artifact_format(&self) -> String {
+        self.be.artifact_format()
     }
 
     /// Returns the unique id of this engine.

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -13,7 +13,7 @@ use crate::eh::{
 use crate::translator::CraneliftUnwindInfo;
 use crate::{
     address_map::get_function_address_map,
-    config::Cranelift,
+    config::{Cranelift, CraneliftOptLevel},
     func_environ::{FuncEnvironment, get_function_name},
     trampoline::{
         FunctionBuilderContext, make_trampoline_dynamic_function, make_trampoline_function_call,
@@ -726,11 +726,26 @@ impl Compiler for CraneliftCompiler {
     }
 
     fn deterministic_id(&self) -> String {
+        let mut components = vec![self.name()];
+        components.push(match self.config.opt_level {
+            CraneliftOptLevel::None => "opt0",
+            CraneliftOptLevel::Speed => "opts",
+            CraneliftOptLevel::SpeedAndSize => "optsz",
+        });
         if self.config.experimental_artifact {
-            String::from("cranelift-elf")
-        } else {
-            String::from("cranelift")
+            components.push("exp_art");
         }
+        if self.config.enable_nan_canonicalization {
+            components.push("nan_canon");
+        }
+        if self.config.enable_pic {
+            components.push("pic");
+        }
+        if self.config.allow_experimental_unaligned_memory_accesses {
+            components.push("unaligned_mem");
+        }
+
+        components.join("-")
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -751,11 +751,11 @@ impl Compiler for CraneliftCompiler {
             .join("-")
     }
 
-    fn container_format(&self) -> String {
+    fn artifact_format(&self) -> String {
         if self.config.experimental_artifact {
-            wasmer_compiler::ArtifactFormatContainer::Native
+            wasmer_compiler::ArtifactFormat::Native
         } else {
-            wasmer_compiler::ArtifactFormatContainer::Rkyv
+            wasmer_compiler::ArtifactFormat::Rkyv
         }
         .to_string()
     }

--- a/lib/compiler-cranelift/src/compiler.rs
+++ b/lib/compiler-cranelift/src/compiler.rs
@@ -726,26 +726,38 @@ impl Compiler for CraneliftCompiler {
     }
 
     fn deterministic_id(&self) -> String {
-        let mut components = vec![self.name()];
+        use wasmer_compiler::DeterministicIdComponent as Component;
+
+        let mut components = vec![Component::Cranelift];
         components.push(match self.config.opt_level {
-            CraneliftOptLevel::None => "opt0",
-            CraneliftOptLevel::Speed => "opts",
-            CraneliftOptLevel::SpeedAndSize => "optsz",
+            CraneliftOptLevel::None => Component::OptNone,
+            CraneliftOptLevel::Speed => Component::OptSpeed,
+            CraneliftOptLevel::SpeedAndSize => Component::OptSpeedAndSize,
         });
-        if self.config.experimental_artifact {
-            components.push("exp_art");
-        }
         if self.config.enable_nan_canonicalization {
-            components.push("nan_canon");
+            components.push(Component::NanCanonicalization);
         }
         if self.config.enable_pic {
-            components.push("pic");
+            components.push(Component::Pic);
         }
         if self.config.allow_experimental_unaligned_memory_accesses {
-            components.push("unaligned_mem");
+            components.push(Component::ExperimentalUnalignedMemoryAccesses);
         }
 
-        components.join("-")
+        components
+            .into_iter()
+            .map(|component| component.to_string())
+            .collect_vec()
+            .join("-")
+    }
+
+    fn container_format(&self) -> String {
+        if self.config.experimental_artifact {
+            wasmer_compiler::ArtifactFormatContainer::Native
+        } else {
+            wasmer_compiler::ArtifactFormatContainer::Rkyv
+        }
+        .to_string()
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-cranelift/src/config.rs
+++ b/lib/compiler-cranelift/src/config.rs
@@ -110,14 +110,14 @@ pub enum CraneliftOptLevel {
 /// consumed by `wasmer_engine::Engine::new`.
 #[derive(Debug, Clone)]
 pub struct Cranelift {
-    enable_nan_canonicalization: bool,
+    pub(crate) enable_nan_canonicalization: bool,
     pub(crate) allow_experimental_unaligned_memory_accesses: bool,
     enable_verifier: bool,
     pub(crate) enable_perfmap: bool,
     pub(crate) debugger: Option<Debugger>,
-    enable_pic: bool,
+    pub(crate) enable_pic: bool,
     pub(crate) experimental_artifact: bool,
-    opt_level: CraneliftOptLevel,
+    pub(crate) opt_level: CraneliftOptLevel,
     /// The number of threads to use for compilation.
     pub num_threads: NonZero<usize>,
     /// The middleware chain.

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -215,11 +215,11 @@ impl Compiler for LLVMCompiler {
             .join("-")
     }
 
-    fn container_format(&self) -> String {
+    fn artifact_format(&self) -> String {
         if self.config.experimental_artifact {
-            wasmer_compiler::ArtifactFormatContainer::Native
+            wasmer_compiler::ArtifactFormat::Native
         } else {
-            wasmer_compiler::ArtifactFormatContainer::Rkyv
+            wasmer_compiler::ArtifactFormat::Rkyv
         }
         .to_string()
     }

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -185,20 +185,30 @@ impl Compiler for LLVMCompiler {
     }
 
     fn deterministic_id(&self) -> String {
-        format!(
-            "llvm-{}{}",
-            match self.config.opt_level {
-                inkwell::OptimizationLevel::None => "opt0",
-                inkwell::OptimizationLevel::Less => "optl",
-                inkwell::OptimizationLevel::Default => "optd",
-                inkwell::OptimizationLevel::Aggressive => "opta",
-            },
-            if self.config.experimental_artifact {
-                "-elf"
-            } else {
-                ""
-            }
-        )
+        let mut components = vec![self.name()];
+        components.push(match self.config.opt_level {
+            inkwell::OptimizationLevel::None => "opt0",
+            inkwell::OptimizationLevel::Less => "optl",
+            inkwell::OptimizationLevel::Default => "optd",
+            inkwell::OptimizationLevel::Aggressive => "opta",
+        });
+        if self.config.experimental_artifact {
+            components.push("exp_art");
+        }
+        if self.config.enable_nan_canonicalization {
+            components.push("nan_canon");
+        }
+        if self.config.enable_non_volatile_memops {
+            components.push("non_vol_mem");
+        }
+        if self.config.is_pic {
+            components.push("pic");
+        }
+        if self.config.enable_readonly_funcref_table {
+            components.push("ro_ftable");
+        }
+
+        components.join("-")
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -3,6 +3,7 @@ use crate::config::OptimizationStyle;
 use crate::object_file::CompiledFunction;
 use crate::translator::FuncTrampoline;
 use crate::translator::FuncTranslator;
+use itertools::Itertools;
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::{
@@ -185,30 +186,42 @@ impl Compiler for LLVMCompiler {
     }
 
     fn deterministic_id(&self) -> String {
-        let mut components = vec![self.name()];
+        use wasmer_compiler::DeterministicIdComponent as Component;
+
+        let mut components = vec![Component::Llvm];
         components.push(match self.config.opt_level {
-            inkwell::OptimizationLevel::None => "opt0",
-            inkwell::OptimizationLevel::Less => "optl",
-            inkwell::OptimizationLevel::Default => "optd",
-            inkwell::OptimizationLevel::Aggressive => "opta",
+            inkwell::OptimizationLevel::None => Component::OptNone,
+            inkwell::OptimizationLevel::Less => Component::OptLess,
+            inkwell::OptimizationLevel::Default => Component::OptDefault,
+            inkwell::OptimizationLevel::Aggressive => Component::OptAggressive,
         });
-        if self.config.experimental_artifact {
-            components.push("exp_art");
-        }
         if self.config.enable_nan_canonicalization {
-            components.push("nan_canon");
+            components.push(Component::NanCanonicalization);
         }
         if self.config.enable_non_volatile_memops {
-            components.push("non_vol_mem");
+            components.push(Component::NonVolatileMemops);
         }
         if self.config.is_pic {
-            components.push("pic");
+            components.push(Component::Pic);
         }
         if self.config.enable_readonly_funcref_table {
-            components.push("ro_ftable");
+            components.push(Component::ReadonlyFuncrefTable);
         }
 
-        components.join("-")
+        components
+            .into_iter()
+            .map(|component| component.to_string())
+            .collect_vec()
+            .join("-")
+    }
+
+    fn container_format(&self) -> String {
+        if self.config.experimental_artifact {
+            wasmer_compiler::ArtifactFormatContainer::Native
+        } else {
+            wasmer_compiler::ArtifactFormatContainer::Rkyv
+        }
+        .to_string()
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -117,7 +117,7 @@ pub struct LLVM {
     pub(crate) enable_perfmap: bool,
     pub(crate) debugger: Option<Debugger>,
     pub(crate) opt_level: LLVMOptLevel,
-    is_pic: bool,
+    pub(crate) is_pic: bool,
     pub(crate) experimental_artifact: bool,
     pub(crate) callbacks: Option<LLVMCallbacks>,
     /// The middleware chain.

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -20,6 +20,7 @@ use crate::unwind::create_systemv_cie;
 use enumset::EnumSet;
 #[cfg(feature = "unwind")]
 use gimli::write::{EhFrame, FrameTable, Writer};
+use itertools::Itertools;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -424,18 +425,30 @@ impl Compiler for SinglepassCompiler {
     }
 
     fn deterministic_id(&self) -> String {
-        let mut components = vec![self.name()];
-        if self.config.experimental_artifact {
-            components.push("exp_art");
-        }
+        use wasmer_compiler::DeterministicIdComponent as Component;
+
+        let mut components = vec![Component::Singlepass];
         if self.config.enable_nan_canonicalization {
-            components.push("nan_canon");
+            components.push(Component::NanCanonicalization);
         }
         if self.config.allow_experimental_unaligned_memory_accesses {
-            components.push("unaligned_mem");
+            components.push(Component::ExperimentalUnalignedMemoryAccesses);
         }
 
-        components.join("-")
+        components
+            .into_iter()
+            .map(|component| component.to_string())
+            .collect_vec()
+            .join("-")
+    }
+
+    fn container_format(&self) -> String {
+        if self.config.experimental_artifact {
+            wasmer_compiler::ArtifactFormatContainer::Native
+        } else {
+            wasmer_compiler::ArtifactFormatContainer::Rkyv
+        }
+        .to_string()
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -424,11 +424,18 @@ impl Compiler for SinglepassCompiler {
     }
 
     fn deterministic_id(&self) -> String {
+        let mut components = vec![self.name()];
         if self.config.experimental_artifact {
-            String::from("singlepass-elf")
-        } else {
-            String::from("singlepass")
+            components.push("exp_art");
         }
+        if self.config.enable_nan_canonicalization {
+            components.push("nan_canon");
+        }
+        if self.config.allow_experimental_unaligned_memory_accesses {
+            components.push("unaligned_mem");
+        }
+
+        components.join("-")
     }
 
     /// Get the middlewares for this compiler

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -442,11 +442,11 @@ impl Compiler for SinglepassCompiler {
             .join("-")
     }
 
-    fn container_format(&self) -> String {
+    fn artifact_format(&self) -> String {
         if self.config.experimental_artifact {
-            wasmer_compiler::ArtifactFormatContainer::Native
+            wasmer_compiler::ArtifactFormat::Native
         } else {
-            wasmer_compiler::ArtifactFormatContainer::Rkyv
+            wasmer_compiler::ArtifactFormat::Rkyv
         }
         .to_string()
     }

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -85,13 +85,13 @@ pub enum DeterministicIdComponent {
     ExperimentalUnalignedMemoryAccesses,
 }
 
-/// The container format used for artifact serialization.
+/// The artifact format used for purpose of serialization.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
-pub enum ArtifactFormatContainer {
+pub enum ArtifactFormat {
     /// rkyv serialization based.
     #[strum(serialize = "rkyv")]
     Rkyv,
-    /// Native container, such as ELF.
+    /// Native format, such as ELF.
     #[strum(serialize = "native")]
     Native,
 }
@@ -190,9 +190,9 @@ pub trait Compiler: Send + std::fmt::Debug {
     /// optimizations map to different deterministic IDs.
     fn deterministic_id(&self) -> String;
 
-    /// Returns the used container for the artifact format: `rkyv` or `native`.
-    fn container_format(&self) -> String {
-        ArtifactFormatContainer::Rkyv.to_string()
+    /// Returns the used artifact format: `rkyv` or `native`.
+    fn artifact_format(&self) -> String {
+        ArtifactFormat::Rkyv.to_string()
     }
 
     /// Add suggested optimizations to this compiler.

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -50,6 +50,52 @@ pub enum Debugger {
     Lldb,
 }
 
+/// A component representing a code-generation-sensitive aspect of a compiler
+/// configuration for artifact format creation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
+#[allow(missing_docs)]
+pub enum DeterministicIdComponent {
+    #[strum(serialize = "llvm")]
+    Llvm,
+    #[strum(serialize = "cranelift")]
+    Cranelift,
+    #[strum(serialize = "singlepass")]
+    Singlepass,
+    #[strum(serialize = "opt0")]
+    OptNone,
+    #[strum(serialize = "optl")]
+    OptLess,
+    #[strum(serialize = "optd")]
+    OptDefault,
+    #[strum(serialize = "opta")]
+    OptAggressive,
+    #[strum(serialize = "opts")]
+    OptSpeed,
+    #[strum(serialize = "optsz")]
+    OptSpeedAndSize,
+    #[strum(serialize = "nan_canon")]
+    NanCanonicalization,
+    #[strum(serialize = "non_vol_mem")]
+    NonVolatileMemops,
+    #[strum(serialize = "pic")]
+    Pic,
+    #[strum(serialize = "ro_ftable")]
+    ReadonlyFuncrefTable,
+    #[strum(serialize = "unaligned_mem")]
+    ExperimentalUnalignedMemoryAccesses,
+}
+
+/// The container format used for artifact serialization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
+pub enum ArtifactFormatContainer {
+    /// rkyv serialization based.
+    #[strum(serialize = "rkyv")]
+    Rkyv,
+    /// Native container, such as ELF.
+    #[strum(serialize = "native")]
+    Native,
+}
+
 /// The compiler configuration options.
 pub trait CompilerConfig {
     /// Enable the experimental artifact format.
@@ -143,6 +189,11 @@ pub trait Compiler: Send + std::fmt::Debug {
     /// Returns the deterministic id of this compiler. Same compilers with different
     /// optimizations map to different deterministic IDs.
     fn deterministic_id(&self) -> String;
+
+    /// Returns the used container for the artifact format: `rkyv` or `native`.
+    fn container_format(&self) -> String {
+        ArtifactFormatContainer::Rkyv.to_string()
+    }
 
     /// Add suggested optimizations to this compiler.
     ///

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -113,6 +113,20 @@ impl Engine {
         }
     }
 
+    /// Returns the container format used for artifacts produced by this engine.
+    pub fn container_format(&self) -> String {
+        #[cfg(feature = "compiler")]
+        {
+            let i = self.inner();
+            if let Some(ref c) = i.compiler {
+                return c.container_format();
+            }
+        }
+
+        #[allow(unreachable_code)]
+        self.name.to_string()
+    }
+
     /// Create a headless `Engine`
     ///
     /// A headless engine is an engine without any compiler attached.

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -113,13 +113,13 @@ impl Engine {
         }
     }
 
-    /// Returns the container format used for artifacts produced by this engine.
-    pub fn container_format(&self) -> String {
+    /// Returns the format used for artifacts produced by this engine.
+    pub fn artifact_format(&self) -> String {
         #[cfg(feature = "compiler")]
         {
             let i = self.inner();
             if let Some(ref c) = i.compiler {
-                return c.container_format();
+                return c.artifact_format();
             }
         }
 

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -40,9 +40,10 @@ pub use self::artifact_builders::*;
 mod compiler;
 #[cfg(feature = "compiler")]
 pub use crate::compiler::{
-    CompiledFunction, CompiledObjects, Compiler, CompilerConfig, Debugger, FuncTranslator,
-    FunctionBucket, WASM_LARGE_FUNCTION_THRESHOLD, WASM_TRAMPOLINE_ESTIMATED_BODY_SIZE,
-    build_function_buckets, emit_metadata_and_link, translate_function_buckets,
+    ArtifactFormatContainer, CompiledFunction, CompiledObjects, Compiler, CompilerConfig, Debugger,
+    DeterministicIdComponent, FuncTranslator, FunctionBucket, WASM_LARGE_FUNCTION_THRESHOLD,
+    WASM_TRAMPOLINE_ESTIMATED_BODY_SIZE, build_function_buckets, emit_metadata_and_link,
+    translate_function_buckets,
 };
 
 #[cfg(feature = "compiler")]

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -40,7 +40,7 @@ pub use self::artifact_builders::*;
 mod compiler;
 #[cfg(feature = "compiler")]
 pub use crate::compiler::{
-    ArtifactFormatContainer, CompiledFunction, CompiledObjects, Compiler, CompilerConfig, Debugger,
+    ArtifactFormat, CompiledFunction, CompiledObjects, Compiler, CompilerConfig, Debugger,
     DeterministicIdComponent, FuncTranslator, FunctionBucket, WASM_LARGE_FUNCTION_THRESHOLD,
     WASM_TRAMPOLINE_ESTIMATED_BODY_SIZE, build_function_buckets, emit_metadata_and_link,
     translate_function_buckets,

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -28,11 +28,11 @@ impl FileSystemCache {
         &self.cache_dir
     }
 
-    fn path(&self, key: ModuleHash, deterministic_id: &str, container_format: &str) -> PathBuf {
+    fn path(&self, key: ModuleHash, deterministic_id: &str, artifact_format: &str) -> PathBuf {
         let artifact_version = wasmer_types::MetadataHeader::CURRENT_VERSION;
         self.cache_dir
             .join(format!(
-                "{deterministic_id}-{container_format}-v{artifact_version}"
+                "{deterministic_id}-{artifact_format}-v{artifact_version}"
             ))
             .join(key.to_string())
             .with_extension("bin")
@@ -133,7 +133,7 @@ async fn tokio_save(path: PathBuf, module: Module) -> Result<(), CacheError> {
 impl ModuleCache for FileSystemCache {
     #[tracing::instrument(level = "debug", skip_all, fields(% key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        let path = self.path(key, &engine.deterministic_id(), &engine.container_format());
+        let path = self.path(key, &engine.deterministic_id(), &engine.artifact_format());
         let engine = engine.clone();
 
         // Use the bundled tokio runtime instead of the given async runtime
@@ -146,7 +146,7 @@ impl ModuleCache for FileSystemCache {
     }
 
     async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
-        let path = self.path(key, &engine.deterministic_id(), &engine.container_format());
+        let path = self.path(key, &engine.deterministic_id(), &engine.artifact_format());
 
         // Use the bundled tokio runtime instead of the given async runtime
         // This is necessary because this function can also be called with a futures_executor
@@ -164,7 +164,7 @@ impl ModuleCache for FileSystemCache {
         engine: &Engine,
         module: &Module,
     ) -> Result<(), CacheError> {
-        let path = self.path(key, &engine.deterministic_id(), &engine.container_format());
+        let path = self.path(key, &engine.deterministic_id(), &engine.artifact_format());
         let module = module.clone();
 
         // Use the bundled tokio runtime instead of the given async runtime
@@ -237,7 +237,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let key = ModuleHash::from_bytes([0; _]);
-        let expected_path = cache.path(key, &engine.deterministic_id(), &engine.container_format());
+        let expected_path = cache.path(key, &engine.deterministic_id(), &engine.artifact_format());
 
         cache.save(key, &engine, &module).await.unwrap();
 
@@ -278,7 +278,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let key = ModuleHash::from_bytes([0; _]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
-        let expected_path = cache.path(key, &engine.deterministic_id(), &engine.container_format());
+        let expected_path = cache.path(key, &engine.deterministic_id(), &engine.artifact_format());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
         let serialized = module.serialize().unwrap();
         std::fs::write(&expected_path, &serialized).unwrap();

--- a/lib/wasix/src/runtime/module_cache/filesystem.rs
+++ b/lib/wasix/src/runtime/module_cache/filesystem.rs
@@ -28,10 +28,12 @@ impl FileSystemCache {
         &self.cache_dir
     }
 
-    fn path(&self, key: ModuleHash, deterministic_id: &str) -> PathBuf {
+    fn path(&self, key: ModuleHash, deterministic_id: &str, container_format: &str) -> PathBuf {
         let artifact_version = wasmer_types::MetadataHeader::CURRENT_VERSION;
         self.cache_dir
-            .join(format!("{deterministic_id}-v{artifact_version}"))
+            .join(format!(
+                "{deterministic_id}-{container_format}-v{artifact_version}"
+            ))
             .join(key.to_string())
             .with_extension("bin")
     }
@@ -131,7 +133,7 @@ async fn tokio_save(path: PathBuf, module: Module) -> Result<(), CacheError> {
 impl ModuleCache for FileSystemCache {
     #[tracing::instrument(level = "debug", skip_all, fields(% key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        let path = self.path(key, &engine.deterministic_id());
+        let path = self.path(key, &engine.deterministic_id(), &engine.container_format());
         let engine = engine.clone();
 
         // Use the bundled tokio runtime instead of the given async runtime
@@ -144,7 +146,7 @@ impl ModuleCache for FileSystemCache {
     }
 
     async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
-        let path = self.path(key, &engine.deterministic_id());
+        let path = self.path(key, &engine.deterministic_id(), &engine.container_format());
 
         // Use the bundled tokio runtime instead of the given async runtime
         // This is necessary because this function can also be called with a futures_executor
@@ -162,7 +164,7 @@ impl ModuleCache for FileSystemCache {
         engine: &Engine,
         module: &Module,
     ) -> Result<(), CacheError> {
-        let path = self.path(key, &engine.deterministic_id());
+        let path = self.path(key, &engine.deterministic_id(), &engine.container_format());
         let module = module.clone();
 
         // Use the bundled tokio runtime instead of the given async runtime
@@ -235,7 +237,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
         let key = ModuleHash::from_bytes([0; _]);
-        let expected_path = cache.path(key, &engine.deterministic_id());
+        let expected_path = cache.path(key, &engine.deterministic_id(), &engine.container_format());
 
         cache.save(key, &engine, &module).await.unwrap();
 
@@ -276,7 +278,7 @@ mod tests {
         let module = Module::new(&engine, ADD_WAT).unwrap();
         let key = ModuleHash::from_bytes([0; _]);
         let cache = FileSystemCache::new(temp.path(), create_tokio_task_manager());
-        let expected_path = cache.path(key, &engine.deterministic_id());
+        let expected_path = cache.path(key, &engine.deterministic_id(), &engine.container_format());
         std::fs::create_dir_all(expected_path.parent().unwrap()).unwrap();
         let serialized = module.serialize().unwrap();
         std::fs::write(&expected_path, &serialized).unwrap();

--- a/lib/wasix/src/runtime/module_cache/shared.rs
+++ b/lib/wasix/src/runtime/module_cache/shared.rs
@@ -4,10 +4,17 @@ use wasmer::{Engine, Module};
 use crate::runtime::module_cache::{CacheError, ModuleCache};
 use wasmer_types::ModuleHash;
 
-/// A [`ModuleCache`] based on a <code>[DashMap]<[ModuleHash], [Module]></code>.
+/// A [`ModuleCache`] based on a <code>[DashMap]</code> keyed by module hash, engine ID, and format.
 #[derive(Debug, Default, Clone)]
 pub struct SharedCache {
-    modules: DashMap<(ModuleHash, String, String), Module>,
+    modules: DashMap<SharedCacheKey, Module>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SharedCacheKey {
+    module_hash: ModuleHash,
+    deterministic_id: String,
+    artifact_format: String,
 }
 
 impl SharedCache {
@@ -15,8 +22,12 @@ impl SharedCache {
         SharedCache::default()
     }
 
-    fn cache_key(key: ModuleHash, engine: &Engine) -> (ModuleHash, String, String) {
-        (key, engine.deterministic_id(), engine.container_format())
+    fn cache_key(key: ModuleHash, engine: &Engine) -> SharedCacheKey {
+        SharedCacheKey {
+            module_hash: key,
+            deterministic_id: engine.deterministic_id(),
+            artifact_format: engine.artifact_format(),
+        }
     }
 }
 

--- a/lib/wasix/src/runtime/module_cache/shared.rs
+++ b/lib/wasix/src/runtime/module_cache/shared.rs
@@ -7,12 +7,16 @@ use wasmer_types::ModuleHash;
 /// A [`ModuleCache`] based on a <code>[DashMap]<[ModuleHash], [Module]></code>.
 #[derive(Debug, Default, Clone)]
 pub struct SharedCache {
-    modules: DashMap<(ModuleHash, String), Module>,
+    modules: DashMap<(ModuleHash, String, String), Module>,
 }
 
 impl SharedCache {
     pub fn new() -> SharedCache {
         SharedCache::default()
+    }
+
+    fn cache_key(key: ModuleHash, engine: &Engine) -> (ModuleHash, String, String) {
+        (key, engine.deterministic_id(), engine.container_format())
     }
 }
 
@@ -20,7 +24,7 @@ impl SharedCache {
 impl ModuleCache for SharedCache {
     #[tracing::instrument(level = "debug", skip_all, fields(%key))]
     async fn load(&self, key: ModuleHash, engine: &Engine) -> Result<Module, CacheError> {
-        let key = (key, engine.deterministic_id());
+        let key = Self::cache_key(key, engine);
 
         match self.modules.get(&key) {
             Some(m) => {
@@ -33,7 +37,7 @@ impl ModuleCache for SharedCache {
     }
 
     async fn contains(&self, key: ModuleHash, engine: &Engine) -> Result<bool, CacheError> {
-        let key = (key, engine.deterministic_id().to_string());
+        let key = Self::cache_key(key, engine);
         Ok(self.modules.contains_key(&key))
     }
 
@@ -44,7 +48,7 @@ impl ModuleCache for SharedCache {
         engine: &Engine,
         module: &Module,
     ) -> Result<(), CacheError> {
-        let key = (key, engine.deterministic_id().to_string());
+        let key = Self::cache_key(key, engine);
         self.modules.insert(key, module.clone());
 
         Ok(())


### PR DESCRIPTION
We must ensure all the config values that influence the code generation are reflected in the compiled artifact location.

Fixes: wasmerio/wasmer#6869