### PR TITLE
feat(napi): grow the guest heap through the store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,6 +3788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +3886,16 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "offset-allocator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234d535da3521eb95106f40f0b73483d80bfb3aacf27c40d7e2b72f1a3e00a2"
+dependencies = [
+ "log",
+ "nonmax",
 ]
 
 [[package]]
@@ -7744,16 +7760,19 @@ dependencies = [
  "anyhow",
  "cc",
  "enum-iterator",
+ "js-sys",
+ "offset-allocator",
  "serde",
  "serde_json",
  "tar",
  "tokio",
  "ureq 2.12.1",
  "virtual-fs",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmer",
  "wasmer-c-api-imports",
  "wasmer-cache",
- "wasmer-compiler-llvm",
  "wasmer-types",
  "wasmer-wasix",
  "wat",

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -1004,6 +1004,7 @@ impl WasiEnvBuilder {
             clock_offset: Default::default(),
             envs: std::sync::Mutex::new(conv_env_vars(self.envs)),
             signals: std::sync::Mutex::new(self.signals.iter().map(|s| (s.sig, s.disp)).collect()),
+            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
         };
 
         let runtime = self.runtime.unwrap_or_else(|| {

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -717,9 +717,10 @@ impl WasiEnv {
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
         let inner = env_inner.main_module_instance_handles();
         // Ask the process, not just this instance: a spawned thread has its own
-        // InstanceHandles and never sees the main instance's registration, so
-        // `inner.signal_set` alone would apply the default disposition on
-        // sibling threads and terminate a process that does handle the signal.
+        // WasiModuleInstanceHandles and never sees the main instance's
+        // registration, so `inner.signal_set` alone would apply the default
+        // disposition on sibling threads and terminate a process that does
+        // handle the signal.
         let handler_registered = inner.signal_set
             || env
                 .state
@@ -763,7 +764,13 @@ impl WasiEnv {
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
         let inner = env_inner.main_module_instance_handles();
         if !inner.signal_set {
-            return Ok(Ok(false));
+            // Process-directed signals are copied into every thread's queue,
+            // but the guest callback belongs only to the instance that
+            // registered it. A sibling instance must discard its copy after
+            // the process-wide registration suppressed the default disposition;
+            // otherwise that copy remains queued forever.
+            let drained = !env.thread.pop_signals().is_empty();
+            return Ok(Ok(drained));
         }
 
         // Check for any signals that we need to trigger

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -128,6 +128,7 @@ impl WasiEnvInit {
                 args: std::sync::Mutex::new(self.state.args.lock().unwrap().clone()),
                 envs: std::sync::Mutex::new(self.state.envs.lock().unwrap().deref().clone()),
                 signals: std::sync::Mutex::new(self.state.signals.lock().unwrap().deref().clone()),
+                signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
                 preopen: self.state.preopen.clone(),
             },
             runtime: self.runtime.clone(),
@@ -715,7 +716,16 @@ impl WasiEnv {
             .try_inner()
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
         let inner = env_inner.main_module_instance_handles();
-        if !inner.signal_set {
+        // Ask the process, not just this instance: a spawned thread has its own
+        // InstanceHandles and never sees the main instance's registration, so
+        // `inner.signal_set` alone would apply the default disposition on
+        // sibling threads and terminate a process that does handle the signal.
+        let handler_registered = inner.signal_set
+            || env
+                .state
+                .signal_handler_registered
+                .load(std::sync::atomic::Ordering::SeqCst);
+        if !handler_registered {
             let signals = env.thread.pop_signals();
             if !signals.is_empty() {
                 for sig in signals {

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -135,6 +135,15 @@ pub(crate) struct WasiState {
     pub args: Mutex<Vec<String>>,
     pub envs: Mutex<Vec<Vec<u8>>>,
     pub signals: Mutex<HashMap<Signal, Disposition>>,
+    /// Whether this *process* has registered a signal handler callback.
+    ///
+    /// `InstanceHandles::signal_set` only records whether the instance doing
+    /// the asking registered one, and every spawned thread gets its own
+    /// instance. Signals are delivered to all of a process's threads, so a
+    /// per-instance flag makes sibling threads believe the program handles no
+    /// signals and apply the runtime's default disposition -- terminating a
+    /// process that does in fact have a handler installed.
+    pub signal_handler_registered: std::sync::atomic::AtomicBool,
 
     // TODO: should not be here, since this requires active work to resolve.
     // State should only hold active runtime state that can be reproducibly re-created.
@@ -246,6 +255,8 @@ impl WasiState {
             args: Mutex::new(self.args.lock().unwrap().clone()),
             envs: Mutex::new(self.envs.lock().unwrap().clone()),
             signals: Mutex::new(self.signals.lock().unwrap().clone()),
+            // A forked process re-registers from its own instance.
+            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
             preopen: self.preopen.clone(),
         }
     }

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -137,11 +137,11 @@ pub(crate) struct WasiState {
     pub signals: Mutex<HashMap<Signal, Disposition>>,
     /// Whether this *process* has registered a signal handler callback.
     ///
-    /// `InstanceHandles::signal_set` only records whether the instance doing
-    /// the asking registered one, and every spawned thread gets its own
-    /// instance. Signals are delivered to all of a process's threads, so a
-    /// per-instance flag makes sibling threads believe the program handles no
-    /// signals and apply the runtime's default disposition -- terminating a
+    /// `WasiModuleInstanceHandles::signal_set` only records whether the
+    /// instance doing the asking registered one, and every spawned thread gets
+    /// its own instance. Signals are delivered to all of a process's threads,
+    /// so a per-instance flag makes sibling threads believe the program handles
+    /// no signals and apply the runtime's default disposition -- terminating a
     /// process that does in fact have a handler installed.
     pub signal_handler_registered: std::sync::atomic::AtomicBool,
 

--- a/lib/wasix/src/syscalls/wasix/callback_signal.rs
+++ b/lib/wasix/src/syscalls/wasix/callback_signal.rs
@@ -42,6 +42,13 @@ pub fn callback_signal<M: MemorySize>(
         inner.signal = funct;
         inner.signal_set = true;
     }
+    // Record it for the whole process: signals are delivered to every thread,
+    // and the sibling threads have their own instances that never see the
+    // registration above.
+    ctx.data()
+        .state
+        .signal_handler_registered
+        .store(true, std::sync::atomic::Ordering::SeqCst);
 
     WasiEnv::do_pending_operations(&mut ctx)?;
 

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -111,7 +111,10 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         match find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name) {
             FindExecutableResult::Found(p) => *name = p,
             FindExecutableResult::AccessError => return Ok(Errno::Access),
-            FindExecutableResult::NotFound => return Ok(Errno::Noexec),
+            // Nothing by that name on PATH is ENOENT. ENOEXEC means the file
+            // was found but is not an executable format, which is what the
+            // spawn failure below reports. proc_exec4 already gets this right.
+            FindExecutableResult::NotFound => return Ok(Errno::Noent),
         }
     } else if name.starts_with("./") {
         *name = ctx.data().state.fs.relative_path_to_absolute(name.clone());


### PR DESCRIPTION
Stacked on #6887 (which is stacked on #6886) — review those first; this PR's diff is the top three commits.

This is #6877 redone. That PR added `SharedMemory::grow`/`data_ptr`/`style` so wasmer-napi's `GuestHeap` could grow guest linear memory from a thread with no store — a store-free mutation of a store-owned object, which is not an operation this API should have. Those methods are gone; the caller they existed for now gets a store instead.

## The napi side

wasmerio/napi#61. The bind `GuestHeap` was in: the allocation that needs the growth arrives with no store in sight, because V8 calls the array-buffer allocator from inside its own frames, several levels below the N-API import that entered it, and no Rust reference survives that trip.

So the import lends its store across the boundary (`StoreMut::parked`), and the heap picks it back up (`Store::with_current`) and grows through the ordinary `Memory::grow`. Fallout on that side: the shared/owned split disappears (any heap grows when a store is lent, any heap falls back to its pre-funded arena when none is — a V8 background thread will find none); memory handles are store-scoped, so the heap keeps one per store that reaches it, since WASIX worker threads share a memory but not a store; and the callback context drops its raw pointer to the installing frame's `FunctionEnvMut` in favour of a store-free `FunctionEnv` handle, because that pointer was reaching around exactly the borrow the import now parks.

The submodule pin is napi#61's head; it moves to napi `main` once that merges.

## Also carried

Two wasix fixes that were part of #6877 and are unrelated to any of the above — happy to split them out if you'd rather:

- **`fix(wasix): track signal-handler registration per process, not per instance`** — the "has a handler" flag lived on `InstanceHandle`, but every spawned thread gets its own instance and signals are delivered to all of them. A sibling thread draining its queue saw `!signal_set`, concluded the program handles no signals, and applied the default disposition, killing a process that had a handler installed and working.
- **`fix(wasix): proc_spawn reports ENOENT, not ENOEXEC, for a missing command`** — POSIX reserves ENOEXEC for a file that exists but is not executable; `proc_exec4` already returned ENOENT from the identical match, so the two syscalls disagreed.

Plus the `offset-allocator`/`nonmax` lock entries the heap's allocator needs.

## Testing

`wasmer-napi --lib`: 40/40, including new tests for an allocation served from the arena with no store lent, the same allocation past the arena failing rather than growing the guest's memory behind its back, it succeeding once a store is lent, and a store that never registered a handle being unable to grow the memory. `wasmer-wasix --lib` green.
