### PR TITLE
fix(wasix): resolve spawn paths after child cwd actions

### DIFF
--- a/lib/wasix/src/bin_factory/mod.rs
+++ b/lib/wasix/src/bin_factory/mod.rs
@@ -92,6 +92,16 @@ impl BinFactory {
         cache.insert(name.to_string(), Some(binary.clone()));
     }
 
+    pub(crate) fn has_registered_command(&self, name: &str) -> bool {
+        self.commands.exists(name)
+            || self
+                .local
+                .read()
+                .unwrap()
+                .get(name)
+                .is_some_and(Option::is_some)
+    }
+
     #[allow(clippy::await_holding_lock)]
     pub async fn get_binary(
         &self,

--- a/lib/wasix/src/os/task/control_plane.rs
+++ b/lib/wasix/src/os/task/control_plane.rs
@@ -167,6 +167,11 @@ impl WasiControlPlane {
             .get(&pid)
             .cloned()
     }
+
+    /// Roll back registration when a spawn fails before parent publication.
+    pub(crate) fn unregister_failed_spawn(&self, pid: WasiProcessId) {
+        self.state.mutable.write().unwrap().processes.remove(&pid);
+    }
 }
 
 impl MutableState {

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -98,12 +98,10 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
     ret: WasmPtr<Pid, M>,
 ) -> Result<Errno, WasiError> {
     let memory = unsafe { ctx.data().memory_view(&ctx) };
+    // Validate before spawning; linear memory cannot shrink before the success write.
     wasi_try_mem_ok!(ret.access(&memory));
 
-    // Fork the environment which will copy all the open file handlers
-    // and associate a new context but otherwise shares things like the
-    // file system interface. The handle to the forked process is stored
-    // in the parent process context
+    // File actions need a private descriptor table and cwd.
     let (mut child_env, child_handle) = match ctx.data().fork() {
         Ok(p) => p,
         Err(err) => {
@@ -111,6 +109,11 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
             // TODO: evaluate the appropriate error code, document it in the spec.
             return Ok(Errno::Perm);
         }
+    };
+
+    let mut registration = SpawnRegistration {
+        control_plane: child_env.control_plane.clone(),
+        pid: Some(child_env.pid()),
     };
 
     // Setup some properties in the child environment
@@ -136,7 +139,6 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         path
     ));
     Span::current().record("full_path", name.as_str());
-    wasi_try_mem_ok!(ret.write(&memory, pid.raw()));
 
     // Create the process and drop the context
     let bin_factory = Box::new(child_env.bin_factory.clone());
@@ -164,11 +166,13 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
 
     match process {
         Ok(_) => {
+            wasi_try_mem_ok!(ret.write(&memory, pid.raw()));
             {
                 let mut inner = ctx.data().process.lock();
                 inner.children.push(child_process);
             }
             ctx.data_mut().owned_handles.push(child_handle);
+            registration.pid = None;
             trace!(child_pid = %pid, "spawned sub-process");
             Ok(Errno::Success)
         }
@@ -178,6 +182,19 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
             debug!(child_pid = %pid, "process failed with (err={})", err_exit_code);
 
             Ok(Errno::Noexec)
+        }
+    }
+}
+
+struct SpawnRegistration {
+    control_plane: crate::os::task::control_plane::WasiControlPlane,
+    pid: Option<crate::WasiProcessId>,
+}
+
+impl Drop for SpawnRegistration {
+    fn drop(&mut self) {
+        if let Some(pid) = self.pid {
+            self.control_plane.unregister_failed_spawn(pid);
         }
     }
 }
@@ -202,7 +219,9 @@ fn resolve_spawn_executable(
         };
     }
 
