### PR TITLE
test: add MemoryStyle::Dynamic into testing matrix

### DIFF
--- a/tests/compilers/config.rs
+++ b/tests/compilers/config.rs
@@ -1,10 +1,59 @@
 use std::path::PathBuf;
+use std::ptr::NonNull;
 use std::sync::Arc;
+use wasmer::WASM_PAGE_SIZE;
 use wasmer::sys::Features;
 use wasmer::{
-    Store,
-    sys::{CompilerConfig, ModuleMiddleware},
+    MemoryError, MemoryStyle, MemoryType, Store, TableStyle, TableType,
+    sys::{
+        BaseTunables, CompilerConfig, ModuleMiddleware, Tunables,
+        vm::{VMMemory, VMMemoryDefinition, VMTable, VMTableDefinition},
+    },
 };
+
+struct DynamicMemoryTunables(BaseTunables);
+
+impl Tunables for DynamicMemoryTunables {
+    fn memory_style(&self, _memory: &MemoryType) -> MemoryStyle {
+        MemoryStyle::Dynamic {
+            offset_guard_size: WASM_PAGE_SIZE as u64,
+        }
+    }
+
+    fn table_style(&self, table: &TableType) -> TableStyle {
+        self.0.table_style(table)
+    }
+
+    fn create_host_memory(
+        &self,
+        ty: &MemoryType,
+        style: &MemoryStyle,
+    ) -> Result<VMMemory, MemoryError> {
+        self.0.create_host_memory(ty, style)
+    }
+
+    unsafe fn create_vm_memory(
+        &self,
+        ty: &MemoryType,
+        style: &MemoryStyle,
+        vm_definition_location: NonNull<VMMemoryDefinition>,
+    ) -> Result<VMMemory, MemoryError> {
+        unsafe { self.0.create_vm_memory(ty, style, vm_definition_location) }
+    }
+
+    fn create_host_table(&self, ty: &TableType, style: &TableStyle) -> Result<VMTable, String> {
+        self.0.create_host_table(ty, style)
+    }
+
+    unsafe fn create_vm_table(
+        &self,
+        ty: &TableType,
+        style: &TableStyle,
+        vm_definition_location: NonNull<VMTableDefinition>,
+    ) -> Result<VMTable, String> {
+        unsafe { self.0.create_vm_table(ty, style, vm_definition_location) }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Compiler {
@@ -22,6 +71,7 @@ pub struct Config {
     pub canonicalize_nans: bool,
     pub allow_unaligned_memory_accesses: bool,
     pub experimental_artifact: bool,
+    pub dynamic_memory: bool,
 }
 
 impl Config {
@@ -32,12 +82,18 @@ impl Config {
             canonicalize_nans: false,
             allow_unaligned_memory_accesses: false,
             experimental_artifact: false,
+            dynamic_memory: false,
             middlewares: vec![],
         }
     }
 
     pub fn with_experimental_artifact(mut self) -> Self {
         self.experimental_artifact = true;
+        self
+    }
+
+    pub fn with_dynamic_memory(mut self) -> Self {
+        self.dynamic_memory = true;
         self
     }
 
@@ -78,7 +134,11 @@ impl Config {
                 if let Some(ref features) = self.features {
                     engine = engine.set_features(Some(features.clone()));
                 }
-                engine.engine().into()
+                let mut engine = engine.engine();
+                if self.dynamic_memory {
+                    engine.set_tunables(DynamicMemoryTunables(BaseTunables::new()));
+                }
+                engine.into()
             }
         }
     }

--- a/tests/lib/compiler-test-derive/src/lib.rs
+++ b/tests/lib/compiler-test-derive/src/lib.rs
@@ -57,18 +57,18 @@ fn compiler_test_impl(attrs: TokenStream, input: TokenStream) -> TokenStream {
                                  compiler_name: &str,
                                  engine_name: &str,
                                  engine_feature_name: &str,
-                                 experimental_artifact: bool|
+                                 experimental_artifact: bool,
+                                 dynamic_memory: bool|
      -> ::proc_macro2::TokenStream {
         let config_compiler = ::quote::format_ident!("{}", compiler_name);
         let test_name = ::quote::format_ident!("{}", engine_name.to_lowercase());
-        let config = if experimental_artifact {
-            quote! {
-                crate::Config::new(crate::Compiler::#config_compiler)
-                    .with_experimental_artifact()
-            }
-        } else {
-            quote! { crate::Config::new(crate::Compiler::#config_compiler) }
-        };
+        let mut config = quote! { crate::Config::new(crate::Compiler::#config_compiler) };
+        if experimental_artifact {
+            config = quote! { #config.with_experimental_artifact() };
+        }
+        if dynamic_memory {
+            config = quote! { #config.with_dynamic_memory() };
+        }
         let experimental_artifact_cfg =
             experimental_artifact.then(|| quote! { #[cfg(target_os = "linux")] });
         let mut new_sig = func.sig.clone();
@@ -112,13 +112,26 @@ fn compiler_test_impl(attrs: TokenStream, input: TokenStream) -> TokenStream {
                 compiler_name,
                 &compiler_name.to_lowercase(),
                 false,
+                false,
             );
-            let experimental_artifact_test = (compiler_name != "V8").then(|| {
+            let native_compiler = compiler_name != "V8";
+            let experimental_artifact_test = native_compiler.then(|| {
                 construct_engine_test(
                     func,
                     compiler_name,
                     &format!("{compiler_name}_exp_artifact"),
                     &compiler_name.to_lowercase(),
+                    true,
+                    false,
+                )
+            });
+            let dynamic_memory_experimental_artifact_test = native_compiler.then(|| {
+                construct_engine_test(
+                    func,
+                    compiler_name,
+                    &format!("{compiler_name}_dynamic_memory_exp_artifact"),
+                    &compiler_name.to_lowercase(),
+                    true,
                     true,
                 )
             });
@@ -131,6 +144,7 @@ fn compiler_test_impl(attrs: TokenStream, input: TokenStream) -> TokenStream {
 
                     #engine_test
                     #experimental_artifact_test
+                    #dynamic_memory_experimental_artifact_test
                 }
             }
         };

--- a/tests/lib/compiler-test-derive/src/tests.rs
+++ b/tests/lib/compiler-test-derive/src/tests.rs
@@ -71,6 +71,15 @@ gen_tests! {
                         crate::Compiler::Singlepass
                     ).with_experimental_artifact())
                 }
+                #[test_log::test]
+                #[cold]
+                #[cfg(feature = "singlepass")]
+                #[cfg(target_os = "linux")]
+                fn singlepass_dynamic_memory_exp_artifact() {
+                    foo(crate::Config::new(
+                        crate::Compiler::Singlepass
+                    ).with_experimental_artifact().with_dynamic_memory())
+                }
             }
 
             #[cfg(feature = "cranelift")]
@@ -93,6 +102,15 @@ gen_tests! {
                         crate::Compiler::Cranelift
                     ).with_experimental_artifact())
                 }
+                #[test_log::test]
+                #[cold]
+                #[cfg(feature = "cranelift")]
+                #[cfg(target_os = "linux")]
+                fn cranelift_dynamic_memory_exp_artifact() {
+                    foo(crate::Config::new(
+                        crate::Compiler::Cranelift
+                    ).with_experimental_artifact().with_dynamic_memory())
+                }
             }
 
             #[cfg(feature = "llvm")]
@@ -114,6 +132,15 @@ gen_tests! {
                     foo(crate::Config::new(
                         crate::Compiler::LLVM
                     ).with_experimental_artifact())
+                }
+                #[test_log::test]
+                #[cold]
+                #[cfg(feature = "llvm")]
+                #[cfg(target_os = "linux")]
+                fn llvm_dynamic_memory_exp_artifact() {
+                    foo(crate::Config::new(
+                        crate::Compiler::LLVM
+                    ).with_experimental_artifact().with_dynamic_memory())
                 }
             }
 


### PR DESCRIPTION
While working on the various `MemoryStyle` issues I noticed we haven't been testing the functionality. Let's fix it and use it for the compiler tests as a variant (together with the experimental artifact format).