### PR TITLE
fix(wasix): distinguish data-only file synchronization

### DIFF
--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -347,6 +347,17 @@ impl<'a> OpenOptions<'a> {
 pub trait VirtualFile:
     fmt::Debug + AsyncRead + AsyncWrite + AsyncSeek + Unpin + Upcastable + Send
 {
+    /// Polls until file data has reached durable storage.
+    ///
+    /// Unlike [`AsyncWrite::poll_flush`], this operation need not synchronize
+    /// metadata that is not required to retrieve the file's data. The default
+    /// delegates to `poll_flush`, preserving the stronger behavior of existing
+    /// backends. Implementors should override this only when they can provide a
+    /// genuine data-durability barrier.
+    fn poll_sync_data(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+
     /// the last time the file was accessed in nanoseconds as a UNIX timestamp
     fn last_accessed(&self) -> u64;
 

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -72,6 +72,10 @@ pub(crate) struct FlushPoller {
     pub(crate) file: VirtualFileLock,
 }
 
+pub(crate) struct DataSyncPoller {
+    pub(crate) file: VirtualFileLock,
+}
+
 /// Result of removing an fd under `fd_map.write()`, with an optional flush target
 /// captured before `drop_one_handle` may clear the inode handle.
 pub(crate) struct CloseFdOutcome {
@@ -97,6 +101,17 @@ impl Future for FlushPoller {
         let mut file = self.file.write().unwrap();
         Pin::new(file.as_mut())
             .poll_flush(cx)
+            .map_err(|_| Errno::Io)
+    }
+}
+
+impl Future for DataSyncPoller {
+    type Output = Result<(), Errno>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut file = self.file.write().unwrap();
+        Pin::new(file.as_mut())
+            .poll_sync_data(cx)
             .map_err(|_| Errno::Io)
     }
 }
@@ -2898,13 +2913,122 @@ pub fn fs_error_into_wasi_err(fs_error: FsError) -> Errno {
 mod tests {
     use super::*;
     use once_cell::sync::OnceCell;
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll};
     use tempfile::tempdir;
+    use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
     use virtual_fs::{RootFileSystemBuilder, TmpFileSystem};
     use wasmer::Engine;
     use wasmer_config::package::PackageId;
 
     use crate::WasiEnvBuilder;
     use crate::bin_factory::{BinaryPackage, BinaryPackageMount, BinaryPackageMounts};
+
+    #[derive(Debug)]
+    struct SyncProbe {
+        flushes: Arc<AtomicUsize>,
+        data_syncs: Arc<AtomicUsize>,
+    }
+
+    impl AsyncRead for SyncProbe {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for SyncProbe {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.flushes.fetch_add(1, Ordering::Relaxed);
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncSeek for SyncProbe {
+        fn start_seek(self: Pin<&mut Self>, _position: io::SeekFrom) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    impl VirtualFile for SyncProbe {
+        fn poll_sync_data(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.data_syncs.fetch_add(1, Ordering::Relaxed);
+            Poll::Ready(Ok(()))
+        }
+
+        fn last_accessed(&self) -> u64 {
+            0
+        }
+
+        fn last_modified(&self) -> u64 {
+            0
+        }
+
+        fn created_time(&self) -> u64 {
+            0
+        }
+
+        fn size(&self) -> u64 {
+            0
+        }
+
+        fn set_len(&mut self, _new_size: u64) -> virtual_fs::Result<()> {
+            Ok(())
+        }
+
+        fn unlink(&mut self) -> virtual_fs::Result<()> {
+            Ok(())
+        }
+
+        fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+
+        fn poll_write_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(usize::MAX))
+        }
+    }
+
+    #[tokio::test]
+    async fn data_sync_poller_uses_data_barrier_without_flushing() {
+        let flushes = Arc::new(AtomicUsize::new(0));
+        let data_syncs = Arc::new(AtomicUsize::new(0));
+        let file: VirtualFileLock = Arc::new(RwLock::new(Box::new(SyncProbe {
+            flushes: flushes.clone(),
+            data_syncs: data_syncs.clone(),
+        })));
+
+        DataSyncPoller { file: file.clone() }.await.unwrap();
+        assert_eq!(data_syncs.load(Ordering::Relaxed), 1);
+        assert_eq!(flushes.load(Ordering::Relaxed), 0);
+
+        FlushPoller { file }.await.unwrap();
+        assert_eq!(data_syncs.load(Ordering::Relaxed), 1);
+        assert_eq!(flushes.load(Ordering::Relaxed), 1);
+    }
 
     fn webc_symlink_fs() -> virtual_fs::WebcVolumeFileSystem {
         let timestamps = webc::v3::Timestamps::default();

--- a/lib/wasix/src/syscalls/wasi/fd_datasync.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_datasync.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::fs::FlushPoller;
+use crate::fs::DataSyncPoller;
 use crate::syscalls::*;
 
 /// ### `fd_datasync()`
@@ -33,6 +33,6 @@ pub fn fd_datasync(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<E
     drop(fd_entry);
 
     Ok(wasi_try_ok!(__asyncify(&mut ctx, None, async move {
-        FlushPoller { file }.await.map(|_| Errno::Success)
+        DataSyncPoller { file }.await.map(|_| Errno::Success)
     })?))
 }


### PR DESCRIPTION
# Description

Route WASI fd_datasync through a distinct VirtualFile data-durability operation instead of treating it as an ordinary flush.

VirtualFile::poll_sync_data defaults to poll_flush, so existing filesystem backends retain their current, stronger behavior. Backends with a real data-only durability primitive can override it without changing fd_sync semantics.

This matters for PostgreSQL and other durability-sensitive WASI guests: fd_datasync is an explicit commit barrier and should remain distinguishable from both buffered flushing and full metadata synchronization.

Focused validation on current main:

- cargo fmt with Rust 1.95
- exact data-sync dispatch test passes
- virtual-fs test suite: 121 passed, 2 ignored on the 7.2.1 backport
- wasmer-wasix test suite: 209 passed, 2 ignored on the 7.2.1 backport
- Linux host probe confirms a backend override can issue fdatasync rather than fsync

The default is deliberately conservative; this PR does not weaken durability for existing implementations.
