### PR TITLE
fix(VMOffsets): handle gracefully u32 -> i32 casting

### DIFF
--- a/lib/compiler-cranelift/src/func_environ.rs
+++ b/lib/compiler-cranelift/src/func_environ.rs
@@ -31,6 +31,7 @@ use wasmer_types::{
     SignatureHash, SignatureIndex, TableIndex, TableStyle, TagIndex, Type as WasmerType,
     VMBuiltinFunctionIndex, VMOffsets, WasmError, WasmResult,
     entity::{EntityRef, PrimaryMap, SecondaryMap},
+    vmctx_offset,
 };
 
 fn insert_mem_flags(func: &mut Function, flags: ir::MemFlagsData) -> ir::MemFlags {
@@ -261,9 +262,13 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         self.target_config.pointer_type()
     }
 
-    fn ensure_table_exists(&mut self, func: &mut ir::Function, index: TableIndex) {
+    fn ensure_table_exists(
+        &mut self,
+        func: &mut ir::Function,
+        index: TableIndex,
+    ) -> WasmResult<()> {
         if self.tables[index].is_some() {
-            return;
+            return Ok(());
         }
 
         let pointer_type = self.pointer_type();
@@ -275,12 +280,11 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             {
                 (
                     self.vmctx(func),
-                    i32::try_from(
+                    vmctx_offset(
                         self.offsets
                             .vmctx_fixed_funcref_table_anyfuncs(def_index)
                             .expect("fixed funcref table must have inline VMContext storage"),
-                    )
-                    .unwrap(),
+                    )?,
                     TableSize::Static {
                         bound: table.minimum,
                     },
@@ -292,20 +296,18 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                     let vmctx = self.vmctx(func);
                     if let Some(def_index) = self.module.local_table_index(index) {
                         let base_offset =
-                            i32::try_from(self.offsets.vmctx_vmtable_definition_base(def_index))
-                                .unwrap();
-                        let current_elements_offset = i32::try_from(
+                            vmctx_offset(self.offsets.vmctx_vmtable_definition_base(def_index))?;
+                        let current_elements_offset = vmctx_offset(
                             self.offsets
                                 .vmctx_vmtable_definition_current_elements(def_index),
-                        )
-                        .unwrap();
+                        )?;
                         (vmctx, base_offset, current_elements_offset)
                     } else {
                         let from_offset = self.offsets.vmctx_vmtable_import(index);
                         let flags = insert_mem_flags(func, MemFlagsData::trusted().with_readonly());
                         let table = func.create_global_value(ir::GlobalValueData::Load {
                             base: vmctx,
-                            offset: Offset32::new(i32::try_from(from_offset).unwrap()),
+                            offset: Offset32::new(vmctx_offset(from_offset)?),
                             global_type: pointer_type,
                             flags,
                         });
@@ -361,6 +363,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             element_size,
             inline_anyfunc,
         });
+        Ok(())
     }
 
     fn vmctx(&mut self, func: &mut Function) -> ir::GlobalValue {
@@ -1316,7 +1319,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         &mut self,
         pos: &mut FuncCursor<'_>,
         callee_func_idx: VMBuiltinFunctionIndex,
-    ) -> (ir::Value, ir::Value) {
+    ) -> WasmResult<(ir::Value, ir::Value)> {
         // We use an indirect call so that we don't have to patch the code at runtime.
         let pointer_type = self.pointer_type();
         let vmctx = self.vmctx(pos.func);
@@ -1326,11 +1329,10 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         mem_flags.set_readonly();
 
         // Load the callee address.
-        let body_offset =
-            i32::try_from(self.offsets.vmctx_builtin_function(callee_func_idx)).unwrap();
+        let body_offset = vmctx_offset(self.offsets.vmctx_builtin_function(callee_func_idx))?;
         let func_addr = pos.ins().load(pointer_type, mem_flags, base, body_offset);
 
-        (base, func_addr)
+        Ok((base, func_addr))
     }
 
     fn get_or_init_funcref_table_elem(
@@ -1338,21 +1340,21 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         builder: &mut FunctionBuilder,
         table_index: TableIndex,
         index: ir::Value,
-    ) -> (ir::Value, bool) {
+    ) -> WasmResult<(ir::Value, bool)> {
         let pointer_type = self.pointer_type();
-        self.ensure_table_exists(builder.func, table_index);
+        self.ensure_table_exists(builder.func, table_index)?;
         let table_data = self.tables[table_index].as_ref().unwrap();
 
         let (table_entry_addr, flags) =
             table_data.prepare_table_addr(builder, index, pointer_type, false);
-        if table_data.inline_anyfunc {
+        Ok(if table_data.inline_anyfunc {
             (table_entry_addr, true)
         } else {
             (
                 builder.ins().load(pointer_type, flags, table_entry_addr, 0),
                 false,
             )
-        }
+        })
     }
 }
 
@@ -1367,7 +1369,7 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<()> {
         let (func_sig, func_idx) = self.get_raise_trap_func(builder.func);
         let mut pos = builder.cursor();
-        let (_, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (_, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let trap_code = pos
             .ins()
             .iconst(I32, wasmer_types::TrapCode::UnreachableCodeReached as i64);
@@ -1387,10 +1389,11 @@ impl FuncEnvironment<'_> {
         delta: ir::Value,
         init_value: ir::Value,
     ) -> WasmResult<ir::Value> {
-        self.ensure_table_exists(pos.func, table_index);
+        self.ensure_table_exists(pos.func, table_index)?;
         let (func_sig, index_arg, func_idx) = self.get_table_grow_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst = pos.ins().call_indirect(
             func_sig,
             func_addr,
@@ -1405,12 +1408,13 @@ impl FuncEnvironment<'_> {
         table_index: TableIndex,
         index: ir::Value,
     ) -> WasmResult<ir::Value> {
-        self.ensure_table_exists(builder.func, table_index);
+        self.ensure_table_exists(builder.func, table_index)?;
         let mut pos = builder.cursor();
 
         let (func_sig, table_index_arg, func_idx) = self.get_table_get_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, table_index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst = pos
             .ins()
             .call_indirect(func_sig, func_addr, &[vmctx, table_index, index]);
@@ -1424,12 +1428,13 @@ impl FuncEnvironment<'_> {
         value: ir::Value,
         index: ir::Value,
     ) -> WasmResult<()> {
-        self.ensure_table_exists(builder.func, table_index);
+        self.ensure_table_exists(builder.func, table_index)?;
         let mut pos = builder.cursor();
 
         let (func_sig, table_index_arg, func_idx) = self.get_table_set_func(pos.func, table_index);
         let n_table_index = pos.ins().iconst(I32, table_index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         pos.ins()
             .call_indirect(func_sig, func_addr, &[vmctx, n_table_index, index, value]);
         Ok(())
@@ -1443,9 +1448,10 @@ impl FuncEnvironment<'_> {
         val: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        self.ensure_table_exists(pos.func, table_index);
+        self.ensure_table_exists(pos.func, table_index)?;
         let (func_sig, table_index_arg, func_idx) = self.get_table_fill_func(pos.func, table_index);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         let table_index_arg = pos.ins().iconst(I32, table_index_arg as i64);
         pos.ins().call_indirect(
@@ -1510,7 +1516,8 @@ impl FuncEnvironment<'_> {
         func_index: FunctionIndex,
     ) -> WasmResult<ir::Value> {
         let (func_sig, func_index_arg, func_idx) = self.get_func_ref_func(pos.func, func_index);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         let func_index_arg = pos.ins().iconst(I32, func_index_arg as i64);
         let call_inst = pos
@@ -1548,19 +1555,18 @@ impl FuncEnvironment<'_> {
             let vmctx = self.vmctx(func);
             if let Some(def_index) = self.module.local_memory_index(index) {
                 let base_offset =
-                    i32::try_from(self.offsets.vmctx_vmmemory_definition_base(def_index)).unwrap();
-                let current_length_offset = i32::try_from(
+                    vmctx_offset(self.offsets.vmctx_vmmemory_definition_base(def_index))?;
+                let current_length_offset = vmctx_offset(
                     self.offsets
                         .vmctx_vmmemory_definition_current_length(def_index),
-                )
-                .unwrap();
+                )?;
                 (vmctx, base_offset, current_length_offset)
             } else {
                 let from_offset = self.offsets.vmctx_vmmemory_import_definition(index);
                 let flags = insert_mem_flags(func, ir::MemFlagsData::trusted().with_readonly());
                 let memory = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
-                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
+                    offset: Offset32::new(vmctx_offset(from_offset)?),
                     global_type: pointer_type,
                     flags,
                 });
@@ -1637,13 +1643,13 @@ impl FuncEnvironment<'_> {
             if let Some(def_index) = self.module.local_global_index(index) {
                 let from_offset = self.offsets.vmctx_vmglobal_definition(def_index);
                 let global = func.create_global_value(ir::GlobalValueData::VMContext);
-                (global, i32::try_from(from_offset).unwrap())
+                (global, vmctx_offset(from_offset)?)
             } else {
                 let from_offset = self.offsets.vmctx_vmglobal_import_definition(index);
                 let flags = insert_mem_flags(func, MemFlagsData::trusted());
                 let global = func.create_global_value(ir::GlobalValueData::Load {
                     base: vmctx,
-                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
+                    offset: Offset32::new(vmctx_offset(from_offset)?),
                     global_type: pointer_type,
                     flags,
                 });
@@ -1740,7 +1746,7 @@ impl FuncEnvironment<'_> {
 
         // Get the anyfunc pointer (the funcref) from the table.
         let (anyfunc_ptr, inline_anyfunc) =
-            self.get_or_init_funcref_table_elem(builder, table_index, callee);
+            self.get_or_init_funcref_table_elem(builder, table_index, callee)?;
 
         // Dereference table_entry_addr to get the function address.
         let mem_flags = ir::MemFlagsData::trusted();
@@ -1873,15 +1879,13 @@ impl FuncEnvironment<'_> {
         let mem_flags = ir::MemFlagsData::trusted();
 
         // Load the callee address.
-        let body_offset =
-            i32::try_from(self.offsets.vmctx_vmfunction_import_body(callee_index)).unwrap();
+        let body_offset = vmctx_offset(self.offsets.vmctx_vmfunction_import_body(callee_index))?;
         let func_addr = builder
             .ins()
             .load(pointer_type, mem_flags, base, body_offset);
 
         // First append the callee vmctx address.
-        let vmctx_offset =
-            i32::try_from(self.offsets.vmctx_vmfunction_import_vmctx(callee_index)).unwrap();
+        let vmctx_offset = vmctx_offset(self.offsets.vmctx_vmfunction_import_vmctx(callee_index))?;
         let vmctx = builder
             .ins()
             .load(pointer_type, mem_flags, base, vmctx_offset);
@@ -1912,12 +1916,12 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder,
         exn_ptr: ir::Value,
-    ) -> ir::Value {
+    ) -> WasmResult<ir::Value> {
         let (read_sig, read_idx) = self.get_read_exception_func(builder.func);
         let mut pos = builder.cursor();
-        let (_, read_addr) = self.translate_load_builtin_function_address(&mut pos, read_idx);
+        let (_, read_addr) = self.translate_load_builtin_function_address(&mut pos, read_idx)?;
         let read_call = builder.ins().call_indirect(read_sig, read_addr, &[exn_ptr]);
-        builder.inst_results(read_call)[0]
+        Ok(builder.inst_results(read_call)[0])
     }
 
     pub(crate) fn translate_exn_unbox(
@@ -1931,7 +1935,7 @@ impl FuncEnvironment<'_> {
         let (read_exnref_sig, read_exnref_idx) = self.get_read_exnref_func(builder.func);
         let mut pos = builder.cursor();
         let (vmctx, read_exnref_addr) =
-            self.translate_load_builtin_function_address(&mut pos, read_exnref_idx);
+            self.translate_load_builtin_function_address(&mut pos, read_exnref_idx)?;
         let read_exnref_call =
             builder
                 .ins()
@@ -1971,7 +1975,8 @@ impl FuncEnvironment<'_> {
 
         let (alloc_sig, alloc_idx) = self.get_alloc_exception_func(builder.func);
         let mut pos = builder.cursor();
-        let (vmctx, alloc_addr) = self.translate_load_builtin_function_address(&mut pos, alloc_idx);
+        let (vmctx, alloc_addr) =
+            self.translate_load_builtin_function_address(&mut pos, alloc_idx)?;
         let tag_value = builder
             .ins()
             .iconst(TAG_TYPE, i64::from(tag_index.as_u32()));
@@ -1983,7 +1988,7 @@ impl FuncEnvironment<'_> {
         let (read_exnref_sig, read_exnref_idx) = self.get_read_exnref_func(builder.func);
         let mut pos = builder.cursor();
         let (vmctx, read_exnref_addr) =
-            self.translate_load_builtin_function_address(&mut pos, read_exnref_idx);
+            self.translate_load_builtin_function_address(&mut pos, read_exnref_idx)?;
         let read_exnref_call =
             builder
                 .ins()
@@ -2008,7 +2013,7 @@ impl FuncEnvironment<'_> {
         let (throw_sig, throw_idx) = self.get_throw_func(builder.func);
         let mut pos = builder.cursor();
         let (vmctx_value, throw_addr) =
-            self.translate_load_builtin_function_address(&mut pos, throw_idx);
+            self.translate_load_builtin_function_address(&mut pos, throw_idx)?;
         let call_args = [vmctx_value, exnref];
 
         let _ = self.call_indirect_with_handlers(
@@ -2033,7 +2038,7 @@ impl FuncEnvironment<'_> {
         let (throw_sig, throw_idx) = self.get_throw_func(builder.func);
         let mut pos = builder.cursor();
         let (vmctx_value, throw_addr) =
-            self.translate_load_builtin_function_address(&mut pos, throw_idx);
+            self.translate_load_builtin_function_address(&mut pos, throw_idx)?;
         let call_args = [vmctx_value, exnref];
 
         let _ = self.call_indirect_with_handlers(
@@ -2066,7 +2071,8 @@ impl FuncEnvironment<'_> {
         };
 
         let mut pos = builder.cursor();
-        let (vmctx_value, func_addr) = self.translate_load_builtin_function_address(&mut pos, idx);
+        let (vmctx_value, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, idx)?;
         let call = builder
             .ins()
             .call_indirect(sig, func_addr, &[vmctx_value, exn_arg]);
@@ -2081,7 +2087,7 @@ impl FuncEnvironment<'_> {
         let (throw_sig, throw_idx) = self.get_throw_func(builder.func);
         let mut pos = builder.cursor();
         let (vmctx_value, throw_addr) =
-            self.translate_load_builtin_function_address(&mut pos, throw_idx);
+            self.translate_load_builtin_function_address(&mut pos, throw_idx)?;
         builder
             .ins()
             .call_indirect(throw_sig, throw_addr, &[vmctx_value, exnref]);
@@ -2098,7 +2104,8 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<ir::Value> {
         let (func_sig, index_arg, func_idx) = self.get_memory_grow_func(pos.func, index);
         let memory_index = pos.ins().iconst(I32, index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst = pos
             .ins()
             .call_indirect(func_sig, func_addr, &[vmctx, val, memory_index]);
@@ -2113,7 +2120,8 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<ir::Value> {
         let (func_sig, index_arg, func_idx) = self.get_memory_size_func(pos.func, index);
         let memory_index = pos.ins().iconst(I32, index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst = pos
             .ins()
             .call_indirect(func_sig, func_addr, &[vmctx, memory_index]);
@@ -2137,7 +2145,8 @@ impl FuncEnvironment<'_> {
         let dst_index_arg = pos.ins().iconst(I32, dst_index.index() as i64);
         let src_index_arg = pos.ins().iconst(I32, src_index.index() as i64);
 
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         pos.ins().call_indirect(
             func_sig,
@@ -2161,7 +2170,8 @@ impl FuncEnvironment<'_> {
 
         let memory_index_arg = pos.ins().iconst(I32, memory_index as i64);
 
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         pos.ins().call_indirect(
             func_sig,
@@ -2188,7 +2198,8 @@ impl FuncEnvironment<'_> {
         let memory_index_arg = pos.ins().iconst(I32, memory_index.index() as i64);
         let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
 
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         pos.ins().call_indirect(
             func_sig,
@@ -2206,7 +2217,8 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<()> {
         let (func_sig, func_idx) = self.get_data_drop_func(pos.func);
         let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         pos.ins()
             .call_indirect(func_sig, func_addr, &[vmctx, seg_index_arg]);
         Ok(())
@@ -2217,10 +2229,11 @@ impl FuncEnvironment<'_> {
         mut pos: FuncCursor,
         table_index: TableIndex,
     ) -> WasmResult<ir::Value> {
-        self.ensure_table_exists(pos.func, table_index);
+        self.ensure_table_exists(pos.func, table_index)?;
         let (func_sig, index_arg, func_idx) = self.get_table_size_func(pos.func, table_index);
         let table_index = pos.ins().iconst(I32, index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst = pos
             .ins()
             .call_indirect(func_sig, func_addr, &[vmctx, table_index]);
@@ -2236,15 +2249,16 @@ impl FuncEnvironment<'_> {
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        self.ensure_table_exists(pos.func, src_table_index);
-        self.ensure_table_exists(pos.func, dst_table_index);
+        self.ensure_table_exists(pos.func, src_table_index)?;
+        self.ensure_table_exists(pos.func, dst_table_index)?;
         let (func_sig, dst_table_index_arg, src_table_index_arg, func_idx) =
             self.get_table_copy_func(pos.func, dst_table_index, src_table_index);
 
         let dst_table_index_arg = pos.ins().iconst(I32, dst_table_index_arg as i64);
         let src_table_index_arg = pos.ins().iconst(I32, src_table_index_arg as i64);
 
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         pos.ins().call_indirect(
             func_sig,
@@ -2271,13 +2285,14 @@ impl FuncEnvironment<'_> {
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        self.ensure_table_exists(pos.func, table_index);
+        self.ensure_table_exists(pos.func, table_index)?;
         let (func_sig, table_index_arg, func_idx) = self.get_table_init_func(pos.func, table_index);
 
         let table_index_arg = pos.ins().iconst(I32, table_index_arg as i64);
         let seg_index_arg = pos.ins().iconst(I32, seg_index as i64);
 
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         pos.ins().call_indirect(
             func_sig,
@@ -2297,7 +2312,8 @@ impl FuncEnvironment<'_> {
 
         let elem_index_arg = pos.ins().iconst(I32, elem_index as i64);
 
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
 
         pos.ins()
             .call_indirect(func_sig, func_addr, &[vmctx, elem_index_arg]);
@@ -2320,7 +2336,8 @@ impl FuncEnvironment<'_> {
             self.get_memory_atomic_wait32_func(pos.func, index)
         };
         let memory_index = pos.ins().iconst(I32, index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst = pos.ins().call_indirect(
             func_sig,
             func_addr,
@@ -2339,7 +2356,8 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<ir::Value> {
         let (func_sig, index_arg, func_idx) = self.get_memory_atomic_notify_func(pos.func, index);
         let memory_index = pos.ins().iconst(I32, index_arg as i64);
-        let (vmctx, func_addr) = self.translate_load_builtin_function_address(&mut pos, func_idx);
+        let (vmctx, func_addr) =
+            self.translate_load_builtin_function_address(&mut pos, func_idx)?;
         let call_inst =
             pos.ins()
                 .call_indirect(func_sig, func_addr, &[vmctx, memory_index, addr, count]);

--- a/lib/compiler-cranelift/src/func_environ.rs
+++ b/lib/compiler-cranelift/src/func_environ.rs
@@ -1885,10 +1885,11 @@ impl FuncEnvironment<'_> {
             .load(pointer_type, mem_flags, base, body_offset);
 
         // First append the callee vmctx address.
-        let vmctx_offset = vmctx_offset(self.offsets.vmctx_vmfunction_import_vmctx(callee_index))?;
+        let vmctx_arg_offset =
+            vmctx_offset(self.offsets.vmctx_vmfunction_import_vmctx(callee_index))?;
         let vmctx = builder
             .ins()
-            .load(pointer_type, mem_flags, base, vmctx_offset);
+            .load(pointer_type, mem_flags, base, vmctx_arg_offset);
         real_call_args.push(vmctx);
 
         // Then append the regular call arguments.

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -3942,7 +3942,7 @@ fn create_dispatch_block(
 
     builder.switch_to_block(dispatch_block);
     let selector = builder.append_block_param(dispatch_block, TAG_TYPE);
-    let exnref = environ.translate_exn_pointer_to_ref(builder, exn_ptr);
+    let exnref = environ.translate_exn_pointer_to_ref(builder, exn_ptr)?;
 
     let rethrow_block = builder.create_block();
     builder.append_block_param(rethrow_block, EXN_REF_TYPE);

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -45,12 +45,15 @@ use wasmer_compiler::{
 #[cfg(feature = "unwind")]
 use wasmer_compiler::types::unwind::CompiledFunctionUnwindInfo;
 
-use wasmer_types::target::{CallingConvention, Target};
 use wasmer_types::{
     CompileError, FunctionIndex, FunctionType, GlobalIndex, LocalFunctionIndex, MemoryIndex,
     MemoryStyle, ModuleInfo, SignatureIndex, TableIndex, TableStyle, TrapCode, Type,
     VMBuiltinFunctionIndex, VMOffsets,
     entity::{EntityRef, PrimaryMap},
+};
+use wasmer_types::{
+    target::{CallingConvention, Target},
+    vmctx_offset,
 };
 
 #[allow(type_alias_bounds)]
@@ -943,7 +946,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
             self,
             need_check,
             is_imported,
-            offset as i32,
+            vmctx_offset(offset)?,
             self.special_labels.heap_access_oob,
             self.special_labels.unaligned_atomic,
         )
@@ -1195,7 +1198,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 {
                     let offset = self.vmoffsets.vmctx_vmglobal_definition(local_global_index);
                     (
-                        Location::Memory(self.machine.get_vmctx_reg(), offset as i32),
+                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset(offset)?),
                         None,
                     )
                 } else {
@@ -1206,7 +1209,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                         .vmctx_vmglobal_import_definition(global_index);
                     self.machine.emit_relaxed_mov(
                         Size::S64,
-                        Location::Memory(self.machine.get_vmctx_reg(), offset as i32),
+                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset(offset)?),
                         Location::GPR(tmp),
                     )?;
                     (Location::Memory(tmp, 0), Some(tmp))
@@ -1225,7 +1228,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 {
                     let offset = self.vmoffsets.vmctx_vmglobal_definition(local_global_index);
                     (
-                        Location::Memory(self.machine.get_vmctx_reg(), offset as i32),
+                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset(offset)?),
                         None,
                     )
                 } else {
@@ -1236,7 +1239,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                         .vmctx_vmglobal_import_definition(global_index);
                     self.machine.emit_relaxed_mov(
                         Size::S64,
-                        Location::Memory(self.machine.get_vmctx_reg(), offset as i32),
+                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset(offset)?),
                         Location::GPR(tmp),
                     )?;
                     (Location::Memory(tmp, 0), Some(tmp))
@@ -2390,12 +2393,18 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     );
                     self.machine.move_location(
                         Size::S64,
-                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset_base as i32),
+                        Location::Memory(
+                            self.machine.get_vmctx_reg(),
+                            vmctx_offset(vmctx_offset_base)?,
+                        ),
                         Location::GPR(table_base),
                     )?;
                     self.machine.move_location(
                         Size::S32,
-                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset_len as i32),
+                        Location::Memory(
+                            self.machine.get_vmctx_reg(),
+                            vmctx_offset(vmctx_offset_len)?,
+                        ),
                         Location::GPR(table_count),
                     )?;
                 } else {
@@ -2403,7 +2412,10 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     let import_offset = self.vmoffsets.vmctx_vmtable_import(table_index);
                     self.machine.move_location(
                         Size::S64,
-                        Location::Memory(self.machine.get_vmctx_reg(), import_offset as i32),
+                        Location::Memory(
+                            self.machine.get_vmctx_reg(),
+                            vmctx_offset(import_offset)?,
+                        ),
                         Location::GPR(table_base),
                     )?;
 
@@ -2757,12 +2769,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(if local_memory_index.is_some() {
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            if local_memory_index.is_some() {
                                 VMBuiltinFunctionIndex::get_memory32_size_index()
                             } else {
                                 VMBuiltinFunctionIndex::get_imported_memory32_size_index()
-                            }) as i32,
+                            },
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -2787,9 +2800,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_memory_init_index())
-                            as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            VMBuiltinFunctionIndex::get_memory_init_index(),
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -2827,9 +2840,11 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_data_drop_index())
-                            as i32,
+                        vmctx_offset(
+                            self.vmoffsets.vmctx_builtin_function(
+                                VMBuiltinFunctionIndex::get_data_drop_index(),
+                            ),
+                        )?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -2855,9 +2870,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_memory_copy_index())
-                            as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            VMBuiltinFunctionIndex::get_memory_copy_index(),
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -2913,7 +2928,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(memory_fill_index) as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(memory_fill_index))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -2950,12 +2965,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(if local_memory_index.is_some() {
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            if local_memory_index.is_some() {
                                 VMBuiltinFunctionIndex::get_memory32_grow_index()
                             } else {
                                 VMBuiltinFunctionIndex::get_imported_memory32_grow_index()
-                            }) as i32,
+                            },
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -3553,9 +3569,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_raise_trap_index())
-                            as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            VMBuiltinFunctionIndex::get_raise_trap_index(),
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5469,9 +5485,11 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_func_ref_index())
-                            as i32,
+                        vmctx_offset(
+                            self.vmoffsets.vmctx_builtin_function(
+                                VMBuiltinFunctionIndex::get_func_ref_index(),
+                            ),
+                        )?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5510,13 +5528,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
                             if self.module.local_table_index(table_index).is_some() {
                                 VMBuiltinFunctionIndex::get_table_set_index()
                             } else {
                                 VMBuiltinFunctionIndex::get_imported_table_set_index()
                             },
-                        ) as i32,
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5554,13 +5572,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
                             if self.module.local_table_index(table_index).is_some() {
                                 VMBuiltinFunctionIndex::get_table_get_index()
                             } else {
                                 VMBuiltinFunctionIndex::get_imported_table_get_index()
                             },
-                        ) as i32,
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5596,13 +5614,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
                             if self.module.local_table_index(table_index).is_some() {
                                 VMBuiltinFunctionIndex::get_table_size_index()
                             } else {
                                 VMBuiltinFunctionIndex::get_imported_table_size_index()
                             },
-                        ) as i32,
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5635,13 +5653,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
                             if self.module.local_table_index(table_index).is_some() {
                                 VMBuiltinFunctionIndex::get_table_grow_index()
                             } else {
                                 VMBuiltinFunctionIndex::get_imported_table_grow_index()
                             },
-                        ) as i32,
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5679,9 +5697,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_table_copy_index())
-                            as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            VMBuiltinFunctionIndex::get_table_copy_index(),
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5724,9 +5742,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_table_fill_index())
-                            as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            VMBuiltinFunctionIndex::get_table_fill_index(),
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5761,9 +5779,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_table_init_index())
-                            as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(
+                            VMBuiltinFunctionIndex::get_table_init_index(),
+                        ))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5801,9 +5819,11 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets
-                            .vmctx_builtin_function(VMBuiltinFunctionIndex::get_elem_drop_index())
-                            as i32,
+                        vmctx_offset(
+                            self.vmoffsets.vmctx_builtin_function(
+                                VMBuiltinFunctionIndex::get_elem_drop_index(),
+                            ),
+                        )?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5844,7 +5864,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(memory_atomic_wait32) as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(memory_atomic_wait32))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5894,7 +5914,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(memory_atomic_wait64) as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(memory_atomic_wait64))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;
@@ -5943,7 +5963,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Size::S64,
                     Location::Memory(
                         self.machine.get_vmctx_reg(),
-                        self.vmoffsets.vmctx_builtin_function(memory_atomic_notify) as i32,
+                        vmctx_offset(self.vmoffsets.vmctx_builtin_function(memory_atomic_notify))?,
                     ),
                     Location::GPR(self.machine.get_gpr_for_call()),
                 )?;

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -2387,24 +2387,20 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     )?;
                 } else if let Some(local_table_index) = self.module.local_table_index(table_index) {
                     let (vmctx_offset_base, vmctx_offset_len) = (
-                        self.vmoffsets.vmctx_vmtable_definition(local_table_index),
-                        self.vmoffsets
-                            .vmctx_vmtable_definition_current_elements(local_table_index),
+                        vmctx_offset(self.vmoffsets.vmctx_vmtable_definition(local_table_index))?,
+                        vmctx_offset(
+                            self.vmoffsets
+                                .vmctx_vmtable_definition_current_elements(local_table_index),
+                        )?,
                     );
                     self.machine.move_location(
                         Size::S64,
-                        Location::Memory(
-                            self.machine.get_vmctx_reg(),
-                            vmctx_offset(vmctx_offset_base)?,
-                        ),
+                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset_base),
                         Location::GPR(table_base),
                     )?;
                     self.machine.move_location(
                         Size::S32,
-                        Location::Memory(
-                            self.machine.get_vmctx_reg(),
-                            vmctx_offset(vmctx_offset_len)?,
-                        ),
+                        Location::Memory(self.machine.get_vmctx_reg(), vmctx_offset_len),
                         Location::GPR(table_count),
                     )?;
                 } else {

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -2449,9 +2449,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 self.machine.emit_imul_imm32(
                     Size::S64,
                     if local_fixed_funcref_table.is_some() {
-                        self.vmoffsets.size_of_vmcaller_checked_anyfunc() as u32
+                        u32::from(self.vmoffsets.size_of_vmcaller_checked_anyfunc())
                     } else {
-                        self.vmoffsets.size_of_vm_funcref() as u32
+                        u32::from(self.vmoffsets.size_of_vm_funcref())
                     },
                     table_count,
                 )?;
@@ -2467,7 +2467,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                         Size::S64,
                         Location::Memory(
                             table_count,
-                            self.vmoffsets.vmcaller_checked_anyfunc_func_ptr() as i32,
+                            i32::from(self.vmoffsets.vmcaller_checked_anyfunc_func_ptr()),
                         ),
                         Location::GPR(table_base),
                     )?;
