### PR TITLE
feat(MemoryStyle::static): adjust API and require mmap of 8GiB (#13)

### DIFF
--- a/examples/tunables_limit_memory.rs
+++ b/examples/tunables_limit_memory.rs
@@ -6,7 +6,7 @@ use wasmer::{
     Engine, Instance, Memory, MemoryError, MemoryStyle, MemoryType, Module, Pages, Store,
     TableStyle, TableType, imports,
     sys::{
-        BaseTunables, NativeEngineExt, Target, Tunables,
+        BaseTunables, NativeEngineExt, Tunables,
         vm::{VMMemory, VMMemoryDefinition, VMTable, VMTableDefinition},
     },
     wat2wasm,
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let compiler = Cranelift::default();
 
     // Here is where the fun begins
-    let base = BaseTunables::for_target(&Target::default());
+    let base = BaseTunables::new();
     let tunables = LimitingTunables::new(base, Pages(24));
     let mut engine: Engine = compiler.into();
     engine.set_tunables(tunables);

--- a/lib/api/src/backend/sys/entities/engine.rs
+++ b/lib/api/src/backend/sys/entities/engine.rs
@@ -45,7 +45,7 @@ pub fn default_engine() -> Engine {
     }
 
     let mut engine = get_engine();
-    let tunables = BaseTunables::for_target(engine.target());
+    let tunables = BaseTunables::new();
     engine.set_tunables(tunables);
     engine
 }

--- a/lib/api/src/backend/sys/tunables.rs
+++ b/lib/api/src/backend/sys/tunables.rs
@@ -9,28 +9,23 @@ mod tests {
     use crate::TableType;
     #[allow(unused)]
     use crate::sys::NativeEngineExt;
-    use std::cell::UnsafeCell;
     use std::ptr::NonNull;
     use wasmer_compiler::Tunables;
-    use wasmer_types::{MemoryType, Pages, WASM_PAGE_SIZE};
+    use wasmer_types::{MemoryType, Pages};
     use wasmer_vm::{
-        LinearMemory, MemoryError, MemoryStyle, TableStyle, VMConfig, VMMemory, VMMemoryDefinition,
-        VMTable, VMTableDefinition,
+        MemoryError, MemoryStyle, TableStyle, VMConfig, VMMemory, VMMemoryDefinition, VMTable,
+        VMTableDefinition,
     };
 
     #[test]
     fn memory_style() {
-        let tunables = BaseTunables {
-            static_memory_bound: Pages(2048),
-            static_memory_offset_guard_size: 128,
-            dynamic_memory_offset_guard_size: 256,
-        };
+        let tunables = BaseTunables::new();
 
-        // No maximum
+        // No maximum: treat as wasm32 maximum, so static.
         let requested = MemoryType::new(3, None, true);
         let style = tunables.memory_style(&requested);
         match style {
-            MemoryStyle::Dynamic { offset_guard_size } => assert_eq!(offset_guard_size, 256),
+            MemoryStyle::Static => {}
             s => panic!("Unexpected memory style: {s:?}"),
         }
 
@@ -38,7 +33,7 @@ mod tests {
         let requested = MemoryType::new(3, Some(5_000_000), true);
         let style = tunables.memory_style(&requested);
         match style {
-            MemoryStyle::Dynamic { offset_guard_size } => assert_eq!(offset_guard_size, 256),
+            MemoryStyle::Static => {}
             s => panic!("Unexpected memory style: {s:?}"),
         }
 
@@ -46,135 +41,15 @@ mod tests {
         let requested = MemoryType::new(3, Some(16), true);
         let style = tunables.memory_style(&requested);
         match style {
-            MemoryStyle::Static {
-                bound,
-                offset_guard_size,
-            } => {
-                assert_eq!(bound, Pages(2048));
-                assert_eq!(offset_guard_size, 128);
-            }
+            MemoryStyle::Static => {}
             s => panic!("Unexpected memory style: {s:?}"),
-        }
-    }
-
-    #[derive(Debug)]
-    struct VMTinyMemory {
-        mem: Vec<u8>,
-        memory_definition: Option<UnsafeCell<VMMemoryDefinition>>,
-    }
-
-    unsafe impl Send for VMTinyMemory {}
-    unsafe impl Sync for VMTinyMemory {}
-
-    impl VMTinyMemory {
-        pub fn new() -> Result<Self, MemoryError> {
-            let sz = 18 * WASM_PAGE_SIZE;
-            let memory = vec![0; sz];
-            let mut ret = Self {
-                mem: memory,
-                memory_definition: None,
-            };
-            ret.memory_definition = Some(UnsafeCell::new(VMMemoryDefinition {
-                base: ret.mem.as_ptr() as _,
-                current_length: sz,
-            }));
-            Ok(ret)
-        }
-    }
-
-    impl LinearMemory for VMTinyMemory {
-        fn ty(&self) -> MemoryType {
-            MemoryType {
-                minimum: Pages::from(18u32),
-                maximum: Some(Pages::from(18u32)),
-                shared: false,
-            }
-        }
-        fn size(&self) -> Pages {
-            Pages::from(18u32)
-        }
-        fn style(&self) -> MemoryStyle {
-            MemoryStyle::Static {
-                bound: Pages::from(18u32),
-                offset_guard_size: 0,
-            }
-        }
-        fn grow(&mut self, delta: Pages) -> Result<Pages, MemoryError> {
-            Err(MemoryError::CouldNotGrow {
-                current: Pages::from(100u32),
-                attempted_delta: delta,
-            })
-        }
-
-        fn grow_at_least(&mut self, min_size: u64) -> Result<(), MemoryError> {
-            let cur_size = self.size().0 as u64 * WASM_PAGE_SIZE as u64;
-            if min_size > cur_size {
-                let delta = min_size - cur_size;
-                return Err(MemoryError::CouldNotGrow {
-                    current: Pages::from(100u32),
-                    attempted_delta: Pages(delta as u32),
-                });
-            }
-            Ok(())
-        }
-
-        fn reset(&mut self) -> Result<(), MemoryError> {
-            self.mem.fill(0);
-            Ok(())
-        }
-
-        fn vmmemory(&self) -> NonNull<VMMemoryDefinition> {
-            unsafe {
-                NonNull::new(
-                    self.memory_definition
-                        .as_ref()
-                        .unwrap()
-                        .get()
-                        .as_mut()
-                        .unwrap() as _,
-                )
-                .unwrap()
-            }
-        }
-
-        fn try_clone(&self) -> Result<Box<dyn LinearMemory + Send + Sync + 'static>, MemoryError> {
-            Err(MemoryError::InvalidMemory {
-                reason: "VMTinyMemory can not be cloned".to_string(),
-            })
-        }
-
-        fn copy(&self) -> Result<Box<dyn LinearMemory + Send + Sync + 'static>, MemoryError> {
-            let mem = self.mem.clone();
-            Ok(Box::new(Self {
-                memory_definition: Some(UnsafeCell::new(VMMemoryDefinition {
-                    base: mem.as_ptr() as _,
-                    current_length: mem.len(),
-                })),
-                mem,
-            }))
-        }
-        /*
-        // this code allow custom memory to be ignoring init_memory
-        use wasmer_vm::Trap;
-        unsafe fn initialize_with_data(&self, _start: usize, _data: &[u8]) -> Result<(), Trap> {
-            Ok(())
-        }
-        */
-    }
-
-    impl From<VMTinyMemory> for wasmer_vm::VMMemory {
-        fn from(mem: VMTinyMemory) -> Self {
-            Self(Box::new(mem))
         }
     }
 
     struct TinyTunables;
     impl Tunables for TinyTunables {
         fn memory_style(&self, _memory: &MemoryType) -> MemoryStyle {
-            MemoryStyle::Static {
-                bound: Pages::from(18u32),
-                offset_guard_size: 0,
-            }
+            MemoryStyle::Static
         }
 
         /// Construct a `TableStyle` for the provided `TableType`
@@ -183,27 +58,18 @@ mod tests {
         }
         fn create_host_memory(
             &self,
-            _ty: &MemoryType,
-            _style: &MemoryStyle,
+            ty: &MemoryType,
+            style: &MemoryStyle,
         ) -> Result<VMMemory, MemoryError> {
-            let memory = VMTinyMemory::new().unwrap();
-            Ok(VMMemory::from_custom(memory))
+            VMMemory::new(ty, style)
         }
         unsafe fn create_vm_memory(
             &self,
-            _ty: &MemoryType,
-            _style: &MemoryStyle,
+            ty: &MemoryType,
+            style: &MemoryStyle,
             vm_definition_location: NonNull<VMMemoryDefinition>,
         ) -> Result<VMMemory, MemoryError> {
-            let memory = VMTinyMemory::new().unwrap();
-            // now, it's important to update vm_definition_location with the memory information!
-            let mut ptr = vm_definition_location;
-            let md = unsafe { ptr.as_mut() };
-            let unsafecell = memory.memory_definition.as_ref().unwrap();
-            let def = unsafe { unsafecell.get().as_ref().unwrap() };
-            md.base = def.base;
-            md.current_length = def.current_length;
-            Ok(memory.into())
+            unsafe { VMMemory::from_definition(ty, style, vm_definition_location) }
         }
 
         /// Create a table owned by the host given a [`TableType`] and a [`TableStyle`].
@@ -230,28 +96,6 @@ mod tests {
                 wasm_stack_size: Some(8 * 1024),
             }
         }
-    }
-
-    #[test]
-    fn check_linearmemory() {
-        let tunables = TinyTunables {};
-        let vmmemory = tunables.create_host_memory(
-            &MemoryType::new(1u32, Some(100u32), true),
-            &MemoryStyle::Static {
-                bound: Pages::from(18u32),
-                offset_guard_size: 0u64,
-            },
-        );
-        let mut vmmemory = vmmemory.unwrap();
-        assert!(vmmemory.grow(Pages::from(50u32)).is_err());
-        assert_eq!(vmmemory.size(), Pages::from(18u32));
-        assert_eq!(
-            vmmemory.grow(Pages::from(0u32)).err().unwrap(),
-            MemoryError::CouldNotGrow {
-                current: Pages::from(100u32),
-                attempted_delta: Pages::from(0u32)
-            }
-        );
     }
 
     #[test]
@@ -300,7 +144,7 @@ mod tests {
             .collect();
         assert_eq!(memories.len(), 1);
         let first_memory = memories.pop().unwrap();
-        assert_eq!(first_memory.ty(&store).maximum.unwrap(), Pages(18));
+        assert_eq!(first_memory.ty(&store).maximum, None);
         let view = first_memory.view(&store);
         let x = unsafe { view.data_unchecked_mut() }[0];
         assert_eq!(x, 0);

--- a/lib/compiler-cranelift/src/func_environ.rs
+++ b/lib/compiler-cranelift/src/func_environ.rs
@@ -1596,14 +1596,9 @@ impl FuncEnvironment<'_> {
                     false,
                 )
             }
