### PR TITLE
fix(wasix): distinguish process signals from foreground delivery

### DIFF
--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -455,7 +455,7 @@ impl WasiProcess {
         impl SignalHandlerAbi for SignalHandler {
             fn signal(&self, signal: u8) -> Result<(), SignalDeliveryError> {
                 if let Ok(signal) = signal.try_into() {
-                    signal_process_internal(&self.0, signal);
+                    signal_foreground_internal(&self.0, signal);
                     Ok(())
                 } else {
                     Err(SignalDeliveryError)
@@ -598,10 +598,13 @@ impl WasiProcess {
         tracing::trace!(%pid, %tid, "signal-thread({:?})", signal);
 
         let inner = self.inner.0.lock().unwrap();
-
-        wake_atomic_waiters(&inner, signal);
-        if let Some(thread) = inner.threads.get(&tid) {
+        if let Some(thread) = inner
+            .threads
+            .get(&tid)
+            .filter(|thread| thread.try_join().is_none())
+        {
             thread.signal(signal);
+            wake_atomic_waiters(&inner, signal);
         } else {
             trace!(
                 "wasi[{}]::lost-signal(tid={}, sig={:?})",
@@ -612,9 +615,13 @@ impl WasiProcess {
         }
     }
 
-    /// Signals all the threads in this process
+    /// Sends a process-directed signal to one live thread.
     pub fn signal_process(&self, signal: Signal) {
         signal_process_internal(&self.inner, signal);
+    }
+
+    fn signal_foreground(&self, signal: Signal) {
+        signal_foreground_internal(&self.inner, signal);
     }
 
     /// Registers the shared memory used by this process.
@@ -867,15 +874,39 @@ impl WasiProcess {
         for thread in guard.threads.values() {
             thread.set_status_finished(Ok(exit_code))
         }
+        wake_all_atomic_waiters(&guard);
     }
 }
 
-/// Signals all the threads in this process
 fn signal_process_internal(process: &LockableWasiProcessInner, signal: Signal) {
+    let guard = process.0.lock().unwrap();
+    let pid = guard.pid;
+    tracing::trace!(%pid, "signal-process({:?})", signal);
+
+    let recipient = guard
+        .threads
+        .values()
+        .find(|thread| thread.is_main() && thread.try_join().is_none())
+        .or_else(|| {
+            guard
+                .threads
+                .values()
+                .find(|thread| thread.try_join().is_none())
+        });
+
+    if let Some(thread) = recipient {
+        thread.signal(signal);
+        wake_atomic_waiters(&guard, signal);
+    } else {
+        tracing::trace!(%pid, ?signal, "signal has no live recipient");
+    }
+}
+
+fn signal_foreground_internal(process: &LockableWasiProcessInner, signal: Signal) {
     #[allow(unused_mut)]
     let mut guard = process.0.lock().unwrap();
     let pid = guard.pid;
-    tracing::trace!(%pid, "signal-process({:?})", signal);
+    tracing::trace!(%pid, "signal-foreground({:?})", signal);
 
     // If the snapshot on ctrl-c is currently registered then we need
     // to take a snapshot and exit
@@ -899,24 +930,19 @@ fn signal_process_internal(process: &LockableWasiProcessInner, signal: Signal) {
         };
     }
 
-    // Check if there are subprocesses that will receive this signal
-    // instead of this process
     if guard.waiting.load(Ordering::Acquire) > 0 {
-        let mut triggered = false;
-        for child in guard.children.iter() {
-            child.signal_process(signal);
-            triggered = true;
-        }
-        if triggered {
+        let children = guard.children.clone();
+        if !children.is_empty() {
+            drop(guard);
+            for child in children {
+                child.signal_foreground(signal);
+            }
             return;
         }
     }
 
-    // Otherwise just send the signal to all the threads
-    wake_atomic_waiters(&guard, signal);
-    for thread in guard.threads.values() {
-        thread.signal(signal);
-    }
+    drop(guard);
+    signal_process_internal(process, signal);
 }
 
 fn wake_atomic_waiters(process: &WasiProcessInner, signal: Signal) {
@@ -924,46 +950,148 @@ fn wake_atomic_waiters(process: &WasiProcessInner, signal: Signal) {
         return;
     };
 
-    if signal == Signal::Sigkill {
-        // On kill, disable atomics to prevent threads from resuming.
-        // NOTE: disable_atomics also wakes all current waiters.
-        if let Err(err) = memory.disable_atomics() {
-            tracing::trace!(
-                pid=%process.pid,
-                error = &err as &dyn std::error::Error,
-                "failed to wake atomic waiters"
-            );
-        }
+    let result = if signal == Signal::Sigkill {
+        memory.disable_atomics()
+    } else {
+        memory.wake_all_atomic_waiters()
+    };
+    if let Err(err) = result {
+        tracing::trace!(
+            pid=%process.pid,
+            error = &err as &dyn std::error::Error,
+            "failed to wake atomic waiters"
+        );
     }
+}
 
-    // TODO: Should other signals also wake up waiters?
-    // We have low confidence this is useful outside the kill path.
-    // SEE https://github.com/wasmerio/wasmer/pull/6536
-    //
-    // Atomic wait wakeups are memory-wide, so only use them for signals
-    // that should interrupt or terminate execution anyway.
-    // if matches!(
-    //     signal,
-    //     Signal::Sigkill
-    //         | Signal::Sigterm
-    //         | Signal::Sigabrt
-    //         | Signal::Sigquit
-    //         | Signal::Sigint
-    //         | Signal::Sigstop
-    //         | Signal::Sigpipe
-    //         | Signal::Sigwakeup
-    // ) {
-    //    memory.wake_all_atomic_waiters();
-    // }
+fn wake_all_atomic_waiters(process: &WasiProcessInner) {
+    let Some(memory) = &process.memory else {
+        return;
+    };
+    if let Err(err) = memory.wake_all_atomic_waiters() {
+        tracing::trace!(
+            pid=%process.pid,
+            error = &err as &dyn std::error::Error,
+            "failed to wake atomic waiters during process shutdown"
+        );
+    }
 }
 
 impl SignalHandlerAbi for WasiProcess {
     fn signal(&self, sig: u8) -> Result<(), SignalDeliveryError> {
         if let Ok(sig) = sig.try_into() {
-            self.signal_process(sig);
+            self.signal_foreground(sig);
             Ok(())
         } else {
             Err(SignalDeliveryError)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{WasiControlPlane, os::task::control_plane::ControlPlaneConfig};
+
+    fn process_with_two_threads() -> (
+        WasiControlPlane,
+        WasiProcess,
+        WasiThreadHandle,
+        WasiThreadHandle,
+    ) {
+        let plane = WasiControlPlane::new(ControlPlaneConfig::default());
+        let process = plane.new_process(ModuleHash::random()).unwrap();
+        let main = process
+            .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+            .unwrap();
+        let worker = process
+            .new_thread(
+                WasiMemoryLayout::default(),
+                ThreadStartType::ThreadSpawn { start_ptr: 0 },
+            )
+            .unwrap();
+        (plane, process, main, worker)
+    }
+
+    #[test]
+    fn process_signal_selects_one_live_thread() {
+        let (_plane, process, main, worker) = process_with_two_threads();
+
+        process.signal_process(Signal::Sigusr1);
+
+        assert_eq!(main.pop_signals(), vec![Signal::Sigusr1]);
+        assert!(worker.pop_signals().is_empty());
+    }
+
+    #[test]
+    fn process_signal_falls_back_when_main_thread_finished() {
+        let (_plane, process, main, worker) = process_with_two_threads();
+        main.set_status_finished(Ok(Errno::Success.into()));
+
+        process.signal_process(Signal::Sigusr1);
+
+        assert!(main.pop_signals().is_empty());
+        assert_eq!(worker.pop_signals(), vec![Signal::Sigusr1]);
+    }
+
+    #[test]
+    fn unknown_thread_signal_does_not_queue_a_signal() {
+        let (_plane, process, main, worker) = process_with_two_threads();
+
+        process.signal_thread(&u32::MAX.into(), Signal::Sigusr1);
+
+        assert!(main.pop_signals().is_empty());
+        assert!(worker.pop_signals().is_empty());
+    }
+
+    #[test]
+    fn foreground_signal_reaches_waited_on_child() {
+        let plane = WasiControlPlane::new(ControlPlaneConfig::default());
+        let parent = plane.new_process(ModuleHash::random()).unwrap();
+        let parent_main = parent
+            .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+            .unwrap();
+        let child = plane.new_process(ModuleHash::random()).unwrap();
+        let child_main = child
+            .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+            .unwrap();
+        parent.lock().children.push(child);
+        parent.waiting.store(1, Ordering::Release);
+
+        SignalHandlerAbi::signal(&parent, Signal::Sigint as u8).unwrap();
+
+        assert!(parent_main.pop_signals().is_empty());
+        assert_eq!(child_main.pop_signals(), vec![Signal::Sigint]);
+    }
+
+    #[test]
+    fn addressed_signal_stays_with_waiting_parent() {
+        let plane = WasiControlPlane::new(ControlPlaneConfig::default());
+        let parent = plane.new_process(ModuleHash::random()).unwrap();
+        let parent_main = parent
+            .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+            .unwrap();
+        let child = plane.new_process(ModuleHash::random()).unwrap();
+        let child_main = child
+            .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+            .unwrap();
+        parent.lock().children.push(child);
+        parent.waiting.store(1, Ordering::Release);
+
+        parent.signal_process(Signal::Sigusr1);
+
+        assert_eq!(parent_main.pop_signals(), vec![Signal::Sigusr1]);
+        assert!(child_main.pop_signals().is_empty());
+    }
+
+    #[test]
+    fn terminate_finishes_every_thread_with_original_exit_code() {
+        let (_plane, process, main, worker) = process_with_two_threads();
+        let exit_code = ExitCode::from(37);
+
+        process.terminate(exit_code);
+
+        assert_eq!(main.try_join().unwrap().unwrap(), exit_code);
+        assert_eq!(worker.try_join().unwrap().unwrap(), exit_code);
     }
 }

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -872,7 +872,9 @@ impl WasiProcess {
         // Need special logic for the main thread.
         let guard = self.inner.0.lock().unwrap();
         for thread in guard.threads.values() {
-            thread.set_status_finished(Ok(exit_code))
+            thread.set_status_finished(Ok(exit_code));
+            // Syscall waiters subscribe to signals, not task status changes.
+            thread.signal(Signal::Sigwakeup);
         }
         wake_all_atomic_waiters(&guard);
     }
@@ -1035,6 +1037,42 @@ mod tests {
     }
 
     #[test]
+    fn selected_main_thread_exit_finishes_the_process() {
+        let (_plane, process, main, worker) = process_with_two_threads();
+
+        process.signal_process(Signal::Sigusr1);
+        main.set_status_finished(Ok(Errno::Success.into()));
+        drop(main);
+
+        assert!(worker.try_join().is_none());
+        assert_eq!(process.try_join().unwrap().unwrap().raw(), 0);
+        assert!(worker.pop_signals().is_empty());
+    }
+
+    #[test]
+    fn process_signal_selects_a_live_worker_without_a_main_thread() {
+        let plane = WasiControlPlane::new(ControlPlaneConfig::default());
+        let process = plane.new_process(ModuleHash::random()).unwrap();
+        let workers: Vec<_> = (0..2)
+            .map(|_| {
+                process
+                    .new_thread(
+                        WasiMemoryLayout::default(),
+                        ThreadStartType::ThreadSpawn { start_ptr: 0 },
+                    )
+                    .unwrap()
+            })
+            .collect();
+        workers[0].set_status_finished(Ok(Errno::Success.into()));
+
+        process.signal_process(Signal::Sigusr1);
+
+        assert!(process.try_join().is_none());
+        assert!(workers[0].pop_signals().is_empty());
+        assert_eq!(workers[1].pop_signals(), vec![Signal::Sigusr1]);
+    }
+
+    #[test]
     fn unknown_thread_signal_does_not_queue_a_signal() {
         let (_plane, process, main, worker) = process_with_two_threads();
 
@@ -1086,12 +1124,64 @@ mod tests {
 
     #[test]
     fn terminate_finishes_every_thread_with_original_exit_code() {
+        #[derive(Default)]
+        struct WakeCounter(AtomicU32);
+
+        impl std::task::Wake for WakeCounter {
+            fn wake(self: Arc<Self>) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
         let (_plane, process, main, worker) = process_with_two_threads();
         let exit_code = ExitCode::from(37);
+        let main_wakes = Arc::new(WakeCounter::default());
+        let worker_wakes = Arc::new(WakeCounter::default());
+        main.signals_subscribe(&Waker::from(main_wakes.clone()));
+        worker.signals_subscribe(&Waker::from(worker_wakes.clone()));
 
         process.terminate(exit_code);
+        process.terminate(ExitCode::from(0));
 
         assert_eq!(main.try_join().unwrap().unwrap(), exit_code);
         assert_eq!(worker.try_join().unwrap().unwrap(), exit_code);
+        assert_eq!(main_wakes.0.load(Ordering::SeqCst), 1);
+        assert_eq!(worker_wakes.0.load(Ordering::SeqCst), 1);
+        for thread in [main, worker] {
+            assert_eq!(thread.pop_signals(), vec![Signal::Sigwakeup]);
+            assert!(thread.signals().lock().unwrap().1.is_empty());
+        }
+    }
+
+    #[cfg(feature = "sys")]
+    #[test]
+    fn terminate_wakes_atomic_waiters_after_publishing_exit_code() {
+        use std::{sync::mpsc, thread, time::Instant};
+        use wasmer::{Memory, MemoryLocation, MemoryType, Store};
+
+        let (_plane, process, main, worker) = process_with_two_threads();
+        let mut store = Store::default();
+        let memory = Memory::new(&mut store, MemoryType::new(1, Some(1), true)).unwrap();
+        let shared = memory.as_shared(&store).unwrap();
+        process.register_memory(shared.ops());
+        let (done_tx, done_rx) = mpsc::channel();
+        let waiter = thread::spawn(move || {
+            let result = shared.wait(MemoryLocation::new_32(0), Some(Duration::from_secs(5)));
+            done_tx.send((result, worker.try_join())).unwrap();
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let (result, status) = loop {
+            process.terminate(ExitCode::from(37));
+            match done_rx.recv_timeout(Duration::from_millis(1)) {
+                Ok(result) => break result,
+                Err(mpsc::RecvTimeoutError::Timeout) if Instant::now() < deadline => continue,
+                Err(err) => panic!("atomic waiter did not finish: {err}"),
+            }
+        };
+        waiter.join().unwrap();
+        assert_eq!(result.unwrap(), 0);
+        assert_eq!(status.unwrap().unwrap(), ExitCode::from(37));
+        assert_eq!(main.try_join().unwrap().unwrap(), ExitCode::from(37));
     }
 }

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -1160,7 +1160,7 @@ mod tests {
         use wasmer::{Memory, MemoryLocation, MemoryType, Store};
 
         let (_plane, process, main, worker) = process_with_two_threads();
-        let mut store = Store::default();
+        let mut store = Store::new(wasmer::sys::EngineBuilder::headless().engine());
         let memory = Memory::new(&mut store, MemoryType::new(1, Some(1), true)).unwrap();
         let shared = memory.as_shared(&store).unwrap();
         process.register_memory(shared.ops());

--- a/lib/wasix/src/state/builder.rs
+++ b/lib/wasix/src/state/builder.rs
@@ -1004,7 +1004,7 @@ impl WasiEnvBuilder {
             clock_offset: Default::default(),
             envs: std::sync::Mutex::new(conv_env_vars(self.envs)),
             signals: std::sync::Mutex::new(self.signals.iter().map(|s| (s.sig, s.disp)).collect()),
-            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
+            signal_handler: std::sync::Mutex::new(None),
         };
 
         let runtime = self.runtime.unwrap_or_else(|| {

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -128,7 +128,7 @@ impl WasiEnvInit {
                 args: std::sync::Mutex::new(self.state.args.lock().unwrap().clone()),
                 envs: std::sync::Mutex::new(self.state.envs.lock().unwrap().deref().clone()),
                 signals: std::sync::Mutex::new(self.state.signals.lock().unwrap().deref().clone()),
-                signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
+                signal_handler: std::sync::Mutex::new(None),
                 preopen: self.state.preopen.clone(),
             },
             runtime: self.runtime.clone(),
@@ -702,17 +702,11 @@ impl WasiEnv {
         let env_inner = env
             .try_inner()
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
-        let inner = env_inner.main_module_instance_handles();
-        // Ask the process, not just this instance: a spawned thread has its own
-        // WasiModuleInstanceHandles and never sees the main instance's
-        // registration, so `inner.signal_set` alone would apply the default
-        // disposition on sibling threads and terminate a process that does
-        // handle the signal.
-        let handler_registered = inner.signal_set
-            || env
-                .state
-                .signal_handler_registered
-                .load(std::sync::atomic::Ordering::SeqCst);
+        let handler_registered = env_inner
+            .main_module_instance_handles()
+            .signal_handler
+            .is_some()
+            || env.state.signal_handler.lock().unwrap().is_some();
         if !handler_registered {
             let signals = env.thread.pop_signals();
             if !signals.is_empty() {
@@ -746,28 +740,8 @@ impl WasiEnv {
         // If a signal handler has never been set then we need to handle signals
         // differently
         let env = ctx.data();
-        let env_inner = env
-            .try_inner()
-            .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
-        let inner = env_inner.main_module_instance_handles();
-        if !inner.signal_set {
-            // Process-directed signals are copied into every thread's queue,
-            // but the guest callback belongs only to the instance that
-            // registered it. A sibling instance must discard its copy after
-            // the process-wide registration suppressed the default disposition;
-            // otherwise that copy remains queued forever.
-            let drained = !env.thread.pop_signals().is_empty();
-            return Ok(Ok(drained));
-        }
-
-        // Check for any signals that we need to trigger
-        // (but only if a signal handler is registered)
-        let ret = if inner.signal.as_ref().is_some() {
-            let signals = env.thread.pop_signals();
-            Self::process_signals_internal(ctx, signals)?
-        } else {
-            false
-        };
+        let signals = env.thread.pop_signals();
+        let ret = Self::process_signals_internal(ctx, signals)?;
 
         Ok(Ok(ret))
     }
@@ -781,7 +755,18 @@ impl WasiEnv {
             .try_inner()
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
         let inner = env_inner.main_module_instance_handles();
-        if let Some(handler) = inner.signal.clone() {
+        let handler_name = inner
+            .signal_handler
+            .clone()
+            .or_else(|| env.state.signal_handler.lock().unwrap().clone());
+        let handler = handler_name.and_then(|name| {
+            inner
+                .instance
+                .exports
+                .get_typed_function::<i32, ()>(&ctx, &name)
+                .ok()
+        });
+        if let Some(handler) = handler {
             // We might also have signals that trigger on timers
             let mut now = 0;
             {
@@ -893,8 +878,7 @@ impl WasiEnv {
         )
     }
 
-    /// Provides safe access to the initialized part of WasiEnv
-    /// (it must be initialized before it can be used)
+    /// Provides safe access to the initialized part of WasiEnv.
     pub(crate) fn inner_mut(&mut self) -> WasiInstanceGuardMut<'_> {
         self.inner.get_mut().expect(
             "You must initialize the WasiEnv before using it and can not pass it between threads",

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -737,8 +737,6 @@ impl WasiEnv {
 
     /// Processes any signals that are batched up
     pub(crate) fn process_signals(ctx: &mut FunctionEnvMut<'_, Self>) -> WasiResult<bool> {
-        // If a signal handler has never been set then we need to handle signals
-        // differently
         let env = ctx.data();
         let signals = env.thread.pop_signals();
         let ret = Self::process_signals_internal(ctx, signals)?;
@@ -1299,11 +1297,7 @@ impl WasiEnv {
                         }
                     }
 
-                    // Record the real exit code before broadcasting Sigquit.
-                    // Otherwise a pending Sigquit can win the status race and
-                    // make waiters observe a successful exit.
                     process.terminate(process_exit_code);
-                    process.signal_process(Signal::Sigquit);
                 }
             })
         } else {

--- a/lib/wasix/src/state/handles/mod.rs
+++ b/lib/wasix/src/state/handles/mod.rs
@@ -60,15 +60,8 @@ pub struct WasiModuleInstanceHandles {
     /// [this takes a user_data field]
     pub(crate) thread_spawn: Option<TypedFunction<(i32, i32), ()>>,
 
-    /// Represents the callback for signals (name = "__wasm_signal")
-    /// Signals are triggered asynchronously at idle times of the process
-    // TODO: why is this here? It can exist in WasiEnv
-    pub(crate) signal: Option<TypedFunction<i32, ()>>,
-
-    /// Flag that indicates if the signal callback has been set by the WASM
-    /// process - if it has not been set then the runtime behaves differently
-    /// when a CTRL-C is pressed.
-    pub(crate) signal_set: bool,
+    /// Signal callback name registered by this instance.
+    pub(crate) signal_handler: Option<String>,
 
     /// Flag that indicates if the stack capture exports are being used by
     /// this WASM process which means that it will be using asyncify
@@ -149,12 +142,8 @@ impl WasiModuleInstanceHandles {
                 .exports
                 .get_typed_function(store, "wasi_thread_start")
                 .ok(),
-            signal: instance
-                .exports
-                .get_typed_function(&store, "__wasm_signal")
-                .ok(),
+            signal_handler: None,
             has_stack_checkpoint,
-            signal_set: false,
             asyncify_start_unwind: instance
                 .exports
                 .get_typed_function(store, "asyncify_start_unwind")

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -135,15 +135,8 @@ pub(crate) struct WasiState {
     pub args: Mutex<Vec<String>>,
     pub envs: Mutex<Vec<Vec<u8>>>,
     pub signals: Mutex<HashMap<Signal, Disposition>>,
-    /// Whether this *process* has registered a signal handler callback.
-    ///
-    /// `WasiModuleInstanceHandles::signal_set` only records whether the
-    /// instance doing the asking registered one, and every spawned thread gets
-    /// its own instance. Signals are delivered to all of a process's threads,
-    /// so a per-instance flag makes sibling threads believe the program handles
-    /// no signals and apply the runtime's default disposition -- terminating a
-    /// process that does in fact have a handler installed.
-    pub signal_handler_registered: std::sync::atomic::AtomicBool,
+    /// The first callback name registered by an instance in this process.
+    pub signal_handler: Mutex<Option<String>>,
 
     // TODO: should not be here, since this requires active work to resolve.
     // State should only hold active runtime state that can be reproducibly re-created.
@@ -255,8 +248,7 @@ impl WasiState {
             args: Mutex::new(self.args.lock().unwrap().clone()),
             envs: Mutex::new(self.envs.lock().unwrap().clone()),
             signals: Mutex::new(self.signals.lock().unwrap().clone()),
-            // A forked process re-registers from its own instance.
-            signal_handler_registered: std::sync::atomic::AtomicBool::new(false),
+            signal_handler: Mutex::new(None),
             preopen: self.preopen.clone(),
         }
     }

--- a/lib/wasix/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_write.rs
@@ -376,7 +376,8 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                             drop(iovs_arr);
 
                             if raise_sigpipe {
-                                env.process.signal_process(Signal::Sigpipe);
+                                env.process
+                                    .signal_thread(&env.thread.tid(), Signal::Sigpipe);
                                 wasi_try_ok_ok!(WasiEnv::process_signals_and_exit(ctx)?);
                                 return Ok(Err(Errno::Pipe));
                             }
@@ -385,7 +386,8 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                             match std::io::Write::write_all(tx, data) {
                                 Ok(()) => (),
                                 Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
-                                    env.process.signal_process(Signal::Sigpipe);
+                                    env.process
+                                        .signal_thread(&env.thread.tid(), Signal::Sigpipe);
                                     wasi_try_ok_ok!(WasiEnv::process_signals_and_exit(ctx)?);
                                     return Ok(Err(Errno::Pipe));
                                 }
@@ -435,7 +437,8 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                             drop(iovs_arr);
 
                             if raise_sigpipe {
-                                env.process.signal_process(Signal::Sigpipe);
+                                env.process
+                                    .signal_thread(&env.thread.tid(), Signal::Sigpipe);
                                 wasi_try_ok_ok!(WasiEnv::process_signals_and_exit(ctx)?);
                                 return Ok(Err(Errno::Pipe));
                             }
@@ -444,7 +447,8 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                             match std::io::Write::write_all(pipe, data) {
                                 Ok(()) => (),
                                 Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
-                                    env.process.signal_process(Signal::Sigpipe);
+                                    env.process
+                                        .signal_thread(&env.thread.tid(), Signal::Sigpipe);
                                     wasi_try_ok_ok!(WasiEnv::process_signals_and_exit(ctx)?);
                                     return Ok(Err(Errno::Pipe));
                                 }

--- a/lib/wasix/src/syscalls/wasi/proc_raise.rs
+++ b/lib/wasix/src/syscalls/wasi/proc_raise.rs
@@ -10,7 +10,7 @@ use crate::syscalls::*;
 #[instrument(level = "trace", skip_all, fields(sig), ret)]
 pub fn proc_raise(mut ctx: FunctionEnvMut<'_, WasiEnv>, sig: Signal) -> Result<Errno, WasiError> {
     let env = ctx.data();
-    env.process.signal_process(sig);
+    env.process.signal_thread(&env.thread.tid(), sig);
 
     WasiEnv::do_pending_operations(&mut ctx)?;
 

--- a/lib/wasix/src/syscalls/wasix/callback_signal.rs
+++ b/lib/wasix/src/syscalls/wasix/callback_signal.rs
@@ -32,23 +32,18 @@ pub fn callback_signal<M: MemorySize>(
         .main_module_instance_handles()
         .instance
         .exports
-        .get_typed_function(&ctx, &name)
+        .get_typed_function::<i32, ()>(&ctx, &name)
         .ok();
     Span::current().record("funct_is_some", funct.is_some());
 
     {
         let mut env_inner = ctx.data_mut().inner_mut();
-        let inner = env_inner.main_module_instance_handles_mut();
-        inner.signal = funct;
-        inner.signal_set = true;
+        env_inner.main_module_instance_handles_mut().signal_handler = Some(name.clone());
     }
-    // Record it for the whole process: signals are delivered to every thread,
-    // and the sibling threads have their own instances that never see the
-    // registration above.
-    ctx.data()
-        .state
-        .signal_handler_registered
-        .store(true, std::sync::atomic::Ordering::SeqCst);
+    {
+        let mut process_handler = ctx.data().state.signal_handler.lock().unwrap();
+        process_handler.get_or_insert(name);
+    }
 
     WasiEnv::do_pending_operations(&mut ctx)?;
 

--- a/lib/wasix/src/syscalls/wasix/callback_signal.rs
+++ b/lib/wasix/src/syscalls/wasix/callback_signal.rs
@@ -35,6 +35,10 @@ pub fn callback_signal<M: MemorySize>(
         .get_typed_function::<i32, ()>(&ctx, &name)
         .ok();
     Span::current().record("funct_is_some", funct.is_some());
+    if funct.is_none() {
+        warn!(%name, "signal callback must export a function taking i32 and returning nothing");
+        return Ok(());
+    }
 
     {
         let mut env_inner = ctx.data_mut().inner_mut();
@@ -48,4 +52,124 @@ pub fn callback_signal<M: MemorySize>(
     WasiEnv::do_pending_operations(&mut ctx)?;
 
     Ok(())
+}
+
+#[cfg(all(test, feature = "sys"))]
+mod tests {
+    use super::*;
+    use crate::WasiFunctionEnv;
+    use wasmer::{Instance, Module, Store, Value};
+
+    fn instance() -> (Store, Instance, WasiFunctionEnv) {
+        let mut store = Store::default();
+        let module = Module::new(
+            &store,
+            r#"(module
+                (import "wasix_32v1" "callback_signal" (func (param i32 i32)))
+                (memory (export "memory") 32)
+                (global $hits (export "hits") (mut i32) (i32.const 0))
+                (func (export "handler") (param i32)
+                    (global.set $hits (i32.add (global.get $hits) (i32.const 1))))
+                (func (export "wrong")))"#,
+        )
+        .unwrap();
+        let (instance, env) = WasiEnv::builder("signal-callback")
+            .engine(store.engine().clone())
+            .instantiate(module, &mut store)
+            .unwrap();
+        (store, instance, env)
+    }
+
+    fn register(store: &mut Store, instance: &Instance, env: &WasiFunctionEnv, name: &str) {
+        instance
+            .exports
+            .get_memory("memory")
+            .unwrap()
+            .view(store)
+            .write(0, name.as_bytes())
+            .unwrap();
+        callback_signal::<Memory32>(
+            env.env.clone().into_mut(store),
+            WasmPtr::new(0),
+            name.len() as u32,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalid_callback_preserves_pending_default_signal() {
+        for name in ["missing", "wrong"] {
+            let (mut store, instance, env) = instance();
+            env.data(&store).thread.signal(Signal::Sigpipe);
+
+            register(&mut store, &instance, &env, name);
+
+            assert!(
+                env.data(&store)
+                    .state
+                    .signal_handler
+                    .lock()
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(env.data(&store).thread.has_signal(&[Signal::Sigpipe]));
+            let result = WasiEnv::process_signals_and_exit(&mut env.env.into_mut(&mut store));
+            assert!(matches!(result, Err(WasiError::Exit(code)) if code == Errno::Pipe.into()));
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_callback_preserves_registered_handler_and_pending_signal() {
+        for name in ["missing", "wrong"] {
+            let (mut store, instance, env) = instance();
+            register(&mut store, &instance, &env, "handler");
+            env.data(&store).thread.signal(Signal::Sigusr1);
+
+            register(&mut store, &instance, &env, name);
+            WasiEnv::process_signals_and_exit(&mut env.env.clone().into_mut(&mut store))
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(
+                env.data(&store)
+                    .inner()
+                    .main_module_instance_handles()
+                    .signal_handler
+                    .as_deref(),
+                Some("handler")
+            );
+            assert_eq!(
+                env.data(&store)
+                    .state
+                    .signal_handler
+                    .lock()
+                    .unwrap()
+                    .as_deref(),
+                Some("handler")
+            );
+            assert_eq!(
+                instance.exports.get_global("hits").unwrap().get(&mut store),
+                Value::I32(1)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_wakeup_never_calls_guest_handler() {
+        let (mut store, instance, env) = instance();
+        register(&mut store, &instance, &env, "handler");
+        WasiEnv::process_signals_internal(
+            &mut env.env.clone().into_mut(&mut store),
+            vec![Signal::Sigwakeup],
+        )
+        .unwrap();
+        env.data(&store).process.terminate(ExitCode::from(37));
+        env.data(&store).process.terminate(ExitCode::from(0));
+        let result = WasiEnv::process_signals_and_exit(&mut env.env.into_mut(&mut store));
+        assert!(matches!(result, Err(WasiError::Exit(code)) if code == ExitCode::from(37)));
+        assert_eq!(
+            instance.exports.get_global("hits").unwrap().get(&mut store),
+            Value::I32(0)
+        );
+    }
 }

--- a/lib/wasix/tests/wasm_tests/process/atomic-wait-signal-children/build.sh
+++ b/lib/wasix/tests/wasm_tests/process/atomic-wait-signal-children/build.sh
@@ -9,14 +9,6 @@
 ##ExpectedStdout: targeted child waiting
 ##ExpectedStdout: targeted parent survived
 
-##Config: forwarded:base
-##Args: forwarded
-##ExpectedStdout: forwarding parent waiting
-##ExpectedStdout: forwarded child 1 waiting
-##ExpectedStdout: forwarded child 2 waiting
-##ExpectedStdout: forwarding parent survived
-##Ignored: SIGTERM atomic waiter wakeups are currently scoped back
-
 ##Config: vfork:base
 ##Args: vfork
 ##ExpectedStdout: vfork child waiting

--- a/lib/wasix/tests/wasm_tests/process/atomic-wait-signal-children/main.c
+++ b/lib/wasix/tests/wasm_tests/process/atomic-wait-signal-children/main.c
@@ -119,47 +119,6 @@ static int vfork_child(void) {
   return EXIT_SUCCESS;
 }
 
-static int forwarded_to_children(void) {
-  pid_t parent = getpid();
-
-  for (int i = 0; i < 2; i++) {
-    pid_t child = fork();
-    if (child < 0) {
-      perror("fork");
-      return EXIT_FAILURE;
-    }
-
-    if (child == 0) {
-      wait_forever(i == 0 ? "forwarded child 1" : "forwarded child 2");
-    }
-  }
-
-  pid_t signaler = fork();
-  if (signaler < 0) {
-    perror("fork");
-    return EXIT_FAILURE;
-  }
-
-  if (signaler == 0) {
-    usleep(100 * 1000);
-    if (kill(parent, SIGTERM) != 0) {
-      perror("kill");
-      _Exit(EXIT_FAILURE);
-    }
-    _Exit(EXIT_SUCCESS);
-  }
-
-  puts("forwarding parent waiting");
-  fflush(stdout);
-
-  if (wait_for_children(3) != EXIT_SUCCESS) {
-    return EXIT_FAILURE;
-  }
-
-  puts("forwarding parent survived");
-  return EXIT_SUCCESS;
-}
-
 int main(int argc, char** argv) {
   if (argc != 2) {
     return EXIT_FAILURE;
@@ -167,10 +126,6 @@ int main(int argc, char** argv) {
 
   if (strcmp(argv[1], "targeted") == 0) {
     return targeted_child();
-  }
-
-  if (strcmp(argv[1], "forwarded") == 0) {
-    return forwarded_to_children();
   }
 
   if (strcmp(argv[1], "vfork") == 0) {

--- a/lib/wasix/tests/wasm_tests/signal/process-delivery/build.sh
+++ b/lib/wasix/tests/wasm_tests/signal/process-delivery/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+##AbstractConfig: base
+##BuildEnv: WASIXCC_WASM_EXCEPTIONS=no
+##SkipEngine:V8:SharedMemoryOps are not supported yet
+
+##Config: process:base
+##Args: process
+##ExpectedStdout: process signal reached one recipient
+
+##Config: thread:base
+##Args: thread
+##ExpectedStdout: thread signal reached its target
+
+##Config: registration:base
+##Args: registration
+##ExpectedStdout: worker registration applied process-wide
+
+##Config: raise:base
+##Args: raise
+##ExpectedStdout: proc_raise stayed on its calling thread
+
+##Config: sigpipe:base
+##Args: sigpipe
+##ExpectedStdout: SIGPIPE reached the writing thread
+
+set -euo pipefail
+
+"$CC" -pthread main.c -o main

--- a/lib/wasix/tests/wasm_tests/signal/process-delivery/main.c
+++ b/lib/wasix/tests/wasm_tests/signal/process-delivery/main.c
@@ -1,0 +1,189 @@
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <wasi/api.h>
+
+static _Thread_local int is_worker;
+static atomic_int main_hits;
+static atomic_int worker_hits;
+static atomic_int ready;
+static atomic_int stop;
+
+static void handler(int signal) {
+  assert(signal == SIGUSR1 || signal == SIGPIPE);
+  atomic_fetch_add(is_worker ? &worker_hits : &main_hits, 1);
+}
+
+static void reset_counts(void) {
+  atomic_store(&main_hits, 0);
+  atomic_store(&worker_hits, 0);
+  atomic_store(&ready, 0);
+  atomic_store(&stop, 0);
+}
+
+static void install_handler(int signal) {
+  struct sigaction action = {0};
+  action.sa_handler = handler;
+  sigemptyset(&action.sa_mask);
+  assert(sigaction(signal, &action, NULL) == 0);
+}
+
+static void wait_until(atomic_int* value, int expected) {
+  for (int i = 0; i < 5000 && atomic_load(value) != expected; ++i) {
+    usleep(1000);
+  }
+  assert(atomic_load(value) == expected);
+}
+
+static void* syscall_worker(void* argument) {
+  (void)argument;
+  is_worker = 1;
+  atomic_fetch_add(&ready, 1);
+  while (!atomic_load(&stop)) {
+    (void)getpid();
+    sched_yield();
+  }
+  return NULL;
+}
+
+static int process_one_recipient(void) {
+  pthread_t workers[2];
+  reset_counts();
+  install_handler(SIGUSR1);
+  for (int i = 0; i < 2; ++i) {
+    assert(pthread_create(&workers[i], NULL, syscall_worker, NULL) == 0);
+  }
+  wait_until(&ready, 2);
+
+  assert(kill(getpid(), SIGUSR1) == 0);
+  usleep(50000);
+  atomic_store(&stop, 1);
+  for (int i = 0; i < 2; ++i) {
+    assert(pthread_join(workers[i], NULL) == 0);
+  }
+
+  assert(atomic_load(&main_hits) == 1);
+  assert(atomic_load(&worker_hits) == 0);
+  puts("process signal reached one recipient");
+  return EXIT_SUCCESS;
+}
+
+static void* targeted_worker(void* argument) {
+  (void)argument;
+  is_worker = 1;
+  atomic_store(&ready, 1);
+  for (int i = 0; i < 100000 && atomic_load(&worker_hits) == 0; ++i) {
+    (void)getpid();
+    sched_yield();
+  }
+  return NULL;
+}
+
+static int target_worker(void) {
+  pthread_t worker;
+  reset_counts();
+  install_handler(SIGUSR1);
+  assert(pthread_create(&worker, NULL, targeted_worker, NULL) == 0);
+  wait_until(&ready, 1);
+
+  assert(pthread_kill(worker, SIGUSR1) == 0);
+  assert(pthread_join(worker, NULL) == 0);
+  (void)getpid();
+
+  assert(atomic_load(&main_hits) == 0);
+  assert(atomic_load(&worker_hits) == 1);
+  puts("thread signal reached its target");
+  return EXIT_SUCCESS;
+}
+
+static void* registering_worker(void* argument) {
+  (void)argument;
+  is_worker = 1;
+  install_handler(SIGUSR1);
+  atomic_store(&ready, 1);
+  while (!atomic_load(&stop)) {
+    (void)getpid();
+    sched_yield();
+  }
+  return NULL;
+}
+
+static int worker_registration(void) {
+  pthread_t worker;
+  reset_counts();
+  assert(pthread_create(&worker, NULL, registering_worker, NULL) == 0);
+  wait_until(&ready, 1);
+
+  assert(kill(getpid(), SIGUSR1) == 0);
+  atomic_store(&stop, 1);
+  assert(pthread_join(worker, NULL) == 0);
+
+  assert(atomic_load(&main_hits) == 1);
+  assert(atomic_load(&worker_hits) == 0);
+  puts("worker registration applied process-wide");
+  return EXIT_SUCCESS;
+}
+
+static void* raising_worker(void* argument) {
+  (void)argument;
+  is_worker = 1;
+  assert(__wasi_proc_raise((__wasi_signal_t)SIGUSR1) == __WASI_ERRNO_SUCCESS);
+  return NULL;
+}
+
+static int raise_on_worker(void) {
+  pthread_t worker;
+  reset_counts();
+  install_handler(SIGUSR1);
+  assert(pthread_create(&worker, NULL, raising_worker, NULL) == 0);
+  assert(pthread_join(worker, NULL) == 0);
+  (void)getpid();
+
+  assert(atomic_load(&main_hits) == 0);
+  assert(atomic_load(&worker_hits) == 1);
+  puts("proc_raise stayed on its calling thread");
+  return EXIT_SUCCESS;
+}
+
+static void* pipe_worker(void* argument) {
+  int fd = *(int*)argument;
+  is_worker = 1;
+  errno = 0;
+  assert(write(fd, "x", 1) == -1);
+  assert(errno == EPIPE);
+  return NULL;
+}
+
+static int sigpipe_on_writer(void) {
+  int fds[2];
+  pthread_t worker;
+  reset_counts();
+  install_handler(SIGPIPE);
+  assert(pipe(fds) == 0);
+  assert(close(fds[0]) == 0);
+  assert(pthread_create(&worker, NULL, pipe_worker, &fds[1]) == 0);
+  assert(pthread_join(worker, NULL) == 0);
+  (void)getpid();
+  assert(close(fds[1]) == 0);
+
+  assert(atomic_load(&main_hits) == 0);
+  assert(atomic_load(&worker_hits) == 1);
+  puts("SIGPIPE reached the writing thread");
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char** argv) {
+  assert(argc == 2);
+  if (strcmp(argv[1], "process") == 0) return process_one_recipient();
+  if (strcmp(argv[1], "thread") == 0) return target_worker();
+  if (strcmp(argv[1], "registration") == 0) return worker_registration();
+  if (strcmp(argv[1], "raise") == 0) return raise_on_worker();
+  if (strcmp(argv[1], "sigpipe") == 0) return sigpipe_on_writer();
+  return EXIT_FAILURE;
+}

--- a/lib/wasix/tests/wasm_tests/signal/process-delivery/main.c
+++ b/lib/wasix/tests/wasm_tests/signal/process-delivery/main.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
+#include <sched.h>
 #include <signal.h>
 #include <stdatomic.h>
 #include <stdio.h>


### PR DESCRIPTION
# Description

Process-directed signals now go to one live thread in the addressed process instead of being broadcast or redirected to children. Host/TTY signals retain foreground child forwarding. `proc_raise` and SIGPIPE go to the calling thread.

Signal callbacks are stored as names and resolved in the receiving instance’s store, so sibling threads can invoke them safely without overwriting each other’s registration. Missing or incorrectly typed exports leave existing registrations and pending signals unchanged.

Signals are queued before atomic waiters are woken. Shutdown also wakes signal and atomic waiters while preserving the original exit status, without invoking guest callbacks.

Recipient selection still does not account for per-thread signal masks.
