### PR TITLE
perf(wasix): shut down final file handles once

### DIFF
--- a/lib/wasix/src/fs/fd_list.rs
+++ b/lib/wasix/src/fs/fd_list.rs
@@ -186,13 +186,11 @@ impl FdList {
             self.fds.resize(idx + 1, None);
         }
 
-        if self.fds[idx].is_some() {
-            if exclusive {
-                return InsertOutcome {
-                    inserted: false,
-                    shutdown_target: None,
-                };
-            }
+        if self.fds[idx].is_some() && exclusive {
+            return InsertOutcome {
+                inserted: false,
+                shutdown_target: None,
+            };
         }
 
         // Acquire the incoming reference before dropping a replaced one. If

--- a/lib/wasix/src/fs/fd_list.rs
+++ b/lib/wasix/src/fs/fd_list.rs
@@ -10,13 +10,32 @@
 //! must be atomic with respect to concurrent open/close. Lock order: fd map before
 //! inode (see module comment in `mod.rs`).
 
-use super::fd::{Fd, FdInner};
+use super::{
+    VirtualFileLock,
+    fd::{Fd, FdInner},
+};
 use wasmer_wasix_types::wasi::Fd as WasiFd;
 
 #[derive(Debug)]
 pub struct FdList {
     fds: Vec<Option<Fd>>,
     first_free: Option<usize>,
+}
+
+/// Result of installing an fd. Replacements surface the old open-file
+/// description only when that replacement dropped its final descriptor.
+#[must_use = "replacement shutdown targets must be drained"]
+pub(crate) struct InsertOutcome {
+    pub inserted: bool,
+    pub shutdown_target: Option<VirtualFileLock>,
+}
+
+/// An fd removed from the map together with the final-handle shutdown target,
+/// if this removal closed the shared open-file description.
+#[must_use = "final-handle shutdown targets must be drained"]
+pub(crate) struct RemoveOutcome {
+    pub fd: Fd,
+    pub shutdown_target: Option<VirtualFileLock>,
 }
 
 pub struct FdListIterator<'a> {
@@ -72,6 +91,12 @@ impl FdList {
 
     pub fn insert_first_free(&mut self, fd: Fd) -> WasiFd {
         fd.inode.acquire_handle();
+        self.insert_first_free_preacquired(fd)
+    }
+
+    /// Installs an fd whose inode handle count was already incremented while
+    /// holding that inode's write lock.
+    pub(crate) fn insert_first_free_preacquired(&mut self, fd: Fd) -> WasiFd {
         match self.first_free {
             Some(free) => {
                 assert!(self.fds[free].is_none());
@@ -93,7 +118,7 @@ impl FdList {
         match self.first_free {
             // We're shorter than `after`, need to extend the list regardless of whether we have holes
             _ if self.fds.len() < after_or_equal as usize => {
-                if !self.insert(true, after_or_equal, fd) {
+                if !self.insert(true, after_or_equal, fd).inserted {
                     panic!(
                         "Internal error in FdList - expected {after_or_equal} to be unoccupied since the list wasn't long enough"
                     );
@@ -143,7 +168,7 @@ impl FdList {
             .map(|idx| idx + skip)
     }
 
-    pub fn insert(&mut self, exclusive: bool, idx: WasiFd, fd: Fd) -> bool {
+    pub(crate) fn insert(&mut self, exclusive: bool, idx: WasiFd, fd: Fd) -> InsertOutcome {
         let idx = idx as usize;
 
         if self.fds.len() <= idx {
@@ -161,51 +186,86 @@ impl FdList {
             self.fds.resize(idx + 1, None);
         }
 
-        if let Some(ref prev_fd) = self.fds[idx] {
+        if self.fds[idx].is_some() {
             if exclusive {
-                return false;
-            } else {
-                prev_fd.inode.drop_one_handle();
+                return InsertOutcome {
+                    inserted: false,
+                    shutdown_target: None,
+                };
             }
         }
 
+        // Acquire the incoming reference before dropping a replaced one. If
+        // both entries share an inode, this prevents a transient final-close
+        // transition during dup2-style replacement.
         fd.inode.acquire_handle();
-        self.fds[idx] = Some(fd);
+        let previous = self.fds[idx].replace(fd);
+        let shutdown_target = previous.and_then(|fd| fd.inode.drop_one_handle());
 
         if self.first_free == Some(idx) {
             self.first_free = self.first_free_after(idx as WasiFd + 1);
         }
 
+        InsertOutcome {
+            inserted: true,
+            shutdown_target,
+        }
+    }
+
+    /// Installs a pre-acquired fd into an unoccupied exact slot.
+    pub(crate) fn insert_preacquired(&mut self, idx: WasiFd, fd: Fd) -> bool {
+        let idx = idx as usize;
+
+        if self.fds.len() <= idx {
+            if self.first_free.is_none() && idx > self.fds.len() {
+                self.first_free = Some(self.fds.len());
+            }
+            self.fds.resize(idx + 1, None);
+        }
+
+        if self.fds[idx].is_some() {
+            return false;
+        }
+
+        self.fds[idx] = Some(fd);
+        if self.first_free == Some(idx) {
+            self.first_free = self.first_free_after(idx as WasiFd + 1);
+        }
         true
     }
 
-    pub fn remove(&mut self, idx: WasiFd) -> Option<Fd> {
+    pub(crate) fn remove(&mut self, idx: WasiFd) -> Option<RemoveOutcome> {
         let idx = idx as usize;
 
-        let result = self.fds.get_mut(idx).and_then(|fd| fd.take());
+        let fd = self.fds.get_mut(idx).and_then(|fd| fd.take())?;
 
-        if let Some(fd) = result.as_ref() {
-            match self.first_free {
-                None => self.first_free = Some(idx),
-                Some(x) if x > idx => self.first_free = Some(idx),
-                _ => (),
-            }
-
-            fd.inode.drop_one_handle();
+        match self.first_free {
+            None => self.first_free = Some(idx),
+            Some(x) if x > idx => self.first_free = Some(idx),
+            _ => (),
         }
 
-        result
+        let shutdown_target = fd.inode.drop_one_handle();
+        Some(RemoveOutcome {
+            fd,
+            shutdown_target,
+        })
     }
 
-    pub fn clear(&mut self) {
-        for fd in &self.fds {
-            if let Some(fd) = fd.as_ref() {
-                fd.inode.drop_one_handle();
+    /// Removes every descriptor and returns all open-file descriptions whose
+    /// final descriptor was dropped. The caller must drain them after releasing
+    /// its fd-map lock.
+    pub fn clear(&mut self) -> Vec<VirtualFileLock> {
+        let mut shutdown_targets = Vec::new();
+        for fd in self.fds.iter_mut().filter_map(Option::take) {
+            if let Some(target) = fd.inode.drop_one_handle() {
+                shutdown_targets.push(target);
             }
         }
 
         self.fds.clear();
         self.first_free = None;
+        shutdown_targets
     }
 
     pub fn iter(&self) -> FdListIterator<'_> {
@@ -244,7 +304,9 @@ impl Clone for FdList {
 
 impl Drop for FdList {
     fn drop(&mut self) {
-        self.clear();
+        // Async shutdown cannot be driven from Drop. Normal process/reinit
+        // paths call `clear` explicitly and drain the returned targets first.
+        let _ = self.clear();
     }
 }
 
@@ -298,16 +360,27 @@ impl<'a> Iterator for FdListIteratorMut<'a> {
 mod tests {
     use std::{
         borrow::Cow,
+        io::{self, SeekFrom},
+        pin::Pin,
         sync::{
             Arc, RwLock,
-            atomic::{AtomicI32, AtomicU64},
+            atomic::{AtomicU64, AtomicUsize, Ordering},
+            mpsc,
         },
+        task::{Context, Poll},
+        thread,
+        time::{Duration, Instant},
     };
 
     use assert_panic::assert_panic;
+    use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+    use virtual_fs::{FsError, Pipe, VirtualFile};
     use wasmer_wasix_types::wasi::{Fdflags, Fdflagsext, Rights};
 
-    use crate::fs::{Inode, InodeGuard, InodeVal, Kind, fd::FdInner};
+    use crate::fs::{
+        FlushPoller, HANDLE_CLOSED, HANDLE_FINALIZING, HandleAcquire, HandleDrop, Inode,
+        InodeGuard, InodeVal, Kind, OpenHandleState, ShutdownPoller, fd::FdInner,
+    };
 
     use super::{Fd, FdList, WasiFd};
 
@@ -322,7 +395,7 @@ mod tests {
                     name: RwLock::new(Cow::Borrowed("")),
                     stat: RwLock::new(Default::default()),
                 }),
-                open_handles: Arc::new(AtomicI32::new(0)),
+                open_handles: Arc::new(OpenHandleState::new()),
             },
             is_stdio: false,
             inner: FdInner {
@@ -333,6 +406,128 @@ mod tests {
                 fd_flags: Fdflagsext::empty(),
             },
         }
+    }
+
+    #[derive(Debug)]
+    struct CountingFile {
+        flushes: Arc<AtomicUsize>,
+        shutdowns: Arc<AtomicUsize>,
+    }
+
+    impl AsyncRead for CountingFile {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for CountingFile {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.flushes.fetch_add(1, Ordering::SeqCst);
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.shutdowns.fetch_add(1, Ordering::SeqCst);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncSeek for CountingFile {
+        fn start_seek(self: Pin<&mut Self>, _position: SeekFrom) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    impl VirtualFile for CountingFile {
+        fn last_accessed(&self) -> u64 {
+            0
+        }
+
+        fn last_modified(&self) -> u64 {
+            0
+        }
+
+        fn created_time(&self) -> u64 {
+            0
+        }
+
+        fn size(&self) -> u64 {
+            0
+        }
+
+        fn set_len(&mut self, _new_size: u64) -> Result<(), FsError> {
+            Ok(())
+        }
+
+        fn unlink(&mut self) -> Result<(), FsError> {
+            Ok(())
+        }
+
+        fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+
+        fn poll_write_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(8192))
+        }
+    }
+
+    fn counting_fd(n: u16) -> (Fd, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let flushes = Arc::new(AtomicUsize::new(0));
+        let shutdowns = Arc::new(AtomicUsize::new(0));
+        let file = CountingFile {
+            flushes: flushes.clone(),
+            shutdowns: shutdowns.clone(),
+        };
+        let fd = Fd {
+            open_flags: 0,
+            inode: InodeGuard {
+                ino: Inode(n as u64),
+                inner: Arc::new(InodeVal {
+                    is_preopened: false,
+                    kind: RwLock::new(Kind::File {
+                        handle: Some(Arc::new(RwLock::new(Box::new(file)))),
+                        path: "".into(),
+                        fd: None,
+                    }),
+                    name: RwLock::new(Cow::Borrowed("counting")),
+                    stat: RwLock::new(Default::default()),
+                }),
+                open_handles: Arc::new(OpenHandleState::new()),
+            },
+            is_stdio: false,
+            inner: FdInner {
+                offset: Arc::new(AtomicU64::new(0)),
+                rights: Rights::FD_SYNC | Rights::FD_DATASYNC,
+                rights_inheriting: Rights::empty(),
+                flags: Fdflags::empty(),
+                fd_flags: Fdflagsext::empty(),
+            },
+        };
+        (fd, flushes, shutdowns)
+    }
+
+    fn drain_shutdown(target: super::VirtualFileLock) {
+        virtual_mio::block_on(ShutdownPoller { file: target }).unwrap();
     }
 
     fn is_useless_fd(fd: &Fd, n: u16) -> bool {
@@ -371,8 +566,8 @@ mod tests {
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
-        l.remove(1);
-        l.remove(2);
+        let _ = l.remove(1);
+        let _ = l.remove(2);
         l.insert_first_free(useless_fd(4));
 
         assert_fds_match(&l, &[(0, 0), (1, 4), (3, 3)]);
@@ -386,8 +581,8 @@ mod tests {
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
         l.insert_first_free(useless_fd(4));
-        l.remove(1);
-        l.remove(3);
+        let _ = l.remove(1);
+        let _ = l.remove(3);
         l.insert_first_free(useless_fd(5));
         l.insert_first_free(useless_fd(6));
 
@@ -401,9 +596,9 @@ mod tests {
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
-        l.remove(3);
+        let _ = l.remove(3);
         assert_eq!(l.first_free, Some(3));
-        l.remove(1);
+        let _ = l.remove(1);
         assert_eq!(l.first_free, Some(1));
         l.insert_first_free(useless_fd(4));
 
@@ -417,9 +612,9 @@ mod tests {
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
-        l.remove(1);
-        l.remove(2);
-        assert!(l.insert(true, 1, useless_fd(4)));
+        let _ = l.remove(1);
+        let _ = l.remove(2);
+        assert!(l.insert(true, 1, useless_fd(4)).inserted);
         assert_eq!(l.first_free, Some(2));
 
         assert_fds_match(&l, &[(0, 0), (1, 4), (3, 3)]);
@@ -444,12 +639,12 @@ mod tests {
         assert_eq!(l.next_free_fd(), 4);
         assert_eq!(l.last_fd(), Some(3));
 
-        l.remove(3);
+        let _ = l.remove(3);
 
         assert_eq!(l.next_free_fd(), 3);
         assert_eq!(l.last_fd(), Some(2));
 
-        l.remove(1);
+        let _ = l.remove(1);
 
         assert_eq!(l.next_free_fd(), 1);
         assert_eq!(l.last_fd(), Some(2));
@@ -464,8 +659,8 @@ mod tests {
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
         l.insert_first_free(useless_fd(4));
-        l.remove(1);
-        l.remove(3);
+        let _ = l.remove(1);
+        let _ = l.remove(3);
 
         assert!(l.get(1).is_none());
         assert!(is_useless_fd(l.get(2).unwrap(), 2));
@@ -486,15 +681,15 @@ mod tests {
         l.insert_first_free(useless_fd(0));
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
-        l.remove(1);
+        let _ = l.remove(1);
 
-        assert!(l.insert(false, 2, useless_fd(3)));
+        assert!(l.insert(false, 2, useless_fd(3)).inserted);
         assert!(is_useless_fd(l.get(2).unwrap(), 3));
 
-        assert!(!l.insert(true, 2, useless_fd(4)));
+        assert!(!l.insert(true, 2, useless_fd(4)).inserted);
         assert!(is_useless_fd(l.get(2).unwrap(), 3));
 
-        assert!(l.insert(true, 1, useless_fd(5)));
+        assert!(l.insert(true, 1, useless_fd(5)).inserted);
         assert!(is_useless_fd(l.get(1).unwrap(), 5));
     }
 
@@ -504,7 +699,7 @@ mod tests {
 
         l.insert_first_free(useless_fd(0));
 
-        assert!(l.insert(false, 1, useless_fd(1)));
+        assert!(l.insert(false, 1, useless_fd(1)).inserted);
         assert!(is_useless_fd(l.get(1).unwrap(), 1));
 
         // Extending by exactly one element shouldn't change first_free
@@ -513,7 +708,7 @@ mod tests {
         assert!(l.first_free.is_none());
 
         // Now create a hole
-        assert!(l.insert(false, 5, useless_fd(5)));
+        assert!(l.insert(false, 5, useless_fd(5)).inserted);
         assert!(is_useless_fd(l.get(5).unwrap(), 5));
 
         for i in 2..=4 {
@@ -536,7 +731,7 @@ mod tests {
     #[test]
     fn insert_first_free_after_beyond_end_of_non_empty_list() {
         let mut l = FdList::new();
-        l.insert(false, 0, useless_fd(0));
+        assert!(l.insert(false, 0, useless_fd(0)).inserted);
         assert_eq!(l.insert_first_free_after(useless_fd(1), 5), 5);
         assert!(is_useless_fd(l.get(5).unwrap(), 1));
     }
@@ -544,8 +739,8 @@ mod tests {
     #[test]
     fn insert_first_free_after_beyond_end_of_non_empty_list_with_hole() {
         let mut l = FdList::new();
-        l.insert(false, 0, useless_fd(0));
-        l.insert(false, 2, useless_fd(2));
+        assert!(l.insert(false, 0, useless_fd(0)).inserted);
+        assert!(l.insert(false, 2, useless_fd(2)).inserted);
         assert_eq!(l.insert_first_free_after(useless_fd(1), 5), 5);
         assert!(is_useless_fd(l.get(5).unwrap(), 1));
     }
@@ -557,7 +752,7 @@ mod tests {
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
-        l.remove(2).unwrap();
+        let _ = l.remove(2).unwrap();
         assert_eq!(l.insert_first_free_after(useless_fd(5), 1), 2);
         assert!(is_useless_fd(l.get(2).unwrap(), 5));
     }
@@ -581,7 +776,7 @@ mod tests {
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
         l.insert_first_free(useless_fd(4));
-        l.remove(1).unwrap();
+        let _ = l.remove(1).unwrap();
         assert_eq!(l.insert_first_free_after(useless_fd(5), 2), 5);
         assert!(is_useless_fd(l.get(5).unwrap(), 5));
     }
@@ -594,8 +789,8 @@ mod tests {
         l.insert_first_free(useless_fd(2));
         l.insert_first_free(useless_fd(3));
         l.insert_first_free(useless_fd(4));
-        l.remove(1).unwrap();
-        l.remove(3).unwrap();
+        let _ = l.remove(1).unwrap();
+        let _ = l.remove(3).unwrap();
         assert_eq!(l.insert_first_free_after(useless_fd(5), 2), 3);
         assert!(is_useless_fd(l.get(3).unwrap(), 5));
     }
@@ -608,7 +803,7 @@ mod tests {
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
 
-        assert!(is_useless_fd(&l.remove(1).unwrap(), 1));
+        assert!(is_useless_fd(&l.remove(1).unwrap().fd, 1));
         assert!(l.remove(1).is_none());
         assert!(l.remove(100000).is_none());
     }
@@ -620,9 +815,9 @@ mod tests {
         l.insert_first_free(useless_fd(0));
         l.insert_first_free(useless_fd(1));
         l.insert_first_free(useless_fd(2));
-        l.remove(1);
+        let _ = l.remove(1);
 
-        l.clear();
+        assert!(l.clear().is_empty());
 
         assert_eq!(l.next_free_fd(), 0);
         assert!(l.last_fd().is_none());
@@ -664,7 +859,7 @@ mod tests {
         // Try removing an FD, should drop the handle
         let fd1 = l.get(1).unwrap().clone();
         assert_eq!(fd1.inode.handle_count(), 1);
-        l.remove(1).unwrap();
+        let _ = l.remove(1).unwrap();
         assert_eq!(fd1.inode.handle_count(), 0);
 
         // Existing FDs should get a new handle when cloning the list
@@ -680,20 +875,302 @@ mod tests {
         }
 
         // Clearing the list should drop open handles
-        l.clear();
+        assert!(l.clear().is_empty());
         assert_eq!(fd0.inode.handle_count(), 1);
 
         // Clear the last handle, should go back to zero
-        l2.clear();
+        assert!(l2.clear().is_empty());
         assert_eq!(fd0.inode.handle_count(), 0);
 
         assert_panic!(
-            fd0.inode.drop_one_handle(),
+            {
+                let _ = fd0.inode.drop_one_handle();
+            },
             &str,
             "InodeGuard handle dropped too many times"
         );
 
         assert_panic!(drop(fd0.inode.write()), String, contains "PoisonError");
+    }
+
+    #[test]
+    fn duplicated_descriptor_shutdowns_only_on_final_close() {
+        let (fd, flushes, shutdowns) = counting_fd(1);
+        let duplicate = fd.clone();
+        let mut fds = FdList::new();
+        fds.insert_first_free(fd);
+        fds.insert_first_free(duplicate);
+
+        let first = fds.remove(0).unwrap();
+        assert!(first.shutdown_target.is_none());
+        assert_eq!(first.fd.inode.handle_count(), 1);
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 0);
+
+        let last = fds.remove(1).unwrap();
+        assert_eq!(last.fd.inode.handle_count(), 0);
+        drain_shutdown(last.shutdown_target.unwrap());
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(flushes.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn forked_fd_map_shutdowns_only_after_both_processes_close() {
+        let (fd, _flushes, shutdowns) = counting_fd(2);
+        let mut parent = FdList::new();
+        parent.insert_first_free(fd);
+        let mut child = parent.clone();
+
+        let parent_close = parent.remove(0).unwrap();
+        assert!(parent_close.shutdown_target.is_none());
+        assert_eq!(parent_close.fd.inode.handle_count(), 1);
+
+        let child_close = child.remove(0).unwrap();
+        assert_eq!(child_close.fd.inode.handle_count(), 0);
+        drain_shutdown(child_close.shutdown_target.unwrap());
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn replacement_returns_only_replaced_final_description() {
+        let (source, _source_flushes, source_shutdowns) = counting_fd(3);
+        let (destination, _destination_flushes, destination_shutdowns) = counting_fd(4);
+        let mut fds = FdList::new();
+        fds.insert_first_free(source);
+        fds.insert_first_free(destination);
+
+        let duplicate = fds.get(0).unwrap().clone();
+        let replacement = fds.insert(false, 1, duplicate);
+        assert!(replacement.inserted);
+        drain_shutdown(replacement.shutdown_target.unwrap());
+        assert_eq!(destination_shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(source_shutdowns.load(Ordering::SeqCst), 0);
+
+        assert!(fds.remove(0).unwrap().shutdown_target.is_none());
+        let final_source = fds.remove(1).unwrap().shutdown_target.unwrap();
+        drain_shutdown(final_source);
+        assert_eq!(source_shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn explicit_sync_flush_is_distinct_from_close_shutdown() {
+        let (fd, flushes, shutdowns) = counting_fd(5);
+        let file = {
+            let guard = fd.inode.read();
+            match &*guard {
+                Kind::File {
+                    handle: Some(file), ..
+                } => file.clone(),
+                _ => unreachable!(),
+            }
+        };
+        let mut fds = FdList::new();
+        fds.insert_first_free(fd);
+
+        virtual_mio::block_on(FlushPoller { file }).unwrap();
+        assert_eq!(flushes.load(Ordering::SeqCst), 1);
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 0);
+
+        drain_shutdown(fds.remove(0).unwrap().shutdown_target.unwrap());
+        assert_eq!(flushes.load(Ordering::SeqCst), 1);
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn nonfinal_handle_changes_do_not_wait_for_inode_lock() {
+        let (fd, _flushes, _shutdowns) = counting_fd(6);
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+        assert_eq!(inode.handle_count(), 1);
+
+        // Holding the heavyweight inode lock must not stall OPEN(n) acquire or
+        // an OPEN(n>1) drop. This is the descriptor hot-path regression guard.
+        let inode_guard = inode.write();
+        let worker_inode = inode.clone();
+        let (tx, rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            worker_inode.acquire_handle();
+            tx.send(worker_inode.handle_count()).unwrap();
+            assert!(worker_inode.drop_one_handle().is_none());
+            tx.send(worker_inode.handle_count()).unwrap();
+        });
+
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), 2);
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), 1);
+        drop(inode_guard);
+        worker.join().unwrap();
+
+        drain_shutdown(inode.drop_one_handle().unwrap());
+    }
+
+    #[test]
+    fn finalizing_state_is_rescuable_but_owned_state_is_not() {
+        let state = OpenHandleState::new();
+        assert_eq!(state.try_acquire(), HandleAcquire::Acquired(1));
+        assert_eq!(state.begin_drop(), HandleDrop::Finalizing);
+        assert_eq!(state.raw(), HANDLE_FINALIZING);
+        assert_eq!(state.count(), 0);
+
+        // An acquire linearized before final ownership rescues the resource.
+        assert_eq!(state.try_acquire(), HandleAcquire::Acquired(1));
+        assert!(!state.try_own_final());
+        assert_eq!(state.count(), 1);
+
+        // Once ownership wins, ordinary acquisition must not silently create
+        // a descriptor; locked activation is required after final completion.
+        assert_eq!(state.begin_drop(), HandleDrop::Finalizing);
+        assert!(state.try_own_final());
+        assert_eq!(state.count(), 0);
+        assert_eq!(state.try_acquire(), HandleAcquire::NeedsLockedActivation);
+        state.finish_final(true);
+        assert_eq!(state.raw(), HANDLE_CLOSED);
+        assert_eq!(state.count(), 0);
+        assert_eq!(state.try_acquire(), HandleAcquire::NeedsLockedActivation);
+    }
+
+    #[test]
+    fn handle_count_overflow_panics_instead_of_wrapping() {
+        let state = OpenHandleState::new();
+        state.state.store(i32::MAX, Ordering::Release);
+        assert_panic!(
+            {
+                let _ = state.try_acquire();
+            },
+            &str,
+            "InodeGuard handle count overflow"
+        );
+        assert_eq!(state.raw(), i32::MAX);
+    }
+
+    #[test]
+    fn locked_path_open_can_rescue_a_waiting_final_drop() {
+        let (fd, _flushes, shutdowns) = counting_fd(7);
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+
+        // The closer can nominate the final transition while path_open holds
+        // the inode lock, but cannot own or extract the handle yet.
+        let inode_guard = inode.write();
+        let closer_inode = inode.clone();
+        let closer = thread::spawn(move || closer_inode.drop_one_handle());
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while inode.open_handles.raw() != HANDLE_FINALIZING {
+            assert!(Instant::now() < deadline, "closer never reached FINALIZING");
+            thread::yield_now();
+        }
+
+        inode.acquire_handle_locked(&inode_guard);
+        assert_eq!(inode.handle_count(), 1);
+        drop(inode_guard);
+        assert!(closer.join().unwrap().is_none());
+
+        drain_shutdown(inode.drop_one_handle().unwrap());
+        assert_eq!(shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn completed_final_close_requires_handle_install_before_locked_reopen() {
+        let (fd, _flushes, old_shutdowns) = counting_fd(8);
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+        drain_shutdown(inode.drop_one_handle().unwrap());
+        assert_eq!(old_shutdowns.load(Ordering::SeqCst), 1);
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+
+        let new_flushes = Arc::new(AtomicUsize::new(0));
+        let new_shutdowns = Arc::new(AtomicUsize::new(0));
+        let replacement = CountingFile {
+            flushes: new_flushes,
+            shutdowns: new_shutdowns.clone(),
+        };
+        {
+            let mut guard = inode.write();
+            let Kind::File { handle, .. } = &mut *guard else {
+                unreachable!();
+            };
+            assert!(handle.is_none());
+            *handle = Some(Arc::new(RwLock::new(Box::new(replacement))));
+            inode.acquire_handle_locked(&guard);
+        }
+        assert_eq!(inode.handle_count(), 1);
+
+        drain_shutdown(inode.drop_one_handle().unwrap());
+        assert_eq!(new_shutdowns.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn closed_file_cannot_reactivate_before_replacement_handle_is_installed() {
+        let (fd, _flushes, _shutdowns) = counting_fd(9);
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+        let _target = inode.drop_one_handle().unwrap();
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+
+        assert_panic!(
+            {
+                let guard = inode.write();
+                inode.acquire_handle_locked(&guard);
+            },
+            &str,
+            "cannot reactivate a closed file before installing its handle"
+        );
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+    }
+
+    #[test]
+    fn ordinary_acquire_cannot_attach_to_a_closed_or_later_reopened_file() {
+        let (fd, _flushes, _shutdowns) = counting_fd(10);
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+        let _target = inode.drop_one_handle().unwrap();
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+
+        assert_panic!(
+            inode.acquire_handle(),
+            &str,
+            "ordinary handle acquisition requires locked reactivation"
+        );
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+    }
+
+    #[test]
+    fn terminal_pipe_cannot_be_resurrected() {
+        let (tx, _rx) = Pipe::new().split();
+        let mut fd = useless_fd(11);
+        fd.inode.inner = Arc::new(InodeVal {
+            is_preopened: false,
+            kind: RwLock::new(Kind::PipeTx { tx }),
+            name: RwLock::new(Cow::Borrowed("pipe")),
+            stat: RwLock::new(Default::default()),
+        });
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+        assert!(inode.drop_one_handle().is_none());
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+
+        assert_panic!(
+            {
+                let guard = inode.write();
+                inode.acquire_handle_locked(&guard);
+            },
+            &str,
+            "cannot reactivate a terminal inode resource"
+        );
+        assert_eq!(inode.open_handles.raw(), HANDLE_CLOSED);
+    }
+
+    #[test]
+    fn resource_retaining_kind_returns_to_ready() {
+        let fd = useless_fd(12);
+        let inode = fd.inode.clone();
+        inode.acquire_handle();
+        assert!(inode.drop_one_handle().is_none());
+        assert_eq!(inode.open_handles.raw(), 0);
+
+        inode.acquire_handle();
+        assert_eq!(inode.handle_count(), 1);
+        assert!(inode.drop_one_handle().is_none());
+        assert_eq!(inode.open_handles.raw(), 0);
     }
 
     #[test]
@@ -704,7 +1181,7 @@ mod tests {
         l.insert_first_free(useless_fd(0));
 
         let fd = l.get(0).unwrap();
-        fd.inode.drop_one_handle();
+        let _ = fd.inode.drop_one_handle();
 
         assert_panic!(drop(l), &str, "InodeGuard handle dropped too many times");
     }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -72,12 +72,20 @@ pub(crate) struct FlushPoller {
     pub(crate) file: VirtualFileLock,
 }
 
-/// Result of removing an fd under `fd_map.write()`, with an optional flush target
-/// captured before `drop_one_handle` may clear the inode handle.
+/// Drives the close-time drain for the final descriptor that references an
+/// open file description. Unlike [`FlushPoller`], this is not a durability
+/// operation: `poll_shutdown` lets buffered/asynchronous backends finish their
+/// writes without turning every close into `fsync`/`fdatasync`.
+pub(crate) struct ShutdownPoller {
+    pub(crate) file: VirtualFileLock,
+}
+
+/// Result of removing an fd under `fd_map.write()`, with an optional shutdown
+/// target returned by the atomic final-handle transition.
 pub(crate) struct CloseFdOutcome {
     pub skipped_preopen: bool,
     pub removed: bool,
-    pub flush_target: Option<VirtualFileLock>,
+    pub shutdown_target: Option<VirtualFileLock>,
 }
 
 impl CloseFdOutcome {
@@ -85,7 +93,7 @@ impl CloseFdOutcome {
         Self {
             skipped_preopen: false,
             removed: false,
-            flush_target: None,
+            shutdown_target: None,
         }
     }
 }
@@ -97,6 +105,17 @@ impl Future for FlushPoller {
         let mut file = self.file.write().unwrap();
         Pin::new(file.as_mut())
             .poll_flush(cx)
+            .map_err(|_| Errno::Io)
+    }
+}
+
+impl Future for ShutdownPoller {
+    type Output = Result<(), Errno>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut file = self.file.write().unwrap();
+        Pin::new(file.as_mut())
+            .poll_shutdown(cx)
             .map_err(|_| Errno::Io)
     }
 }
@@ -177,8 +196,140 @@ pub struct InodeGuard {
     // number of FDs referencing this InodeGuard. We need that number
     // so we can know when to drop the file handle, which should result
     // in the backing file (which may be a host file) getting closed.
-    open_handles: Arc<AtomicI32>,
+    open_handles: Arc<OpenHandleState>,
 }
+
+// Positive values are live descriptor counts. These negative sentinels make
+// the final count transition and ownership of the inode resource linearizable
+// without putting the inode lock on ordinary acquire/drop paths.
+const HANDLE_FINALIZING: i32 = -1;
+const HANDLE_OWNED: i32 = -2;
+const HANDLE_CLOSED: i32 = -3;
+
+#[derive(Debug)]
+struct OpenHandleState {
+    state: AtomicI32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HandleAcquire {
+    Acquired(i32),
+    NeedsLockedActivation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HandleDrop {
+    NonFinal(i32),
+    Finalizing,
+    Invalid,
+}
+
+impl OpenHandleState {
+    fn new() -> Self {
+        // READY=0 is reserved for a newly created inode, or for an inode whose
+        // kind retains everything needed to create a future descriptor.
+        Self {
+            state: AtomicI32::new(0),
+        }
+    }
+
+    fn count(&self) -> u32 {
+        match self.state.load(Ordering::Acquire) {
+            count if count >= 0 => count as u32,
+            HANDLE_FINALIZING | HANDLE_OWNED | HANDLE_CLOSED => 0,
+            _ => panic!("InodeGuard handle state is corrupt"),
+        }
+    }
+
+    /// Acquires a descriptor reference without touching the inode lock on the
+    /// normal path. FINALIZING can still be rescued until a finalizer changes
+    /// it to OWNED under the inode write lock.
+    fn try_acquire(&self) -> HandleAcquire {
+        let mut current = self.state.load(Ordering::Acquire);
+        loop {
+            let next = match current {
+                HANDLE_FINALIZING => 1,
+                HANDLE_OWNED | HANDLE_CLOSED => return HandleAcquire::NeedsLockedActivation,
+                i32::MAX => panic!("InodeGuard handle count overflow"),
+                count if count >= 0 => count + 1,
+                _ => panic!("InodeGuard handle state is corrupt"),
+            };
+
+            match self.state.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return HandleAcquire::Acquired(next),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn begin_drop(&self) -> HandleDrop {
+        let mut current = self.state.load(Ordering::Acquire);
+        loop {
+            let (next, outcome) = match current {
+                count if count > 1 => (count - 1, HandleDrop::NonFinal(count - 1)),
+                1 => (HANDLE_FINALIZING, HandleDrop::Finalizing),
+                _ => return HandleDrop::Invalid,
+            };
+
+            match self.state.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return outcome,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    /// Called only while holding the inode write lock. A concurrent acquire
+    /// can rescue FINALIZING, but it cannot cross OWNED.
+    fn try_own_final(&self) -> bool {
+        self.state
+            .compare_exchange(
+                HANDLE_FINALIZING,
+                HANDLE_OWNED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Reactivates an inode only after the caller, under the inode write lock,
+    /// has verified that its kind still retains a usable resource or installed
+    /// a replacement file handle.
+    fn activate_closed_locked(&self) -> i32 {
+        self.state
+            .compare_exchange(HANDLE_CLOSED, 1, Ordering::AcqRel, Ordering::Acquire)
+            .map(|_| 1)
+            .unwrap_or_else(|state| {
+                panic!("closed InodeGuard activation raced with handle state {state}")
+            })
+    }
+
+    /// Completes final ownership while the inode write lock is still held.
+    fn finish_final(&self, resource_is_terminal: bool) {
+        let next = if resource_is_terminal {
+            HANDLE_CLOSED
+        } else {
+            0
+        };
+        self.state
+            .compare_exchange(HANDLE_OWNED, next, Ordering::AcqRel, Ordering::Acquire)
+            .unwrap_or_else(|state| panic!("final InodeGuard ownership was lost to state {state}"));
+    }
+
+    fn raw(&self) -> i32 {
+        self.state.load(Ordering::Acquire)
+    }
+}
+
 impl InodeGuard {
     pub fn ino(&self) -> Inode {
         self.ino
@@ -197,59 +348,134 @@ impl InodeGuard {
     }
 
     pub fn handle_count(&self) -> u32 {
-        self.open_handles.load(Ordering::SeqCst) as u32
+        self.open_handles.count()
     }
 
     pub fn acquire_handle(&self) {
-        let prev_handles = self.open_handles.fetch_add(1, Ordering::SeqCst);
-        trace!(ino = %self.ino.0, new_count = %(prev_handles + 1), "acquiring handle for InodeGuard");
+        match self.open_handles.try_acquire() {
+            HandleAcquire::Acquired(new_count) => {
+                trace!(ino = %self.ino.0, %new_count, "acquiring handle for InodeGuard");
+            }
+            HandleAcquire::NeedsLockedActivation => {
+                // Ordinary insertion cannot attach a stale descriptor to a
+                // resource already owned by final close, or to a later reopen
+                // of that inode. Only the explicit locked path-open API may
+                // reactivate CLOSED after installing a replacement handle.
+                panic!("ordinary handle acquisition requires locked reactivation")
+            }
+        }
     }
 
-    pub fn drop_one_handle(&self) {
-        let prev_handles = self.open_handles.fetch_sub(1, Ordering::SeqCst);
+    /// Acquires a descriptor reference while the caller already holds this
+    /// inode's write lock. This exists for path-open's handle installation,
+    /// where recursively taking the same `RwLock` would deadlock.
+    pub(crate) fn acquire_handle_locked(&self, guard: &std::sync::RwLockWriteGuard<'_, Kind>) {
+        let new_count = match self.open_handles.try_acquire() {
+            HandleAcquire::Acquired(new_count) => new_count,
+            HandleAcquire::NeedsLockedActivation => {
+                match self.open_handles.raw() {
+                    HANDLE_CLOSED => {}
+                    HANDLE_OWNED => {
+                        // The final owner must hold this same write lock, so
+                        // observing OWNED here means the wrong inode guard was
+                        // supplied or the state is corrupt.
+                        panic!("owned InodeGuard observed while holding its inode lock");
+                    }
+                    state => panic!("unexpected locked InodeGuard handle state {state}"),
+                }
 
-        trace!(ino = %self.ino.0, %prev_handles, "dropping handle for InodeGuard");
+                match guard.deref() {
+                    Kind::File {
+                        handle: Some(_), ..
+                    } => {}
+                    Kind::File { handle: None, .. } => {
+                        panic!("cannot reactivate a closed file before installing its handle")
+                    }
+                    Kind::PipeRx { .. }
+                    | Kind::PipeTx { .. }
+                    | Kind::Socket { .. }
+                    | Kind::DuplexPipe { .. }
+                    | Kind::Epoll { .. }
+                    | Kind::EventNotifications { .. } => {
+                        panic!("cannot reactivate a terminal inode resource")
+                    }
+                    Kind::Dir { .. }
+                    | Kind::Root { .. }
+                    | Kind::Symlink { .. }
+                    | Kind::Buffer { .. } => {
+                        panic!("resource-retaining inode unexpectedly entered CLOSED")
+                    }
+                }
 
-        // If this wasn't the last handle, nothing else to do...
-        if prev_handles > 1 {
-            return;
+                self.open_handles.activate_closed_locked()
+            }
+        };
+
+        if new_count <= 0 {
+            panic!("InodeGuard handle count is corrupt");
+        }
+        trace!(ino = %self.ino.0, %new_count, "acquiring handle for InodeGuard");
+    }
+
+    /// Drops one descriptor reference and returns the file only when this was
+    /// the final reference to the shared open-file description.
+    pub fn drop_one_handle(&self) -> Option<VirtualFileLock> {
+        match self.open_handles.begin_drop() {
+            HandleDrop::NonFinal(new_count) => {
+                trace!(ino = %self.ino.0, %new_count, "dropping non-final handle for InodeGuard");
+                return None;
+            }
+            HandleDrop::Invalid => {
+                // Preserve the existing fail-stop behavior: poison the inode
+                // lock before reporting a corrupt descriptor count.
+                let _guard = self.inner.write();
+                panic!("InodeGuard handle dropped too many times");
+            }
+            HandleDrop::Finalizing => {}
         }
 
-        // ... otherwise, drop the VirtualFile reference
+        // Only the candidate final transition takes the inode lock. An acquire
+        // that changes FINALIZING back to OPEN(1) wins before ownership; once
+        // this changes to OWNED, the handle can no longer be resurrected.
         let mut guard = self.inner.write();
-
-        // Must have at least one open handle before we can drop.
-        // This check happens after `inner` is locked so we can
-        // poison the lock and keep people from using this (possibly
-        // corrupt) InodeGuard.
-        if prev_handles != 1 {
-            panic!("InodeGuard handle dropped too many times");
-        }
-
-        // Re-check the open handles to account for race conditions
-        if self.open_handles.load(Ordering::SeqCst) != 0 {
-            return;
+        if !self.open_handles.try_own_final() {
+            trace!(ino = %self.ino.0, "final handle drop was rescued before ownership");
+            return None;
         }
 
         let ino = self.ino.0;
         trace!(%ino, "InodeGuard has no more open handles");
 
-        match guard.deref_mut() {
+        let (shutdown_target, resource_is_terminal) = match guard.deref_mut() {
             Kind::File { handle, .. } if handle.is_some() => {
                 let file_ref_count = Arc::strong_count(handle.as_ref().unwrap());
                 trace!(%file_ref_count, %ino, "dropping file handle");
-                drop(handle.take().unwrap());
+                (Some(handle.take().unwrap()), true)
             }
             Kind::PipeRx { rx } => {
                 trace!(%ino, "closing pipe rx");
                 rx.close();
+                (None, true)
             }
             Kind::PipeTx { tx } => {
                 trace!(%ino, "closing pipe tx");
                 tx.close();
+                (None, true)
             }
-            _ => (),
-        }
+            // A file whose handle is already absent is terminal too.
+            Kind::File { .. } => (None, true),
+            Kind::Socket { .. }
+            | Kind::DuplexPipe { .. }
+            | Kind::Epoll { .. }
+            | Kind::EventNotifications { .. } => (None, true),
+            // These inode kinds retain all state needed by a future open.
+            Kind::Dir { .. } | Kind::Root { .. } | Kind::Symlink { .. } | Kind::Buffer { .. } => {
+                (None, false)
+            }
+        };
+
+        self.open_handles.finish_final(resource_is_terminal);
+        shutdown_target
     }
 }
 impl std::ops::Deref for InodeGuard {
@@ -262,10 +488,9 @@ impl std::ops::Deref for InodeGuard {
 #[derive(Debug, Clone)]
 pub struct InodeWeakGuard {
     ino: Inode,
-    // Needed for when we want to upgrade back. We don't exactly
-    // care too much when the AtomicI32 is dropped, so this is
-    // a strong reference to keep things simple.
-    open_handles: Arc<AtomicI32>,
+    // Needed for when we want to upgrade back. We keep the descriptor state
+    // strongly referenced independently of the inode's weak reference.
+    open_handles: Arc<OpenHandleState>,
     inner: Weak<InodeVal>,
 }
 impl InodeWeakGuard {
@@ -346,7 +571,7 @@ impl WasiInodes {
             guard.lookup.retain(|_, v| Weak::strong_count(v) > 0);
         }
 
-        let open_handles = Arc::new(AtomicI32::new(0));
+        let open_handles = Arc::new(OpenHandleState::new());
 
         InodeGuard {
             ino,
@@ -716,7 +941,7 @@ impl WasiFs {
 
     /// Closes all file descriptors marked CLOEXEC (except stdio and preopens).
     pub async fn close_cloexec_fds(&self) {
-        let flush_targets = {
+        let shutdown_targets = {
             let mut fd_map = self.fd_map.write().unwrap();
             let to_close: Vec<WasiFd> = fd_map
                 .iter()
@@ -732,49 +957,44 @@ impl WasiFs {
                     }
                 })
                 .collect();
-            let mut flush_targets = Vec::new();
+            let mut shutdown_targets = Vec::new();
             for fd in to_close {
                 let outcome = Self::close_fd_locked(&mut fd_map, fd);
-                if let Some(target) = outcome.flush_target {
-                    flush_targets.push(target);
+                if let Some(target) = outcome.shutdown_target {
+                    shutdown_targets.push(target);
                 }
             }
-            flush_targets
+            shutdown_targets
         };
 
-        for file in flush_targets {
-            Self::flush_file_best_effort(file).await;
+        for file in shutdown_targets {
+            Self::shutdown_file_best_effort(file).await;
         }
     }
 
-    /// Closes all file descriptors, flushing captured handles after dropping the map lock.
+    /// Closes all file descriptors, draining final handles after dropping the map lock.
     pub async fn close_all(&self) {
-        let flush_targets = {
+        let shutdown_targets = {
             let mut fd_map = self.fd_map.write().unwrap();
             let mut fds: HashSet<WasiFd> = fd_map.keys().collect();
             fds.insert(__WASI_STDOUT_FILENO);
             fds.insert(__WASI_STDERR_FILENO);
 
-            let mut flush_targets = Vec::new();
+            let mut shutdown_targets = Vec::new();
             for fd in fds {
                 let outcome = Self::close_fd_locked(&mut fd_map, fd);
-                if let Some(target) = outcome.flush_target {
-                    flush_targets.push(target);
+                if let Some(target) = outcome.shutdown_target {
+                    shutdown_targets.push(target);
                 }
             }
 
             // Preopens skipped by close_fd_locked remain until clear().
-            for (_fd, fd_ref) in fd_map.iter().collect::<Vec<_>>() {
-                if let Some(target) = Self::file_flush_target(&fd_ref.inode) {
-                    flush_targets.push(target);
-                }
-            }
-            fd_map.clear();
-            flush_targets
+            shutdown_targets.extend(fd_map.clear());
+            shutdown_targets
         };
 
-        for file in flush_targets {
-            Self::flush_file_best_effort(file).await;
+        for file in shutdown_targets {
+            Self::shutdown_file_best_effort(file).await;
         }
     }
 
@@ -2049,6 +2269,36 @@ impl WasiFs {
         idx: Option<WasiFd>,
         exclusive: bool,
     ) -> Result<WasiFd, Errno> {
+        let (fd, shutdown_target) = Self::insert_fd_locked_and_capture_shutdown(
+            fd_map,
+            rights,
+            rights_inheriting,
+            fs_flags,
+            fd_flags,
+            open_flags,
+            inode,
+            idx,
+            exclusive,
+        )?;
+        assert!(
+            shutdown_target.is_none(),
+            "replacement insertion must drain its returned shutdown target"
+        );
+        Ok(fd)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_fd_locked_and_capture_shutdown(
+        fd_map: &mut FdList,
+        rights: Rights,
+        rights_inheriting: Rights,
+        fs_flags: Fdflags,
+        fd_flags: Fdflagsext,
+        open_flags: u16,
+        inode: InodeGuard,
+        idx: Option<WasiFd>,
+        exclusive: bool,
+    ) -> Result<(WasiFd, Option<VirtualFileLock>), Errno> {
         let fd = Self::make_fd(
             rights,
             rights_inheriting,
@@ -2064,13 +2314,61 @@ impl WasiFs {
                 if idx > MAX_FD {
                     return Err(Errno::Badf);
                 }
-                if fd_map.insert(exclusive, idx, fd) {
-                    Ok(idx)
+                let outcome = fd_map.insert(exclusive, idx, fd);
+                if outcome.inserted {
+                    Ok((idx, outcome.shutdown_target))
                 } else {
                     Err(Errno::Exist)
                 }
             }
-            None => Ok(fd_map.insert_first_free(fd)),
+            None => Ok((fd_map.insert_first_free(fd), None)),
+        }
+    }
+
+    /// Inserts an fd while path-open already holds this inode's write guard.
+    /// The reference count increment is performed under that existing guard,
+    /// avoiding both a recursive-lock deadlock and a gap in which a close in a
+    /// forked fd map could take the newly installed file handle.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn insert_fd_locked_with_inode_guard(
+        fd_map: &mut FdList,
+        rights: Rights,
+        rights_inheriting: Rights,
+        fs_flags: Fdflags,
+        fd_flags: Fdflagsext,
+        open_flags: u16,
+        inode: InodeGuard,
+        idx: Option<WasiFd>,
+        inode_guard: &std::sync::RwLockWriteGuard<'_, Kind>,
+    ) -> Result<WasiFd, Errno> {
+        if let Some(idx) = idx {
+            if idx > MAX_FD {
+                return Err(Errno::Badf);
+            }
+            if fd_map.get(idx).is_some() {
+                return Err(Errno::Exist);
+            }
+        }
+
+        inode.acquire_handle_locked(inode_guard);
+        let fd = Self::make_fd(
+            rights,
+            rights_inheriting,
+            fs_flags,
+            fd_flags,
+            open_flags,
+            inode,
+            idx,
+        );
+
+        match idx {
+            Some(idx) => {
+                if !fd_map.insert_preacquired(idx, fd) {
+                    unreachable!("fd slot changed while fd_map write lock was held");
+                }
+                Ok(idx)
+            }
+            None => Ok(fd_map.insert_first_free_preacquired(fd)),
         }
     }
 
@@ -2149,9 +2447,9 @@ impl WasiFs {
 
     /// POSIX dup2: copy `src` onto exact slot `dst`, replacing any existing entry.
     ///
-    /// Holds `fd_map.write()` for the full remove+insert. Returns a flush target for
-    /// the replaced `dst` entry (if any), captured while the lock is held and before
-    /// `remove` calls `drop_one_handle`, which may clear the inode's file handle.
+    /// Holds `fd_map.write()` for the full remove+insert. Returns a shutdown target
+    /// only when replacing `dst` drops the final descriptor for its open-file
+    /// description.
     pub(crate) fn dup2_at(
         &self,
         src: WasiFd,
@@ -2161,7 +2459,7 @@ impl WasiFs {
             return Err(Errno::Badf);
         }
 
-        let flush_target = {
+        let shutdown_target = {
             let mut fd_map = self.fd_map.write().unwrap();
 
             let fd_entry = fd_map.get(src).ok_or(Errno::Badf)?;
@@ -2194,20 +2492,18 @@ impl WasiFs {
                 ..*fd_entry
             };
 
-            let flush_target = fd_map
-                .get(dst)
-                .and_then(|fd| Self::file_flush_target(&fd.inode));
+            let shutdown_target = fd_map
+                .remove(dst)
+                .and_then(|removed| removed.shutdown_target);
 
-            fd_map.remove(dst);
-
-            if !fd_map.insert(true, dst, new_fd_entry) {
+            if !fd_map.insert(true, dst, new_fd_entry).inserted {
                 panic!("Internal error: expected FD {dst} to be free after remove in dup2_at");
             }
 
-            flush_target
+            shutdown_target
         };
 
-        Ok(flush_target)
+        Ok(shutdown_target)
     }
 
     pub fn create_fd(
@@ -2267,18 +2563,24 @@ impl WasiFs {
         idx: Option<WasiFd>,
         exclusive: bool,
     ) -> Result<WasiFd, Errno> {
-        let mut fd_map = self.fd_map.write().unwrap();
-        Self::insert_fd_locked(
-            &mut fd_map,
-            rights,
-            rights_inheriting,
-            fs_flags,
-            fd_flags,
-            open_flags,
-            inode,
-            idx,
-            exclusive,
-        )
+        let (fd, shutdown_target) = {
+            let mut fd_map = self.fd_map.write().unwrap();
+            Self::insert_fd_locked_and_capture_shutdown(
+                &mut fd_map,
+                rights,
+                rights_inheriting,
+                fs_flags,
+                fd_flags,
+                open_flags,
+                inode,
+                idx,
+                exclusive,
+            )?
+        };
+        if let Some(file) = shutdown_target {
+            virtual_mio::block_on(Self::shutdown_file_best_effort(file));
+        }
+        Ok(fd)
     }
 
     pub fn clone_fd(&self, fd: WasiFd) -> Result<WasiFd, Errno> {
@@ -2589,23 +2891,30 @@ impl WasiFs {
                 kind: RwLock::new(kind),
             })
         };
-        self.fd_map.write().unwrap().insert(
-            false,
-            raw_fd,
-            Fd {
-                inner: FdInner {
-                    rights,
-                    rights_inheriting: Rights::empty(),
-                    flags: fd_flags,
-                    offset: Arc::new(AtomicU64::new(0)),
-                    fd_flags: Fdflagsext::empty(),
+        let outcome = {
+            let mut fd_map = self.fd_map.write().unwrap();
+            fd_map.insert(
+                false,
+                raw_fd,
+                Fd {
+                    inner: FdInner {
+                        rights,
+                        rights_inheriting: Rights::empty(),
+                        flags: fd_flags,
+                        offset: Arc::new(AtomicU64::new(0)),
+                        fd_flags: Fdflagsext::empty(),
+                    },
+                    // since we're not calling open on this, we don't need open flags
+                    open_flags: 0,
+                    inode,
+                    is_stdio: true,
                 },
-                // since we're not calling open on this, we don't need open flags
-                open_flags: 0,
-                inode,
-                is_stdio: true,
-            },
-        );
+            )
+        };
+        debug_assert!(outcome.inserted);
+        if let Some(file) = outcome.shutdown_target {
+            virtual_mio::block_on(Self::shutdown_file_best_effort(file));
+        }
     }
 
     pub fn get_stat_for_kind(&self, kind: &Kind) -> Result<Filestat, Errno> {
@@ -2668,11 +2977,11 @@ impl WasiFs {
         })
     }
 
-    /// Closes an open FD under `fd_map.write()`, capturing a file handle for
-    /// post-close flush while the map lock is held.
+    /// Closes an open FD under `fd_map.write()`, returning the file handle only
+    /// for the atomic final-descriptor transition.
     ///
-    /// Lock order: `fd_map` write, then inode read (never the reverse).
-    pub(crate) fn close_fd_and_capture_flush(&self, fd: WasiFd) -> CloseFdOutcome {
+    /// Lock order: `fd_map` write, then inode write (never the reverse).
+    pub(crate) fn close_fd_and_capture_shutdown(&self, fd: WasiFd) -> CloseFdOutcome {
         let mut fd_map = self.fd_map.write().unwrap();
         Self::close_fd_locked(&mut fd_map, fd)
     }
@@ -2688,14 +2997,14 @@ impl WasiFs {
             return CloseFdOutcome {
                 skipped_preopen: true,
                 removed: false,
-                flush_target: None,
+                shutdown_target: None,
             };
         }
 
-        let flush_target = Self::file_flush_target(&fd_ref.inode);
-
-        match fd_map.remove(fd) {
-            Some(fd_ref) => {
+        let shutdown_target = match fd_map.remove(fd) {
+            Some(removed) => {
+                let shutdown_target = removed.shutdown_target;
+                let fd_ref = removed.fd;
                 let inode = fd_ref.inode.ino().as_u64();
                 let ref_cnt = fd_ref.inode.ref_cnt();
                 if ref_cnt == 1 {
@@ -2703,22 +3012,23 @@ impl WasiFs {
                 } else {
                     trace!(%fd, %inode, %ref_cnt, "weakening file descriptor");
                 }
+                shutdown_target
             }
             None => {
                 trace!(%fd, "closing file descriptor failed - {}", Errno::Badf);
                 return CloseFdOutcome::not_found();
             }
-        }
+        };
 
         CloseFdOutcome {
             skipped_preopen: false,
             removed: true,
-            flush_target,
+            shutdown_target,
         }
     }
 
-    pub(crate) async fn flush_file_best_effort(file: VirtualFileLock) {
-        let result = FlushPoller { file }.await;
+    pub(crate) async fn shutdown_file_best_effort(file: VirtualFileLock) {
+        let result = ShutdownPoller { file }.await;
         match result {
             Ok(())
             | Err(Errno::Isdir)
@@ -2726,23 +3036,16 @@ impl WasiFs {
             | Err(Errno::Access)
             // EINVAL is returned by e.g. pipe-backed stdio and is safe to ignore.
             | Err(Errno::Inval) => {}
-            Err(err) => trace!("flush during bulk close failed - {}", err),
-        }
-    }
-
-    fn file_flush_target(inode: &InodeGuard) -> Option<VirtualFileLock> {
-        let guard = inode.read();
-        match guard.deref() {
-            Kind::File {
-                handle: Some(file), ..
-            } => Some(file.clone()),
-            _ => None,
+            Err(err) => trace!("shutdown during bulk close failed - {}", err),
         }
     }
 
     /// Closes an open FD, handling all details such as FD being preopen
     pub(crate) fn close_fd(&self, fd: WasiFd) -> Result<(), Errno> {
-        let _ = self.close_fd_and_capture_flush(fd);
+        let outcome = self.close_fd_and_capture_shutdown(fd);
+        if let Some(file) = outcome.shutdown_target {
+            virtual_mio::block_on(Self::shutdown_file_best_effort(file));
+        }
         Ok(())
     }
 }

--- a/lib/wasix/src/journal/effector/syscalls/fd_close.rs
+++ b/lib/wasix/src/journal/effector/syscalls/fd_close.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::syscalls::flush_captured_handle;
+use crate::syscalls::shutdown_captured_handle;
 
 impl JournalEffector {
     pub fn save_fd_close(ctx: &mut FunctionEnvMut<'_, WasiEnv>, fd: Fd) -> anyhow::Result<()> {
@@ -9,7 +9,7 @@ impl JournalEffector {
     pub fn apply_fd_close(ctx: &mut FunctionEnvMut<'_, WasiEnv>, fd: Fd) -> anyhow::Result<()> {
         let env = ctx.data();
         let (_, state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
-        let outcome = state.fs.close_fd_and_capture_flush(fd);
+        let outcome = state.fs.close_fd_and_capture_shutdown(fd);
 
         if outcome.skipped_preopen {
             return Ok(());
@@ -22,9 +22,9 @@ impl JournalEffector {
             );
         }
 
-        flush_captured_handle(env, outcome.flush_target).map_err(|err| {
+        shutdown_captured_handle(env, outcome.shutdown_target).map_err(|err| {
             anyhow::anyhow!(
-                "journal restore error: failed to flush before closing descriptor (fd={fd}) - {err:?}"
+                "journal restore error: failed to drain before closing descriptor (fd={fd}) - {err:?}"
             )
         })?;
 

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -313,8 +313,13 @@ impl WasiEnv {
         if !self.disable_fs_cleanup {
             // First we clear any open files as the descriptors would
             // otherwise clash
-            if let Ok(mut map) = self.state.fs.fd_map.write() {
-                map.clear();
+            let shutdown_targets = if let Ok(mut map) = self.state.fs.fd_map.write() {
+                map.clear()
+            } else {
+                Vec::new()
+            };
+            for file in shutdown_targets {
+                block_on(crate::fs::WasiFs::shutdown_file_best_effort(file));
             }
             self.state.fs.preopen_fds.write().unwrap().clear();
             *self.state.fs.current_dir.lock().unwrap() = "/".to_string();

--- a/lib/wasix/src/syscalls/wasi/fd_close.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_close.rs
@@ -1,19 +1,19 @@
 use super::*;
-use crate::fs::FlushPoller;
+use crate::fs::ShutdownPoller;
 use crate::syscalls::*;
 
-/// Best-effort flush of a file handle captured before fd removal.
-pub(crate) fn flush_captured_handle(
+/// Best-effort close-time drain of the final file handle returned by fd removal.
+pub(crate) fn shutdown_captured_handle(
     env: &WasiEnv,
-    flush_target: Option<
+    shutdown_target: Option<
         std::sync::Arc<std::sync::RwLock<Box<dyn virtual_fs::VirtualFile + Send + Sync>>>,
     >,
 ) -> Result<Errno, WasiError> {
-    let Some(file) = flush_target else {
+    let Some(file) = shutdown_target else {
         return Ok(Errno::Success);
     };
 
-    match __asyncify_light(env, None, FlushPoller { file })? {
+    match __asyncify_light(env, None, ShutdownPoller { file })? {
         Ok(_)
         | Err(Errno::Isdir)
         | Err(Errno::Io)
@@ -42,7 +42,7 @@ pub fn fd_close(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errn
     let env = ctx.data();
     let (_, mut state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
 
-    let outcome = state.fs.close_fd_and_capture_flush(fd);
+    let outcome = state.fs.close_fd_and_capture_shutdown(fd);
 
     if outcome.skipped_preopen {
         trace!("Skipping fd_close for pre-opened FD ({})", fd);
@@ -53,7 +53,7 @@ pub fn fd_close(mut ctx: FunctionEnvMut<'_, WasiEnv>, fd: WasiFd) -> Result<Errn
         return Ok(Errno::Badf);
     }
 
-    flush_captured_handle(env, outcome.flush_target)?;
+    shutdown_captured_handle(env, outcome.shutdown_target)?;
 
     #[cfg(feature = "journal")]
     if env.enable_journal {

--- a/lib/wasix/src/syscalls/wasi/fd_renumber.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_renumber.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::fs::FlushPoller;
+use crate::fs::ShutdownPoller;
 use crate::syscalls::*;
 
 /// ### `fd_renumber()`
@@ -41,14 +41,14 @@ pub(crate) fn fd_renumber_internal(
     let env = ctx.data();
     let (_, state) = unsafe { env.get_memory_and_wasi_state(&ctx, 0) };
 
-    let flush_target = match state.fs.dup2_at(from, to) {
+    let shutdown_target = match state.fs.dup2_at(from, to) {
         Err(errno) => return Ok(errno),
-        Ok(flush_target) => flush_target,
+        Ok(shutdown_target) => shutdown_target,
     };
 
-    // Best-effort flush of the replaced entry; result depends only on map updates.
-    if let Some(file) = flush_target {
-        let _ = __asyncify_light(env, None, FlushPoller { file })?;
+    // Best-effort drain of a replaced final handle; result depends only on map updates.
+    if let Some(file) = shutdown_target {
+        let _ = __asyncify_light(env, None, ShutdownPoller { file })?;
     }
 
     Ok(Errno::Success)

--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -474,7 +474,7 @@ fn path_open_internal_with_symlink_depth(
                     return Ok(Ok(dup_fd));
                 }
 
-                let out_fd = wasi_try_ok_ok!(insert_fd_locked(
+                let out_fd = wasi_try_ok_ok!(insert_fd_locked_with_inode_guard(
                     &mut fd_map,
                     state,
                     adjusted_rights,
@@ -484,6 +484,7 @@ fn path_open_internal_with_symlink_depth(
                     file_open_flags,
                     inode.clone(),
                     with_fd,
+                    &guard,
                 ));
                 drop(guard);
                 out_fd
@@ -741,5 +742,31 @@ fn insert_fd_locked(
         inode,
         with_fd,
         with_fd.is_some(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_fd_locked_with_inode_guard(
+    fd_map: &mut FdList,
+    _state: &WasiState,
+    adjusted_rights: Rights,
+    adjusted_rights_inheriting: Rights,
+    fs_flags: Fdflags,
+    fd_flags: Fdflagsext,
+    open_flags: u16,
+    inode: InodeGuard,
+    with_fd: Option<WasiFd>,
+    inode_guard: &std::sync::RwLockWriteGuard<'_, Kind>,
+) -> Result<WasiFd, Errno> {
+    WasiFs::insert_fd_locked_with_inode_guard(
+        fd_map,
+        adjusted_rights,
+        adjusted_rights_inheriting,
+        fs_flags,
+        fd_flags,
+        open_flags,
+        inode,
+        with_fd,
+        inode_guard,
     )
 }

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -213,9 +213,9 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             env.state.fs.close_fd(op.fd)
         }
         ProcSpawnFdOpName::Dup2 => {
-            let flush_target = env.state.fs.dup2_at(op.src_fd, op.fd)?;
-            if let Some(file) = flush_target {
-                block_on(WasiFs::flush_file_best_effort(file));
+            let shutdown_target = env.state.fs.dup2_at(op.src_fd, op.fd)?;
+            if let Some(file) = shutdown_target {
+                block_on(WasiFs::shutdown_file_best_effort(file));
             }
             Ok(())
         }


### PR DESCRIPTION
# Description

Run VirtualFile shutdown exactly once when the final descriptor for a shared open-file description is removed.

The current descriptor map can drive shutdown while sibling descriptors still refer to the same inode, and normal descriptor teardown consequently repeats backend flush/sync work. This is especially expensive for durability-sensitive guests such as PostgreSQL, where ordinary close paths become thousands of redundant full-file syncs.

This change:

- tracks open handles through explicit open, finalizing, and closed states
- acquires replacement or duplicated handles before dropping the old reference
- surfaces final-handle shutdown targets from descriptor-map mutations
- drains asynchronous shutdown only after releasing descriptor-map locks
- handles close, renumber, journal replay, spawn, process teardown, and path-open replacement consistently
- keeps the final durability barrier: shutdown is moved to the actual final handle, not removed

The state machine prevents a concurrent acquisition from racing through final shutdown, and it avoids awaiting filesystem work while descriptor or inode locks are held.

## Validation

On current main with Rust 1.95:

- cargo fmt passes
- 34 focused descriptor/finalization tests pass
- independent branch contains no data-sync API dependency

In an alternating A/C/C/A PostgreSQL WASIX probe using the same guest and AOT artifacts, the candidate reduced full sync syscalls from 14,140 to 8,050 (-43.1%, 6,090 redundant syncs removed). Median improvements included reopen -8.7%, recovery -10.2%, memory open -5.6%, transactional inserts -4.6%, indexed reads -3.7%, and checkpoint -13.9%.

This is independent of the separate fd_datasync API change in #6962.
