### PR TITLE
test(wasix): cover ephemeral symlink metadata

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -3509,6 +3509,16 @@ mod tests {
         let link = wasi_fs
             .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/link", false)
             .unwrap();
+        let stat = *link.stat.read().unwrap();
+        assert_eq!(stat.st_filetype, Filetype::SymbolicLink);
+        assert_ne!(stat.st_ino, 0);
+        assert_eq!(stat.st_nlink, 1);
+        assert_eq!(stat.st_size, 10);
+
+        let resolved_again = wasi_fs
+            .get_inode_at_path(&inodes, crate::VIRTUAL_ROOT_FD, "/link", false)
+            .unwrap();
+        assert_eq!(resolved_again.ino(), link.ino());
         assert!(matches!(
             link.read().deref(),
             Kind::Symlink {

--- a/lib/wasix/tests/wasm_tests/ephemeral_symlink.rs
+++ b/lib/wasix/tests/wasm_tests/ephemeral_symlink.rs
@@ -1,31 +1,42 @@
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, ensure};
 use wasmer_wasix::virtual_fs::{FsError, Metadata, OpenOptions, ReadDir};
 
 use super::*;
 
-#[derive(Debug)]
-struct UnsupportedSymlinkFileSystem(mem_fs::FileSystem);
+#[derive(Debug, Default)]
+struct UnsupportedSymlinkFileSystem {
+    inner: mem_fs::FileSystem,
+    symlink_requests: Mutex<Vec<(PathBuf, PathBuf)>>,
+}
 
 impl FileSystem for UnsupportedSymlinkFileSystem {
     fn readlink(&self, path: &Path) -> Result<PathBuf, FsError> {
-        self.0.readlink(path)
+        self.inner.readlink(path)
     }
 
     fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
-        self.0.read_dir(path)
+        self.inner.read_dir(path)
     }
 
     fn create_dir(&self, path: &Path) -> Result<(), FsError> {
-        self.0.create_dir(path)
+        self.inner.create_dir(path)
+    }
+
+    fn create_symlink(&self, source: &Path, target: &Path) -> Result<(), FsError> {
+        self.symlink_requests
+            .lock()
+            .unwrap()
+            .push((source.to_path_buf(), target.to_path_buf()));
+        Err(FsError::Unsupported)
     }
 
     fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
-        self.0.remove_dir(path)
+        self.inner.remove_dir(path)
     }
 
     fn rename<'a>(
@@ -33,23 +44,23 @@ impl FileSystem for UnsupportedSymlinkFileSystem {
         from: &'a Path,
         to: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<(), FsError>> + Send + 'a>> {
-        self.0.rename(from, to)
+        self.inner.rename(from, to)
     }
 
     fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
-        self.0.metadata(path)
+        self.inner.metadata(path)
     }
 
     fn symlink_metadata(&self, path: &Path) -> Result<Metadata, FsError> {
-        self.0.symlink_metadata(path)
+        self.inner.symlink_metadata(path)
     }
 
     fn remove_file(&self, path: &Path) -> Result<(), FsError> {
-        self.0.remove_file(path)
+        self.inner.remove_file(path)
     }
 
     fn new_open_options(&self) -> OpenOptions<'_> {
-        self.0.new_open_options()
+        self.inner.new_open_options()
     }
 }
 
