### PR TITLE
fix(api): give each call its own store context entry

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -252,6 +252,23 @@ jobs:
         run: ${{ matrix.build-what.lint-cmd }}
       - name: Test V8 API
         run: ${{ matrix.build-what.build-cmd }}
+  test_store_context_miri:
+    name: Store context under Miri
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: miri
+      # These tests replay the store context's borrow flow without executing
+      # any Wasm, so Miri can check that a store re-acquired inside a nested
+      # call does not invalidate the borrow its caller is still holding. They
+      # pass trivially when run natively — Miri is the point.
+      - name: Borrow provenance of the store context
+        run: cargo miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs
     runs-on: ubuntu-22.04
@@ -804,6 +821,7 @@ jobs:
       - cargo_deny
       - test_nodejs
       - test_interpreter_api
+      - test_store_context_miri
       - test_build_docs_rs
       - build_linux_riscv64
       - build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -262,14 +262,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: miri
+          components: miri, rust-src
+      # Build Miri's sysroot as its own step: it needs `rust-src`, it takes a
+      # few minutes, and doing it here keeps a sysroot problem from being
+      # reported as a test failure. `+nightly` throughout, since
+      # rust-toolchain.toml pins a stable channel for this directory and that
+      # overrides the default the toolchain action sets.
+      - name: Prepare the Miri sysroot
+        run: cargo +nightly miri setup
       # These tests replay the store context's borrow flow without executing
       # any Wasm, so Miri can check that a store re-acquired inside a nested
       # call does not invalidate the borrow its caller is still holding. They
       # pass trivially when run natively — Miri is the point.
       - name: Borrow provenance of the store context
-        # `+nightly` explicitly: rust-toolchain.toml pins a stable channel
-        # for the directory, which has no miri component.
         run: cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -268,7 +268,9 @@ jobs:
       # call does not invalidate the borrow its caller is still holding. They
       # pass trivially when run natively — Miri is the point.
       - name: Borrow provenance of the store context
-        run: cargo miri test -p wasmer --features sys --lib borrow_provenance
+        # `+nightly` explicitly: rust-toolchain.toml pins a stable channel
+        # for the directory, which has no miri component.
+        run: cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs
     runs-on: ubuntu-22.04

--- a/lib/api/src/backend/sys/entities/function/mod.rs
+++ b/lib/api/src/backend/sys/entities/function/mod.rs
@@ -526,7 +526,7 @@ impl Function {
             // Safety: the store context is uninstalled before we return, and the
             // store mut is valid for the duration of the call.
             let store_install_guard =
-                unsafe { StoreContext::ensure_installed(store.as_store_mut().inner as *mut _) };
+                unsafe { StoreContext::install(store.as_store_mut().inner as *mut _) };
 
             let mut r;
             // TODO: This loop is needed for asyncify. It will be refactored with https://github.com/wasmerio/wasmer/issues/3451

--- a/lib/api/src/backend/sys/entities/function/typed.rs
+++ b/lib/api/src/backend/sys/entities/function/typed.rs
@@ -69,7 +69,7 @@ macro_rules! impl_native_traits {
 
                 // Install the store into the store context
                 let store_install_guard = unsafe {
-                    StoreContext::ensure_installed(store.as_store_mut().inner as *mut _)
+                    StoreContext::install(store.as_store_mut().inner as *mut _)
                 };
 
                 let mut r;
@@ -206,7 +206,7 @@ macro_rules! impl_native_traits {
 
                 // Install the store into the store context
                 let store_install_guard = unsafe {
-                    StoreContext::ensure_installed(store.as_store_mut().inner as *mut _)
+                    StoreContext::install(store.as_store_mut().inner as *mut _)
                 };
 
                 let mut r;

--- a/lib/api/src/backend/sys/entities/module.rs
+++ b/lib/api/src/backend/sys/entities/module.rs
@@ -209,7 +209,7 @@ impl Module {
                 }
             };
 
-            let store_install_guard = StoreContext::ensure_installed(store_ptr);
+            let store_install_guard = StoreContext::install(store_ptr);
 
             // After the instance handle is created, we need to initialize
             // the data, call the start function and so. However, if any

--- a/lib/api/src/entities/store/context.rs
+++ b/lib/api/src/entities/store/context.rs
@@ -519,7 +519,7 @@ impl Drop for StoreInstallGuard {
                 (None, false) => panic!("Store context stack underflow"),
                 (None, true) => {
                     // Nothing to do if we're panicking; panics can put the context
-                    // in an invalid state, and we don't to cause another panic here.
+                    // in an invalid state, and we don't want to cause another panic here.
                 }
             }
         })
