### PR TITLE
feat: directly fetch cronjob invocations by ID & bump schema

### DIFF
--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -1816,13 +1816,7 @@ type CronJobInvocation {
 
 type CronJobInvocationConnection {
 	pageInfo: PageInfo!
-	edges: [CronJobInvocationEdge!]!
 	nodes: [CronJobInvocation!]!
-}
-
-type CronJobInvocationEdge {
-	cursor: String!
-	node: CronJobInvocation!
 }
 
 union CronJobInvocationResult = ExecuteCronJobInvocationResult | FetchCronJobInvocationResult
@@ -5837,6 +5831,7 @@ type Query {
 		"""
 		id: ID!
 	): Node
+	getCronJobInvocation(id: ID!): CronJobInvocation
 	nodes(ids: [ID!]!): [Node]!
 	info: RegistryInfo!
 }

--- a/lib/backend-api/schema.graphql
+++ b/lib/backend-api/schema.graphql
@@ -1802,7 +1802,6 @@ type CronJobEdge {
 
 type CronJobInvocation {
 	id: ID!
-	edgeJobId: String!
 	status: CronJobInvocationStatus
 	scheduledAt: DateTime
 	startedAt: DateTime

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -18,9 +18,7 @@ use crate::{
 
 pub const CRON_JOB_PAGE_SIZE: i32 = 100;
 
-/// Prefix of a cron job invocation's opaque id. An invocation carrying this
-/// prefix can be resolved directly, without searching a cron job's invocation
-/// pages.
+/// Prefix required by direct cron job invocation lookups.
 pub const CRON_JOB_INVOCATION_ID_PREFIX: &str = "croninv_";
 
 /// Retrieve the persistent `AppVolume` nodes of an app, including their S3
@@ -554,145 +552,22 @@ pub async fn get_cron_job_invocations_page_by_id(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn get_cron_job_invocation_logs(
-    client: &WasmerClient,
-    owner: impl Into<String>,
-    name: impl Into<String>,
-    cron_job: impl AsRef<str>,
-    invocation: impl AsRef<str>,
-    log_first: Option<i32>,
-    start: Option<OffsetDateTime>,
-    end: Option<OffsetDateTime>,
-) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
-    let owner = owner.into();
-    let name = name.into();
-    let cron_job = cron_job.as_ref().to_string();
-    let invocation = invocation.as_ref().to_string();
-    let (start, end) = default_cron_invocation_window(start, end)?;
-    let start = types::DateTime::try_from(start)?;
-    let end = types::DateTime::try_from(end)?;
-    let mut cron_after = None;
-
-    loop {
-        let mut invocation_after = None;
-        loop {
-            let vars = types::GetCronJobInvocationLogsVars {
-                owner: owner.clone(),
-                name: name.clone(),
-                cron_after: cron_after.clone(),
-                cron_first: Some(CRON_JOB_PAGE_SIZE),
-                invocation_start: Some(start.clone()),
-                invocation_end: Some(end.clone()),
-                invocation_after: invocation_after.clone(),
-                invocation_first: Some(1),
-                log_first,
-            };
-            let res = client
-                .run_graphql_strict(types::GetCronJobInvocationLogs::build(vars))
-                .await?;
-            let app = res.get_deploy_app.context("app not found")?;
-            let con = app.cron_jobs;
-            let page_info = con.page_info;
-
-            if let Some(cron) = con
-                .nodes
-                .into_iter()
-                .find(|node| node.id.inner() == cron_job || node.name == cron_job)
-            {
-                if let Some(invocation_logs) =
-                    cron.invocations.nodes.into_iter().find(|node| {
-                        node.id.inner() == invocation || node.edge_job_id == invocation
-                    })
-                {
-                    return Ok(logs_from_connection(invocation_logs.logs));
-                }
-
-                if !cron.invocations.page_info.has_next_page {
-                    bail!("cron job invocation '{invocation}' not found");
-                }
-                invocation_after = Some(
-                    cron.invocations
-                        .page_info
-                        .end_cursor
-                        .context("cron job invocations cursor missing")?,
-                );
-                continue;
-            }
-
-            if !page_info.has_next_page {
-                bail!("cron job '{cron_job}' not found");
-            }
-            cron_after = Some(page_info.end_cursor.context("cron jobs cursor missing")?);
-            break;
-        }
-    }
-}
-
-pub async fn get_cron_job_invocation_logs_by_id(
-    client: &WasmerClient,
-    cron_job_id: impl Into<String>,
-    invocation: impl AsRef<str>,
-    log_first: Option<i32>,
-    start: Option<OffsetDateTime>,
-    end: Option<OffsetDateTime>,
-) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
-    let cron_job_id = cron_job_id.into();
-    let invocation = invocation.as_ref().to_string();
-    let (start, end) = default_cron_invocation_window(start, end)?;
-    let start = types::DateTime::try_from(start)?;
-    let end = types::DateTime::try_from(end)?;
-    let mut invocation_after = None;
-
-    loop {
-        let res = client
-            .run_graphql_strict(types::GetCronJobInvocationLogsById::build(
-                types::GetCronJobInvocationLogsByIdVars {
-                    id: types::Id::from(cron_job_id.clone()),
-                    invocation_start: Some(start.clone()),
-                    invocation_end: Some(end.clone()),
-                    invocation_after: invocation_after.clone(),
-                    invocation_first: Some(1),
-                    log_first,
-                },
-            ))
-            .await?;
-        let cron = res
-            .cron_job
-            .and_then(types::NodeCronJobWithInvocationLogs::into_cron_job)
-            .with_context(|| format!("cron job '{cron_job_id}' not found"))?;
-
-        if let Some(invocation_logs) = cron
-            .invocations
-            .nodes
-            .into_iter()
-            .find(|node| node.id.inner() == invocation || node.edge_job_id == invocation)
-        {
-            return Ok(logs_from_connection(invocation_logs.logs));
-        }
-
-        if !cron.invocations.page_info.has_next_page {
-            bail!("cron job invocation '{invocation}' not found");
-        }
-        invocation_after = Some(
-            cron.invocations
-                .page_info
-                .end_cursor
-                .context("cron job invocations cursor missing")?,
-        );
-    }
-}
-
 /// Retrieve the logs of one cron job invocation, referenced by its own id.
 ///
-/// Unlike the cron-job-scoped lookups this resolves the invocation directly,
-/// so it needs neither the owning cron job nor a time window to search in.
+/// This resolves the invocation directly, so it needs neither the owning cron
+/// job nor a time window.
 pub async fn get_cron_job_invocation_logs_by_invocation_id(
     client: &WasmerClient,
     invocation_id: impl Into<String>,
     log_first: Option<i32>,
 ) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
     let invocation_id = invocation_id.into();
+    if !invocation_id.starts_with(CRON_JOB_INVOCATION_ID_PREFIX) {
+        bail!(
+            "invalid cron job invocation id '{invocation_id}': expected an id starting with '{CRON_JOB_INVOCATION_ID_PREFIX}'"
+        );
+    }
+
     let res = client
         .run_graphql_strict(types::GetCronJobInvocationLogsByInvocationId::build(
             types::GetCronJobInvocationLogsByInvocationIdVars {

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -18,6 +18,11 @@ use crate::{
 
 pub const CRON_JOB_PAGE_SIZE: i32 = 100;
 
+/// Prefix of a cron job invocation's opaque id. An invocation carrying this
+/// prefix can be resolved directly, without searching a cron job's invocation
+/// pages.
+pub const CRON_JOB_INVOCATION_ID_PREFIX: &str = "croninv_";
+
 /// Retrieve the persistent `AppVolume` nodes of an app, including their S3
 /// state and (for S3-enabled volumes) credentials.
 ///
@@ -472,13 +477,7 @@ pub async fn get_cron_job_invocations_page(
             .into_iter()
             .find(|node| node.id.inner() == cron_job || node.name == cron_job)
         {
-            let invocations = cron
-                .invocations
-                .edges
-                .iter()
-                .flatten()
-                .flat_map(|edge| edge.node.clone())
-                .collect::<Vec<_>>();
+            let invocations = cron.invocations.nodes.clone();
             let next_cursor = cron
                 .invocations
                 .page_info
@@ -538,13 +537,7 @@ pub async fn get_cron_job_invocations_page_by_id(
         .cron_job
         .and_then(types::NodeCronJobWithInvocations::into_cron_job)
         .with_context(|| format!("cron job '{cron_job_id}' not found"))?;
-    let invocations = cron
-        .invocations
-        .edges
-        .iter()
-        .flatten()
-        .flat_map(|edge| edge.node.clone())
-        .collect::<Vec<_>>();
+    let invocations = cron.invocations.nodes.clone();
     let next_cursor = cron
         .invocations
         .page_info
@@ -607,13 +600,10 @@ pub async fn get_cron_job_invocation_logs(
                 .into_iter()
                 .find(|node| node.id.inner() == cron_job || node.name == cron_job)
             {
-                if let Some(invocation_logs) = cron
-                    .invocations
-                    .edges
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|edge| edge.node)
-                    .find(|node| node.id.inner() == invocation || node.edge_job_id == invocation)
+                if let Some(invocation_logs) =
+                    cron.invocations.nodes.into_iter().find(|node| {
+                        node.id.inner() == invocation || node.edge_job_id == invocation
+                    })
                 {
                     return Ok(logs_from_connection(invocation_logs.logs));
                 }
@@ -674,10 +664,8 @@ pub async fn get_cron_job_invocation_logs_by_id(
 
         if let Some(invocation_logs) = cron
             .invocations
-            .edges
+            .nodes
             .into_iter()
-            .flatten()
-            .filter_map(|edge| edge.node)
             .find(|node| node.id.inner() == invocation || node.edge_job_id == invocation)
         {
             return Ok(logs_from_connection(invocation_logs.logs));
@@ -693,6 +681,34 @@ pub async fn get_cron_job_invocation_logs_by_id(
                 .context("cron job invocations cursor missing")?,
         );
     }
+}
+
+/// Retrieve the logs of one cron job invocation, referenced by its own id.
+///
+/// Unlike the cron-job-scoped lookups this resolves the invocation directly,
+/// so it needs neither the owning cron job nor a time window to search in.
+pub async fn get_cron_job_invocation_logs_by_invocation_id(
+    client: &WasmerClient,
+    invocation_id: impl Into<String>,
+    log_first: Option<i32>,
+) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
+    let invocation_id = invocation_id.into();
+    let res = client
+        .run_graphql_strict(types::GetCronJobInvocationLogsByInvocationId::build(
+            types::GetCronJobInvocationLogsByInvocationIdVars {
+                id: types::Id::from(invocation_id.clone()),
+                log_first,
+            },
+        ))
+        .await?;
+
+    // The backend answers null for an invocation the caller may not see just as
+    // it does for one that does not exist, so both land on the same message.
+    let invocation = res.get_cron_job_invocation.with_context(|| {
+        format!("cron job invocation '{invocation_id}' not found or not accessible")
+    })?;
+
+    Ok(logs_from_connection(invocation.logs))
 }
 
 fn default_cron_invocation_window(

--- a/lib/backend-api/src/query.rs
+++ b/lib/backend-api/src/query.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, time::Duration};
 
-use anyhow::{Context, bail};
+use anyhow::{Context, bail, ensure};
 use cynic::{MutationBuilder, QueryBuilder};
 use futures::StreamExt;
 use merge_streams::MergeStreams;
@@ -562,11 +562,10 @@ pub async fn get_cron_job_invocation_logs_by_invocation_id(
     log_first: Option<i32>,
 ) -> Result<Vec<types::CronJobLog>, anyhow::Error> {
     let invocation_id = invocation_id.into();
-    if !invocation_id.starts_with(CRON_JOB_INVOCATION_ID_PREFIX) {
-        bail!(
-            "invalid cron job invocation id '{invocation_id}': expected an id starting with '{CRON_JOB_INVOCATION_ID_PREFIX}'"
-        );
-    }
+    ensure!(
+        invocation_id.starts_with(CRON_JOB_INVOCATION_ID_PREFIX),
+        "invalid cron job invocation id '{invocation_id}': expected an id starting with '{CRON_JOB_INVOCATION_ID_PREFIX}'"
+    );
 
     let res = client
         .run_graphql_strict(types::GetCronJobInvocationLogsByInvocationId::build(

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1419,6 +1419,12 @@ mod queries {
         pub log_first: Option<i32>,
     }
 
+    #[derive(cynic::QueryVariables, Debug, Clone)]
+    pub struct GetCronJobInvocationLogsByInvocationIdVars {
+        pub id: cynic::Id,
+        pub log_first: Option<i32>,
+    }
+
     #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationsByIdVars")]
     pub struct GetCronJobInvocationsById {
@@ -1440,6 +1446,18 @@ mod queries {
         #[arguments(id: $id)]
         #[cynic(rename = "node")]
         pub cron_job: Option<NodeCronJobWithInvocationLogs>,
+    }
+
+    /// Resolve one invocation directly by its own id, without walking the
+    /// cron job's invocation pages.
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "Query",
+        variables = "GetCronJobInvocationLogsByInvocationIdVars"
+    )]
+    pub struct GetCronJobInvocationLogsByInvocationId {
+        #[arguments(id: $id)]
+        pub get_cron_job_invocation: Option<CronJobInvocationWithLogsByInvocationId>,
     }
 
     #[derive(cynic::InlineFragments, Debug, Clone)]
@@ -1559,13 +1577,7 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
     pub struct CronJobInvocationConnection {
         pub page_info: PageInfo,
-        pub edges: Vec<Option<CronJobInvocationEdge>>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
-    pub struct CronJobInvocationEdge {
-        pub cursor: String,
-        pub node: Option<CronJobInvocation>,
+        pub nodes: Vec<CronJobInvocation>,
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
@@ -1589,16 +1601,7 @@ mod queries {
     )]
     pub struct CronJobInvocationLogsConnection {
         pub page_info: PageInfo,
-        pub edges: Vec<Option<CronJobInvocationLogsEdge>>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJobInvocationEdge",
-        variables = "GetCronJobInvocationLogsVars"
-    )]
-    pub struct CronJobInvocationLogsEdge {
-        pub node: Option<CronJobInvocationWithLogs>,
+        pub nodes: Vec<CronJobInvocationWithLogs>,
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
@@ -1608,16 +1611,7 @@ mod queries {
     )]
     pub struct CronJobInvocationLogsConnectionById {
         pub page_info: PageInfo,
-        pub edges: Vec<Option<CronJobInvocationLogsEdgeById>>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJobInvocationEdge",
-        variables = "GetCronJobInvocationLogsByIdVars"
-    )]
-    pub struct CronJobInvocationLogsEdgeById {
-        pub node: Option<CronJobInvocationWithLogsById>,
+        pub nodes: Vec<CronJobInvocationWithLogsById>,
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
@@ -1638,6 +1632,18 @@ mod queries {
         variables = "GetCronJobInvocationLogsByIdVars"
     )]
     pub struct CronJobInvocationWithLogsById {
+        pub id: cynic::Id,
+        pub edge_job_id: String,
+        #[arguments(first: $log_first)]
+        pub logs: CronJobLogConnection,
+    }
+
+    #[derive(cynic::QueryFragment, Debug, Clone)]
+    #[cynic(
+        graphql_type = "CronJobInvocation",
+        variables = "GetCronJobInvocationLogsByInvocationIdVars"
+    )]
+    pub struct CronJobInvocationWithLogsByInvocationId {
         pub id: cynic::Id,
         pub edge_job_id: String,
         #[arguments(first: $log_first)]

--- a/lib/backend-api/src/types.rs
+++ b/lib/backend-api/src/types.rs
@@ -1397,29 +1397,6 @@ mod queries {
     }
 
     #[derive(cynic::QueryVariables, Debug, Clone)]
-    pub struct GetCronJobInvocationLogsVars {
-        pub owner: String,
-        pub name: String,
-        pub cron_after: Option<String>,
-        pub cron_first: Option<i32>,
-        pub invocation_start: Option<DateTime>,
-        pub invocation_end: Option<DateTime>,
-        pub invocation_after: Option<String>,
-        pub invocation_first: Option<i32>,
-        pub log_first: Option<i32>,
-    }
-
-    #[derive(cynic::QueryVariables, Debug, Clone)]
-    pub struct GetCronJobInvocationLogsByIdVars {
-        pub id: cynic::Id,
-        pub invocation_start: Option<DateTime>,
-        pub invocation_end: Option<DateTime>,
-        pub invocation_after: Option<String>,
-        pub invocation_first: Option<i32>,
-        pub log_first: Option<i32>,
-    }
-
-    #[derive(cynic::QueryVariables, Debug, Clone)]
     pub struct GetCronJobInvocationLogsByInvocationIdVars {
         pub id: cynic::Id,
         pub log_first: Option<i32>,
@@ -1431,21 +1408,6 @@ mod queries {
         #[arguments(id: $id)]
         #[cynic(rename = "node")]
         pub cron_job: Option<NodeCronJobWithInvocations>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationLogsVars")]
-    pub struct GetCronJobInvocationLogs {
-        #[arguments(owner: $owner, name: $name)]
-        pub get_deploy_app: Option<DeployAppCronJobInvocationLogs>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationLogsByIdVars")]
-    pub struct GetCronJobInvocationLogsById {
-        #[arguments(id: $id)]
-        #[cynic(rename = "node")]
-        pub cron_job: Option<NodeCronJobWithInvocationLogs>,
     }
 
     /// Resolve one invocation directly by its own id, without walking the
@@ -1477,23 +1439,6 @@ mod queries {
         }
     }
 
-    #[derive(cynic::InlineFragments, Debug, Clone)]
-    #[cynic(graphql_type = "Node", variables = "GetCronJobInvocationLogsByIdVars")]
-    pub enum NodeCronJobWithInvocationLogs {
-        CronJob(CronJobWithInvocationLogsById),
-        #[cynic(fallback)]
-        Unknown,
-    }
-
-    impl NodeCronJobWithInvocationLogs {
-        pub fn into_cron_job(self) -> Option<CronJobWithInvocationLogsById> {
-            match self {
-                Self::CronJob(cron_job) => Some(cron_job),
-                Self::Unknown => None,
-            }
-        }
-    }
-
     #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(graphql_type = "Query", variables = "GetCronJobInvocationsVars")]
     pub struct GetCronJobInvocations {
@@ -1509,13 +1454,6 @@ mod queries {
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(graphql_type = "DeployApp", variables = "GetCronJobInvocationLogsVars")]
-    pub struct DeployAppCronJobInvocationLogs {
-        #[arguments(first: $cron_first, after: $cron_after)]
-        pub cron_jobs: CronJobConnectionForInvocationLogs,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(
         graphql_type = "CronJobConnection",
         variables = "GetCronJobInvocationsVars"
@@ -1523,16 +1461,6 @@ mod queries {
     pub struct CronJobConnectionForInvocations {
         pub page_info: PageInfo,
         pub nodes: Vec<CronJobWithInvocations>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJobConnection",
-        variables = "GetCronJobInvocationLogsVars"
-    )]
-    pub struct CronJobConnectionForInvocationLogs {
-        pub page_info: PageInfo,
-        pub nodes: Vec<CronJobWithInvocationLogs>,
     }
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
@@ -1553,27 +1481,6 @@ mod queries {
         pub invocations: CronJobInvocationConnection,
     }
 
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(graphql_type = "CronJob", variables = "GetCronJobInvocationLogsVars")]
-    pub struct CronJobWithInvocationLogs {
-        pub id: cynic::Id,
-        pub name: String,
-        #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
-        pub invocations: CronJobInvocationLogsConnection,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJob",
-        variables = "GetCronJobInvocationLogsByIdVars"
-    )]
-    pub struct CronJobWithInvocationLogsById {
-        pub id: cynic::Id,
-        pub name: String,
-        #[arguments(first: $invocation_first, after: $invocation_after, start: $invocation_start, end: $invocation_end)]
-        pub invocations: CronJobInvocationLogsConnectionById,
-    }
-
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
     pub struct CronJobInvocationConnection {
         pub page_info: PageInfo,
@@ -1583,7 +1490,6 @@ mod queries {
     #[derive(cynic::QueryFragment, Debug, Clone, Serialize)]
     pub struct CronJobInvocation {
         pub id: cynic::Id,
-        pub edge_job_id: String,
         pub status: Option<CronJobInvocationStatus>,
         pub scheduled_at: Option<DateTime>,
         pub started_at: Option<DateTime>,
@@ -1596,56 +1502,10 @@ mod queries {
 
     #[derive(cynic::QueryFragment, Debug, Clone)]
     #[cynic(
-        graphql_type = "CronJobInvocationConnection",
-        variables = "GetCronJobInvocationLogsVars"
-    )]
-    pub struct CronJobInvocationLogsConnection {
-        pub page_info: PageInfo,
-        pub nodes: Vec<CronJobInvocationWithLogs>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJobInvocationConnection",
-        variables = "GetCronJobInvocationLogsByIdVars"
-    )]
-    pub struct CronJobInvocationLogsConnectionById {
-        pub page_info: PageInfo,
-        pub nodes: Vec<CronJobInvocationWithLogsById>,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJobInvocation",
-        variables = "GetCronJobInvocationLogsVars"
-    )]
-    pub struct CronJobInvocationWithLogs {
-        pub id: cynic::Id,
-        pub edge_job_id: String,
-        #[arguments(first: $log_first)]
-        pub logs: CronJobLogConnection,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
-        graphql_type = "CronJobInvocation",
-        variables = "GetCronJobInvocationLogsByIdVars"
-    )]
-    pub struct CronJobInvocationWithLogsById {
-        pub id: cynic::Id,
-        pub edge_job_id: String,
-        #[arguments(first: $log_first)]
-        pub logs: CronJobLogConnection,
-    }
-
-    #[derive(cynic::QueryFragment, Debug, Clone)]
-    #[cynic(
         graphql_type = "CronJobInvocation",
         variables = "GetCronJobInvocationLogsByInvocationIdVars"
     )]
     pub struct CronJobInvocationWithLogsByInvocationId {
-        pub id: cynic::Id,
-        pub edge_job_id: String,
         #[arguments(first: $log_first)]
         pub logs: CronJobLogConnection,
     }

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -283,11 +283,16 @@ pub struct CmdCronLogs {
     cron_job: String,
 
     /// Cron job invocation id or edge job id.
+    ///
+    /// An invocation id resolves directly, so the cron job, --start and --end
+    /// are only used to search for an edge job id.
     invocation: String,
 
     /// The earliest invocation timestamp to include.
     ///
     /// Defaults to 31 days before --end, or 31 days before now.
+    ///
+    /// Ignored when the invocation is given by id.
     ///
     /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
     #[clap(long = "start", alias = "from", value_parser = parse_timestamp_or_relative_time_negative_offset)]
@@ -296,6 +301,8 @@ pub struct CmdCronLogs {
     /// The latest invocation timestamp to include.
     ///
     /// Defaults to now.
+    ///
+    /// Ignored when the invocation is given by id.
     ///
     /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
     #[clap(long = "end", alias = "until", value_parser = parse_timestamp_or_relative_time_negative_offset)]
@@ -321,7 +328,16 @@ impl AsyncCliCommand for CmdCronLogs {
         }
 
         let client = self.env.client()?;
-        let logs = if should_resolve_cron_job_by_id(&self.ident, &self.cron_job) {
+        let logs = if is_cron_job_invocation_id(&self.invocation) {
+            // An invocation id identifies the invocation on its own, so neither
+            // the app, nor the cron job, nor a window to search in is needed.
+            wasmer_backend_api::query::get_cron_job_invocation_logs_by_invocation_id(
+                &client,
+                &self.invocation,
+                Some(self.max),
+            )
+            .await?
+        } else if should_resolve_cron_job_by_id(&self.ident, &self.cron_job) {
             wasmer_backend_api::query::get_cron_job_invocation_logs_by_id(
                 &client,
                 &self.cron_job,
@@ -436,6 +452,10 @@ async fn resolve_cron_job(
 
 fn should_resolve_cron_job_by_id(ident: &AppIdentArgOpts, cron_job: &str) -> bool {
     ident.app.is_none() && cron_job.starts_with("cron_")
+}
+
+fn is_cron_job_invocation_id(invocation: &str) -> bool {
+    invocation.starts_with(wasmer_backend_api::query::CRON_JOB_INVOCATION_ID_PREFIX)
 }
 
 async fn find_app_cron_job(

--- a/lib/cli/src/commands/cron.rs
+++ b/lib/cli/src/commands/cron.rs
@@ -276,37 +276,8 @@ pub struct CmdCronLogs {
     #[clap(flatten)]
     env: WasmerEnv,
 
-    #[clap(flatten)]
-    ident: AppIdentArgOpts,
-
-    /// Cron job id or name.
-    cron_job: String,
-
-    /// Cron job invocation id or edge job id.
-    ///
-    /// An invocation id resolves directly, so the cron job, --start and --end
-    /// are only used to search for an edge job id.
+    /// Cron job invocation id.
     invocation: String,
-
-    /// The earliest invocation timestamp to include.
-    ///
-    /// Defaults to 31 days before --end, or 31 days before now.
-    ///
-    /// Ignored when the invocation is given by id.
-    ///
-    /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
-    #[clap(long = "start", alias = "from", value_parser = parse_timestamp_or_relative_time_negative_offset)]
-    start: Option<OffsetDateTime>,
-
-    /// The latest invocation timestamp to include.
-    ///
-    /// Defaults to now.
-    ///
-    /// Ignored when the invocation is given by id.
-    ///
-    /// Accepts RFC 3339, RFC 2822, date, Unix timestamp, or relative time.
-    #[clap(long = "end", alias = "until", value_parser = parse_timestamp_or_relative_time_negative_offset)]
-    end: Option<OffsetDateTime>,
 
     /// Maximum log lines to fetch.
     #[clap(long, default_value = "1000")]
@@ -321,46 +292,14 @@ impl AsyncCliCommand for CmdCronLogs {
         if self.max < 1 {
             bail!("--max must be greater than 0");
         }
-        if let (Some(start), Some(end)) = (self.start, self.end)
-            && start > end
-        {
-            bail!("--start must be before or equal to --end");
-        }
 
         let client = self.env.client()?;
-        let logs = if is_cron_job_invocation_id(&self.invocation) {
-            // An invocation id identifies the invocation on its own, so neither
-            // the app, nor the cron job, nor a window to search in is needed.
-            wasmer_backend_api::query::get_cron_job_invocation_logs_by_invocation_id(
-                &client,
-                &self.invocation,
-                Some(self.max),
-            )
-            .await?
-        } else if should_resolve_cron_job_by_id(&self.ident, &self.cron_job) {
-            wasmer_backend_api::query::get_cron_job_invocation_logs_by_id(
-                &client,
-                &self.cron_job,
-                &self.invocation,
-                Some(self.max),
-                self.start,
-                self.end,
-            )
-            .await?
-        } else {
-            let (_ident, app) = self.ident.to_opts().load_app(&client).await?;
-            wasmer_backend_api::query::get_cron_job_invocation_logs(
-                &client,
-                &app.owner.global_name,
-                &app.name,
-                &self.cron_job,
-                &self.invocation,
-                Some(self.max),
-                self.start,
-                self.end,
-            )
-            .await?
-        };
+        let logs = wasmer_backend_api::query::get_cron_job_invocation_logs_by_invocation_id(
+            &client,
+            &self.invocation,
+            Some(self.max),
+        )
+        .await?;
 
         if logs.is_empty() {
             eprintln!("Cron job invocation {} has no logs!", self.invocation);
@@ -452,10 +391,6 @@ async fn resolve_cron_job(
 
 fn should_resolve_cron_job_by_id(ident: &AppIdentArgOpts, cron_job: &str) -> bool {
     ident.app.is_none() && cron_job.starts_with("cron_")
-}
-
-fn is_cron_job_invocation_id(invocation: &str) -> bool {
-    invocation.starts_with(wasmer_backend_api::query::CRON_JOB_INVOCATION_ID_PREFIX)
 }
 
 async fn find_app_cron_job(

--- a/lib/cli/src/types.rs
+++ b/lib/cli/src/types.rs
@@ -108,7 +108,6 @@ impl CliRender for CronJobInvocation {
         let mut table = Table::new();
         table.add_rows([
             vec!["Id".to_string(), self.id.inner().to_string()],
-            vec!["Edge job id".to_string(), self.edge_job_id.clone()],
             vec![
                 "Status".to_string(),
                 self.status

--- a/tests/integration/cli/tests/cron.rs
+++ b/tests/integration/cli/tests/cron.rs
@@ -180,23 +180,17 @@ jobs:
         });
 
         if let Some(invocation) = invocations.first() {
-            let invocation_id = invocation["id"]
-                .as_str()
-                .or_else(|| invocation["edge_job_id"].as_str())
-                .unwrap_or_else(|| {
-                    panic!(
-                        "cron invocation should include id or edge_job_id: {}",
-                        serde_json::to_string(invocation).unwrap()
-                    )
-                });
+            let invocation_id = invocation["id"].as_str().unwrap_or_else(|| {
+                panic!(
+                    "cron invocation should include id: {}",
+                    serde_json::to_string(invocation).unwrap()
+                )
+            });
 
             let logs_output = wasmer_command()
                 .arg("cron")
                 .arg("logs")
-                .arg(HOURLY_JOB)
                 .arg(invocation_id)
-                .arg("--app")
-                .arg(&app_ident)
                 .arg("--max=1")
                 .arg("--format=json")
                 .arg(format!("--registry={REGISTRY}"))


### PR DESCRIPTION
# Changes
- switch over to more optimized queries - direct fetching of invocations via croninv ID
- removed deprecated path that would fetch all invocations just to get one via the `edgeJobId`
- drop `edgeJobId` from public API in favor of opaque ID derived from edge-job ID and cronjob ID