### PR TITLE
feat!: drop unused and broken no-std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7548,7 +7548,6 @@ dependencies = [
  "enum-iterator",
  "enumset",
  "gimli 0.34.0",
- "hashbrown 0.17.1",
  "itertools 0.15.0",
  "leb128",
  "libc",

--- a/lib/api/src/backend/js/entities/function/mod.rs
+++ b/lib/api/src/backend/js/entities/function/mod.rs
@@ -402,11 +402,6 @@ macro_rules! impl_host_function {
                         let c_struct = unsafe { result.into_c_struct(&mut store) };
                         return c_struct;
                     },
-                    #[cfg(feature = "std")]
-                    #[allow(deprecated)]
-                    Ok(Err(trap)) => crate::backend::js::error::raise(Box::new(trap)),
-                    #[cfg(feature = "core")]
-                    #[allow(deprecated)]
                     Ok(Err(trap)) => crate::backend::js::error::raise(Box::new(trap)),
                     Err(_panic) => unimplemented!(),
                 }

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmer-compiler"
 description = "Base compiler abstraction for Wasmer WebAssembly runtime"
-categories = ["wasm", "no-std"]
+categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler"]
 readme = "README.md"
 authors.workspace = true
@@ -16,7 +16,6 @@ version.workspace = true
 wasmer-types = { path = "../types", version = "=7.2.1", default-features = false }
 wasmparser = { workspace = true, default-features = false, optional = true }
 enumset.workspace = true
-hashbrown = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
 serde_bytes = { workspace = true, optional = true }
@@ -75,8 +74,9 @@ wasmer-artifact-load = []
 wasmer-artifact-create = []
 static-artifact-load = []
 static-artifact-create = ["translator", "compiler"]
-std = ["wasmer-types/std"]
-core = ["hashbrown", "wasmer-types/core"]
+# Keep for backward compatibility.
+std = []
+core = []
 enable-serde = ["serde", "serde_bytes", "wasmer-types/enable-serde"]
 artifact-size = ["dep:loupe"]
 # Signal-free trap-handler backend; see wasmer-vm's baremetal feature for details.

--- a/lib/compiler/src/abi.rs
+++ b/lib/compiler/src/abi.rs
@@ -1,7 +1,7 @@
 //! Shared WebAssembly return-value ABI classification.
 
-use crate::lib::std::vec::Vec;
 use itertools::Itertools;
+use std::vec::Vec;
 use wasmer_types::Type;
 
 /// How a single-register return slot is typed.

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -15,9 +15,7 @@ use crate::types::function::Compilation;
 use crate::types::module::CompileModuleInfo;
 use crate::{
     FunctionBodyData, ModuleTranslationState, WASMER_FUNCTION_OFFSETS_SECTION_NAME,
-    WASMER_TRAP_FUNCTION_OFFSETS_SECTION_NAME,
-    lib::std::{boxed::Box, sync::Arc},
-    translator::ModuleMiddleware,
+    WASMER_TRAP_FUNCTION_OFFSETS_SECTION_NAME, translator::ModuleMiddleware,
 };
 use crossbeam_channel::unbounded;
 use enumset::EnumSet;
@@ -30,6 +28,7 @@ use object::{
     RelocationEncoding, RelocationFlags, RelocationKind, SectionFlags, SectionKind, SymbolFlags,
     SymbolKind, SymbolScope, elf,
 };
