### PR TITLE
fix(virtual-net): match loopback TCP addresses correctly

### DIFF
--- a/lib/virtual-net/src/loopback.rs
+++ b/lib/virtual-net/src/loopback.rs
@@ -39,6 +39,7 @@ impl Default for LoopbackNetworkingState {
 
 impl LoopbackNetworkingState {
     fn contains_tcp_addr(&self, addr: SocketAddr) -> bool {
+        let addr = LoopbackNetworking::tcp_addr_key(addr);
         self.tcp_listeners.contains_key(&addr) || self.tcp_bound.contains(&addr)
     }
 
@@ -57,6 +58,7 @@ impl LoopbackNetworkingState {
     }
 
     fn reserve_tcp_addr(&mut self, addr: SocketAddr) -> bool {
+        let addr = LoopbackNetworking::tcp_addr_key(addr);
         if self.tcp_addr_conflicts(addr) || !self.tcp_bound.insert(addr) {
             return false;
         }
@@ -68,6 +70,7 @@ impl LoopbackNetworkingState {
     }
 
     fn release_tcp_bound_addr(&mut self, addr: SocketAddr) -> bool {
+        let addr = LoopbackNetworking::tcp_addr_key(addr);
         if !self.tcp_bound.remove(&addr) {
             return false;
         }
@@ -80,6 +83,7 @@ impl LoopbackNetworkingState {
         addr: SocketAddr,
         listener: LoopbackTcpListener,
     ) -> crate::Result<()> {
+        let addr = LoopbackNetworking::tcp_addr_key(addr);
         if !self.tcp_bound.contains(&addr) {
             return Err(NetworkError::InvalidFd);
         }
@@ -140,11 +144,11 @@ impl LoopbackNetworking {
             let state = self.state.lock().unwrap();
             state
                 .tcp_listeners
-                .get(&peer_addr)
+                .get(&Self::tcp_addr_key(peer_addr))
                 .or_else(|| state.tcp_listeners.get(&Self::wildcard_addr(peer_addr)))
                 .cloned()
         }?;
-        Some(listener.connect_to(local_addr, Self::concrete_addr(peer_addr)))
+        Some(listener.connect_to_addr(local_addr, Self::concrete_addr(peer_addr)))
     }
 
     fn allocate_tcp_bind_addr(
@@ -155,9 +159,8 @@ impl LoopbackNetworking {
             let start = state.next_ephemeral_port;
             let mut candidate = start;
             loop {
-                let candidate_addr = SocketAddr::new(addr.ip(), candidate);
-                if state.reserve_tcp_addr(candidate_addr) {
-                    addr.set_port(candidate);
+                addr.set_port(candidate);
+                if state.reserve_tcp_addr(addr) {
                     state.next_ephemeral_port = if candidate == u16::MAX {
                         LOOPBACK_EPHEMERAL_PORT_START
                     } else {
@@ -195,6 +198,15 @@ impl LoopbackNetworking {
 
     fn tcp_port_key(addr: SocketAddr) -> (bool, u16) {
         (addr.is_ipv6(), addr.port())
+    }
+
+    fn tcp_addr_key(addr: SocketAddr) -> SocketAddr {
+        // Wildcard reservations cover the family regardless of IPv6 scope or flow information.
+        if addr.ip().is_unspecified() {
+            Self::wildcard_addr(addr)
+        } else {
+            addr
+        }
     }
 
     fn wildcard_addr(addr: SocketAddr) -> SocketAddr {
@@ -494,7 +506,12 @@ impl LoopbackTcpListener {
         }
     }
 
-    pub fn connect_to(&self, addr_local: SocketAddr, listener_addr: SocketAddr) -> TcpSocketHalf {
+    pub fn connect_to(&self, addr_local: SocketAddr) -> TcpSocketHalf {
+        let listener_addr = self.state.lock().unwrap().addr_local;
+        self.connect_to_addr(addr_local, LoopbackNetworking::concrete_addr(listener_addr))
+    }
+
+    fn connect_to_addr(&self, addr_local: SocketAddr, listener_addr: SocketAddr) -> TcpSocketHalf {
         let mut state = self.state.lock().unwrap();
         let (mut half1, half2) =
             TcpSocketHalf::channel(DEFAULT_MAX_BUFFER_SIZE, listener_addr, addr_local);
@@ -607,16 +624,14 @@ impl VirtualTcpBoundSocket for LoopbackTcpBoundSocket {
     }
 
     fn connect(&mut self, peer: SocketAddr) -> crate::Result<Box<dyn VirtualTcpSocket + Sync>> {
+        let reservation_key = self.reservation_key.ok_or(NetworkError::InvalidFd)?;
         let mut socket = self
             .networking
             .loopback_connect_to(self.local_addr, peer)
             .ok_or(NetworkError::ConnectionRefused)?;
-        // Transfer the port reservation to the connected socket so that the
-        // local port stays in `tcp_bound` for the socket's entire lifetime,
-        // matching POSIX/Linux semantics (a connected socket holds its local
-        // port; rebinding it returns EADDRINUSE).
-        let reservation_key = self.reservation_key.take().ok_or(NetworkError::InvalidFd)?;
         socket.set_ttl(self.ttl)?;
+        // The connected socket owns the bind reservation until close or drop.
+        self.reservation_key = None;
         Ok(Box::new(LoopbackConnectedSocket {
             inner: socket,
             networking: self.networking.clone(),

--- a/lib/virtual-net/src/loopback.rs
+++ b/lib/virtual-net/src/loopback.rs
@@ -19,6 +19,8 @@ const LOOPBACK_EPHEMERAL_PORT_START: u16 = 49152;
 struct LoopbackNetworkingState {
     tcp_listeners: HashMap<SocketAddr, LoopbackTcpListener>,
     tcp_bound: HashSet<SocketAddr>,
+    // Keeps wildcard ephemeral-port checks constant-time per candidate.
+    tcp_ports_in_use: HashMap<(bool, u16), usize>,
     ip_addresses: Vec<IpCidr>,
     next_ephemeral_port: u16,
 }
@@ -28,8 +30,76 @@ impl Default for LoopbackNetworkingState {
         Self {
             tcp_listeners: HashMap::new(),
             tcp_bound: HashSet::new(),
+            tcp_ports_in_use: HashMap::new(),
             ip_addresses: Vec::new(),
             next_ephemeral_port: LOOPBACK_EPHEMERAL_PORT_START,
+        }
+    }
+}
+
+impl LoopbackNetworkingState {
+    fn contains_tcp_addr(&self, addr: SocketAddr) -> bool {
+        self.tcp_listeners.contains_key(&addr) || self.tcp_bound.contains(&addr)
+    }
+
+    fn tcp_addr_conflicts(&self, addr: SocketAddr) -> bool {
+        if addr.ip().is_unspecified() {
+            return self
+                .tcp_ports_in_use
+                .contains_key(&LoopbackNetworking::tcp_port_key(addr));
+        }
+
+        [addr, LoopbackNetworking::wildcard_addr(addr)]
+            .into_iter()
+            .any(|bound| {
+                self.contains_tcp_addr(bound) && LoopbackNetworking::tcp_addrs_conflict(bound, addr)
+            })
+    }
+
+    fn reserve_tcp_addr(&mut self, addr: SocketAddr) -> bool {
+        if self.tcp_addr_conflicts(addr) || !self.tcp_bound.insert(addr) {
+            return false;
+        }
+        *self
+            .tcp_ports_in_use
+            .entry(LoopbackNetworking::tcp_port_key(addr))
+            .or_default() += 1;
+        true
+    }
+
+    fn release_tcp_bound_addr(&mut self, addr: SocketAddr) -> bool {
+        if !self.tcp_bound.remove(&addr) {
+            return false;
+        }
+        self.release_tcp_port(addr);
+        true
+    }
+
+    fn promote_tcp_bound_addr(
+        &mut self,
+        addr: SocketAddr,
+        listener: LoopbackTcpListener,
+    ) -> crate::Result<()> {
+        if !self.tcp_bound.contains(&addr) {
+            return Err(NetworkError::InvalidFd);
+        }
+        if self.tcp_listeners.contains_key(&addr) {
+            return Err(NetworkError::AddressInUse);
+        }
+        self.tcp_bound.remove(&addr);
+        self.tcp_listeners.insert(addr, listener);
+        Ok(())
+    }
+
+    fn release_tcp_port(&mut self, addr: SocketAddr) {
+        let key = LoopbackNetworking::tcp_port_key(addr);
+        let count = self
+            .tcp_ports_in_use
+            .get_mut(&key)
+            .expect("reserved TCP address must have a port entry");
+        *count -= 1;
+        if *count == 0 {
+            self.tcp_ports_in_use.remove(&key);
         }
     }
 }
@@ -66,43 +136,34 @@ impl LoopbackNetworking {
             ip => SocketAddr::new(ip, port),
         };
 
-        let peer_key = Self::normalize_listener_addr(peer_addr);
-        let state = self.state.lock().unwrap();
-        if let Some(listener) = state.tcp_listeners.get(&peer_key) {
-            Some(listener.connect_to(local_addr))
-        } else {
+        let listener = {
+            let state = self.state.lock().unwrap();
             state
                 .tcp_listeners
-                .iter()
-                .next()
-                .map(|listener| listener.1.connect_to(local_addr))
-        }
+                .get(&peer_addr)
+                .or_else(|| state.tcp_listeners.get(&Self::wildcard_addr(peer_addr)))
+                .cloned()
+        }?;
+        Some(listener.connect_to(local_addr, Self::concrete_addr(peer_addr)))
     }
 
     fn allocate_tcp_bind_addr(
         state: &mut LoopbackNetworkingState,
         mut addr: SocketAddr,
     ) -> crate::Result<SocketAddr> {
-        let is_available = |candidate: SocketAddr, state: &LoopbackNetworkingState| {
-            let key = Self::normalize_listener_addr(candidate);
-            !state.tcp_listeners.contains_key(&key) && !state.tcp_bound.contains(&key)
-        };
-
         if addr.port() == 0 {
             let start = state.next_ephemeral_port;
             let mut candidate = start;
             loop {
                 let candidate_addr = SocketAddr::new(addr.ip(), candidate);
-                if is_available(candidate_addr, state) {
+                if state.reserve_tcp_addr(candidate_addr) {
                     addr.set_port(candidate);
-                    let normalized = Self::normalize_listener_addr(addr);
-                    state.tcp_bound.insert(normalized);
                     state.next_ephemeral_port = if candidate == u16::MAX {
                         LOOPBACK_EPHEMERAL_PORT_START
                     } else {
                         candidate + 1
                     };
-                    return Ok(normalized);
+                    return Ok(addr);
                 }
 
                 candidate = if candidate == u16::MAX {
@@ -116,23 +177,43 @@ impl LoopbackNetworking {
             }
         }
 
-        let reservation_key = Self::normalize_listener_addr(addr);
-        if state.tcp_listeners.contains_key(&reservation_key)
-            || state.tcp_bound.contains(&reservation_key)
-        {
+        if !state.reserve_tcp_addr(addr) {
             return Err(NetworkError::AddressInUse);
         }
-        state.tcp_bound.insert(reservation_key);
-        Ok(reservation_key)
+        Ok(addr)
     }
 
-    fn normalize_listener_addr(mut addr: SocketAddr) -> SocketAddr {
-        if addr.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {
-            addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), addr.port());
-        } else if addr.ip() == IpAddr::V6(Ipv6Addr::UNSPECIFIED) {
-            addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), addr.port());
+    fn tcp_addr_covers(bound: SocketAddr, destination: SocketAddr) -> bool {
+        bound.port() == destination.port()
+            && bound.is_ipv4() == destination.is_ipv4()
+            && (bound.ip().is_unspecified() || bound.ip() == destination.ip())
+    }
+
+    fn tcp_addrs_conflict(left: SocketAddr, right: SocketAddr) -> bool {
+        Self::tcp_addr_covers(left, right) || Self::tcp_addr_covers(right, left)
+    }
+
+    fn tcp_port_key(addr: SocketAddr) -> (bool, u16) {
+        (addr.is_ipv6(), addr.port())
+    }
+
+    fn wildcard_addr(addr: SocketAddr) -> SocketAddr {
+        match addr {
+            SocketAddr::V4(_) => SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), addr.port()),
+            SocketAddr::V6(_) => SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), addr.port()),
         }
-        addr
+    }
+
+    fn concrete_addr(addr: SocketAddr) -> SocketAddr {
+        match addr.ip() {
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED) => {
+                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), addr.port())
+            }
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED) => {
+                SocketAddr::new(Ipv6Addr::LOCALHOST.into(), addr.port())
+            }
+            _ => addr,
+        }
     }
 }
 
@@ -222,9 +303,11 @@ impl LoopbackNetworking {
         let mut state = self.state.lock().unwrap();
         for port in LOOPBACK_EPHEMERAL_PORT_START..=u16::MAX {
             let addr = SocketAddr::new(ip, port);
-            state
-                .tcp_listeners
-                .insert(addr, LoopbackTcpListener::new(addr, 64));
+            if state.reserve_tcp_addr(addr) {
+                state
+                    .promote_tcp_bound_addr(addr, LoopbackTcpListener::new(addr, 64))
+                    .unwrap();
+            }
         }
         state.next_ephemeral_port = LOOPBACK_EPHEMERAL_PORT_START;
     }
@@ -245,7 +328,11 @@ struct LoopbackConnectedSocket {
 impl LoopbackConnectedSocket {
     fn release_reservation(&mut self) {
         if let Some(key) = self.reservation_key.take() {
-            self.networking.state.lock().unwrap().tcp_bound.remove(&key);
+            self.networking
+                .state
+                .lock()
+                .unwrap()
+                .release_tcp_bound_addr(key);
         }
     }
 }
@@ -407,10 +494,10 @@ impl LoopbackTcpListener {
         }
     }
 
-    pub fn connect_to(&self, addr_local: SocketAddr) -> TcpSocketHalf {
+    pub fn connect_to(&self, addr_local: SocketAddr, listener_addr: SocketAddr) -> TcpSocketHalf {
         let mut state = self.state.lock().unwrap();
         let (mut half1, half2) =
-            TcpSocketHalf::channel(DEFAULT_MAX_BUFFER_SIZE, state.addr_local, addr_local);
+            TcpSocketHalf::channel(DEFAULT_MAX_BUFFER_SIZE, listener_addr, addr_local);
         half1.set_ttl(u32::from(state.ttl)).ok();
 
         state.backlog.push_back(half1);
@@ -499,7 +586,7 @@ impl Drop for LoopbackTcpBoundSocket {
     fn drop(&mut self) {
         if let Some(reservation_key) = self.reservation_key.take() {
             let mut state = self.networking.state.lock().unwrap();
-            state.tcp_bound.remove(&reservation_key);
+            state.release_tcp_bound_addr(reservation_key);
         }
     }
 }
@@ -514,16 +601,7 @@ impl VirtualTcpBoundSocket for LoopbackTcpBoundSocket {
             LoopbackTcpListener::new(self.local_addr, u8::try_from(self.ttl).unwrap_or(u8::MAX));
         let mut state = self.networking.state.lock().unwrap();
         let reservation_key = self.reservation_key.ok_or(NetworkError::InvalidFd)?;
-        if !state.tcp_bound.remove(&reservation_key) {
-            return Err(NetworkError::InvalidFd);
-        }
-        if state.tcp_listeners.contains_key(&reservation_key) {
-            state.tcp_bound.insert(reservation_key);
-            return Err(NetworkError::AddressInUse);
-        }
-        state
-            .tcp_listeners
-            .insert(reservation_key, listener.clone());
+        state.promote_tcp_bound_addr(reservation_key, listener.clone())?;
         self.reservation_key = None;
         Ok(Box::new(listener))
     }

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -954,3 +954,197 @@ async fn test_loopback_connected_socket_holds_local_port_reservation() {
         .await
         .unwrap();
 }
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_wildcard_listener_preserves_bind_and_connects_concrete_endpoints() {
+    let networking = LoopbackNetworking::new();
+    let mut listener = networking
+        .listen_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let bound_addr = listener.addr_local().unwrap();
+    assert_eq!(bound_addr.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    assert_ne!(bound_addr.port(), 0);
+
+    let destination = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 42), bound_addr.port()));
+    let mut client_bound = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let client = client_bound.connect(destination).unwrap();
+    let client_local = client.addr_local().unwrap();
+    assert!(!client_local.ip().is_unspecified());
+    assert_eq!(client.addr_peer().unwrap(), destination);
+
+    let (accepted, accepted_peer) = listener.try_accept().unwrap();
+    assert_eq!(accepted.addr_local().unwrap(), destination);
+    assert_eq!(accepted.addr_peer().unwrap(), client_local);
+    assert_eq!(accepted_peer, client_local);
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_wildcard_and_specific_bind_conflicts_are_symmetric() {
+    let networking = LoopbackNetworking::new();
+    let wildcard = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 40201));
+    let specific = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 42), wildcard.port()));
+
+    let mut wildcard_bound = networking
+        .bind_tcp(wildcard, false, false, false)
+        .await
+        .unwrap();
+    let err = networking
+        .bind_tcp(specific, false, false, false)
+        .await
+        .unwrap_err();
+    assert_eq!(err, NetworkError::AddressInUse);
+
+    let _wildcard_listener = wildcard_bound.listen().unwrap();
+    let err = networking
+        .bind_tcp(specific, false, false, false)
+        .await
+        .unwrap_err();
+    assert_eq!(err, NetworkError::AddressInUse);
+
+    let networking = LoopbackNetworking::new();
+    let mut specific_bound = networking
+        .bind_tcp(specific, false, false, false)
+        .await
+        .unwrap();
+    let err = networking
+        .bind_tcp(wildcard, false, false, false)
+        .await
+        .unwrap_err();
+    assert_eq!(err, NetworkError::AddressInUse);
+
+    let _specific_listener = specific_bound.listen().unwrap();
+    let err = networking
+        .bind_tcp(wildcard, false, false, false)
+        .await
+        .unwrap_err();
+    assert_eq!(err, NetworkError::AddressInUse);
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_connect_selects_only_exact_or_wildcard_listener() {
+    let networking = LoopbackNetworking::new();
+    let first_addr = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 40202));
+    let second_addr = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 2), first_addr.port()));
+    let missing_addr = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 3), first_addr.port()));
+    let mut first = networking
+        .listen_tcp(first_addr, false, false, false)
+        .await
+        .unwrap();
+    let mut second = networking
+        .listen_tcp(second_addr, false, false, false)
+        .await
+        .unwrap();
+
+    let mut bound = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let _client = bound.connect(second_addr).unwrap();
+    assert!(second.try_accept().is_ok());
+    assert_eq!(first.try_accept().unwrap_err(), NetworkError::WouldBlock);
+
+    let mut bound = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        bound.connect(missing_addr),
+        Err(NetworkError::ConnectionRefused)
+    ));
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_bind_conflicts_only_within_the_same_address_family() {
+    let networking = LoopbackNetworking::new();
+    let port = 40203;
+    let _ipv4 = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, port)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let _ipv6 = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, port)),
+            true,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_wildcard_conflict_tracks_all_specific_bindings_on_a_port() {
+    let networking = LoopbackNetworking::new();
+    let port = 40204;
+    let first = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), port)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let second = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::new(127, 0, 0, 2), port)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+    drop(first);
+    let wildcard = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
+    let err = networking
+        .bind_tcp(wildcard, false, false, false)
+        .await
+        .unwrap_err();
+    assert_eq!(err, NetworkError::AddressInUse);
+
+    drop(second);
+    networking
+        .bind_tcp(wildcard, false, false, false)
+        .await
+        .unwrap();
+}

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -864,23 +864,26 @@ async fn test_loopback_bind_tcp_preserves_ttl_across_connect() {
 #[tokio::test]
 #[serial_test::serial]
 async fn test_loopback_bind_tcp_returns_error_when_ephemeral_ports_are_exhausted() {
-    let networking = LoopbackNetworking::new();
-    networking.exhaust_tcp_ephemeral_ports_for_test(Ipv4Addr::LOCALHOST.into());
-
-    let err = networking
-        .bind_tcp(
-            SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
-            false,
-            false,
-            false,
-        )
-        .await
-        .unwrap_err();
-
-    assert!(
-        matches!(err, NetworkError::AddressInUse),
-        "expected AddressInUse when all loopback ephemeral ports are exhausted, got {err:?}"
-    );
+    for (specific, wildcard) in [
+        (
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        ),
+        (
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+        ),
+    ] {
+        let networking = LoopbackNetworking::new();
+        networking.exhaust_tcp_ephemeral_ports_for_test(specific);
+        for ip in [specific, wildcard] {
+            let err = networking
+                .bind_tcp(SocketAddr::new(ip, 0), ip.is_ipv6(), false, false)
+                .await
+                .unwrap_err();
+            assert_eq!(err, NetworkError::AddressInUse);
+        }
+    }
 }
 
 #[traced_test]
@@ -1147,4 +1150,291 @@ async fn test_loopback_wildcard_conflict_tracks_all_specific_bindings_on_a_port(
         .bind_tcp(wildcard, false, false, false)
         .await
         .unwrap();
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_ipv6_ephemeral_reservation_matches_reported_address() {
+    for (flowinfo, scope_id) in [(42, 0), (0, 7), (42, 7)] {
+        let networking = LoopbackNetworking::new();
+        let addr = std::net::SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, flowinfo, scope_id);
+        let bound = networking
+            .bind_tcp(addr.into(), true, false, false)
+            .await
+            .unwrap();
+        let bound_addr = bound.addr_local().unwrap();
+        let err = networking
+            .bind_tcp(bound_addr, true, false, false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, NetworkError::AddressInUse);
+
+        drop(bound);
+        networking
+            .bind_tcp(
+                SocketAddr::from((Ipv6Addr::UNSPECIFIED, bound_addr.port())),
+                true,
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+    }
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_ipv6_ephemeral_reservation_can_be_promoted() {
+    let networking = LoopbackNetworking::new();
+    let addr = std::net::SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 42, 7);
+    let mut bound = networking
+        .bind_tcp(addr.into(), true, false, false)
+        .await
+        .unwrap();
+    let bound_addr = bound.addr_local().unwrap();
+    let listener = bound.listen().unwrap();
+    assert_eq!(listener.addr_local().unwrap(), bound_addr);
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_repeated_connect_does_not_enqueue_a_connection() {
+    let networking = LoopbackNetworking::new();
+    let mut listener = networking
+        .listen_tcp(
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let peer = listener.addr_local().unwrap();
+    let mut bound = networking
+        .bind_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let local = bound.addr_local().unwrap();
+    let missing = SocketAddr::from((Ipv4Addr::LOCALHOST, 40208));
+    assert!(matches!(
+        bound.connect(missing),
+        Err(NetworkError::ConnectionRefused)
+    ));
+    let mut connected = bound.connect(peer).unwrap();
+    let _accepted = listener.try_accept().unwrap();
+    assert!(matches!(bound.connect(peer), Err(NetworkError::InvalidFd)));
+    assert!(matches!(
+        listener.try_accept(),
+        Err(NetworkError::WouldBlock)
+    ));
+
+    drop(bound);
+    assert_eq!(
+        networking
+            .bind_tcp(local, false, false, false)
+            .await
+            .unwrap_err(),
+        NetworkError::AddressInUse
+    );
+    connected.close().unwrap();
+    let replacement = networking
+        .bind_tcp(local, false, false, false)
+        .await
+        .unwrap();
+    drop(connected);
+    assert_eq!(
+        networking
+            .bind_tcp(local, false, false, false)
+            .await
+            .unwrap_err(),
+        NetworkError::AddressInUse
+    );
+    drop(replacement);
+    let mut listening_bound = networking
+        .bind_tcp(local, false, false, false)
+        .await
+        .unwrap();
+    let _listener = listening_bound.listen().unwrap();
+    assert!(matches!(
+        listening_bound.connect(peer),
+        Err(NetworkError::InvalidFd)
+    ));
+    assert!(matches!(
+        listener.try_accept(),
+        Err(NetworkError::WouldBlock)
+    ));
+}
+
+#[test]
+fn test_loopback_direct_listener_connect_preserves_public_api() {
+    let local = SocketAddr::from((Ipv4Addr::LOCALHOST, 40206));
+    let remote = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 2), 40207));
+    let mut listener = crate::loopback::LoopbackTcpListener::new(local, 42);
+    let client = listener.clone().connect_to(remote);
+    let (accepted, peer) = listener.try_accept().unwrap();
+    assert_eq!(client.addr_local().unwrap(), remote);
+    assert_eq!(client.addr_peer().unwrap(), local);
+    assert_eq!(accepted.addr_local().unwrap(), local);
+    assert_eq!(accepted.addr_peer().unwrap(), remote);
+    assert_eq!(accepted.ttl().unwrap(), 42);
+    assert_eq!(peer, remote);
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_ipv6_listener_matching_is_family_scoped() {
+    let networking = LoopbackNetworking::new();
+    let specific = SocketAddr::from((Ipv6Addr::LOCALHOST, 40209));
+    let wildcard = SocketAddr::from((Ipv6Addr::UNSPECIFIED, specific.port()));
+    let mut listener = networking
+        .listen_tcp(specific, true, false, false)
+        .await
+        .unwrap();
+    let _ipv4 = networking
+        .listen_tcp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, specific.port())),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        networking
+            .bind_tcp(wildcard, true, false, false)
+            .await
+            .unwrap_err(),
+        NetworkError::AddressInUse
+    );
+
+    let source = SocketAddr::from((Ipv6Addr::LOCALHOST, 40210));
+    let _client = networking.loopback_connect_to(source, specific).unwrap();
+    let (accepted, peer) = listener.try_accept().unwrap();
+    assert_eq!(accepted.addr_local().unwrap(), specific);
+    assert_eq!(peer, source);
+    let missing = SocketAddr::from((Ipv6Addr::from(2), specific.port()));
+    assert!(networking.loopback_connect_to(source, missing).is_none());
+
+    let mut wildcard_listener = networking
+        .listen_tcp(
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)),
+            true,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let destination = SocketAddr::from((
+        Ipv6Addr::from(2),
+        wildcard_listener.addr_local().unwrap().port(),
+    ));
+    assert_eq!(
+        networking
+            .bind_tcp(destination, true, false, false)
+            .await
+            .unwrap_err(),
+        NetworkError::AddressInUse
+    );
+    let client = networking.loopback_connect_to(source, destination).unwrap();
+    let (accepted, peer) = wildcard_listener.try_accept().unwrap();
+    assert_eq!(client.addr_peer().unwrap(), destination);
+    assert_eq!(accepted.addr_local().unwrap(), destination);
+    assert_eq!(peer, source);
+}
+
+#[traced_test]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_loopback_ipv6_wildcard_metadata_uses_one_reservation_key() {
+    for port in [0, 40211] {
+        let networking = LoopbackNetworking::new();
+        let original = std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 42, 7);
+        let bound = networking
+            .bind_tcp(original.into(), true, false, false)
+            .await
+            .unwrap();
+        let local = bound.addr_local().unwrap();
+        let specific = SocketAddr::from((Ipv6Addr::LOCALHOST, local.port()));
+        assert_eq!(
+            networking
+                .bind_tcp(specific, true, false, false)
+                .await
+                .unwrap_err(),
+            NetworkError::AddressInUse
+        );
+        drop(bound);
+
+        let mut rebound = networking
+            .bind_tcp(local, true, false, false)
+            .await
+            .unwrap();
+        let mut listener = rebound.listen().unwrap();
+        assert_eq!(listener.addr_local().unwrap(), local);
+        drop(rebound);
+        assert_eq!(
+            networking
+                .bind_tcp(specific, true, false, false)
+                .await
+                .unwrap_err(),
+            NetworkError::AddressInUse
+        );
+        let source = SocketAddr::from((Ipv6Addr::LOCALHOST, 40212));
+        let client = networking.loopback_connect_to(source, specific).unwrap();
+        let (accepted, peer) = listener.try_accept().unwrap();
+        assert_eq!(client.addr_peer().unwrap(), specific);
+        assert_eq!(accepted.addr_local().unwrap(), specific);
+        assert_eq!(peer, source);
+
+        let client_addr = std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 43, 8);
+        let mut bound_client = networking
+            .bind_tcp(client_addr.into(), true, false, false)
+            .await
+            .unwrap();
+        let reserved = bound_client.addr_local().unwrap();
+        let mut connected = bound_client.connect(specific).unwrap();
+        let _accepted = listener.try_accept().unwrap();
+        drop(bound_client);
+        assert_eq!(
+            networking
+                .bind_tcp(reserved, true, false, false)
+                .await
+                .unwrap_err(),
+            NetworkError::AddressInUse
+        );
+        connected.close().unwrap();
+        let replacement = networking
+            .bind_tcp(reserved, true, false, false)
+            .await
+            .unwrap();
+        drop(connected);
+        assert_eq!(
+            networking
+                .bind_tcp(reserved, true, false, false)
+                .await
+                .unwrap_err(),
+            NetworkError::AddressInUse
+        );
+        drop(replacement);
+        let mut rebound_client = networking
+            .bind_tcp(reserved, true, false, false)
+            .await
+            .unwrap();
+        let connected = rebound_client.connect(specific).unwrap();
+        let _accepted = listener.try_accept().unwrap();
+        drop(rebound_client);
+        drop(connected);
+        networking
+            .bind_tcp(reserved, true, false, false)
+            .await
+            .unwrap();
+    }
 }

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -79,6 +79,9 @@
 //! `FileSystems:{kind}` selects the filesystem backend. Supported values are
 //! `host`, `inmemory`, `tmp`, `passthrumemory`, `union`, `root`, comma-separated
 //! lists of those values, and `all`.
