### PR TITLE
fix(wasix): drop epoll handlers outside resource locks

### DIFF
--- a/lib/virtual-fs/src/pipe.rs
+++ b/lib/virtual-fs/src/pipe.rs
@@ -130,12 +130,18 @@ impl PipeRx {
         }
     }
 
-    pub fn set_interest_handler(&self, interest_handler: Box<dyn InterestHandler>) {
+    // Returns the replaced handler: its drop chain can re-acquire locks the
+    // caller holds (an epoll handler owns join guards that detach from this
+    // pipe), so the caller drops it after releasing them.
+    pub fn set_interest_handler(
+        &self,
+        interest_handler: Box<dyn InterestHandler>,
+    ) -> Option<Box<dyn InterestHandler>> {
         let Some(ref rx) = self.rx else {
-            return;
+            return None;
         };
         let mut rx = rx.lock().unwrap();
-        rx.interest_handler.replace(interest_handler);
+        rx.interest_handler.replace(interest_handler)
     }
 
     pub fn remove_interest_handler(&self) -> Option<Box<dyn InterestHandler>> {
@@ -198,8 +204,11 @@ impl Pipe {
         self.recv.close();
     }
 
-    pub fn set_interest_handler(&self, interest_handler: Box<dyn InterestHandler>) {
-        self.recv.set_interest_handler(interest_handler);
+    pub fn set_interest_handler(
+        &self,
+        interest_handler: Box<dyn InterestHandler>,
+    ) -> Option<Box<dyn InterestHandler>> {
+        self.recv.set_interest_handler(interest_handler)
     }
 
     pub fn remove_interest_handler(&self) -> Option<Box<dyn InterestHandler>> {

--- a/lib/wasix/src/fs/notification.rs
+++ b/lib/wasix/src/fs/notification.rs
@@ -111,9 +111,14 @@ impl NotificationInner {
         state.counter = 0;
     }
 
-    pub fn set_interest_handler(&self, handler: Box<dyn InterestHandler>) {
+    // Returns the replaced handler; the caller drops it after releasing its
+    // locks (see PipeRx::set_interest_handler).
+    pub fn set_interest_handler(
+        &self,
+        handler: Box<dyn InterestHandler>,
+    ) -> Option<Box<dyn InterestHandler>> {
         let mut state = self.state.lock().unwrap();
-        state.interest_handler.replace(handler);
+        state.interest_handler.replace(handler)
     }
 
     pub fn remove_interest_handler(&self) -> Option<Box<dyn InterestHandler>> {

--- a/lib/wasix/src/os/epoll/mod.rs
+++ b/lib/wasix/src/os/epoll/mod.rs
@@ -142,30 +142,34 @@ impl EpollJoinGuard {
 
 impl Drop for EpollJoinGuard {
     fn drop(&mut self) {
-        // Dropping a subscription must detach its interest handler from the source.
-        match &self.fd_guard.mode {
+        // Detach the interest handler, then drop it only after the resource
+        // lock is released: a stale epoll handler owns join guards whose drop
+        // re-enters this function and re-acquires the same lock.
+        let detached = match &self.fd_guard.mode {
             InodeValFilePollGuardMode::File(_) => {
                 // Intentionally ignored, epoll doesn't work with files
+                None
             }
             InodeValFilePollGuardMode::Socket { inner } => {
                 let mut inner = inner.protected.write().unwrap();
                 inner.remove_handler();
+                None
             }
-            InodeValFilePollGuardMode::EventNotifications(inner) => {
-                inner.remove_interest_handler();
-            }
+            InodeValFilePollGuardMode::EventNotifications(inner) => inner.remove_interest_handler(),
             InodeValFilePollGuardMode::DuplexPipe { pipe } => {
                 let inner = pipe.write().unwrap();
-                inner.remove_interest_handler();
+                inner.remove_interest_handler()
             }
             InodeValFilePollGuardMode::PipeRx { rx } => {
                 let inner = rx.write().unwrap();
-                inner.remove_interest_handler();
+                inner.remove_interest_handler()
             }
             InodeValFilePollGuardMode::PipeTx { .. } => {
                 // Intentionally ignored, the sending end of a pipe can't have an interest handler
+                None
             }
-        }
+        };
+        drop(detached);
     }
 }
 
@@ -614,7 +618,10 @@ pub(crate) fn register_epoll_handler(
     let fd_guard = poll_fd_guard(state, peb.build(), event.fd(), s)?;
     let handler = EpollHandler::new(event.fd(), epoll_state.clone(), sub_state.clone());
 
-    match &fd_guard.mode {
+    // A replaced handler from a closed epoll owns that epoll's join guards;
+    // its drop re-acquires the lock held in the arms below, so it stays alive
+    // until every lock is released.
+    let detached = match &fd_guard.mode {
         InodeValFilePollGuardMode::File(_) => {
             // Intentionally ignored, epoll doesn't work with files
             return Ok(None);
@@ -623,15 +630,16 @@ pub(crate) fn register_epoll_handler(
             let mut inner = inner.protected.write().unwrap();
             inner.set_handler(handler).map_err(net_error_into_io_err)?;
             drop(inner);
+            None
         }
         InodeValFilePollGuardMode::EventNotifications(inner) => inner.set_interest_handler(handler),
         InodeValFilePollGuardMode::DuplexPipe { pipe } => {
             let inner = pipe.write().unwrap();
-            inner.set_interest_handler(handler);
+            inner.set_interest_handler(handler)
         }
         InodeValFilePollGuardMode::PipeRx { rx } => {
             let inner = rx.write().unwrap();
-            inner.set_interest_handler(handler);
+            inner.set_interest_handler(handler)
         }
         InodeValFilePollGuardMode::PipeTx { .. } => {
             // The sending end of a pipe can't have an interest handler, since we
@@ -640,7 +648,8 @@ pub(crate) fn register_epoll_handler(
             prime_immediate_writable_if_applicable(event, &fd_guard, &epoll_state, &sub_state);
             return Ok(None);
         }
-    }
+    };
+    drop(detached);
 
     prime_immediate_writable_if_applicable(event, &fd_guard, &epoll_state, &sub_state);
 


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description

Return replaced interest handlers to the epoll caller and drop them after releasing pipe and notification locks. A stale handler owns join guards whose destructor re-enters the same resources.


<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

## Wasinix downstream context

- Related patch: [`wasmer-epoll-stale-handler-deadlock.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-epoll-stale-handler-deadlock.patch)
- Patch-removal experiment: [wasix-org/wasinix#247](https://github.com/wasix-org/wasinix/pull/247)