+use std::{boxed::Box, sync::Arc};
 use wasmer_types::{
     CompilationProgressCallback, Features, FunctionIndex, LocalFunctionIndex,
     entity::{EntityRef, PrimaryMap},

--- a/lib/compiler/src/engine/artifact.rs
+++ b/lib/compiler/src/engine/artifact.rs
@@ -19,7 +19,6 @@ use crate::{
     FrameInfosVariant, FunctionExtent, GlobalFrameInfoRegistration, InstantiationError, Tunables,
     WASMER_TRAP_FUNCTION_OFFSETS_SECTION_NAME, WASMER_TRAPS_SECTION_NAME,
     engine::{link::link_module, resolver::resolve_tags, trap::register_frame_info_source},
-    lib::std::vec::IntoIter,
     resolve_imports,
     serialize::{MetadataHeader, SerializableCompilation, SerializableModule},
     types::relocation::{RelocationLike, RelocationTarget},
@@ -31,6 +30,7 @@ use crate::{serialize::RkyvSerializableCompilation, types::symbols::ModuleMetada
 use itertools::Itertools;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
+use std::vec::IntoIter;
 #[cfg(feature = "compiler")]
 use wasmer_types::CompilationProgressCallback;
 

--- a/lib/compiler/src/engine/trap/frame_info.rs
+++ b/lib/compiler/src/engine/trap/frame_info.rs
@@ -23,7 +23,7 @@ use crate::types::function::{ArchivedCompiledFunctionFrameInfo, CompiledFunction
 use rkyv::vec::ArchivedVec;
 use std::collections::BTreeMap;
 use std::sync::{Arc, LazyLock, RwLock};
-use wasmer_types::lib::std::{cmp, ops::Deref};
+use std::{cmp, ops::Deref};
 use wasmer_types::{
     FrameInfo, LocalFunctionIndex, ModuleInfo, SourceLoc, TrapInformation,
     entity::{BoxedSlice, EntityRef, PrimaryMap},
@@ -165,7 +165,7 @@ impl GlobalFrameInfo {
         // to DWARF line info via `addr2line`, keyed off offsets into the
         // original ELF image.
         let get_line = |context: &addr2line::Context<crate::engine::mapped_binary::DwarfReader>,
-                         pc: u64| {
+                        pc: u64| {
             if let Ok(Some(location)) = context.find_location(pc)
                 && let Some(line) = location.line
                 && let Some(line) = line.checked_sub(1)

--- a/lib/compiler/src/lib.rs
+++ b/lib/compiler/src/lib.rs
@@ -7,7 +7,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::new_without_default, clippy::upper_case_acronyms)]
 #![warn(
     clippy::float_arithmetic,
@@ -20,63 +19,22 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-macro_rules! cfg_std_or_core {
-    ($($item:item)*) => {
-        $(
-            #[cfg(any(
-                feature = "std",
-                feature = "core",
-            ))]
-            $item
-        )*
-    };
-}
+mod engine;
+mod traits;
 
-#[cfg(all(feature = "std", feature = "core"))]
-compile_error!(
-    "The `std` and `core` features are both enabled, which is an error. Please enable only once."
-);
+pub mod abi;
+pub mod misc;
+pub mod object;
+pub mod progress;
+pub mod serialize;
+pub mod types;
 
-#[cfg(all(not(feature = "std"), not(feature = "core")))]
-compile_error!("Both the `std` and `core` features are disabled. Please enable one of them.");
+pub use crate::engine::*;
+pub use crate::traits::*;
 
-#[cfg(feature = "core")]
-extern crate alloc;
+mod artifact_builders;
 
-#[allow(unused_imports)]
-#[cfg(any(feature = "std", feature = "core"))]
-mod lib {
-    #[cfg(feature = "core")]
-    pub mod std {
-        pub use alloc::{borrow, boxed, str, string, sync, vec};
-        pub use core::fmt;
-        pub use hashbrown as collections;
-    }
-
-    #[cfg(feature = "std")]
-    pub mod std {
-        pub use std::{borrow, boxed, collections, fmt, str, string, sync, vec};
-    }
-}
-
-cfg_std_or_core! {
-    mod engine;
-    mod traits;
-
-    pub mod abi;
-    pub mod misc;
-    pub mod object;
-    pub mod progress;
-    pub mod serialize;
-    pub mod types;
-
-    pub use crate::engine::*;
-    pub use crate::traits::*;
-
-    mod artifact_builders;
-
-    pub use self::artifact_builders::*;
-}
+pub use self::artifact_builders::*;
 
 #[cfg(feature = "compiler")]
 mod compiler;

--- a/lib/compiler/src/progress.rs
+++ b/lib/compiler/src/progress.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for reporting compilation progress across the different backends.
 
-use crate::lib::std::{
+use std::{
     borrow::Cow,
     sync::{
         Arc,

--- a/lib/compiler/src/source_map.rs
+++ b/lib/compiler/src/source_map.rs
@@ -1,9 +1,5 @@
 use addr2line::gimli::{Dwarf, EndianRcSlice, LittleEndian, SectionId};
-#[cfg(feature = "core")]
-use alloc::{collections::BTreeMap, rc::Rc};
-use std::path::PathBuf;
-#[cfg(feature = "std")]
-use std::{collections::BTreeMap, rc::Rc};
+use std::{collections::BTreeMap, path::PathBuf, rc::Rc};
 use wasmer_types::{LocalFunctionIndex, ModuleInfo, entity::PrimaryMap};
 
 use crate::{

--- a/lib/compiler/src/translator/environ.rs
+++ b/lib/compiler/src/translator/environ.rs
@@ -1,13 +1,13 @@
 // This file contains code from external sources.
 // Attributions: https://github.com/wasmerio/wasmer/blob/main/docs/ATTRIBUTIONS.md
 use super::state::ModuleTranslationState;
-use crate::lib::std::string::ToString;
-use crate::lib::std::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use crate::translate_module;
 use crate::wasmparser::{Operator, ValType};
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::ops::Range;
+use std::string::ToString;
+use std::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use wasmer_types::FunctionType;
 use wasmer_types::entity::PrimaryMap;
 use wasmer_types::{

--- a/lib/compiler/src/types/address_map.rs
+++ b/lib/compiler/src/types/address_map.rs
@@ -7,10 +7,10 @@
 //! Data structures to provide transformation of the source
 // addresses of a WebAssembly module into the native code.
 
-use crate::lib::std::vec::Vec;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::vec::Vec;
 use wasmer_types::SourceLoc;
 
 /// Single source location to generated address mapping.

--- a/lib/compiler/src/types/section.rs
+++ b/lib/compiler/src/types/section.rs
@@ -12,10 +12,10 @@
 //! it can be patched later by the engine (native or JIT).
 
 use super::relocation::{ArchivedRelocation, Relocation, RelocationLike};
-use crate::lib::std::vec::Vec;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::vec::Vec;
 use wasmer_types::entity_impl;
 
 /// Index type of a Section defined inside a WebAssembly `Compilation`.

--- a/lib/compiler/src/types/unwind.rs
+++ b/lib/compiler/src/types/unwind.rs
@@ -5,10 +5,10 @@
 //! function called that one, and so forth.
 //!
 //! [Learn more](https://en.wikipedia.org/wiki/Call_stack).
-use crate::lib::std::vec::Vec;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::vec::Vec;
 
 /// Compiled function unwind information.
 ///

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmer-types"
 description = "Wasmer Common Types"
-categories = ["wasm", "no-std", "data-structures"]
+categories = ["wasm", "data-structures"]
 keywords = ["wasm", "webassembly", "types"]
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/lib/types/src/entity/boxed_slice.rs
+++ b/lib/types/src/entity/boxed_slice.rs
@@ -6,10 +6,10 @@
 use crate::entity::EntityRef;
 use crate::entity::iter::{Iter, IterMut};
 use crate::entity::keys::Keys;
-use crate::lib::std::boxed::Box;
-use crate::lib::std::marker::PhantomData;
-use crate::lib::std::ops::{Index, IndexMut};
-use crate::lib::std::slice;
+use std::boxed::Box;
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+use std::slice;
 
 /// A slice mapping `K -> V` allocating dense entity references.
 ///
@@ -166,7 +166,7 @@ where
 mod tests {
     use super::*;
     use crate::entity::PrimaryMap;
-    use crate::lib::std::vec::Vec;
+    use std::vec::Vec;
 
     // `EntityRef` impl for testing.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/lib/types/src/entity/iter.rs
+++ b/lib/types/src/entity/iter.rs
@@ -4,10 +4,10 @@
 //! A double-ended iterator over entity references and entities.
 
 use crate::entity::EntityRef;
-use crate::lib::std::iter::Enumerate;
-use crate::lib::std::marker::PhantomData;
-use crate::lib::std::slice;
-use crate::lib::std::vec;
+use std::iter::Enumerate;
+use std::marker::PhantomData;
+use std::slice;
+use std::vec;
 
 /// Iterate over all keys in order.
 pub struct Iter<'a, K: EntityRef, V>

--- a/lib/types/src/entity/keys.rs
+++ b/lib/types/src/entity/keys.rs
@@ -7,7 +7,7 @@
 //! `core::ops::Range`, but for now, we implement it manually.
 
 use crate::entity::EntityRef;
-use crate::lib::std::marker::PhantomData;
+use std::marker::PhantomData;
 
 /// Iterate over all keys in order.
 pub struct Keys<K: EntityRef> {

--- a/lib/types/src/entity/mod.rs
+++ b/lib/types/src/entity/mod.rs
@@ -59,21 +59,15 @@ macro_rules! entity_impl {
     ($entity:ident, $display_prefix:expr) => {
         entity_impl!($entity);
 
-        impl $crate::lib::std::fmt::Display for $entity {
-            fn fmt(
-                &self,
-                f: &mut $crate::lib::std::fmt::Formatter,
-            ) -> $crate::lib::std::fmt::Result {
+        impl ::core::fmt::Display for $entity {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 write!(f, concat!($display_prefix, "{}"), self.0)
             }
         }
 
-        impl $crate::lib::std::fmt::Debug for $entity {
-            fn fmt(
-                &self,
-                f: &mut $crate::lib::std::fmt::Formatter,
-            ) -> $crate::lib::std::fmt::Result {
-                (self as &dyn $crate::lib::std::fmt::Display).fmt(f)
+        impl ::core::fmt::Debug for $entity {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                (self as &dyn ::core::fmt::Display).fmt(f)
             }
         }
     };

--- a/lib/types/src/entity/packed_option.rs
+++ b/lib/types/src/entity/packed_option.rs
@@ -10,8 +10,8 @@
 //! This module provides a `PackedOption<T>` for types that have a reserved value that can be used
 //! to represent `None`.
 
-use crate::lib::std::fmt;
-use crate::lib::std::mem;
+use std::fmt;
+use std::mem;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};

--- a/lib/types/src/entity/primary_map.rs
+++ b/lib/types/src/entity/primary_map.rs
@@ -6,15 +6,15 @@ use crate::entity::EntityRef;
 use crate::entity::boxed_slice::BoxedSlice;
 use crate::entity::iter::{IntoIter, Iter, IterMut};
 use crate::entity::keys::Keys;
-use crate::lib::std::boxed::Box;
-use crate::lib::std::iter::FromIterator;
-use crate::lib::std::marker::PhantomData;
-use crate::lib::std::ops::{Index, IndexMut};
-use crate::lib::std::slice;
-use crate::lib::std::vec::Vec;
 use rkyv::{Archive, Archived, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::boxed::Box;
+use std::iter::FromIterator;
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+use std::slice;
+use std::vec::Vec;
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///

--- a/lib/types/src/entity/secondary_map.rs
+++ b/lib/types/src/entity/secondary_map.rs
@@ -6,11 +6,6 @@
 use crate::entity::EntityRef;
 use crate::entity::iter::{Iter, IterMut};
 use crate::entity::keys::Keys;
-use crate::lib::std::cmp::min;
-use crate::lib::std::marker::PhantomData;
-use crate::lib::std::ops::{Index, IndexMut};
-use crate::lib::std::slice;
-use crate::lib::std::vec::Vec;
 use rkyv::{Archive, Archived, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{
@@ -18,6 +13,11 @@ use serde::{
     de::{Deserializer, SeqAccess, Visitor},
     ser::{SerializeSeq, Serializer},
 };
+use std::cmp::min;
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+use std::slice;
+use std::vec::Vec;
 
 /// A mapping `K -> V` for densely indexed entity references.
 ///
@@ -284,7 +284,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        use crate::lib::std::fmt;
+        use std::fmt;
 
         struct SecondaryMapVisitor<K, V> {
             unused: PhantomData<fn(K) -> V>,

--- a/lib/types/src/error.rs
+++ b/lib/types/src/error.rs
@@ -151,55 +151,48 @@ pub enum PreInstantiationError {
     CpuFeature(String),
 }
 
-use crate::lib::std::string::String;
+use std::string::String;
 
 // Compilation Errors
-//
-// If `std` feature is enable, we can't use `thiserror` until
-// https://github.com/dtolnay/thiserror/pull/64 is merged.
 
 /// The WebAssembly.CompileError object indicates an error during
 /// WebAssembly decoding or validation.
 ///
 /// This mirrors the WebAssembly `CompileError` API described at
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError>.
-#[derive(Debug)]
-#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Error, Debug)]
 pub enum CompileError {
     /// A Wasm translation error occurred.
-    #[cfg_attr(feature = "std", error("WebAssembly translation error: {0}"))]
+    #[error("WebAssembly translation error: {0}")]
     Wasm(WasmError),
 
     /// A compilation error occurred.
-    #[cfg_attr(feature = "std", error("Compilation error: {0}"))]
+    #[error("Compilation error: {0}")]
     Codegen(String),
 
     /// The module did not pass validation.
-    #[cfg_attr(feature = "std", error("Validation error: {0}"))]
+    #[error("Validation error: {0}")]
     Validate(String),
 
     /// The compiler doesn't support a Wasm feature
-    #[cfg_attr(feature = "std", error("Feature {0} is not yet supported"))]
+    #[error("Feature {0} is not yet supported")]
     UnsupportedFeature(String),
 
     /// The compiler cannot compile for the given target.
     /// This can refer to the OS, the chipset or any other aspect of the target system.
-    #[cfg_attr(
-        feature = "std",
-        error("The target {0} is not yet supported (see https://docs.wasmer.io/runtime/features)")
-    )]
+    #[error("The target {0} is not yet supported (see https://docs.wasmer.io/runtime/features)")]
     UnsupportedTarget(String),
 
     /// Insufficient resources available for execution.
-    #[cfg_attr(feature = "std", error("Insufficient resources: {0}"))]
+    #[error("Insufficient resources: {0}")]
     Resource(String),
 
     /// Middleware error occurred.
-    #[cfg_attr(feature = "std", error("Middleware error: {0}"))]
+    #[error("Middleware error: {0}")]
     MiddlewareError(String),
 
     /// Compilation aborted by a user callback.
-    #[cfg_attr(feature = "std", error("Compilation aborted: {0}"))]
+    #[error("Compilation aborted: {0}")]
     Aborted(UserAbort),
 }
 
@@ -216,9 +209,8 @@ impl From<UserAbort> for CompileError {
 }
 
 /// A error in the middleware.
-#[derive(Debug)]
-#[cfg_attr(feature = "std", derive(Error))]
-#[cfg_attr(feature = "std", error("Error in middleware {name}: {message}"))]
+#[derive(Error, Debug)]
+#[error("Error in middleware {name}: {message}")]
 pub struct MiddlewareError {
     /// The name of the middleware where the error was created
     pub name: String,
@@ -246,17 +238,13 @@ impl From<MiddlewareError> for CompileError {
 ///
 /// When a WebAssembly function can't be translated, one of these error codes will be returned
 /// to describe the failure.
-#[derive(Debug)]
-#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Error, Debug)]
 pub enum WasmError {
     /// The input WebAssembly code is invalid.
     ///
     /// This error code is used by a WebAssembly translator when it encounters invalid WebAssembly
     /// code. This should never happen for validated WebAssembly code.
-    #[cfg_attr(
-        feature = "std",
-        error("Invalid input WebAssembly code at offset {offset}: {message}")
-    )]
+    #[error("Invalid input WebAssembly code at offset {offset}: {message}")]
     InvalidWebAssembly {
         /// A string describing the validation error.
         message: String,
@@ -267,19 +255,19 @@ pub enum WasmError {
     /// A feature used by the WebAssembly code is not supported by the embedding environment.
     ///
     /// Embedding environments may have their own limitations and feature restrictions.
-    #[cfg_attr(feature = "std", error("Unsupported feature: {0}"))]
+    #[error("Unsupported feature: {0}")]
     Unsupported(String),
 
     /// An implementation limit was exceeded.
-    #[cfg_attr(feature = "std", error("Implementation limit exceeded"))]
+    #[error("Implementation limit exceeded")]
     ImplLimitExceeded,
 
     /// An error from the middleware error.
-    #[cfg_attr(feature = "std", error("{0}"))]
+    #[error("{0}")]
     Middleware(MiddlewareError),
 
     /// A generic error.
-    #[cfg_attr(feature = "std", error("{0}"))]
+    #[error("{0}")]
     Generic(String),
 }
 
@@ -291,11 +279,10 @@ impl From<MiddlewareError> for WasmError {
 
 /// The error that can happen while parsing a `str`
 /// to retrieve a [`CpuFeature`](crate::target::CpuFeature).
-#[derive(Debug)]
-#[cfg_attr(feature = "std", derive(Error))]
+#[derive(Error, Debug)]
 pub enum ParseCpuFeatureError {
     /// The provided string feature doesn't exist
-    #[cfg_attr(feature = "std", error("CpuFeature {0} not recognized"))]
+    #[error("CpuFeature {0} not recognized")]
     Missing(String),
 }
 

--- a/lib/types/src/initializers.rs
+++ b/lib/types/src/initializers.rs
@@ -5,8 +5,8 @@
 #![allow(missing_docs)]
 
 use crate::indexes::{FunctionIndex, MemoryIndex, TableIndex};
-use crate::lib::std::boxed::Box;
 use crate::types::InitExpr;
+use std::boxed::Box;
 
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -6,7 +6,6 @@
 
 #![deny(missing_docs, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::new_without_default)]
 #![warn(
     clippy::float_arithmetic,
@@ -19,36 +18,6 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(all(feature = "std", feature = "core"))]
-compile_error!(
-    "The `std` and `core` features are both enabled, which is an error. Please enable only once."
-);
-
-#[cfg(all(not(feature = "std"), not(feature = "core")))]
-compile_error!("Both the `std` and `core` features are disabled. Please enable one of them.");
-
-#[cfg(feature = "core")]
-extern crate alloc;
-
-/// The `lib` module defines a `std` module that is identical whether
-/// the `core` or the `std` feature is enabled.
-pub mod lib {
-    /// Custom `std` module.
-    #[cfg(feature = "core")]
-    pub mod std {
-        pub use alloc::{borrow, boxed, format, iter, rc, slice, string, vec};
-        pub use core::{any, cell, cmp, convert, fmt, hash, marker, mem, ops, ptr, sync};
-    }
-
-    /// Custom `std` module.
-    #[cfg(feature = "std")]
-    pub mod std {
-        pub use std::{
-            any, borrow, boxed, cell, cmp, convert, fmt, format, hash, iter, marker, mem, ops, ptr,
-            rc, slice, string, sync, vec,
-        };
-    }
-}
 
 pub mod error;
 mod exception;

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -18,7 +18,6 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-
 pub mod error;
 mod exception;
 mod features;

--- a/lib/types/src/progress.rs
+++ b/lib/types/src/progress.rs
@@ -1,6 +1,6 @@
 //! Types used to report and handle compilation progress.
 
-use crate::lib::std::{borrow::Cow, fmt, string::String, sync::Arc};
+use std::{borrow::Cow, fmt, string::String, sync::Arc};
 use thiserror::Error;
 
 /// Indicates the current compilation progress.

--- a/lib/types/src/serialize.rs
+++ b/lib/types/src/serialize.rs
@@ -1,4 +1,5 @@
-use crate::{DeserializeError, lib::std::mem};
+use crate::DeserializeError;
+use std::mem;
 
 /// Metadata header which holds an ABI version and the length of the remaining
 /// metadata.

--- a/lib/types/src/stack/sourceloc.rs
+++ b/lib/types/src/stack/sourceloc.rs
@@ -7,10 +7,10 @@
 //! relative to the WebAssembly module. This is used mainly for debugging
 //! and tracing errors.
 
-use crate::lib::std::fmt;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// A source location.
 ///
@@ -64,7 +64,7 @@ impl fmt::Display for SourceLoc {
 #[cfg(test)]
 mod tests {
     use super::SourceLoc;
-    use crate::lib::std::string::ToString;
+    use std::string::ToString;
 
     #[test]
     fn display() {

--- a/lib/types/src/types.rs
+++ b/lib/types/src/types.rs
@@ -1,11 +1,11 @@
 use crate::indexes::{FunctionIndex, GlobalIndex};
-use crate::lib::std::borrow::ToOwned;
-use crate::lib::std::boxed::Box;
-use crate::lib::std::fmt;
-use crate::lib::std::format;
-use crate::lib::std::string::{String, ToString};
-use crate::lib::std::vec::Vec;
 use crate::units::Pages;
+use std::borrow::ToOwned;
+use std::boxed::Box;
+use std::fmt;
+use std::format;
+use std::string::{String, ToString};
+use std::vec::Vec;
 
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]

--- a/lib/types/src/units.rs
+++ b/lib/types/src/units.rs
@@ -1,10 +1,10 @@
-use crate::lib::std::convert::TryFrom;
-use crate::lib::std::fmt;
-use crate::lib::std::ops::{Add, Sub};
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::convert::TryInto;
+use std::fmt;
+use std::ops::{Add, Sub};
 use thiserror::Error;
 
 /// WebAssembly page sizes are fixed to be 64KiB.


### PR DESCRIPTION
The `--no-default-features --features core` support has been broken for quite some time (at least Wasmer 5.0) and don't think it's worth supporting it for `wasmer-compiler` and `wasmer-types`.

Resolves: #6846