### PR TITLE
fix(Singlepass): simplify stack rounding logic

### DIFF
--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -308,10 +308,15 @@ impl<'a, M: Machine> FuncGen<'a, M> {
 
     /// Acquire location that will live on the stack.
     fn acquire_location_on_stack(&mut self) -> Result<Location<M::GPR, M::SIMD>, CompileError> {
+        let old_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
         self.stack_offset += 8;
+        let new_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
+
         let loc = self.machine.local_on_stack(self.stack_offset.get() as i32);
-        self.machine
-            .extend_stack(self.machine.round_stack_adjust(8) as u32)?;
+        let stack_diff = new_adjust - old_adjust;
+        if stack_diff > 0 {
+            self.machine.extend_stack(stack_diff as u32)?;
+        }
 
         Ok(loc)
     }
@@ -347,13 +352,17 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         &mut self,
         locs: &[LocationWithCanonicalization<M>],
     ) -> Result<(), CompileError> {
+        let old_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
         for (loc, _) in locs.iter().rev() {
             if let Location::Memory(..) = *loc {
                 self.check_location_on_stack(loc, self.stack_offset.get())?;
                 self.stack_offset -= 8;
-                self.machine
-                    .truncate_stack(self.machine.round_stack_adjust(8) as u32)?;
             }
+        }
+        let new_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
+        let stack_diff = old_adjust - new_adjust;
+        if stack_diff > 0 {
+            self.machine.truncate_stack(stack_diff as u32)?;
         }
 
         Ok(())
@@ -364,15 +373,19 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         stack_depth: usize,
     ) -> Result<(), CompileError> {
         let mut stack_offset = self.stack_offset.get();
+        let old_adjust = stack_offset.next_multiple_of(M::STACK_ALIGNMENT);
         let locs = &self.value_stack[stack_depth..];
 
         for (loc, _) in locs.iter().rev() {
             if let Location::Memory(..) = *loc {
                 self.check_location_on_stack(loc, stack_offset)?;
                 stack_offset -= 8;
-                self.machine
-                    .truncate_stack(self.machine.round_stack_adjust(8) as u32)?;
             }
+        }
+        let new_adjust = stack_offset.next_multiple_of(M::STACK_ALIGNMENT);
+        let stack_diff = old_adjust - new_adjust;
+        if stack_diff > 0 {
+            self.machine.truncate_stack(stack_diff as u32)?;
         }
 
         Ok(())
@@ -513,7 +526,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         static_area_size += num_mem_slots * 8;
 
         // Allocate save area, without actually writing to it.
-        static_area_size = self.machine.round_stack_adjust(static_area_size);
+        static_area_size = static_area_size.next_multiple_of(M::STACK_ALIGNMENT);
 
         // Stack probe.
         //
@@ -832,9 +845,10 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         }
 
         // Align stack to 16 bytes.
-        let stack_unaligned =
-            (self.machine.round_stack_adjust(self.stack_offset.get()) + used_stack + stack_offset)
-                % 16;
+        let stack_unaligned = (self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT)
+            + used_stack
+            + stack_offset)
+            % 16;
         if stack_unaligned != 0 {
             stack_offset += 16 - stack_unaligned;
         }

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -310,10 +310,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
     fn acquire_location_on_stack(&mut self) -> Result<Location<M::GPR, M::SIMD>, CompileError> {
         let old_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
         self.stack_offset += 8;
-        let new_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
+        let stack_diff = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT) - old_adjust;
 
         let loc = self.machine.local_on_stack(self.stack_offset.get() as i32);
-        let stack_diff = new_adjust - old_adjust;
         if stack_diff > 0 {
             self.machine.extend_stack(stack_diff as u32)?;
         }
@@ -359,8 +358,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.stack_offset -= 8;
             }
         }
-        let new_adjust = self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
-        let stack_diff = old_adjust - new_adjust;
+        let stack_diff = old_adjust - self.stack_offset.get().next_multiple_of(M::STACK_ALIGNMENT);
         if stack_diff > 0 {
             self.machine.truncate_stack(stack_diff as u32)?;
         }
@@ -382,8 +380,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 stack_offset -= 8;
             }
         }
