### PR TITLE
script: release submodules from a dedicated 'wasmer-release' branch

### DIFF
--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -14,6 +14,7 @@ DATE = datetime.date.today().strftime("%d/%m/%Y")
 SIGNOFF_REVIEWER = "Arshia001"
 TAG = "main"
 RELEASE_SUBMODULES = ("lib/napi",)
+SUBMODULE_BRANCH = "wasmer-release"
 
 if len(sys.argv) > 1:
     RELEASE_VERSION = sys.argv[1]
@@ -58,7 +59,7 @@ def replace(file, pattern, subst):
 def sync_submodule(repo_dir, path):
     submodule_dir = os.path.join(repo_dir, path)
     subprocess.run(
-        ["git", "-C", submodule_dir, "fetch", "origin", "wasmer-release"], check=True
+        ["git", "-C", submodule_dir, "fetch", "origin", SUBMODULE_BRANCH], check=True
     )
     subprocess.run(
         ["git", "-C", submodule_dir, "checkout", "--detach", "FETCH_HEAD"], check=True
@@ -270,7 +271,7 @@ def make_release(version):
                 print(line.rstrip())
             raise Exception("could not commit CHANGELOG " + RELEASE_VERSION_WITH_V)
 
-        # Sync submodules to main (must contain version bump)
+        # Sync submodules to SUBMODULE_BRANCH branch (must contain version bump)
         for path in RELEASE_SUBMODULES:
             sync_submodule(temp_dir.name, path)
             print(f"synchronized submodule {path}")

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -57,8 +57,12 @@ def replace(file, pattern, subst):
 
 def sync_submodule(repo_dir, path):
     submodule_dir = os.path.join(repo_dir, path)
-    subprocess.run(["git", "-C", submodule_dir, "checkout", "main"], check=True)
-    subprocess.run(["git", "-C", submodule_dir, "pull"], check=True)
+    subprocess.run(
+        ["git", "-C", submodule_dir, "fetch", "origin", "wasmer-release"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", submodule_dir, "checkout", "--detach", "FETCH_HEAD"], check=True
+    )
     subprocess.run(["git", "-C", submodule_dir, "rev-parse", "HEAD"], check=True)
 
 

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -101,7 +101,7 @@ for root, dirs, files in os.walk("."):
     path = root.split(os.sep)
     # print((len(path) - 1) * '---', os.path.basename(root))
     for file in files:
-        if "Cargo.toml" in file:
+        if "Cargo.toml" in file or "Cargo.standalone.toml" in file:
             replace_version(root + "/" + file)
         elif "wasmer.iss" in file:
             replace_version_iss(root + "/" + file)


### PR DESCRIPTION
We should start using a dedicated branch for releases of the submodules as we can't always bump to the `main` branch of the submodules.