### PR TITLE
fix(wasix): use backing state for directory removal

### DIFF
--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -709,17 +709,37 @@ impl WasiFs {
             return Err(Errno::Noent);
         }
 
-        let inode = self.get_inode_at_path(inodes, base, path, false)?;
-        if inode.is_preopened {
-            return Err(Errno::Access);
-        }
-
-        let (parent, backing_path) = match inode.read().deref() {
-            Kind::Dir { parent, path, .. } => {
-                let parent = parent.upgrade().ok_or(Errno::Noent)?;
-                (parent, path.clone())
+        let direct_virtual_root = base == VIRTUAL_ROOT_FD
+            && matches!(
+                self.root_inode.read().deref(),
+                Kind::Root { entries } if entries.is_empty()
+            );
+        let (cache_entry, backing_path) = match self.get_inode_at_path(inodes, base, path, false) {
+            Ok(inode) => {
+                if inode.is_preopened {
+                    return Err(Errno::Access);
+                }
+                let (parent, backing_path) = match inode.read().deref() {
+                    Kind::Dir { parent, path, .. } => {
+                        let parent = parent.upgrade().ok_or(Errno::Noent)?;
+                        (parent, path.clone())
+                    }
+                    _ => return Err(Errno::Notdir),
+                };
+                (Some((parent, inode)), backing_path)
             }
-            _ => return Err(Errno::Notdir),
+            Err(Errno::Notcapable) if direct_virtual_root => {
+                let backing_path = PathBuf::from(path);
+                let metadata = self
+                    .root_fs
+                    .symlink_metadata(&backing_path)
+                    .map_err(fs_error_into_wasi_err)?;
+                if !metadata.file_type().is_dir() {
+                    return Err(Errno::Notdir);
+                }
+                (None, backing_path)
+            }
+            Err(error) => return Err(error),
         };
 
         let directory_key = PosixPath::from_path(&backing_path)
@@ -739,6 +759,9 @@ impl WasiFs {
             .remove_dir(&backing_path)
             .map_err(fs_error_into_wasi_err)?;
 
+        let Some((parent, inode)) = cache_entry else {
+            return Ok(());
+        };
         let mut parent = parent.write();
         let entries = match parent.deref_mut() {
             Kind::Dir { entries, .. } | Kind::Root { entries } => entries,

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -714,33 +714,58 @@ impl WasiFs {
                 self.root_inode.read().deref(),
                 Kind::Root { entries } if entries.is_empty()
             );
-        let (cache_entry, backing_path) = match self.get_inode_at_path(inodes, base, path, false) {
-            Ok(inode) => {
-                if inode.is_preopened {
-                    return Err(Errno::Access);
-                }
-                let (parent, backing_path) = match inode.read().deref() {
-                    Kind::Dir { parent, path, .. } => {
-                        let parent = parent.upgrade().ok_or(Errno::Noent)?;
-                        (parent, path.clone())
-                    }
-                    _ => return Err(Errno::Notdir),
-                };
-                (Some((parent, inode)), backing_path)
-            }
-            Err(Errno::Notcapable) if direct_virtual_root => {
-                let backing_path = PathBuf::from(path);
-                let metadata = self
-                    .root_fs
-                    .symlink_metadata(&backing_path)
-                    .map_err(fs_error_into_wasi_err)?;
-                if !metadata.file_type().is_dir() {
-                    return Err(Errno::Notdir);
-                }
-                (None, backing_path)
-            }
-            Err(error) => return Err(error),
+        let root_relative_path = || {
+            PosixPath::new("/")
+                .join(&PosixPath::new(path.trim_end_matches('/')))
+                .into_path_buf()
         };
+        // Resolve only the parent: a trailing slash must not follow the final symlink.
+        let (cache_entry, backing_path) =
+            match self.get_parent_inode_at_path(inodes, base, Path::new(path), true) {
+                Ok((parent, _)) => {
+                    let root_mount = match parent.read().deref() {
+                        Kind::Root { entries } if !entries.contains_key(&entry_name) => {
+                            entries.get("/").cloned()
+                        }
+                        _ => None,
+                    };
+                    let parent = root_mount.unwrap_or(parent);
+                    let guard = parent.read();
+                    match guard.deref() {
+                        Kind::Dir { entries, path, .. } => {
+                            let cached = entries.get(&entry_name).cloned();
+                            if cached.as_ref().is_some_and(|inode| inode.is_preopened) {
+                                return Err(Errno::Access);
+                            }
+                            let backing_path = PosixPath::from_path(path)
+                                .join(&PosixPath::new(&entry_name))
+                                .into_path_buf();
+                            (cached.map(|inode| (parent.clone(), inode)), backing_path)
+                        }
+                        Kind::Root { entries } if entries.is_empty() && direct_virtual_root => {
+                            (None, root_relative_path())
+                        }
+                        Kind::Root { entries } if entries.contains_key(&entry_name) => {
+                            return Err(Errno::Access);
+                        }
+                        Kind::Root { .. } => return Err(Errno::Notcapable),
+                        _ => return Err(Errno::Notdir),
+                    }
+                }
+                Err(Errno::Notcapable) if direct_virtual_root => (None, root_relative_path()),
+                Err(error) => return Err(error),
+            };
+
+        if self.ephemeral_symlink_at(&backing_path).is_some() {
+            return Err(Errno::Notdir);
+        }
+        let metadata = self
+            .root_fs
+            .symlink_metadata(&backing_path)
+            .map_err(fs_error_into_wasi_err)?;
+        if !metadata.file_type().is_dir() {
+            return Err(Errno::Notdir);
+        }
 
         let directory_key = PosixPath::from_path(&backing_path)
             .normalize_virtual_symlink_key()
@@ -2993,6 +3018,8 @@ mod tests {
         inner: TmpFileSystem,
         remove_errors: Mutex<VecDeque<FsError>>,
         remove_hook: Mutex<Option<RemoveHook>>,
+        metadata_errors: Mutex<VecDeque<FsError>>,
+        metadata_hook: Mutex<Option<RemoveHook>>,
         remove_calls: AtomicUsize,
     }
 
@@ -3008,6 +3035,8 @@ mod tests {
                 inner: TmpFileSystem::new(),
                 remove_errors: Mutex::new(VecDeque::new()),
                 remove_hook: Mutex::new(None),
+                metadata_errors: Mutex::new(VecDeque::new()),
+                metadata_hook: Mutex::new(None),
                 remove_calls: AtomicUsize::new(0),
             }
         }
@@ -3040,7 +3069,8 @@ mod tests {
                 return Err(error);
             }
             self.inner.remove_dir(path)?;
-            if let Some(hook) = self.remove_hook.lock().unwrap().take() {
+            let hook = self.remove_hook.lock().unwrap().take();
+            if let Some(hook) = hook {
                 hook();
             }
             Ok(())
@@ -3059,6 +3089,13 @@ mod tests {
         }
 
         fn symlink_metadata(&self, path: &Path) -> Result<virtual_fs::Metadata, FsError> {
+            let hook = self.metadata_hook.lock().unwrap().take();
+            if let Some(hook) = hook {
+                hook();
+            }
+            if let Some(error) = self.metadata_errors.lock().unwrap().pop_front() {
+                return Err(error);
+            }
             self.inner.symlink_metadata(path)
         }
 
@@ -3888,5 +3925,158 @@ mod tests {
         fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/dir")
             .unwrap();
         assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn directory_remove_does_not_follow_a_final_symlink_with_a_trailing_slash() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/target")).unwrap();
+        fs.register_ephemeral_symlink("/link".into(), "link".into(), "target".into());
+
+        assert_eq!(
+            fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/link/"),
+            Err(Errno::Notdir)
+        );
+        assert!(backing.metadata(Path::new("/target")).unwrap().is_dir());
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn directory_remove_rootless_relative_path_checks_ephemeral_children() {
+        let inodes = WasiInodes::new();
+        let backing = Arc::new(DirectoryRemoveFileSystem::new());
+        let fs = WasiFs::new_with_preopen(
+            &inodes,
+            &[],
+            &[],
+            WasiFsRoot::from_filesystem(backing.clone()),
+        )
+        .unwrap();
+        backing.create_dir(Path::new("/dir")).unwrap();
+        fs.register_ephemeral_symlink("/dir/link".into(), "dir/link".into(), "target".into());
+
+        assert_eq!(
+            fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "dir"),
+            Err(Errno::Notempty)
+        );
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 0);
+        assert!(backing.metadata(Path::new("/dir")).unwrap().is_dir());
+    }
+
+    #[tokio::test]
+    async fn directory_remove_preserves_metadata_errors() {
+        for error in [
+            FsError::PermissionDenied,
+            FsError::IOError,
+            FsError::EntryNotFound,
+        ] {
+            for populate_cache in [false, true] {
+                let (backing, fs, inodes) = directory_remove_fs();
+                backing.create_dir(Path::new("/dir")).unwrap();
+                let selected = populate_cache.then(|| {
+                    fs.get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/dir", false)
+                        .unwrap()
+                });
+                backing.metadata_errors.lock().unwrap().push_back(error);
+                assert_eq!(
+                    fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/dir"),
+                    Err(fs_error_into_wasi_err(error))
+                );
+                assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 0);
+                if let Some(selected) = selected {
+                    let cached = fs
+                        .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/dir", false)
+                        .unwrap();
+                    assert!(Arc::ptr_eq(&cached.inner, &selected.inner));
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn directory_remove_metadata_callback_can_lock_the_parent() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/dir")).unwrap();
+        let parent = fs
+            .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/", true)
+            .unwrap();
+        *backing.metadata_hook.lock().unwrap() = Some(Box::new(move || {
+            assert!(
+                parent.inner.kind.try_write().is_ok(),
+                "backend metadata must not run under the parent lock"
+            );
+        }));
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/dir")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn directory_remove_uses_backing_type_after_a_cached_file_is_replaced() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing
+            .new_open_options()
+            .create_new(true)
+            .write(true)
+            .open(Path::new("/entry"))
+            .unwrap();
+        fs.get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/entry", false)
+            .unwrap();
+        backing.remove_file(Path::new("/entry")).unwrap();
+        backing.create_dir(Path::new("/entry")).unwrap();
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/entry")
+            .unwrap();
+        assert_eq!(
+            backing.metadata(Path::new("/entry")),
+            Err(FsError::EntryNotFound)
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_remove_does_not_bypass_configured_preopens() {
+        let inodes = WasiInodes::new();
+        let backing = Arc::new(DirectoryRemoveFileSystem::new());
+        backing.create_dir(Path::new("/sandbox")).unwrap();
+        backing.create_dir(Path::new("/outside")).unwrap();
+        let fs = WasiFs::new_with_preopen(
+            &inodes,
+            &[],
+            &["sandbox".to_owned()],
+            WasiFsRoot::from_filesystem(backing.clone()),
+        )
+        .unwrap();
+        assert_eq!(
+            fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/outside"),
+            Err(Errno::Notcapable)
+        );
+        assert_eq!(
+            fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/sandbox"),
+            Err(Errno::Access)
+        );
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn directory_remove_callback_can_reenter_removal() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        for path in ["/first", "/second"] {
+            backing.create_dir(Path::new(path)).unwrap();
+            fs.get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, path, false)
+                .unwrap();
+        }
+        let parent = fs
+            .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/", true)
+            .unwrap();
+        let fs_for_hook = fs.clone();
+        let inodes_for_hook = inodes.clone();
+        backing.run_after_remove(move || {
+            assert!(parent.inner.kind.try_write().is_ok());
+            assert!(fs_for_hook.ephemeral_symlinks.try_write().is_ok());
+            fs_for_hook
+                .remove_directory(&inodes_for_hook, VIRTUAL_ROOT_FD, "/second")
+                .unwrap();
+        });
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/first")
+            .unwrap();
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -698,6 +698,62 @@ impl WasiFs {
         );
     }
 
+    pub(crate) fn remove_directory(
+        &self,
+        inodes: &WasiInodes,
+        base: WasiFd,
+        path: &str,
+    ) -> Result<(), Errno> {
+        let (_, entry_name) = PosixPath::new(path).parent_path_and_name()?;
+        if entry_name == "." || entry_name == ".." {
+            return Err(Errno::Noent);
+        }
+
+        let inode = self.get_inode_at_path(inodes, base, path, false)?;
+        if inode.is_preopened {
+            return Err(Errno::Access);
+        }
+
+        let (parent, backing_path) = match inode.read().deref() {
+            Kind::Dir { parent, path, .. } => {
+                let parent = parent.upgrade().ok_or(Errno::Noent)?;
+                (parent, path.clone())
+            }
+            _ => return Err(Errno::Notdir),
+        };
+
+        let directory_key = PosixPath::from_path(&backing_path)
+            .normalize_virtual_symlink_key()
+            .into_path_buf();
+        let contains_ephemeral_symlink = self
+            .ephemeral_symlinks
+            .read()
+            .unwrap()
+            .keys()
+            .any(|key| key != &directory_key && key.starts_with(&directory_key));
+        if contains_ephemeral_symlink {
+            return Err(Errno::Notempty);
+        }
+
+        self.root_fs
+            .remove_dir(&backing_path)
+            .map_err(fs_error_into_wasi_err)?;
+
+        let mut parent = parent.write();
+        let entries = match parent.deref_mut() {
+            Kind::Dir { entries, .. } | Kind::Root { entries } => entries,
+            _ => return Ok(()),
+        };
+        if entries
+            .get(&entry_name)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.inner, &inode.inner))
+        {
+            entries.remove(&entry_name);
+        }
+
+        Ok(())
+    }
+
     /// Forking the WasiState is used when either fork or vfork is called
     pub fn fork(&self) -> Self {
         Self {
@@ -2898,6 +2954,8 @@ pub fn fs_error_into_wasi_err(fs_error: FsError) -> Errno {
 mod tests {
     use super::*;
     use once_cell::sync::OnceCell;
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicUsize;
     use tempfile::tempdir;
     use virtual_fs::{RootFileSystemBuilder, TmpFileSystem};
     use wasmer::Engine;
@@ -2905,6 +2963,99 @@ mod tests {
 
     use crate::WasiEnvBuilder;
     use crate::bin_factory::{BinaryPackage, BinaryPackageMount, BinaryPackageMounts};
+
+    type RemoveHook = Box<dyn FnOnce() + Send>;
+
+    struct DirectoryRemoveFileSystem {
+        inner: TmpFileSystem,
+        remove_errors: Mutex<VecDeque<FsError>>,
+        remove_hook: Mutex<Option<RemoveHook>>,
+        remove_calls: AtomicUsize,
+    }
+
+    impl std::fmt::Debug for DirectoryRemoveFileSystem {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("DirectoryRemoveFileSystem").finish()
+        }
+    }
+
+    impl DirectoryRemoveFileSystem {
+        fn new() -> Self {
+            Self {
+                inner: TmpFileSystem::new(),
+                remove_errors: Mutex::new(VecDeque::new()),
+                remove_hook: Mutex::new(None),
+                remove_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn fail_next_remove(&self, error: FsError) {
+            self.remove_errors.lock().unwrap().push_back(error);
+        }
+
+        fn run_after_remove(&self, hook: impl FnOnce() + Send + 'static) {
+            *self.remove_hook.lock().unwrap() = Some(Box::new(hook));
+        }
+    }
+
+    impl FileSystem for DirectoryRemoveFileSystem {
+        fn readlink(&self, path: &Path) -> Result<PathBuf, FsError> {
+            self.inner.readlink(path)
+        }
+
+        fn read_dir(&self, path: &Path) -> Result<virtual_fs::ReadDir, FsError> {
+            self.inner.read_dir(path)
+        }
+
+        fn create_dir(&self, path: &Path) -> Result<(), FsError> {
+            self.inner.create_dir(path)
+        }
+
+        fn remove_dir(&self, path: &Path) -> Result<(), FsError> {
+            self.remove_calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(error) = self.remove_errors.lock().unwrap().pop_front() {
+                return Err(error);
+            }
+            self.inner.remove_dir(path)?;
+            if let Some(hook) = self.remove_hook.lock().unwrap().take() {
+                hook();
+            }
+            Ok(())
+        }
+
+        fn rename<'a>(
+            &'a self,
+            from: &'a Path,
+            to: &'a Path,
+        ) -> BoxFuture<'a, Result<(), FsError>> {
+            self.inner.rename(from, to)
+        }
+
+        fn metadata(&self, path: &Path) -> Result<virtual_fs::Metadata, FsError> {
+            self.inner.metadata(path)
+        }
+
+        fn symlink_metadata(&self, path: &Path) -> Result<virtual_fs::Metadata, FsError> {
+            self.inner.symlink_metadata(path)
+        }
+
+        fn remove_file(&self, path: &Path) -> Result<(), FsError> {
+            self.inner.remove_file(path)
+        }
+
+        fn new_open_options(&self) -> OpenOptions<'_> {
+            self.inner.new_open_options()
+        }
+    }
+
+    fn directory_remove_fs() -> (Arc<DirectoryRemoveFileSystem>, Arc<WasiFs>, WasiInodes) {
+        let inodes = WasiInodes::new();
+        let backing = Arc::new(DirectoryRemoveFileSystem::new());
+        let root = WasiFsRoot::from_filesystem(backing.clone());
+        let fs =
+            Arc::new(WasiFs::new_with_preopen(&inodes, &[], &["/".to_string()], root).unwrap());
+        (backing, fs, inodes)
+    }
 
     fn webc_symlink_fs() -> virtual_fs::WebcVolumeFileSystem {
         let timestamps = webc::v3::Timestamps::default();
@@ -3580,5 +3731,139 @@ mod tests {
             wasi_fs.remove_symlink_file(Path::new("/missing")),
             Errno::Noent
         );
+    }
+
+    #[tokio::test]
+    async fn directory_remove_uses_backing_state_instead_of_cached_children() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/stale")).unwrap();
+        backing
+            .new_open_options()
+            .create_new(true)
+            .write(true)
+            .open(Path::new("/stale/child"))
+            .unwrap();
+
+        fs.get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/stale/child", false)
+            .unwrap();
+        backing.remove_file(Path::new("/stale/child")).unwrap();
+
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/stale")
+            .unwrap();
+        assert_eq!(
+            backing.symlink_metadata(Path::new("/stale")),
+            Err(FsError::EntryNotFound)
+        );
+    }
+
+    #[tokio::test]
+    async fn directory_remove_resolves_an_uncached_final_target() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/uncached")).unwrap();
+
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/uncached")
+            .unwrap();
+
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn directory_remove_preserves_cache_after_a_backing_error() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/retry")).unwrap();
+        let selected = fs
+            .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/retry", false)
+            .unwrap();
+        backing.fail_next_remove(FsError::PermissionDenied);
+
+        assert_eq!(
+            fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/retry"),
+            Err(Errno::Perm)
+        );
+        let cached = fs
+            .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/retry", false)
+            .unwrap();
+        assert!(Arc::ptr_eq(&cached.inner, &selected.inner));
+
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/retry")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn directory_remove_does_not_evict_a_replacement_inode() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/replace")).unwrap();
+        let selected = fs
+            .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/replace", false)
+            .unwrap();
+        let parent = match selected.read().deref() {
+            Kind::Dir { parent, .. } => parent.upgrade().unwrap(),
+            _ => panic!("expected a directory inode"),
+        };
+        let replacement_slot = Arc::new(Mutex::new(None));
+        let replacement_slot_for_hook = replacement_slot.clone();
+        let backing_for_hook = backing.clone();
+        let fs_for_hook = fs.clone();
+        let inodes_for_hook = inodes.clone();
+        let parent_for_hook = parent.clone();
+        backing.run_after_remove(move || {
+            backing_for_hook.create_dir(Path::new("/replace")).unwrap();
+            let replacement = fs_for_hook
+                .create_inode(
+                    &inodes_for_hook,
+                    Kind::Dir {
+                        parent: parent_for_hook.downgrade(),
+                        path: PathBuf::from("/replace"),
+                        entries: HashMap::new(),
+                    },
+                    false,
+                    "/replace".to_string(),
+                )
+                .unwrap();
+            match parent_for_hook.write().deref_mut() {
+                Kind::Dir { entries, .. } | Kind::Root { entries } => {
+                    entries.insert("replace".to_string(), replacement.clone());
+                }
+                _ => panic!("expected a directory parent"),
+            }
+            *replacement_slot_for_hook.lock().unwrap() = Some(replacement);
+        });
+
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/replace")
+            .unwrap();
+
+        let replacement = replacement_slot.lock().unwrap().clone().unwrap();
+        let cached = fs
+            .get_inode_at_path(&inodes, VIRTUAL_ROOT_FD, "/replace", false)
+            .unwrap();
+        assert!(Arc::ptr_eq(&cached.inner, &replacement.inner));
+        assert!(!Arc::ptr_eq(&cached.inner, &selected.inner));
+    }
+
+    #[tokio::test]
+    async fn directory_remove_checks_normalized_ephemeral_descendants() {
+        let (backing, fs, inodes) = directory_remove_fs();
+        backing.create_dir(Path::new("/dir")).unwrap();
+        fs.register_ephemeral_symlink(
+            PathBuf::from("/dir/nested/../link"),
+            PathBuf::from("link"),
+            PathBuf::from("target"),
+        );
+        fs.register_ephemeral_symlink(
+            PathBuf::from("/directory/link"),
+            PathBuf::from("link"),
+            PathBuf::from("target"),
+        );
+
+        assert_eq!(
+            fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/dir"),
+            Err(Errno::Notempty)
+        );
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 0);
+
+        fs.unregister_ephemeral_symlink(Path::new("/dir/link"));
+        fs.remove_directory(&inodes, VIRTUAL_ROOT_FD, "/dir")
+            .unwrap();
+        assert_eq!(backing.remove_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
@@ -1,9 +1,3 @@
-use std::path::Path;
-
-use virtual_fs::FileSystem;
-
-use crate::VIRTUAL_ROOT_FD;
-
 use super::*;
 
 impl JournalEffector {
@@ -26,21 +20,50 @@ impl JournalEffector {
         fd: Fd,
         path: &str,
     ) -> anyhow::Result<()> {
-        // see `VIRTUAL_ROOT_FD` for details as to why this exists
-        if fd == VIRTUAL_ROOT_FD {
-            ctx.data().state.fs.root_fs.remove_dir(Path::new(path))?;
-        } else {
-            let base_dir = ctx.data().state.fs.get_fd(fd).map_err(|err| {
-                anyhow::format_err!(
-                    "journal restore error: invalid directory descriptor (fd={fd}) - {err}"
-                )
-            })?;
-            if let Err(err) =
-                crate::syscalls::path_remove_directory_internal(ctx, fd, base_dir, path)
-            {
-                bail!("journal restore error: failed to remove directory - {err}");
-            }
+        let base_dir = ctx.data().state.fs.get_fd(fd).map_err(|err| {
+            anyhow::format_err!(
+                "journal restore error: invalid directory descriptor (fd={fd}) - {err}"
+            )
+        })?;
+        if let Err(err) = crate::syscalls::path_remove_directory_internal(ctx, fd, base_dir, path) {
+            bail!("journal restore error: failed to remove directory - {err}");
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, sync::Arc};
+
+    use virtual_fs::{FileSystem, FsError, TmpFileSystem};
+    use wasmer::{Engine, Store};
+
+    use crate::{VIRTUAL_ROOT_FD, WasiEnvBuilder, WasiFunctionEnv};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn journal_remove_directory_resolves_virtual_root_entries() {
+        let backing = Arc::new(TmpFileSystem::new());
+        backing.create_dir(Path::new("/journal-dir")).unwrap();
+        let env = WasiEnvBuilder::new("test")
+            .engine(Engine::default())
+            .fs(backing.clone() as Arc<dyn FileSystem + Send + Sync>)
+            .preopen_dir("/")
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut store = Store::default();
+        let function_env = WasiFunctionEnv::new(&mut store, env);
+        let mut ctx = function_env.env.into_mut(&mut store);
+
+        JournalEffector::apply_path_remove_directory(&mut ctx, VIRTUAL_ROOT_FD, "journal-dir")
+            .unwrap();
+
+        assert_eq!(
+            backing.symlink_metadata(Path::new("/journal-dir")),
+            Err(FsError::EntryNotFound)
+        );
     }
 }

--- a/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
@@ -56,6 +56,26 @@ mod tests {
         let function_env = WasiFunctionEnv::new(&mut store, env);
         let mut ctx = function_env.env.into_mut(&mut store);
 
+        ctx.data().state.fs.register_ephemeral_symlink(
+            "/journal-dir/link".into(),
+            "journal-dir/link".into(),
+            "target".into(),
+        );
+        assert!(
+            JournalEffector::apply_path_remove_directory(&mut ctx, VIRTUAL_ROOT_FD, "journal-dir")
+                .is_err()
+        );
+        assert!(
+            backing
+                .metadata(Path::new("/journal-dir"))
+                .unwrap()
+                .is_dir()
+        );
+        ctx.data()
+            .state
+            .fs
+            .unregister_ephemeral_symlink(Path::new("/journal-dir/link"));
+
         JournalEffector::apply_path_remove_directory(&mut ctx, VIRTUAL_ROOT_FD, "journal-dir")
             .unwrap();
 

--- a/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
+++ b/lib/wasix/src/journal/effector/syscalls/path_remove_directory.rs
@@ -50,8 +50,6 @@ mod tests {
         let env = WasiEnvBuilder::new("test")
             .engine(Engine::default())
             .fs(backing.clone() as Arc<dyn FileSystem + Send + Sync>)
-            .preopen_dir("/")
-            .unwrap()
             .build()
             .unwrap();
         let mut store = Store::default();

--- a/lib/wasix/src/state/mod.rs
+++ b/lib/wasix/src/state/mod.rs
@@ -185,13 +185,6 @@ impl WasiState {
             .map_err(fs_error_into_wasi_err)
     }
 
-    pub(crate) fn fs_remove_dir<P: AsRef<Path>>(&self, path: P) -> Result<(), Errno> {
-        self.fs
-            .root_fs
-            .remove_dir(path.as_ref())
-            .map_err(fs_error_into_wasi_err)
-    }
-
     pub(crate) async fn fs_rename<P: AsRef<Path>, Q: AsRef<Path>>(
         &self,
         from: P,

--- a/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
+++ b/lib/wasix/src/syscalls/wasi/path_remove_directory.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use super::*;
 use crate::syscalls::*;
 
@@ -46,56 +44,6 @@ pub(crate) fn path_remove_directory_internal(
     path: &str,
 ) -> Result<(), Errno> {
     let env = ctx.data();
-    let (memory, state, inodes) = unsafe { env.get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-
-    let (parent_inode, dir_name) =
-        state
-            .fs
-            .get_parent_inode_at_path(inodes, fd, Path::new(path), true)?;
-
-    let mut guard = parent_inode.write();
-    match guard.deref_mut() {
-        Kind::Dir {
-            entries: parent_entries,
-            ..
-        } => {
-            let Some(child_inode) = parent_entries.get(&dir_name) else {
-                return Err(Errno::Noent);
-            };
-
-            {
-                let Kind::Dir {
-                    entries: ref child_entries,
-                    path: ref child_path,
-                    ..
-                } = *child_inode.read()
-                else {
-                    return Err(Errno::Notdir);
-                };
-
-                if !child_entries.is_empty() {
-                    return Err(Errno::Notempty);
-                }
-
-                if let Err(e) = state.fs_remove_dir(child_path) {
-                    tracing::warn!(path = ?child_path, error = ?e, "failed to remove directory");
-                    return Err(e);
-                }
-            }
-
-            parent_entries.remove(&dir_name).expect(
-                "Entry should exist since we checked before and have an exclusive write lock",
-            );
-
-            Ok(())
-        }
-        Kind::Root { .. } => {
-            trace!("directories directly in the root node can not be removed");
-            Err(Errno::Access)
-        }
-        _ => {
-            trace!("path is not a directory");
-            Err(Errno::Notdir)
-        }
-    }
+    let (state, inodes) = env.get_wasi_state_and_inodes();
+    state.fs.remove_directory(inodes, fd, path)
 }

--- a/lib/wasix/tests/wasm_tests/path/directory-remove-cache/build.sh
+++ b/lib/wasix/tests/wasm_tests/path/directory-remove-cache/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ##AbstractConfig: base
+##FileSystems: host,tmp
 ##MappedDirectory: shared:/left
 ##MappedDirectory: shared:/right
 ##ExpectedStdout: directory remove case passed

--- a/lib/wasix/tests/wasm_tests/path/directory-remove-cache/build.sh
+++ b/lib/wasix/tests/wasm_tests/path/directory-remove-cache/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+##AbstractConfig: base
+##MappedDirectory: shared:/left
+##MappedDirectory: shared:/right
+##ExpectedStdout: directory remove case passed
+
+##Config: stale-cache:base
+##Args: stale-cache
+
+##Config: uncached-target:base
+##Args: uncached-target
+
+##Config: nonempty:base
+##Args: nonempty
+
+##Config: retry:base
+##Args: retry
+
+##Config: file:base
+##Args: file
+
+##Config: symlink:base
+##Args: symlink
+
+##Config: missing:base
+##Args: missing
+
+set -euo pipefail
+
+"$CC" main.c -o main

--- a/lib/wasix/tests/wasm_tests/path/directory-remove-cache/main.c
+++ b/lib/wasix/tests/wasm_tests/path/directory-remove-cache/main.c
@@ -5,13 +5,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-static int fail(const char *operation) {
+static int fail(const char* operation) {
   fprintf(stderr, "%s failed: errno=%d (%s)\n", operation, errno,
           strerror(errno));
   return 1;
 }
 
-static int expect_rmdir_error(const char *path, int expected) {
+static int expect_rmdir_error(const char* path, int expected) {
   errno = 0;
   if (rmdir(path) != -1) {
     fprintf(stderr, "rmdir(%s) unexpectedly succeeded\n", path);
@@ -25,73 +25,54 @@ static int expect_rmdir_error(const char *path, int expected) {
   return 0;
 }
 
-static int create_file(const char *path) {
+static int create_file(const char* path) {
   int fd = open(path, O_CREAT | O_EXCL | O_WRONLY, 0600);
-  if (fd < 0)
-    return fail("open");
+  if (fd < 0) return fail("open");
   if (write(fd, "x", 1) != 1) {
     close(fd);
     return fail("write");
   }
-  if (close(fd) != 0)
-    return fail("close");
+  if (close(fd) != 0) return fail("close");
   return 0;
 }
 
 static int stale_cache(void) {
-  if (mkdir("/left/stale", 0700) != 0)
-    return fail("mkdir stale");
-  if (create_file("/right/stale/child") != 0)
-    return 1;
-  if (unlink("/left/stale/child") != 0)
-    return fail("unlink stale child");
-  if (rmdir("/right/stale") != 0)
-    return fail("rmdir stale");
+  if (mkdir("/left/stale", 0700) != 0) return fail("mkdir stale");
+  if (create_file("/right/stale/child") != 0) return 1;
+  if (unlink("/left/stale/child") != 0) return fail("unlink stale child");
+  if (rmdir("/right/stale") != 0) return fail("rmdir stale");
   return 0;
 }
 
 static int uncached_target(void) {
-  if (mkdir("/left/uncached", 0700) != 0)
-    return fail("mkdir uncached");
-  if (rmdir("/right/uncached") != 0)
-    return fail("rmdir uncached");
+  if (mkdir("/left/uncached", 0700) != 0) return fail("mkdir uncached");
+  if (rmdir("/right/uncached") != 0) return fail("rmdir uncached");
   return 0;
 }
 
 static int nonempty(void) {
   struct stat metadata;
-  if (mkdir("/left/nonempty", 0700) != 0)
-    return fail("mkdir nonempty");
-  if (create_file("/left/nonempty/child") != 0)
-    return 1;
-  if (stat("/right/nonempty", &metadata) != 0)
-    return fail("stat nonempty");
+  if (mkdir("/left/nonempty", 0700) != 0) return fail("mkdir nonempty");
+  if (create_file("/left/nonempty/child") != 0) return 1;
+  if (stat("/right/nonempty", &metadata) != 0) return fail("stat nonempty");
   return expect_rmdir_error("/right/nonempty", ENOTEMPTY);
 }
 
 static int retry(void) {
   struct stat metadata;
-  if (mkdir("/left/retry", 0700) != 0)
-    return fail("mkdir retry");
-  if (create_file("/left/retry/child") != 0)
-    return 1;
-  if (stat("/right/retry", &metadata) != 0)
-    return fail("stat retry");
-  if (expect_rmdir_error("/right/retry", ENOTEMPTY) != 0)
-    return 1;
-  if (unlink("/left/retry/child") != 0)
-    return fail("unlink retry child");
-  if (rmdir("/right/retry") != 0)
-    return fail("rmdir retry");
+  if (mkdir("/left/retry", 0700) != 0) return fail("mkdir retry");
+  if (create_file("/left/retry/child") != 0) return 1;
+  if (stat("/right/retry", &metadata) != 0) return fail("stat retry");
+  if (expect_rmdir_error("/right/retry", ENOTEMPTY) != 0) return 1;
+  if (unlink("/left/retry/child") != 0) return fail("unlink retry child");
+  if (rmdir("/right/retry") != 0) return fail("rmdir retry");
   return 0;
 }
 
 static int file_target(void) {
   struct stat metadata;
-  if (create_file("/left/file") != 0)
-    return 1;
-  if (stat("/right/file", &metadata) != 0)
-    return fail("stat file");
+  if (create_file("/left/file") != 0) return 1;
+  if (stat("/right/file", &metadata) != 0) return fail("stat file");
   return expect_rmdir_error("/right/file", ENOTDIR);
 }
 
@@ -99,18 +80,25 @@ static int symlink_target(void) {
   struct stat metadata;
   if (mkdir("/left/symlink-target", 0700) != 0)
     return fail("mkdir symlink target");
-  if (symlink("symlink-target", "/left/symlink") != 0)
-    return fail("symlink");
-  if (lstat("/left/symlink", &metadata) != 0)
-    return fail("lstat symlink");
-  return expect_rmdir_error("/left/symlink", ENOTDIR);
+  if (symlink("symlink-target", "/left/symlink") != 0) return fail("symlink");
+  if (lstat("/left/symlink", &metadata) != 0) return fail("lstat symlink");
+  if (expect_rmdir_error("/left/symlink", ENOTDIR) != 0 ||
+      expect_rmdir_error("/left/symlink/", ENOTDIR) != 0)
+    return 1;
+  if (stat("/left/symlink-target", &metadata) != 0 ||
+      !S_ISDIR(metadata.st_mode))
+    return fail("symlink target was removed");
+  if (mkdir("/left/symlink-target/child", 0700) != 0 ||
+      rmdir("/left/symlink/child") != 0)
+    return fail("remove through intermediate symlink");
+  return 0;
 }
 
 static int missing(void) {
   return expect_rmdir_error("/right/missing", ENOENT);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   if (argc != 2) {
     fprintf(stderr, "expected one case name\n");
     return 1;
@@ -136,8 +124,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (result != 0)
-    return result;
+  if (result != 0) return result;
   puts("directory remove case passed");
   return 0;
 }

--- a/lib/wasix/tests/wasm_tests/path/directory-remove-cache/main.c
+++ b/lib/wasix/tests/wasm_tests/path/directory-remove-cache/main.c
@@ -1,0 +1,143 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int fail(const char *operation) {
+  fprintf(stderr, "%s failed: errno=%d (%s)\n", operation, errno,
+          strerror(errno));
+  return 1;
+}
+
+static int expect_rmdir_error(const char *path, int expected) {
+  errno = 0;
+  if (rmdir(path) != -1) {
+    fprintf(stderr, "rmdir(%s) unexpectedly succeeded\n", path);
+    return 1;
+  }
+  if (errno != expected) {
+    fprintf(stderr, "rmdir(%s) returned errno=%d (%s), expected %d (%s)\n",
+            path, errno, strerror(errno), expected, strerror(expected));
+    return 1;
+  }
+  return 0;
+}
+
+static int create_file(const char *path) {
+  int fd = open(path, O_CREAT | O_EXCL | O_WRONLY, 0600);
+  if (fd < 0)
+    return fail("open");
+  if (write(fd, "x", 1) != 1) {
+    close(fd);
+    return fail("write");
+  }
+  if (close(fd) != 0)
+    return fail("close");
+  return 0;
+}
+
+static int stale_cache(void) {
+  if (mkdir("/left/stale", 0700) != 0)
+    return fail("mkdir stale");
+  if (create_file("/right/stale/child") != 0)
+    return 1;
+  if (unlink("/left/stale/child") != 0)
+    return fail("unlink stale child");
+  if (rmdir("/right/stale") != 0)
+    return fail("rmdir stale");
+  return 0;
+}
+
+static int uncached_target(void) {
+  if (mkdir("/left/uncached", 0700) != 0)
+    return fail("mkdir uncached");
+  if (rmdir("/right/uncached") != 0)
+    return fail("rmdir uncached");
+  return 0;
+}
+
+static int nonempty(void) {
+  struct stat metadata;
+  if (mkdir("/left/nonempty", 0700) != 0)
+    return fail("mkdir nonempty");
+  if (create_file("/left/nonempty/child") != 0)
+    return 1;
+  if (stat("/right/nonempty", &metadata) != 0)
+    return fail("stat nonempty");
+  return expect_rmdir_error("/right/nonempty", ENOTEMPTY);
+}
+
+static int retry(void) {
+  struct stat metadata;
+  if (mkdir("/left/retry", 0700) != 0)
+    return fail("mkdir retry");
+  if (create_file("/left/retry/child") != 0)
+    return 1;
+  if (stat("/right/retry", &metadata) != 0)
+    return fail("stat retry");
+  if (expect_rmdir_error("/right/retry", ENOTEMPTY) != 0)
+    return 1;
+  if (unlink("/left/retry/child") != 0)
+    return fail("unlink retry child");
+  if (rmdir("/right/retry") != 0)
+    return fail("rmdir retry");
+  return 0;
+}
+
+static int file_target(void) {
+  struct stat metadata;
+  if (create_file("/left/file") != 0)
+    return 1;
+  if (stat("/right/file", &metadata) != 0)
+    return fail("stat file");
+  return expect_rmdir_error("/right/file", ENOTDIR);
+}
+
+static int symlink_target(void) {
+  struct stat metadata;
+  if (mkdir("/left/symlink-target", 0700) != 0)
+    return fail("mkdir symlink target");
+  if (symlink("symlink-target", "/left/symlink") != 0)
+    return fail("symlink");
+  if (lstat("/left/symlink", &metadata) != 0)
+    return fail("lstat symlink");
+  return expect_rmdir_error("/left/symlink", ENOTDIR);
+}
+
+static int missing(void) {
+  return expect_rmdir_error("/right/missing", ENOENT);
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "expected one case name\n");
+    return 1;
+  }
+
+  int result;
+  if (strcmp(argv[1], "stale-cache") == 0)
+    result = stale_cache();
+  else if (strcmp(argv[1], "uncached-target") == 0)
+    result = uncached_target();
+  else if (strcmp(argv[1], "nonempty") == 0)
+    result = nonempty();
+  else if (strcmp(argv[1], "retry") == 0)
+    result = retry();
+  else if (strcmp(argv[1], "file") == 0)
+    result = file_target();
+  else if (strcmp(argv[1], "symlink") == 0)
+    result = symlink_target();
+  else if (strcmp(argv[1], "missing") == 0)
+    result = missing();
+  else {
+    fprintf(stderr, "unknown case: %s\n", argv[1]);
+    return 1;
+  }
+
+  if (result != 0)
+    return result;
+  puts("directory remove case passed");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/path/directory-remove-cache/shared/fixture.txt
+++ b/lib/wasix/tests/wasm_tests/path/directory-remove-cache/shared/fixture.txt
@@ -1,0 +1,1 @@
+fixture


### PR DESCRIPTION
Directory removal now checks the backing filesystem instead of cached directory children, so stale or missing cache entries do not prevent removal through another mount alias.

The final component is checked without following symlinks, including paths with a trailing slash. Ephemeral symlink descendants still make a directory nonempty. Backend errors leave the cache unchanged, and successful removal evicts only the inode that was selected before the operation. Final metadata checks and removal run outside inode locks.

Journal replay uses the same removal path, including rootless records whose relative paths must match absolute backing and symlink-registry keys.