-            MemoryStyle::Static {
-                bound,
-                offset_guard_size,
-            } => (
-                Uimm64::new(offset_guard_size),
-                HeapStyle::Static {
-                    bound: bound.bytes().0 as u64,
-                },
+            MemoryStyle::Static => (
+                Uimm64::new(MemoryStyle::static_offset_guard_size()),
+                HeapStyle::Static,
                 true,
             ),
         };

--- a/lib/compiler-cranelift/src/heap.rs
+++ b/lib/compiler-cranelift/src/heap.rs
@@ -100,11 +100,6 @@ pub enum HeapStyle {
         bound_gv: GlobalValue,
     },
 
-    /// A static heap has a fixed base address and a number of not-yet-allocated
-    /// pages before the offset-guard pages.
-    Static {
-        /// Heap bound in bytes. The offset-guard pages are allocated after the
-        /// bound.
-        bound: u64,
-    },
+    /// A static heap access is fully covered by memory protection mechanism.
+    Static,
 }

--- a/lib/compiler-cranelift/src/translator/code_translator.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator.rs
@@ -3015,6 +3015,7 @@ pub enum Reachability<T> {
     /// The Wasm execution state has been determined to be statically
     /// unreachable. It is the receiver of this value's responsibility to update
     /// `FuncTranslationState::reachable` as necessary.
+    #[allow(dead_code)]
     Unreachable,
 }
 

