### PR TITLE
fix(virtual-fs): notify pipe readers when writers close

### DIFF
--- a/lib/virtual-fs/src/pipe.rs
+++ b/lib/virtual-fs/src/pipe.rs
@@ -33,8 +33,8 @@ pub struct Pipe {
 
 #[derive(Debug, Clone)]
 pub struct PipeTx {
-    /// Sends bytes down the pipe
-    tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    /// Shared across clones to identify the final writer atomically.
+    tx: Option<Arc<mpsc::UnboundedSender<Vec<u8>>>>,
     rx_end: Weak<Mutex<PipeReceiver>>,
 }
 
@@ -130,11 +130,14 @@ impl PipeRx {
         }
     }
 
-    pub fn set_interest_handler(&self, interest_handler: Box<dyn InterestHandler>) {
+    pub fn set_interest_handler(&self, mut interest_handler: Box<dyn InterestHandler>) {
         let Some(ref rx) = self.rx else {
             return;
         };
         let mut rx = rx.lock().unwrap();
+        if rx.chan.is_closed() {
+            interest_handler.push_interest(InterestType::Closed);
+        }
         rx.interest_handler.replace(interest_handler);
     }
 
@@ -165,7 +168,7 @@ impl Pipe {
         }));
         Pipe {
             send: PipeTx {
-                tx: Some(tx),
+                tx: Some(Arc::new(tx)),
                 rx_end: Arc::downgrade(&recv),
             },
             recv: PipeRx { rx: Some(recv) },
@@ -215,7 +218,21 @@ impl Default for Pipe {
 
 impl PipeTx {
     pub fn close(&mut self) {
-        _ = self.tx.take();
+        let Some(sender) = self.tx.take() else {
+            return;
+        };
+        let Some(sender) = Arc::into_inner(sender) else {
+            return;
+        };
+        drop(sender);
+
+        let Some(rx_end) = self.rx_end.upgrade() else {
+            return;
+        };
+        let mut receiver = rx_end.lock().unwrap();
+        if let Some(interest_handler) = receiver.interest_handler.as_mut() {
+            interest_handler.push_interest(InterestType::Closed);
+        }
     }
 
     pub fn poll_write_ready(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
@@ -240,6 +257,12 @@ impl PipeTx {
                 interest_handler.push_interest(InterestType::Readable);
             }
         }
+    }
+}
+
+impl Drop for PipeTx {
+    fn drop(&mut self) {
+        self.close();
     }
 }
 
@@ -601,3 +624,170 @@ impl DuplexPipe {
 /// Shared version of BidiPipe for situations where you need
 /// to emulate the old behaviour of `Pipe` (both send and recv on one channel).
 pub type WasiBidirectionalSharedPipePair = ArcFile<DuplexPipe>;
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Barrier, Mutex, mpsc},
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct RecordingHandler {
+        interests: Arc<Mutex<Vec<InterestType>>>,
+    }
+
+    impl InterestHandler for RecordingHandler {
+        fn push_interest(&mut self, interest: InterestType) {
+            self.interests.lock().unwrap().push(interest);
+        }
+
+        fn pop_interest(&mut self, interest: InterestType) -> bool {
+            let mut interests = self.interests.lock().unwrap();
+            let Some(index) = interests.iter().position(|item| *item == interest) else {
+                return false;
+            };
+            interests.remove(index);
+            true
+        }
+
+        fn has_interest(&self, interest: InterestType) -> bool {
+            self.interests.lock().unwrap().contains(&interest)
+        }
+    }
+
+    fn recording_handler() -> (Box<RecordingHandler>, Arc<Mutex<Vec<InterestType>>>) {
+        let interests = Arc::new(Mutex::new(Vec::new()));
+        (
+            Box::new(RecordingHandler {
+                interests: interests.clone(),
+            }),
+            interests,
+        )
+    }
+
+    #[test]
+    fn final_sender_close_notifies_once_and_exposes_eof() {
+        let (mut sender, mut receiver) = Pipe::new().split();
+        let mut other_sender = sender.clone();
+        let (handler, interests) = recording_handler();
+        receiver.set_interest_handler(handler);
+
+        sender.close();
+        assert!(interests.lock().unwrap().is_empty());
+        assert_eq!(receiver.try_read(&mut [0; 1]), None);
+
+        other_sender.close();
+        assert_eq!(*interests.lock().unwrap(), [InterestType::Closed]);
+        assert_eq!(receiver.try_read(&mut [0; 1]), Some(0));
+
+        other_sender.close();
+        assert_eq!(*interests.lock().unwrap(), [InterestType::Closed]);
+    }
+
+    #[test]
+    fn dropping_final_sender_notifies_receiver() {
+        let (sender, receiver) = Pipe::new().split();
+        let (handler, interests) = recording_handler();
+        receiver.set_interest_handler(handler);
+
+        drop(sender);
+
+        assert_eq!(*interests.lock().unwrap(), [InterestType::Closed]);
+    }
+
+    #[test]
+    fn late_handler_observes_closed_channel() {
+        let (sender, receiver) = Pipe::new().split();
+        drop(sender);
+        let (handler, interests) = recording_handler();
+
+        receiver.set_interest_handler(handler);
+
+        assert_eq!(*interests.lock().unwrap(), [InterestType::Closed]);
+    }
+
+    #[test]
+    fn buffered_data_survives_final_sender_close() {
+        let (mut sender, mut receiver) = Pipe::new().split();
+        std::io::Write::write_all(&mut sender, b"payload").unwrap();
+        drop(sender);
+        let (handler, interests) = recording_handler();
+        receiver.set_interest_handler(handler);
+
+        let mut payload = [0; 7];
+        assert_eq!(receiver.try_read(&mut payload), Some(payload.len()));
+        assert_eq!(&payload, b"payload");
+        assert_eq!(receiver.try_read(&mut [0; 1]), Some(0));
+        assert_eq!(*interests.lock().unwrap(), [InterestType::Closed]);
+    }
+
+    #[test]
+    fn sender_keeps_only_a_weak_receiver_reference() {
+        let (mut sender, receiver) = Pipe::new().split();
+        let receiver_ref = sender.rx_end.clone();
+        drop(receiver);
+
+        assert!(receiver_ref.upgrade().is_none());
+        sender.close();
+        assert!(sender.tx.is_none());
+    }
+
+    #[test]
+    fn non_final_sender_close_does_not_take_receiver_lock() {
+        let (mut sender, receiver) = Pipe::new().split();
+        let other_sender = sender.clone();
+        let receiver_ref = receiver.rx.as_ref().unwrap().clone();
+        let receiver_guard = receiver_ref.lock().unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = barrier.clone();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let worker = thread::spawn(move || {
+            worker_barrier.wait();
+            sender.close();
+            done_tx.send(()).unwrap();
+        });
+        barrier.wait();
+
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("a non-final close waited for the receiver lock");
+        assert!(!receiver_guard.chan.is_closed());
+        drop(receiver_guard);
+        worker.join().unwrap();
+        drop(other_sender);
+    }
+
+    #[test]
+    fn final_sender_drops_channel_before_taking_receiver_lock() {
+        let (mut sender, receiver) = Pipe::new().split();
+        let receiver_ref = receiver.rx.as_ref().unwrap().clone();
+        let receiver_guard = receiver_ref.lock().unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = barrier.clone();
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let worker = thread::spawn(move || {
+            worker_barrier.wait();
+            sender.close();
+            done_tx.send(()).unwrap();
+        });
+        barrier.wait();
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !receiver_guard.chan.is_closed() && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        let channel_closed_before_unlock = receiver_guard.chan.is_closed();
+        let close_result = done_rx.recv_timeout(Duration::from_millis(50));
+        drop(receiver_guard);
+        worker.join().unwrap();
+
+        assert!(channel_closed_before_unlock);
+        assert!(matches!(close_result, Err(mpsc::RecvTimeoutError::Timeout)));
+    }
+}

