### PR TITLE
feat(api): let host code lend the executing store

### DIFF
--- a/lib/api/src/entities/store/context.rs
+++ b/lib/api/src/entities/store/context.rs
@@ -305,6 +305,29 @@ impl StoreContext {
         })
     }
 
+    /// The active entry's store, if no frame on this thread's stack is holding
+    /// a borrow of it.
+    ///
+    /// A non-zero borrow count means some frame further up still holds a
+    /// `StoreMut` it can reach, so handing out a second one would alias it;
+    /// the caller gets `None` instead. A frame that has lent its borrow out
+    /// ([`StoreMut::parked`]) installed an entry of its own, whose count is
+    /// zero until somebody takes it — which is how an imported function lends
+    /// its store to code it calls into.
+    pub(crate) fn try_get_current_unborrowed() -> Option<StorePtrWrapper> {
+        STORE_CONTEXT_STACK.with(|cell| {
+            let mut stack = cell.borrow_mut();
+            let top = stack.last_mut()?;
+            if top.borrow_count != 0 {
+                return None;
+            }
+            top.borrow_count += 1;
+            Some(StorePtrWrapper {
+                store_ptr: unsafe { top.entry.get().as_mut().unwrap().as_ptr() },
+            })
+        })
+    }
+
     /// Safety: This method lets you borrow multiple mutable references
     /// to the currently active store context. The caller must ensure that:
     ///   * there is only one mutable reference alive, or
@@ -643,6 +666,36 @@ mod borrow_provenance {
         }
 
         // --- and goes on using the borrow it held throughout
