### PR TITLE
feat(wasi): support env files and deduplicate variables

### DIFF
--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -591,7 +591,7 @@ impl Run {
         runner
             .with_args(&self.args)
             .with_injected_packages(packages)
-            .with_envs(self.wasi.env_vars.clone())
+            .with_envs(self.wasi.resolved_env_vars()?)
             .with_mapped_host_commands(self.wasi.build_mapped_commands()?)
             .with_mapped_directories(mapped_directories)
             .with_home_mapped(is_home_mapped)

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -10,6 +10,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use bytes::Bytes;
 use clap::Parser;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use tokio::runtime::Handle;
 use url::Url;
@@ -99,6 +100,10 @@ pub struct Wasi {
         value_parser=parse_envvar,
     )]
     pub(crate) env_vars: Vec<(String, String)>,
+
+    /// Load environment variables from a dotenv file.
+    #[clap(long = "env-file", name = "PATH")]
+    pub(crate) env_file: Option<PathBuf>,
 
     /// Forward all host env variables to guest
     #[clap(long, env)]
@@ -290,6 +295,23 @@ impl Wasi {
         self.env_vars.push((key.to_string(), value.to_string()));
     }
 
+    pub(crate) fn resolved_env_vars(&self) -> Result<Vec<(String, String)>> {
+        let mut env = IndexMap::new();
+        if let Some(path) = &self.env_file {
+            let entries = dotenvy::from_path_iter(path)
+                .with_context(|| format!("Could not read env file '{}'", path.display()))?;
+            for entry in entries {
+                let (key, value) = entry
+                    .with_context(|| format!("Could not parse env file '{}'", path.display()))?;
+                env.insert(key, value);
+            }
+        }
+        for (key, value) in &self.env_vars {
+            env.insert(key.clone(), value.clone());
+        }
+        Ok(env.into_iter().collect())
+    }
+
     /// Gets the WASI version (if any) for the provided module
     pub fn get_versions(module: &Module) -> Option<BTreeSet<WasiVersion>> {
         // Get the wasi version in non-strict mode, so multiple wasi versions
@@ -352,7 +374,7 @@ impl Wasi {
         let mut builder = WasiEnv::builder(program_name)
             .runtime(Arc::clone(&rt))
             .args(args)
-            .envs(self.env_vars.clone())
+            .envs(self.resolved_env_vars()?)
             .uses(uses)
             .map_commands(map_commands);
 
@@ -830,4 +852,29 @@ fn tokens_by_authority(env: &WasmerEnv) -> Result<HashMap<String, String>> {
     tokens.extend(frontend_tokens);
 
     Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_file_is_merged_and_explicit_env_wins() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = temporary.path().join("runtime.env");
+        std::fs::write(&path, "FROM_FILE=yes\nSHARED=file\n").unwrap();
+        let wasi = Wasi {
+            env_file: Some(path),
+            env_vars: vec![("SHARED".to_owned(), "explicit".to_owned())],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            wasi.resolved_env_vars().unwrap(),
+            [
+                ("FROM_FILE".to_owned(), "yes".to_owned()),
+                ("SHARED".to_owned(), "explicit".to_owned()),
+            ]
+        );
+    }
 }

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -544,9 +544,12 @@ mod tests {
     #[tokio::test]
     async fn mix_env_vars_from_the_webc_and_user() {
         let args = CommonWasiOptions {
-            env: vec![("EXTRA".to_string(), "envs".to_string())]
-                .into_iter()
-                .collect(),
+            env: vec![
+                ("EXTRA".to_string(), "envs".to_string()),
+                ("HARD_CODED".to_string(), "user-override".to_string()),
+            ]
+            .into_iter()
+            .collect(),
             ..Default::default()
         };
         let mut builder = WasiEnvBuilder::new("python");
@@ -559,7 +562,7 @@ mod tests {
         assert_eq!(
             builder.get_env(),
             [
-                ("HARD_CODED".to_string(), b"env-vars".to_vec()),
+                ("HARD_CODED".to_string(), b"user-override".to_vec()),
                 ("EXTRA".to_string(), b"envs".to_vec()),
             ]
         );

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -213,10 +213,17 @@ impl WasiEnvBuilder {
         Key: AsRef<[u8]>,
         Value: AsRef<[u8]>,
     {
-        self.envs.push((
-            String::from_utf8_lossy(key.as_ref()).to_string(),
-            value.as_ref().to_vec(),
-        ));
+        let key = String::from_utf8_lossy(key.as_ref()).to_string();
+        let value = value.as_ref().to_vec();
+        if let Some((_, existing_value)) = self
+            .envs
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key == &key)
+        {
+            *existing_value = value;
+        } else {
+            self.envs.push((key, value));
+        }
     }
 
     /// Add multiple environment variable pairs.
@@ -1299,6 +1306,22 @@ mod test {
         {
             None
         }
+    }
+
+    #[test]
+    fn duplicate_environment_variables_use_the_last_value() {
+        let mut builder = WasiEnvBuilder::new("test");
+        builder.add_env("PORT", "5000");
+        builder.add_env("OTHER", "value");
+        builder.add_env("PORT", "8080");
+
+        assert_eq!(
+            builder.get_env(),
+            [
+                ("PORT".to_owned(), b"8080".to_vec()),
+                ("OTHER".to_owned(), b"value".to_vec()),
+            ]
+        );
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
# Description

Add --env-file PATH to wasmer run for both raw WASI modules and WebC-backed runners. Values from explicit --env arguments override values loaded from the dotenv file.

Deduplicate environment variables in WasiEnvBuilder using last-value-wins semantics. This prevents duplicate keys when package annotations, forwarded host variables, env files, and explicit CLI values overlap.

## Tests

- cargo test -p wasmer-cli env_file_is_merged_and_explicit_env_wins --lib
- cargo test -p wasmer-wasix duplicate_environment_variables_use_the_last_value --lib
- cargo test -p wasmer-wasix mix_env_vars_from_the_webc_and_user --lib

The full CLI and WASIX unit suites were also run. All non-network tests passed; the existing CDN-backed package download tests could not resolve cdn.wasmer.io in the test environment.