-        let new_adjust = stack_offset.next_multiple_of(M::STACK_ALIGNMENT);
-        let stack_diff = old_adjust - new_adjust;
+        let stack_diff = old_adjust - stack_offset.next_multiple_of(M::STACK_ALIGNMENT);
         if stack_diff > 0 {
             self.machine.truncate_stack(stack_diff as u32)?;
         }

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -104,6 +104,10 @@ pub(crate) struct FinalizedAssembly {
 pub trait Machine {
     type GPR: Copy + Eq + Debug + Reg;
     type SIMD: Copy + Eq + Debug + Reg;
+
+    /// A stack alignment in bytes that fullfills the ABI requirement.
+    const STACK_ALIGNMENT: usize;
+
     /// Get current assembler offset
     fn assembler_get_offset(&self) -> Offset;
     /// Get the GPR that hold vmctx
@@ -150,8 +154,6 @@ pub trait Machine {
     fn push_used_simd(&mut self, simds: &[Self::SIMD]) -> Result<usize, CompileError>;
     /// Pop used simd regs to the stack
     fn pop_used_simd(&mut self, simds: &[Self::SIMD]) -> Result<(), CompileError>;
-    /// Return a rounded stack adjustment value (must be multiple of 16bytes on ARM64 for example)
-    fn round_stack_adjust(&self, value: usize) -> usize;
     /// Set the source location of the Wasm to the given offset.
     fn set_srcloc(&mut self, offset: u32);
     /// Marks each address in the code range emitted by `f` with the trap code `code`.

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -105,7 +105,7 @@ pub trait Machine {
     type GPR: Copy + Eq + Debug + Reg;
     type SIMD: Copy + Eq + Debug + Reg;
 
-    /// A stack alignment in bytes that fullfills the ABI requirement.
+    /// A stack alignment in bytes that fulfills the ABI requirement.
     const STACK_ALIGNMENT: usize;
 
     /// Get current assembler offset

--- a/lib/compiler-singlepass/src/machine_arm64.rs
+++ b/lib/compiler-singlepass/src/machine_arm64.rs
@@ -1339,6 +1339,8 @@ impl Machine for MachineARM64 {
     type GPR = GPR;
     type SIMD = NEON;
 
+    const STACK_ALIGNMENT: usize = 16;
+
     fn assembler_get_offset(&self) -> Offset {
         self.assembler.get_offset()
     }
@@ -1555,10 +1557,6 @@ impl Machine for MachineARM64 {
 
     fn instructions_address_map(&self) -> Vec<InstructionAddressMap> {
         self.instructions_address_map.clone()
-    }
-
-    fn round_stack_adjust(&self, value: usize) -> usize {
-        value.next_multiple_of(16)
     }
 
     fn local_on_stack(&mut self, stack_offset: i32) -> Location {

--- a/lib/compiler-singlepass/src/machine_riscv.rs
+++ b/lib/compiler-singlepass/src/machine_riscv.rs
@@ -1912,6 +1912,8 @@ impl Machine for MachineRiscv {
     type GPR = GPR;
     type SIMD = FPR;
 
+    const STACK_ALIGNMENT: usize = 16;
+
     fn assembler_get_offset(&self) -> Offset {
         self.assembler.get_offset()
     }
@@ -2065,14 +2067,6 @@ impl Machine for MachineRiscv {
             Location::Imm64(stack_adjust as _),
             Location::GPR(GPR::Sp),
         )
-    }
-
-    fn round_stack_adjust(&self, value: usize) -> usize {
-        if value & 0xf != 0 {
-            ((value >> 4) + 1) << 4
-        } else {
-            value
-        }
     }
 
     fn set_srcloc(&mut self, offset: u32) {

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -1965,6 +1965,8 @@ impl Machine for MachineX86_64 {
     type GPR = GPR;
     type SIMD = XMM;
 
+    const STACK_ALIGNMENT: usize = 8;
+
     fn assembler_get_offset(&self) -> Offset {
         self.assembler.get_offset()
     }
@@ -2169,10 +2171,6 @@ impl Machine for MachineX86_64 {
 
     fn local_on_stack(&mut self, stack_offset: i32) -> Location {
         Location::Memory(GPR::RBP, -stack_offset)
-    }
-
-    fn round_stack_adjust(&self, value: usize) -> usize {
-        value
     }
 
     fn extend_stack(&mut self, delta_stack_offset: u32) -> Result<(), CompileError> {

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -1965,6 +1965,7 @@ impl Machine for MachineX86_64 {
     type GPR = GPR;
     type SIMD = XMM;
 
+    /// x86_64 stack slots are 8 bytes; 16-byte stack alignment for calls is handled separately.
     const STACK_ALIGNMENT: usize = 8;
 
     fn assembler_get_offset(&self) -> Offset {


### PR DESCRIPTION
Previously, we rounded each stack allocation and so our stack usage got 2x bigger than necessary on platforms with 16B stack alignment requirement (AArch64 and RISC-V). That's changed in the PR, where we bump the real stack pointer only if the aligned `self.stack_offset` needs to be adjusted.