-    if name.starts_with('/') {
+    if name.starts_with('/')
+        || (!name.starts_with("./") && env.bin_factory.has_registered_command(name))
+    {
         Ok(name.to_string())
     } else {
         Ok(env.state.fs.relative_path_to_absolute(name.to_string()))
@@ -295,7 +314,219 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wasmer::Engine;
+    use wasmer::{Engine, Instance, Module, Store};
+
+    fn spawn_test_env() -> (Store, crate::WasiFunctionEnv) {
+        let mut store = Store::default();
+        let module = Module::new(&store, r#"(module (memory (export "memory") 1))"#).unwrap();
+        let instance = Instance::new(&mut store, &module, &wasmer::imports! {}).unwrap();
+        let env = WasiEnv::builder("test")
+            .engine(store.engine().clone())
+            .build()
+            .unwrap();
+        let mut env = crate::WasiFunctionEnv::new(&mut store, env);
+        env.initialize(&mut store, instance).unwrap();
+        (store, env)
+    }
+
+    fn spawn_for_test(
+        store: &mut Store,
+        env: &crate::WasiFunctionEnv,
+        name: &str,
+        search_path: Bool,
+    ) -> Errno {
+        proc_spawn3_impl::<Memory32>(
+            env.env.clone().into_mut(store),
+            &mut name.to_string(),
+            vec![name.to_string()],
+            None,
+            vec![],
+            None,
+            search_path,
+            Some("/missing"),
+            WasmPtr::new(16),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn failed_start_does_not_write_pid() {
+        let (mut store, env) = spawn_test_env();
+        let memory = unsafe { env.data(&store).memory() }.clone();
+        let pid = WasmPtr::<Pid>::new(16);
+        pid.write(&memory.view(&store), 12345).unwrap();
+        assert_eq!(
+            spawn_for_test(&mut store, &env, "/missing", Bool::False),
+            Errno::Noexec
+        );
+        assert_eq!(pid.read(&memory.view(&store)).unwrap(), 12345);
+        assert!(env.data(&store).process.lock().children.is_empty());
+        assert!(
+            env.data(&store)
+                .control_plane
+                .get_process((env.data(&store).pid().raw() + 1).into())
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_resolution_does_not_register_process() {
+        let (mut store, env) = spawn_test_env();
+        let next_pid = env.data(&store).pid().raw() + 1;
+        assert_eq!(
+            spawn_for_test(&mut store, &env, "missing", Bool::True),
+            Errno::Noent
+        );
+        assert!(
+            env.data(&store)
+                .control_plane
+                .get_process(next_pid.into())
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_pid_output_prevents_fork_and_execution() {
+        use crate::os::command::BuiltinCommand;
+
+        let (mut store, env) = spawn_test_env();
+        let next_pid = env.data(&store).pid().raw() + 1;
+        env.data_mut(&mut store)
+            .bin_factory
+            .register_builtin_command_with_path(
+                BuiltinCommand::new("tool", |_, _, _| {
+                    panic!("invalid PID output must prevent execution")
+                }),
+                "/tool",
+            );
+        let result = proc_spawn3_impl::<Memory32>(
+            env.env.clone().into_mut(&mut store),
+            &mut "/tool".to_string(),
+            vec![],
+            None,
+            vec![],
+            None,
+            Bool::False,
+            None,
+            WasmPtr::new(65535),
+        )
+        .unwrap();
+        assert_eq!(result, Errno::Memviolation);
+        assert_eq!(
+            env.data(&store).control_plane.generate_id().unwrap().raw(),
+            next_pid
+        );
+        assert!(env.data(&store).process.lock().children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_action_unregisters_child() {
+        let (mut store, env) = spawn_test_env();
+        let next_pid = env.data(&store).pid().raw() + 1;
+        let action = ProcSpawnFdOp {
+            cmd: ProcSpawnFdOpName::Fchdir,
+            fd: u32::MAX,
+            src_fd: 0,
+            name: 0,
+            name_len: 0,
+            dirflags: 0,
+            oflags: Oflags::empty(),
+            fs_rights_base: Rights::empty(),
+            fs_rights_inheriting: Rights::empty(),
+            fdflags: Fdflags::empty(),
+            fdflagsext: Fdflagsext::empty(),
+        };
+        let result = proc_spawn3_impl::<Memory32>(
+            env.env.clone().into_mut(&mut store),
+            &mut "/missing".to_string(),
+            vec![],
+            None,
+            vec![action],
+            None,
+            Bool::False,
+            None,
+            WasmPtr::new(16),
+        )
+        .unwrap();
+        assert_eq!(result, Errno::Badf);
+        assert!(
+            env.data(&store)
+                .control_plane
+                .get_process(next_pid.into())
+                .is_none()
+        );
+        assert!(env.data(&store).process.lock().children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn relative_builtin_keeps_registered_name() {
+        use crate::os::{
+            command::BuiltinCommand,
+            task::{OwnedTaskStatus, TaskStatus},
+        };
+
+        let (mut store, env) = spawn_test_env();
+        let owned_handles = env.data(&store).owned_handles.len();
+        env.data_mut(&mut store)
+            .bin_factory
+            .register_builtin_command_with_path(
+                BuiltinCommand::new("tool", |parent, name, _| {
+                    assert_eq!(name, "tool");
+                    assert!(parent.data().process.lock().children.is_empty());
+                    Ok(
+                        OwnedTaskStatus::new(TaskStatus::Finished(Ok(Errno::Success.into())))
+                            .handle(),
+                    )
+                }),
+                "tool",
+            );
+        assert_eq!(
+            spawn_for_test(&mut store, &env, "tool", Bool::False),
+            Errno::Success
+        );
+        let memory = unsafe { env.data(&store).memory_view(&store) };
+        let pid = WasmPtr::<Pid>::new(16).read(&memory).unwrap();
+        assert!(
+            env.data(&store)
+                .control_plane
+                .get_process(pid.into())
+                .is_some()
+        );
+        assert_eq!(env.data(&store).process.lock().children[0].pid().raw(), pid);
+        assert_eq!(env.data(&store).owned_handles.len(), owned_handles + 1);
+        assert_eq!(
+            resolve_spawn_executable(env.data(&store), "tool", Bool::True, Some("/missing")),
+            Err(Errno::Noent)
+        );
+    }
+
+    #[tokio::test]
+    async fn relative_package_keeps_cache_key() {
+        use crate::bin_factory::BinaryPackage;
+        use wasmer_config::package::{PackageHash, PackageId};
+
+        let env = WasiEnv::builder("test")
+            .engine(Engine::default())
+            .build()
+            .unwrap();
+        let package = Arc::new(BinaryPackage {
+            id: PackageId::Hash(PackageHash::from_sha256_bytes([0; 32])),
+            package_ids: vec![],
+            webc_version: webc::Version::V3,
+            when_cached: None,
+            entrypoint_cmd: None,
+            hash: Default::default(),
+            package_mounts: None,
+            commands: vec![],
+            uses: vec![],
+            file_system_memory_footprint: 0,
+            additional_host_mapped_directories: vec![],
+        });
+        env.bin_factory.set_binary("namespace/tool", &package);
+        let name = resolve_spawn_executable(&env, "namespace/tool", Bool::False, None).unwrap();
+        let resolved = env.bin_factory.get_binary(&name, Some(env.fs_root())).await;
+        assert!(resolved.is_some_and(|resolved| Arc::ptr_eq(&resolved, &package)));
+    }
 
     #[tokio::test]
     async fn spawn_resolution_uses_prepared_child_cwd() {

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -98,35 +98,13 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
     ret: WasmPtr<Pid, M>,
 ) -> Result<Errno, WasiError> {
     let memory = unsafe { ctx.data().memory_view(&ctx) };
-
-    // Convert relative paths into absolute paths
-    if search_path == Bool::True && !name.contains('/') {
-        let path = if let Some(path) = path {
-            path.split(':').collect::<Vec<_>>()
-        } else {
-            vec!["/usr/local/bin", "/bin", "/usr/bin"]
-        };
-        let (_, state, inodes) =
-            unsafe { ctx.data().get_memory_and_wasi_state_and_inodes(&ctx, 0) };
-        match find_executable_in_path(&state.fs, inodes, path.iter().map(AsRef::as_ref), name) {
-            FindExecutableResult::Found(p) => *name = p,
-            FindExecutableResult::AccessError => return Ok(Errno::Access),
-            // Nothing by that name on PATH is ENOENT. ENOEXEC means the file
-            // was found but is not an executable format, which is what the
-            // spawn failure below reports. proc_exec4 already gets this right.
-            FindExecutableResult::NotFound => return Ok(Errno::Noent),
-        }
-    } else if name.starts_with("./") {
-        *name = ctx.data().state.fs.relative_path_to_absolute(name.clone());
-    }
-
-    Span::current().record("full_path", name.as_str());
+    wasi_try_mem_ok!(ret.access(&memory));
 
     // Fork the environment which will copy all the open file handlers
     // and associate a new context but otherwise shares things like the
     // file system interface. The handle to the forked process is stored
     // in the parent process context
-    let (mut child_env, mut child_handle) = match ctx.data().fork() {
+    let (mut child_env, child_handle) = match ctx.data().fork() {
         Ok(p) => p,
         Err(err) => {
             debug!("could not fork process: {err}");
@@ -135,17 +113,12 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         }
     };
 
-    {
-        let mut inner = ctx.data().process.lock();
-        inner.children.push(child_env.process.clone());
-    }
-
     // Setup some properties in the child environment
     let pid = child_env.pid();
     let tid = child_env.tid();
+    let child_process = child_env.process.clone();
     let child_finished = child_env.process.finished.clone();
     let tasks = child_env.tasks().clone();
-    wasi_try_mem_ok!(ret.write(&memory, pid.raw()));
     Span::current()
         .record("pid", pid.raw())
         .record("tid", tid.raw());
@@ -155,6 +128,15 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
     for fd_op in fd_ops {
         wasi_try_ok!(apply_fd_op(&mut child_env, &memory, &fd_op));
     }
+
+    *name = wasi_try_ok!(resolve_spawn_executable(
+        &child_env,
+        name,
+        search_path,
+        path
+    ));
+    Span::current().record("full_path", name.as_str());
+    wasi_try_mem_ok!(ret.write(&memory, pid.raw()));
 
     // Create the process and drop the context
     let bin_factory = Box::new(child_env.bin_factory.clone());
@@ -182,6 +164,10 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
 
     match process {
         Ok(_) => {
+            {
+                let mut inner = ctx.data().process.lock();
+                inner.children.push(child_process);
+            }
             ctx.data_mut().owned_handles.push(child_handle);
             trace!(child_pid = %pid, "spawned sub-process");
             Ok(Errno::Success)
@@ -194,6 +180,41 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
             Ok(Errno::Noexec)
         }
     }
+}
+
+fn resolve_spawn_executable(
+    env: &WasiEnv,
+    name: &str,
+    search_path: Bool,
+    path: Option<&str>,
+) -> Result<String, Errno> {
+    if search_path == Bool::True && !name.contains('/') {
+        let path = resolve_spawn_search_path(env, path);
+        return match find_executable_in_path(
+            &env.state.fs,
+            &env.state.inodes,
+            path.iter().map(AsRef::as_ref),
+            name,
+        ) {
+            FindExecutableResult::Found(path) => Ok(path),
+            FindExecutableResult::AccessError => Err(Errno::Access),
+            FindExecutableResult::NotFound => Err(Errno::Noent),
+        };
+    }
+
+    if name.starts_with('/') {
+        Ok(name.to_string())
+    } else {
+        Ok(env.state.fs.relative_path_to_absolute(name.to_string()))
+    }
+}
+
+fn resolve_spawn_search_path(env: &WasiEnv, path: Option<&str>) -> Vec<String> {
+    path.map(|path| path.split(':').collect::<Vec<_>>())
+        .unwrap_or_else(|| vec!["/usr/local/bin", "/bin", "/usr/bin"])
+        .into_iter()
+        .map(|entry| env.state.fs.relative_path_to_absolute(entry.to_string()))
+        .collect()
 }
 
 pub(crate) fn apply_fd_op<M: MemorySize>(
@@ -268,5 +289,62 @@ pub(crate) fn apply_fd_op<M: MemorySize>(
             }
         }
         _ => Err(Errno::Inval),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmer::Engine;
+
+    #[tokio::test]
+    async fn spawn_resolution_uses_prepared_child_cwd() {
+        let env = WasiEnv::builder("test")
+            .engine(Engine::default())
+            .build()
+            .unwrap();
+        env.state.fs.set_current_dir("/child");
+
+        assert_eq!(
+            resolve_spawn_executable(&env, "tool", Bool::False, None),
+            Ok("/child/tool".to_string())
+        );
+        assert_eq!(
+            resolve_spawn_executable(&env, "./tool", Bool::False, None),
+            Ok("/child/./tool".to_string())
+        );
+        assert_eq!(
+            resolve_spawn_executable(&env, "sub/tool", Bool::False, None),
+            Ok("/child/sub/tool".to_string())
+        );
+        assert_eq!(
+            resolve_spawn_search_path(&env, Some("bin::/absolute")),
+            vec![
+                "/child/bin".to_string(),
+                "/child/".to_string(),
+                "/absolute".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn uncommitted_child_is_finished_without_parent_publication() {
+        let parent = WasiEnv::builder("test")
+            .engine(Engine::default())
+            .build()
+            .unwrap();
+        let owned_handles = parent.owned_handles.len();
+        let children = parent.process.lock().children.len();
+        let (child, child_handle) = parent.fork().unwrap();
+        let child_process = child.process.clone();
+
+        drop(child);
+        drop(child_handle);
+
+        assert_eq!(parent.owned_handles.len(), owned_handles);
+        assert_eq!(parent.process.lock().children.len(), children);
+        assert!(
+            matches!(child_process.try_join(), Some(Ok(code)) if code == Errno::Success.into())
+        );
     }
 }

--- a/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/build.sh
+++ b/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+##MappedDirectory:.:/home
+##CurrentDirectory: /home
+
+set -euo pipefail
+
+mkdir -p chdir/sub fchdir/nested path-relative/bin path-empty
+
+$CC -sRUN_WASM_OPT=no main.c -o main
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=10 -o tool
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=11 -o chdir/tool
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=12 -o chdir/sub/tool
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=13 -o fchdir/tool
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=14 -o path-relative/bin/tool
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=15 -o path-empty/tool
+$CC -sRUN_WASM_OPT=no child.c -DCHILD_EXIT=16 -o fchdir/nested/tool

--- a/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/child.c
+++ b/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/child.c
@@ -1,0 +1,3 @@
+#include <stdlib.h>
+
+int main(void) { return CHILD_EXIT; }

--- a/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/main.c
+++ b/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/main.c
@@ -1,0 +1,139 @@
+//#ExpectedStdout: child cwd spawn resolution passed
+
+#include <errno.h>
+#include <fcntl.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char** environ;
+
+static int expect_parent_cwd(void) {
+  char cwd[64];
+  if (getcwd(cwd, sizeof(cwd)) == NULL) {
+    perror("getcwd");
+    return -1;
+  }
+  if (strcmp(cwd, "/home") != 0) {
+    fprintf(stderr, "parent cwd changed to %s\n", cwd);
+    return -1;
+  }
+  return 0;
+}
+
+static int spawn_and_expect(const char* name,
+                            posix_spawn_file_actions_t* actions,
+                            int search_path, int expected_exit) {
+  pid_t pid = -1;
+  char* argv[] = {(char*)name, NULL};
+  int error = search_path
+                  ? posix_spawnp(&pid, name, actions, NULL, argv, environ)
+                  : posix_spawn(&pid, name, actions, NULL, argv, environ);
+  if (error != 0) {
+    fprintf(stderr, "spawn %s failed: %s\n", name, strerror(error));
+    return -1;
+  }
+
+  int status;
+  if (waitpid(pid, &status, 0) != pid) {
+    perror("waitpid");
+    return -1;
+  }
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != expected_exit) {
+    fprintf(stderr, "spawn %s: expected exit %d, got status %d\n", name,
+            expected_exit, status);
+    return -1;
+  }
+  return expect_parent_cwd();
+}
+
+static int expect_failed_spawn(const char* name,
+                               posix_spawn_file_actions_t* actions,
+                               int search_path, int expected_error) {
+  pid_t pid = 12345;
+  char* argv[] = {(char*)name, NULL};
+  int error = search_path
+                  ? posix_spawnp(&pid, name, actions, NULL, argv, environ)
+                  : posix_spawn(&pid, name, actions, NULL, argv, environ);
+  if (error != expected_error) {
+    fprintf(stderr, "spawn %s: expected error %s, got %s\n", name,
+            strerror(expected_error), strerror(error));
+    return -1;
+  }
+  if (pid != 12345) {
+    fprintf(stderr, "failed spawn %s published pid %d\n", name, (int)pid);
+    return -1;
+  }
+
+  int status;
+  errno = 0;
+  if (waitpid(-1, &status, WNOHANG) != -1 || errno != ECHILD) {
+    fprintf(stderr, "failed spawn %s left a waitable child\n", name);
+    return -1;
+  }
+  return expect_parent_cwd();
+}
+
+int main(void) {
+  posix_spawn_file_actions_t actions;
+
+  if (posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "chdir") != 0 ||
+      spawn_and_expect("./tool", &actions, 0, 11) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "chdir") != 0 ||
+      spawn_and_expect("sub/tool", &actions, 0, 12) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  int dirfd = open("fchdir", O_RDONLY | O_DIRECTORY);
+  if (dirfd < 0 || posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addfchdir_np(&actions, dirfd) != 0 ||
+      spawn_and_expect("tool", &actions, 0, 13) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (setenv("PATH", "bin:/missing", 1) != 0 ||
+      posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "path-relative") != 0 ||
+      spawn_and_expect("tool", &actions, 1, 14) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (setenv("PATH", ":/missing", 1) != 0 ||
+      posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "path-empty") != 0 ||
+      spawn_and_expect("tool", &actions, 1, 15) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addfchdir_np(&actions, dirfd) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "nested") != 0 ||
+      spawn_and_expect("./tool", &actions, 0, 16) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "missing") != 0 ||
+      expect_failed_spawn("/home/tool", &actions, 0, ENOENT) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (setenv("PATH", "", 1) != 0 ||
+      posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "path-empty") != 0 ||
+      expect_failed_spawn("missing", &actions, 1, ENOENT) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  close(dirfd);
+  puts("child cwd spawn resolution passed");
+  return EXIT_SUCCESS;
+}

--- a/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/main.c
+++ b/lib/wasix/tests/wasm_tests/process/spawn-cwd-actions/main.c
@@ -83,6 +83,9 @@ int main(void) {
   if (posix_spawn_file_actions_init(&actions) != 0 ||
       posix_spawn_file_actions_addchdir_np(&actions, "chdir") != 0 ||
       spawn_and_expect("./tool", &actions, 0, 11) != 0 ||
+      spawn_and_expect("tool", &actions, 0, 11) != 0 ||
+      spawn_and_expect("./tool", &actions, 1, 11) != 0 ||
+      spawn_and_expect("/home/tool", &actions, 1, 10) != 0 ||
       posix_spawn_file_actions_destroy(&actions) != 0)
     return EXIT_FAILURE;
 
@@ -99,7 +102,7 @@ int main(void) {
       posix_spawn_file_actions_destroy(&actions) != 0)
     return EXIT_FAILURE;
 
-  if (setenv("PATH", "bin:/missing", 1) != 0 ||
+  if (setenv("PATH", "missing:bin:/missing", 1) != 0 ||
       posix_spawn_file_actions_init(&actions) != 0 ||
       posix_spawn_file_actions_addchdir_np(&actions, "path-relative") != 0 ||
       spawn_and_expect("tool", &actions, 1, 14) != 0 ||
@@ -109,6 +112,12 @@ int main(void) {
   if (setenv("PATH", ":/missing", 1) != 0 ||
       posix_spawn_file_actions_init(&actions) != 0 ||
       posix_spawn_file_actions_addchdir_np(&actions, "path-empty") != 0 ||
+      spawn_and_expect("tool", &actions, 1, 15) != 0 ||
+      setenv("PATH", "/missing:", 1) != 0 ||
+      spawn_and_expect("tool", &actions, 1, 15) != 0 ||
+      setenv("PATH", "/missing::/also-missing", 1) != 0 ||
+      spawn_and_expect("tool", &actions, 1, 15) != 0 ||
+      setenv("PATH", "", 1) != 0 ||
       spawn_and_expect("tool", &actions, 1, 15) != 0 ||
       posix_spawn_file_actions_destroy(&actions) != 0)
     return EXIT_FAILURE;
@@ -131,6 +140,29 @@ int main(void) {
       posix_spawn_file_actions_addchdir_np(&actions, "path-empty") != 0 ||
       expect_failed_spawn("missing", &actions, 1, ENOENT) != 0 ||
       posix_spawn_file_actions_destroy(&actions) != 0)
+    return EXIT_FAILURE;
+
+  if (posix_spawn_file_actions_init(&actions) != 0 ||
+      posix_spawn_file_actions_addopen(&actions, 20, "before-chdir",
+                                       O_WRONLY | O_CREAT | O_EXCL,
+                                       0600) != 0 ||
+      posix_spawn_file_actions_addchdir_np(&actions, "chdir") != 0 ||
+      posix_spawn_file_actions_addopen(&actions, 21, "after-chdir",
+                                       O_WRONLY | O_CREAT | O_EXCL,
+                                       0600) != 0 ||
+      spawn_and_expect("./tool", &actions, 0, 11) != 0 ||
+      posix_spawn_file_actions_destroy(&actions) != 0 ||
+      access("before-chdir", F_OK) != 0 ||
+      access("chdir/after-chdir", F_OK) != 0)
+    return EXIT_FAILURE;
+
+  if (expect_failed_spawn("/home/missing", NULL, 0, ENOEXEC) != 0)
+    return EXIT_FAILURE;
+
+  FILE* invalid = fopen("invalid", "w");
+  if (invalid == NULL || fputs("not a wasm module", invalid) == EOF ||
+      fclose(invalid) != 0 ||
+      expect_failed_spawn("/home/invalid", NULL, 0, ENOEXEC) != 0)
     return EXIT_FAILURE;
 
   close(dirfd);


### PR DESCRIPTION
Resolve spawned executables after the child's file actions so relative names and relative or empty `PATH` components use the child's final working directory. Keep registered builtin and package command precedence unchanged.

Write the PID and add the child to its parent only after startup succeeds. Reject invalid PID output before forking, and remove failed spawn setup from the process registry so errors do not leave a phantom child.
