### PR TITLE
fix(nix): install C header from Cargo artifacts

### DIFF
--- a/scripts/nix/pkg.nix
+++ b/scripts/nix/pkg.nix
@@ -112,7 +112,7 @@ in
         ''
           install -Dm755 target/release/wasmer $out/bin/wasmer
 
-          install -Dm644 lib/c-api/wasmer.h $out/include/wasmer.h
+          install -Dm644 target/release/build/wasmer-c-api-*/out/wasmer.h $out/include/wasmer.h
           install -Dm644 lib/c-api/wasmer_wasm.h $out/include/wasmer_wasm.h
           install -Dm644 lib/c-api/tests/wasm-c-api/include/wasm.h $out/include/wasm.h
           install -Dm644 lib/c-api/tests/wasm-c-api/include/wasm.hh $out/include/wasm.hh


### PR DESCRIPTION
## Summary

- install the generated Wasmer C header from Cargo's target output
- keep installation correct when a complete Crane cargoArtifacts derivation is reused

## Why

The wasmer-c-api build script writes wasmer.h to both OUT_DIR and the source tree. The Nix package installed the source-tree copy, which is absent when Cargo reuses the completed build-script result from cargoArtifacts. The target output is the artifact Cargo owns and is available in both fresh and reused builds.

## Testing

- evaluated the Nix install phase and confirmed it reads target/release/build/wasmer-c-api-*/out/wasmer.h
- checked scripts/nix/pkg.nix formatting with Alejandra