### PR TITLE
fix(wasix): don't inherit a dependency's entrypoint over the root's own commands

### DIFF
--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -797,10 +797,11 @@ fn resolve_package(dependency_graph: &DependencyGraph) -> Result<ResolvedPackage
 
     let mut entrypoint = dependency_graph.root_info().entrypoint.clone();
 
-    // A package that ships commands of its own must resolve to one of them, so
-    // only a command-less root may inherit an entrypoint from a dependency.
+    // Only a command-less root may inherit an entrypoint from a dependency.
     // Otherwise a dependency like wasmer/bash, which declares an entrypoint,
-    // would hijack the root package's own commands.
+    // would hijack a root package that ships commands of its own. A root with
+    // commands falls through to the "only command" fallback below instead, and
+    // is left without an entrypoint if that can't pick one unambiguously.
     let may_inherit_entrypoint = dependency_graph.root_info().commands.is_empty();
 
     for index in petgraph::algo::toposort(dependency_graph.graph(), None).expect("acyclic") {
@@ -2122,13 +2123,10 @@ mod tests {
             .await
             .unwrap();
 
-        // Ambiguous between "anybuild" and "shipit", but never "bash".
-        assert_ne!(
-            resolution.package.entrypoint.as_deref(),
-            Some("bash"),
-            "the entrypoint must not come from a dependency when the root has \
-             commands of its own",
-        );
+        // "anybuild" and "shipit" are equally good candidates and neither is
+        // declared as the entrypoint, so the caller has to error out rather
+        // than guess -- and it certainly must not reach for "bash".
+        assert_eq!(resolution.package.entrypoint, None);
     }
 
     /// Same as above, but with a single root command, so the "root package's

--- a/lib/wasix/src/runtime/resolver/resolve.rs
+++ b/lib/wasix/src/runtime/resolver/resolve.rs
@@ -797,6 +797,12 @@ fn resolve_package(dependency_graph: &DependencyGraph) -> Result<ResolvedPackage
 
     let mut entrypoint = dependency_graph.root_info().entrypoint.clone();
 
+    // A package that ships commands of its own must resolve to one of them, so
+    // only a command-less root may inherit an entrypoint from a dependency.
+    // Otherwise a dependency like wasmer/bash, which declares an entrypoint,
+    // would hijack the root package's own commands.
+    let may_inherit_entrypoint = dependency_graph.root_info().commands.is_empty();
+
     for index in petgraph::algo::toposort(dependency_graph.graph(), None).expect("acyclic") {
         let node = &dependency_graph[index];
         let id = &node.id;
@@ -804,6 +810,7 @@ fn resolve_package(dependency_graph: &DependencyGraph) -> Result<ResolvedPackage
 
         // update the entrypoint, if necessary
         if entrypoint.is_none()
+            && may_inherit_entrypoint
             && let Some(entry) = &pkg.entrypoint
         {
             tracing::trace!(
@@ -2088,6 +2095,68 @@ mod tests {
                 builder.get(&dep_id).package_id(),
                 builder.get(&root_id).package_id(),
             ]
+        );
+    }
+
+    /// A root with commands of its own and no explicit entrypoint must not fall
+    /// back to a dependency's entrypoint.
+    ///
+    /// See https://github.com/wasmerio/wasmer/issues/6870.
+    #[tokio::test]
+    async fn entrypoint_is_not_inherited_when_root_has_its_own_commands() {
+        let root_id = PackageId::new_named("anybuild", "1.0.0".parse().unwrap());
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("anybuild", "1.0.0")
+            .with_command("anybuild")
+            .with_command("shipit")
+            .with_dependency("bash", "=1.0.0");
+        builder
+            .register("bash", "1.0.0")
+            .with_command("bash")
+            .with_entrypoint("bash");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        // Ambiguous between "anybuild" and "shipit", but never "bash".
+        assert_ne!(
+            resolution.package.entrypoint.as_deref(),
+            Some("bash"),
+            "the entrypoint must not come from a dependency when the root has \
+             commands of its own",
+        );
+    }
+
+    /// Same as above, but with a single root command, so the "root package's
+    /// only command" fallback has an unambiguous answer to give.
+    #[tokio::test]
+    async fn root_package_only_command_wins_over_dependency_entrypoint() {
+        let root_id = PackageId::new_named("anybuild", "1.0.0".parse().unwrap());
+        let mut builder = RegistryBuilder::new();
+        builder
+            .register("anybuild", "1.0.0")
+            .with_command("anybuild")
+            .with_dependency("bash", "=1.0.0");
+        builder
+            .register("bash", "1.0.0")
+            .with_command("bash")
+            .with_entrypoint("bash");
+        let registry = builder.finish();
+        let root = builder.get(&root_id);
+
+        let resolution = resolve(&root.package_id(), &root.pkg, &registry)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resolution.package.entrypoint.as_deref(),
+            Some("anybuild"),
+            "the root package's own only command should win over a dependency's \
+             entrypoint",
         );
     }
 


### PR DESCRIPTION
`resolve_package` walked the whole dependency graph looking for an entrypoint whenever the root package didn't declare one, so a dependency's entrypoint would win over the root package's own commands.

`wasmer/anybuild` declares no entrypoint and depends on `wasmer/bash`, which declares `entrypoint = "bash"` — so it ran bash instead of anybuild.

Only a command-less root may now inherit an entrypoint from a dependency. That also makes the existing "root package's only command" fallback reachable, which it previously wasn't whenever any dependency declared an entrypoint.

Behaviour by case:

<!-- linear:table-colwidths:266,266,266 -->
| root | before | after |
| -- | -- | -- |
| no commands | inherits from dependency | unchanged |
| one command | dependency's entrypoint | its own command |
| 2+ commands, no entrypoint | dependency's entrypoint | `None`, i.e. an error rather than silently running the wrong binary |

Not a recent regression — the inheritance loop dates to the original resolver (2023). It surfaced when `wasmer/bash` added `entrypoint = "bash"` in 1.0.21.

Two regression tests added. Full `wasmer-wasix` lib suite passes (225).

Fixes wasmerio/wasmer#6870

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)