### PR TITLE
feat(nix): provide shell completions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,9 +56,16 @@
         };
         defaultApp = apps.${NAME};
 
+        # Shell with the built CLI and its shell completions on PATH.
+        # Run "nix develop .#cli" to activate.
+        devShells.cli = pkgs.mkShell {
+          name = "${NAME}-cli";
+          packages = [wasmerPkg];
+        };
+
         # Development shell.
         # Run "nix develop" to activate.
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           name = NAME;
           src = self;
           packages = with pkgs; [

--- a/scripts/nix/pkg.nix
+++ b/scripts/nix/pkg.nix
@@ -6,6 +6,7 @@
   lib,
   stdenv,
   rustPlatform,
+  installShellFiles,
   craneLib,
   v8Prebuilt,
   llvmPackages_22,
@@ -93,6 +94,8 @@ in
 
       inherit cargoArtifacts;
 
+      nativeBuildInputs = commonArgs.nativeBuildInputs ++ [installShellFiles];
+
       buildPhaseCargoCommand = ''
         WASMER_INSTALL_PREFIX=$out \
           cargo build --release \
@@ -118,6 +121,18 @@ in
           install -Dm644 lib/c-api/tests/wasm-c-api/include/wasm.hh $out/include/wasm.hh
           install -Dm644 lib/c-api/README.md $out/include/wasmer-README.md
           install -Dm644 LICENSE $out/share/licenses/wasmer/LICENSE
+
+          # clap derives the completion function names from argv[0], so invoke
+          # the binary through PATH rather than by its store path.
+          completions=$(mktemp -d)
+          for shell in bash zsh fish; do
+            env -u WASMER_DIR PATH="$out/bin:$PATH" \
+              wasmer gen-completions "$shell" --out "$completions/$shell"
+          done
+          installShellCompletion --cmd wasmer \
+            --bash "$completions/bash" \
+            --zsh "$completions/zsh" \
+            --fish "$completions/fish"
         ''
         + lib.optionalString stdenv.hostPlatform.isLinux ''
           install -Dm755 target/release/libwasmer.so $out/lib/libwasmer.so


### PR DESCRIPTION
# Description

Adds shell-completions to the nix-packaged wasmer package.

Also adds a new dev-shell `nix develop .#cli`, which provides just wasmer; doing this via a dev-shell makes nix wire up shell-completions into the actual user shell for us.
