### PR TITLE
feat(api): let embedders grow a shared memory without a store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,6 +3794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,6 +3892,16 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "offset-allocator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234d535da3521eb95106f40f0b73483d80bfb3aacf27c40d7e2b72f1a3e00a2"
+dependencies = [
+ "log",
+ "nonmax",
 ]
 
 [[package]]
@@ -7763,6 +7779,7 @@ dependencies = [
  "anyhow",
  "cc",
  "enum-iterator",
+ "offset-allocator",
  "serde",
  "serde_json",
  "tar",

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -220,4 +220,65 @@ mod tests {
         assert_send::<super::MemoryOps>();
         assert_sync::<super::MemoryOps>();
     }
+
+    #[cfg(feature = "sys")]
+    mod store_free_ops {
+        use crate::{Memory, Store};
+        use wasmer_types::{MemoryStyle, MemoryType, Pages};
+
+        fn shared_memory() -> (Store, crate::SharedMemory) {
+            let mut store = Store::default();
+            let ty = MemoryType {
+                minimum: Pages(1),
+                maximum: Some(Pages(4)),
+                shared: true,
+            };
+            let memory = Memory::new(&mut store, ty).expect("shared memory");
+            let shared = memory.as_shared(&store).expect("shared handle");
+            (store, shared)
+        }
+
+        /// `grow` reports the size the memory had beforehand, and the growth is
+        /// visible through a separate clone of the handle: the whole point of
+        /// the API is that several threads can hold their own handle.
+        #[test]
+        fn grow_returns_previous_size_and_is_shared_across_clones() {
+            let (_store, shared) = shared_memory();
+            let clone = shared.clone();
+
+            assert_eq!(shared.grow(Pages(1)).expect("grow"), Pages(1));
+            assert_eq!(clone.grow(Pages(2)).expect("grow via clone"), Pages(2));
+
+            // Past the declared maximum of 4 pages.
+            assert!(shared.grow(Pages(1)).is_err());
+        }
+
+        /// A shared memory is reserved up front, so its base must not move when
+        /// it grows — that invariant is what lets an embedder cache `data_ptr`.
+        #[test]
+        fn data_ptr_is_available_and_stable_across_grow() {
+            let (_store, shared) = shared_memory();
+
+            let before = shared.data_ptr().expect("data_ptr on the sys backend");
+            assert!(!before.is_null());
+
+            shared.grow(Pages(1)).expect("grow");
+
+            let after = shared.data_ptr().expect("data_ptr after grow");
+            match shared.style().expect("style on the sys backend") {
+                MemoryStyle::Static { bound, .. } if bound >= Pages(4) => {
+                    assert_eq!(before, after, "a fully reserved mapping must not move");
+                }
+                // A dynamic mapping is allowed to move; only assert we can still
+                // read a base.
+                _ => assert!(!after.is_null()),
+            }
+        }
+
+        #[test]
+        fn style_is_reported() {
+            let (_store, shared) = shared_memory();
+            assert!(shared.style().is_some());
+        }
+    }
 }

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -221,64 +221,79 @@ mod tests {
         assert_sync::<super::MemoryOps>();
     }
 
