### PR TITLE
Fix duplicate words in CLI comments

### DIFF
--- a/lib/cli/src/c_gen/staticlib_header.rs
+++ b/lib/cli/src/c_gen/staticlib_header.rs
@@ -79,7 +79,7 @@ pub fn generate_header_file(
     c_statements.push(CStatement::LiteralConstant {
         value: r#"
 // Compiled Wasm function pointers ordered by function index: the order they
-// appeared in in the Wasm module.
+// appeared in the Wasm module.
 "#
         .to_string(),
     });

--- a/lib/cli/src/commands/app/util.rs
+++ b/lib/cli/src/commands/app/util.rs
@@ -47,7 +47,7 @@ impl AppIdent {
             AppIdent::Name(name) => {
                 // The API only allows to query by owner + name,
                 // so default to the current user as the owner.
-                // To to so the username must first be retrieved.
+                // To do so, the username must first be retrieved.
                 let user = wasmer_backend_api::query::current_user(client)
                     .await?
                     .context("not logged in")?;


### PR DESCRIPTION
<!-- 
Prior to submitting a PR, review the CONTRIBUTING.md document for recommendations on how to test:
https://github.com/wasmerio/wasmer/blob/main/docs/CONTRIBUTING.md#pull-requests

-->

# Description
<!-- 
Provide details regarding the change including motivation,
links to related issues, and the context of the PR.
-->

Correct two duplicated-word errors in CLI source comments:

- “appeared in in the Wasm module” becomes “appeared in the Wasm module” in the generated static-library header;
- “To to so” becomes “To do so” before retrieving the current username.

This is documentation-only and does not affect generated symbols or command behavior.

Validation: `cargo clippy -p wasmer --lib` and `cargo fmt --all -- --check`.
