### PR TITLE
feat(CICD): Upgrade wasmer runtime pipelines to use AWS ARC runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
   build:
     name: ${{ matrix.build }}
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-')
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build == 'linux-x64' && (github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64') || matrix.build == 'linux-arm64' && (github.event_name == 'pull_request' && 'aux-pub-16cpu-arm64' || 'aux-pub-trusted-16cpu-arm64') || matrix.os }}
     needs: setup
     strategy:
       fail-fast: false
@@ -259,7 +259,7 @@ jobs:
   windows_gnu:
     name: windows-gnu
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-')
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -327,7 +327,7 @@ jobs:
   linux-riscv64:
     name: linux-riscv64
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-')
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,11 +99,11 @@ jobs:
       - name: Install Linux tools
         if: startsWith(matrix.build, 'linux-x64')
         run: |
-          sudo apt install ninja-build
+          sudo apt-get update -y && sudo apt-get install -y ninja-build
       - name: Install Linux ARM tools
         if: startsWith(matrix.build, 'linux-arm64')
         run: |
-          sudo apt install ninja-build cmake make libzstd1 zstd libzstd-dev
+          sudo apt-get update -y && sudo apt-get install -y ninja-build cmake make libzstd1 zstd libzstd-dev
       - name: Install `ninja` on macOS
         if: startsWith(matrix.build, 'macos-')
         shell: bash
@@ -267,7 +267,7 @@ jobs:
       - name: Install Windows-GNU linker
         shell: bash
         run: |
-          sudo apt install -y mingw-w64
+          sudo apt-get update -y && sudo apt-get install -y mingw-w64
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: x86_64-pc-windows-gnu

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,20 +73,24 @@ jobs:
       - name: Install libtinfo
         shell: bash
         run: |
-          sudo apt install -y libtinfo6
+          sudo apt-get update -y && sudo apt-get install -y libtinfo6
       - uses: actions/setup-go@v6
         with:
           go-version: "1.26.0"
           cache: false
       - run: go install github.com/google/yamlfmt/cmd/yamlfmt@v0.21.0
       - name: Install LLVM (Linux)
+        # $HOME instead of /opt: not root-writable on hardened ARC runners
         run: |
-          mkdir -p /opt/llvm-22
-          curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --retry 3 --proto '=https' --tlsv1.2 -sSf https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-linux-amd64.tar.zst -L -o - | tar --zstd -xf - --strip-components=1 -C /opt/llvm-22
-          echo '/opt/llvm-22/bin' >> $GITHUB_PATH
-          echo 'LLVM_SYS_221_PREFIX=/opt/llvm-22' >> $GITHUB_ENV
+          mkdir -p $HOME/llvm-22
+          curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --retry 3 --proto '=https' --tlsv1.2 -sSf https://github.com/wasmerio/llvm-custom-builds/releases/download/22.x/llvm-linux-amd64.tar.zst -L -o - | tar --zstd -xf - --strip-components=1 -C $HOME/llvm-22
+          echo "$HOME/llvm-22/bin" >> $GITHUB_PATH
+          echo "LLVM_SYS_221_PREFIX=$HOME/llvm-22" >> $GITHUB_ENV
       - name: Install taplo
-        run: curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+        run: |
+          mkdir -p $HOME/.local/bin
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin $HOME/.local/bin/taplo
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Cache
         # TODO: v3 is unable to Restore the cache for some reason
         uses: whywaita/actions-cache-s3@v2
@@ -291,7 +295,7 @@ jobs:
       - name: Install `ninja` on Ubuntu
         shell: bash
         run: |
-          sudo apt-get install ninja-build -y
+          sudo apt-get update -y && sudo apt-get install -y ninja-build
       - name: Install LLVM 22
         run: |
           LLVM_DIR=$(pwd)/${{ env.LLVM_DIR }}
@@ -455,7 +459,8 @@ jobs:
         if: matrix.metadata.build == 'linux-x64'
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y --allow-downgrades libstdc++6 libtinfo5
+          # libtinfo6: libtinfo5 does not exist on ubuntu >= 24.04 (ARC image)
+          sudo apt-get install -y --allow-downgrades libstdc++6 libtinfo6
           sudo apt-get install --reinstall g++
       - name: Set up base deps on musl
         if: matrix.metadata.build == 'linux-musl'
@@ -482,7 +487,7 @@ jobs:
         if: ${{ matrix.metadata.build == 'windows-gnu' }}
         shell: bash
         run: |
-          sudo apt install -y mingw-w64
+          sudo apt-get update -y && sudo apt-get install -y mingw-w64
       - name: Install Windows-GNU target
         if: ${{ matrix.metadata.build == 'windows-gnu' }}
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ env:
 jobs:
   setup:
     name: Set up
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     outputs:
       VERSION: ${{ steps.setup.outputs.VERSION }}
       DOING_RELEASE: ${{ steps.setup.outputs.DOING_RELEASE }}
@@ -57,7 +57,7 @@ jobs:
         run: cargo +nightly update
   lint:
     name: Code lint
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -142,7 +142,7 @@ jobs:
           fi
   cargo_deny:
     name: cargo-deny
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -152,7 +152,7 @@ jobs:
           log-level: error
   test_nodejs:
     name: NodeJS
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -194,7 +194,7 @@ jobs:
         #     make test-js-core
   test_interpreter_api:
     name: ${{ matrix.build-what.name }} - ${{ matrix.metadata.build }}
-    runs-on: ${{ matrix.metadata.os }}
+    runs-on: ${{ matrix.metadata.build == 'linux-x64' && (github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64') || matrix.metadata.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -282,7 +282,7 @@ jobs:
         run: cargo +nightly miri test -p wasmer --features sys --lib borrow_provenance
   test_build_docs_rs:
     name: Build docs.rs
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -311,7 +311,7 @@ jobs:
         run: make test-build-docs-rs-ci
   build_linux_riscv64:
     name: ${{ matrix.build-what.name }} - linux-riscv64
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     strategy:
       fail-fast: false
       matrix:
@@ -370,7 +370,7 @@ jobs:
           retention-days: 2
   build:
     name: ${{ matrix.build-what.name }} - ${{ matrix.metadata.build }}
-    runs-on: ${{ matrix.metadata.os }}
+    runs-on: ${{ (matrix.metadata.build == 'linux-x64' || matrix.metadata.build == 'linux-musl' || matrix.metadata.build == 'windows-gnu') && (github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64') || matrix.metadata.build == 'linux-arm64' && (github.event_name == 'pull_request' && 'aux-pub-16cpu-arm64' || 'aux-pub-trusted-16cpu-arm64') || matrix.metadata.os }}
     needs: setup
     strategy:
       fail-fast: false
@@ -623,7 +623,7 @@ jobs:
           retention-days: 2
   test:
     name: ${{ matrix.stage.description }} - ${{ matrix.metadata.build }}
-    runs-on: ${{ matrix.metadata.os }}
+    runs-on: ${{ (matrix.metadata.build == 'linux-x64' || matrix.metadata.build == 'linux-musl') && (github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64') || matrix.metadata.build == 'linux-arm64' && (github.event_name == 'pull_request' && 'aux-pub-16cpu-arm64' || 'aux-pub-trusted-16cpu-arm64') || matrix.metadata.os }}
     needs: setup
     strategy:
       fail-fast: false
@@ -826,7 +826,7 @@ jobs:
           CARGO_TARGET: ${{ matrix.metadata.target }}
   ci_success:
     name: Tests CI
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.event_name == 'pull_request' && 'aux-pub-16cpu-amd64' || 'aux-pub-trusted-16cpu-amd64' }}
     needs:
       - setup
       - lint


### PR DESCRIPTION
# Description
In order to save money on CI, avoid outages and potentially speed up runtime, we can utilize our own AWS ARC
runners.

There are two kinds, one is for PRs, the other for changes when merged to main. The reason why is that the PRs
may contain code which is malicious, and the runners are hosted within our infrastructure. This may put some strain
on external contributions, but by design it should be seamless. Might take a bit of tweaking to get right.

Once this PR is OK and vetted I'll cherry-pick it into "real" Wasmer. 

PR is copied from wasmer-internal. Closes SRE-1696