### PR TITLE
fix(Singlepass): drop wrong constant folding for emit comparison on x86_64

### DIFF
--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -513,17 +513,7 @@ impl EmitterARM64 for Assembler {
         4 // relative jump, not full 32bits capable
     }
 
-    fn finalize_function(&mut self) {
-        dynasm!(
-            self
-            ; const_neg_one_32:
-            ; .i32 -1
-            ; const_zero_32:
-            ; .i32 0
-            ; const_pos_one_32:
-            ; .i32 1
-        );
-    }
+    fn finalize_function(&mut self) {}
 
     fn emit_str(&mut self, sz: Size, reg: Location, addr: Location) -> Result<(), CompileError> {
         match (sz, reg, addr) {

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -916,15 +916,6 @@ impl EmitterX64 for AssemblerX64 {
     }
 
     fn finalize_function(&mut self) -> Result<(), CompileError> {
-        dynasm!(
-            self
-            ; const_neg_one_32:
-            ; .i32 -1
-            ; const_zero_32:
-            ; .i32  0
-            ; const_pos_one_32:
-            ; .i32 1
-        );
         Ok(())
     }
 
@@ -1251,36 +1242,13 @@ impl EmitterX64 for AssemblerX64 {
         Ok(())
     }
 
-    /// Emit a CMP instruction that compares `left` against `right`.
-    ///
-    /// Note: callers sometimes pass operands in the opposite order compared
-    /// to other binary operators. This function performs the comparison as
-    /// provided (i.e. it emits `cmp left, right` semantics).
     fn emit_cmp(&mut self, sz: Size, left: Location, right: Location) -> Result<(), CompileError> {
-        // Constant elimination for comparison between consts.
-        //
-        // Only needed for `emit_cmp`, since other binary operators actually write to `right` and `right` must
-        // be a writable location for them.
-        let consts = match (left, right) {
-            (Location::Imm32(x), Location::Imm32(y)) => Some((x as i32 as i64, y as i32 as i64)),
-            (Location::Imm32(x), Location::Imm64(y)) => Some((x as i32 as i64, y as i64)),
-            (Location::Imm64(x), Location::Imm32(y)) => Some((x as i64, y as i32 as i64)),
-            (Location::Imm64(x), Location::Imm64(y)) => Some((x as i64, y as i64)),
-            _ => None,
-        };
-        use std::cmp::Ordering;
-        match consts {
-            Some((x, y)) => match x.cmp(&y) {
-                Ordering::Less => dynasm!(self ; cmp DWORD [>const_neg_one_32], 0),
-                Ordering::Equal => dynasm!(self ; cmp DWORD [>const_zero_32], 0),
-                Ordering::Greater => dynasm!(self ; cmp DWORD [>const_pos_one_32], 0),
-            },
-            None => binop_all_nofp!(cmp, self, sz, left, right, {
-                codegen_error!("singlepass can't emit CMP {:?} {:?} {:?}", sz, left, right);
-            }),
-        }
+        binop_all_nofp!(cmp, self, sz, left, right, {
+            codegen_error!("singlepass can't emit CMP {:?} {:?} {:?}", sz, left, right);
+        });
         Ok(())
     }
+
     fn emit_add(&mut self, sz: Size, src: Location, dst: Location) -> Result<(), CompileError> {
         // Fast path
         if let Location::Imm32(0) = src {

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -108,6 +108,9 @@ pub struct MachineX86_64 {
 /// NOTE: The register set must be disjoint from pick_gpr registers!
 pub(crate) const X86_64_RETURN_VALUE_REGISTERS: [GPR; 2] = [GPR::RAX, GPR::RDX];
 
+/// Implicit registers used for the div/rem instructions.
+const DIV_REM_REGISTERS: [GPR; 2] = [GPR::RAX, GPR::RDX];
+
 impl MachineX86_64 {
     pub fn new(target: Option<Target>) -> Result<Self, CompileError> {
         let assembler = AssemblerX64::new(0, target)?;
@@ -381,7 +384,7 @@ impl MachineX86_64 {
         loc: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        self.assembler.emit_cmp(sz, Location::Imm32(0), loc)?;
+        self.emit_relaxed_cmp(sz, Location::Imm32(0), loc)?;
         self.assembler
             .emit_jmp(Condition::Equal, integer_division_by_zero)?;
 
@@ -536,8 +539,7 @@ impl MachineX86_64 {
                 Location::GPR(tmp2),
             )?;
             // Trap if the end address of the requested area is above that of the linear memory.
-            self.assembler
-                .emit_cmp(Size::S64, Location::GPR(tmp2), Location::GPR(tmp_addr))?;
+            self.emit_relaxed_cmp(Size::S64, Location::GPR(tmp2), Location::GPR(tmp_addr))?;
 
             // `tmp_bound` is inclusive. So trap only if `tmp_addr > tmp_bound`.
             self.assembler.emit_jmp(Condition::Above, heap_access_oob)?;
@@ -680,8 +682,7 @@ impl MachineX86_64 {
         self.assembler
             .emit_vcmpless(reg, XMMOrMemory::XMM(tmp_x), tmp_x)?;
         self.move_location(Size::S32, Location::SIMD(tmp_x), Location::GPR(tmp))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
+        self.emit_relaxed_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
         self.assembler
             .emit_jmp(Condition::NotEqual, underflow_label)?;
 
@@ -691,8 +692,7 @@ impl MachineX86_64 {
         self.assembler
             .emit_vcmpgess(reg, XMMOrMemory::XMM(tmp_x), tmp_x)?;
         self.move_location(Size::S32, Location::SIMD(tmp_x), Location::GPR(tmp))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
+        self.emit_relaxed_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
         self.assembler
             .emit_jmp(Condition::NotEqual, overflow_label)?;
 
@@ -700,8 +700,7 @@ impl MachineX86_64 {
         self.assembler
             .emit_vcmpeqss(reg, XMMOrMemory::XMM(reg), tmp_x)?;
         self.move_location(Size::S32, Location::SIMD(tmp_x), Location::GPR(tmp))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
+        self.emit_relaxed_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
         self.assembler.emit_jmp(Condition::Equal, nan_label)?;
 
         self.assembler.emit_jmp(Condition::None, succeed_label)?;
@@ -829,8 +828,7 @@ impl MachineX86_64 {
         self.assembler
             .emit_vcmplesd(reg, XMMOrMemory::XMM(tmp_x), tmp_x)?;
         self.move_location(Size::S32, Location::SIMD(tmp_x), Location::GPR(tmp))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
+        self.emit_relaxed_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
         self.assembler
             .emit_jmp(Condition::NotEqual, underflow_label)?;
 
@@ -840,8 +838,7 @@ impl MachineX86_64 {
         self.assembler
             .emit_vcmpgesd(reg, XMMOrMemory::XMM(tmp_x), tmp_x)?;
         self.move_location(Size::S32, Location::SIMD(tmp_x), Location::GPR(tmp))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
+        self.emit_relaxed_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
         self.assembler
             .emit_jmp(Condition::NotEqual, overflow_label)?;
 
@@ -849,8 +846,7 @@ impl MachineX86_64 {
         self.assembler
             .emit_vcmpeqsd(reg, XMMOrMemory::XMM(reg), tmp_x)?;
         self.move_location(Size::S32, Location::SIMD(tmp_x), Location::GPR(tmp))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
+        self.emit_relaxed_cmp(Size::S32, Location::Imm32(0), Location::GPR(tmp))?;
         self.assembler.emit_jmp(Condition::Equal, nan_label)?;
 
         self.assembler.emit_jmp(Condition::None, succeed_label)?;
@@ -2679,7 +2675,7 @@ impl Machine for MachineX86_64 {
         source: Location,
         dest: Location,
     ) -> Result<(), CompileError> {
-        self.assembler.emit_cmp(size, source, dest)
+        self.emit_relaxed_cmp(size, source, dest)
     }
 
     fn jmp_unconditional(&mut self, label: Label) -> Result<(), CompileError> {
@@ -2694,7 +2690,7 @@ impl Machine for MachineX86_64 {
         loc_b: AbstractLocation<Self::GPR, Self::SIMD>,
         label: Label,
     ) -> Result<(), CompileError> {
-        self.assembler.emit_cmp(size, loc_b, loc_a)?;
+        self.emit_relaxed_cmp(size, loc_b, loc_a)?;
         let cond = match cond {
             UnsignedCondition::Equal => Condition::Equal,
             UnsignedCondition::NotEqual => Condition::NotEqual,
@@ -2832,7 +2828,9 @@ impl Machine for MachineX86_64 {
         ret: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         self.assembler
             .emit_mov(Size::S32, loc_a, Location::GPR(GPR::RAX))?;
         self.assembler
@@ -2845,6 +2843,9 @@ impl Machine for MachineX86_64 {
         )?;
         self.assembler
             .emit_mov(Size::S32, Location::GPR(GPR::RAX), ret)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -2856,7 +2857,9 @@ impl Machine for MachineX86_64 {
         integer_division_by_zero: Label,
         _integer_overflow: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         self.assembler
             .emit_mov(Size::S32, loc_a, Location::GPR(GPR::RAX))?;
         self.assembler.emit_cdq()?;
@@ -2868,6 +2871,9 @@ impl Machine for MachineX86_64 {
         )?;
         self.assembler
             .emit_mov(Size::S32, Location::GPR(GPR::RAX), ret)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -2878,7 +2884,9 @@ impl Machine for MachineX86_64 {
         ret: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         self.assembler
             .emit_mov(Size::S32, loc_a, Location::GPR(GPR::RAX))?;
         self.assembler
@@ -2891,6 +2899,9 @@ impl Machine for MachineX86_64 {
         )?;
         self.assembler
             .emit_mov(Size::S32, Location::GPR(GPR::RDX), ret)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -2901,7 +2912,9 @@ impl Machine for MachineX86_64 {
         ret: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         let normal_path = self.assembler.get_label();
         let end = self.assembler.get_label();
 
@@ -2926,6 +2939,9 @@ impl Machine for MachineX86_64 {
             .emit_mov(Size::S32, Location::GPR(GPR::RDX), ret)?;
 
         self.emit_label(end)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -4536,7 +4552,9 @@ impl Machine for MachineX86_64 {
         ret: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         self.assembler
             .emit_mov(Size::S64, loc_a, Location::GPR(GPR::RAX))?;
         self.assembler
@@ -4549,6 +4567,9 @@ impl Machine for MachineX86_64 {
         )?;
         self.assembler
             .emit_mov(Size::S64, Location::GPR(GPR::RAX), ret)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -4560,7 +4581,9 @@ impl Machine for MachineX86_64 {
         integer_division_by_zero: Label,
         _integer_overflow: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         self.assembler
             .emit_mov(Size::S64, loc_a, Location::GPR(GPR::RAX))?;
         self.assembler.emit_cqo()?;
@@ -4572,6 +4595,9 @@ impl Machine for MachineX86_64 {
         )?;
         self.assembler
             .emit_mov(Size::S64, Location::GPR(GPR::RAX), ret)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -4582,7 +4608,9 @@ impl Machine for MachineX86_64 {
         ret: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         self.assembler
             .emit_mov(Size::S64, loc_a, Location::GPR(GPR::RAX))?;
         self.assembler
@@ -4595,6 +4623,9 @@ impl Machine for MachineX86_64 {
         )?;
         self.assembler
             .emit_mov(Size::S64, Location::GPR(GPR::RDX), ret)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -4605,7 +4636,9 @@ impl Machine for MachineX86_64 {
         ret: Location,
         integer_division_by_zero: Label,
     ) -> Result<usize, CompileError> {
-        // We assume that RAX and RDX are temporary registers here.
+        for reg in DIV_REM_REGISTERS {
+            self.reserve_unused_temp_gpr(reg);
+        }
         let normal_path = self.assembler.get_label();
         let end = self.assembler.get_label();
 
@@ -4630,6 +4663,9 @@ impl Machine for MachineX86_64 {
             .emit_mov(Size::S64, Location::GPR(GPR::RDX), ret)?;
 
         self.emit_label(end)?;
+        for reg in DIV_REM_REGISTERS {
+            self.release_gpr(reg);
+        }
         Ok(offset)
     }
 
@@ -7228,8 +7264,7 @@ impl Machine for MachineX86_64 {
 
         self.move_location(Size::S64, Location::SIMD(src1), Location::GPR(tmpg1))?;
         self.move_location(Size::S64, Location::SIMD(src2), Location::GPR(tmpg2))?;
-        self.assembler
-            .emit_cmp(Size::S64, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
+        self.emit_relaxed_cmp(Size::S64, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
         self.assembler
             .emit_vminsd(src1, XMMOrMemory::XMM(src2), tmp_xmm1)?;
         let label1 = self.assembler.get_label();
@@ -7349,8 +7384,7 @@ impl Machine for MachineX86_64 {
 
         self.move_location(Size::S64, Location::SIMD(src1), Location::GPR(tmpg1))?;
         self.move_location(Size::S64, Location::SIMD(src2), Location::GPR(tmpg2))?;
-        self.assembler
-            .emit_cmp(Size::S64, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
+        self.emit_relaxed_cmp(Size::S64, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
         self.assembler
             .emit_vmaxsd(src1, XMMOrMemory::XMM(src2), tmp_xmm1)?;
         let label1 = self.assembler.get_label();
@@ -7632,8 +7666,7 @@ impl Machine for MachineX86_64 {
 
         self.move_location(Size::S32, Location::SIMD(src1), Location::GPR(tmpg1))?;
         self.move_location(Size::S32, Location::SIMD(src2), Location::GPR(tmpg2))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
+        self.emit_relaxed_cmp(Size::S32, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
         self.assembler
             .emit_vminss(src1, XMMOrMemory::XMM(src2), tmp_xmm1)?;
         let label1 = self.assembler.get_label();
@@ -7753,8 +7786,7 @@ impl Machine for MachineX86_64 {
 
         self.move_location(Size::S32, Location::SIMD(src1), Location::GPR(tmpg1))?;
         self.move_location(Size::S32, Location::SIMD(src2), Location::GPR(tmpg2))?;
-        self.assembler
-            .emit_cmp(Size::S32, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
+        self.emit_relaxed_cmp(Size::S32, Location::GPR(tmpg2), Location::GPR(tmpg1))?;
         self.assembler
             .emit_vmaxss(src1, XMMOrMemory::XMM(src2), tmp_xmm1)?;
         let label1 = self.assembler.get_label();

--- a/tests/wast/wasmer/br_table.wast
+++ b/tests/wast/wasmer/br_table.wast
@@ -1,0 +1,92 @@
+(module
+  ;; Entry 0 branches to the innermost label.
+  (func (export "index_0") (result i32)
+    (block $outer
+      (block $middle
+        (block $inner
+          i32.const 0
+          br_table $inner $middle $outer
+        )
+        i32.const 10
+        return
+      )
+      i32.const 20
+      return
+    )
+    i32.const 30
+  )
+
+  ;; Entry 1 branches to the middle label.
+  (func (export "index_1") (result i32)
+    (block $outer
+      (block $middle
+        (block $inner
+          i32.const 1
+          br_table $inner $middle $outer
+        )
+        i32.const 10
+        return
+      )
+      i32.const 20
+      return
+    )
+    i32.const 30
+  )
+
+  ;; Index 2 is just past the two table entries, so it uses the default.
+  (func (export "index_2") (result i32)
+    (block $outer
+      (block $middle
+        (block $inner
+          i32.const 2
+          br_table $inner $middle $outer
+        )
+        i32.const 10
+        return
+      )
+      i32.const 20
+      return
+    )
+    i32.const 30
+  )
+
+  ;; A larger positive index also uses the default.
+  (func (export "index_42") (result i32)
+    (block $outer
+      (block $middle
+        (block $inner
+          i32.const 42
+          br_table $inner $middle $outer
+        )
+        i32.const 10
+        return
+      )
+      i32.const 20
+      return
+    )
+    i32.const 30
+  )
+
+  ;; br_table treats the index as unsigned, so -1 uses the default.
+  (func (export "index_neg_1") (result i32)
+    (block $outer
+      (block $middle
+        (block $inner
+          i32.const -1
+          br_table $inner $middle $outer
+        )
+        i32.const 10
+        return
+      )
+      i32.const 20
+      return
+    )
+    i32.const 30
+  )
+)
+
+(assert_return (invoke "index_0") (i32.const 10))
+(assert_return (invoke "index_1") (i32.const 20))
+(assert_return (invoke "index_2") (i32.const 30))
+(assert_return (invoke "index_42") (i32.const 30))
+(assert_return (invoke "index_neg_1") (i32.const 30))


### PR DESCRIPTION
It's actually connected to wasmerio/wasmer#6334, where the current $cst0 CMP $cst1 simplification does not work correctly for all the cases (especially for unsigned integers -> right now we cast to i64).

Cherry-pick from: [https://github.com/wasmerio/wasmer-internal/pull/8](<https://github.com/wasmerio/wasmer-internal/pull/8>)