+        let _ = shim.objects_mut().id();
+
+        drop(wrapper);
+        drop(install);
+    }
+
+    /// The lending path, which is the nesting above with the inner entry
+    /// installed by [`StoreMut::parked`] instead of by a nested call: the
+    /// borrow handed out by [`crate::Store::with_current`] must not invalidate
+    /// the one the lender is holding. Miri checks the last line.
+    #[test]
+    fn a_lend_keeps_the_lending_borrow_usable() {
+        let mut store = Store::default();
+        let id = store.id();
+
+        let mut caller = store.as_store_mut();
+        let install = unsafe { StoreContext::install(caller.as_store_mut().inner as *mut _) };
+
+        let mut wrapper = unsafe { StoreContext::get_current(id) };
+        let mut shim = wrapper.as_mut();
+        let _ = shim.objects_mut().id();
+
+        shim.parked(|| {
+            crate::Store::with_current(|lent| {
+                let _ = lent.objects_mut().id();
+            })
+            .expect("a parked store is lendable");
+        });
+
+        // The lender goes back to the borrow it held throughout.
         let _ = shim.objects_mut().id();
 
         drop(wrapper);

--- a/lib/api/src/entities/store/mod.rs
+++ b/lib/api/src/entities/store/mod.rs
@@ -121,6 +121,38 @@ impl Store {
         self.inner.objects.id()
     }
 
+    /// Runs `f` with the store this thread is currently executing, if that
+    /// store has been lent out with [`StoreMut::parked`].
+    ///
+    /// Host code called from Wasm normally receives the store as a
+    /// [`FunctionEnvMut`](crate::FunctionEnvMut), but code the host in turn
+    /// calls into cannot always be handed one: an embedded engine invoking a
+    /// callback, a C library's allocator hook, anything reached through frames
+    /// that carry no Rust references. This is how such code gets the store the
+    /// current call is running under, so it can use the ordinary store-taking
+    /// APIs — [`Memory::grow`](crate::Memory::grow) and friends — instead of
+    /// reaching around them.
+    ///
+    /// Returns `None` unless a store is executing on this thread *and* every
+    /// borrow of it on this thread's stack has been parked. Holding a
+    /// [`StoreMut`] and calling this would alias that borrow, so the answer
+    /// there is `None` rather than a second handle to the same store; parking
+    /// is what makes the outstanding borrow provably unreachable.
+    ///
+    /// A store starts executing when a call enters it, which only the `sys`
+    /// backend tracks — so on the others this is `None` inside a host function.
+    /// [`StoreMut::parked`] works everywhere, though, so an embedder can always
+    /// lend a store it owns, whether or not a call is running.
+    ///
+    /// Nothing guarantees the store is the one the caller expects — a thread
+    /// may run several — so check any handle before using it, with
+    /// [`Memory::is_from_store`](crate::Memory::is_from_store) or by comparing
+    /// [`StoreObjects::id`]. Using a handle from another store panics.
+    pub fn with_current<R>(f: impl FnOnce(&mut StoreMut<'_>) -> R) -> Option<R> {
+        let mut store = StoreContext::try_get_current_unborrowed()?;
+        Some(f(&mut store.as_mut()))
+    }
+
     /// Installs this store's context for the duration of a coroutine resume.
     /// The guard removes the context when dropped; hold it for exactly the
     /// duration of the resume() call.

--- a/lib/api/src/entities/store/store_ref.rs
+++ b/lib/api/src/entities/store/store_ref.rs
@@ -75,6 +75,53 @@ impl StoreMut<'_> {
         (self.inner.store.engine(), &mut self.inner.objects)
     }
 
+    /// Parks this borrow of the store for the duration of `f`, lending the
+    /// store to code that runs inside `f` without reaching it through Rust:
+    /// [`Store::with_current`](crate::Store::with_current) hands the store back to any frame `f` reaches,
+    /// however many foreign frames deep.
+    ///
+    /// This is how host code lends the store across an FFI boundary. An
+    /// embedded engine that calls back into the host — a JS engine's allocator
+    /// hook, say — cannot be handed a Rust reference through its own C frames,
+    /// and cannot be given one out of band either, because the imported
+    /// function it was called from is still holding the only borrow. Parking
+    /// that borrow, which the `&mut self` receiver here makes unreachable for
+    /// exactly as long as `f` runs, is what makes lending it sound rather than
+    /// aliasing.
+    ///
+    /// Parks nest, and a store nobody parked stays unlendable:
+    /// [`Store::with_current`](crate::Store::with_current) returns `None`
+    /// unless every borrow on this thread's stack has been parked this way.
+    ///
+    /// ```
+    /// use wasmer::{AsStoreMut, FunctionEnvMut, Store};
+    ///
+    /// // A host function lending its store to code it calls into.
+    /// fn host_call(mut env: FunctionEnvMut<'_, ()>) {
+    ///     // `env` holds the store, so nobody else may have it.
+    ///     assert!(Store::with_current(|_| ()).is_none());
+    ///
+    ///     env.as_store_mut().parked(|| {
+    ///         // ...but code reached from here can pick it back up.
+    ///         assert!(Store::with_current(|_| ()).is_some());
+    ///     });
+    /// }
+    /// ```
+    pub fn parked<R>(&mut self, f: impl FnOnce() -> R) -> R {
+        // This is the same thing `Function::call` does before entering Wasm:
+        // install this borrow as the store executing on the thread, so that
+        // code which reaches the store through the context — rather than
+        // through a reference it was handed — picks up a borrow derived from
+        // *this* one. The new entry starts unborrowed, which is what makes the
+        // store lendable for as long as it is on top.
+        let ptr: *mut StoreInner = &mut *self.inner;
+        // SAFETY: `ptr` comes from `&mut *self.inner`, which `&mut self` keeps
+        // alive and unreachable for every frame on this thread until `f`
+        // returns and the guard is dropped.
+        let _guard = unsafe { super::StoreContext::install(ptr) };
+        f()
+    }
+
     // TODO: OnCalledAction is needed for asyncify. It will be refactored with https://github.com/wasmerio/wasmer/issues/3451
     /// Sets the unwind callback which will be invoked when the call finishes
     pub fn on_called<F>(&mut self, callback: F)

--- a/lib/api/tests/current_store.rs
+++ b/lib/api/tests/current_store.rs
@@ -1,0 +1,248 @@
+//! Lending the executing store to code that cannot be handed a reference to
+//! it: [`StoreMut::parked`] + [`Store::with_current`].
+
+use macro_wasmer_engine_test::engine_test;
+#[cfg(feature = "js")]
+use wasm_bindgen_test::wasm_bindgen_test;
+
+use wasmer::*;
+
+/// Stands in for the foreign code an embedder calls into — a JS engine's
+/// allocator hook, a C callback — which reaches the host again with no store
+/// of its own and no way to have been handed one.
+fn called_through_foreign_frames<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
+
+/// A memory the host can grow, shared where the backend allows it (the case
+/// the API exists for) and plain where it does not.
+fn growable_memory(store: &mut Store) -> Memory {
+    let shared = MemoryType::new(Pages(1), Some(Pages(4)), true);
+    let owned = MemoryType::new(Pages(1), Some(Pages(4)), false);
+    Memory::new(&mut *store, shared)
+        .or_else(|_| Memory::new(&mut *store, owned))
+        .expect("create memory")
+}
+
+/// Calls `"run"` on a module whose only body is a call to the `"host"."run"`
+/// import, so `host` runs with a store the runtime installed for the call.
+fn run_host_function(store: &mut Store, host: Function) -> Result<(), String> {
+    let wat = r#"(module
+        (func $host (import "host" "run"))
+        (func (export "run") (call $host))
+    )"#;
+    let module = Module::new(&*store, wat).map_err(|e| format!("{e:?}"))?;
+    let imports = imports! { "host" => { "run" => host } };
+    let instance = Instance::new(&mut *store, &module, &imports).map_err(|e| format!("{e:?}"))?;
+    instance
+        .exports
+        .get_typed_function::<(), ()>(&*store, "run")
+        .map_err(|e| format!("{e:?}"))?
+        .call(&mut *store)
+        .map_err(|e| format!("{e:?}"))
+}
+
+#[derive(Default)]
+struct Report {
+    /// Whether the store was lent out before anyone parked it.
+    lent_unparked: bool,
+    /// Whether it was lent out from inside the park.
+    lent_parked: bool,
+    /// Whether it was lent out again once the park ended.
+    lent_after_park: bool,
+    /// Whether the store lent out is the one the host function is running
+    /// under, rather than some other store on this thread.
+    same_store: bool,
+    /// Size the memory reported before the lent store grew it.
+    size_before_grow: Option<Pages>,
+}
+
+struct HostEnv {
+    memory: Memory,
+    report: Report,
+}
+
+#[engine_test]
+fn store_is_lent_out_only_while_parked() -> Result<(), String> {
+    let mut store = Store::default();
+    let memory = growable_memory(&mut store);
+    let env = FunctionEnv::new(
+        &mut store,
+        HostEnv {
+            memory: memory.clone(),
+            report: Report::default(),
+        },
+    );
+
+    let host =
+        Function::new_typed_with_env(&mut store, &env, |mut env: FunctionEnvMut<HostEnv>| {
+            let memory = env.data().memory.clone();
+            let store_id = env.objects_mut().id();
+
+            // The host function is holding the store, so nobody else may have it.
+            let lent_unparked =
+                called_through_foreign_frames(|| Store::with_current(|_| ()).is_some());
+
+            let mut same_store = false;
+            let size_before_grow = Some(memory.view(&env).size());
+            let lent_parked = env
+                .as_store_mut()
+                .parked(|| {
+                    called_through_foreign_frames(|| {
+                        Store::with_current(|store| {
+                            same_store = store.objects_mut().id() == store_id
+                                && memory.is_from_store(&*store);
+                            // The whole point: reach the store's ordinary API from
+                            // code that was never given a store.
+                            memory.grow(store, Pages(1)).expect("grow the lent memory");
+                        })
+                    })
+                })
+                .is_some();
+
+            // The park is over; the store belongs to this function again.
+            let lent_after_park =
+                called_through_foreign_frames(|| Store::with_current(|_| ()).is_some());
+
+            env.data_mut().report = Report {
+                lent_unparked,
+                lent_parked,
+                lent_after_park,
+                same_store,
+                size_before_grow,
+            };
+        });
+
+    run_host_function(&mut store, host)?;
+
+    let report = &env.as_ref(&store).report;
+    assert!(
+        !report.lent_unparked,
+        "a store still held by the host function must not be lent out"
+    );
+
+    if !report.lent_parked {
+        // Backends that do not track an executing store (v8, js) lend nothing.
+        // What matters is that they say so instead of panicking or handing
+        // back some other store, which the assertions above already cover.
+        return Ok(());
+    }
+
+    assert!(
+        report.same_store,
+        "the store lent out must be the one the call is running under"
+    );
+    assert!(
+        !report.lent_after_park,
+        "the lend must end with the park, not outlive it"
+    );
+    assert_eq!(
+        Some(memory.view(&store).size()),
+        report.size_before_grow.map(|before| before + Pages(1)),
+        "a grow through the lent store must be visible to its owner"
+    );
+
+    Ok(())
+}
+
+#[engine_test]
+fn parks_nest() -> Result<(), String> {
+    let mut store = Store::default();
+    let env = FunctionEnv::new(&mut store, Vec::<bool>::new());
+
+    let host =
+        Function::new_typed_with_env(&mut store, &env, |mut env: FunctionEnvMut<Vec<bool>>| {
+            let mut lends = Vec::new();
+            env.as_store_mut().parked(|| {
+                Store::with_current(|lent| {
+                    // The lent borrow is itself a borrow: until it is parked in
+                    // turn, it is the one thing standing in the way of a
+                    // further lend.
+                    lends.push(Store::with_current(|_| ()).is_some());
+                    lent.parked(|| lends.push(Store::with_current(|_| ()).is_some()));
+                    // ...and unparking it puts it back in the way.
+                    lends.push(Store::with_current(|_| ()).is_some());
+                });
+            });
+            *env.data_mut() = lends;
+        });
+
+    run_host_function(&mut store, host)?;
+
+    let lends = env.as_ref(&store);
+    if lends.is_empty() {
+        // Backend does not track an executing store; nothing was lent at all.
+        return Ok(());
+    }
+    assert_eq!(
+        lends.as_slice(),
+        [false, true, false],
+        "a lent store is lendable again only while it is itself parked"
+    );
+
+    Ok(())
+}
+
+/// A park that ends by unwinding must hand the borrow back, or the host
+/// function that caught the panic would keep using a store that has been
+/// declared lendable.
+#[engine_test]
+fn a_park_that_unwinds_gives_the_borrow_back() -> Result<(), String> {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let mut store = Store::default();
+    let env = FunctionEnv::new(&mut store, None::<bool>);
+
+    let host =
+        Function::new_typed_with_env(&mut store, &env, |mut env: FunctionEnvMut<Option<bool>>| {
+            // The panic below is the point of the test, not a failure; keep it
+            // from printing a scary backtrace in the middle of a passing run.
+            let hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(|_| {}));
+            let unwound = catch_unwind(AssertUnwindSafe(|| {
+                env.as_store_mut().parked(|| panic!("boom"))
+            }))
+            .is_err();
+            std::panic::set_hook(hook);
+            assert!(unwound, "the park must not swallow the panic");
+
+            // `env` still holds the store, exactly as it did before the park.
+            *env.data_mut() = Some(Store::with_current(|_| ()).is_some());
+        });
+
+    run_host_function(&mut store, host)?;
+
+    assert_eq!(
+        *env.as_ref(&store),
+        Some(false),
+        "a store whose park unwound must not stay lendable"
+    );
+
+    Ok(())
+}
+
+/// An idle store — one no call is executing — is nobody's to take until its
+/// owner parks it. Parking is what an embedder does to lend a store to a
+/// callback that runs outside any call at all.
+#[engine_test]
+fn an_idle_store_is_lent_only_once_parked() -> Result<(), String> {
+    let mut store = Store::default();
+    let store_id = store.id();
+
+    assert!(
+        Store::with_current(|_| ()).is_none(),
+        "an idle store is not lendable on its own"
+    );
+
+    let lent = store
+        .as_store_mut()
+        .parked(|| Store::with_current(|store| store.objects_mut().id()));
+    assert_eq!(lent, Some(store_id), "parking lends the store it parked");
+
+    assert!(
+        Store::with_current(|_| ()).is_none(),
+        "and the lend ends with the park"
+    );
+
+    Ok(())
+}

