### PR TITLE
feat(vm): make the host interrupt signal configurable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -241,6 +241,23 @@ jobs:
         run: ${{ matrix.build-what.lint-cmd }}
       - name: Test V8 API
         run: ${{ matrix.build-what.build-cmd }}
+  test_store_context_miri:
+    name: Store context under Miri
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: miri
+      # These tests replay the store context's borrow flow without executing
+      # any Wasm, so Miri can check that a store re-acquired inside a nested
+      # call does not invalidate the borrow its caller is still holding. They
+      # pass trivially when run natively — Miri is the point.
+      - name: Borrow provenance of the store context
+        run: cargo miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs
     runs-on: ubuntu-22.04
@@ -796,6 +813,7 @@ jobs:
       - cargo_deny
       - test_nodejs
       - test_interpreter_api
+      - test_store_context_miri
       - test_build_docs_rs
       - build_linux_riscv64
       - build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -251,14 +251,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: miri
+          components: miri, rust-src
+      # Build Miri's sysroot as its own step: it needs `rust-src`, it takes a
+      # few minutes, and doing it here keeps a sysroot problem from being
+      # reported as a test failure. `+nightly` throughout, since
+      # rust-toolchain.toml pins a stable channel for this directory and that
+      # overrides the default the toolchain action sets.
+      - name: Prepare the Miri sysroot
+        run: cargo +nightly miri setup
       # These tests replay the store context's borrow flow without executing
       # any Wasm, so Miri can check that a store re-acquired inside a nested
       # call does not invalidate the borrow its caller is still holding. They
       # pass trivially when run natively — Miri is the point.
       - name: Borrow provenance of the store context
-        # `+nightly` explicitly: rust-toolchain.toml pins a stable channel
-        # for the directory, which has no miri component.
         run: cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -257,7 +257,9 @@ jobs:
       # call does not invalidate the borrow its caller is still holding. They
       # pass trivially when run natively — Miri is the point.
       - name: Borrow provenance of the store context