@@ -549,7 +549,7 @@ impl Drop for ForcedStoreInstallGuard {
                 (None, false) => panic!("Store context stack underflow"),
                 (None, true) => {
                     // Nothing to do if we're panicking; panics can put the context
-                    // in an invalid state, and we don't to cause another panic here.
+                    // in an invalid state, and we don't want to cause another panic here.
                 }
             }
         })

--- a/lib/api/src/entities/store/context.rs
+++ b/lib/api/src/entities/store/context.rs
@@ -114,9 +114,10 @@ pub(crate) struct ForcedStoreInstallGuard {
     store_id: StoreId,
 }
 
-pub(crate) enum StoreInstallGuard {
-    Installed(StoreId),
-    NotInstalled,
+pub(crate) struct StoreInstallGuard {
+    /// `None` when this guard installed nothing, which happens only for a
+    /// store an async context already holds — see [`StoreContext::install`].
+    store_id: Option<StoreId>,
 }
 
 thread_local! {
@@ -139,7 +140,7 @@ impl StoreContext {
             })
     }
 
-    fn install(id: StoreId, entry: StoreContextEntry) {
+    fn push(id: StoreId, entry: StoreContextEntry) {
         STORE_CONTEXT_STACK.with(|cell| {
             let mut stack = cell.borrow_mut();
             stack.push(Self {
@@ -151,7 +152,7 @@ impl StoreContext {
     }
 
     #[cfg(feature = "unsafe-cothread")]
-    fn install_cothread(id: StoreId, store_ptr: NonNull<StoreInner>) {
+    fn push_cothread(id: StoreId, store_ptr: NonNull<StoreInner>) {
         STORE_CONTEXT_STACK.with(|cell| {
             let mut stack = cell.borrow_mut();
             stack.push(Self {
@@ -194,27 +195,75 @@ impl StoreContext {
         guard: LocalRwLockWriteGuard<Box<StoreInner>>,
     ) -> ForcedStoreInstallGuard {
         let store_id = guard.objects.id();
-        Self::install(store_id, StoreContextEntry::Async(guard));
+        Self::push(store_id, StoreContextEntry::Async(guard));
         ForcedStoreInstallGuard { store_id }
     }
 
-    /// Install the store context as sync if it is not already installed.
+    /// Whether the active entry is `id`'s, held by an async context.
+    fn active_is_async(id: StoreId) -> bool {
+        STORE_CONTEXT_STACK.with(|cell| {
+            let stack = cell.borrow();
+            let Some(top) = stack.last() else {
+                return false;
+            };
+            if top.id != id {
+                return false;
+            }
+            match unsafe { top.entry.get().as_ref().unwrap() } {
+                StoreContextEntry::Sync(_) => false,
+                #[cfg(feature = "experimental-async")]
+                StoreContextEntry::Async(_) => true,
+            }
+        })
+    }
+
+    /// Install `store_ptr` as this thread's executing store until the returned
+    /// guard is dropped.
+    ///
+    /// A store already executing here gets a *second* entry rather than
+    /// re-using its first: the entries differ in which borrow their pointer was
+    /// derived from, and that difference is load-bearing. Every re-acquisition
+    /// ([`Self::get_current`] and friends) reborrows the top entry's pointer,
+    /// so re-using an outer entry would make the inner borrow a *sibling* of
+    /// the one the caller is still holding — creating it invalidates the
+    /// caller's, and the caller's next use of its own store is undefined
+    /// behaviour. Installing the pointer the caller just derived from its live
+    /// borrow makes the inner borrow a child of it instead, which is what lets
+    /// the caller carry on once the nested call returns. See the
+    /// `borrow_provenance` tests, which fail under Miri if this re-uses the
+    /// outer entry.
+    ///
+    /// An async context is the exception, and installs nothing: it owns the
+    /// store through a write guard held in the entry itself, and every
+    /// re-acquisition re-derives from that guard rather than from a caller's
+    /// borrow (see `AsyncCallStoreMut`), so there is no borrow to nest under.
+    /// Shadowing it would also hide the guard from async host functions, which
+    /// reach it by inspecting the active entry.
     ///
     /// # Safety
-    /// The pointer must be dereferenceable and remain valid until the
-    /// store context is uninstalled.
-    pub(crate) unsafe fn ensure_installed(store_ptr: *mut StoreInner) -> StoreInstallGuard {
+    /// `store_ptr` must be derived from a mutable borrow of the store that
+    /// stays alive, and unreachable to every frame on this thread, until the
+    /// guard is dropped.
+    pub(crate) unsafe fn install(store_ptr: *mut StoreInner) -> StoreInstallGuard {
         let store_id = unsafe { store_ptr.as_ref().unwrap().objects.id() };
-        if Self::is_active(store_id) {
-            let current_ptr = STORE_CONTEXT_STACK.with(|cell| {
-                let stack = cell.borrow();
-                unsafe { stack.last().unwrap().entry.get().as_ref().unwrap().as_ptr() }
-            });
-            assert_eq!(store_ptr, current_ptr, "Store context pointer mismatch");
-            StoreInstallGuard::NotInstalled
-        } else {
-            Self::install(store_id, StoreContextEntry::Sync(store_ptr));
-            StoreInstallGuard::Installed(store_id)
+        // Nesting changes a pointer's provenance, never which store it
+        // addresses, so the same store must arrive at the same address.
+        debug_assert!(
+            !Self::is_active(store_id)
+                || STORE_CONTEXT_STACK.with(|cell| {
+                    let stack = cell.borrow();
+                    let active =
+                        unsafe { stack.last().unwrap().entry.get().as_ref().unwrap().as_ptr() };
+                    active == store_ptr
+                }),
+            "Store context pointer mismatch"
+        );
+        if Self::active_is_async(store_id) {
+            return StoreInstallGuard { store_id: None };
+        }
+        Self::push(store_id, StoreContextEntry::Sync(store_ptr));
+        StoreInstallGuard {
+            store_id: Some(store_id),
         }
     }
 
@@ -358,7 +407,7 @@ impl<'a> CoroutineStoreGuard<'a> {
             !StoreContext::is_active(store_id) && !StoreContext::is_suspended(store_id),
             "store is already on the current thread's context stack (active or suspended)"
         );
-        StoreContext::install_cothread(store_id, NonNull::from(store));
+        StoreContext::push_cothread(store_id, NonNull::from(store));
         Self {
             store_id,
             _store: std::marker::PhantomData,
@@ -446,33 +495,34 @@ impl Drop for StoreAsyncGuardWrapper {
 
 impl Drop for StoreInstallGuard {
     fn drop(&mut self) {
-        if let Self::Installed(store_id) = self {
-            STORE_CONTEXT_STACK.with(|cell| {
-                let mut stack = cell.borrow_mut();
-                match (stack.pop(), std::thread::panicking()) {
-                    (Some(top), false) => {
-                        assert_eq!(top.id, *store_id, "Mismatched store context uninstall");
-                        assert_eq!(
-                            top.borrow_count, 0,
-                            "Cannot uninstall store context while it is still borrowed"
-                        );
-                    }
-                    (Some(top), true) => {
-                        // If we're panicking and there's a store ID mismatch, just
-                        // put the store back in the hope that its own install guard
-                        // take care of uninstalling it later.
-                        if top.id != *store_id {
-                            stack.push(top);
-                        }
-                    }
-                    (None, false) => panic!("Store context stack underflow"),
-                    (None, true) => {
-                        // Nothing to do if we're panicking; panics can put the context
-                        // in an invalid state, and we don't to cause another panic here.
+        let Some(store_id) = self.store_id else {
+            return;
+        };
+        STORE_CONTEXT_STACK.with(|cell| {
+            let mut stack = cell.borrow_mut();
+            match (stack.pop(), std::thread::panicking()) {
+                (Some(top), false) => {
+                    assert_eq!(top.id, store_id, "Mismatched store context uninstall");
+                    assert_eq!(
+                        top.borrow_count, 0,
+                        "Cannot uninstall store context while it is still borrowed"
+                    );
+                }
+                (Some(top), true) => {
+                    // If we're panicking and there's a store ID mismatch, just
+                    // put the store back in the hope that its own install guard
+                    // take care of uninstalling it later.
+                    if top.id != store_id {
+                        stack.push(top);
                     }
                 }
-            })
-        }
+                (None, false) => panic!("Store context stack underflow"),
+                (None, true) => {
+                    // Nothing to do if we're panicking; panics can put the context
+                    // in an invalid state, and we don't to cause another panic here.
+                }
+            }
+        })
     }
 }
 
@@ -526,5 +576,76 @@ impl Drop for StorePtrPauseGuard {
                 top.borrow_count += 1;
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod borrow_provenance {
+    use super::*;
+    use crate::{AsStoreMut, Store};
+
+    /// Replays a recursive guest call at the level of the store context, which
+    /// is the part of it that has nothing to do with executing Wasm:
+    ///
+    /// ```text
+    /// Function::call(&mut store)          install(ptr from the caller's borrow)
+    ///   wasm -> import                    get_current            -> the shim's borrow
+    ///     shim: Function::call(&mut env)  install(ptr from *that* borrow)
+    ///       wasm -> import                get_current            -> the inner borrow
+    ///     shim carries on using its own borrow
+    /// ```
+    ///
+    /// Natively this always passes; it earns its keep under Miri, which is
+    /// where the last step is checked. If [`StoreContext::install`] ever goes
+    /// back to re-using an entry that is already active, the inner borrow
+    /// becomes a sibling of the shim's rather than a child of it, and this test
+    /// reports the shim's own store as invalidated:
+    ///
+    /// ```text
+    /// error: Undefined Behavior: trying to retag from <..> for Unique
+    ///        permission, but that tag does not exist in the borrow stack
+    ///   --> lib/api/src/entities/store/store_ref.rs   &mut self.inner.objects
+    /// ```
+    ///
+    /// Run it with:
+    ///
+    /// ```text
+    /// cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
+    /// ```
+    #[test]
+    fn nested_call_keeps_the_outer_borrow_usable() {
+        let mut store = Store::default();
+        let id = store.id();
+
+        // --- the embedder's Function::call(&mut store)
+        let mut caller = store.as_store_mut();
+        let install = unsafe { StoreContext::install(caller.as_store_mut().inner as *mut _) };
+
+        // --- the import trampoline, handing the shim its store
+        let mut wrapper = unsafe { StoreContext::get_current(id) };
+        let mut shim = wrapper.as_mut();
+        let _ = shim.objects_mut().id();
+
+        {
+            // --- the shim calls back into the guest
+            let inner_install =
+                unsafe { StoreContext::install(shim.as_store_mut().inner as *mut _) };
+            let pause = unsafe { StoreContext::pause(id) };
+
+            // --- the inner import trampoline
+            let mut inner_wrapper = unsafe { StoreContext::get_current(id) };
+            let mut inner_shim = inner_wrapper.as_mut();
+            let _ = inner_shim.objects_mut().id();
+            drop(inner_wrapper);
+
+            drop(pause);
+            drop(inner_install);
+        }
+
+        // --- and goes on using the borrow it held throughout
+        let _ = shim.objects_mut().id();
+
+        drop(wrapper);
+        drop(install);
     }
 }

--- a/lib/vm/src/trap/traphandlers.rs
+++ b/lib/vm/src/trap/traphandlers.rs
@@ -808,6 +808,13 @@ cfg_select! {
 /// WebAssembly. Currently in wasmer's integration this function is called on
 /// creation of a `Store`.
 pub fn init_traps() {
+    // Miri cannot call `sigaction`/`sigemptyset`, and nothing under Miri
+    // executes compiled Wasm, so there is no trap for a handler to catch.
+    // Without this, building a `Store` at all is out of reach there, and the
+    // store-context tests that need one cannot run.
+    if cfg!(miri) {
+        return;
+    }
     static INIT: Once = Once::new();
     INIT.call_once(|| unsafe {
         platform_init();


### PR DESCRIPTION
`ensure_installed` re-used the active store context entry whenever the same store was already executing on this thread. That is exactly what happens on a recursive guest call — an imported function calling back into Wasm — and re-using the entry there is unsound.

## What goes wrong

Both entries would hold the same address, so re-using one looks free. But they differ in *which borrow their pointer was derived from*, and every re-acquisition (`get_current` and friends) reborrows the top entry's pointer. Re-using the outer entry makes the inner shim's borrow a **sibling** of the outer shim's rather than a child of it — and creating a sibling `&mut` invalidates the one already outstanding. The outer shim then carries on using its own store (`env.data_mut()` after `func.call(env, ..)` returns) through a reference that no longer exists as far as the aliasing model is concerned.

Miri, on a real `Store`, with no Wasm involved (this is the new `borrow_provenance` test, run against the code as it stands today):

```
error: Undefined Behavior: trying to retag from <164766> for Unique permission
       at alloc60201[0x0], but that tag does not exist in the borrow stack
  --> lib/api/src/entities/store/store_ref.rs:186:9    &mut self.inner.objects
help: <164766> was created by a Unique retag        (the outer shim's borrow)
help: <164766> was later invalidated by a Unique retag
  --> lib/api/src/entities/store/context.rs:476:18
      unsafe { self.store_ptr.as_mut().unwrap().as_store_mut() }
```

It is not only a model complaint. `StoreMut` is a single-field wrapper around `&mut StoreInner`, so it lowers to a `noalias` pointer argument, and LLVM exploits that. In a reduction of this shape it eliminates **both** loads around the nested call and infers the argument `readnone`, so the inner write becomes invisible:

```llvm
define i64 @shim_passing_env(ptr noalias readnone align 8 captures(none) %0)
  tail call void @opaque_with_env(ptr noalias nonnull align 8 poison)
```

What keeps our own shims out of trouble today is an accident of ABI: they take `FunctionEnvMut`, which is wide enough to be passed indirectly, so the promise lands on the outer pointer and the store pointer is reloaded. Widen or narrow that struct and the protection goes away.

## The change

`ensure_installed` becomes `install`, which always installs, carrying the pointer the caller just derived from the borrow it is holding. The inner borrow is then a child of the outer one — invalidated when the outer frame resumes, which is the correct order, rather than the reverse.

An async context is the exception and still installs nothing: it owns the store through a write guard held in the entry, and re-acquisitions re-derive from that guard rather than from a caller's borrow, so there is no borrow to nest under. Shadowing it would also hide the guard from async host functions, which find it by inspecting the active entry — three `jspi_async` tests fail if you do.

## Tests

`borrow_provenance` replays the call/import/nested-call/import sequence directly against the context stack, so it needs no JIT and Miri can check it. It passes trivially when run natively and fails under Miri if `install` goes back to re-using an active entry — verified in both directions. A CI job runs it:

```
cargo miri test -p wasmer --features sys --lib borrow_provenance
```

Miri also cannot call `sigaction`, which put building a `Store` out of reach; `init_traps` now skips signal-handler setup under `cfg!(miri)`, where no compiled Wasm runs for a handler to catch anyway.

Green: the `lib/api` suite under `sys,cranelift` and under `experimental-async,unsafe-cothread`; `wasmer-wasix --lib` (220); the `compilers` integration suite (344 passed, and the one failure — `artifact_deserialization_roundtrip`, a stale fixture — fails identically on `main`).

## Not addressed here

`Module::instantiate` derives its pointer *before* taking another borrow of the same store, so what it installs is already stale. Same defect class, different fix — the `objects` and `vmconfig` borrows are live across `finish_instantiation`, i.e. across the start function — and Miri cannot reach it, since that path needs Wasm to run. Worth a follow-up.

A second PR stacks on this one, adding `StoreMut::parked` / `Store::with_current` so host code can lend the executing store across an FFI boundary. It needs this fix underneath it: without it, every lend is the sibling case.
