### PR TITLE
fix(wasix): reap child processes once after they exit

### DIFF
--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -85,6 +85,8 @@ impl std::fmt::Debug for WasiProcessId {
 }
 
 pub type LockableWasiProcessInner = Arc<(Mutex<WasiProcessInner>, Condvar)>;
+pub(crate) type ChildExitResult = Result<ExitCode, Arc<WasiRuntimeError>>;
+pub(crate) type ReapedChild = (WasiProcessId, ChildExitResult);
 
 /// Represents a process running within the compute state
 /// TODO: fields should be private and only accessed via methods.
@@ -799,6 +801,73 @@ impl WasiProcess {
         self.finished.status().into_finished()
     }
 
+    /// Claims one finished child from this process.
+    pub(crate) fn try_reap_child(
+        &self,
+        pid: Option<WasiProcessId>,
+    ) -> Result<Option<ReapedChild>, Errno> {
+        let mut inner = self.inner.0.lock().unwrap();
+        if inner.children.is_empty() {
+            return Err(Errno::Child);
+        }
+
+        let finished = match pid {
+            Some(pid) => {
+                let index = inner
+                    .children
+                    .iter()
+                    .position(|child| child.pid == pid)
+                    .ok_or(Errno::Child)?;
+                inner.children[index]
+                    .try_join()
+                    .map(|result| (index, result))
+            }
+            None => inner
+                .children
+                .iter()
+                .enumerate()
+                .find_map(|(index, child)| child.try_join().map(|result| (index, result))),
+        };
+
+        let Some((index, result)) = finished else {
+            return Ok(None);
+        };
+        let child = inner.children.remove(index);
+        Ok(Some((child.pid, result)))
+    }
+
+    pub(crate) fn child_exit_code(result: ChildExitResult) -> ExitCode {
+        result.unwrap_or_else(|error| {
+            error
+                .as_exit_code()
+                .unwrap_or_else(|| Errno::Canceled.into())
+        })
+    }
+
+    /// Waits for and claims a specific child process.
+    pub(crate) async fn join_child(
+        &self,
+        pid: WasiProcessId,
+    ) -> Result<(WasiProcessId, ExitCode), Errno> {
+        let _guard = WasiProcessWait::new(self);
+        loop {
+            if let Some((pid, result)) = self.try_reap_child(Some(pid))? {
+                return Ok((pid, Self::child_exit_code(result)));
+            }
+
+            let child = {
+                let inner = self.inner.0.lock().unwrap();
+                inner
+                    .children
+                    .iter()
+                    .find(|child| child.pid == pid)
+                    .cloned()
+                    .ok_or(Errno::Child)?
+            };
+            let _ = child.join().await;
+        }
+    }
+
     /// Waits for all the children to be finished
     pub async fn join_children(&mut self) -> Option<Result<ExitCode, Arc<WasiRuntimeError>>> {
         let _guard = WasiProcessWait::new(self);
@@ -809,52 +878,40 @@ impl WasiProcess {
         if children.is_empty() {
             return None;
         }
-        let mut waits = Vec::new();
+
+        futures::future::join_all(children.iter().map(WasiProcess::join)).await;
+
+        let mut first = None;
         for child in children {
-            if let Some(process) = self.compute.must_upgrade().get_process(child.pid) {
-                let inner = self.inner.clone();
-                waits.push(async move {
-                    let join = process.join().await;
-                    let mut inner = inner.0.lock().unwrap();
-                    inner.children.retain(|a| a.pid != child.pid);
-                    join
-                })
+            if let Ok(Some((_, result))) = self.try_reap_child(Some(child.pid)) {
+                first = first.or(Some(result));
             }
         }
-        futures::future::join_all(waits).await.into_iter().next()
+        first
     }
 
-    /// Waits for any of the children to finished
-    pub async fn join_any_child(&mut self) -> Result<Option<(WasiProcessId, ExitCode)>, Errno> {
+    /// Waits for any of the children to finish
+    pub async fn join_any_child(&self) -> Result<Option<(WasiProcessId, ExitCode)>, Errno> {
         let _guard = WasiProcessWait::new(self);
-        let children: Vec<_> = {
-            let inner = self.inner.0.lock().unwrap();
-            inner.children.clone()
-        };
-        if children.is_empty() {
-            return Err(Errno::Child);
-        }
-
-        let mut waits = Vec::new();
-        for child in children {
-            if let Some(process) = self.compute.must_upgrade().get_process(child.pid) {
-                let inner = self.inner.clone();
-                waits.push(async move {
-                    let join = process.join().await;
-                    let mut inner = inner.0.lock().unwrap();
-                    inner.children.retain(|a| a.pid != child.pid);
-                    (child, join)
-                })
+        loop {
+            if let Some((pid, result)) = self.try_reap_child(None)? {
+                return Ok(Some((pid, Self::child_exit_code(result))));
             }
+
+            let children = {
+                let inner = self.inner.0.lock().unwrap();
+                if inner.children.is_empty() {
+                    return Err(Errno::Child);
+                }
+                inner.children.clone()
+            };
+
+            let waits = children
+                .iter()
+                .map(|child| Box::pin(child.join()))
+                .collect::<Vec<_>>();
+            let _ = futures::future::select_all(waits).await;
         }
-        let (child, res) = futures::future::select_all(waits.into_iter().map(Box::pin))
-            .await
-            .0;
-
-        let code =
-            res.unwrap_or_else(|e| e.as_exit_code().unwrap_or_else(|| Errno::Canceled.into()));
-
-        Ok(Some((child.pid, code)))
     }
 
     /// Terminate the process and all its threads
@@ -965,5 +1022,323 @@ impl SignalHandlerAbi for WasiProcess {
         } else {
             Err(SignalDeliveryError)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future::Future, sync::Arc, time::Duration};
+
+    use futures::FutureExt;
+    use tokio::sync::Barrier;
+
+    use super::*;
+    use crate::os::task::control_plane::WasiControlPlane;
+
+    fn parent_with_children(count: usize) -> (WasiProcess, Vec<WasiProcess>) {
+        let control_plane = WasiControlPlane::default();
+        let parent = control_plane.new_process(ModuleHash::random()).unwrap();
+        let children = (0..count)
+            .map(|_| control_plane.new_process(ModuleHash::random()).unwrap())
+            .collect::<Vec<_>>();
+        parent.lock().children.extend(children.iter().cloned());
+        (parent, children)
+    }
+
+    fn finish(child: &WasiProcess, code: u16) {
+        child.finished.set_finished(Ok(ExitCode::from(code)));
+    }
+
+    fn fail(child: &WasiProcess) {
+        child
+            .finished
+            .set_finished(Err(Arc::new(WasiRuntimeError::Anyhow(Arc::new(
+                anyhow::anyhow!("child failed"),
+            )))));
+    }
+
+    async fn wait_for_waiters(process: &WasiProcess, expected: u32) {
+        for _ in 0..10_000 {
+            if process.waiting.load(Ordering::Acquire) == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("expected {expected} waiters");
+    }
+
+    async fn gated_specific(
+        process: WasiProcess,
+        pid: WasiProcessId,
+        barrier: Arc<Barrier>,
+    ) -> Result<WasiProcessId, Errno> {
+        barrier.wait().await;
+        process.join_child(pid).await.map(|(pid, _)| pid)
+    }
+
+    async fn gated_any(
+        process: WasiProcess,
+        barrier: Arc<Barrier>,
+    ) -> Result<WasiProcessId, Errno> {
+        barrier.wait().await;
+        process
+            .join_any_child()
+            .await
+            .map(|result| result.expect("a successful wait returns a child").0)
+    }
+
+    async fn run_race<A, B>(
+        parent: &WasiProcess,
+        child: &WasiProcess,
+        first: A,
+        second: B,
+        barrier: Arc<Barrier>,
+    ) -> (Result<WasiProcessId, Errno>, Result<WasiProcessId, Errno>)
+    where
+        A: Future<Output = Result<WasiProcessId, Errno>>,
+        B: Future<Output = Result<WasiProcessId, Errno>>,
+    {
+        let release = async {
+            barrier.wait().await;
+            wait_for_waiters(parent, 2).await;
+            finish(child, 17);
+        };
+        let (first, second, ()) = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::join!(first, second, release)
+        })
+        .await
+        .expect("child wait race timed out");
+        (first, second)
+    }
+
+    fn assert_one_reaper(
+        pid: WasiProcessId,
+        first: Result<WasiProcessId, Errno>,
+        second: Result<WasiProcessId, Errno>,
+    ) {
+        let results = [first, second];
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Ok(result_pid) if *result_pid == pid))
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(Errno::Child)))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn no_or_unknown_child_is_not_waitable() {
+        let (parent, _) = parent_with_children(0);
+        let unknown = WasiProcessId::from(u32::MAX - 1);
+
+        assert!(matches!(parent.try_reap_child(None), Err(Errno::Child)));
+        assert!(matches!(
+            parent.try_reap_child(Some(unknown)),
+            Err(Errno::Child)
+        ));
+        assert!(matches!(
+            parent.join_child(unknown).await,
+            Err(Errno::Child)
+        ));
+        assert!(matches!(parent.join_any_child().await, Err(Errno::Child)));
+    }
+
+    #[test]
+    fn running_children_remain_registered() {
+        let (parent, children) = parent_with_children(2);
+
+        assert!(
+            parent
+                .try_reap_child(Some(children[0].pid()))
+                .unwrap()
+                .is_none()
+        );
+        assert!(parent.try_reap_child(None).unwrap().is_none());
+        assert_eq!(parent.lock().children.len(), 2);
+    }
+
+    #[test]
+    fn finished_status_is_claimed_once() {
+        let (parent, children) = parent_with_children(1);
+        finish(&children[0], 7);
+
+        let (pid, status) = parent.try_reap_child(None).unwrap().unwrap();
+        assert_eq!(pid, children[0].pid());
+        assert_eq!(status.unwrap().raw(), 7);
+        assert!(matches!(parent.try_reap_child(None), Err(Errno::Child)));
+    }
+
+    #[tokio::test]
+    async fn parent_children_are_the_only_waitable_processes() {
+        let control_plane = WasiControlPlane::default();
+        let parent = control_plane.new_process(ModuleHash::random()).unwrap();
+        let child = control_plane.new_process(ModuleHash::random()).unwrap();
+        let outsider = control_plane.new_process(ModuleHash::random()).unwrap();
+        parent.lock().children.push(child.clone());
+        finish(&outsider, 8);
+
+        assert!(matches!(
+            parent.try_reap_child(Some(outsider.pid())),
+            Err(Errno::Child)
+        ));
+        assert!(matches!(
+            parent.join_child(outsider.pid()).await,
+            Err(Errno::Child)
+        ));
+        assert_eq!(parent.lock().children.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn child_waits_do_not_need_the_control_plane() {
+        let (parent, children) = parent_with_children(1);
+        finish(&children[0], 9);
+
+        let (pid, code) = parent.join_any_child().await.unwrap().unwrap();
+        assert_eq!(pid, children[0].pid());
+        assert_eq!(code.raw(), 9);
+    }
+
+    #[tokio::test]
+    async fn runtime_errors_use_one_exit_code() {
+        let (specific_parent, specific_children) = parent_with_children(1);
+        fail(&specific_children[0]);
+        let (_, specific_code) = specific_parent
+            .join_child(specific_children[0].pid())
+            .await
+            .unwrap();
+
+        let (any_parent, any_children) = parent_with_children(1);
+        fail(&any_children[0]);
+        let (_, any_code) = any_parent.join_any_child().await.unwrap().unwrap();
+
+        let expected: ExitCode = Errno::Canceled.into();
+        assert_eq!(specific_code, expected);
+        assert_eq!(any_code, expected);
+    }
+
+    #[tokio::test]
+    async fn dropped_pending_wait_keeps_the_child_registered() {
+        let (parent, children) = parent_with_children(1);
+        let pid = children[0].pid();
+
+        assert!(parent.join_child(pid).now_or_never().is_none());
+        assert_eq!(parent.waiting.load(Ordering::Acquire), 0);
+        assert_eq!(children[0].waiting.load(Ordering::Acquire), 0);
+        assert_eq!(parent.lock().children.len(), 1);
+
+        finish(&children[0], 10);
+        assert!(parent.try_reap_child(Some(pid)).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn specific_waiters_race_for_one_status() {
+        let (parent, children) = parent_with_children(1);
+        let pid = children[0].pid();
+        let barrier = Arc::new(Barrier::new(3));
+        let results = run_race(
+            &parent,
+            &children[0],
+            gated_specific(parent.clone(), pid, barrier.clone()),
+            gated_specific(parent.clone(), pid, barrier.clone()),
+            barrier,
+        )
+        .await;
+
+        assert_one_reaper(pid, results.0, results.1);
+    }
+
+    #[tokio::test]
+    async fn any_waiters_race_for_one_status() {
+        let (parent, children) = parent_with_children(1);
+        let pid = children[0].pid();
+        let barrier = Arc::new(Barrier::new(3));
+        let results = run_race(
+            &parent,
+            &children[0],
+            gated_any(parent.clone(), barrier.clone()),
+            gated_any(parent.clone(), barrier.clone()),
+            barrier,
+        )
+        .await;
+
+        assert_one_reaper(pid, results.0, results.1);
+    }
+
+    #[tokio::test]
+    async fn specific_and_any_waiters_race_for_one_status() {
+        let (parent, children) = parent_with_children(1);
+        let pid = children[0].pid();
+        let barrier = Arc::new(Barrier::new(3));
+        let results = run_race(
+            &parent,
+            &children[0],
+            gated_specific(parent.clone(), pid, barrier.clone()),
+            gated_any(parent.clone(), barrier.clone()),
+            barrier,
+        )
+        .await;
+
+        assert_one_reaper(pid, results.0, results.1);
+    }
+
+    #[tokio::test]
+    async fn any_wait_and_join_children_race_for_one_status() {
+        let (parent, children) = parent_with_children(1);
+        let pid = children[0].pid();
+        let barrier = Arc::new(Barrier::new(3));
+        let join_all = {
+            let mut process = parent.clone();
+            let barrier = barrier.clone();
+            async move {
+                barrier.wait().await;
+                match process.join_children().await {
+                    Some(_) => Ok(pid),
+                    None => Err(Errno::Child),
+                }
+            }
+        };
+        let results = run_race(
+            &parent,
+            &children[0],
+            gated_any(parent.clone(), barrier.clone()),
+            join_all,
+            barrier,
+        )
+        .await;
+
+        assert_one_reaper(pid, results.0, results.1);
+    }
+
+    #[tokio::test]
+    async fn simultaneous_children_go_to_distinct_any_waiters() {
+        let (parent, children) = parent_with_children(2);
+        let barrier = Arc::new(Barrier::new(3));
+        let first = gated_any(parent.clone(), barrier.clone());
+        let second = gated_any(parent.clone(), barrier.clone());
+        let release = async {
+            barrier.wait().await;
+            wait_for_waiters(&parent, 2).await;
+            finish(&children[0], 21);
+            finish(&children[1], 22);
+        };
+        let (first, second, ()) = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::join!(first, second, release)
+        })
+        .await
+        .expect("two-child wait race timed out");
+
+        let mut pids = [first.unwrap(), second.unwrap()];
+        pids.sort();
+        let mut expected = [children[0].pid(), children[1].pid()];
+        expected.sort();
+        assert_eq!(pids, expected);
+        assert!(parent.lock().children.is_empty());
     }
 }

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -1238,6 +1238,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropped_any_and_all_waits_keep_children_registered() {
+        let (mut parent, children) = parent_with_children(2);
+
+        assert!(parent.join_any_child().now_or_never().is_none());
+        assert!(parent.join_children().now_or_never().is_none());
+        assert_eq!(parent.waiting.load(Ordering::Acquire), 0);
+        assert_eq!(parent.lock().children.len(), 2);
+        for child in &children {
+            assert_eq!(child.waiting.load(Ordering::Acquire), 0);
+            finish(child, 10);
+            assert!(parent.try_reap_child(Some(child.pid())).unwrap().is_some());
+        }
+    }
+
+    #[test]
+    fn concurrent_nonblocking_waiters_claim_one_status() {
+        let (parent, children) = parent_with_children(1);
+        let pid = children[0].pid();
+        finish(&children[0], 17);
+        let barrier = std::sync::Barrier::new(3);
+
+        let claim = |filter| {
+            barrier.wait();
+            parent.try_reap_child(filter).map(|result| {
+                let (pid, status) = result.expect("child is finished");
+                assert_eq!(status.unwrap().raw(), 17);
+                pid
+            })
+        };
+        let (first, second) = std::thread::scope(|scope| {
+            let first = scope.spawn(|| claim(Some(pid)));
+            let second = scope.spawn(|| claim(None));
+            barrier.wait();
+            (first.join().unwrap(), second.join().unwrap())
+        });
+
+        assert_one_reaper(pid, first, second);
+        assert!(parent.lock().children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn any_wait_retries_when_a_nonblocking_wait_claims_the_exit() {
+        let (parent, children) = parent_with_children(2);
+        let wait = parent.join_any_child();
+        tokio::pin!(wait);
+        assert!(futures::poll!(&mut wait).is_pending());
+
+        finish(&children[0], 21);
+        let (pid, status) = parent.try_reap_child(None).unwrap().unwrap();
+        assert_eq!(pid, children[0].pid());
+        assert_eq!(status.unwrap().raw(), 21);
+        assert!(futures::poll!(&mut wait).is_pending());
+
+        finish(&children[1], 22);
+        let (pid, status) = wait.await.unwrap().unwrap();
+        assert_eq!(pid, children[1].pid());
+        assert_eq!(status.raw(), 22);
+        assert!(parent.lock().children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn join_children_returns_only_a_status_it_claimed() {
+        let (mut parent, children) = parent_with_children(2);
+        let competing_parent = parent.clone();
+        let wait = parent.join_children();
+        tokio::pin!(wait);
+        assert!(futures::poll!(&mut wait).is_pending());
+
+        finish(&children[0], 21);
+        assert!(futures::poll!(&mut wait).is_pending());
+        let (pid, status) = competing_parent.try_reap_child(None).unwrap().unwrap();
+        assert_eq!(pid, children[0].pid());
+        assert_eq!(status.unwrap().raw(), 21);
+
+        finish(&children[1], 22);
+        assert_eq!(wait.await.unwrap().unwrap().raw(), 22);
+        assert!(competing_parent.lock().children.is_empty());
+    }
+
+    #[tokio::test]
     async fn specific_waiters_race_for_one_status() {
         let (parent, children) = parent_with_children(1);
         let pid = children[0].pid();

--- a/lib/wasix/src/syscalls/wasix/proc_join.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_join.rs
@@ -48,16 +48,25 @@ pub(super) fn proc_join_internal<M: MemorySize + 'static>(
 
             let view = unsafe { ctx.data().memory_view(&ctx) };
             let status = match status {
-                JoinStatusResult::Nothing => JoinStatus {
-                    tag: JoinStatusType::Nothing,
-                    u: JoinStatusUnion { nothing: 0 },
-                },
+                JoinStatusResult::Nothing => {
+                    wasi_try_mem_ok!(pid_ptr.write(
+                        &view,
+                        OptionPid {
+                            tag: OptionTag::Some,
+                            pid: 0,
+                        }
+                    ));
+                    JoinStatus {
+                        tag: JoinStatusType::Nothing,
+                        u: JoinStatusUnion { nothing: 0 },
+                    }
+                }
                 JoinStatusResult::ExitNormal(pid, exit_code) => {
                     let option_pid = OptionPid {
                         tag: OptionTag::Some,
                         pid: pid.raw() as Pid,
                     };
-                    pid_ptr.write(&view, option_pid).ok();
+                    wasi_try_mem_ok!(pid_ptr.write(&view, option_pid));
 
                     JoinStatus {
                         tag: JoinStatusType::ExitNormal,
@@ -116,7 +125,18 @@ pub(super) fn proc_join_internal<M: MemorySize + 'static>(
     // If the ID is maximum then it means wait for any of the children
     let pid = match option_pid {
         None => {
-            let mut process = ctx.data_mut().process.clone();
+            let process = ctx.data().process.clone();
+
+            if flags.contains(JoinFlags::NON_BLOCKING) {
+                let result = match process.try_reap_child(None) {
+                    Ok(Some((pid, status))) => {
+                        JoinStatusResult::ExitNormal(pid, WasiProcess::child_exit_code(status))
+                    }
+                    Ok(None) => JoinStatusResult::Nothing,
+                    Err(error) => JoinStatusResult::Err(error),
+                };
+                return ret_result(ctx, result);
+            }
 
             // We wait for any process to exit (if it takes too long
             // then we go into a deep sleep)
@@ -148,59 +168,30 @@ pub(super) fn proc_join_internal<M: MemorySize + 'static>(
 
     // Otherwise we wait for the specific PID
     let pid: WasiProcessId = pid.into();
+    let process = ctx.data().process.clone();
 
-    // Waiting for a process that is an explicit child will join it
-    // meaning it will no longer be a sub-process of the main process
-    let mut process = {
-        let mut inner = ctx.data().process.lock();
-        let process = inner
-            .children
-            .iter()
-            .filter(|c| c.pid == pid)
-            .map(Clone::clone)
-            .next();
-        inner.children.retain(|c| c.pid != pid);
-        process
-    };
-
-    // Otherwise it could be the case that we are waiting for a process
-    // that is not a child of this process but may still be running
-    if process.is_none() {
-        process = ctx.data().control_plane.get_process(pid);
-    }
-
-    if let Some(process) = process {
-        // We can already set the process ID
-        wasi_try_mem_ok!(pid_ptr.write(
-            &memory,
-            OptionPid {
-                tag: OptionTag::Some,
-                pid: pid.raw(),
-            }
-        ));
-
-        if flags.contains(JoinFlags::NON_BLOCKING) {
-            if let Some(status) = process.try_join() {
-                let exit_code = status.unwrap_or_else(|_| Errno::Child.into());
-                ret_result(ctx, JoinStatusResult::ExitNormal(pid, exit_code))
-            } else {
-                ret_result(ctx, JoinStatusResult::Nothing)
-            }
-        } else {
-            // Wait for the process to finish
-            let process2 = process.clone();
-            let res = __asyncify_with_deep_sleep::<M, _, _>(ctx, async move {
-                let exit_code = process.join().await.unwrap_or_else(|_| Errno::Child.into());
-                tracing::trace!(%exit_code, "triggered child join");
-                JoinStatusResult::ExitNormal(pid, exit_code)
-            })?;
-            match res {
-                AsyncifyAction::Finish(ctx, result) => ret_result(ctx, result),
-                AsyncifyAction::Unwind => Ok(Errno::Success),
-            }
+    if flags.contains(JoinFlags::NON_BLOCKING) {
+        match process.try_reap_child(Some(pid)) {
+            Ok(Some((pid, status))) => ret_result(
+                ctx,
+                JoinStatusResult::ExitNormal(pid, WasiProcess::child_exit_code(status)),
+            ),
+            Ok(None) => ret_result(ctx, JoinStatusResult::Nothing),
+            Err(error) => ret_result(ctx, JoinStatusResult::Err(error)),
         }
     } else {
-        trace!(ret_id = pid.raw(), "status=nothing");
-        ret_result(ctx, JoinStatusResult::Nothing)
+        let res = __asyncify_with_deep_sleep::<M, _, _>(ctx, async move {
+            match process.join_child(pid).await {
+                Ok((pid, exit_code)) => {
+                    tracing::trace!(%exit_code, "triggered child join");
+                    JoinStatusResult::ExitNormal(pid, exit_code)
+                }
+                Err(error) => JoinStatusResult::Err(error),
+            }
+        })?;
+        match res {
+            AsyncifyAction::Finish(ctx, result) => ret_result(ctx, result),
+            AsyncifyAction::Unwind => Ok(Errno::Success),
+        }
     }
 }

--- a/lib/wasix/tests/wasm_tests/process/waitpid-reaping/main.c
+++ b/lib/wasix/tests/wasm_tests/process/waitpid-reaping/main.c
@@ -1,11 +1,9 @@
 //#BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
 
 #include <errno.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/wait.h>
-#include <time.h>
 #include <unistd.h>
 
 struct blocked_child {
@@ -77,32 +75,6 @@ static struct blocked_child spawn_blocked_child(int exit_code) {
   return (struct blocked_child){.pid = pid, .release_fd = release[1]};
 }
 
-static pid_t spawn_delayed_child(int exit_code, useconds_t delay_us) {
-  int ready[2];
-  if (pipe(ready) != 0) {
-    fail("pipe");
-  }
-
-  pid_t pid = fork();
-  if (pid < 0) {
-    fail("fork");
-  }
-  if (pid == 0) {
-    close(ready[0]);
-    write_byte(ready[1]);
-    close(ready[1]);
-    if (delay_us != 0) {
-      usleep(delay_us);
-    }
-    _Exit(exit_code);
-  }
-
-  close(ready[1]);
-  read_byte(ready[0]);
-  close(ready[0]);
-  return pid;
-}
-
 static int exited_with(int status, int exit_code) {
   return WIFEXITED(status) && WEXITSTATUS(status) == exit_code;
 }
@@ -139,31 +111,16 @@ static void specific_nonblocking_reaps_once(void) {
   expect_echild(child.pid, "repeated targeted wait did not return ECHILD");
 }
 
-static int64_t elapsed_milliseconds(struct timespec start,
-                                    struct timespec finish) {
-  return (finish.tv_sec - start.tv_sec) * 1000 +
-         (finish.tv_nsec - start.tv_nsec) / 1000000;
-}
-
 static void any_nonblocking_returns_promptly(void) {
-  pid_t child = spawn_delayed_child(38, 500000);
-  struct timespec start;
-  struct timespec finish;
+  struct blocked_child child = spawn_blocked_child(38);
   int status = 0;
-  if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
-    fail("clock_gettime");
-  }
-  pid_t result = waitpid(-1, &status, WNOHANG);
-  if (clock_gettime(CLOCK_MONOTONIC, &finish) != 0) {
-    fail("clock_gettime");
-  }
 
-  check(result == 0, "any-child WNOHANG did not return zero");
-  check(elapsed_milliseconds(start, finish) < 250,
-        "any-child WNOHANG blocked for a running child");
-  if (result == 0) {
-    wait_for_child(child, 38);
-  }
+  check(waitpid(-1, &status, WNOHANG) == 0,
+        "first any-child WNOHANG did not return zero");
+  check(waitpid(-1, &status, WNOHANG) == 0,
+        "second any-child WNOHANG did not return zero");
+  release_child(child);
+  wait_for_child(child.pid, 38);
   expect_echild(-1,
                 "wait after the only child was reaped did not return ECHILD");
 }
@@ -200,20 +157,21 @@ static void two_children_are_reported_once(void) {
 }
 
 static void completed_nonblocking_child_is_reaped(void) {
-  pid_t child = spawn_delayed_child(43, 0);
+  struct blocked_child child = spawn_blocked_child(43);
+  release_child(child);
   int status = 0;
   pid_t result = 0;
 
   for (int attempt = 0; attempt < 5000 && result == 0; attempt++) {
-    result = waitpid(child, &status, WNOHANG);
+    result = waitpid(child.pid, &status, WNOHANG);
     if (result == 0) {
       usleep(1000);
     }
   }
 
-  check(result == child, "completed child was not returned by WNOHANG");
+  check(result == child.pid, "completed child was not returned by WNOHANG");
   check(exited_with(status, 43), "completed WNOHANG returned the wrong status");
-  expect_echild(child, "completed child was reported more than once");
+  expect_echild(child.pid, "completed child was reported more than once");
 }
 
 int main(void) {

--- a/lib/wasix/tests/wasm_tests/process/waitpid-reaping/main.c
+++ b/lib/wasix/tests/wasm_tests/process/waitpid-reaping/main.c
@@ -1,0 +1,226 @@
+//#BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+struct blocked_child {
+  pid_t pid;
+  int release_fd;
+};
+
+static int failures;
+
+static void fail(const char* message) {
+  perror(message);
+  exit(EXIT_FAILURE);
+}
+
+static void check(int condition, const char* message) {
+  if (!condition) {
+    fprintf(stderr, "%s\n", message);
+    failures++;
+  }
+}
+
+static void write_byte(int fd) {
+  const char byte = 'x';
+  ssize_t count;
+  do {
+    count = write(fd, &byte, sizeof(byte));
+  } while (count < 0 && errno == EINTR);
+  if (count != sizeof(byte)) {
+    fail("write");
+  }
+}
+
+static void read_byte(int fd) {
+  char byte;
+  ssize_t count;
+  do {
+    count = read(fd, &byte, sizeof(byte));
+  } while (count < 0 && errno == EINTR);
+  if (count != sizeof(byte)) {
+    fail("read");
+  }
+}
+
+static struct blocked_child spawn_blocked_child(int exit_code) {
+  int ready[2];
+  int release[2];
+  if (pipe(ready) != 0 || pipe(release) != 0) {
+    fail("pipe");
+  }
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    fail("fork");
+  }
+  if (pid == 0) {
+    close(ready[0]);
+    close(release[1]);
+    write_byte(ready[1]);
+    close(ready[1]);
+    read_byte(release[0]);
+    close(release[0]);
+    _Exit(exit_code);
+  }
+
+  close(ready[1]);
+  close(release[0]);
+  read_byte(ready[0]);
+  close(ready[0]);
+  return (struct blocked_child){.pid = pid, .release_fd = release[1]};
+}
+
+static pid_t spawn_delayed_child(int exit_code, useconds_t delay_us) {
+  int ready[2];
+  if (pipe(ready) != 0) {
+    fail("pipe");
+  }
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    fail("fork");
+  }
+  if (pid == 0) {
+    close(ready[0]);
+    write_byte(ready[1]);
+    close(ready[1]);
+    if (delay_us != 0) {
+      usleep(delay_us);
+    }
+    _Exit(exit_code);
+  }
+
+  close(ready[1]);
+  read_byte(ready[0]);
+  close(ready[0]);
+  return pid;
+}
+
+static int exited_with(int status, int exit_code) {
+  return WIFEXITED(status) && WEXITSTATUS(status) == exit_code;
+}
+
+static void release_child(struct blocked_child child) {
+  write_byte(child.release_fd);
+  close(child.release_fd);
+}
+
+static void wait_for_child(pid_t pid, int exit_code) {
+  int status = 0;
+  check(waitpid(pid, &status, 0) == pid, "blocking wait returned wrong pid");
+  check(exited_with(status, exit_code), "blocking wait returned wrong status");
+}
+
+static void expect_echild(pid_t pid, const char* message) {
+  int status = 0;
+  errno = 0;
+  pid_t result = waitpid(pid, &status, WNOHANG);
+  check(result == -1 && errno == ECHILD, message);
+}
+
+static void specific_nonblocking_reaps_once(void) {
+  struct blocked_child child = spawn_blocked_child(37);
+  int status = 0;
+
+  check(waitpid(child.pid, &status, WNOHANG) == 0,
+        "first targeted WNOHANG did not return zero");
+  check(waitpid(child.pid, &status, WNOHANG) == 0,
+        "second targeted WNOHANG did not return zero");
+
+  release_child(child);
+  wait_for_child(child.pid, 37);
+  expect_echild(child.pid, "repeated targeted wait did not return ECHILD");
+}
+
+static int64_t elapsed_milliseconds(struct timespec start,
+                                    struct timespec finish) {
+  return (finish.tv_sec - start.tv_sec) * 1000 +
+         (finish.tv_nsec - start.tv_nsec) / 1000000;
+}
+
+static void any_nonblocking_returns_promptly(void) {
+  pid_t child = spawn_delayed_child(38, 500000);
+  struct timespec start;
+  struct timespec finish;
+  int status = 0;
+  if (clock_gettime(CLOCK_MONOTONIC, &start) != 0) {
+    fail("clock_gettime");
+  }
+  pid_t result = waitpid(-1, &status, WNOHANG);
+  if (clock_gettime(CLOCK_MONOTONIC, &finish) != 0) {
+    fail("clock_gettime");
+  }
+
+  check(result == 0, "any-child WNOHANG did not return zero");
+  check(elapsed_milliseconds(start, finish) < 250,
+        "any-child WNOHANG blocked for a running child");
+  if (result == 0) {
+    wait_for_child(child, 38);
+  }
+  expect_echild(-1,
+                "wait after the only child was reaped did not return ECHILD");
+}
+
+static void nonchild_is_not_waitable(void) {
+  struct blocked_child child = spawn_blocked_child(39);
+  expect_echild(getpid(), "waitpid accepted a process that was not a child");
+  release_child(child);
+  wait_for_child(child.pid, 39);
+}
+
+static void two_children_are_reported_once(void) {
+  struct blocked_child first = spawn_blocked_child(41);
+  struct blocked_child second = spawn_blocked_child(42);
+  release_child(first);
+  release_child(second);
+
+  int first_status = 0;
+  int second_status = 0;
+  pid_t first_result = waitpid(-1, &first_status, 0);
+  pid_t second_result = waitpid(-1, &second_status, 0);
+  check(first_result > 0 && second_result > 0 && first_result != second_result,
+        "any-child waits did not report two distinct children");
+
+  int first_ok = first_result == first.pid && exited_with(first_status, 41);
+  int second_ok = first_result == second.pid && exited_with(first_status, 42);
+  check(first_ok || second_ok,
+        "first any-child wait returned the wrong status");
+  first_ok = second_result == first.pid && exited_with(second_status, 41);
+  second_ok = second_result == second.pid && exited_with(second_status, 42);
+  check(first_ok || second_ok,
+        "second any-child wait returned the wrong status");
+  expect_echild(-1, "third any-child wait did not return ECHILD");
+}
+
+static void completed_nonblocking_child_is_reaped(void) {
+  pid_t child = spawn_delayed_child(43, 0);
+  int status = 0;
+  pid_t result = 0;
+
+  for (int attempt = 0; attempt < 5000 && result == 0; attempt++) {
+    result = waitpid(child, &status, WNOHANG);
+    if (result == 0) {
+      usleep(1000);
+    }
+  }
+
+  check(result == child, "completed child was not returned by WNOHANG");
+  check(exited_with(status, 43), "completed WNOHANG returned the wrong status");
+  expect_echild(child, "completed child was reported more than once");
+}
+
+int main(void) {
+  specific_nonblocking_reaps_once();
+  any_nonblocking_returns_promptly();
+  nonchild_is_not_waitable();
+  two_children_are_reported_once();
+  completed_nonblocking_child_is_reaped();
+  return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
# Description

`proc_join` removed running children during targeted `WNOHANG` polls, blocked on any-child nonblocking waits, and allowed already-reaped or unrelated processes to be joined through the global process table.

Keep children waitable until their exit status is claimed under the parent lock. Targeted waits, any-child waits, and `join_children` now share that operation, so concurrent waiters cannot reap the same child twice. Nonblocking waits return PID zero while a matching child is running, and waits for missing or already-reaped children return `ECHILD`. Blocking waits release the parent lock before sleeping, preserve children when cancelled, and retry after another waiter claims an exit. Guest-memory write faults are propagated.

This change is independent of the process-lifetime work in #6892.
