### PR TITLE
fix(virtual-fs): use atomic host rename across directories

### DIFF
--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -215,28 +215,7 @@ impl crate::FileSystem for FileSystem {
             if !to_parent.exists() {
                 return Err(FsError::EntryNotFound);
             }
-            let result = if from_parent != to_parent {
-                let _ = std::fs::create_dir_all(to_parent);
-                if from.is_dir() {
-                    fs_extra::move_items(
-                        &[&from],
-                        &to,
-                        &fs_extra::dir::CopyOptions {
-                            copy_inside: true,
-                            ..Default::default()
-                        },
-                    )
-                    .map(|_| ())
-                    .map_err(|_| FsError::UnknownError)?;
-                    let _ = fs_extra::remove_items(&[&from]);
-                    Ok(())
-                } else {
-                    fs::copy(&from, &to).map(|_| ()).map_err(FsError::from)?;
-                    fs::remove_file(&from).map(|_| ()).map_err(Into::into)
-                }
-            } else {
-                fs::rename(&from, &to).map_err(Into::into)
-            };
+            let result = fs::rename(&from, &to).map_err(Into::into);
             let _ = set_file_mtime(&to, FileTime::now()).map(|_| ());
             result
         })


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->
Use the host `rename` operation for moves between directories instead of copy followed by deletion. This preserves atomic replacement and returns the host error for cross-filesystem moves.

I don't really know why the prior implementation did it in that manual way, I assume there was some reason but could not infer it from the git blame.

## Wasinix downstream context

- Related patch: [`wasmer-path-rename-hardlink.patch`](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasmer/wasmer-path-rename-hardlink.patch)
- Patch-removal experiment: [wasix-org/wasinix#241](https://github.com/wasix-org/wasinix/pull/241)