@@ -72,18 +83,14 @@ pub(super) fn fallback_metadata_config(
 
 pub(super) fn run_fallback_metadata_test(config: Config) -> Result<()> {
     let wasm = run_build_script(&config)?;
-    let backing = Arc::new(UnsupportedSymlinkFileSystem(mem_fs::FileSystem::default()));
-    ensure!(matches!(
-        backing.create_symlink(Path::new("target.txt"), Path::new("/probe")),
-        Err(FsError::Unsupported)
-    ));
+    let backing = Arc::new(UnsupportedSymlinkFileSystem::default());
 
     let result = runner::run_wasm_with_runner_config(
         &wasm,
         &config.build_path(),
         config.engine,
         None,
-        true,
+        false,
         |runner| {
             runner.with_mount("/ephemeral".to_owned(), backing.clone());
             runner.with_current_dir("/ephemeral".to_owned());
@@ -100,6 +107,15 @@ pub(super) fn run_fallback_metadata_test(config: Config) -> Result<()> {
         String::from_utf8_lossy(&result.stdout).trim() == "ephemeral symlink metadata passed",
         "unexpected fixture output\n{}",
         runner::format_captured_output(&result)
+    );
+    ensure!(
+        *backing.symlink_requests.lock().unwrap()
+            == [
+                (PathBuf::from("target.txt"), PathBuf::from("/link")),
+                (PathBuf::from("target.txt"), PathBuf::from("/second")),
+                (PathBuf::from("absent.txt"), PathBuf::from("/dangling")),
+            ],
+        "guest symlink requests did not reach the unsupported backend"
     );
     ensure!(backing.metadata(Path::new("/target.txt"))?.is_file());
     ensure!(matches!(

--- a/lib/wasix/tests/wasm_tests/ephemeral_symlink.rs
+++ b/lib/wasix/tests/wasm_tests/ephemeral_symlink.rs
@@ -1,0 +1,119 @@
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use anyhow::{Result, ensure};
+use wasmer_wasix::virtual_fs::{FsError, Metadata, OpenOptions, ReadDir};
+
+use super::*;
+
+#[derive(Debug)]
+struct UnsupportedSymlinkFileSystem(mem_fs::FileSystem);
+
+impl FileSystem for UnsupportedSymlinkFileSystem {
+    fn readlink(&self, path: &Path) -> Result<PathBuf, FsError> {
+        self.0.readlink(path)
+    }
+
+    fn read_dir(&self, path: &Path) -> Result<ReadDir, FsError> {
+        self.0.read_dir(path)
+    }
+
+    fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+        self.0.create_dir(path)
+    }
+
+    fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
+        self.0.remove_dir(path)
+    }
+
+    fn rename<'a>(
+        &'a self,
+        from: &'a Path,
+        to: &'a Path,
+    ) -> Pin<Box<dyn Future<Output = Result<(), FsError>> + Send + 'a>> {
+        self.0.rename(from, to)
+    }
+
+    fn metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+        self.0.metadata(path)
+    }
+
+    fn symlink_metadata(&self, path: &Path) -> Result<Metadata, FsError> {
+        self.0.symlink_metadata(path)
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+        self.0.remove_file(path)
+    }
+
+    fn new_open_options(&self) -> OpenOptions<'_> {
+        self.0.new_open_options()
+    }
+}
+
+pub(super) fn fallback_metadata_config(
+    tests_dir: &Path,
+    build_root: &Path,
+    sysroot: Option<&'static str>,
+) -> Result<Config> {
+    let mut config = Config::new(
+        PrimarySource::CSourceFile("main.c".to_owned()),
+        tests_dir.join("path/ephemeral-symlink-metadata"),
+        build_root.to_path_buf(),
+        "path/ephemeral-symlink-metadata-fallback".to_owned(),
+    );
+    if let Some(sysroot) = sysroot {
+        config.set_sysroot(sysroot)?;
+    }
+    Ok(config)
+}
+
+pub(super) fn run_fallback_metadata_test(config: Config) -> Result<()> {
+    let wasm = run_build_script(&config)?;
+    let backing = Arc::new(UnsupportedSymlinkFileSystem(mem_fs::FileSystem::default()));
+    ensure!(matches!(
+        backing.create_symlink(Path::new("target.txt"), Path::new("/probe")),
+        Err(FsError::Unsupported)
+    ));
+
+    let result = runner::run_wasm_with_runner_config(
+        &wasm,
+        &config.build_path(),
+        config.engine,
+        None,
+        true,
+        |runner| {
+            runner.with_mount("/ephemeral".to_owned(), backing.clone());
+            runner.with_current_dir("/ephemeral".to_owned());
+            Ok(())
+        },
+    )?;
+
+    ensure!(
+        result.exit_code == 0,
+        "ephemeral symlink fallback fixture failed\n{}",
+        runner::format_captured_output(&result)
+    );
+    ensure!(
+        String::from_utf8_lossy(&result.stdout).trim() == "ephemeral symlink metadata passed",
+        "unexpected fixture output\n{}",
+        runner::format_captured_output(&result)
+    );
+    ensure!(backing.metadata(Path::new("/target.txt"))?.is_file());
+    ensure!(matches!(
+        backing.symlink_metadata(Path::new("/link")),
+        Err(FsError::EntryNotFound)
+    ));
+    ensure!(matches!(
+        backing.symlink_metadata(Path::new("/second")),
+        Err(FsError::EntryNotFound)
+    ));
+    ensure!(matches!(
+        backing.symlink_metadata(Path::new("/dangling")),
+        Err(FsError::EntryNotFound)
+    ));
+
+    Ok(())
+}

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -103,6 +103,7 @@ use wasmer_wasix::virtual_fs::{
     StaticFile, TmpFileSystem, create_dir_all as create_virtual_dir_all, mem_fs,
 };
 
