### PR TITLE
test: fix `cargo-nextest` installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -965,7 +965,7 @@ update-graphql-schema:
 	curl -sSfL https://registry.wapm.io/graphql/schema.graphql > lib/registry/graphql/schema.graphql
 
 require-nextest:
-	cargo nextest --version > /dev/null || cargo binstall cargo-nextest --secure || cargo install cargo-nextest
+	cargo nextest --version > /dev/null || cargo binstall cargo-nextest --secure || cargo install cargo-nextest --locked
 
 # Check all the features compatible with the `sys` backend.
 check-api-features:


### PR DESCRIPTION
Currently, if `cargo bininstall` is not available (which it wasn't on my machine), the integration tests run `cargo install` without passing `--locked`, which results in:
```
error: Nextest does not support being installed without --locked. To install nextest from source, run:

       cargo install --locked cargo-nextest

       For more, see https://nexte.st/docs/installation/from-source/.
  --> /home/yunusey/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/locked-tripwire-0.1.1002/src/lib.rs:5:1
   |
 5 | / compile_error!(
 6 | |     "Nextest does not support being installed without --locked. To install nextest from source, run:
 7 | |
 8 | | cargo install --locked cargo-nextest
 9 | |
10 | | For more, see https://nexte.st/docs/installation/from-source/.");
   | |________________________________________________________________^
```

I just passed it :)