--- a/lib/api/tests/current_store.rs
+++ b/lib/api/tests/current_store.rs
@@ -186,6 +186,10 @@ fn parks_nest() -> Result<(), String> {
 /// A park that ends by unwinding must hand the borrow back, or the host
 /// function that caught the panic would keep using a store that has been
 /// declared lendable.
+///
+/// Native only: panics abort on `wasm32-unknown-unknown`, so there is no
+/// unwinding there to observe.
+#[cfg(not(target_arch = "wasm32"))]
 #[engine_test]
 fn a_park_that_unwinds_gives_the_borrow_back() -> Result<(), String> {
     use std::panic::{AssertUnwindSafe, catch_unwind};


### PR DESCRIPTION
Stacked on #6886 — review that first; this PR's diff is the top commit only. It needs that fix underneath it: without it, every lend is the sibling-reborrow case that PR fixes.

## Why

Host code called from Wasm gets the store as a `FunctionEnvMut`, but code it in turn calls into cannot always be handed one — an embedded engine invoking a callback, a C library's allocator hook, anything reached through frames that carry no Rust references. The workaround so far has been to add store-free operations to the API (a `SharedMemory::grow` that takes no store, in the case that prompted this), and each of those is a hole in the store's ownership model: an operation that mutates a store nobody can prove they own.

The runtime already knows the answer. The thread's store context stack holds the store the current call is running under — every `sys` host-function trampoline gets its `FunctionEnvMut` out of it. It just wasn't reachable from outside the crate.

## The pair

```rust
impl StoreMut<'_> {
    pub fn parked<R>(&mut self, f: impl FnOnce() -> R) -> R;
}

impl Store {
    pub fn with_current<R>(f: impl FnOnce(&mut StoreMut<'_>) -> R) -> Option<R>;
}
```

Both safe, and the pairing is what makes them safe. `get_current`'s contract has always been *"only one mutable reference alive, or all but one inaccessible"* — and *inaccessible* is a property of the caller's stack that the callee cannot check. The `&mut self` receiver on `parked` is the caller proving it, at compile time, for exactly as long as `f` runs; the entry it installs starts unborrowed, which is the runtime half. Ask for the store while holding it and you get `None`, not a second handle — misuse degrades to a missing lend rather than aliasing.

`parked` installs its borrow as the executing store, which is the same thing `Function::call` does before entering Wasm, so this adds no new mechanism — it reuses the one #6886 makes correct.

Why the borrow count is a sound gate: an entry is on the stack only while the borrow it was installed from is held by an in-progress call (`Function::call`, `Instance::new`, or a `parked`), all of which the borrow checker freezes until they return. A count of zero therefore means no frame on this thread can reach the store.

## Notes

- Parking an idle store lends it too — that's how an embedder hands its own store to a callback outside any call.
- `with_current` inside a host function is `sys`-only, since the other backends don't track an executing store. `parked` works everywhere.
- `with_current` gives you *a* store, not necessarily *yours* (a thread may run several), so check handles with `Memory::is_from_store` or by comparing `StoreObjects::id`. Using a handle from the wrong store panics in `StoreHandle::get_mut` rather than doing anything worse.

## Tests

`lib/api/tests/current_store.rs`: a host function lending its store and growing a memory through the lend (visible to the owner afterwards); parks nesting; a park that ends by unwinding handing the borrow back; and an idle store. All four take the lending branch under `sys,cranelift`.

`a_lend_keeps_the_lending_borrow_usable` joins the `borrow_provenance` module, so the Miri job from #6886 also checks that a lent borrow does not invalidate the lender's.

Also green: the `lib/api` suite with and without `experimental-async,unsafe-cothread`, and `cargo doc` for `--no-default-features --features v8`.

## What comes next

wasmer-napi's `GuestHeap` grows guest linear memory from V8's array-buffer allocator, which runs with no store in reach — that is what the store-free `SharedMemory::grow` in #6877 was for. With this, it parks around the bridge call and grows through the ordinary `Memory::grow`, and that API addition can be dropped.
