### PR TITLE
CI: skip 2 tests on macOS

### DIFF
--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -52,6 +52,8 @@
 //!
 //! `UnixOnly:{bool}` ignores the configuration on non-Unix hosts when true.
 //!
+//! `IgnoreMacOS:{bool}` ignores the configuration on macOS hosts when true.
+//!
 //! `MinimalLibc:{version}` ignores the configuration when the selected sysroot
 //! version is older than the given minimal libc version.
 //!
@@ -259,6 +261,7 @@ struct Config {
     ignored: Option<String>,
     skipped_engines: Vec<(Engine, String)>,
     unix_only: bool,
+    ignore_macos: bool,
     mapped_directories: Vec<MappedDirectory>,
     current_directory: Option<String>,
     prefilled_files: Vec<(PathBuf, String)>,
@@ -303,6 +306,7 @@ impl Config {
             ignored: None,
             skipped_engines: Vec::new(),
             unix_only: false,
+            ignore_macos: false,
             mapped_directories: Vec::new(),
             current_directory: None,
             prefilled_files: Vec::new(),
@@ -554,6 +558,7 @@ fn process_directive(
             }
         }
         "UnixOnly" => config.unix_only = arg.parse::<bool>()?,
+        "IgnoreMacOS" => config.ignore_macos = arg.parse::<bool>()?,
         "MinimalLibc" => {
             ensure!(!arg.is_empty(), "MinimalLibc version must not be empty");
             config.minimal_libc = Some(arg.to_owned());
@@ -1179,6 +1184,9 @@ fn run_integration_test(config: Config) -> Result<libtest_mimic::Completion> {
     }
     if !cfg!(unix) && config.unix_only {
         return Ok(libtest_mimic::Completion::ignored_with("Unix only"));
+    }
+    if cfg!(target_os = "macos") && config.ignore_macos {
+        return Ok(libtest_mimic::Completion::ignored_with("Ignored on macOS"));
     }
     if let Some((_, reason)) = config
         .skipped_engines

--- a/lib/wasix/tests/wasm_tests/socket/stream-tcp-writev-partial/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/stream-tcp-writev-partial/main.c
@@ -1,4 +1,5 @@
 //#ExpectedStdout: stream TCP writev returns partial success after peer close
+//#IgnoreMacOS: true
 /*
  * Regression test for stream-socket fd_write partial success.
  *

--- a/lib/wasix/tests/wasm_tests/socket/stream-tcp-writev/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/stream-tcp-writev/main.c
@@ -1,4 +1,5 @@
 //#ExpectedStdout: stream TCP writev delivers full payload
+//#IgnoreMacOS: true
 
 #include <arpa/inet.h>
 #include <errno.h>


### PR DESCRIPTION
A workaround for #6756 for now.