-    #[cfg(feature = "sys")]
     mod store_free_ops {
         use crate::{Memory, Store};
-        use wasmer_types::{MemoryStyle, MemoryType, Pages};
+        use wasmer_types::{MemoryError, MemoryStyle, MemoryType, Pages};
 
-        fn shared_memory() -> (Store, crate::SharedMemory) {
+        /// `None` when the default backend of this build cannot create a shared
+        /// memory at all, which is not something these tests can assert about.
+        ///
+        /// Note this deliberately does *not* key off `cfg(feature = "sys")`: the
+        /// workspace test matrix builds `wasmer` with `sys` compiled in while
+        /// `Store::default()` resolves to another backend (feature unification
+        /// plus `v8-default`), so the feature says nothing about which backend
+        /// is actually in play.
+        fn shared_memory() -> Option<(Store, crate::SharedMemory)> {
             let mut store = Store::default();
             let ty = MemoryType {
                 minimum: Pages(1),
                 maximum: Some(Pages(4)),
                 shared: true,
             };
-            let memory = Memory::new(&mut store, ty).expect("shared memory");
-            let shared = memory.as_shared(&store).expect("shared handle");
-            (store, shared)
+            let memory = Memory::new(&mut store, ty).ok()?;
+            let shared = memory.as_shared(&store)?;
+            Some((store, shared))
         }
 
-        /// `grow` reports the size the memory had beforehand, and the growth is
-        /// visible through a separate clone of the handle: the whole point of
-        /// the API is that several threads can hold their own handle.
+        /// The three store-free accessors are all-or-nothing: a backend either
+        /// implements the set (sys) or reports it unavailable (v8/js). Assert
+        /// whichever contract this build implements, and that the three agree
+        /// with one another — a backend offering `data_ptr` but no `style`
+        /// would leave a caller unable to tell whether caching the base is safe.
         #[test]
-        fn grow_returns_previous_size_and_is_shared_across_clones() {
-            let (_store, shared) = shared_memory();
-            let clone = shared.clone();
+        fn store_free_ops_match_the_backend_contract() {
+            let Some((_store, shared)) = shared_memory() else {
+                return;
+            };
 
-            assert_eq!(shared.grow(Pages(1)).expect("grow"), Pages(1));
-            assert_eq!(clone.grow(Pages(2)).expect("grow via clone"), Pages(2));
+            match (shared.data_ptr(), shared.style()) {
+                (Some(before), Some(style)) => {
+                    assert!(!before.is_null());
 
-            // Past the declared maximum of 4 pages.
-            assert!(shared.grow(Pages(1)).is_err());
-        }
+                    // `grow` reports the size the memory had beforehand, and the
+                    // growth is visible through an independent clone: the whole
+                    // point of the `&self` receiver is that several threads can
+                    // hold their own handle.
+                    let clone = shared.clone();
+                    assert_eq!(shared.grow(Pages(1)).expect("grow"), Pages(1));
+                    assert_eq!(clone.grow(Pages(2)).expect("grow via clone"), Pages(2));
+                    // Past the declared maximum of 4 pages.
+                    assert!(shared.grow(Pages(1)).is_err());
 
-        /// A shared memory is reserved up front, so its base must not move when
-        /// it grows — that invariant is what lets an embedder cache `data_ptr`.
-        #[test]
-        fn data_ptr_is_available_and_stable_across_grow() {
-            let (_store, shared) = shared_memory();
-
-            let before = shared.data_ptr().expect("data_ptr on the sys backend");
-            assert!(!before.is_null());
-
-            shared.grow(Pages(1)).expect("grow");
-
-            let after = shared.data_ptr().expect("data_ptr after grow");
-            match shared.style().expect("style on the sys backend") {
-                MemoryStyle::Static { bound, .. } if bound >= Pages(4) => {
-                    assert_eq!(before, after, "a fully reserved mapping must not move");
+                    let after = shared.data_ptr().expect("data_ptr after grow");
+                    match style {
+                        // A fully reserved mapping cannot move, which is the
+                        // invariant that makes caching the base sound.
+                        MemoryStyle::Static { bound, .. } if bound >= Pages(4) => {
+                            assert_eq!(before, after, "a reserved mapping must not move")
+                        }
+                        // A dynamic mapping may move; only require a readable base.
+                        _ => assert!(!after.is_null()),
+                    }
                 }
-                // A dynamic mapping is allowed to move; only assert we can still
-                // read a base.
-                _ => assert!(!after.is_null()),
+                (None, None) => {
+                    // Must degrade with an error rather than panicking.
+                    assert!(matches!(
+                        shared.grow(Pages(1)),
+                        Err(MemoryError::UnsupportedOperation { .. })
+                    ));
+                }
+                (data_ptr, style) => panic!(
+                    "data_ptr and style must agree on support: data_ptr={} style={}",
+                    data_ptr.is_some(),
+                    style.is_some()
+                ),
             }
-        }
-
-        #[test]
-        fn style_is_reported() {
-            let (_store, shared) = shared_memory();
-            assert!(shared.style().is_some());
         }
     }
 }

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use wasmer_types::{MemoryError, MemoryStyle, Pages};
+
 use crate::{
     AsStoreMut, Memory,
     error::AtomicsError,
@@ -73,6 +75,50 @@ impl SharedMemory {
         MemoryOps {
             ops: self.ops.clone(),
         }
+    }
+
+    /// Grows this memory by `delta` pages, returning the previous size.
+    ///
+    /// Unlike [`Memory::grow`] this needs no store, so an embedder holding a
+    /// clone of this handle can grow the memory from a thread that has no
+    /// access to one. Growth is shared: every clone of the handle addresses
+    /// the same allocation and observes the new size.
+    ///
+    /// Growing is serialized per memory and returns the size the memory had
+    /// beforehand, so concurrent callers each learn the range they claimed.
+    ///
+    /// Returns [`MemoryError::UnsupportedOperation`] on backends that cannot
+    /// grow a shared memory without a store (currently every backend except
+    /// `sys`).
+    pub fn grow(&self, delta: Pages) -> Result<Pages, MemoryError> {
+        self.memory.grow(delta)
+    }
+
+    /// The host address of guest offset 0, without a store.
+    ///
+    /// This is the same pointer [`MemoryView::data_ptr`] returns, for
+    /// embedders that need it on a thread with no store. Returns `None` on
+    /// backends that cannot report it store-free.
+    ///
+    /// The pointer is only stable across [`SharedMemory::grow`] if the host
+    /// mapping was reserved up front — see [`SharedMemory::style`]. For a
+    /// [`MemoryStyle::Dynamic`] memory, growth may move the mapping and
+    /// invalidate any previously returned pointer.
+    ///
+    /// [`MemoryView::data_ptr`]: crate::MemoryView::data_ptr
+    pub fn data_ptr(&self) -> Option<*mut u8> {
+        self.memory.data_ptr()
+    }
+
+    /// How this memory's host mapping is laid out, or `None` on backends that
+    /// do not model a style.
+    ///
+    /// A [`MemoryStyle::Static`] memory whose `bound` covers its maximum has
+    /// its whole range reserved up front, so growing it can never move the
+    /// mapping and [`SharedMemory::data_ptr`] stays valid for the memory's
+    /// lifetime.
+    pub fn style(&self) -> Option<MemoryStyle> {
+        self.memory.style()
     }
 
     #[inline]

--- a/lib/api/src/vm/impls.rs
+++ b/lib/api/src/vm/impls.rs
@@ -85,7 +85,7 @@ impl VMSharedMemory {
     /// Grows this memory by `delta` pages, returning the previous size.
     ///
     /// Only the `sys` backend can grow a shared memory without a store; the
-    /// others report [`MemoryError::UnsupportedOperation`].
+    /// others report [`crate::MemoryError::UnsupportedOperation`].
     pub(crate) fn grow(
         &self,
         delta: wasmer_types::Pages,

--- a/lib/api/src/vm/impls.rs
+++ b/lib/api/src/vm/impls.rs
@@ -82,6 +82,76 @@ impl VMSharedMemory {
         }
     }
 
+    /// Grows this memory by `delta` pages, returning the previous size.
+    ///
+    /// Only the `sys` backend can grow a shared memory without a store; the
+    /// others report [`MemoryError::UnsupportedOperation`].
+    pub(crate) fn grow(
+        &self,
+        delta: wasmer_types::Pages,
+    ) -> Result<wasmer_types::Pages, wasmer_types::MemoryError> {
+        match self {
+            #[cfg(feature = "sys")]
+            Self::Sys(s) => {
+                use wasmer_vm::LinearMemory;
+                // `LinearMemory::grow` wants `&mut self`, but a shared memory
+                // is an `Arc<RwLock<..>>` internally, so every clone addresses
+                // the same allocation and growing through one is growing them
+                // all. Taking a clone here is what lets the public API keep a
+                // `&self` receiver, which is the honest signature for a handle
+                // several threads may hold at once.
+                let mut memory = s.clone();
+                memory.grow(delta)
+            }
+            #[cfg(feature = "v8")]
+            Self::V8(_) => Err(wasmer_types::MemoryError::UnsupportedOperation {
+                message: "growing a shared memory without a store is not supported by the v8 \
+                          backend"
+                    .into(),
+            }),
+            #[cfg(feature = "js")]
+            Self::Js(_) => Err(wasmer_types::MemoryError::UnsupportedOperation {
+                message: "growing a shared memory without a store is not supported by the js \
+                          backend"
+                    .into(),
+            }),
+        }
+    }
+
+    /// The host address of guest offset 0, or `None` on backends that cannot
+    /// report it without a store.
+    pub(crate) fn data_ptr(&self) -> Option<*mut u8> {
+        match self {
+            #[cfg(feature = "sys")]
+            Self::Sys(s) => {
+                use wasmer_vm::LinearMemory;
+                // SAFETY: the definition pointer is valid for as long as the
+                // memory is, and this handle keeps it alive.
+                Some(unsafe { s.vmmemory().as_ref().base })
+            }
+            #[cfg(feature = "v8")]
+            Self::V8(_) => None,
+            #[cfg(feature = "js")]
+            Self::Js(_) => None,
+        }
+    }
+
+    /// How this memory's host mapping is laid out, or `None` on backends that
+    /// do not model a style.
+    pub(crate) fn style(&self) -> Option<wasmer_types::MemoryStyle> {
+        match self {
+            #[cfg(feature = "sys")]
+            Self::Sys(s) => {
+                use wasmer_vm::LinearMemory;
+                Some(s.style())
+            }
+            #[cfg(feature = "v8")]
+            Self::V8(_) => None,
+            #[cfg(feature = "js")]
+            Self::Js(_) => None,
+        }
+    }
+
     pub(crate) fn into_vm_memory(self, store: &mut impl AsStoreMut) -> VMMemory {
         match self {
             #[cfg(feature = "sys")]

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -1004,6 +1004,7 @@ impl WasiEnvBuilder {
             clock_offset: Default::default(),
             envs: std::sync::Mutex::new(conv_env_vars(self.envs)),
             signals: std::sync::Mutex::new(self.signals.iter().map(|s| (s.sig, s.disp)).collect()),
+            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
         };
 
         let runtime = self.runtime.unwrap_or_else(|| {

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -128,6 +128,7 @@ impl WasiEnvInit {
                 args: std::sync::Mutex::new(self.state.args.lock().unwrap().clone()),
                 envs: std::sync::Mutex::new(self.state.envs.lock().unwrap().deref().clone()),
                 signals: std::sync::Mutex::new(self.state.signals.lock().unwrap().deref().clone()),
+                signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
                 preopen: self.state.preopen.clone(),
             },
             runtime: self.runtime.clone(),
@@ -715,7 +716,16 @@ impl WasiEnv {
             .try_inner()
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
         let inner = env_inner.main_module_instance_handles();
-        if !inner.signal_set {
+        // Ask the process, not just this instance: a spawned thread has its own
+        // InstanceHandles and never sees the main instance's registration, so
+        // `inner.signal_set` alone would apply the default disposition on
+        // sibling threads and terminate a process that does handle the signal.
+        let handler_registered = inner.signal_set
+            || env
+                .state
+                .signal_handler_registered
+                .load(std::sync::atomic::Ordering::SeqCst);
+        if !handler_registered {
             let signals = env.thread.pop_signals();
             if !signals.is_empty() {
                 for sig in signals {

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -135,6 +135,15 @@ pub(crate) struct WasiState {
     pub args: Mutex<Vec<String>>,
     pub envs: Mutex<Vec<Vec<u8>>>,
     pub signals: Mutex<HashMap<Signal, Disposition>>,
+    /// Whether this *process* has registered a signal handler callback.
+    ///
+    /// `InstanceHandles::signal_set` only records whether the instance doing
+    /// the asking registered one, and every spawned thread gets its own
+    /// instance. Signals are delivered to all of a process's threads, so a
+    /// per-instance flag makes sibling threads believe the program handles no
+    /// signals and apply the runtime's default disposition -- terminating a
+    /// process that does in fact have a handler installed.
+    pub signal_handler_registered: std::sync::atomic::AtomicBool,
 
     // TODO: should not be here, since this requires active work to resolve.
     // State should only hold active runtime state that can be reproducibly re-created.
@@ -246,6 +255,8 @@ impl WasiState {
             args: Mutex::new(self.args.lock().unwrap().clone()),
             envs: Mutex::new(self.envs.lock().unwrap().clone()),
             signals: Mutex::new(self.signals.lock().unwrap().clone()),
+            // A forked process re-registers from its own instance.
+            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
             preopen: self.preopen.clone(),
         }
     }

--- a/lib/wasix/src/syscalls/wasix/callback_signal.rs
+++ b/lib/wasix/src/syscalls/wasix/callback_signal.rs
@@ -42,6 +42,13 @@ pub fn callback_signal<M: MemorySize>(
         inner.signal = funct;
         inner.signal_set = true;
     }
+    // Record it for the whole process: signals are delivered to every thread,
+    // and the sibling threads have their own instances that never see the
+    // registration above.
+    ctx.data()
+        .state
+        .signal_handler_registered
+        .store(true, std::sync::atomic::Ordering::SeqCst);
 
     WasiEnv::do_pending_operations(&mut ctx)?;
 

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -111,7 +111,10 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         match find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name) {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
-            FindExecutableResult::NotFound => return Ok(Errno::Noexec),
+            // Nothing by that name on PATH is ENOENT. ENOEXEC means the file
+            // was found but is not an executable format, which is what the
+            // spawn failure below reports. proc_exec4 already gets this right.
+            FindExecutableResult::NotFound => return Ok(Errno::Noent),
         }
     } else if name.starts_with("./") {
         *name = ctx.data().state.fs.relative_path_to_absolute(name.clone());


### PR DESCRIPTION
Replaces the whole `chore: bump napi` stack (#6819, #6820, #6821, #6822, #6823, #6825, #6829, #6844, #6845, #6850) with a single PR. Nine of those ten were pure `lib/napi` submodule bumps; the napi pin here is a descendant of every one of them, so this subsumes the lot. The tenth, #6822, is the only one that carried code, and it is reworked below.

## The problem with #6822

#6822 added `SharedMemory::vm_shared_memory() -> &VMSharedMemory` so wasmer-napi's `GuestHeap` could grow guest linear memory from host code running on V8's GC threads. That accessor was the wrong seam:

- **It returns a type callers cannot name.** `mod vm` in `lib/api/src/lib.rs` is private and re-exported nowhere, so `wasmer::vm::VMSharedMemory` has no public path. The consumer had to write one unbreakable expression, `shared.vm_shared_memory().unwrap_sys_ref().clone()`, because the intermediate can never be bound.
- **`unwrap_sys_ref()` panics** on a v8 or js memory — a "sys backend only" contract expressed nowhere in the type.
- **It broke `cargo doc` off the `sys` feature.** The doc comment linked `wasmer_vm::LinearMemory::grow`, but `wasmer-vm` is optional and the crate has `#![deny(rustdoc::broken_intra_doc_links)]`, so `cargo doc --no-default-features --features v8` failed. (Copilot flagged this on #6822; reproduced, and it was the only error in that build.) The mismatch was a symptom: the docs described the *sys* type while the signature returned the *backend enum*.
- **The motivation was already met.** `SharedMemory` is a clonable, `Send + Sync`, store-free handle — there's a test asserting it. The actual gap was that it had no store-free `grow`.

## This PR instead

Three store-free methods on `SharedMemory`, all keeping the VM types encapsulated:

| method | notes |
| --- | --- |
| `grow(&self, delta) -> Result<Pages, MemoryError>` | `&self`, not `&mut self`: a shared memory is an `Arc<RwLock<..>>` internally and any clone can already grow it, so `&mut` would be a distinction the type can't defend |
| `data_ptr(&self) -> Option<*mut u8>` | the same pointer `MemoryView::data_ptr` already returns publicly, minus the store |
| `style(&self) -> Option<MemoryStyle>` | `MemoryStyle` is already public API; lets a caller confirm the mapping is reserved up front before caching `data_ptr` |

`data_ptr` and `style` are needed together because growth is **not** always base-stable — `WasmMmap::grow` remaps a dynamic heap ("it's a dynamic heap and it can move"). A caller caching the base must confirm a `MemoryStyle::Static` bound covering the maximum and re-check the base after each grow. Both are now possible without reaching into the VM layer; previously the second required an unsafe deref of `VMMemoryDefinition`.

Only `sys` supports any of this store-free. v8 and js return `MemoryError::UnsupportedOperation` / `None` instead of panicking.

Also carries the `offset-allocator` / `nonmax` `Cargo.lock` entries that #6822 introduced for the GuestHeap allocator.

## Testing

- `cargo check -p wasmer --features sys` — green.
- `cargo check -p wasmer --no-default-features --features v8` — green.
- `cargo doc -p wasmer --no-default-features --features v8 --no-deps` — **green** (fails on #6822).
- `cargo test -p wasmer --features sys --lib` — the existing `ensure_shared_memory_handles_are_send_and_sync` test passes.
- `cargo test -p wasmer-napi --lib` — 38/38.
- End-to-end with a `napi-v8` CLI built from this branch: payload load test, 20 rounds / 3.91 GiB verified byte-for-byte, per-round retention flat.

Paired napi change: wasmerio/napi#54 (stacked on wasmerio/napi#53). The submodule here points at #54's head, so **#53 and #54 need to merge first**.