### PR TITLE
fix(gen-c-header): fix wasm detection

### DIFF
--- a/lib/cli/src/commands/gen_c_header.rs
+++ b/lib/cli/src/commands/gen_c_header.rs
@@ -8,7 +8,7 @@ use wasmer_compiler::{
 };
 use wasmer_package::{package::WasmerPackageError, utils::from_bytes};
 use wasmer_types::target::{CpuFeature, Triple};
-use webc::{Container, ContainerError, DetectError, compat::SharedBytes};
+use webc::{Container, DetectError, compat::SharedBytes};
 
 use crate::backend::RuntimeOptions;
 
@@ -62,9 +62,7 @@ impl GenCHeader {
 
         let atom = match from_bytes(file.clone()) {
             Ok(webc) => self.get_atom(&webc)?,
-            Err(WasmerPackageError::ContainerError(ContainerError::Detect(
-                DetectError::InvalidMagic { .. },
-            ))) => {
+            Err(WasmerPackageError::DetectError(DetectError::InvalidMagic { .. })) => {
                 // we've probably got a WebAssembly file
                 file.into()
             }

--- a/tests/integration/cli/tests/gen_c_header.rs
+++ b/tests/integration/cli/tests/gen_c_header.rs
@@ -41,3 +41,30 @@ fn gen_c_header_works_pirita() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn gen_c_header_works_wasm() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let operating_dir: PathBuf = temp_dir.path().to_owned();
+
+    let wasm_path = operating_dir.join(fixtures::qjs());
+    let out_path = temp_dir.path().join("header.h");
+
+    let cmd = wasmer_command()
+        .arg("gen-c-header")
+        .arg(&wasm_path)
+        .arg("-o")
+        .arg(&out_path)
+        .output()
+        .unwrap();
+    let file = std::fs::read_to_string(&out_path).expect("no header.h file");
+    assert!(
+        file.contains(
+            "wasmer_function_6f62a6bc5c8f8e3e12a54e2ecbc5674ccfe1c75f91d8e4dd6ebb3fec422a4d6c_0"
+        ),
+        "no wasmer_function_6f62a6bc5c8f8e3e12a54e2ecbc5674ccfe1c75f91d8e4dd6ebb3fec422a4d6c_930 in file"
+    );
+    assert!(cmd.status.success());
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

If you try to pass a WASM file instead of a WEBC file into gen-c-headers, it reports:
```
error: Unable to parse the webc file
│   1: detect error: InvalidMagic { found: [0, 97, 115, 109, 1], expected: [0, 119, 101, 98, 99] }
╰─▶ 2: Expected the magic bytes to be "\x00webc", but found "\x00asm\x01"
```
I just updated the error type to what `from_bytes` actually returns when `webc` can't detect a WEBC file.

I also verified that this now works on WASM files.

Just a side note: I think it could be nice to update the [docs](https://github.com/wasmerio/wasmer/blob/1e62ffbf298c6082ab889aac48d41fd86c5b7c78/docs/dev/create-exe.md?plain=1#L72) for `gen-c-headers`. Since the preferred input file is WEBC, I think the docs could be updated to reflect that. I would be happy to do that, if this makes sense to you.