-        run: cargo miri test -p wasmer --features sys --lib borrow_provenance
+        # `+nightly` explicitly: rust-toolchain.toml pins a stable channel
+        # for the directory, which has no miri component.
+        run: cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,6 +7272,7 @@ dependencies = [
  "indexmap",
  "itertools 0.15.0",
  "js-sys",
+ "libc",
  "loupe",
  "macro-wasmer-engine-test",
  "more-asserts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,6 +3794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,6 +3892,16 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "offset-allocator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234d535da3521eb95106f40f0b73483d80bfb3aacf27c40d7e2b72f1a3e00a2"
+dependencies = [
+ "log",
+ "nonmax",
 ]
 
 [[package]]
@@ -7762,12 +7778,16 @@ dependencies = [
  "anyhow",
  "cc",
  "enum-iterator",
+ "js-sys",
+ "offset-allocator",
  "serde",
  "serde_json",
  "tar",
  "tokio",
  "ureq 2.12.1",
  "virtual-fs",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmer",
  "wasmer-c-api-imports",
  "wasmer-cache",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -77,6 +77,7 @@ macro-wasmer-engine-test = { version = "7.2.1", path = "./macro-wasmer-engine-te
 futures = "0.3"
 tokio = { workspace = true, features = ["full"] }
 crossbeam-channel.workspace = true
+libc = { workspace = true, default-features = true }
 
 # Dependencies and Develoment Dependencies for `js`.
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/lib/api/src/backend/sys/entities/function/mod.rs
+++ b/lib/api/src/backend/sys/entities/function/mod.rs
@@ -526,7 +526,7 @@ impl Function {
             // Safety: the store context is uninstalled before we return, and the
             // store mut is valid for the duration of the call.
             let store_install_guard =
-                unsafe { StoreContext::ensure_installed(store.as_store_mut().inner as *mut _) };
+                unsafe { StoreContext::install(store.as_store_mut().inner as *mut _) };
 
             let mut r;
             // TODO: This loop is needed for asyncify. It will be refactored with https://github.com/wasmerio/wasmer/issues/3451

--- a/lib/api/src/backend/sys/entities/function/typed.rs
+++ b/lib/api/src/backend/sys/entities/function/typed.rs
@@ -69,7 +69,7 @@ macro_rules! impl_native_traits {
 
                 // Install the store into the store context
                 let store_install_guard = unsafe {
-                    StoreContext::ensure_installed(store.as_store_mut().inner as *mut _)
+                    StoreContext::install(store.as_store_mut().inner as *mut _)
                 };
 
                 let mut r;
@@ -206,7 +206,7 @@ macro_rules! impl_native_traits {
 
                 // Install the store into the store context
                 let store_install_guard = unsafe {
-                    StoreContext::ensure_installed(store.as_store_mut().inner as *mut _)
+                    StoreContext::install(store.as_store_mut().inner as *mut _)
                 };
 
                 let mut r;

--- a/lib/api/src/backend/sys/entities/module.rs
+++ b/lib/api/src/backend/sys/entities/module.rs
@@ -209,7 +209,7 @@ impl Module {
                 }
             };
 
-            let store_install_guard = StoreContext::ensure_installed(store_ptr);
+            let store_install_guard = StoreContext::install(store_ptr);
 
             // After the instance handle is created, we need to initialize
             // the data, call the start function and so. However, if any

--- a/lib/api/src/backend/sys/entities/store/mod.rs
+++ b/lib/api/src/backend/sys/entities/store/mod.rs
@@ -105,13 +105,20 @@ impl crate::BackendStore {
 #[derive(Clone)]
 pub struct Interrupter {
     store_id: StoreId,
+    liveness: std::sync::Weak<()>,
 }
 
 #[cfg(all(unix, feature = "experimental-host-interrupt"))]
 impl Interrupter {
-    /// Builds a new interrupter.
-    pub fn new(store_id: StoreId) -> Self {
-        Self { store_id }
+    /// Builds a new interrupter. `liveness` comes from
+    /// [`StoreObjects::liveness_token`].
+    pub fn new(store_id: StoreId, liveness: std::sync::Weak<()>) -> Self {
+        Self { store_id, liveness }
+    }
+
+    /// Whether the store this interrupter targets still exists.
+    pub fn is_alive(&self) -> bool {
+        self.liveness.strong_count() > 0
     }
 
     /// Interrupts running WASM instances from the owning `Store`.

--- a/lib/api/src/entities/store/context.rs
+++ b/lib/api/src/entities/store/context.rs
@@ -305,6 +305,29 @@ impl StoreContext {
         })
     }
 
+    /// The active entry's store, if no frame on this thread's stack is holding
+    /// a borrow of it.
+    ///
+    /// A non-zero borrow count means some frame further up still holds a
+    /// `StoreMut` it can reach, so handing out a second one would alias it;
+    /// the caller gets `None` instead. A frame that has lent its borrow out
+    /// ([`StoreMut::parked`]) installed an entry of its own, whose count is
+    /// zero until somebody takes it — which is how an imported function lends
+    /// its store to code it calls into.
+    pub(crate) fn try_get_current_unborrowed() -> Option<StorePtrWrapper> {
+        STORE_CONTEXT_STACK.with(|cell| {
+            let mut stack = cell.borrow_mut();
+            let top = stack.last_mut()?;
+            if top.borrow_count != 0 {
+                return None;
+            }
+            top.borrow_count += 1;
+            Some(StorePtrWrapper {
+                store_ptr: unsafe { top.entry.get().as_mut().unwrap().as_ptr() },
+            })
+        })
+    }
+
     /// Safety: This method lets you borrow multiple mutable references
     /// to the currently active store context. The caller must ensure that:
     ///   * there is only one mutable reference alive, or
@@ -643,6 +666,36 @@ mod borrow_provenance {
         }
 
         // --- and goes on using the borrow it held throughout
+        let _ = shim.objects_mut().id();
+
+        drop(wrapper);
+        drop(install);
+    }
+
+    /// The lending path, which is the nesting above with the inner entry
+    /// installed by [`StoreMut::parked`] instead of by a nested call: the
+    /// borrow handed out by [`crate::Store::with_current`] must not invalidate
+    /// the one the lender is holding. Miri checks the last line.
+    #[test]
+    fn a_lend_keeps_the_lending_borrow_usable() {
+        let mut store = Store::default();
+        let id = store.id();
+
+        let mut caller = store.as_store_mut();
+        let install = unsafe { StoreContext::install(caller.as_store_mut().inner as *mut _) };
+
+        let mut wrapper = unsafe { StoreContext::get_current(id) };
+        let mut shim = wrapper.as_mut();
+        let _ = shim.objects_mut().id();
+
+        shim.parked(|| {
+            crate::Store::with_current(|lent| {
+                let _ = lent.objects_mut().id();
+            })
+            .expect("a parked store is lendable");
+        });
+
+        // The lender goes back to the borrow it held throughout.
         let _ = shim.objects_mut().id();
 
         drop(wrapper);

--- a/lib/api/src/entities/store/context.rs
+++ b/lib/api/src/entities/store/context.rs
@@ -519,7 +519,7 @@ impl Drop for StoreInstallGuard {
                 (None, false) => panic!("Store context stack underflow"),
                 (None, true) => {
                     // Nothing to do if we're panicking; panics can put the context
-                    // in an invalid state, and we don't to cause another panic here.
+                    // in an invalid state, and we don't want to cause another panic here.
                 }
             }
         })
@@ -549,7 +549,7 @@ impl Drop for ForcedStoreInstallGuard {
                 (None, false) => panic!("Store context stack underflow"),
                 (None, true) => {
                     // Nothing to do if we're panicking; panics can put the context
-                    // in an invalid state, and we don't to cause another panic here.
+                    // in an invalid state, and we don't want to cause another panic here.
                 }
             }
         })

--- a/lib/api/src/entities/store/context.rs
+++ b/lib/api/src/entities/store/context.rs
@@ -114,9 +114,10 @@ pub(crate) struct ForcedStoreInstallGuard {
     store_id: StoreId,
 }
 
-pub(crate) enum StoreInstallGuard {
-    Installed(StoreId),
-    NotInstalled,
+pub(crate) struct StoreInstallGuard {
+    /// `None` when this guard installed nothing, which happens only for a
+    /// store an async context already holds — see [`StoreContext::install`].
+    store_id: Option<StoreId>,
 }
 
 thread_local! {
@@ -139,7 +140,7 @@ impl StoreContext {
             })
     }
 
-    fn install(id: StoreId, entry: StoreContextEntry) {
+    fn push(id: StoreId, entry: StoreContextEntry) {
         STORE_CONTEXT_STACK.with(|cell| {
             let mut stack = cell.borrow_mut();
             stack.push(Self {
@@ -151,7 +152,7 @@ impl StoreContext {
     }
 
     #[cfg(feature = "unsafe-cothread")]
-    fn install_cothread(id: StoreId, store_ptr: NonNull<StoreInner>) {
+    fn push_cothread(id: StoreId, store_ptr: NonNull<StoreInner>) {
         STORE_CONTEXT_STACK.with(|cell| {
             let mut stack = cell.borrow_mut();
             stack.push(Self {
@@ -194,27 +195,75 @@ impl StoreContext {
         guard: LocalRwLockWriteGuard<Box<StoreInner>>,
     ) -> ForcedStoreInstallGuard {
         let store_id = guard.objects.id();
-        Self::install(store_id, StoreContextEntry::Async(guard));
+        Self::push(store_id, StoreContextEntry::Async(guard));
         ForcedStoreInstallGuard { store_id }
     }
 
-    /// Install the store context as sync if it is not already installed.
+    /// Whether the active entry is `id`'s, held by an async context.
+    fn active_is_async(id: StoreId) -> bool {
+        STORE_CONTEXT_STACK.with(|cell| {
+            let stack = cell.borrow();
+            let Some(top) = stack.last() else {
+                return false;
+            };
+            if top.id != id {
+                return false;
+            }
+            match unsafe { top.entry.get().as_ref().unwrap() } {
+                StoreContextEntry::Sync(_) => false,
+                #[cfg(feature = "experimental-async")]
+                StoreContextEntry::Async(_) => true,
+            }
+        })
+    }
+
+    /// Install `store_ptr` as this thread's executing store until the returned
+    /// guard is dropped.
+    ///
+    /// A store already executing here gets a *second* entry rather than
+    /// re-using its first: the entries differ in which borrow their pointer was
+    /// derived from, and that difference is load-bearing. Every re-acquisition
+    /// ([`Self::get_current`] and friends) reborrows the top entry's pointer,
+    /// so re-using an outer entry would make the inner borrow a *sibling* of
+    /// the one the caller is still holding — creating it invalidates the
+    /// caller's, and the caller's next use of its own store is undefined
+    /// behaviour. Installing the pointer the caller just derived from its live
+    /// borrow makes the inner borrow a child of it instead, which is what lets
+    /// the caller carry on once the nested call returns. See the
+    /// `borrow_provenance` tests, which fail under Miri if this re-uses the
+    /// outer entry.
+    ///
+    /// An async context is the exception, and installs nothing: it owns the
+    /// store through a write guard held in the entry itself, and every
+    /// re-acquisition re-derives from that guard rather than from a caller's
+    /// borrow (see `AsyncCallStoreMut`), so there is no borrow to nest under.
+    /// Shadowing it would also hide the guard from async host functions, which
+    /// reach it by inspecting the active entry.
     ///
     /// # Safety
-    /// The pointer must be dereferenceable and remain valid until the
-    /// store context is uninstalled.
-    pub(crate) unsafe fn ensure_installed(store_ptr: *mut StoreInner) -> StoreInstallGuard {
+    /// `store_ptr` must be derived from a mutable borrow of the store that
+    /// stays alive, and unreachable to every frame on this thread, until the
+    /// guard is dropped.
+    pub(crate) unsafe fn install(store_ptr: *mut StoreInner) -> StoreInstallGuard {
         let store_id = unsafe { store_ptr.as_ref().unwrap().objects.id() };
-        if Self::is_active(store_id) {
-            let current_ptr = STORE_CONTEXT_STACK.with(|cell| {
-                let stack = cell.borrow();
-                unsafe { stack.last().unwrap().entry.get().as_ref().unwrap().as_ptr() }
-            });
-            assert_eq!(store_ptr, current_ptr, "Store context pointer mismatch");
-            StoreInstallGuard::NotInstalled
-        } else {
-            Self::install(store_id, StoreContextEntry::Sync(store_ptr));
-            StoreInstallGuard::Installed(store_id)
+        // Nesting changes a pointer's provenance, never which store it
+        // addresses, so the same store must arrive at the same address.
+        debug_assert!(
+            !Self::is_active(store_id)
+                || STORE_CONTEXT_STACK.with(|cell| {
+                    let stack = cell.borrow();
+                    let active =
+                        unsafe { stack.last().unwrap().entry.get().as_ref().unwrap().as_ptr() };
+                    active == store_ptr
+                }),
+            "Store context pointer mismatch"
+        );
+        if Self::active_is_async(store_id) {
+            return StoreInstallGuard { store_id: None };
+        }
+        Self::push(store_id, StoreContextEntry::Sync(store_ptr));
+        StoreInstallGuard {
+            store_id: Some(store_id),
         }
     }
 
@@ -358,7 +407,7 @@ impl<'a> CoroutineStoreGuard<'a> {
             !StoreContext::is_active(store_id) && !StoreContext::is_suspended(store_id),
             "store is already on the current thread's context stack (active or suspended)"
         );
-        StoreContext::install_cothread(store_id, NonNull::from(store));
+        StoreContext::push_cothread(store_id, NonNull::from(store));
         Self {
             store_id,
             _store: std::marker::PhantomData,
@@ -446,33 +495,34 @@ impl Drop for StoreAsyncGuardWrapper {
 
 impl Drop for StoreInstallGuard {
     fn drop(&mut self) {
-        if let Self::Installed(store_id) = self {
-            STORE_CONTEXT_STACK.with(|cell| {
-                let mut stack = cell.borrow_mut();
-                match (stack.pop(), std::thread::panicking()) {
-                    (Some(top), false) => {
-                        assert_eq!(top.id, *store_id, "Mismatched store context uninstall");
-                        assert_eq!(
-                            top.borrow_count, 0,
-                            "Cannot uninstall store context while it is still borrowed"
-                        );
-                    }
-                    (Some(top), true) => {
-                        // If we're panicking and there's a store ID mismatch, just
-                        // put the store back in the hope that its own install guard
-                        // take care of uninstalling it later.
-                        if top.id != *store_id {
-                            stack.push(top);
-                        }
-                    }
-                    (None, false) => panic!("Store context stack underflow"),
-                    (None, true) => {
-                        // Nothing to do if we're panicking; panics can put the context
-                        // in an invalid state, and we don't to cause another panic here.
+        let Some(store_id) = self.store_id else {
+            return;
+        };
+        STORE_CONTEXT_STACK.with(|cell| {
+            let mut stack = cell.borrow_mut();
+            match (stack.pop(), std::thread::panicking()) {
+                (Some(top), false) => {
+                    assert_eq!(top.id, store_id, "Mismatched store context uninstall");
+                    assert_eq!(
+                        top.borrow_count, 0,
+                        "Cannot uninstall store context while it is still borrowed"
+                    );
+                }
+                (Some(top), true) => {
+                    // If we're panicking and there's a store ID mismatch, just
+                    // put the store back in the hope that its own install guard
+                    // take care of uninstalling it later.
+                    if top.id != store_id {
+                        stack.push(top);
                     }
                 }
-            })
-        }
+                (None, false) => panic!("Store context stack underflow"),
+                (None, true) => {
+                    // Nothing to do if we're panicking; panics can put the context
+                    // in an invalid state, and we don't to cause another panic here.
+                }
+            }
+        })
     }
 }
 
@@ -526,5 +576,76 @@ impl Drop for StorePtrPauseGuard {
                 top.borrow_count += 1;
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod borrow_provenance {
+    use super::*;
+    use crate::{AsStoreMut, Store};
+
+    /// Replays a recursive guest call at the level of the store context, which
+    /// is the part of it that has nothing to do with executing Wasm:
+    ///
+    /// ```text
+    /// Function::call(&mut store)          install(ptr from the caller's borrow)
+    ///   wasm -> import                    get_current            -> the shim's borrow
+    ///     shim: Function::call(&mut env)  install(ptr from *that* borrow)
+    ///       wasm -> import                get_current            -> the inner borrow
+    ///     shim carries on using its own borrow
+    /// ```
+    ///
+    /// Natively this always passes; it earns its keep under Miri, which is
+    /// where the last step is checked. If [`StoreContext::install`] ever goes
+    /// back to re-using an entry that is already active, the inner borrow
+    /// becomes a sibling of the shim's rather than a child of it, and this test
+    /// reports the shim's own store as invalidated:
+    ///
+    /// ```text
+    /// error: Undefined Behavior: trying to retag from <..> for Unique
+    ///        permission, but that tag does not exist in the borrow stack
+    ///   --> lib/api/src/entities/store/store_ref.rs   &mut self.inner.objects
+    /// ```
+    ///
+    /// Run it with:
+    ///
+    /// ```text
+    /// cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
+    /// ```
+    #[test]
+    fn nested_call_keeps_the_outer_borrow_usable() {
+        let mut store = Store::default();
+        let id = store.id();
+
+        // --- the embedder's Function::call(&mut store)
+        let mut caller = store.as_store_mut();
+        let install = unsafe { StoreContext::install(caller.as_store_mut().inner as *mut _) };
+
+        // --- the import trampoline, handing the shim its store
+        let mut wrapper = unsafe { StoreContext::get_current(id) };
+        let mut shim = wrapper.as_mut();
+        let _ = shim.objects_mut().id();
+
+        {
+            // --- the shim calls back into the guest
+            let inner_install =
+                unsafe { StoreContext::install(shim.as_store_mut().inner as *mut _) };
+            let pause = unsafe { StoreContext::pause(id) };
+
+            // --- the inner import trampoline
+            let mut inner_wrapper = unsafe { StoreContext::get_current(id) };
+            let mut inner_shim = inner_wrapper.as_mut();
+            let _ = inner_shim.objects_mut().id();
+            drop(inner_wrapper);
+
+            drop(pause);
+            drop(inner_install);
+        }
+
+        // --- and goes on using the borrow it held throughout
+        let _ = shim.objects_mut().id();
+
+        drop(wrapper);
+        drop(install);
     }
 }

--- a/lib/api/src/entities/store/mod.rs
+++ b/lib/api/src/entities/store/mod.rs
@@ -190,6 +190,11 @@ impl Store {
     /// to interrupt running imported functions. Embedders are expected to
     /// implement support for interruption of long-running or blocking
     /// imported functions separately.
+    ///
+    /// Interrupts are delivered through a process-wide signal, `SIGUSR1` by
+    /// default. Embedders that use that signal themselves can switch Wasmer
+    /// over to `SIGUSR2` with [`set_interrupt_signal`], before building the
+    /// first store.
     #[cfg(all(unix, feature = "experimental-host-interrupt"))]
     pub fn interrupter(&self) -> Interrupter {
         self.inner.objects.interrupter()

--- a/lib/api/src/entities/store/mod.rs
+++ b/lib/api/src/entities/store/mod.rs
@@ -121,6 +121,38 @@ impl Store {
         self.inner.objects.id()
     }
 
+    /// Runs `f` with the store this thread is currently executing, if that
+    /// store has been lent out with [`StoreMut::parked`].
+    ///
+    /// Host code called from Wasm normally receives the store as a
+    /// [`FunctionEnvMut`](crate::FunctionEnvMut), but code the host in turn
+    /// calls into cannot always be handed one: an embedded engine invoking a
+    /// callback, a C library's allocator hook, anything reached through frames
+    /// that carry no Rust references. This is how such code gets the store the
+    /// current call is running under, so it can use the ordinary store-taking
+    /// APIs — [`Memory::grow`](crate::Memory::grow) and friends — instead of
+    /// reaching around them.
+    ///
+    /// Returns `None` unless a store is executing on this thread *and* every
+    /// borrow of it on this thread's stack has been parked. Holding a
+    /// [`StoreMut`] and calling this would alias that borrow, so the answer
+    /// there is `None` rather than a second handle to the same store; parking
+    /// is what makes the outstanding borrow provably unreachable.
+    ///
+    /// A store starts executing when a call enters it, which only the `sys`
+    /// backend tracks — so on the others this is `None` inside a host function.
+    /// [`StoreMut::parked`] works everywhere, though, so an embedder can always
+    /// lend a store it owns, whether or not a call is running.
+    ///
+    /// Nothing guarantees the store is the one the caller expects — a thread
+    /// may run several — so check any handle before using it, with
+    /// [`Memory::is_from_store`](crate::Memory::is_from_store) or by comparing
+    /// [`StoreObjects::id`]. Using a handle from another store panics.
+    pub fn with_current<R>(f: impl FnOnce(&mut StoreMut<'_>) -> R) -> Option<R> {
+        let mut store = StoreContext::try_get_current_unborrowed()?;
+        Some(f(&mut store.as_mut()))
+    }
+
     /// Installs this store's context for the duration of a coroutine resume.
     /// The guard removes the context when dropped; hold it for exactly the
     /// duration of the resume() call.

--- a/lib/api/src/entities/store/obj.rs
+++ b/lib/api/src/entities/store/obj.rs
@@ -83,12 +83,18 @@ impl StoreObjects {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(s) => Interrupter(InterrupterInner::Sys(
-                crate::backend::sys::store::Interrupter::new(s.id()),
+                crate::backend::sys::store::Interrupter::new(s.id(), s.liveness_token()),
             )),
             _ => panic!("Interrupters can only be built for stores from the sys backend"),
         }
     }
 }
+
+#[cfg(all(unix, feature = "experimental-host-interrupt"))]
+pub use wasmer_vm::interrupt_registry::{
+    DEFAULT_INTERRUPT_SIGNAL, InterruptSignal, SetInterruptSignalError, interrupt_signal,
+    set_interrupt_signal,
+};
 
 /// Allows embedders to interrupt a running WASM instance.
 #[cfg(all(unix, feature = "experimental-host-interrupt"))]
@@ -100,6 +106,16 @@ impl Interrupter {
     /// Interrupts running WASM instances from the owning [`Store`](crate::Store).
     pub fn interrupt(&self) {
         self.0.interrupt()
+    }
+
+    /// Whether the [`Store`](crate::Store) this interrupter was built for still
+    /// exists.
+    ///
+    /// Interrupting a dropped store is harmless but pointless, so an embedder
+    /// holding interrupters for many short-lived stores can use this to drop
+    /// the ones that can never fire again.
+    pub fn is_alive(&self) -> bool {
+        self.0.is_alive()
     }
 }
 
@@ -119,6 +135,14 @@ impl InterrupterInner {
         match self {
             #[cfg(feature = "sys")]
             Self::Sys(i) => i.interrupt(),
+        }
+    }
+
+    /// Whether the owning [`Store`](crate::Store) still exists.
+    pub fn is_alive(&self) -> bool {
+        match self {
+            #[cfg(feature = "sys")]
+            Self::Sys(i) => i.is_alive(),
         }
     }
 }

--- a/lib/api/src/entities/store/store_ref.rs
+++ b/lib/api/src/entities/store/store_ref.rs
@@ -75,6 +75,53 @@ impl StoreMut<'_> {
         (self.inner.store.engine(), &mut self.inner.objects)
     }
 
+    /// Parks this borrow of the store for the duration of `f`, lending the
+    /// store to code that runs inside `f` without reaching it through Rust:
+    /// [`Store::with_current`](crate::Store::with_current) hands the store back to any frame `f` reaches,
+    /// however many foreign frames deep.
+    ///
+    /// This is how host code lends the store across an FFI boundary. An
+    /// embedded engine that calls back into the host — a JS engine's allocator
+    /// hook, say — cannot be handed a Rust reference through its own C frames,
+    /// and cannot be given one out of band either, because the imported
+    /// function it was called from is still holding the only borrow. Parking
+    /// that borrow, which the `&mut self` receiver here makes unreachable for
+    /// exactly as long as `f` runs, is what makes lending it sound rather than
+    /// aliasing.
+    ///
+    /// Parks nest, and a store nobody parked stays unlendable:
+    /// [`Store::with_current`](crate::Store::with_current) returns `None`
+    /// unless every borrow on this thread's stack has been parked this way.
+    ///
+    /// ```
+    /// use wasmer::{AsStoreMut, FunctionEnvMut, Store};
+    ///
+    /// // A host function lending its store to code it calls into.
+    /// fn host_call(mut env: FunctionEnvMut<'_, ()>) {
+    ///     // `env` holds the store, so nobody else may have it.
+    ///     assert!(Store::with_current(|_| ()).is_none());
+    ///
+    ///     env.as_store_mut().parked(|| {
+    ///         // ...but code reached from here can pick it back up.
+    ///         assert!(Store::with_current(|_| ()).is_some());
+    ///     });
+    /// }
+    /// ```
+    pub fn parked<R>(&mut self, f: impl FnOnce() -> R) -> R {
+        // This is the same thing `Function::call` does before entering Wasm:
+        // install this borrow as the store executing on the thread, so that
+        // code which reaches the store through the context — rather than
+        // through a reference it was handed — picks up a borrow derived from
+        // *this* one. The new entry starts unborrowed, which is what makes the
+        // store lendable for as long as it is on top.
+        let ptr: *mut StoreInner = &mut *self.inner;
+        // SAFETY: `ptr` comes from `&mut *self.inner`, which `&mut self` keeps
+        // alive and unreachable for every frame on this thread until `f`
+        // returns and the guard is dropped.
+        let _guard = unsafe { super::StoreContext::install(ptr) };
+        f()
+    }
+
     // TODO: OnCalledAction is needed for asyncify. It will be refactored with https://github.com/wasmerio/wasmer/issues/3451
     /// Sets the unwind callback which will be invoked when the call finishes
     pub fn on_called<F>(&mut self, callback: F)

--- a/lib/api/tests/current_store.rs
+++ b/lib/api/tests/current_store.rs
@@ -1,0 +1,248 @@
+//! Lending the executing store to code that cannot be handed a reference to
+//! it: [`StoreMut::parked`] + [`Store::with_current`].
+
+use macro_wasmer_engine_test::engine_test;
+#[cfg(feature = "js")]
+use wasm_bindgen_test::wasm_bindgen_test;
+
+use wasmer::*;
+
+/// Stands in for the foreign code an embedder calls into — a JS engine's
+/// allocator hook, a C callback — which reaches the host again with no store
+/// of its own and no way to have been handed one.
+fn called_through_foreign_frames<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
+
+/// A memory the host can grow, shared where the backend allows it (the case
+/// the API exists for) and plain where it does not.
+fn growable_memory(store: &mut Store) -> Memory {
+    let shared = MemoryType::new(Pages(1), Some(Pages(4)), true);
+    let owned = MemoryType::new(Pages(1), Some(Pages(4)), false);
+    Memory::new(&mut *store, shared)
+        .or_else(|_| Memory::new(&mut *store, owned))
+        .expect("create memory")
+}
+
+/// Calls `"run"` on a module whose only body is a call to the `"host"."run"`
+/// import, so `host` runs with a store the runtime installed for the call.
+fn run_host_function(store: &mut Store, host: Function) -> Result<(), String> {
+    let wat = r#"(module
+        (func $host (import "host" "run"))
+        (func (export "run") (call $host))
+    )"#;
+    let module = Module::new(&*store, wat).map_err(|e| format!("{e:?}"))?;
+    let imports = imports! { "host" => { "run" => host } };
+    let instance = Instance::new(&mut *store, &module, &imports).map_err(|e| format!("{e:?}"))?;
+    instance
+        .exports
+        .get_typed_function::<(), ()>(&*store, "run")
+        .map_err(|e| format!("{e:?}"))?
+        .call(&mut *store)
+        .map_err(|e| format!("{e:?}"))
+}
+
+#[derive(Default)]
+struct Report {
+    /// Whether the store was lent out before anyone parked it.
+    lent_unparked: bool,
+    /// Whether it was lent out from inside the park.
+    lent_parked: bool,
+    /// Whether it was lent out again once the park ended.
+    lent_after_park: bool,
+    /// Whether the store lent out is the one the host function is running
+    /// under, rather than some other store on this thread.
+    same_store: bool,
+    /// Size the memory reported before the lent store grew it.
+    size_before_grow: Option<Pages>,
+}
+
+struct HostEnv {
+    memory: Memory,
+    report: Report,
+}
+
+#[engine_test]
+fn store_is_lent_out_only_while_parked() -> Result<(), String> {
+    let mut store = Store::default();
+    let memory = growable_memory(&mut store);
+    let env = FunctionEnv::new(
+        &mut store,
+        HostEnv {
+            memory: memory.clone(),
+            report: Report::default(),
+        },
+    );
+
+    let host =
+        Function::new_typed_with_env(&mut store, &env, |mut env: FunctionEnvMut<HostEnv>| {
+            let memory = env.data().memory.clone();
+            let store_id = env.objects_mut().id();
+
+            // The host function is holding the store, so nobody else may have it.
+            let lent_unparked =
+                called_through_foreign_frames(|| Store::with_current(|_| ()).is_some());
+
+            let mut same_store = false;
+            let size_before_grow = Some(memory.view(&env).size());
+            let lent_parked = env
+                .as_store_mut()
+                .parked(|| {
+                    called_through_foreign_frames(|| {
+                        Store::with_current(|store| {
+                            same_store = store.objects_mut().id() == store_id
+                                && memory.is_from_store(&*store);
+                            // The whole point: reach the store's ordinary API from
+                            // code that was never given a store.
+                            memory.grow(store, Pages(1)).expect("grow the lent memory");
+                        })
+                    })
+                })
+                .is_some();
+
+            // The park is over; the store belongs to this function again.
+            let lent_after_park =
+                called_through_foreign_frames(|| Store::with_current(|_| ()).is_some());
+
+            env.data_mut().report = Report {
+                lent_unparked,
+                lent_parked,
+                lent_after_park,
+                same_store,
+                size_before_grow,
+            };
+        });
+
+    run_host_function(&mut store, host)?;
+
+    let report = &env.as_ref(&store).report;
+    assert!(
+        !report.lent_unparked,
+        "a store still held by the host function must not be lent out"
+    );
+
+    if !report.lent_parked {
+        // Backends that do not track an executing store (v8, js) lend nothing.
+        // What matters is that they say so instead of panicking or handing
+        // back some other store, which the assertions above already cover.
+        return Ok(());
+    }
+
+    assert!(
+        report.same_store,
+        "the store lent out must be the one the call is running under"
+    );
+    assert!(
+        !report.lent_after_park,
+        "the lend must end with the park, not outlive it"
+    );
+    assert_eq!(
+        Some(memory.view(&store).size()),
+        report.size_before_grow.map(|before| before + Pages(1)),
+        "a grow through the lent store must be visible to its owner"
+    );
+
+    Ok(())
+}
+
+#[engine_test]
+fn parks_nest() -> Result<(), String> {
+    let mut store = Store::default();
+    let env = FunctionEnv::new(&mut store, Vec::<bool>::new());
+
+    let host =
+        Function::new_typed_with_env(&mut store, &env, |mut env: FunctionEnvMut<Vec<bool>>| {
+            let mut lends = Vec::new();
+            env.as_store_mut().parked(|| {
+                Store::with_current(|lent| {
+                    // The lent borrow is itself a borrow: until it is parked in
+                    // turn, it is the one thing standing in the way of a
+                    // further lend.
+                    lends.push(Store::with_current(|_| ()).is_some());
+                    lent.parked(|| lends.push(Store::with_current(|_| ()).is_some()));
+                    // ...and unparking it puts it back in the way.
+                    lends.push(Store::with_current(|_| ()).is_some());
+                });
+            });
+            *env.data_mut() = lends;
+        });
+
+    run_host_function(&mut store, host)?;
+
+    let lends = env.as_ref(&store);
+    if lends.is_empty() {
+        // Backend does not track an executing store; nothing was lent at all.
+        return Ok(());
+    }
+    assert_eq!(
+        lends.as_slice(),
+        [false, true, false],
+        "a lent store is lendable again only while it is itself parked"
+    );
+
+    Ok(())
+}
+
+/// A park that ends by unwinding must hand the borrow back, or the host
+/// function that caught the panic would keep using a store that has been
+/// declared lendable.
+#[engine_test]
+fn a_park_that_unwinds_gives_the_borrow_back() -> Result<(), String> {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let mut store = Store::default();
+    let env = FunctionEnv::new(&mut store, None::<bool>);
+
+    let host =
+        Function::new_typed_with_env(&mut store, &env, |mut env: FunctionEnvMut<Option<bool>>| {
+            // The panic below is the point of the test, not a failure; keep it
+            // from printing a scary backtrace in the middle of a passing run.
+            let hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(|_| {}));
+            let unwound = catch_unwind(AssertUnwindSafe(|| {
+                env.as_store_mut().parked(|| panic!("boom"))
+            }))
+            .is_err();
+            std::panic::set_hook(hook);
+            assert!(unwound, "the park must not swallow the panic");
+
+            // `env` still holds the store, exactly as it did before the park.
+            *env.data_mut() = Some(Store::with_current(|_| ()).is_some());
+        });
+
+    run_host_function(&mut store, host)?;
+
+    assert_eq!(
+        *env.as_ref(&store),
+        Some(false),
+        "a store whose park unwound must not stay lendable"
+    );
+
+    Ok(())
+}
+
+/// An idle store — one no call is executing — is nobody's to take until its
+/// owner parks it. Parking is what an embedder does to lend a store to a
+/// callback that runs outside any call at all.
+#[engine_test]
+fn an_idle_store_is_lent_only_once_parked() -> Result<(), String> {
+    let mut store = Store::default();
+    let store_id = store.id();
+
+    assert!(
+        Store::with_current(|_| ()).is_none(),
+        "an idle store is not lendable on its own"
+    );
+
+    let lent = store
+        .as_store_mut()
+        .parked(|| Store::with_current(|store| store.objects_mut().id()));
+    assert_eq!(lent, Some(store_id), "parking lends the store it parked");
+
+    assert!(
+        Store::with_current(|_| ()).is_none(),
+        "and the lend ends with the park"
+    );
+
+    Ok(())
+}

--- a/lib/api/tests/current_store.rs
+++ b/lib/api/tests/current_store.rs
@@ -186,6 +186,10 @@ fn parks_nest() -> Result<(), String> {
 /// A park that ends by unwinding must hand the borrow back, or the host
 /// function that caught the panic would keep using a store that has been
 /// declared lendable.
+///
+/// Native only: panics abort on `wasm32-unknown-unknown`, so there is no
+/// unwinding there to observe.
+#[cfg(not(target_arch = "wasm32"))]
 #[engine_test]
 fn a_park_that_unwinds_gives_the_borrow_back() -> Result<(), String> {
     use std::panic::{AssertUnwindSafe, catch_unwind};

--- a/lib/api/tests/interrupt.rs
+++ b/lib/api/tests/interrupt.rs
@@ -151,6 +151,23 @@ fn correct_store_is_interrupted_only() -> Result<()> {
 }
 
 #[test]
+fn interrupters_report_whether_their_store_is_alive() {
+    let store = Store::default();
+    let interrupter = store.interrupter();
+    assert!(interrupter.is_alive());
+
+    drop(store);
+    assert!(
+        !interrupter.is_alive(),
+        "an interrupter should not claim a dropped store is alive"
+    );
+
+    // Still harmless to use: embedders holding a pile of interrupters
+    // shouldn't have to check first.
+    interrupter.interrupt();
+}
+
+#[test]
 fn interrupted_store_cant_be_entered_again() -> Result<()> {
     // It's important to build an actual Store here so that initialization
     // logic is run and the signal handler is registered

--- a/lib/api/tests/interrupt_signal.rs
+++ b/lib/api/tests/interrupt_signal.rs
@@ -1,0 +1,309 @@
+#![cfg(all(unix, feature = "experimental-host-interrupt"))]
+
+//! Tests for the signal used to interrupt running WASM code: selecting it,
+//! and how a delivery nobody asked for is handled.
+//!
+//! Both the selection and the installed signal handlers are process-global
+//! state that can only be set up once, so every scenario runs in its own
+//! subprocess: the test binary re-executes itself with
+//! [`SCENARIO_ENV_VAR`] set, which makes [`scenario_entrypoint`] run the
+//! requested scenario.
+
+use std::{
+    env, mem,
+    os::unix::process::ExitStatusExt,
+    process::Command,
+    ptr,
+    sync::{
+        Arc, Barrier, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use anyhow::Result;
+use wasmer::{
+    DEFAULT_INTERRUPT_SIGNAL, Instance, InterruptSignal, Module, SetInterruptSignalError, Store,
+    imports, interrupt_signal, set_interrupt_signal,
+};
+use wasmer_vm::TrapCode;
+
+const SCENARIO_ENV_VAR: &str = "WASMER_INTERRUPT_SIGNAL_TEST_SCENARIO";
+
+const INFINITE_LOOP_WAT: &str = r#"
+    (module
+      (func (export "infinite")
+        loop
+          br 0
+        end
+      )
+    )"#;
+
+#[test]
+fn default_signal_is_sigusr1() {
+    run_scenario("default_signal_is_sigusr1");
+}
+
+#[test]
+fn sigusr2_can_be_selected() {
+    run_scenario("sigusr2_can_be_selected");
+}
+
+#[test]
+fn signal_cant_be_selected_after_handler_installation() {
+    run_scenario("signal_cant_be_selected_after_handler_installation");
+}
+
+/// A delivery of the interrupt signal that Wasmer didn't request means
+/// something else in the process is using it. That can't be handled here and
+/// can't be reported by panicking either — unwinding out of a signal handler
+/// is undefined behaviour — so the handler explains itself on stderr and
+/// aborts.
+#[test]
+fn unrequested_interrupt_signal_kills_the_process() {
+    let output = run_scenario_expecting_death("unrequested_interrupt_signal");
+
+    assert_eq!(
+        output.status.signal(),
+        Some(libc::SIGABRT),
+        "expected the handler to abort, got {}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("delivered without an interrupt being requested"),
+        "the handler didn't explain itself\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stderr.contains("set_interrupt_signal"),
+        "the message should point at the fix\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "the handler panicked instead of aborting\n--- stderr ---\n{stderr}"
+    );
+}
+
+/// The entrypoint the subprocesses spawned by [`run_scenario`] run. Does
+/// nothing when the test binary is run normally.
+#[test]
+fn scenario_entrypoint() {
+    let Ok(scenario) = env::var(SCENARIO_ENV_VAR) else {
+        return;
+    };
+
+    match scenario.as_str() {
+        "default_signal_is_sigusr1" => default_signal_is_sigusr1_scenario(),
+        "sigusr2_can_be_selected" => sigusr2_can_be_selected_scenario(),
+        "signal_cant_be_selected_after_handler_installation" => {
+            signal_cant_be_selected_after_handler_installation_scenario()
+        }
+        "unrequested_interrupt_signal" => unrequested_interrupt_signal_scenario(),
+        other => panic!("unknown scenario: {other}"),
+    }
+    .unwrap();
+}
+
+/// Runs a scenario that is expected to take the process down, and hands the
+/// caller its output to inspect.
+fn run_scenario_expecting_death(scenario: &str) -> std::process::Output {
+    let output = spawn_scenario(scenario);
+
+    assert!(
+        !output.status.success(),
+        "scenario `{scenario}` was expected to terminate the process, but it succeeded\
+         \n--- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    output
+}
+
+fn spawn_scenario(scenario: &str) -> std::process::Output {
+    let test_binary = env::current_exe().expect("failed to locate the test binary");
+    Command::new(&test_binary)
+        .args([
+            "scenario_entrypoint",
+            "--exact",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(SCENARIO_ENV_VAR, scenario)
+        .output()
+        .expect("failed to run the scenario subprocess")
+}
+
+fn run_scenario(scenario: &str) {
+    let output = spawn_scenario(scenario);
+
+    assert!(
+        output.status.success(),
+        "scenario `{scenario}` failed with {}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn default_signal_is_sigusr1_scenario() -> Result<()> {
+    assert_eq!(DEFAULT_INTERRUPT_SIGNAL, InterruptSignal::Sigusr1);
+    assert_eq!(interrupt_signal(), InterruptSignal::Sigusr1);
+
+    // Explicitly selecting the default is fine, and doesn't change anything.
+    set_interrupt_signal(InterruptSignal::Sigusr1)?;
+    assert_eq!(interrupt_signal(), InterruptSignal::Sigusr1);
+
+    assert_running_wasm_is_interrupted()
+}
+
+fn sigusr2_can_be_selected_scenario() -> Result<()> {
+    set_interrupt_signal(InterruptSignal::Sigusr2)?;
+    assert_eq!(interrupt_signal(), InterruptSignal::Sigusr2);
+
+    // Repeating the same selection is a no-op...
+    set_interrupt_signal(InterruptSignal::Sigusr2)?;
+
+    // ... but switching to another signal is an error, even before the
+    // handler is installed.
+    assert!(matches!(
+        set_interrupt_signal(InterruptSignal::Sigusr1),
+        Err(SetInterruptSignalError::AlreadySet {
+            current: InterruptSignal::Sigusr2,
+            requested: InterruptSignal::Sigusr1
+        })
+    ));
+    assert_eq!(interrupt_signal(), InterruptSignal::Sigusr2);
+
+    // Nothing should touch SIGUSR1 anymore, so an embedder is free to use it
+    // for its own purposes.
+    install_sigusr1_observer();
+    assert_running_wasm_is_interrupted()?;
+    assert!(
+        !sigusr1_was_observed(),
+        "interrupting WASM code raised SIGUSR1 even though SIGUSR2 was selected"
+    );
+    // Make sure the observer is actually still installed, i.e. the assertion
+    // above didn't pass just because Wasmer replaced the handler.
+    unsafe { libc::raise(libc::SIGUSR1) };
+    assert!(
+        sigusr1_was_observed(),
+        "the SIGUSR1 handler installed by the embedder was overwritten"
+    );
+
+    // Now that the handler is installed, the selection is locked in.
+    assert!(matches!(
+        set_interrupt_signal(InterruptSignal::Sigusr1),
+        Err(SetInterruptSignalError::HandlerAlreadyInstalled {
+            current: InterruptSignal::Sigusr2,
+            requested: InterruptSignal::Sigusr1
+        })
+    ));
+    // ... though repeating the current selection still succeeds.
+    set_interrupt_signal(InterruptSignal::Sigusr2)?;
+
+    Ok(())
+}
+
+fn signal_cant_be_selected_after_handler_installation_scenario() -> Result<()> {
+    // Building a store installs the signal handlers.
+    let _store = Store::default();
+
+    assert!(matches!(
+        set_interrupt_signal(InterruptSignal::Sigusr2),
+        Err(SetInterruptSignalError::HandlerAlreadyInstalled {
+            current: InterruptSignal::Sigusr1,
+            requested: InterruptSignal::Sigusr2
+        })
+    ));
+    assert_eq!(interrupt_signal(), InterruptSignal::Sigusr1);
+
+    // The signal that *was* installed keeps working.
+    assert_running_wasm_is_interrupted()
+}
+
+fn unrequested_interrupt_signal_scenario() -> Result<()> {
+    // Building a store installs the handler for the interrupt signal.
+    let _store = Store::default();
+
+    // Nobody asked for an interrupt, so this stands in for an unrelated part
+    // of the process using the same signal. The handler should print an
+    // explanation and exit before `raise` returns.
+    unsafe { libc::raise(libc::SIGUSR1) };
+
+    panic!("the process should have been terminated by the interrupt handler");
+}
+
+/// Runs an infinite WASM loop on a worker thread and interrupts it through
+/// the currently selected signal, asserting that the code actually traps.
+fn assert_running_wasm_is_interrupted() -> Result<()> {
+    let barrier = Arc::new(Barrier::new(2));
+    let interrupter_slot = Arc::new(Mutex::new(None));
+
+    let worker = thread::spawn({
+        let barrier = barrier.clone();
+        let interrupter_slot = interrupter_slot.clone();
+        move || {
+            let wasm = wat::parse_str(INFINITE_LOOP_WAT)?;
+
+            let mut store = Store::default();
+            interrupter_slot
+                .lock()
+                .unwrap()
+                .replace(store.interrupter());
+            let module = Module::new(&store, &wasm)?;
+            let instance = Instance::new(&mut store, &module, &imports! {})?;
+            let f = instance
+                .exports
+                .get_typed_function::<(), ()>(&store, "infinite")?;
+
+            barrier.wait();
+            anyhow::Ok(f.call(&mut store))
+        }
+    });
+
+    barrier.wait();
+    // Make absolutely sure the function is running WASM when we raise the signal
+    thread::sleep(Duration::from_millis(500));
+
+    interrupter_slot
+        .lock()
+        .unwrap()
+        .as_ref()
+        .unwrap()
+        .interrupt();
+    let result = worker.join().unwrap().unwrap().unwrap_err();
+    assert_eq!(result.to_trap().unwrap(), TrapCode::HostInterrupt);
+
+    Ok(())
+}
+
+static SIGUSR1_OBSERVED: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn sigusr1_observer(_signum: libc::c_int) {
+    SIGUSR1_OBSERVED.store(true, Ordering::SeqCst);
+}
+
+/// Installs a SIGUSR1 handler standing in for an embedder that uses the
+/// signal for its own purposes.
+fn install_sigusr1_observer() {
+    unsafe {
+        let mut action: libc::sigaction = mem::zeroed();
+        action.sa_sigaction = sigusr1_observer as *const () as usize;
+        action.sa_flags = 0;
+        libc::sigemptyset(&mut action.sa_mask);
+        assert_eq!(
+            libc::sigaction(libc::SIGUSR1, &action, ptr::null_mut()),
+            0,
+            "failed to install the SIGUSR1 observer: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+}
+
+fn sigusr1_was_observed() -> bool {
+    SIGUSR1_OBSERVED.swap(false, Ordering::SeqCst)
+}

--- a/lib/vm/src/interrupt_registry/mod.rs
+++ b/lib/vm/src/interrupt_registry/mod.rs
@@ -22,6 +22,47 @@ mod unsupported;
 #[cfg(not(unix))]
 pub use unsupported::*;
 
+/// The OS signal used to interrupt running WASM code.
+///
+/// Since the signal handler is installed process-wide, embedders that use
+/// one of these signals for their own purposes can pick the other one
+/// through [`set_interrupt_signal`]. The set of choices is intentionally
+/// constrained: any other signal either has a well-defined meaning that
+/// must not be hijacked, or can't be reliably delivered to a specific
+/// thread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterruptSignal {
+    /// `SIGUSR1`. This is the default.
+    Sigusr1,
+    /// `SIGUSR2`.
+    Sigusr2,
+}
+
+/// The signal Wasmer uses to interrupt running WASM code unless the
+/// embedder selects a different one.
+pub const DEFAULT_INTERRUPT_SIGNAL: InterruptSignal = InterruptSignal::Sigusr1;
+
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum SetInterruptSignalError {
+    #[error(
+        "The interrupt signal was already set to {current:?} and can't be changed to {requested:?}"
+    )]
+    AlreadySet {
+        current: InterruptSignal,
+        requested: InterruptSignal,
+    },
+    #[error(
+        "The interrupt signal handler was already installed for {current:?}, so it can't be \
+         changed to {requested:?}; the interrupt signal must be selected before creating any \
+         Wasmer engine or store"
+    )]
+    HandlerAlreadyInstalled {
+        current: InterruptSignal,
+        requested: InterruptSignal,
+    },
+}
+
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum InstallError {

--- a/lib/vm/src/interrupt_registry/unix.rs
+++ b/lib/vm/src/interrupt_registry/unix.rs
@@ -2,8 +2,8 @@ use std::{
     cell::UnsafeCell,
     ffi::CStr,
     sync::{
-        Arc, LazyLock,
-        atomic::{AtomicUsize, Ordering},
+        Arc, LazyLock, Mutex,
+        atomic::{AtomicI32, AtomicUsize, Ordering},
     },
 };
 
@@ -11,6 +11,102 @@ use dashmap::{DashMap, Entry};
 use wasmer_types::StoreId;
 
 use super::*;
+
+impl InterruptSignal {
+    fn as_raw(self) -> i32 {
+        match self {
+            Self::Sigusr1 => libc::SIGUSR1,
+            Self::Sigusr2 => libc::SIGUSR2,
+        }
+    }
+}
+
+struct InterruptSignalConfig {
+    selected: InterruptSignal,
+    /// Whether an embedder explicitly selected the signal. Needed to tell
+    /// "still at the default" apart from "explicitly set to the default",
+    /// since only the latter conflicts with a later, different selection.
+    explicitly_selected: bool,
+    /// Whether the signal handler was already installed, after which the
+    /// selection can no longer change.
+    handler_installed: bool,
+}
+
+/// Guards changes to the selected interrupt signal. Never locked from
+/// within the signal handler.
+static INTERRUPT_SIGNAL_CONFIG: Mutex<InterruptSignalConfig> = Mutex::new(InterruptSignalConfig {
+    selected: DEFAULT_INTERRUPT_SIGNAL,
+    explicitly_selected: false,
+    handler_installed: false,
+});
+
+/// The raw value of the selected signal, kept in sync with
+/// [`INTERRUPT_SIGNAL_CONFIG`]. This exists separately because mutexes can't
+/// be locked from within a signal handler, and the handler needs to know
+/// which signal is the interrupt signal.
+static INTERRUPT_SIGNAL_RAW: AtomicI32 = AtomicI32::new(libc::SIGUSR1);
+
+/// Selects the process-wide signal used to interrupt running WASM code.
+///
+/// This must be called before any Wasmer engine or store is created, since
+/// the signal handler is installed as part of that process and the signal
+/// can't be changed afterwards. Selecting the same signal more than once is
+/// allowed, even after the handler was installed.
+pub fn set_interrupt_signal(signal: InterruptSignal) -> Result<(), SetInterruptSignalError> {
+    let mut config = INTERRUPT_SIGNAL_CONFIG
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    if config.selected == signal {
+        config.explicitly_selected = true;
+        return Ok(());
+    }
+
+    if config.handler_installed {
+        return Err(SetInterruptSignalError::HandlerAlreadyInstalled {
+            current: config.selected,
+            requested: signal,
+        });
+    }
+
+    if config.explicitly_selected {
+        return Err(SetInterruptSignalError::AlreadySet {
+            current: config.selected,
+            requested: signal,
+        });
+    }
+
+    config.selected = signal;
+    config.explicitly_selected = true;
+    INTERRUPT_SIGNAL_RAW.store(signal.as_raw(), Ordering::SeqCst);
+
+    Ok(())
+}
+
+/// Returns the signal currently selected for interrupting WASM code.
+pub fn interrupt_signal() -> InterruptSignal {
+    INTERRUPT_SIGNAL_CONFIG
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .selected
+}
+
+/// Locks in the selected interrupt signal and returns its raw value. Called
+/// when the trap handlers are installed; any later attempt to select a
+/// different signal fails.
+pub(crate) fn install_interrupt_signal() -> i32 {
+    let mut config = INTERRUPT_SIGNAL_CONFIG
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    config.handler_installed = true;
+    config.selected.as_raw()
+}
+
+/// Returns the raw value of the selected interrupt signal. Safe to call from
+/// within a signal handler.
+pub(crate) fn interrupt_signal_raw() -> i32 {
+    INTERRUPT_SIGNAL_RAW.load(Ordering::Relaxed)
+}
 
 /// All necessary data for interrupting a store running WASM code
 /// on a thread.
@@ -181,7 +277,10 @@ pub fn interrupt(store_id: StoreId) -> Result<(), InterruptError> {
 
     unsafe {
         #[allow(trivial_numeric_casts)]
-        let errno = libc::pthread_kill(store_state.pthread as libc::pthread_t, libc::SIGUSR1);
+        let errno = libc::pthread_kill(
+            store_state.pthread as libc::pthread_t,
+            interrupt_signal_raw(),
+        );
         if errno != 0 {
             let error_str = CStr::from_ptr(libc::strerror(errno)).to_str().unwrap();
             return Err(InterruptError::FailedToSendSignal(error_str));
@@ -191,11 +290,48 @@ pub fn interrupt(store_id: StoreId) -> Result<(), InterruptError> {
     Ok(())
 }
 
+/// Writes `message` to stderr and aborts the process.
+///
+/// This stands in for the panic these checks would otherwise be: unwinding out
+/// of a signal handler is undefined behaviour, and the machinery a panic needs
+/// — formatting, allocation, the panic hook — isn't async-signal-safe anyway.
+/// `write(2)` and `abort(3)` are; `eprintln!` takes a lock and `exit(3)` runs
+/// atexit handlers and flushes stdio, so neither may be called from here.
+///
+/// Aborting rather than exiting leaves a core dump behind, which is what you
+/// want for a state that was believed unreachable.
+fn die_in_signal_handler(message: &str) -> ! {
+    let mut remaining = message.as_bytes();
+    // Safety: `write` and `abort` are async-signal-safe.
+    unsafe {
+        while !remaining.is_empty() {
+            let written = libc::write(
+                libc::STDERR_FILENO,
+                remaining.as_ptr() as *const libc::c_void,
+                remaining.len(),
+            );
+            // Best effort: if stderr can't take the message, there is nothing
+            // useful left to do but abort, and retrying could loop forever.
+            if written <= 0 {
+                break;
+            }
+            remaining = &remaining[written as usize..];
+        }
+
+        libc::abort();
+    }
+}
+
 /// Called from within the signal handler to decide whether we should interrupt
 /// the currently running WASM code. This function *MAY* return junk results in
 /// case a signal comes in during an install or uninstall operation. However,
 /// in such cases, there is no WASM code running, and the result will be ignored
 /// by the signal handler anyway.
+///
+/// Terminates the process through [`die_in_signal_handler`] if no interrupt was
+/// pending, which means the signal came from outside Wasmer. Only `interrupt`
+/// writes the target store, so install and uninstall can't produce that state
+/// spuriously.
 pub(crate) fn on_interrupted() -> bool {
     THREAD_INTERRUPT_STATE.with(|t| {
         // Safety: See comments on THREAD_INTERRUPT_STATE.
@@ -204,10 +340,14 @@ pub(crate) fn on_interrupted() -> bool {
         let current_active_store = state.current_active_store.load(Ordering::Acquire);
 
         let current_signal_target_store = state.current_signal_target_store.load(Ordering::Acquire);
-        assert_ne!(
-            current_signal_target_store, 0,
-            "current_signal_target_store should be set before signalling the WASM thread"
-        );
+        if current_signal_target_store == 0 {
+            die_in_signal_handler(concat!(
+                "wasmer: the interrupt signal was delivered without an interrupt being requested.\n",
+                "Something other than Wasmer sent this signal to the process. If your program uses\n",
+                "this signal for its own purposes, select a different one for Wasmer with\n",
+                "`wasmer::set_interrupt_signal` before creating any store.\n",
+            ));
+        }
         if state
             .current_signal_target_store
             .compare_exchange(
@@ -218,7 +358,10 @@ pub(crate) fn on_interrupted() -> bool {
             )
             .is_err()
         {
-            unreachable!("current_signal_target_store isn't changed unless it's zero");
+            die_in_signal_handler(
+                "wasmer: the interrupt target store changed while an interrupt was being \
+                 delivered.\nThis is a bug in Wasmer's interrupt registry.\n",
+            );
         }
 
         current_active_store == current_signal_target_store

--- a/lib/vm/src/interrupt_registry/unix.rs
+++ b/lib/vm/src/interrupt_registry/unix.rs
@@ -290,58 +290,34 @@ pub fn interrupt(store_id: StoreId) -> Result<(), InterruptError> {
     Ok(())
 }
 
-/// Writes `message` to stderr and aborts the process.
-///
-/// This stands in for the panic these checks would otherwise be: unwinding out
-/// of a signal handler is undefined behaviour, and the machinery a panic needs
-/// — formatting, allocation, the panic hook — isn't async-signal-safe anyway.
-/// `write(2)` and `abort(3)` are; `eprintln!` takes a lock and `exit(3)` runs
-/// atexit handlers and flushes stdio, so neither may be called from here.
-///
-/// Aborting rather than exiting leaves a core dump behind, which is what you
-/// want for a state that was believed unreachable.
-fn die_in_signal_handler(message: &str) -> ! {
-    let mut remaining = message.as_bytes();
-    // Safety: `write` and `abort` are async-signal-safe.
-    unsafe {
-        while !remaining.is_empty() {
-            let written = libc::write(
-                libc::STDERR_FILENO,
-                remaining.as_ptr() as *const libc::c_void,
-                remaining.len(),
-            );
-            // Best effort: if stderr can't take the message, there is nothing
-            // useful left to do but abort, and retrying could loop forever.
-            if written <= 0 {
-                break;
-            }
-            remaining = &remaining[written as usize..];
-        }
-
-        libc::abort();
-    }
-}
-
 /// Called from within the signal handler to decide whether we should interrupt
 /// the currently running WASM code. This function *MAY* return junk results in
 /// case a signal comes in during an install or uninstall operation. However,
 /// in such cases, there is no WASM code running, and the result will be ignored
 /// by the signal handler anyway.
 ///
-/// Terminates the process through [`die_in_signal_handler`] if no interrupt was
-/// pending, which means the signal came from outside Wasmer. Only `interrupt`
-/// writes the target store, so install and uninstall can't produce that state
+/// Terminates the process through
+/// [`crate::signal_safe::die_in_signal_handler`] if no interrupt was pending,
+/// which means the signal came from outside Wasmer. Only `interrupt` writes
+/// the target store, so install and uninstall can't produce that state
 /// spuriously.
 pub(crate) fn on_interrupted() -> bool {
-    THREAD_INTERRUPT_STATE.with(|t| {
-        // Safety: See comments on THREAD_INTERRUPT_STATE.
-        let state = unsafe { t.get().as_ref().unwrap() };
+    // `with` panics once the thread-local has been destroyed. Getting here in
+    // that state would mean an interrupt was delivered to a thread that has
+    // already torn down its state, which cannot happen while the store is
+    // installed and running WASM -- so it is reported, not ignored. `try_with`
+    // is used only so the report is a write-and-abort rather than a panic
+    // unwinding out of a signal handler.
+    let Ok(interrupted) = THREAD_INTERRUPT_STATE.try_with(|t| {
+        // Safety: See comments on THREAD_INTERRUPT_STATE. The pointer comes
+        // from `UnsafeCell::get`, so it is never null.
+        let state = unsafe { &*t.get() };
 
         let current_active_store = state.current_active_store.load(Ordering::Acquire);
 
         let current_signal_target_store = state.current_signal_target_store.load(Ordering::Acquire);
         if current_signal_target_store == 0 {
-            die_in_signal_handler(concat!(
+            crate::signal_safe::die_in_signal_handler(concat!(
                 "wasmer: the interrupt signal was delivered without an interrupt being requested.\n",
                 "Something other than Wasmer sent this signal to the process. If your program uses\n",
                 "this signal for its own purposes, select a different one for Wasmer with\n",
@@ -358,14 +334,21 @@ pub(crate) fn on_interrupted() -> bool {
             )
             .is_err()
         {
-            die_in_signal_handler(
+            crate::signal_safe::die_in_signal_handler(
                 "wasmer: the interrupt target store changed while an interrupt was being \
                  delivered.\nThis is a bug in Wasmer's interrupt registry.\n",
             );
         }
 
         current_active_store == current_signal_target_store
-    })
+    }) else {
+        crate::signal_safe::die_in_signal_handler(
+            "wasmer: an interrupt was delivered to a thread whose interrupt state is already \
+             gone.\nThis is a bug in Wasmer's interrupt registry.\n",
+        );
+    };
+
+    interrupted
 }
 
 /// Returns true if the store with the given ID has already been interrupted.

--- a/lib/vm/src/interrupt_registry/unsupported.rs
+++ b/lib/vm/src/interrupt_registry/unsupported.rs
@@ -2,6 +2,21 @@ use wasmer_types::StoreId;
 
 use super::*;
 
+/// Selects the process-wide signal used to interrupt running WASM code.
+///
+/// On unsupported platforms this is a no-op.
+pub fn set_interrupt_signal(_signal: InterruptSignal) -> Result<(), SetInterruptSignalError> {
+    Ok(())
+}
+
+/// Returns the signal currently selected for interrupting WASM code.
+///
+/// On unsupported platforms no signal is ever used, so this always reports
+/// the default.
+pub fn interrupt_signal() -> InterruptSignal {
+    DEFAULT_INTERRUPT_SIGNAL
+}
+
 /// Install interrupt state for the given store.
 ///
 /// On unsupported platforms this is a no-op.

--- a/lib/vm/src/lib.rs
+++ b/lib/vm/src/lib.rs
@@ -31,6 +31,9 @@ mod threadconditions;
 mod trap;
 mod vmcontext;
 
+#[cfg(unix)]
+pub(crate) mod signal_safe;
+
 #[cfg(feature = "experimental-host-interrupt")]
 pub mod interrupt_registry;
 pub mod libcalls;

--- a/lib/vm/src/signal_safe.rs
+++ b/lib/vm/src/signal_safe.rs
@@ -1,0 +1,38 @@
+//! Helpers that are safe to call from inside a signal handler.
+//!
+//! Very little is: POSIX defines a short list of async-signal-safe functions,
+//! and anything else may deadlock or corrupt state if it happens to interrupt
+//! the same facility it needs. In particular a Rust panic is not usable here —
+//! unwinding out of a signal handler is undefined behaviour, and formatting,
+//! allocation and the panic hook are all off-limits regardless.
+
+/// Writes `message` to stderr and aborts the process.
+///
+/// This stands in for the panic that reporting a broken invariant would
+/// otherwise be. `write(2)` and `abort(3)` are both on POSIX's
+/// async-signal-safe list, unlike `eprintln!`, which takes a lock, and
+/// `exit(3)`, which runs atexit handlers and flushes stdio.
+///
+/// Aborting rather than exiting leaves a core dump behind, which is what you
+/// want for a state that was believed unreachable.
+pub(crate) fn die_in_signal_handler(message: &str) -> ! {
+    let mut remaining = message.as_bytes();
+    // Safety: `write` and `abort` are async-signal-safe.
+    unsafe {
+        while !remaining.is_empty() {
+            let written = libc::write(
+                libc::STDERR_FILENO,
+                remaining.as_ptr() as *const libc::c_void,
+                remaining.len(),
+            );
+            // Best effort: if stderr can't take the message, there is nothing
+            // useful left to do but abort, and retrying could loop forever.
+            if written <= 0 {
+                break;
+            }
+            remaining = &remaining[written as usize..];
+        }
+
+        libc::abort();
+    }
+}

--- a/lib/vm/src/store.rs
+++ b/lib/vm/src/store.rs
@@ -47,6 +47,13 @@ impl_context_object! {
 #[derive(Debug, Default)]
 pub struct StoreObjects {
     id: StoreId,
+    /// Liveness token for the store. Interrupters hold a `Weak` to it, so an
+    /// embedder holding interrupters for many short-lived stores can tell
+    /// which ones are still worth keeping. Store ids are never reused, so
+    /// there is nothing else to tell a dropped store from one that simply
+    /// isn't executing right now.
+    #[cfg(feature = "experimental-host-interrupt")]
+    liveness: std::sync::Arc<()>,
     memories: Vec<VMMemory>,
     tables: Vec<VMTable>,
     globals: Vec<VMGlobal>,
@@ -75,6 +82,8 @@ impl StoreObjects {
     ) -> Self {
         Self {
             id,
+            #[cfg(feature = "experimental-host-interrupt")]
+            liveness: std::sync::Arc::new(()),
             memories,
             tables,
             globals,
@@ -90,6 +99,13 @@ impl StoreObjects {
     /// Returns the ID of this context.
     pub fn id(&self) -> StoreId {
         self.id
+    }
+
+    /// A handle that reports whether this store is still alive. See the
+    /// `liveness` field.
+    #[cfg(feature = "experimental-host-interrupt")]
+    pub fn liveness_token(&self) -> std::sync::Weak<()> {
+        std::sync::Arc::downgrade(&self.liveness)
     }
 
     /// Sets the ID of this store

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -808,6 +808,13 @@ cfg_select! {
 /// WebAssembly. Currently in wasmer's integration this function is called on
 /// creation of a `Store`.
 pub fn init_traps() {
+    // Miri cannot call `sigaction`/`sigemptyset`, and nothing under Miri
+    // executes compiled Wasm, so there is no trap for a handler to catch.
+    // Without this, building a `Store` at all is out of reach there, and the
+    // store-context tests that need one cannot run.
+    if cfg!(miri) {
+        return;
+    }
     static INIT: Once = Once::new();
     INIT.call_once(|| unsafe {
         platform_init();

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -260,7 +260,7 @@ cfg_select! {
         static mut PREV_SIGFPE: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
 
         #[cfg(feature = "experimental-host-interrupt")]
-        static mut PREV_SIGUSR1: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
+        static mut PREV_INTERRUPT_SIGNAL: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
 
         unsafe fn platform_init() { unsafe {
             let register = |slot: &mut MaybeUninit<libc::sigaction>, signal: i32, nodefer: bool| {
@@ -298,12 +298,19 @@ cfg_select! {
             // Handle `unreachable` instructions which execute `ud2` right now
             register(&mut PREV_SIGILL, libc::SIGILL, true);
 
-            // SIGUSR1 is used to interrupt long-running WASM code.
+            // The interrupt signal (SIGUSR1 unless the embedder selected
+            // another one) is used to interrupt long-running WASM code.
             // It doesn't use NODEFER since, if a second interruption
             // request comes in while one is already being processed,
             // there's nothing meaningful we can do.
+            // Note that this locks in the selected signal, so embedders
+            // can no longer change it.
             #[cfg(feature = "experimental-host-interrupt")]
-            register(&mut PREV_SIGUSR1, libc::SIGUSR1, false);
+            register(
+                &mut PREV_INTERRUPT_SIGNAL,
+                interrupt_registry::install_interrupt_signal(),
+                false,
+            );
 
             // x86 uses SIGFPE to report division by zero
             if cfg!(target_arch = "x86") || cfg!(target_arch = "x86_64") {
@@ -359,14 +366,26 @@ cfg_select! {
             siginfo: *mut libc::siginfo_t,
             context: *mut libc::c_void,
         ) { unsafe {
-            let previous = match signum {
-                libc::SIGSEGV => &PREV_SIGSEGV,
-                libc::SIGBUS => &PREV_SIGBUS,
-                libc::SIGFPE => &PREV_SIGFPE,
-                libc::SIGILL => &PREV_SIGILL,
+            // The interrupt signal is chosen at runtime, so it can't be part
+            // of the `match` patterns below.
+            #[cfg(feature = "experimental-host-interrupt")]
+            let is_interrupt_signal = signum == interrupt_registry::interrupt_signal_raw();
+            #[cfg(not(feature = "experimental-host-interrupt"))]
+            let is_interrupt_signal = false;
+
+            #[cfg_attr(not(feature = "experimental-host-interrupt"), allow(unused_labels))]
+            let previous = 'previous: {
                 #[cfg(feature = "experimental-host-interrupt")]
-                libc::SIGUSR1 => &PREV_SIGUSR1,
-                _ => panic!("unknown signal: {signum}"),
+                if is_interrupt_signal {
+                    break 'previous &PREV_INTERRUPT_SIGNAL;
+                }
+                match signum {
+                    libc::SIGSEGV => &PREV_SIGSEGV,
+                    libc::SIGBUS => &PREV_SIGBUS,
+                    libc::SIGFPE => &PREV_SIGFPE,
+                    libc::SIGILL => &PREV_SIGILL,
+                    _ => panic!("unknown signal: {signum}"),
+                }
             };
             // We try to get the fault address associated to this signal
             let maybe_fault_address = match signum {
@@ -375,22 +394,25 @@ cfg_select! {
                 }
                 _ => None,
             };
-            let trap_code = match signum {
-                // check if it was cased by a UD and if the Trap info is a payload to it
-                libc::SIGILL => {
-                    let addr = (*siginfo).si_addr() as usize;
-                    process_illegal_op(addr)
-                }
+            #[cfg_attr(not(feature = "experimental-host-interrupt"), allow(unused_labels))]
+            let trap_code = 'trap_code: {
                 #[cfg(feature = "experimental-host-interrupt")]
-                libc::SIGUSR1 => {
+                if is_interrupt_signal {
                     // If we're not running WASM code from the specific store for which
                     // an interrupt was requested, there's nothing to do.
                     if !interrupt_registry::on_interrupted() {
                         return;
                     }
-                    Some(TrapCode::HostInterrupt)
+                    break 'trap_code Some(TrapCode::HostInterrupt);
                 }
-                _ => None,
+                match signum {
+                    // check if it was cased by a UD and if the Trap info is a payload to it
+                    libc::SIGILL => {
+                        let addr = (*siginfo).si_addr() as usize;
+                        process_illegal_op(addr)
+                    }
+                    _ => None,
+                }
             };
             let ucontext = &mut *(context as *mut ucontext_t);
             let (pc, sp) = get_pc_sp(ucontext);
@@ -409,8 +431,7 @@ cfg_select! {
 
             // If we're not running WASM code at all, there's nothing to
             // do for an interrupt.
-            #[cfg(feature = "experimental-host-interrupt")]
-            if signum == libc::SIGUSR1 {
+            if is_interrupt_signal {
                 return;
             }
 

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -384,7 +384,14 @@ cfg_select! {
                     libc::SIGBUS => &PREV_SIGBUS,
                     libc::SIGFPE => &PREV_SIGFPE,
                     libc::SIGILL => &PREV_SIGILL,
-                    _ => panic!("unknown signal: {signum}"),
+                    // We only ever install this handler for the signals above,
+                    // so reaching this means someone else pointed a signal at
+                    // it. There is nothing sensible to do with it, and it
+                    // cannot be reported by panicking from a signal handler.
+                    _ => crate::signal_safe::die_in_signal_handler(
+                        "wasmer: the trap handler was invoked for a signal it was not installed \
+                         for; something else in the process redirected a signal to it.\n",
+                    ),
                 }
             };
             // We try to get the fault address associated to this signal

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -1004,6 +1004,7 @@ impl WasiEnvBuilder {
             clock_offset: Default::default(),
             envs: std::sync::Mutex::new(conv_env_vars(self.envs)),
             signals: std::sync::Mutex::new(self.signals.iter().map(|s| (s.sig, s.disp)).collect()),
+            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
         };
 
         let runtime = self.runtime.unwrap_or_else(|| {

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -128,6 +128,7 @@ impl WasiEnvInit {
                 args: std::sync::Mutex::new(self.state.args.lock().unwrap().clone()),
                 envs: std::sync::Mutex::new(self.state.envs.lock().unwrap().deref().clone()),
                 signals: std::sync::Mutex::new(self.state.signals.lock().unwrap().deref().clone()),
+                signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
                 preopen: self.state.preopen.clone(),
             },
             runtime: self.runtime.clone(),
@@ -715,7 +716,16 @@ impl WasiEnv {
             .try_inner()
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
         let inner = env_inner.main_module_instance_handles();
-        if !inner.signal_set {
+        // Ask the process, not just this instance: a spawned thread has its own
+        // InstanceHandles and never sees the main instance's registration, so
+        // `inner.signal_set` alone would apply the default disposition on
+        // sibling threads and terminate a process that does handle the signal.
+        let handler_registered = inner.signal_set
+            || env
+                .state
+                .signal_handler_registered
+                .load(std::sync::atomic::Ordering::SeqCst);
+        if !handler_registered {
             let signals = env.thread.pop_signals();
             if !signals.is_empty() {
                 for sig in signals {

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -135,6 +135,15 @@ pub(crate) struct WasiState {
     pub args: Mutex<Vec<String>>,
     pub envs: Mutex<Vec<Vec<u8>>>,
     pub signals: Mutex<HashMap<Signal, Disposition>>,
+    /// Whether this *process* has registered a signal handler callback.
+    ///
+    /// `InstanceHandles::signal_set` only records whether the instance doing
+    /// the asking registered one, and every spawned thread gets its own
+    /// instance. Signals are delivered to all of a process's threads, so a
+    /// per-instance flag makes sibling threads believe the program handles no
+    /// signals and apply the runtime's default disposition -- terminating a
+    /// process that does in fact have a handler installed.
+    pub signal_handler_registered: std::sync::atomic::AtomicBool,
 
     // TODO: should not be here, since this requires active work to resolve.
     // State should only hold active runtime state that can be reproducibly re-created.
@@ -246,6 +255,8 @@ impl WasiState {
             args: Mutex::new(self.args.lock().unwrap().clone()),
             envs: Mutex::new(self.envs.lock().unwrap().clone()),
             signals: Mutex::new(self.signals.lock().unwrap().clone()),
+            // A forked process re-registers from its own instance.
+            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
             preopen: self.preopen.clone(),
         }
     }

--- a/lib/wasix/src/syscalls/wasix/callback_signal.rs
+++ b/lib/wasix/src/syscalls/wasix/callback_signal.rs
@@ -42,6 +42,13 @@ pub fn callback_signal<M: MemorySize>(
         inner.signal = funct;
         inner.signal_set = true;
     }
+    // Record it for the whole process: signals are delivered to every thread,
+    // and the sibling threads have their own instances that never see the
+    // registration above.
+    ctx.data()
+        .state
+        .signal_handler_registered
+        .store(true, std::sync::atomic::Ordering::SeqCst);
 
     WasiEnv::do_pending_operations(&mut ctx)?;
 

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -111,7 +111,10 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         match find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name) {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
-            FindExecutableResult::NotFound => return Ok(Errno::Noexec),
+            // Nothing by that name on PATH is ENOENT. ENOEXEC means the file
+            // was found but is not an executable format, which is what the
+            // spawn failure below reports. proc_exec4 already gets this right.
+            FindExecutableResult::NotFound => return Ok(Errno::Noent),
         }
     } else if name.starts_with("./") {
         *name = ctx.data().state.fs.relative_path_to_absolute(name.clone());


### PR DESCRIPTION
Interrupting running Wasm has always gone through `SIGUSR1`. An embedder that
already uses that signal has no way out today: Wasmer's handler swallows the
embedder's signal *and* takes it for an interrupt request, so the embedder
never sees its own signal and Wasmer acts on one nobody sent.

## Selecting the signal

`wasmer::set_interrupt_signal` picks between `Sigusr1` (still the default) and
`Sigusr2`. The choice is process-wide and is locked in when the trap handlers
are installed, i.e. when the first store is built, so:

- repeating a selection succeeds, including after installation;
- a conflicting selection, or one made too late, returns a structured error
  instead of quietly doing nothing.

The set of choices is deliberately closed rather than an arbitrary signal
number: everything else either has a defined meaning that must not be hijacked
or cannot be delivered reliably to a specific thread.

## No more panicking from the signal handler

`on_interrupted` asserted two invariants and panicked on failure. Unwinding out
of a signal handler is undefined behaviour, and the machinery a panic needs —
formatting, allocation, the panic hook — is not async-signal-safe either.

Worse, one of the two conditions is not a bug at all. "The interrupt signal
arrived with no interrupt pending" is reachable by *anything* in the process
sending that signal, which is exactly the collision described above.

Both checks now write an explanation with `write(2)` and call `abort(3)`, both
async-signal-safe. The process still dies loudly, with a core dump, and the
message names the fix:

```
wasmer: the interrupt signal was delivered without an interrupt being requested.
Something other than Wasmer sent this signal to the process. If your program uses
this signal for its own purposes, select a different one for Wasmer with
`wasmer::set_interrupt_signal` before creating any store.
```

## Telling whether an interrupter's store is still alive

`Interrupter::is_alive()`, backed by a liveness token on the store. Store ids
are never reused, and "not currently in the interrupt registry" only means the
store is not executing right now — so an embedder holding interrupters for many
short-lived stores previously had no sound way to drop the dead ones and would
accumulate them for the lifetime of the process. Interrupting a dropped store
remains harmless, so callers never have to check first.

## Tests

The selection and the installed handlers are process-global, so each scenario
runs in its own subprocess: the default is `SIGUSR1`; `SIGUSR2` can be selected
and then interrupts real Wasm while leaving an embedder's own `SIGUSR1` handler
untouched in both directions; late selection is refused while the installed
signal keeps working; and an unrequested delivery aborts with the message above
rather than panicking.
