### PR TITLE
fix(wasix): clear CLOEXEC for same-fd spawn dup2

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -2157,6 +2157,24 @@ impl WasiFs {
         src: WasiFd,
         dst: WasiFd,
     ) -> Result<Option<VirtualFileLock>, Errno> {
+        self.dup2_at_impl(src, dst, false)
+    }
+
+    /// Apply a dup2 spawn action, including its same-fd CLOEXEC semantics.
+    pub(crate) fn dup2_for_spawn(
+        &self,
+        src: WasiFd,
+        dst: WasiFd,
+    ) -> Result<Option<VirtualFileLock>, Errno> {
+        self.dup2_at_impl(src, dst, true)
+    }
+
+    fn dup2_at_impl(
+        &self,
+        src: WasiFd,
+        dst: WasiFd,
+        clear_cloexec_on_same_fd: bool,
+    ) -> Result<Option<VirtualFileLock>, Errno> {
         if dst > MAX_FD {
             return Err(Errno::Badf);
         }
@@ -2168,6 +2186,13 @@ impl WasiFs {
             Self::ensure_file_handle_present(fd_entry)?;
 
             if src == dst {
+                if clear_cloexec_on_same_fd {
+                    fd_map
+                        .get_mut(src)
+                        .unwrap()
+                        .fd_flags
+                        .set(Fdflagsext::CLOEXEC, false);
+                }
                 return Ok(None);
             }
 
@@ -2900,7 +2925,7 @@ mod tests {
     use once_cell::sync::OnceCell;
     use tempfile::tempdir;
     use virtual_fs::{RootFileSystemBuilder, TmpFileSystem};
-    use wasmer::Engine;
+    use wasmer::{Engine, Store};
     use wasmer_config::package::PackageId;
 
     use crate::WasiEnvBuilder;
@@ -2938,6 +2963,84 @@ mod tests {
         let volume = container.volumes()["atom"].clone();
 
         virtual_fs::WebcVolumeFileSystem::new(volume)
+    }
+
+    fn assert_same_fd_state(before: &Fd, after: &Fd) {
+        assert_eq!(before.inner.rights, after.inner.rights);
+        assert_eq!(
+            before.inner.rights_inheriting,
+            after.inner.rights_inheriting
+        );
+        assert_eq!(before.inner.flags, after.inner.flags);
+        assert!(Arc::ptr_eq(&before.inner.offset, &after.inner.offset));
+        assert_eq!(before.open_flags, after.open_flags);
+        assert_eq!(before.inode.ino(), after.inode.ino());
+        assert!(Arc::ptr_eq(&before.inode.inner, &after.inode.inner));
+        assert_eq!(before.is_stdio, after.is_stdio);
+    }
+
+    #[tokio::test]
+    async fn spawn_dup2_identity_is_child_local_and_preserves_fd_state() {
+        let store = Store::default();
+        let env = WasiEnvBuilder::new("test")
+            .engine(store.engine().clone())
+            .build()
+            .unwrap();
+        let parent = &env.state.fs;
+        parent.fd_map.write().unwrap().get_mut(0).unwrap().fd_flags = Fdflagsext::CLOEXEC;
+
+        let child = parent.fork();
+        let before = child.get_fd(0).unwrap();
+
+        assert_eq!(child.dup2_for_spawn(99, 0).unwrap_err(), Errno::Badf);
+        let after_invalid_source = child.get_fd(0).unwrap();
+        assert_same_fd_state(&before, &after_invalid_source);
+        assert_eq!(before.inner.fd_flags, after_invalid_source.inner.fd_flags);
+
+        assert!(child.dup2_for_spawn(0, 0).unwrap().is_none());
+        let after_spawn_action = child.get_fd(0).unwrap();
+        assert_same_fd_state(&before, &after_spawn_action);
+        let mut expected_flags = before.inner.fd_flags;
+        expected_flags.set(Fdflagsext::CLOEXEC, false);
+        assert_eq!(after_spawn_action.inner.fd_flags, expected_flags);
+        assert!(
+            parent
+                .get_fd(0)
+                .unwrap()
+                .inner
+                .fd_flags
+                .contains(Fdflagsext::CLOEXEC)
+        );
+
+        assert!(parent.dup2_at(0, 0).unwrap().is_none());
+        assert!(
+            parent
+                .get_fd(0)
+                .unwrap()
+                .inner
+                .fd_flags
+                .contains(Fdflagsext::CLOEXEC)
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_dup2_distinct_fd_keeps_existing_dup2_behavior() {
+        let store = Store::default();
+        let env = WasiEnvBuilder::new("test")
+            .engine(store.engine().clone())
+            .build()
+            .unwrap();
+        let fs = &env.state.fs;
+        fs.fd_map.write().unwrap().get_mut(0).unwrap().fd_flags = Fdflagsext::CLOEXEC;
+        let source = fs.get_fd(0).unwrap();
+
+        fs.dup2_for_spawn(0, 1).unwrap();
+
+        let target = fs.get_fd(1).unwrap();
+        assert_eq!(source.inode.ino(), target.inode.ino());
+        assert!(Arc::ptr_eq(&source.inner.offset, &target.inner.offset));
+        assert!(source.inner.fd_flags.contains(Fdflagsext::CLOEXEC));
+        assert!(!target.inner.fd_flags.contains(Fdflagsext::CLOEXEC));
     }
 
     #[tokio::test]

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -2979,6 +2979,31 @@ mod tests {
         assert_eq!(before.is_stdio, after.is_stdio);
     }
 
+    fn spawn_dup2_test_file(env: &crate::WasiEnv, name: &str) -> WasiFd {
+        let fs = &env.state.fs;
+        let inode = fs.create_inode_with_default_stat(
+            &env.state.inodes,
+            Kind::File {
+                handle: Some(Arc::new(RwLock::new(Box::new(
+                    virtual_fs::StaticFile::new(vec![b'S']),
+                )))),
+                path: name.into(),
+                fd: None,
+            },
+            false,
+            name.to_owned().into(),
+        );
+        fs.create_fd(
+            Rights::FD_READ,
+            Rights::FD_WRITE,
+            Fdflags::APPEND | Fdflags::NONBLOCK,
+            Fdflagsext::from_bits_preserve(Fdflagsext::CLOEXEC.bits() | 0x80),
+            Fd::READ,
+            inode,
+        )
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn spawn_dup2_identity_is_child_local_and_preserves_fd_state() {
         let store = Store::default();
@@ -2987,40 +3012,75 @@ mod tests {
             .build()
             .unwrap();
         let parent = &env.state.fs;
-        parent.fd_map.write().unwrap().get_mut(0).unwrap().fd_flags = Fdflagsext::CLOEXEC;
+        let fd = spawn_dup2_test_file(&env, "source");
+        let control = spawn_dup2_test_file(&env, "control");
+        let parent_before = parent.get_fd(fd).unwrap();
+        parent_before.inner.offset.store(37, Ordering::Relaxed);
+        assert!(fd > 2 && !parent_before.is_stdio && !parent_before.inode.is_preopened);
 
         let child = parent.fork();
-        let before = child.get_fd(0).unwrap();
+        let before = child.get_fd(fd).unwrap();
+        let handles = before.inode.handle_count();
 
-        assert_eq!(child.dup2_for_spawn(99, 0).unwrap_err(), Errno::Badf);
-        let after_invalid_source = child.get_fd(0).unwrap();
+        assert_eq!(child.dup2_for_spawn(99, fd).unwrap_err(), Errno::Badf);
+        assert_eq!(child.dup2_for_spawn(99, 99).unwrap_err(), Errno::Badf);
+        assert_eq!(
+            child.dup2_for_spawn(fd, MAX_FD + 1).unwrap_err(),
+            Errno::Badf
+        );
+        let after_invalid_source = child.get_fd(fd).unwrap();
         assert_same_fd_state(&before, &after_invalid_source);
         assert_eq!(before.inner.fd_flags, after_invalid_source.inner.fd_flags);
 
-        assert!(child.dup2_for_spawn(0, 0).unwrap().is_none());
-        let after_spawn_action = child.get_fd(0).unwrap();
+        assert!(child.dup2_for_spawn(fd, fd).unwrap().is_none());
+        assert!(child.dup2_for_spawn(fd, fd).unwrap().is_none());
+        let after_spawn_action = child.get_fd(fd).unwrap();
         assert_same_fd_state(&before, &after_spawn_action);
         let mut expected_flags = before.inner.fd_flags;
         expected_flags.set(Fdflagsext::CLOEXEC, false);
         assert_eq!(after_spawn_action.inner.fd_flags, expected_flags);
-        assert!(
-            parent
-                .get_fd(0)
-                .unwrap()
-                .inner
-                .fd_flags
-                .contains(Fdflagsext::CLOEXEC)
-        );
+        assert_eq!(after_spawn_action.inner.offset.load(Ordering::Relaxed), 37);
+        assert_eq!(before.inode.handle_count(), handles);
 
-        assert!(parent.dup2_at(0, 0).unwrap().is_none());
-        assert!(
-            parent
-                .get_fd(0)
-                .unwrap()
-                .inner
-                .fd_flags
-                .contains(Fdflagsext::CLOEXEC)
-        );
+        child.close_cloexec_fds().await;
+        assert_same_fd_state(&before, &child.get_fd(fd).unwrap());
+        assert_eq!(child.get_fd(control).unwrap_err(), Errno::Badf);
+        assert!(parent.get_fd(control).is_ok());
+        assert_eq!(before.inode.handle_count(), handles);
+
+        assert!(parent.dup2_at(fd, fd).unwrap().is_none());
+        let parent_after = parent.get_fd(fd).unwrap();
+        assert_same_fd_state(&parent_before, &parent_after);
+        assert_eq!(parent_before.inner.fd_flags, parent_after.inner.fd_flags);
+    }
+
+    #[tokio::test]
+    async fn spawn_dup2_rejects_a_file_without_an_open_handle() {
+        let store = Store::default();
+        let env = WasiEnvBuilder::new("test")
+            .engine(store.engine().clone())
+            .build()
+            .unwrap();
+        let fs = &env.state.fs;
+        let fd = spawn_dup2_test_file(&env, "closed");
+        let target = spawn_dup2_test_file(&env, "target");
+        let before = fs.get_fd(fd).unwrap();
+        let target_before = fs.get_fd(target).unwrap();
+        if let Kind::File { handle, .. } = &mut *before.inode.write() {
+            *handle = None;
+        } else {
+            panic!("expected a file");
+        }
+        for destination in [fd, target] {
+            assert_eq!(fs.dup2_for_spawn(fd, destination).unwrap_err(), Errno::Badf);
+        }
+        assert_eq!(fs.dup2_at(fd, fd).unwrap_err(), Errno::Badf);
+        let after = fs.get_fd(fd).unwrap();
+        let target_after = fs.get_fd(target).unwrap();
+        assert_same_fd_state(&before, &after);
+        assert_same_fd_state(&target_before, &target_after);
+        assert_eq!(before.inner.fd_flags, after.inner.fd_flags);
+        assert_eq!(target_before.inner.fd_flags, target_after.inner.fd_flags);
     }
 
     #[tokio::test]
@@ -3031,12 +3091,18 @@ mod tests {
             .build()
             .unwrap();
         let fs = &env.state.fs;
-        fs.fd_map.write().unwrap().get_mut(0).unwrap().fd_flags = Fdflagsext::CLOEXEC;
-        let source = fs.get_fd(0).unwrap();
+        let src = spawn_dup2_test_file(&env, "source");
+        let dst = spawn_dup2_test_file(&env, "target");
+        let source = fs.get_fd(src).unwrap();
+        let ordinary = fs.fork();
 
-        fs.dup2_for_spawn(0, 1).unwrap();
+        assert!(fs.dup2_for_spawn(src, dst).unwrap().is_some());
+        assert!(ordinary.dup2_at(src, dst).unwrap().is_some());
 
-        let target = fs.get_fd(1).unwrap();
+        let target = fs.get_fd(dst).unwrap();
+        let ordinary_target = ordinary.get_fd(dst).unwrap();
+        assert_same_fd_state(&ordinary_target, &target);
+        assert_eq!(ordinary_target.inner.fd_flags, target.inner.fd_flags);
         assert_eq!(source.inode.ino(), target.inode.ino());
         assert!(Arc::ptr_eq(&source.inner.offset, &target.inner.offset));
         assert!(source.inner.fd_flags.contains(Fdflagsext::CLOEXEC));

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -275,15 +275,15 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
 mod tests {
     use super::*;
     use crate::WasiEnvBuilder;
-    use wasmer::{Memory, Memory32, MemoryType, Store};
+    use wasmer::{Memory, Memory32, Memory64, MemoryType, Store};
 
-    fn dup2_op(source: WasiFd, target: WasiFd) -> ProcSpawnFdOp<Memory32> {
+    fn dup2_op<M: MemorySize>(source: WasiFd, target: WasiFd) -> ProcSpawnFdOp<M> {
         ProcSpawnFdOp {
             cmd: ProcSpawnFdOpName::Dup2,
             fd: target,
             src_fd: source,
-            name: 0,
-            name_len: 0,
+            name: Default::default(),
+            name_len: Default::default(),
             dirflags: 0,
             oflags: Oflags::empty(),
             fs_rights_base: Rights::empty(),
@@ -295,6 +295,11 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_dup2_identity_clears_cloexec() {
+        check_spawn_dup2_identity::<Memory32>();
+        check_spawn_dup2_identity::<Memory64>();
+    }
+
+    fn check_spawn_dup2_identity<M: MemorySize>() {
         let mut store = Store::default();
         let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
         let view = memory.view(&store);
@@ -311,7 +316,11 @@ mod tests {
             .unwrap()
             .fd_flags = Fdflagsext::CLOEXEC;
 
-        apply_fd_op(&mut env, &view, &dup2_op(0, 0)).unwrap();
+        assert_eq!(
+            apply_fd_op(&mut env, &view, &dup2_op::<M>(99, 99)),
+            Err(Errno::Badf)
+        );
+        apply_fd_op(&mut env, &view, &dup2_op::<M>(0, 0)).unwrap();
 
         assert!(
             !env.state

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -213,7 +213,7 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             env.state.fs.close_fd(op.fd)
         }
         ProcSpawnFdOpName::Dup2 => {
-            let flush_target = env.state.fs.dup2_at(op.src_fd, op.fd)?;
+            let flush_target = env.state.fs.dup2_for_spawn(op.src_fd, op.fd)?;
             if let Some(file) = flush_target {
                 block_on(WasiFs::flush_file_best_effort(file));
             }
@@ -268,5 +268,59 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             }
         }
         _ => Err(Errno::Inval),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::WasiEnvBuilder;
+    use wasmer::{Memory, Memory32, MemoryType, Store};
+
+    fn dup2_op(source: WasiFd, target: WasiFd) -> ProcSpawnFdOp<Memory32> {
+        ProcSpawnFdOp {
+            cmd: ProcSpawnFdOpName::Dup2,
+            fd: target,
+            src_fd: source,
+            name: 0,
+            name_len: 0,
+            dirflags: 0,
+            oflags: Oflags::empty(),
+            fs_rights_base: Rights::empty(),
+            fs_rights_inheriting: Rights::empty(),
+            fdflags: Fdflags::empty(),
+            fdflagsext: Fdflagsext::empty(),
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_dup2_identity_clears_cloexec() {
+        let mut store = Store::default();
+        let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
+        let view = memory.view(&store);
+        let mut env = WasiEnvBuilder::new("test")
+            .engine(store.engine().clone())
+            .build()
+            .unwrap();
+        env.state
+            .fs
+            .fd_map
+            .write()
+            .unwrap()
+            .get_mut(0)
+            .unwrap()
+            .fd_flags = Fdflagsext::CLOEXEC;
+
+        apply_fd_op(&mut env, &view, &dup2_op(0, 0)).unwrap();
+
+        assert!(
+            !env.state
+                .fs
+                .get_fd(0)
+                .unwrap()
+                .inner
+                .fd_flags
+                .contains(Fdflagsext::CLOEXEC)
+        );
     }
 }

--- a/lib/wasix/tests/wasm_tests/fd/proc-spawn2-dup2-same-fd-cloexec/main.c
+++ b/lib/wasix/tests/wasm_tests/fd/proc-spawn2-dup2-same-fd-cloexec/main.c
@@ -1,0 +1,214 @@
+//#Config: libc
+//#Args: libc
+//#ExpectedStdout: proc_spawn2 same-fd dup2 test passed
+//
+//#Config: raw
+//#Args: raw
+//#ExpectedStdout: proc_spawn2 same-fd dup2 test passed
+
+#include <errno.h>
+#include <fcntl.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <wasi/api_wasix.h>
+
+#define DISTINCT_FD 40
+
+enum spawn_api { SPAWN_LIBC, SPAWN_RAW };
+
+static const char* source_path = "proc_spawn2_same_fd_source";
+static const char* decoy_path = "proc_spawn2_same_fd_decoy";
+
+static int check_flags(int fd, int expected) {
+  int flags = fcntl(fd, F_GETFD, 0);
+  if (flags < 0) {
+    fprintf(stderr, "fcntl(F_GETFD, %d) failed: %s\n", fd, strerror(errno));
+    return -1;
+  }
+  if ((flags & FD_CLOEXEC) != expected) {
+    fprintf(stderr, "fd %d CLOEXEC was %d, expected %d\n", fd,
+            flags & FD_CLOEXEC, expected);
+    return -1;
+  }
+  return 0;
+}
+
+static int child_main(int argc, char** argv) {
+  if (argc != 4) {
+    fprintf(stderr, "child received %d arguments\n", argc);
+    return 1;
+  }
+
+  int fd = atoi(argv[2]);
+  if (check_flags(fd, 0) != 0) {
+    return 2;
+  }
+
+  char value = 0;
+  if (pread(fd, &value, 1, 0) != 1) {
+    fprintf(stderr, "child pread(%d) failed: %s\n", fd, strerror(errno));
+    return 3;
+  }
+  if (value != argv[3][0]) {
+    fprintf(stderr, "child read %c from fd %d, expected %c\n", value, fd,
+            argv[3][0]);
+    return 4;
+  }
+  return 0;
+}
+
+static int spawn_with_dup2(enum spawn_api api, int source, int target,
+                           char expected) {
+  char target_arg[16];
+  snprintf(target_arg, sizeof(target_arg), "%d", target);
+
+  pid_t pid = 0;
+  if (api == SPAWN_LIBC) {
+    posix_spawn_file_actions_t actions;
+    int err = posix_spawn_file_actions_init(&actions);
+    if (err != 0) {
+      fprintf(stderr, "posix_spawn_file_actions_init failed: %s\n",
+              strerror(err));
+      return -1;
+    }
+    err = posix_spawn_file_actions_adddup2(&actions, source, target);
+    if (err == 0) {
+      char expected_arg[] = {expected, '\0'};
+      char* child_argv[] = {"main", "child", target_arg, expected_arg, NULL};
+      err = posix_spawn(&pid, "./main", &actions, NULL, child_argv, NULL);
+    }
+    posix_spawn_file_actions_destroy(&actions);
+    if (err != 0) {
+      fprintf(stderr, "posix_spawn dup2(%d, %d) failed: %s\n", source, target,
+              strerror(err));
+      return -1;
+    }
+  } else {
+    __wasi_proc_spawn_fd_op_t op = {0};
+    op.cmd = __WASI_PROC_SPAWN_FD_OP_NAME_DUP2;
+    op.fd = target;
+    op.src_fd = source;
+
+    char args[64];
+    int args_len =
+        snprintf(args, sizeof(args), "main\nchild\n%d\n%c\n", target, expected);
+    if (args_len < 0 || (size_t)args_len >= sizeof(args)) {
+      fputs("failed to format raw spawn arguments\n", stderr);
+      return -1;
+    }
+
+    __wasi_pid_t raw_pid = 0;
+    __wasi_errno_t err =
+        __wasi_proc_spawn2("./main", args, "", &op, 1, 0, 0, 0, "", &raw_pid);
+    if (err != __WASI_ERRNO_SUCCESS) {
+      fprintf(stderr, "proc_spawn2 dup2(%d, %d) failed: %u\n", source, target,
+              (unsigned)err);
+      return -1;
+    }
+    pid = (pid_t)raw_pid;
+  }
+
+  int status = 0;
+  if (waitpid(pid, &status, 0) != pid) {
+    fprintf(stderr, "waitpid failed: %s\n", strerror(errno));
+    return -1;
+  }
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+    fprintf(stderr, "child exited with status %d\n", status);
+    return -1;
+  }
+  return 0;
+}
+
+static int parent_main(enum spawn_api api) {
+  unlink(source_path);
+  unlink(decoy_path);
+
+  int source = open(source_path, O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, 0600);
+  if (source < 3 || write(source, "S", 1) != 1) {
+    fprintf(stderr, "failed to create source fd: %s\n", strerror(errno));
+    return 1;
+  }
+
+  if (dup2(source, source) != source || check_flags(source, FD_CLOEXEC) != 0) {
+    fputs("ordinary same-fd dup2 changed descriptor flags\n", stderr);
+    return 2;
+  }
+  if (spawn_with_dup2(api, source, source, 'S') != 0) {
+    fputs("same-fd spawn action failed\n", stderr);
+    return 3;
+  }
+  if (check_flags(source, FD_CLOEXEC) != 0) {
+    fputs("same-fd spawn action changed the parent descriptor\n", stderr);
+    return 3;
+  }
+
+  if (__wasi_fd_fdflags_set(source, 0) != __WASI_ERRNO_SUCCESS ||
+      check_flags(source, 0) != 0) {
+    fputs("failed to clear CLOEXEC for the control case\n", stderr);
+    return 4;
+  }
+  if (spawn_with_dup2(api, source, source, 'S') != 0 ||
+      check_flags(source, 0) != 0) {
+    fputs("same-fd spawn action failed for an already-clear descriptor\n",
+          stderr);
+    return 4;
+  }
+
+  if (__wasi_fd_fdflags_set(source, __WASI_FDFLAGSEXT_CLOEXEC) !=
+      __WASI_ERRNO_SUCCESS) {
+    fprintf(stderr, "failed to restore source CLOEXEC: %s\n", strerror(errno));
+    return 5;
+  }
+  int decoy = open(decoy_path, O_CREAT | O_TRUNC | O_RDWR, 0600);
+  if (decoy < 0 || write(decoy, "D", 1) != 1 ||
+      dup2(decoy, DISTINCT_FD) != DISTINCT_FD) {
+    fprintf(stderr, "failed to create distinct target fd: %s\n",
+            strerror(errno));
+    return 6;
+  }
+  close(decoy);
+
+  if (spawn_with_dup2(api, source, DISTINCT_FD, 'S') != 0) {
+    fputs("distinct-fd spawn action failed\n", stderr);
+    return 7;
+  }
+  if (check_flags(source, FD_CLOEXEC) != 0) {
+    fputs("distinct-fd spawn action changed the parent source\n", stderr);
+    return 7;
+  }
+  char parent_value = 0;
+  if (pread(DISTINCT_FD, &parent_value, 1, 0) != 1 || parent_value != 'D') {
+    fputs("distinct-fd spawn action changed the parent target\n", stderr);
+    return 8;
+  }
+
+  close(DISTINCT_FD);
+  close(source);
+  unlink(source_path);
+  unlink(decoy_path);
+  puts("proc_spawn2 same-fd dup2 test passed");
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  if (argc >= 2 && strcmp(argv[1], "child") == 0) {
+    return child_main(argc, argv);
+  }
+  if (argc != 2) {
+    fputs("expected libc or raw argument\n", stderr);
+    return 1;
+  }
+  if (strcmp(argv[1], "libc") == 0) {
+    return parent_main(SPAWN_LIBC);
+  }
+  if (strcmp(argv[1], "raw") == 0) {
+    return parent_main(SPAWN_RAW);
+  }
+  fputs("unknown spawn API\n", stderr);
+  return 1;
+}

--- a/lib/wasix/tests/wasm_tests/fd/proc-spawn2-dup2-same-fd-cloexec/main.c
+++ b/lib/wasix/tests/wasm_tests/fd/proc-spawn2-dup2-same-fd-cloexec/main.c
@@ -147,9 +147,12 @@ static int parent_main(enum spawn_api api) {
     return 3;
   }
 
-  if (__wasi_fd_fdflags_set(source, 0) != __WASI_ERRNO_SUCCESS ||
-      check_flags(source, 0) != 0) {
-    fputs("failed to clear CLOEXEC for the control case\n", stderr);
+  __wasi_errno_t err = __wasi_fd_fdflags_set(source, 0);
+  if (err != __WASI_ERRNO_SUCCESS) {
+    fprintf(stderr, "failed to clear source CLOEXEC: %u\n", (unsigned)err);
+    return 4;
+  }
+  if (check_flags(source, 0) != 0) {
     return 4;
   }
   if (spawn_with_dup2(api, source, source, 'S') != 0 ||
@@ -159,9 +162,9 @@ static int parent_main(enum spawn_api api) {
     return 4;
   }
 
-  if (__wasi_fd_fdflags_set(source, __WASI_FDFLAGSEXT_CLOEXEC) !=
-      __WASI_ERRNO_SUCCESS) {
-    fprintf(stderr, "failed to restore source CLOEXEC: %s\n", strerror(errno));
+  err = __wasi_fd_fdflags_set(source, __WASI_FDFLAGSEXT_CLOEXEC);
+  if (err != __WASI_ERRNO_SUCCESS) {
+    fprintf(stderr, "failed to restore source CLOEXEC: %u\n", (unsigned)err);
     return 5;
   }
   int decoy = open(decoy_path, O_CREAT | O_TRUNC | O_RDWR, 0600);


### PR DESCRIPTION
# Description

Clear `FD_CLOEXEC` when a spawn file action duplicates a descriptor onto itself, so it survives child startup. Unlike ordinary `dup2(fd, fd)`, a spawn identity action must make the descriptor inheritable.

Spawn actions use the shared dup2 implementation with source validation and flag clearing under one descriptor-map lock. Only the forked child’s descriptor flag changes; ordinary identity dup2, distinct-descriptor replacement, and flushing after the lock is released keep their existing behavior.
