### PR TITLE
wasix: preserve IPV6_V6ONLY for UDP sockets

### DIFF
--- a/lib/cli/src/commands/run/capabilities/net.rs
+++ b/lib/cli/src/commands/run/capabilities/net.rs
@@ -275,10 +275,11 @@ impl VirtualNetworking for AskingNetworking {
     async fn bind_udp(
         &self,
         addr: SocketAddr,
+        only_v6: bool,
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
-        call!(self, bind_udp, addr, reuse_port, reuse_addr);
+        call!(self, bind_udp, addr, only_v6, reuse_port, reuse_addr);
     }
 
     /// Creates a socket that can be used to send and receive ICMP packets
@@ -304,5 +305,51 @@ impl VirtualNetworking for AskingNetworking {
         dns_server: Option<IpAddr>,
     ) -> Result<Vec<IpAddr>> {
         call!(self, resolve, host, port, dns_server);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct RecordingNetworking {
+        udp_binds: Mutex<Vec<(SocketAddr, bool, bool, bool)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl VirtualNetworking for RecordingNetworking {
+        async fn bind_udp(
+            &self,
+            addr: SocketAddr,
+            only_v6: bool,
+            reuse_port: bool,
+            reuse_addr: bool,
+        ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
+            self.udp_binds
+                .lock()
+                .unwrap()
+                .push((addr, only_v6, reuse_port, reuse_addr));
+            Err(NetworkError::Unsupported)
+        }
+    }
+
+    #[tokio::test]
+    async fn network_capability_gate_preserves_udp_v6only() {
+        let capable = Arc::new(RecordingNetworking::default());
+        let networking = AskingNetworking::new(PathBuf::new(), capable.clone());
+        networking.enable.set(Ok(true)).unwrap();
+        let addr = "[::]:41005".parse().unwrap();
+
+        assert!(matches!(
+            networking.bind_udp(addr, true, false, true).await,
+            Err(NetworkError::Unsupported)
+        ));
+        assert_eq!(
+            capable.udp_binds.lock().unwrap().as_slice(),
+            &[(addr, true, false, true)]
+        );
     }
 }

--- a/lib/virtual-net/Cargo.toml
+++ b/lib/virtual-net/Cargo.toml
@@ -47,6 +47,7 @@ features = ["proto-ipv4", "std", "alloc"]
 tokio = { workspace = true, default-features = false, features = [
   "macros",
   "rt-multi-thread",
+  "time",
 ] }
 tracing-test.workspace = true
 serial_test.workspace = true

--- a/lib/virtual-net/src/client.rs
+++ b/lib/virtual-net/src/client.rs
@@ -798,6 +798,7 @@ impl VirtualNetworking for RemoteNetworkingClient {
     async fn bind_udp(
         &self,
         addr: SocketAddr,
+        only_v6: bool,
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
@@ -806,16 +807,23 @@ impl VirtualNetworking for RemoteNetworkingClient {
             .socket_seed
             .fetch_add(1, Ordering::SeqCst)
             .into();
-        match self
-            .common
-            .io_iface(RequestType::BindUdp {
+        let request = if only_v6 {
+            RequestType::BindUdpV2 {
+                socket_id,
+                addr,
+                only_v6,
+                reuse_port,
+                reuse_addr,
+            }
+        } else {
+            RequestType::BindUdp {
                 socket_id,
                 addr,
                 reuse_port,
                 reuse_addr,
-            })
-            .await
-        {
+            }
+        };
+        match self.common.io_iface(request).await {
             ResponseType::Err(err) => Err(err),
             ResponseType::None => Ok(Box::new(self.new_socket(socket_id))),
             ResponseType::Socket(socket_id) => Ok(Box::new(self.new_socket(socket_id))),

--- a/lib/virtual-net/src/host.rs
+++ b/lib/virtual-net/src/host.rs
@@ -173,10 +173,10 @@ impl VirtualNetworking for LocalNetworking {
     async fn bind_udp(
         &self,
         addr: SocketAddr,
+        only_v6: bool,
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
-        #[cfg(not(windows))]
         use socket2::{Domain, Socket, Type};
 
         if let Some(ruleset) = self.ruleset.as_ref()
@@ -186,7 +186,6 @@ impl VirtualNetworking for LocalNetworking {
             return Err(NetworkError::PermissionDenied);
         }
 
-        #[cfg(not(windows))]
         let socket = {
             let domain = if addr.is_ipv4() {
                 Domain::IPV4
@@ -194,20 +193,26 @@ impl VirtualNetworking for LocalNetworking {
                 Domain::IPV6
             };
             let std_sock = Socket::new(domain, Type::DGRAM, None).map_err(io_err_into_net_error)?;
+            if addr.is_ipv6() {
+                std_sock
+                    .set_only_v6(only_v6)
+                    .map_err(io_err_into_net_error)?;
+            }
             std_sock
                 .set_nonblocking(true)
                 .map_err(io_err_into_net_error)?;
-            std_sock
-                .set_reuse_address(reuse_addr)
-                .map_err(io_err_into_net_error)?;
-            std_sock
-                .set_reuse_port(reuse_port)
-                .map_err(io_err_into_net_error)?;
+            #[cfg(not(windows))]
+            {
+                std_sock
+                    .set_reuse_address(reuse_addr)
+                    .map_err(io_err_into_net_error)?;
+                std_sock
+                    .set_reuse_port(reuse_port)
+                    .map_err(io_err_into_net_error)?;
+            }
             std_sock.bind(&addr.into()).map_err(io_err_into_net_error)?;
             mio::net::UdpSocket::from_std(std_sock.into())
         };
-        #[cfg(windows)]
-        let socket = mio::net::UdpSocket::bind(addr).map_err(io_err_into_net_error)?;
 
         #[allow(unused_mut)]
         let mut ret = LocalUdpSocket {

--- a/lib/virtual-net/src/lib.rs
+++ b/lib/virtual-net/src/lib.rs
@@ -205,6 +205,7 @@ pub trait VirtualNetworking: fmt::Debug + Send + Sync + 'static {
     async fn bind_udp(
         &self,
         addr: SocketAddr,
+        only_v6: bool,
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {

--- a/lib/virtual-net/src/meta.rs
+++ b/lib/virtual-net/src/meta.rs
@@ -357,7 +357,7 @@ pub enum MessageResponse {
     },
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "remote"))]
 mod wire_tests {
     use std::pin::Pin;
 
@@ -385,6 +385,49 @@ mod wire_tests {
         frame
     }
 
+    async fn assert_server_accepts_legacy_frame(frame: &[u8], format: FrameSerializationFormat) {
+        use std::sync::{Arc, Mutex};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        #[derive(Debug, Default)]
+        struct RecordingNetworking(Mutex<Vec<(SocketAddr, bool, bool, bool)>>);
+
+        #[async_trait::async_trait]
+        impl crate::VirtualNetworking for RecordingNetworking {
+            async fn bind_udp(
+                &self,
+                addr: SocketAddr,
+                only_v6: bool,
+                reuse_port: bool,
+                reuse_addr: bool,
+            ) -> crate::Result<Box<dyn crate::VirtualUdpSocket + Sync>> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push((addr, only_v6, reuse_port, reuse_addr));
+                Err(NetworkError::Unsupported)
+            }
+        }
+
+        let networking = Arc::new(RecordingNetworking::default());
+        let (mut peer, transport) = tokio::io::duplex(1024);
+        let (rx, tx) = tokio::io::split(transport);
+        let (_server, driver) =
+            crate::RemoteNetworkingServer::new_from_async_io(tx, rx, format, networking.clone());
+        let driver = tokio::spawn(driver);
+        peer.write_all(frame).await.unwrap();
+        let response_length = tokio::time::timeout(Duration::from_secs(2), peer.read_u32())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(response_length > 0);
+        assert_eq!(
+            networking.0.lock().unwrap().as_slice(),
+            &[("[2001:db8::1234]:4242".parse().unwrap(), false, true, false)],
+        );
+        driver.abort();
+    }
+
     fn assert_legacy_bind_udp(request: MessageRequest) {
         let MessageRequest::Interface {
             req:
@@ -406,8 +449,8 @@ mod wire_tests {
         assert_eq!(req_id, Some(0x1112_1314_1516_1718));
     }
 
-    #[test]
-    fn legacy_bind_udp_bincode_frame_is_stable() {
+    #[tokio::test]
+    async fn legacy_bind_udp_bincode_frame_is_stable() {
         const FRAME: &[u8] = &[
             0, 0, 0, 43, 0, 17, 253, 8, 7, 6, 5, 4, 3, 2, 1, 1, 32, 1, 13, 184, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 18, 52, 251, 146, 16, 1, 0, 1, 253, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -420,11 +463,12 @@ mod wire_tests {
         let payload = BytesMut::from(&FRAME[4..]);
         let decoded = Pin::new(&mut bincode).deserialize(&payload).unwrap();
         assert_legacy_bind_udp(decoded);
+        assert_server_accepts_legacy_frame(FRAME, FrameSerializationFormat::Bincode).await;
     }
 
     #[cfg(feature = "messagepack")]
-    #[test]
-    fn legacy_bind_udp_messagepack_frame_is_stable() {
+    #[tokio::test]
+    async fn legacy_bind_udp_messagepack_frame_is_stable() {
         use tokio_serde::formats::SymmetricalMessagePack;
 
         const FRAME: &[u8] = &[
@@ -441,5 +485,6 @@ mod wire_tests {
         let payload = BytesMut::from(&FRAME[4..]);
         let decoded = Pin::new(&mut messagepack).deserialize(&payload).unwrap();
         assert_legacy_bind_udp(decoded);
+        assert_server_accepts_legacy_frame(FRAME, FrameSerializationFormat::MessagePack).await;
     }
 }

--- a/lib/virtual-net/src/meta.rs
+++ b/lib/virtual-net/src/meta.rs
@@ -251,6 +251,14 @@ pub enum RequestType {
     /// Tells this interface that it will unsubscribe to a
     /// particular multicast address. This applies to IPv6 addresses
     LeaveMulticastV6 { multiaddr: Ipv6Addr, iface: u32 },
+    /// Binds a UDP socket with explicit IPv6-only behavior.
+    BindUdpV2 {
+        socket_id: SocketId,
+        addr: SocketAddr,
+        only_v6: bool,
+        reuse_port: bool,
+        reuse_addr: bool,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -347,4 +355,91 @@ pub enum MessageResponse {
     Closed {
         socket_id: SocketId,
     },
+}
+
+#[cfg(test)]
+mod wire_tests {
+    use std::pin::Pin;
+
+    use bytes::BytesMut;
+    use tokio_serde::{Deserializer, Serializer, formats::SymmetricalBincode};
+
+    use super::*;
+
+    fn legacy_bind_udp_request() -> MessageRequest {
+        MessageRequest::Interface {
+            req: RequestType::BindUdp {
+                socket_id: 0x0102_0304_0506_0708_u64.into(),
+                addr: "[2001:db8::1234]:4242".parse().unwrap(),
+                reuse_port: true,
+                reuse_addr: false,
+            },
+            req_id: Some(0x1112_1314_1516_1718),
+        }
+    }
+
+    fn frame(payload: &[u8]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(4 + payload.len());
+        frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    fn assert_legacy_bind_udp(request: MessageRequest) {
+        let MessageRequest::Interface {
+            req:
+                RequestType::BindUdp {
+                    socket_id,
+                    addr,
+                    reuse_port,
+                    reuse_addr,
+                },
+            req_id,
+        } = request
+        else {
+            panic!("expected legacy BindUdp interface request");
+        };
+        assert_eq!(socket_id, 0x0102_0304_0506_0708_u64.into());
+        assert_eq!(addr, "[2001:db8::1234]:4242".parse::<SocketAddr>().unwrap());
+        assert!(reuse_port);
+        assert!(!reuse_addr);
+        assert_eq!(req_id, Some(0x1112_1314_1516_1718));
+    }
+
+    #[test]
+    fn legacy_bind_udp_bincode_frame_is_stable() {
+        const FRAME: &[u8] = &[
+            0, 0, 0, 43, 0, 17, 253, 8, 7, 6, 5, 4, 3, 2, 1, 1, 32, 1, 13, 184, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 18, 52, 251, 146, 16, 1, 0, 1, 253, 24, 23, 22, 21, 20, 19, 18, 17,
+        ];
+        let request = legacy_bind_udp_request();
+        let mut bincode = SymmetricalBincode::<MessageRequest>::default();
+        let bytes = Pin::new(&mut bincode).serialize(&request).unwrap();
+        assert_eq!(frame(&bytes), FRAME);
+
+        let payload = BytesMut::from(&FRAME[4..]);
+        let decoded = Pin::new(&mut bincode).deserialize(&payload).unwrap();
+        assert_legacy_bind_udp(decoded);
+    }
+
+    #[cfg(feature = "messagepack")]
+    #[test]
+    fn legacy_bind_udp_messagepack_frame_is_stable() {
+        use tokio_serde::formats::SymmetricalMessagePack;
+
+        const FRAME: &[u8] = &[
+            0, 0, 0, 70, 129, 169, 73, 110, 116, 101, 114, 102, 97, 99, 101, 146, 129, 167, 66,
+            105, 110, 100, 85, 100, 112, 148, 207, 1, 2, 3, 4, 5, 6, 7, 8, 129, 162, 86, 54, 146,
+            220, 0, 16, 32, 1, 13, 204, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 52, 205, 16, 146,
+            195, 194, 207, 17, 18, 19, 20, 21, 22, 23, 24,
+        ];
+        let request = legacy_bind_udp_request();
+        let mut messagepack = SymmetricalMessagePack::<MessageRequest>::default();
+        let bytes = Pin::new(&mut messagepack).serialize(&request).unwrap();
+        assert_eq!(frame(&bytes), FRAME);
+
+        let payload = BytesMut::from(&FRAME[4..]);
+        let decoded = Pin::new(&mut messagepack).deserialize(&payload).unwrap();
+        assert_legacy_bind_udp(decoded);
+    }
 }

--- a/lib/virtual-net/src/rx_tx.rs
+++ b/lib/virtual-net/src/rx_tx.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use crate::Result;
+#[cfg(any(feature = "hyper", feature = "tokio-tungstenite"))]
 use bincode::config;
+#[cfg(any(feature = "hyper", feature = "tokio-tungstenite"))]
 use bytes::Bytes;
 use futures_util::{Future, Sink, SinkExt, Stream, future::BoxFuture};
 #[cfg(feature = "hyper")]

--- a/lib/virtual-net/src/server.rs
+++ b/lib/virtual-net/src/server.rs
@@ -281,10 +281,13 @@ impl VirtualNetworking for RemoteNetworkingServer {
     async fn bind_udp(
         &self,
         addr: SocketAddr,
+        only_v6: bool,
         reuse_port: bool,
         reuse_addr: bool,
     ) -> Result<Box<dyn VirtualUdpSocket + Sync>, NetworkError> {
-        self.inner.bind_udp(addr, reuse_port, reuse_addr).await
+        self.inner
+            .bind_udp(addr, only_v6, reuse_port, reuse_addr)
+            .await
     }
 
     async fn bind_icmp(
@@ -561,6 +564,28 @@ impl RemoteNetworkingServerDriver {
         )
     }
 
+    fn process_bind_udp(
+        &self,
+        socket_id: SocketId,
+        addr: SocketAddr,
+        only_v6: bool,
+        reuse_port: bool,
+        reuse_addr: bool,
+        req_id: Option<u64>,
+    ) -> BackgroundTask {
+        self.process_async_new_socket(
+            move |inner: Arc<dyn VirtualNetworking + Send + Sync>| async move {
+                Ok(RemoteAdapterSocket::UdpSocket(
+                    inner
+                        .bind_udp(addr, only_v6, reuse_port, reuse_addr)
+                        .await?,
+                ))
+            },
+            socket_id,
+            req_id,
+        )
+    }
+
     fn process_inner<F, R, T>(
         &self,
         work: F,
@@ -803,15 +828,14 @@ impl RemoteNetworkingServerDriver {
                 addr,
                 reuse_port,
                 reuse_addr,
-            } => self.process_async_new_socket(
-                move |inner: Arc<dyn VirtualNetworking + Send + Sync>| async move {
-                    Ok(RemoteAdapterSocket::UdpSocket(
-                        inner.bind_udp(addr, reuse_port, reuse_addr).await?,
-                    ))
-                },
+            } => self.process_bind_udp(socket_id, addr, false, reuse_port, reuse_addr, req_id),
+            RequestType::BindUdpV2 {
                 socket_id,
-                req_id,
-            ),
+                addr,
+                only_v6,
+                reuse_port,
+                reuse_addr,
+            } => self.process_bind_udp(socket_id, addr, only_v6, reuse_port, reuse_addr, req_id),
             RequestType::BindIcmp { socket_id, addr } => self.process_async_new_socket(
                 move |inner: Arc<dyn VirtualNetworking + Send + Sync>| async move {
                     Ok(RemoteAdapterSocket::IcmpSocket(

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -1,7 +1,10 @@
 #![allow(unused)]
 use std::{
-    net::{Ipv4Addr, SocketAddrV4},
-    sync::atomic::{AtomicU16, Ordering},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU16, Ordering},
+    },
 };
 
 use tracing_test::traced_test;
@@ -16,8 +19,63 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::*;
 
+#[cfg(feature = "host-net")]
+#[tokio::test]
+#[serial_test::serial]
+async fn test_udp_only_v6_controls_ipv4_co_bind() {
+    let net = LocalNetworking::new();
+    let ipv6 = net
+        .bind_udp(
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)),
+            true,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let port = ipv6.addr_local().unwrap().port();
+    let ipv4 = net
+        .bind_udp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, port)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    drop((ipv4, ipv6));
+
+    let dual_stack = net
+        .bind_udp(
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)),
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+    let port = dual_stack.addr_local().unwrap().port();
+    assert!(matches!(
+        net.bind_udp(
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, port)),
+            false,
+            false,
+            false,
+        )
+        .await,
+        Err(NetworkError::AddressInUse)
+    ));
+}
+
 #[cfg(feature = "remote")]
 async fn setup_mpsc() -> (RemoteNetworkingClient, RemoteNetworkingServer) {
+    setup_mpsc_with_networking(Arc::new(LocalNetworking::new())).await
+}
+
+#[cfg(feature = "remote")]
+async fn setup_mpsc_with_networking(
+    networking: Arc<dyn VirtualNetworking + Send + Sync>,
+) -> (RemoteNetworkingClient, RemoteNetworkingServer) {
     tracing::info!("building MPSC channels");
     let (tx1, rx1) = tokio::sync::mpsc::channel(100);
     let (tx2, rx2) = tokio::sync::mpsc::channel(100);
@@ -28,12 +86,8 @@ async fn setup_mpsc() -> (RemoteNetworkingClient, RemoteNetworkingServer) {
     tracing::info!("spawning driver for remote client");
     tokio::task::spawn(client_driver);
 
-    tracing::info!("create local networking provider");
-    let local_networking = LocalNetworking::new();
-
     tracing::info!("constructing remote server (mpsc)");
-    let (server, server_driver) =
-        RemoteNetworkingServer::new_from_mpsc(tx2, rx1, Arc::new(local_networking));
+    let (server, server_driver) = RemoteNetworkingServer::new_from_mpsc(tx2, rx1, networking);
 
     tracing::info!("spawning driver for remote server");
     tokio::task::spawn(server_driver);
@@ -46,6 +100,15 @@ async fn setup_pipe(
     buf_size: usize,
     format: FrameSerializationFormat,
 ) -> (RemoteNetworkingClient, RemoteNetworkingServer) {
+    setup_pipe_with_networking(buf_size, format, Arc::new(LocalNetworking::new())).await
+}
+
+#[cfg(feature = "remote")]
+async fn setup_pipe_with_networking(
+    buf_size: usize,
+    format: FrameSerializationFormat,
+    networking: Arc<dyn VirtualNetworking + Send + Sync>,
+) -> (RemoteNetworkingClient, RemoteNetworkingServer) {
     tracing::info!("building duplex streams");
     let (tx1, rx1) = tokio::io::duplex(buf_size);
     let (tx2, rx2) = tokio::io::duplex(buf_size);
@@ -56,17 +119,143 @@ async fn setup_pipe(
     tracing::info!("spawning driver for remote client");
     tokio::task::spawn(client_driver);
 
-    tracing::info!("create local networking provider");
-    let local_networking = LocalNetworking::new();
-
     tracing::info!("constructing remote server (mpsc)");
     let (server, server_driver) =
-        RemoteNetworkingServer::new_from_async_io(tx2, rx1, format, Arc::new(local_networking));
+        RemoteNetworkingServer::new_from_async_io(tx2, rx1, format, networking);
 
     tracing::info!("spawning driver for remote server");
     tokio::task::spawn(server_driver);
 
     (client, server)
+}
+
+#[cfg(feature = "remote")]
+#[derive(Debug, Default)]
+struct RecordingUdpNetworking {
+    binds: Mutex<Vec<(SocketAddr, bool, bool, bool)>>,
+}
+
+#[cfg(feature = "remote")]
+#[async_trait::async_trait]
+impl VirtualNetworking for RecordingUdpNetworking {
+    async fn bind_udp(
+        &self,
+        addr: SocketAddr,
+        only_v6: bool,
+        reuse_port: bool,
+        reuse_addr: bool,
+    ) -> Result<Box<dyn VirtualUdpSocket + Sync>> {
+        self.binds
+            .lock()
+            .unwrap()
+            .push((addr, only_v6, reuse_port, reuse_addr));
+        Err(NetworkError::Unsupported)
+    }
+}
+
+#[cfg(feature = "remote")]
+async fn test_remote_udp_v6only(
+    client: RemoteNetworkingClient,
+    _server: RemoteNetworkingServer,
+    networking: Arc<RecordingUdpNetworking>,
+) {
+    let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 41003));
+    assert!(matches!(
+        client.bind_udp(addr, true, false, true).await,
+        Err(NetworkError::Unsupported)
+    ));
+    assert_eq!(
+        networking.binds.lock().unwrap().as_slice(),
+        &[(addr, true, false, true)]
+    );
+}
+
+#[cfg(feature = "remote")]
+#[tokio::test]
+async fn test_remote_udp_v6only_with_mpsc() {
+    let networking = Arc::new(RecordingUdpNetworking::default());
+    let (client, server) = setup_mpsc_with_networking(networking.clone()).await;
+    test_remote_udp_v6only(client, server, networking).await;
+}
+
+#[cfg(feature = "remote")]
+#[tokio::test]
+async fn test_remote_udp_v6only_with_bincode() {
+    let networking = Arc::new(RecordingUdpNetworking::default());
+    let (client, server) =
+        setup_pipe_with_networking(1024, FrameSerializationFormat::Bincode, networking.clone())
+            .await;
+    test_remote_udp_v6only(client, server, networking).await;
+}
+
+#[cfg(all(feature = "remote", feature = "json"))]
+#[tokio::test]
+async fn test_remote_udp_v6only_with_json() {
+    let networking = Arc::new(RecordingUdpNetworking::default());
+    let (client, server) =
+        setup_pipe_with_networking(1024, FrameSerializationFormat::Json, networking.clone()).await;
+    test_remote_udp_v6only(client, server, networking).await;
+}
+
+#[cfg(all(feature = "remote", feature = "messagepack"))]
+#[tokio::test]
+async fn test_remote_udp_v6only_with_messagepack() {
+    let networking = Arc::new(RecordingUdpNetworking::default());
+    let (client, server) = setup_pipe_with_networking(
+        1024,
+        FrameSerializationFormat::MessagePack,
+        networking.clone(),
+    )
+    .await;
+    test_remote_udp_v6only(client, server, networking).await;
+}
+
+#[cfg(all(feature = "remote", feature = "cbor"))]
+#[tokio::test]
+async fn test_remote_udp_v6only_with_cbor() {
+    let networking = Arc::new(RecordingUdpNetworking::default());
+    let (client, server) =
+        setup_pipe_with_networking(1024, FrameSerializationFormat::Cbor, networking.clone()).await;
+    test_remote_udp_v6only(client, server, networking).await;
+}
+
+#[cfg(feature = "remote")]
+#[tokio::test]
+async fn test_remote_udp_dual_stack_uses_legacy_request() {
+    use crate::meta::{MessageRequest, MessageResponse, RequestType, ResponseType};
+
+    let (request_tx, mut request_rx) = tokio::sync::mpsc::channel(1);
+    let (response_tx, response_rx) = tokio::sync::mpsc::channel(1);
+    let (client, driver) = RemoteNetworkingClient::new_from_mpsc(request_tx, response_rx);
+    tokio::spawn(driver);
+
+    let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 41004));
+    let request = tokio::spawn(async move { client.bind_udp(addr, false, true, false).await });
+    let MessageRequest::Interface {
+        req:
+            RequestType::BindUdp {
+                socket_id,
+                addr: request_addr,
+                reuse_port,
+                reuse_addr,
+            },
+        req_id: Some(req_id),
+    } = request_rx.recv().await.unwrap()
+    else {
+        panic!("dual-stack UDP bind did not use the legacy request");
+    };
+    assert_eq!(request_addr, addr);
+    assert!(reuse_port);
+    assert!(!reuse_addr);
+
+    response_tx
+        .send(MessageResponse::ResponseToRequest {
+            req_id,
+            res: ResponseType::Socket(socket_id),
+        })
+        .await
+        .unwrap();
+    assert!(request.await.unwrap().is_ok());
 }
 
 #[cfg(feature = "remote")]

--- a/lib/virtual-net/src/tests.rs
+++ b/lib/virtual-net/src/tests.rs
@@ -24,6 +24,18 @@ use super::*;
 #[serial_test::serial]
 async fn test_udp_only_v6_controls_ipv4_co_bind() {
     let net = LocalNetworking::new();
+    for only_v6 in [true, false] {
+        let ipv4 = net
+            .bind_udp(
+                SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+                only_v6,
+                false,
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(ipv4.addr_local().unwrap().is_ipv4());
+    }
     let ipv6 = net
         .bind_udp(
             SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)),
@@ -156,18 +168,140 @@ impl VirtualNetworking for RecordingUdpNetworking {
 #[cfg(feature = "remote")]
 async fn test_remote_udp_v6only(
     client: RemoteNetworkingClient,
-    _server: RemoteNetworkingServer,
+    server: RemoteNetworkingServer,
     networking: Arc<RecordingUdpNetworking>,
 ) {
     let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, 41003));
-    assert!(matches!(
-        client.bind_udp(addr, true, false, true).await,
-        Err(NetworkError::Unsupported)
-    ));
+    for only_v6 in [true, false] {
+        assert!(matches!(
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                client.bind_udp(addr, only_v6, !only_v6, only_v6),
+            )
+            .await
+            .unwrap(),
+            Err(NetworkError::Unsupported)
+        ));
+        assert_eq!(server.socket_count_for_test(), 0);
+    }
     assert_eq!(
         networking.binds.lock().unwrap().as_slice(),
-        &[(addr, true, false, true)]
+        &[(addr, true, false, true), (addr, false, true, false)]
     );
+}
+
+#[cfg(all(feature = "remote", feature = "host-net"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remote_udp_success_preserves_ipv6_binding() {
+    let (client, _server) = setup_pipe(1024, FrameSerializationFormat::Bincode).await;
+    for only_v6 in [true, false] {
+        let socket = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            client.bind_udp("[::]:0".parse().unwrap(), only_v6, false, false),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let (socket, port) = tokio::task::spawn_blocking(move || {
+            let port = socket.addr_local().unwrap().port();
+            (socket, port)
+        })
+        .await
+        .unwrap();
+        let ipv4 = LocalNetworking::new()
+            .bind_udp(
+                SocketAddr::from((Ipv4Addr::UNSPECIFIED, port)),
+                false,
+                false,
+                false,
+            )
+            .await;
+        if only_v6 {
+            assert!(ipv4.is_ok());
+        } else {
+            assert!(matches!(ipv4, Err(NetworkError::AddressInUse)));
+        }
+        drop(socket);
+    }
+}
+
+#[cfg(all(feature = "remote", feature = "tokio-tungstenite"))]
+#[tokio::test]
+async fn test_remote_udp_websocket_uses_legacy_bincode() {
+    use crate::meta::{MessageRequest, MessageResponse, RequestType, ResponseType};
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::{
+        MaybeTlsStream, WebSocketStream,
+        tungstenite::{Message, protocol::Role},
+    };
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let (connection, accepted) = tokio::join!(
+        tokio::net::TcpStream::connect(listener.local_addr().unwrap()),
+        listener.accept(),
+    );
+    let transport = WebSocketStream::from_raw_socket(
+        MaybeTlsStream::Plain(connection.unwrap()),
+        Role::Client,
+        None,
+    )
+    .await;
+    let mut peer = WebSocketStream::from_raw_socket(accepted.unwrap().0, Role::Server, None).await;
+    let (tx, rx) = transport.split();
+    let (client, driver) =
+        RemoteNetworkingClient::new_from_tokio_ws_io(tx, rx, FrameSerializationFormat::Bincode);
+    let driver = tokio::spawn(driver);
+    let exchange = async {
+        for only_v6 in [false, true] {
+            let bind = client.bind_udp(
+                "[2001:db8::1234]:4242".parse().unwrap(),
+                only_v6,
+                true,
+                false,
+            );
+            let respond = async {
+                let Message::Binary(bytes) = peer.next().await.unwrap().unwrap() else {
+                    panic!("expected binary WebSocket frame");
+                };
+                if !only_v6 {
+                    const LEGACY_FRAME: &[u8] = &[
+                        0, 0, 0, 0, 17, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 32, 1, 13,
+                        184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 52, 146, 16, 1, 0, 1, 1, 0, 0, 0, 0,
+                        0, 0, 0,
+                    ];
+                    assert_eq!(bytes.as_ref(), LEGACY_FRAME);
+                }
+                let (request, consumed): (MessageRequest, _) =
+                    bincode::serde::decode_from_slice(&bytes, bincode::config::legacy()).unwrap();
+                assert_eq!(consumed, bytes.len());
+                let MessageRequest::Interface {
+                    req,
+                    req_id: Some(req_id),
+                } = request
+                else {
+                    panic!("expected interface request");
+                };
+                match req {
+                    RequestType::BindUdp { .. } => assert!(!only_v6),
+                    RequestType::BindUdpV2 { only_v6: true, .. } => assert!(only_v6),
+                    other => panic!("unexpected UDP request: {other:?}"),
+                }
+                let response = MessageResponse::ResponseToRequest {
+                    req_id,
+                    res: ResponseType::Err(NetworkError::Unsupported),
+                };
+                let bytes =
+                    bincode::serde::encode_to_vec(response, bincode::config::legacy()).unwrap();
+                peer.send(Message::Binary(bytes.into())).await.unwrap();
+            };
+            let (result, ()) = tokio::join!(bind, respond);
+            assert!(matches!(result, Err(NetworkError::Unsupported)));
+        }
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(2), exchange)
+        .await
+        .unwrap();
+    driver.abort();
 }
 
 #[cfg(feature = "remote")]

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -99,6 +99,7 @@ pub enum InodeSocketKind {
     UdpSocket {
         socket: Box<dyn VirtualUdpSocket + Sync>,
         peer: Option<SocketAddr>,
+        only_v6: bool,
     },
     RemoteSocket {
         props: SocketProperties,
@@ -320,6 +321,7 @@ impl InodeSocket {
             },
             Udp {
                 addr: SocketAddr,
+                only_v6: bool,
                 reuse_port: bool,
                 reuse_addr: bool,
             },
@@ -361,6 +363,7 @@ impl InodeSocket {
                         },
                         Socktype::Dgram => PendingBind::Udp {
                             addr,
+                            only_v6: props.only_v6,
                             reuse_port: props.reuse_port,
                             reuse_addr: props.reuse_addr,
                         },
@@ -405,6 +408,7 @@ impl InodeSocket {
                         }
                         Socktype::Dgram => PendingBind::Udp {
                             addr,
+                            only_v6: props.only_v6,
                             reuse_port: props.reuse_port,
                             reuse_addr: props.reuse_addr,
                         },
@@ -472,15 +476,17 @@ impl InodeSocket {
             }
             PendingBind::Udp {
                 addr,
+                only_v6,
                 reuse_port,
                 reuse_addr,
             } => {
                 tokio::select! {
-                    socket = net.bind_udp(addr, reuse_port, reuse_addr) => {
+                    socket = net.bind_udp(addr, only_v6, reuse_port, reuse_addr) => {
                         match socket {
                             Ok(socket) => Ok(Some(InodeSocket::new(InodeSocketKind::UdpSocket {
                                 socket,
                                 peer: None,
+                                only_v6,
                             }))),
                             Err(err) => {
                                 let mut inner = self.inner.protected.write().unwrap();
@@ -1000,7 +1006,10 @@ impl InodeSocket {
                 }
                 _ => return Err(Errno::Inval),
             },
-            InodeSocketKind::UdpSocket { socket, .. } => match option {
+            InodeSocketKind::UdpSocket {
+                socket, only_v6, ..
+            } => match option {
+                WasiSocketOption::OnlyV6 => *only_v6,
                 WasiSocketOption::Broadcast => {
                     socket.broadcast().map_err(net_error_into_wasi_err)?
                 }
@@ -1333,7 +1342,7 @@ impl InodeSocket {
                     let res = match &mut inner.kind {
                         InodeSocketKind::Raw(socket) => socket.try_send(self.data),
                         InodeSocketKind::TcpStream { socket, .. } => socket.try_send(self.data),
-                        InodeSocketKind::UdpSocket { socket, peer } => {
+                        InodeSocketKind::UdpSocket { socket, peer, .. } => {
                             if let Some(peer) = peer {
                                 socket.try_send_to(self.data, *peer)
                             } else {
@@ -1509,7 +1518,7 @@ impl InodeSocket {
                         InodeSocketKind::TcpStream { socket, .. } => {
                             socket.try_recv(self.data, peek)
                         }
-                        InodeSocketKind::UdpSocket { socket, peer } => match peer {
+                        InodeSocketKind::UdpSocket { socket, peer, .. } => match peer {
                             Some(peer) => {
                                 try_recv_from_connected_udp(socket.as_mut(), self.data, peek, peer)
                                     .map(|(amt, _)| amt)
@@ -1599,7 +1608,7 @@ impl InodeSocket {
                 loop {
                     let res = match &mut inner.kind {
                         InodeSocketKind::Icmp(socket) => socket.try_recv_from(self.data, peek),
-                        InodeSocketKind::UdpSocket { socket, peer } => match peer {
+                        InodeSocketKind::UdpSocket { socket, peer, .. } => match peer {
                             Some(peer) => {
                                 try_recv_from_connected_udp(socket.as_mut(), self.data, peek, peer)
                             }
@@ -1763,6 +1772,7 @@ impl InodeSocketProtected {
             InodeSocketKind::UdpSocket {
                 socket,
                 peer: Some(peer),
+                ..
             } => loop {
                 if let Err(err) = discard_non_matching_udp_datagrams(socket.as_mut(), peer) {
                     break Poll::Ready(Err(err));
@@ -1781,7 +1791,9 @@ impl InodeSocketProtected {
                     }
                 }
             },
-            InodeSocketKind::UdpSocket { socket, peer: None } => socket.poll_read_ready(cx),
+            InodeSocketKind::UdpSocket {
+                socket, peer: None, ..
+            } => socket.poll_read_ready(cx),
             InodeSocketKind::Raw(socket) => socket.poll_read_ready(cx),
             InodeSocketKind::Icmp(socket) => socket.poll_read_ready(cx),
             InodeSocketKind::BoundTcp { .. } => Poll::Pending,
@@ -1856,7 +1868,11 @@ pub(crate) fn all_socket_rights() -> Rights {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(feature = "sys", feature = "host-vnet"))]
+    use super::WasiSocketOption;
     use super::{InodeSocket, InodeSocketKind, SocketProperties, WasiSocketStatus};
+    #[cfg(all(feature = "sys", feature = "host-vnet"))]
+    use std::net::Ipv6Addr;
     use std::{
         future::pending,
         mem::MaybeUninit,
@@ -1890,6 +1906,28 @@ mod tests {
         match value {
             MOCK_STATUS_OPENED => SocketStatus::Opened,
             _ => SocketStatus::Opening,
+        }
+    }
+
+    #[cfg(all(feature = "sys", feature = "host-vnet"))]
+    fn ipv6_udp_properties(only_v6: bool) -> SocketProperties {
+        SocketProperties {
+            family: Addressfamily::Inet6,
+            ty: Socktype::Dgram,
+            pt: SockProto::Udp,
+            only_v6,
+            reuse_port: false,
+            reuse_addr: false,
+            no_delay: None,
+            keep_alive: None,
+            dont_route: None,
+            send_buf_size: None,
+            recv_buf_size: None,
+            write_timeout: None,
+            read_timeout: None,
+            accept_timeout: None,
+            connect_timeout: None,
+            handler: None,
         }
     }
 
@@ -2170,5 +2208,37 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err, Errno::Timedout);
+    }
+
+    #[cfg(all(feature = "sys", feature = "host-vnet"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn inode_socket_udp_bind_preserves_only_v6() {
+        let inode = InodeSocket::new(InodeSocketKind::PreSocket {
+            props: ipv6_udp_properties(true),
+            addr: None,
+        });
+        let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
+        let net = virtual_net::host::LocalNetworking::new();
+
+        let bound = inode
+            .bind(&tasks, &net, SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
+    }
+
+    #[cfg(all(feature = "sys", feature = "host-vnet"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn inode_socket_udp_autobind_preserves_only_v6() {
+        let inode = InodeSocket::new(InodeSocketKind::PreSocket {
+            props: ipv6_udp_properties(true),
+            addr: None,
+        });
+        let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
+        let net = virtual_net::host::LocalNetworking::new();
+
+        let bound = inode.auto_bind_udp(&tasks, &net).await.unwrap().unwrap();
+        assert!(bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
     }
 }

--- a/lib/wasix/src/net/socket.rs
+++ b/lib/wasix/src/net/socket.rs
@@ -2213,32 +2213,131 @@ mod tests {
     #[cfg(all(feature = "sys", feature = "host-vnet"))]
     #[tokio::test(flavor = "current_thread")]
     async fn inode_socket_udp_bind_preserves_only_v6() {
-        let inode = InodeSocket::new(InodeSocketKind::PreSocket {
-            props: ipv6_udp_properties(true),
-            addr: None,
-        });
         let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
         let net = virtual_net::host::LocalNetworking::new();
 
-        let bound = inode
-            .bind(&tasks, &net, SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)))
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
+        for only_v6 in [true, false] {
+            for kind in [
+                InodeSocketKind::PreSocket {
+                    props: ipv6_udp_properties(only_v6),
+                    addr: None,
+                },
+                InodeSocketKind::RemoteSocket {
+                    props: ipv6_udp_properties(only_v6),
+                    local_addr: "[::]:0".parse().unwrap(),
+                    peer_addr: "[::1]:9".parse().unwrap(),
+                    ttl: 0,
+                    multicast_ttl: 0,
+                    is_dead: false,
+                },
+            ] {
+                let inode = InodeSocket::new(kind);
+                let mut bound = inode
+                    .bind(&tasks, &net, SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)))
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap(),
+                    only_v6
+                );
+                assert_eq!(
+                    bound.set_opt_flag(WasiSocketOption::OnlyV6, !only_v6),
+                    Err(Errno::Inval)
+                );
+                assert_eq!(
+                    bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap(),
+                    only_v6
+                );
+            }
+        }
     }
 
     #[cfg(all(feature = "sys", feature = "host-vnet"))]
     #[tokio::test(flavor = "current_thread")]
     async fn inode_socket_udp_autobind_preserves_only_v6() {
+        let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
+        let net = virtual_net::host::LocalNetworking::new();
+
+        for only_v6 in [true, false] {
+            let inode = InodeSocket::new(InodeSocketKind::PreSocket {
+                props: ipv6_udp_properties(only_v6),
+                addr: None,
+            });
+            let bound = inode.auto_bind_udp(&tasks, &net).await.unwrap().unwrap();
+            assert_eq!(
+                bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap(),
+                only_v6
+            );
+        }
+    }
+
+    #[cfg(all(feature = "sys", feature = "host-vnet"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn inode_socket_udp_failed_bind_preserves_options_for_retry() {
+        let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
+        let net = virtual_net::host::LocalNetworking::new();
+        let occupied = net
+            .bind_udp("[::]:0".parse().unwrap(), true, false, false)
+            .await
+            .unwrap();
+        let addr = occupied.addr_local().unwrap();
+        let mut inode = InodeSocket::new(InodeSocketKind::PreSocket {
+            props: ipv6_udp_properties(true),
+            addr: None,
+        });
+        assert_eq!(
+            inode.bind(&tasks, &net, addr).await.unwrap_err(),
+            Errno::Addrinuse
+        );
+        assert_eq!(inode.addr_local().unwrap().port(), 0);
+        assert!(inode.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
+        inode.set_opt_flag(WasiSocketOption::OnlyV6, false).unwrap();
+        let bound = inode
+            .bind(&tasks, &net, "[::]:0".parse().unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
+    }
+
+    #[cfg(all(feature = "sys", feature = "host-vnet", feature = "remote-vnet"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn inode_socket_udp_unanswered_v2_request_obeys_bind_timeout() {
+        use virtual_net::meta::{MessageRequest, RequestType};
+
+        let (request_tx, mut requests) = tokio::sync::mpsc::channel(1);
+        let (_response_tx, responses) = tokio::sync::mpsc::channel(1);
+        let (net, driver) =
+            virtual_net::RemoteNetworkingClient::new_from_mpsc(request_tx, responses);
+        let driver = tokio::spawn(driver);
+        let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
         let inode = InodeSocket::new(InodeSocketKind::PreSocket {
             props: ipv6_udp_properties(true),
             addr: None,
         });
-        let tasks = crate::runtime::task_manager::tokio::TokioTaskManager::default();
-        let net = virtual_net::host::LocalNetworking::new();
-
-        let bound = inode.auto_bind_udp(&tasks, &net).await.unwrap().unwrap();
-        assert!(bound.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
+        let bind = inode.bind_internal(
+            &tasks,
+            &net,
+            "[::]:0".parse().unwrap(),
+            Duration::from_millis(20),
+        );
+        // Old peers cannot decode V2 and may leave the request unanswered.
+        let (result, request) = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::join!(bind, requests.recv())
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            request.unwrap(),
+            MessageRequest::Interface {
+                req: RequestType::BindUdpV2 { only_v6: true, .. },
+                ..
+            }
+        ));
+        assert_eq!(result.unwrap_err(), Errno::Timedout);
+        assert_eq!(inode.addr_local().unwrap().port(), 0);
+        assert!(inode.get_opt_flag(WasiSocketOption::OnlyV6).unwrap());
+        driver.abort();
     }
 }

--- a/lib/wasix/tests/wasm_tests/socket/udp-ipv6-v6only/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-ipv6-v6only/main.c
@@ -1,0 +1,189 @@
+//#AbstractConfig: false-bool
+//#MinimalLibc: v2026-06-18.1
+//
+//#Config: explicit-v6only
+//#Args: explicit-v6only
+//#ExpectedStdout: explicit IPV6_V6ONLY preserved
+//
+//#Config: explicit-dual-stack:false-bool
+//#Args: explicit-dual-stack
+//#ExpectedStdout: explicit dual-stack setting preserved
+//
+//#Config: replacement:false-bool
+//#Args: replacement
+//#ExpectedStdout: latest IPV6_V6ONLY setting preserved
+//
+//#Config: autobind-connect
+//#Args: autobind-connect
+//#ExpectedStdout: connect autobind preserved IPV6_V6ONLY
+//
+//#Config: autobind-sendto
+//#Args: autobind-sendto
+//#ExpectedStdout: sendto autobind preserved IPV6_V6ONLY
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int set_only_v6(int fd, int value) {
+  if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &value, sizeof(value)) < 0) {
+    perror("setsockopt(IPV6_V6ONLY)");
+    return -1;
+  }
+  return 0;
+}
+
+static int expect_only_v6(int fd, int expected) {
+  int value = -1;
+  socklen_t len = sizeof(value);
+  if (getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &value, &len) < 0) {
+    perror("getsockopt(IPV6_V6ONLY)");
+    return -1;
+  }
+  if (len != sizeof(value) || value != expected) {
+    fprintf(stderr, "IPV6_V6ONLY: expected %d, got %d (length %u)\n", expected,
+            value, (unsigned)len);
+    return -1;
+  }
+  return 0;
+}
+
+static int bind_ipv6_any(int fd) {
+  struct sockaddr_in6 addr = {
+      .sin6_family = AF_INET6,
+      .sin6_port = htons(0),
+      .sin6_addr = IN6ADDR_ANY_INIT,
+  };
+  if (bind(fd, (const struct sockaddr*)&addr, sizeof(addr)) < 0) {
+    perror("bind(AF_INET6)");
+    return -1;
+  }
+  return 0;
+}
+
+static int local_port(int fd) {
+  struct sockaddr_in6 addr;
+  socklen_t len = sizeof(addr);
+  if (getsockname(fd, (struct sockaddr*)&addr, &len) < 0) {
+    perror("getsockname");
+    return -1;
+  }
+  if (len != sizeof(addr) || addr.sin6_family != AF_INET6 ||
+      addr.sin6_port == 0) {
+    fputs("unexpected IPv6 local address\n", stderr);
+    return -1;
+  }
+  return ntohs(addr.sin6_port);
+}
+
+static int bind_ipv4_port(int port) {
+  int fd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (fd < 0) {
+    perror("socket(AF_INET)");
+    return -1;
+  }
+  struct sockaddr_in addr = {
+      .sin_family = AF_INET,
+      .sin_port = htons((uint16_t)port),
+      .sin_addr.s_addr = htonl(INADDR_ANY),
+  };
+  if (bind(fd, (const struct sockaddr*)&addr, sizeof(addr)) < 0) {
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return -1;
+  }
+  return fd;
+}
+
+static int new_ipv6_socket(void) {
+  int fd = socket(AF_INET6, SOCK_DGRAM, 0);
+  if (fd < 0) perror("socket(AF_INET6)");
+  return fd;
+}
+
+static int test_explicit_v6only(void) {
+  int fd6 = new_ipv6_socket();
+  if (fd6 < 0 || set_only_v6(fd6, 1) < 0 || bind_ipv6_any(fd6) < 0 ||
+      expect_only_v6(fd6, 1) < 0)
+    return EXIT_FAILURE;
+
+  int port = local_port(fd6);
+  int fd4 = port < 0 ? -1 : bind_ipv4_port(port);
+  if (fd4 < 0) {
+    perror("IPv4 co-bind with IPV6_V6ONLY=1");
+    return EXIT_FAILURE;
+  }
+
+  close(fd4);
+  close(fd6);
+  puts("explicit IPV6_V6ONLY preserved");
+  return EXIT_SUCCESS;
+}
+
+static int test_dual_stack(int replacement) {
+  int fd6 = new_ipv6_socket();
+  if (fd6 < 0 || (replacement && set_only_v6(fd6, 1) < 0) ||
+      set_only_v6(fd6, 0) < 0 || expect_only_v6(fd6, 0) < 0 ||
+      bind_ipv6_any(fd6) < 0 || expect_only_v6(fd6, 0) < 0)
+    return EXIT_FAILURE;
+
+  int port = local_port(fd6);
+  errno = 0;
+  int fd4 = port < 0 ? -1 : bind_ipv4_port(port);
+  if (fd4 >= 0 || errno != EADDRINUSE) {
+    if (fd4 >= 0) close(fd4);
+    fprintf(stderr,
+            "IPv4 co-bind with IPV6_V6ONLY=0: expected EADDRINUSE, got %s\n",
+            strerror(errno));
+    return EXIT_FAILURE;
+  }
+
+  close(fd6);
+  puts(replacement ? "latest IPV6_V6ONLY setting preserved"
+                   : "explicit dual-stack setting preserved");
+  return EXIT_SUCCESS;
+}
+
+static int test_autobind(int use_connect) {
+  int fd = new_ipv6_socket();
+  if (fd < 0 || set_only_v6(fd, 1) < 0) return EXIT_FAILURE;
+
+  struct sockaddr_in6 peer = {
+      .sin6_family = AF_INET6,
+      .sin6_port = htons(9),
+      .sin6_addr = IN6ADDR_LOOPBACK_INIT,
+  };
+  if (use_connect) {
+    if (connect(fd, (const struct sockaddr*)&peer, sizeof(peer)) < 0) {
+      perror("connect");
+      return EXIT_FAILURE;
+    }
+  } else if (sendto(fd, "x", 1, 0, (const struct sockaddr*)&peer,
+                    sizeof(peer)) != 1) {
+    perror("sendto");
+    return EXIT_FAILURE;
+  }
+
+  if (local_port(fd) < 0 || expect_only_v6(fd, 1) < 0) return EXIT_FAILURE;
+
+  close(fd);
+  puts(use_connect ? "connect autobind preserved IPV6_V6ONLY"
+                   : "sendto autobind preserved IPV6_V6ONLY");
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) return EXIT_FAILURE;
+  if (!strcmp(argv[1], "explicit-v6only")) return test_explicit_v6only();
+  if (!strcmp(argv[1], "explicit-dual-stack")) return test_dual_stack(0);
+  if (!strcmp(argv[1], "replacement")) return test_dual_stack(1);
+  if (!strcmp(argv[1], "autobind-connect")) return test_autobind(1);
+  if (!strcmp(argv[1], "autobind-sendto")) return test_autobind(0);
+  return EXIT_FAILURE;
+}

--- a/lib/wasix/tests/wasm_tests/socket/udp-ipv6-v6only/main.c
+++ b/lib/wasix/tests/wasm_tests/socket/udp-ipv6-v6only/main.c
@@ -24,6 +24,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netinet/in.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -51,6 +52,17 @@ static int expect_only_v6(int fd, int expected) {
     return -1;
   }
   return 0;
+}
+
+static int expect_bound_option_unchanged(int fd, int expected) {
+  int value = 1;
+  errno = 0;
+  if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &value, sizeof(value)) != -1 ||
+      errno != EINVAL) {
+    fputs("bound IPV6_V6ONLY change must fail with EINVAL\n", stderr);
+    return -1;
+  }
+  return expect_only_v6(fd, expected);
 }
 
 static int bind_ipv6_any(int fd) {
@@ -110,7 +122,7 @@ static int new_ipv6_socket(void) {
 static int test_explicit_v6only(void) {
   int fd6 = new_ipv6_socket();
   if (fd6 < 0 || set_only_v6(fd6, 1) < 0 || bind_ipv6_any(fd6) < 0 ||
-      expect_only_v6(fd6, 1) < 0)
+      expect_only_v6(fd6, 1) < 0 || expect_bound_option_unchanged(fd6, 1) < 0)
     return EXIT_FAILURE;
 
   int port = local_port(fd6);
@@ -130,7 +142,8 @@ static int test_dual_stack(int replacement) {
   int fd6 = new_ipv6_socket();
   if (fd6 < 0 || (replacement && set_only_v6(fd6, 1) < 0) ||
       set_only_v6(fd6, 0) < 0 || expect_only_v6(fd6, 0) < 0 ||
-      bind_ipv6_any(fd6) < 0 || expect_only_v6(fd6, 0) < 0)
+      bind_ipv6_any(fd6) < 0 || expect_only_v6(fd6, 0) < 0 ||
+      expect_bound_option_unchanged(fd6, 0) < 0)
     return EXIT_FAILURE;
 
   int port = local_port(fd6);
@@ -170,7 +183,16 @@ static int test_autobind(int use_connect) {
     return EXIT_FAILURE;
   }
 
-  if (local_port(fd) < 0 || expect_only_v6(fd, 1) < 0) return EXIT_FAILURE;
+  int port = local_port(fd);
+  if (port < 0 || expect_only_v6(fd, 1) < 0 ||
+      expect_bound_option_unchanged(fd, 1) < 0)
+    return EXIT_FAILURE;
+  int fd4 = bind_ipv4_port(port);
+  if (fd4 < 0) {
+    perror("IPv4 co-bind after automatic bind");
+    return EXIT_FAILURE;
+  }
+  close(fd4);
 
   close(fd);
   puts(use_connect ? "connect autobind preserved IPV6_V6ONLY"


### PR DESCRIPTION
Preserve `IPV6_V6ONLY` when an unbound WASIX UDP socket becomes a host socket through `bind`, `connect`, or `sendto`. The setting now reaches the networking backend before binding and remains available for bound-socket readback. Networking providers receive it through `VirtualNetworking::bind_udp`.

Remote binds keep the existing `BindUdp` wire layout for false and use an appended `BindUdpV2` request for true. IPv6-only remote binds require an upgraded server; older peers may leave V2 unanswered until the WASIX bind timeout. Legacy requests remain compatible, but older servers retain their original host-default IPv6 behavior.