### PR TITLE
fix(wasix): enforce process SIGKILL with registered handlers

### DIFF
--- a/lib/wasix/src/os/task/process.rs
+++ b/lib/wasix/src/os/task/process.rs
@@ -912,10 +912,21 @@ fn signal_process_internal(process: &LockableWasiProcessInner, signal: Signal) {
         }
     }
 
-    // Otherwise just send the signal to all the threads
-    wake_atomic_waiters(&guard, signal);
-    for thread in guard.threads.values() {
-        thread.signal(signal);
+    // SIGKILL cannot be caught by a guest handler. Complete every thread before
+    // waking execution so process-wide handler registration cannot suppress it.
+    if signal == Signal::Sigkill {
+        for thread in guard.threads.values() {
+            thread.set_status_finished(Ok(Errno::Intr.into()));
+        }
+        wake_atomic_waiters(&guard, signal);
+        for thread in guard.threads.values() {
+            thread.signal(Signal::Sigwakeup);
+        }
+    } else {
+        wake_atomic_waiters(&guard, signal);
+        for thread in guard.threads.values() {
+            thread.signal(signal);
+        }
     }
 }
 
@@ -964,6 +975,65 @@ impl SignalHandlerAbi for WasiProcess {
             Ok(())
         } else {
             Err(SignalDeliveryError)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::os::task::control_plane::{ControlPlaneConfig, WasiControlPlane};
+
+    fn test_process() -> (WasiControlPlane, WasiProcess) {
+        let plane = WasiControlPlane::new(ControlPlaneConfig {
+            max_task_count: None,
+            enable_asynchronous_threading: false,
+            enable_exponential_cpu_backoff: None,
+        });
+        let process = plane.new_process(ModuleHash::random()).unwrap();
+        (plane, process)
+    }
+
+    fn add_threads(process: &WasiProcess) -> [WasiThreadHandle; 2] {
+        [
+            process
+                .new_thread(WasiMemoryLayout::default(), ThreadStartType::MainThread)
+                .unwrap(),
+            process
+                .new_thread(
+                    WasiMemoryLayout::default(),
+                    ThreadStartType::ThreadSpawn { start_ptr: 0 },
+                )
+                .unwrap(),
+        ]
+    }
+
+    #[test]
+    fn sigkill_finishes_all_threads_without_guest_visible_sigkill() {
+        let (_plane, process) = test_process();
+        let threads = add_threads(&process);
+
+        process.signal_process(Signal::Sigkill);
+
+        for thread in threads {
+            assert_eq!(
+                thread.try_join().unwrap().unwrap(),
+                ExitCode::from(Errno::Intr)
+            );
+            assert_eq!(thread.pop_signals(), vec![Signal::Sigwakeup]);
+        }
+    }
+
+    #[test]
+    fn catchable_process_signals_remain_guest_visible() {
+        let (_plane, process) = test_process();
+        let threads = add_threads(&process);
+
+        process.signal_process(Signal::Sigpipe);
+
+        for thread in threads {
+            assert!(thread.try_join().is_none());
+            assert_eq!(thread.pop_signals(), vec![Signal::Sigpipe]);
         }
     }
 }

