### PR TITLE
Enable asynchronous JavaScript host reentry

### DIFF
--- a/lib/api/src/backend/js/entities/function/env.rs
+++ b/lib/api/src/backend/js/entities/function/env.rs
@@ -280,7 +280,7 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
         let store = self
             .store
             .upgrade()
-            .expect("async function store was dropped");
+            .expect("async function environment outlived its Function::call_async store context");
         AsyncFunctionEnvHandle {
             read_lock: store.read_lock().await,
             func_env: self.func_env.clone(),
@@ -291,7 +291,7 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
         let store = self
             .store
             .upgrade()
-            .expect("async function store was dropped");
+            .expect("async function environment outlived its Function::call_async store context");
         AsyncFunctionEnvHandleMut {
             write_lock: store.write_lock().await,
             func_env: self.func_env.clone(),
@@ -309,7 +309,12 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
     /// Uses the Store context already installed on the current JSPI stack.
     /// This permits synchronous callbacks to re-enter the guest without
     /// attempting to acquire the async Store lock a second time.
-    pub fn with_current_mut<R>(
+    ///
+    /// # Safety
+    ///
+    /// No other mutable handle to this Store may be accessible while the
+    /// closure runs.
+    pub unsafe fn with_current_mut<R>(
         &self,
         f: impl FnOnce(FunctionEnvMut<'_, T>) -> R,
     ) -> Option<R> {
@@ -331,7 +336,7 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
     pub fn as_store_async(&self) -> impl AsStoreAsync + 'static {
         self.store
             .upgrade()
-            .expect("async function store was dropped")
+            .expect("async function environment outlived its Function::call_async store context")
     }
 }
 

--- a/lib/api/src/backend/js/entities/function/env.rs
+++ b/lib/api/src/backend/js/entities/function/env.rs
@@ -1,13 +1,13 @@
 use std::{any::Any, fmt::Debug, marker::PhantomData};
 
-use crate::{
-    StoreMut,
-    js::{store::StoreHandle, vm::VMFunctionEnvironment},
-    store::{AsStoreMut, AsStoreRef, StoreRef},
-};
 #[cfg(feature = "experimental-async")]
 use crate::{
-    AsStoreAsync, StoreAsync, StoreAsyncReadLock, StoreAsyncWriteLock,
+    AsStoreAsync, StoreAsync, StoreAsyncReadLock, StoreAsyncWriteLock, WeakStoreAsync,
+};
+use crate::{
+    StoreContext, StoreMut,
+    js::{store::StoreHandle, vm::VMFunctionEnvironment},
+    store::{AsStoreMut, AsStoreRef, StoreRef},
 };
 #[cfg(feature = "experimental-async")]
 use wasmer_types::StoreId;
@@ -157,6 +157,15 @@ impl<T: Send + 'static> FunctionEnvMut<'_, T> {
     pub fn as_store_async(&self) -> Option<impl AsStoreAsync + 'static> {
         self.store_mut.as_store_async()
     }
+
+    #[cfg(feature = "experimental-async")]
+    pub fn as_async_mut(&self) -> Option<AsyncFunctionEnvMut<T>> {
+        let store = StoreAsync::from_context(self.store_mut.as_store_ref().objects().id())?;
+        Some(AsyncFunctionEnvMut {
+            store: store.downgrade(),
+            func_env: self.func_env.clone(),
+        })
+    }
 }
 
 impl<T> AsStoreRef for FunctionEnvMut<'_, T> {
@@ -219,7 +228,7 @@ impl<T> From<FunctionEnv<T>> for crate::FunctionEnv<T> {
 
 #[cfg(feature = "experimental-async")]
 pub struct AsyncFunctionEnvMut<T> {
-    pub(crate) store: StoreAsync,
+    pub(crate) store: WeakStoreAsync,
     pub(crate) func_env: FunctionEnv<T>,
 }
 
@@ -239,10 +248,7 @@ pub struct AsyncFunctionEnvHandleMut<T> {
 impl<T> Clone for AsyncFunctionEnvMut<T> {
     fn clone(&self) -> Self {
         Self {
-            store: StoreAsync {
-                id: self.store.id,
-                inner: self.store.inner.clone(),
-            },
+            store: self.store.clone(),
             func_env: self.func_env.clone(),
         }
     }
@@ -254,7 +260,10 @@ where
     T: Send + Debug + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.store.inner.try_read() {
+        let Some(store) = self.store.upgrade() else {
+            return write!(f, "AsyncFunctionEnvMut {{ <STORE DROPPED> }}");
+        };
+        match store.inner.try_read() {
             Some(read_lock) => self.func_env.as_ref(&read_lock).fmt(f),
             None => write!(f, "AsyncFunctionEnvMut {{ <STORE LOCKED> }}"),
         }
@@ -264,21 +273,51 @@ where
 #[cfg(feature = "experimental-async")]
 impl<T: 'static> AsyncFunctionEnvMut<T> {
     pub(crate) fn store_id(&self) -> StoreId {
-        self.store.id
+        self.store.id()
     }
 
     pub async fn read(&self) -> AsyncFunctionEnvHandle<T> {
+        let store = self
+            .store
+            .upgrade()
+            .expect("async function store was dropped");
         AsyncFunctionEnvHandle {
-            read_lock: self.store.read_lock().await,
+            read_lock: store.read_lock().await,
             func_env: self.func_env.clone(),
         }
     }
 
     pub async fn write(&self) -> AsyncFunctionEnvHandleMut<T> {
+        let store = self
+            .store
+            .upgrade()
+            .expect("async function store was dropped");
         AsyncFunctionEnvHandleMut {
-            write_lock: self.store.write_lock().await,
+            write_lock: store.write_lock().await,
             func_env: self.func_env.clone(),
         }
+    }
+
+    pub fn try_write(&self) -> Option<AsyncFunctionEnvHandleMut<T>> {
+        let store = self.store.upgrade()?;
+        Some(AsyncFunctionEnvHandleMut {
+            write_lock: StoreAsyncWriteLock::try_acquire(&store)?,
+            func_env: self.func_env.clone(),
+        })
+    }
+
+    /// Uses the Store context already installed on the current JSPI stack.
+    /// This permits synchronous callbacks to re-enter the guest without
+    /// attempting to acquire the async Store lock a second time.
+    pub fn with_current_mut<R>(
+        &self,
+        f: impl FnOnce(FunctionEnvMut<'_, T>) -> R,
+    ) -> Option<R> {
+        let mut store_wrapper = unsafe { StoreContext::try_get_current(self.store_id()) }?;
+        Some(f(FunctionEnvMut {
+            store_mut: store_wrapper.as_mut(),
+            func_env: self.func_env.clone(),
+        }))
     }
 
     pub fn as_ref(&self) -> FunctionEnv<T> {
@@ -290,10 +329,9 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
     }
 
     pub fn as_store_async(&self) -> impl AsStoreAsync + 'static {
-        StoreAsync {
-            id: self.store.id,
-            inner: self.store.inner.clone(),
-        }
+        self.store
+            .upgrade()
+            .expect("async function store was dropped")
     }
 }
 

--- a/lib/api/src/backend/js/entities/function/mod.rs
+++ b/lib/api/src/backend/js/entities/function/mod.rs
@@ -130,7 +130,7 @@ impl Function {
             };
             let callback_store = async_store.store();
             let js_env = JsAsyncFunctionEnvMut {
-                store: async_store,
+                store: async_store.downgrade(),
                 func_env: raw_env.clone(),
             };
             let env_mut =

--- a/lib/api/src/backend/js/entities/memory/mod.rs
+++ b/lib/api/src/backend/js/entities/memory/mod.rs
@@ -42,6 +42,14 @@ unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}
 
 impl Memory {
+    /// Returns the JavaScript backing buffer for this WebAssembly memory.
+    ///
+    /// Host integrations can use this to create zero-copy typed-array views
+    /// over shared guest memory.
+    pub fn js_buffer(&self) -> wasm_bindgen::JsValue {
+        self.handle.memory.buffer()
+    }
+
     pub fn new(store: &mut impl AsStoreMut, mut ty: MemoryType) -> Result<Self, MemoryError> {
         if ty.shared
             && let Some(maximum) = ty.maximum

--- a/lib/api/src/entities/function/env/inner.rs
+++ b/lib/api/src/entities/function/env/inner.rs
@@ -289,13 +289,20 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
     }
 
     /// Uses the Store context already installed on the current JSPI stack.
+    ///
+    /// # Safety
+    ///
+    /// No other mutable handle to this Store may be accessible while the
+    /// closure runs.
     #[cfg(feature = "js")]
-    pub fn with_current_mut<R>(
+    pub unsafe fn with_current_mut<R>(
         &self,
         f: impl FnOnce(BackendFunctionEnvMut<'_, T>) -> R,
     ) -> Option<R> {
         match self {
-            Self::Js(env) => env.with_current_mut(|env| f(BackendFunctionEnvMut::Js(env))),
+            Self::Js(env) => unsafe {
+                env.with_current_mut(|env| f(BackendFunctionEnvMut::Js(env)))
+            },
             #[allow(unreachable_patterns)]
             _ => None,
         }

--- a/lib/api/src/entities/function/env/inner.rs
+++ b/lib/api/src/entities/function/env/inner.rs
@@ -158,6 +158,17 @@ impl<T: Send + 'static> BackendFunctionEnvMut<'_, T> {
         let id = self.as_store_ref().inner.objects.id();
         crate::StoreAsync::from_context(id)
     }
+
+    /// Creates a shared async function-environment handle from a synchronous
+    /// import running inside an async store context.
+    #[cfg(all(feature = "experimental-async", feature = "js"))]
+    pub fn as_async_mut(&self) -> Option<BackendAsyncFunctionEnvMut<T>> {
+        match self {
+            Self::Js(f) => f.as_async_mut().map(BackendAsyncFunctionEnvMut::Js),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
 }
 
 impl<T> AsStoreRef for BackendFunctionEnvMut<'_, T> {
@@ -262,6 +273,31 @@ impl<T: 'static> BackendAsyncFunctionEnvMut<T> {
             Self::Js(f) => BackendAsyncFunctionEnvHandleMut::Js(f.write().await),
             #[cfg(feature = "v8")]
             _ => unsupported_async_backend(),
+        }
+    }
+
+    /// Attempts to acquire the store immediately and returns a mutable handle
+    /// when it is not currently executing on another stack.
+    #[cfg(feature = "js")]
+    pub fn try_write(&self) -> Option<BackendAsyncFunctionEnvHandleMut<T>> {
+        match self {
+            #[cfg(feature = "js")]
+            Self::Js(f) => f.try_write().map(BackendAsyncFunctionEnvHandleMut::Js),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    }
+
+    /// Uses the Store context already installed on the current JSPI stack.
+    #[cfg(feature = "js")]
+    pub fn with_current_mut<R>(
+        &self,
+        f: impl FnOnce(BackendFunctionEnvMut<'_, T>) -> R,
+    ) -> Option<R> {
+        match self {
+            Self::Js(env) => env.with_current_mut(|env| f(BackendFunctionEnvMut::Js(env))),
+            #[allow(unreachable_patterns)]
+            _ => None,
         }
     }
 

--- a/lib/api/src/entities/function/env/mod.rs
+++ b/lib/api/src/entities/function/env/mod.rs
@@ -161,9 +161,17 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
     }
 
     /// Uses the Store context already installed on the current JSPI stack.
+    ///
+    /// # Safety
+    ///
+    /// No other [`StoreMut`](crate::StoreMut), [`FunctionEnvMut`], or other
+    /// mutable handle to this Store may be accessible while the closure runs.
     #[cfg(feature = "js")]
-    pub fn with_current_mut<R>(&self, f: impl FnOnce(FunctionEnvMut<'_, T>) -> R) -> Option<R> {
-        self.0.with_current_mut(|env| f(FunctionEnvMut(env)))
+    pub unsafe fn with_current_mut<R>(
+        &self,
+        f: impl FnOnce(FunctionEnvMut<'_, T>) -> R,
+    ) -> Option<R> {
+        unsafe { self.0.with_current_mut(|env| f(FunctionEnvMut(env))) }
     }
 
     /// Borrows a new immmutable reference

--- a/lib/api/src/entities/function/env/mod.rs
+++ b/lib/api/src/entities/function/env/mod.rs
@@ -92,6 +92,13 @@ impl<T: Send + 'static> FunctionEnvMut<'_, T> {
     pub fn as_store_async(&self) -> Option<impl AsStoreAsync + 'static> {
         self.0.as_store_async()
     }
+
+    /// Creates a shared async handle to this function environment when the
+    /// synchronous import is running as part of [`Function::call_async`].
+    #[cfg(all(feature = "experimental-async", feature = "js"))]
+    pub fn as_async_mut(&self) -> Option<AsyncFunctionEnvMut<T>> {
+        self.0.as_async_mut().map(AsyncFunctionEnvMut)
+    }
 }
 
 impl<T> AsStoreRef for FunctionEnvMut<'_, T> {
@@ -144,6 +151,19 @@ impl<T: 'static> AsyncFunctionEnvMut<T> {
     /// function environment.
     pub async fn write(&self) -> AsyncFunctionEnvHandleMut<T> {
         AsyncFunctionEnvHandleMut(self.0.write().await)
+    }
+
+    /// Attempts to acquire the store immediately and returns a mutable handle
+    /// if no other stack currently owns it.
+    #[cfg(feature = "js")]
+    pub fn try_write(&self) -> Option<AsyncFunctionEnvHandleMut<T>> {
+        self.0.try_write().map(AsyncFunctionEnvHandleMut)
+    }
+
+    /// Uses the Store context already installed on the current JSPI stack.
+    #[cfg(feature = "js")]
+    pub fn with_current_mut<R>(&self, f: impl FnOnce(FunctionEnvMut<'_, T>) -> R) -> Option<R> {
+        self.0.with_current_mut(|env| f(FunctionEnvMut(env)))
     }
 
     /// Borrows a new immmutable reference

--- a/lib/api/src/entities/memory/shared.rs
+++ b/lib/api/src/entities/memory/shared.rs
@@ -75,6 +75,14 @@ impl SharedMemory {
         }
     }
 
+    /// The backing VM shared-memory handle.
+    ///
+    /// Clones share the underlying allocation, allowing embedders to grow the
+    /// memory from a thread that does not hold a Store.
+    pub fn vm_shared_memory(&self) -> &VMSharedMemory {
+        &self.memory
+    }
+
     #[inline]
     fn shared_ops(&self) -> Result<&(dyn SharedMemoryOps + Send + Sync), AtomicsError> {
         self.ops

--- a/lib/api/src/entities/store/async_.rs
+++ b/lib/api/src/entities/store/async_.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 use crate::{
-    AsStoreMut, AsStoreRef, LocalRwLock, LocalRwLockReadGuard, LocalRwLockWriteGuard, Store,
-    StoreContext, StoreInner, StoreMut, StorePtrWrapper, StoreRef,
+    AsStoreMut, AsStoreRef, LocalRwLock, LocalRwLockReadGuard, LocalRwLockWeak,
+    LocalRwLockWriteGuard, Store, StoreContext, StoreInner, StoreMut, StorePtrWrapper, StoreRef,
 };
 
 use wasmer_types::StoreId;
@@ -13,6 +13,12 @@ pub struct StoreAsync {
     pub(crate) id: StoreId,
     // We use a box inside the RW lock because the StoreInner shouldn't be moved
     pub(crate) inner: LocalRwLock<Box<StoreInner>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct WeakStoreAsync {
+    id: StoreId,
+    inner: LocalRwLockWeak<Box<StoreInner>>,
 }
 
 impl StoreAsync {
@@ -27,6 +33,13 @@ impl StoreAsync {
                 }),
             }),
             _ => None,
+        }
+    }
+
+    pub(crate) fn downgrade(&self) -> WeakStoreAsync {
+        WeakStoreAsync {
+            id: self.id,
+            inner: self.inner.downgrade(),
         }
     }
 
@@ -65,6 +78,19 @@ impl StoreAsync {
 
         let store_guard = self.inner.try_write().expect("StoreAsync is locked");
         StoreAsyncWriteLock { inner: store_guard }
+    }
+}
+
+impl WeakStoreAsync {
+    pub(crate) fn id(&self) -> StoreId {
+        self.id
+    }
+
+    pub(crate) fn upgrade(&self) -> Option<StoreAsync> {
+        Some(StoreAsync {
+            id: self.id,
+            inner: self.inner.upgrade()?,
+        })
     }
 }
 
@@ -138,6 +164,12 @@ impl StoreAsyncWriteLock {
     pub(crate) async fn acquire(store: &StoreAsync) -> Self {
         let store_guard = store.inner.write().await;
         Self { inner: store_guard }
+    }
+
+    pub(crate) fn try_acquire(store: &StoreAsync) -> Option<Self> {
+        Some(Self {
+            inner: store.inner.try_write()?,
+        })
     }
 }
 

--- a/lib/api/src/entities/store/local_rwlock.rs
+++ b/lib/api/src/entities/store/local_rwlock.rs
@@ -13,12 +13,16 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::task::{Context, Poll, Waker};
 
 /// The main lock type.
 pub struct LocalRwLock<T> {
     inner: Rc<LocalRwLockInner<T>>,
+}
+
+pub struct LocalRwLockWeak<T> {
+    inner: Weak<LocalRwLockInner<T>>,
 }
 
 struct LocalRwLockInner<T> {
@@ -68,6 +72,12 @@ impl<T> LocalRwLock<T> {
         }
     }
 
+    pub fn downgrade(&self) -> LocalRwLockWeak<T> {
+        LocalRwLockWeak {
+            inner: Rc::downgrade(&self.inner),
+        }
+    }
+
     /// Attempts to acquire a read lock with a `'static` lifetime without waiting.
     pub fn try_read(&self) -> Option<LocalRwLockReadGuard<T>> {
         if self.inner.try_read() {
@@ -103,6 +113,22 @@ impl<T> LocalRwLock<T> {
             }
         } else {
             Err(self)
+        }
+    }
+}
+
+impl<T> LocalRwLockWeak<T> {
+    pub fn upgrade(&self) -> Option<LocalRwLock<T>> {
+        Some(LocalRwLock {
+            inner: self.inner.upgrade()?,
+        })
+    }
+}
+
+impl<T> Clone for LocalRwLockWeak<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
         }
     }
 }


### PR DESCRIPTION
This PR adds the Wasmer API pieces needed for a JavaScript host callback to reenter a guest running through JSPI:

- creates an async function environment from a synchronous import callback
- keeps only a weak reference to the async store
- supports non-blocking store acquisition and reuse of the store already active on the current JSPI stack
- exposes the JavaScript memory buffer and the VM shared-memory handle for zero-copy host integrations