### PR TITLE
fix(wasix): keep readdir cookies stable

### DIFF
--- a/lib/wasix/src/fs/fd.rs
+++ b/lib/wasix/src/fs/fd.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use virtual_fs::{Pipe, PipeRx, PipeTx, VirtualFile};
-use wasmer_wasix_types::wasi::{Fdflags, Fdflagsext, Filestat, Rights};
+use wasmer_wasix_types::wasi::{Fdflags, Fdflagsext, Filestat, Filetype, Rights};
 
 use crate::net::socket::InodeSocket;
 use crate::os::epoll::EpollState;
@@ -37,6 +37,8 @@ pub struct FdInner {
     pub flags: Fdflags,         // This is file table related flags, not fd flags
     pub offset: Arc<AtomicU64>, // This also belongs in the file table
     pub fd_flags: Fdflagsext,   // This is the actual FD flags that belongs here
+    /// Stable directory entries for `fd_readdir` continuation cookies.
+    pub readdir_snapshot: Arc<RwLock<Option<Vec<(String, Filetype, u64)>>>>,
 }
 
 impl Fd {

--- a/lib/wasix/src/fs/fd_list.rs
+++ b/lib/wasix/src/fs/fd_list.rs
@@ -331,6 +331,7 @@ mod tests {
                 rights_inheriting: Rights::empty(),
                 flags: Fdflags::from_bits_preserve(n),
                 fd_flags: Fdflagsext::empty(),
+                readdir_snapshot: Arc::new(RwLock::new(None)),
             },
         }
     }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -2026,6 +2026,7 @@ impl WasiFs {
                 flags: fs_flags,
                 offset: Arc::new(AtomicU64::new(0)),
                 fd_flags,
+                readdir_snapshot: Arc::new(RwLock::new(None)),
             },
             open_flags,
             inode,
@@ -2094,6 +2095,7 @@ impl WasiFs {
                     rights_inheriting: fd.inner.rights_inheriting,
                     flags: fd.inner.flags,
                     offset: fd.inner.offset.clone(),
+                    readdir_snapshot: fd.inner.readdir_snapshot.clone(),
                     fd_flags: match cloexec {
                         None => fd.inner.fd_flags,
                         Some(cloexec) => {
@@ -2132,6 +2134,7 @@ impl WasiFs {
                 flags: Fdflags::empty(),
                 offset: Arc::new(AtomicU64::new(0)),
                 fd_flags: Fdflagsext::empty(),
+                readdir_snapshot: Arc::new(RwLock::new(None)),
             },
             open_flags: 0,
             inode: root_inode,
@@ -2182,6 +2185,7 @@ impl WasiFs {
             let new_fd_entry = Fd {
                 inner: FdInner {
                     offset: fd_entry.inner.offset.clone(),
+                    readdir_snapshot: fd_entry.inner.readdir_snapshot.clone(),
                     rights: fd_entry.inner.rights_inheriting,
                     fd_flags: {
                         let mut f = fd_entry.inner.fd_flags;
@@ -2599,6 +2603,7 @@ impl WasiFs {
                     flags: fd_flags,
                     offset: Arc::new(AtomicU64::new(0)),
                     fd_flags: Fdflagsext::empty(),
+                    readdir_snapshot: Arc::new(RwLock::new(None)),
                 },
                 // since we're not calling open on this, we don't need open flags
                 open_flags: 0,

--- a/lib/wasix/src/syscalls/wasi/fd_readdir.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_readdir.rs
@@ -37,9 +37,19 @@ pub fn fd_readdir<M: MemorySize>(
     let working_dir = wasi_try_ok!(state.fs.get_fd(fd));
     let mut buf_idx = 0usize;
 
-    let entries: Vec<(String, Filetype, u64)> = {
+    // Cookies index a stable snapshot for the lifetime of this directory
+    // stream. Rebuilding the sorted list for every call makes deletions shift
+    // later entries below the caller's cookie, so recursive removal skips them.
+    let cached_entries = if cookie == 0 {
+        None
+    } else {
+        working_dir.inner.readdir_snapshot.read().unwrap().clone()
+    };
+    let entries: Vec<(String, Filetype, u64)> = if let Some(entries) = cached_entries {
+        entries
+    } else {
         let guard = working_dir.inode.read();
-        match guard.deref() {
+        let entries = match guard.deref() {
             Kind::Dir { path, entries, .. } => {
                 trace!("reading dir {:?}", path);
                 // TODO: refactor this code
@@ -115,7 +125,9 @@ pub fn fd_readdir<M: MemorySize>(
             | Kind::DuplexPipe { .. }
             | Kind::EventNotifications { .. }
             | Kind::Epoll { .. } => return Ok(Errno::Notdir),
-        }
+        };
+        *working_dir.inner.readdir_snapshot.write().unwrap() = Some(entries.clone());
+        entries
     };
 
     for (cur_cookie, (entry_path_str, wasi_file_type, ino)) in

--- a/lib/wasix/tests/wasm_tests/wasi_fyi/fs_remove_dir_all.rs
+++ b/lib/wasix/tests/wasm_tests/wasi_fyi/fs_remove_dir_all.rs
@@ -11,6 +11,15 @@ fn main() {
             .collect::<Vec<_>>(),
         vec!["bar", "baz"]
     );
+    // Fill more than one `fd_readdir` buffer so `remove_dir_all` continues
+    // enumeration after deleting entries returned by an earlier call.
+    for index in 0..16 {
+        fs::write(
+            format!("/fyi/foo/entry-with-a-long-name-{index:02}"),
+            b"data",
+        )
+        .unwrap();
+    }
     assert!(fs::remove_dir_all("/fyi/foo").is_ok());
     assert!(fs::read_dir("/fyi/foo").is_err());
 }


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
Keep a sorted directory snapshot on the open descriptor so continuation cookies retain their meaning across repeated `fd_readdir` calls.

This is deterministic WASI compatibility behavior. POSIX leaves directory mutation during iteration unspecified.

## Wasinix downstream context

- Related patch: [`wasmer-fd-readdir-stable-cookie.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-fd-readdir-stable-cookie.patch)
- Patch-removal experiment: [wasix-org/wasinix#242](https://github.com/wasix-org/wasinix/pull/242)