+//!
+//! `Networking:loopback` runs the fixture with an isolated in-memory loopback
+//! network.
 
 use anyhow::{Context, Result, anyhow, ensure};
 use itertools::Itertools;
@@ -220,6 +223,12 @@ enum FileSystemKind {
     Root,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumString)]
+#[strum(ascii_case_insensitive, serialize_all = "lowercase")]
+enum NetworkingKind {
+    Loopback,
+}
+
 impl Engine {
     pub fn name(self) -> &'static str {
         match self {
@@ -249,6 +258,7 @@ struct Config {
     rust_toolchains: Option<Vec<RustToolchain>>,
     selected_file_system: FileSystemKind,
     file_systems: Option<Vec<FileSystemKind>>,
+    networking: Option<NetworkingKind>,
     is_abstract: bool,
 
     nonzero_exit_code: bool,
@@ -294,6 +304,7 @@ impl Config {
             rust_toolchain: RustToolchain::Wasix,
             rust_toolchains: None,
             file_systems: None,
+            networking: None,
             selected_file_system: FileSystemKind::Host,
             is_abstract: false,
             arguments: Vec::new(),
@@ -650,6 +661,12 @@ fn process_directive(
                 );
                 file_systems
             });
+        }
+        "Networking" => {
+            config.networking = Some(
+                arg.parse::<NetworkingKind>()
+                    .map_err(|_| anyhow!("unsupported networking: '{arg}'"))?,
+            );
         }
         other => bail!("Unknown directive '{other}'"),
     }
