### PR TITLE
feat!(CLI): disable gen-c-header

### DIFF
--- a/lib/cli/src/commands/gen_c_header.rs
+++ b/lib/cli/src/commands/gen_c_header.rs
@@ -51,6 +51,7 @@ pub struct GenCHeader {
 
 impl GenCHeader {
     /// Runs logic for the `gen-c-header` subcommand
+    #[allow(unused)]
     pub fn execute(&self) -> Result<(), Error> {
         let file: Bytes = std::fs::read(&self.path)
             .with_context(|| format!("Unable to read \"{}\"", self.path.display()))?

--- a/lib/cli/src/commands/gen_c_header.rs
+++ b/lib/cli/src/commands/gen_c_header.rs
@@ -51,7 +51,7 @@ pub struct GenCHeader {
 
 impl GenCHeader {
     /// Runs logic for the `gen-c-header` subcommand
-    #[allow(unused)]
+    #[allow(dead_code)]
     pub fn execute(&self) -> Result<(), Error> {
         let file: Bytes = std::fs::read(&self.path)
             .with_context(|| format!("Unable to read \"{}\"", self.path.display()))?

--- a/lib/cli/src/commands/mod.rs
+++ b/lib/cli/src/commands/mod.rs
@@ -181,11 +181,13 @@ impl WasmerCmd {
             Some(Cmd::Validate(validate)) => validate.execute(),
             #[cfg(feature = "compiler")]
             Some(Cmd::Compile(compile)) => compile.execute(),
-            // CreateExe and CreateObj commands are temporarily disabled
+            // CreateExe, CreateObj and GenCHeader commands are temporarily disabled
             // #[cfg(any(feature = "static-artifact-create", feature = "wasmer-artifact-create"))]
             // Some(Cmd::CreateExe(create_exe)) => create_exe.run(),
             // #[cfg(feature = "static-artifact-create")]
             // Some(Cmd::CreateObj(create_obj)) => create_obj.execute(),
+            // #[cfg(feature = "static-artifact-create")]
+            // Some(Cmd::GenCHeader(gen_header)) => gen_header.execute(),
             Some(Cmd::Config(config)) => config.run(),
             Some(Cmd::Inspect(inspect)) => inspect.execute(),
             Some(Cmd::Init(init)) => init.run(),
@@ -206,8 +208,6 @@ impl WasmerCmd {
             Some(Cmd::Container(cmd)) => match cmd {
                 crate::commands::Container::Unpack(cmd) => cmd.execute(),
             },
-            #[cfg(feature = "static-artifact-create")]
-            Some(Cmd::GenCHeader(gen_header)) => gen_header.execute(),
             #[cfg(feature = "wast")]
             Some(Cmd::Wast(wast)) => wast.execute(),
             #[cfg(target_os = "linux")]
@@ -429,8 +429,8 @@ enum Cmd {
     ///
     /// Generate the C static_defs.h header file for the input .wasm module
     ///
-    #[cfg(feature = "static-artifact-create")]
-    GenCHeader(GenCHeader),
+    // #[cfg(feature = "static-artifact-create")]
+    // GenCHeader(GenCHeader),
 
     /// Get various configuration information needed
     /// to compile programs which use Wasmer


### PR DESCRIPTION
The command line is a complement to `create-exe` and `create-obj` - these were disabled some time ago.

Relates: #5957