### PR TITLE
chore: simplify table element checking

### DIFF
--- a/lib/types/src/types.rs
+++ b/lib/types/src/types.rs
@@ -162,13 +162,6 @@ fn is_global_compatible(exported: GlobalType, imported: GlobalType) -> bool {
     exported_ty == imported_ty && imported_mutability == exported_mutability
 }
 
-fn is_table_element_type_compatible(exported_type: Type, imported_type: Type) -> bool {
-    match exported_type {
-        Type::FuncRef => true,
-        _ => imported_type == exported_type,
-    }
-}
-
 fn is_table_compatible(
     exported: &TableType,
     imported: &TableType,
@@ -187,7 +180,7 @@ fn is_table_compatible(
         ..
     } = imported;
 
-    is_table_element_type_compatible(*exported_ty, *imported_ty)
+    exported_ty == imported_ty
         && *imported_minimum <= imported_runtime_size.unwrap_or(*exported_minimum)
         && (imported_maximum.is_none()
             || (!exported_maximum.is_none()

--- a/tests/compilers/issues.rs
+++ b/tests/compilers/issues.rs
@@ -1468,3 +1468,29 @@ fn functions_max_stack_usage(mut config: crate::Config) -> Result<()> {
 
     Ok(())
 }
+
+#[compiler_test(issues)]
+fn table_import_element_type_mismatch(mut config: crate::Config) -> Result<()> {
+    let mut store = config.store();
+    let module = Module::new(
+        &store,
+        r#"(module (import "env" "table" (table 1 externref)))"#,
+    )?;
+    let table = Table::new(
+        &mut store,
+        TableType::new(Type::FuncRef, 1, None),
+        Value::FuncRef(None),
+    )?;
+    let imports = imports! {
+        "env" => {
+            "table" => table,
+        },
+    };
+
+    assert!(
+        Instance::new(&mut store, &module, &imports).is_err(),
+        "a funcref table was accepted for an externref table import"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The `is_table_element_type_compatible` is wrong, but it seems the check is redundant and the test would fail even with the vanilla main function. Let's simplify the code then.