### PR TITLE
fix(wasix): add root process force termination

### DIFF
--- a/lib/wasix/src/os/task/control_plane.rs
+++ b/lib/wasix/src/os/task/control_plane.rs
@@ -156,11 +156,7 @@ impl WasiControlPlane {
 
         // Child creation and subtree shutdown take the same control-plane lock.
         // A child is either included in the shutdown snapshot or rejected here.
-        let mut parent_inner = parent.map(WasiProcess::lock);
-        if parent_inner
-            .as_ref()
-            .is_some_and(|inner| inner.forced_exit_code.is_some())
-        {
+        if parent.is_some_and(|parent| parent.forced_exit_code().is_some()) {
             return Err(ControlPlaneError::ProcessTerminated);
         }
 
@@ -168,8 +164,13 @@ impl WasiControlPlane {
         proc.set_pid(pid);
         proc.parent = parent.map(|parent| Arc::downgrade(&parent.inner));
         mutable.processes.insert(pid, proc.clone());
-        if let Some(parent_inner) = parent_inner.as_mut() {
-            parent_inner.children.push(proc.clone());
+        drop(mutable);
+
+        // Never acquire a published process lock under the control-plane lock:
+        // signal/checkpoint wakers may re-enter the control plane. Shutdown can
+        // already find this child by ancestry while reap-list attachment waits.
+        if let Some(parent) = parent {
+            parent.lock().children.push(proc.clone());
         }
         Ok(proc)
     }
@@ -196,7 +197,11 @@ impl WasiControlPlane {
             let mut cursor = 0;
             while cursor < processes.len() {
                 let process = &processes[cursor];
-                process.lock().forced_exit_code.get_or_insert(exit_code);
+                process
+                    .forced_exit_code
+                    .lock()
+                    .unwrap()
+                    .get_or_insert(exit_code);
                 if let Some(descendants) = children.remove(&Arc::as_ptr(&process.inner)) {
                     processes.extend(descendants);
                 }
@@ -289,6 +294,55 @@ mod tests {
 
     #[cfg(all(feature = "sys-thread", not(target_arch = "wasm32")))]
     #[tokio::test]
+    async fn force_terminate_finds_child_before_reap_list_attachment_without_lock_inversion() {
+        let env = crate::WasiEnv::builder("shutdown-before-child-attachment")
+            .engine(wasmer::Store::default().engine().clone())
+            .build()
+            .unwrap();
+        let plane = env.control_plane.clone();
+        let parent = env.process.clone();
+        let parent_guard = parent.lock();
+        let fork = std::thread::spawn(move || env.fork());
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while plane.state.mutable.read().unwrap().processes.len() == 1 {
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+
+        let root = parent.clone();
+        let shutdown = std::thread::spawn(move || root.force_terminate(ExitCode::from(137)));
+        while parent.forced_exit_code().is_none() {
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        let child = loop {
+            if let Ok(registry) = plane.state.mutable.try_read() {
+                break registry
+                    .processes
+                    .values()
+                    .find(|process| process.parent.is_some())
+                    .unwrap()
+                    .clone();
+            }
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        };
+        assert_eq!(child.forced_exit_code(), Some(ExitCode::from(137)));
+        assert!(parent_guard.children.is_empty());
+        // Both fork attachment and local parent cancellation are waiting for
+        // this lock, but neither may keep the control plane locked while doing so.
+        drop(parent_guard);
+        assert!(matches!(
+            fork.join().unwrap(),
+            Err(ControlPlaneError::ProcessTerminated)
+        ));
+        shutdown.join().unwrap().unwrap();
+        assert_eq!(child.try_join().unwrap().unwrap(), ExitCode::from(137));
+        assert!(parent.lock().children.is_empty());
+    }
+
+    #[cfg(all(feature = "sys-thread", not(target_arch = "wasm32")))]
+    #[tokio::test]
     async fn failed_fork_main_thread_does_not_leave_a_pending_child() {
         let plane = WasiControlPlane::new(ControlPlaneConfig {
             max_task_count: Some(4),
@@ -307,7 +361,7 @@ mod tests {
         let parent_guard = parent.lock();
         let fork = std::thread::spawn(move || env.fork());
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while plane.state.mutable.try_write().is_ok() {
+        while plane.state.mutable.read().unwrap().processes.len() == 1 {
             assert!(std::time::Instant::now() < deadline);
             std::thread::yield_now();
         }

--- a/lib/wasix/src/os/task/control_plane.rs
+++ b/lib/wasix/src/os/task/control_plane.rs
@@ -9,6 +9,7 @@ use std::{
 
 use crate::{WasiProcess, WasiProcessId};
 use wasmer_types::ModuleHash;
+use wasmer_wasix_types::wasi::ExitCode;
 
 #[derive(Debug, Clone)]
 pub struct WasiControlPlane {
@@ -132,6 +133,14 @@ impl WasiControlPlane {
     // FIXME: De-register terminated processes!
     // Currently they just accumulate.
     pub fn new_process(&self, module_hash: ModuleHash) -> Result<WasiProcess, ControlPlaneError> {
+        self.new_process_with_parent(module_hash, None)
+    }
+
+    pub(super) fn new_process_with_parent(
+        &self,
+        module_hash: ModuleHash,
+        parent: Option<&WasiProcess>,
+    ) -> Result<WasiProcess, ControlPlaneError> {
         if let Some(max) = self.state.config.max_task_count
             && self.active_task_count() >= max
         {
@@ -145,10 +154,62 @@ impl WasiControlPlane {
 
         let mut mutable = self.state.mutable.write().unwrap();
 
+        // Child creation and subtree shutdown take the same control-plane lock.
+        // A child is either included in the shutdown snapshot or rejected here.
+        let mut parent_inner = parent.map(WasiProcess::lock);
+        if parent_inner
+            .as_ref()
+            .is_some_and(|inner| inner.forced_exit_code.is_some())
+        {
+            return Err(ControlPlaneError::ProcessTerminated);
+        }
+
         let pid = mutable.next_process_id()?;
         proc.set_pid(pid);
+        proc.parent = parent.map(|parent| Arc::downgrade(&parent.inner));
         mutable.processes.insert(pid, proc.clone());
+        if let Some(parent_inner) = parent_inner.as_mut() {
+            parent_inner.children.push(proc.clone());
+        }
         Ok(proc)
+    }
+
+    pub(super) fn force_terminate(&self, root: &WasiProcess, exit_code: ExitCode) {
+        let processes = {
+            // Keep ancestry in the existing process registry, not in the reap
+            // lists: proc_join can remove a child while it is still running.
+            // Exclusivity also serializes competing force requests, so the
+            // first requested exit code is latched throughout the whole family.
+            #[allow(clippy::readonly_write_lock)]
+            let mutable = self.state.mutable.write().unwrap();
+            let mut children = HashMap::<_, Vec<_>>::new();
+            for process in mutable.processes.values() {
+                if let Some(parent) = &process.parent {
+                    children
+                        .entry(parent.as_ptr())
+                        .or_default()
+                        .push(process.clone());
+                }
+            }
+
+            let mut processes = vec![root.clone()];
+            let mut cursor = 0;
+            while cursor < processes.len() {
+                let process = &processes[cursor];
+                process.lock().forced_exit_code.get_or_insert(exit_code);
+                if let Some(descendants) = children.remove(&Arc::as_ptr(&process.inner)) {
+                    processes.extend(descendants);
+                }
+                cursor += 1;
+            }
+            processes
+        };
+
+        // Complete children before parents and never wake user tasks under the
+        // control-plane lock. All registration gates are already closed.
+        for process in processes.into_iter().rev() {
+            process.force_terminate_local(exit_code);
+        }
     }
 
     /// Generates a new process ID
@@ -201,6 +262,15 @@ impl Drop for TaskCountGuard {
 
 #[derive(thiserror::Error, PartialEq, Eq, Clone, Debug)]
 pub enum ControlPlaneError {
+    /// The owning control plane was dropped.
+    #[error("The control plane is unavailable")]
+    Unavailable,
+    /// Forced execution-family shutdown must be requested on its root process.
+    #[error("Forced termination requires a root process")]
+    NotRootProcess,
+    /// The process has been forcibly terminated and cannot create more work.
+    #[error("The process has been forcibly terminated")]
+    ProcessTerminated,
     /// The maximum number of execution tasks has been reached.
     #[error("The maximum number of execution tasks has been reached ({max})")]
     TaskLimitReached {
@@ -216,6 +286,54 @@ mod tests {
     use crate::os::task::thread::WasiMemoryLayout;
 
     use super::*;
+
+    #[cfg(all(feature = "sys-thread", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn failed_fork_main_thread_does_not_leave_a_pending_child() {
+        let plane = WasiControlPlane::new(ControlPlaneConfig {
+            max_task_count: Some(4),
+            ..ControlPlaneConfig::default()
+        });
+        let mut init = crate::WasiEnv::builder("fork-capacity-race")
+            .engine(wasmer::Store::default().engine().clone())
+            .build_init()
+            .unwrap();
+        init.control_plane = plane.clone();
+        let env = crate::WasiEnv::from_init(init, ModuleHash::random()).unwrap();
+        let parent = env.process.clone();
+
+        // Pause child registration after its initial capacity check but before
+        // it can return from new_child and create the child's main thread.
+        let parent_guard = parent.lock();
+        let fork = std::thread::spawn(move || env.fork());
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while plane.state.mutable.try_write().is_ok() {
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::yield_now();
+        }
+        let capacity_guards = (0..4)
+            .map(|_| plane.register_task().unwrap())
+            .collect::<Vec<_>>();
+        drop(parent_guard);
+        assert!(matches!(
+            fork.join().unwrap(),
+            Err(ControlPlaneError::TaskLimitReached { .. })
+        ));
+        assert!(parent.lock().children.is_empty());
+        let children = plane
+            .state
+            .mutable
+            .read()
+            .unwrap()
+            .processes
+            .values()
+            .filter(|process| process.parent.is_some())
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(children.len(), 1);
+        assert!(children[0].try_join().is_some());
+        drop(capacity_guards);
+    }
 
     /// Simple test to ensure task limits are respected.
     #[test]

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -9,7 +9,7 @@ use std::{
     convert::TryInto,
     ops::Range,
     sync::{
-        Arc, Condvar, Mutex, MutexGuard, RwLock, Weak,
+        Arc, Condvar, Mutex, MutexGuard, Weak,
         atomic::{AtomicU32, Ordering},
     },
     task::Waker,
@@ -37,6 +37,9 @@ use super::{
     task_join_handle::OwnedTaskStatus,
     thread::WasiMemoryLayout,
 };
+
+#[cfg(test)]
+mod tests;
 
 /// Represents the ID of a sub-process
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -94,8 +97,8 @@ pub struct WasiProcess {
     pub(crate) pid: WasiProcessId,
     /// Hash of the module that this process is using
     pub(crate) module_hash: ModuleHash,
-    /// List of all the children spawned from this thread
-    pub(crate) parent: Option<Weak<RwLock<WasiProcessInner>>>,
+    /// Creation ancestry, independent of the list of children still awaiting reaping.
+    pub(crate) parent: Option<Weak<(Mutex<WasiProcessInner>, Condvar)>>,
     /// The inner protected region of the process with a conditional
     /// variable that is used for coordination such as snapshots.
     pub(crate) inner: LockableWasiProcessInner,
@@ -183,6 +186,8 @@ pub struct WasiProcessInner {
     pub cleanup_started: bool,
     /// Shared process memory.
     pub memory: Option<MemoryOps>,
+    /// Sticky host-requested shutdown, serialized with thread and memory registration.
+    pub(crate) forced_exit_code: Option<ExitCode>,
     /// The snapshot memory significantly reduce the amount of
     /// duplicate entries in the journal for memory that has not changed
     #[cfg(feature = "journal")]
@@ -438,6 +443,7 @@ impl WasiProcess {
                 wakers: Default::default(),
                 cleanup_started: false,
                 memory: Default::default(),
+                forced_exit_code: None,
                 waiting: waiting.clone(),
                 #[cfg(feature = "journal")]
                 snapshot_on: Default::default(),
@@ -492,6 +498,7 @@ impl WasiProcess {
 
     pub(super) fn set_pid(&mut self, pid: WasiProcessId) {
         self.pid = pid;
+        self.inner.0.lock().unwrap().pid = pid;
     }
 
     /// Gets the process ID of this process
@@ -504,7 +511,7 @@ impl WasiProcess {
         self.parent
             .iter()
             .filter_map(|parent| parent.upgrade())
-            .map(|parent| parent.read().unwrap().pid)
+            .map(|parent| parent.0.lock().unwrap().pid)
             .next()
             .unwrap_or(WasiProcessId(0))
     }
@@ -513,6 +520,16 @@ impl WasiProcess {
     // TODO: Make this private, all inner access should be exposed with methods.
     pub fn lock(&self) -> MutexGuard<'_, WasiProcessInner> {
         self.inner.0.lock().unwrap()
+    }
+
+    /// Creates and registers a child before it can start executing.
+    ///
+    /// The control plane retains its ancestry even after the child is reaped, so
+    /// [`Self::force_terminate`] also reaches surviving grandchildren.
+    pub fn new_child(&self, module_hash: ModuleHash) -> Result<Self, ControlPlaneError> {
+        self.compute
+            .must_upgrade()
+            .new_process_with_parent(module_hash, Some(self))
     }
 
     /// Creates a thread and returns it
@@ -552,6 +569,9 @@ impl WasiProcess {
 
         // The wait finished should be the process version if its the main thread
         let mut inner = self.inner.0.lock().unwrap();
+        if inner.forced_exit_code.is_some() {
+            return Err(ControlPlaneError::ProcessTerminated);
+        }
         let finished = if is_main {
             self.finished.clone()
         } else {
@@ -619,8 +639,23 @@ impl WasiProcess {
 
     /// Registers the shared memory used by this process.
     pub fn register_memory(&self, memory: impl Into<MemoryOps>) {
-        let mut inner = self.inner.0.lock().unwrap();
-        inner.memory = Some(memory.into());
+        let memory = memory.into();
+        let terminating = {
+            let mut inner = self.inner.0.lock().unwrap();
+            inner.memory = Some(memory.clone());
+            inner.forced_exit_code.is_some()
+        };
+        if terminating {
+            disable_atomic_waiters(self.pid, &memory);
+        }
+    }
+
+    /// Returns the sticky exit code requested by [`Self::force_terminate`].
+    ///
+    /// Task managers should check this before starting queued guest work. A
+    /// process's ordinary exit status does not imply this stronger shutdown.
+    pub fn forced_exit_code(&self) -> Option<ExitCode> {
+        self.inner.0.lock().unwrap().forced_exit_code
     }
 
     /// Takes a snapshot of the process and disables journaling returning
@@ -860,12 +895,83 @@ impl WasiProcess {
     /// Terminate the process and all its threads
     pub fn terminate(&self, exit_code: ExitCode) {
         let pid = self.pid;
-        tracing::trace!(%pid, %exit_code, "process-terminate");
         // FIXME: this is wrong, threads might still be running!
         // Need special logic for the main thread.
         let guard = self.inner.0.lock().unwrap();
+        let exit_code = guard.forced_exit_code.unwrap_or(exit_code);
+        tracing::trace!(%pid, %exit_code, "process-terminate");
         for thread in guard.threads.values() {
             thread.set_status_finished(Ok(exit_code))
+        }
+    }
+
+    /// Forcibly shuts down a root process and all its descendants.
+    ///
+    /// Unlike [`Self::terminate`], this is a host cancellation operation: it
+    /// prevents new threads and children, interrupts shared-memory atomic waits,
+    /// and delivers `SIGKILL` to every local thread without child-join signal
+    /// forwarding. Descendants remain in scope after they are reaped, including
+    /// descendants whose main thread has exited but whose other threads remain.
+    /// Memories registered during or after shutdown also have atomics disabled.
+    /// Repeated calls preserve the first forced exit code and existing completed
+    /// task results, including tasks that finish concurrently with cancellation.
+    ///
+    /// This operation requires a root process. Calling it on a child returns
+    /// [`ControlPlaneError::NotRootProcess`] without changing any process.
+    /// In particular, a `vfork` child shares its parent's memory: permanently
+    /// disabling that memory's atomics is only safe when the entire execution
+    /// family is being cancelled. Embedders must likewise avoid sharing the
+    /// root's memories with other independently running workloads.
+    /// The owning control plane must still be alive; otherwise this returns
+    /// [`ControlPlaneError::Unavailable`] without attempting a partial shutdown.
+    ///
+    /// This requests cancellation and wakes execution; it does not wait for host
+    /// workers or memory owners to be dropped. Arbitrary host callbacks and guest
+    /// code that never reaches a WASIX call or atomic wait cannot be preempted.
+    /// Atomic interruption requires a backend that supports disabling atomics.
+    pub fn force_terminate(&self, exit_code: ExitCode) -> Result<(), ControlPlaneError> {
+        if self.parent.is_some() {
+            return Err(ControlPlaneError::NotRootProcess);
+        }
+        let plane = self
+            .compute
+            .upgrade()
+            .ok_or(ControlPlaneError::Unavailable)?;
+        plane.force_terminate(self, exit_code);
+        Ok(())
+    }
+
+    /// The control plane marks the entire subtree before calling this outside
+    /// its lock. Waking a task may re-enter the control plane or process.
+    pub(crate) fn force_terminate_local(&self, exit_code: ExitCode) {
+        let (exit_code, threads, memory, wakers) = {
+            let mut inner = self.inner.0.lock().unwrap();
+            let exit_code = *inner.forced_exit_code.get_or_insert(exit_code);
+            inner.checkpoint = WasiProcessCheckpoint::Execute;
+            inner.stop_running_after_checkpoint = true;
+            (
+                exit_code,
+                inner.threads.values().cloned().collect::<Vec<_>>(),
+                inner.memory.clone(),
+                std::mem::take(&mut inner.wakers),
+            )
+        };
+
+        // Publish the requested status before waking atomics or delivering a
+        // fatal signal, which could otherwise win the exit-code race.
+        for thread in &threads {
+            thread.set_status_finished(Ok(exit_code));
+        }
+        self.finished.set_finished(Ok(exit_code));
+        if let Some(memory) = memory {
+            disable_atomic_waiters(self.pid, &memory);
+        }
+        for thread in threads {
+            thread.signal(Signal::Sigkill);
+        }
+        self.inner.1.notify_all();
+        for waker in wakers {
+            waker.wake();
         }
     }
 }
@@ -927,13 +1033,7 @@ fn wake_atomic_waiters(process: &WasiProcessInner, signal: Signal) {
     if signal == Signal::Sigkill {
         // On kill, disable atomics to prevent threads from resuming.
         // NOTE: disable_atomics also wakes all current waiters.
-        if let Err(err) = memory.disable_atomics() {
-            tracing::trace!(
-                pid=%process.pid,
-                error = &err as &dyn std::error::Error,
-                "failed to wake atomic waiters"
-            );
-        }
+        disable_atomic_waiters(process.pid, memory);
     }
 
     // TODO: Should other signals also wake up waiters?
@@ -955,6 +1055,16 @@ fn wake_atomic_waiters(process: &WasiProcessInner, signal: Signal) {
     // ) {
     //    memory.wake_all_atomic_waiters();
     // }
+}
+
+fn disable_atomic_waiters(pid: WasiProcessId, memory: &MemoryOps) {
+    if let Err(err) = memory.disable_atomics() {
+        tracing::trace!(
+            %pid,
+            error = &err as &dyn std::error::Error,
+            "failed to wake atomic waiters"
+        );
+    }
 }
 
 impl SignalHandlerAbi for WasiProcess {

--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -108,6 +108,9 @@ pub struct WasiProcess {
     pub(crate) compute: WasiControlPlaneHandle,
     /// Reference to the exit code for the main thread
     pub(crate) finished: Arc<OwnedTaskStatus>,
+    /// Separate from `inner` so control-plane cancellation never takes a
+    /// published process lock while holding the control-plane lock.
+    pub(super) forced_exit_code: Arc<Mutex<Option<ExitCode>>>,
     /// Number of threads waiting for children to exit
     pub(crate) waiting: Arc<AtomicU32>,
     /// Number of tokens that are currently active and thus
@@ -186,8 +189,6 @@ pub struct WasiProcessInner {
     pub cleanup_started: bool,
     /// Shared process memory.
     pub memory: Option<MemoryOps>,
-    /// Sticky host-requested shutdown, serialized with thread and memory registration.
-    pub(crate) forced_exit_code: Option<ExitCode>,
     /// The snapshot memory significantly reduce the amount of
     /// duplicate entries in the journal for memory that has not changed
     #[cfg(feature = "journal")]
@@ -443,7 +444,6 @@ impl WasiProcess {
                 wakers: Default::default(),
                 cleanup_started: false,
                 memory: Default::default(),
-                forced_exit_code: None,
                 waiting: waiting.clone(),
                 #[cfg(feature = "journal")]
                 snapshot_on: Default::default(),
@@ -479,6 +479,7 @@ impl WasiProcess {
                 OwnedTaskStatus::new(TaskStatus::Pending)
                     .with_signal_handler(Arc::new(SignalHandler(inner))),
             ),
+            forced_exit_code: Arc::new(Mutex::new(None)),
             waiting,
             cpu_run_tokens: Arc::new(AtomicU32::new(0)),
         }
@@ -569,7 +570,7 @@ impl WasiProcess {
 
         // The wait finished should be the process version if its the main thread
         let mut inner = self.inner.0.lock().unwrap();
-        if inner.forced_exit_code.is_some() {
+        if self.forced_exit_code().is_some() {
             return Err(ControlPlaneError::ProcessTerminated);
         }
         let finished = if is_main {
@@ -643,7 +644,7 @@ impl WasiProcess {
         let terminating = {
             let mut inner = self.inner.0.lock().unwrap();
             inner.memory = Some(memory.clone());
-            inner.forced_exit_code.is_some()
+            self.forced_exit_code().is_some()
         };
         if terminating {
             disable_atomic_waiters(self.pid, &memory);
@@ -655,7 +656,7 @@ impl WasiProcess {
     /// Task managers should check this before starting queued guest work. A
     /// process's ordinary exit status does not imply this stronger shutdown.
     pub fn forced_exit_code(&self) -> Option<ExitCode> {
-        self.inner.0.lock().unwrap().forced_exit_code
+        *self.forced_exit_code.lock().unwrap()
     }
 
     /// Takes a snapshot of the process and disables journaling returning
@@ -897,10 +898,15 @@ impl WasiProcess {
         let pid = self.pid;
         // FIXME: this is wrong, threads might still be running!
         // Need special logic for the main thread.
-        let guard = self.inner.0.lock().unwrap();
-        let exit_code = guard.forced_exit_code.unwrap_or(exit_code);
+        let (exit_code, threads) = {
+            let guard = self.inner.0.lock().unwrap();
+            (
+                self.forced_exit_code().unwrap_or(exit_code),
+                guard.threads.values().cloned().collect::<Vec<_>>(),
+            )
+        };
         tracing::trace!(%pid, %exit_code, "process-terminate");
-        for thread in guard.threads.values() {
+        for thread in threads {
             thread.set_status_finished(Ok(exit_code))
         }
     }
@@ -946,7 +952,11 @@ impl WasiProcess {
     pub(crate) fn force_terminate_local(&self, exit_code: ExitCode) {
         let (exit_code, threads, memory, wakers) = {
             let mut inner = self.inner.0.lock().unwrap();
-            let exit_code = *inner.forced_exit_code.get_or_insert(exit_code);
+            let exit_code = *self
+                .forced_exit_code
+                .lock()
+                .unwrap()
+                .get_or_insert(exit_code);
             inner.checkpoint = WasiProcessCheckpoint::Execute;
             inner.stop_running_after_checkpoint = true;
             (

--- a/lib/wasix/src/os/task/process/tests.rs
+++ b/lib/wasix/src/os/task/process/tests.rs
@@ -125,6 +125,30 @@ fn ordinary_terminate_does_not_force_descendants_or_close_registration() {
 }
 
 #[test]
+fn ordinary_terminate_releases_process_lock_before_waking_completion_waiters() {
+    use std::{future::Future, task::Context};
+
+    let plane = WasiControlPlane::default();
+    let process = plane.new_process(ModuleHash::random()).unwrap();
+    let _main = thread(&process, true);
+    let check_process = process.clone();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let waker = waker_fn::waker_fn(move || {
+        assert!(check_process.inner.0.try_lock().is_ok());
+        assert!(plane.get_process(check_process.pid()).is_some());
+        tx.send(()).unwrap();
+    });
+    let mut join = Box::pin(process.join());
+    assert!(
+        join.as_mut()
+            .poll(&mut Context::from_waker(&waker))
+            .is_pending()
+    );
+    process.terminate(ExitCode::from(0));
+    rx.recv_timeout(Duration::from_secs(2)).unwrap();
+}
+
+#[test]
 fn force_terminate_closes_every_registration_gate_before_waking_tasks() {
     let plane = WasiControlPlane::default();
     let root = plane.new_process(ModuleHash::random()).unwrap();

--- a/lib/wasix/src/os/task/process/tests.rs
+++ b/lib/wasix/src/os/task/process/tests.rs
@@ -1,0 +1,326 @@
+use super::*;
+use crate::os::task::control_plane::WasiControlPlane;
+
+fn thread(process: &WasiProcess, main: bool) -> WasiThreadHandle {
+    process
+        .new_thread(
+            WasiMemoryLayout::default(),
+            if main {
+                ThreadStartType::MainThread
+            } else {
+                ThreadStartType::ThreadSpawn { start_ptr: 0 }
+            },
+        )
+        .unwrap()
+}
+
+#[test]
+fn force_terminate_includes_reaped_descendants_but_not_other_roots() {
+    let plane = WasiControlPlane::default();
+    let root = plane.new_process(ModuleHash::random()).unwrap();
+    let child = root.new_child(ModuleHash::random()).unwrap();
+    let grandchild = child.new_child(ModuleHash::random()).unwrap();
+    let unrelated = plane.new_process(ModuleHash::random()).unwrap();
+    let root_thread = thread(&root, true);
+    let child_thread = thread(&child, true);
+    let child_worker = thread(&child, false);
+    let grandchild_thread = thread(&grandchild, true);
+    let unrelated_thread = thread(&unrelated, true);
+
+    assert_eq!(child.ppid(), root.pid());
+    assert_eq!(grandchild.ppid(), child.pid());
+
+    // Reaping is distinct from host cancellation ancestry. The main thread
+    // may have exited while its workers and grandchildren are still alive.
+    child_thread.set_status_finished(Ok(ExitCode::from(0)));
+    root.lock().children.clear();
+    child.lock().children.clear();
+    let exit_code = ExitCode::from(137);
+    root.force_terminate(exit_code).unwrap();
+
+    for process in [&root, &child, &grandchild] {
+        assert_eq!(process.forced_exit_code(), Some(exit_code));
+        assert_eq!(
+            process.new_child(ModuleHash::random()).unwrap_err(),
+            ControlPlaneError::ProcessTerminated
+        );
+        assert_eq!(
+            process
+                .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+                .unwrap_err(),
+            ControlPlaneError::ProcessTerminated
+        );
+    }
+    for worker in [&root_thread, &child_worker, &grandchild_thread] {
+        assert_eq!(worker.try_join().unwrap().unwrap(), exit_code);
+        assert!(worker.has_signal(&[Signal::Sigkill]));
+    }
+    assert_eq!(child_thread.try_join().unwrap().unwrap(), ExitCode::from(0));
+    assert!(unrelated_thread.try_join().is_none());
+    assert_eq!(unrelated.forced_exit_code(), None);
+    assert!(unrelated.new_child(ModuleHash::random()).is_ok());
+}
+
+#[test]
+fn force_terminate_rejects_child_without_changing_the_family() {
+    let plane = WasiControlPlane::default();
+    let root = plane.new_process(ModuleHash::random()).unwrap();
+    let child = root.new_child(ModuleHash::random()).unwrap();
+    let sibling = root.new_child(ModuleHash::random()).unwrap();
+    let grandchild = child.new_child(ModuleHash::random()).unwrap();
+    assert_eq!(
+        child.force_terminate(ExitCode::from(7)),
+        Err(ControlPlaneError::NotRootProcess)
+    );
+    assert!(grandchild.try_join().is_none());
+    assert!(child.try_join().is_none());
+    assert!(root.try_join().is_none());
+    assert!(sibling.try_join().is_none());
+}
+
+#[test]
+fn force_terminate_is_sticky_before_the_main_thread_is_created() {
+    let plane = WasiControlPlane::default();
+    let process = plane.new_process(ModuleHash::random()).unwrap();
+    process.force_terminate(ExitCode::from(42)).unwrap();
+    process.force_terminate(ExitCode::from(99)).unwrap();
+    assert_eq!(process.try_join().unwrap().unwrap(), ExitCode::from(42));
+    assert_eq!(process.forced_exit_code(), Some(ExitCode::from(42)));
+    assert_eq!(
+        process
+            .new_thread_with_id(
+                WasiMemoryLayout::default(),
+                ThreadStartType::MainThread,
+                process.pid().raw().into(),
+            )
+            .unwrap_err(),
+        ControlPlaneError::ProcessTerminated
+    );
+}
+
+#[test]
+fn force_terminate_requires_the_control_plane_to_reach_the_entire_family() {
+    let plane = WasiControlPlane::default();
+    let process = plane.new_process(ModuleHash::random()).unwrap();
+    drop(plane);
+    assert_eq!(
+        process.force_terminate(ExitCode::from(137)),
+        Err(ControlPlaneError::Unavailable)
+    );
+    assert!(process.try_join().is_none());
+}
+
+#[test]
+fn ordinary_terminate_does_not_force_descendants_or_close_registration() {
+    let plane = WasiControlPlane::default();
+    let root = plane.new_process(ModuleHash::random()).unwrap();
+    let child = root.new_child(ModuleHash::random()).unwrap();
+    let _root_thread = thread(&root, true);
+    let child_thread = thread(&child, true);
+    root.terminate(ExitCode::from(0));
+    assert!(child_thread.try_join().is_none());
+    assert_eq!(root.forced_exit_code(), None);
+    assert!(root.new_child(ModuleHash::random()).is_ok());
+    let _late_thread = thread(&root, false);
+}
+
+#[test]
+fn force_terminate_closes_every_registration_gate_before_waking_tasks() {
+    let plane = WasiControlPlane::default();
+    let root = plane.new_process(ModuleHash::random()).unwrap();
+    let child = root.new_child(ModuleHash::random()).unwrap();
+    let _root_main = thread(&root, true);
+    let worker = thread(&child, false);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let check_root = root.clone();
+    let check_child = child.clone();
+    let waker = waker_fn::waker_fn(move || {
+        // Re-entering both locks must be safe. This also deterministically
+        // attempts child/thread creation while force_terminate is delivering
+        // wakeups, after its snapshot but before the parent has completed.
+        assert!(plane.get_process(check_root.pid()).is_some());
+        assert_eq!(
+            check_root.new_child(ModuleHash::random()).unwrap_err(),
+            ControlPlaneError::ProcessTerminated
+        );
+        assert_eq!(
+            check_child
+                .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+                .unwrap_err(),
+            ControlPlaneError::ProcessTerminated
+        );
+        // Ordinary exit racing the delivery phase must honor the already
+        // latched force request instead of publishing a successful result.
+        check_root.terminate(ExitCode::from(0));
+        assert_eq!(check_root.try_join().unwrap().unwrap(), ExitCode::from(137));
+        tx.send(()).unwrap();
+    });
+    worker.signals_subscribe(&waker);
+    root.force_terminate(ExitCode::from(137)).unwrap();
+    rx.recv_timeout(Duration::from_secs(2)).unwrap();
+}
+
+#[cfg(all(feature = "sys-thread", not(target_arch = "wasm32")))]
+mod native {
+    use super::*;
+    use wasmer::{AtomicsError, Memory, MemoryLocation, MemoryType, Store};
+
+    #[tokio::test]
+    async fn force_terminate_rejects_vfork_child_without_disabling_parent_memory() {
+        let mut store = Store::default();
+        let module = wasmer::Module::new(
+            &store,
+            r#"(module
+                (import "env" "memory" (memory 1 1 shared))
+                (import "wasix_32v1" "proc_fork_env"
+                    (func $fork (param i32) (result i32)))
+                (export "memory" (memory 0))
+                (func (export "fork") (result i32)
+                    (call $fork (i32.const 0))))"#,
+        )
+        .unwrap();
+        let (instance, env) = WasiEnv::builder("force-terminate-vfork")
+            .engine(store.engine().clone())
+            .instantiate(module, &mut store)
+            .unwrap();
+        let parent = env.data(&store).process.clone();
+        instance
+            .exports
+            .get_typed_function::<(), i32>(&store, "fork")
+            .unwrap()
+            .call(&mut store)
+            .unwrap();
+        let child = env.data(&store).process.clone();
+        assert_ne!(parent.pid(), child.pid());
+        assert_eq!(
+            child.force_terminate(ExitCode::from(137)),
+            Err(ControlPlaneError::NotRootProcess)
+        );
+        let memory = instance
+            .exports
+            .get_memory("memory")
+            .unwrap()
+            .as_shared(&store)
+            .unwrap();
+        assert!(
+            memory
+                .wait(MemoryLocation::new_32(32), Some(Duration::ZERO))
+                .is_ok()
+        );
+        assert!(parent.try_join().is_none());
+        assert!(child.try_join().is_none());
+        parent.force_terminate(ExitCode::from(137)).unwrap();
+        assert!(matches!(
+            memory.wait(MemoryLocation::new_32(32), Some(Duration::ZERO)),
+            Err(AtomicsError::AtomicsDisabled)
+        ));
+        assert_eq!(child.try_join().unwrap().unwrap(), ExitCode::from(137));
+    }
+
+    #[tokio::test]
+    async fn force_terminate_wakes_parent_atomics_while_joining_a_child() {
+        let plane = WasiControlPlane::default();
+        let mut root = plane.new_process(ModuleHash::random()).unwrap();
+        let child = root.new_child(ModuleHash::random()).unwrap();
+        let main = thread(&root, true);
+        let sibling = thread(&root, false);
+        let child_main = thread(&child, true);
+        let mut store = Store::default();
+        let memory = Memory::new(&mut store, MemoryType::new(1, Some(1), true))
+            .unwrap()
+            .as_shared(&store)
+            .unwrap();
+        root.register_memory(memory.clone());
+        let shutdown = root.clone();
+        let mut join = Box::pin(root.join_any_child());
+        assert!(futures::poll!(&mut join).is_pending());
+        let worker_memory = memory.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let worker = tokio::task::spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            // The timeout ensures a failing regression does not strand a host
+            // worker indefinitely during test teardown.
+            worker_memory.wait(MemoryLocation::new_32(0), Some(Duration::from_secs(3)))
+        });
+        started_rx.await.unwrap();
+
+        shutdown.force_terminate(ExitCode::from(137)).unwrap();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), worker)
+                .await
+                .unwrap()
+                .unwrap(),
+            Err(AtomicsError::AtomicsDisabled)
+        ));
+        for worker in [&main, &sibling, &child_main] {
+            assert_eq!(worker.try_join().unwrap().unwrap(), ExitCode::from(137));
+            assert!(worker.has_signal(&[Signal::Sigkill]));
+        }
+    }
+
+    #[test]
+    fn force_terminate_disables_late_and_replacement_memories_without_retaining_them() {
+        let plane = WasiControlPlane::default();
+        let process = plane.new_process(ModuleHash::random()).unwrap();
+        process.force_terminate(ExitCode::from(137)).unwrap();
+        for _ in 0..8 {
+            let ops = {
+                let mut store = Store::default();
+                let memory = Memory::new(&mut store, MemoryType::new(1, Some(1), true))
+                    .unwrap()
+                    .as_shared(&store)
+                    .unwrap();
+                let ops = memory.ops();
+                process.register_memory(memory);
+                assert!(matches!(
+                    ops.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+                    Err(AtomicsError::AtomicsDisabled)
+                ));
+                ops
+            };
+            assert!(matches!(
+                ops.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+                Err(AtomicsError::MemoryDropped)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn force_terminate_reaches_live_child_detached_by_specific_proc_join() {
+        let mut store = Store::default();
+        let module = wasmer::Module::new(
+            &store,
+            r#"(module
+                (import "env" "memory" (memory 1 1 shared))
+                (import "wasix_32v1" "proc_join"
+                    (func $proc_join (param i32 i32 i32) (result i32)))
+                (export "memory" (memory 0))
+                (func (export "join_child") (param $pid i32) (result i32)
+                    (i32.store8 (i32.const 0) (i32.const 1))
+                    (i32.store (i32.const 4) (local.get $pid))
+                    (call $proc_join (i32.const 0) (i32.const 1) (i32.const 16))))"#,
+        )
+        .unwrap();
+        let (instance, env) = WasiEnv::builder("force-terminate-proc-join")
+            .engine(store.engine().clone())
+            .instantiate(module, &mut store)
+            .unwrap();
+        let parent = env.data(&store).process.clone();
+        let (child_env, _child_handle) = env.data(&store).fork().unwrap();
+        let child = child_env.process.clone();
+        assert_eq!(parent.lock().children.len(), 1);
+        assert_eq!(
+            instance
+                .exports
+                .get_typed_function::<i32, i32>(&store, "join_child")
+                .unwrap()
+                .call(&mut store, child.pid().raw() as i32)
+                .unwrap(),
+            Errno::Success as i32
+        );
+        assert!(parent.lock().children.is_empty());
+        assert!(child.try_join().is_none());
+        parent.force_terminate(ExitCode::from(137)).unwrap();
+        assert_eq!(child.try_join().unwrap().unwrap(), ExitCode::from(137));
+    }
+}

--- a/lib/wasix/src/os/task/thread.rs
+++ b/lib/wasix/src/os/task/thread.rs
@@ -614,6 +614,8 @@ impl std::ops::Deref for WasiThreadHandle {
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum WasiThreadError {
+    #[error("The process has been forcibly terminated with exit code {0}")]
+    ProcessTerminated(ExitCode),
     #[error("Multithreading is not supported")]
     Unsupported,
     #[error("The method named is not an exported function")]
@@ -643,6 +645,7 @@ pub enum WasiThreadError {
 impl From<WasiThreadError> for Errno {
     fn from(a: WasiThreadError) -> Errno {
         match a {
+            WasiThreadError::ProcessTerminated(_) => Errno::Canceled,
             WasiThreadError::Unsupported => Errno::Notsup,
             WasiThreadError::MethodNotFound => Errno::Inval,
             WasiThreadError::MemoryCreateFailed(_) => Errno::Nomem,

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -10,6 +10,9 @@ use crate::{WasiFunctionEnv, os::task::thread::WasiThreadError};
 
 use super::{SpawnMemoryTypeOrStore, TaskWasm, TaskWasmRunProperties, VirtualTaskManager};
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests;
+
 #[derive(Debug, Clone)]
 pub enum RuntimeOrHandle {
     Handle(Handle),
@@ -195,6 +198,13 @@ impl VirtualTaskManager for TokioTaskManager {
                             let env = ctx.data(store);
                             break tokio::select! {
                                 r = &mut trigger => r,
+                                result = env.thread.join() => {
+                                    Err(result.unwrap_or_else(|err| {
+                                        err.as_exit_code().unwrap_or_else(|| {
+                                            wasmer_wasix_types::wasi::Errno::Canceled.into()
+                                        })
+                                    }))
+                                }
                                 _ = env.thread.wait_for_signal() => {
                                     tracing::debug!("wait-for-signal(triggered)");
                                     let mut ctx = ctx.env.clone().into_mut(store);
@@ -230,7 +240,10 @@ impl VirtualTaskManager for TokioTaskManager {
                             pre_run(ctx, store).await;
                         }
 
-                        result
+                        match ctx.data(store).process.forced_exit_code() {
+                            Some(exit_code) => Err(exit_code),
+                            None => result,
+                        }
                     })
                 };
 
@@ -261,6 +274,10 @@ impl VirtualTaskManager for TokioTaskManager {
 
                 if let Some(pre_run) = callbacks.pre_run {
                     block_on(pre_run(&mut ctx, &mut store));
+                }
+
+                if ctx.data(&store).process.forced_exit_code().is_some() {
+                    return;
                 }
 
                 // Invoke the callback

--- a/lib/wasix/src/runtime/task_manager/tokio/tests.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio/tests.rs
@@ -1,0 +1,296 @@
+use super::*;
+use crate::{WasiEnv, runtime::PluggableRuntime};
+use wasmer::{MemoryLocation, MemoryOps, Module, Store};
+use wasmer_wasix_types::wasi::ExitCode;
+
+const MODULE: &str = r#"(module
+    (import "env" "memory" (memory 1 1 shared))
+    (export "memory" (memory 0)))"#;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminated_trigger_task_releases_environment_without_another_signal() {
+    let manager = TokioTaskManager::new(Handle::current());
+    let store = Store::default();
+    let module = Module::new(&store, MODULE).unwrap();
+    let mut runtime = PluggableRuntime::new(Arc::new(manager.clone()));
+    runtime.set_engine(store.engine().clone());
+    let env = WasiEnv::builder("termination-wakeup")
+        .runtime(Arc::new(runtime))
+        .build()
+        .unwrap();
+    let process = env.process.clone();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+    // Releasing this sender also releases the worker if an assertion fails.
+    let (_release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let task = TaskWasm::new(
+        Box::new(move |props| {
+            let result = props.trigger_result.clone().unwrap();
+            drop(props);
+            done_tx.send(result).unwrap();
+        }),
+        env,
+        module,
+        false,
+        false,
+    )
+    .with_trigger(Box::new(move || {
+        Box::pin(async move {
+            ready_tx.send(()).unwrap();
+            let _ = release_rx.await;
+            Err(ExitCode::from(1))
+        })
+    }));
+    manager.task_wasm(task).unwrap();
+    ready_rx.await.unwrap();
+    process.terminate(ExitCode::from(137));
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), done_rx)
+            .await
+            .expect("completion status must wake a pending trigger without another signal")
+            .unwrap()
+            .unwrap_err(),
+        ExitCode::from(137)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_terminate_rejects_previously_created_queued_environments() {
+    let manager = TokioTaskManager::new(Handle::current());
+    let store = Store::default();
+    let module = Module::new(&store, MODULE).unwrap();
+    let env = WasiEnv::builder("queued-before-termination")
+        .engine(store.engine().clone())
+        .build()
+        .unwrap();
+    env.process.force_terminate(ExitCode::from(137)).unwrap();
+    let task = TaskWasm::new(
+        Box::new(|_| panic!("terminated guest work must not run")),
+        env,
+        module,
+        false,
+        false,
+    );
+    assert!(matches!(
+        manager.task_wasm(task),
+        Err(WasiThreadError::ProcessTerminated(code)) if code == ExitCode::from(137)
+    ));
+}
+
+async fn force_terminate_during_environment_creation(has_trigger: bool) {
+    let manager = TokioTaskManager::new(Handle::current());
+    let store = Store::default();
+    let module = Module::new(&store, MODULE).unwrap();
+    let mut runtime = PluggableRuntime::new(Arc::new(manager.clone()));
+    runtime.set_engine(store.engine().clone());
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<MemoryOps>();
+    let ready_tx = Mutex::new(Some(ready_tx));
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    let release_rx = Mutex::new(release_rx);
+    runtime.with_instance_setup(move |_, store, _, imported_memory| {
+        let memory = imported_memory.unwrap().as_shared(store).unwrap();
+        ready_tx
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap()
+            .send(memory.ops())
+            .unwrap();
+        release_rx
+            .lock()
+            .unwrap()
+            .recv_timeout(Duration::from_secs(5))?;
+        Ok(())
+    });
+    let env = WasiEnv::builder("shutdown-during-instantiation")
+        .runtime(Arc::new(runtime))
+        .build()
+        .unwrap();
+    let process = env.process.clone();
+    let mut task = TaskWasm::new(
+        Box::new(|_| panic!("guest work must not run after shutdown during instantiation")),
+        env,
+        module,
+        false,
+        false,
+    );
+    if has_trigger {
+        task = task.with_trigger(Box::new(|| {
+            Box::pin(async { panic!("a terminated trigger must not start") })
+        }));
+    }
+    let submit = tokio::task::spawn_blocking(move || manager.task_wasm(task));
+    let memory = tokio::time::timeout(Duration::from_secs(2), ready_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    process.force_terminate(ExitCode::from(137)).unwrap();
+    release_tx.send(()).unwrap();
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_secs(2), submit)
+            .await
+            .unwrap()
+            .unwrap(),
+        Err(WasiThreadError::ProcessTerminated(code)) if code == ExitCode::from(137)
+    ));
+    assert_eq!(process.try_join().unwrap().unwrap(), ExitCode::from(137));
+    assert!(matches!(
+        memory.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+        Err(wasmer::AtomicsError::MemoryDropped)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_terminate_during_synchronous_environment_creation() {
+    force_terminate_during_environment_creation(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_terminate_during_triggered_environment_creation() {
+    force_terminate_during_environment_creation(true).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_terminate_reclaims_repeated_synchronous_guest_tasks() {
+    let manager = TokioTaskManager::new(Handle::current());
+    let store = Store::default();
+    let module = Module::new(
+        &store,
+        r#"(module
+            (import "env" "memory" (memory 1 1 shared))
+            (export "memory" (memory 0))
+            (func (export "wait") (result i32)
+                (memory.atomic.wait32
+                    (i32.const 0) (i32.const 0) (i64.const 3000000000))))"#,
+    )
+    .unwrap();
+    let mut runtime = PluggableRuntime::new(Arc::new(manager.clone()));
+    runtime.set_engine(store.engine().clone());
+    let runtime = Arc::new(runtime);
+
+    for _ in 0..8 {
+        let parent = WasiEnv::builder("repeated-force-terminate")
+            .runtime(runtime.clone())
+            .build()
+            .unwrap();
+        let (mut child, child_handle) = parent.fork().unwrap();
+        child.owned_handles.push(child_handle);
+        let child_process = child.process.clone();
+        // The real specific-PID syscall case is covered by process tests.
+        parent.process.lock().children.clear();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let task = TaskWasm::new(
+            Box::new(move |mut props| {
+                let memory = props
+                    .ctx
+                    .data(&props.store)
+                    .process
+                    .lock()
+                    .memory
+                    .clone()
+                    .unwrap();
+                let wait = props
+                    .ctx
+                    .data(&props.store)
+                    .inner()
+                    .static_module_instance_handles()
+                    .unwrap()
+                    .instance
+                    .exports
+                    .get_typed_function::<(), i32>(&props.store, "wait")
+                    .unwrap();
+                ready_tx.send(memory).unwrap();
+                let result = wait.call(&mut props.store);
+                drop(props);
+                done_tx.send(result.is_err()).unwrap();
+            }),
+            child,
+            module.clone(),
+            false,
+            false,
+        );
+        manager.task_wasm(task).unwrap();
+        let memory = ready_rx.await.unwrap();
+        parent.process.force_terminate(ExitCode::from(137)).unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), done_rx)
+                .await
+                .expect("synchronous guest atomic wait must be interrupted")
+                .unwrap()
+        );
+        assert_eq!(
+            child_process.try_join().unwrap().unwrap(),
+            ExitCode::from(137)
+        );
+        assert!(matches!(
+            memory.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+            Err(wasmer::AtomicsError::MemoryDropped)
+        ));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn force_terminate_interrupts_atomic_wait_in_wasm_start_function() {
+    let manager = TokioTaskManager::new(Handle::current());
+    let store = Store::default();
+    let module = Module::new(
+        &store,
+        r#"(module
+            (import "env" "memory" (memory 1 1 shared))
+            (import "test" "started" (func $started))
+            (export "memory" (memory 0))
+            (func $start
+                (call $started)
+                (drop (memory.atomic.wait32
+                    (i32.const 0) (i32.const 0) (i64.const 3000000000))))
+            (start $start))"#,
+    )
+    .unwrap();
+    let mut runtime = PluggableRuntime::new(Arc::new(manager.clone()));
+    runtime.set_engine(store.engine().clone());
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+    runtime.with_additional_imports(move |_, store| {
+        let started_tx = started_tx.clone();
+        let started = wasmer::Function::new_typed(store, move || {
+            started_tx.lock().unwrap().take().unwrap().send(()).unwrap();
+        });
+        Ok(wasmer::imports! { "test" => { "started" => started } })
+    });
+    let env = WasiEnv::builder("force-terminate-wasm-start")
+        .runtime(Arc::new(runtime))
+        .build()
+        .unwrap();
+    let process = env.process.clone();
+    let task = TaskWasm::new(
+        Box::new(|_| panic!("terminated start function must not reach the run callback")),
+        env,
+        module,
+        false,
+        false,
+    );
+    let submit = tokio::task::spawn_blocking(move || manager.task_wasm(task));
+    tokio::time::timeout(Duration::from_secs(2), started_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    let memory = process
+        .lock()
+        .memory
+        .clone()
+        .expect("start memory must be registered");
+    process.force_terminate(ExitCode::from(137)).unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(2), submit)
+            .await
+            .expect("start function's atomic wait must be interrupted")
+            .unwrap()
+            .is_err()
+    );
+    assert_eq!(process.try_join().unwrap().unwrap(), ExitCode::from(137));
+    assert!(matches!(
+        memory.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+        Err(wasmer::AtomicsError::MemoryDropped)
+    ));
+}

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -254,8 +254,21 @@ impl WasiEnv {
 
     /// Forking the WasiState is used when either fork or vfork is called
     pub fn fork(&self) -> Result<(Self, WasiThreadHandle), ControlPlaneError> {
-        let process = self.control_plane.new_process(self.process.module_hash)?;
-        let handle = process.new_thread(self.layout.clone(), ThreadStartType::MainThread)?;
+        let process = self.process.new_child(self.process.module_hash)?;
+        let handle = match process.new_thread(self.layout.clone(), ThreadStartType::MainThread) {
+            Ok(handle) => handle,
+            Err(err) => {
+                // Registration precedes execution so shutdown cannot miss the
+                // child. If creating its main thread fails, there is no child
+                // execution to reap.
+                process.force_terminate_local(Errno::Canceled.into());
+                self.process
+                    .lock()
+                    .children
+                    .retain(|child| child.pid() != process.pid());
+                return Err(err);
+            }
+        };
 
         let thread = handle.as_thread();
         thread.copy_stack_from(&self.thread);
@@ -471,6 +484,9 @@ impl WasiEnv {
         call_initialize: bool,
         linker_instance_group_data: Option<PreparedInstanceGroupData>,
     ) -> Result<(Instance, WasiFunctionEnv), WasiThreadError> {
+        if let Some(exit_code) = self.process.forced_exit_code() {
+            return Err(WasiThreadError::ProcessTerminated(exit_code));
+        }
         let pid = self.process.pid();
 
         let mut store = store.as_store_mut();
@@ -554,6 +570,18 @@ impl WasiEnv {
                 _ => None,
             });
 
+        // A Wasm start function can already block on atomics during
+        // Instance::new, before initialize_handles_and_layout is reached.
+        if let Some(memory) = imported_memory
+            .as_ref()
+            .and_then(|memory| memory.as_shared(&store))
+        {
+            func_env.data(&store).process.register_memory(memory);
+        }
+        if let Some(exit_code) = func_env.data(&store).process.forced_exit_code() {
+            return Err(WasiThreadError::ProcessTerminated(exit_code));
+        }
+
         // Construct the instance.
         let instance = match Instance::new(&mut store, &module, &import_object) {
             Ok(a) => a,
@@ -628,6 +656,10 @@ impl WasiEnv {
                 .data(&store)
                 .blocking_on_exit(Some(Errno::Noexec.into()));
             return Err(WasiThreadError::ExportError(err));
+        }
+
+        if let Some(exit_code) = func_env.data(&store).process.forced_exit_code() {
+            return Err(WasiThreadError::ProcessTerminated(exit_code));
         }
 
         // If this module exports an _initialize function, run that first.

--- a/lib/wasix/src/state/func_env.rs
+++ b/lib/wasix/src/state/func_env.rs
@@ -45,6 +45,9 @@ impl WasiFunctionEnv {
         call_initialize: bool,
         linker_instance_group_data: Option<PreparedInstanceGroupData>,
     ) -> Result<(Self, Store), WasiThreadError> {
+        if let Some(exit_code) = env.process.forced_exit_code() {
+            return Err(WasiThreadError::ProcessTerminated(exit_code));
+        }
         // Create a new store and put the memory object in it
         // (but only if it has imported memory)
         let (memory, store): (Option<wasmer::Memory>, Option<wasmer::Store>) = match spawn_type {
@@ -81,6 +84,10 @@ impl WasiFunctionEnv {
             call_initialize,
             linker_instance_group_data,
         )?;
+
+        if let Some(exit_code) = ctx.data(&store).process.forced_exit_code() {
+            return Err(WasiThreadError::ProcessTerminated(exit_code));
+        }
 
         // FIXME: shouldn't this happen _before_ instantiating, so the startup code in the instance
         // has access to the globals?

--- a/lib/wasix/src/state/linker/runtime_hooks.rs
+++ b/lib/wasix/src/state/linker/runtime_hooks.rs
@@ -20,6 +20,16 @@ pub(super) fn instantiate_with_runtime_hooks(
             .map_err(LinkError::RuntimeHookError)?
     };
 
+    // Start functions run inside Instance::new, before the final environment
+    // handles are installed. Make their shared memory interruptible already.
+    if let Some(memory) = imported_memory.as_shared(store) {
+        env.as_ref(store).process.register_memory(memory);
+    }
+    if let Some(exit_code) = env.as_ref(store).process.forced_exit_code() {
+        return Err(LinkError::RuntimeHookError(anyhow::anyhow!(
+            crate::WasiThreadError::ProcessTerminated(exit_code)
+        )));
+    }
     let instance = Instance::new(store, module, imports)?;
 
     {

--- a/lib/wasix/src/syscalls/wasix/proc_fork.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork.rs
@@ -78,12 +78,6 @@ pub fn proc_fork<M: MemorySize>(
     let child_pid = child_env.process.pid();
     let child_finished = child_env.process.finished.clone();
 
-    // We write a zero to the PID before we capture the stack
-    // so that this is what will be returned to the child
-    {
-        let mut inner = ctx.data().process.lock();
-        inner.children.push(child_env.process.clone());
-    }
     let env = ctx.data();
     let memory = unsafe { env.memory_view(&ctx) };
 

--- a/lib/wasix/src/syscalls/wasix/proc_fork_env.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_fork_env.rs
@@ -61,12 +61,6 @@ pub fn proc_fork_env<M: MemorySize>(
 
     let parent_env = ctx.data_mut();
 
-    // Add the child to the parent's list of children
-    parent_env
-        .process
-        .lock()
-        .children
-        .push(child_env.process.clone());
     // Swap the current environment with the child environment
     child_env.swap_inner(parent_env);
     std::mem::swap(parent_env, &mut child_env);

--- a/lib/wasix/src/syscalls/wasix/proc_spawn.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn.rs
@@ -263,11 +263,6 @@ pub fn proc_spawn_internal(
         }
     }
 
-    // Add the process to the environment state
-    {
-        let mut inner = ctx.data().process.lock();
-        inner.children.push(child_process);
-    }
     let env = ctx.data();
     let memory = unsafe { env.memory_view(&ctx) };
 

--- a/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
+++ b/lib/wasix/src/syscalls/wasix/proc_spawn3.rs
@@ -135,11 +135,6 @@ pub(crate) fn proc_spawn3_impl<M: MemorySize>(
         }
     };
 
-    {
-        let mut inner = ctx.data().process.lock();
-        inner.children.push(child_env.process.clone());
-    }
-
     // Setup some properties in the child environment
     let pid = child_env.pid();
     let tid = child_env.tid();


### PR DESCRIPTION
# Description

Host shutdown can leave WASIX workers and their Wasm memories alive. When a parent is joining a child, `signal_process(SIGKILL)` forwards the signal to children without interrupting the parent's atomic waiters; `terminate()` only completes task statuses. A child can also disappear from the parent's reap list while it is still running, and new work can race a shutdown snapshot.

Add `WasiProcess::force_terminate(exit_code) -> Result<(), ControlPlaneError>` for root execution shutdown:

- Use the existing control-plane process registry and creation ancestry to reach every descendant, including reaped children and surviving grandchildren. Register forked/spawned children before execution and serialize creation with shutdown, without nesting published process locks under the control-plane lock.
- Latch cancellation before wakeups, reject late threads and children, complete task statuses, directly deliver `SIGKILL`, interrupt registered atomic waits, and release checkpoint waiters. Disable memories registered after cancellation as well.
- Register imported shared memory before Wasm start functions execute, and reject queued or concurrently initialized environments after cancellation.
- Have the Tokio task manager observe thread completion while waiting for a trigger, avoiding a lost-signal wakeup.

This is a root-only host operation. Child calls fail without side effects because `vfork` can share the parent's memory and atomic disabling is memory-wide. Normal `proc_exit`/`exec` termination remains process-local. Cancellation does not synchronously join host workers or preempt arbitrary host callbacks/guest code that never reaches an interruptible operation.

Regression coverage includes real `proc_join` and `proc_fork_env` calls, a parent atomic waiter during child join, eight repeated synchronous Wasm wait/reclamation cycles, Wasm start-function interruption, late/replacement memories, shutdown during environment construction, reentrant wakeups, child registration before reap-list attachment, and a deterministic failed-fork capacity race.

Validation:

- `cargo test -p wasmer-wasix --lib`: **249 passed, 2 ignored**.
- `cargo test -p wasmer-wasix --lib --no-default-features --features sys-minimal,host-reqwest`: **242 passed, 4 ignored**; HTTP test responses are mocked.
- `cargo clippy -p wasmer-wasix --lib --tests`: passed; one existing `vec_init_then_push` warning in `tests/wasm_tests/mod.rs`.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `cargo build --locked -p wasmer-cli --bin wasmer`: passed.
- `make lint` was attempted but stops at the first target because `yamlfmt` is not installed in the development shell.
