### PR TITLE
fix(wasix): refresh file size in fd_filestat_get

### DIFF
--- a/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_filestat_get.rs
@@ -55,6 +55,22 @@ pub(crate) fn fd_filestat_get_internal(
         return Err(Errno::Access);
     }
 
+    // path_rename stamps the source inode's cached size onto the target, so a
+    // path whose file was replaced by a smaller one keeps the larger size and a
+    // read_exact sized from it runs off the end. The open handle stats the host
+    // file, so take the size from there.
+    let handle = {
+        let guard = fd_entry.inode.read();
+        match guard.deref() {
+            Kind::File { handle, .. } => handle.clone(),
+            _ => None,
+        }
+    };
+    if let Some(handle) = handle {
+        let size = handle.read().unwrap().size();
+        fd_entry.inode.stat.write().unwrap().st_size = size;
+    }
+
     let guard = fd_entry.inode.stat.read().unwrap();
     Ok(*guard.deref())
 }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
Refresh `st_size` from the open virtual file before returning descriptor status. This prevents writes through the descriptor from leaving `fstat()` results stale.

## Wasinix downstream context

- Related patch: [`wasmer-fd-filestat-stale-size.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-fd-filestat-stale-size.patch)
- Patch-removal experiment: [wasix-org/wasinix#243](https://github.com/wasix-org/wasinix/pull/243)
