### PR TITLE
fix(LLVM): use correct BBs as PHI inputs in call_indirect

### DIFF
--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -2152,9 +2152,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
             }
         }
 
-        let needs_switch = self.m0_param.is_some()
-            && !local_func_indices.is_empty()
-            && !foreign_func_indices.is_empty();
+        let needs_switch = !local_func_indices.is_empty() && !foreign_func_indices.is_empty();
 
         if needs_switch {
             let foreign_idx_block = self
@@ -2184,7 +2182,7 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                             self.intrinsics.i32_ty.const_int(v as _, false),
                             foreign_idx_block
                         )))
-                        .collect::<Vec<_>>()
+                        .collect_vec()
                 )
             );
 
@@ -2219,6 +2217,10 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                 );
                 rets
             };
+            let local_call_block = self
+                .builder
+                .get_insert_block()
+                .ok_or_else(|| CompileError::Codegen("not currently in a block".to_string()))?;
 
             self.builder.position_at_end(foreign_idx_block);
             let (foreign_call_site, foreign_llvm_func_type) = self
@@ -2247,6 +2249,10 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
                 );
                 rets
             };
+            let foreign_call_block = self
+                .builder
+                .get_insert_block()
+                .ok_or_else(|| CompileError::Codegen("not currently in a block".to_string()))?;
 
             if is_return_call {
                 return Ok(());
@@ -2255,12 +2261,12 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
             self.builder
                 .position_at_end(cont.expect("non-return call requires cont"));
 
-            for i in 0..foreign_rets.len() {
-                let f_i = foreign_rets[i];
-                let l_i = local_rets[i];
-                let ty = f_i.get_type();
-                let v = err!(self.builder.build_phi(ty, ""));
-                v.add_incoming(&[(&f_i, foreign_idx_block), (&l_i, local_idx_block)]);
+            for (foreign_ret, local_ret) in foreign_rets.iter().zip(local_rets.iter()) {
+                let v = err!(self.builder.build_phi(foreign_ret.get_type(), ""));
+                v.add_incoming(&[
+                    (foreign_ret, foreign_call_block),
+                    (local_ret, local_call_block),
+                ]);
                 self.state.push1(v.as_basic_value());
             }
         } else if foreign_func_indices.is_empty() {

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -2261,6 +2261,14 @@ impl<'ctx> LLVMFunctionCodeGenerator<'ctx, '_> {
             self.builder
                 .position_at_end(cont.expect("non-return call requires cont"));
 
+            if foreign_rets.len() != local_rets.len() {
+                return Err(CompileError::Codegen(format!(
+                    "mismatched return counts in indirect call branches: foreign={}, local={}.",
+                    foreign_rets.len(),
+                    local_rets.len()
+                )));
+            }
+
             for (foreign_ret, local_ret) in foreign_rets.iter().zip(local_rets.iter()) {
                 let v = err!(self.builder.build_phi(foreign_ret.get_type(), ""));
                 v.add_incoming(&[

--- a/tests/ignores.txt
+++ b/tests/ignores.txt
@@ -19,6 +19,7 @@ singlepass wasmer::simd
 singlepass      spec::throw
 singlepass      spec::try_table
 singlepass      wasmer::exception_handling
+singlepass      wasmer::exceptions_call_indirect
 
 # Misc
 singlepass wide_arithmetic

--- a/tests/wast/wasmer/exceptions-call-indirect.wast
+++ b/tests/wast/wasmer/exceptions-call-indirect.wast
@@ -1,0 +1,29 @@
+(module $env
+  (func (export "add_one") (param i32) (result i32)
+    local.get 0
+    i32.const 1
+    i32.add))
+(register "env" $env)
+
+(module $test
+  (type $t0 (func (param i32) (result i32)))
+  (import "env" "add_one" (func $add_one (type $t0)))
+  (memory 1 1)
+  (table 2 funcref)
+  (elem (i32.const 0) func $add_one $add_ten)
+  (tag $err (param i32))
+
+  (func $add_ten (type $t0) (param i32) (result i32)
+    local.get 0
+    i32.const 10
+    i32.add)
+
+  (func (export "dispatch") (param i32 i32) (result i32)
+    (block $catch (result i32)
+      (try_table (result i32) (catch $err $catch)
+        local.get 0
+        local.get 1
+        call_indirect (type $t0)))))
+
+(assert_return (invoke $test "dispatch" (i32.const 41) (i32.const 0)) (i32.const 42))
+(assert_return (invoke $test "dispatch" (i32.const 41) (i32.const 1)) (i32.const 51))


### PR DESCRIPTION
The build_indirect_call_with_params might actually create extra BBs and so we must use these basic blocks when we put PHI nodes after the dispatch switch.

Fixes: #6964