### PR TITLE
fix(wasix): report duplex pipes writable to epoll

### DIFF
--- a/lib/wasix/src/os/epoll/mod.rs
+++ b/lib/wasix/src/os/epoll/mod.rs
@@ -447,7 +447,9 @@ fn prime_immediate_writable_if_applicable(
     // Prime EPOLLOUT once at registration so level-triggered epoll can observe them.
     let writable_now = matches!(
         fd_guard.mode,
-        InodeValFilePollGuardMode::EventNotifications(_) | InodeValFilePollGuardMode::PipeTx { .. }
+        InodeValFilePollGuardMode::EventNotifications(_)
+            | InodeValFilePollGuardMode::PipeTx { .. }
+            | InodeValFilePollGuardMode::DuplexPipe { .. }
     );
 
     if !writable_now {


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description

Prime `EPOLLOUT` when registering a duplex pipe. Socketpair writes use its unbounded channel, so level-triggered epoll should report immediate write readiness.

## Wasinix downstream context

- Related patch: [`wasmer-epoll-stale-handler-deadlock.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-epoll-stale-handler-deadlock.patch)
- Patch-removal experiment: [wasix-org/wasinix#247](https://github.com/wasix-org/wasinix/pull/247)
