### PR TITLE
fix(tests): reflect recent Nix-based python package changes

### DIFF
--- a/tests/integration/cli/resources/python/temp-dir-in-child/main.py
+++ b/tests/integration/cli/resources/python/temp-dir-in-child/main.py
@@ -1,5 +1,7 @@
 import subprocess
 
-result = subprocess.run(["/bin/python", '/code/child.py'], capture_output=True, text=True)
+result = subprocess.run(
+    ["/bin/python3.13", "/code/child.py"], capture_output=True, text=True
+)
 
 print(f"{result.returncode}", end="")

--- a/tests/integration/cli/resources/python/temp-dir-in-child/main.py
+++ b/tests/integration/cli/resources/python/temp-dir-in-child/main.py
@@ -1,7 +1,5 @@
 import subprocess
 
-result = subprocess.run(
-    ["/bin/python3.13", "/code/child.py"], capture_output=True, text=True
-)
+result = subprocess.run(["/bin/python", '/code/child.py'], capture_output=True, text=True)
 
 print(f"{result.returncode}", end="")

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -786,6 +786,8 @@ fn issue_3794_unable_to_mount_relative_paths() {
 fn merged_filesystem_contains_all_files() {
     let assert = wasmer_command()
         .arg("run")
+        .arg("--use")
+        .arg("wasmer/bash")
         .arg("python/python")
         // TODO: drop once #6419 gets implemented (EH support for Cranelift on macOS)
         .arg("--llvm")

--- a/tests/integration/cli/tests/run.rs
+++ b/tests/integration/cli/tests/run.rs
@@ -786,21 +786,17 @@ fn issue_3794_unable_to_mount_relative_paths() {
 fn merged_filesystem_contains_all_files() {
     let assert = wasmer_command()
         .arg("run")
-        .arg("wasmer/bash")
-        .arg("--entrypoint=bash")
-        .arg("--use")
         .arg("python/python")
         // TODO: drop once #6419 gets implemented (EH support for Cranelift on macOS)
         .arg("--llvm")
         .arg("--")
         .arg("-c")
-        .arg("ls -l /usr/local/lib/python3.13/*.py")
-        .env("RUST_LOG", &*RUST_LOG)
+        .arg("import this")
         .assert();
 
     assert
         .success()
-        .stdout(contains("/usr/local/lib/python3.13/this.py"));
+        .stdout(contains("Beautiful is better than ugly."));
 }
 
 #[test]


### PR DESCRIPTION
There are 2 issues that are addressed by the PR:
1. https://github.com/wasix-org/wasinix/issues/184 - will be addressed and published soon
2. `sysconfig.get_paths()` changed its location (a Nix-prefix path), not longer pointing at `/usr/local/lib/python3.13` -> test adjusted

FYI @kilyanni