### PR TITLE
feat(LLVM): always verify emitted LLVM IR

### DIFF
--- a/fuzz/fuzz_targets/deterministic.rs
+++ b/fuzz/fuzz_targets/deterministic.rs
@@ -50,7 +50,6 @@ fuzz_target!(|module: SinglePassFuzzModule| {
 
     let mut compiler = LLVM::default();
     compiler.canonicalize_nans(true);
-    compiler.enable_verifier();
     compile_and_compare(
         "llvm",
         EngineBuilder::new(compiler.clone()).engine(),

--- a/fuzz/fuzz_targets/equivalence.rs
+++ b/fuzz/fuzz_targets/equivalence.rs
@@ -52,7 +52,6 @@ fn maybe_instantiate_cranelift(wasm_bytes: &[u8]) -> Result<Option<(Store, Insta
 fn maybe_instantiate_llvm(wasm_bytes: &[u8]) -> Result<Option<(Store, Instance)>> {
     let mut compiler = LLVM::default();
     compiler.canonicalize_nans(true);
-    compiler.enable_verifier();
     let mut store = Store::new(EngineBuilder::new(compiler));
     let module = Module::new(&store, wasm_bytes)?;
     let instance = Instance::new(&mut store, &module, &imports! {})?;

--- a/fuzz/fuzz_targets/llvm.rs
+++ b/fuzz/fuzz_targets/llvm.rs
@@ -44,7 +44,6 @@ fuzz_target!(|module: LLVMPassFuzzModule| {
 
     let mut compiler = LLVM::default();
     compiler.canonicalize_nans(true);
-    compiler.enable_verifier();
     let mut store = Store::new(EngineBuilder::new(compiler));
     // Save early (and always) as we might hit a crash or a validation error in the LLVM library.
     save_wasm_file(&wasm_bytes);

--- a/lib/cli/src/backend.rs
+++ b/lib/cli/src/backend.rs
@@ -145,7 +145,7 @@ pub struct RuntimeOptions {
 
     /// Enable compiler internal verification.
     ///
-    /// Available for Cranelift, LLVM and Singlepass.
+    /// Available for Cranelift (enabled always for LLVM).
     #[clap(long)]
     enable_verifier: bool,
 
@@ -443,9 +443,6 @@ impl RuntimeOptions {
                 if self.enable_experimental_unaligned_memory_accesses {
                     config.allow_experimental_unaligned_memory_accesses(true);
                 }
-                if self.enable_verifier {
-                    config.enable_verifier();
-                }
                 if self.enable_nan_canonicalization {
                     config.canonicalize_nans(true);
                 }
@@ -515,9 +512,6 @@ impl RuntimeOptions {
                     debug_dir.push("llvm");
                     config.callbacks(Some(LLVMCallbacks::new(debug_dir)?));
                     config.verbose_asm(true);
-                }
-                if self.enable_verifier {
-                    config.enable_verifier();
                 }
                 if self.enable_nan_canonicalization {
                     config.canonicalize_nans(true);
@@ -602,9 +596,6 @@ impl BackendType {
                     config.allow_experimental_unaligned_memory_accesses(true);
                 }
                 let supported_features = config.supported_features_for_target(target);
-                if runtime_opts.enable_verifier {
-                    config.enable_verifier();
-                }
                 if runtime_opts.enable_nan_canonicalization {
                     config.canonicalize_nans(true);
                 }
@@ -689,9 +680,6 @@ impl BackendType {
                     debug_dir.push("llvm");
                     config.callbacks(Some(LLVMCallbacks::new(debug_dir)?));
                     config.verbose_asm(true);
-                }
-                if runtime_opts.enable_verifier {
-                    config.enable_verifier();
                 }
                 if runtime_opts.enable_nan_canonicalization {
                     config.canonicalize_nans(true);

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -113,7 +113,6 @@ pub struct LLVM {
     pub(crate) enable_nan_canonicalization: bool,
     pub(crate) enable_non_volatile_memops: bool,
     pub(crate) enable_readonly_funcref_table: bool,
-    pub(crate) enable_verifier: bool,
     pub(crate) enable_perfmap: bool,
     pub(crate) debugger: Option<Debugger>,
     pub(crate) opt_level: LLVMOptLevel,
@@ -142,7 +141,6 @@ impl LLVM {
             enable_nan_canonicalization: false,
             enable_non_volatile_memops: false,
             enable_readonly_funcref_table: false,
-            enable_verifier: false,
             enable_perfmap: false,
             debugger: None,
             opt_level: LLVMOptLevel::Aggressive,
@@ -178,6 +176,10 @@ impl LLVM {
         self.verbose_asm = verbose_asm;
         self
     }
+
+    /// Compiler IR verification is always enabled for LLVM.
+    #[deprecated(note = "LLVM compiler IR verification is always enabled")]
+    pub fn enable_verifier(&mut self) {}
 
     /// Callbacks that will triggered in the different compilation
     /// phases in LLVM.
@@ -397,11 +399,6 @@ impl CompilerConfig for LLVM {
 
     fn enable_debugger(&mut self, debugger: Debugger) {
         self.debugger = Some(debugger)
-    }
-
-    /// Whether to verify compiler IR.
-    fn enable_verifier(&mut self) {
-        self.enable_verifier = true;
     }
 
     /// For the LLVM compiler, we can use non-volatile memory operations which lead to a better performance

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -479,10 +479,7 @@ impl FuncTranslator {
             callbacks.preopt_ir(&function, &wasm_module.hash_string(), &module);
         }
 
-        // Always verify the LLVM IR; otherwise, invalid IR could cause a nasty
-        // miscompilation instead of a compilation error. Measurements show that
-        // verification adds approximately 2% to compilation time.
-        let mut passes = vec!["verify"];
+        let mut passes = Vec::new();
 
         match opt_style {
             OptimizationStyle::Disabled => {
@@ -522,13 +519,16 @@ impl FuncTranslator {
             }
         }
 
-        module
-            .run_passes(
-                &passes.join(","),
-                target_machine,
-                PassBuilderOptions::create(),
-            )
-            .unwrap();
+        // Always verify the LLVM IR; otherwise, invalid IR could cause a nasty
+        // miscompilation instead of a compilation error. Measurements show that
+        // verification adds approximately 2% to compilation time.
+        err!(module.verify());
+
+        err!(module.run_passes(
+            &passes.join(","),
+            target_machine,
+            PassBuilderOptions::create(),
+        ));
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.postopt_ir(&function, &wasm_module.hash_string(), &module);

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -479,10 +479,10 @@ impl FuncTranslator {
             callbacks.preopt_ir(&function, &wasm_module.hash_string(), &module);
         }
 
-        let mut passes = vec![];
-        if config.enable_verifier {
-            passes.push("verify");
-        }
+        // Always verify the LLVM IR; otherwise, invalid IR could cause a nasty
+        // miscompilation instead of a compilation error. Measurements show that
+        // verification adds approximately 2% to compilation time.
+        let mut passes = vec!["verify"];
 
         match opt_style {
             OptimizationStyle::Disabled => {

--- a/lib/compiler-llvm/src/translator/trampoline.rs
+++ b/lib/compiler-llvm/src/translator/trampoline.rs
@@ -149,13 +149,7 @@ impl FuncTrampoline {
             callbacks.preopt_ir(function, &compile_info.module.hash_string(), &module);
         }
 
-        let mut passes = vec![];
-
-        if config.enable_verifier {
-            passes.push("verify");
-        }
-
-        passes.push("instcombine");
+        let passes = &["verify", "instcombine"];
         module
             .run_passes(
                 passes.join(",").as_str(),
@@ -311,13 +305,7 @@ impl FuncTrampoline {
             callbacks.preopt_ir(function, module_hash, &module);
         }
 
-        let mut passes = vec![];
-
-        if config.enable_verifier {
-            passes.push("verify");
-        }
-
-        passes.push("early-cse");
+        let passes = &["verify", "early-cse"];
         module
             .run_passes(
                 passes.join(",").as_str(),

--- a/lib/compiler-llvm/src/translator/trampoline.rs
+++ b/lib/compiler-llvm/src/translator/trampoline.rs
@@ -149,14 +149,10 @@ impl FuncTrampoline {
             callbacks.preopt_ir(function, &compile_info.module.hash_string(), &module);
         }
 
-        let passes = &["verify", "instcombine"];
-        module
-            .run_passes(
-                passes.join(",").as_str(),
-                target_machine,
-                PassBuilderOptions::create(),
-            )
-            .unwrap();
+        // Always verify the LLVM IR.
+        err!(module.verify());
+
+        err!(module.run_passes("instcombine", target_machine, PassBuilderOptions::create(),));
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.postopt_ir(function, &compile_info.module.hash_string(), &module);
@@ -305,14 +301,10 @@ impl FuncTrampoline {
             callbacks.preopt_ir(function, module_hash, &module);
         }
 
-        let passes = &["verify", "early-cse"];
-        module
-            .run_passes(
-                passes.join(",").as_str(),
-                target_machine,
-                PassBuilderOptions::create(),
-            )
-            .unwrap();
+        // Always verify the LLVM IR.
+        err!(module.verify());
+
+        err!(module.run_passes("early-cse", target_machine, PassBuilderOptions::create(),));
 
         if let Some(ref callbacks) = config.callbacks {
             callbacks.postopt_ir(function, module_hash, &module);

--- a/tests/compilers/config.rs
+++ b/tests/compilers/config.rs
@@ -123,7 +123,6 @@ impl Config {
                 let mut compiler = wasmer_compiler_llvm::LLVM::new();
                 compiler.experimental_artifact(self.experimental_artifact);
                 compiler.canonicalize_nans(canonicalize_nans);
-                compiler.enable_verifier();
                 if let Some(mut debug_dir) = debug_dir {
                     use wasmer_compiler_llvm::LLVMCallbacks;
                     debug_dir.push("llvm");


### PR DESCRIPTION
The LLVMIR verification is pretty cheap compared to the total number of work needed to compile a module - **~2%** (tested on `python` and `cowsay` packages). But pretty high for Cranelift, **+40%**, thus keeping the currently used default for it.