--- a/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
+++ b/lib/compiler-cranelift/src/translator/code_translator/bounds_checks.rs
@@ -202,64 +202,10 @@ pub fn bounds_check_and_compute_addr(
 
         // ====== Static Memories ======
         //
-        // With static memories we know the size of the heap bound at compile
-        // time.
-        //
-        // 1. First special case: trap immediately if `offset + access_size >
-        //    bound`, since we will end up being out-of-bounds regardless of the
-        //    given `index`.
-        HeapStyle::Static { bound } if offset_and_size > bound => {
-            assert!(
-                can_use_virtual_memory,
-                "static memories require the ability to use virtual memory"
-            );
-            builder.ins().trap(ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-            Unreachable
-        }
-
-        // 2. Second special case for when we can completely omit explicit
-        //    bounds checks for 32-bit static memories.
-        //
-        //    First, let's rewrite our comparison to move all of the constants
-        //    to one side:
-        //
-        //            index + offset + access_size > bound
-        //        ==> index > bound - (offset + access_size)
-        //
-        //    We know the subtraction on the right-hand side won't wrap because
-        //    we didn't hit the first special case.
-        //
-        //    Additionally, we add our guard pages (if any) to the right-hand
-        //    side, since we can rely on the virtual memory subsystem at runtime
-        //    to catch out-of-bound accesses within the range `bound .. bound +
-        //    guard_size`. So now we are dealing with
-        //
-        //        index > bound + guard_size - (offset + access_size)
-        //
-        //    Note that `bound + guard_size` cannot overflow for
-        //    correctly-configured heaps, as otherwise the heap wouldn't fit in
-        //    a 64-bit memory space.
-        //
-        //    The complement of our should-this-trap comparison expression is
-        //    the should-this-not-trap comparison expression:
-        //
-        //        index <= bound + guard_size - (offset + access_size)
-        //
-        //    If we know the right-hand side is greater than or equal to
-        //    `u32::MAX`, then
-        //
-        //        index <= u32::MAX <= bound + guard_size - (offset + access_size)
-        //
-        //    This expression is always true when the heap is indexed with
-        //    32-bit integers because `index` cannot be larger than
-        //    `u32::MAX`. This means that `index` is always either in bounds or
-        //    within the guard page region, neither of which require emitting an
-        //    explicit bounds check.
-        HeapStyle::Static { bound }
-            if can_use_virtual_memory
-                && heap.index_type == ir::types::I32
-                && u64::from(u32::MAX) <= bound + heap.offset_guard_size - offset_and_size =>
-        {
+        // Static memories reserve the full wasm32 address space plus the offset
+        // guard up front: omit explicit bounds checks and rely on virtual memory
+        // protection to trap out-of-bounds accesses.
+        HeapStyle::Static => {
             assert!(
                 can_use_virtual_memory,
                 "static memories require the ability to use virtual memory"
@@ -270,45 +216,6 @@ pub fn bounds_check_and_compute_addr(
                 env.pointer_type(),
                 index,
                 offset,
-            ))
-        }
-
-        // 3. General case for static memories.
-        //
-        //    We have to explicitly test whether
-        //
-        //        index > bound - (offset + access_size)
-        //
-        //    and trap if so.
-        //
-        //    Since we have to emit explicit bounds checks, we might as well be
-        //    precise, not rely on the virtual memory subsystem at all, and not
-        //    factor in the guard pages here.
-        HeapStyle::Static { bound } => {
-            assert!(
-                can_use_virtual_memory,
-                "static memories require the ability to use virtual memory"
-            );
-            // NB: this subtraction cannot wrap because we didn't hit the first
-            // special case.
-            let adjusted_bound = bound - offset_and_size;
-            let adjusted_bound_value = builder
-                .ins()
-                .iconst(env.pointer_type(), adjusted_bound as i64);
-            let oob = make_compare(
-                builder,
-                IntCC::UnsignedGreaterThan,
-                index,
-                adjusted_bound_value,
-            );
-            Reachable(explicit_check_oob_condition_and_compute_addr(
-                &mut builder.cursor(),
-                heap,
-                env.pointer_type(),
-                index,
-                offset,
-                spectre_mitigations_enabled,
-                oob,
             ))
         }
     })
@@ -329,7 +236,7 @@ fn get_dynamic_heap_bound(
         (_, HeapStyle::Dynamic { bound_gv }) => {
             materialize_global_value(&mut builder.cursor(), env.pointer_type(), *bound_gv)
         }
-        (_, HeapStyle::Static { .. }) => unreachable!("not a dynamic heap"),
+        (_, HeapStyle::Static) => unreachable!("not a dynamic heap"),
     }
 }
 

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -151,7 +151,7 @@ impl FuncTranslator {
         // the allocated heap is never moved to a different location.
         let m0_is_enabled = memory_styles
             .get(MemoryIndex::from_u32(0))
-            .is_some_and(|memory| matches!(memory, MemoryStyle::Static { .. }));
+            .is_some_and(|memory| matches!(memory, MemoryStyle::Static));
 
         let (function_name, module_name) = if config.experimental_artifact {
             (function.linkage_name(), String::new())

--- a/lib/compiler-llvm/src/translator/trampoline.rs
+++ b/lib/compiler-llvm/src/translator/trampoline.rs
@@ -51,7 +51,7 @@ fn enable_m0_optimization(compile_info: &CompileModuleInfo) -> bool {
     compile_info
         .memory_styles
         .get(MemoryIndex::from_u32(0))
-        .is_some_and(|memory| matches!(memory, MemoryStyle::Static { .. }))
+        .is_some_and(|memory| matches!(memory, MemoryStyle::Static))
 }
 
 impl FuncTrampoline {

--- a/lib/compiler-singlepass/src/codegen.rs
+++ b/lib/compiler-singlepass/src/codegen.rs
@@ -930,7 +930,7 @@ impl<'a, M: Machine> FuncGen<'a, M> {
         cb: F,
     ) -> Result<(), CompileError> {
         let need_check = match self.memory_styles[memory_index] {
-            MemoryStyle::Static { .. } => false,
+            MemoryStyle::Static => false,
             MemoryStyle::Dynamic { .. } => true,
         };
 

--- a/lib/compiler/src/engine/inner.rs
+++ b/lib/compiler/src/engine/inner.rs
@@ -68,7 +68,7 @@ impl Engine {
         features: Features,
     ) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
-        let tunables = BaseTunables::for_target(&target);
+        let tunables = BaseTunables::new();
         let compiler = compiler_config.compiler();
         let name = format!("engine-{}", compiler.name());
         Self {
@@ -143,7 +143,7 @@ impl Engine {
     pub fn headless() -> Self {
         let target = Target::default();
         #[cfg(not(target_arch = "wasm32"))]
-        let tunables = BaseTunables::for_target(&target);
+        let tunables = BaseTunables::new();
         Self {
             inner: Arc::new(Mutex::new(EngineInner {
                 #[cfg(feature = "compiler")]

--- a/lib/compiler/src/engine/resolver.rs
+++ b/lib/compiler/src/engine/resolver.rs
@@ -157,19 +157,21 @@ pub fn resolve_imports(
                 let m = handle.get(context);
                 match import_index {
                     ImportIndex::Memory(index) => {
-                        // Sanity-check: Ensure that the imported memory has at least
-                        // guard-page protections the importing module expects it to have.
+                        // Ensure that the imported memory has the allocation guarantees
+                        // assumed by the importing module's generated code.
                         let export_memory_style = m.style();
                         let import_memory_style = &memory_styles[*index];
-                        if let (
-                            MemoryStyle::Static { bound, .. },
-                            MemoryStyle::Static {
-                                bound: import_bound,
-                                ..
-                            },
-                        ) = (export_memory_style, &import_memory_style)
+                        if matches!(import_memory_style, MemoryStyle::Static)
+                            && !matches!(export_memory_style, MemoryStyle::Static)
                         {
-                            assert_ge!(bound, *import_bound);
+                            return Err(LinkError::Import(
+                                import_key.module.to_string(),
+                                import_key.field.to_string(),
+                                ImportError::MemoryError(
+                                    "a static memory import cannot use a dynamic allocation"
+                                        .to_string(),
+                                ),
+                            ));
                         }
                         assert_ge!(
                             export_memory_style.offset_guard_size(),

--- a/lib/compiler/src/engine/tunables.rs
+++ b/lib/compiler/src/engine/tunables.rs
@@ -2,9 +2,7 @@ use crate::engine::error::LinkError;
 use std::ptr::NonNull;
 use wasmer_types::{
     FunctionType, GlobalType, LocalGlobalIndex, LocalMemoryIndex, LocalTableIndex, MemoryIndex,
-    MemoryType, ModuleInfo, Pages, TableIndex, TableType, TagKind, WASM_MAX_PAGES,
-    entity::PrimaryMap,
-    target::{PointerWidth, Target},
+    MemoryType, ModuleInfo, TableIndex, TableType, TagKind, entity::PrimaryMap,
 };
 use wasmer_vm::{InternalStoreHandle, MemoryError, StoreObjects, VMTag};
 use wasmer_vm::{MemoryStyle, TableStyle};
@@ -188,76 +186,20 @@ pub trait Tunables {
 /// implementation or use composition to wrap your Tunables around
 /// this one. The later approach is demonstrated in the
 /// tunables-limit-memory example.
-#[derive(Clone)]
-pub struct BaseTunables {
-    /// For static heaps, the size in wasm pages of the heap protected by bounds checking.
-    pub static_memory_bound: Pages,
-
-    /// The size in bytes of the offset guard for static heaps.
-    pub static_memory_offset_guard_size: u64,
-
-    /// The size in bytes of the offset guard for dynamic heaps.
-    pub dynamic_memory_offset_guard_size: u64,
-}
+#[derive(Clone, Default)]
+pub struct BaseTunables {}
 
 impl BaseTunables {
-    /// Get the `BaseTunables` for a specific Target
-    pub fn for_target(target: &Target) -> Self {
-        let triple = target.triple();
-        let pointer_width: PointerWidth = triple.pointer_width().unwrap();
-        let (static_memory_bound, static_memory_offset_guard_size): (Pages, u64) =
-            match pointer_width {
-                PointerWidth::U16 => (0x400.into(), 0x1000),
-                PointerWidth::U32 => (0x4000.into(), 0x1_0000),
-                // Static Memory Bound:
-                //   Allocating 4 GiB of address space let us avoid the
-                //   need for explicit bounds checks.
-                // Static Memory Guard size:
-                //   Allocating 4 GiB of address space lets us translate WASM
-                //   offsets into x86_64 offsets as aggressively as we can.
-                //
-                // Note that although `i32::MAX` is 2 GiB, negative base values for operations
-                // such as `i64.load` are zero-extended during expansion, making the full 4 GiB accessible.
-                PointerWidth::U64 => (WASM_MAX_PAGES.into(), 0x1_0000_0000),
-            };
-
-        // Allocate a small guard to optimize common cases but without
-        // wasting too much memory.
-        // The Windows memory manager seems more laxed than the other ones
-        // And a guard of just 1 page may not be enough is some borderline cases
-        // So using 2 pages for guard on this platform
-        #[cfg(target_os = "windows")]
-        let dynamic_memory_offset_guard_size: u64 = 0x2_0000;
-        #[cfg(not(target_os = "windows"))]
-        let dynamic_memory_offset_guard_size: u64 = 0x1_0000;
-
-        Self {
-            static_memory_bound,
-            static_memory_offset_guard_size,
-            dynamic_memory_offset_guard_size,
-        }
+    /// Get the default `BaseTunables`.
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
 impl Tunables for BaseTunables {
-    /// Get a `MemoryStyle` for the provided `MemoryType`
-    fn memory_style(&self, memory: &MemoryType) -> MemoryStyle {
-        // A heap with a maximum that doesn't exceed the static memory bound specified by the
-        // tunables make it static.
-        //
-        // If the module doesn't declare an explicit maximum treat it as 4GiB.
-        let maximum = memory.maximum.unwrap_or_else(Pages::max_value);
-        if maximum <= self.static_memory_bound {
-            MemoryStyle::Static {
-                // Bound can be larger than the maximum for performance reasons
-                bound: self.static_memory_bound,
-                offset_guard_size: self.static_memory_offset_guard_size,
-            }
-        } else {
-            MemoryStyle::Dynamic {
-                offset_guard_size: self.dynamic_memory_offset_guard_size,
-            }
-        }
+    /// Always return Static memory style.
+    fn memory_style(&self, _memory: &MemoryType) -> MemoryStyle {
+        MemoryStyle::Static
     }
 
     /// Get a [`TableStyle`] for the provided [`TableType`].

--- a/lib/sys-utils/src/memory/fd_memory/memories.rs
+++ b/lib/sys-utils/src/memory/fd_memory/memories.rs
@@ -271,13 +271,15 @@ impl VMOwnedMemory {
             }
         }
 
-        let offset_guard_bytes = style.offset_guard_size() as usize;
+        let offset_guard_bytes = usize::try_from(style.offset_guard_size())
+            .map_err(|e| MemoryError::Generic(format!("cannot install memory guard page: {e}")))?;
 
         let minimum_pages = match style {
             MemoryStyle::Dynamic { .. } => memory.minimum,
-            MemoryStyle::Static { bound, .. } => {
-                assert!(*bound >= memory.minimum);
-                *bound
+            MemoryStyle::Static => {
+                let bound = MemoryStyle::static_bound();
+                assert!(bound >= memory.minimum);
+                bound
             }
         };
         let minimum_bytes = minimum_pages.bytes().0;

--- a/lib/types/src/memory.rs
+++ b/lib/types/src/memory.rs
@@ -1,4 +1,4 @@
-use crate::{Pages, ValueType};
+use crate::{Pages, ValueType, WASM_PAGE_SIZE};
 use core::ops::SubAssign;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "enable-serde")]
@@ -23,25 +23,31 @@ pub enum MemoryStyle {
         offset_guard_size: u64,
     },
     /// Address space is allocated up front.
-    Static {
-        /// The number of mapped and unmapped pages.
-        bound: Pages,
-        /// Our chosen offset-guard size.
-        ///
-        /// It represents the size in bytes of extra guard pages after the end
-        /// to optimize loads and stores with constant offsets.
-        offset_guard_size: u64,
-    },
+    ///
+    /// Static memories reserve 8 GiB (plus one extra page) of virtual address space at runtime:
+    /// the 4 GiB wasm32 address space plus a 4 GiB offset guard. This lets generated
+    /// code omit bounds checks while still relying on protected virtual memory
+    /// to trap out-of-bounds accesses.
+    Static,
 }
 
 impl MemoryStyle {
-    /// Returns the offset-guard size
+    /// Static memory reserves the wasm32 address space up front.
+    pub const fn static_bound() -> Pages {
+        Pages::max_value()
+    }
+
+    /// Static memory reserves an additional 4 GiB offset guard
+    /// (plus one extra page as one can access up to 16B at the effective address).
+    pub const fn static_offset_guard_size() -> u64 {
+        0x1_0000_0000 + WASM_PAGE_SIZE as u64
+    }
+
+    /// Returns the offset-guard size.
     pub fn offset_guard_size(&self) -> u64 {
         match self {
             Self::Dynamic { offset_guard_size } => *offset_guard_size,
-            Self::Static {
-                offset_guard_size, ..
-            } => *offset_guard_size,
+            Self::Static => Self::static_offset_guard_size(),
         }
     }
 }

--- a/lib/types/src/serialize.rs
+++ b/lib/types/src/serialize.rs
@@ -14,7 +14,7 @@ pub struct MetadataHeader {
 impl MetadataHeader {
     /// Current ABI version. Increment this any time breaking changes are made
     /// to the format of the serialized data.
-    pub const CURRENT_VERSION: u32 = 23;
+    pub const CURRENT_VERSION: u32 = 24;
 
     /// Magic number to identify wasmer metadata.
     const MAGIC: [u8; 8] = *b"WASMER\0\0";

--- a/lib/vm/src/memory.rs
+++ b/lib/vm/src/memory.rs
@@ -326,13 +326,16 @@ impl VMOwnedMemory {
                 }
             }
 
-            let offset_guard_bytes = style.offset_guard_size() as usize;
+            let offset_guard_bytes = usize::try_from(style.offset_guard_size()).map_err(|e| {
+                MemoryError::Generic(format!("cannot install memory guard page: {e}"))
+            })?;
 
             let minimum_pages = match style {
                 MemoryStyle::Dynamic { .. } => memory.minimum,
-                MemoryStyle::Static { bound, .. } => {
-                    assert_ge!(*bound, memory.minimum);
-                    *bound
+                MemoryStyle::Static => {
+                    let bound = MemoryStyle::static_bound();
+                    assert_ge!(bound, memory.minimum);
+                    bound
                 }
             };
             let minimum_bytes = minimum_pages.bytes().0;


### PR DESCRIPTION
This PR follows up on with the following adjustments:

1. `BaseTunables` no longer allows custom values for `static_memory_bound` or `static_memory_offset_guard_size`. Because the compilers do not emit bounds checks, we rely entirely on memory protection. As a result, each memory allocation must reserve 8 GiB plus one page; otherwise, we cannot guarantee that linear memory accesses cannot escape the protected region.

2. Historically, Cranelift emitted some bounds checks. Since the memory is now fully protected, Cranelift should behave consistently with LLVM and Singlepass, which do not emit these checks.

The change is leading to an API adjustments and we should be part of a new Wasmer major release.

Cherry-pick from https://github.com/wasmerio/wasmer-internal/pull/13