--- a/lib/virtual-fs/src/pipe.rs
+++ b/lib/virtual-fs/src/pipe.rs
@@ -224,6 +224,7 @@ impl PipeTx {
         let Some(sender) = Arc::into_inner(sender) else {
             return;
         };
+        // Wake blocking_recv before waiting for the receiver lock.
         drop(sender);
 
         let Some(rx_end) = self.rx_end.upgrade() else {
@@ -700,6 +701,75 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_sender_close_and_drop_notify_once() {
+        for _ in 0..128 {
+            let (mut sender, mut receiver) = Pipe::new().split();
+            let other_sender = sender.clone();
+            let (handler, interests) = recording_handler();
+            receiver.set_interest_handler(handler);
+            let barrier = Arc::new(Barrier::new(2));
+            let worker_barrier = barrier.clone();
+            let (done_tx, done_rx) = mpsc::channel();
+            let other_done_tx = done_tx.clone();
+
+            let closer = thread::spawn(move || {
+                worker_barrier.wait();
+                sender.close();
+                done_tx.send(()).unwrap();
+            });
+            let dropper = thread::spawn(move || {
+                barrier.wait();
+                drop(other_sender);
+                other_done_tx.send(()).unwrap();
+            });
+
+            for _ in 0..2 {
+                done_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("concurrent writer close did not finish");
+            }
+            closer.join().unwrap();
+            dropper.join().unwrap();
+            assert_eq!(*interests.lock().unwrap(), [InterestType::Closed]);
+            assert_eq!(receiver.try_read(&mut [0; 1]), Some(0));
+        }
+    }
+
+    #[test]
+    fn handler_registration_racing_final_close_observes_eof() {
+        for _ in 0..128 {
+            let (sender, receiver) = Pipe::new().split();
+            let (handler, interests) = recording_handler();
+            let barrier = Arc::new(Barrier::new(2));
+            let worker_barrier = barrier.clone();
+            let (done_tx, done_rx) = mpsc::channel();
+            let other_done_tx = done_tx.clone();
+
+            let closer = thread::spawn(move || {
+                worker_barrier.wait();
+                drop(sender);
+                done_tx.send(()).unwrap();
+            });
+            let registrar = thread::spawn(move || {
+                barrier.wait();
+                receiver.set_interest_handler(handler);
+                other_done_tx.send(()).unwrap();
+                receiver
+            });
+
+            for _ in 0..2 {
+                done_rx
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("handler registration or writer close did not finish");
+            }
+            closer.join().unwrap();
+            let mut receiver = registrar.join().unwrap();
+            assert!(interests.lock().unwrap().contains(&InterestType::Closed));
+            assert_eq!(receiver.try_read(&mut [0; 1]), Some(0));
+        }
+    }
+
+    #[test]
     fn late_handler_observes_closed_channel() {
         let (sender, receiver) = Pipe::new().split();
         drop(sender);
@@ -753,13 +823,14 @@ mod tests {
         });
         barrier.wait();
 
-        done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("a non-final close waited for the receiver lock");
-        assert!(!receiver_guard.chan.is_closed());
+        let close_result = done_rx.recv_timeout(Duration::from_secs(1));
+        let channel_closed = receiver_guard.chan.is_closed();
         drop(receiver_guard);
         worker.join().unwrap();
         drop(other_sender);
+
+        close_result.expect("a non-final close waited for the receiver lock");
+        assert!(!channel_closed);
     }
 
     #[test]

--- a/lib/wasix/tests/wasm_tests/poll/epoll-pipe-eof/main.c
+++ b/lib/wasix/tests/wasm_tests/poll/epoll-pipe-eof/main.c
@@ -1,0 +1,153 @@
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+static int failures;
+
+static void check(int condition, const char* message) {
+  if (!condition) {
+    fprintf(stderr, "%s\n", message);
+    failures++;
+  }
+}
+
+static void require(int condition, const char* message) {
+  if (!condition) {
+    perror(message);
+    exit(EXIT_FAILURE);
+  }
+}
+
+static int add_reader(int epoll_fd, int reader) {
+  struct epoll_event event = {.events = EPOLLIN, .data.fd = reader};
+  return epoll_ctl(epoll_fd, EPOLL_CTL_ADD, reader, &event);
+}
+
+static int wait_for_hup(int epoll_fd, int reader, int timeout_ms) {
+  struct epoll_event event = {0};
+  int count = epoll_wait(epoll_fd, &event, 1, timeout_ms);
+  return count == 1 && event.data.fd == reader &&
+         (event.events & EPOLLHUP) != 0;
+}
+
+static void cloned_writer_defers_hup_until_final_close(void) {
+  int fds[2];
+  require(pipe(fds) == 0, "pipe failed for cloned-writer test");
+  int duplicate = dup(fds[1]);
+  require(duplicate >= 0, "dup failed for cloned-writer test");
+  int epoll_fd = epoll_create1(0);
+  require(epoll_fd >= 0, "epoll_create1 failed for cloned-writer test");
+  require(add_reader(epoll_fd, fds[0]) == 0,
+          "epoll_ctl failed for cloned-writer test");
+
+  require(close(fds[1]) == 0, "first writer close failed");
+  struct epoll_event event = {0};
+  check(epoll_wait(epoll_fd, &event, 1, 25) == 0,
+        "non-final writer close reported HUP");
+
+  require(close(duplicate) == 0, "final writer close failed");
+  check(wait_for_hup(epoll_fd, fds[0], 1000),
+        "final writer close did not report HUP");
+  char byte;
+  check(read(fds[0], &byte, sizeof(byte)) == 0,
+        "final writer close did not expose EOF");
+
+  close(fds[0]);
+  close(epoll_fd);
+}
+
+static void late_registration_observes_hup(void) {
+  int fds[2];
+  require(pipe(fds) == 0, "pipe failed for late-registration test");
+  require(close(fds[1]) == 0, "writer close failed before registration");
+  int epoll_fd = epoll_create1(0);
+  require(epoll_fd >= 0, "epoll_create1 failed for late-registration test");
+  require(add_reader(epoll_fd, fds[0]) == 0,
+          "late epoll_ctl registration failed");
+
+  check(wait_for_hup(epoll_fd, fds[0], 1000),
+        "late registration did not report HUP");
+
+  close(fds[0]);
+  close(epoll_fd);
+}
+
+static void buffered_payload_precedes_eof(void) {
+  static const char payload[] = "payload";
+  int fds[2];
+  require(pipe(fds) == 0, "pipe failed for buffered-payload test");
+  require(write(fds[1], payload, sizeof(payload)) == (ssize_t)sizeof(payload),
+          "buffered payload write failed");
+  require(close(fds[1]) == 0, "buffered writer close failed");
+  int epoll_fd = epoll_create1(0);
+  require(epoll_fd >= 0, "epoll_create1 failed for buffered-payload test");
+  require(add_reader(epoll_fd, fds[0]) == 0,
+          "epoll_ctl failed for buffered-payload test");
+
+  check(wait_for_hup(epoll_fd, fds[0], 1000),
+        "buffered final close did not report HUP");
+  char buffer[sizeof(payload)] = {0};
+  check(read(fds[0], buffer, sizeof(buffer)) == (ssize_t)sizeof(buffer),
+        "buffered read returned the wrong length");
+  check(memcmp(buffer, payload, sizeof(payload)) == 0,
+        "buffered read returned the wrong payload");
+  check(read(fds[0], buffer, sizeof(buffer)) == 0,
+        "buffered pipe did not return EOF after its payload");
+
+  close(fds[0]);
+  close(epoll_fd);
+}
+
+struct waiter_args {
+  int epoll_fd;
+  int reader;
+  atomic_bool ready;
+  int saw_hup;
+};
+
+static void* wait_for_writer_close(void* raw_args) {
+  struct waiter_args* args = raw_args;
+  atomic_store(&args->ready, true);
+  args->saw_hup = wait_for_hup(args->epoll_fd, args->reader, 1000);
+  return NULL;
+}
+
+static void blocked_pthread_is_woken_by_final_close(void) {
+  int fds[2];
+  require(pipe(fds) == 0, "pipe failed for pthread test");
+  int epoll_fd = epoll_create1(0);
+  require(epoll_fd >= 0, "epoll_create1 failed for pthread test");
+  require(add_reader(epoll_fd, fds[0]) == 0,
+          "epoll_ctl failed for pthread test");
+
+  struct waiter_args args = {
+      .epoll_fd = epoll_fd, .reader = fds[0], .saw_hup = 0};
+  atomic_init(&args.ready, false);
+  pthread_t waiter;
+  require(pthread_create(&waiter, NULL, wait_for_writer_close, &args) == 0,
+          "pthread_create failed");
+  while (!atomic_load(&args.ready)) {
+    sched_yield();
+  }
+  usleep(25000);
+  require(close(fds[1]) == 0, "writer close failed for pthread test");
+  require(pthread_join(waiter, NULL) == 0, "pthread_join failed");
+  check(args.saw_hup, "blocked pthread did not wake with HUP");
+
+  close(fds[0]);
+  close(epoll_fd);
+}
+
+int main(void) {
+  cloned_writer_defers_hup_until_final_close();
+  late_registration_observes_hup();
+  buffered_payload_precedes_eof();
+  blocked_pthread_is_woken_by_final_close();
+  return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/lib/wasix/tests/wasm_tests/poll/epoll-pipe-eof/main.c
+++ b/lib/wasix/tests/wasm_tests/poll/epoll-pipe-eof/main.c
@@ -24,6 +24,13 @@ static void require(int condition, const char* message) {
   }
 }
 
+static void require_pthread(int error, const char* message) {
+  if (error != 0) {
+    fprintf(stderr, "%s: %s\n", message, strerror(error));
+    exit(EXIT_FAILURE);
+  }
+}
+
 static int add_reader(int epoll_fd, int reader) {
   struct epoll_event event = {.events = EPOLLIN, .data.fd = reader};
   return epoll_ctl(epoll_fd, EPOLL_CTL_ADD, reader, &event);
@@ -130,14 +137,14 @@ static void blocked_pthread_is_woken_by_final_close(void) {
       .epoll_fd = epoll_fd, .reader = fds[0], .saw_hup = 0};
   atomic_init(&args.ready, false);
   pthread_t waiter;
-  require(pthread_create(&waiter, NULL, wait_for_writer_close, &args) == 0,
-          "pthread_create failed");
+  require_pthread(pthread_create(&waiter, NULL, wait_for_writer_close, &args),
+                  "pthread_create failed");
   while (!atomic_load(&args.ready)) {
     sched_yield();
   }
   usleep(25000);
   require(close(fds[1]) == 0, "writer close failed for pthread test");
-  require(pthread_join(waiter, NULL) == 0, "pthread_join failed");
+  require_pthread(pthread_join(waiter, NULL), "pthread_join failed");
   check(args.saw_hup, "blocked pthread did not wake with HUP");
 
   close(fds[0]);


### PR DESCRIPTION
# Description

Closing or dropping the last pipe writer now wakes epoll waiters with HUP. Handlers registered after the writer closes also observe the closed channel, while buffered bytes remain readable before EOF.

Writer clones share one sender so the final close is identified atomically. Dropping that sender before taking the receiver lock lets blocked reads wake and release the lock, preventing a deadlock during close.
