### PR TITLE
feat(wasix): report stdio as a terminal only when it actually is

### DIFF
--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -598,6 +598,12 @@ impl Run {
             .with_forward_host_env(self.wasi.forward_host_env)
             .with_capabilities(self.wasi.capabilities());
 
+        // `--no-tty` means the guest should see no terminal at all, not just
+        // that we withhold the `TtyBridge`, so force `isatty` to say so too.
+        if self.wasi.no_tty {
+            runner.with_stdio_is_terminal(false);
+        }
+
         if let Some(cwd) = self.wasi.cwd.as_ref() {
             if !cwd.starts_with("/") {
                 bail!("The argument to --cwd must be an absolute path");

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -148,7 +148,8 @@ pub struct Wasi {
     // and when --net=<ruleset> is specified, the inner Option will be initialized: Some(Some(ruleset))
     pub networking: Option<Option<String>>,
 
-    /// Disables the TTY bridge
+    /// Disables the TTY bridge, and makes the guest see stdio as not being a
+    /// terminal
     #[clap(long = "no-tty")]
     pub no_tty: bool,
 
@@ -355,6 +356,12 @@ impl Wasi {
             .envs(self.env_vars.clone())
             .uses(uses)
             .map_commands(map_commands);
+
+        // `--no-tty` means the guest should see no terminal at all, not just
+        // that we withhold the `TtyBridge`, so force `isatty` to say so too.
+        if self.no_tty {
+            builder.set_stdio_is_terminal(Some(false));
+        }
 
         let mut builder = {
             let mount_fs = RootFileSystemBuilder::new()

--- a/lib/virtual-fs/src/arc_box_file.rs
+++ b/lib/virtual-fs/src/arc_box_file.rs
@@ -123,6 +123,10 @@ impl VirtualFile for ArcBoxFile {
         let inner = self.inner.lock().unwrap();
         inner.get_special_fd()
     }
+    fn is_terminal(&self) -> Option<bool> {
+        let inner = self.inner.lock().unwrap();
+        inner.is_terminal()
+    }
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         let mut inner = self.inner.lock().unwrap();
         let inner = Pin::new(inner.as_mut());

--- a/lib/virtual-fs/src/arc_file.rs
+++ b/lib/virtual-fs/src/arc_file.rs
@@ -139,6 +139,10 @@ where
         let inner = self.inner.lock().unwrap();
         inner.get_special_fd()
     }
+    fn is_terminal(&self) -> Option<bool> {
+        let inner = self.inner.lock().unwrap();
+        inner.is_terminal()
+    }
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         let mut inner = self.inner.lock().unwrap();
         let inner = Pin::new(inner.as_mut());

--- a/lib/virtual-fs/src/combine_file.rs
+++ b/lib/virtual-fs/src/combine_file.rs
@@ -46,6 +46,13 @@ impl VirtualFile for CombineFile {
         self.tx.unlink()
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        // A `CombineFile` models a single bidirectional device (see `Tty`), so
+        // either half may know the answer; `rx` alone would be wrong for a
+        // write-only console.
+        self.rx.is_terminal().or_else(|| self.tx.is_terminal())
+    }
+
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         Pin::new(self.rx.as_mut()).poll_read_ready(cx)
     }

--- a/lib/virtual-fs/src/cow_file.rs
+++ b/lib/virtual-fs/src/cow_file.rs
@@ -237,6 +237,15 @@ impl VirtualFile for CopyOnWriteFile {
         }
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        match &self.state {
+            CowState::ReadOnly(inner) => inner.is_terminal(),
+            // Mid-copy the source is owned by the future; once copied we are
+            // backed by an in-memory buffer, which has no opinion either way.
+            CowState::Copying { .. } | CowState::Copied(_) => None,
+        }
+    }
+
     fn set_len(&mut self, new_size: u64) -> crate::Result<()> {
         match self.state {
             CowState::ReadOnly(_) => {

--- a/lib/virtual-fs/src/dual_write_file.rs
+++ b/lib/virtual-fs/src/dual_write_file.rs
@@ -54,6 +54,10 @@ impl VirtualFile for DualWriteFile {
         self.inner.unlink()
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        self.inner.is_terminal()
+    }
+
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         Pin::new(self.inner.as_mut()).poll_read_ready(cx)
     }

--- a/lib/virtual-fs/src/host_fs.rs
+++ b/lib/virtual-fs/src/host_fs.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, Bytes};
 use futures::future::BoxFuture;
 use std::convert::TryInto;
 use std::fs;
-use std::io::{self, Seek};
+use std::io::{self, IsTerminal, Seek};
 use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -468,6 +468,10 @@ impl VirtualFile for File {
         None
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        Some(self.inner_std.is_terminal())
+    }
+
     fn poll_read_ready(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         let cursor = match self.inner_std.stream_position() {
             Ok(a) => a,
@@ -614,6 +618,10 @@ impl VirtualFile for Stdout {
 
     fn get_special_fd(&self) -> Option<u32> {
         Some(1)
+    }
+
+    fn is_terminal(&self) -> Option<bool> {
+        Some(io::stdout().is_terminal())
     }
 
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
@@ -790,6 +798,10 @@ impl VirtualFile for Stderr {
         Some(2)
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        Some(io::stderr().is_terminal())
+    }
+
     fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(0))
     }
@@ -904,6 +916,10 @@ impl VirtualFile for Stdin {
     }
     fn get_special_fd(&self) -> Option<u32> {
         Some(0)
+    }
+
+    fn is_terminal(&self) -> Option<bool> {
+        Some(io::stdin().is_terminal())
     }
     fn poll_read_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         {

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -387,6 +387,26 @@ pub trait VirtualFile:
         None
     }
 
+    /// Whether this file is connected to an interactive terminal, when that is
+    /// knowable.
+    ///
+    /// `None` means "no opinion", and is the default. WASIX has always reported
+    /// stdio as a character device, and an embedder that wires up its own stdio
+    /// -- a browser terminal, an SSH session, a test harness -- is usually
+    /// driving a real terminal that this crate cannot see. Only implementations
+    /// that actually know, such as a host file descriptor that can be probed
+    /// with `isatty(3)`, return `Some`.
+    ///
+    /// # Implementors
+    ///
+    /// Every *wrapper* type must forward this to the file it wraps; a missed
+    /// forward silently degrades to "no opinion". Single-field wrappers should
+    /// use [`forward_virtual_file_capability_queries!`]. The rest are covered by
+    /// the `is_terminal_forwarding` tests at the bottom of this module.
+    fn is_terminal(&self) -> Option<bool> {
+        None
+    }
+
     /// Writes to this file using an mmap offset and reference
     /// (this method only works for mmap optimized file systems)
     fn write_from_mmap(&mut self, _offset: u64, _len: u64) -> std::io::Result<()> {
@@ -776,5 +796,201 @@ impl Iterator for ReadDir {
             return Some(Ok(v));
         }
         None
+    }
+}
+
+/// Every wrapper in this crate has to hand-forward [`VirtualFile::is_terminal`]
+/// to the file it wraps. A missed forward is invisible -- it just quietly
+/// degrades to "no opinion" -- so each one is pinned down here.
+#[cfg(test)]
+mod is_terminal_forwarding {
+    use std::io::{self, IoSlice, SeekFrom};
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+
+    use super::*;
+
+    /// A leaf that claims to be a terminal. If a wrapper forgets to forward,
+    /// the assertion below sees `None` instead of `Some(true)`.
+    #[derive(Debug, Default)]
+    struct TerminalProbe;
+
+    impl AsyncSeek for TerminalProbe {
+        fn start_seek(self: Pin<&mut Self>, _position: SeekFrom) -> io::Result<()> {
+            Ok(())
+        }
+        fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    impl AsyncWrite for TerminalProbe {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(bufs.len()))
+        }
+        fn is_write_vectored(&self) -> bool {
+            false
+        }
+    }
+
+    impl AsyncRead for TerminalProbe {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl VirtualFile for TerminalProbe {
+        fn last_accessed(&self) -> u64 {
+            0
+        }
+        fn last_modified(&self) -> u64 {
+            0
+        }
+        fn created_time(&self) -> u64 {
+            0
+        }
+        fn size(&self) -> u64 {
+            0
+        }
+        fn set_len(&mut self, _new_size: u64) -> Result<()> {
+            Ok(())
+        }
+        fn unlink(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn is_terminal(&self) -> Option<bool> {
+            Some(true)
+        }
+        fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+        fn poll_write_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(8192))
+        }
+    }
+
+    /// A mem-fs holding a `TerminalProbe` at `/probe`, so the wrappers that are
+    /// private and only reachable through a `FileSystem` can be exercised too.
+    fn probe_fs() -> Arc<mem_fs::FileSystem> {
+        let fs = Arc::new(mem_fs::FileSystem::default());
+        fs.insert_device_file("/probe".into(), Box::new(TerminalProbe))
+            .unwrap();
+        fs
+    }
+
+    fn open(fs: &dyn FileSystem, write: bool) -> Box<dyn VirtualFile + Send + Sync + 'static> {
+        fs.new_open_options()
+            .read(true)
+            .write(write)
+            .open("/probe")
+            .unwrap()
+    }
+
+    #[test]
+    fn arc_box_file_forwards() {
+        assert_eq!(
+            ArcBoxFile::new(Box::new(TerminalProbe)).is_terminal(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn arc_file_forwards() {
+        assert_eq!(
+            ArcFile::new(Box::new(TerminalProbe)).is_terminal(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn dual_write_file_forwards() {
+        assert_eq!(
+            DualWriteFile::new(Box::new(TerminalProbe), |_| {}).is_terminal(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn combine_file_forwards_either_half() {
+        assert_eq!(
+            CombineFile::new(Box::new(TerminalProbe), Box::new(NullFile::default())).is_terminal(),
+            Some(true),
+            "the tx half should be consulted"
+        );
+        assert_eq!(
+            CombineFile::new(Box::new(NullFile::default()), Box::new(TerminalProbe)).is_terminal(),
+            Some(true),
+            "the rx half should be consulted"
+        );
+    }
+
+    #[test]
+    fn mem_fs_custom_file_forwards() {
+        assert_eq!(open(&*probe_fs(), false).is_terminal(), Some(true));
+    }
+
+    #[test]
+    fn trace_file_forwards() {
+        let fs = TraceFileSystem::new(probe_fs());
+        assert_eq!(open(&fs, false).is_terminal(), Some(true));
+    }
+
+    #[test]
+    fn overlay_secondary_file_forwards() {
+        // A read-only open of a secondary-only path yields a `SecondaryFile`.
+        let fs = OverlayFileSystem::new(mem_fs::FileSystem::default(), [probe_fs()]);
+        assert_eq!(open(&fs, false).is_terminal(), Some(true));
+    }
+
+    #[test]
+    fn overlay_copy_on_write_file_forwards() {
+        // A writable open of a secondary-only path yields a `CopyOnWriteFile`.
+        let fs = OverlayFileSystem::new(mem_fs::FileSystem::default(), [probe_fs()]);
+        assert_eq!(open(&fs, true).is_terminal(), Some(true));
+    }
+
+    #[test]
+    fn pipe_is_opt_in_both_ways() {
+        assert_eq!(Pipe::new().is_terminal(), None);
+        assert_eq!(Pipe::new().with_terminal(true).is_terminal(), Some(true));
+        assert_eq!(Pipe::new().with_terminal(false).is_terminal(), Some(false));
+    }
+
+    /// The default must stay `None` rather than drifting to `Some(false)`:
+    /// WASIX reads an absent opinion as "character device", which is what keeps
+    /// existing embedders reporting a terminal.
+    #[test]
+    fn plain_leaves_have_no_opinion() {
+        assert_eq!(NullFile::default().is_terminal(), None);
+        assert_eq!(StaticFile::new(Vec::<u8>::new()).is_terminal(), None);
+        assert_eq!(BufferFile::default().is_terminal(), None);
+        assert_eq!(ZeroFile::default().is_terminal(), None);
     }
 }

--- a/lib/virtual-fs/src/lib.rs
+++ b/lib/virtual-fs/src/lib.rs
@@ -400,9 +400,9 @@ pub trait VirtualFile:
     /// # Implementors
     ///
     /// Every *wrapper* type must forward this to the file it wraps; a missed
-    /// forward silently degrades to "no opinion". Single-field wrappers should
-    /// use [`forward_virtual_file_capability_queries!`]. The rest are covered by
-    /// the `is_terminal_forwarding` tests at the bottom of this module.
+    /// forward silently degrades to "no opinion". The `is_terminal_forwarding`
+    /// tests at the bottom of this module cover each wrapper in this crate, so
+    /// add a case there when adding one.
     fn is_terminal(&self) -> Option<bool> {
         None
     }
@@ -846,7 +846,8 @@ mod is_terminal_forwarding {
             _cx: &mut Context<'_>,
             bufs: &[IoSlice<'_>],
         ) -> Poll<io::Result<usize>> {
-            Poll::Ready(Ok(bufs.len()))
+            // Bytes written, not the number of slices.
+            Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
         }
         fn is_write_vectored(&self) -> bool {
             false
@@ -970,8 +971,17 @@ mod is_terminal_forwarding {
     }
 
     #[test]
+    fn cow_file_forwards_while_read_only() {
+        assert_eq!(
+            CopyOnWriteFile::new(Box::new(TerminalProbe)).is_terminal(),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn overlay_copy_on_write_file_forwards() {
-        // A writable open of a secondary-only path yields a `CopyOnWriteFile`.
+        // A writable open of a secondary-only path yields `overlay_fs`'s own
+        // `CopyOnWriteFile`, which is distinct from `cow_file`'s above.
         let fs = OverlayFileSystem::new(mem_fs::FileSystem::default(), [probe_fs()]);
         assert_eq!(open(&fs, true).is_terminal(), Some(true));
     }

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -318,6 +318,36 @@ impl VirtualFile for FileHandle {
         }
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        let fs = match self.filesystem.inner.read() {
+            Ok(a) => a,
+            Err(_) => {
+                return None;
+            }
+        };
+
+        let inode = fs.storage.get(self.inode);
+        match inode {
+            Some(Node::CustomFile(node)) => {
+                let file = node.file.lock().unwrap();
+                file.is_terminal()
+            }
+            Some(Node::ArcFile(node)) => match self.arc_file.as_ref() {
+                Some(file) => file.as_ref().map(|file| file.is_terminal()).unwrap_or(None),
+                None => node
+                    .fs
+                    .new_open_options()
+                    .read(self.readable)
+                    .write(self.writable)
+                    .append(self.append_mode)
+                    .open(node.path.as_path())
+                    .map(|file| file.is_terminal())
+                    .unwrap_or(None),
+            },
+            _ => None,
+        }
+    }
+
     fn copy_reference(
         &mut self,
         src: Box<dyn VirtualFile + Send + Sync + 'static>,

--- a/lib/virtual-fs/src/mem_fs/file.rs
+++ b/lib/virtual-fs/src/mem_fs/file.rs
@@ -332,18 +332,16 @@ impl VirtualFile for FileHandle {
                 let file = node.file.lock().unwrap();
                 file.is_terminal()
             }
-            Some(Node::ArcFile(node)) => match self.arc_file.as_ref() {
-                Some(file) => file.as_ref().map(|file| file.is_terminal()).unwrap_or(None),
-                None => node
-                    .fs
-                    .new_open_options()
-                    .read(self.readable)
-                    .write(self.writable)
-                    .append(self.append_mode)
-                    .open(node.path.as_path())
-                    .map(|file| file.is_terminal())
-                    .unwrap_or(None),
-            },
+            // Only answered from an already-open handle. Unlike
+            // `get_special_fd`, this deliberately does not lazily open the
+            // backing file: `None` means "no opinion", which is a correct and
+            // free answer, and a predicate should not allocate a descriptor or
+            // touch the backing store to produce it.
+            Some(Node::ArcFile(_)) => self
+                .arc_file
+                .as_ref()
+                .and_then(|file| file.as_ref().ok())
+                .and_then(|file| file.is_terminal()),
             _ => None,
         }
     }

--- a/lib/virtual-fs/src/overlay_fs.rs
+++ b/lib/virtual-fs/src/overlay_fs.rs
@@ -103,6 +103,10 @@ where
         self.inner.get_special_fd()
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        self.inner.is_terminal()
+    }
+
     fn write_from_mmap(&mut self, offset: u64, len: u64) -> std::io::Result<()> {
         self.inner.write_from_mmap(offset, len)
     }
@@ -1059,6 +1063,10 @@ where
 
         fn created_time(&self) -> u64 {
             self.state.as_ref().created_time()
+        }
+
+        fn is_terminal(&self) -> Option<bool> {
+            self.state.as_ref().is_terminal()
         }
 
         fn size(&self) -> u64 {

--- a/lib/virtual-fs/src/pipe.rs
+++ b/lib/virtual-fs/src/pipe.rs
@@ -29,6 +29,12 @@ pub struct Pipe {
     send: PipeTx,
     /// Receive side of the pipe
     recv: PipeRx,
+    /// What this pipe claims about being a terminal, for embedders that know
+    /// what is on the other end. `None` -- the default -- means "no opinion",
+    /// which WASIX still reports to guests as a character device.
+    ///
+    /// Not preserved across [`Pipe::split`] / [`Pipe::combine`].
+    is_terminal: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -169,7 +175,24 @@ impl Pipe {
                 rx_end: Arc::downgrade(&recv),
             },
             recv: PipeRx { rx: Some(recv) },
+            is_terminal: None,
         }
+    }
+
+    /// Declare whether this pipe is driving an interactive terminal.
+    ///
+    /// Use this when the embedder knows what sits on the other end -- an
+    /// emulated terminal that renders to a web page, say, or a capture buffer
+    /// that definitely is not one.
+    pub fn with_terminal(mut self, is_terminal: bool) -> Self {
+        self.is_terminal = Some(is_terminal);
+        self
+    }
+
+    /// See [`Pipe::with_terminal`]. `None` restores the default of having no
+    /// opinion on the matter.
+    pub fn set_terminal(&mut self, is_terminal: Option<bool>) {
+        self.is_terminal = is_terminal;
     }
 
     pub fn channel() -> (Pipe, Pipe) {
@@ -186,7 +209,11 @@ impl Pipe {
     }
 
     pub fn combine(tx: PipeTx, rx: PipeRx) -> Self {
-        Self { send: tx, recv: rx }
+        Self {
+            send: tx,
+            recv: rx,
+            is_terminal: None,
+        }
     }
 
     pub fn try_read(&mut self, buf: &mut [u8]) -> Option<usize> {
@@ -522,6 +549,10 @@ impl VirtualFile for Pipe {
             .as_ref()
             .map(|a| !a.is_closed())
             .unwrap_or_else(|| false)
+    }
+
+    fn is_terminal(&self) -> Option<bool> {
+        self.is_terminal
     }
 
     /// Polls the file for when there is data to be read

--- a/lib/virtual-fs/src/trace_fs.rs
+++ b/lib/virtual-fs/src/trace_fs.rs
@@ -148,6 +148,10 @@ impl VirtualFile for TraceFile {
         self.file.unlink()
     }
 
+    fn is_terminal(&self) -> Option<bool> {
+        self.file.is_terminal()
+    }
+
     #[tracing::instrument(level = "trace", skip_all, fields(path=%self.path.display()))]
     fn poll_read_ready(
         mut self: Pin<&mut Self>,

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -422,13 +422,6 @@ impl InodeValFileWriteGuard {
             guard: crate::utils::write_owned(file).unwrap(),
         }
     }
-    pub(crate) fn swap(
-        &mut self,
-        mut file: Box<dyn VirtualFile + Send + Sync + 'static>,
-    ) -> Box<dyn VirtualFile + Send + Sync + 'static> {
-        std::mem::swap(self.guard.deref_mut(), &mut file);
-        file
-    }
 }
 
 impl Deref for InodeValFileWriteGuard {
@@ -556,6 +549,15 @@ impl VirtualFile for WasiStateFileGuard {
         } else {
             false
         }
+    }
+
+    fn is_terminal(&self) -> Option<bool> {
+        // Like `is_open`, this takes a blocking read lock on the underlying
+        // file handle. Callers must not already hold that lock -- see
+        // `WasiFs::swap_file`, which queries the incoming file before it
+        // acquires anything.
+        let guard = self.lock_read();
+        guard.as_ref().and_then(|file| file.is_terminal())
     }
 
     fn poll_read_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<usize>> {

--- a/lib/wasix/src/fs/inode_guard.rs
+++ b/lib/wasix/src/fs/inode_guard.rs
@@ -439,6 +439,7 @@ impl DerefMut for InodeValFileWriteGuard {
 #[derive(Debug)]
 pub(crate) struct WasiStateFileGuard {
     inode: InodeGuard,
+    is_stdio: bool,
 }
 
 impl WasiStateFileGuard {
@@ -447,6 +448,7 @@ impl WasiStateFileGuard {
         if let Some(fd) = fd_map.get(fd) {
             Ok(Some(Self {
                 inode: fd.inode.clone(),
+                is_stdio: fd.is_stdio,
             }))
         } else {
             Ok(None)
@@ -552,10 +554,13 @@ impl VirtualFile for WasiStateFileGuard {
     }
 
     fn is_terminal(&self) -> Option<bool> {
-        // Like `is_open`, this takes a blocking read lock on the underlying
-        // file handle. Callers must not already hold that lock -- see
-        // `WasiFs::swap_file`, which queries the incoming file before it
-        // acquires anything.
+        if self.is_stdio {
+            // Export the effective status, including overrides, without waiting
+            // for a read or write that holds the backing file's lock.
+            return Some(
+                self.inode.stat.read().unwrap().st_filetype == wasi::Filetype::CharacterDevice,
+            );
+        }
         let guard = self.lock_read();
         guard.as_ref().and_then(|file| file.is_terminal())
     }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -1056,9 +1056,14 @@ impl WasiFs {
     /// Override what one of stdin/stdout/stderr reports about being connected
     /// to a terminal, ignoring whatever the handle behind it has to say.
     ///
-    /// `None` restores the default of deferring to the handle. Has no effect on
-    /// a descriptor that is no longer stdio (after a `dup2` onto it, say).
-    pub fn set_stdio_terminal(&self, fd: WasiFd, is_terminal: Option<bool>) {
+    /// This is one-way on purpose. There is no "stop overriding": undoing it
+    /// would mean re-asking the handle, and the reason the answer is cached at
+    /// all is so that no caller has to take the handle's lock. An embedder that
+    /// wants the handle to decide should simply not call this.
+    ///
+    /// Has no effect on a descriptor that is no longer stdio (after a `dup2`
+    /// onto it, say).
+    pub fn set_stdio_terminal(&self, fd: WasiFd, is_terminal: bool) {
         let inode = {
             let fd_map = self.fd_map.read().unwrap();
             match fd_map.get(fd) {
@@ -1066,7 +1071,7 @@ impl WasiFs {
                 _ => return,
             }
         };
-        inode.stat.write().unwrap().st_filetype = stdio_filetype(is_terminal);
+        inode.stat.write().unwrap().st_filetype = stdio_filetype(Some(is_terminal));
     }
 
     /// Change the backing of a given file descriptor
@@ -3014,10 +3019,10 @@ mod tests {
         )
         .unwrap();
 
-        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, Some(false));
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, false);
         assert_stdio_filetype(&fs, __WASI_STDOUT_FILENO, Filetype::Unknown);
 
-        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, None);
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, true);
         assert_stdio_filetype(&fs, __WASI_STDOUT_FILENO, Filetype::CharacterDevice);
     }
 
@@ -3037,7 +3042,7 @@ mod tests {
             "a dup of stdout used to report RegularFile"
         );
 
-        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, Some(true));
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, true);
         assert_eq!(
             fs.fdstat(dup).unwrap().fs_filetype,
             Filetype::CharacterDevice
@@ -3073,7 +3078,7 @@ mod tests {
         );
 
         // fd 1 is no longer stdio, so the override must leave it alone.
-        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, Some(true));
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, true);
         assert_eq!(
             fs.fdstat(__WASI_STDOUT_FILENO).unwrap().fs_filetype,
             Filetype::RegularFile

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -151,6 +151,27 @@ const STDOUT_DEFAULT_RIGHTS: Rights = {
 };
 const STDERR_DEFAULT_RIGHTS: Rights = STDOUT_DEFAULT_RIGHTS;
 
+/// The file type WASIX reports for stdin/stdout/stderr, which is what libc's
+/// `isatty(3)` keys off.
+///
+/// `None` means the handle behind the descriptor has no opinion on whether it
+/// is a terminal (see [`virtual_fs::VirtualFile::is_terminal`]). WASIX has
+/// always reported stdio as a character device, and an embedder that wires up
+/// its own stdio is usually driving a terminal we cannot see from here, so an
+/// absent opinion keeps the historical answer. Only a handle that positively
+/// knows it is not a terminal -- a redirected host descriptor, say -- makes us
+/// say otherwise.
+///
+/// `Unknown` rather than `RegularFile` for the negative case: stdio carries
+/// neither [`Rights::FD_SEEK`] nor [`Rights::FD_TELL`], so claiming a regular
+/// file would invite guests to seek or mmap stdout and collect an error.
+fn stdio_filetype(is_terminal: Option<bool>) -> Filetype {
+    match is_terminal {
+        Some(false) => Filetype::Unknown,
+        Some(true) | None => Filetype::CharacterDevice,
+    }
+}
+
 /// A completely arbitrary "big enough" number used as the upper limit for
 /// the number of symlinks that can be traversed when resolving a path
 pub const MAX_SYMLINKS: u32 = 128;
@@ -353,11 +374,6 @@ impl WasiInodes {
             open_handles,
             inner: val,
         }
-    }
-
-    /// Get the `VirtualFile` object at stdout mutably
-    pub(crate) fn stdout_mut(fd_map: &RwLock<FdList>) -> Result<InodeValFileWriteGuard, FsError> {
-        Self::std_dev_get_mut(fd_map, __WASI_STDOUT_FILENO)
     }
 
     /// Get the `VirtualFile` object at stderr mutably
@@ -1037,6 +1053,22 @@ impl WasiFs {
         }
     }
 
+    /// Override what one of stdin/stdout/stderr reports about being connected
+    /// to a terminal, ignoring whatever the handle behind it has to say.
+    ///
+    /// `None` restores the default of deferring to the handle. Has no effect on
+    /// a descriptor that is no longer stdio (after a `dup2` onto it, say).
+    pub fn set_stdio_terminal(&self, fd: WasiFd, is_terminal: Option<bool>) {
+        let inode = {
+            let fd_map = self.fd_map.read().unwrap();
+            match fd_map.get(fd) {
+                Some(entry) if entry.is_stdio => entry.inode.clone(),
+                _ => return,
+            }
+        };
+        inode.stat.write().unwrap().st_filetype = stdio_filetype(is_terminal);
+    }
+
     /// Change the backing of a given file descriptor
     /// Returns the old backing
     /// TODO: add examples
@@ -1047,17 +1079,47 @@ impl WasiFs {
         mut file: Box<dyn VirtualFile + Send + Sync + 'static>,
     ) -> Result<Option<Box<dyn VirtualFile + Send + Sync + 'static>>, FsError> {
         match fd {
-            __WASI_STDIN_FILENO => {
-                let mut target = WasiInodes::stdin_mut(&self.fd_map)?;
-                Ok(Some(target.swap(file)))
-            }
-            __WASI_STDOUT_FILENO => {
-                let mut target = WasiInodes::stdout_mut(&self.fd_map)?;
-                Ok(Some(target.swap(file)))
-            }
-            __WASI_STDERR_FILENO => {
-                let mut target = WasiInodes::stderr_mut(&self.fd_map)?;
-                Ok(Some(target.swap(file)))
+            __WASI_STDIN_FILENO | __WASI_STDOUT_FILENO | __WASI_STDERR_FILENO => {
+                // Ask the incoming file first, while holding nothing: wrappers
+                // such as `ArcBoxFile` and `WasiStateFileGuard` take locks of
+                // their own to answer this.
+                let new_is_terminal = file.is_terminal();
+
+                // Lock order is fd_map -> inode.kind -> handle, with
+                // inode.stat taken on its own. Each is released before the
+                // next is acquired, so unlike `WasiInodes::std_dev_get_mut` we
+                // never block on the handle while holding the fd map.
+                let (inode, is_stdio) = {
+                    let fd_map = self.fd_map.read().unwrap();
+                    let entry = fd_map.get(fd).ok_or(FsError::NoDevice)?;
+                    (entry.inode.clone(), entry.is_stdio)
+                };
+
+                let handle = {
+                    let guard = inode.read();
+                    match guard.deref() {
+                        Kind::File {
+                            handle: Some(handle),
+                            ..
+                        } => handle.clone(),
+                        _ => return Err(FsError::NotAFile),
+                    }
+                };
+
+                {
+                    let mut guard = handle.write().map_err(|_| FsError::Lock)?;
+                    std::mem::swap(guard.deref_mut(), &mut file);
+                }
+
+                // Guarded on `is_stdio`: after a guest `dup2(3, 1)` this fd
+                // resolves to a regular file's inode, and stamping a stdio file
+                // type onto it would corrupt that file's `fstat`.
+                if is_stdio {
+                    inode.stat.write().map_err(|_| FsError::Lock)?.st_filetype =
+                        stdio_filetype(new_is_terminal);
+                }
+
+                Ok(Some(file))
             }
             _ => {
                 let base_inode = self.get_fd_inode(fd).map_err(fs_error_from_wasi_err)?;
@@ -1839,49 +1901,36 @@ impl WasiFs {
     }
 
     pub fn fdstat(&self, fd: WasiFd) -> Result<Fdstat, Errno> {
-        match fd {
-            __WASI_STDIN_FILENO => {
-                return Ok(Fdstat {
-                    fs_filetype: Filetype::CharacterDevice,
-                    fs_flags: Fdflags::empty(),
-                    fs_rights_base: STDIN_DEFAULT_RIGHTS,
-                    fs_rights_inheriting: Rights::empty(),
-                });
-            }
-            __WASI_STDOUT_FILENO => {
-                return Ok(Fdstat {
-                    fs_filetype: Filetype::CharacterDevice,
-                    fs_flags: Fdflags::APPEND,
-                    fs_rights_base: STDOUT_DEFAULT_RIGHTS,
-                    fs_rights_inheriting: Rights::empty(),
-                });
-            }
-            __WASI_STDERR_FILENO => {
-                return Ok(Fdstat {
-                    fs_filetype: Filetype::CharacterDevice,
-                    fs_flags: Fdflags::APPEND,
-                    fs_rights_base: STDERR_DEFAULT_RIGHTS,
-                    fs_rights_inheriting: Rights::empty(),
-                });
-            }
-            VIRTUAL_ROOT_FD => {
-                return Ok(Fdstat {
-                    fs_filetype: Filetype::Directory,
-                    fs_flags: Fdflags::empty(),
-                    // TODO: fix this
-                    fs_rights_base: ALL_RIGHTS,
-                    fs_rights_inheriting: ALL_RIGHTS,
-                });
-            }
-            _ => (),
+        // Note that stdin/stdout/stderr are deliberately *not* special-cased
+        // here. The rights and flags below already come from the `Fd` entry,
+        // which `create_std_dev_inner` populates with exactly the values the
+        // old hardcoded arms returned, and the file type now comes from the
+        // inode -- so `fdstat`, `fd_filestat_get` and a `dup`'d stdio
+        // descriptor all report the same thing.
+        if fd == VIRTUAL_ROOT_FD {
+            return Ok(Fdstat {
+                fs_filetype: Filetype::Directory,
+                fs_flags: Fdflags::empty(),
+                // TODO: fix this
+                fs_rights_base: ALL_RIGHTS,
+                fs_rights_inheriting: ALL_RIGHTS,
+            });
         }
         let fd = self.get_fd(fd)?;
+
+        // Read before the kind guard is taken, to avoid a needless
+        // inode.kind -> inode.stat lock edge.
+        let cached_stdio_filetype = if fd.is_stdio {
+            Some(fd.inode.stat.read().unwrap().st_filetype)
+        } else {
+            None
+        };
 
         let guard = fd.inode.read();
         let deref = guard.deref();
         Ok(Fdstat {
             fs_filetype: match deref {
-                Kind::File { .. } => Filetype::RegularFile,
+                Kind::File { .. } => cached_stdio_filetype.unwrap_or(Filetype::RegularFile),
                 Kind::Dir { .. } => Filetype::Directory,
                 Kind::Symlink { .. } => Filetype::SymbolicLink,
                 Kind::Socket { socket } => match &socket.inner.protected.read().unwrap().kind {
@@ -2571,9 +2620,14 @@ impl WasiFs {
         fd_flags: Fdflags,
         st_ino: Inode,
     ) {
+        // Asked here, with no locks held, and cached on the inode: `fdstat` and
+        // `fd_filestat_get` both read that one field, so they cannot disagree,
+        // and neither has to touch the file handle's lock (which `fd_read` and
+        // `fd_write` hold across an await).
+        let is_terminal = handle.is_terminal();
         let inode = {
             let stat = Filestat {
-                st_filetype: Filetype::CharacterDevice,
+                st_filetype: stdio_filetype(is_terminal),
                 st_ino: st_ino.as_u64(),
                 ..Filestat::default()
             };
@@ -2905,6 +2959,190 @@ mod tests {
 
     use crate::WasiEnvBuilder;
     use crate::bin_factory::{BinaryPackage, BinaryPackageMount, BinaryPackageMounts};
+
+    fn test_fs() -> (WasiInodes, WasiFs) {
+        let inodes = WasiInodes::new();
+        let fs_backing =
+            WasiFsRoot::from_filesystem(Arc::new(RootFileSystemBuilder::default().build_tmp()));
+        let fs = WasiFs::new_init(fs_backing, &inodes, FS_ROOT_INO).unwrap();
+        (inodes, fs)
+    }
+
+    const STDIO: [WasiFd; 3] = [
+        __WASI_STDIN_FILENO,
+        __WASI_STDOUT_FILENO,
+        __WASI_STDERR_FILENO,
+    ];
+
+    /// `fdstat` and `fd_filestat_get` read the same cached field, so they can
+    /// never disagree about whether stdio is a terminal.
+    fn assert_stdio_filetype(fs: &WasiFs, fd: WasiFd, expected: Filetype) {
+        assert_eq!(fs.fdstat(fd).unwrap().fs_filetype, expected);
+        assert_eq!(fs.filestat_fd(fd).unwrap().st_filetype, expected);
+    }
+
+    #[tokio::test]
+    async fn stdio_defaults_to_a_terminal_when_the_handle_has_no_opinion() {
+        let (_inodes, fs) = test_fs();
+        for fd in STDIO {
+            fs.swap_file(fd, Box::<virtual_fs::NullFile>::default())
+                .unwrap();
+            assert_stdio_filetype(&fs, fd, Filetype::CharacterDevice);
+        }
+    }
+
+    #[tokio::test]
+    async fn swap_file_recomputes_the_stdio_filetype() {
+        let (_inodes, fs) = test_fs();
+        for fd in STDIO {
+            fs.swap_file(fd, Box::new(virtual_fs::Pipe::new().with_terminal(false)))
+                .unwrap();
+            assert_stdio_filetype(&fs, fd, Filetype::Unknown);
+
+            fs.swap_file(fd, Box::new(virtual_fs::Pipe::new().with_terminal(true)))
+                .unwrap();
+            assert_stdio_filetype(&fs, fd, Filetype::CharacterDevice);
+        }
+    }
+
+    #[tokio::test]
+    async fn the_stdio_terminal_override_beats_the_handle() {
+        let (_inodes, fs) = test_fs();
+        fs.swap_file(
+            __WASI_STDOUT_FILENO,
+            Box::new(virtual_fs::Pipe::new().with_terminal(true)),
+        )
+        .unwrap();
+
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, Some(false));
+        assert_stdio_filetype(&fs, __WASI_STDOUT_FILENO, Filetype::Unknown);
+
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, None);
+        assert_stdio_filetype(&fs, __WASI_STDOUT_FILENO, Filetype::CharacterDevice);
+    }
+
+    #[tokio::test]
+    async fn a_duplicate_of_stdio_reports_the_same_filetype() {
+        let (_inodes, fs) = test_fs();
+        fs.swap_file(
+            __WASI_STDOUT_FILENO,
+            Box::new(virtual_fs::Pipe::new().with_terminal(false)),
+        )
+        .unwrap();
+
+        let dup = fs.clone_fd(__WASI_STDOUT_FILENO).unwrap();
+        assert_eq!(
+            fs.fdstat(dup).unwrap().fs_filetype,
+            Filetype::Unknown,
+            "a dup of stdout used to report RegularFile"
+        );
+
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, Some(true));
+        assert_eq!(
+            fs.fdstat(dup).unwrap().fs_filetype,
+            Filetype::CharacterDevice
+        );
+    }
+
+    /// After a shell redirect, fd 1 is a regular file and must say so -- and
+    /// swapping stdio afterwards must not stamp a stdio file type onto it.
+    #[tokio::test]
+    async fn dup2_onto_stdout_reports_the_target() {
+        let (inodes, mut fs) = test_fs();
+        let file = fs
+            .open_file_at(
+                &inodes,
+                VIRTUAL_ROOT_FD,
+                Box::<virtual_fs::BufferFile>::default(),
+                0,
+                "redirect".to_string(),
+                ALL_RIGHTS,
+                ALL_RIGHTS,
+                Fdflags::empty(),
+                Fdflagsext::empty(),
+            )
+            .unwrap();
+        let file_filetype = fs.fdstat(file).unwrap().fs_filetype;
+        assert_eq!(file_filetype, Filetype::RegularFile);
+
+        fs.dup2_at(file, __WASI_STDOUT_FILENO).unwrap();
+        assert_eq!(
+            fs.fdstat(__WASI_STDOUT_FILENO).unwrap().fs_filetype,
+            Filetype::RegularFile,
+            "a redirected stdout used to keep claiming CharacterDevice"
+        );
+
+        // fd 1 is no longer stdio, so the override must leave it alone.
+        fs.set_stdio_terminal(__WASI_STDOUT_FILENO, Some(true));
+        assert_eq!(
+            fs.fdstat(__WASI_STDOUT_FILENO).unwrap().fs_filetype,
+            Filetype::RegularFile
+        );
+    }
+
+    #[tokio::test]
+    async fn fdstat_on_closed_stdio_is_badf() {
+        let (_inodes, fs) = test_fs();
+        fs.close_fd(__WASI_STDOUT_FILENO).unwrap();
+        assert_eq!(fs.fdstat(__WASI_STDOUT_FILENO).unwrap_err(), Errno::Badf);
+    }
+
+    /// The rights and flags the removed hardcoded arms used to return have to
+    /// keep coming out of the `Fd` entry unchanged.
+    #[tokio::test]
+    async fn stdio_rights_and_flags_are_unchanged() {
+        let (_inodes, fs) = test_fs();
+        for (fd, rights, flags) in [
+            (__WASI_STDIN_FILENO, STDIN_DEFAULT_RIGHTS, Fdflags::empty()),
+            (__WASI_STDOUT_FILENO, STDOUT_DEFAULT_RIGHTS, Fdflags::APPEND),
+            (__WASI_STDERR_FILENO, STDERR_DEFAULT_RIGHTS, Fdflags::APPEND),
+        ] {
+            let stat = fs.fdstat(fd).unwrap();
+            assert_eq!(stat.fs_rights_base, rights);
+            assert_eq!(stat.fs_rights_inheriting, Rights::empty());
+            assert_eq!(stat.fs_flags, flags);
+        }
+    }
+
+    #[cfg(all(unix, feature = "host-fs"))]
+    #[tokio::test]
+    async fn a_pty_swapped_into_stdin_reports_a_terminal() {
+        use std::{
+            io::IsTerminal,
+            os::fd::{FromRawFd, RawFd},
+        };
+
+        let mut controller: RawFd = -1;
+        let mut device: RawFd = -1;
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut controller,
+                    &mut device,
+                    std::ptr::null_mut(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                )
+            },
+            0
+        );
+
+        let _controller = unsafe { std::fs::File::from_raw_fd(controller) };
+        let device = unsafe { std::fs::File::from_raw_fd(device) };
+        assert!(device.is_terminal());
+
+        let (_inodes, fs) = test_fs();
+        let pty = virtual_fs::host_fs::File::new(
+            tokio::runtime::Handle::current(),
+            device,
+            PathBuf::from("/dev/pts/test"),
+            true,
+            true,
+            false,
+        );
+        fs.swap_file(__WASI_STDIN_FILENO, Box::new(pty)).unwrap();
+        assert_stdio_filetype(&fs, __WASI_STDIN_FILENO, Filetype::CharacterDevice);
+    }
 
     fn webc_symlink_fs() -> virtual_fs::WebcVolumeFileSystem {
         let timestamps = webc::v3::Timestamps::default();

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -1053,13 +1053,8 @@ impl WasiFs {
         }
     }
 
-    /// Override what one of stdin/stdout/stderr reports about being connected
-    /// to a terminal, ignoring whatever the handle behind it has to say.
-    ///
-    /// This is one-way on purpose. There is no "stop overriding": undoing it
-    /// would mean re-asking the handle, and the reason the answer is cached at
-    /// all is so that no caller has to take the handle's lock. An embedder that
-    /// wants the handle to decide should simply not call this.
+    /// Override the terminal status of a stdio inode, including its duplicates.
+    /// Replacing its backing handle with [`Self::swap_file`] recomputes the status.
     ///
     /// Has no effect on a descriptor that is no longer stdio (after a `dup2`
     /// onto it, say).
@@ -1083,82 +1078,49 @@ impl WasiFs {
         fd: WasiFd,
         mut file: Box<dyn VirtualFile + Send + Sync + 'static>,
     ) -> Result<Option<Box<dyn VirtualFile + Send + Sync + 'static>>, FsError> {
-        match fd {
-            __WASI_STDIN_FILENO | __WASI_STDOUT_FILENO | __WASI_STDERR_FILENO => {
-                // Ask the incoming file first, while holding nothing: wrappers
-                // such as `ArcBoxFile` and `WasiStateFileGuard` take locks of
-                // their own to answer this.
-                let new_is_terminal = file.is_terminal();
-
-                // Lock order is fd_map -> inode.kind -> handle, with
-                // inode.stat taken on its own. Each is released before the
-                // next is acquired, so unlike `WasiInodes::std_dev_get_mut` we
-                // never block on the handle while holding the fd map.
-                let (inode, is_stdio) = {
-                    let fd_map = self.fd_map.read().unwrap();
-                    let entry = fd_map.get(fd).ok_or(FsError::NoDevice)?;
-                    (entry.inode.clone(), entry.is_stdio)
-                };
-
-                let handle = {
-                    let guard = inode.read();
-                    match guard.deref() {
-                        Kind::File {
-                            handle: Some(handle),
-                            ..
-                        } => handle.clone(),
-                        _ => return Err(FsError::NotAFile),
-                    }
-                };
-
-                {
-                    let mut guard = handle.write().map_err(|_| FsError::Lock)?;
-                    std::mem::swap(guard.deref_mut(), &mut file);
-                }
-
-                // Guarded on `is_stdio`: after a guest `dup2(3, 1)` this fd
-                // resolves to a regular file's inode, and stamping a stdio file
-                // type onto it would corrupt that file's `fstat`.
-                if is_stdio {
-                    inode.stat.write().map_err(|_| FsError::Lock)?.st_filetype =
-                        stdio_filetype(new_is_terminal);
-                }
-
-                Ok(Some(file))
+        let stdio_slot = matches!(
+            fd,
+            __WASI_STDIN_FILENO | __WASI_STDOUT_FILENO | __WASI_STDERR_FILENO
+        );
+        let entry = self.get_fd(fd).map_err(|err| {
+            if stdio_slot {
+                FsError::NoDevice
+            } else {
+                fs_error_from_wasi_err(err)
             }
-            _ => {
-                let base_inode = self.get_fd_inode(fd).map_err(fs_error_from_wasi_err)?;
-                {
-                    // happy path
-                    let guard = base_inode.read();
-                    match guard.deref() {
-                        Kind::File { handle, .. } => {
-                            if let Some(handle) = handle {
-                                let mut handle = handle.write().unwrap();
-                                std::mem::swap(handle.deref_mut(), &mut file);
-                                return Ok(Some(file));
-                            }
-                        }
-                        _ => return Err(FsError::NotAFile),
+        })?;
+
+        // Wrappers can take their own locks when queried. Probe before taking
+        // any inode or handle lock, including when replacing a stdio duplicate.
+        let new_filetype = entry.is_stdio.then(|| stdio_filetype(file.is_terminal()));
+        let inode = entry.inode;
+        let handle = {
+            let mut guard = inode.write();
+            match guard.deref_mut() {
+                Kind::File { handle, .. } => match handle {
+                    Some(handle) => handle.clone(),
+                    None if stdio_slot || entry.is_stdio => return Err(FsError::NotAFile),
+                    None => {
+                        handle.replace(Arc::new(RwLock::new(file)));
+                        return Ok(None);
                     }
-                }
-                // slow path
-                let mut guard = base_inode.write();
-                match guard.deref_mut() {
-                    Kind::File { handle, .. } => {
-                        if let Some(handle) = handle {
-                            let mut handle = handle.write().unwrap();
-                            std::mem::swap(handle.deref_mut(), &mut file);
-                            Ok(Some(file))
-                        } else {
-                            handle.replace(Arc::new(RwLock::new(file)));
-                            Ok(None)
-                        }
-                    }
-                    _ => Err(FsError::NotAFile),
-                }
+                },
+                _ => return Err(FsError::NotAFile),
             }
+        };
+
+        // Release the map and inode locks before waiting for I/O. Keep the
+        // handle locked until its metadata is updated so concurrent swaps
+        // cannot publish their terminal answers in a different order.
+        let mut target = handle.write().map_err(|_| FsError::Lock)?;
+        let mut stat = new_filetype
+            .map(|_| inode.stat.write().map_err(|_| FsError::Lock))
+            .transpose()?;
+        std::mem::swap(target.deref_mut(), &mut file);
+        if let (Some(stat), Some(filetype)) = (stat.as_mut(), new_filetype) {
+            stat.st_filetype = filetype;
         }
+        Ok(Some(file))
     }
 
     /// refresh size from filesystem
@@ -3011,6 +2973,150 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn swap_file_through_a_stdio_duplicate_updates_all_aliases() {
+        let (_inodes, fs) = test_fs();
+        for fd in STDIO {
+            fs.swap_file(fd, Box::new(virtual_fs::Pipe::new().with_terminal(true)))
+                .unwrap();
+            let duplicate = fs.clone_fd(fd).unwrap();
+            fs.swap_file(
+                duplicate,
+                Box::new(virtual_fs::Pipe::new().with_terminal(false)),
+            )
+            .unwrap();
+            assert_stdio_filetype(&fs, fd, Filetype::Unknown);
+            assert_stdio_filetype(&fs, duplicate, Filetype::Unknown);
+        }
+    }
+
+    #[tokio::test]
+    async fn exported_stdio_preserves_the_terminal_override() {
+        for is_terminal in [false, true] {
+            let init = WasiEnvBuilder::new("parent")
+                .engine(Engine::default())
+                .stdin(Box::new(
+                    virtual_fs::Pipe::new().with_terminal(!is_terminal),
+                ))
+                .stdout(Box::new(
+                    virtual_fs::Pipe::new().with_terminal(!is_terminal),
+                ))
+                .stderr(Box::new(
+                    virtual_fs::Pipe::new().with_terminal(!is_terminal),
+                ))
+                .stdio_is_terminal(is_terminal)
+                .build_init()
+                .unwrap();
+            let child = WasiEnvBuilder::new("child")
+                .engine(Engine::default())
+                .stdin(init.state.stdin().unwrap().unwrap())
+                .stdout(init.state.stdout().unwrap().unwrap())
+                .stderr(init.state.stderr().unwrap().unwrap())
+                .build_init()
+                .unwrap();
+            for fd in STDIO {
+                assert_stdio_filetype(&child.state.fs, fd, stdio_filetype(Some(is_terminal)));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_stdio_swaps_keep_metadata_with_the_installed_handle() {
+        const ROUNDS: usize = 2000;
+        let (_inodes, fs) = test_fs();
+        let barrier = std::sync::Barrier::new(3);
+        let inode = fs.get_fd_inode(__WASI_STDOUT_FILENO).unwrap();
+        let handle = WasiFs::file_flush_target(&inode).unwrap();
+        std::thread::scope(|scope| {
+            for is_terminal in [false, true] {
+                let fs = &fs;
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    for _ in 0..ROUNDS {
+                        barrier.wait();
+                        fs.swap_file(
+                            __WASI_STDOUT_FILENO,
+                            Box::new(virtual_fs::Pipe::new().with_terminal(is_terminal)),
+                        )
+                        .unwrap();
+                        barrier.wait();
+                        barrier.wait();
+                    }
+                });
+            }
+            let mut mismatches = 0;
+            for _ in 0..ROUNDS {
+                barrier.wait();
+                barrier.wait();
+                let expected = stdio_filetype(handle.read().unwrap().is_terminal());
+                if fs.fdstat(__WASI_STDOUT_FILENO).unwrap().fs_filetype != expected {
+                    mismatches += 1;
+                }
+                barrier.wait();
+            }
+            assert_eq!(mismatches, 0);
+        });
+    }
+
+    #[tokio::test]
+    async fn stdio_swap_does_not_publish_a_handle_before_its_metadata() {
+        let (_inodes, fs) = test_fs();
+        fs.swap_file(
+            __WASI_STDOUT_FILENO,
+            Box::new(virtual_fs::Pipe::new().with_terminal(true)),
+        )
+        .unwrap();
+        let inode = fs.get_fd_inode(__WASI_STDOUT_FILENO).unwrap();
+        let handle = WasiFs::file_flush_target(&inode).unwrap();
+        let stat = inode.stat.read().unwrap();
+        let inconsistent = std::thread::scope(|scope| {
+            let swap = scope.spawn(|| {
+                fs.swap_file(
+                    __WASI_STDOUT_FILENO,
+                    Box::new(virtual_fs::Pipe::new().with_terminal(false)),
+                )
+                .unwrap();
+            });
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            let mut inconsistent = false;
+            while std::time::Instant::now() < deadline {
+                if let Ok(file) = handle.try_read()
+                    && stdio_filetype(file.is_terminal()) != stat.st_filetype
+                {
+                    inconsistent = true;
+                    break;
+                }
+                std::thread::yield_now();
+            }
+            drop(stat);
+            swap.join().unwrap();
+            inconsistent
+        });
+        assert!(
+            !inconsistent,
+            "new handle was visible with the old file type"
+        );
+    }
+
+    #[tokio::test]
+    async fn exported_stdio_terminal_queries_do_not_wait_for_io() {
+        let init = WasiEnvBuilder::new("parent")
+            .engine(Engine::default())
+            .stdio_is_terminal(false)
+            .build_init()
+            .unwrap();
+        let stdout = init.state.stdout().unwrap().unwrap();
+        let inode = init.state.fs.get_fd_inode(__WASI_STDOUT_FILENO).unwrap();
+        let handle = WasiFs::file_flush_target(&inode).unwrap();
+        let io_guard = handle.write().unwrap();
+        let (send, recv) = std::sync::mpsc::channel();
+        let query = std::thread::spawn(move || send.send(stdout.is_terminal()).unwrap());
+        let answer = recv.recv_timeout(std::time::Duration::from_secs(2));
+        drop(io_guard);
+        query.join().unwrap();
+        assert_eq!(answer.unwrap(), Some(false));
+    }
+
+    #[tokio::test]
     async fn the_stdio_terminal_override_beats_the_handle() {
         let (_inodes, fs) = test_fs();
         fs.swap_file(
@@ -3083,6 +3189,52 @@ mod tests {
             fs.fdstat(__WASI_STDOUT_FILENO).unwrap().fs_filetype,
             Filetype::RegularFile
         );
+
+        for fd in [file, __WASI_STDOUT_FILENO] {
+            assert!(
+                fs.swap_file(fd, Box::new(virtual_fs::Pipe::new().with_terminal(true)))
+                    .unwrap()
+                    .is_some()
+            );
+            assert_stdio_filetype(&fs, file, Filetype::RegularFile);
+            assert_stdio_filetype(&fs, __WASI_STDOUT_FILENO, Filetype::RegularFile);
+        }
+    }
+
+    #[tokio::test]
+    async fn swap_file_installs_an_unopened_regular_file() {
+        let (inodes, fs) = test_fs();
+        let inode = fs.create_inode_with_stat(
+            &inodes,
+            Kind::File {
+                handle: None,
+                path: "/file".into(),
+                fd: None,
+            },
+            false,
+            "file".into(),
+            Filestat {
+                st_filetype: Filetype::RegularFile,
+                ..Filestat::default()
+            },
+        );
+        let fd = fs
+            .create_fd(
+                ALL_RIGHTS,
+                ALL_RIGHTS,
+                Fdflags::empty(),
+                Fdflagsext::empty(),
+                Fd::READ,
+                inode,
+            )
+            .unwrap();
+        assert!(
+            fs.swap_file(fd, Box::new(virtual_fs::Pipe::new().with_terminal(true)))
+                .unwrap()
+                .is_none()
+        );
+        assert_stdio_filetype(&fs, fd, Filetype::RegularFile);
+        assert!(fs.clone_fd(fd).is_ok());
     }
 
     #[tokio::test]

--- a/lib/wasix/src/runners/wasi.rs
+++ b/lib/wasix/src/runners/wasi.rs
@@ -28,6 +28,7 @@ pub struct WasiRunner {
     stdin: Option<ArcBoxFile>,
     stdout: Option<ArcBoxFile>,
     stderr: Option<ArcBoxFile>,
+    stdio_is_terminal: Option<bool>,
 }
 
 pub enum PackageOrHash<'a> {
@@ -252,6 +253,13 @@ impl WasiRunner {
         self
     }
 
+    /// Force what stdin, stdout and stderr report about being connected to a
+    /// terminal, instead of letting the handles behind them decide.
+    pub fn with_stdio_is_terminal(&mut self, is_terminal: bool) -> &mut Self {
+        self.stdio_is_terminal = Some(is_terminal);
+        self
+    }
+
     fn ensure_tokio_runtime() -> Option<tokio::runtime::Runtime> {
         #[cfg(feature = "sys-thread")]
         {
@@ -345,6 +353,7 @@ impl WasiRunner {
         if let Some(stderr) = &self.stderr {
             builder.set_stderr(Box::new(stderr.clone()));
         }
+        builder.set_stdio_is_terminal(self.stdio_is_terminal);
 
         Ok(builder)
     }

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -999,7 +999,7 @@ impl WasiEnvBuilder {
                     __WASI_STDOUT_FILENO,
                     __WASI_STDERR_FILENO,
                 ] {
-                    wasi_fs.set_stdio_terminal(fd, Some(is_terminal));
+                    wasi_fs.set_stdio_terminal(fd, is_terminal);
                 }
             }
 

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -67,6 +67,7 @@ pub struct WasiEnvBuilder {
     pub(super) stdout: Option<Box<dyn VirtualFile + Send + Sync + 'static>>,
     pub(super) stderr: Option<Box<dyn VirtualFile + Send + Sync + 'static>>,
     pub(super) stdin: Option<Box<dyn VirtualFile + Send + Sync + 'static>>,
+    pub(super) stdio_is_terminal: Option<bool>,
     pub(super) fs: Option<WasiFsRoot>,
     pub(super) engine: Option<Engine>,
     pub(super) runtime: Option<Arc<dyn crate::Runtime + Send + Sync + 'static>>,
@@ -761,6 +762,19 @@ impl WasiEnvBuilder {
         self.stdin = Some(new_file);
     }
 
+    /// Force what stdin, stdout and stderr report about being connected to a
+    /// terminal, instead of letting the handles behind them decide.
+    pub fn stdio_is_terminal(mut self, is_terminal: bool) -> Self {
+        self.set_stdio_is_terminal(Some(is_terminal));
+        self
+    }
+
+    /// See [`WasiEnvBuilder::stdio_is_terminal`]. `None` restores the default of
+    /// deferring to the stdio handles.
+    pub fn set_stdio_is_terminal(&mut self, is_terminal: Option<bool>) {
+        self.stdio_is_terminal = is_terminal;
+    }
+
     /// Sets the FileSystem to be used with this WASI instance.
     ///
     /// This is usually used in case a custom `virtual_fs::FileSystem` is needed.
@@ -977,6 +991,18 @@ impl WasiEnvBuilder {
             if let Some(f) = &self.setup_fs_fn {
                 f(&inodes, &mut wasi_fs).map_err(WasiStateCreationError::WasiFsSetupError)?;
             }
+
+            // Applied last so it wins over every handle installed above.
+            if let Some(is_terminal) = self.stdio_is_terminal {
+                for fd in [
+                    __WASI_STDIN_FILENO,
+                    __WASI_STDOUT_FILENO,
+                    __WASI_STDERR_FILENO,
+                ] {
+                    wasi_fs.set_stdio_terminal(fd, Some(is_terminal));
+                }
+            }
+
             wasi_fs
         };
 

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -320,6 +320,10 @@ impl WasiEnv {
             *self.state.fs.current_dir.lock().unwrap() = "/".to_string();
 
             // We need to rebuild the basic file descriptors
+            // TODO: this reinstalls the *default* stdio, discarding whatever the
+            // embedder supplied via `WasiEnvBuilder`/`WasiRunner`. One visible
+            // symptom is that `isatty` flips back to the host's answer after a
+            // reinit; the handles themselves are lost too.
             self.state.fs.create_stdin(&self.state.inodes);
             self.state.fs.create_stdout(&self.state.inodes);
             self.state.fs.create_stderr(&self.state.inodes);

--- a/lib/wasix/tests/wasm_tests/isatty/main.c
+++ b/lib/wasix/tests/wasm_tests/isatty/main.c
@@ -1,0 +1,26 @@
+// Stdio whose backing handle has no opinion on being a terminal is reported as
+// a character device, so `isatty` says yes. A descriptor duplicated from stdio
+// has to give the same answer.
+
+#include <assert.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(void) {
+  assert(isatty(STDIN_FILENO) == 1);
+  assert(isatty(STDOUT_FILENO) == 1);
+  assert(isatty(STDERR_FILENO) == 1);
+
+  int dup_of_stdout = dup(STDOUT_FILENO);
+  assert(dup_of_stdout >= 0);
+  assert(isatty(dup_of_stdout) == 1);
+  assert(close(dup_of_stdout) == 0);
+
+  // `fstat` reads the same file type `isatty` does, so the two must agree.
+  struct stat st;
+  assert(fstat(STDOUT_FILENO, &st) == 0);
+  assert(S_ISCHR(st.st_mode));
+
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/isatty_non_tty/main.c
+++ b/lib/wasix/tests/wasm_tests/isatty_non_tty/main.c
@@ -1,0 +1,27 @@
+//#StdioIsTerminal: false
+
+// When the embedder says stdio is not a terminal, `isatty` has to say so, and
+// `fstat` has to agree rather than keep claiming a character device.
+
+#include <assert.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(void) {
+  assert(isatty(STDIN_FILENO) == 0);
+  assert(errno == ENOTTY);
+  assert(isatty(STDOUT_FILENO) == 0);
+  assert(isatty(STDERR_FILENO) == 0);
+
+  int dup_of_stdout = dup(STDOUT_FILENO);
+  assert(dup_of_stdout >= 0);
+  assert(isatty(dup_of_stdout) == 0);
+  assert(close(dup_of_stdout) == 0);
+
+  struct stat st;
+  assert(fstat(STDOUT_FILENO, &st) == 0);
+  assert(!S_ISCHR(st.st_mode));
+
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -72,6 +72,10 @@
 //!
 //! `StdinFile:{relative_path}` writes a fixture file to the test program's stdin.
 //!
+//! `StdioIsTerminal:{bool}` forces whether the guest sees stdin/stdout/stderr as
+//! a terminal. Stdio otherwise has no opinion, which WASIX reports as a
+//! character device, so `isatty` defaults to true.
+//!
 //! `ProgramName:{name}` overrides argv[0].
 //!
 //! `DefaultMappedDirectories:{bool}` controls the harness default directory mappings.
@@ -259,6 +263,7 @@ struct Config {
     build_env: Vec<(String, String)>,
     env: Vec<(String, String)>,
     stdin: Option<Vec<u8>>,
+    stdio_is_terminal: Option<bool>,
     ignored: Option<String>,
     skipped_engines: Vec<(Engine, String)>,
     unix_only: bool,
@@ -304,6 +309,7 @@ impl Config {
             expected_stdout: Vec::new(),
             expected_stderr: Vec::new(),
             stdin: None,
+            stdio_is_terminal: None,
             ignored: None,
             skipped_engines: Vec::new(),
             unix_only: false,
@@ -603,6 +609,9 @@ fn process_directive(
         }
         "StdinFile" => {
             config.stdin = Some(read_fixture_bytes(&config.test_src_dir, arg, "StdinFile")?);
+        }
+        "StdioIsTerminal" => {
+            config.stdio_is_terminal = Some(arg.parse::<bool>()?);
         }
         "ProgramName" => {
             config.program_name = Some(arg.to_owned());
@@ -1208,6 +1217,7 @@ fn run_integration_test(config: Config) -> Result<libtest_mimic::Completion> {
     }
 
     let stdin = config.stdin.clone();
+    let stdio_is_terminal = config.stdio_is_terminal;
 
     let mut extra_temporary_folders = Vec::new();
     let result = runner::run_wasm_with_runner_config(
@@ -1225,8 +1235,13 @@ fn run_integration_test(config: Config) -> Result<libtest_mimic::Completion> {
                 runner.with_envs(config.env.iter().cloned());
             }
 
-            if let Some(stdin) = stdin {
-                runner.with_stdin(Box::new(StaticFile::new(stdin)));
+            // Always pinned: left unset, stdin would be the host process's own,
+            // and `isatty(0)` would then depend on whether the suite was run
+            // from a terminal.
+            runner.with_stdin(Box::new(StaticFile::new(stdin.unwrap_or_default())));
+
+            if let Some(stdio_is_terminal) = stdio_is_terminal {
+                runner.with_stdio_is_terminal(stdio_is_terminal);
             }
 
             configure_mapped_directories(runner, &config, &mut extra_temporary_folders)?;

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_bash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_bash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1196
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hi\nhi2\n",
-      "stderr": "test.wasm-5.1# bash-dist# bash-dist# exit\ntest.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_cd_ls.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_cd_ls.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1164
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "arch\nbase32\nbase64\nbaseenc\nbasename\nbash\ncat\nchcon\nchgrp\nchmod\nchown\nchroot\ncksum\ncomm\ncp\ncsplit\ncut\ndate\ndd\ndf\ndircolors\ndirname\ndu\necho\nenv\nexpand\nexpr\nfactor\nfalse\nfmt\nfold\ngroups\nhashsum\nhead\nhostid\nhostname\nid\ninstall\njoin\nkill\nlink\nln\nlogname\nls\nmkdir\nmkfifo\nmknod\nmktemp\nmore\nmv\nnice\nnl\nnohup\nnproc\nnumfmt\nod\npaste\npathchk\npinky\npr\nprintenv\nprintf\nptx\npwd\nreadlink\nrealpath\nrelpath\nrm\nrmdir\nruncon\nseq\nsh\nshred\nshuf\nsleep\nsort\nsplit\nstat\nstdbuf\nsum\nsync\ntac\ntail\ntee\ntest\ntimeout\ntouch\ntr\ntrue\ntruncate\ntsort\ntty\nuname\nunexpand\nuniq\nunlink\nuptime\nusers\nwasmer\nwc\nwho\nwhoami\nyes\n",
-      "stderr": "test.wasm-5.1# test.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_dash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_dash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1209
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hi\n",
-      "stderr": "test.wasm-5.1# test.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_echo.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_echo.snap
@@ -15,7 +15,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hello\n",
-      "stderr": "test.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_ls.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_ls.snap
@@ -17,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "bin\ndev\netc\ntmp\nusr\n",
-      "stderr": "test.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_pipe.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_pipe.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1181
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hello\n",
-      "stderr": "test.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_python.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_bash_python.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1189
 expression: snapshot
 ---
 {
@@ -22,7 +21,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "10\n",
-      "stderr": "test.wasm-5.1# test.wasm-5.1# exit\n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_bash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_bash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1117
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hi\n",
-      "stderr": "# bash-dist# exit\n# # ",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dash.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_dash.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1104
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hi\n",
-      "stderr": "# # # ",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo.snap
@@ -15,7 +15,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "2\n",
-      "stderr": "# # \n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo_to_cat.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_echo_to_cat.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1070
 expression: snapshot
 ---
 {
@@ -18,7 +17,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "hello\n",
-      "stderr": "# # \n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_python.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_dash_python.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 1084
 expression: snapshot
 ---
 {
@@ -22,7 +21,7 @@ expression: snapshot
   "result": {
     "Success": {
       "stdout": "10\n",
-      "stderr": "# # \n",
+      "stderr": "",
       "exit_code": 0
     }
   }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll.snap
@@ -13,7 +13,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "EFD_NONBLOCK:4\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\n",
+      "stdout": "EFD_NONBLOCK:4\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\n",
       "stderr": "",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_epoll_async.snap
@@ -14,7 +14,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "EFD_NONBLOCK:4\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\n",
+      "stdout": "EFD_NONBLOCK:4\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess write to efd, write 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\nsuccess read from efd, read 8 bytes(4)\n",
       "stderr": "",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_execve.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_execve.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 563
 expression: snapshot
 ---
 {
@@ -16,7 +15,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "Main program started\nexecve: echo hi-from-child\nhi-from-child\nhi-from-parent\n",
+      "stdout": "Main program started\nhi-from-child\nhi-from-parent\n",
       "stderr": "Child(2) exited with 0\nexecve: echo hi-from-parent\n",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/cli/tests/snapshot.rs
-assertion_line: 780
 expression: snapshot
 ---
 {
@@ -16,7 +15,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "Main program started\nexecve: echo hi-from-child\nhi-from-child\nhi-from-parent\n",
+      "stdout": "Main program started\nhi-from-child\nhi-from-parent\n",
       "stderr": "Child(2) exited with 0\nexecve: echo hi-from-parent\n",
       "exit_code": 0
     }

--- a/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec_async.snap
+++ b/tests/integration/cli/tests/snapshots/snapshot__snapshot_fork_and_exec_async.snap
@@ -16,7 +16,7 @@ expression: snapshot
   },
   "result": {
     "Success": {
-      "stdout": "Main program started\nexecve: echo hi-from-child\nhi-from-child\nhi-from-parent\n",
+      "stdout": "Main program started\nhi-from-child\nhi-from-parent\n",
       "stderr": "Child(2) exited with 0\nexecve: echo hi-from-parent\n",
       "exit_code": 0
     }


### PR DESCRIPTION
Fix stdio terminal detection so programs using redirected CLI input or output no longer treat those streams as interactive terminals.

Virtual files can report whether they are terminals, and wrappers forward that capability. Host handles use `std::io::IsTerminal`; handles without an answer retain the existing character-device behavior for compatibility with embedders. Pipes, the environment builder, and the runner support explicit terminal settings, and `--no-tty` forces non-terminal stdio.

WASIX caches the effective status on the stdio inode so `fdstat`, `fd_filestat_get`, and duplicated descriptors agree without waiting for I/O. Replacing a handle updates that shared status atomically, and exporting stdio to another environment preserves its terminal override. Known non-terminal stdio reports `Filetype::Unknown` because the underlying stream is not necessarily a regular file.

Supersedes #6857.
