### PR TITLE
Modularize package execution and caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7766,6 +7766,7 @@ version = "0.703.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "cfg-if",
  "ciborium",
  "flate2",
  "hexdump",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7995,6 +7995,7 @@ dependencies = [
  "wcgi",
  "wcgi-host",
  "web-sys",
+ "web-time",
  "webc",
  "windows-sys 0.61.2",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,13 +85,13 @@ version = "7.3.0"
 
 [workspace.dependencies]
 # Repo-local crates
-wasmer-package = { version = "0.703.0", path = "lib/package" }
+wasmer-package = { version = "0.703.0", path = "lib/package", default-features = false }
 wasmer-config = { path = "./lib/config" }
 wasmer-wasix = { path = "./lib/wasix" }
 wasmer-sdk = { path = "./lib/sdk" }
 
 # Wasmer-owned crates
-webc = "=12.0.1"
+webc = { version = "=12.0.1", default-features = false }
 shared-buffer = "0.1.4"
 loupe = "0.2.0"
 
@@ -118,6 +118,7 @@ bytesize = "2.3.1"
 cargo_metadata = "0.23.1"
 cbindgen = { version = "0.29", default-features = false }
 cc = "1.2.47"
+cfg-if = "1.0"
 chrono = { version = "0.4.38", default-features = false }
 ciborium = "0.2.2"
 clap = { version = "4.5.53", default-features = false }

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -16,7 +16,12 @@ rust-version.workspace = true
 [dependencies]
 # Wasmer dependencies.
 wasmer-config = { version = "0.703.0", path = "../config" }
-wasmer-package = { workspace = true, features = ["execution", "webc-v1", "webc-v2", "webc-v3"] }
+wasmer-package = { workspace = true, features = [
+  "execution",
+  "webc-v1",
+  "webc-v2",
+  "webc-v3",
+] }
 webc.workspace = true
 
 # crates.io dependencies.

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 [dependencies]
 # Wasmer dependencies.
 wasmer-config = { version = "0.703.0", path = "../config" }
-wasmer-package = { workspace = true, features = ["webc-v1", "webc-v2", "webc-v3"] }
+wasmer-package = { workspace = true, features = ["execution", "webc-v1", "webc-v2", "webc-v3"] }
 webc.workspace = true
 
 # crates.io dependencies.

--- a/lib/backend-api/Cargo.toml
+++ b/lib/backend-api/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 [dependencies]
 # Wasmer dependencies.
 wasmer-config = { version = "0.703.0", path = "../config" }
-wasmer-package.workspace = true
+wasmer-package = { workspace = true, features = ["webc-v1", "webc-v2", "webc-v3"] }
 webc.workspace = true
 
 # crates.io dependencies.

--- a/lib/c-api/Cargo.toml
+++ b/lib/c-api/Cargo.toml
@@ -148,7 +148,7 @@ static-artifact-create = [
   "wasmer-compiler/static-artifact-create",
   "wasmer-c-api-imports/static-artifact-create",
 ]
-webc_runner = ["virtual-fs", "webc"]
+webc_runner = ["virtual-fs", "webc", "webc/v1"]
 # Deprecated features.
 jit = ["compiler"]
 

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -137,7 +137,7 @@ wasmer-compiler = { version = "=7.3.0", path = "../compiler", features = [
 wasmer-compiler-cranelift = { version = "=7.3.0", path = "../compiler-cranelift", optional = true }
 wasmer-compiler-singlepass = { version = "=7.3.0", path = "../compiler-singlepass", optional = true }
 wasmer-compiler-llvm = { version = "=7.3.0", path = "../compiler-llvm", optional = true }
-wasmer-package.workspace = true
+wasmer-package = { workspace = true, features = ["webc-v1", "webc-v2", "webc-v3"] }
 wasmer-vm = { version = "=7.3.0", path = "../vm", optional = true }
 wasmer-wasix = { path = "../wasix", version = "=0.703.0", features = [
   "logging",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -137,7 +137,7 @@ wasmer-compiler = { version = "=7.3.0", path = "../compiler", features = [
 wasmer-compiler-cranelift = { version = "=7.3.0", path = "../compiler-cranelift", optional = true }
 wasmer-compiler-singlepass = { version = "=7.3.0", path = "../compiler-singlepass", optional = true }
 wasmer-compiler-llvm = { version = "=7.3.0", path = "../compiler-llvm", optional = true }
-wasmer-package = { workspace = true, features = ["webc-v1", "webc-v2", "webc-v3"] }
+wasmer-package = { workspace = true, features = ["authoring", "webc-v1", "webc-v2", "webc-v3"] }
 wasmer-vm = { version = "=7.3.0", path = "../vm", optional = true }
 wasmer-wasix = { path = "../wasix", version = "=0.703.0", features = [
   "logging",

--- a/lib/cli/Cargo.toml
+++ b/lib/cli/Cargo.toml
@@ -137,7 +137,12 @@ wasmer-compiler = { version = "=7.3.0", path = "../compiler", features = [
 wasmer-compiler-cranelift = { version = "=7.3.0", path = "../compiler-cranelift", optional = true }
 wasmer-compiler-singlepass = { version = "=7.3.0", path = "../compiler-singlepass", optional = true }
 wasmer-compiler-llvm = { version = "=7.3.0", path = "../compiler-llvm", optional = true }
-wasmer-package = { workspace = true, features = ["authoring", "webc-v1", "webc-v2", "webc-v3"] }
+wasmer-package = { workspace = true, features = [
+  "authoring",
+  "webc-v1",
+  "webc-v2",
+  "webc-v3",
+] }
 wasmer-vm = { version = "=7.3.0", path = "../vm", optional = true }
 wasmer-wasix = { path = "../wasix", version = "=0.703.0", features = [
   "logging",

--- a/lib/package/Cargo.toml
+++ b/lib/package/Cargo.toml
@@ -44,3 +44,9 @@ tempfile.workspace = true
 regex.workspace = true
 ureq.workspace = true
 hexdump.workspace = true
+
+[features]
+default = ["webc-v3"]
+webc-v1 = ["webc/v1"]
+webc-v2 = ["webc/v2"]
+webc-v3 = ["webc/v3"]

--- a/lib/package/Cargo.toml
+++ b/lib/package/Cargo.toml
@@ -29,7 +29,6 @@ thiserror.workspace = true
 ciborium.workspace = true
 semver.workspace = true
 url.workspace = true
-insta = { workspace = true, features = ["filters", "yaml"] }
 flate2.workspace = true
 tar.workspace = true
 tempfile.workspace = true
@@ -39,6 +38,7 @@ ignore.workspace = true
 libc.workspace = true
 
 [dev-dependencies]
+insta = { workspace = true, features = ["filters", "yaml"] }
 pretty_assertions.workspace = true
 tempfile.workspace = true
 regex.workspace = true

--- a/lib/package/Cargo.toml
+++ b/lib/package/Cargo.toml
@@ -14,25 +14,26 @@ rust-version.workspace = true
 
 [dependencies]
 webc.workspace = true
-wasmer-config = { version = "0.703.0", path = "../config" }
-wasmer-types = { version = "7.3.0", path = "../types", features = [
+wasmer-config = { version = "0.703.0", path = "../config", optional = true }
+wasmer-types = { version = "7.3.0", path = "../types", optional = true, features = [
   "detect-wasm-features",
 ] }
-toml.workspace = true
-bytes.workspace = true
-sha2.workspace = true
-shared-buffer.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-anyhow.workspace = true
+toml = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+shared-buffer = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
 thiserror.workspace = true
-ciborium.workspace = true
-semver.workspace = true
-url.workspace = true
-flate2.workspace = true
-tar.workspace = true
-tempfile.workspace = true
-ignore.workspace = true
+cfg-if = { workspace = true, optional = true }
+ciborium = { workspace = true, optional = true }
+semver = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
+tar = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
+ignore = { workspace = true, optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "wasi"))'.dependencies]
 libc.workspace = true
@@ -46,7 +47,26 @@ ureq.workspace = true
 hexdump.workspace = true
 
 [features]
-default = ["webc-v3"]
+default = ["execution", "authoring", "webc-v3"]
+execution = ["dep:bytes", "dep:wasmer-types"]
+authoring = [
+  "execution",
+  "dep:anyhow",
+  "dep:cfg-if",
+  "dep:ciborium",
+  "dep:flate2",
+  "dep:ignore",
+  "dep:semver",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:sha2",
+  "dep:shared-buffer",
+  "dep:tar",
+  "dep:tempfile",
+  "dep:toml",
+  "dep:url",
+  "dep:wasmer-config",
+]
 webc-v1 = ["webc/v1"]
 webc-v2 = ["webc/v2"]
 webc-v3 = ["webc/v3"]

--- a/lib/package/src/error.rs
+++ b/lib/package/src/error.rs
@@ -1,0 +1,83 @@
+#[cfg(feature = "authoring")]
+use std::path::PathBuf;
+
+use webc::{ContainerError, DetectError};
+
+#[cfg(feature = "authoring")]
+use crate::package::ManifestError;
+
+/// Errors that may occur while loading a Wasmer package.
+#[derive(Debug, thiserror::Error)]
+#[allow(clippy::result_large_err)]
+#[non_exhaustive]
+pub enum WasmerPackageError {
+    #[cfg(feature = "authoring")]
+    #[error("Unable to create a temporary directory")]
+    TempDir(#[source] std::io::Error),
+    #[cfg(feature = "authoring")]
+    #[error("Unable to open \"{}\"", path.display())]
+    FileOpen {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
+    #[cfg(feature = "authoring")]
+    #[error("Unable to read \"{}\"", path.display())]
+    FileRead {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
+    #[cfg(feature = "authoring")]
+    #[error("IO Error: {0:?}")]
+    IoError(#[from] std::io::Error),
+    #[cfg(feature = "authoring")]
+    #[error("Malformed path format: {0:?}")]
+    MalformedPath(PathBuf),
+    #[cfg(feature = "authoring")]
+    #[error("Unable to extract the tarball")]
+    Tarball(#[source] std::io::Error),
+    #[cfg(feature = "authoring")]
+    #[error("Unable to deserialize \"{}\"", path.display())]
+    TomlDeserialize {
+        path: PathBuf,
+        #[source]
+        error: toml::de::Error,
+    },
+    #[cfg(feature = "authoring")]
+    #[error("Unable to deserialize \"{}\"", path.display())]
+    JsonDeserialize {
+        path: PathBuf,
+        #[source]
+        error: serde_json::Error,
+    },
+    #[cfg(feature = "authoring")]
+    #[error("Unable to find the \"wasmer.toml\"")]
+    MissingManifest,
+    #[cfg(feature = "authoring")]
+    #[error("Unable to get the absolute path for \"{}\"", path.display())]
+    Canonicalize {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
+    #[cfg(feature = "authoring")]
+    #[error("Unable to load the \"wasmer.toml\" manifest")]
+    Manifest(#[from] ManifestError),
+    #[cfg(feature = "authoring")]
+    #[error("The manifest is invalid")]
+    Validation(#[from] wasmer_config::package::ValidationError),
+    #[cfg(feature = "authoring")]
+    #[error("Path: \"{}\" does not exist", path.display())]
+    PathNotExists { path: PathBuf },
+    #[cfg(feature = "authoring")]
+    #[error("Volume creation failed: {0:?}")]
+    VolumeCreation(#[from] anyhow::Error),
+    #[cfg(feature = "authoring")]
+    #[error("serde error: {0:?}")]
+    SerdeError(#[from] ciborium::value::Error),
+    #[error("container error: {0:?}")]
+    ContainerError(#[from] ContainerError),
+    #[error("detect error: {0:?}")]
+    DetectError(#[from] DetectError),
+}

--- a/lib/package/src/lib.rs
+++ b/lib/package/src/lib.rs
@@ -1,7 +1,14 @@
 #[macro_use]
-#[cfg(test)]
+#[cfg(all(test, feature = "authoring"))]
 mod macros;
 
+mod error;
+
+pub use error::WasmerPackageError;
+
+#[cfg(feature = "authoring")]
 pub mod convert;
+#[cfg(feature = "authoring")]
 pub mod package;
+#[cfg(feature = "execution")]
 pub mod utils;

--- a/lib/package/src/package/mod.rs
+++ b/lib/package/src/package/mod.rs
@@ -7,13 +7,11 @@ pub(crate) mod volume;
 
 pub use self::{
     manifest::ManifestError,
-    package::{
-        Package, WalkBuilderFactory, WasmerPackageError, include_everything_walker,
-        wasmer_ignore_walker,
-    },
+    package::{Package, WalkBuilderFactory, include_everything_walker, wasmer_ignore_walker},
     strictness::Strictness,
     volume::{WasmerPackageVolume, fs::*, in_memory::*},
 };
+pub use crate::WasmerPackageError;
 
 #[cfg(test)]
 mod tests {

--- a/lib/package/src/package/mod.rs
+++ b/lib/package/src/package/mod.rs
@@ -17,18 +17,21 @@ pub use self::{
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "webc-v2")]
     use sha2::Digest;
+    #[cfg(feature = "webc-v2")]
     use shared_buffer::OwnedBuffer;
     use tempfile::TempDir;
 
-    use webc::{
-        metadata::annotations::FileSystemMapping,
-        migration::{are_semantically_equivalent, v2_to_v3, v3_to_v2},
-    };
+    #[cfg(feature = "webc-v2")]
+    use webc::metadata::annotations::FileSystemMapping;
+    #[cfg(feature = "webc-v2")]
+    use webc::migration::{are_semantically_equivalent, v2_to_v3, v3_to_v2};
 
     use crate::{package::Package, utils::from_bytes};
 
     #[test]
+    #[cfg(feature = "webc-v2")]
     fn migration_roundtrip() {
         let temp = TempDir::new().unwrap();
         let wasmer_toml = r#"
@@ -218,6 +221,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "webc-v2")]
     fn fs_entry_is_not_required_for_migration() {
         let temp = TempDir::new().unwrap();
         let wasmer_toml = r#"

--- a/lib/package/src/package/package.rs
+++ b/lib/package/src/package/package.rs
@@ -22,8 +22,7 @@ use tempfile::TempDir;
 use wasmer_config::package::Manifest as WasmerManifest;
 
 use webc::{
-    AbstractVolume, AbstractWebc, Container, ContainerError, DetectError, PathSegment, Version,
-    Volume,
+    AbstractVolume, AbstractWebc, Container, PathSegment, Version, Volume,
     metadata::{Manifest as WebcManifest, annotations::Wapm},
     v3::{
         ChecksumAlgorithm, Timestamps,
@@ -31,108 +30,13 @@ use webc::{
     },
 };
 
+use crate::WasmerPackageError;
+
 use super::{
-    ManifestError, MemoryVolume, Strictness,
+    MemoryVolume, Strictness,
     manifest::wasmer_manifest_to_webc,
     volume::{WasmerPackageVolume, fs::FsVolume},
 };
-
-/// Errors that may occur while loading a Wasmer package from disk.
-#[derive(Debug, thiserror::Error)]
-#[allow(clippy::result_large_err)]
-#[non_exhaustive]
-pub enum WasmerPackageError {
-    /// Unable to create a temporary directory.
-    #[error("Unable to create a temporary directory")]
-    TempDir(#[source] std::io::Error),
-    /// Unable to open a file.
-    #[error("Unable to open \"{}\"", path.display())]
-    FileOpen {
-        /// The file being opened.
-        path: PathBuf,
-        /// The underlying error.
-        #[source]
-        error: std::io::Error,
-    },
-    /// Unable to read a file.
-    #[error("Unable to read \"{}\"", path.display())]
-    FileRead {
-        /// The file being opened.
-        path: PathBuf,
-        /// The underlying error.
-        #[source]
-        error: std::io::Error,
-    },
-
-    /// Generic IO error.
-    #[error("IO Error: {0:?}")]
-    IoError(#[from] std::io::Error),
-
-    /// Unexpected path format
-    #[error("Malformed path format: {0:?}")]
-    MalformedPath(PathBuf),
-
-    /// Unable to extract the tarball.
-    #[error("Unable to extract the tarball")]
-    Tarball(#[source] std::io::Error),
-    /// Unable to deserialize the `wasmer.toml` file.
-    #[error("Unable to deserialize \"{}\"", path.display())]
-    TomlDeserialize {
-        /// The file being deserialized.
-        path: PathBuf,
-        /// The underlying error.
-        #[source]
-        error: toml::de::Error,
-    },
-    /// Unable to deserialize a json file.
-    #[error("Unable to deserialize \"{}\"", path.display())]
-    JsonDeserialize {
-        /// The file being deserialized.
-        path: PathBuf,
-        /// The underlying error.
-        #[source]
-        error: serde_json::Error,
-    },
-    /// Unable to find the `wasmer.toml` file.
-    #[error("Unable to find the \"wasmer.toml\"")]
-    MissingManifest,
-    /// Unable to canonicalize a path.
-    #[error("Unable to get the absolute path for \"{}\"", path.display())]
-    Canonicalize {
-        /// The path being canonicalized.
-        path: PathBuf,
-        /// The underlying error.
-        #[source]
-        error: std::io::Error,
-    },
-    /// Unable to load the `wasmer.toml` manifest.
-    #[error("Unable to load the \"wasmer.toml\" manifest")]
-    Manifest(#[from] ManifestError),
-    /// A manifest validation error.
-    #[error("The manifest is invalid")]
-    Validation(#[from] wasmer_config::package::ValidationError),
-    /// A path in the fs mapping does not exist
-    #[error("Path: \"{}\" does not exist", path.display())]
-    PathNotExists {
-        /// Path entry in fs mapping
-        path: PathBuf,
-    },
-    /// Any error happening when populating the volumes tree map of a package
-    #[error("Volume creation failed: {0:?}")]
-    VolumeCreation(#[from] anyhow::Error),
-
-    /// Error when serializing or deserializing
-    #[error("serde error: {0:?}")]
-    SerdeError(#[from] ciborium::value::Error),
-
-    /// Container Error
-    #[error("container error: {0:?}")]
-    ContainerError(#[from] ContainerError),
-
-    /// Detect Error
-    #[error("detect error: {0:?}")]
-    DetectError(#[from] DetectError),
-}
 
 // Serious Java vibes from this one! Still better than repeating the
 // function type everywhere.

--- a/lib/package/src/utils.rs
+++ b/lib/package/src/utils.rs
@@ -97,6 +97,7 @@ fn parse_dir(path: &Path) -> Result<Container, WasmerPackageError> {
 }
 
 #[allow(clippy::result_large_err)]
+#[cfg(feature = "webc-v1")]
 fn parse_v1_mmap(f: File) -> Result<Container, ContainerError> {
     // We need to explicitly use WebcMmap to get a memory-mapped
     // parser
@@ -106,6 +107,13 @@ fn parse_v1_mmap(f: File) -> Result<Container, ContainerError> {
 }
 
 #[allow(clippy::result_large_err)]
+#[cfg(not(feature = "webc-v1"))]
+fn parse_v1_mmap(_f: File) -> Result<Container, ContainerError> {
+    Err(ContainerError::FeatureNotEnabled { feature: "v1" })
+}
+
+#[allow(clippy::result_large_err)]
+#[cfg(feature = "webc-v2")]
 fn parse_v2_mmap(f: File) -> Result<Container, ContainerError> {
     // Note: OwnedReader::from_file() will automatically try to
     // use a memory-mapped file when possible.
@@ -114,11 +122,24 @@ fn parse_v2_mmap(f: File) -> Result<Container, ContainerError> {
 }
 
 #[allow(clippy::result_large_err)]
+#[cfg(not(feature = "webc-v2"))]
+fn parse_v2_mmap(_f: File) -> Result<Container, ContainerError> {
+    Err(ContainerError::FeatureNotEnabled { feature: "v2" })
+}
+
+#[allow(clippy::result_large_err)]
+#[cfg(feature = "webc-v3")]
 fn parse_v3_mmap(f: File) -> Result<Container, ContainerError> {
     // Note: OwnedReader::from_file() will automatically try to
     // use a memory-mapped file when possible.
     let webc = webc::v3::read::OwnedReader::from_file(f)?;
     Ok(Container::new(webc))
+}
+
+#[allow(clippy::result_large_err)]
+#[cfg(not(feature = "webc-v3"))]
+fn parse_v3_mmap(_f: File) -> Result<Container, ContainerError> {
+    Err(ContainerError::FeatureNotEnabled { feature: "v3" })
 }
 
 /// Convert a `Features` object to a list of WebAssembly feature strings
@@ -226,4 +247,15 @@ pub fn wasm_annotations_to_features(feature_strings: &[String]) -> Features {
     }
 
     features
+}
+
+#[cfg(all(test, not(feature = "webc-v1"), not(feature = "webc-v2")))]
+mod modern_webc_tests {
+    use super::from_bytes;
+
+    #[test]
+    fn rejects_legacy_versions() {
+        assert!(from_bytes(b"\0webc001".to_vec()).is_err());
+        assert!(from_bytes(b"\0webc002".to_vec()).is_err());
+    }
 }

--- a/lib/package/src/utils.rs
+++ b/lib/package/src/utils.rs
@@ -3,16 +3,22 @@
     reason = "WasmerPackageError is large, but not often used"
 )]
 
-use bytes::{Buf, Bytes};
+#[cfg(feature = "authoring")]
+use bytes::Buf;
+use bytes::Bytes;
+#[cfg(feature = "authoring")]
+use std::io::{BufRead, BufReader};
 use std::{
     fs::File,
-    io::{BufRead, BufReader, Read, Seek},
+    io::{Read, Seek},
     path::Path,
 };
 use wasmer_types::Features;
 use webc::{Container, ContainerError, Version};
 
-use crate::package::{Package, WasmerPackageError};
+use crate::WasmerPackageError;
+#[cfg(feature = "authoring")]
+use crate::package::Package;
 
 /// Check if something looks like a `*.tar.gz` file.
 fn is_tarball(mut file: impl Read + Seek) -> bool {
@@ -35,7 +41,13 @@ pub fn from_disk(path: impl AsRef<Path>) -> Result<Container, WasmerPackageError
     let path = path.as_ref();
 
     if path.is_dir() {
+        #[cfg(feature = "authoring")]
         return parse_dir(path);
+        #[cfg(not(feature = "authoring"))]
+        return Err(ContainerError::FeatureNotEnabled {
+            feature: "authoring",
+        }
+        .into());
     }
 
     let mut f = File::open(path).map_err(|error| ContainerError::Open {
@@ -44,7 +56,13 @@ pub fn from_disk(path: impl AsRef<Path>) -> Result<Container, WasmerPackageError
     })?;
 
     if is_tarball(&mut f) {
+        #[cfg(feature = "authoring")]
         return parse_tarball(BufReader::new(f));
+        #[cfg(not(feature = "authoring"))]
+        return Err(ContainerError::FeatureNotEnabled {
+            feature: "authoring",
+        }
+        .into());
     }
 
     match webc::detect(&mut f) {
@@ -76,7 +94,13 @@ pub fn from_bytes(bytes: impl Into<Bytes>) -> Result<Container, WasmerPackageErr
     let bytes: Bytes = bytes.into();
 
     if is_tarball(std::io::Cursor::new(&bytes)) {
+        #[cfg(feature = "authoring")]
         return parse_tarball(bytes.reader());
+        #[cfg(not(feature = "authoring"))]
+        return Err(ContainerError::FeatureNotEnabled {
+            feature: "authoring",
+        }
+        .into());
     }
 
     let version = webc::detect(bytes.as_ref())?;
@@ -84,12 +108,14 @@ pub fn from_bytes(bytes: impl Into<Bytes>) -> Result<Container, WasmerPackageErr
 }
 
 #[allow(clippy::result_large_err)]
+#[cfg(feature = "authoring")]
 fn parse_tarball(reader: impl BufRead) -> Result<Container, WasmerPackageError> {
     let pkg = Package::from_tarball(reader)?;
     Ok(Container::new(pkg))
 }
 
 #[allow(clippy::result_large_err)]
+#[cfg(feature = "authoring")]
 fn parse_dir(path: &Path) -> Result<Container, WasmerPackageError> {
     let wasmer_toml = path.join("wasmer.toml");
     let pkg = Package::from_manifest(wasmer_toml)?;
@@ -257,5 +283,24 @@ mod modern_webc_tests {
     fn rejects_legacy_versions() {
         assert!(from_bytes(b"\0webc001".to_vec()).is_err());
         assert!(from_bytes(b"\0webc002".to_vec()).is_err());
+    }
+}
+
+#[cfg(all(test, feature = "execution", not(feature = "authoring")))]
+mod execution_only_tests {
+    use webc::ContainerError;
+
+    use super::from_bytes;
+    use crate::WasmerPackageError;
+
+    #[test]
+    fn rejects_authoring_formats() {
+        let error = from_bytes(vec![0x1f, 0x8b]).unwrap_err();
+        assert!(matches!(
+            error,
+            WasmerPackageError::ContainerError(ContainerError::FeatureNotEnabled {
+                feature: "authoring"
+            })
+        ));
     }
 }

--- a/lib/sdk/Cargo.toml
+++ b/lib/sdk/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 [dependencies]
 wasmer-backend-api = { path = "../backend-api", version = "=0.703.0" }
 wasmer-config = { path = "../config", version = "=0.703.0" }
-wasmer-package = { path = "../package", version = "=0.703.0", features = ["authoring"] }
+wasmer-package = { path = "../package", version = "=0.703.0", features = [
+  "authoring",
+] }
 
 reqwest = { workspace = true, default-features = false, features = [
   "json",

--- a/lib/sdk/Cargo.toml
+++ b/lib/sdk/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 wasmer-backend-api = { path = "../backend-api", version = "=0.703.0" }
 wasmer-config = { path = "../config", version = "=0.703.0" }
-wasmer-package = { path = "../package", version = "=0.703.0" }
+wasmer-package = { path = "../package", version = "=0.703.0", features = ["authoring"] }
 
 reqwest = { workspace = true, default-features = false, features = [
   "json",

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -26,7 +26,7 @@ wasmer-wasix = { version = "=0.703.0", path = "../wasix", default-features = fal
   "sys",
 ] }
 webc.workspace = true
-wasmer-package.workspace = true
+wasmer-package = { workspace = true, features = ["webc-v1", "webc-v2", "webc-v3"] }
 
 
 [build-dependencies]

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -26,7 +26,7 @@ wasmer-wasix = { version = "=0.703.0", path = "../wasix", default-features = fal
   "sys",
 ] }
 webc.workspace = true
-wasmer-package = { workspace = true, features = ["webc-v1", "webc-v2", "webc-v3"] }
+wasmer-package = { workspace = true, features = ["execution", "webc-v1", "webc-v2", "webc-v3"] }
 
 
 [build-dependencies]

--- a/lib/swift/Cargo.toml
+++ b/lib/swift/Cargo.toml
@@ -26,7 +26,12 @@ wasmer-wasix = { version = "=0.703.0", path = "../wasix", default-features = fal
   "sys",
 ] }
 webc.workspace = true
-wasmer-package = { workspace = true, features = ["execution", "webc-v1", "webc-v2", "webc-v3"] }
+wasmer-package = { workspace = true, features = [
+  "execution",
+  "webc-v1",
+  "webc-v2",
+  "webc-v3",
+] }
 
 
 [build-dependencies]

--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-wasmer-package.workspace = true
+wasmer-package = { workspace = true, features = ["webc-v3"] }
 virtual-mio = { path = "../virtual-io", version = "0.703.0", default-features = false }
 dashmap.workspace = true
 derive_more.workspace = true
@@ -35,7 +35,7 @@ tokio = { workspace = true, features = [
   "macros",
 ], default-features = false }
 tracing = { workspace = true, default-features = true }
-webc = { workspace = true, optional = true, features = ["v1"] }
+webc = { workspace = true, optional = true }
 serde = { workspace = true, default-features = false, features = [
   "derive",
 ], optional = true }
@@ -61,8 +61,8 @@ host-fs = [
   "tokio/io-std",
   "tokio/rt",
 ]
-webc-fs = ["webc", "anyhow"]
-static-fs = ["webc", "anyhow"]
+webc-fs = ["webc", "webc/v3", "anyhow"]
+static-fs = ["webc", "webc/v1", "anyhow"]
 # Deprecated feature (a compile-time warning reported if used).
 enable-serde = []
 js = ["dep:web-time", "getrandom/wasm_js"]

--- a/lib/virtual-fs/Cargo.toml
+++ b/lib/virtual-fs/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-wasmer-package = { workspace = true, features = ["webc-v3"] }
+wasmer-package = { workspace = true, features = ["execution", "webc-v3"] }
 virtual-mio = { path = "../virtual-io", version = "0.703.0", default-features = false }
 dashmap.workspace = true
 derive_more.workspace = true

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 required-features = ["sys-thread"]
 
 [dependencies]
-wasmer-package = { workspace = true, default-features = false, features = ["webc-v3"] }
+wasmer-package = { workspace = true, default-features = false, features = ["execution", "webc-v3"] }
 wasmer-wasix-types = { path = "../wasi-types", version = "0.703.0", features = [
   "enable-serde",
 ] }
@@ -218,6 +218,7 @@ ctrlc = ["tokio/signal"]
 # the minimal sys implementation
 sys-minimal = ["wasmer/sys", "sys-thread", "tokio/fs"]
 sys = [
+  "package-authoring",
   "webc/mmap",
   "time",
   "virtual-mio/sys",
@@ -242,6 +243,7 @@ sys = [
   "webc/v1",
   "webc/v2",
 ]
+package-authoring = ["wasmer-package/authoring"]
 sys-default = ["sys"]
 sys-poll = []
 extra-logging = []

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -20,7 +20,10 @@ harness = false
 required-features = ["sys-thread"]
 
 [dependencies]
-wasmer-package = { workspace = true, default-features = false, features = ["execution", "webc-v3"] }
+wasmer-package = { workspace = true, default-features = false, features = [
+  "execution",
+  "webc-v3",
+] }
 wasmer-wasix-types = { path = "../wasi-types", version = "0.703.0", features = [
   "enable-serde",
 ] }

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -233,6 +233,7 @@ sys = [
   "wasmer/wat",
   "wasmer/js-serializable-module",
   "wasmer/sys",
+  "wasmer/demangle",
   # We must ensure at least one compiler backend (or `headless`) is enabled for `wasmer/sys`.
   "wasmer/headless",
 ]
@@ -259,7 +260,6 @@ js = [
   "web-sys",
   "wasmer/js-default",
   "wasmer/wasm-types-polyfill",
-  "wasmer/wat",
   "wasmer/js-serializable-module",
 ]
 js-default = ["js"]

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -63,6 +63,7 @@ chrono = { workspace = true, default-features = false, features = [
   "clock",
 ], optional = true }
 bytes.workspace = true
+web-time.workspace = true
 anyhow.workspace = true
 sha2.workspace = true
 waker-fn.workspace = true

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -273,7 +273,7 @@ js = [
   "wasmer/js-serializable-module",
 ]
 js-default = ["js"]
-test-js = ["js", "wasmer/wat"]
+test-js = ["js", "wasmer/wat", "webc/v2"]
 
 host-vnet = ["virtual-net/host-net"]
 host-threads = []

--- a/lib/wasix/Cargo.toml
+++ b/lib/wasix/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 required-features = ["sys-thread"]
 
 [dependencies]
-wasmer-package.workspace = true
+wasmer-package = { workspace = true, default-features = false, features = ["webc-v3"] }
 wasmer-wasix-types = { path = "../wasi-types", version = "0.703.0", features = [
   "enable-serde",
 ] }
@@ -42,7 +42,7 @@ http.workspace = true
 dashmap.workspace = true
 fnv.workspace = true
 base64.workspace = true
-webc.workspace = true
+webc = { workspace = true, features = ["v3"] }
 serde_yaml.workspace = true
 rkyv.workspace = true
 shared-buffer.workspace = true
@@ -236,6 +236,11 @@ sys = [
   "wasmer/demangle",
   # We must ensure at least one compiler backend (or `headless`) is enabled for `wasmer/sys`.
   "wasmer/headless",
+  "memory64",
+  "wasmer-package/webc-v1",
+  "wasmer-package/webc-v2",
+  "webc/v1",
+  "webc/v2",
 ]
 sys-default = ["sys"]
 sys-poll = []
@@ -245,6 +250,9 @@ journal = ["tokio/fs", "wasmer-journal/log-file"]
 
 # Deprecated. Kept it for compatibility
 compiler = []
+
+# Enables the `wasix_64v1` ABI and its 64-bit syscall implementations.
+memory64 = []
 
 singlepass = ["wasmer/singlepass"]
 v8 = ["wasmer/v8"]

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -5,9 +5,11 @@ use std::{
 
 use anyhow::Context;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "package-authoring")]
 use sha2::Digest;
 use virtual_fs::{FileSystem, MountFileSystem};
 use wasmer_config::package::{PackageHash, PackageId, PackageSource};
+#[cfg(feature = "package-authoring")]
 use wasmer_package::package::Package;
 use webc::Container;
 use webc::compat::SharedBytes;
@@ -176,6 +178,7 @@ pub struct BinaryPackage {
 }
 
 impl BinaryPackage {
+    #[cfg(feature = "package-authoring")]
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn from_dir(
         dir: &Path,

--- a/lib/wasix/src/bin_factory/binary_package.rs
+++ b/lib/wasix/src/bin_factory/binary_package.rs
@@ -345,7 +345,7 @@ impl BinaryPackage {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "package-authoring"))]
 mod tests {
     use sha2::Digest;
     use tempfile::TempDir;

--- a/lib/wasix/src/lib.rs
+++ b/lib/wasix/src/lib.rs
@@ -84,6 +84,9 @@ use thiserror::Error;
 pub use wasmer;
 pub use wasmer_wasix_types;
 
+#[cfg(feature = "memory64")]
+#[allow(unused_imports, reason = "used by namespace! expansions")]
+use wasmer::Memory64;
 use wasmer::{
     AsStoreMut, Exports, FunctionEnv, Imports, Memory32, MemoryAccessError, MemorySize,
     RuntimeError, imports, namespace,
@@ -657,6 +660,7 @@ fn wasix_exports_32(mut store: &mut impl AsStoreMut, env: &FunctionEnv<WasiEnv>)
     namespace
 }
 
+#[cfg(feature = "memory64")]
 fn wasix_exports_64(mut store: &mut impl AsStoreMut, env: &FunctionEnv<WasiEnv>) -> Exports {
     let engine_supports_async = store.as_store_ref().engine().supports_async();
 
@@ -817,7 +821,6 @@ fn import_object_for_all_wasi_versions(
     let exports_wasi_unstable = wasi_unstable_exports(store, env);
     let exports_wasi_snapshot_preview1 = wasi_snapshot_preview1_exports(store, env);
     let exports_wasix_32v1 = wasix_exports_32(store, env);
-    let exports_wasix_64v1 = wasix_exports_64(store, env);
 
     // Allowed due to JS feature flag complications.
     #[allow(unused_mut)]
@@ -826,8 +829,15 @@ fn import_object_for_all_wasi_versions(
         "wasi_unstable" => exports_wasi_unstable,
         "wasi_snapshot_preview1" => exports_wasi_snapshot_preview1,
         "wasix_32v1" => exports_wasix_32v1,
-        "wasix_64v1" => exports_wasix_64v1,
     };
+
+    #[cfg(feature = "memory64")]
+    {
+        let exports_wasix_64v1 = wasix_exports_64(store, env);
+        imports.extend(&imports! {
+            "wasix_64v1" => exports_wasix_64v1,
+        });
+    }
 
     imports
 }
@@ -864,6 +874,7 @@ fn generate_import_object_wasix32_v1(
     }
 }
 
+#[cfg(feature = "memory64")]
 fn generate_import_object_wasix64_v1(
     store: &mut impl AsStoreMut,
     env: &FunctionEnv<WasiEnv>,
@@ -872,6 +883,14 @@ fn generate_import_object_wasix64_v1(
     imports! {
         "wasix_64v1" => exports_wasix_64v1
     }
+}
+
+#[cfg(not(feature = "memory64"))]
+fn generate_import_object_wasix64_v1(
+    _store: &mut impl AsStoreMut,
+    _env: &FunctionEnv<WasiEnv>,
+) -> Imports {
+    Imports::new()
 }
 
 fn mem_error_to_wasi(err: MemoryAccessError) -> Errno {

--- a/lib/wasix/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasix/src/runtime/package_loader/builtin_loader.rs
@@ -11,7 +11,7 @@ use http::{HeaderMap, Method};
 use tempfile::NamedTempFile;
 use url::Url;
 use wasmer_package::{
-    package::WasmerPackageError,
+    WasmerPackageError,
     utils::{from_bytes, from_disk},
 };
 use webc::DetectError;

--- a/lib/wasix/src/runtime/package_loader/builtin_loader.rs
+++ b/lib/wasix/src/runtime/package_loader/builtin_loader.rs
@@ -32,7 +32,8 @@ use crate::{
 pub struct BuiltinPackageLoader {
     client: Arc<dyn HttpClient + Send + Sync>,
     in_memory: Option<InMemoryCache>,
-    cache: Option<FileSystemCache>,
+    cache: Option<Arc<dyn PackageCache>>,
+    filesystem_cache: Option<Arc<FileSystemCache>>,
     /// A mapping from hostnames to tokens
     tokens: HashMap<String, String>,
 
@@ -57,6 +58,7 @@ impl BuiltinPackageLoader {
             in_memory: Some(InMemoryCache::default()),
             client: Arc::new(crate::http::default_http_client().unwrap()),
             cache: None,
+            filesystem_cache: None,
             hash_validation: HashIntegrityValidationMode::NoValidate,
             tokens: HashMap::new(),
         }
@@ -71,10 +73,21 @@ impl BuiltinPackageLoader {
     }
 
     pub fn with_cache_dir(self, cache_dir: impl Into<PathBuf>) -> Self {
+        let cache = Arc::new(FileSystemCache {
+            cache_dir: cache_dir.into(),
+        });
         BuiltinPackageLoader {
-            cache: Some(FileSystemCache {
-                cache_dir: cache_dir.into(),
-            }),
+            cache: Some(cache.clone()),
+            filesystem_cache: Some(cache),
+            ..self
+        }
+    }
+
+    /// Use a target-provided persistent package cache.
+    pub fn with_cache(self, cache: Arc<dyn PackageCache>) -> Self {
+        BuiltinPackageLoader {
+            cache: Some(cache),
+            filesystem_cache: None,
             ..self
         }
     }
@@ -88,7 +101,7 @@ impl BuiltinPackageLoader {
     }
 
     pub fn cache(&self) -> Option<&FileSystemCache> {
-        self.cache.as_ref()
+        self.filesystem_cache.as_deref()
     }
 
     pub fn validate_cache(
@@ -96,9 +109,9 @@ impl BuiltinPackageLoader {
         mode: CacheValidationMode,
     ) -> Result<Vec<ImageHashMismatchError>, anyhow::Error> {
         let cache = self
-            .cache
-            .as_ref()
-            .context("can not validate cache - no cache configured")?;
+            .filesystem_cache
+            .as_deref()
+            .context("can not validate cache - no filesystem cache configured")?;
 
         let items = cache.validate_hashes()?;
         let mut errors = Vec::new();
@@ -185,14 +198,24 @@ impl BuiltinPackageLoader {
             return Ok(Some(cached));
         }
 
-        if let Some(cache) = self.cache.as_ref()
-            && let Some(cached) = cache.lookup(hash).await?
-        {
-            if let Some(in_memory) = &self.in_memory {
-                tracing::debug!("Copying from the filesystem cache to the in-memory cache");
-                in_memory.save(&cached, *hash);
+        if let Some(cache) = self.cache.as_ref() {
+            match cache.lookup(hash).await {
+                Ok(Some(cached)) => {
+                    if let Some(in_memory) = &self.in_memory {
+                        tracing::debug!("Copying from the persistent cache to the in-memory cache");
+                        in_memory.save(&cached, *hash);
+                    }
+                    return Ok(Some(cached));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        error = &*error,
+                        pkg.hash = %hash,
+                        "Unable to read a cached package; treating it as a cache miss",
+                    );
+                }
             }
-            return Ok(Some(cached));
         }
 
         Ok(None)
@@ -438,10 +461,7 @@ impl PackageLoader for BuiltinPackageLoader {
         // in a smart way to keep memory usage down.
 
         if let Some(cache) = &self.cache {
-            match cache
-                .save_and_load_as_mmapped(bytes.clone(), &summary.dist)
-                .await
-            {
+            match cache.save(bytes.clone(), &summary.dist).await {
                 Ok(container) => {
                     tracing::debug!("Cached to disk");
                     if let Some(in_memory) = &self.in_memory {
@@ -519,6 +539,16 @@ pub struct FileSystemCache {
     cache_dir: PathBuf,
 }
 
+/// Persistent storage for immutable WEBC package contents.
+#[async_trait::async_trait]
+pub trait PackageCache: Send + Sync + std::fmt::Debug {
+    /// Load and decode a package by its expected content hash.
+    async fn lookup(&self, hash: &WebcHash) -> Result<Option<Container>, Error>;
+
+    /// Persist downloaded bytes and return a decoded container.
+    async fn save(&self, webc: Bytes, dist: &DistributionInfo) -> Result<Container, Error>;
+}
+
 impl FileSystemCache {
     const FILE_SUFFIX: &'static str = ".bin";
 
@@ -584,7 +614,7 @@ impl FileSystemCache {
         Ok(items)
     }
 
-    async fn lookup(&self, hash: &WebcHash) -> Result<Option<Container>, Error> {
+    async fn lookup_impl(&self, hash: &WebcHash) -> Result<Option<Container>, Error> {
         let path = self.path(hash);
 
         let container = crate::spawn_blocking({
@@ -606,7 +636,7 @@ impl FileSystemCache {
         }
     }
 
-    async fn save(&self, webc: Bytes, dist: &DistributionInfo) -> Result<PathBuf, Error> {
+    async fn save_impl(&self, webc: Bytes, dist: &DistributionInfo) -> Result<PathBuf, Error> {
         let path = self.path(&dist.webc_sha256);
         let dist = dist.clone();
         let temp_dir = self.temp_dir();
@@ -648,11 +678,11 @@ impl FileSystemCache {
         dist: &DistributionInfo,
     ) -> Result<Container, Error> {
         // First, save it to disk
-        self.save(webc, dist).await?;
+        self.save_impl(webc, dist).await?;
 
         // Now try to load it again. The resulting container should use
         // a memory-mapped file rather than an in-memory buffer.
-        match self.lookup(&dist.webc_sha256).await? {
+        match self.lookup_impl(&dist.webc_sha256).await? {
             Some(container) => Ok(container),
             None => {
                 // Something really weird has occurred and we can't see the
@@ -760,6 +790,17 @@ impl FileSystemCache {
         })
         .await?
         .context("tokio runtime failed")
+    }
+}
+
+#[async_trait::async_trait]
+impl PackageCache for FileSystemCache {
+    async fn lookup(&self, hash: &WebcHash) -> Result<Option<Container>, Error> {
+        self.lookup_impl(hash).await
+    }
+
+    async fn save(&self, webc: Bytes, dist: &DistributionInfo) -> Result<Container, Error> {
+        self.save_and_load_as_mmapped(webc, dist).await
     }
 }
 
@@ -875,7 +916,7 @@ mod tests {
         assert_eq!(manifest.entrypoint.as_deref(), Some("python"));
         // it should have been automatically saved to disk
         let path = loader
-            .cache
+            .filesystem_cache
             .as_ref()
             .unwrap()
             .path(&summary.dist.webc_sha256);
@@ -1155,7 +1196,7 @@ mod tests {
         }
 
         let path1 = cache
-            .save(
+            .save_impl(
                 Bytes::from_static(b"test1"),
                 &DistributionInfo {
                     webc: Url::parse("file:///test1.webc").unwrap(),
@@ -1165,7 +1206,7 @@ mod tests {
             .await
             .unwrap();
         let path2 = cache
-            .save(
+            .save_impl(
                 Bytes::from_static(b"test2"),
                 &DistributionInfo {
                     webc: Url::parse("file:///test2.webc").unwrap(),

--- a/lib/wasix/src/runtime/package_loader/mod.rs
+++ b/lib/wasix/src/runtime/package_loader/mod.rs
@@ -4,6 +4,9 @@ mod types;
 mod unsupported;
 
 pub use self::{
-    builtin_loader::BuiltinPackageLoader, load_package_tree::load_package_tree,
-    types::PackageLoader, types::to_module_hash, unsupported::UnsupportedPackageLoader,
+    builtin_loader::{BuiltinPackageLoader, PackageCache},
+    load_package_tree::load_package_tree,
+    types::PackageLoader,
+    types::to_module_hash,
+    unsupported::UnsupportedPackageLoader,
 };

--- a/lib/wasix/src/runtime/resolver/backend_source.rs
+++ b/lib/wasix/src/runtime/resolver/backend_source.rs
@@ -1,14 +1,12 @@
-use std::{
-    path::{MAIN_SEPARATOR_STR, PathBuf},
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{io::Write, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{Context, Error};
+use bytes::Bytes;
 use http::{HeaderMap, Method};
 use semver::{Version, VersionReq};
 use url::Url;
 use wasmer_config::package::{NamedPackageId, PackageHash, PackageId, PackageIdent, PackageSource};
+use web_time::SystemTime;
 use webc::metadata::Manifest;
 
 use crate::{
@@ -24,7 +22,7 @@ use crate::{
 pub struct BackendSource {
     registry_endpoint: Url,
     client: Arc<dyn HttpClient + Send + Sync>,
-    cache: Option<FileSystemCache>,
+    cache: Option<QueryCacheConfig>,
     token: Option<String>,
     preferred_webc_version: webc::Version,
 }
@@ -45,8 +43,13 @@ impl BackendSource {
 
     /// Cache query results locally.
     pub fn with_local_cache(self, cache_dir: impl Into<PathBuf>, timeout: Duration) -> Self {
+        self.with_query_cache(Arc::new(FileSystemQueryCache::new(cache_dir)), timeout)
+    }
+
+    /// Cache registry query results in target-provided persistent storage.
+    pub fn with_query_cache(self, cache: Arc<dyn QueryCache>, timeout: Duration) -> Self {
         BackendSource {
-            cache: Some(FileSystemCache::new(cache_dir, timeout)),
+            cache: Some(QueryCacheConfig { cache, timeout }),
             ..self
         }
     }
@@ -262,7 +265,7 @@ impl Source for BackendSource {
         };
 
         if let Some(cache) = &self.cache {
-            match cache.lookup_cached_query(&package_name) {
+            match lookup_cached_query(cache, &package_name).await {
                 Ok(Some(cached)) => {
                     if let Ok(cached) = matching_package_summaries(
                         package,
@@ -291,7 +294,7 @@ impl Source for BackendSource {
             .map_err(|error| QueryError::new_other(error, package))?;
 
         if let Some(cache) = &self.cache
-            && let Err(e) = cache.update(&package_name, &response)
+            && let Err(e) = update_cached_query(cache, &package_name, &response).await
         {
             tracing::warn!(
                 package_name,
@@ -444,100 +447,76 @@ fn decode_summary(
     })
 }
 
-/// A local cache for package queries.
+/// Persistent storage for serialized registry query responses.
+#[async_trait::async_trait]
+pub trait QueryCache: Send + Sync + std::fmt::Debug {
+    /// Load the serialized cache entry for a package name.
+    async fn load(&self, package_name: &str) -> Result<Option<Bytes>, Error>;
+
+    /// Persist a serialized cache entry for a package name.
+    async fn save(&self, package_name: &str, bytes: Bytes) -> Result<(), Error>;
+
+    /// Remove the cache entry for a package name, if present.
+    async fn remove(&self, package_name: &str) -> Result<(), Error>;
+}
+
 #[derive(Debug, Clone)]
-struct FileSystemCache {
-    cache_dir: PathBuf,
+struct QueryCacheConfig {
+    cache: Arc<dyn QueryCache>,
     timeout: Duration,
 }
 
-impl FileSystemCache {
-    fn new(cache_dir: impl Into<PathBuf>, timeout: Duration) -> Self {
-        FileSystemCache {
+/// A local filesystem cache for registry queries.
+#[derive(Debug, Clone)]
+struct FileSystemQueryCache {
+    cache_dir: PathBuf,
+}
+
+impl FileSystemQueryCache {
+    fn new(cache_dir: impl Into<PathBuf>) -> Self {
+        Self {
             cache_dir: cache_dir.into(),
-            timeout,
         }
     }
 
     fn path(&self, package_name: &str) -> PathBuf {
         self.cache_dir
-            .join(package_name.replace(MAIN_SEPARATOR_STR, "#"))
+            .join(package_name.replace('/', "#").replace('\\', "#"))
     }
+}
 
-    fn lookup_cached_query(&self, package_name: &str) -> Result<Option<WebQuery>, Error> {
+#[async_trait::async_trait]
+impl QueryCache for FileSystemQueryCache {
+    async fn load(&self, package_name: &str) -> Result<Option<Bytes>, Error> {
         let filename = self.path(package_name);
 
         let _span =
             tracing::debug_span!("lookup_cached_query", filename=%filename.display()).entered();
 
         tracing::trace!("Reading cached entry from disk");
-        let json = match std::fs::read(&filename) {
-            Ok(json) => json,
+        match std::fs::read(&filename) {
+            Ok(json) => Ok(Some(Bytes::from(json))),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 tracing::debug!("Cache miss");
-                return Ok(None);
+                Ok(None)
             }
             Err(e) => {
-                return Err(
-                    Error::new(e).context(format!("Unable to read \"{}\"", filename.display()))
-                );
+                Err(Error::new(e).context(format!("Unable to read \"{}\"", filename.display())))
             }
-        };
-
-        let entry: CacheEntry = match serde_json::from_slice(&json) {
-            Ok(entry) => entry,
-            Err(e) => {
-                // If the entry is invalid, we should delete it to avoid work
-                // in the future
-                let _ = std::fs::remove_file(&filename);
-
-                return Err(Error::new(e).context("Unable to parse the cached query"));
-            }
-        };
-
-        if !entry.is_still_valid(self.timeout) {
-            tracing::debug!(timestamp = entry.unix_timestamp, "Cached entry is stale");
-            let _ = std::fs::remove_file(&filename);
-            return Ok(None);
         }
-
-        if entry.package_name != package_name {
-            let _ = std::fs::remove_file(&filename);
-            anyhow::bail!(
-                "The cached response at \"{}\" corresponds to the \"{}\" package, but expected \"{}\"",
-                filename.display(),
-                entry.package_name,
-                package_name,
-            );
-        }
-
-        Ok(Some(entry.response))
     }
 
-    fn update(&self, package_name: &str, response: &WebQuery) -> Result<(), Error> {
-        let entry = CacheEntry {
-            unix_timestamp: SystemTime::UNIX_EPOCH
-                .elapsed()
-                .unwrap_or_default()
-                .as_secs(),
-            package_name: package_name.to_string(),
-            response: response.clone(),
-        };
-
+    async fn save(&self, package_name: &str, bytes: Bytes) -> Result<(), Error> {
         let _ = std::fs::create_dir_all(&self.cache_dir);
 
-        // First, save our cache entry to disk
         let mut temp = tempfile::NamedTempFile::new_in(&self.cache_dir)
             .context("Unable to create a temporary file")?;
-        serde_json::to_writer_pretty(&mut temp, &entry)
-            .context("Unable to serialize the cache entry")?;
+        temp.write_all(&bytes)
+            .context("Unable to write the cached query")?;
         temp.as_file()
             .sync_all()
             .context("Flushing the temp file failed")?;
 
-        // Now we've saved our cache entry we need to move it to the right
-        // location. We do this in two steps so concurrent queries don't see
-        // the cache entry until it has been completely written.
         let filename = self.path(package_name);
         tracing::debug!(
             filename=%filename.display(),
@@ -557,6 +536,65 @@ impl FileSystemCache {
 
         Ok(())
     }
+
+    async fn remove(&self, package_name: &str) -> Result<(), Error> {
+        match std::fs::remove_file(self.path(package_name)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+async fn lookup_cached_query(
+    cache: &QueryCacheConfig,
+    package_name: &str,
+) -> Result<Option<WebQuery>, Error> {
+    let Some(json) = cache.cache.load(package_name).await? else {
+        return Ok(None);
+    };
+
+    let entry: CacheEntry = match serde_json::from_slice(&json) {
+        Ok(entry) => entry,
+        Err(error) => {
+            let _ = cache.cache.remove(package_name).await;
+            return Err(Error::new(error).context("Unable to parse the cached query"));
+        }
+    };
+
+    if !entry.is_still_valid(cache.timeout) {
+        tracing::debug!(timestamp = entry.unix_timestamp, "Cached entry is stale");
+        let _ = cache.cache.remove(package_name).await;
+        return Ok(None);
+    }
+
+    if entry.package_name != package_name {
+        let _ = cache.cache.remove(package_name).await;
+        anyhow::bail!(
+            "The cached response corresponds to the \"{}\" package, but expected \"{}\"",
+            entry.package_name,
+            package_name,
+        );
+    }
+
+    Ok(Some(entry.response))
+}
+
+async fn update_cached_query(
+    cache: &QueryCacheConfig,
+    package_name: &str,
+    response: &WebQuery,
+) -> Result<(), Error> {
+    let entry = CacheEntry {
+        unix_timestamp: SystemTime::UNIX_EPOCH
+            .elapsed()
+            .unwrap_or_default()
+            .as_secs(),
+        package_name: package_name.to_string(),
+        response: response.clone(),
+    };
+    let bytes = serde_json::to_vec_pretty(&entry).context("Unable to serialize cached query")?;
+    cache.cache.save(package_name, Bytes::from(bytes)).await
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1211,12 +1249,13 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let source = BackendSource::new(registry_endpoint, client.clone())
             .with_local_cache(temp.path(), Duration::from_secs(0));
-        source
-            .cache
-            .as_ref()
-            .unwrap()
-            .update("wasmer/python", &cached_value)
-            .unwrap();
+        update_cached_query(
+            source.cache.as_ref().unwrap(),
+            "wasmer/python",
+            &cached_value,
+        )
+        .await
+        .unwrap();
 
         let summaries = source.query(&request).await.unwrap();
 

--- a/lib/wasix/src/runtime/resolver/backend_source.rs
+++ b/lib/wasix/src/runtime/resolver/backend_source.rs
@@ -480,8 +480,7 @@ impl FileSystemQueryCache {
     }
 
     fn path(&self, package_name: &str) -> PathBuf {
-        self.cache_dir
-            .join(package_name.replace('/', "#").replace('\\', "#"))
+        self.cache_dir.join(package_name.replace(['/', '\\'], "#"))
     }
 }
 
@@ -490,33 +489,24 @@ impl QueryCache for FileSystemQueryCache {
     async fn load(&self, package_name: &str) -> Result<Option<Bytes>, Error> {
         let filename = self.path(package_name);
 
-        let _span =
-            tracing::debug_span!("lookup_cached_query", filename=%filename.display()).entered();
-
-        tracing::trace!("Reading cached entry from disk");
-        match std::fs::read(&filename) {
+        tracing::trace!(filename=%filename.display(), "Reading cached entry from disk");
+        let result = crate::spawn_blocking(move || match std::fs::read(&filename) {
             Ok(json) => Ok(Some(Bytes::from(json))),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                tracing::debug!("Cache miss");
-                Ok(None)
-            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(e) => {
                 Err(Error::new(e).context(format!("Unable to read \"{}\"", filename.display())))
             }
+        })
+        .await
+        .context("Unable to run the cache read task")??;
+        if result.is_none() {
+            tracing::debug!("Cache miss");
         }
+        Ok(result)
     }
 
     async fn save(&self, package_name: &str, bytes: Bytes) -> Result<(), Error> {
-        let _ = std::fs::create_dir_all(&self.cache_dir);
-
-        let mut temp = tempfile::NamedTempFile::new_in(&self.cache_dir)
-            .context("Unable to create a temporary file")?;
-        temp.write_all(&bytes)
-            .context("Unable to write the cached query")?;
-        temp.as_file()
-            .sync_all()
-            .context("Flushing the temp file failed")?;
-
+        let cache_dir = self.cache_dir.clone();
         let filename = self.path(package_name);
         tracing::debug!(
             filename=%filename.display(),
@@ -524,25 +514,44 @@ impl QueryCache for FileSystemQueryCache {
             "Saving the query to disk",
         );
 
-        if let Some(parent) = filename.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        temp.persist(&filename).with_context(|| {
-            format!(
-                "Unable to persist the temp file to \"{}\"",
-                filename.display()
-            )
-        })?;
+        crate::spawn_blocking(move || -> Result<(), Error> {
+            let _ = std::fs::create_dir_all(&cache_dir);
+
+            let mut temp = tempfile::NamedTempFile::new_in(&cache_dir)
+                .context("Unable to create a temporary file")?;
+            temp.write_all(&bytes)
+                .context("Unable to write the cached query")?;
+            temp.as_file()
+                .sync_all()
+                .context("Flushing the temp file failed")?;
+
+            if let Some(parent) = filename.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            temp.persist(&filename).with_context(|| {
+                format!(
+                    "Unable to persist the temp file to \"{}\"",
+                    filename.display()
+                )
+            })?;
+
+            Ok(())
+        })
+        .await
+        .context("Unable to run the cache write task")??;
 
         Ok(())
     }
 
     async fn remove(&self, package_name: &str) -> Result<(), Error> {
-        match std::fs::remove_file(self.path(package_name)) {
+        let filename = self.path(package_name);
+        crate::spawn_blocking(move || match std::fs::remove_file(filename) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(error.into()),
-        }
+        })
+        .await
+        .context("Unable to run the cache removal task")?
     }
 }
 

--- a/lib/wasix/src/runtime/resolver/mod.rs
+++ b/lib/wasix/src/runtime/resolver/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod utils;
 mod web_source;
 
 pub use self::{
-    backend_source::BackendSource,
+    backend_source::{BackendSource, QueryCache},
     filesystem_source::FileSystemSource,
     in_memory_source::InMemorySource,
     inputs::{


### PR DESCRIPTION
This PR makes package loading more modular (via feature flags), allowing smaller builds on the SDK

- splits wasmer-package into execution and authoring features
- adds explicit WebC version features
- lets WASIX use custom package and registry query caches
- updates the workspace crates to enable only the package features they need

This reduces the dependencies required by runtime-only builds while keeping the full package authoring functionality available for the SDK and CLI.