### PR TITLE
feat(cli): add env file support to deploy

### DIFF
--- a/lib/cli/src/commands/app/create.rs
+++ b/lib/cli/src/commands/app/create.rs
@@ -827,6 +827,7 @@ the app:\n"
                 publish_package: !build_remote,
                 dir: self.app_dir_path.clone(),
                 path: path.map(|v| v.to_path_buf()),
+                env_file: None,
                 no_wait: self.no_wait,
                 no_default: false,
                 no_persist_id: false,

--- a/lib/cli/src/commands/app/deploy.rs
+++ b/lib/cli/src/commands/app/deploy.rs
@@ -67,6 +67,10 @@ pub struct CmdAppDeploy {
     #[clap(long, conflicts_with = "dir")]
     pub path: Option<PathBuf>,
 
+    /// Load environment variables from a dotenv file for this deployment.
+    #[clap(long = "env-file", name = "PATH")]
+    pub env_file: Option<PathBuf>,
+
     /// Do not wait for the app to become reachable.
     #[clap(long)]
     pub no_wait: bool,
@@ -292,15 +296,20 @@ impl CmdAppDeploy {
         };
 
         let RemoteBuildInput {
-            app_config,
+            mut app_config,
             owner,
             original_config,
             config_path,
         } = prep;
+        let persisted_app_config = app_config.clone();
+        if let Some(path) = &self.env_file {
+            apply_env_file(&mut app_config, path)?;
+        }
 
         let opts = DeployAppOpts {
             app: &app_config,
             original_config: original_config.clone(),
+            env_file: None,
             allow_create: true,
             make_default: !self.no_default,
             owner: Some(owner.clone()),
@@ -325,11 +334,14 @@ impl CmdAppDeploy {
                 new_app_config.app_id = None;
             }
 
-            new_app_config.package = app_config.package.clone();
+            new_app_config.package = persisted_app_config.package.clone();
+            // An env file applies only to this deployment and must not be
+            // written back into app.yaml.
+            new_app_config.env = persisted_app_config.env.clone();
 
-            if new_app_config != app_config {
+            if new_app_config != persisted_app_config {
                 let new_merged = crate::utils::merge_yaml_values(
-                    &app_config.clone().to_yaml_value()?,
+                    &persisted_app_config.clone().to_yaml_value()?,
                     &new_app_config.to_yaml_value()?,
                 );
                 let new_config_raw =
@@ -793,6 +805,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                 DeployAppOpts {
                     app: &app_cfg_new,
                     original_config: Some(app_config.clone().to_yaml_value().unwrap()),
+                    env_file: self.env_file.clone(),
                     allow_create: true,
                     make_default: !self.no_default,
                     owner: Some(owner),
@@ -865,6 +878,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                                         original_config: Some(
                                             app_config.clone().to_yaml_value().unwrap(),
                                         ),
+                                        env_file: self.env_file.clone(),
                                         allow_create: true,
                                         make_default: !self.no_default,
                                         owner: Some(owner),
@@ -882,6 +896,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                                         original_config: Some(
                                             app_config.clone().to_yaml_value().unwrap(),
                                         ),
+                                        env_file: self.env_file.clone(),
                                         allow_create: true,
                                         make_default: !self.no_default,
                                         owner: Some(owner),
@@ -894,6 +909,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                                     original_config: Some(
                                         app_config.clone().to_yaml_value().unwrap(),
                                     ),
+                                    env_file: self.env_file.clone(),
                                     allow_create: true,
                                     make_default: !self.no_default,
                                     owner: Some(owner),
@@ -904,6 +920,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                             DeployAppOpts {
                                 app: &app_config,
                                 original_config: Some(app_config.clone().to_yaml_value().unwrap()),
+                                env_file: self.env_file.clone(),
                                 allow_create: true,
                                 make_default: !self.no_default,
                                 owner: Some(owner),
@@ -914,6 +931,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                         DeployAppOpts {
                             app: &app_config,
                             original_config: Some(app_config.clone().to_yaml_value().unwrap()),
+                            env_file: self.env_file.clone(),
                             allow_create: true,
                             make_default: !self.no_default,
                             owner: Some(owner),
@@ -925,6 +943,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                     DeployAppOpts {
                         app: &app_config,
                         original_config: Some(app_config.clone().to_yaml_value().unwrap()),
+                        env_file: self.env_file.clone(),
                         allow_create: true,
                         make_default: !self.no_default,
                         owner: Some(owner),
@@ -937,6 +956,7 @@ impl AsyncCliCommand for CmdAppDeploy {
                 DeployAppOpts {
                     app: &app_config,
                     original_config: Some(app_config.clone().to_yaml_value().unwrap()),
+                    env_file: self.env_file.clone(),
                     allow_create: true,
                     make_default: !self.no_default,
                     owner: Some(owner),
@@ -979,6 +999,9 @@ impl AsyncCliCommand for CmdAppDeploy {
 
         // Don't override the package field.
         new_app_config.package = app_config.package.clone();
+        // An env file applies only to this deployment and must not be written
+        // back into app.yaml.
+        new_app_config.env = app_config.env.clone();
         // [TODO]: check if name was added...
 
         // If the config changed, write it back.
@@ -1014,6 +1037,8 @@ pub struct DeployAppOpts<'a> {
     // Present here to enable forwarding unknown fields to the backend, which
     // preserves forwards-compatibility for schema changes.
     pub original_config: Option<serde_yaml::value::Value>,
+    /// Optional dotenv file overlaid on the app configuration for deployment.
+    pub env_file: Option<PathBuf>,
     #[allow(dead_code)]
     pub allow_create: bool,
     pub make_default: bool,
@@ -1086,13 +1111,29 @@ fn remote_progress_handler(quiet: bool) -> impl FnMut(DeployRemoteEvent) {
     }
 }
 
+fn apply_env_file(app: &mut AppConfigV1, path: &Path) -> anyhow::Result<()> {
+    let entries = dotenvy::from_path_iter(path)
+        .with_context(|| format!("Could not read env file '{}'", path.display()))?;
+    for entry in entries {
+        let (key, value) =
+            entry.with_context(|| format!("Could not parse env file '{}'", path.display()))?;
+        app.env.insert(key, value);
+    }
+    Ok(())
+}
+
 pub async fn deploy_app(
     client: &WasmerClient,
     opts: DeployAppOpts<'_>,
 ) -> Result<DeployAppVersion, anyhow::Error> {
-    let app = opts.app;
+    let mut app = opts.app.clone();
 
-    let config_value = app.clone().to_yaml_value()?;
+    if let Some(path) = &opts.env_file {
+        apply_env_file(&mut app, path)?;
+    }
+
+    let name = app.name.clone().context("Expected an app name")?;
+    let config_value = app.to_yaml_value()?;
     let final_config = if let Some(old) = &opts.original_config {
         crate::utils::merge_yaml_values(old, &config_value)
     } else {
@@ -1107,7 +1148,7 @@ pub async fn deploy_app(
         client,
         wasmer_backend_api::types::PublishDeployAppVars {
             config: raw_config,
-            name: app.name.clone().context("Expected an app name")?.into(),
+            name: name.into(),
             owner: opts.owner.map(|o| o.into()),
             make_default: Some(opts.make_default),
         },
@@ -1372,8 +1413,39 @@ pub fn app_config_from_api(version: &DeployAppVersion) -> Result<AppConfigV1, an
 
 #[cfg(test)]
 mod tests {
-    use super::format_duration_words;
+    use super::{CmdAppDeploy, apply_env_file, format_duration_words};
+    use crate::commands::app::create::minimal_app_config;
+    use clap::Parser as _;
+    use std::path::PathBuf;
     use time::Duration as TimeDuration;
+
+    #[test]
+    fn env_file_can_be_used_with_remote_build() {
+        let command = CmdAppDeploy::try_parse_from([
+            "wasmer deploy",
+            "--env-file",
+            "deploy.env",
+            "--build-remote",
+        ])
+        .unwrap();
+
+        assert_eq!(command.env_file, Some(PathBuf::from("deploy.env")));
+        assert!(command.build_remote);
+    }
+
+    #[test]
+    fn env_file_is_overlaid_on_deployment_config() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = temporary.path().join("deploy.env");
+        std::fs::write(&path, "FROM_FILE=yes\nSHARED=file\n").unwrap();
+        let mut app = minimal_app_config("owner", "name");
+        app.env.insert("SHARED".to_owned(), "app-yaml".to_owned());
+
+        apply_env_file(&mut app, &path).unwrap();
+
+        assert_eq!(app.env.get("FROM_FILE").map(String::as_str), Some("yes"));
+        assert_eq!(app.env.get("SHARED").map(String::as_str), Some("file"));
+    }
 
     #[test]
     fn format_duration_words_seconds() {

--- a/lib/cli/src/commands/run/mod.rs
+++ b/lib/cli/src/commands/run/mod.rs
@@ -591,7 +591,7 @@ impl Run {
         runner
             .with_args(&self.args)
             .with_injected_packages(packages)
-            .with_envs(self.wasi.env_vars.clone())
+            .with_envs(self.wasi.resolved_env_vars()?)
             .with_mapped_host_commands(self.wasi.build_mapped_commands()?)
             .with_mapped_directories(mapped_directories)
             .with_home_mapped(is_home_mapped)

--- a/lib/cli/src/commands/run/wasi.rs
+++ b/lib/cli/src/commands/run/wasi.rs
@@ -10,6 +10,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use bytes::Bytes;
 use clap::Parser;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use tokio::runtime::Handle;
 use url::Url;
@@ -99,6 +100,10 @@ pub struct Wasi {
         value_parser=parse_envvar,
     )]
     pub(crate) env_vars: Vec<(String, String)>,
+
+    /// Load environment variables from a dotenv file.
+    #[clap(long = "env-file", name = "PATH")]
+    pub(crate) env_file: Option<PathBuf>,
 
     /// Forward all host env variables to guest
     #[clap(long, env)]
@@ -290,6 +295,23 @@ impl Wasi {
         self.env_vars.push((key.to_string(), value.to_string()));
     }
 
+    pub(crate) fn resolved_env_vars(&self) -> Result<Vec<(String, String)>> {
+        let mut env = IndexMap::new();
+        if let Some(path) = &self.env_file {
+            let entries = dotenvy::from_path_iter(path)
+                .with_context(|| format!("Could not read env file '{}'", path.display()))?;
+            for entry in entries {
+                let (key, value) = entry
+                    .with_context(|| format!("Could not parse env file '{}'", path.display()))?;
+                env.insert(key, value);
+            }
+        }
+        for (key, value) in &self.env_vars {
+            env.insert(key.clone(), value.clone());
+        }
+        Ok(env.into_iter().collect())
+    }
+
     /// Gets the WASI version (if any) for the provided module
     pub fn get_versions(module: &Module) -> Option<BTreeSet<WasiVersion>> {
         // Get the wasi version in non-strict mode, so multiple wasi versions
@@ -352,7 +374,7 @@ impl Wasi {
         let mut builder = WasiEnv::builder(program_name)
             .runtime(Arc::clone(&rt))
             .args(args)
-            .envs(self.env_vars.clone())
+            .envs(self.resolved_env_vars()?)
             .uses(uses)
             .map_commands(map_commands);
 
@@ -830,4 +852,29 @@ fn tokens_by_authority(env: &WasmerEnv) -> Result<HashMap<String, String>> {
     tokens.extend(frontend_tokens);
 
     Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_file_is_merged_and_explicit_env_wins() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = temporary.path().join("runtime.env");
+        std::fs::write(&path, "FROM_FILE=yes\nSHARED=file\n").unwrap();
+        let wasi = Wasi {
+            env_file: Some(path),
+            env_vars: vec![("SHARED".to_owned(), "explicit".to_owned())],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            wasi.resolved_env_vars().unwrap(),
+            [
+                ("FROM_FILE".to_owned(), "yes".to_owned()),
+                ("SHARED".to_owned(), "explicit".to_owned()),
+            ]
+        );
+    }
 }

--- a/lib/wasix/src/runners/wasi_common.rs
+++ b/lib/wasix/src/runners/wasi_common.rs
@@ -544,9 +544,12 @@ mod tests {
     #[tokio::test]
     async fn mix_env_vars_from_the_webc_and_user() {
         let args = CommonWasiOptions {
-            env: vec![("EXTRA".to_string(), "envs".to_string())]
-                .into_iter()
-                .collect(),
+            env: vec![
+                ("EXTRA".to_string(), "envs".to_string()),
+                ("HARD_CODED".to_string(), "user-override".to_string()),
+            ]
+            .into_iter()
+            .collect(),
             ..Default::default()
         };
         let mut builder = WasiEnvBuilder::new("python");
@@ -559,7 +562,7 @@ mod tests {
         assert_eq!(
             builder.get_env(),
             [
-                ("HARD_CODED".to_string(), b"env-vars".to_vec()),
+                ("HARD_CODED".to_string(), b"user-override".to_vec()),
                 ("EXTRA".to_string(), b"envs".to_vec()),
             ]
         );

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -213,10 +213,17 @@ impl WasiEnvBuilder {
         Key: AsRef<[u8]>,
         Value: AsRef<[u8]>,
     {
-        self.envs.push((
-            String::from_utf8_lossy(key.as_ref()).to_string(),
-            value.as_ref().to_vec(),
-        ));
+        let key = String::from_utf8_lossy(key.as_ref()).to_string();
+        let value = value.as_ref().to_vec();
+        if let Some((_, existing_value)) = self
+            .envs
+            .iter_mut()
+            .find(|(existing_key, _)| existing_key == &key)
+        {
+            *existing_value = value;
+        } else {
+            self.envs.push((key, value));
+        }
     }
 
     /// Add multiple environment variable pairs.
@@ -1299,6 +1306,22 @@ mod test {
         {
             None
         }
+    }
+
+    #[test]
+    fn duplicate_environment_variables_use_the_last_value() {
+        let mut builder = WasiEnvBuilder::new("test");
+        builder.add_env("PORT", "5000");
+        builder.add_env("OTHER", "value");
+        builder.add_env("PORT", "8080");
+
+        assert_eq!(
+            builder.get_env(),
+            [
+                ("PORT".to_owned(), b"8080".to_vec()),
+                ("OTHER".to_owned(), b"value".to_vec()),
+            ]
+        );
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
# Description

Stacked on #6976.

Add --env-file PATH support to wasmer deploy for both local-package and --build-remote deployments. Values from the dotenv file override same-named values from app.yaml for the deployment request.

The dotenv values are deployment-only and are not written back into app.yaml.

## Tests

- cargo test -p wasmer-cli env_file_ --lib
- cargo test -p wasmer-cli --lib -- --skip commands::package::download::tests::test_cmd_package_download

All 41 non-network CLI tests pass. The skipped existing download test requires resolving cdn.wasmer.io, which is unavailable in the test environment.