### PR TITLE
script: rework release-related scripts

### DIFF
--- a/scripts/RELEASE.md
+++ b/scripts/RELEASE.md
@@ -13,7 +13,14 @@ git pull
 
 First, prepare a PR (or push) version bump for all submodules!
 
-Run the release script (adjust the version as needed):
+Run the release script with the current repository version and the version being
+released. Both arguments are required:
+
+```bash
+python3 ./scripts/make-release.py OLD_VERSION RELEASE_VERSION
+```
+
+For example:
 
 ```bash
 python3 ./scripts/make-release.py 6.0.1 6.1.0

--- a/scripts/RELEASE.md
+++ b/scripts/RELEASE.md
@@ -16,7 +16,7 @@ First, prepare a PR (or push) version bump for all submodules!
 Run the release script (adjust the version as needed):
 
 ```bash
-python3 ./scripts/make-release.py v6.1.0
+python3 ./scripts/make-release.py 6.0.1 6.1.0
 ```
 
 Wait for the script to open a PR and note the PR branch name.

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -378,7 +378,7 @@ def make_release():
             + "    https://github.com/wasmerio/wasmer/pull/"
             + pr_number
         )
-        print("")
+        print()
 
         for line in proc.stdout:
             line = line.decode("utf-8").rstrip()

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 from itertools import takewhile
+from pathlib import Path
 import argparse
 import os
 import time
@@ -17,6 +18,7 @@ parser.add_argument(
 parser.add_argument("release_version", metavar="NEW_VERSION", help="version to release")
 args = parser.parse_args()
 
+UPDATE_VERSION_SCRIPT = Path(__file__).resolve().with_name("update-version.py")
 DATE = datetime.date.today().strftime("%d/%m/%Y")
 SIGNOFF_REVIEWER = "Arshia001"
 RELEASE_SUBMODULES = ("lib/napi",)
@@ -279,11 +281,10 @@ def make_release():
         subprocess.check_output(
             [
                 "python3",
-                temp_dir.name + "/scripts/update-version.py",
+                UPDATE_VERSION_SCRIPT,
                 args.old_version,
                 args.release_version,
             ],
-            shell=True,
             cwd=temp_dir.name,
         )
         for path in RELEASE_SUBMODULES:

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -1,37 +1,35 @@
 #! /usr/bin/env python3
 
 from itertools import takewhile
+import argparse
 import os
 import time
-import sys
 import subprocess
 import tempfile
 import datetime
 import re
 
-RELEASE_VERSION = ""
+parser = argparse.ArgumentParser(description="Create a Wasmer release")
+parser.add_argument(
+    "old_version",
+    metavar="OLD_VERSION",
+    help="version currently used by the repository",
+)
+parser.add_argument("release_version", metavar="NEW_VERSION", help="version to release")
+args = parser.parse_args()
+
 DATE = datetime.date.today().strftime("%d/%m/%Y")
 SIGNOFF_REVIEWER = "Arshia001"
-TAG = "main"
 RELEASE_SUBMODULES = ("lib/napi",)
 SUBMODULE_BRANCH = "wasmer-release"
 
-if len(sys.argv) > 1:
-    RELEASE_VERSION = sys.argv[1]
+args.old_version = args.old_version.removeprefix("v")
+
+RELEASE_VERSION_WITH_V = args.release_version
+if not args.release_version.startswith("v"):
+    RELEASE_VERSION_WITH_V = "v" + args.release_version
 else:
-    print("no release version as first argument")
-    sys.exit(1)
-
-
-if len(sys.argv) > 2:
-    TAG = sys.argv[2]
-
-RELEASE_VERSION_WITH_V = RELEASE_VERSION
-
-if not (RELEASE_VERSION.startswith("v")):
-    RELEASE_VERSION_WITH_V = "v" + RELEASE_VERSION
-else:
-    RELEASE_VERSION = RELEASE_VERSION[1:]
+    args.release_version = args.release_version[1:]
 
 subprocess.check_output(["git", "--version"])
 subprocess.check_output(["gh", "--version"])
@@ -76,7 +74,7 @@ def verify_submodule(repo_dir, path):
         raise Exception(f"submodule {path} has unexpected local changes:\n{status}")
 
 
-def make_release(version):
+def make_release():
     subprocess.check_output(["gh", "auth", "status"])
 
     temp_dir = tempfile.TemporaryDirectory(prefix="wasmer-git-")
@@ -87,7 +85,7 @@ def make_release(version):
             "git@github.com:wasmerio/wasmer.git",
             "--recurse-submodules",
             "--branch",
-            TAG,
+            "main",
             "--depth",
             "1",
             temp_dir.name,
@@ -150,7 +148,7 @@ def make_release(version):
 
     changelog.append("## **Unreleased**")
     changelog.append("")
-    changelog.append("## " + RELEASE_VERSION + " - " + DATE)
+    changelog.append("## " + args.release_version + " - " + DATE)
     changelog.append("")
     changelog.append("## Added")
     changelog.append("")
@@ -191,7 +189,7 @@ def make_release(version):
     already_released_str = ""
     for line in proc.stdout:
         line = line.decode("utf-8").rstrip()
-        if RELEASE_VERSION + "\t" in line:
+        if args.release_version + "\t" in line:
             already_released_str = line
             break
 
@@ -207,7 +205,7 @@ def make_release(version):
     github_link_line = ""
     for line in proc.stdout:
         line = line.decode("utf-8").rstrip()
-        if "release-" + RELEASE_VERSION + "\t" in line:
+        if "release-" + args.release_version + "\t" in line:
             github_link_line = line
             break
 
@@ -215,21 +213,21 @@ def make_release(version):
 
     if github_link_line != "":
         proc = subprocess.Popen(
-            ["git", "pull", "origin", "release-" + RELEASE_VERSION],
+            ["git", "pull", "origin", "release-" + args.release_version],
             stdout=subprocess.PIPE,
             cwd=temp_dir.name,
         )
         proc.wait()
 
         proc = subprocess.Popen(
-            ["git", "checkout", "-b", "release-" + RELEASE_VERSION],
+            ["git", "checkout", "-b", "release-" + args.release_version],
             stdout=subprocess.PIPE,
             cwd=temp_dir.name,
         )
         proc.wait()
 
         proc = subprocess.Popen(
-            ["git", "pull", "origin", "release-" + RELEASE_VERSION],
+            ["git", "pull", "origin", "release-" + args.release_version],
             stdout=subprocess.PIPE,
             cwd=temp_dir.name,
         )
@@ -245,7 +243,7 @@ def make_release(version):
     if github_link_line == "" and not (already_released):
         # git checkout -b release-3.0.0-rc.2
         proc = subprocess.Popen(
-            ["git", "checkout", "-b", "release-" + RELEASE_VERSION],
+            ["git", "checkout", "-b", "release-" + args.release_version],
             stdout=subprocess.PIPE,
             cwd=temp_dir.name,
         )
@@ -254,7 +252,9 @@ def make_release(version):
         if proc.returncode != 0:
             for line in proc.stdout:
                 print(line.rstrip())
-            raise Exception("could not run git checkout -b release-" + RELEASE_VERSION)
+            raise Exception(
+                "could not run git checkout -b release-" + args.release_version
+            )
 
         replace(
             temp_dir.name + "/CHANGELOG.md", "## **Unreleased**", "\n".join(changelog)
@@ -280,10 +280,8 @@ def make_release(version):
         update_version_py = get_file_string(
             temp_dir.name + "/scripts/update-version.py"
         )
-        previous_version = re.search('NEXT_VERSION = "(.*)"', update_version_py).groups(
-            1
-        )[0]
-        next_version = RELEASE_VERSION
+        previous_version = args.old_version
+        next_version = args.release_version
         print("updating version " + previous_version + " -> " + next_version)
         update_version_py = re.sub(
             'PREVIOUS_VERSION = ".*"',
@@ -309,7 +307,7 @@ def make_release(version):
             print(f"verified submodule {path}")
 
         proc = subprocess.Popen(
-            ["git", "commit", "-am", "Release " + RELEASE_VERSION],
+            ["git", "commit", "-am", "Release " + args.release_version],
             stdout=subprocess.PIPE,
             cwd=temp_dir.name,
         )
@@ -328,7 +326,14 @@ def make_release(version):
         proc.wait()
 
         proc = subprocess.Popen(
-            ["git", "push", "-f", "-u", "origin", "release-" + RELEASE_VERSION],
+            [
+                "git",
+                "push",
+                "-f",
+                "-u",
+                "origin",
+                "release-" + args.release_version,
+            ],
             stdout=subprocess.PIPE,
             cwd=temp_dir.name,
         )
@@ -340,11 +345,11 @@ def make_release(version):
                 "pr",
                 "create",
                 "--head",
-                "release-" + RELEASE_VERSION,
+                "release-" + args.release_version,
                 "--title",
-                "Release " + RELEASE_VERSION,
+                "Release " + args.release_version,
                 "--body",
-                "[bot] Release wasmer version " + RELEASE_VERSION,
+                "[bot] Release wasmer version " + args.release_version,
                 "--reviewer",
                 SIGNOFF_REVIEWER,
             ],
@@ -362,7 +367,7 @@ def make_release(version):
 
         for line in proc.stdout:
             line = line.decode("utf-8").rstrip()
-            if "release-" + RELEASE_VERSION + "\t" in line:
+            if "release-" + args.release_version + "\t" in line:
                 github_link_line = line
                 break
 
@@ -470,7 +475,7 @@ def make_release(version):
         github_link_line = ""
         for line in proc.stdout:
             line = line.decode("utf-8").rstrip()
-            if RELEASE_VERSION + "\t" in line:
+            if args.release_version + "\t" in line:
                 github_link_line = line
                 break
 
@@ -629,7 +634,7 @@ def make_release(version):
     for c in changed:
         release_notes.append(c)
 
-    hash = RELEASE_VERSION + "---" + DATE
+    hash = args.release_version + "---" + DATE
     hash = hash.replace(".", "")
     hash = hash.replace("/", "")
 
@@ -657,4 +662,4 @@ def make_release(version):
     print("Script done and merged 🎉🎉🎉")
 
 
-make_release(RELEASE_VERSION)
+make_release()

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -7,7 +7,6 @@ import time
 import subprocess
 import tempfile
 import datetime
-import re
 
 parser = argparse.ArgumentParser(description="Create a Wasmer release")
 parser.add_argument(
@@ -277,31 +276,16 @@ def make_release():
             print(f"synchronized submodule {path}")
 
         # Update version numbers
-        update_version_py = get_file_string(
-            temp_dir.name + "/scripts/update-version.py"
-        )
-        previous_version = args.old_version
-        next_version = args.release_version
-        print("updating version " + previous_version + " -> " + next_version)
-        update_version_py = re.sub(
-            'PREVIOUS_VERSION = ".*"',
-            f'PREVIOUS_VERSION = "{previous_version}"',
-            update_version_py,
-        )
-        update_version_py = re.sub(
-            'NEXT_VERSION = ".*"',
-            f'NEXT_VERSION = "{next_version}"',
-            update_version_py,
-        )
-        write_file_string(
-            temp_dir.name + "/scripts/update-version.py", update_version_py
-        )
-        proc = subprocess.Popen(
-            ["python3", temp_dir.name + "/scripts/update-version.py"],
-            stdout=subprocess.PIPE,
+        subprocess.check_output(
+            [
+                "python3",
+                temp_dir.name + "/scripts/update-version.py",
+                args.old_version,
+                args.release_version,
+            ],
+            shell=True,
             cwd=temp_dir.name,
         )
-        proc.wait()
         for path in RELEASE_SUBMODULES:
             verify_submodule(temp_dir.name, path)
             print(f"verified submodule {path}")

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -16,6 +16,8 @@ parser.add_argument(
     help="version_to_release",
 )
 args = parser.parse_args()
+args.old_version = args.old_version.removeprefix("v")
+args.release_version = args.release_version.removeprefix("v")
 
 
 def make_prerelease_version(version: str) -> str:

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -34,18 +34,16 @@ release_prerelease_version = make_prerelease_version(args.release_version)
 
 def replace(file, pattern, subst):
     # Read contents from file as a single string
-    file_handle = open(file, "r")
-    file_string = file_handle.read()
-    file_handle.close()
+    with open(file, "r") as file_handle:
+        file_string = file_handle.read()
 
     # Use RE package to allow for replacement (also allowing for (multiline) REGEX)
     file_string = re.sub(pattern, subst, file_string)
 
     # Write contents to file.
     # Using mode 'w' truncates the file.
-    file_handle = open(file, "w")
-    file_handle.write(file_string)
-    file_handle.close()
+    with open(file, "w") as file_handle:
+        file_handle.write(file_string)
 
 
 def replace_version(path):

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -39,8 +39,7 @@ def replace(file, pattern, subst):
     with open(file, "r") as file_handle:
         file_string = file_handle.read()
 
-    # Use RE package to allow for replacement (also allowing for (multiline) REGEX)
-    file_string = re.sub(pattern, subst, file_string)
+    file_string = file_string.replace(pattern, subst)
 
     # Write contents to file.
     # Using mode 'w' truncates the file.

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -1,10 +1,21 @@
 #!/usr/bin/python
 
+import argparse
 import os
 import re
 
-PREVIOUS_VERSION = "7.2.1"
-NEXT_VERSION = "7.3.0-rc.1"
+parser = argparse.ArgumentParser(description="Update Wasmer versions")
+parser.add_argument(
+    "old_version",
+    metavar="OLD_VERSION",
+    help="version currently used by the repository",
+)
+parser.add_argument(
+    "release_version",
+    metavar="RELEASE_VERSION",
+    help="version_to_release",
+)
+args = parser.parse_args()
 
 
 def make_prerelease_version(version: str) -> str:
@@ -17,8 +28,8 @@ def make_prerelease_version(version: str) -> str:
     return f"0.{new_minor}.{patch}"
 
 
-PREVIOUS_PRERELEASE_VERSION = make_prerelease_version(PREVIOUS_VERSION)
-NEXT_PRERELEASE_VERSION = make_prerelease_version(NEXT_VERSION)
+old_prerelease_version = make_prerelease_version(args.old_version)
+release_prerelease_version = make_prerelease_version(args.release_version)
 
 
 def replace(file, pattern, subst):
@@ -38,63 +49,66 @@ def replace(file, pattern, subst):
 
 
 def replace_version(path):
-    print(PREVIOUS_VERSION + " -> " + NEXT_VERSION + " (" + path + ")")
+    print(args.old_version + " -> " + args.release_version + " (" + path + ")")
     replace(
-        path, 'version = "' + PREVIOUS_VERSION + '"', 'version = "' + NEXT_VERSION + '"'
+        path,
+        'version = "' + args.old_version + '"',
+        'version = "' + args.release_version + '"',
     )
     replace(
         path,
-        'version = "=' + PREVIOUS_VERSION + '"',
-        'version = "=' + NEXT_VERSION + '"',
+        'version = "=' + args.old_version + '"',
+        'version = "=' + args.release_version + '"',
     )
     replace(
         path,
-        'version = "' + PREVIOUS_PRERELEASE_VERSION + '"',
-        'version = "' + NEXT_PRERELEASE_VERSION + '"',
+        'version = "' + old_prerelease_version + '"',
+        'version = "' + release_prerelease_version + '"',
     )
     replace(
         path,
-        'version = "=' + PREVIOUS_PRERELEASE_VERSION + '"',
-        'version = "=' + NEXT_PRERELEASE_VERSION + '"',
+        'version = "=' + old_prerelease_version + '"',
+        'version = "=' + release_prerelease_version + '"',
     )
-    pass
 
 
 def replace_version_py(path):
-    print(PREVIOUS_VERSION + " -> " + NEXT_VERSION + " (" + path + ")")
+    print(args.old_version + " -> " + args.release_version + " (" + path + ")")
     replace(
         path,
-        'target_version = "' + PREVIOUS_VERSION + '"',
-        'target_version = "' + NEXT_VERSION + '"',
+        'target_version = "' + args.old_version + '"',
+        'target_version = "' + args.release_version + '"',
     )
     replace(
         path,
-        'target_version = "' + PREVIOUS_PRERELEASE_VERSION + '"',
-        'target_version = "' + NEXT_PRERELEASE_VERSION + '"',
+        'target_version = "' + old_prerelease_version + '"',
+        'target_version = "' + release_prerelease_version + '"',
     )
-    pass
 
 
 def replace_version_iss(path):
-    print(PREVIOUS_VERSION + " -> " + NEXT_VERSION + " (" + path + ")")
-    replace(path, "AppVersion=" + PREVIOUS_VERSION, "AppVersion=" + NEXT_VERSION)
+    print(args.old_version + " -> " + args.release_version + " (" + path + ")")
     replace(
         path,
-        "AppVersion=" + PREVIOUS_PRERELEASE_VERSION,
-        "AppVersion=" + NEXT_PRERELEASE_VERSION,
+        "AppVersion=" + args.old_version,
+        "AppVersion=" + args.release_version,
     )
-    pass
+    replace(
+        path,
+        "AppVersion=" + old_prerelease_version,
+        "AppVersion=" + release_prerelease_version,
+    )
 
 
 print(
     "Updating crate versions from "
-    + PREVIOUS_VERSION
+    + args.old_version
     + " to "
-    + NEXT_VERSION
+    + args.release_version
     + " (and prerelease versions from "
-    + PREVIOUS_PRERELEASE_VERSION
+    + old_prerelease_version
     + " to "
-    + NEXT_PRERELEASE_VERSION
+    + release_prerelease_version
     + ")"
 )
 for root, dirs, files in os.walk("."):


### PR DESCRIPTION
The release scripts tend to be really fragile and so I decided to make it move convenient for making upcoming releases:

- update-version.py script version replacement replaced with a proper argument passing (useful now for manual `napi` bump)
- make-release.py newly requires old and new version
- ArgumentParser used
- some Ruff issues addressed