### PR TITLE
fix(virtual-fs): report mounted entries as directories

### DIFF
--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -189,7 +189,7 @@ impl FileSystem {
                             let time = time();
                             Metadata {
                                 ft: FileType {
-                                    file: true,
+                                    dir: true,
                                     ..Default::default()
                                 },
                                 accessed: time,
@@ -847,7 +847,7 @@ mod test_file_opener {
     }
 
     #[tokio::test]
-    async fn test_opening_existing_file_in_arc_directory_redirects() {
+    async fn test_arc_directory_metadata_and_redirection() {
         let fs = FileSystem::default();
         let backing = FileSystem::default();
         let backing_arc: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(backing.clone());
@@ -865,6 +865,21 @@ mod test_file_opener {
             path!("/").to_path_buf(),
         )
         .expect("mount arc directory");
+
+        let metadata = fs.metadata(path!("/mnt")).expect("stat arc directory");
+        assert!(metadata.is_dir());
+        assert!(!metadata.is_file());
+
+        let entry = fs
+            .read_dir(path!("/"))
+            .expect("read parent directory")
+            .next()
+            .expect("arc directory entry")
+            .expect("stat arc directory entry");
+        assert_eq!(entry.path, path!("/mnt"));
+        let entry_metadata = entry.metadata.expect("read arc directory metadata");
+        assert!(entry_metadata.is_dir());
+        assert!(!entry_metadata.is_file());
 
         let mut file = fs
             .new_open_options()

--- a/lib/virtual-fs/src/mem_fs/file_opener.rs
+++ b/lib/virtual-fs/src/mem_fs/file_opener.rs
@@ -857,7 +857,10 @@ mod test_file_opener {
             .write(true)
             .create_new(true)
             .open(path!("/foo.txt"))
-            .expect("create file in backing fs");
+            .expect("create file in backing fs")
+            .write_all(b"backing contents")
+            .await
+            .unwrap();
 
         fs.insert_arc_directory_at(
             path!("/mnt").to_path_buf(),
@@ -866,9 +869,14 @@ mod test_file_opener {
         )
         .expect("mount arc directory");
 
-        let metadata = fs.metadata(path!("/mnt")).expect("stat arc directory");
-        assert!(metadata.is_dir());
-        assert!(!metadata.is_file());
+        for metadata in [
+            fs.metadata(path!("/mnt")),
+            fs.symlink_metadata(path!("/mnt")),
+        ] {
+            let metadata = metadata.expect("stat arc directory");
+            assert!(metadata.is_dir());
+            assert!(!metadata.is_file());
+        }
 
         let entry = fs
             .read_dir(path!("/"))
@@ -891,7 +899,15 @@ mod test_file_opener {
         file.read_to_string(&mut contents)
             .await
             .expect("read redirected file");
-        assert_eq!(contents, "");
+        assert_eq!(contents, "backing contents");
+
+        backing
+            .new_open_options()
+            .write(true)
+            .create_new(true)
+            .open(path!("/added.txt"))
+            .unwrap();
+        assert!(fs.metadata(path!("/mnt/added.txt")).unwrap().is_file());
 
         assert!(
             matches!(

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -2085,6 +2085,21 @@ mod test_filesystem {
         main.mount_directory_entries(Path::new("/"), &other, Path::new("/a"))
             .unwrap();
 
+        let metadata = main.metadata(Path::new("/x")).unwrap();
+        assert!(metadata.is_dir());
+        assert!(!metadata.is_file());
+
+        let entry = main
+            .read_dir(Path::new("/"))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(entry.path, Path::new("/x"));
+        let entry_metadata = entry.metadata.unwrap();
+        assert!(entry_metadata.is_dir());
+        assert!(!entry_metadata.is_file());
+
         let mut buf = Vec::new();
 
         let mut f = main

--- a/lib/virtual-fs/src/mem_fs/filesystem.rs
+++ b/lib/virtual-fs/src/mem_fs/filesystem.rs
@@ -86,7 +86,8 @@ impl FileSystem {
                 return Err(FsError::AlreadyExists);
             }
             Err(_) => {
-                // Root directory does not exist, so we can just mount.
+                // mount acquires the write lock.
+                drop(fs_lock);
                 return self.mount(target_path.to_path_buf(), other, source_path.to_path_buf());
             }
         };
@@ -184,73 +185,53 @@ impl FileSystem {
         other: &Arc<dyn crate::FileSystem + Send + Sync>,
         source_path: PathBuf,
     ) -> Result<()> {
-        if crate::FileSystem::read_dir(self, target_path.as_path()).is_ok() {
+        // Keep collision checks and insertion under one lock.
+        let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+        let path = fs.canonicalize_without_inode(target_path.as_path())?;
+        if fs.inode_of(&path).is_ok() {
             return Err(FsError::AlreadyExists);
         }
 
-        let (inode_of_parent, name_of_directory) = {
-            // Read lock.
-            let guard = self.inner.read().map_err(|_| FsError::Lock)?;
-
-            // Canonicalize the path without checking the path exists,
-            // because it's about to be created.
-            let path = guard.canonicalize_without_inode(target_path.as_path())?;
-
-            // Check the path has a parent.
-            let parent_of_path = path.parent().ok_or(FsError::BaseNotDirectory)?;
-
-            // Check the directory name.
-            let name_of_directory = path
-                .file_name()
-                .ok_or(FsError::InvalidInput)?
-                .to_os_string();
-
-            // Find the parent inode.
-            let inode_of_parent = match guard.inode_of_parent(parent_of_path)? {
-                InodeResolution::Found(a) => a,
-                InodeResolution::Redirect(..) => {
-                    return Err(FsError::AlreadyExists);
-                }
-            };
-
-            (inode_of_parent, name_of_directory)
+        let parent_of_path = path.parent().ok_or(FsError::BaseNotDirectory)?;
+        let name_of_directory = path
+            .file_name()
+            .ok_or(FsError::InvalidInput)?
+            .to_os_string();
+        let inode_of_parent = match fs.inode_of_parent(parent_of_path)? {
+            InodeResolution::Found(a) => a,
+            InodeResolution::Redirect(..) => {
+                return Err(FsError::AlreadyExists);
+            }
         };
 
-        {
-            // Write lock.
-            let mut fs = self.inner.write().map_err(|_| FsError::Lock)?;
+        let inode_of_directory = fs.storage.vacant_entry().key();
+        let real_inode_of_directory = fs.storage.insert(Node::ArcDirectory(ArcDirectoryNode {
+            inode: inode_of_directory,
+            name: name_of_directory,
+            fs: other.clone(),
+            path: source_path,
+            metadata: {
+                let time = time();
 
-            // Creating the directory in the storage.
-            let inode_of_directory = fs.storage.vacant_entry().key();
-            let real_inode_of_directory = fs.storage.insert(Node::ArcDirectory(ArcDirectoryNode {
-                inode: inode_of_directory,
-                name: name_of_directory,
-                fs: other.clone(),
-                path: source_path,
-                metadata: {
-                    let time = time();
+                Metadata {
+                    ft: FileType {
+                        dir: true,
+                        ..Default::default()
+                    },
+                    accessed: time,
+                    created: time,
+                    modified: time,
+                    len: 0,
+                }
+            },
+        }));
 
-                    Metadata {
-                        ft: FileType {
-                            dir: true,
-                            ..Default::default()
-                        },
-                        accessed: time,
-                        created: time,
-                        modified: time,
-                        len: 0,
-                    }
-                },
-            }));
+        assert_eq!(
+            inode_of_directory, real_inode_of_directory,
+            "new directory inode should have been correctly calculated",
+        );
 
-            assert_eq!(
-                inode_of_directory, real_inode_of_directory,
-                "new directory inode should have been correctly calculated",
-            );
-
-            // Adding the new directory to its parent.
-            fs.add_child_to_node(inode_of_parent, inode_of_directory)?;
-        }
+        fs.add_child_to_node(inode_of_parent, inode_of_directory)?;
 
         Ok(())
     }
@@ -2061,6 +2042,73 @@ mod test_filesystem {
         assert_eq!(entries, vec![Path::new("/mnt/file.txt").to_path_buf()]);
     }
 
+    #[test]
+    fn mount_directory_entries_at_absent_destination_does_not_deadlock() {
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let fs = FileSystem::default();
+            let backing = FileSystem::default();
+            crate::ops::create_dir_all(&backing, "/source/subdir").unwrap();
+            let backing: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(backing);
+            let result =
+                fs.mount_directory_entries(Path::new("/mounted"), &backing, Path::new("/source"));
+            done_tx.send((fs, result)).unwrap();
+        });
+        let (fs, result) = done_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("mount_directory_entries must release its read lock before mounting");
+        worker.join().unwrap();
+        result.unwrap();
+        let entry = fs
+            .read_dir(Path::new("/mounted"))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(entry.path, Path::new("/mounted/subdir"));
+        assert!(entry.metadata.unwrap().is_dir());
+        for path in ["/mounted", "/mounted/subdir"] {
+            for metadata in [
+                fs.metadata(Path::new(path)),
+                fs.symlink_metadata(Path::new(path)),
+            ] {
+                let metadata = metadata.unwrap();
+                assert!(metadata.is_dir());
+                assert!(!metadata.is_file());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn mount_preserves_existing_entries() {
+        let fs = FileSystem::default();
+        fs.insert_ro_file(Path::new("/mounted"), OwnedBuffer::from_static(b"existing"))
+            .unwrap();
+        let backing: Arc<dyn crate::FileSystem + Send + Sync> = Arc::new(FileSystem::default());
+        fs.create_dir(Path::new("/dir")).unwrap();
+        fs.create_symlink(Path::new("/mounted"), Path::new("/link"))
+            .unwrap();
+        fs.mount("/arc".into(), &backing, "/".into()).unwrap();
+        for path in ["/mounted", "/dir", "/link", "/arc"] {
+            let before = fs.symlink_metadata(Path::new(path)).unwrap();
+            assert_eq!(
+                fs.mount(path.into(), &backing, "/".into()),
+                Err(FsError::AlreadyExists)
+            );
+            assert_eq!(fs.symlink_metadata(Path::new(path)).unwrap(), before);
+        }
+        assert_eq!(fs.read_dir(Path::new("/")).unwrap().count(), 4);
+        let mut contents = String::new();
+        fs.new_open_options()
+            .read(true)
+            .open(Path::new("/mounted"))
+            .unwrap()
+            .read_to_string(&mut contents)
+            .await
+            .unwrap();
+        assert_eq!(contents, "existing");
+    }
+
     #[tokio::test]
     async fn test_merge_flat() {
         let main = FileSystem::default();
@@ -2085,9 +2133,14 @@ mod test_filesystem {
         main.mount_directory_entries(Path::new("/"), &other, Path::new("/a"))
             .unwrap();
 
-        let metadata = main.metadata(Path::new("/x")).unwrap();
-        assert!(metadata.is_dir());
-        assert!(!metadata.is_file());
+        for metadata in [
+            main.metadata(Path::new("/x")),
+            main.symlink_metadata(Path::new("/x")),
+        ] {
+            let metadata = metadata.unwrap();
+            assert!(metadata.is_dir());
+            assert!(!metadata.is_file());
+        }
 
         let entry = main
             .read_dir(Path::new("/"))
@@ -2099,6 +2152,22 @@ mod test_filesystem {
         let entry_metadata = entry.metadata.unwrap();
         assert!(entry_metadata.is_dir());
         assert!(!entry_metadata.is_file());
+
+        let entries: Vec<_> = main
+            .read_dir(Path::new("/x"))
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                let metadata = entry.metadata.unwrap();
+                assert!(metadata.is_file());
+                assert!(!metadata.is_dir());
+                entry.path
+            })
+            .collect();
+        assert_eq!(
+            entries,
+            ["/x/a.txt", "/x/b.txt", "/x/c.txt"].map(PathBuf::from)
+        );
 
         let mut buf = Vec::new();
 

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1472,6 +1472,19 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         }
     }));
 
+    tests.push(libtest_mimic::Trial::test(
+        "wasm/path/mounted-directory-metadata/legacy/cranelift",
+        {
+            let tests_dir = tests_dir.clone();
+            let tests_build_root = tests_build_root.clone();
+            move || {
+                run_legacy_mounted_directory_metadata(&tests_dir, &tests_build_root)
+                    .map(|_| ())
+                    .map_err(|e| libtest_mimic::Failed::from(format!("{e:?}")))
+            }
+        },
+    ));
+
     for entry in WalkDir::new(&tests_dir)
         .into_iter()
         .filter_map(Result::ok)
@@ -1594,6 +1607,60 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn run_legacy_mounted_directory_metadata(
+    tests_dir: &Path,
+    tests_build_root: &Path,
+) -> Result<libtest_mimic::Completion> {
+    if cfg!(target_os = "windows") {
+        return Ok(libtest_mimic::Completion::ignored_with(
+            "WASIXCC toolchain does not cover Windows yet",
+        ));
+    }
+
+    let source_dir = tests_dir.join("path/mounted-directory-metadata");
+    let mut config = Config::new(
+        PrimarySource::CSourceFile("main.c".to_owned()),
+        source_dir.clone(),
+        tests_build_root.to_path_buf(),
+        "path/mounted-directory-metadata".to_owned(),
+    );
+    config.config_name = "legacy".to_owned();
+    config.default_mapped_directories = false;
+
+    let wasm = run_build_script(&config)?;
+    let run_dir = config.build_path();
+    let backing: Arc<dyn FileSystem + Send + Sync> = Arc::new(mem_fs::FileSystem::default());
+    copy_host_tree_to_virtual_fs(&*backing, &source_dir.join("mapped"), Path::new("/"))?;
+    let front = mem_fs::FileSystem::default();
+    front.mount_directory_entries(Path::new("/"), &backing, Path::new("/"))?;
+    let front: Arc<dyn FileSystem + Send + Sync> = Arc::new(front);
+
+    let result = runner::run_wasm_with_runner_config(
+        &wasm,
+        &run_dir,
+        config.engine,
+        config.program_name.as_deref(),
+        config.default_mapped_directories,
+        move |runner| {
+            runner.with_mount("/mounted".to_owned(), front);
+            Ok(())
+        },
+    )?;
+
+    ensure!(
+        result.exit_code == 0,
+        "legacy mounted-directory metadata exited with {}\n{}",
+        result.exit_code,
+        runner::format_captured_output(&result),
+    );
+    ensure!(
+        result.stdout == b"mounted directory metadata ok\n",
+        "unexpected legacy mounted-directory output\n{}",
+        runner::format_captured_output(&result),
+    );
+    Ok(libtest_mimic::Completion::Completed)
 }
 
 fn run_dynamic_runtime_hook_smoke(

--- a/lib/wasix/tests/wasm_tests/mod.rs
+++ b/lib/wasix/tests/wasm_tests/mod.rs
@@ -1472,16 +1472,20 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
         }
     }));
 
-    tests.push(libtest_mimic::Trial::test(
-        "wasm/path/mounted-directory-metadata/legacy/cranelift",
-        {
-            let tests_dir = tests_dir.clone();
-            let tests_build_root = tests_build_root.clone();
-            move || {
-                run_legacy_mounted_directory_metadata(&tests_dir, &tests_build_root)
-                    .map(|_| ())
-                    .map_err(|e| libtest_mimic::Failed::from(format!("{e:?}")))
-            }
+    let test_name = "path/mounted-directory-metadata";
+    let mut config = Config::new(
+        PrimarySource::CSourceFile("main.c".to_owned()),
+        tests_dir.join(test_name),
+        tests_build_root.clone(),
+        test_name.to_owned(),
+    );
+    config.config_name = "legacy".to_owned();
+    config.default_mapped_directories = false;
+    tests.push(libtest_mimic::Trial::ignorable_test(
+        config.full_test_name(),
+        move || {
+            run_legacy_mounted_directory_metadata(config)
+                .map_err(|e| libtest_mimic::Failed::from(format!("{e:?}")))
         },
     ));
 
@@ -1609,30 +1613,21 @@ fn collect_tests(tests: &mut Vec<Trial>) -> Result<()> {
     Ok(())
 }
 
-fn run_legacy_mounted_directory_metadata(
-    tests_dir: &Path,
-    tests_build_root: &Path,
-) -> Result<libtest_mimic::Completion> {
+fn run_legacy_mounted_directory_metadata(config: Config) -> Result<libtest_mimic::Completion> {
     if cfg!(target_os = "windows") {
         return Ok(libtest_mimic::Completion::ignored_with(
             "WASIXCC toolchain does not cover Windows yet",
         ));
     }
 
-    let source_dir = tests_dir.join("path/mounted-directory-metadata");
-    let mut config = Config::new(
-        PrimarySource::CSourceFile("main.c".to_owned()),
-        source_dir.clone(),
-        tests_build_root.to_path_buf(),
-        "path/mounted-directory-metadata".to_owned(),
-    );
-    config.config_name = "legacy".to_owned();
-    config.default_mapped_directories = false;
-
     let wasm = run_build_script(&config)?;
     let run_dir = config.build_path();
     let backing: Arc<dyn FileSystem + Send + Sync> = Arc::new(mem_fs::FileSystem::default());
-    copy_host_tree_to_virtual_fs(&*backing, &source_dir.join("mapped"), Path::new("/"))?;
+    copy_host_tree_to_virtual_fs(
+        &*backing,
+        &config.test_src_dir.join("mapped"),
+        Path::new("/"),
+    )?;
     let front = mem_fs::FileSystem::default();
     front.mount_directory_entries(Path::new("/"), &backing, Path::new("/"))?;
     let front: Arc<dyn FileSystem + Send + Sync> = Arc::new(front);

--- a/lib/wasix/tests/wasm_tests/path/mounted-directory-metadata/main.c
+++ b/lib/wasix/tests/wasm_tests/path/mounted-directory-metadata/main.c
@@ -41,8 +41,31 @@ static int check_directory(const char* path) {
   return 0;
 }
 
+static int check_entry(const char* path, const char* name, unsigned char type) {
+  DIR* directory = opendir(path);
+  if (directory == NULL) {
+    fprintf(stderr, "opendir(%s): %s\n", path, strerror(errno));
+    return 1;
+  }
+  int found = 0;
+  struct dirent* entry;
+  while ((entry = readdir(directory)) != NULL) {
+    if (strcmp(entry->d_name, name) == 0 && entry->d_type == type) {
+      found = 1;
+    }
+  }
+  if (closedir(directory) != 0 || !found) {
+    fprintf(stderr, "readdir(%s) did not report %s with type %u\n", path, name,
+            type);
+    return 1;
+  }
+  return 0;
+}
+
 int main(void) {
-  if (check_directory("/mounted/subdir") != 0) {
+  if (check_directory("/mounted/subdir") != 0 ||
+      check_entry("/mounted", "subdir", DT_DIR) != 0 ||
+      check_entry("/mounted/subdir", "file.txt", DT_REG) != 0) {
     return 1;
   }
 
@@ -55,6 +78,20 @@ int main(void) {
     fprintf(stderr, "nested file reported mode %#o\n", st.st_mode);
     return 1;
   }
+
+  FILE* file = fopen("/mounted/subdir/file.txt", "r");
+  if (file == NULL) {
+    fprintf(stderr, "open nested file: %s\n", strerror(errno));
+    return 1;
+  }
+  char contents[64];
+  if (fgets(contents, sizeof(contents), file) == NULL ||
+      strcmp(contents, "mounted directory metadata fixture\n") != 0) {
+    fprintf(stderr, "nested file did not contain backing contents\n");
+    fclose(file);
+    return 1;
+  }
+  if (fclose(file) != 0) return 1;
 
   puts("mounted directory metadata ok");
   return 0;

--- a/lib/wasix/tests/wasm_tests/path/mounted-directory-metadata/main.c
+++ b/lib/wasix/tests/wasm_tests/path/mounted-directory-metadata/main.c
@@ -1,0 +1,61 @@
+//#Config: control
+//#MappedDirectory: mapped:/mounted
+//#DefaultMappedDirectories: false
+//#ExpectedStdout: mounted directory metadata ok
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+static int check_directory(const char* path) {
+  struct stat st;
+
+  if (stat(path, &st) != 0) {
+    fprintf(stderr, "stat(%s): %s\n", path, strerror(errno));
+    return 1;
+  }
+  if (!S_ISDIR(st.st_mode)) {
+    fprintf(stderr, "stat(%s) reported mode %#o\n", path, st.st_mode);
+    return 1;
+  }
+  if (lstat(path, &st) != 0) {
+    fprintf(stderr, "lstat(%s): %s\n", path, strerror(errno));
+    return 1;
+  }
+  if (!S_ISDIR(st.st_mode)) {
+    fprintf(stderr, "lstat(%s) reported mode %#o\n", path, st.st_mode);
+    return 1;
+  }
+
+  DIR* directory = opendir(path);
+  if (directory == NULL) {
+    fprintf(stderr, "opendir(%s): %s\n", path, strerror(errno));
+    return 1;
+  }
+  if (closedir(directory) != 0) {
+    fprintf(stderr, "closedir(%s): %s\n", path, strerror(errno));
+    return 1;
+  }
+  return 0;
+}
+
+int main(void) {
+  if (check_directory("/mounted/subdir") != 0) {
+    return 1;
+  }
+
+  struct stat st;
+  if (stat("/mounted/subdir/file.txt", &st) != 0) {
+    fprintf(stderr, "stat nested file: %s\n", strerror(errno));
+    return 1;
+  }
+  if (!S_ISREG(st.st_mode)) {
+    fprintf(stderr, "nested file reported mode %#o\n", st.st_mode);
+    return 1;
+  }
+
+  puts("mounted directory metadata ok");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/path/mounted-directory-metadata/mapped/subdir/file.txt
+++ b/lib/wasix/tests/wasm_tests/path/mounted-directory-metadata/mapped/subdir/file.txt
@@ -1,0 +1,1 @@
+mounted directory metadata fixture


### PR DESCRIPTION
# Description

Mounted directory entries now report directory metadata, so `stat`, `lstat`, and `readdir` agree with traversal through the backing filesystem. This fixes callers that reject directories after checking their mode bits.

Mounting entries into a missing destination no longer deadlocks. Mount insertion checks the target and parent under a single write lock, preventing duplicate names and preserving existing files, directories, and symlinks.