@@ -1210,32 +1227,49 @@ fn run_integration_test(config: Config) -> Result<libtest_mimic::Completion> {
     let stdin = config.stdin.clone();
 
     let mut extra_temporary_folders = Vec::new();
-    let result = runner::run_wasm_with_runner_config(
-        &wasm,
-        run_dir,
-        config.engine,
-        config.program_name.as_deref(),
-        config.default_mapped_directories,
-        |runner| {
-            if !config.arguments.is_empty() {
-                runner.with_args(config.arguments.iter().cloned());
-            }
+    let configure_runner = |runner: &mut wasmer_wasix::runners::wasi::WasiRunner| {
+        if !config.arguments.is_empty() {
+            runner.with_args(config.arguments.iter().cloned());
+        }
 
-            if !config.env.is_empty() {
-                runner.with_envs(config.env.iter().cloned());
-            }
+        if !config.env.is_empty() {
+            runner.with_envs(config.env.iter().cloned());
+        }
 
-            if let Some(stdin) = stdin {
-                runner.with_stdin(Box::new(StaticFile::new(stdin)));
-            }
+        if let Some(stdin) = stdin {
+            runner.with_stdin(Box::new(StaticFile::new(stdin)));
+        }
 
-            configure_mapped_directories(runner, &config, &mut extra_temporary_folders)?;
-            if let Some(current_directory) = &config.current_directory {
-                runner.with_current_dir(current_directory.clone());
-            }
-            Ok(())
-        },
-    )?;
+        configure_mapped_directories(runner, &config, &mut extra_temporary_folders)?;
+        if let Some(current_directory) = &config.current_directory {
+            runner.with_current_dir(current_directory.clone());
+        }
+        Ok(())
+    };
+    let result = match config.networking {
+        None => runner::run_wasm_with_runner_config(
+            &wasm,
+            run_dir,
+            config.engine,
+            config.program_name.as_deref(),
+            config.default_mapped_directories,
+            configure_runner,
+        )?,
+        Some(NetworkingKind::Loopback) => runner::run_wasm_with_runner_and_runtime_config(
+            &wasm,
+            run_dir,
+            config.engine,
+            config.program_name.as_deref(),
+            config.default_mapped_directories,
+            configure_runner,
+            |runtime| {
+                runtime.set_networking_implementation(
+                    wasmer_wasix::virtual_net::LoopbackNetworking::new(),
+                );
+                Ok(())
+            },
+        )?,
+    };
 
     if config.nonzero_exit_code {
         ensure!(

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1664,7 +1664,7 @@ fn check_networking_directive() -> Result<()> {
         ensure!(config.networking.is_none());
     }
     apply("AbstractConfig:isolated", &mut config)?;
-    apply("Networking: LoOpBaCk ", &mut config)?;
+    apply("Networking: LOOPBACK ", &mut config)?;
     apply("Config:inherited:isolated", &mut config)?;
     ensure!(config.networking == Some(NetworkingKind::Loopback));
     apply("Config:default", &mut config)?;

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1496,6 +1496,11 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     let tests_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))?.join("tests/wasm_tests/");
     let tests_build_root = tests_dir.join("build");
 
+    tests.push(libtest_mimic::Trial::test(
+        "wasm/networking_directive",
+        || check_networking_directive().map_err(|e| libtest_mimic::Failed::from(format!("{e:?}"))),
+    ));
+
     tests.push(libtest_mimic::Trial::test("wasm/dynamic_runtime_hooks", {
         let tests_dir = tests_dir.clone();
         let tests_build_root = tests_build_root.clone();
@@ -1627,6 +1632,44 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+fn check_networking_directive() -> Result<()> {
+    let default = Config::new(
+        PrimarySource::CSourceFile("main.c".into()),
+        PathBuf::new(),
+        PathBuf::new(),
+        "networking_directive".into(),
+    );
+    let mut config = default.clone();
+    let mut build_env = Vec::new();
+    let mut names = HashMap::new();
+    let mut configs = Vec::new();
+    let mut apply = |directive: &str, config: &mut Config| {
+        process_directive(
+            directive,
+            &mut build_env,
+            config,
+            &default,
+            &mut names,
+            &mut configs,
+        )
+    };
+
+    for invalid in ["", "host", "loopback,host", "loopbak"] {
+        let directive = format!("Networking:{invalid}");
+        let error = apply(&directive, &mut config).unwrap_err();
+        ensure!(error.to_string().contains("unsupported networking"));
+        ensure!(config.networking.is_none());
+    }
+    apply("AbstractConfig:isolated", &mut config)?;
+    apply("Networking: LoOpBaCk ", &mut config)?;
+    apply("Config:inherited:isolated", &mut config)?;
+    ensure!(config.networking == Some(NetworkingKind::Loopback));
+    apply("Config:default", &mut config)?;
+    ensure!(config.networking.is_none());
+    ensure!(default.networking.is_none());
     Ok(())
 }
 

--- a/lib/wasix/tests/wasm_tests/socket/loopback-tcp-address-matching/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/loopback-tcp-address-matching/main.c
@@ -1,0 +1,198 @@
+//#Networking: loopback
+//#ExpectedStdout: loopback TCP address matching works
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static struct sockaddr_in ipv4_addr(const char* ip, unsigned short port) {
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  if (inet_pton(AF_INET, ip, &addr.sin_addr) != 1) {
+    fprintf(stderr, "inet_pton failed for %s\n", ip);
+  }
+  return addr;
+}
+
+static int local_addr(int fd, struct sockaddr_in* addr) {
+  socklen_t len = sizeof(*addr);
+  memset(addr, 0, sizeof(*addr));
+  return getsockname(fd, (struct sockaddr*)addr, &len);
+}
+
+static int peer_addr(int fd, struct sockaddr_in* addr) {
+  socklen_t len = sizeof(*addr);
+  memset(addr, 0, sizeof(*addr));
+  return getpeername(fd, (struct sockaddr*)addr, &len);
+}
+
+static int bind_client(int fd) {
+  struct sockaddr_in addr = ipv4_addr("0.0.0.0", 0);
+  return bind(fd, (struct sockaddr*)&addr, sizeof(addr));
+}
+
+static int expect_bind_conflict(const char* label, const char* ip,
+                                unsigned short port) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  struct sockaddr_in addr = ipv4_addr(ip, port);
+  if (fd < 0) {
+    perror("socket(conflict)");
+    return -1;
+  }
+  errno = 0;
+  if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) == 0 ||
+      errno != EADDRINUSE) {
+    fprintf(stderr, "%s: expected EADDRINUSE, got errno %d (%s)\n", label,
+            errno, strerror(errno));
+    close(fd);
+    return -1;
+  }
+  close(fd);
+  return 0;
+}
+
+static int test_wildcard_listener(void) {
+  int listener = socket(AF_INET, SOCK_STREAM, 0);
+  struct sockaddr_in wildcard = ipv4_addr("0.0.0.0", 0);
+  if (listener < 0 ||
+      bind(listener, (struct sockaddr*)&wildcard, sizeof(wildcard)) != 0 ||
+      listen(listener, 2) != 0) {
+    perror("wildcard listener");
+    return -1;
+  }
+
+  struct sockaddr_in bound;
+  if (local_addr(listener, &bound) != 0) {
+    perror("getsockname(wildcard listener)");
+    return -1;
+  }
+  if (bound.sin_addr.s_addr != htonl(INADDR_ANY) ||
+      ntohs(bound.sin_port) == 0) {
+    fprintf(stderr, "wildcard bind was not preserved\n");
+    return -1;
+  }
+  unsigned short port = ntohs(bound.sin_port);
+  if (expect_bind_conflict("wildcard listener then specific bind", "127.0.0.42",
+                           port) != 0) {
+    return -1;
+  }
+
+  struct sockaddr_in destination = ipv4_addr("127.0.0.42", port);
+  int client = socket(AF_INET, SOCK_STREAM, 0);
+  if (client < 0 || bind_client(client) != 0 ||
+      connect(client, (struct sockaddr*)&destination, sizeof(destination)) !=
+          0) {
+    perror("connect(wildcard listener)");
+    return -1;
+  }
+
+  struct sockaddr_in client_local;
+  struct sockaddr_in client_peer;
+  if (local_addr(client, &client_local) != 0 ||
+      peer_addr(client, &client_peer) != 0) {
+    perror("getname(client)");
+    return -1;
+  }
+  if (client_local.sin_addr.s_addr == htonl(INADDR_ANY) ||
+      client_peer.sin_addr.s_addr != destination.sin_addr.s_addr) {
+    fprintf(stderr, "client connection endpoints were not concrete\n");
+    return -1;
+  }
+
+  struct sockaddr_in accepted_peer;
+  socklen_t accepted_peer_len = sizeof(accepted_peer);
+  int accepted =
+      accept(listener, (struct sockaddr*)&accepted_peer, &accepted_peer_len);
+  struct sockaddr_in accepted_local;
+  if (accepted < 0 || local_addr(accepted, &accepted_local) != 0) {
+    perror("accept(wildcard listener)");
+    return -1;
+  }
+  if (accepted_local.sin_addr.s_addr != destination.sin_addr.s_addr ||
+      accepted_peer.sin_addr.s_addr == htonl(INADDR_ANY)) {
+    fprintf(stderr, "accepted connection endpoints were not concrete\n");
+    return -1;
+  }
+
+  close(accepted);
+  close(client);
+  close(listener);
+  return 0;
+}
+
+static int test_specific_listeners(void) {
+  int first = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+  struct sockaddr_in first_addr = ipv4_addr("127.0.0.1", 0);
+  if (first < 0 ||
+      bind(first, (struct sockaddr*)&first_addr, sizeof(first_addr)) != 0 ||
+      listen(first, 2) != 0 || local_addr(first, &first_addr) != 0) {
+    perror("first specific listener");
+    return -1;
+  }
+
+  unsigned short port = ntohs(first_addr.sin_port);
+  struct sockaddr_in second_addr = ipv4_addr("127.0.0.2", port);
+  int second = socket(AF_INET, SOCK_STREAM, 0);
+  if (second < 0 ||
+      bind(second, (struct sockaddr*)&second_addr, sizeof(second_addr)) != 0 ||
+      listen(second, 2) != 0) {
+    perror("second specific listener");
+    return -1;
+  }
+  if (expect_bind_conflict("specific listeners then wildcard bind", "0.0.0.0",
+                           port) != 0) {
+    return -1;
+  }
+
+  int client = socket(AF_INET, SOCK_STREAM, 0);
+  if (client < 0 || bind_client(client) != 0 ||
+      connect(client, (struct sockaddr*)&second_addr, sizeof(second_addr)) !=
+          0) {
+    perror("connect(second specific listener)");
+    return -1;
+  }
+  int accepted = accept(second, NULL, NULL);
+  if (accepted < 0) {
+    perror("accept(second specific listener)");
+    return -1;
+  }
+  struct pollfd first_poll = {.fd = first, .events = POLLIN};
+  if (poll(&first_poll, 1, 0) != 0 || (first_poll.revents & POLLIN) != 0) {
+    fprintf(stderr, "connection was delivered to the wrong exact listener\n");
+    return -1;
+  }
+
+  struct sockaddr_in missing = ipv4_addr("127.0.0.3", port);
+  int missing_client = socket(AF_INET, SOCK_STREAM, 0);
+  errno = 0;
+  if (missing_client < 0 || bind_client(missing_client) != 0 ||
+      connect(missing_client, (struct sockaddr*)&missing, sizeof(missing)) ==
+          0 ||
+      errno != ECONNREFUSED) {
+    fprintf(stderr,
+            "missing destination unexpectedly matched a listener: %d (%s)\n",
+            errno, strerror(errno));
+    return -1;
+  }
+
+  close(missing_client);
+  close(accepted);
+  close(client);
+  close(second);
+  close(first);
+  return 0;
+}
+
+int main(void) {
+  if (test_wildcard_listener() != 0 || test_specific_listeners() != 0) {
+    return 1;
+  }
+  puts("loopback TCP address matching works");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/socket/loopback-tcp-address-matching/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/loopback-tcp-address-matching/main.c
@@ -1,5 +1,7 @@
+//#Config: first
 //#Networking: loopback
 //#ExpectedStdout: loopback TCP address matching works
+//#Config: second:first
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -100,7 +102,8 @@ static int test_wildcard_listener(void) {
     return -1;
   }
   if (client_local.sin_addr.s_addr == htonl(INADDR_ANY) ||
-      client_peer.sin_addr.s_addr != destination.sin_addr.s_addr) {
+      client_peer.sin_addr.s_addr != destination.sin_addr.s_addr ||
+      client_peer.sin_port != destination.sin_port) {
     fprintf(stderr, "client connection endpoints were not concrete\n");
     return -1;
   }
@@ -115,7 +118,9 @@ static int test_wildcard_listener(void) {
     return -1;
   }
   if (accepted_local.sin_addr.s_addr != destination.sin_addr.s_addr ||
-      accepted_peer.sin_addr.s_addr == htonl(INADDR_ANY)) {
+      accepted_local.sin_port != destination.sin_port ||
+      accepted_peer.sin_addr.s_addr != client_local.sin_addr.s_addr ||
+      accepted_peer.sin_port != client_local.sin_port) {
     fprintf(stderr, "accepted connection endpoints were not concrete\n");
     return -1;
   }
@@ -128,7 +133,8 @@ static int test_wildcard_listener(void) {
 
 static int test_specific_listeners(void) {
   int first = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-  struct sockaddr_in first_addr = ipv4_addr("127.0.0.1", 0);
+  // Reusing this port detects a network shared between fixture configurations.
+  struct sockaddr_in first_addr = ipv4_addr("127.0.0.1", 40205);
   if (first < 0 ||
       bind(first, (struct sockaddr*)&first_addr, sizeof(first_addr)) != 0 ||
       listen(first, 2) != 0 || local_addr(first, &first_addr) != 0) {


### PR DESCRIPTION
# Description

Keep loopback TCP bind addresses intact, including wildcard addresses. Wildcard and specific binds now conflict symmetrically within the same address family and port, while distinct concrete addresses can share a port. Connections reach only the exact destination or its family’s wildcard listener, and connected sockets report concrete endpoints.

A per-family port index avoids rescanning every socket during ephemeral allocation. Reservation keys preserve concrete IPv6 metadata and consistently normalize wildcard metadata, so bind, listen, connect, and release agree on ownership. Reusing a consumed bound socket fails before creating a connection, and the public listener connection API stays compatible.

The WASIX fixture harness can select an isolated loopback backend without changing networking for other fixtures.