--- a/lib/wasix/src/runtime/task_manager/tokio.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio.rs
@@ -329,3 +329,6 @@ impl Drop for SleepNow {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/lib/wasix/src/runtime/task_manager/tokio/tests.rs
+++ b/lib/wasix/src/runtime/task_manager/tokio/tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+use crate::{WasiEnv, runtime::PluggableRuntime};
+use std::sync::atomic::Ordering;
+use wasmer::{AtomicsError, MemoryLocation, Module, Store};
+use wasmer_wasix_types::{types::Signal, wasi::Errno};
+
+const SHARED_MEMORY_MODULE: &str = r#"(module
+    (import "env" "memory" (memory 1 1 shared))
+    (export "memory" (memory 0)))"#;
+
+async fn assert_process_sigkill_reclaims_trigger_task(handler_registered: bool) {
+    let manager = TokioTaskManager::new(Handle::current());
+    let store = Store::default();
+    let module = Module::new(&store, SHARED_MEMORY_MODULE).unwrap();
+    let mut runtime = PluggableRuntime::new(Arc::new(manager.clone()));
+    runtime.set_engine(store.engine().clone());
+    let env = WasiEnv::builder("sigkill-process-handler")
+        .runtime(Arc::new(runtime))
+        .build()
+        .unwrap();
+    // A callback lives on the instance that registered it, while sibling
+    // instances only observe this process-wide flag.
+    env.state
+        .signal_handler_registered
+        .store(handler_registered, Ordering::SeqCst);
+    let process = env.process.clone();
+
+    let (trigger_ready_tx, trigger_ready_rx) = tokio::sync::oneshot::channel();
+    let (_keep_trigger_pending, trigger_pending_rx) = tokio::sync::oneshot::channel::<()>();
+    let (task_done_tx, task_done_rx) = tokio::sync::oneshot::channel();
+    let task = TaskWasm::new(
+        Box::new(move |properties| {
+            let result = properties.trigger_result.clone().unwrap();
+            drop(properties);
+            let _ = task_done_tx.send(result);
+        }),
+        env,
+        module,
+        false,
+        false,
+    )
+    .with_trigger(Box::new(move || {
+        Box::pin(async move {
+            trigger_ready_tx.send(()).unwrap();
+            let _ = trigger_pending_rx.await;
+            Ok(Vec::new().into())
+        })
+    }));
+
+    manager.task_wasm(task).unwrap();
+    trigger_ready_rx.await.unwrap();
+    let memory = process
+        .lock()
+        .memory
+        .clone()
+        .expect("task memory must be registered before its trigger starts");
+    let waiter_memory = memory.clone();
+    let (waiter_ready_tx, waiter_ready_rx) = tokio::sync::oneshot::channel();
+    let waiter = tokio::task::spawn_blocking(move || {
+        waiter_ready_tx.send(()).unwrap();
+        waiter_memory.wait(MemoryLocation::new_32(0), None)
+    });
+    waiter_ready_rx.await.unwrap();
+
+    process.signal_process(Signal::Sigkill);
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), task_done_rx)
+            .await
+            .expect("SIGKILL must release the pending trigger task")
+            .unwrap()
+            .unwrap_err(),
+        Errno::Intr.into()
+    );
+    assert!(matches!(
+        waiter.await.unwrap(),
+        Err(AtomicsError::AtomicsDisabled | AtomicsError::MemoryDropped)
+    ));
+    assert_eq!(process.try_join().unwrap().unwrap(), Errno::Intr.into());
+    assert!(matches!(
+        memory.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+        Err(AtomicsError::MemoryDropped)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn process_sigkill_reclaims_trigger_task_with_process_signal_handler() {
+    assert_process_sigkill_reclaims_trigger_task(true).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn process_sigkill_reclaims_trigger_task_without_signal_handler() {
+    assert_process_sigkill_reclaims_trigger_task(false).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn process_sigkill_interrupts_guest_atomic_wait() {
+    let manager = TokioTaskManager::new(Handle::current());
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+
+    tokio::task::spawn_blocking(move || {
+        let mut store = Store::default();
+        let module = Module::new(
+            &store,
+            r#"(module
+                (import "env" "memory" (memory 1 1 shared))
+                (export "memory" (memory 0))
+                (func (export "wait") (result i32)
+                    (memory.atomic.wait32
+                        (i32.const 0) (i32.const 0) (i64.const -1))))"#,
+        )
+        .unwrap();
+        let mut runtime = PluggableRuntime::new(Arc::new(manager));
+        runtime.set_engine(store.engine().clone());
+        let (instance, env) = WasiEnv::builder("sigkill-guest-atomic-wait")
+            .runtime(Arc::new(runtime))
+            .instantiate(module, &mut store)
+            .unwrap();
+        let process = env.data(&store).process.clone();
+        let memory = instance
+            .exports
+            .get_memory("memory")
+            .unwrap()
+            .as_shared(&store)
+            .unwrap();
+        ready_tx.send((process, memory.ops())).unwrap();
+        let interrupted = instance
+            .exports
+            .get_typed_function::<(), i32>(&store, "wait")
+            .unwrap()
+            .call(&mut store)
+            .is_err();
+        drop(memory);
+        drop(instance);
+        drop(store);
+        done_tx.send(interrupted).unwrap();
+    });
+
+    let (process, memory) = ready_rx.await.unwrap();
+    process.signal_process(Signal::Sigkill);
+    let done = tokio::time::timeout(Duration::from_secs(2), done_rx).await;
+    if done.is_err() {
+        let _ = memory.disable_atomics();
+    }
+    assert!(
+        done.expect("SIGKILL must interrupt a guest atomic wait")
+            .unwrap()
+    );
+    assert_eq!(process.try_join().unwrap().unwrap(), Errno::Intr.into());
+    assert!(matches!(
+        memory.wait(MemoryLocation::new_32(0), Some(Duration::ZERO)),
+        Err(AtomicsError::MemoryDropped)
+    ));
+}

--- a/lib/wasix/src/state/env.rs
+++ b/lib/wasix/src/state/env.rs
@@ -696,9 +696,16 @@ impl WasiEnv {
 
     /// Processes any signals that are batched up or any forced exit codes
     pub fn process_signals_and_exit(ctx: &mut FunctionEnvMut<'_, Self>) -> WasiResult<bool> {
+        // Forced completion takes precedence over queued signals. In particular,
+        // process SIGKILL uses a host-only wakeup that must not be drained and
+        // ignored by instances without their own guest signal callback.
+        let env = ctx.data();
+        if let Some(forced_exit) = env.should_exit() {
+            return Err(WasiError::Exit(forced_exit));
+        }
+
         // If a signal handler has never been set then we need to handle signals
         // differently
-        let env = ctx.data();
         let env_inner = env
             .try_inner()
             .ok_or_else(|| WasiError::Exit(Errno::Fault.into()))?;
@@ -713,8 +720,9 @@ impl WasiEnv {
                 .state
                 .signal_handler_registered
                 .load(std::sync::atomic::Ordering::SeqCst);
-        if !handler_registered {
+        let processed = if !handler_registered {
             let signals = env.thread.pop_signals();
+            let processed = !signals.is_empty();
             if !signals.is_empty() {
                 for sig in signals {
                     if sig == Signal::Sigint
@@ -729,16 +737,20 @@ impl WasiEnv {
                         tracing::trace!(pid=%env.pid(), ?sig, "Signal ignored");
                     }
                 }
-                return Ok(Ok(true));
             }
-        }
+            Ok(processed)
+        } else {
+            Self::process_signals(ctx)?
+        };
 
-        // Check for forced exit
-        if let Some(forced_exit) = env.should_exit() {
+        // Close the race between the first status check and signal draining.
+        // SIGKILL publishes completion before it queues Sigwakeup, so either
+        // this check observes it or the wake remains pending for the next pass.
+        if let Some(forced_exit) = ctx.data().should_exit() {
             return Err(WasiError::Exit(forced_exit));
         }
 
-        Self::process_signals(ctx)
+        Ok(processed)
     }
 
     /// Processes any signals that are batched up


### PR DESCRIPTION
After #6888 made signal-handler registration process-wide, sibling threads without their own guest callback could discard `SIGKILL` instead of exiting. This could leave blocked WASIX tasks alive and keep their memory allocated after the process was killed.

This change handles process-directed `SIGKILL` in the host: it marks all process threads as finished before waking atomic waiters, then sends the host-only `Sigwakeup` signal to wake pending tasks. Signal dispatch checks for forced completion both before and after draining signals so a concurrent kill cannot be missed.

Catchable signals such as `SIGPIPE` retain the process-wide handling introduced in #6888.
