### PR TITLE
fix(LLVM): honor m0 optimization setting with static memory

### DIFF
--- a/lib/compiler-llvm/src/compiler.rs
+++ b/lib/compiler-llvm/src/compiler.rs
@@ -207,6 +207,9 @@ impl Compiler for LLVMCompiler {
         if self.config.enable_readonly_funcref_table {
             components.push(Component::ReadonlyFuncrefTable);
         }
+        if !self.config.enable_m0 {
+            components.push(Component::DisableM0);
+        }
 
         components
             .into_iter()
@@ -638,8 +641,11 @@ impl Compiler for LLVMCompiler {
 
     fn with_opts(
         &mut self,
-        _suggested_compiler_opts: &wasmer_types::target::UserCompilerOptimizations,
+        suggested_compiler_opts: &wasmer_types::target::UserCompilerOptimizations,
     ) -> Result<(), CompileError> {
+        if let Some(enable) = suggested_compiler_opts.pass_params {
+            self.config.enable_m0 = enable;
+        }
         Ok(())
     }
 }

--- a/lib/compiler-llvm/src/config.rs
+++ b/lib/compiler-llvm/src/config.rs
@@ -17,9 +17,11 @@ use wasmer_compiler::{
     Compiler, CompilerConfig, Debugger, Engine, EngineBuilder, ModuleMiddleware,
 };
 use wasmer_types::{
-    Features,
+    Features, MemoryIndex,
+    entity::PrimaryMap,
     target::{Architecture, OperatingSystem, Target, Triple},
 };
+use wasmer_vm::MemoryStyle;
 
 /// The InkWell ModuleInfo type
 pub type InkwellModule<'ctx> = inkwell::module::Module<'ctx>;
@@ -113,6 +115,7 @@ pub struct LLVM {
     pub(crate) enable_nan_canonicalization: bool,
     pub(crate) enable_non_volatile_memops: bool,
     pub(crate) enable_readonly_funcref_table: bool,
+    pub(crate) enable_m0: bool,
     pub(crate) enable_verifier: bool,
     pub(crate) enable_perfmap: bool,
     pub(crate) debugger: Option<Debugger>,
@@ -142,6 +145,7 @@ impl LLVM {
             enable_nan_canonicalization: false,
             enable_non_volatile_memops: false,
             enable_readonly_funcref_table: false,
+            enable_m0: true,
             enable_verifier: false,
             enable_perfmap: false,
             debugger: None,
@@ -198,6 +202,16 @@ impl LLVM {
     pub fn readonly_funcref_table(&mut self, enable_readonly_funcref_table: bool) -> &mut Self {
         self.enable_readonly_funcref_table = enable_readonly_funcref_table;
         self
+    }
+
+    pub(crate) fn m0_is_enabled(
+        &self,
+        memory_styles: &PrimaryMap<MemoryIndex, MemoryStyle>,
+    ) -> bool {
+        self.enable_m0
+            && memory_styles
+                .get(MemoryIndex::from_u32(0))
+                .is_some_and(|memory| matches!(memory, MemoryStyle::Static))
     }
 
     fn reloc_mode(&self, binary_format: BinaryFormat) -> RelocMode {
@@ -449,5 +463,61 @@ impl Default for LLVM {
 impl From<LLVM> for Engine {
     fn from(config: LLVM) -> Self {
         EngineBuilder::new(config).engine()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn m0_requires_static_memory_zero_and_can_be_disabled() {
+        let mut config = LLVM::new();
+        let mut styles = PrimaryMap::new();
+        assert!(!config.m0_is_enabled(&styles));
+        styles.push(MemoryStyle::Dynamic {
+            offset_guard_size: 0,
+        });
+        styles.push(MemoryStyle::Static);
+        assert!(!config.m0_is_enabled(&styles));
+        styles[MemoryIndex::from_u32(0)] = MemoryStyle::Static;
+        assert!(config.m0_is_enabled(&styles));
+        config.enable_m0 = false;
+        assert!(!config.m0_is_enabled(&styles));
+        assert!(matches!(
+            styles[MemoryIndex::from_u32(0)],
+            MemoryStyle::Static
+        ));
+        config.enable_m0 = true;
+        assert!(config.m0_is_enabled(&styles));
+    }
+
+    #[test]
+    fn m0_options_preserve_unspecified_settings_and_change_compiler_id() {
+        use wasmer_types::target::UserCompilerOptimizations;
+
+        let mut compiler = LLVMCompiler::new(LLVM::new());
+        let default_id = compiler.deterministic_id();
+        compiler
+            .with_opts(&UserCompilerOptimizations::default())
+            .unwrap();
+        assert_eq!(default_id, compiler.deterministic_id());
+        compiler
+            .with_opts(&UserCompilerOptimizations {
+                pass_params: Some(false),
+            })
+            .unwrap();
+        let disabled_id = compiler.deterministic_id();
+        assert_ne!(default_id, disabled_id);
+        compiler
+            .with_opts(&UserCompilerOptimizations::default())
+            .unwrap();
+        assert_eq!(disabled_id, compiler.deterministic_id());
+        compiler
+            .with_opts(&UserCompilerOptimizations {
+                pass_params: Some(true),
+            })
+            .unwrap();
+        assert_eq!(default_id, compiler.deterministic_id());
     }
 }

--- a/lib/compiler-llvm/src/translator/code.rs
+++ b/lib/compiler-llvm/src/translator/code.rs
@@ -147,11 +147,7 @@ impl FuncTranslator {
         let function =
             CompiledKind::Local(*local_func_index, wasm_module.get_function_name(func_index));
 
-        // We can pass and use the heap pointer (memory #0) only and only if the memory static, that means
-        // the allocated heap is never moved to a different location.
-        let m0_is_enabled = memory_styles
-            .get(MemoryIndex::from_u32(0))
-            .is_some_and(|memory| matches!(memory, MemoryStyle::Static));
+        let m0_is_enabled = config.m0_is_enabled(memory_styles);
 
         let (function_name, module_name) = if config.experimental_artifact {
             (function.linkage_name(), String::new())

--- a/lib/compiler-llvm/src/translator/trampoline.rs
+++ b/lib/compiler-llvm/src/translator/trampoline.rs
@@ -30,8 +30,7 @@ use wasmer_compiler::{
     },
 };
 use wasmer_types::{
-    CompileError, FunctionIndex, FunctionType as FuncType, LocalFunctionIndex, MemoryIndex,
-    entity::PrimaryMap,
+    CompileError, FunctionIndex, FunctionType as FuncType, LocalFunctionIndex, entity::PrimaryMap,
 };
 use wasmer_vm::MemoryStyle;
 
@@ -46,13 +45,6 @@ pub struct FuncTrampoline {
 
 const FUNCTION_SECTION_ELF: &str = "__TEXT,wasmer_trmpl"; // Needs to be between 1 and 16 chars
 const FUNCTION_SECTION_MACHO: &str = "wasmer_trmpl"; // Needs to be between 1 and 16 chars
-
-fn enable_m0_optimization(compile_info: &CompileModuleInfo) -> bool {
-    compile_info
-        .memory_styles
-        .get(MemoryIndex::from_u32(0))
-        .is_some_and(|memory| matches!(memory, MemoryStyle::Static))
-}
 
 impl FuncTrampoline {
     pub fn new(
@@ -101,7 +93,7 @@ impl FuncTrampoline {
             &self.binary_fmt,
         );
 
-        let m0_is_enabled = enable_m0_optimization(compile_info);
+        let m0_is_enabled = config.m0_is_enabled(&compile_info.memory_styles);
         let (callee_ty, callee_attrs) =
             self.abi
                 .func_type_to_llvm(&self.ctx, &intrinsics, None, ty, m0_is_enabled)?;
@@ -511,7 +503,7 @@ impl FuncTrampoline {
         callee_vmctx_ptr.set_name("vmctx");
         args_vec.push(callee_vmctx_ptr.into());
 
-        if enable_m0_optimization(compile_info) {
+        if config.m0_is_enabled(&compile_info.memory_styles) {
             let wasm_module = &compile_info.module;
             let memory_styles = &compile_info.memory_styles;
             let callee_vmctx_ptr_value = callee_vmctx_ptr.into_pointer_value();

--- a/lib/compiler/src/compiler.rs
+++ b/lib/compiler/src/compiler.rs
@@ -81,6 +81,8 @@ pub enum DeterministicIdComponent {
     Pic,
     #[strum(serialize = "ro_ftable")]
     ReadonlyFuncrefTable,
+    #[strum(serialize = "no_m0")]
+    DisableM0,
     #[strum(serialize = "unaligned_mem")]
     ExperimentalUnalignedMemoryAccesses,
 }

--- a/lib/types/src/target.rs
+++ b/lib/types/src/target.rs
@@ -247,5 +247,9 @@ impl Default for Target {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct UserCompilerOptimizations {
     /// Suggest the `pass_params` (also known as m0) optimization pass.
+    ///
+    /// LLVM enables this by default for static memory zero. `Some(false)` disables
+    /// passing its base pointer as a hidden function argument without changing the
+    /// memory style or allocation strategy. `None` preserves the current setting.
     pub pass_params: Option<bool>,
 }

--- a/tests/compilers/llvm_m0.rs
+++ b/tests/compilers/llvm_m0.rs
@@ -1,0 +1,145 @@
+use anyhow::Result;
+use std::{fs, path::Path};
+use wasmer::{
+    Function, FunctionType, Instance, MemoryStyle, MemoryType, Module, Store, Type, Value, imports,
+    sys::{BaseTunables, CompilerConfig, EngineBuilder, Tunables},
+};
+use wasmer_compiler_llvm::{LLVM, LLVMCallbacks};
+use wasmer_types::target::UserCompilerOptimizations;
+
+fn read_preopt_ir(path: &Path) -> Result<Vec<String>> {
+    let mut modules = Vec::new();
+    for entry in fs::read_dir(path)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            modules.extend(read_preopt_ir(&path)?);
+        } else if path.to_string_lossy().ends_with(".preopt.ll") {
+            modules.push(fs::read_to_string(path)?);
+        }
+    }
+    Ok(modules)
+}
+
+fn static_memory_calls(enable_m0: bool) -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let mut config = LLVM::new();
+    config.enable_verifier();
+    config.callbacks(Some(LLVMCallbacks::new(temp.path().to_owned())?));
+    let tunables = BaseTunables::new();
+    assert!(matches!(
+        tunables.memory_style(&MemoryType::new(1, Some(2), false)),
+        MemoryStyle::Static
+    ));
+    let mut engine = EngineBuilder::new(config).engine();
+    engine.with_opts(&UserCompilerOptimizations {
+        pass_params: Some(enable_m0),
+    })?;
+    engine.set_tunables(tunables);
+    let mut store = Store::new(engine);
+    let module = Module::new(
+        &store,
+        r#"(module
+            (type $unary (func (param i32) (result i32)))
+            (import "host" "typed" (func $typed (type $unary)))
+            (import "host" "dynamic" (func $dynamic (type $unary)))
+            (memory (export "memory") 1 2)
+            (table (export "table") 4 funcref)
+            (elem (i32.const 0) $load $typed $dynamic)
+            (data (i32.const 0) "\2a\00\00\00")
+            (func $load (export "load") (type $unary)
+                (i32.load (local.get 0)))
+            (func (export "direct") (type $unary)
+                (call $load (local.get 0)))
+            (func (export "indirect") (param i32 i32) (result i32)
+                (call_indirect (type $unary) (local.get 0) (local.get 1)))
+            (func (export "host_calls") (type $unary)
+                (i32.add (call $typed (local.get 0)) (call $dynamic (local.get 0))))
+            (func (export "multi") (param i32) (result i32 i64 i32)
+                (call $load (local.get 0))
+                (i64.const 123456789)
+                (i32.const 7))
+            (func (export "grow") (result i32)
+                (memory.grow (i32.const 1))))"#,
+    )?;
+
+    // Check the lowered ABI before executing it: functions and call trampolines
+    // must agree, and disabling m0 must retain static memory code generation.
+    let ir = read_preopt_ir(temp.path())?;
+    assert!(!ir.is_empty());
+    assert_eq!(ir.iter().any(|ir| ir.contains("%m0_base_ptr")), enable_m0);
+    assert_eq!(
+        ir.iter().any(|ir| ir.contains("%trmpl_m0_base_ptr")),
+        enable_m0
+    );
+    assert!(ir.iter().all(|ir| !ir.contains("load_offset_end")));
+
+    let typed = Function::new_typed(&mut store, |value: i32| value + 10);
+    let dynamic = Function::new(
+        &mut store,
+        FunctionType::new([Type::I32], [Type::I32]),
+        |args| Ok(vec![Value::I32(args[0].unwrap_i32() + 20)]),
+    );
+    let imports = imports! { "host" => { "typed" => typed, "dynamic" => dynamic } };
+    // Exercise the serialized artifact too: its trampolines must retain this ABI.
+    let serialized = module.serialize()?;
+    let module = unsafe { Module::deserialize(&store, serialized)? };
+    let instance = Instance::new(&mut store, &module, &imports)?;
+    let direct = instance
+        .exports
+        .get_typed_function::<i32, i32>(&store, "direct")?;
+    assert_eq!(direct.call(&mut store, 0)?, 42);
+    let indirect = instance
+        .exports
+        .get_typed_function::<(i32, i32), i32>(&store, "indirect")?;
+    assert_eq!(indirect.call(&mut store, 0, 0)?, 42);
+    assert_eq!(indirect.call(&mut store, 7, 1)?, 17);
+    assert_eq!(indirect.call(&mut store, 7, 2)?, 27);
+    assert_eq!(
+        &*instance
+            .exports
+            .get_function("host_calls")?
+            .call(&mut store, &[Value::I32(7)])?,
+        &[Value::I32(44)]
+    );
+    assert_eq!(
+        &*instance
+            .exports
+            .get_function("multi")?
+            .call(&mut store, &[Value::I32(0)])?,
+        &[Value::I32(42), Value::I64(123456789), Value::I32(7)]
+    );
+    let memory = instance.exports.get_memory("memory")?;
+    let base = memory.view(&store).data_ptr();
+    let grow = instance
+        .exports
+        .get_typed_function::<(), i32>(&store, "grow")?;
+    assert_eq!(grow.call(&mut store)?, 1);
+    assert_eq!(memory.view(&store).data_ptr(), base);
+    memory.view(&store).write(65536, &99_i32.to_le_bytes())?;
+    assert_eq!(direct.call(&mut store, 65536)?, 99);
+    assert_eq!(indirect.call(&mut store, 65536, 0)?, 99);
+    assert!(direct.call(&mut store, 131072).is_err());
+    assert_eq!(grow.call(&mut store)?, -1);
+
+    if !enable_m0 {
+        // A runtime-populated table entry must not be dispatched using the m0
+        // optimization's assumptions about the original element initializer.
+        let load = instance.exports.get_function("load")?.clone();
+        instance
+            .exports
+            .get_table("table")?
+            .set(&mut store, 3, Value::FuncRef(Some(load)))?;
+        assert_eq!(indirect.call(&mut store, 65536, 3)?, 99);
+    }
+    Ok(())
+}
+
+#[test]
+fn static_memory_without_m0() -> Result<()> {
+    static_memory_calls(false)
+}
+
+#[test]
+fn static_memory_with_m0() -> Result<()> {
+    static_memory_calls(true)
+}

--- a/tests/compilers/main.rs
+++ b/tests/compilers/main.rs
@@ -10,6 +10,8 @@ mod config;
 mod deterministic;
 mod imports;
 mod issues;
+#[cfg(feature = "llvm")]
+mod llvm_m0;
 #[cfg(feature = "middlewares")]
 mod metering;
 mod middlewares;


### PR DESCRIPTION
LLVM currently ignores `UserCompilerOptimizations.pass_params`, so embedders cannot disable the m0 hidden-memory-pointer optimization while retaining static memory. Honor the existing setting through `Engine::with_opts`: `Some(false)` disables m0, `Some(true)` enables it for eligible static memories, and `None` preserves the current setting. The default remains enabled.

Use one eligibility check for function and trampoline generation, preserving `MemoryStyle::Static`, static allocations, and existing bounds-check behavior. Add `no_m0` to the deterministic compiler ID when disabled so artifact cache keys distinguish the modes. 