### PR TITLE
fix(virtual-fs): poll_write_vectored returned a slice count, not bytes

### DIFF
--- a/lib/virtual-fs/src/null_file.rs
+++ b/lib/virtual-fs/src/null_file.rs
@@ -40,7 +40,9 @@ impl AsyncWrite for NullFile {
         _cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        Poll::Ready(Ok(bufs.len()))
+        // Bytes written, not the number of slices. `/dev/null` swallows all of
+        // them, so that is the total length.
+        Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
     }
     fn is_write_vectored(&self) -> bool {
         false
@@ -85,3 +87,35 @@ impl VirtualFile for NullFile {
 }
 
 impl CloneableVirtualFile for NullFile {}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    /// `poll_write_vectored` reports bytes written, not slices. Returning the
+    /// slice count made a caller believe a 300-byte write had moved 3 bytes.
+    #[tokio::test]
+    async fn write_vectored_reports_bytes_not_slices() {
+        let mut file = NullFile::default();
+        let bufs = [
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+        ];
+
+        let written = std::future::poll_fn(|cx| Pin::new(&mut file).poll_write_vectored(cx, &bufs))
+            .await
+            .unwrap();
+
+        assert_eq!(written, 300);
+    }
+
+    /// The unvectored path already agreed; keep the two consistent.
+    #[tokio::test]
+    async fn write_reports_bytes() {
+        let mut file = NullFile::default();
+        assert_eq!(file.write(&[0u8; 100]).await.unwrap(), 100);
+    }
+}

--- a/lib/virtual-fs/src/random_file.rs
+++ b/lib/virtual-fs/src/random_file.rs
@@ -40,7 +40,9 @@ impl AsyncWrite for RandomFile {
         _cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        Poll::Ready(Ok(bufs.len()))
+        // Bytes written, not the number of slices. Writes here are discarded,
+        // so that is the total length.
+        Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
     }
     fn is_write_vectored(&self) -> bool {
         false
@@ -84,5 +86,28 @@ impl VirtualFile for RandomFile {
     }
     fn poll_write_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `poll_write_vectored` reports bytes written, not slices. Returning the
+    /// slice count made a caller believe a 300-byte write had moved 3 bytes.
+    #[tokio::test]
+    async fn write_vectored_reports_bytes_not_slices() {
+        let mut file = RandomFile::default();
+        let bufs = [
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+        ];
+
+        let written = std::future::poll_fn(|cx| Pin::new(&mut file).poll_write_vectored(cx, &bufs))
+            .await
+            .unwrap();
+
+        assert_eq!(written, 300);
     }
 }

--- a/lib/virtual-fs/src/special_file.rs
+++ b/lib/virtual-fs/src/special_file.rs
@@ -59,7 +59,9 @@ impl AsyncWrite for DeviceFile {
         _cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        Poll::Ready(Ok(bufs.len()))
+        // Bytes written, not the number of slices. Writes here are discarded,
+        // so that is the total length.
+        Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
     }
 
     fn is_write_vectored(&self) -> bool {
@@ -104,5 +106,28 @@ impl VirtualFile for DeviceFile {
     }
     fn poll_write_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `poll_write_vectored` reports bytes written, not slices. Returning the
+    /// slice count made a caller believe a 300-byte write had moved 3 bytes.
+    #[tokio::test]
+    async fn write_vectored_reports_bytes_not_slices() {
+        let mut file = DeviceFile::new(1);
+        let bufs = [
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+        ];
+
+        let written = std::future::poll_fn(|cx| Pin::new(&mut file).poll_write_vectored(cx, &bufs))
+            .await
+            .unwrap();
+
+        assert_eq!(written, 300);
     }
 }

--- a/lib/virtual-fs/src/zero_file.rs
+++ b/lib/virtual-fs/src/zero_file.rs
@@ -43,7 +43,9 @@ impl AsyncWrite for ZeroFile {
         _cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        Poll::Ready(Ok(bufs.len()))
+        // Bytes written, not the number of slices. Writes here are discarded,
+        // so that is the total length.
+        Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
     }
     fn is_write_vectored(&self) -> bool {
         false
@@ -86,5 +88,28 @@ impl VirtualFile for ZeroFile {
     }
     fn poll_write_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `poll_write_vectored` reports bytes written, not slices. Returning the
+    /// slice count made a caller believe a 300-byte write had moved 3 bytes.
+    #[tokio::test]
+    async fn write_vectored_reports_bytes_not_slices() {
+        let mut file = ZeroFile::default();
+        let bufs = [
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+            IoSlice::new(&[0u8; 100]),
+        ];
+
+        let written = std::future::poll_fn(|cx| Pin::new(&mut file).poll_write_vectored(cx, &bufs))
+            .await
+            .unwrap();
+
+        assert_eq!(written, 300);
     }
 }


### PR DESCRIPTION
`AsyncWrite::poll_write_vectored` must return the number of **bytes** written. Four `VirtualFile` leaves returned `bufs.len()` — the number of *slices*:

```rust
fn poll_write_vectored(
    self: Pin<&mut Self>,
    _cx: &mut Context<'_>,
    bufs: &[IoSlice<'_>],
) -> Poll<io::Result<usize>> {
    Poll::Ready(Ok(bufs.len()))   // <-- slices, not bytes
}
```

So a caller writing three 100-byte slices is told 3 bytes moved, and dutifully retries the remaining 297 against a sink that already swallowed them.

| File | Type | |
| --- | --- | --- |
| `null_file.rs` | `NullFile` | `/dev/null` |
| `zero_file.rs` | `ZeroFile` | `/dev/zero` |
| `random_file.rs` | `RandomFile` | `/dev/urandom` |
| `special_file.rs` | `DeviceFile` | `/dev/stdin`, `/dev/stdout`, `/dev/stderr` |

All four are pure sinks whose `poll_write` correctly returns `buf.len()`, so in every case the vectored method disagreed with the unvectored one sitting directly above it.

## This is all of them

I checked every `poll_write_vectored` in the tree — 17 impls. The other thirteen either delegate to an inner file (`ArcFile`, `ArcBoxFile`, `BufferFile`, `Pipe`, `TraceFile`, `SecondaryFile`, both `CopyOnWriteFile`s, `WasiStateFileGuard`, `host_fs`) or return a real byte count (`mem_fs::FileHandle` returns `bytes_written` from the first non-empty slice, which is a valid partial write). `Pipe`'s `std::io::Write::write_vectored` delegates as well. No other `bufs.len()` occurrences remain.

## Reachability

Latent in practice: all four have `is_write_vectored() == false`, which steers well-behaved callers — tokio's own `AsyncWriteExt` included — to the unvectored path. But the method is public and forwarded to directly by `ArcFile`, `ArcBoxFile` and `WasiStateFileGuard`, so nothing structurally prevents it being hit.

## Tests

One regression test per file, pinning the byte count. Each was confirmed to **fail** against the old implementation (`3` vs `300`) rather than pass vacuously.

`virtual-fs`: 132 passed, 0 failed. Clippy and rustfmt clean.

Found by review on #6974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoHa2FN7orALN5TDtusK