@@ -2484,7 +2484,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                         Size::S64,
                         Location::Memory(
                             table_count,
-                            self.vmoffsets.vm_funcref_anyfunc_ptr() as i32,
+                            i32::from(self.vmoffsets.vm_funcref_anyfunc_ptr()),
                         ),
                         Location::GPR(table_count),
                     )?;
@@ -2510,7 +2510,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                     Location::GPR(sig_hash),
                     Location::Memory(
                         table_count,
-                        (self.vmoffsets.vmcaller_checked_anyfunc_signature_hash() as usize) as i32,
+                        i32::from(self.vmoffsets.vmcaller_checked_anyfunc_signature_hash()),
                     ),
                     self.special_labels.bad_signature,
                 )?;
@@ -2528,9 +2528,9 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                 }
 
                 let vmcaller_checked_anyfunc_func_ptr =
-                    self.vmoffsets.vmcaller_checked_anyfunc_func_ptr() as usize;
+                    i32::from(self.vmoffsets.vmcaller_checked_anyfunc_func_ptr());
                 let vmcaller_checked_anyfunc_vmctx =
-                    self.vmoffsets.vmcaller_checked_anyfunc_vmctx() as usize;
+                    i32::from(self.vmoffsets.vmcaller_checked_anyfunc_vmctx());
 
                 self.emit_call_native(
                     |this| {
@@ -2541,13 +2541,13 @@ impl<'a, M: Machine> FuncGen<'a, M> {
                         // We set the context pointer
                         this.machine.move_location(
                             Size::S64,
-                            Location::Memory(gpr_for_call, vmcaller_checked_anyfunc_vmctx as i32),
+                            Location::Memory(gpr_for_call, vmcaller_checked_anyfunc_vmctx),
                             Location::GPR(this.machine.get_simple_param_location(0)),
                         )?;
 
                         this.machine.emit_call_location(Location::Memory(
                             gpr_for_call,
-                            vmcaller_checked_anyfunc_func_ptr as i32,
+                            vmcaller_checked_anyfunc_func_ptr,
                         ))?;
                         this.machine.mark_instruction_address_end(offset);
                         Ok(())

--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -3236,33 +3236,35 @@ pub fn gen_import_call_trampoline_arm64(
             )?;
             0
         };
-    let offset = vmctx_offset(offset)?;
+    let ptr_arg_offset = vmctx_offset(offset)?;
+    let vmctx_arg_offset = vmctx_offset(offset.saturating_add(8))?;
+
     #[allow(clippy::match_single_binding)]
     match calling_convention {
         _ => {
-            if (offset as u32).is_multiple_of(8) {
+            if (ptr_arg_offset as u32).is_multiple_of(8) {
                 a.emit_ldr(
                     Size::S64,
                     Location::GPR(GPR::X16),
-                    Location::Memory(GPR::X0, offset), // function pointer
+                    Location::Memory(GPR::X0, ptr_arg_offset), // function pointer
                 )?;
                 a.emit_ldr(
                     Size::S64,
                     Location::GPR(GPR::X0),
-                    Location::Memory(GPR::X0, offset + 8), // target vmctx
+                    Location::Memory(GPR::X0, vmctx_arg_offset), // target vmctx
                 )?;
             } else {
                 a.emit_ldur(
                     Size::S64,
                     Location::GPR(GPR::X16),
                     GPR::X0,
-                    offset, // function pointer
+                    ptr_arg_offset, // function pointer
                 )?;
                 a.emit_ldur(
                     Size::S64,
                     Location::GPR(GPR::X0),
                     GPR::X0,
-                    offset + 8, // target vmctx
+                    vmctx_arg_offset, // target vmctx
                 )?;
             }
         }

--- a/lib/compiler-singlepass/src/emitter_arm64.rs
+++ b/lib/compiler-singlepass/src/emitter_arm64.rs
@@ -18,6 +18,7 @@ use wasmer_compiler::types::{
 };
 use wasmer_types::{
     CompileError, FunctionIndex, FunctionType, Type, VMOffsets, target::CallingConvention,
+    vmctx_offset,
 };
 
 type Assembler = VecAssembler<Aarch64Relocation>;
@@ -3235,32 +3236,33 @@ pub fn gen_import_call_trampoline_arm64(
             )?;
             0
         };
+    let offset = vmctx_offset(offset)?;
     #[allow(clippy::match_single_binding)]
     match calling_convention {
         _ => {
-            if offset.is_multiple_of(8) {
+            if (offset as u32).is_multiple_of(8) {
                 a.emit_ldr(
                     Size::S64,
                     Location::GPR(GPR::X16),
-                    Location::Memory(GPR::X0, offset as i32), // function pointer
+                    Location::Memory(GPR::X0, offset), // function pointer
                 )?;
                 a.emit_ldr(
                     Size::S64,
                     Location::GPR(GPR::X0),
-                    Location::Memory(GPR::X0, offset as i32 + 8), // target vmctx
+                    Location::Memory(GPR::X0, offset + 8), // target vmctx
                 )?;
             } else {
                 a.emit_ldur(
                     Size::S64,
                     Location::GPR(GPR::X16),
                     GPR::X0,
-                    offset as i32, // function pointer
+                    offset, // function pointer
                 )?;
                 a.emit_ldur(
                     Size::S64,
                     Location::GPR(GPR::X0),
                     GPR::X0,
-                    offset as i32 + 8, // target vmctx
+                    offset + 8, // target vmctx
                 )?;
             }
         }

--- a/lib/compiler-singlepass/src/emitter_riscv.rs
+++ b/lib/compiler-singlepass/src/emitter_riscv.rs
@@ -2142,19 +2142,21 @@ pub fn gen_import_call_trampoline_riscv(
     // Emits a tail call trampoline that loads the address of the target import function
     // from Ctx and jumps to it.
 
-    let offset = vmctx_offset(vmoffsets.vmctx_vmfunction_import(index))?;
+    let offset = vmoffsets.vmctx_vmfunction_import(index);
+    let ptr_arg_offset = vmctx_offset(offset)?;
+    let vmctx_arg_offset = vmctx_offset(offset.saturating_add(8))?;
 
     a.emit_ld(
         Size::S64,
         false,
         Location::GPR(SCRATCH_REG),
-        Location::Memory(GPR::X10, offset), // function pointer
+        Location::Memory(GPR::X10, ptr_arg_offset), // function pointer
     )?;
     a.emit_ld(
         Size::S64,
         false,
         Location::GPR(GPR::X10),
-        Location::Memory(GPR::X10, offset + 8), // target vmctx
+        Location::Memory(GPR::X10, vmctx_arg_offset), // target vmctx
     )?;
 
     a.emit_j_register(SCRATCH_REG)?;

--- a/lib/compiler-singlepass/src/emitter_riscv.rs
+++ b/lib/compiler-singlepass/src/emitter_riscv.rs
@@ -20,6 +20,7 @@ use wasmer_compiler::types::{
 use wasmer_types::{
     CompileError, FunctionIndex, FunctionType, Type, VMOffsets,
     target::{CallingConvention, CpuFeature},
+    vmctx_offset,
 };
 
 type Assembler = VecAssembler<RiscvRelocation>;
@@ -2141,19 +2142,19 @@ pub fn gen_import_call_trampoline_riscv(
     // Emits a tail call trampoline that loads the address of the target import function
     // from Ctx and jumps to it.
 
-    let offset = vmoffsets.vmctx_vmfunction_import(index);
+    let offset = vmctx_offset(vmoffsets.vmctx_vmfunction_import(index))?;
 
     a.emit_ld(
         Size::S64,
         false,
         Location::GPR(SCRATCH_REG),
-        Location::Memory(GPR::X10, offset as i32), // function pointer
+        Location::Memory(GPR::X10, offset), // function pointer
     )?;
     a.emit_ld(
         Size::S64,
         false,
         Location::GPR(GPR::X10),
-        Location::Memory(GPR::X10, offset as i32 + 8), // target vmctx
+        Location::Memory(GPR::X10, offset + 8), // target vmctx
     )?;
 
     a.emit_j_register(SCRATCH_REG)?;

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -8140,16 +8140,18 @@ impl Machine for MachineX86_64 {
         // Emits a tail call trampoline that loads the address of the target import function
         // from Ctx and jumps to it.
 
-        let offset = vmctx_offset(vmoffsets.vmctx_vmfunction_import(index))?;
+        let offset = vmoffsets.vmctx_vmfunction_import(index);
+        let ptr_arg_offset = vmctx_offset(offset)?;
+        let vmctx_arg_offset = vmctx_offset(offset.saturating_add(8))?;
 
         a.emit_mov(
             Size::S64,
-            Location::Memory(GPR::RDI, offset), // function pointer
+            Location::Memory(GPR::RDI, ptr_arg_offset), // function pointer
             Location::GPR(GPR::RAX),
         )?;
         a.emit_mov(
             Size::S64,
-            Location::Memory(GPR::RDI, offset + 8), // target vmctx
+            Location::Memory(GPR::RDI, vmctx_arg_offset), // target vmctx
             Location::GPR(GPR::RDI),
         )?;
         a.emit_host_redirection(GPR::RAX)?;

--- a/lib/compiler-singlepass/src/machine_x64.rs
+++ b/lib/compiler-singlepass/src/machine_x64.rs
@@ -30,6 +30,7 @@ use wasmer_types::{
     CompileError, FunctionIndex, FunctionType, SourceLoc, TrapCode, TrapInformation, Type,
     VMOffsets,
     target::{CallingConvention, CpuFeature, Target},
+    vmctx_offset,
 };
 
 type Assembler = VecAssembler<X64Relocation>;
@@ -8139,16 +8140,16 @@ impl Machine for MachineX86_64 {
         // Emits a tail call trampoline that loads the address of the target import function
         // from Ctx and jumps to it.
 
-        let offset = vmoffsets.vmctx_vmfunction_import(index);
+        let offset = vmctx_offset(vmoffsets.vmctx_vmfunction_import(index))?;
 
         a.emit_mov(
             Size::S64,
-            Location::Memory(GPR::RDI, offset as i32), // function pointer
+            Location::Memory(GPR::RDI, offset), // function pointer
             Location::GPR(GPR::RAX),
         )?;
         a.emit_mov(
             Size::S64,
-            Location::Memory(GPR::RDI, offset as i32 + 8), // target vmctx
+            Location::Memory(GPR::RDI, offset + 8), // target vmctx
             Location::GPR(GPR::RDI),
         )?;
         a.emit_host_redirection(GPR::RAX)?;

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::stack::{FrameInfo, SourceLoc, TrapInformation};
 pub use crate::store_id::StoreId;
 pub use crate::trapcode::{OnCalledAction, TrapCode};
 pub use crate::utils::is_wasm;
-pub use crate::vmoffsets::{VMBuiltinFunctionIndex, VMOffsets};
+pub use crate::vmoffsets::{VMBuiltinFunctionIndex, VMOffsets, vmctx_offset};
 
 /// Offset in bytes from the beginning of the function.
 pub type CodeOffset = u32;

--- a/lib/types/src/vmoffsets.rs
+++ b/lib/types/src/vmoffsets.rs
@@ -679,7 +679,7 @@ impl VMOffsets {
 /// Convert a `VMContext` offset to the signed displacement used by compilers.
 pub fn vmctx_offset(offset: u32) -> WasmResult<i32> {
     i32::try_from(offset)
-        .map_err(|_| WasmError::Unsupported(format!("VMContext offset {offset} exceeds i32::MAX")))
+        .map_err(|_| WasmError::Generic(format!("VMContext offset {offset} exceeds i32::MAX")))
 }
 
 // TODO: make a breaking change where the return type will be `i32` instead!

--- a/lib/types/src/vmoffsets.rs
+++ b/lib/types/src/vmoffsets.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     FunctionIndex, GlobalIndex, LocalGlobalIndex, LocalMemoryIndex, LocalTableIndex, MemoryIndex,
-    ModuleInfo, TableIndex, entity::EntityRef,
+    ModuleInfo, TableIndex, WasmError, WasmResult, entity::EntityRef,
 };
 use more_asserts::assert_lt;
 use std::convert::TryFrom;
@@ -675,6 +675,14 @@ impl VMOffsets {
         4
     }
 }
+
+/// Convert a `VMContext` offset to the signed displacement used by compilers.
+pub fn vmctx_offset(offset: u32) -> WasmResult<i32> {
+    i32::try_from(offset)
+        .map_err(|_| WasmError::Unsupported(format!("VMContext offset {offset} exceeds i32::MAX")))
+}
+
+// TODO: make a breaking change where the return type will be `i32` instead!
 
 /// Offsets for `VMContext`.
 impl VMOffsets {


### PR DESCRIPTION
The offsets get from `VMOffsets` might be in `[i32::MAX+1..u32::MAX]` and we should propagate the error instead of calling unwrap, or silently casting them with `as i32`.