### PR TITLE
fix(wasix): implement HostFS hard links

### DIFF
--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -169,6 +169,17 @@ impl crate::FileSystem for FileSystem {
         fs::create_dir(path).map_err(Into::into)
     }
 
+    fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+        let source = self.prepare_path(source)?;
+        let target = self.prepare_path(target)?;
+
+        if target.parent().is_none() {
+            return Err(FsError::BaseNotDirectory);
+        }
+
+        fs::hard_link(source, target).map_err(Into::into)
+    }
+
     fn remove_dir(&self, path: &Path) -> Result<()> {
         let path = self.prepare_path(path)?;
 

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -149,6 +149,10 @@ where
         (**self).create_symlink(source, target)
     }
 
+    fn hard_link(&self, source: &Path, target: &Path) -> Result<()> {
+        (**self).hard_link(source, target)
+    }
+
     fn remove_dir(&self, path: &Path) -> Result<()> {
         (**self).remove_dir(path)
     }

--- a/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/path_filestat_get.rs
@@ -79,7 +79,7 @@ pub(crate) fn path_filestat_get_internal(
         flags & __WASI_LOOKUP_SYMLINK_FOLLOW != 0,
     )?;
 
-    let st_ino = file_inode.ino().as_u64();
+    let st_ino = file_inode.stat.read().unwrap().st_ino;
     let mut stat = if file_inode.is_preopened {
         *file_inode.stat.read().unwrap().deref()
     } else {

--- a/lib/wasix/src/syscalls/wasi/path_link.rs
+++ b/lib/wasix/src/syscalls/wasi/path_link.rs
@@ -175,18 +175,20 @@ pub(crate) fn path_link_internal(
                     .fs
                     .create_inode(inodes, kind, false, new_entry_name.clone())
                 {
-                    Ok(inode) => inode,
+                    Ok(inode) => {
+                        // Keep distinct cached paths for the two directory
+                        // entries, but expose the shared host inode identity.
+                        // Programs like git verify this after link(2) to
+                        // catch TOCTOU swaps.
+                        inode.stat.write().unwrap().st_ino =
+                            source_inode.stat.read().unwrap().st_ino;
+                        inode
+                    }
                     Err(err) => {
                         let _ = state.fs.root_fs.remove_file(&target_path);
                         return Err(err);
                     }
                 }
-            }
-            Err(virtual_fs::FsError::Unsupported) => {
-                // Some virtual filesystems cannot materialize hard links in
-                // their backing store. Preserve the old WASIX behavior there
-                // by linking the target directory entry to the same inode.
-                source_inode.clone()
             }
             Err(err) => return Err(fs_error_into_wasi_err(err)),
         }

--- a/lib/wasix/src/syscalls/wasi/path_rename.rs
+++ b/lib/wasix/src/syscalls/wasi/path_rename.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use anyhow::Context;
-
 use super::*;
 use crate::syscalls::*;
 
@@ -341,10 +339,11 @@ fn rename_inode_tree(inode: &InodeGuard, source_dir_path: &Path, target_dir_path
 fn adjust_path(path: &Path, source_dir_path: &Path, target_dir_path: &Path) -> PathBuf {
     let path = crate::fs::PosixPath::from_path(path);
     let source_dir_path = crate::fs::PosixPath::from_path(source_dir_path);
-    let relative_path = path
-        .strip_prefix(&source_dir_path)
-        .with_context(|| format!("Expected path {path:?} to be a subpath of {source_dir_path:?}"))
-        .expect("Fatal filesystem error");
+    let Some(relative_path) = path.strip_prefix(&source_dir_path) else {
+        // A directory tree can contain an inode also referenced by a hard link
+        // outside the moved tree. Keep that alias's cached path unchanged.
+        return PathBuf::from(path.as_str());
+    };
     crate::fs::PosixPath::from_path(target_dir_path)
         .join(&relative_path)
         .into_path_buf()

--- a/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
+++ b/lib/wasix/src/syscalls/wasi/path_unlink_file.rs
@@ -56,6 +56,13 @@ pub(crate) fn path_unlink_file_internal(
     let (memory, mut state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
 
     let inode = wasi_try_ok!(state.fs.get_inode_at_path(inodes, fd, path, false));
+    {
+        let guard = inode.read();
+        if matches!(guard.deref(), Kind::Dir { .. } | Kind::Root { .. }) {
+            return Ok(Errno::Isdir);
+        }
+    }
+
     let (parent_inode, child_name) = wasi_try_ok!(state.fs.get_parent_inode_at_path(
         inodes,
         fd,
@@ -102,39 +109,29 @@ pub(crate) fn path_unlink_file_internal(
         removed_inode
     };
 
-    let st_nlink = {
+    {
         let mut guard = removed_inode.stat.write().unwrap();
         guard.st_nlink -= 1;
-        guard.st_nlink
-    };
-    if st_nlink == 0 {
-        {
-            let mut guard = removed_inode.read();
-            match guard.deref() {
-                Kind::File { handle, path, .. } => {
-                    if let Some(h) = handle {
-                        let mut h = h.write().unwrap();
-                        wasi_try_ok!(h.unlink().map_err(fs_error_into_wasi_err));
-                    } else {
-                        // File is closed
-                        // problem with the abstraction, we can't call unlink because there's no handle
-                        // drop mutable borrow on `path`
-                        let path = path.clone();
-                        drop(guard);
-                        wasi_try_ok!(state.fs_remove_file(path));
-                    }
-                }
-                Kind::Dir { .. } | Kind::Root { .. } => return Ok(Errno::Isdir),
-                Kind::Symlink { .. } => {
-                    drop(guard);
-                    let errno = state.fs.remove_symlink_file(host_adjusted_path.as_path());
-                    if errno != Errno::Success {
-                        return Ok(errno);
-                    }
-                }
-                _ => unimplemented!("wasi::path_unlink_file for Buffer"),
+    }
+
+    let guard = removed_inode.read();
+    match guard.deref() {
+        Kind::File { .. } => {
+            // Unlink removes this pathname even while other hard links or open
+            // handles keep the file alive. The backing filesystem owns that
+            // lifetime; cached link counts must not suppress the operation.
+            drop(guard);
+            wasi_try_ok!(state.fs_remove_file(host_adjusted_path.as_path()));
+        }
+        Kind::Dir { .. } | Kind::Root { .. } => return Ok(Errno::Isdir),
+        Kind::Symlink { .. } => {
+            drop(guard);
+            let errno = state.fs.remove_symlink_file(host_adjusted_path.as_path());
+            if errno != Errno::Success {
+                return Ok(errno);
             }
         }
+        _ => unimplemented!("wasi::path_unlink_file for Buffer"),
     }
 
     Ok(Errno::Success)


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
Implement host-backed hard links, preserve shared inode identity, and unlink each pathname regardless of the remaining link count. Keep aliases outside a renamed directory tree at their existing cached path.

## Wasinix downstream context

- Related patch: [`wasmer-path-rename-hardlink.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-path-rename-hardlink.patch)
- Patch-removal experiment: [wasix-org/wasinix#241](https://github.com/wasix-org/wasinix/pull/241)