+#[cfg(not(target_os = "windows"))]
 mod ephemeral_symlink;
 mod error;
 mod runner;
@@ -1463,6 +1464,7 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     let tests_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))?.join("tests/wasm_tests/");
     let tests_build_root = tests_dir.join("build");
 
+    #[cfg(not(target_os = "windows"))]
     for sysroot in TESTED_LIBC_VERSIONS {
         let config =
             ephemeral_symlink::fallback_metadata_config(&tests_dir, &tests_build_root, *sysroot)?;

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -103,6 +103,7 @@ use wasmer_wasix::virtual_fs::{
     StaticFile, TmpFileSystem, create_dir_all as create_virtual_dir_all, mem_fs,
 };
 
+mod ephemeral_symlink;
 mod error;
 mod runner;
 
@@ -1461,6 +1462,15 @@ fn has_primary_source_file(path: &Path) -> bool {
 fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     let tests_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))?.join("tests/wasm_tests/");
     let tests_build_root = tests_dir.join("build");
+
+    for sysroot in TESTED_LIBC_VERSIONS {
+        let config =
+            ephemeral_symlink::fallback_metadata_config(&tests_dir, &tests_build_root, *sysroot)?;
+        tests.push(Trial::test(config.full_test_name(), move || {
+            ephemeral_symlink::run_fallback_metadata_test(config)
+                .map_err(|error| libtest_mimic::Failed::from(format!("{error:?}")))
+        }));
+    }
 
     tests.push(libtest_mimic::Trial::test("wasm/dynamic_runtime_hooks", {
         let tests_dir = tests_dir.clone();

--- a/lib/wasix/tests/wasm_tests/path/ephemeral-symlink-metadata/main.c
+++ b/lib/wasix/tests/wasm_tests/path/ephemeral-symlink-metadata/main.c
@@ -19,11 +19,23 @@ static void assert_symlink_metadata(const struct stat* metadata,
   assert(metadata->st_size == (off_t)target_length);
 }
 
+static void unlink_and_assert_missing(const char* path) {
+  struct stat metadata;
+  assert(unlink(path) == 0);
+  errno = 0;
+  assert(lstat(path, &metadata) == -1);
+  assert(errno == ENOENT);
+  errno = 0;
+  assert(unlink(path) == -1);
+  assert(errno == ENOENT);
+}
+
 int main(void) {
   static const char target_name[] = "target.txt";
   static const char target_contents[] = "target-data";
   static const char dangling_target[] = "absent.txt";
   struct stat first;
+  struct stat target;
   struct stat metadata;
   char link_target[sizeof(target_name)] = {0};
 
@@ -32,12 +44,16 @@ int main(void) {
   assert(write(fd, target_contents, sizeof(target_contents) - 1) ==
          sizeof(target_contents) - 1);
   assert(close(fd) == 0);
+  assert(stat(target_name, &target) == 0);
+  assert(target.st_ino != 0);
 
   assert(symlink(target_name, "link") == 0);
   assert(lstat("link", &first) == 0);
   assert_symlink_metadata(&first, sizeof(target_name) - 1);
+  assert(first.st_ino != target.st_ino);
 
   assert(lstat("link", &metadata) == 0);
+  assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
   assert(metadata.st_ino == first.st_ino);
   assert(fstatat(AT_FDCWD, "link", &metadata, AT_SYMLINK_NOFOLLOW) == 0);
   assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
@@ -46,6 +62,16 @@ int main(void) {
   assert(stat("link", &metadata) == 0);
   assert(S_ISREG(metadata.st_mode));
   assert(metadata.st_size == sizeof(target_contents) - 1);
+  assert(metadata.st_ino == target.st_ino);
+
+  int directory_fd = open(".", O_RDONLY | O_DIRECTORY);
+  assert(directory_fd >= 0);
+  assert(fstatat(directory_fd, "link", &metadata, AT_SYMLINK_NOFOLLOW) == 0);
+  assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
+  assert(metadata.st_ino == first.st_ino);
+  assert(fstatat(directory_fd, "link", &metadata, 0) == 0);
+  assert(S_ISREG(metadata.st_mode));
+  assert(metadata.st_ino == target.st_ino);
 
   assert(readlink("link", link_target, sizeof(link_target)) ==
          sizeof(target_name) - 1);
@@ -55,10 +81,22 @@ int main(void) {
   assert(lstat("second", &metadata) == 0);
   assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
   assert(metadata.st_ino != first.st_ino);
+  ino_t second_ino = metadata.st_ino;
 
   assert(symlink(dangling_target, "dangling") == 0);
   assert(lstat("dangling", &metadata) == 0);
   assert_symlink_metadata(&metadata, sizeof(dangling_target) - 1);
+  assert(metadata.st_ino != first.st_ino);
+  assert(metadata.st_ino != second_ino);
+  ino_t dangling_ino = metadata.st_ino;
+  assert(fstatat(directory_fd, "dangling", &metadata, AT_SYMLINK_NOFOLLOW) ==
+         0);
+  assert_symlink_metadata(&metadata, sizeof(dangling_target) - 1);
+  assert(metadata.st_ino == dangling_ino);
+  errno = 0;
+  assert(fstatat(directory_fd, "dangling", &metadata, 0) == -1);
+  assert(errno == ENOENT);
+  assert(close(directory_fd) == 0);
   errno = 0;
   assert(stat("dangling", &metadata) == -1);
   assert(errno == ENOENT);
@@ -72,23 +110,38 @@ int main(void) {
   assert(directory != NULL);
   int found_link = 0;
   struct dirent* entry;
-  while ((entry = readdir(directory)) != NULL) {
+  for (;;) {
+    errno = 0;
+    entry = readdir(directory);
+    if (entry == NULL) {
+      assert(errno == 0);
+      break;
+    }
     if (strcmp(entry->d_name, "link") != 0) {
       continue;
     }
     assert(entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN);
     assert(lstat(entry->d_name, &metadata) == 0);
     assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
+    assert(metadata.st_ino == first.st_ino);
     found_link++;
   }
   assert(closedir(directory) == 0);
   assert(found_link == 1);
 
-  assert(unlink("link") == 0);
-  assert(unlink("second") == 0);
+  unlink_and_assert_missing("link");
+  unlink_and_assert_missing("second");
+  unlink_and_assert_missing("dangling");
   assert(stat(target_name, &metadata) == 0);
   assert(S_ISREG(metadata.st_mode));
   assert(metadata.st_size == sizeof(target_contents) - 1);
+  assert(metadata.st_ino == target.st_ino);
+  fd = open(target_name, O_RDONLY);
+  assert(fd >= 0);
+  char contents[sizeof(target_contents)] = {0};
+  assert(read(fd, contents, sizeof(contents)) == sizeof(target_contents) - 1);
+  assert(strcmp(contents, target_contents) == 0);
+  assert(close(fd) == 0);
 
   puts("ephemeral symlink metadata passed");
   return 0;

--- a/lib/wasix/tests/wasm_tests/path/ephemeral-symlink-metadata/main.c
+++ b/lib/wasix/tests/wasm_tests/path/ephemeral-symlink-metadata/main.c
@@ -1,0 +1,95 @@
+//#MappedDirectory: $temp:/ephemeral
+//#CurrentDirectory: /ephemeral
+//#ExpectedStdout: ephemeral symlink metadata passed
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static void assert_symlink_metadata(const struct stat* metadata,
+                                    size_t target_length) {
+  assert(S_ISLNK(metadata->st_mode));
+  assert(metadata->st_ino != 0);
+  assert(metadata->st_nlink == 1);
+  assert(metadata->st_size == (off_t)target_length);
+}
+
+int main(void) {
+  static const char target_name[] = "target.txt";
+  static const char target_contents[] = "target-data";
+  static const char dangling_target[] = "absent.txt";
+  struct stat first;
+  struct stat metadata;
+  char link_target[sizeof(target_name)] = {0};
+
+  int fd = open(target_name, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+  assert(fd >= 0);
+  assert(write(fd, target_contents, sizeof(target_contents) - 1) ==
+         sizeof(target_contents) - 1);
+  assert(close(fd) == 0);
+
+  assert(symlink(target_name, "link") == 0);
+  assert(lstat("link", &first) == 0);
+  assert_symlink_metadata(&first, sizeof(target_name) - 1);
+
+  assert(lstat("link", &metadata) == 0);
+  assert(metadata.st_ino == first.st_ino);
+  assert(fstatat(AT_FDCWD, "link", &metadata, AT_SYMLINK_NOFOLLOW) == 0);
+  assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
+  assert(metadata.st_ino == first.st_ino);
+
+  assert(stat("link", &metadata) == 0);
+  assert(S_ISREG(metadata.st_mode));
+  assert(metadata.st_size == sizeof(target_contents) - 1);
+
+  assert(readlink("link", link_target, sizeof(link_target)) ==
+         sizeof(target_name) - 1);
+  assert(memcmp(link_target, target_name, sizeof(target_name) - 1) == 0);
+
+  assert(symlink(target_name, "second") == 0);
+  assert(lstat("second", &metadata) == 0);
+  assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
+  assert(metadata.st_ino != first.st_ino);
+
+  assert(symlink(dangling_target, "dangling") == 0);
+  assert(lstat("dangling", &metadata) == 0);
+  assert_symlink_metadata(&metadata, sizeof(dangling_target) - 1);
+  errno = 0;
+  assert(stat("dangling", &metadata) == -1);
+  assert(errno == ENOENT);
+  memset(link_target, 0, sizeof(link_target));
+  assert(readlink("dangling", link_target, sizeof(link_target)) ==
+         sizeof(dangling_target) - 1);
+  assert(memcmp(link_target, dangling_target, sizeof(dangling_target) - 1) ==
+         0);
+
+  DIR* directory = opendir(".");
+  assert(directory != NULL);
+  int found_link = 0;
+  struct dirent* entry;
+  while ((entry = readdir(directory)) != NULL) {
+    if (strcmp(entry->d_name, "link") != 0) {
+      continue;
+    }
+    assert(entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN);
+    assert(lstat(entry->d_name, &metadata) == 0);
+    assert_symlink_metadata(&metadata, sizeof(target_name) - 1);
+    found_link++;
+  }
+  assert(closedir(directory) == 0);
+  assert(found_link == 1);
+
+  assert(unlink("link") == 0);
+  assert(unlink("second") == 0);
+  assert(stat(target_name, &metadata) == 0);
+  assert(S_ISREG(metadata.st_mode));
+  assert(metadata.st_size == sizeof(target_contents) - 1);
+
+  puts("ephemeral symlink metadata passed");
+  return 0;
+}


### PR DESCRIPTION
Add regression coverage for symlink metadata when a mounted filesystem returns `Unsupported` and WASIX keeps the link in its ephemeral overlay. The Go WASIX port relies on this fallback reporting normal symlink metadata; the runtime already provides it, so no production changes are needed.

The same fixture exercises host-backed and forced-fallback links, including stable inode identity, link count and size, followed and unfollowed metadata, directory enumeration, dangling links, and removal without changing the target. The fallback backend records the guest's symlink requests to verify that the intended path is exercised. Its C fixture follows the harness's existing platform restrictions so Windows test discovery does not require an unsupported toolchain.
