### PR TITLE
deps: update wasm-tools related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7198,16 +7198,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.256.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.256.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
@@ -7218,14 +7208,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f39c3a9855dd7a4b4554511a14a455f7ff813cb5c1ec473277f93061395ee7"
+checksum = "7f44c78d502a2164ad2f1d8865ea64242454395190836951e95676a0e270cf73"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
- "wasm-encoder 0.256.0",
+ "wasm-encoder 0.257.1",
 ]
 
 [[package]]
@@ -7284,7 +7274,7 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
  "wat",
  "which",
  "windows-sys 0.61.2",
@@ -7576,7 +7566,7 @@ dependencies = [
  "thiserror 2.0.20",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
  "which",
  "windows-sys 0.61.2",
 ]
@@ -7888,7 +7878,7 @@ dependencies = [
  "sha2",
  "target-lexicon 0.13.5",
  "thiserror 2.0.20",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]
@@ -8005,14 +7995,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-encoder 0.256.0",
+ "wasm-encoder 0.257.1",
  "wasmer",
  "wasmer-config",
  "wasmer-journal",
  "wasmer-package",
  "wasmer-types",
  "wasmer-wasix-types",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
  "wcgi",
  "wcgi-host",
  "web-sys",
@@ -8052,7 +8042,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.20",
  "wasmer",
- "wast 256.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -8106,17 +8096,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.256.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
-dependencies = [
- "bitflags 2.13.1",
- "indexmap",
- "semver 1.0.28",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
@@ -8128,13 +8107,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e15994b4797b3826dc466488a9019975fda659a9746d28c29b9a09fc02c8ea"
+checksum = "39aefcb16c1b7d9a93b494e4e38da3b36893178f65084bfe852b2a574a5c65ab"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]
@@ -8145,19 +8124,6 @@ checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
-]
-
-[[package]]
-name = "wast"
-version = "256.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width",
- "wasm-encoder 0.256.0",
 ]
 
 [[package]]
