### PR TITLE
fix(wasix): preserve futex wakes during registration

### DIFF
--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -76,6 +76,13 @@ impl FileOpener for WasiStateOpener {
 #[derive(Debug, Default)]
 pub struct WasiFutex {
     pub(crate) wakers: BTreeMap<u64, Option<Waker>>,
+    /// Wakes that arrived while every registered waiter was still
+    /// mid-registration (slot reserved but `Waker` not yet installed by the
+    /// first poll). A waiter's first poll consumes one so a wake landing in the
+    /// registration gap is not lost (see `futex_wake`). Only ever non-zero while
+    /// `wakers` is non-empty: a token outlives neither its waiters nor this
+    /// futex, which is what keeps it from accumulating.
+    pub(crate) pending_wakes: u64,
 }
 
 /// Structure that holds the state of BUS calls to this process and from

--- a/lib/wasix/src/syscalls/wasix/futex_wait.rs
+++ b/lib/wasix/src/syscalls/wasix/futex_wait.rs
@@ -22,13 +22,29 @@ impl Future for FutexPoller {
             Some(f) => f,
             None => return Poll::Ready(true),
         };
-        let waker = match futex.wakers.get_mut(&self.poller_idx) {
-            Some(w) => w,
-            None => return Poll::Ready(true),
-        };
+        // If our slot is gone then `futex_wake` already claimed us and we are
+        // woken. Checked before `pending_wakes` so an already-woken poller cannot
+        // swallow a token meant for a waiter that is still asleep.
+        if !futex.wakers.contains_key(&self.poller_idx) {
+            return Poll::Ready(true);
+        }
+        // A wake that arrived while we were still mid-registration left a
+        // pending token; consume it and report woken instead of sleeping
+        // through it.
+        if futex.pending_wakes > 0 {
+            futex.pending_wakes -= 1;
+            futex.wakers.remove(&self.poller_idx);
+            // An unclaimed token must not outlive the waiters it was meant for.
+            if futex.wakers.is_empty() {
+                guard.futexes.remove(&self.futex_idx);
+            }
+            return Poll::Ready(true);
+        }
 
         // Register the waker
-        waker.replace(cx.waker().clone());
+        if let Some(waker) = futex.wakers.get_mut(&self.poller_idx) {
+            waker.replace(cx.waker().clone());
+        }
 
         // Check for timeout
         drop(guard);

--- a/lib/wasix/src/syscalls/wasix/futex_wake.rs
+++ b/lib/wasix/src/syscalls/wasix/futex_wake.rs
@@ -27,11 +27,25 @@ pub fn futex_wake<M: MemorySize>(
     let woken = {
         let mut guard = state.futexs.lock().unwrap();
         if let Some(futex) = guard.futexes.get_mut(&pointer) {
-            let first = futex.wakers.keys().copied().next();
-            if let Some(id) = first
-                && let Some(Some(w)) = futex.wakers.remove(&id)
-            {
-                w.wake();
+            // Wake the first waiter that has actually installed its `Waker`
+            // (i.e. is genuinely asleep). A slot mapped to `None` is a waiter
+            // that reserved its place but has not been polled yet to install its
+            // `Waker`; consuming that slot would drop the wake without waking a
+            // real sleeper.
+            // When no installed waker exists, record a pending wake for the
+            // imminent first poll to consume, so the wake is not lost in the
+            // registration gap.
+            let sleeper = futex
+                .wakers
+                .iter()
+                .find(|(_, w)| w.is_some())
+                .map(|(id, _)| *id);
+            if let Some(id) = sleeper {
+                if let Some(Some(w)) = futex.wakers.remove(&id) {
+                    w.wake();
+                }
+            } else if !futex.wakers.is_empty() {
+                futex.pending_wakes += 1;
             }
             if futex.wakers.is_empty() {
                 guard.futexes.remove(&pointer);


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Record a wake that arrives while a matching futex waiter is registering, rather than discarding it before the waiter stores its waker.

## Wasinix downstream context

- Related patch: [`wasmer-futex-wake-lost-wakeup.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-futex-wake-lost-wakeup.patch)
- Patch-removal experiment: [wasix-org/wasinix#238](https://github.com/wasix-org/wasinix/pull/238)
