### PR TITLE
fix(wasix): honor exact fds in spawn open actions

### DIFF
--- a/lib/wasix/src/fs/fd.rs
+++ b/lib/wasix/src/fs/fd.rs
@@ -40,6 +40,29 @@ pub struct FdInner {
 }
 
 impl Fd {
+    fn is_stdio_device(&self) -> bool {
+        matches!(
+            *self.inode.read(),
+            Kind::File {
+                fd: Some(0..=2),
+                ..
+            }
+        )
+    }
+
+    pub(crate) fn is_preopened(&self) -> bool {
+        // Device aliases share a preopened inode but are not preopens themselves.
+        self.inode.is_preopened && (self.is_stdio || !self.is_stdio_device())
+    }
+
+    pub(crate) fn is_protected_preopen(&self) -> bool {
+        !self.is_stdio && self.is_preopened()
+    }
+
+    pub(crate) fn uses_stream_io(&self) -> bool {
+        self.is_stdio || self.is_stdio_device()
+    }
+
     /// This [`Fd`] can be used with read system calls.
     pub const READ: u16 = 1;
     /// This [`Fd`] can be used with write system calls.

--- a/lib/wasix/src/fs/mod.rs
+++ b/lib/wasix/src/fs/mod.rs
@@ -723,7 +723,7 @@ impl WasiFs {
                 .filter_map(|(k, v)| {
                     if v.inner.fd_flags.contains(Fdflagsext::CLOEXEC)
                         && !v.is_stdio
-                        && !v.inode.is_preopened
+                        && !v.is_protected_preopen()
                     {
                         tracing::trace!(fd = %k, "Closing FD due to CLOEXEC flag");
                         Some(k)
@@ -1905,10 +1905,11 @@ impl WasiFs {
     }
 
     pub fn prestat_fd(&self, fd: WasiFd) -> Result<Prestat, Errno> {
-        let inode = self.get_fd_inode(fd)?;
+        let entry = self.get_fd(fd)?;
+        let inode = &entry.inode;
         //trace!("in prestat_fd {:?}", self.get_fd(fd)?);
 
-        if inode.is_preopened {
+        if entry.is_preopened() {
             Ok(self.prestat_fd_inner(inode.deref()))
         } else {
             Err(Errno::Badf)
@@ -2139,7 +2140,7 @@ impl WasiFs {
         }
     }
 
-    fn ensure_file_handle_present(fd: &Fd) -> Result<(), Errno> {
+    pub(crate) fn ensure_file_handle_present(fd: &Fd) -> Result<(), Errno> {
         let guard = fd.inode.read();
         match guard.deref() {
             Kind::File { handle: None, .. } => Err(Errno::Badf),
@@ -2172,8 +2173,7 @@ impl WasiFs {
             }
 
             if let Some(target_fd) = fd_map.get(dst)
-                && !target_fd.is_stdio
-                && target_fd.inode.is_preopened
+                && target_fd.is_protected_preopen()
             {
                 warn!("Refusing dup2({src}, {dst}) because FD {dst} is pre-opened");
                 return Err(Errno::Notsup);
@@ -2684,7 +2684,7 @@ impl WasiFs {
             return CloseFdOutcome::not_found();
         };
 
-        if !fd_ref.is_stdio && fd_ref.inode.is_preopened {
+        if fd_ref.is_protected_preopen() {
             return CloseFdOutcome {
                 skipped_preopen: true,
                 removed: false,

--- a/lib/wasix/src/syscalls/wasi/fd_read.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_read.rs
@@ -146,6 +146,7 @@ pub(crate) fn fd_read_internal<M: MemorySize>(
     let memory = unsafe { env.memory_view(&ctx) };
     let state = env.state();
     let is_stdio = fd_entry.is_stdio;
+    let uses_stream_io = fd_entry.uses_stream_io();
 
     let bytes_read = {
         if !is_stdio && !fd_entry.inner.rights.contains(Rights::FD_READ) {
@@ -180,7 +181,7 @@ pub(crate) fn fd_read_internal<M: MemorySize>(
                                 Ok(a) => a,
                                 Err(_) => return Err(Errno::Fault),
                             };
-                            if !is_stdio {
+                            if !uses_stream_io {
                                 handle
                                     .seek(std::io::SeekFrom::Start(offset as u64))
                                     .await
@@ -458,7 +459,7 @@ pub(crate) fn fd_read_internal<M: MemorySize>(
             }
         };
 
-        if !is_stdio && should_update_cursor && can_update_cursor {
+        if !uses_stream_io && should_update_cursor && can_update_cursor {
             fd_entry
                 .inner
                 .offset

--- a/lib/wasix/src/syscalls/wasi/fd_write.rs
+++ b/lib/wasix/src/syscalls/wasi/fd_write.rs
@@ -181,6 +181,7 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
     let mut env = ctx.data();
     let state = env.state.clone();
     let is_stdio = fd_entry.is_stdio;
+    let uses_stream_io = fd_entry.uses_stream_io();
 
     let bytes_written = {
         if !is_stdio && !fd_entry.inner.rights.contains(Rights::FD_WRITE) {
@@ -208,7 +209,7 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
                             },
                             async {
                                 let mut handle = handle.write().unwrap();
-                                if !is_stdio {
+                                if !uses_stream_io {
                                     if fd_entry.inner.flags.contains(Fdflags::APPEND) {
                                         // `fdflags::append` means we need to seek to the end before writing.
                                         offset = fd_entry.inode.stat.read().unwrap().st_size;
@@ -572,7 +573,7 @@ pub(crate) fn fd_write_internal<M: MemorySize>(
         memory = unsafe { env.memory_view(&ctx) };
 
         // reborrow and update the size
-        if !is_stdio {
+        if !uses_stream_io {
             let curr_offset = if is_file && should_update_cursor {
                 let bytes_written = bytes_written as u64;
                 fd_entry

--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::VIRTUAL_ROOT_FD;
-use crate::fs::{FdInner, FdList, MAX_FD, WasiFs};
+use crate::fs::{FdList, MAX_FD, WasiFs};
 use crate::syscalls::*;
 
 /// ### `path_open()`
@@ -167,6 +167,9 @@ pub(crate) fn path_open_internal(
     fd_flags: Fdflagsext,
     with_fd: Option<WasiFd>,
 ) -> Result<Result<WasiFd, Errno>, WasiError> {
+    if let Some(target) = with_fd {
+        wasi_try_ok_ok!(validate_open_target(&env.state.fs, target));
+    }
     path_open_internal_with_symlink_depth(
         env,
         dirfd,
@@ -425,19 +428,22 @@ fn path_open_internal_with_symlink_depth(
                 fd: Some(special_fd),
                 ..
             } => {
-                assert!(handle.is_some());
+                if handle.is_none() {
+                    return Ok(Err(Errno::Badf));
+                }
                 let special_fd = *special_fd;
                 if let Some(target) = with_fd {
                     drop(guard);
-                    wasi_try_ok_ok!(insert_special_fd_locked(
+                    wasi_try_ok_ok!(insert_fd_locked(
                         &mut fd_map,
+                        state,
                         adjusted_rights,
                         adjusted_rights_inheriting,
                         fs_flags,
                         fd_flags,
                         file_open_flags,
                         inode,
-                        target,
+                        Some(target),
                     ))
                 } else {
                     special_fd
@@ -481,15 +487,17 @@ fn path_open_internal_with_symlink_depth(
                         let source = wasi_try_ok_ok!(WasiFs::get_fd_from_locked_map(
                             &state.fs, &fd_map, special_fd,
                         ));
-                        wasi_try_ok_ok!(insert_special_fd_locked(
+                        wasi_try_ok_ok!(WasiFs::ensure_file_handle_present(&source));
+                        wasi_try_ok_ok!(insert_fd_locked(
                             &mut fd_map,
+                            state,
                             adjusted_rights,
                             adjusted_rights_inheriting,
                             fs_flags,
                             fd_flags,
                             file_open_flags,
                             source.inode,
-                            target,
+                            Some(target),
                         ))
                     } else {
                         wasi_try_ok_ok!(WasiFs::clone_fd_locked(
@@ -748,37 +756,19 @@ fn path_open_internal_with_symlink_depth(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn insert_special_fd_locked(
-    fd_map: &mut FdList,
-    rights: Rights,
-    rights_inheriting: Rights,
-    fs_flags: Fdflags,
-    fd_flags: Fdflagsext,
-    open_flags: u16,
-    inode: InodeGuard,
-    target: WasiFd,
-) -> Result<WasiFd, Errno> {
+pub(crate) fn validate_open_target(fs: &WasiFs, target: WasiFd) -> Result<(), Errno> {
     if target > MAX_FD {
         return Err(Errno::Badf);
     }
-    let fd = Fd {
-        inner: FdInner {
-            rights,
-            rights_inheriting,
-            flags: fs_flags,
-            offset: Arc::new(AtomicU64::new(0)),
-            fd_flags,
-        },
-        open_flags,
-        inode,
-        is_stdio: true,
-    };
-    if fd_map.insert(true, target, fd) {
-        Ok(target)
-    } else {
-        Err(Errno::Exist)
+    if target == VIRTUAL_ROOT_FD {
+        return Err(Errno::Notsup);
     }
+    if let Ok(fd) = fs.get_fd(target)
+        && fd.is_protected_preopen()
+    {
+        return Err(Errno::Notsup);
+    }
+    Ok(())
 }
 
 fn insert_fd_locked(

--- a/lib/wasix/src/syscalls/wasix/path_open2.rs
+++ b/lib/wasix/src/syscalls/wasix/path_open2.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::VIRTUAL_ROOT_FD;
-use crate::fs::{FdList, WasiFs};
+use crate::fs::{FdInner, FdList, MAX_FD, WasiFs};
 use crate::syscalls::*;
 
 /// ### `path_open()`
@@ -422,12 +422,26 @@ fn path_open_internal_with_symlink_depth(
         let out_fd = match guard.deref_mut() {
             Kind::File {
                 handle,
-                path,
                 fd: Some(special_fd),
                 ..
             } => {
                 assert!(handle.is_some());
-                *special_fd
+                let special_fd = *special_fd;
+                if let Some(target) = with_fd {
+                    drop(guard);
+                    wasi_try_ok_ok!(insert_special_fd_locked(
+                        &mut fd_map,
+                        adjusted_rights,
+                        adjusted_rights_inheriting,
+                        fs_flags,
+                        fd_flags,
+                        file_open_flags,
+                        inode,
+                        target,
+                    ))
+                } else {
+                    special_fd
+                }
             }
             Kind::File {
                 handle,
@@ -463,15 +477,31 @@ fn path_open_internal_with_symlink_depth(
                     }
                 {
                     drop(guard);
-                    let dup_fd = wasi_try_ok_ok!(WasiFs::clone_fd_locked(
-                        &state.fs,
-                        &mut fd_map,
-                        special_fd,
-                        0,
-                        None,
-                    ));
-                    trace!(%dup_fd);
-                    return Ok(Ok(dup_fd));
+                    let out_fd = if let Some(target) = with_fd {
+                        let source = wasi_try_ok_ok!(WasiFs::get_fd_from_locked_map(
+                            &state.fs, &fd_map, special_fd,
+                        ));
+                        wasi_try_ok_ok!(insert_special_fd_locked(
+                            &mut fd_map,
+                            adjusted_rights,
+                            adjusted_rights_inheriting,
+                            fs_flags,
+                            fd_flags,
+                            file_open_flags,
+                            source.inode,
+                            target,
+                        ))
+                    } else {
+                        wasi_try_ok_ok!(WasiFs::clone_fd_locked(
+                            &state.fs,
+                            &mut fd_map,
+                            special_fd,
+                            0,
+                            None,
+                        ))
+                    };
+                    trace!(%out_fd);
+                    return Ok(Ok(out_fd));
                 }
 
                 let out_fd = wasi_try_ok_ok!(insert_fd_locked(
@@ -715,6 +745,39 @@ fn path_open_internal_with_symlink_depth(
         } else {
             Ok(Err(maybe_inode.unwrap_err()))
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_special_fd_locked(
+    fd_map: &mut FdList,
+    rights: Rights,
+    rights_inheriting: Rights,
+    fs_flags: Fdflags,
+    fd_flags: Fdflagsext,
+    open_flags: u16,
+    inode: InodeGuard,
+    target: WasiFd,
+) -> Result<WasiFd, Errno> {
+    if target > MAX_FD {
+        return Err(Errno::Badf);
+    }
+    let fd = Fd {
+        inner: FdInner {
+            rights,
+            rights_inheriting,
+            flags: fs_flags,
+            offset: Arc::new(AtomicU64::new(0)),
+            fd_flags,
+        },
+        open_flags,
+        inode,
+        is_stdio: true,
+    };
+    if fd_map.insert(true, target, fd) {
+        Ok(target)
+    } else {
+        Err(Errno::Exist)
     }
 }
 

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -2,7 +2,7 @@ use virtual_mio::block_on;
 use wasmer_wasix_types::wasi::ProcSpawnFdOpName;
 
 use super::*;
-use crate::{VIRTUAL_ROOT_FD, WasiFs, fs::MAX_FD, syscalls::*};
+use crate::{VIRTUAL_ROOT_FD, WasiFs, syscalls::*};
 
 /// Spawns a new sub-process (posix-spawn style) with proper `WasmPtr<WasmPtr<u8>>` string lists.
 ///
@@ -204,8 +204,7 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
     match op.cmd {
         ProcSpawnFdOpName::Close => {
             if let Ok(fd) = env.state.fs.get_fd(op.fd)
-                && !fd.is_stdio
-                && fd.inode.is_preopened
+                && fd.is_protected_preopen()
             {
                 trace!("Skipping close FD action for pre-opened FD ({})", op.fd);
                 return Ok(());
@@ -220,7 +219,7 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             Ok(())
         }
         ProcSpawnFdOpName::Open => {
-            validate_spawn_open_target(&env.state.fs, op.fd)?;
+            validate_open_target(&env.state.fs, op.fd)?;
             let mut name = unsafe {
                 WasmPtr::<u8, M>::new(op.name)
                     .read_utf8_string(memory, op.name_len)
@@ -254,28 +253,12 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
     }
 }
 
-fn validate_spawn_open_target(fs: &WasiFs, target: WasiFd) -> Result<(), Errno> {
-    if target > MAX_FD {
-        return Err(Errno::Badf);
-    }
-    if target == VIRTUAL_ROOT_FD {
-        return Err(Errno::Notsup);
-    }
-    if let Ok(fd) = fs.get_fd(target)
-        && !fd.is_stdio
-        && fd.inode.is_preopened
-    {
-        return Err(Errno::Notsup);
-    }
-    Ok(())
-}
-
 fn open_for_spawn<M: MemorySize>(
     env: &WasiEnv,
     op: &ProcSpawnFdOp<M>,
     name: &str,
 ) -> Result<(), Errno> {
-    validate_spawn_open_target(&env.state.fs, op.fd)?;
+    validate_open_target(&env.state.fs, op.fd)?;
 
     let close = env.state.fs.close_fd_and_capture_flush(op.fd);
     if let Some(file) = close.flush_target {
@@ -321,7 +304,7 @@ mod tests {
         path::Path,
         pin::Pin,
         sync::{
-            Arc, RwLock,
+            Arc, RwLock, Weak,
             atomic::{AtomicUsize, Ordering},
         },
         task::{Context, Poll},
@@ -329,11 +312,14 @@ mod tests {
 
     use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
     use virtual_fs::{FileSystem, FsError, NullFile, VirtualFile};
-    use wasmer::{Memory32, Store};
+    use wasmer::{Memory, Memory32, Memory64, MemoryType, Store};
     use wasmer_wasix_types::wasi::ProcSpawnFdOp;
 
     use super::*;
-    use crate::{WasiEnvBuilder, fs::Kind};
+    use crate::{
+        WasiEnvBuilder,
+        fs::{Kind, MAX_FD},
+    };
 
     const TARGET_FD: WasiFd = 10;
 
@@ -490,6 +476,9 @@ mod tests {
 
         let target = env.state.fs.get_fd(TARGET_FD).unwrap();
         assert_eq!(target.inode.ino(), stdout.inode.ino());
+        assert!(!target.is_stdio && !target.is_preopened());
+        assert!(target.uses_stream_io());
+        assert_eq!(env.state.fs.prestat_fd(TARGET_FD).unwrap_err(), Errno::Badf);
         assert_eq!(target.inner.rights, expected_rights);
         assert_eq!(target.inner.rights_inheriting, Rights::FD_WRITE);
         assert_eq!(target.inner.flags, Fdflags::APPEND);
@@ -531,10 +520,189 @@ mod tests {
         assert_eq!(target.inode.ino(), direct_inode.ino());
         assert_eq!(target.inner.rights, expected_rights);
         assert!(env.state.fs.get_fd(1).is_ok());
+        env.state.fs.close_cloexec_fds().await;
+        assert_eq!(env.state.fs.get_fd(direct_target).unwrap_err(), Errno::Badf);
+        assert_eq!(
+            open_for_spawn(&env, &direct, "/direct-special"),
+            Err(Errno::Badf)
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_open_special_cloexec_is_closed_at_startup() {
+        let parent = test_env();
+        let stdout = parent.state.fs.get_fd(1).unwrap();
+        let mut env = parent.clone();
+        env.state = Arc::new(parent.state.fork());
+        let op = open_op(
+            TARGET_FD,
+            Oflags::empty(),
+            Rights::FD_WRITE,
+            Fdflags::empty(),
+            Fdflagsext::CLOEXEC,
+        );
+        open_for_spawn(&env, &op, "/dev/stdout").unwrap();
+        env.state.fs.close_cloexec_fds().await;
+        assert_eq!(env.state.fs.get_fd(TARGET_FD).unwrap_err(), Errno::Badf);
+        assert!(env.state.fs.get_fd(1).is_ok());
+        assert_eq!(
+            parent.state.fs.get_fd(1).unwrap().inode.ino(),
+            stdout.inode.ino()
+        );
+        assert_eq!(
+            parent.state.fs.get_fd(1).unwrap().inner.fd_flags,
+            stdout.inner.fd_flags
+        );
+        assert_eq!(parent.state.fs.get_fd(TARGET_FD).unwrap_err(), Errno::Badf);
+    }
+
+    #[tokio::test]
+    async fn exact_target_open_preserves_real_preopens() {
+        let env = test_env();
+        env.state
+            .fs
+            .with_fd(
+                Rights::all(),
+                Rights::all(),
+                Fdflags::empty(),
+                Fdflagsext::CLOEXEC,
+                Fd::READ,
+                env.state.fs.root_inode.clone(),
+                TARGET_FD,
+            )
+            .unwrap();
+        let target = env.state.fs.get_fd(TARGET_FD).unwrap();
+        assert!(target.is_preopened() && target.is_protected_preopen());
+        assert!(env.state.fs.prestat_fd(TARGET_FD).is_ok());
+        let op = open_op(
+            TARGET_FD,
+            Oflags::CREATE,
+            Rights::FD_WRITE,
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+        );
+        assert_eq!(
+            open_for_spawn(&env, &op, "/protected-preopen"),
+            Err(Errno::Notsup)
+        );
+        assert!(
+            env.state
+                .fs
+                .root_fs
+                .metadata(Path::new("/protected-preopen"))
+                .is_err()
+        );
+        assert_eq!(
+            env.state.fs.dup2_at(1, TARGET_FD).unwrap_err(),
+            Errno::Notsup
+        );
+        env.state.fs.close_fd_and_capture_flush(TARGET_FD);
+        env.state.fs.close_cloexec_fds().await;
+        assert_eq!(
+            env.state.fs.get_fd(TARGET_FD).unwrap().inode.ino(),
+            target.inode.ino()
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_target_open_rejects_closed_device_sources_without_leaking() {
+        let env = test_env();
+        let stdout = env.state.fs.get_fd(1).unwrap();
+        env.state.fs.close_fd_and_capture_flush(1);
+        assert_eq!(stdout.inode.handle_count(), 0);
+        let op = open_op(
+            TARGET_FD,
+            Oflags::empty(),
+            Rights::FD_WRITE,
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+        );
+        assert_eq!(open_for_spawn(&env, &op, "/dev/stdout"), Err(Errno::Badf));
+        assert_eq!(env.state.fs.get_fd(TARGET_FD).unwrap_err(), Errno::Badf);
+        assert_eq!(stdout.inode.handle_count(), 0);
+
+        env.state
+            .fs
+            .with_fd(
+                stdout.inner.rights,
+                stdout.inner.rights_inheriting,
+                stdout.inner.flags,
+                stdout.inner.fd_flags,
+                stdout.open_flags,
+                stdout.inode.clone(),
+                1,
+            )
+            .unwrap();
+        assert_eq!(open_for_spawn(&env, &op, "/dev/stdout"), Err(Errno::Badf));
+        assert_eq!(env.state.fs.get_fd(TARGET_FD).unwrap_err(), Errno::Badf);
+        assert_eq!(stdout.inode.handle_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn spawn_open_validates_before_reading_guest_memory() {
+        check_spawn_open_memory::<Memory32>();
+        check_spawn_open_memory::<Memory64>();
+    }
+
+    fn check_spawn_open_memory<M: MemorySize>() {
+        let mut env = test_env();
+        let mut store = Store::default();
+        let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
+        let view = memory.view(&store);
+        let mut op = ProcSpawnFdOp::<M> {
+            cmd: ProcSpawnFdOpName::Open,
+            fd: MAX_FD + 1,
+            src_fd: 0,
+            name: M::Offset::try_from(65536u64).ok().unwrap(),
+            name_len: M::Offset::try_from(1u64).ok().unwrap(),
+            dirflags: 0,
+            oflags: Oflags::CREATE,
+            fs_rights_base: Rights::FD_WRITE,
+            fs_rights_inheriting: Rights::FD_WRITE,
+            fdflags: Fdflags::empty(),
+            fdflagsext: Fdflagsext::empty(),
+        };
+        assert_eq!(apply_fd_op(&mut env, &view, &op), Err(Errno::Badf));
+        op.fd = VIRTUAL_ROOT_FD;
+        assert_eq!(apply_fd_op(&mut env, &view, &op), Err(Errno::Notsup));
+        env.state.fs.dup2_at(1, TARGET_FD).unwrap();
+        let inode = env.state.fs.get_fd(TARGET_FD).unwrap().inode.ino();
+        op.fd = TARGET_FD;
+        assert_eq!(apply_fd_op(&mut env, &view, &op), Err(Errno::Memviolation));
+        assert_eq!(env.state.fs.get_fd(TARGET_FD).unwrap().inode.ino(), inode);
+        view.write(0, b"/dev/stdout").unwrap();
+        op.name = M::ZERO;
+        op.name_len = M::Offset::try_from(11u64).ok().unwrap();
+        apply_fd_op(&mut env, &view, &op).unwrap();
+        assert!(!env.state.fs.get_fd(TARGET_FD).unwrap().is_stdio);
+        op.cmd = ProcSpawnFdOpName::Close;
+        apply_fd_op(&mut env, &view, &op).unwrap();
+        assert_eq!(env.state.fs.get_fd(TARGET_FD).unwrap_err(), Errno::Badf);
+        assert!(env.state.fs.get_fd(1).is_ok());
+    }
+
+    #[tokio::test]
+    async fn exact_target_special_open_cannot_shadow_virtual_root() {
+        let env = test_env();
+        env.state.fs.fd_map.write().unwrap().remove(VIRTUAL_ROOT_FD);
+        let result = path_open_internal(
+            &env,
+            VIRTUAL_ROOT_FD,
+            0,
+            "/dev/stdout",
+            Oflags::empty(),
+            Rights::FD_WRITE,
+            Rights::empty(),
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+            Some(VIRTUAL_ROOT_FD),
+        )
+        .unwrap();
+        assert_eq!(result, Err(Errno::Notsup));
     }
 
     #[derive(Debug)]
-    struct FlushCountingFile(Arc<AtomicUsize>);
+    struct FlushCountingFile(Arc<AtomicUsize>, Weak<WasiState>);
 
     impl AsyncRead for FlushCountingFile {
         fn poll_read(
@@ -555,9 +723,14 @@ mod tests {
             Poll::Ready(Ok(buf.len()))
         }
 
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            self.0.fetch_add(1, Ordering::SeqCst);
-            Poll::Ready(Ok(()))
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            assert!(self.1.upgrade().unwrap().fs.fd_map.try_write().is_ok());
+            if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(Ok(()))
+            }
         }
 
         fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -621,6 +794,7 @@ mod tests {
             Kind::File {
                 handle: Some(Arc::new(RwLock::new(Box::new(FlushCountingFile(
                     flushes.clone(),
+                    Arc::downgrade(&env.state),
                 ))))),
                 path: "".into(),
                 fd: None,
@@ -649,6 +823,6 @@ mod tests {
             Fdflagsext::empty(),
         );
         open_for_spawn(&env, &op, "/spawn-open-after-flush").unwrap();
-        assert_eq!(flushes.load(Ordering::SeqCst), 1);
+        assert_eq!(flushes.load(Ordering::SeqCst), 2);
     }
 }

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -2,7 +2,7 @@ use virtual_mio::block_on;
 use wasmer_wasix_types::wasi::ProcSpawnFdOpName;
 
 use super::*;
-use crate::{VIRTUAL_ROOT_FD, WasiFs, syscalls::*};
+use crate::{VIRTUAL_ROOT_FD, WasiFs, fs::MAX_FD, syscalls::*};
 
 /// Spawns a new sub-process (posix-spawn style) with proper `WasmPtr<WasmPtr<u8>>` string lists.
 ///
@@ -220,31 +220,14 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             Ok(())
         }
         ProcSpawnFdOpName::Open => {
+            validate_spawn_open_target(&env.state.fs, op.fd)?;
             let mut name = unsafe {
                 WasmPtr::<u8, M>::new(op.name)
                     .read_utf8_string(memory, op.name_len)
                     .map_err(mem_error_to_wasi)?
             };
             name = env.state.fs.relative_path_to_absolute(name.to_owned());
-            match path_open_internal(
-                env,
-                VIRTUAL_ROOT_FD,
-                op.dirflags,
-                &name,
-                op.oflags,
-                op.fs_rights_base,
-                op.fs_rights_inheriting,
-                op.fdflags,
-                op.fdflagsext,
-                Some(op.fd),
-            ) {
-                Err(e) => {
-                    tracing::warn!("Failed to open file for posix_spawn: {:?}", e);
-                    Err(Errno::Io)
-                }
-                Ok(Err(e)) => Err(e),
-                Ok(Ok(_)) => Ok(()),
-            }
+            open_for_spawn(env, op, &name)
         }
         ProcSpawnFdOpName::Chdir => {
             let mut path = unsafe {
@@ -268,5 +251,404 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             }
         }
         _ => Err(Errno::Inval),
+    }
+}
+
+fn validate_spawn_open_target(fs: &WasiFs, target: WasiFd) -> Result<(), Errno> {
+    if target > MAX_FD {
+        return Err(Errno::Badf);
+    }
+    if target == VIRTUAL_ROOT_FD {
+        return Err(Errno::Notsup);
+    }
+    if let Ok(fd) = fs.get_fd(target)
+        && !fd.is_stdio
+        && fd.inode.is_preopened
+    {
+        return Err(Errno::Notsup);
+    }
+    Ok(())
+}
+
+fn open_for_spawn<M: MemorySize>(
+    env: &WasiEnv,
+    op: &ProcSpawnFdOp<M>,
+    name: &str,
+) -> Result<(), Errno> {
+    validate_spawn_open_target(&env.state.fs, op.fd)?;
+
+    let close = env.state.fs.close_fd_and_capture_flush(op.fd);
+    if let Some(file) = close.flush_target {
+        block_on(WasiFs::flush_file_best_effort(file));
+    }
+
+    let opened_fd = match path_open_internal(
+        env,
+        VIRTUAL_ROOT_FD,
+        op.dirflags,
+        name,
+        op.oflags,
+        op.fs_rights_base,
+        op.fs_rights_inheriting,
+        op.fdflags,
+        op.fdflagsext,
+        Some(op.fd),
+    ) {
+        Err(err) => {
+            tracing::warn!("Failed to open file for posix_spawn: {err:?}");
+            return Err(Errno::Io);
+        }
+        Ok(Err(err)) => return Err(err),
+        Ok(Ok(fd)) => fd,
+    };
+
+    if opened_fd != op.fd {
+        tracing::error!(
+            requested_fd = op.fd,
+            %opened_fd,
+            "path_open_internal did not honor the requested descriptor"
+        );
+        return Err(Errno::Io);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{self, SeekFrom},
+        path::Path,
+        pin::Pin,
+        sync::{
+            Arc, RwLock,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll},
+    };
+
+    use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+    use virtual_fs::{FileSystem, FsError, NullFile, VirtualFile};
+    use wasmer::{Memory32, Store};
+    use wasmer_wasix_types::wasi::ProcSpawnFdOp;
+
+    use super::*;
+    use crate::{WasiEnvBuilder, fs::Kind};
+
+    const TARGET_FD: WasiFd = 10;
+
+    fn test_env() -> WasiEnv {
+        let store = Store::default();
+        let mut builder = WasiEnvBuilder::new("spawn-open-test").engine(store.engine().clone());
+        builder.preopen_vfs_dirs(["/".to_owned()]).unwrap();
+        builder.build().unwrap()
+    }
+
+    fn open_op(
+        fd: WasiFd,
+        oflags: Oflags,
+        rights: Rights,
+        fdflags: Fdflags,
+        fdflagsext: Fdflagsext,
+    ) -> ProcSpawnFdOp<Memory32> {
+        ProcSpawnFdOp {
+            cmd: ProcSpawnFdOpName::Open,
+            fd,
+            src_fd: 0,
+            name: 0,
+            name_len: 0,
+            dirflags: 0,
+            oflags,
+            fs_rights_base: rights,
+            fs_rights_inheriting: rights,
+            fdflags,
+            fdflagsext,
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_open_replaces_only_the_child_target() {
+        let parent = test_env();
+        parent.state.fs.dup2_at(0, TARGET_FD).unwrap();
+        let parent_inode = parent.state.fs.get_fd(TARGET_FD).unwrap().inode.ino();
+
+        let mut child = parent.clone();
+        child.state = Arc::new(parent.state.fork());
+        let op = open_op(
+            TARGET_FD,
+            Oflags::CREATE,
+            Rights::FD_READ | Rights::FD_WRITE,
+            Fdflags::NONBLOCK,
+            Fdflagsext::CLOEXEC,
+        );
+        open_for_spawn(&child, &op, "/spawn-open-child").unwrap();
+
+        let child_fd = child.state.fs.get_fd(TARGET_FD).unwrap();
+        assert_ne!(child_fd.inode.ino(), parent_inode);
+        assert!(child_fd.inner.rights.contains(Rights::FD_READ));
+        assert!(child_fd.inner.rights.contains(Rights::FD_WRITE));
+        assert_eq!(child_fd.inner.rights_inheriting, op.fs_rights_inheriting);
+        assert_eq!(child_fd.inner.flags, Fdflags::NONBLOCK);
+        assert_eq!(child_fd.inner.fd_flags, Fdflagsext::CLOEXEC);
+        assert_eq!(
+            child_fd.open_flags & (Fd::READ | Fd::WRITE),
+            Fd::READ | Fd::WRITE
+        );
+
+        assert_eq!(
+            parent.state.fs.get_fd(TARGET_FD).unwrap().inode.ino(),
+            parent_inode
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_open_errors_leave_the_child_target_closed_without_path_side_effects() {
+        let parent = test_env();
+        parent.state.fs.dup2_at(0, TARGET_FD).unwrap();
+        let mut child = parent.clone();
+        child.state = Arc::new(parent.state.fork());
+
+        let missing = open_op(
+            TARGET_FD,
+            Oflags::empty(),
+            Rights::FD_READ,
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+        );
+        assert_eq!(
+            open_for_spawn(&child, &missing, "/missing-spawn-open"),
+            Err(Errno::Noent)
+        );
+        assert_eq!(child.state.fs.get_fd(TARGET_FD).unwrap_err(), Errno::Badf);
+        assert!(parent.state.fs.get_fd(TARGET_FD).is_ok());
+
+        let protected = open_op(
+            VIRTUAL_ROOT_FD,
+            Oflags::CREATE,
+            Rights::FD_WRITE,
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+        );
+        assert_eq!(
+            open_for_spawn(&child, &protected, "/protected-spawn-open"),
+            Err(Errno::Notsup)
+        );
+        assert!(
+            child
+                .state
+                .fs
+                .root_fs
+                .metadata(Path::new("/protected-spawn-open"))
+                .is_err()
+        );
+
+        let huge = open_op(
+            MAX_FD + 1,
+            Oflags::CREATE,
+            Rights::FD_WRITE,
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+        );
+        assert_eq!(
+            open_for_spawn(&child, &huge, "/huge-spawn-open"),
+            Err(Errno::Badf)
+        );
+        assert!(
+            child
+                .state
+                .fs
+                .root_fs
+                .metadata(Path::new("/huge-spawn-open"))
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_target_open_preserves_special_sources_and_requested_flags() {
+        let env = test_env();
+        let stdout = env.state.fs.get_fd(1).unwrap();
+        let stdout_handles = stdout.inode.handle_count();
+        let expected_rights = Rights::FD_ADVISE
+            | Rights::FD_TELL
+            | Rights::FD_SEEK
+            | Rights::FD_DATASYNC
+            | Rights::FD_FDSTAT_SET_FLAGS
+            | Rights::FD_WRITE
+            | Rights::FD_SYNC
+            | Rights::FD_ALLOCATE
+            | Rights::FD_FILESTAT_GET
+            | Rights::FD_FILESTAT_SET_SIZE
+            | Rights::FD_FILESTAT_SET_TIMES;
+        let op = open_op(
+            TARGET_FD,
+            Oflags::empty(),
+            Rights::FD_WRITE,
+            Fdflags::APPEND,
+            Fdflagsext::CLOEXEC,
+        );
+        open_for_spawn(&env, &op, "/dev/stdout").unwrap();
+
+        let target = env.state.fs.get_fd(TARGET_FD).unwrap();
+        assert_eq!(target.inode.ino(), stdout.inode.ino());
+        assert_eq!(target.inner.rights, expected_rights);
+        assert_eq!(target.inner.rights_inheriting, Rights::FD_WRITE);
+        assert_eq!(target.inner.flags, Fdflags::APPEND);
+        assert_eq!(target.inner.fd_flags, Fdflagsext::CLOEXEC);
+        assert!(env.state.fs.get_fd(1).is_ok());
+        assert_eq!(stdout.inode.handle_count(), stdout_handles + 1);
+
+        env.state.fs.close_fd_and_capture_flush(TARGET_FD);
+        assert_eq!(stdout.inode.handle_count(), stdout_handles);
+
+        let direct_inode = env.state.fs.create_inode_with_default_stat(
+            &env.state.inodes,
+            Kind::File {
+                handle: Some(Arc::new(RwLock::new(Box::<NullFile>::default()))),
+                path: "".into(),
+                fd: Some(1),
+            },
+            false,
+            "direct-special".into(),
+        );
+        {
+            let mut root = env.state.fs.root_inode.write();
+            let Kind::Root { entries } = root.deref_mut() else {
+                panic!("expected root inode");
+            };
+            entries.insert("direct-special".to_owned(), direct_inode.clone());
+        }
+
+        let direct_target = TARGET_FD + 1;
+        let direct = open_op(
+            direct_target,
+            Oflags::empty(),
+            Rights::FD_WRITE,
+            Fdflags::APPEND,
+            Fdflagsext::CLOEXEC,
+        );
+        open_for_spawn(&env, &direct, "/direct-special").unwrap();
+        let target = env.state.fs.get_fd(direct_target).unwrap();
+        assert_eq!(target.inode.ino(), direct_inode.ino());
+        assert_eq!(target.inner.rights, expected_rights);
+        assert!(env.state.fs.get_fd(1).is_ok());
+    }
+
+    #[derive(Debug)]
+    struct FlushCountingFile(Arc<AtomicUsize>);
+
+    impl AsyncRead for FlushCountingFile {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for FlushCountingFile {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncSeek for FlushCountingFile {
+        fn start_seek(self: Pin<&mut Self>, _position: SeekFrom) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn poll_complete(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    impl VirtualFile for FlushCountingFile {
+        fn last_accessed(&self) -> u64 {
+            0
+        }
+
+        fn last_modified(&self) -> u64 {
+            0
+        }
+
+        fn created_time(&self) -> u64 {
+            0
+        }
+
+        fn size(&self) -> u64 {
+            0
+        }
+
+        fn set_len(&mut self, _new_size: u64) -> Result<(), FsError> {
+            Ok(())
+        }
+
+        fn unlink(&mut self) -> Result<(), FsError> {
+            Ok(())
+        }
+
+        fn poll_read_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+
+        fn poll_write_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(8192))
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_open_flushes_the_replaced_target_after_unlocking_the_fd_map() {
+        let env = test_env();
+        let flushes = Arc::new(AtomicUsize::new(0));
+        let inode = env.state.fs.create_inode_with_default_stat(
+            &env.state.inodes,
+            Kind::File {
+                handle: Some(Arc::new(RwLock::new(Box::new(FlushCountingFile(
+                    flushes.clone(),
+                ))))),
+                path: "".into(),
+                fd: None,
+            },
+            false,
+            "flush-counting".into(),
+        );
+        env.state
+            .fs
+            .with_fd(
+                Rights::FD_WRITE,
+                Rights::FD_WRITE,
+                Fdflags::empty(),
+                Fdflagsext::empty(),
+                Fd::WRITE,
+                inode,
+                TARGET_FD,
+            )
+            .unwrap();
+
+        let op = open_op(
+            TARGET_FD,
+            Oflags::CREATE,
+            Rights::FD_WRITE,
+            Fdflags::empty(),
+            Fdflagsext::empty(),
+        );
+        open_for_spawn(&env, &op, "/spawn-open-after-flush").unwrap();
+        assert_eq!(flushes.load(Ordering::SeqCst), 1);
     }
 }

--- a/lib/wasix/tests/wasm_tests/fd/proc-spawn2-open-exact-target/main.c
+++ b/lib/wasix/tests/wasm_tests/fd/proc-spawn2-open-exact-target/main.c
@@ -1,0 +1,228 @@
+//#ExpectedStdout: ST
+//#ExpectedStdout: proc_spawn2 open exact target test passed
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <wasi/api_wasix.h>
+
+#define OCCUPIED_FD 10
+#define EMPTY_FD 11
+#define ORDERED_FD 12
+#define FAILURE_FD 14
+
+static void write_file(const char* path, char value) {
+  int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
+  assert(fd >= 0);
+  assert(write(fd, &value, 1) == 1);
+  assert(close(fd) == 0);
+}
+
+static char read_at(int fd) {
+  char value = 0;
+  assert(pread(fd, &value, 1, 0) == 1);
+  return value;
+}
+
+static __wasi_proc_spawn_fd_op_t open_op(__wasi_fd_t fd, const char* path,
+                                         __wasi_oflags_t oflags,
+                                         __wasi_rights_t rights,
+                                         __wasi_fdflags_t fdflags,
+                                         __wasi_fdflagsext_t fdflagsext) {
+  __wasi_proc_spawn_fd_op_t op = {0};
+  op.cmd = __WASI_PROC_SPAWN_FD_OP_NAME_OPEN;
+  op.fd = fd;
+  op.path = (uint8_t*)path;
+  op.path_len = strlen(path);
+  op.dirflags = 0;
+  op.oflags = oflags;
+  op.fs_rights_base = rights;
+  op.fs_rights_inheriting = rights;
+  op.fdflags = fdflags;
+  op.fdflagsext = fdflagsext;
+  return op;
+}
+
+static __wasi_errno_t spawn(const char* child_args,
+                            const __wasi_proc_spawn_fd_op_t* ops,
+                            size_t ops_len, __wasi_pid_t* pid) {
+  char args[128];
+  int len = snprintf(args, sizeof(args), "main\n%s", child_args);
+  assert(len > 0 && (size_t)len < sizeof(args));
+  return __wasi_proc_spawn2("./main", args, "", ops, ops_len, 0, 0, 0, "", pid);
+}
+
+static void wait_ok(__wasi_pid_t pid) {
+  int status = 0;
+  assert(waitpid((pid_t)pid, &status, 0) == (pid_t)pid);
+  assert(WIFEXITED(status));
+  assert(WEXITSTATUS(status) == 0);
+}
+
+static int child_main(int argc, char** argv) {
+  assert(argc >= 3);
+
+  if (strcmp(argv[1], "read") == 0) {
+    int fd = atoi(argv[2]);
+    assert(argc == 4);
+    assert(read_at(fd) == argv[3][0]);
+    return 0;
+  }
+
+  if (strcmp(argv[1], "write") == 0) {
+    int fd = atoi(argv[2]);
+    assert(argc == 4);
+    assert(write(fd, argv[3], strlen(argv[3])) == (ssize_t)strlen(argv[3]));
+    return 0;
+  }
+
+  if (strcmp(argv[1], "special") == 0) {
+    int fd = atoi(argv[2]);
+    assert(argc == 3);
+    assert(write(fd, "S", 1) == 1);
+    assert(close(fd) == 0);
+    errno = 0;
+    assert(write(fd, "X", 1) == -1);
+    assert(errno == EBADF);
+    assert(write(STDOUT_FILENO, "T\n", 2) == 2);
+    return 0;
+  }
+
+  return 2;
+}
+
+static void test_occupied_target(void) {
+  write_file("open-source-a", 'A');
+  write_file("open-decoy", 'D');
+
+  int decoy = open("open-decoy", O_RDONLY);
+  assert(decoy >= 0);
+  assert(dup2(decoy, OCCUPIED_FD) == OCCUPIED_FD);
+  if (decoy != OCCUPIED_FD) {
+    assert(close(decoy) == 0);
+  }
+
+  __wasi_proc_spawn_fd_op_t op =
+      open_op(OCCUPIED_FD, "open-source-a", 0, __WASI_RIGHTS_FD_READ, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("read\n10\nA\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+
+  assert(read_at(OCCUPIED_FD) == 'D');
+  assert(close(OCCUPIED_FD) == 0);
+}
+
+static void test_empty_target(void) {
+  close(EMPTY_FD);
+  __wasi_proc_spawn_fd_op_t op =
+      open_op(EMPTY_FD, "open-source-a", 0, __WASI_RIGHTS_FD_READ, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("read\n11\nA\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+}
+
+static void test_ordered_replacement(void) {
+  write_file("open-source-b", 'B');
+  __wasi_proc_spawn_fd_op_t ops[2] = {
+      open_op(ORDERED_FD, "open-source-a", 0, __WASI_RIGHTS_FD_READ, 0, 0),
+      open_op(ORDERED_FD, "open-source-b", 0, __WASI_RIGHTS_FD_READ, 0, 0),
+  };
+  __wasi_pid_t pid = 0;
+  assert(spawn("read\n12\nB\n", ops, 2, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+}
+
+static void test_stdio_target(void) {
+  unlink("open-stdout");
+  __wasi_proc_spawn_fd_op_t op = open_op(
+      STDOUT_FILENO, "open-stdout", __WASI_OFLAGS_CREAT | __WASI_OFLAGS_TRUNC,
+      __WASI_RIGHTS_FD_WRITE, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("write\n1\nredirected\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+
+  int fd = open("open-stdout", O_RDONLY);
+  assert(fd >= 0);
+  char output[16] = {0};
+  assert(read(fd, output, sizeof(output)) == 10);
+  assert(strcmp(output, "redirected") == 0);
+  assert(close(fd) == 0);
+}
+
+static void test_special_file_target(void) {
+  close(OCCUPIED_FD);
+  __wasi_proc_spawn_fd_op_t op =
+      open_op(OCCUPIED_FD, "/dev/stdout", 0, __WASI_RIGHTS_FD_WRITE, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("special\n10\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+}
+
+static void test_missing_path_closes_only_child_target(void) {
+  unlink("open-missing");
+  write_file("open-failure-decoy", 'F');
+  int decoy = open("open-failure-decoy", O_RDONLY);
+  assert(decoy >= 0);
+  assert(dup2(decoy, FAILURE_FD) == FAILURE_FD);
+  if (decoy != FAILURE_FD) {
+    assert(close(decoy) == 0);
+  }
+
+  __wasi_proc_spawn_fd_op_t op =
+      open_op(FAILURE_FD, "open-missing", 0, __WASI_RIGHTS_FD_READ, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("read\n14\nX\n", &op, 1, &pid) == __WASI_ERRNO_NOENT);
+  assert(read_at(FAILURE_FD) == 'F');
+  assert(close(FAILURE_FD) == 0);
+}
+
+static void test_protected_target_has_no_side_effect(void) {
+  write_file("open-protected", 'P');
+  __wasi_proc_spawn_fd_op_t op = open_op(
+      3, "open-protected", __WASI_OFLAGS_TRUNC, __WASI_RIGHTS_FD_WRITE, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("write\n3\nX\n", &op, 1, &pid) == __WASI_ERRNO_NOTSUP);
+
+  int fd = open("open-protected", O_RDONLY);
+  assert(fd >= 0);
+  assert(read_at(fd) == 'P');
+  assert(close(fd) == 0);
+}
+
+static void test_huge_target_has_no_side_effect(void) {
+  unlink("open-huge");
+  __wasi_proc_spawn_fd_op_t op = open_op(
+      65536, "open-huge", __WASI_OFLAGS_CREAT, __WASI_RIGHTS_FD_WRITE, 0, 0);
+  __wasi_pid_t pid = 0;
+  assert(spawn("write\n65536\nX\n", &op, 1, &pid) == __WASI_ERRNO_BADF);
+  assert(access("open-huge", F_OK) == -1);
+  assert(errno == ENOENT);
+}
+
+int main(int argc, char** argv) {
+  if (argc >= 2) {
+    return child_main(argc, argv);
+  }
+
+  test_occupied_target();
+  test_empty_target();
+  test_ordered_replacement();
+  test_stdio_target();
+  test_special_file_target();
+  test_missing_path_closes_only_child_target();
+  test_protected_target_has_no_side_effect();
+  test_huge_target_has_no_side_effect();
+
+  unlink("open-source-a");
+  unlink("open-source-b");
+  unlink("open-decoy");
+  unlink("open-stdout");
+  unlink("open-failure-decoy");
+  unlink("open-protected");
+  printf("proc_spawn2 open exact target test passed\n");
+  return 0;
+}

--- a/lib/wasix/tests/wasm_tests/fd/proc-spawn2-open-exact-target/main.c
+++ b/lib/wasix/tests/wasm_tests/fd/proc-spawn2-open-exact-target/main.c
@@ -1,5 +1,6 @@
 //#ExpectedStdout: ST
 //#ExpectedStdout: proc_spawn2 open exact target test passed
+//#Stdin: AB
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -84,11 +85,42 @@ static int child_main(int argc, char** argv) {
     int fd = atoi(argv[2]);
     assert(argc == 3);
     assert(write(fd, "S", 1) == 1);
+    __wasi_filesize_t offset = 99;
+    assert(__wasi_fd_tell(fd, &offset) == __WASI_ERRNO_SUCCESS);
+    assert(offset == 0);
     assert(close(fd) == 0);
     errno = 0;
     assert(write(fd, "X", 1) == -1);
     assert(errno == EBADF);
     assert(write(STDOUT_FILENO, "T\n", 2) == 2);
+    return 0;
+  }
+
+  if (strcmp(argv[1], "closed") == 0) {
+    int fd = atoi(argv[2]);
+    errno = 0;
+    assert(fcntl(fd, F_GETFD) == -1 && errno == EBADF);
+    assert(fcntl(STDOUT_FILENO, F_GETFD) >= 0);
+    return 0;
+  }
+
+  if (strcmp(argv[1], "readonly") == 0) {
+    int fd = atoi(argv[2]);
+    errno = 0;
+    assert(write(fd, "X", 1) == -1 && errno == EACCES);
+    assert(close(fd) == 0);
+    return 0;
+  }
+
+  if (strcmp(argv[1], "special-read") == 0) {
+    int fd = atoi(argv[2]);
+    char value = 0;
+    assert(read(fd, &value, 1) == 1 && value == 'A');
+    __wasi_filesize_t offset = 99;
+    assert(__wasi_fd_tell(fd, &offset) == __WASI_ERRNO_SUCCESS);
+    assert(offset == 0);
+    assert(close(fd) == 0);
+    assert(read(STDIN_FILENO, &value, 1) == 1 && value == 'B');
     return 0;
   }
 
@@ -159,6 +191,20 @@ static void test_special_file_target(void) {
       open_op(OCCUPIED_FD, "/dev/stdout", 0, __WASI_RIGHTS_FD_WRITE, 0, 0);
   __wasi_pid_t pid = 0;
   assert(spawn("special\n10\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+
+  op.fdflagsext = __WASI_FDFLAGSEXT_CLOEXEC;
+  assert(spawn("closed\n10\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+
+  op.fdflagsext = 0;
+  op.fs_rights_base = __WASI_RIGHTS_FD_READ;
+  op.fs_rights_inheriting = __WASI_RIGHTS_FD_READ;
+  assert(spawn("readonly\n10\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
+  wait_ok(pid);
+
+  op = open_op(OCCUPIED_FD, "/dev/stdin", 0, __WASI_RIGHTS_FD_READ, 0, 0);
+  assert(spawn("special-read\n10\n", &op, 1, &pid) == __WASI_ERRNO_SUCCESS);
   wait_ok(pid);
 }
 


### PR DESCRIPTION
# Description

Make spawn Open actions replace the requested child descriptor, including occupied targets and special files such as `/dev/stdout`. Reject reserved or protected targets before pathname access or filesystem changes, and flush replaced handles after releasing the descriptor-map lock. If opening subsequently fails, the child target stays closed and the parent descriptor table is unchanged.

Exact-target device opens share the source stream without allocating a temporary descriptor or consuming a distinct source. Non-stdio aliases use the requested rights and flags, remain closeable, and honor `CLOEXEC` without seeking the underlying stream; actual preopens stay protected.
