### PR TITLE
fix(security): add missing bounds check for static linear 

### DIFF
--- a/lib/compiler/src/engine/tunables.rs
+++ b/lib/compiler/src/engine/tunables.rs
@@ -2,7 +2,7 @@ use crate::engine::error::LinkError;
 use std::ptr::NonNull;
 use wasmer_types::{
     FunctionType, GlobalType, LocalGlobalIndex, LocalMemoryIndex, LocalTableIndex, MemoryIndex,
-    MemoryType, ModuleInfo, Pages, TableIndex, TableType, TagKind,
+    MemoryType, ModuleInfo, Pages, TableIndex, TableType, TagKind, WASM_MAX_PAGES,
     entity::PrimaryMap,
     target::{PointerWidth, Target},
 };
@@ -213,9 +213,12 @@ impl BaseTunables {
                 //   Allocating 4 GiB of address space let us avoid the
                 //   need for explicit bounds checks.
                 // Static Memory Guard size:
-                //   Allocating 2 GiB of address space lets us translate wasm
-                //   offsets into x86 offsets as aggressively as we can.
-                PointerWidth::U64 => (0x1_0000.into(), 0x8000_0000),
+                //   Allocating 4 GiB of address space lets us translate WASM
+                //   offsets into x86_64 offsets as aggressively as we can.
+                //
+                // Note that although `i32::MAX` is 2 GiB, negative base values for operations
+                // such as `i64.load` are zero-extended during expansion, making the full 4 GiB accessible.
+                PointerWidth::U64 => (WASM_MAX_PAGES.into(), 0x1_0000_0000),
             };
 
         // Allocate a small guard to optimize common cases but without

--- a/tests/wast/wasmer/memory-load-offset-overflow.wast
+++ b/tests/wast/wasmer/memory-load-offset-overflow.wast
@@ -1,0 +1,39 @@
+(module
+  (memory 1)
+
+  (func (export "load-at-4gib")
+    (local $base i32)
+    (local.set $base (i32.const -2147483648))
+    (drop (i64.load offset=2147483648 (local.get $base)))
+  )
+
+  (func (export "load-at-5gib")
+    (local $base i32)
+    (local.set $base (i32.const -1073741824))
+    (drop (i64.load offset=2147483648 (local.get $base)))
+  )
+
+  (func (export "load-at-6gib")
+    (local $base i32)
+    (local.set $base (i32.const -2147483647))
+    (drop (i64.load offset=4294967295 (local.get $base)))
+  )
+
+  (func (export "load-at-7gib")
+    (local $base i32)
+    (local.set $base (i32.const -1073741823))
+    (drop (i64.load offset=4294967295 (local.get $base)))
+  )
+
+  (func (export "load-at-8gib")
+    (local $base i32)
+    (local.set $base (i32.const -1))
+    (drop (i64.load offset=4294967295 (local.get $base)))
+  )
+)
+
+(assert_trap (invoke "load-at-4gib") "out of bounds memory access")
+(assert_trap (invoke "load-at-5gib") "out of bounds memory access")
+(assert_trap (invoke "load-at-6gib") "out of bounds memory access")
+(assert_trap (invoke "load-at-7gib") "out of bounds memory access")
+(assert_trap (invoke "load-at-8gib") "out of bounds memory access")


### PR DESCRIPTION
For `MemoryStyle::Static``, the compiler omits runtime bounds checks and relies on memory mappings to mark out-of-bounds addresses as `PROT_NONE`.

Previously, only a 2 GiB guard region was allocated. With zero-extended offsets, addresses in the `[6 GiB, 8 GiB)`` range could still be accessed.

Cherry-pick from: https://github.com/wasmerio/wasmer-internal/pull/5