### PR TITLE
docs: Singlepass supports multi-value experimentally

### DIFF
--- a/lib/c-api/src/wasm_c_api/unstable/features.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/features.rs
@@ -204,8 +204,8 @@ pub extern "C" fn wasmer_features_bulk_memory(
 /// This feature gates functions and blocks returning multiple values in a
 /// module, for example.
 ///
-/// Singlepass support is experimental and does not include integration with
-/// host functions.
+/// Singlepass support for multi-value is experimental and does not include
+/// integration with host functions returning multiple values.
 ///
 /// This is `true` by default.
 ///

--- a/lib/c-api/src/wasm_c_api/unstable/features.rs
+++ b/lib/c-api/src/wasm_c_api/unstable/features.rs
@@ -204,6 +204,9 @@ pub extern "C" fn wasmer_features_bulk_memory(
 /// This feature gates functions and blocks returning multiple values in a
 /// module, for example.
 ///
+/// Singlepass support is experimental and does not include integration with
+/// host functions.
+///
 /// This is `true` by default.
 ///
 /// [proposal]: https://github.com/webassembly/multi-value

--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -42,7 +42,8 @@ pub struct WasmFeatures {
     #[clap(long = "enable-reference-types")]
     pub reference_types: bool,
 
-    /// Enable support for the multi value proposal.
+    /// Enable support for the multi-value proposal. Singlepass support is
+    /// experimental and does not include integration with host functions.
     #[clap(long = "enable-multi-value")]
     pub multi_value: bool,
 

--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -42,8 +42,8 @@ pub struct WasmFeatures {
     #[clap(long = "enable-reference-types")]
     pub reference_types: bool,
 
-    /// Enable support for the multi-value proposal. Singlepass support is
-    /// experimental and does not include integration with host functions.
+    /// Enable support for the multi-value proposal. Singlepass support for multi-value is
+    /// experimental and does not include integration with host functions returning multiple values.
     #[clap(long = "enable-multi-value")]
     pub multi_value: bool,
 

--- a/lib/cli/src/common.rs
+++ b/lib/cli/src/common.rs
@@ -23,7 +23,8 @@ pub struct WasmFeatures {
     #[clap(long = "enable-reference-types")]
     pub reference_types: bool,
 
-    /// Enable support for the multi value proposal.
+    /// Enable support for the multi-value proposal. Singlepass support is
+    /// experimental and does not include integration with host functions.
     #[clap(long = "enable-multi-value")]
     pub multi_value: bool,
 

--- a/lib/cli/src/common.rs
+++ b/lib/cli/src/common.rs
@@ -23,8 +23,8 @@ pub struct WasmFeatures {
     #[clap(long = "enable-reference-types")]
     pub reference_types: bool,
 
-    /// Enable support for the multi-value proposal. Singlepass support is
-    /// experimental and does not include integration with host functions.
+    /// Enable support for the multi-value proposal. Singlepass support for multi-value is
+    /// experimental and does not include integration with host functions returning multiple values.
     #[clap(long = "enable-multi-value")]
     pub multi_value: bool,
 

--- a/lib/types/src/features.rs
+++ b/lib/types/src/features.rs
@@ -211,8 +211,8 @@ impl Features {
     /// This feature gates functions and blocks returning multiple values in a
     /// module, for example.
     ///
-    /// Singlepass support is experimental and does not include integration with
-    /// host functions.
+    /// Singlepass support for multi-value is experimental and does not include
+    /// integration with host functions returning multiple values.
     ///
     /// This is `true` by default.
     ///

--- a/lib/types/src/features.rs
+++ b/lib/types/src/features.rs
@@ -22,7 +22,7 @@ pub struct Features {
     pub simd: bool,
     /// Bulk Memory proposal should be enabled
     pub bulk_memory: bool,
-    /// Multi Value proposal should be enabled
+    /// Multi-value proposal should be enabled
     pub multi_value: bool,
     /// Tail call proposal should be enabled
     pub tail_call: bool,
@@ -210,6 +210,9 @@ impl Features {
     ///
     /// This feature gates functions and blocks returning multiple values in a
     /// module, for example.
+    ///
+    /// Singlepass support is experimental and does not include integration with
+    /// host functions.
     ///
     /// This is `true` by default.
     ///


### PR DESCRIPTION
And adjust the wording, the spec tells about `multi-value`.

Related to #5943.