@@ -8179,7 +8145,7 @@ version = "1.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
 dependencies = [
- "wast 257.0.1",
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,17 +308,17 @@ wasm-bindgen = "0.2.120"
 wasm-bindgen-futures = "0.4.70"
 wasm-bindgen-test = "0.3.70"
 wasm-coredump-builder = "0.2.2"
-wasm-encoder = { version = "0.256.0", default-features = false, features = [
+wasm-encoder = { version = "0.257.1", default-features = false, features = [
   "std",
 ] }
-wasm-smith = "0.256.0"
-wasmparser = { version = "0.256.0", default-features = false, features = [
+wasm-smith = "0.257.1"
+wasmparser = { version = "0.257.1", default-features = false, features = [
   "validate",
   "features",
   "simd",
 ] }
-wasmprinter = "0.256.0"
-wast = "256.0.0"
+wasmprinter = "0.257.1"
+wast = "257.0.0"
 wat = "1.256.0"
 wcgi = "0.3.0"
 wcgi-host = "0.3.0"

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -447,7 +447,7 @@ impl FuncTranslator {
             let op = reader.read_operator()?;
             if let Some((dibuilder, subprogram)) = debug_info.as_ref() {
                 let (line, column, scope) =
-                    if let Some(location) = self.source_map.get(original_pos as usize) {
+                    if let Some(location) = self.source_map.get(u64::from(original_pos)) {
                         let file = dibuilder.create_file(&location.file, &location.directory);
                         // TODO: try caching the lexical scopes (might be a space saver)
                         let block = dibuilder.create_lexical_block(

--- a/lib/compiler-singlepass/src/address_map.rs
+++ b/lib/compiler-singlepass/src/address_map.rs
@@ -10,7 +10,7 @@ pub fn get_function_address_map(
     // Generate source loc for a function start/end to identify boundary within module.
     // It will wrap around if byte code is larger than 4 GB.
     let start_srcloc = SourceLoc::new(data.module_offset as u32);
-    let end_srcloc = SourceLoc::new((data.module_offset + data.data.len()) as u32);
+    let end_srcloc = SourceLoc::new((data.module_offset + data.data.len() as u64) as u32);
 
     FunctionAddressMap {
         instructions,

--- a/lib/compiler/src/dwarf.rs
+++ b/lib/compiler/src/dwarf.rs
@@ -401,7 +401,7 @@ impl DwarfState {
         srcloc: SourceLoc,
         source_map: &WasmSourceMap,
     ) {
-        let Some(location) = source_map.get(srcloc.bits() as usize) else {
+        let Some(location) = source_map.get(u64::from(srcloc.bits())) else {
             self.add_row(code_offset, srcloc);
             return;
         };

--- a/lib/compiler/src/source_map.rs
+++ b/lib/compiler/src/source_map.rs
@@ -27,7 +27,7 @@ pub struct SourceLocation {
 /// module. This map performs that translation once before parallel codegen.
 #[derive(Default)]
 pub struct WasmSourceMap {
-    locations: BTreeMap<usize, SourceLocation>,
+    locations: BTreeMap<u64, SourceLocation>,
 }
 
 impl WasmSourceMap {
@@ -70,7 +70,7 @@ impl WasmSourceMap {
                     format!(
                         "Wasm operator offset {offset} precedes code section offset {code_base}"
                     )
-                })? as u64;
+                })?;
                 let Ok(Some(location)) = context.find_location(address) else {
                     continue;
                 };
@@ -102,14 +102,14 @@ impl WasmSourceMap {
     }
 
     /// Return the source location for a module-relative Wasm offset.
-    pub fn get(&self, wasm_offset: usize) -> Option<&SourceLocation> {
+    pub fn get(&self, wasm_offset: u64) -> Option<&SourceLocation> {
         self.locations.get(&wasm_offset)
     }
 
     /// Return the first mapped source location in a function body.
     pub fn first_in_function(&self, body: &FunctionBodyData<'_>) -> Option<&SourceLocation> {
         self.locations
-            .range(body.module_offset..body.module_offset.saturating_add(body.data.len()))
+            .range(body.module_offset..body.module_offset.saturating_add(body.data.len() as u64))
             .next()
             .map(|(_, location)| location)
     }

--- a/lib/compiler/src/translator/environ.rs
+++ b/lib/compiler/src/translator/environ.rs
@@ -25,7 +25,7 @@ pub struct FunctionBodyData<'a> {
     pub data: &'a [u8],
 
     /// Body offset relative to the module file.
-    pub module_offset: usize,
+    pub module_offset: u64,
 }
 
 /// Trait for iterating over the operators of a Wasm Function
@@ -411,7 +411,7 @@ impl<'data> ModuleEnvironment<'data> {
         &mut self,
         _module_translation_state: &ModuleTranslationState,
         body_bytes: &'data [u8],
-        body_offset: usize,
+        body_offset: u64,
     ) -> WasmResult<()> {
         self.function_body_inputs.push(FunctionBodyData {
             data: body_bytes,

--- a/lib/compiler/src/translator/error.rs
+++ b/lib/compiler/src/translator/error.rs
@@ -12,7 +12,7 @@ macro_rules! wasm_unsupported {
 pub fn from_binaryreadererror_wasmerror(original: BinaryReaderError) -> WasmError {
     WasmError::InvalidWebAssembly {
         message: original.message().into(),
-        offset: original.offset(),
+        offset: original.offset() as usize,
     }
 }
 

--- a/lib/compiler/src/translator/middleware.rs
+++ b/lib/compiler/src/translator/middleware.rs
@@ -133,7 +133,7 @@ impl<'a: 'b, 'b> Extend<&'b Operator<'a>> for MiddlewareReaderState<'a> {
 
 impl<'a> MiddlewareBinaryReader<'a> {
     /// Constructs a `MiddlewareBinaryReader` with an explicit starting offset.
-    pub fn new_with_offset(data: &'a [u8], original_offset: usize) -> Self {
+    pub fn new_with_offset(data: &'a [u8], original_offset: u64) -> Self {
         let inner = BinaryReader::new(data, original_offset);
         Self {
             state: MiddlewareReaderState {
@@ -273,8 +273,10 @@ impl<'a> FunctionBinaryReader<'a> for MiddlewareBinaryReader<'a> {
 
     fn original_position(&self) -> usize {
         match self.state.inner.as_ref().expect("inner state must exist") {
-            MiddlewareInnerReader::Binary { reader, .. } => reader.original_position(),
-            MiddlewareInnerReader::Operator(operator_reader) => operator_reader.original_position(),
+            MiddlewareInnerReader::Binary { reader, .. } => reader.original_position() as usize,
+            MiddlewareInnerReader::Operator(operator_reader) => {
+                operator_reader.original_position() as usize
+            }
         }
     }
 
@@ -295,11 +297,12 @@ impl<'a> FunctionBinaryReader<'a> for MiddlewareBinaryReader<'a> {
     }
 
     fn range(&self) -> Range<usize> {
-        match self.state.inner.as_ref().expect("inner state must exist") {
+        let range = match self.state.inner.as_ref().expect("inner state must exist") {
             MiddlewareInnerReader::Binary { reader, .. } => reader.range(),
             MiddlewareInnerReader::Operator(operator_reader) => {
                 operator_reader.get_binary_reader().range()
             }
-        }
+        };
+        range.start as usize..range.end as usize
     }
 }

--- a/lib/compiler/src/translator/state.rs
+++ b/lib/compiler/src/translator/state.rs
@@ -18,7 +18,7 @@ pub(crate) type WasmTypes =
 #[derive(Debug)]
 pub struct ModuleTranslationState {
     /// Offset of the code-section payload in the original Wasm file.
-    pub(crate) code_section_offset: Option<usize>,
+    pub(crate) code_section_offset: Option<u64>,
 
     /// A map containing a Wasm module's original, raw signatures.
     ///
@@ -37,7 +37,7 @@ impl ModuleTranslationState {
     }
 
     /// Get the offset of the code-section payload in the original Wasm file.
-    pub fn code_section_offset(&self) -> Option<usize> {
+    pub fn code_section_offset(&self) -> Option<u64> {
         self.code_section_offset
     }
 


### PR DESCRIPTION
There's a signature change from `usize` -> `u64` and thus a code polishing is necessary. Right now, we're not supporting any 32-bit target, so we implicitly assume `usize::BITS == u64::BITS`.

The PR will be ready for landing on 7.3 gets out of the door.