### PR TITLE
CI: add dependency cooldown CI job (3 days)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 min-publish-age = true
 
 [registry]
-# Even one day makes a big diffence: https://cooldowns.dev/#does-it-actually-work
+# Even one day makes a big difference: https://cooldowns.dev/#does-it-actually-work
 global-min-publish-age = "3 days"
 
 [resolver]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[unstable]
+min-publish-age = true
+
+[registry]
+# Even one day makes a big diffence: https://cooldowns.dev/#does-it-actually-work
+global-min-publish-age = "3 days"
+
+[resolver]
+incompatible-publish-age = "deny"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+            submodules: true
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Check for eligible dependency updates

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,15 @@ jobs:
           echo "DOING_RELEASE=${DOING_RELEASE}" >> $GITHUB_OUTPUT
           echo $VERSION
           echo $DOING_RELEASE
+  dependency_cooldown:
+    name: Dependency cooldown
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Check for eligible dependency updates
+        run: cargo +nightly update
   lint:
     name: Code lint
     runs-on: ubuntu-24.04
@@ -792,6 +801,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - setup
+      - dependency_cooldown
       - lint
       - cargo_deny
       - test_nodejs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-            submodules: true
+          submodules: true
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Check for eligible dependency updates

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -2,7 +2,7 @@
 
 import argparse
 import os
-import re
+import subprocess
 
 parser = argparse.ArgumentParser(description="Update Wasmer versions")
 parser.add_argument(
@@ -121,4 +121,5 @@ for root, dirs, files in os.walk("."):
         elif "publish.py" in file:
             replace_version_py(root + "/" + file)
 
-os.system("cargo generate-lockfile")
+
+subprocess.check_output("cargo +nightly generate-lockfile", shell=True)


### PR DESCRIPTION
Inspired by the new Cargo nightly feature.

One limitation that comes to my mind - the check ignores all the existing versions present in a Cargo.lock file. So if a user runs `cargo update` with a stable cargo, the option is ignored and we can pull in a newer dependency. On the other hand, if a dependency is updated in Cargo.toml file (like SemVer-breaking update), it's properly caught by the CI job.

Resolves: #6928